### PR TITLE
cf view: reveal diff context where the reader is looking

### DIFF
--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -511,13 +511,24 @@ function expandContext(
   const moved = (n: number) =>
     n + (n >= insertedAt ? k : 0) -
     (removedAt !== null && n > removedAt ? 1 : 0);
+  // A cursor can rest on a hunk's header. When an upward reveal met the hunk
+  // above and the two joined, that header is the one the join removed, so
+  // `moved` would leave the cursor on its old line number — now the first
+  // revealed line. Send it to the surviving header of the merged hunk instead,
+  // the header of the hunk above, which the join kept.
+  const mergedHeader = removedAt !== null && up
+    ? model.files.flatMap((f) => f.hunks)[index - 1]?.headerLine
+    : undefined;
+  const cursorAfter = mergedHeader !== undefined && cursorLine === removedAt
+    ? mergedHeader
+    : moved(cursorLine);
   return {
     text: joined?.text ?? text,
     baseline: joined?.baseline ?? newBaseline,
     // The cursor stays on its own line. Revealing upwards puts the lines below
     // the hunk's header, so a cursor resting on that header does not move while
     // one in the body rides down ahead of them.
-    cursorLine: moved(cursorLine),
+    cursorLine: cursorAfter,
     insertedAt,
     inserted: k,
     up,
@@ -526,16 +537,11 @@ function expandContext(
   };
 }
 
-/** Insert `ctx` context lines at the top (`up`) or just before `bodyEnd` (the
- * line after the hunk's last body line) of the `index`-th hunk in `text`,
- * growing that hunk header's counts by `k`. Null when the hunk or its header
- * cannot be found. */
-const HUNK_HEADER_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
-
 /** Take the `@@` header off the second of two hunks and give its counts to the
  * first, leaving one hunk where there were two. Null when the text does not hold
  * them back to back — anything between the first's last line and the second's
- * header would land inside the joined body. */
+ * header would land inside the joined body. The counts come from the parsed
+ * hunks rather than a re-read of the header line, which the parse already read. */
 function dropHeaderBetween(
   text: string,
   first: number,
@@ -546,17 +552,13 @@ function dropHeaderBetween(
   const a = all[first];
   const b = all[first + 1];
   if (!a || !b || b.headerLine !== a.endLine + 1) return null;
-  const lines = text.split("\n");
-  const ma = lines[a.headerLine]?.match(HUNK_HEADER_RE);
-  const mb = lines[b.headerLine]?.match(HUNK_HEADER_RE);
-  if (!ma || !mb) return null;
-  const count = (m: RegExpMatchArray, i: number) =>
-    m[i] !== undefined ? parseInt(m[i], 10) : 1;
   // The joined hunk starts where the first did and runs to the end of the
   // second, which is both counts together — they meet with nothing in between.
-  const header = `@@ -${ma[1]},${count(ma, 2) + count(mb, 2)} +${ma[3]},${
-    count(ma, 4) + count(mb, 4)
-  } @@${ma[5] ?? ""}`;
+  // The first hunk's trailing context (its enclosing function) carries over.
+  const header = `@@ -${a.oldStart},${a.oldCount + b.oldCount} +${a.newStart},${
+    a.newCount + b.newCount
+  } @@${a.context ? ` ${a.context}` : ""}`;
+  const lines = text.split("\n");
   const out = [
     ...lines.slice(0, a.headerLine),
     header,
@@ -593,6 +595,10 @@ function joinAdjacent(
   return { text: joined.text, baseline: joinedBase.text };
 }
 
+/** Insert `ctx` context lines at the top (`up`) or just before `bodyEnd` (the
+ * line after the hunk's last body line) of the `index`-th hunk in `text`,
+ * growing that hunk header's counts by `k`. Null when the hunk or its header
+ * cannot be found. */
 function applyExpansion(
   text: string,
   index: number,
@@ -799,7 +805,13 @@ function isMarkdownDiffLine(rawLines: string[], lineIdx: number): boolean {
   return false;
 }
 
-export const _internal = { editableStart, pendingAmend, amendCommit };
+export const _internal = {
+  editableStart,
+  pendingAmend,
+  amendCommit,
+  dropHeaderBetween,
+  joinAdjacent,
+};
 
 function reparse(
   ws: DiffWorkspace,

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -33,6 +33,7 @@ import type {
   EditableSource,
   EditPolicy,
   ExpandResult,
+  HunkRoom,
   RevertScope,
 } from "./editsource.ts";
 import { shortName } from "./editsource.ts";
@@ -153,8 +154,9 @@ export function diffSource(
     dirtyLabels: (original, current) => dirtyLabels(original, current),
     revert: (original, current, cursorLine, scope) =>
       revert(original, current, cursorLine, scope),
-    expandContext: (current, baseline, cursorLine) =>
-      expandContext(ws, cache, saveHunks, current, baseline, cursorLine),
+    expandContext: (current, baseline, cursorLine, up) =>
+      expandContext(ws, cache, saveHunks, current, baseline, cursorLine, up),
+    expandRoom: (current) => expandRoom(ws, cache, saveHunks, current),
     save: (text) => save(text, edit.fileText, saveHunks),
     pendingAmend: (baseline, current) =>
       pendingAmend(editableMessage, baseline, current),
@@ -318,44 +320,23 @@ function revertMessage(
   };
 }
 
-/**
- * Reveal more of the underlying file around the cursor's hunk, at the hunk
- * boundary nearest the cursor. The extra lines are read from the workspace file
- * just above (or below) the hunk's current new-side range and inserted as
- * context, with the hunk header's counts grown to match. The same expansion is
- * applied to `baseline` and to the save map, so revealing context does not
- * register as an edit (dirtiness still reflects only real changes), a later
- * revert keeps it, and a save still writes the correct file range. Returns the
- * new texts and where the cursor moves, or null when there is no backing file or
- * no more context to show.
- */
-function expandContext(
+/** What a hunk's file offers around it: the workspace file's lines, and how far
+ * the hunk's new-side range could grow each way. Null when the hunk has no
+ * backing file to read. */
+function hunkFooting(
   ws: DiffWorkspace,
   cache: WorkspaceCache | undefined,
   hunks: MutableHunk[],
-  current: string,
-  baseline: string,
-  cursorLine: number,
-  amount = 10,
-): ExpandResult | null {
-  const model = parseDiff(current);
-  if (!model) return null;
-  let index = -1;
-  let target: DiffHunk | undefined;
-  let targetFile: DiffModel["files"][number] | undefined;
-  let gi = 0;
-  for (const f of model.files) {
-    for (const h of f.hunks) {
-      if (cursorLine >= h.headerLine && cursorLine <= h.endLine) {
-        index = gi;
-        target = h;
-        targetFile = f;
-      }
-      gi++;
-    }
-  }
-  if (!target || !targetFile || targetFile.newPath === undefined) return null;
-  const absPath = ws.resolve(targetFile.newPath);
+  file: DiffModel["files"][number],
+  index: number,
+): {
+  fileLines: string[];
+  range: MutableHunk;
+  downFrom: number;
+  room: HunkRoom;
+} | null {
+  if (file.newPath === undefined) return null;
+  const absPath = ws.resolve(file.newPath);
   if (!absPath) return null;
   const content = cache?.get(absPath)?.fileText ?? ws.read(absPath);
   if (content === null) return null;
@@ -372,6 +353,7 @@ function expandContext(
   // hunk's file range — that would make save() splice the two ranges into each
   // other (silently dropping edits or duplicating lines) and malform the diff.
   const range = hunks[index];
+  if (!range) return null;
   const prev = index > 0 && hunks[index - 1].absPath === range.absPath
     ? hunks[index - 1]
     : null;
@@ -380,15 +362,111 @@ function expandContext(
     ? hunks[index + 1]
     : null;
   const prevEnd = prev ? prev.newStart + prev.newCount : 1; // 1-based, free above
-  const upAvail = Math.max(0, range.newStart - prevEnd);
   const downFrom = range.newStart - 1 + range.newCount; // 0-based, below it
   const nextStart = next ? next.newStart : fileLen + 1; // 1-based, blocked below
-  const downAvail = Math.max(0, nextStart - (downFrom + 1));
+  return {
+    fileLines,
+    range,
+    downFrom,
+    room: {
+      up: Math.max(0, range.newStart - prevEnd),
+      down: Math.max(0, nextStart - (downFrom + 1)),
+      // Nothing left is the file running out only where the range reaches its
+      // edge; otherwise it is the neighbouring hunk in the way.
+      atFileTop: range.newStart <= 1,
+      atFileBottom: downFrom >= fileLen,
+    },
+  };
+}
 
-  const mid = (target.headerLine + 1 + target.endLine) / 2;
-  let up = cursorLine <= mid;
-  if (up && upAvail === 0) up = false; // nothing left above
-  if (!up && downAvail === 0) up = true; // nothing left below
+/** The hunk `line` sits in, with its file and its index across the whole diff. */
+function hunkAt(model: DiffModel, line: number): {
+  hunk: DiffHunk;
+  file: DiffModel["files"][number];
+  index: number;
+} | null {
+  let found = null;
+  let gi = 0;
+  for (const f of model.files) {
+    for (const h of f.hunks) {
+      if (line >= h.headerLine && line <= h.endLine) {
+        found = { hunk: h, file: f, index: gi };
+      }
+      gi++;
+    }
+  }
+  return found;
+}
+
+/** How much context each hunk of `current` could still reveal, keyed by the line
+ * its header sits on. */
+function expandRoom(
+  ws: DiffWorkspace,
+  cache: WorkspaceCache | undefined,
+  hunks: MutableHunk[],
+  current: string,
+): ReadonlyMap<number, HunkRoom> {
+  const out = new Map<number, HunkRoom>();
+  const model = parseDiff(current);
+  if (!model) return out;
+  let gi = 0;
+  for (const f of model.files) {
+    for (const h of f.hunks) {
+      const footing = hunkFooting(ws, cache, hunks, f, gi);
+      if (footing) out.set(h.headerLine, footing.room);
+      gi++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Reveal more of the underlying file around the cursor's hunk. The extra lines
+ * are read from the workspace file just above (or below) the hunk's current
+ * new-side range and inserted as context, with the hunk header's counts grown to
+ * match. The same expansion is applied to `baseline` and to the save map, so
+ * revealing context does not register as an edit (dirtiness still reflects only
+ * real changes), a later revert keeps it, and a save still writes the correct
+ * file range.
+ *
+ * Which way to grow comes from `up` when it is given, and the call fails rather
+ * than growing the other way when that side has run out — a caller that names an
+ * edge is naming the one the user is looking at. Without it the boundary nearest
+ * `cursorLine` grows, falling back to the other when that one has run out.
+ *
+ * Returns the new texts and where the cursor moves, or null when there is no
+ * backing file or no more context that way.
+ */
+function expandContext(
+  ws: DiffWorkspace,
+  cache: WorkspaceCache | undefined,
+  hunks: MutableHunk[],
+  current: string,
+  baseline: string,
+  cursorLine: number,
+  upIn?: boolean,
+  amount = 10,
+): ExpandResult | null {
+  const model = parseDiff(current);
+  if (!model) return null;
+  const at = hunkAt(model, cursorLine);
+  if (!at) return null;
+  const footing = hunkFooting(ws, cache, hunks, at.file, at.index);
+  if (!footing) return null;
+  const { fileLines, range, downFrom, room } = footing;
+  const { up: upAvail, down: downAvail } = room;
+  const target = at.hunk;
+  const index = at.index;
+
+  let up: boolean;
+  if (upIn !== undefined) {
+    up = upIn;
+  } else {
+    const mid = (target.headerLine + 1 + target.endLine) / 2;
+    up = cursorLine <= mid;
+    if (up && upAvail === 0) up = false; // nothing left above
+    if (!up && downAvail === 0) up = true; // nothing left below
+  }
   const k = Math.min(amount, up ? upAvail : downAvail);
   if (k <= 0) return null;
 
@@ -396,6 +474,11 @@ function expandContext(
     (up
       ? fileLines.slice(range.newStart - 1 - k, range.newStart - 1)
       : fileLines.slice(downFrom, downFrom + k)).map((l) => ` ${l}`);
+  // Which file lines those are, counting from one, while `range` still holds
+  // where the hunk started — growing it upwards moves that.
+  const revealed = up
+    ? { from: range.newStart - k, to: range.newStart - 1 }
+    : { from: downFrom + 1, to: downFrom + k };
 
   // Insert at the parser's hunk boundary (one past its last body line), not a
   // re-scan, so a blank separator below the hunk (git log -p) is not absorbed.
@@ -417,12 +500,29 @@ function expandContext(
   // The revealed lines land just after the hunk header (up) or just after its
   // last body line (down), both in current-text coordinates.
   const insertedAt = up ? target.headerLine + 1 : target.endLine + 1;
+  // Those lines may have been the last between this hunk and its neighbour, in
+  // which case the two now touch and the header between them describes nothing.
+  // The header that goes is the one at the join: this hunk's own when the lines
+  // came from above it, the next hunk's when they came from below.
+  const joined = joinAdjacent(text, newBaseline, hunks, up ? index - 1 : index);
+  const removedAt = joined ? (up ? insertedAt - 1 : insertedAt) : null;
+  // Where a line of the old text ends up: down by the lines that went in above
+  // it, and back up over a header that is no longer between them.
+  const moved = (n: number) =>
+    n + (n >= insertedAt ? k : 0) -
+    (removedAt !== null && n > removedAt ? 1 : 0);
   return {
-    text,
-    baseline: newBaseline,
-    cursorLine: cursorLine + (up ? k : 0),
+    text: joined?.text ?? text,
+    baseline: joined?.baseline ?? newBaseline,
+    // The cursor stays on its own line. Revealing upwards puts the lines below
+    // the hunk's header, so a cursor resting on that header does not move while
+    // one in the body rides down ahead of them.
+    cursorLine: moved(cursorLine),
     insertedAt,
     inserted: k,
+    up,
+    removedAt,
+    revealed,
   };
 }
 
@@ -430,6 +530,69 @@ function expandContext(
  * line after the hunk's last body line) of the `index`-th hunk in `text`,
  * growing that hunk header's counts by `k`. Null when the hunk or its header
  * cannot be found. */
+const HUNK_HEADER_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
+
+/** Take the `@@` header off the second of two hunks and give its counts to the
+ * first, leaving one hunk where there were two. Null when the text does not hold
+ * them back to back — anything between the first's last line and the second's
+ * header would land inside the joined body. */
+function dropHeaderBetween(
+  text: string,
+  first: number,
+): { text: string; removedAt: number } | null {
+  const model = parseDiff(text);
+  if (!model) return null;
+  const all = model.files.flatMap((f) => f.hunks);
+  const a = all[first];
+  const b = all[first + 1];
+  if (!a || !b || b.headerLine !== a.endLine + 1) return null;
+  const lines = text.split("\n");
+  const ma = lines[a.headerLine]?.match(HUNK_HEADER_RE);
+  const mb = lines[b.headerLine]?.match(HUNK_HEADER_RE);
+  if (!ma || !mb) return null;
+  const count = (m: RegExpMatchArray, i: number) =>
+    m[i] !== undefined ? parseInt(m[i], 10) : 1;
+  // The joined hunk starts where the first did and runs to the end of the
+  // second, which is both counts together — they meet with nothing in between.
+  const header = `@@ -${ma[1]},${count(ma, 2) + count(mb, 2)} +${ma[3]},${
+    count(ma, 4) + count(mb, 4)
+  } @@${ma[5] ?? ""}`;
+  const out = [
+    ...lines.slice(0, a.headerLine),
+    header,
+    ...lines.slice(a.headerLine + 1, b.headerLine),
+    ...lines.slice(b.headerLine + 1),
+  ];
+  return { text: out.join("\n"), removedAt: b.headerLine };
+}
+
+/** Join hunk `first` to the one after it when revealing context has left them
+ * touching, in the diff, its baseline and the save map together. Null when they
+ * still have file lines between them, are not the same file, or are not both
+ * known to match it — joining an unverified hunk to a verified one would put
+ * lines of unknown provenance into a range that a save writes, or stop the
+ * verified one from being written at all. */
+function joinAdjacent(
+  text: string,
+  baseline: string,
+  hunks: MutableHunk[],
+  first: number,
+): { text: string; baseline: string } | null {
+  const a = hunks[first];
+  const b = hunks[first + 1];
+  if (!a || !b || a.absPath === null || a.absPath !== b.absPath) return null;
+  if (a.newStart + a.newCount !== b.newStart) return null; // a gap remains
+  if (!a.verified || !b.verified) return null;
+  const joined = dropHeaderBetween(text, first);
+  const joinedBase = dropHeaderBetween(baseline, first);
+  if (!joined || !joinedBase) return null;
+  // save() pairs the text's hunks with this map by position, so it loses an
+  // entry exactly as the text loses a header.
+  a.newCount += b.newCount;
+  hunks.splice(first + 1, 1);
+  return { text: joined.text, baseline: joinedBase.text };
+}
+
 function applyExpansion(
   text: string,
   index: number,

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -22,16 +22,42 @@ export type RevertScope = "chunk" | "file" | "message" | "all";
 
 /** The outcome of revealing more context (a diff only): the grown diff and its
  * matching grown baseline, where the cursor moves, and — so the pager can hold
- * its viewport and selection steady across the change — where the revealed lines
- * were inserted (`insertedAt`, a line index into the pre-expansion text) and how
- * many there are (`inserted`). Lines at or below `insertedAt` shift down by
- * `inserted`; lines above it do not move. */
+ * its viewport and selection steady across the change — what moved where.
+ *
+ * `inserted` lines went in at `insertedAt`, a line of the pre-expansion text.
+ * `up` tells which edge of the hunk they went in at: its top when they came from
+ * above the hunk, its bottom when they came from below.
+ *
+ * `removedAt` is the `@@` header a join took out, also a line of the
+ * pre-expansion text, or null when nothing joined. Revealing the last file line
+ * between two hunks leaves them touching, and a header between lines that are
+ * neighbours in the file describes nothing: the two become one hunk.
+ *
+ * So a line `n` of the pre-expansion text is afterwards at
+ * `n + (n >= insertedAt ? inserted : 0) - (removedAt !== null && n > removedAt ?
+ * 1 : 0)`, and the line at `removedAt` is gone. */
 export interface ExpandResult {
   text: string;
   baseline: string;
   cursorLine: number;
   insertedAt: number;
   inserted: number;
+  up: boolean;
+  removedAt: number | null;
+  /** Which lines of the workspace file the reveal showed, as the file numbers
+   * them and counting from one: `from` to `to`, both ends included. */
+  revealed: { from: number; to: number };
+}
+
+/** How much context a hunk can still reveal each way, and what stops it where it
+ * cannot: `atFileTop` / `atFileBottom` say the hunk's range reaches the file's
+ * first or last line, so a zero there is the file running out. A zero without
+ * one is the neighbouring hunk butting against it, with nothing in between. */
+export interface HunkRoom {
+  up: number;
+  down: number;
+  atFileTop: boolean;
+  atFileBottom: boolean;
 }
 
 export interface EditableSource {
@@ -81,15 +107,23 @@ export interface EditableSource {
     cursorLine: number,
     scope: RevertScope,
   ): { text: string; cursorLine: number } | null;
-  /** Reveal more of the underlying file around the cursor's hunk (a diff only).
-   * Returns the grown diff text, the matching grown baseline (so revealing
-   * context is not itself an edit), and where the cursor moves — or null when
-   * there is nothing to expand. */
+  /** Reveal more of the underlying file around the hunk `cursorLine` sits in (a
+   * diff only). Returns the grown diff text, the matching grown baseline (so
+   * revealing context is not itself an edit), and where the cursor moves — or
+   * null when there is nothing to expand. `up` names the edge to grow, and the
+   * call fails rather than growing the other one when that edge has run out;
+   * without it the boundary nearest `cursorLine` grows, falling back to the
+   * other. */
   expandContext?(
     current: string,
     baseline: string,
     cursorLine: number,
+    up?: boolean,
   ): ExpandResult | null;
+  /** How much context each hunk of `current` could still reveal, keyed by the
+   * line its header sits on. The pager offers Ctrl-L only where the edge the
+   * user is looking at has room, and says what stopped it where it has not. */
+  expandRoom?(current: string): ReadonlyMap<number, HunkRoom>;
   /** Constrains where editing may happen. Present only for a diff, whose lines
    * map to fixed file lines: edits stay within a line, past the diff marker. A
    * plain file has no policy and is edited freely. */

--- a/packages/cli/lib/view/pager.ts
+++ b/packages/cli/lib/view/pager.ts
@@ -228,6 +228,9 @@ export async function runPager(
     stopExpiry();
     session.resize(s.width, s.height);
     draw();
+    // A message that takes itself away is still up after the redraw, so start
+    // its clock again — the one just cancelled would have left it there for good.
+    startExpiry();
   };
   const terminate = (code: number) => {
     cleanup();

--- a/packages/cli/lib/view/pager.ts
+++ b/packages/cli/lib/view/pager.ts
@@ -12,7 +12,7 @@
 import { CSI, term } from "./ansi.ts";
 import type { Document } from "./model.ts";
 import { decodeKeys } from "./keys.ts";
-import { cursorScreenPos, renderFrame } from "./render.ts";
+import { cursorScreenPos, renderFrame, type ViewState } from "./render.ts";
 import { Session, type SessionOptions } from "./session.ts";
 import { ui } from "./theme.ts";
 import { createSemantics, type Semantics } from "./semantics.ts";
@@ -25,6 +25,13 @@ const encoder = new TextEncoder();
 /** Idle gap after the last keystroke before the deferred structure re-parse
  * runs. Highlighting is not deferred — it re-runs on every keystroke. */
 const REPARSE_DEBOUNCE_MS = 150;
+
+/** Gap between frames while the lines a Ctrl-L revealed land, one per frame. */
+const REVEAL_FRAME_MS = 16;
+
+/** How long a status message that takes itself away stands before it goes. Long
+ * enough to read twice over, short enough not to outstay what prompted it. */
+const MESSAGE_LINGER_MS = 2000;
 
 export type PagerOptions = SessionOptions;
 
@@ -112,9 +119,7 @@ export async function runPager(
     realFileGateway(),
   );
 
-  const draw = () => {
-    const view = session.view();
-    const doc = session.displayDoc();
+  const paint = (doc: Document, view: ViewState) => {
     const rows = renderFrame(doc, view);
     // Re-assert the padding background every frame. Some terminals drop the
     // OSC 11 default set at startup after the first repaint, so setting it once
@@ -130,6 +135,60 @@ export async function runPager(
     const cur = cursorScreenPos(doc, view);
     if (cur) out += term.moveTo(cur.row, cur.col) + term.showCursor;
     deps.write(out);
+  };
+
+  const draw = () => paint(session.displayDoc(), session.view());
+
+  // Ctrl-L leaves the session at the finished state; these frames walk the lines
+  // it revealed in one at a time so where they land is visible. Any key, or a
+  // resize, drops the frames left and the draw that follows shows the finish.
+  let cancelReveal: (() => void) | undefined;
+  const stopReveal = () => {
+    if (cancelReveal) {
+      cancelReveal();
+      cancelReveal = undefined;
+    }
+  };
+  const startReveal = (): boolean => {
+    const reveal = session.pendingReveal;
+    if (!reveal || reveal.count < 2) return false; // one line lands on its own
+    let shown = 1;
+    const step = () => {
+      const frame = shown < reveal.count ? session.revealFrame(shown) : null;
+      if (!frame) {
+        cancelReveal = undefined;
+        draw();
+        // What it says stands from when the lines finish landing, not from
+        // before they started.
+        startExpiry();
+        return;
+      }
+      paint(frame.doc, frame.view);
+      shown++;
+      cancelReveal = deps.setTimer(step, REVEAL_FRAME_MS);
+    };
+    cancelReveal = deps.setTimer(step, REVEAL_FRAME_MS);
+    return true;
+  };
+
+  // Ctrl-L pressed where the bar does not offer it says why, and the key changed
+  // nothing else. The reason has served its purpose once it has been read, so it
+  // stands for a moment and then goes rather than sitting in the bar describing
+  // a keypress the user has long since moved on from.
+  let cancelExpiry: (() => void) | undefined;
+  const stopExpiry = () => {
+    if (cancelExpiry) {
+      cancelExpiry();
+      cancelExpiry = undefined;
+    }
+  };
+  const startExpiry = () => {
+    if (!session.transientMessage) return;
+    cancelExpiry = deps.setTimer(() => {
+      cancelExpiry = undefined;
+      session.expireMessage();
+      draw();
+    }, MESSAGE_LINGER_MS);
   };
 
   // The session re-highlights on every keystroke but defers the full parse;
@@ -165,6 +224,8 @@ export async function runPager(
 
   const onResize = () => {
     const s = consoleSize(deps);
+    stopReveal(); // the frames left were laid out for the old size
+    stopExpiry();
     session.resize(s.width, s.height);
     draw();
   };
@@ -177,6 +238,8 @@ export async function runPager(
   // unsaved edits; the read loop then handles the y/n/c answer. A second
   // interrupt, or a clean buffer, terminates.
   const onInterrupt = () => {
+    stopReveal();
+    stopExpiry();
     if (session.requestQuitFromSignal()) draw();
     else terminate(130);
   };
@@ -215,11 +278,19 @@ export async function runPager(
         if (session.quit) break;
       }
       if (!session.quit) {
-        draw();
+        stopReveal();
+        stopExpiry();
+        // A reveal draws its own frames, ending on the finished one.
+        if (!startReveal()) {
+          draw();
+          startExpiry(); // starts the clock on the message the draw put up
+        }
         if (session.needsReparse) scheduleReparse();
       }
     }
   } finally {
+    stopReveal();
+    stopExpiry();
     if (cancelReparse) {
       cancelReparse();
     }

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -50,7 +50,12 @@ import { parseDiff } from "./diff.ts";
 import { findCommitMessages } from "./commitmsg.ts";
 import type { Semantics } from "./semantics.ts";
 import { EditBuffer } from "./editbuffer.ts";
-import type { EditableSource, RevertScope } from "./editsource.ts";
+import type {
+  EditableSource,
+  ExpandResult,
+  HunkRoom,
+  RevertScope,
+} from "./editsource.ts";
 import type { Highlighter } from "./parse.ts";
 import type { DirEntry, FileGateway } from "./filegateway.ts";
 
@@ -152,6 +157,19 @@ export class Session {
    * structure, cross-references, and multi-line token colours) is owed. The
    * driver runs it on a short idle, so typing stays responsive. */
   needsReparse = false;
+  /** What the last key revealed (Ctrl-L in pager mode), for the driver to walk
+   * the lines in a few at a time with {@link revealFrame}: the display row they
+   * start at, how many there are, and whether they came from above the hunk (so
+   * the viewport holds still) or below it (so it slides as they land). The next
+   * key clears it. */
+  pendingReveal: { row: number; count: number; up: boolean } | null = null;
+  /** The last key set a message that takes itself away again rather than sitting
+   * in the bar — Ctrl-L pressed where it is not offered, which changed nothing
+   * else. The driver leaves it up for a moment and then calls
+   * {@link expireMessage}; the next key takes it away too. */
+  transientMessage = false;
+  /** How much context each hunk can reveal, cached against the document. */
+  private roomCache?: { doc: Document; room: ReadonlyMap<number, HunkRoom> };
 
   // --- editing ---
   private source?: EditableSource;
@@ -268,6 +286,54 @@ export class Session {
     return this.foldPlan().displayLines.length;
   }
 
+  /** A frame part way through the last reveal: the finished document with only
+   * the first `shown` of the revealed lines in it, and a viewport holding the
+   * same line still as the finished frame will. `shown` of `count` is the
+   * finished frame; 0 is the picture the reveal started from. Null when the last
+   * key revealed nothing. */
+  revealFrame(shown: number): { doc: Document; view: ViewState } | null {
+    const rev = this.pendingReveal;
+    if (!rev) return null;
+    const waiting = rev.count - clamp(shown, 0, rev.count);
+    // The lines still to come are the ones furthest from the hunk, so what is on
+    // screen is always a run of the file that meets the hunk's edge rather than
+    // a jump across the lines that have not arrived.
+    const from = rev.up ? rev.row : rev.row + rev.count - waiting;
+    const to = from + waiting;
+    // Rows past the ones still to come sit `waiting` lower in the finished
+    // document than in this frame; rows before them are in the same place.
+    const back = (n: number) => n >= to ? n - waiting : n;
+    const drop = <T>(xs: readonly T[]) => [
+      ...xs.slice(0, from),
+      ...xs.slice(to),
+    ];
+    const doc = this.displayDoc();
+    const view = this.view();
+    const sel = view.selected;
+    return {
+      doc: { ...doc, lines: drop(doc.lines) },
+      view: {
+        ...view,
+        top: rev.up ? view.top : Math.max(0, view.top - waiting),
+        lineNumbers: view.lineNumbers
+          ? drop(view.lineNumbers)
+          : view.lineNumbers,
+        selected: sel
+          ? {
+            ...sel,
+            startLine: back(sel.startLine),
+            endLine: back(sel.endLine),
+          }
+          : null,
+        // A match on a line that has not landed yet has nowhere to be drawn.
+        matches: view.matches
+          ? view.matches.filter((m) => m.line < from || m.line >= to)
+            .map((m) => ({ ...m, line: back(m.line) }))
+          : null,
+      },
+    };
+  }
+
   /** A document line → its display row (a hidden line maps to its summary row). */
   private toDisplay(docLine: number): number {
     return this.foldPlan().docToDisplay(docLine);
@@ -372,7 +438,7 @@ export class Session {
         ? { line: this.toDisplay(this.buffer.row), col: this.buffer.col }
         : null,
       editHint: this.cursorOn ? this.editHint() : null,
-      canExpand: !this.cursorOn && !!this.source?.expandContext,
+      canExpand: this.canExpand(),
       canEdit: !this.cursorOn && !!this.source?.editable,
       hasNonPrintables: this.hasNonPrintables(),
       notice: null,
@@ -475,6 +541,12 @@ export class Session {
   }
 
   handleKey(key: Key): void {
+    // A reveal is animated by the driver over the frames after the key that
+    // caused it, so the next key ends it whatever it was. A message that takes
+    // itself away goes now rather than waiting out its moment, before this key
+    // has the chance to set one of its own.
+    this.pendingReveal = null;
+    this.expireMessage();
     if (this.mode === "savePrompt") {
       this.handleSavePrompt(key);
       return;
@@ -1789,6 +1861,15 @@ export class Session {
     this.ensureCursorVisible();
   }
 
+  /** Take away a message that was set to go away on its own, once the driver has
+   * left it up for its moment. Does nothing to a message that is not one of
+   * those, so a later one is never cleared out from under itself. */
+  expireMessage(): void {
+    if (!this.transientMessage) return;
+    this.transientMessage = false;
+    this.message = "";
+  }
+
   /** Live re-highlight `text` into rendered lines, or null when the source has
    * no live highlighter (then the caller does a full parse). Prefers the
    * incremental highlighter, created lazily and seeded with the current text so
@@ -2161,33 +2242,70 @@ export class Session {
   }
 
   /** Reveal more of the underlying file around a hunk (Ctrl-L). When the text
-   * cursor is active the hunk is the one it sits in; in pager mode it is the
-   * selected node's hunk, or the first hunk on screen. The extra context is
-   * applied to the baseline too, so it does not count as an unsaved edit. */
+   * cursor is active the hunk is the one it sits in and the view follows the
+   * cursor; in pager mode it is the hunk at the middle of the screen, and the
+   * view holds the far edge of that hunk still so the revealed lines open a gap
+   * in front of the user. The extra context is applied to the baseline too, so
+   * it does not count as an unsaved edit. */
   private performExpand(): void {
     if (!this.source?.expandContext || !this.buffer) {
       this.message = "Expanding context isn't available here.";
       return;
     }
-    const refLine = this.cursorOn ? this.buffer.row : this.expandRefLine();
-    if (refLine === null) {
-      this.message = "Move to a hunk first, then Ctrl-L to expand its context.";
-      return;
+    let refLine: number;
+    let up: boolean | undefined;
+    if (this.cursorOn) {
+      refLine = this.buffer.row; // the cursor names a point, not an edge
+    } else {
+      const offer = this.expandOffer();
+      // Ctrl-L is not offered in any of these, so it changes nothing and there
+      // is nothing to leave the reason standing next to: say why, and take it
+      // away again once it has been read.
+      if (offer === null) {
+        this.message = "Move to a hunk's edge, then Ctrl-L to expand it.";
+        this.transientMessage = true;
+        return;
+      }
+      if ("blocked" in offer) {
+        this.message = offer.blocked === "top"
+          ? "Top of file."
+          : offer.blocked === "bottom"
+          ? "Bottom of file."
+          : "No more context to show.";
+        this.transientMessage = true;
+        return;
+      }
+      refLine = offer.line;
+      up = offer.up;
     }
     const r = this.source.expandContext(
       this.buffer.text(),
       this.buffer.baseline(),
       refLine,
+      up,
     );
     if (!r) {
       this.message = "No more context to show.";
       return;
     }
     // The node the selection denotes, captured before the reparse renumbers the
-    // structure tree under it. The viewport's document anchor is captured too,
-    // before the fold plan (which the reparse invalidates) changes.
+    // structure tree under it. The pinned line's row is captured too, before the
+    // fold plan (which the reparse invalidates) changes.
     const selected = this.cursorOn ? null : this.selectedNode();
-    const anchorDoc = this.toDoc(this.top);
+    // Where a line of the old text lands in the new one.
+    const moved = (n: number) =>
+      n + (n >= r.insertedAt ? r.inserted : 0) -
+      (r.removedAt !== null && n > r.removedAt ? 1 : 0);
+    // The line held still on screen: the one just outside the edge the revealed
+    // lines go in at, so they open a gap on the hunk's side of it. Expanding
+    // upwards holds the hunk's header and pushes the body down; expanding
+    // downwards holds what follows the hunk and lifts the body up. A join takes
+    // that very header away, so what is held is the line the other side of it —
+    // the neighbouring hunk's body, which is what is left to hold on to.
+    const pinDoc = r.removedAt !== null
+      ? (r.up ? r.removedAt - 1 : r.removedAt + 1)
+      : (r.up ? r.insertedAt - 1 : r.insertedAt);
+    const pinRow = this.toDisplay(pinDoc) - this.top;
     const col = this.cursorOn ? this.buffer.col : 0;
     this.buffer.setBaseline(r.baseline);
     this.buffer.setText(r.text, r.cursorLine, col);
@@ -2198,36 +2316,55 @@ export class Session {
       this.seedHighlighter();
       this.clampScroll();
       this.ensureCursorVisible();
-      this.message = "Expanded context.";
+      this.reportReveal(r);
       return;
     }
-    // Pager mode: re-point the selection at the same node (its line shifted),
-    // and hold the viewport on the same content. Only lines at or below the
-    // insertion point moved down, so the top shifts only when it is below it.
-    this.reselectAfterExpand(selected, r.insertedAt, r.inserted);
-    const newAnchorDoc = anchorDoc >= r.insertedAt
-      ? anchorDoc + r.inserted
-      : anchorDoc;
-    this.top = this.toDisplay(newAnchorDoc);
+    // Pager mode: re-point the selection at the same node (its line moved), and
+    // put the pinned line back on the row it was on.
+    this.reselectAfterExpand(selected, moved);
+    this.top = this.toDisplay(moved(pinDoc)) - pinRow;
     this.clampScroll();
-    this.message = "Expanded context.";
+    // The revealed lines fill the gap the insertion point opened, so the driver
+    // can walk them in from the held edge. A join is drawn in one step instead:
+    // its frames would stand the two hunks' bodies next to each other before the
+    // lines that join them had arrived, showing a file that reads nothing like
+    // the one on disk.
+    this.pendingReveal = r.removedAt !== null ? null : {
+      row: this.toDisplay(r.insertedAt),
+      count: r.inserted,
+      up: r.up,
+    };
+    this.reportReveal(r);
+  }
+
+  /** Say what a reveal showed: which way it reached, and which lines of the file
+   * came back with it. Naming the lines is the point — one run of context looks
+   * like any other, and the file's own numbers are what tie them to it. A reveal
+   * that closed the last gap between two hunks says so too, since a header
+   * disappearing is otherwise left to be puzzled over. */
+  private reportReveal(r: ExpandResult): void {
+    const { from, to } = r.revealed;
+    const lines = from === to ? `line ${from}` : `lines ${from}-${to}`;
+    const where = r.up ? "above" : "below";
+    this.message = r.removedAt !== null
+      ? `Showing ${lines} ${where} — the two hunks are now one.`
+      : `Showing ${lines} ${where} the hunk.`;
+    this.transientMessage = true;
   }
 
   /** After a pager-mode expand rebuilds the structure tree, point the selection
-   * back at the same node, whose line shifted down by `inserted` when it sat at
-   * or below the insertion point. Cleared when the node can no longer be found.
-   * A hunk is matched on its line alone — only one hunk starts at a given header
-   * line, and its label (the `@@` counts) changes as the hunk grows; other kinds
-   * keep the label, which is stable and tells apart nodes sharing a start line. */
+   * back at the same node, at wherever `moved` puts its line. Cleared when the
+   * node can no longer be found — a join takes one of the two hunks away, and
+   * there is nothing to point at. A hunk is matched on its line alone: only one
+   * hunk starts at a given header line, and its label (the `@@` counts) changes
+   * as the hunk grows; other kinds keep the label, which is stable and tells
+   * apart nodes sharing a start line. */
   private reselectAfterExpand(
     node: StructureNode | null,
-    insertedAt: number,
-    inserted: number,
+    moved: (line: number) => number,
   ): void {
     if (!node) return;
-    const startLine = node.startLine >= insertedAt
-      ? node.startLine + inserted
-      : node.startLine;
+    const startLine = moved(node.startLine);
     const idx = this.doc.flatStructure.findIndex((n) =>
       n.startLine === startLine && n.kind === node.kind &&
       (node.kind === "hunk" || n.label === node.label)
@@ -2235,38 +2372,127 @@ export class Session {
     this.selectedIndex = idx >= 0 ? idx : null;
   }
 
-  /** The reference line for an expand in pager mode: a line inside the hunk the
-   * user is focused on — the selected node's hunk when a node is selected and on
-   * screen, otherwise the first hunk overlapping the viewport. A node that spans
-   * hunks rather than sitting in one (the file node) resolves to the first hunk
-   * it covers that is on screen. Null when no hunk is in view. */
-  private expandRefLine(): number | null {
-    const rows = this.contentRows();
-    // The viewport is display rows; compare hunk (document) lines against it in
-    // document space.
-    const viewTop = this.toDoc(this.top);
-    const viewEnd = this.toDoc(this.top + rows);
-    const onScreen = (n: StructureNode) =>
-      n.endLine >= viewTop && n.startLine < viewEnd;
-    const hunks = this.doc.flatStructure.filter((n) => n.kind === "hunk");
-    if (hunks.length === 0) return null;
-    const sel = this.selectedNode();
-    if (sel && onScreen(sel)) {
-      // A selection sitting inside a hunk keeps its line, so the up/down bias
-      // follows where the user is.
-      const inHunk = hunks.some((h) =>
-        sel.startLine >= h.startLine && sel.startLine <= h.endLine
-      );
-      if (inHunk) return sel.startLine;
-      // A selection spanning hunks (the file node) expands the first hunk it
-      // covers that is on screen.
-      const covered = hunks.find((h) =>
-        h.startLine >= sel.startLine && onScreen(h)
-      );
-      if (covered) return covered.startLine;
+  /** Whether a node is on screen: its display rows overlap the viewport, and it
+   * is not inside a collapsed file. A collapsed file's inner lines all map to
+   * its summary row, which overlaps the viewport whenever that row is shown, so
+   * the hidden range is excluded by its document extent instead. */
+  private nodeOnScreen(node: StructureNode): boolean {
+    const inHiddenFile = this.foldFiles().some((f) =>
+      this.collapsed.has(f.index) &&
+      node.startLine > f.headerLine && node.startLine <= f.endLine
+    );
+    if (inHiddenFile) return false;
+    return this.toDisplay(node.endLine) >= this.top &&
+      this.toDisplay(node.startLine) < this.top + this.contentRows();
+  }
+
+  /** The middle of the content on screen, as a display row. The rows the
+   * content occupies, rather than the rows the terminal has: a document shorter
+   * than the screen ends part-way down it, and the rows past its end are not
+   * somewhere the user is looking. */
+  private middleRow(): number {
+    const last = Math.min(this.top + this.contentRows(), this.displayCount()) -
+      1;
+    return Math.floor((this.top + last) / 2);
+  }
+
+  /** How much context each hunk can still reveal, keyed by its header line.
+   * Cached against the document, which the source rebuilds on every expand. */
+  private expandRoom(): ReadonlyMap<number, HunkRoom> {
+    if (this.roomCache?.doc !== this.currentDoc) {
+      this.roomCache = {
+        doc: this.currentDoc,
+        room: this.source?.expandRoom?.(this.currentDoc.text) ?? new Map(),
+      };
     }
-    const first = hunks.find(onScreen);
-    return first ? first.startLine : null;
+    return this.roomCache.room;
+  }
+
+  /** Every hunk edge the user can see: the row it sits on, the line to expand
+   * from, which way that grows, and what the file offers there. A hunk with
+   * neither edge on screen offers nothing to aim at — its boundaries are off in
+   * the dark, and growing one would happen where it could not be watched. */
+  private visibleEdges(): {
+    row: number;
+    line: number;
+    up: boolean;
+    room: HunkRoom;
+  }[] {
+    const room = this.expandRoom();
+    const rows = this.contentRows();
+    const onScreen = (row: number) => row >= this.top && row < this.top + rows;
+    const out = [];
+    for (const h of this.doc.flatStructure) {
+      if (h.kind !== "hunk" || !this.nodeOnScreen(h)) continue;
+      const r = room.get(h.startLine);
+      if (!r) continue;
+      // The top edge is the header the revealed lines land under; the bottom is
+      // the last body line they land after.
+      for (
+        const [line, up] of [[h.startLine, true], [h.endLine, false]] as const
+      ) {
+        const row = this.toDisplay(line);
+        if (onScreen(row)) out.push({ row, line, up, room: r });
+      }
+    }
+    return out;
+  }
+
+  /** The hunk edge Ctrl-L acts on in pager mode: the visible one nearest the
+   * middle of the screen, or nearest a selected node when one sits in a hunk.
+   * Null when no edge is on screen. The edge is returned whether or not it has
+   * room, so that the offer of Ctrl-L and what Ctrl-L does agree. */
+  private expandEdge():
+    | { line: number; up: boolean; room: HunkRoom }
+    | null {
+    const edges = this.visibleEdges();
+    if (edges.length === 0) return null;
+    // A selected node sitting in a hunk aims at that hunk, and its own row is
+    // what the edges are measured from: the user picked a place to look.
+    const sel = this.selectedNode();
+    const own = sel && this.nodeOnScreen(sel)
+      ? edges.filter((e) =>
+        this.doc.flatStructure.some((h) =>
+          h.kind === "hunk" && h.startLine <= e.line && e.line <= h.endLine &&
+          sel.startLine >= h.startLine && sel.startLine <= h.endLine
+        )
+      )
+      : [];
+    const from = own.length > 0
+      ? this.toDisplay(sel!.startLine)
+      : this.middleRow();
+    const pool = own.length > 0 ? own : edges;
+    // Distance in display rows: a collapsed file stands on one row, and the
+    // lines it hides are not distance the eye travels.
+    let best = pool[0];
+    for (const e of pool) {
+      if (Math.abs(e.row - from) < Math.abs(best.row - from)) best = e;
+    }
+    return { line: best.line, up: best.up, room: best.room };
+  }
+
+  /** Whether Ctrl-L would reveal anything from where the user is looking, which
+   * is what the status bar offers it on. Edit mode aims with the cursor rather
+   * than the screen, and keeps its own offer. */
+  private canExpand(): boolean {
+    if (this.cursorOn || !this.source?.expandContext) return false;
+    const offer = this.expandOffer();
+    return offer !== null && !("blocked" in offer);
+  }
+
+  /** Whether Ctrl-L would reveal anything, and what stops it when it would not.
+   * Drives both the status bar's offer of Ctrl-L and the key itself. */
+  private expandOffer():
+    | { line: number; up: boolean }
+    | { blocked: "top" | "bottom" | "hunk" }
+    | null {
+    const edge = this.expandEdge();
+    if (!edge) return null;
+    if ((edge.up ? edge.room.up : edge.room.down) > 0) {
+      return { line: edge.line, up: edge.up };
+    }
+    if (edge.up) return { blocked: edge.room.atFileTop ? "top" : "hunk" };
+    return { blocked: edge.room.atFileBottom ? "bottom" : "hunk" };
   }
 
   // --- file picker (C-x C-f) -------------------------------------------------
@@ -2277,6 +2503,10 @@ export class Session {
       return;
     }
     this.cursorOn = false;
+    // Opening the picker drops the text cursor, and cancelling it returns to
+    // navigation, which reads the structure tree. Refresh it here as leaving
+    // edit mode by Esc does, so that return lands on a current tree.
+    this.reparse();
     this.overlay = null;
     this.overlayStack = [];
     this.pickerDir = this.pickerStartDir();
@@ -2566,7 +2796,7 @@ export function helpOverlay(): {
     ["  A / D", "parent / first child"],
     ["  Tab / ⇧Tab", "next / previous node (depth-first)"],
     ["  Z", "centre selected node"],
-    ["  ^L", "diff: reveal more of the file around the hunk in view"],
+    ["  ^L", "diff: reveal more of the file at the middle of the view"],
     ["  Esc", "clear selection / search"],
     ["", ""],
     ["Editing (a file or a diff)", ""],

--- a/packages/cli/test/view-diffedit-cov.test.ts
+++ b/packages/cli/test/view-diffedit-cov.test.ts
@@ -783,3 +783,104 @@ Deno.test("diffedit cov: message revert is null when the baseline has no such re
     done();
   }
 });
+
+// --- expandRoom and the join helpers ----------------------------------------
+
+Deno.test("diffedit cov: expandRoom is empty when the text no longer parses", () => {
+  const { ws, done } = tempWs({ "m.ts": EXPAND_FILE });
+  try {
+    const { src } = sourceFor(EXPAND_DIFF, ws);
+    // A non-diff has no hunks to report room for.
+    assertEquals(src.expandRoom!("not a diff\n").size, 0);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit cov: expandRoom skips a hunk whose file has no new side", () => {
+  const { ws, done } = tempWs({ "m.ts": EXPAND_FILE });
+  try {
+    const { src } = sourceFor(EXPAND_DIFF, ws);
+    // A deleted file's new path is /dev/null, i.e. absent, so its hunk backs no
+    // workspace file and offers no room — hunkFooting returns null for it.
+    const del = `diff --git a/m.ts b/m.ts
+deleted file mode 100644
+--- a/m.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-alpha
+-beta
+`;
+    assertEquals(src.expandRoom!(del).size, 0);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit cov: expandContext declines when the save map lacks the cursor's hunk", () => {
+  const { ws, done } = tempWs({ "m.ts": "a\nb\nc\nd\ne\nf\ng\nh\n" });
+  try {
+    // The source is built from a one-hunk diff, so its save map has one entry.
+    // A later `current` grows a second hunk; a cursor in it resolves to global
+    // index 1, which the save map does not have — hunkFooting finds no range.
+    const oneHunk = `diff --git a/m.ts b/m.ts
+--- a/m.ts
++++ b/m.ts
+@@ -1,3 +1,3 @@
+ a
+-x
++b
+ c
+`;
+    const { src } = sourceFor(oneHunk, ws);
+    const current = `diff --git a/m.ts b/m.ts
+--- a/m.ts
++++ b/m.ts
+@@ -1,3 +1,3 @@
+ a
+-x
++b
+ c
+@@ -6,3 +6,3 @@
+ f
+-y
++g
+ h
+`;
+    const cursor = current.split("\n").indexOf(" f");
+    assertEquals(src.expandContext!(current, current, cursor), null);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit cov: dropHeaderBetween declines a non-diff and a lone hunk", () => {
+  // A non-diff has no hunks to join.
+  assertEquals(_de.dropHeaderBetween("not a diff", 0), null);
+  // A single hunk has no second one to take the header off.
+  const oneHunk = `diff --git a/m.ts b/m.ts
+--- a/m.ts
++++ b/m.ts
+@@ -1,1 +1,1 @@
+-a
++A
+`;
+  assertEquals(_de.dropHeaderBetween(oneHunk, 0), null);
+});
+
+Deno.test("diffedit cov: joinAdjacent declines when the text will not drop a header", () => {
+  // The save map claims two adjacent, verified, same-file hunks, but the text
+  // holds only one, so dropHeaderBetween finds no pair and the join backs out.
+  const oneHunk = `diff --git a/m.ts b/m.ts
+--- a/m.ts
++++ b/m.ts
+@@ -1,1 +1,1 @@
+-a
++A
+`;
+  const hunks = [
+    { absPath: "/x", newStart: 1, newCount: 1, verified: true },
+    { absPath: "/x", newStart: 2, newCount: 1, verified: true },
+  ];
+  assertEquals(_de.joinAdjacent(oneHunk, oneHunk, hunks, 0), null);
+});

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -710,7 +710,8 @@ Deno.test("diffedit: Ctrl-L expands context in pager mode (no text cursor)", () 
 Deno.test("diffedit: in pager mode Ctrl-L expands the selected hunk", () => {
   const root = Deno.makeTempDirSync();
   try {
-    const file = Array.from({ length: 20 }, (_, i) =>
+    // Long enough to back FAR_DIFF's second hunk, which sits at line 30.
+    const file = Array.from({ length: 40 }, (_, i) =>
       `line${i + 1}`).join("\n") +
       "\n";
     Deno.writeTextFileSync(join(root, "m.ts"), file);
@@ -724,8 +725,8 @@ Deno.test("diffedit: in pager mode Ctrl-L expands the selected hunk", () => {
         }
       },
     };
-    const model = parseDiff(MULTI_DIFF)!;
-    const { doc, edit } = buildDiffDocument(MULTI_DIFF, model, ws);
+    const model = parseDiff(FAR_DIFF)!;
+    const { doc, edit } = buildDiffDocument(FAR_DIFF, model, ws);
     const s = new Session(
       doc,
       { color: false, showLineNumbers: false },
@@ -735,6 +736,7 @@ Deno.test("diffedit: in pager mode Ctrl-L expands the selected hunk", () => {
     );
     // Select the second hunk via the structure tree (no text cursor), then
     // expand: the choice of hunk must follow the selection, not a stale buffer.
+    // Left alone the middle of the screen would reach down from the first.
     let guard = 0;
     while ((s.view().selected?.startLine ?? -1) !== 9 && guard++ < 200) {
       s.handleKey({ name: "tab" });
@@ -747,8 +749,8 @@ Deno.test("diffedit: in pager mode Ctrl-L expands the selected hunk", () => {
     assertEquals(s.view().cursor, null, "no text cursor");
     s.handleKey({ name: "ctrl-l" });
     assert(
-      s.doc.text.includes("@@ -7,7 +7,7 @@"),
-      "the selected (second) hunk expanded up",
+      s.doc.text.includes("@@ -20,13 +20,13 @@"),
+      `the selected (second) hunk expanded up: ${s.doc.text}`,
     );
     assert(
       s.doc.text.includes("@@ -4,3 +4,3 @@"),
@@ -759,7 +761,7 @@ Deno.test("diffedit: in pager mode Ctrl-L expands the selected hunk", () => {
     assertEquals(s.view().selected?.kind, "hunk", "still a hunk selected");
     assertEquals(s.view().selected?.startLine, 9, "still the second hunk");
     assert(
-      s.view().selected?.label.startsWith("@@ -7,7 +7,7"),
+      s.view().selected?.label.startsWith("@@ -20,13 +20,13"),
       `selected hunk label: ${s.view().selected?.label}`,
     );
   } finally {
@@ -783,7 +785,7 @@ Deno.test("diffedit: pager Ctrl-L keeps the hunk header in view when expanding u
   }
 });
 
-Deno.test("diffedit: pager Ctrl-L anchors the visible content when scrolled into the hunk body", () => {
+Deno.test("diffedit: pager Ctrl-L fills a short screen from the held edge", () => {
   const root = Deno.makeTempDirSync();
   try {
     const file = Array.from({ length: 40 }, (_, i) =>
@@ -820,15 +822,14 @@ Deno.test("diffedit: pager Ctrl-L anchors the visible content when scrolled into
     );
     // Scroll down so the hunk body is at the top and the header is off screen.
     for (let i = 0; i < 6; i++) s.handleKey({ name: "j" });
-    const topLine = s.doc.text.split("\n")[s.view().top];
-    s.handleKey({ name: "ctrl-l" }); // expand up: lines inserted above the body
-    // Now the top of the viewport IS below the insertion point, so it shifts to
-    // keep the same line on screen rather than letting it scroll away.
-    assertEquals(
-      s.doc.text.split("\n")[s.view().top],
-      topLine,
-      "the same line stays at the top of the screen",
-    );
+    s.handleKey({ name: "ctrl-l" });
+    // The middle of the screen sits in the hunk's lower half, so the lines come
+    // from below it and what follows the hunk is held still. Ten lines land on
+    // a five-row screen, so they fill it from that held edge: the last of them
+    // is on screen and the hunk has been pushed off the top.
+    assert(s.view().message.startsWith("Showing line"), s.view().message);
+    const rows = s.doc.text.split("\n").slice(s.view().top, s.view().top + 5);
+    assert(rows.includes(" line32"), rows.join("|"));
   } finally {
     Deno.removeSync(root, { recursive: true });
   }
@@ -837,7 +838,8 @@ Deno.test("diffedit: pager Ctrl-L anchors the visible content when scrolled into
 Deno.test("diffedit: in pager mode Ctrl-L with the whole-file node selected still expands a hunk", () => {
   const root = Deno.makeTempDirSync();
   try {
-    const file = Array.from({ length: 20 }, (_, i) =>
+    // Long enough to back FAR_DIFF's second hunk, which sits at line 30.
+    const file = Array.from({ length: 40 }, (_, i) =>
       `line${i + 1}`).join("\n") +
       "\n";
     Deno.writeTextFileSync(join(root, "m.ts"), file);
@@ -851,8 +853,8 @@ Deno.test("diffedit: in pager mode Ctrl-L with the whole-file node selected stil
         }
       },
     };
-    const model = parseDiff(MULTI_DIFF)!;
-    const { doc, edit } = buildDiffDocument(MULTI_DIFF, model, ws);
+    const model = parseDiff(FAR_DIFF)!;
+    const { doc, edit } = buildDiffDocument(FAR_DIFF, model, ws);
     const s = new Session(
       doc,
       { color: false, showLineNumbers: false },
@@ -864,9 +866,15 @@ Deno.test("diffedit: in pager mode Ctrl-L with the whole-file node selected stil
     // is the "diff --git" header — in no hunk.
     assertEquals(s.view().selected?.label, "▸ m.ts");
     s.handleKey({ name: "ctrl-l" });
-    // It must resolve to the file's first on-screen hunk, not report nothing.
-    assertEquals(s.view().message, "Expanded context.");
-    assert(s.doc.text.includes("@@ -1,"), "the first hunk expanded up");
+    // It must resolve to a hunk, not report nothing. The whole diff is on
+    // screen, so the middle of the content is nearest the first hunk's bottom
+    // edge and that is the one that grows.
+    assert(s.view().message.startsWith("Showing line"), s.view().message);
+    assert(s.doc.text.includes("@@ -4,13 +4,13 @@"), s.doc.text);
+    assert(
+      s.doc.text.includes("@@ -30,3 +30,3 @@"),
+      "the other hunk is untouched",
+    );
   } finally {
     Deno.removeSync(root, { recursive: true });
   }
@@ -975,7 +983,23 @@ index 0000000..1111111 100644
  line13
 `;
 
-Deno.test("diffedit: expanding context stops at the adjacent hunk and save stays correct", () => {
+const FAR_DIFF = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -4,3 +4,3 @@
+ line4
+-OLD5
++line5
+ line6
+@@ -30,3 +30,3 @@
+ line30
+-OLD31
++line31
+ line32
+`;
+
+Deno.test("diffedit: expanding context into the next hunk joins them and save stays correct", () => {
   const root = Deno.makeTempDirSync();
   try {
     const file = Array.from({ length: 20 }, (_, i) =>
@@ -1002,11 +1026,18 @@ Deno.test("diffedit: expanding context stops at the adjacent hunk and save stays
       diffSource(ws, edit),
     );
     toLine(s, 8); // " line6", the bottom of the first hunk
-    s.handleKey({ name: "ctrl-l" }); // expand down — must stop before hunk 2
+    s.handleKey({ name: "ctrl-l" }); // expand down — the four lines to hunk 2
+    // The reveal closes the gap, so the two hunks meet and become one: the
+    // header that sat between line10 and line11 described nothing.
     assertEquals(
       s.doc.text.split("\n")[4],
-      "@@ -4,7 +4,7 @@",
-      "expansion abuts the next hunk (k=4) instead of overlapping it",
+      "@@ -4,10 +4,10 @@",
+      "the two hunks joined into one covering both ranges",
+    );
+    assertEquals(
+      parseDiff(s.doc.text)!.files.flatMap((f) => f.hunks).length,
+      1,
+      "one hunk where there were two",
     );
     // Now edit the SECOND hunk and save: the edit must survive and no line may
     // be dropped or duplicated.

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -16,6 +16,9 @@ import {
   runPager,
 } from "../lib/view/pager.ts";
 import { fileSource } from "../lib/view/editsource.ts";
+import { parseDiff } from "../lib/view/diff.ts";
+import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
+import { diffSource } from "../lib/view/diffedit.ts";
 import { ViewError } from "../lib/view/errors.ts";
 import { term } from "../lib/view/ansi.ts";
 import { ui } from "../lib/view/theme.ts";
@@ -351,4 +354,212 @@ Deno.test("realPagerDeps: the wrappers reach the real primitives", () => {
   try {
     d.openTty().close();
   } catch { /* no controlling terminal in this environment */ }
+});
+
+// --- Ctrl-L reveal frames ---------------------------------------------------
+
+/** A one-file diff whose hunk has room to reveal ten lines above it. */
+function revealFixture() {
+  const root = Deno.makeTempDirSync();
+  const lines = Array.from(
+    { length: 60 },
+    (_, i) => `L${String(i + 1).padStart(2, "0")}`,
+  );
+  Deno.writeTextFileSync(join(root, "a.ts"), `${lines.join("\n")}\n`);
+  const diff = `diff --git a/a.ts b/a.ts
+index 0000000..1111111 100644
+--- a/a.ts
++++ b/a.ts
+@@ -25,20 +25,20 @@
+${lines.slice(24, 33).map((l) => ` ${l}`).join("\n")}
+-old L34
++L34
+${lines.slice(34, 44).map((l) => ` ${l}`).join("\n")}
+`;
+  const ws: DiffWorkspace = {
+    resolve: (p) => join(root, p),
+    read: (a) => {
+      try {
+        return Deno.readTextFileSync(a);
+      } catch {
+        return null;
+      }
+    },
+  };
+  const model = parseDiff(diff)!;
+  const { doc, edit } = buildDiffDocument(diff, model, ws);
+  return {
+    doc,
+    source: diffSource(ws, edit),
+    done: () => Deno.removeSync(root, { recursive: true }),
+  };
+}
+
+Deno.test("pager: Ctrl-L walks the revealed lines in a frame at a time", async () => {
+  const { doc, source, done } = revealFixture();
+  try {
+    const { deps, writes } = makeFake({
+      consoleSize: { columns: 80, rows: 13 },
+      steps: [
+        { bytes: enc("\x0c") }, // Ctrl-L: reveals L15..L24 above the hunk
+        { fireTimers: true }, // one line has landed
+        { fireTimers: true }, // two
+        { bytes: enc("q") },
+      ],
+    });
+    await runPager(doc, OPTS, undefined, source, deps);
+    // The line meeting the hunk lands first, and it lands on its own: the frame
+    // holding it does not already hold the furthest line.
+    const first = writes.findIndex((w) => w.includes("L24"));
+    assert(first > 0, "a frame drew the first revealed line");
+    assert(!writes[first].includes("L15"), "the furthest line had not landed");
+    const second = writes.findIndex((w) => w.includes("L23"));
+    assert(second > first, "the next frame drew the next line");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("pager: Ctrl-L draws no frames of its own accord", async () => {
+  const { doc, source, done } = revealFixture();
+  try {
+    const { deps, writes } = makeFake({
+      consoleSize: { columns: 80, rows: 13 },
+      steps: [{ bytes: enc("\x0c") }, { eof: true }],
+    });
+    await runPager(doc, OPTS, undefined, source, deps);
+    // Without the timers running there are no frames, so the finished reveal
+    // never reaches the screen: the walk is what draws, not the keystroke.
+    assert(!writes.some((w) => w.includes("L15")), "nothing was drawn");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("pager: a key during the reveal drops the frames left", async () => {
+  const { doc, source, done } = revealFixture();
+  try {
+    const { deps, writes } = makeFake({
+      consoleSize: { columns: 80, rows: 13 },
+      steps: [
+        { bytes: enc("\x0c") },
+        { fireTimers: true }, // one line in
+        { bytes: enc("j") }, // impatient: ends the walk
+        { fireTimers: true }, // the frames left are gone, so this draws nothing
+        { bytes: enc("q") },
+      ],
+    });
+    await runPager(doc, OPTS, undefined, source, deps);
+    const frames = writes.filter((w) => w.includes("@@"));
+    // The opening picture, the one frame that ran, and the finish the key drew.
+    assertEquals(frames.length, 3);
+    assert(frames.at(-1)!.includes("L15"), "the finish is on screen");
+  } finally {
+    done();
+  }
+});
+
+/** A diff whose only hunk runs to the last line of its file, so its bottom edge
+ * has nowhere to go. */
+function atBottomFixture() {
+  const root = Deno.makeTempDirSync();
+  const lines = Array.from({ length: 20 }, (_, i) => `line${i + 1}`);
+  Deno.writeTextFileSync(join(root, "a.ts"), `${lines.join("\n")}\n`);
+  const diff = `diff --git a/a.ts b/a.ts
+index 0000000..1111111 100644
+--- a/a.ts
++++ b/a.ts
+@@ -18,3 +18,3 @@
+ line18
+-OLD19
++line19
+ line20
+`;
+  const ws: DiffWorkspace = {
+    resolve: (p) => join(root, p),
+    read: (a) => {
+      try {
+        return Deno.readTextFileSync(a);
+      } catch {
+        return null;
+      }
+    },
+  };
+  const model = parseDiff(diff)!;
+  const { doc, edit } = buildDiffDocument(diff, model, ws);
+  return {
+    doc,
+    source: diffSource(ws, edit),
+    done: () => Deno.removeSync(root, { recursive: true }),
+  };
+}
+
+Deno.test("pager: the reason Ctrl-L did nothing stands, then takes itself away", async () => {
+  const { doc, source, done } = atBottomFixture();
+  try {
+    const { deps, writes } = makeFake({
+      // Short enough that the end of the document shows the hunk's bottom edge
+      // and not its top, so the bottom is the only edge to aim at.
+      consoleSize: { columns: 80, rows: 6 },
+      steps: [
+        { bytes: enc("G") },
+        { bytes: enc("\x0c") }, // Ctrl-L, which the bar does not offer here
+        { fireTimers: true }, // its moment is up
+        { bytes: enc("q") },
+      ],
+    });
+    await runPager(doc, OPTS, undefined, source, deps);
+    const said = writes.findIndex((w) => w.includes("Bottom of file"));
+    assert(said >= 0, "the reason was drawn");
+    // And a later frame is drawn without it, so it does not sit in the bar
+    // describing a keypress the user has moved on from.
+    const gone = writes.slice(said + 1).some((w) =>
+      w.includes("line20") && !w.includes("Bottom of file")
+    );
+    assert(gone, "the reason was taken away again");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("pager: the reason stays up until its moment is up", async () => {
+  const { doc, source, done } = atBottomFixture();
+  try {
+    const { deps, writes } = makeFake({
+      consoleSize: { columns: 80, rows: 6 },
+      // No timers fire, so nothing takes the message away.
+      steps: [{ bytes: enc("G") }, { bytes: enc("\x0c") }, { eof: true }],
+    });
+    await runPager(doc, OPTS, undefined, source, deps);
+    const last = writes.filter((w) => w.includes("line20")).at(-1)!;
+    assert(last.includes("Bottom of file"), "still up when nothing has fired");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("pager: what a reveal says takes itself away once the lines have landed", async () => {
+  const { doc, source, done } = revealFixture();
+  try {
+    const { deps, writes } = makeFake({
+      consoleSize: { columns: 80, rows: 13 },
+      steps: [
+        { bytes: enc("\x0c") }, // Ctrl-L: ten lines to walk in
+        // Nine frames walk them in; the tenth draws the finish and starts the
+        // clock, so the message stands from when the lines stop moving.
+        ...Array.from({ length: 10 }, () => ({ fireTimers: true as const })),
+        { fireTimers: true }, // the clock runs out
+        { bytes: enc("q") },
+      ],
+    });
+    await runPager(doc, OPTS, undefined, source, deps);
+    const said = writes.findIndex((w) => w.includes("Showing lines"));
+    assert(said >= 0, "the reveal said what it showed");
+    const gone = writes.slice(said + 1).some((w) =>
+      w.includes("@@") && !w.includes("Showing lines")
+    );
+    assert(gone, "and it was taken away again");
+  } finally {
+    done();
+  }
 });

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -563,3 +563,31 @@ Deno.test("pager: what a reveal says takes itself away once the lines have lande
     done();
   }
 });
+
+Deno.test("pager: a resize does not strand the reason Ctrl-L put up", async () => {
+  const { doc, source, done } = atBottomFixture();
+  try {
+    const { deps, writes } = makeFake({
+      consoleSize: { columns: 80, rows: 6 },
+      steps: [
+        { bytes: enc("G") },
+        { bytes: enc("\x0c") }, // Ctrl-L: "Bottom of file."
+        { fire: "SIGWINCH" }, // a resize redraws and would cancel the clock
+        { fireTimers: true }, // the clock the resize restarted runs out
+        { bytes: enc("q") },
+      ],
+    });
+    await runPager(doc, OPTS, undefined, source, deps);
+    // Without restarting expiry after the resize, the message would sit in the
+    // bar for good; here a later frame is drawn without it.
+    const said = writes.findIndex((w) => w.includes("Bottom of file"));
+    assert(said >= 0, "the reason was drawn");
+    const last = writes.filter((w) => w.includes("line20")).at(-1)!;
+    assert(
+      !last.includes("Bottom of file"),
+      "the resize left the reason free to expire",
+    );
+  } finally {
+    done();
+  }
+});

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -3032,3 +3032,173 @@ index 0000000..1111111 100644
     Deno.removeSync(root, { recursive: true });
   }
 });
+
+// --- reveal-frame remapping and room-less hunks -----------------------------
+
+Deno.test("diffcov: a reveal frame carries a selected node to its shifted place", () => {
+  const { s, done } = tallSession(13);
+  try {
+    // Select the hunk, then reveal: the animation frames redraw the structure,
+    // so revealFrame remaps the selection to where the reveal will leave it.
+    selectByLabel(s, "@@");
+    press(s, "ctrl-l");
+    assert(s.pendingReveal !== null, "a reveal is pending");
+    const frame = s.revealFrame(1)!;
+    assert(frame.view.selected !== null, "the frame keeps the selection");
+    assertEquals(frame.view.selected!.kind, "hunk");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a reveal frame carries surviving search matches to their shifted rows", () => {
+  const { s, done } = tallSession(13);
+  try {
+    // A search on a line low in the hunk leaves a match below the revealed
+    // range. Revealing upward walks lines in above it; a mid-reveal frame keeps
+    // that match, remapped to the row it will end on.
+    press(s, "/");
+    type(s, "L43");
+    press(s, "enter");
+    press(s, "g"); // back to the top so the hunk's top edge is in view
+    assertEquals(s.view().matches?.length, 1, "the search found the line");
+    press(s, "ctrl-l");
+    assert(s.pendingReveal !== null, "a reveal is pending");
+    const frame = s.revealFrame(1)!;
+    assertEquals(
+      frame.view.matches?.length,
+      1,
+      "the surviving match is carried into the frame",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a hunk backing no file offers no edge to expand", () => {
+  // A deleted file's hunk has no workspace file, so expandRoom records nothing
+  // for it; visibleEdges must skip it rather than read a missing room. The
+  // second file's hunk still offers its edges.
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(
+      join(root, "keep.ts"),
+      `${
+        Array.from(
+          { length: 10 },
+          (_, i) => `K${String(i + 1).padStart(2, "0")}`,
+        )
+          .join("\n")
+      }\n`,
+    );
+    const ws: DiffWorkspace = {
+      resolve: (p) => join(root, p),
+      read: (a) => {
+        try {
+          return Deno.readTextFileSync(a);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const diff = `diff --git a/gone.ts b/gone.ts
+deleted file mode 100644
+--- a/gone.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-old1
+-old2
+diff --git a/keep.ts b/keep.ts
+--- a/keep.ts
++++ b/keep.ts
+@@ -3,3 +3,3 @@
+ K03
+-old K04
++K04
+ K05
+`;
+    const model = parseDiff(diff)!;
+    const { doc, edit } = buildDiffDocument(diff, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 24 },
+      undefined,
+      diffSource(ws, edit),
+    );
+    // Evaluating the offer walks every visible hunk, including the deletion's,
+    // and must not stumble on the one with no room. The kept file's hunk still
+    // has edges, so Ctrl-L is offered and reveals from it.
+    assertEquals(s.view().canExpand, true, "the kept file's hunk can expand");
+    press(s, "ctrl-l");
+    assert(s.view().message.startsWith("Showing line"), s.view().message);
+    assert(s.doc.text.includes(" K02"), "the kept file's hunk grew");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffcov: a cursor on a header that a join removes moves to the merged header", () => {
+  // Two hunks close enough that revealing the second one upward closes the gap
+  // and joins them. The cursor rests on the second hunk's header — the header
+  // the join removes — so it must land on the surviving merged header rather
+  // than on the revealed content that slid up into its old line.
+  const lines = Array.from(
+    { length: 30 },
+    (_, i) => `L${String(i + 1).padStart(2, "0")}`,
+  );
+  const diff = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -4,3 +4,3 @@
+ L04
+-old L05
++L05
+ L06
+@@ -12,3 +12,3 @@
+ L12
+-old L13
++L13
+ L14
+`;
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(join(root, "m.ts"), `${lines.join("\n")}\n`);
+    const ws: DiffWorkspace = {
+      resolve: (p) => join(root, p),
+      read: (a) => {
+        try {
+          return Deno.readTextFileSync(a);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const model = parseDiff(diff)!;
+    const { doc, edit } = buildDiffDocument(diff, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 24 },
+      undefined,
+      diffSource(ws, edit),
+    );
+    press(s, "e");
+    for (let i = 0; i < 20; i++) {
+      if (s.doc.text.split("\n")[s.view().cursor!.line].startsWith("@@ -12")) {
+        break;
+      }
+      press(s, "down");
+    }
+    press(s, "ctrl-l");
+    assert(s.doc.text.includes("@@ -4,11 +4,11 @@"), "the hunks joined");
+    assertEquals(
+      s.doc.text.split("\n")[s.view().cursor!.line],
+      "@@ -4,11 +4,11 @@",
+      "the cursor is on the surviving merged header",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -15,7 +15,8 @@ import type { DirEntry, FileGateway } from "../lib/view/filegateway.ts";
 import { parseDiff } from "../lib/view/diff.ts";
 import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { diffSource } from "../lib/view/diffedit.ts";
-import { overlayBox } from "../lib/view/render.ts";
+import { overlayBox, type ViewState } from "../lib/view/render.ts";
+import type { Document } from "../lib/view/model.ts";
 
 // --- key helpers -----------------------------------------------------------
 
@@ -1096,7 +1097,7 @@ Deno.test("session: ctrl-l in pager mode with no hunk in view reports move-to-a-
   // Pager mode (no cursor): expandRefLine finds no hunk and returns null.
   press(s, "ctrl-l");
   assert(
-    s.view().message.includes("Move to a hunk first"),
+    s.view().message.includes("Move to a hunk's edge"),
     s.view().message,
   );
 });
@@ -1541,6 +1542,502 @@ Deno.test("diffcov: pager-mode ctrl-l with a selected hunk expands that hunk", (
     selectByLabel(s, "@@");
     press(s, "ctrl-l");
     assert(s.doc.text.includes("alpha") || s.doc.text.includes("beta"));
+  } finally {
+    done();
+  }
+});
+
+// A hunk tall enough that the middle of the screen can be scrolled into either
+// half of it, with room to reveal a full expansion (10 lines) above and below.
+const TALL_LINES = Array.from(
+  { length: 60 },
+  (_, i) => `L${String(i + 1).padStart(2, "0")}`,
+);
+const TALL_FILE = `${TALL_LINES.join("\n")}\n`;
+const TALL_DIFF = `diff --git a/t.ts b/t.ts
+index 0000000..1111111 100644
+--- a/t.ts
++++ b/t.ts
+@@ -25,20 +25,20 @@
+${TALL_LINES.slice(24, 33).map((l) => ` ${l}`).join("\n")}
+-old L34
++L34
+${TALL_LINES.slice(34, 44).map((l) => ` ${l}`).join("\n")}
+`;
+
+/** A session over TALL_DIFF, in pager mode, `height` rows tall. */
+function tallSession(height: number): { s: Session; done: () => void } {
+  const root = Deno.makeTempDirSync();
+  Deno.writeTextFileSync(join(root, "t.ts"), TALL_FILE);
+  const ws: DiffWorkspace = {
+    resolve: (p) => join(root, p),
+    read: (a) => {
+      try {
+        return Deno.readTextFileSync(a);
+      } catch {
+        return null;
+      }
+    },
+  };
+  const model = parseDiff(TALL_DIFF)!;
+  const { doc, edit } = buildDiffDocument(TALL_DIFF, model, ws);
+  const s = new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 80, height },
+    undefined,
+    diffSource(ws, edit),
+  );
+  return { s, done: () => Deno.removeSync(root, { recursive: true }) };
+}
+
+Deno.test("diffcov: pager-mode ctrl-l at a hunk's top expands upwards", () => {
+  const { s, done } = tallSession(13);
+  try {
+    // Viewport at the top of the hunk: the middle of the screen sits in the
+    // hunk's upper half, so the context comes from above it.
+    press(s, "ctrl-l");
+    assert(s.view().message.startsWith("Showing line"), s.view().message);
+    assert(s.doc.text.includes("L24"), "revealed the line above the hunk");
+    assert(!s.doc.text.includes("L45"), "did not reveal below the hunk");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: pager-mode ctrl-l at a hunk's bottom expands downwards", () => {
+  const { s, done } = tallSession(13);
+  try {
+    // Scrolled to the end, the middle of the screen sits in the hunk's lower
+    // half, so the context comes from below it.
+    press(s, "G", "ctrl-l");
+    assert(s.view().message.startsWith("Showing line"), s.view().message);
+    assert(s.doc.text.includes("L45"), "revealed the line below the hunk");
+    assert(!s.doc.text.includes("L24"), "did not reveal above the hunk");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: pager-mode ctrl-l follows the middle as the view scrolls", () => {
+  const { s, done } = tallSession(13);
+  try {
+    // The same session expands up first, then down once scrolled, rather than
+    // repeating one direction until it is exhausted.
+    press(s, "ctrl-l");
+    assert(s.doc.text.includes("L24"), s.doc.text);
+    press(s, "G", "ctrl-l");
+    assert(s.doc.text.includes("L45"), s.doc.text);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: pager-mode ctrl-l measures a selection's hunk from the selection", () => {
+  // Tall enough that both of the hunk's edges are on screen, so which one is
+  // nearest is a real question rather than the only one left.
+  const plain = tallSession(30);
+  try {
+    // Left alone, the middle of the screen is nearer the hunk's top edge.
+    press(plain.s, "ctrl-l");
+    assert(plain.s.doc.text.includes("L24"), "the middle reached upwards");
+  } finally {
+    plain.done();
+  }
+  const { s, done } = tallSession(30);
+  try {
+    // A selected line low in the hunk puts its bottom edge nearest instead, and
+    // that is the edge that grows: the user picked a place to look.
+    selectByLabel(s, "L37");
+    press(s, "ctrl-l");
+    assert(s.view().message.startsWith("Showing line"), s.view().message);
+    assert(s.doc.text.includes("L45"), "revealed below the selected line");
+    assert(!s.doc.text.includes("L24"), "did not reveal above the hunk");
+  } finally {
+    done();
+  }
+});
+
+const TWO_HUNK_FILE = `${
+  Array.from({ length: 30 }, (_, i) => `line${i + 1}`).join("\n")
+}\n`;
+const TWO_HUNK_DIFF = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -4,3 +4,3 @@
+ line4
+-OLD5
++line5
+ line6
+@@ -20,3 +20,3 @@
+ line20
+-OLD21
++line21
+ line22
+`;
+
+Deno.test("filepicker: opening it after an edit leaves the structure tree current", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(join(root, "m.ts"), TWO_HUNK_FILE);
+    const ws: DiffWorkspace = {
+      resolve: (p) => join(root, p),
+      read: (a) => {
+        try {
+          return Deno.readTextFileSync(a);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const model = parseDiff(TWO_HUNK_DIFF)!;
+    const { doc, edit } = buildDiffDocument(TWO_HUNK_DIFF, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 30 },
+      undefined,
+      diffSource(ws, edit),
+      gateway(),
+    );
+    press(s, "e");
+    // Land an edit, then split the line so the hunks below it move down.
+    for (let r = 0; r < 12; r++) {
+      const before = s.doc.text;
+      press(s, "x");
+      if (s.doc.text !== before) break;
+      press(s, "down");
+    }
+    press(s, "enter", "enter", "enter");
+    press(s, "ctrl-x", "ctrl-f"); // the picker drops the text cursor
+    press(s, "escape"); // cancelling returns to navigation
+    // The tree navigation lands on must describe the text as it now stands.
+    const real = parseDiff(s.doc.text)!.files.flatMap((f) => f.hunks).map((
+      h,
+    ) => [h.headerLine, h.endLine]);
+    const tree = s.doc.flatStructure.filter((n) => n.kind === "hunk").map((
+      n,
+    ) => [n.startLine, n.endLine]);
+    assertEquals(tree, real);
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+// Three files, the middle one big enough that hiding it takes a large slice of
+// the document off screen while leaving one row behind.
+const FOLD_FILE = (p: string) =>
+  `${
+    Array.from(
+      { length: 40 },
+      (_, i) => `${p}${String(i + 1).padStart(3, "0")}`,
+    )
+      .join("\n")
+  }\n`;
+const FOLD_SMALL = (name: string, p: string) =>
+  `diff --git a/${name} b/${name}
+index 0000000..1111111 100644
+--- a/${name}
++++ b/${name}
+@@ -20,3 +20,3 @@
+ ${p}020
+-old ${p}021
++${p}021
+ ${p}022`;
+const FOLD_DIFF = `${FOLD_SMALL("a.ts", "A")}
+diff --git a/big.ts b/big.ts
+index 0000000..1111111 100644
+--- a/big.ts
++++ b/big.ts
+@@ -5,20 +5,20 @@
+${
+  Array.from({ length: 9 }, (_, i) => ` B${String(i + 5).padStart(3, "0")}`)
+    .join("\n")
+}
+-old B014
++B014
+${
+  Array.from({ length: 10 }, (_, i) => ` B${String(i + 15).padStart(3, "0")}`)
+    .join("\n")
+}
+${FOLD_SMALL("c.ts", "C")}
+`;
+
+Deno.test("diffcov: pager-mode ctrl-l measures nearest in rows, not document lines", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    for (const [name, p] of [["a.ts", "A"], ["big.ts", "B"], ["c.ts", "C"]]) {
+      Deno.writeTextFileSync(join(root, name), FOLD_FILE(p));
+    }
+    const ws: DiffWorkspace = {
+      resolve: (p) => join(root, p),
+      read: (a) => {
+        try {
+          return Deno.readTextFileSync(a);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const model = parseDiff(FOLD_DIFF)!;
+    const { doc, edit } = buildDiffDocument(FOLD_DIFF, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 20 },
+      undefined,
+      diffSource(ws, edit),
+    );
+    selectByLabel(s, "big.ts");
+    press(s, "f", "escape", "G"); // hide the middle file, drop the selection
+    // The middle of the screen lands on c.ts's header, two rows below a.ts's
+    // hunk and four above c.ts's. a.ts is what the eye is nearest, so a.ts is
+    // what grows — even though big.ts's hidden lines put it 27 document lines
+    // away against c.ts's four.
+    press(s, "ctrl-l");
+    assert(s.view().message.startsWith("Showing line"), s.view().message);
+    assert(s.doc.text.includes("A023"), "the hunk nearest on screen grew");
+    assert(!s.doc.text.includes("C019"), "the hunk further away did not");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+// The tall hunk with a second file after it, so the content on either side of
+// the hunk can be found by name.
+const PIN_DIFF = `diff --git a/a.ts b/a.ts
+index 0000000..1111111 100644
+--- a/a.ts
++++ b/a.ts
+@@ -25,20 +25,20 @@
+${TALL_LINES.slice(24, 33).map((l) => ` ${l}`).join("\n")}
+-old L34
++L34
+${TALL_LINES.slice(34, 44).map((l) => ` ${l}`).join("\n")}
+diff --git a/b.ts b/b.ts
+index 0000000..1111111 100644
+--- a/b.ts
++++ b/b.ts
+@@ -20,3 +20,3 @@
+ B020
+-old B021
++B021
+ B022
+`;
+
+function pinSession(): { s: Session; done: () => void } {
+  const root = Deno.makeTempDirSync();
+  Deno.writeTextFileSync(join(root, "a.ts"), TALL_FILE);
+  Deno.writeTextFileSync(
+    join(root, "b.ts"),
+    `${
+      Array.from({ length: 40 }, (_, i) => `B${String(i + 1).padStart(3, "0")}`)
+        .join("\n")
+    }\n`,
+  );
+  const ws: DiffWorkspace = {
+    resolve: (p) => join(root, p),
+    read: (a) => {
+      try {
+        return Deno.readTextFileSync(a);
+      } catch {
+        return null;
+      }
+    },
+  };
+  const model = parseDiff(PIN_DIFF)!;
+  const { doc, edit } = buildDiffDocument(PIN_DIFF, model, ws);
+  const s = new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 80, height: 13 },
+    undefined,
+    diffSource(ws, edit),
+  );
+  return { s, done: () => Deno.removeSync(root, { recursive: true }) };
+}
+
+/** The screen row `text` sits on: negative above the viewport, at or past the
+ * content rows below it. A display row is a document line while nothing is
+ * collapsed. */
+function screenRow(s: Session, text: string): number {
+  const line = s.doc.text.split("\n").indexOf(text);
+  if (line < 0) throw new Error(`line not in the document: ${text}`);
+  return line - s.view().top;
+}
+
+Deno.test("diffcov: expanding upwards holds the content before the hunk still", () => {
+  const { s, done } = pinSession();
+  try {
+    const held = screenRow(s, "+++ b/a.ts");
+    press(s, "ctrl-l");
+    assert(s.view().message.startsWith("Showing line"), s.view().message);
+    assertEquals(
+      screenRow(s, "+++ b/a.ts"),
+      held,
+      "the content before it held",
+    );
+    const revealed = screenRow(s, " L20");
+    assert(
+      revealed >= 0 && revealed < 12,
+      `revealed line on screen: ${revealed}`,
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: expanding downwards holds the content after the hunk still", () => {
+  const { s, done } = pinSession();
+  try {
+    press(s, "ctrl-d", "ctrl-d", "j", "j", "j"); // the middle in its lower half
+    const held = screenRow(s, "diff --git a/b.ts b/b.ts");
+    press(s, "ctrl-l");
+    assert(s.view().message.startsWith("Showing line"), s.view().message);
+    assertEquals(
+      screenRow(s, "diff --git a/b.ts b/b.ts"),
+      held,
+      "the content after it held",
+    );
+    const revealed = screenRow(s, " L50");
+    assert(
+      revealed >= 0 && revealed < 12,
+      `revealed line on screen: ${revealed}`,
+    );
+  } finally {
+    done();
+  }
+});
+
+/** The row texts a frame — or the session itself — puts on screen. */
+function rows(f: { doc: Document; view: ViewState }): string[] {
+  return f.doc.lines.slice(f.view.top, f.view.top + f.view.height - 1)
+    .map((l) => l.text);
+}
+
+function screenOf(s: Session): string[] {
+  return rows({ doc: s.displayDoc(), view: s.view() });
+}
+
+Deno.test("diffcov: the reveal frames run from the screen before to the one after", () => {
+  const { s, done } = pinSession();
+  try {
+    const before = screenOf(s);
+    press(s, "ctrl-l");
+    const reveal = s.pendingReveal!;
+    assertEquals(reveal.count, 10);
+    assertEquals(reveal.up, true);
+    const body = (ls: string[]) => ls.filter((l) => !l.startsWith("@@"));
+    // Nothing shown yet is the picture the user was already looking at, and
+    // everything shown is where it settles, so the frames only ever interpolate.
+    // The lines are what arrive: the header carries its finished counts from the
+    // first frame, reading the range the reveal is heading for rather than
+    // counting up to it.
+    assertEquals(body(rows(s.revealFrame(0)!)), body(before));
+    assert(
+      rows(s.revealFrame(0)!).some((l) => l.startsWith("@@ -15,30")),
+      "the header is already at the range it is heading for",
+    );
+    assertEquals(rows(s.revealFrame(reveal.count)!), screenOf(s));
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: reveal frames land the line meeting the hunk first", () => {
+  const { s, done } = pinSession();
+  try {
+    press(s, "ctrl-l"); // upwards: L15..L24 revealed above the body
+    const first = s.revealFrame(1)!.doc.lines.map((l) => l.text);
+    // L24 meets the hunk, L15 is furthest from it. Landing the furthest first
+    // would put L15 next to the body and show a file that reads L15, L25.
+    assert(first.includes(" L24"), "the line meeting the hunk has landed");
+    assert(!first.includes(" L15"), "the furthest line has not");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: reveal frames landing downwards also start at the hunk", () => {
+  const { s, done } = pinSession();
+  try {
+    press(s, "ctrl-d", "ctrl-d", "j", "j", "j", "ctrl-l"); // downwards
+    const reveal = s.pendingReveal!;
+    assertEquals(reveal.up, false);
+    const first = s.revealFrame(1)!.doc.lines.map((l) => l.text);
+    assert(first.includes(" L45"), "the line meeting the hunk has landed");
+    assert(!first.includes(" L54"), "the furthest line has not");
+    // The held edge stays on its row throughout, not only at the end.
+    for (let shown = 0; shown <= reveal.count; shown++) {
+      const f = s.revealFrame(shown)!;
+      assertEquals(
+        rows(f).indexOf("diff --git a/b.ts b/b.ts"),
+        11,
+        `held edge moved at frame ${shown}`,
+      );
+    }
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: the next key ends the reveal", () => {
+  const { s, done } = pinSession();
+  try {
+    press(s, "ctrl-l");
+    assert(s.pendingReveal !== null, "a reveal is pending");
+    press(s, "j");
+    assertEquals(s.pendingReveal, null);
+    assertEquals(s.revealFrame(1), null);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: pager-mode ctrl-l drops a selection that scrolls out of view", () => {
+  const { s, done } = tallSession(13);
+  try {
+    // The selected line governs only while the user can see it. Scrolling it
+    // off the top hands the decision back to the middle, which is in the
+    // hunk's upper half and so expands upwards — the opposite of what the
+    // selection alone would have chosen.
+    selectByLabel(s, "L37");
+    press(s, "g", "ctrl-l");
+    assert(s.view().message.startsWith("Showing line"), s.view().message);
+    assert(s.doc.text.includes("L24"), "the middle decided, not the selection");
+    assert(!s.doc.text.includes("L45"), "the off-screen selection did not");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: pager-mode ctrl-l with a hidden file reports move-to-a-hunk", () => {
+  const { s, done } = tallSession(13);
+  try {
+    press(s, "F"); // hide every file: only the summary row is on screen
+    const before = s.doc.text;
+    press(s, "ctrl-l");
+    assert(
+      s.view().message.includes("Move to a hunk's edge"),
+      s.view().message,
+    );
+    assertEquals(s.doc.text, before, "a hidden hunk is not expanded");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: pager-mode ctrl-l with the file node selected uses the middle", () => {
+  const { s, done } = tallSession(13);
+  try {
+    // The file node spans the hunk rather than sitting in it, so it does not
+    // pin the reference line to its own start; the middle still decides.
+    // Selecting scrolls to the node, so scroll to the end after selecting.
+    press(s, "tab", "a", "a", "a");
+    assert(s.view().selected?.label?.includes("t.ts"), "file node selected");
+    press(s, "G", "ctrl-l");
+    assert(s.doc.text.includes("L45"), s.doc.text);
   } finally {
     done();
   }
@@ -2194,5 +2691,344 @@ Deno.test("diffcov: removing an added line shrinks the hunk header counts", () =
     assert(headerAfter === "" || headerAfter.startsWith("@@"));
   } finally {
     done();
+  }
+});
+
+// --- only visible hunk edges, and what stops them ---------------------------
+
+/** A diff whose only hunk sits hard against the top of its file, with a second
+ * hunk close enough below that expanding down soon meets it. */
+function edgeSession(diff: string, fileLines: number, height: number) {
+  const root = Deno.makeTempDirSync();
+  Deno.writeTextFileSync(
+    join(root, "m.ts"),
+    `${
+      Array.from({ length: fileLines }, (_, i) => `line${i + 1}`).join("\n")
+    }\n`,
+  );
+  const ws: DiffWorkspace = {
+    resolve: (p) => join(root, p),
+    read: (a) => {
+      try {
+        return Deno.readTextFileSync(a);
+      } catch {
+        return null;
+      }
+    },
+  };
+  const model = parseDiff(diff)!;
+  const { doc, edit } = buildDiffDocument(diff, model, ws);
+  const s = new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 80, height },
+    undefined,
+    diffSource(ws, edit),
+  );
+  return { s, done: () => Deno.removeSync(root, { recursive: true }) };
+}
+
+const AT_TOP_DIFF = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -1,3 +1,3 @@
+ line1
+-OLD2
++line2
+ line3
+`;
+
+Deno.test("diffcov: a hunk with neither edge on screen offers nothing to expand", () => {
+  const { s, done } = tallSession(13);
+  try {
+    // The hunk runs from row 4 to row 25; twelve rows starting at 6 hold
+    // neither end of it, so there is no edge to aim at and none to offer.
+    press(s, "ctrl-d");
+    assertEquals(s.view().top, 6);
+    assertEquals(s.view().canExpand, false);
+    const before = s.doc.text;
+    press(s, "ctrl-l");
+    assertEquals(s.doc.text, before, "nothing was revealed");
+    assert(
+      s.view().message.includes("Move to a hunk's edge"),
+      s.view().message,
+    );
+    assert(s.transientMessage, "the message takes itself away again");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a hunk against the top of its file says so", () => {
+  const { s, done } = edgeSession(AT_TOP_DIFF, 20, 13);
+  try {
+    // The hunk starts at file line 1, so its top edge — the nearest one to the
+    // middle — has nowhere to go.
+    assertEquals(s.view().canExpand, false);
+    const before = s.doc.text;
+    press(s, "ctrl-l");
+    assertEquals(s.view().message, "Top of file.");
+    assert(s.transientMessage, "the message takes itself away again");
+    // Emphatically not the other way: naming an edge means that edge.
+    assertEquals(s.doc.text, before, "nothing was revealed");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a hunk against the bottom of its file says so", () => {
+  const diff = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -18,3 +18,3 @@
+ line18
+-OLD19
++line19
+ line20
+`;
+  // A short screen, so scrolling to the end leaves the hunk's bottom edge on it
+  // and its top edge off: the bottom is the only edge to aim at.
+  const { s, done } = edgeSession(diff, 20, 6);
+  try {
+    press(s, "G");
+    assertEquals(s.view().canExpand, false);
+    const before = s.doc.text;
+    press(s, "ctrl-l");
+    assertEquals(s.view().message, "Bottom of file.");
+    assert(s.transientMessage, "the message takes itself away again");
+    // Emphatically not the other way: the top edge has room, but it is not the
+    // edge the user is looking at.
+    assertEquals(s.doc.text, before, "nothing was revealed");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: revealing the last line between two hunks joins them", () => {
+  const diff = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -4,3 +4,3 @@
+ line4
+-OLD5
++line5
+ line6
+@@ -14,3 +14,3 @@
+ line14
+-OLD15
++line15
+ line16
+`;
+  const { s, done } = edgeSession(diff, 20, 20);
+  try {
+    press(s, "ctrl-l"); // reveals the seven lines between the two hunks
+    // Nothing is left between them, so the header that sat there described no
+    // gap at all: one hunk covering both ranges takes its place.
+    assertEquals(
+      parseDiff(s.doc.text)!.files.flatMap((f) => f.hunks).length,
+      1,
+      s.doc.text,
+    );
+    assert(s.doc.text.includes("@@ -4,13 +4,13 @@"), s.doc.text);
+    assert(!s.doc.text.includes("@@ -14,3"), "the joined-away header is gone");
+    // The body reads straight through where the header used to be.
+    const body = s.doc.text.split("\n");
+    assertEquals(body[body.indexOf(" line13") + 1], " line14");
+    // Its room is now measured against the file, not the hunk it swallowed.
+    assertEquals(s.view().canExpand, true, "there is still context to reveal");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a hunk that does not match the file is not joined to one that does", () => {
+  // The second hunk's new side says DIFFERENT15 where the file says line15, so
+  // it is not known to match. Joining it to the first would put lines of
+  // unknown provenance into a range that a save writes.
+  const diff = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -4,3 +4,3 @@
+ line4
+-OLD5
++line5
+ line6
+@@ -14,3 +14,3 @@
+ line14
+-OLD15
++DIFFERENT15
+ line16
+`;
+  const { s, done } = edgeSession(diff, 20, 20);
+  try {
+    press(s, "ctrl-l");
+    assertEquals(
+      parseDiff(s.doc.text)!.files.flatMap((f) => f.hunks).length,
+      2,
+      "the two hunks stay apart",
+    );
+    // They touch, so there is nothing left to reveal that way — and the file has
+    // not run out, so saying it had would be a lie.
+    press(s, "ctrl-l");
+    assertEquals(s.view().message, "No more context to show.");
+    assertEquals(s.view().canExpand, false);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a one-line hunk still grows the edge it was asked for", () => {
+  // `git diff -U0` emits hunks with no context. A pure insertion is one body
+  // line, so the hunk's midpoint falls exactly on its bottom edge — reading the
+  // direction off the midpoint alone would send this one upwards.
+  const diff = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -9,0 +10,1 @@
++line10
+`;
+  const { s, done } = edgeSession(diff, 20, 4);
+  try {
+    press(s, "G"); // the middle of what is left lands on the bottom edge
+    press(s, "ctrl-l");
+    assert(s.view().message.startsWith("Showing line"), s.view().message);
+    assert(s.doc.text.includes(" line11"), "revealed below the hunk");
+    assert(!s.doc.text.includes(" line9"), "did not reveal above it");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a reveal says which way it reached and what it brought back", () => {
+  const { s, done } = tallSession(13);
+  try {
+    // One run of context looks like any other, so the file's own line numbers
+    // are what tie the lines on screen to the file they came from.
+    press(s, "ctrl-l"); // the hunk covers file lines 25-44; upwards from there
+    assertEquals(s.view().message, "Showing lines 15-24 above the hunk.");
+    assert(s.transientMessage, "and it takes itself away again");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a reveal downwards counts from the hunk's last line", () => {
+  const { s, done } = tallSession(13);
+  try {
+    press(s, "G", "ctrl-l");
+    assertEquals(s.view().message, "Showing lines 45-54 below the hunk.");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a reveal that joins two hunks says that too", () => {
+  const diff = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -4,3 +4,3 @@
+ line4
+-OLD5
++line5
+ line6
+@@ -14,3 +14,3 @@
+ line14
+-OLD15
++line15
+ line16
+`;
+  const { s, done } = edgeSession(diff, 20, 20);
+  try {
+    // A header disappearing is otherwise left to be puzzled over.
+    press(s, "ctrl-l");
+    assertEquals(
+      s.view().message,
+      "Showing lines 7-13 below — the two hunks are now one.",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a reveal of a single line does not say lines 15-15", () => {
+  const diff = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -2,3 +2,3 @@
+ line2
+-OLD3
++line3
+ line4
+`;
+  // Only line 1 sits above the hunk, so only one line can come back.
+  const { s, done } = edgeSession(diff, 20, 13);
+  try {
+    press(s, "ctrl-l");
+    assertEquals(s.view().message, "Showing line 1 above the hunk.");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: expanding upwards in edit mode leaves a cursor on the header alone", () => {
+  // The revealed lines go in below the hunk's header, so the header does not
+  // move — and the text cursor can rest on one, where it cannot type.
+  const lines = Array.from(
+    { length: 60 },
+    (_, i) => `L${String(i + 1).padStart(2, "0")}`,
+  );
+  const diff = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -40,3 +40,3 @@
+ L40
+-old L41
++L41
+ L42
+`;
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(join(root, "m.ts"), `${lines.join("\n")}\n`);
+    const ws: DiffWorkspace = {
+      resolve: (p) => join(root, p),
+      read: (a) => {
+        try {
+          return Deno.readTextFileSync(a);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const model = parseDiff(diff)!;
+    const { doc, edit } = buildDiffDocument(diff, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 13 },
+      undefined,
+      diffSource(ws, edit),
+    );
+    press(s, "e", "down", "down", "down", "down"); // onto the `@@` header
+    assertEquals(s.view().cursor?.line, 4);
+    press(s, "ctrl-l");
+    // Still on the header, which is still where it was: carrying the cursor down
+    // with the lines would drop it ten rows away on a line it never chose, and
+    // drag the view along behind it.
+    assertEquals(s.view().cursor?.line, 4, "the cursor stayed on the header");
+    assert(
+      s.doc.text.split("\n")[4].startsWith("@@ -30,13"),
+      s.doc.text.split("\n")[4],
+    );
+    assertEquals(s.view().top, 0, "and the view did not jump");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
   }
 });


### PR DESCRIPTION
Ctrl-L reveals more of the file around a hunk. It picked a line, and everything followed from that: the hunk was the one containing it, and the direction came from whether it fell in the hunk's top or bottom half. Pager mode chose that line badly — the start line of the selected node, or of the first hunk overlapping the viewport. A hunk node's start line is its header, and a header is always at or above the midpoint, so the direction test could only ever come out upwards. Pager-mode Ctrl-L could not reveal context below a hunk while any remained above it; reaching downwards meant dropping into edit mode and moving the text cursor.

The screen now names the edge. Every hunk end the reader can see is a candidate, and the nearest to the middle of the visible content wins, settling the hunk and the direction together rather than deriving the second from a midpoint. A hunk with neither end on screen offers nothing to aim at: its boundaries are off in the dark, and growing one would happen where it could not be watched. A selected node aims at its own hunk, measured from the selection, since the reader picked a place to look.

Ctrl-L is offered only where it would do something. That needs to know what the file still holds around each hunk, which lived inside expandContext and was thrown away; expandRoom reports it and the session caches it against the document. The offer on the bar and the key itself read the same answer, so the bar cannot promise what the key will not do. Where an edge has nothing left, the reason is specific: reaching the file's first or last line says so, and stands for a moment before taking itself away rather than sitting in the bar describing a keypress the reader has moved on from.

Naming an edge had to become something expandContext could hear. It read the direction off the midpoint and quietly grew the other way when the one it chose had run out, so asking for a blocked edge revealed lines at the far end of the hunk instead of refusing. It now takes the direction and fails rather than substituting one. The midpoint was also wrong for the smallest hunks: a zero-context pure insertion is a single body line, which puts the midpoint exactly on the bottom edge and sent that edge upwards.

Where the lines land is now visible. The view holds still the line just outside the edge they go in at, so they open a gap in front of the reader against a fixed landmark: revealing upwards holds the hunk's header and pushes its body down, revealing downwards holds what follows the hunk and lifts it up. They land one to a frame, walking out from the hunk's edge, nearest first — the lines furthest away arriving first would stand one against the hunk body and draw a file that skips everything between them. The session goes straight to the finished state and parses once; each frame leaves out the lines still to come, so a frame costs an array copy. The driver holds the timing, through the same injected timer as the deferred re-parse, which fires while the read loop waits on the terminal, and any key ends the walk.

Revealing the last file line between two hunks leaves them touching, and a header between lines that are neighbours in the file describes nothing. The two become one, the header at the join goes, and the first header's counts cover both — the diff git would have emitted had it been asked for that much context. The diff text, the save map and the viewport geometry move together: save() pairs the text's hunks with the map by position, so a map disagreeing by one hunk would write file ranges belonging to another. A pair is joined only where both are known to match the file, since joining a verified hunk to an unverified one would either carry lines of unknown provenance into a range that saves, or stop the verified one from being written at all. A joined reveal draws in one step: its frames would stand the two bodies against each other before the lines joining them arrived.

What a reveal did is now what it says. "Expanded context" named the request rather than the result; ten lines of context arrive looking like the context already there, and which are new was left to the gutter. It now names them — "Showing lines 15-24 above the hunk" — in the file's own numbers, which are what can be looked up, and says when a reveal joined two hunks, since a header disappearing is otherwise left to be puzzled over.

Two faults surfaced while building this, both older than it.

The file picker dropped the text cursor without the deferred re-parse that leaving edit mode by Esc runs. Cancelling it returns to navigation, so an edit that moved lines followed by Ctrl-x Ctrl-f and Esc left everything working from the structure tree reading line numbers for text that no longer existed.

Revealing upwards carried the text cursor down by however many lines came back, whatever line it was on. The lines go in below the hunk's header, so the header does not move, and a cursor resting on one was thrown clear of it with the view scrolling away after it. The blanket shift stood on the reasoning that the cursor is never on a header, which is not editable; but not being able to type on a line is not the same as not being able to rest on one, and the first line of a hunk anyone scrolls to is its header. The cursor now moves by the same mapping as every other line.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Ctrl-L reveal context at the hunk edge the reader is looking at, with clear, transient messaging and a smooth in-place animation. This enables expanding downwards in pager mode, keeps the view stable, and merges hunks when a reveal closes the last gap.

- **New Features**
  - Pager picks the nearest visible hunk edge (selection biases it); only edges on screen are candidates and Ctrl-L is offered only when that edge has room.
  - Internal API: `expandContext(current, baseline, cursorLine, up?)` refuses the other edge; `expandRoom(current)` caches per-hunk room.
  - Smooth reveal: lines land one per frame from the hunk outward; the landmark line just outside the growing edge stays fixed; any key or resize cancels.
  - When a reveal fills the gap between two hunks, they join into one; baseline and save map stay in sync; the status bar names exactly what was shown (file line numbers, above/below) and when hunks were joined; messages auto-expire after the landing finishes.

- **Bug Fixes**
  - Cancelling the file picker after edits now re-parses, keeping the structure tree current.
  - Cursor resting on a hunk header no longer jumps after an upward reveal, including after a join; cursor/selection are remapped with inserted/removed lines.
  - Auto-expiring status messages no longer get stranded by a terminal resize.

<sup>Written for commit 751cb7df21a8a94c0ea5f2b7019c45d71c1cbd4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

