### PR TITLE
fuse: keep inode numbers stable across piece-property rebuilds

### DIFF
--- a/docs/history/packages/fuse/stable-inode-mtime-verification.md
+++ b/docs/history/packages/fuse/stable-inode-mtime-verification.md
@@ -1,0 +1,77 @@
+---
+status: historical
+created: 2026-07-17
+archived: 2026-07-17
+reason: "Point-in-time record of the on-hardware FUSE-T verification of stable inodes and the moving mtime, including the measurement that the same-size staleness is bounded rather than unbounded"
+---
+
+# Verification: stable FUSE inodes and moving mtime on FUSE-T
+
+This records the on-hardware verification of the stable-inode rebuild work
+(`fuse-stable-inodes` branch) against FUSE-T 1.2.7 on macOS 26, arm64, run
+against a local toolshed. It captures what was confirmed and one measurement
+that corrects the framing the change was built with.
+
+## Setup
+
+A local toolshed on a copy-specific port offset served one deployed piece (the
+`fuse-exec` integration fixture, whose result exposes a `messageCount` counter
+and a `lastMessage` string). Two FUSE-T mounts of the same space ran side by
+side: one from the branch head (stable inodes plus a per-node mtime) and one
+from the commit just before the mtime work (stable inodes, no mtime, stat
+carries no modification time). Driving the `recordMessage` handler stepped the
+counter through single-digit values, each step a same-byte-length content
+change (`1`→`2`→`3`…), which is the case the mtime was added to keep fresh.
+
+## Confirmed
+
+- **Inode stability holds.** The `result/messageCount` value file kept the same
+  inode number (`26`) across every rebuild on both mounts. This is the branch's
+  core deliverable, and it reproduces on real FUSE-T.
+- **The mtime moves.** On the branch-head mount the file's stat `mtime` advanced
+  with each content change; on the pre-mtime mount it stayed `0`. `ls -l`
+  reported `Jul 17 16:52` on the branch-head mount and `Dec 31 1969` (the epoch)
+  on the pre-mtime mount — a user-visible correctness difference independent of
+  freshness.
+- **Same-size changes read fresh through the mount.** Stepping the counter
+  through same-length values and reading the value file back through the NFS
+  mount reflected each new value on both mounts.
+
+## The correcting measurement
+
+The mtime work was motivated by a review finding that predicted a same-size
+content change on a stable inode would "read stale indefinitely" on the macOS
+NFS backend, because FUSE-T ignores the inode-invalidation notifications and
+stat carried no modification time. On FUSE-T 1.2.7 that unbounded staleness
+does not occur.
+
+Polling both mounts every 0.2 s immediately after a same-size change, with the
+default one-second attribute-cache timeout:
+
+| | with moving mtime | no mtime |
+| --- | --- | --- |
+| same-size change read fresh after | ~0.4 s | ~0.8–1.2 s |
+
+The no-mtime mount refreshed within roughly the attribute-cache timeout rather
+than staying stale — the one-second `attrcache-timeout` default (established in
+the earlier [FUSE-T cache-tuning
+evaluation](./noattrcache-mount-option-evaluation.md)) forces a revalidation
+that refetches the content regardless of whether the mtime moved. A repeat with
+an untuned mount (`--attrcache-timeout 0`) also refreshed both mounts within a
+couple of seconds; FUSE-T's NFS backend does not appear to cache positive file
+content long enough for a same-size change to go stale for the tens of seconds
+the earlier evaluation measured for negative-name and directory-listing
+staleness.
+
+So the moving mtime **tightens the freshness window** for a same-size change
+(here roughly halving it) and **restores correct file timestamps**, but it does
+not rescue an otherwise-broken read on this backend, because the staleness it
+guards against is bounded by the attribute-cache timeout, not unbounded. It
+remains worth keeping: correct mtimes are expected by ordinary tools, the
+tighter window is a real improvement, and the signal is load-bearing for any
+client that caches file data by mtime-and-size for longer than FUSE-T does.
+
+## Cleanup
+
+All four mounts were unmounted, the pre-mtime git worktree removed, and the
+local dev servers stopped; the working tree was left clean on the branch.

--- a/docs/specs/fuse-filesystem/4-read-write.md
+++ b/docs/specs/fuse-filesystem/4-read-write.md
@@ -18,19 +18,36 @@ Every path must resolve to a valid `stat` result:
 | `.tool` file | `-r--r--r--` (0444) | byte length of shebang text |
 | Symlink (cell ref) | `lrwxrwxrwx` | target path length |
 
-**Timestamps**: `mtime` reflects the cell's last modification time (from the
-`since` lamport clock, mapped to wall-clock time if available, or mount time
-as fallback). `ctime` = `mtime`. `atime` = current time or mount time (atime
-tracking is expensive and not useful here).
+**Timestamps**: each node carries an `mtime` that advances to the daemon's
+wall-clock time whenever the node's content changes or a directory gains or
+loses an entry, clamped to strictly greater than the node's previous `mtime` so
+two changes within one millisecond still differ; a rebuild that leaves a node
+unchanged preserves its `mtime`. `ctime` and `atime` are reported equal to
+`mtime`. `FsTree` tracks the value and `buildNodeStat` surfaces it. A moving
+`mtime` gives tools that key on it (`ls -l`, `make`, `find -newer`, file
+watchers) correct times, and is the signal by which a client detects a content
+change that keeps the same inode and size — the change the macOS NFS backend
+cannot see through inode invalidation, which it ignores.
 
 **Inode assignment**: Inodes are assigned from a counter that only ever counts
-up (`FsTree.allocInode` in `packages/fuse/tree.ts`). Nothing keys them by cell
-identity or by path, so a path keeps its inode only for as long as the subtree
-holding it survives. Rebuilding a piece property replaces that subtree and
-allocates fresh inodes, so the same logical cell presents a new inode after
-each rebuild. A rebuild detaches the old subtree rather than dropping it
-immediately, which keeps the old inodes resolvable for a short window so that
-file handles opened before the rebuild continue to reach the same cell.
+up (`FsTree.allocInode` in `packages/fuse/tree.ts`). A new inode is allocated
+the first time a path appears and is reused for as long as that path keeps
+existing with the same node kind. Rebuilding a piece property builds the
+replacement under a staging name and reconciles it onto the live subtree
+(`FsTree.transplantSubtree`). A path that still exists with the same node kind
+keeps its inode and takes the new content; a genuinely new path is allocated a
+fresh inode; a genuinely removed path has its inode freed. Freed inode numbers
+are never reused, because the counter only counts up. A path whose node kind
+changes (a scalar becoming an object, a file becoming a directory, an array
+index that shrank away) is a removal followed by an addition, so its inode
+changes; this is the one case where a surviving path does not keep its inode.
+
+The reconciliation is synchronous, so no filesystem request observes a
+half-rebuilt tree: a reader sees either the pre-rebuild subtree or the fully
+rebuilt one. A surviving inode's content changes under it, so the rebuild
+invalidates the kernel caches for exactly the inodes whose content changed and
+the directory entries that appeared, disappeared or moved to a different inode;
+caches for unchanged paths are left intact.
 
 ### `readdir`
 

--- a/docs/specs/fuse-filesystem/6-reactivity.md
+++ b/docs/specs/fuse-filesystem/6-reactivity.md
@@ -9,17 +9,33 @@ runtime itself), the filesystem must reflect the update.
 
 1. The Deno process subscribes to cell changes via the existing subscription
    mechanism (WebSocket to toolshed).
-2. On change notification, rebuild the affected subtree of the in-memory tree.
-3. Invalidate kernel caches for affected inodes via
+2. On change notification, rebuild the affected piece property. The rebuild
+   builds the new subtree under a staging name and reconciles it onto the live
+   subtree in place (`FsTree.transplantSubtree`), so a path that still exists
+   keeps its inode. The whole swap is synchronous, so no filesystem request
+   observes a half-rebuilt tree.
+3. Invalidate the kernel caches the rebuild actually made stale via
    `fuse_lowlevel_notify_inval_inode` / `fuse_lowlevel_notify_inval_entry`.
 
 ### Kernel Cache Invalidation
 
 The FUSE protocol supports `notify_inval_inode` and `notify_inval_entry` to
-tell the kernel that cached data is stale. When a cell changes:
+tell the kernel that cached data is stale. A rebuild reports the exact caches
+it invalidated, and only those are dropped:
 
-- `notify_inval_inode(inode, offset, len)` — invalidates cached file data
-- `notify_inval_entry(parent_inode, name)` — invalidates a directory entry
+- `notify_inval_inode(inode, offset, len)` — invalidates cached file data, for
+  each surviving inode whose file data, symlink target or callable script
+  changed.
+- `notify_inval_entry(parent_inode, name)` — invalidates a directory entry, for
+  each child name that appeared, disappeared, or now points at a different
+  inode.
+
+A path that kept its inode and content is invalidated by neither, so a client
+that walked into a piece keeps its cached lookups when an unrelated rebuild
+runs. A removed subtree needs no per-descendant inode
+invalidation: dropping the parent's directory entry is enough, and because
+inode numbers are only ever allocated upward and never reused, a stale cache
+for a freed inode number can never be observed.
 
 This ensures that subsequent reads from userspace processes get fresh data
 without requiring the process to close and reopen files.

--- a/docs/specs/fuse-filesystem/7-open-questions.md
+++ b/docs/specs/fuse-filesystem/7-open-questions.md
@@ -86,6 +86,23 @@ through the same transaction mechanism, so they participate in the same
 conflict resolution. No special handling needed, but users should be aware
 that concurrent edits may lose data.
 
+### Timestamps (`ctime`, `atime`)
+
+Should `ctime` and `atime` be tracked separately from `mtime`?
+
+They are reported equal to `mtime`. In this filesystem the only metadata that
+changes independently of content is the CFC annotation — mode is derived at
+stat time, and ownership and link counts are fixed — so a separately-tracked
+`ctime` would expose the timing of a node's label and generation changes to
+anyone who can `stat` it. The CFC spec treats that as an information channel:
+metadata field labels default to the content label, and §18.2.3.5 permits
+refining `mtime`/`ctime` "with a specific update event" but forbids labeling a
+field below what its metadata reveals. Reporting `ctime = mtime` exposes no
+channel beyond content-change timing, so the content-label default is exactly
+right. Tracking `ctime` separately would need a threat-model analysis and a
+label refinement for a benefit few tools use (`find -cnewer`, `ls -lc`), so it
+stays collapsed onto `mtime` until a concrete consumer needs it.
+
 ## Implementation
 
 ### macOS vs Linux

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -371,10 +371,13 @@ independently from libfuse. FUSE callbacks are registered via
 `Deno.UnsafeCallback` with `nonblocking: true` on the session loop, so WebSocket
 subscriptions and FUSE requests run concurrently on Deno's event loop.
 
-Cell data is cached in an in-memory tree (`FsTree`). Subscriptions rebuild
-affected subtrees on cell changes and ask the kernel to drop what it cached for
-them, naming the stale directory entries with `fuse_lowlevel_notify_inval_entry`
-and each stale inode with `fuse_lowlevel_notify_inval_inode`.
+Cell data is cached in an in-memory tree (`FsTree`). On a cell change the
+affected piece property is rebuilt by reconciling a freshly built subtree onto
+the live one in place, so a path that still exists keeps its inode across the
+rebuild. The rebuild then asks the kernel to drop only what actually went stale,
+naming the changed directory entries with `fuse_lowlevel_notify_inval_entry` and
+the inodes whose content changed with `fuse_lowlevel_notify_inval_inode`; caches
+for unchanged paths are left intact.
 
 Those notifications reach the kernel on Linux. FUSE-T returns success for both
 calls but its NFS backend does not act on either, so a rebuilt subtree stays

--- a/packages/fuse/RELIABILITY_DESIGN.md
+++ b/packages/fuse/RELIABILITY_DESIGN.md
@@ -23,10 +23,11 @@ The implementation already has several reliability foundations:
 - `cell-bridge.ts` exposes `.status`, marks the mount disconnected/read-only on
   transport errors, and reconnects with capped exponential backoff.
 - `cell-bridge.ts` serializes and coalesces per-piece-property rebuilds, dedupes
-  in-flight hydrations, stages rebuilds under pending roots, and invalidates
-  cache entries after committed cell changes.
+  in-flight hydrations, stages rebuilds under pending roots and reconciles them
+  onto the live subtree in place so inodes stay stable, and invalidates the
+  exact cache entries a rebuild changed.
 - `cfc-writeback.ts` persists prepared CFC writeback records, tracks crash-point
-  states, and reconciles records after inode churn or subtree rebuild.
+  states, and reconciles records after a subtree rebuild.
 
 The main gap is that several mutating paths still acknowledge FUSE success
 before the Common Fabric operation has reached a clear commit or acceptance

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -1,5 +1,6 @@
 // cell-bridge.test.ts — Integration tests for CellBridge using fake piece objects
 import { assertEquals, assertNotEquals } from "@std/assert";
+import { FakeTime } from "@std/testing/time";
 import { defer } from "@commonfabric/utils/defer";
 import { FsTree } from "./tree.ts";
 import {
@@ -1008,7 +1009,7 @@ Deno.test("CellBridge.hydratePieceProp returns early when a prop is already hydr
   assertEquals(tree.lookup(pieceIno, "result") !== undefined, true);
 });
 
-Deno.test("CellBridge.rebuildPieceProp keeps replaced callable inodes alive briefly", async () => {
+Deno.test("CellBridge.rebuildPieceProp reuses a callable's inode across a rebuild", async () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const state = buildTestSpace(bridge, "home", []);
@@ -1111,12 +1112,82 @@ Deno.test("CellBridge.rebuildPieceProp keeps replaced callable inodes alive brie
       spaceName: "home",
     });
 
+  // The result directory and the callable inside it both still exist at the
+  // same path with the same kind, so the rebuild adopts their inodes rather
+  // than allocating new ones.
   const currentResultIno = tree.lookup(pieceIno, "result");
-  assertEquals(currentResultIno !== undefined, true);
+  assertEquals(currentResultIno, initialResultIno);
   const currentToolIno = tree.lookup(currentResultIno!, "search.tool");
-  assertEquals(currentToolIno !== undefined, true);
-  assertEquals(currentToolIno === initialToolIno, false);
-  assertEquals(tree.getNode(initialToolIno!)?.kind, "callable");
+  assertEquals(currentToolIno, initialToolIno);
+  assertEquals(tree.getNode(currentToolIno!)?.kind, "callable");
+});
+
+Deno.test("CellBridge.rebuildPieceProp keeps inodes stable and invalidates only changed values", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+
+  const inputSchema = {
+    type: "object",
+    properties: { title: { type: "string" }, count: { type: "number" } },
+  };
+  const piece = {
+    id: "of:stable-inode-piece",
+    name: () => "Stable Piece",
+    getPatternMeta: () => Promise.resolve({}),
+    input: {
+      getCell: () =>
+        Promise.resolve(makeCell({ title: "before", count: 1 }, inputSchema)),
+      get: () => Promise.resolve({ title: "before", count: 1 }),
+    },
+    result: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+  };
+
+  state.pieceControllers.set(
+    "Stable Piece",
+    piece as unknown as SpaceState["pieceControllers"] extends
+      Map<string, infer T> ? T : never,
+  );
+  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
+    .loadPieceTree(piece, state.piecesIno, "Stable Piece", "home");
+  state.pieceMap.set("Stable Piece", piece.id);
+  state.pieceInos.set("Stable Piece", pieceIno);
+
+  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
+    .hydratePieceProp.call(bridge, pieceIno, "input");
+
+  const inputIno = tree.lookup(pieceIno, "input")!;
+  const titleIno = tree.lookup(inputIno, "title")!;
+  const countIno = tree.lookup(inputIno, "count")!;
+
+  const invalidatedInodes: bigint[] = [];
+  bridge.onInvalidateInode = (ino) => invalidatedInodes.push(ino);
+
+  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
+    .rebuildPieceProp.call(bridge, {
+      cell: makeCell({ title: "after", count: 1 }, inputSchema),
+      newValue: { title: "after", count: 1 },
+      pieceId: piece.id,
+      pieceIno,
+      pieceName: "Stable Piece",
+      propName: "input",
+      resolveLink: () => null,
+      spaceName: "home",
+    });
+
+  // Same paths, same kinds: the inodes are reused, not reallocated.
+  assertEquals(tree.lookup(pieceIno, "input"), inputIno);
+  assertEquals(tree.lookup(inputIno, "title"), titleIno);
+  assertEquals(tree.lookup(inputIno, "count"), countIno);
+  assertEquals(getFileContent(tree, inputIno, "title"), "after");
+
+  // Only the changed value's inode cache is dropped; the unchanged sibling is
+  // left cached.
+  assertEquals(invalidatedInodes.includes(titleIno), true);
+  assertEquals(invalidatedInodes.includes(countIno), false);
 });
 
 Deno.test("CellBridge queues piece prop rebuilds for the same prop", async () => {
@@ -1297,6 +1368,76 @@ Deno.test("CellBridge.rebuildPieceProp clears stale FS projection mounts when va
   assertEquals(tree.lookup(pieceIno, "index.md"), undefined);
   assertEquals(tree.lookup(pieceIno, "index.json"), undefined);
   assertEquals(tree.lookup(pieceIno, "meta"), undefined);
+});
+
+Deno.test("CellBridge.rebuildPieceProp keeps the FS projection index inode stable across a rebuild", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+
+  const makeFsResult = (content: string) => ({
+    $FS: { type: "text/markdown", content, frontmatter: { pinned: true } },
+  });
+  const resultCell = new SinkableCell(makeFsResult("Hello"));
+
+  const piece = {
+    id: "of:entity-stable-fs",
+    name: () => "Stable FS Fixture",
+    getPatternMeta: () => Promise.resolve({}),
+    input: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    result: {
+      getCell: () => Promise.resolve(resultCell as unknown as FakeCell),
+      get: () => Promise.resolve(resultCell.get()),
+    },
+  };
+
+  state.pieceControllers.set(
+    "Stable FS Fixture",
+    piece as unknown as SpaceState["pieceControllers"] extends
+      Map<string, infer T> ? T : never,
+  );
+  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
+    .loadPieceTree(piece, state.piecesIno, "Stable FS Fixture", "home");
+  state.pieceMap.set("Stable FS Fixture", piece.id);
+  state.pieceInos.set("Stable FS Fixture", pieceIno);
+
+  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
+    .hydratePieceProp.call(bridge, pieceIno, "result");
+
+  const indexIno = tree.lookup(pieceIno, "index.md")!;
+  assertEquals(indexIno !== undefined, true);
+  assertEquals(
+    getFileContent(tree, pieceIno, "index.md").includes("Hello"),
+    true,
+  );
+
+  const invalidatedInodes: bigint[] = [];
+  bridge.onInvalidateInode = (ino) => invalidatedInodes.push(ino);
+
+  resultCell.set(makeFsResult("Goodbye"));
+  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
+    .rebuildPieceProp.call(bridge, {
+      cell: resultCell as unknown as ReturnType<typeof makeCell>,
+      newValue: resultCell.get(),
+      pieceId: piece.id,
+      pieceIno,
+      pieceName: "Stable FS Fixture",
+      propName: "result",
+      resolveLink: () => null,
+      spaceName: "home",
+    });
+
+  // The projection index survives with the same inode and updated content, and
+  // its stale data cache is dropped.
+  assertEquals(tree.lookup(pieceIno, "index.md"), indexIno);
+  assertEquals(
+    getFileContent(tree, pieceIno, "index.md").includes("Goodbye"),
+    true,
+  );
+  assertEquals(invalidatedInodes.includes(indexIno), true);
 });
 
 Deno.test("CellBridge.hydratePieceProp labels void handlers as no-arg callables in .handlers", async () => {
@@ -1631,6 +1772,60 @@ Deno.test("CellBridge result hydration updates pieces.json summary from current 
   // Cancel subscriptions to avoid timer leaks
   const subs = state.pieceSubs.get("Summary-Piece");
   if (subs) { for (const cancel of subs) cancel(); }
+});
+
+Deno.test("CellBridge reactive rebuild keeps inodes stable across a cell change", async () => {
+  const time = new FakeTime();
+  try {
+    const tree = new FsTree();
+    const bridge = new CellBridge(tree, "/tmp/cf-exec");
+    const state = buildTestSpace(bridge, "home", []);
+    const resultCell = new SinkableCell({ title: "before", count: 1 });
+
+    const piece = {
+      id: "of:reactive-stable",
+      name: () => "Reactive Stable",
+      getPatternMeta: () => Promise.resolve({}),
+      input: {
+        getCell: () => Promise.resolve(makeCell({}, undefined)),
+        get: () => Promise.resolve({}),
+      },
+      result: {
+        getCell: () => Promise.resolve(resultCell as unknown as FakeCell),
+        get: () => Promise.resolve(resultCell.get()),
+      },
+    };
+
+    const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
+      .addPieceToSpace.bind(bridge);
+    await addPiece(state, piece, "home");
+
+    const pieceIno = tree.lookup(state.piecesIno, "Reactive-Stable")!;
+    await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
+      .hydratePieceProp.call(bridge, pieceIno, "result");
+
+    const resultIno = tree.lookup(pieceIno, "result")!;
+    const titleIno = tree.lookup(resultIno, "title")!;
+    const countIno = tree.lookup(resultIno, "count")!;
+
+    // An external mutation flows through the cell.sink subscription and is
+    // rebuilt after the debounce.
+    resultCell.set({ title: "after", count: 1 });
+    await time.tickAsync(200);
+    await time.runMicrotasks();
+
+    // The reactive rebuild reconciled the mounted tree in place instead of
+    // tearing it down, so a client that cached these paths keeps their inodes.
+    assertEquals(tree.lookup(pieceIno, "result"), resultIno);
+    assertEquals(tree.lookup(resultIno, "title"), titleIno);
+    assertEquals(tree.lookup(resultIno, "count"), countIno);
+    assertEquals(getFileContent(tree, resultIno, "title"), "after");
+
+    const subs = state.pieceSubs.get("Reactive-Stable");
+    if (subs) { for (const cancel of subs) cancel(); }
+  } finally {
+    time.restore();
+  }
 });
 
 Deno.test("CellBridge refreshes pattern references after an in-place swap", async () => {
@@ -2007,23 +2202,25 @@ Deno.test("CellBridge decodes encoded space directory names for write paths", ()
   assertEquals(writePath?.jsonPath, ["title"]);
 });
 
-Deno.test("CellBridge resolves write paths through a detached prop subtree", () => {
+Deno.test("CellBridge resolves a value file's write path after an in-place rebuild", () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const state = buildTestSpace(bridge, "did:key:zSpace", []);
-  const piece = { id: "of:detached-piece", name: () => "Detached Piece" };
+  const piece = { id: "of:rebuilt-piece", name: () => "Rebuilt Piece" };
   state.pieceControllers.set("notes", piece as never);
 
   const pieceIno = tree.addDir(state.piecesIno, "notes");
-  const inputIno = tree.addDir(pieceIno, "input");
+  const inputIno = tree.addDir(pieceIno, "input", "object");
   const lastMessageIno = tree.addFile(inputIno, "lastMessage", "hi", "string");
 
-  // A prop rebuild detaches the old `input` subtree, retains it so open handles
-  // keep working, and builds a replacement under the same name.
-  (bridge as unknown as { retainDetachedSubtree: (ino: bigint) => void })
-    .retainDetachedSubtree(inputIno);
-  const rebuiltInputIno = tree.addDir(pieceIno, "input");
-  tree.addFile(rebuiltInputIno, "lastMessage", "hi", "string");
+  // A rebuild reconciles a freshly built staging subtree onto the live one, so
+  // the value file survives the rebuild with the same inode. A write that
+  // arrives on that cached inode still resolves to the same cell.
+  const pendingIno = tree.addDir(pieceIno, ".input.pending", "object");
+  tree.addFile(pendingIno, "lastMessage", "hello", "string");
+  tree.transplantSubtree(inputIno, pendingIno);
+
+  assertEquals(tree.lookup(inputIno, "lastMessage"), lastMessageIno);
 
   const writePath = bridge.resolveWritePath(lastMessageIno);
   assertEquals(writePath?.spaceName, "did:key:zSpace");

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -1440,6 +1440,165 @@ Deno.test("CellBridge.rebuildPieceProp keeps the FS projection index inode stabl
   assertEquals(invalidatedInodes.includes(indexIno), true);
 });
 
+Deno.test("CellBridge.rebuildPieceProp invalidates the index dentry when an FS projection is removed", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+
+  const resultCell = new SinkableCell({
+    $FS: { type: "text/markdown", content: "Hello", frontmatter: {} },
+  });
+  const piece = {
+    id: "of:entity-fs-removed",
+    name: () => "FS Removed Fixture",
+    getPatternMeta: () => Promise.resolve({}),
+    input: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    result: {
+      getCell: () => Promise.resolve(resultCell as unknown as FakeCell),
+      get: () => Promise.resolve(resultCell.get()),
+    },
+  };
+  state.pieceControllers.set(
+    "FS Removed Fixture",
+    piece as unknown as SpaceState["pieceControllers"] extends
+      Map<string, infer T> ? T : never,
+  );
+  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
+    .loadPieceTree(piece, state.piecesIno, "FS Removed Fixture", "home");
+  state.pieceMap.set("FS Removed Fixture", piece.id);
+  state.pieceInos.set("FS Removed Fixture", pieceIno);
+
+  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
+    .hydratePieceProp.call(bridge, pieceIno, "result");
+  assertEquals(tree.lookup(pieceIno, "index.md") !== undefined, true);
+
+  const entryInvalidations: string[] = [];
+  bridge.onInvalidate = (parent, names) => {
+    if (parent === pieceIno) entryInvalidations.push(...names);
+  };
+
+  resultCell.set(null);
+  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
+    .rebuildPieceProp.call(bridge, {
+      cell: resultCell as unknown as ReturnType<typeof makeCell>,
+      newValue: null,
+      pieceId: piece.id,
+      pieceIno,
+      pieceName: "FS Removed Fixture",
+      propName: "result",
+      resolveLink: () => null,
+      spaceName: "home",
+    });
+
+  // The projection is gone from the tree, and its `index.md` dentry is
+  // invalidated so a client drops the entry instead of resolving a freed inode.
+  assertEquals(tree.lookup(pieceIno, "index.md"), undefined);
+  assertEquals(entryInvalidations.includes("index.md"), true);
+});
+
+Deno.test("CellBridge.rebuildPieceProp advances the piece dir mtime only when its entries change", async () => {
+  let clock = 1_000;
+  const tree = new FsTree(() => clock);
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+
+  const resultSchema = {
+    type: "object",
+    properties: { title: { type: "string" }, count: { type: "number" } },
+  };
+  const piece = {
+    id: "of:piece-dir-mtime",
+    name: () => "Dir Mtime Fixture",
+    getPatternMeta: () => Promise.resolve({}),
+    input: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    result: {
+      getCell: () =>
+        Promise.resolve(makeCell({ title: "a", count: 1 }, resultSchema)),
+      get: () => Promise.resolve({ title: "a", count: 1 }),
+    },
+  };
+  state.pieceControllers.set(
+    "Dir Mtime Fixture",
+    piece as unknown as SpaceState["pieceControllers"] extends
+      Map<string, infer T> ? T : never,
+  );
+  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
+    .loadPieceTree(piece, state.piecesIno, "Dir Mtime Fixture", "home");
+  state.pieceMap.set("Dir Mtime Fixture", piece.id);
+  state.pieceInos.set("Dir Mtime Fixture", pieceIno);
+
+  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
+    .hydratePieceProp.call(bridge, pieceIno, "result");
+  const afterHydrate = tree.getNode(pieceIno)!.mtime;
+
+  // A content-only rebuild leaves the piece directory's entry set unchanged, so
+  // its mtime is preserved.
+  clock = 2_000;
+  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
+    .rebuildPieceProp.call(bridge, {
+      cell: makeCell({ title: "b", count: 1 }, resultSchema),
+      newValue: { title: "b", count: 1 },
+      pieceId: piece.id,
+      pieceIno,
+      pieceName: "Dir Mtime Fixture",
+      propName: "result",
+      resolveLink: () => null,
+      spaceName: "home",
+    });
+  assertEquals(tree.getNode(pieceIno)!.mtime, afterHydrate);
+
+  // Removing the result drops result/, result.json and .handlers from the piece
+  // directory, so its mtime advances.
+  clock = 3_000;
+  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
+    .rebuildPieceProp.call(bridge, {
+      cell: makeCell(null, undefined),
+      newValue: null,
+      pieceId: piece.id,
+      pieceIno,
+      pieceName: "Dir Mtime Fixture",
+      propName: "result",
+      resolveLink: () => null,
+      spaceName: "home",
+    });
+  assertEquals(tree.getNode(pieceIno)!.mtime, 3_000);
+});
+
+Deno.test("CellBridge.addPieceToSpace advances the pieces directory mtime", async () => {
+  let clock = 1_000;
+  const tree = new FsTree(() => clock);
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+  const beforeAdd = tree.getNode(state.piecesIno)!.mtime;
+
+  const piece = {
+    id: "of:added-piece",
+    name: () => "Added Piece",
+    getPatternMeta: () => Promise.resolve({}),
+    input: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    result: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+  };
+  clock = 5_000;
+  await (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
+    .addPieceToSpace(state, piece, "home");
+
+  // The pieces directory gained an entry, so its mtime advances past its value
+  // at space construction.
+  assertEquals(tree.getNode(state.piecesIno)!.mtime > beforeAdd, true);
+});
+
 Deno.test("CellBridge.hydratePieceProp labels void handlers as no-arg callables in .handlers", async () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -1440,6 +1440,64 @@ Deno.test("CellBridge.rebuildPieceProp keeps the FS projection index inode stabl
   assertEquals(invalidatedInodes.includes(indexIno), true);
 });
 
+Deno.test("CellBridge.rebuildPieceProp reconciles a prop changing from an object to a scalar", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+
+  const objectSchema = {
+    type: "object",
+    properties: { title: { type: "string" } },
+  };
+  const piece = {
+    id: "of:object-to-scalar",
+    name: () => "Object To Scalar",
+    getPatternMeta: () => Promise.resolve({}),
+    input: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    result: {
+      getCell: () => Promise.resolve(makeCell({ title: "x" }, objectSchema)),
+      get: () => Promise.resolve({ title: "x" }),
+    },
+  };
+  state.pieceControllers.set(
+    "Object To Scalar",
+    piece as unknown as SpaceState["pieceControllers"] extends
+      Map<string, infer T> ? T : never,
+  );
+  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
+    .loadPieceTree(piece, state.piecesIno, "Object To Scalar", "home");
+  state.pieceMap.set("Object To Scalar", piece.id);
+  state.pieceInos.set("Object To Scalar", pieceIno);
+
+  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
+    .hydratePieceProp.call(bridge, pieceIno, "result");
+  assertEquals(tree.getNode(tree.lookup(pieceIno, "result")!)?.kind, "dir");
+  assertEquals(tree.lookup(pieceIno, "result.json") !== undefined, true);
+
+  // The result becomes a bare string: `result` changes kind from a directory
+  // to a file (its inode is replaced), and its `.json` sibling disappears
+  // because a scalar has no aggregate form.
+  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
+    .rebuildPieceProp.call(bridge, {
+      cell: makeCell("y", undefined),
+      newValue: "y",
+      pieceId: piece.id,
+      pieceIno,
+      pieceName: "Object To Scalar",
+      propName: "result",
+      resolveLink: () => null,
+      spaceName: "home",
+    });
+
+  const resultIno = tree.lookup(pieceIno, "result");
+  assertEquals(tree.getNode(resultIno!)?.kind, "file");
+  assertEquals(getFileContent(tree, pieceIno, "result"), "y");
+  assertEquals(tree.lookup(pieceIno, "result.json"), undefined);
+});
+
 Deno.test("CellBridge.rebuildPieceProp invalidates the index dentry when an FS projection is removed", async () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -17,7 +17,7 @@ import {
   deriveCfcProjectionGeneration,
   joinLabels,
 } from "./annotations.ts";
-import { FsTree } from "./tree.ts";
+import { FsTree, type TransplantChanges } from "./tree.ts";
 import {
   buildCallableScript,
   type CallableKind,
@@ -304,7 +304,6 @@ export class CellBridge {
   /** In-flight hydration promises keyed by `${pieceIno}-${propName}`. */
   private pendingHydrations = new Map<string, Promise<boolean>>();
   private pendingPropRebuildQueues = new Map<string, Promise<void>>();
-  private retainedSubtrees = new Map<bigint, number>();
   /** Monotonic invalidation epoch per hydration key. */
   private hydrationEpochs = new Map<string, number>();
   /**
@@ -828,20 +827,6 @@ export class CellBridge {
     this.hydratedPieceProps.get(pieceIno)?.delete(propName);
   }
 
-  private cleanupRetainedSubtrees(now = Date.now()): void {
-    for (const [ino, expiresAt] of this.retainedSubtrees) {
-      if (expiresAt > now) continue;
-      this.retainedSubtrees.delete(ino);
-      this.tree.clear(ino);
-    }
-  }
-
-  private retainDetachedSubtree(ino: bigint, ttlMs = 1000): void {
-    if (!this.tree.getNode(ino)) return;
-    this.tree.detach(ino);
-    this.retainedSubtrees.set(ino, Date.now() + ttlMs);
-  }
-
   private getPieceInfo(
     pieceIno: bigint,
   ): (PieceRootInfo & { state?: SpaceState }) | null {
@@ -867,7 +852,6 @@ export class CellBridge {
   }
 
   async prepareLookup(parentIno: bigint, name: string): Promise<boolean> {
-    this.cleanupRetainedSubtrees();
     if (this.isEntitiesDir(parentIno)) {
       return await this.resolveEntity(parentIno, name);
     }
@@ -898,7 +882,6 @@ export class CellBridge {
   }
 
   async prepareDirectory(ino: bigint): Promise<boolean> {
-    this.cleanupRetainedSubtrees();
     const pieceInfo = this.getPieceInfo(ino);
     if (pieceInfo) {
       await this.hydratePieceProp(ino, "input");
@@ -1234,6 +1217,121 @@ export class CellBridge {
     this.updateStatus();
   }
 
+  /**
+   * Swap a freshly built staging node into its live position.
+   *
+   * When the live node and the staging node share a kind, their subtrees are
+   * reconciled in place so the live inode survives (see
+   * {@link FsTree.transplantSubtree}); the inodes whose content changed are
+   * appended to `changedInodes` so the caller can drop their kernel data
+   * cache. When the kinds differ, or when there is no live node, the staging
+   * node takes the live name with its freshly allocated inode. When the
+   * replacement produced no staging node, the live node is removed.
+   *
+   * This runs synchronously, so no filesystem request observes a half-swapped
+   * tree.
+   */
+  private swapPending(
+    parentIno: bigint,
+    liveName: string,
+    pendingName: string,
+    oldIno: bigint | undefined,
+    changes: TransplantChanges,
+    annotator?: CfcProjectionAnnotator,
+  ): void {
+    const pendingIno = this.tree.lookup(parentIno, pendingName);
+    if (pendingIno === undefined) {
+      if (oldIno !== undefined) {
+        this.tree.clear(oldIno);
+        this.recordEntryChange(changes, parentIno, liveName);
+      }
+      return;
+    }
+    const pendingNode = this.tree.getNode(pendingIno);
+    const oldNode = oldIno !== undefined
+      ? this.tree.getNode(oldIno)
+      : undefined;
+    if (oldNode && pendingNode && oldNode.kind === pendingNode.kind) {
+      // Same path, same kind: the live inode survives, so its entry under the
+      // parent is unchanged and is left cached.
+      this.mergeTransplantChanges(
+        changes,
+        this.tree.transplantSubtree(oldIno!, pendingIno),
+      );
+      annotator?.annotateEntry(parentIno, liveName, oldIno!);
+    } else {
+      if (oldIno !== undefined) {
+        this.tree.clear(oldIno);
+      }
+      this.tree.rename(parentIno, pendingName, parentIno, liveName);
+      const movedIno = this.tree.lookup(parentIno, liveName);
+      if (movedIno !== undefined) {
+        annotator?.annotateEntry(parentIno, liveName, movedIno);
+      }
+      this.recordEntryChange(changes, parentIno, liveName);
+    }
+  }
+
+  private recordEntryChange(
+    changes: TransplantChanges,
+    parentIno: bigint,
+    name: string,
+  ): void {
+    let names = changes.entryChanges.get(parentIno);
+    if (!names) {
+      names = new Set();
+      changes.entryChanges.set(parentIno, names);
+    }
+    names.add(name);
+  }
+
+  private mergeTransplantChanges(
+    into: TransplantChanges,
+    from: TransplantChanges,
+  ): void {
+    for (const ino of from.changedInodes) {
+      into.changedInodes.add(ino);
+    }
+    for (const [parentIno, names] of from.entryChanges) {
+      for (const name of names) {
+        this.recordEntryChange(into, parentIno, name);
+      }
+    }
+  }
+
+  /**
+   * Drop exactly the kernel caches a rebuild made stale: the changed inodes'
+   * data, and the changed directory entries. Entries and inodes the rebuild
+   * left untouched stay cached, so a client that walked into the piece does
+   * not have its cached dentries invalidated by an unrelated rebuild.
+   */
+  private emitInvalidations(changes: TransplantChanges): void {
+    if (this.onInvalidateInode) {
+      for (const ino of changes.changedInodes) {
+        this.onInvalidateInode(ino);
+      }
+    }
+    if (this.onInvalidate) {
+      for (const [parentIno, names] of changes.entryChanges) {
+        this.onInvalidate(parentIno, [...names]);
+      }
+    }
+  }
+
+  /**
+   * Advance the hydration epoch for a prop so an in-flight hydration that read
+   * a now-superseded value re-reads and rebuilds. Used when a cell change
+   * arrives: the mounted tree is rebuilt in place rather than torn down, so
+   * this is all the reactive path needs to stay consistent.
+   */
+  private bumpHydrationEpoch(
+    rootIno: bigint,
+    propName: "input" | "result",
+  ): void {
+    const key = `${rootIno}-${propName}`;
+    this.hydrationEpochs.set(key, (this.hydrationEpochs.get(key) ?? 0) + 1);
+  }
+
   private async rebuildPieceProp(args: {
     cell: Cell<unknown>;
     newValue: unknown;
@@ -1244,7 +1342,6 @@ export class CellBridge {
     resolveLink: ResolveLink;
     spaceName: string;
   }): Promise<void> {
-    this.cleanupRetainedSubtrees();
     const startedAt = Date.now();
     if (this.tree.getNode(args.pieceIno)?.kind !== "dir") {
       return;
@@ -1288,6 +1385,14 @@ export class CellBridge {
     let callables: Array<
       { key: string; callableKind: CallableKind; schema?: JSONSchema }
     > = [];
+    // The kernel caches that this rebuild made stale: inodes whose content
+    // changed and, per directory, the child names whose entry changed. Only
+    // these are invalidated, so a client keeps every cache entry the rebuild
+    // left untouched.
+    const changes: TransplantChanges = {
+      changedInodes: new Set(),
+      entryChanges: new Map(),
+    };
     if (treeValue !== undefined && treeValue !== null) {
       const {
         callables: discoveredCallables,
@@ -1300,15 +1405,36 @@ export class CellBridge {
         const fsValue = this.readFsValue(cell, treeValue);
         if (fsValue !== null) {
           this.markPiecePropCleared(pieceIno, propName);
+
+          // The projection entries currently at the piece root; a rebuild
+          // adopts the ones that survive with the same kind and removes the
+          // rest.
+          const oldFsNames = new Set<string>(
+            this.fsProjectionEntries.get(pieceIno) ?? [],
+          );
+          oldFsNames.add("index.md");
+          oldFsNames.add("index.json");
+
+          // Switching from a normal result/ tree to an [FS] projection replaces
+          // the result directory and its .json sibling.
           if (existingIno !== undefined) {
             this.tree.clear(existingIno);
+            this.recordEntryChange(changes, pieceIno, propName);
           }
           if (jsonIno !== undefined) {
             this.tree.clear(jsonIno);
+            this.recordEntryChange(changes, pieceIno, `${propName}.json`);
           }
-          this.clearFsProjectionEntries(pieceIno);
-          const indexName = this.buildFsProjectionTree(
-            pieceIno,
+
+          // Build the projection under a staging container, then reconcile it
+          // onto the piece directory so a surviving entry keeps its inode.
+          const staleStage = this.tree.lookup(pieceIno, ".fs.pending");
+          if (staleStage !== undefined) {
+            this.tree.clear(staleStage);
+          }
+          const stageIno = this.tree.addDir(pieceIno, ".fs.pending");
+          this.buildFsProjectionTree(
+            stageIno,
             pieceId,
             fsValue,
             treeValue,
@@ -1318,7 +1444,18 @@ export class CellBridge {
             classifyEntry,
             cfcAnnotator,
           );
+          const newFsNames = this.swapFsProjection(
+            pieceIno,
+            stageIno,
+            oldFsNames,
+            changes,
+            cfcAnnotator,
+          );
+          this.fsProjectionEntries.set(pieceIno, newFsNames);
+
           this.buildHandlersFile(pieceIno, callables, cfcAnnotator);
+          this.recordEntryChange(changes, pieceIno, ".handlers");
+
           const state = this.spaces.get(spaceName);
           if (state) {
             const summaryChanged = this.updatePieceManifest(state, pieceId, {
@@ -1331,9 +1468,7 @@ export class CellBridge {
               }
             }
           }
-          if (this.onInvalidate) {
-            this.onInvalidate(pieceIno, [indexName, ".handlers"]);
-          }
+          this.emitInvalidations(changes);
           this.markPiecePropHydrated(pieceIno, "result");
           this.rebuildStats.completed++;
           this.rebuildStats.lastDurationMs = Date.now() - startedAt;
@@ -1377,59 +1512,62 @@ export class CellBridge {
       }
       if (buildRootName === pendingPropName) {
         this.markPiecePropCleared(pieceIno, propName);
-        if (existingIno !== undefined) {
-          this.retainDetachedSubtree(existingIno);
-        }
-        if (jsonIno !== undefined) {
-          this.retainDetachedSubtree(jsonIno);
-        }
         if (propName === "result") {
           this.clearFsProjectionEntries(pieceIno);
         }
-        this.tree.rename(pieceIno, pendingPropName, pieceIno, propName);
-        const renamedPropIno = this.tree.lookup(pieceIno, propName);
-        if (renamedPropIno !== undefined) {
-          cfcAnnotator?.annotateEntry(pieceIno, propName, renamedPropIno);
+        // Reconcile the freshly built staging subtree onto the existing one,
+        // reusing the existing inodes rather than swapping in fresh ones, so a
+        // path that still exists keeps its inode across the rebuild.
+        this.swapPending(
+          pieceIno,
+          propName,
+          pendingPropName,
+          existingIno,
+          changes,
+          cfcAnnotator,
+        );
+        this.swapPending(
+          pieceIno,
+          `${propName}.json`,
+          pendingJsonName,
+          jsonIno,
+          changes,
+          cfcAnnotator,
+        );
+      } else {
+        if (propName === "result") {
+          this.clearFsProjectionEntries(pieceIno);
         }
-        if (this.tree.lookup(pieceIno, pendingJsonName) !== undefined) {
-          this.tree.rename(
-            pieceIno,
-            pendingJsonName,
-            pieceIno,
-            `${propName}.json`,
-          );
-          const renamedJsonIno = this.tree.lookup(pieceIno, `${propName}.json`);
-          if (renamedJsonIno !== undefined) {
-            cfcAnnotator?.annotateEntry(
-              pieceIno,
-              `${propName}.json`,
-              renamedJsonIno,
-            );
-          }
+        // First hydration: the prop directory and its `.json` sibling are new
+        // to any cache, so their entries under the piece are invalidated.
+        this.recordEntryChange(changes, pieceIno, propName);
+        if (this.tree.lookup(pieceIno, `${propName}.json`) !== undefined) {
+          this.recordEntryChange(changes, pieceIno, `${propName}.json`);
         }
-      } else if (propName === "result") {
-        this.clearFsProjectionEntries(pieceIno);
       }
       this.markPiecePropHydrated(pieceIno, propName);
     } else {
       this.markPiecePropCleared(pieceIno, propName);
       if (existingIno !== undefined) {
-        this.retainDetachedSubtree(existingIno);
+        this.tree.clear(existingIno);
+        this.recordEntryChange(changes, pieceIno, propName);
       }
       if (jsonIno !== undefined) {
-        this.retainDetachedSubtree(jsonIno);
+        this.tree.clear(jsonIno);
+        this.recordEntryChange(changes, pieceIno, `${propName}.json`);
       }
       if (propName === "result") {
         this.clearFsProjectionEntries(pieceIno);
       }
     }
     if (propName === "result") {
+      // `.handlers` is rebuilt on the piece directory, outside the prop
+      // subtree the transplant reconciled, so its entry is invalidated here.
       this.buildHandlersFile(pieceIno, callables, cfcAnnotator);
+      this.recordEntryChange(changes, pieceIno, ".handlers");
     }
 
-    if (this.onInvalidate) {
-      this.onInvalidate(pieceIno, [propName, `${propName}.json`]);
-    }
+    this.emitInvalidations(changes);
 
     if (propName === "result") {
       const state = this.spaces.get(spaceName);
@@ -2421,7 +2559,7 @@ export class CellBridge {
     const entries = this.fsProjectionEntries.get(pieceIno);
     this.fsProjectionEntries.delete(pieceIno);
 
-    for (const name of ["index.md", "index.json"]) {
+    for (const name of ["index.md", "index.json", ".fs.pending"]) {
       const ino = this.tree.lookup(pieceIno, name);
       if (ino !== undefined) this.tree.clear(ino);
     }
@@ -2433,8 +2571,15 @@ export class CellBridge {
     }
   }
 
+  /**
+   * Build a piece's [FS] projection under `parentIno`, which is a staging
+   * container so the finished projection can be reconciled onto the piece
+   * directory without churning inodes. Returns the index file name and the set
+   * of entry names produced, so the caller can swap them into place and record
+   * which piece-root names the projection now owns.
+   */
   private buildFsProjectionTree(
-    pieceIno: bigint,
+    parentIno: bigint,
     pieceId: string,
     fsValue: FsValue,
     treeValue: unknown,
@@ -2445,7 +2590,7 @@ export class CellBridge {
     skipEntry: (value: unknown) => boolean,
     classifyEntry: (key: string, value: unknown) => CallableKind | null,
     annotator?: CfcProjectionAnnotator,
-  ): "index.md" | "index.json" {
+  ): { indexName: "index.md" | "index.json"; entries: Set<string> } {
     const entries = new Set<string>();
     const indexName = fsValue.type === "text/markdown"
       ? "index.md"
@@ -2454,11 +2599,11 @@ export class CellBridge {
 
     const indexIno = buildFsProjection(
       this.tree,
-      pieceIno,
+      parentIno,
       fsValue,
       pieceId,
       (siblingParentIno, name, value) => {
-        if (siblingParentIno === pieceIno) {
+        if (siblingParentIno === parentIno) {
           entries.add(encodeFuseComponent(name, { reserveJsonSuffix: true }));
         }
         this.makeFsSubtreeBuilder(
@@ -2475,11 +2620,11 @@ export class CellBridge {
       indexIno,
       "fs-projection",
       [indexName],
-      { ino: pieceIno, name: indexName },
+      { ino: parentIno, name: indexName },
       projectionLabel,
     );
 
-    this.addVNodeJsonFiles(pieceIno, treeValue, annotator);
+    this.addVNodeJsonFiles(parentIno, treeValue, annotator);
     if (
       typeof treeValue === "object" && treeValue !== null &&
       !Array.isArray(treeValue)
@@ -2489,13 +2634,63 @@ export class CellBridge {
       }
     }
 
-    this.addCallableFiles(pieceIno, callables, "result", annotator);
+    this.addCallableFiles(parentIno, callables, "result", annotator);
     for (const { key, callableKind } of callables) {
       entries.add(`${encodeFuseComponent(key)}.${callableKind}`);
     }
 
-    this.fsProjectionEntries.set(pieceIno, entries);
-    return indexName;
+    return { indexName, entries };
+  }
+
+  /**
+   * Reconcile a staging container's children onto the piece directory, adopting
+   * an existing inode whenever a name survives with the same node kind so [FS]
+   * projection entries keep their inode across a rebuild. Old projection entries
+   * absent from the rebuild are removed. Returns the entry names now present.
+   */
+  private swapFsProjection(
+    pieceIno: bigint,
+    stageIno: bigint,
+    oldNames: Iterable<string>,
+    changes: TransplantChanges,
+    annotator?: CfcProjectionAnnotator,
+  ): Set<string> {
+    const newNames = new Set<string>();
+    for (const [name, stagedIno] of this.tree.getChildren(stageIno)) {
+      newNames.add(name);
+      const oldIno = this.tree.lookup(pieceIno, name);
+      const oldNode = oldIno !== undefined
+        ? this.tree.getNode(oldIno)
+        : undefined;
+      const stagedNode = this.tree.getNode(stagedIno);
+      if (oldNode && stagedNode && oldNode.kind === stagedNode.kind) {
+        this.mergeTransplantChanges(
+          changes,
+          this.tree.transplantSubtree(oldIno!, stagedIno),
+        );
+        annotator?.annotateEntry(pieceIno, name, oldIno!);
+      } else {
+        if (oldIno !== undefined) {
+          this.tree.clear(oldIno);
+        }
+        this.tree.rename(stageIno, name, pieceIno, name);
+        const movedIno = this.tree.lookup(pieceIno, name);
+        if (movedIno !== undefined) {
+          annotator?.annotateEntry(pieceIno, name, movedIno);
+        }
+        this.recordEntryChange(changes, pieceIno, name);
+      }
+    }
+    for (const name of oldNames) {
+      if (newNames.has(name)) continue;
+      const oldIno = this.tree.lookup(pieceIno, name);
+      if (oldIno !== undefined) {
+        this.tree.clear(oldIno);
+        this.recordEntryChange(changes, pieceIno, name);
+      }
+    }
+    this.tree.clear(stageIno);
+    return newNames;
   }
 
   private discoverCallableEntries(
@@ -2922,7 +3117,11 @@ export class CellBridge {
               // the piece getter in that case. If the value is still
               // undefined, keep the current mounted tree intact until a
               // concrete replacement arrives.
-              this.invalidateRootPropCache(pieceIno, propName);
+              //
+              // The rebuild reconciles onto the mounted tree in place, so the
+              // tree is not torn down first; advancing the hydration epoch is
+              // enough to make an in-flight hydration re-read the new value.
+              this.bumpHydrationEpoch(pieceIno, propName);
               await this.enqueuePiecePropRebuild({
                 cell,
                 newValue: rebuildValue,

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -1319,6 +1319,25 @@ export class CellBridge {
   }
 
   /**
+   * Advance the piece directory's mtime if its top-level entry set changed
+   * since `namesBefore`. Compares names, not inodes, so a rebuilt `.handlers`
+   * (same name, new inode) does not count while a prop appearing or an
+   * `index.md` replacing the result tree does.
+   */
+  private touchPieceDirIfEntriesChanged(
+    pieceIno: bigint,
+    namesBefore: Set<string>,
+  ): void {
+    const namesAfter = this.tree.getChildren(pieceIno).map(([name]) => name);
+    if (
+      namesAfter.length !== namesBefore.size ||
+      namesAfter.some((name) => !namesBefore.has(name))
+    ) {
+      this.tree.touch(pieceIno);
+    }
+  }
+
+  /**
    * Advance the hydration epoch for a prop so an in-flight hydration that read
    * a now-superseded value re-reads and rebuilds. Used when a cell change
    * arrives: the mounted tree is rebuilt in place rather than torn down, so
@@ -1393,6 +1412,15 @@ export class CellBridge {
       changedInodes: new Set(),
       entryChanges: new Map(),
     };
+    // The piece directory's top-level entries (input, result, index.md,
+    // .handlers, …) can appear or disappear across this rebuild — a prop
+    // hydrating, or a result switching between the normal tree and an [FS]
+    // projection. Its mtime is advanced only if that name set changes; a
+    // content-only rebuild leaves it untouched. Staging containers are transient
+    // within a rebuild, so they are absent from both the before and after names.
+    const pieceNamesBefore = new Set(
+      this.tree.getChildren(pieceIno).map(([name]) => name),
+    );
     if (treeValue !== undefined && treeValue !== null) {
       const {
         callables: discoveredCallables,
@@ -1468,6 +1496,7 @@ export class CellBridge {
               }
             }
           }
+          this.touchPieceDirIfEntriesChanged(pieceIno, pieceNamesBefore);
           this.emitInvalidations(changes);
           this.markPiecePropHydrated(pieceIno, "result");
           this.rebuildStats.completed++;
@@ -1513,7 +1542,7 @@ export class CellBridge {
       if (buildRootName === pendingPropName) {
         this.markPiecePropCleared(pieceIno, propName);
         if (propName === "result") {
-          this.clearFsProjectionEntries(pieceIno);
+          this.clearFsProjectionEntries(pieceIno, changes);
         }
         // Reconcile the freshly built staging subtree onto the existing one,
         // reusing the existing inodes rather than swapping in fresh ones, so a
@@ -1536,7 +1565,7 @@ export class CellBridge {
         );
       } else {
         if (propName === "result") {
-          this.clearFsProjectionEntries(pieceIno);
+          this.clearFsProjectionEntries(pieceIno, changes);
         }
         // First hydration: the prop directory and its `.json` sibling are new
         // to any cache, so their entries under the piece are invalidated.
@@ -1557,7 +1586,7 @@ export class CellBridge {
         this.recordEntryChange(changes, pieceIno, `${propName}.json`);
       }
       if (propName === "result") {
-        this.clearFsProjectionEntries(pieceIno);
+        this.clearFsProjectionEntries(pieceIno, changes);
       }
     }
     if (propName === "result") {
@@ -1567,6 +1596,7 @@ export class CellBridge {
       this.recordEntryChange(changes, pieceIno, ".handlers");
     }
 
+    this.touchPieceDirIfEntriesChanged(pieceIno, pieceNamesBefore);
     this.emitInvalidations(changes);
 
     if (propName === "result") {
@@ -2304,6 +2334,10 @@ export class CellBridge {
       piece,
     });
 
+    // The pieces and entities directories gained an entry.
+    this.tree.touch(state.piecesIno);
+    this.tree.touch(state.entitiesIno);
+
     return name;
   }
 
@@ -2326,7 +2360,9 @@ export class CellBridge {
     }
 
     // Remove tree nodes
-    this.tree.removeChild(state.piecesIno, name);
+    if (this.tree.removeChild(state.piecesIno, name) !== undefined) {
+      this.tree.touch(state.piecesIno);
+    }
 
     // Clean up entity tree
     if (pieceId) {
@@ -2336,7 +2372,9 @@ export class CellBridge {
         this.unregisterPieceRoot(entityIno);
         this.fsProjectionEntries.delete(entityIno);
       }
-      this.tree.removeChild(state.entitiesIno, entityName);
+      if (this.tree.removeChild(state.entitiesIno, entityName) !== undefined) {
+        this.tree.touch(state.entitiesIno);
+      }
     }
 
     state.pieceMap.delete(name);
@@ -2555,19 +2593,39 @@ export class CellBridge {
     }
   }
 
-  private clearFsProjectionEntries(pieceIno: bigint): void {
+  /**
+   * Remove a piece's [FS] projection entries from the tree. When `changes` is
+   * supplied, each removed entry is recorded so its cached directory entry is
+   * invalidated — a projection leaving the piece root (the result becomes null
+   * or switches back to the normal result tree) must drop the client's cached
+   * `index.md` and sibling dentries, or they resolve to freed inodes. The
+   * `.fs.pending` staging container is internal and never has a cached entry,
+   * so it is cleared but not recorded.
+   */
+  private clearFsProjectionEntries(
+    pieceIno: bigint,
+    changes?: TransplantChanges,
+  ): void {
     const entries = this.fsProjectionEntries.get(pieceIno);
     this.fsProjectionEntries.delete(pieceIno);
 
     for (const name of ["index.md", "index.json", ".fs.pending"]) {
       const ino = this.tree.lookup(pieceIno, name);
-      if (ino !== undefined) this.tree.clear(ino);
+      if (ino !== undefined) {
+        this.tree.clear(ino);
+        if (changes && name !== ".fs.pending") {
+          this.recordEntryChange(changes, pieceIno, name);
+        }
+      }
     }
 
     if (!entries) return;
     for (const name of entries) {
       const ino = this.tree.lookup(pieceIno, name);
-      if (ino !== undefined) this.tree.clear(ino);
+      if (ino !== undefined) {
+        this.tree.clear(ino);
+        if (changes) this.recordEntryChange(changes, pieceIno, name);
+      }
     }
   }
 

--- a/packages/fuse/platform-darwin.ts
+++ b/packages/fuse/platform-darwin.ts
@@ -12,6 +12,7 @@ import {
   type FuseProvider,
   makeWriteEntryParam,
   type MountHandle,
+  msToTimespec,
   type StatOpts,
 } from "./platform.ts";
 
@@ -76,6 +77,19 @@ type DarwinLib = Deno.DynamicLibrary<typeof DARWIN_SYMBOLS>;
 
 const STAT_SIZE = 144;
 const STAT_ST_SIZE_OFFSET = 96;
+const STAT_ST_MTIM_OFFSET = 48;
+
+// macOS struct stat timespec offsets (64-bit inode layout):
+//   st_atimespec @ 32 (tv_sec @ 32, tv_nsec @ 40)
+//   st_mtimespec @ 48 (tv_sec @ 48, tv_nsec @ 56)
+//   st_ctimespec @ 64 (tv_sec @ 64, tv_nsec @ 72)
+function writeTimespecs(view: DataView, mtime?: number): void {
+  const { sec, nsec } = msToTimespec(mtime);
+  for (const secOffset of [32, 48, 64]) {
+    view.setBigInt64(secOffset, sec, true);
+    view.setBigInt64(secOffset + 8, nsec, true);
+  }
+}
 
 function writeStat(buf: ArrayBuffer, opts: StatOpts): void {
   const view = new DataView(buf);
@@ -85,6 +99,7 @@ function writeStat(buf: ArrayBuffer, opts: StatOpts): void {
   view.setBigUint64(8, opts.ino, true); // st_ino
   view.setUint32(16, opts.uid ?? 0, true); // st_uid
   view.setUint32(20, opts.gid ?? 0, true); // st_gid
+  writeTimespecs(view, opts.mtime); // st_atimespec/st_mtimespec/st_ctimespec
   view.setBigInt64(96, BigInt(opts.size), true); // st_size
 }
 
@@ -219,6 +234,7 @@ const darwinPlatform: FusePlatform = {
   OPS_OFFSETS,
   FUSE_ARGS_STRUCT_SIZE,
   STAT_ST_SIZE_OFFSET,
+  STAT_ST_MTIM_OFFSET,
 
   writeStat,
   writeEntryParam,

--- a/packages/fuse/platform-linux.ts
+++ b/packages/fuse/platform-linux.ts
@@ -11,6 +11,7 @@ import {
   type FusePlatform,
   makeWriteEntryParam,
   type MountHandle,
+  msToTimespec,
   type StatOpts,
 } from "./platform.ts";
 
@@ -67,6 +68,11 @@ type LinuxLib = Deno.DynamicLibrary<typeof LINUX_SYMBOLS>;
 
 const STAT_SIZE = 144;
 const STAT_ST_SIZE_OFFSET = 48;
+// struct timespec members (Linux x86_64):
+//   st_atim @ 72 (tv_sec @ 72, tv_nsec @ 80)
+//   st_mtim @ 88 (tv_sec @ 88, tv_nsec @ 96)
+//   st_ctim @ 104 (tv_sec @ 104, tv_nsec @ 112)
+const STAT_ST_MTIM_OFFSET = 88;
 
 function writeStat(buf: ArrayBuffer, opts: StatOpts): void {
   const view = new DataView(buf);
@@ -77,6 +83,11 @@ function writeStat(buf: ArrayBuffer, opts: StatOpts): void {
   view.setUint32(28, opts.uid ?? 0, true); // st_uid @ 28
   view.setUint32(32, opts.gid ?? 0, true); // st_gid @ 32
   view.setBigInt64(48, BigInt(opts.size), true); // st_size @ 48
+  const { sec, nsec } = msToTimespec(opts.mtime);
+  for (const secOffset of [72, 88, 104]) { // st_atim/st_mtim/st_ctim
+    view.setBigInt64(secOffset, sec, true);
+    view.setBigInt64(secOffset + 8, nsec, true);
+  }
 }
 
 // --- fuse_entry_param ---
@@ -219,6 +230,7 @@ const linuxPlatform: FusePlatform = {
   OPS_OFFSETS,
   FUSE_ARGS_STRUCT_SIZE,
   STAT_ST_SIZE_OFFSET,
+  STAT_ST_MTIM_OFFSET,
 
   writeStat,
   writeEntryParam,

--- a/packages/fuse/platform-structs.test.ts
+++ b/packages/fuse/platform-structs.test.ts
@@ -1,0 +1,75 @@
+// platform-structs.test.ts — Exercise the platform struct writers directly.
+//
+// These functions marshal `struct stat` / `fuse_entry_param` into raw byte
+// buffers for the FFI layer. They are only run through libfuse during a real
+// mount, so on the opposite platform (and in CI, which runs on Linux) the
+// macOS writer never executes and the Linux writer is never called by a unit
+// test. They are pure `DataView` writes with no FFI, so they can be exercised
+// and asserted directly here, on either host, which also pins the byte layout
+// of the timestamp fields.
+
+import { assertEquals } from "@std/assert";
+import darwinPlatform from "./platform-darwin.ts";
+import linuxPlatform from "./platform-linux.ts";
+import type { FusePlatform } from "./platform.ts";
+
+function testPlatformStructs(name: string, p: FusePlatform): void {
+  Deno.test(`${name} writeStat marshals ino, size, and the mtime/atime/ctime timespecs`, () => {
+    const buf = new ArrayBuffer(p.STAT_SIZE);
+    p.writeStat(buf, {
+      ino: 7n,
+      mode: 0o644,
+      nlink: 1,
+      size: 42,
+      uid: 501,
+      gid: 20,
+      mtime: 1_700_000_000_500,
+    });
+    const view = new DataView(buf);
+
+    // st_ino is at offset 8 on both platforms.
+    assertEquals(view.getBigUint64(8, true), 7n);
+    assertEquals(Number(view.getBigInt64(p.STAT_ST_SIZE_OFFSET, true)), 42);
+
+    // mtime is split into seconds and nanoseconds, and ctime/atime are reported
+    // equal to it. The three timespecs are 16 bytes apart around st_mtim.
+    const mtim = p.STAT_ST_MTIM_OFFSET;
+    for (const offset of [mtim - 16, mtim, mtim + 16]) {
+      assertEquals(view.getBigInt64(offset, true), 1_700_000_000n);
+      assertEquals(view.getBigInt64(offset + 8, true), 500_000_000n);
+    }
+  });
+
+  Deno.test(`${name} writeStat leaves the timestamps at the epoch when mtime is omitted`, () => {
+    const buf = new ArrayBuffer(p.STAT_SIZE);
+    p.writeStat(buf, { ino: 1n, mode: 0o755, nlink: 2, size: 0 });
+    const view = new DataView(buf);
+    assertEquals(view.getBigInt64(p.STAT_ST_MTIM_OFFSET, true), 0n);
+    assertEquals(view.getBigInt64(p.STAT_ST_MTIM_OFFSET + 8, true), 0n);
+    // A missing uid/gid marshals as 0.
+    assertEquals(view.getBigUint64(8, true), 1n);
+  });
+
+  Deno.test(`${name} writeEntryParam embeds the attr stat with its mtime`, () => {
+    const buf = new ArrayBuffer(p.ENTRY_PARAM_SIZE);
+    p.writeEntryParam(buf, {
+      ino: 9n,
+      generation: 3n,
+      attr: { ino: 9n, mode: 0o644, nlink: 1, size: 5, mtime: 2_000 },
+      attrTimeout: 1,
+      entryTimeout: 1,
+    });
+    const view = new DataView(buf);
+
+    // Layout: ino @ 0, generation @ 8, embedded struct stat @ 16.
+    assertEquals(view.getBigUint64(0, true), 9n);
+    assertEquals(view.getBigUint64(8, true), 3n);
+    // The embedded stat's own ino sits at 16 + 8.
+    assertEquals(view.getBigUint64(16 + 8, true), 9n);
+    // The embedded stat's mtime (2000 ms -> 2s) sits at 16 + st_mtim offset.
+    assertEquals(view.getBigInt64(16 + p.STAT_ST_MTIM_OFFSET, true), 2n);
+  });
+}
+
+testPlatformStructs("darwin", darwinPlatform);
+testPlatformStructs("linux", linuxPlatform);

--- a/packages/fuse/platform.ts
+++ b/packages/fuse/platform.ts
@@ -13,6 +13,8 @@ export interface StatOpts {
   size: number;
   uid?: number;
   gid?: number;
+  /** Modification time in milliseconds since the epoch. */
+  mtime?: number;
 }
 
 export interface EntryParamOpts {
@@ -32,6 +34,19 @@ export interface MountHandle {
   session: Deno.PointerValue;
   /** Channel pointer on macOS (FUSE v2), session pointer on Linux (FUSE v3). */
   notifyTarget: Deno.PointerValue;
+}
+
+/**
+ * Split a millisecond timestamp into the seconds and nanoseconds of a
+ * `struct timespec`. An undefined timestamp maps to the epoch (all zero), which
+ * is what an uninitialized stat buffer already holds.
+ */
+export function msToTimespec(ms?: number): { sec: bigint; nsec: bigint } {
+  if (ms === undefined) return { sec: 0n, nsec: 0n };
+  return {
+    sec: BigInt(Math.floor(ms / 1000)),
+    nsec: BigInt(Math.floor((ms % 1000) * 1_000_000)),
+  };
 }
 
 // --- Common FFI symbols (identical between FUSE v2 and v3) ---
@@ -138,6 +153,8 @@ export interface FusePlatform {
   FUSE_ARGS_STRUCT_SIZE: number;
   /** Byte offset of st_size within struct stat. */
   STAT_ST_SIZE_OFFSET: number;
+  /** Byte offset of st_mtim(espec) within struct stat. */
+  STAT_ST_MTIM_OFFSET: number;
 
   // Struct helpers
   writeStat(buf: ArrayBuffer, opts: StatOpts): void;

--- a/packages/fuse/stat.test.ts
+++ b/packages/fuse/stat.test.ts
@@ -1,7 +1,21 @@
 import { assertEquals } from "@std/assert";
-import { DIR_MODE, DIR_MODE_RW, FILE_MODE_RWX } from "./platform.ts";
+import {
+  DIR_MODE,
+  DIR_MODE_RW,
+  FILE_MODE_RWX,
+  msToTimespec,
+} from "./platform.ts";
 import { buildNodeStat, getMountOwnership, nodeMode } from "./stat.ts";
 import type { FsNode } from "./types.ts";
+
+Deno.test("msToTimespec splits milliseconds into seconds and nanoseconds", () => {
+  assertEquals(msToTimespec(1_700_000_000_500), {
+    sec: 1_700_000_000n,
+    nsec: 500_000_000n,
+  });
+  assertEquals(msToTimespec(0), { sec: 0n, nsec: 0n });
+  assertEquals(msToTimespec(undefined), { sec: 0n, nsec: 0n });
+});
 
 Deno.test("getMountOwnership uses the current process ids when available", () => {
   assertEquals(
@@ -39,6 +53,7 @@ Deno.test("buildNodeStat assigns mounted handler files to the current user", () 
     cellKey: "addItem",
     cellProp: "result",
     script,
+    mtime: 1_700_000_000_000,
   };
 
   assertEquals(
@@ -52,6 +67,7 @@ Deno.test("buildNodeStat assigns mounted handler files to the current user", () 
       size: script.length,
       uid: 501,
       gid: 20,
+      mtime: 1_700_000_000_000,
     },
   );
 });
@@ -60,6 +76,7 @@ Deno.test("nodeMode exposes directories as read-only", () => {
   const node: FsNode = {
     kind: "dir",
     children: new Map(),
+    mtime: 0,
   };
 
   assertEquals(nodeMode(node), DIR_MODE);
@@ -69,6 +86,7 @@ Deno.test("nodeMode exposes writable directories with write bits", () => {
   const node: FsNode = {
     kind: "dir",
     children: new Map(),
+    mtime: 0,
   };
 
   assertEquals(nodeMode(node, true), DIR_MODE_RW);
@@ -79,10 +97,12 @@ Deno.test("nodeMode gives writable nodes user-independent write bits", () => {
     kind: "file",
     content: new Uint8Array(),
     jsonType: "string",
+    mtime: 0,
   };
   const dir: FsNode = {
     kind: "dir",
     children: new Map(),
+    mtime: 0,
   };
   const handler: FsNode = {
     kind: "callable",
@@ -90,6 +110,7 @@ Deno.test("nodeMode gives writable nodes user-independent write bits", () => {
     cellKey: "addItem",
     cellProp: "result",
     script: new Uint8Array(),
+    mtime: 0,
   };
 
   assertEquals(nodeMode(file, true) & 0o777, 0o666);

--- a/packages/fuse/stat.ts
+++ b/packages/fuse/stat.ts
@@ -71,5 +71,6 @@ export function buildNodeStat(
     size: nodeSize(node),
     uid: options.ownership.uid,
     gid: options.ownership.gid,
+    mtime: node.mtime,
   };
 }

--- a/packages/fuse/tree.test.ts
+++ b/packages/fuse/tree.test.ts
@@ -546,3 +546,18 @@ Deno.test("mtime advances strictly even when the clock does not move", () => {
   tree.updateFile(ino, "c", "string");
   assertEquals(tree.getNode(ino)?.mtime, 1_002);
 });
+
+Deno.test("touch advances a directory's mtime, clamped strictly upward", () => {
+  const clock = 1_000; // does not advance
+  const tree = new FsTree(() => clock);
+  const dir = tree.addDir(tree.rootIno, "dir");
+  assertEquals(tree.getNode(dir)?.mtime, 1_000);
+
+  tree.touch(dir);
+  assertEquals(tree.getNode(dir)?.mtime, 1_001);
+  tree.touch(dir);
+  assertEquals(tree.getNode(dir)?.mtime, 1_002);
+
+  // Touching a missing inode is a no-op.
+  tree.touch(9_999n);
+});

--- a/packages/fuse/tree.test.ts
+++ b/packages/fuse/tree.test.ts
@@ -561,3 +561,22 @@ Deno.test("touch advances a directory's mtime, clamped strictly upward", () => {
   // Touching a missing inode is a no-op.
   tree.touch(9_999n);
 });
+
+Deno.test("transplantSubtree throws when a root inode does not exist", () => {
+  const tree = new FsTree();
+  const dir = tree.addDir(tree.rootIno, "dir");
+  let threw = false;
+  try {
+    tree.transplantSubtree(dir, 9_999n);
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("clear on a missing inode is a no-op", () => {
+  const tree = new FsTree();
+  const before = tree.inodes.size;
+  tree.clear(9_999n);
+  assertEquals(tree.inodes.size, before);
+});

--- a/packages/fuse/tree.test.ts
+++ b/packages/fuse/tree.test.ts
@@ -2,6 +2,7 @@
 import { assertEquals } from "@std/assert";
 import { CfcProjectionAnnotator } from "./annotations.ts";
 import { FsTree } from "./tree.ts";
+import type { JsonType } from "./types.ts";
 
 const decoder = new TextDecoder();
 
@@ -129,61 +130,6 @@ Deno.test("removeChild clears dir and nested file recursively", () => {
   assertEquals(tree.lookup(tree.rootIno, "dir"), undefined);
 });
 
-Deno.test("detached subtrees stay readable by inode until cleared", () => {
-  const tree = new FsTree();
-  const dir = tree.addDir(tree.rootIno, "dir");
-  const file = tree.addFile(dir, "nested.txt", "content", "string");
-
-  tree.detach(dir);
-
-  assertEquals(tree.lookup(tree.rootIno, "dir"), undefined);
-  assertEquals(tree.inodes.has(dir), true);
-  assertEquals(tree.inodes.has(file), true);
-  assertEquals(tree.getPath(dir), "/dir");
-  assertEquals(tree.getPath(file), "/dir/nested.txt");
-
-  assertEquals(tree.getNameForIno(dir), "dir");
-  assertEquals(tree.getNameForIno(file), "nested.txt");
-
-  tree.clear(dir);
-
-  assertEquals(tree.inodes.has(dir), false);
-  assertEquals(tree.inodes.has(file), false);
-  assertEquals(tree.getNameForIno(dir), undefined);
-  assertEquals(tree.getNameForIno(file), undefined);
-});
-
-Deno.test("a detached subtree keeps its name after a replacement takes the path", () => {
-  const tree = new FsTree();
-  const oldDir = tree.addDir(tree.rootIno, "dir");
-  const oldFile = tree.addFile(oldDir, "nested.txt", "old", "string");
-
-  tree.detach(oldDir);
-
-  const newDir = tree.addDir(tree.rootIno, "dir");
-  tree.addFile(newDir, "nested.txt", "new", "string");
-
-  assertEquals(tree.getNameForIno(oldDir), "dir");
-  assertEquals(tree.getNameForIno(oldFile), "nested.txt");
-});
-
-Deno.test("clearing a detached subtree does not remove a replacement path mapping", () => {
-  const tree = new FsTree();
-  const oldDir = tree.addDir(tree.rootIno, "dir");
-  const oldFile = tree.addFile(oldDir, "nested.txt", "old", "string");
-
-  tree.detach(oldDir);
-
-  const newDir = tree.addDir(tree.rootIno, "dir");
-  const newFile = tree.addFile(newDir, "nested.txt", "new", "string");
-
-  tree.clear(oldDir);
-
-  assertEquals(tree.lookup(tree.rootIno, "dir"), newDir);
-  assertEquals(tree.getPath(newFile), "/dir/nested.txt");
-  assertEquals(tree.inodes.has(oldFile), false);
-});
-
 Deno.test("clear removes subtree but keeps sibling", () => {
   const tree = new FsTree();
   const a = tree.addDir(tree.rootIno, "a");
@@ -203,4 +149,400 @@ Deno.test("getNameForIno returns the registered child name", () => {
   const tree = new FsTree();
   const ino = tree.addFile(tree.rootIno, "myfile.txt", "data", "string");
   assertEquals(tree.getNameForIno(ino), "myfile.txt");
+});
+
+// --- transplantSubtree ---------------------------------------------------
+
+type BuildSpec =
+  | { file: string; jsonType?: JsonType }
+  | { symlink: string }
+  | { dir: Record<string, BuildSpec>; jsonType?: "object" | "array" };
+
+/** Build a subtree from a compact spec so transplant tests stay readable. */
+function build(
+  tree: FsTree,
+  parent: bigint,
+  name: string,
+  spec: BuildSpec,
+): bigint {
+  if ("file" in spec) {
+    return tree.addFile(parent, name, spec.file, spec.jsonType ?? "string");
+  }
+  if ("symlink" in spec) {
+    return tree.addSymlink(parent, name, spec.symlink);
+  }
+  const dirIno = tree.addDir(parent, name, spec.jsonType ?? "object");
+  for (const [childName, childSpec] of Object.entries(spec.dir)) {
+    build(tree, dirIno, childName, childSpec);
+  }
+  return dirIno;
+}
+
+Deno.test("transplant keeps the inode of a path that survives unchanged", () => {
+  const tree = new FsTree();
+  const oldIno = build(tree, tree.rootIno, "input", {
+    dir: { title: { file: "hello" }, count: { file: "1", jsonType: "number" } },
+  });
+  const oldTitleIno = tree.lookup(oldIno, "title")!;
+  const oldCountIno = tree.lookup(oldIno, "count")!;
+
+  const pendingIno = build(tree, tree.rootIno, ".input.pending", {
+    dir: { title: { file: "hello" }, count: { file: "1", jsonType: "number" } },
+  });
+
+  const changes = tree.transplantSubtree(oldIno, pendingIno);
+
+  // The survivor keeps its inodes at their original path.
+  assertEquals(tree.lookup(tree.rootIno, "input"), oldIno);
+  assertEquals(tree.lookup(oldIno, "title"), oldTitleIno);
+  assertEquals(tree.lookup(oldIno, "count"), oldCountIno);
+  // Nothing changed, so no cache invalidation is reported.
+  assertEquals(changes.changedInodes.size, 0);
+  assertEquals(changes.entryChanges.size, 0);
+  // The staging root is gone.
+  assertEquals(tree.lookup(tree.rootIno, ".input.pending"), undefined);
+  assertEquals(tree.inodes.has(pendingIno), false);
+});
+
+Deno.test("transplant preserves the inode but reports a changed value", () => {
+  const tree = new FsTree();
+  const oldIno = build(tree, tree.rootIno, "input", {
+    dir: { title: { file: "old" }, count: { file: "1", jsonType: "number" } },
+  });
+  const oldTitleIno = tree.lookup(oldIno, "title")!;
+  const oldCountIno = tree.lookup(oldIno, "count")!;
+
+  const pendingIno = build(tree, tree.rootIno, ".input.pending", {
+    dir: { title: { file: "new" }, count: { file: "1", jsonType: "number" } },
+  });
+
+  const changes = tree.transplantSubtree(oldIno, pendingIno);
+
+  assertEquals(tree.lookup(oldIno, "title"), oldTitleIno);
+  const titleNode = tree.getNode(oldTitleIno);
+  assertEquals(titleNode?.kind, "file");
+  if (titleNode?.kind === "file") {
+    assertEquals(decoder.decode(titleNode.content), "new");
+  }
+  // Only the changed file is reported; the untouched sibling is not.
+  assertEquals([...changes.changedInodes], [oldTitleIno]);
+  assertEquals(changes.changedInodes.has(oldCountIno), false);
+  assertEquals(changes.entryChanges.size, 0);
+});
+
+Deno.test("transplant allocates a new inode for an added path", () => {
+  const tree = new FsTree();
+  const oldIno = build(tree, tree.rootIno, "input", {
+    dir: { title: { file: "hello" } },
+  });
+  const oldTitleIno = tree.lookup(oldIno, "title")!;
+
+  const pendingIno = build(tree, tree.rootIno, ".input.pending", {
+    dir: { title: { file: "hello" }, extra: { file: "brand new" } },
+  });
+  const pendingExtraIno = tree.lookup(pendingIno, "extra")!;
+
+  const changes = tree.transplantSubtree(oldIno, pendingIno);
+
+  // Surviving path keeps its inode; the added path keeps its fresh inode.
+  assertEquals(tree.lookup(oldIno, "title"), oldTitleIno);
+  const extraIno = tree.lookup(oldIno, "extra");
+  assertEquals(extraIno, pendingExtraIno);
+  assertEquals(tree.getPath(extraIno!), "/input/extra");
+  // Only the parent's "extra" entry changed.
+  assertEquals(changes.entryChanges.get(oldIno), new Set(["extra"]));
+  assertEquals(changes.changedInodes.size, 0);
+});
+
+Deno.test("transplant frees the inode of a removed path", () => {
+  const tree = new FsTree();
+  const oldIno = build(tree, tree.rootIno, "input", {
+    dir: { title: { file: "hello" }, gone: { file: "removed" } },
+  });
+  const oldGoneIno = tree.lookup(oldIno, "gone")!;
+
+  const pendingIno = build(tree, tree.rootIno, ".input.pending", {
+    dir: { title: { file: "hello" } },
+  });
+
+  const changes = tree.transplantSubtree(oldIno, pendingIno);
+
+  assertEquals(tree.lookup(oldIno, "gone"), undefined);
+  assertEquals(tree.inodes.has(oldGoneIno), false);
+  assertEquals(changes.entryChanges.get(oldIno), new Set(["gone"]));
+});
+
+Deno.test("transplant allocates a new inode when a path changes kind", () => {
+  const tree = new FsTree();
+  const oldIno = build(tree, tree.rootIno, "input", {
+    dir: { data: { file: "scalar" } },
+  });
+  const oldDataIno = tree.lookup(oldIno, "data")!;
+
+  // "data" goes from a file to a directory.
+  const pendingIno = build(tree, tree.rootIno, ".input.pending", {
+    dir: { data: { dir: { nested: { file: "x" } } } },
+  });
+  const pendingDataIno = tree.lookup(pendingIno, "data")!;
+
+  const changes = tree.transplantSubtree(oldIno, pendingIno);
+
+  const dataIno = tree.lookup(oldIno, "data");
+  assertEquals(dataIno, pendingDataIno);
+  assertEquals(dataIno === oldDataIno, false);
+  assertEquals(tree.inodes.has(oldDataIno), false);
+  assertEquals(tree.getNode(dataIno!)?.kind, "dir");
+  assertEquals(
+    tree.getPath(tree.lookup(dataIno!, "nested")!),
+    "/input/data/nested",
+  );
+  assertEquals(changes.entryChanges.get(oldIno), new Set(["data"]));
+});
+
+Deno.test("transplant preserves inodes through unchanged nested directories", () => {
+  const tree = new FsTree();
+  const oldIno = build(tree, tree.rootIno, "input", {
+    dir: {
+      a: { dir: { b: { dir: { c: { file: "deep" } } } } },
+    },
+  });
+  const oldA = tree.lookup(oldIno, "a")!;
+  const oldB = tree.lookup(oldA, "b")!;
+  const oldC = tree.lookup(oldB, "c")!;
+
+  const pendingIno = build(tree, tree.rootIno, ".input.pending", {
+    dir: {
+      a: { dir: { b: { dir: { c: { file: "deep" } } } } },
+    },
+  });
+
+  const inodeCountBefore = tree.inodes.size;
+  const changes = tree.transplantSubtree(oldIno, pendingIno);
+
+  assertEquals(tree.lookup(oldIno, "a"), oldA);
+  assertEquals(tree.lookup(oldA, "b"), oldB);
+  assertEquals(tree.lookup(oldB, "c"), oldC);
+  assertEquals(changes.changedInodes.size, 0);
+  assertEquals(changes.entryChanges.size, 0);
+  // The four staging inodes (.input.pending and a/b/c) are freed; nothing
+  // else leaks.
+  assertEquals(tree.inodes.size, inodeCountBefore - 4);
+});
+
+Deno.test("transplant preserves a directory inode across an object/array flip", () => {
+  const tree = new FsTree();
+  const oldIno = build(tree, tree.rootIno, "input", {
+    dir: { items: { dir: { "0": { file: "a" } }, jsonType: "object" } },
+  });
+  const oldItemsIno = tree.lookup(oldIno, "items")!;
+
+  const pendingIno = build(tree, tree.rootIno, ".input.pending", {
+    dir: { items: { dir: { "0": { file: "a" } }, jsonType: "array" } },
+  });
+
+  tree.transplantSubtree(oldIno, pendingIno);
+
+  const itemsIno = tree.lookup(oldIno, "items");
+  assertEquals(itemsIno, oldItemsIno);
+  const itemsNode = tree.getNode(itemsIno!);
+  assertEquals(itemsNode?.kind, "dir");
+  if (itemsNode?.kind === "dir") {
+    assertEquals(itemsNode.jsonType, "array");
+  }
+});
+
+Deno.test("transplant adopts a changed symlink target", () => {
+  const tree = new FsTree();
+  const oldIno = build(tree, tree.rootIno, "input", {
+    dir: { link: { symlink: "../old/target" } },
+  });
+  const oldLinkIno = tree.lookup(oldIno, "link")!;
+
+  const pendingIno = build(tree, tree.rootIno, ".input.pending", {
+    dir: { link: { symlink: "../new/target" } },
+  });
+
+  const changes = tree.transplantSubtree(oldIno, pendingIno);
+
+  assertEquals(tree.lookup(oldIno, "link"), oldLinkIno);
+  const linkNode = tree.getNode(oldLinkIno);
+  assertEquals(linkNode?.kind, "symlink");
+  if (linkNode?.kind === "symlink") {
+    assertEquals(linkNode.target, "../new/target");
+  }
+  assertEquals([...changes.changedInodes], [oldLinkIno]);
+});
+
+Deno.test("transplant adopts a changed callable script", () => {
+  const tree = new FsTree();
+  const oldIno = tree.addDir(tree.rootIno, "result", "object");
+  const oldCallableIno = tree.addCallable(
+    oldIno,
+    "run.handler",
+    "handler",
+    "cellKey",
+    "result",
+    new TextEncoder().encode("old script"),
+  );
+
+  const pendingIno = tree.addDir(tree.rootIno, ".result.pending", "object");
+  tree.addCallable(
+    pendingIno,
+    "run.handler",
+    "handler",
+    "cellKey",
+    "result",
+    new TextEncoder().encode("new script"),
+  );
+
+  const changes = tree.transplantSubtree(oldIno, pendingIno);
+
+  assertEquals(tree.lookup(oldIno, "run.handler"), oldCallableIno);
+  const node = tree.getNode(oldCallableIno);
+  assertEquals(node?.kind, "callable");
+  if (node?.kind === "callable") {
+    assertEquals(new TextDecoder().decode(node.script), "new script");
+  }
+  assertEquals([...changes.changedInodes], [oldCallableIno]);
+});
+
+Deno.test("transplant throws when the roots differ in kind", () => {
+  const tree = new FsTree();
+  const dirIno = tree.addDir(tree.rootIno, "input", "object");
+  const fileIno = tree.addFile(tree.rootIno, ".input.pending", "x", "string");
+
+  let threw = false;
+  try {
+    tree.transplantSubtree(dirIno, fileIno);
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("transplant removes a vanished child's CFC directory entry", () => {
+  const tree = new FsTree();
+  const annotator = new CfcProjectionAnnotator(tree, {
+    space: "did:key:zSpace",
+    entity: "of:piece",
+    rootKind: "pieces",
+    cell: "result",
+    generation: "generation-1",
+    labelView: { version: 1, entries: [] },
+  });
+
+  const oldIno = tree.addDir(tree.rootIno, "result", "object");
+  annotator.annotateJsonDirectory(oldIno, [], { keep: "a", gone: "b" });
+  const keepIno = tree.addFile(oldIno, "keep", "a", "string");
+  annotator.annotateJsonScalar(keepIno, ["keep"], "a");
+  annotator.annotateEntry(oldIno, "keep", keepIno);
+  const goneIno = tree.addFile(oldIno, "gone", "b", "string");
+  annotator.annotateJsonScalar(goneIno, ["gone"], "b");
+  annotator.annotateEntry(oldIno, "gone", goneIno);
+
+  // Rebuild without "gone".
+  const pendingIno = tree.addDir(tree.rootIno, ".result.pending", "object");
+  annotator.annotateJsonDirectory(pendingIno, [], { keep: "a" });
+  const pendingKeepIno = tree.addFile(pendingIno, "keep", "a", "string");
+  annotator.annotateJsonScalar(pendingKeepIno, ["keep"], "a");
+  annotator.annotateEntry(pendingIno, "keep", pendingKeepIno);
+
+  tree.transplantSubtree(oldIno, pendingIno);
+
+  const entries = tree.getCfcAnnotation(oldIno)?.entries?.entries;
+  assertEquals(entries?.map((entry) => entry.name), ["keep"]);
+});
+
+// --- mtime tracking ------------------------------------------------------
+
+Deno.test("a node records the clock time it was created at", () => {
+  let clock = 1_000;
+  const tree = new FsTree(() => clock);
+  clock = 2_000;
+  const ino = tree.addFile(tree.rootIno, "f", "hi", "string");
+  assertEquals(tree.getNode(ino)?.mtime, 2_000);
+});
+
+Deno.test("updateFile advances mtime only when the content changes", () => {
+  let clock = 1_000;
+  const tree = new FsTree(() => clock);
+  const ino = tree.addFile(tree.rootIno, "f", "hi", "string");
+  assertEquals(tree.getNode(ino)?.mtime, 1_000);
+
+  clock = 2_000;
+  tree.updateFile(ino, "hi", "string"); // same bytes
+  assertEquals(tree.getNode(ino)?.mtime, 1_000);
+
+  clock = 3_000;
+  tree.updateFile(ino, "bye", "string"); // changed
+  assertEquals(tree.getNode(ino)?.mtime, 3_000);
+});
+
+Deno.test("transplant advances mtime for a changed file but not an unchanged one", () => {
+  let clock = 1_000;
+  const tree = new FsTree(() => clock);
+  const oldIno = build(tree, tree.rootIno, "input", {
+    dir: { title: { file: "old" }, count: { file: "1", jsonType: "number" } },
+  });
+  const titleIno = tree.lookup(oldIno, "title")!;
+  const countIno = tree.lookup(oldIno, "count")!;
+
+  clock = 5_000;
+  const pendingIno = build(tree, tree.rootIno, ".input.pending", {
+    dir: { title: { file: "new" }, count: { file: "1", jsonType: "number" } },
+  });
+  tree.transplantSubtree(oldIno, pendingIno);
+
+  // The changed file's mtime advances to the transplant time; the unchanged
+  // sibling keeps its original mtime.
+  assertEquals(tree.getNode(titleIno)?.mtime, 5_000);
+  assertEquals(tree.getNode(countIno)?.mtime, 1_000);
+});
+
+Deno.test("transplant advances a directory's mtime when its entries change", () => {
+  let clock = 1_000;
+  const tree = new FsTree(() => clock);
+  const oldIno = build(tree, tree.rootIno, "input", {
+    dir: { keep: { file: "a" } },
+  });
+
+  clock = 5_000;
+  const pendingIno = build(tree, tree.rootIno, ".input.pending", {
+    dir: { keep: { file: "a" }, added: { file: "b" } },
+  });
+  tree.transplantSubtree(oldIno, pendingIno);
+
+  // The directory gained an entry, so its mtime advances.
+  assertEquals(tree.getNode(oldIno)?.mtime, 5_000);
+});
+
+Deno.test("transplant leaves a directory's mtime alone when only a child's content changes", () => {
+  let clock = 1_000;
+  const tree = new FsTree(() => clock);
+  const oldIno = build(tree, tree.rootIno, "input", {
+    dir: { title: { file: "old" } },
+  });
+
+  clock = 5_000;
+  const pendingIno = build(tree, tree.rootIno, ".input.pending", {
+    dir: { title: { file: "new" } },
+  });
+  tree.transplantSubtree(oldIno, pendingIno);
+
+  // The directory's own entry set is unchanged, so its mtime is preserved even
+  // though a child's content changed.
+  assertEquals(tree.getNode(oldIno)?.mtime, 1_000);
+});
+
+Deno.test("mtime advances strictly even when the clock does not move", () => {
+  const clock = 1_000; // never advances
+  const tree = new FsTree(() => clock);
+  const ino = tree.addFile(tree.rootIno, "f", "a", "string");
+  assertEquals(tree.getNode(ino)?.mtime, 1_000);
+
+  tree.updateFile(ino, "b", "string");
+  assertEquals(tree.getNode(ino)?.mtime, 1_001);
+
+  tree.updateFile(ino, "c", "string");
+  assertEquals(tree.getNode(ino)?.mtime, 1_002);
 });

--- a/packages/fuse/tree.ts
+++ b/packages/fuse/tree.ts
@@ -24,6 +24,30 @@ import type { FsNode } from "./types.ts";
 const ROOT_INO = 1n;
 const encoder = new TextEncoder();
 
+/**
+ * The kernel caches that a transplant invalidated.
+ *
+ * `changedInodes` lists inodes that survived the transplant but whose file
+ * data, symlink target or callable script changed, so their cached data and
+ * attributes are stale. `entryChanges` maps a directory inode to the child
+ * names whose directory entry changed — a name that appeared, disappeared, or
+ * now points at a different inode — so the directory's cached listing for
+ * exactly those names is stale. Names that kept their inode are absent from
+ * both, which is what lets the caller leave unchanged entries cached.
+ */
+export interface TransplantChanges {
+  changedInodes: Set<bigint>;
+  entryChanges: Map<bigint, Set<string>>;
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
 export class FsTree {
   inodes: Map<bigint, FsNode> = new Map();
   parents: Map<bigint, bigint> = new Map();
@@ -31,10 +55,16 @@ export class FsTree {
   /** Reverse map: inode → path string (O(1) lookup). */
   private inoPaths: Map<bigint, string> = new Map();
   private nextIno = 2n;
+  private now: () => number;
 
-  constructor() {
+  constructor(now: () => number = () => Date.now()) {
+    this.now = now;
     // Create root directory (inode 1)
-    this.inodes.set(ROOT_INO, { kind: "dir", children: new Map() });
+    this.inodes.set(ROOT_INO, {
+      kind: "dir",
+      children: new Map(),
+      mtime: this.now(),
+    });
     this.paths.set("/", ROOT_INO);
     this.inoPaths.set(ROOT_INO, "/");
   }
@@ -89,7 +119,12 @@ export class FsTree {
     }
 
     const ino = this.allocInode();
-    const node: FsNode = { kind: "dir", children: new Map(), jsonType };
+    const node: FsNode = {
+      kind: "dir",
+      children: new Map(),
+      jsonType,
+      mtime: this.now(),
+    };
     this.inodes.set(ino, node);
     parent.children.set(name, ino);
     this.parents.set(ino, parentIno);
@@ -113,7 +148,12 @@ export class FsTree {
     const data = typeof content === "string"
       ? encoder.encode(content)
       : content;
-    const node: FsNode = { kind: "file", content: data, jsonType };
+    const node: FsNode = {
+      kind: "file",
+      content: data,
+      jsonType,
+      mtime: this.now(),
+    };
     this.inodes.set(ino, node);
     parent.children.set(name, ino);
     this.parents.set(ino, parentIno);
@@ -142,6 +182,7 @@ export class FsTree {
       cellKey,
       cellProp,
       script,
+      mtime: this.now(),
     };
     this.inodes.set(ino, node);
     parent.children.set(name, ino);
@@ -158,7 +199,7 @@ export class FsTree {
     }
 
     const ino = this.allocInode();
-    const node: FsNode = { kind: "symlink", target };
+    const node: FsNode = { kind: "symlink", target, mtime: this.now() };
     this.inodes.set(ino, node);
     parent.children.set(name, ino);
     this.parents.set(ino, parentIno);
@@ -250,9 +291,13 @@ export class FsTree {
     if (!node || node.kind !== "file") {
       throw new Error(`Inode ${ino} is not a file`);
     }
-    node.content = typeof content === "string"
+    const data = typeof content === "string"
       ? encoder.encode(content)
       : content;
+    if (!bytesEqual(node.content, data)) {
+      this.bumpMtime(node);
+    }
+    node.content = data;
     if (jsonType !== undefined) {
       node.jsonType = jsonType;
     }
@@ -269,21 +314,6 @@ export class FsTree {
     parent.children.delete(name);
     this.removeCfcEntryAnnotation(parentIno, name);
     return childIno;
-  }
-
-  /**
-   * Unlink a subtree from its parent while keeping its inodes temporarily live.
-   *
-   * A piece-prop rebuild detaches the old subtree and builds a replacement with
-   * fresh inodes. A client can still hold the old inode for as long as its
-   * kernel caches allow, so the detached inodes stay resolvable until they are
-   * cleared: `getNode`, `getPath` and `getNameForIno` all keep answering for
-   * them, which lets a write that arrives on a detached inode resolve to the
-   * same cell as the path it was opened on.
-   */
-  detach(ino: bigint): void {
-    if (!this.inodes.has(ino)) return;
-    this.unlinkFromParent(ino);
   }
 
   /** Recursively remove an inode and all its descendants from tracking maps. */
@@ -377,13 +407,192 @@ export class FsTree {
     for (const [name, childIno] of parent.children) {
       if (childIno === ino) return name;
     }
-    // A detached subtree keeps its inodes and its recorded path until it is
-    // cleared. The parent no longer lists it, so recover the name from the
-    // recorded path.
-    const path = this.inoPaths.get(ino);
-    if (path === undefined) return undefined;
-    const name = path.slice(path.lastIndexOf("/") + 1);
-    return name === "" ? undefined : name;
+    return undefined;
+  }
+
+  /**
+   * Adopt an existing subtree's inodes into a freshly built replacement.
+   *
+   * `oldIno` roots the live subtree; `newIno` roots a replacement built with
+   * fresh inodes under a staging name. The two roots must have the same node
+   * kind. For every path present in both trees with the same node kind, the
+   * existing inode survives: the replacement's content is copied onto it and
+   * its inode number is preserved, so a client that cached the path keeps
+   * resolving it. Paths only in the replacement move across keeping their
+   * freshly allocated inodes; paths only in the old tree are removed. The
+   * replacement's nodes are discarded as their content is adopted, leaving
+   * `oldIno` in place at its original path carrying the new content.
+   *
+   * The whole operation is synchronous, so no filesystem request can observe a
+   * half-adopted tree: callers build the replacement asynchronously under a
+   * staging name, then call this to swap it in atomically.
+   *
+   * Returns the kernel caches that went stale; see {@link TransplantChanges}.
+   */
+  transplantSubtree(oldIno: bigint, newIno: bigint): TransplantChanges {
+    const oldNode = this.inodes.get(oldIno);
+    const newNode = this.inodes.get(newIno);
+    if (!oldNode || !newNode) {
+      throw new Error(`Transplant root ${oldIno} or ${newIno} does not exist`);
+    }
+    if (oldNode.kind !== newNode.kind) {
+      throw new Error(
+        `Transplant roots differ in kind: ${oldNode.kind} vs ${newNode.kind}`,
+      );
+    }
+    const changes: TransplantChanges = {
+      changedInodes: new Set(),
+      entryChanges: new Map(),
+    };
+    this.transplantNode(oldIno, newIno, changes);
+    this.discardNodeShallow(newIno);
+    return changes;
+  }
+
+  /**
+   * Reconcile one replacement node onto its live counterpart, recursing into
+   * directory children. Assumes the two nodes share a kind. Leaves `newIno`'s
+   * node in place for the caller to discard once its content has been adopted.
+   */
+  private transplantNode(
+    oldIno: bigint,
+    newIno: bigint,
+    changes: TransplantChanges,
+  ): void {
+    const oldNode = this.inodes.get(oldIno)!;
+    const newNode = this.inodes.get(newIno)!;
+
+    // Move the replacement's annotation onto the surviving node and clear it
+    // from the replacement so discarding the replacement's children can't
+    // mutate the now-shared entries list out from under the survivor.
+    oldNode.cfc = newNode.cfc;
+    newNode.cfc = undefined;
+
+    if (this.adoptContent(oldNode, newNode)) {
+      this.bumpMtime(oldNode);
+      changes.changedInodes.add(oldIno);
+    }
+
+    if (oldNode.kind !== "dir" || newNode.kind !== "dir") return;
+
+    const oldChildren = [...oldNode.children];
+    const newChildren = [...newNode.children];
+    const oldByName = new Map(oldChildren);
+    const newByName = new Map(newChildren);
+    let entriesChanged = false;
+
+    for (const [name, newChildIno] of newChildren) {
+      const oldChildIno = oldByName.get(name);
+      const newChildNode = this.inodes.get(newChildIno)!;
+      if (
+        oldChildIno !== undefined &&
+        this.inodes.get(oldChildIno)!.kind === newChildNode.kind
+      ) {
+        // Same path, same kind: the existing inode survives.
+        this.transplantNode(oldChildIno, newChildIno, changes);
+        this.discardNodeShallow(newChildIno);
+      } else {
+        // New path, or a kind change that forces a new inode. Drop any old
+        // node at this name, then splice the replacement's subtree in with
+        // its freshly allocated inodes.
+        if (oldChildIno !== undefined) {
+          this.clearSubtree(oldChildIno);
+        }
+        oldNode.children.set(name, newChildIno);
+        this.parents.set(newChildIno, oldIno);
+        this.retrackSubtree(newChildIno, oldIno, name);
+        this.recordEntryChange(changes, oldIno, name);
+        entriesChanged = true;
+      }
+    }
+
+    for (const [name, oldChildIno] of oldChildren) {
+      if (newByName.has(name)) continue;
+      // Present in the old tree, gone from the replacement: remove it.
+      this.clearSubtree(oldChildIno);
+      oldNode.children.delete(name);
+      this.recordEntryChange(changes, oldIno, name);
+      entriesChanged = true;
+    }
+
+    // A directory whose entry set changed has been modified; advance its mtime
+    // so a client that revalidates by attribute sees the change.
+    if (entriesChanged) {
+      this.bumpMtime(oldNode);
+    }
+  }
+
+  /**
+   * Advance a node's mtime on a content change. Clamps to strictly greater than
+   * the node's previous mtime so two changes that land in the same wall-clock
+   * millisecond still produce distinct times — a client revalidating by
+   * attribute always sees a newer mtime after a content change, even on a
+   * backend that ignores the inode-invalidation notifications.
+   */
+  private bumpMtime(node: FsNode): void {
+    node.mtime = Math.max(this.now(), node.mtime + 1);
+  }
+
+  /**
+   * Copy a replacement node's content onto its surviving counterpart. Returns
+   * true if the file data, symlink target or callable script changed, so the
+   * caller can invalidate the inode's cached data. A directory returns false —
+   * its listing changes are reported through `entryChanges` instead.
+   */
+  private adoptContent(oldNode: FsNode, newNode: FsNode): boolean {
+    if (oldNode.kind === "dir" && newNode.kind === "dir") {
+      oldNode.jsonType = newNode.jsonType;
+      return false;
+    }
+    if (oldNode.kind === "file" && newNode.kind === "file") {
+      const changed = oldNode.jsonType !== newNode.jsonType ||
+        !bytesEqual(oldNode.content, newNode.content);
+      oldNode.content = newNode.content;
+      oldNode.jsonType = newNode.jsonType;
+      return changed;
+    }
+    if (oldNode.kind === "symlink" && newNode.kind === "symlink") {
+      const changed = oldNode.target !== newNode.target;
+      oldNode.target = newNode.target;
+      return changed;
+    }
+    if (oldNode.kind === "callable" && newNode.kind === "callable") {
+      const changed = oldNode.callableKind !== newNode.callableKind ||
+        oldNode.cellKey !== newNode.cellKey ||
+        oldNode.cellProp !== newNode.cellProp ||
+        !bytesEqual(oldNode.script, newNode.script);
+      oldNode.callableKind = newNode.callableKind;
+      oldNode.cellKey = newNode.cellKey;
+      oldNode.cellProp = newNode.cellProp;
+      oldNode.script = newNode.script;
+      return changed;
+    }
+    return false;
+  }
+
+  private recordEntryChange(
+    changes: TransplantChanges,
+    parentIno: bigint,
+    name: string,
+  ): void {
+    let names = changes.entryChanges.get(parentIno);
+    if (!names) {
+      names = new Set();
+      changes.entryChanges.set(parentIno, names);
+    }
+    names.add(name);
+  }
+
+  /**
+   * Remove a single node from tracking without touching its children. Used to
+   * drop a replacement node once its content has been adopted; its children
+   * have already been adopted or moved, so recursing would wrongly clear them.
+   */
+  private discardNodeShallow(ino: bigint): void {
+    this.unlinkFromParent(ino);
+    this.inodes.delete(ino);
+    this.parents.delete(ino);
+    this.untrackPath(ino);
   }
 
   /** Remove a subtree rooted at `ino`, including the node itself. */

--- a/packages/fuse/tree.ts
+++ b/packages/fuse/tree.ts
@@ -218,6 +218,17 @@ export class FsTree {
     return this.inodes.get(ino);
   }
 
+  /**
+   * Advance a node's mtime because its directory entries changed through a path
+   * other than a transplant — a piece appearing under a space, or a piece
+   * directory gaining or losing a top-level entry. Content changes and
+   * transplant-reconciled entry changes advance mtime on their own.
+   */
+  touch(ino: bigint): void {
+    const node = this.inodes.get(ino);
+    if (node) this.bumpMtime(node);
+  }
+
   setCfcAnnotation(ino: bigint, annotation: CfcNodeAnnotation): void {
     const node = this.inodes.get(ino);
     if (!node) {

--- a/packages/fuse/types.ts
+++ b/packages/fuse/types.ts
@@ -14,20 +14,34 @@ export type CfcAnnotatedNode = {
   cfc?: CfcNodeAnnotation;
 };
 
+/** Fields carried by every node regardless of kind. */
+export type NodeCommon = CfcAnnotatedNode & {
+  /**
+   * Modification time in milliseconds since the epoch, advanced whenever the
+   * node's content changes or a directory gains or loses an entry. Surfaced as
+   * the stat `mtime` so a client sees a fresh attribute after an in-place
+   * content change. This gives tools that key on mtime correct times, and is a
+   * freshness signal for a same-size change on a stable inode — the change the
+   * macOS NFS backend cannot see through the inode-invalidation notifications,
+   * which it ignores.
+   */
+  mtime: number;
+};
+
 export type FsNode =
   | (
     & { kind: "dir"; children: Map<string, bigint>; jsonType?: JsonType }
-    & CfcAnnotatedNode
+    & NodeCommon
   )
   | (
     & { kind: "file"; content: Uint8Array; jsonType: JsonType }
-    & CfcAnnotatedNode
+    & NodeCommon
   )
-  | ({ kind: "symlink"; target: string } & CfcAnnotatedNode)
+  | ({ kind: "symlink"; target: string } & NodeCommon)
   | ({
     kind: "callable";
     callableKind: CallableKind;
     cellKey: string;
     cellProp: "input" | "result";
     script: Uint8Array;
-  } & CfcAnnotatedNode);
+  } & NodeCommon);

--- a/packages/fuse/verify-structs.c
+++ b/packages/fuse/verify-structs.c
@@ -22,6 +22,7 @@ int main(void) {
     printf("stat_st_uid=%zu\n", offsetof(struct stat, st_uid));
     printf("stat_st_gid=%zu\n", offsetof(struct stat, st_gid));
     printf("stat_st_size=%zu\n", offsetof(struct stat, st_size));
+    printf("stat_st_mtim=%zu\n", offsetof(struct stat, st_mtim));
 
     // fuse_entry_param
     printf("entry_param_size=%zu\n", sizeof(struct fuse_entry_param));

--- a/packages/fuse/verify-structs.test.ts
+++ b/packages/fuse/verify-structs.test.ts
@@ -122,6 +122,11 @@ Deno.test({
       values.get("stat_st_size"),
       p.STAT_ST_SIZE_OFFSET,
     );
+    check(
+      "STAT_ST_MTIM_OFFSET",
+      values.get("stat_st_mtim"),
+      p.STAT_ST_MTIM_OFFSET,
+    );
 
     // fuse_entry_param
     check(


### PR DESCRIPTION
Rebuilding a piece property threw away the property's whole subtree and built a replacement with brand-new inode numbers. A path whose value did not change got a new inode anyway, so a client that had cached a directory entry saw the path's inode change under it after every rebuild. Everything downstream was compensation for that churn: the old subtree was detached and kept alive on a one-second timer so cached inodes stayed resolvable, and a chain of fixes patched the cases where that timer was not enough. The timer put an upper bound on success — a file handle idle past one second stopped resolving.

This makes a path keep its inode when its subtree rebuilds, and removes the compensation.

## Reconcile in place

`FsTree.transplantSubtree` takes the live subtree and a freshly built replacement and reconciles the replacement onto the live one: for every path present in both with the same node kind the existing inode survives and takes the new content; a genuinely new path keeps its freshly allocated inode; a genuinely removed path has its inode freed. The replacement is still built off to the side under a staging name, so the async build never mutates what a reader can see; the transplant that swaps it in is synchronous, so no filesystem request observes a half-rebuilt tree. A directory's CFC annotation, including its child-entry list, transfers onto the survivor and is cleared from the replacement so discarding the replacement cannot corrupt it; the entry list is keyed by child name and Common Fabric ref, not by inode, so it is correct regardless of which inodes the children end up with.

`rebuildPieceProp` swaps both the property directory and its `.json` sibling through this path. The `[FS]` projection rebuild — where the result is an `index.md`/`index.json` plus siblings and callables at the piece root — is reconciled the same way, through a staging container, so its entries keep their inodes too.

## Do not tear the tree down on the reactive path

A cell change arriving through the piece's subscription used to clear the property's whole subtree, recreate an empty stub, and invalidate every descendant inode before rebuilding — so the in-place reconciliation had nothing to reconcile against and inodes still churned on the path a value change takes after a background recompute or a mounted write. The reactive path no longer tears the tree down; it advances the hydration epoch (all that is needed to make an in-flight hydration re-read a superseded value) and rebuilds onto the still-present tree.

## Precise invalidation

Because a surviving inode now changes content in place rather than being replaced by a fresh inode the kernel never saw, the rebuild reports the exact caches it made stale — the inodes whose content changed and, per directory, the child names whose entry appeared, disappeared or moved to a different inode — and invalidates only those. A path that kept its inode and content keeps its cached lookups. A removed subtree needs no per-descendant inode invalidation: dropping the parent's directory entry is enough, and because inode numbers are only ever allocated upward and never reused, a stale cache for a freed inode can never be observed.

## Retention removed

With nothing detached, the one-second retention window and everything serving it are gone: `retainDetachedSubtree`, the retained-subtree map and time-to-live, `FsTree.detach`, and the `getNameForIno` basename fallback. A file handle open on a path a rebuild genuinely removes now stops resolving as soon as the rebuild lands rather than lingering for up to a second; that window only ever held by luck. A handle on a path that survives is strictly better off — the inode is preserved outright.

## Modification times

Stat carried no modification time, so every path reported the epoch. Nodes now carry an mtime that advances whenever content changes or a directory's entries change and is preserved when a rebuild leaves a node untouched, clamped to strictly greater than its previous value so two changes within one millisecond still differ. `buildNodeStat` surfaces it and both platform writers place it in `st_mtim`/`st_mtimespec` (ctime and atime reported equal); the Linux offset is checked against the system headers by the struct-verification test.

A real, moving mtime gives tools that key on it (`ls -l`, `make`, `find -newer`, watchers) correct times, and is a freshness signal for a same-size content change on a stable inode — the change the macOS NFS backend cannot see through the inode-invalidation notifications, which it ignores. Verified against FUSE-T 1.2.7: two mounts of one space, at the branch head and just before the mtime work, both kept the value file's inode stable across rebuilds, and a same-size counter change refreshed in about 0.4 s with the moving mtime versus about 0.8 to 1.2 s without it, with `ls -l` showing a real date versus the epoch. The staleness without mtime is bounded by the mount's one-second attribute-cache default, not unbounded, so the mtime tightens the freshness window and restores correct timestamps rather than rescuing an otherwise-broken read. The measurements are recorded in docs/history.

## Docs and tests

The filesystem spec's inode-assignment and timestamp paragraphs, the reactivity spec's change-propagation and cache-invalidation sections, and the reliability-design and README summaries are updated for the stable model, and the open-questions doc records why `ctime` and `atime` are reported equal to `mtime` rather than tracked separately. Unit tests cover the transplant primitive, inode stability through both the direct and reactive rebuild paths, kind changes, removed paths, precise invalidation, mtime advancement, and the `[FS]` projection; the detach-and-retain tests are removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps inode numbers stable across piece-property rebuilds by reconciling subtrees in place and adds real per-node mtimes. This removes inode churn, narrows cache invalidations, and improves freshness and timestamps.

- **New Features**
  - In-place reconciliation via `FsTree.transplantSubtree`: surviving paths keep their inode; new paths get fresh inodes; removed paths free theirs. Swap is synchronous and staged; applies to both the prop dir and its `.json` sibling, and to the `[FS]` projection.
  - Precise cache invalidation: only invalidates changed inodes’ data and parent entry names that appeared/disappeared/moved. Also covers `[FS]` projection removal, dropping `index.md`/`index.json` and sibling dentries so freed inodes aren’t resolved.
  - Per-node `mtime`: advances on content changes and when a directory’s entries change; preserved when untouched, and clamped strictly upward. Piece dirs advance only when their top-level names change (staging names ignored). `pieces/` and `entities/` dirs advance on piece add/remove. Surfaced via `buildNodeStat` and written to `st_mtim`/`st_mtimespec` (with `ctime`/`atime` = `mtime`).
  - Reactive path keeps the subtree: bumps the hydration epoch and rebuilds onto the existing tree, preserving inodes.

- **Migration**
  - The 1s detached-subtree retention is removed. If a rebuild removes a path, open handles to it stop resolving immediately.

<sup>Written for commit 995db656814c80b13828010f5b32ee069f5a8459. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

