### PR TITLE
fix(fuse): dispatch reverse invalidation off the request thread

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -194,6 +194,10 @@ One line per archived document; each document's header carries the fuller
 
 ### Investigations, journals, and working notes
 
+- [reverse-invalidation-deadlock.md](packages/fuse/reverse-invalidation-deadlock.md)
+  — root cause of the FUSE daemon hang that flaked the CLI FUSE integration
+  suite: synchronous reverse invalidation deadlocking the request thread,
+  July 2026.
 - [settle-wave-2026-03-findings.md](development/debugging/settle-wave-2026-03-findings.md)
   — March 2026 settle-wave measurements.
 - [2026-07-group-chat-idempotency-false-positive.md](development/debugging/2026-07-group-chat-idempotency-false-positive.md)

--- a/docs/history/packages/fuse/reverse-invalidation-deadlock.md
+++ b/docs/history/packages/fuse/reverse-invalidation-deadlock.md
@@ -162,10 +162,16 @@ running inline. Only the reverse-invalidation calls, which take a lock that a
 request can hold, needed to move off the isolate thread.
 
 One lifetime detail: because an invalidation can now still be running on an FFI
-thread when the daemon shuts down, `main()` awaits the last flush before it
-destroys the session, so a notify call cannot dereference freed session memory.
-By shutdown the session has been unmounted, which releases any blocked notify,
-so the wait resolves promptly.
+thread when the daemon shuts down, a notify call must not touch the session
+after `fuse_session_destroy` frees it. Before destroying the session, `main()`
+closes the queue, cancels any pending flush timer, and awaits the flush still
+running. Closing refuses new invalidations and stops an in-flight flush after
+its current call. It does not rely on the session already being unmounted: only
+the SIGINT/SIGTERM handler unmounts, yet the session loop can also exit on an
+external unmount or a kernel abort with no signal, so the queue is closed on the
+shutdown path itself rather than through that handler. The one notify still in
+flight is released by the torn-down connection that made the loop exit, so the
+await resolves without blocking.
 
 `packages/fuse/platform.test.ts` guards the invariant: the reverse-invalidation
 symbols must be nonblocking and the reply functions must not be, so a later edit

--- a/docs/history/packages/fuse/reverse-invalidation-deadlock.md
+++ b/docs/history/packages/fuse/reverse-invalidation-deadlock.md
@@ -1,0 +1,181 @@
+---
+status: historical
+created: 2026-07-18
+archived: 2026-07-18
+reason: "Root-cause record for the FUSE daemon hang that flaked the CLI FUSE integration suite; the fix shipped in packages/fuse."
+---
+
+# FUSE daemon hang: reverse invalidation deadlocks the request thread
+
+## Summary
+
+The CLI FUSE integration suite (`packages/cli/integration/fuse-exec.sh`)
+failed on roughly a quarter of CI runs, across many unrelated branches. On a
+failing run the daemon mounted cleanly and then served zero filesystem
+operations: every `test -e` probe timed out because the mount never answered a
+single lookup. The daemon's worker process sat in uninterruptible kernel sleep
+(process state `D`) before it handled its first request.
+
+The daemon deadlocked itself. It issued a kernel cache reverse invalidation
+(`fuse_lowlevel_notify_inval_entry`) synchronously, on the same thread that
+answers filesystem requests. On Linux that call enters the kernel and takes the
+target directory's inode lock for writing. A lookup that is already in flight
+under that directory holds the same lock for reading until the daemon answers
+it. The daemon answers on the thread now blocked inside the invalidation, so the
+lookup can never be answered, the read lock is never released, and the write
+wait never completes. The mount is dead.
+
+The fix runs the two reverse-invalidation calls off the request thread, so the
+request thread stays free to answer the lookup that the invalidation is waiting
+behind.
+
+## Why it looked like a random CI flake
+
+The bug is a timing race, so it surfaced as load-dependent flakiness rather than
+a deterministic failure. It needs a reverse invalidation to run while a lookup
+under the same directory is in flight in the kernel but has not yet been
+answered by the daemon. Under light load a probe's lookup is answered before the
+next invalidation fires, and nothing collides. Under CI contention the gap
+between "a piece rebuild finished and scheduled an invalidation" and "the
+scheduled invalidation actually ran" widens, and a probe's lookup is far more
+likely to be sitting in that gap. That is why the failures clustered by runner
+load and hit branches whose code had nothing to do with FUSE.
+
+The daemon's last log line on a hung run was the piece-list sync finishing a
+rebuild (`Updated <Piece>/result`). That rebuild is exactly what schedules the
+reverse invalidations that then deadlock, which is why the log stops there.
+
+## Why it never reproduced on macOS
+
+FUSE-T, the macOS provider, returns success from `notify_inval_entry` and
+`notify_inval_inode` without doing anything (see the note in
+`packages/fuse/mount-options.ts`). The call never enters the kernel lock path,
+so it never blocks, so the deadlock cannot form. The bug is specific to Linux
+libfuse3, where the invalidation does real work.
+
+## The two threads, and why they wait on each other
+
+The daemon is single-threaded for request handling. `fuse_session_loop` runs on
+one Deno FFI blocking-pool thread for the mount's lifetime. Every operation
+callback and, before this fix, every reverse-invalidation call runs on the one
+V8 isolate thread. When the session-loop thread reads a request from
+`/dev/fuse`, it hands the work to the isolate thread and waits; the isolate
+thread runs the callback and calls the reply function. So a reply can only be
+produced by the isolate thread.
+
+Reverse invalidation was issued on that same isolate thread. On Linux the call
+path is `writev` on `/dev/fuse` into the kernel, then
+`fuse_reverse_inval_entry`, which takes the parent directory's inode read/write
+semaphore for writing. A concurrent lookup holds that same semaphore for
+reading across its whole request: the kernel takes it in `__lookup_slow` before
+sending the lookup to the daemon and releases it only after the daemon replies.
+
+The wait graph is a cycle:
+
+- The isolate thread is inside the invalidation, waiting to take the parent
+  inode semaphore for writing.
+- The write wait is queued behind a lookup that holds the same semaphore for
+  reading.
+- That lookup is waiting for the daemon to reply.
+- The daemon replies on the isolate thread, which is stuck in the invalidation.
+
+Nothing breaks the cycle, so the isolate thread stays in uninterruptible sleep
+and the mount serves nothing.
+
+The existing mitigation did not cover this. The daemon already defers
+invalidations onto a timer and skips the flush while `pendingFuseReplies > 0`.
+But `pendingFuseReplies` only counts requests whose callback has begun running
+on the isolate thread and deferred its reply. The lookup in the deadlock has
+been accepted by the kernel — which is already holding the read lock — but its
+callback has not started on the isolate thread yet, so the counter is still
+zero and the flush proceeds.
+
+## Reproduction
+
+The repro is a self-contained libfuse3 daemon (about 250 lines) that mirrors the
+real daemon's threading: `fuse_session_loop` as a nonblocking FFI symbol,
+op callbacks and reverse invalidations on the isolate thread. It mounts a
+trivial tree (a root directory containing `dir`, which contains `file`) and
+runs on Linux libfuse3. It reproduces on aarch64 and x86_64 alike; the deadlock
+is in the kernel's inode-lock handling and is architecture-independent.
+
+It was run under Colima (an aarch64 Linux VM), in a container started with
+`--cap-add SYS_ADMIN --device /dev/fuse`. Two triggers were exercised:
+
+1. A deterministic trigger, where the lookup handler issues the invalidation for
+   `dir` inline, before replying. This guarantees the invalidation runs while
+   this very lookup holds the parent read lock, so the deadlock forms every
+   time. It is a stand-in that pins the exact lock topology.
+2. The realistic trigger, matching the daemon's actual shape: a timer-driven
+   flush that issues invalidations for `dir` while forty-eight parallel
+   processes hammer `stat` on `dir` and `dir/file`. This reproduces the same
+   deadlock probabilistically under contention, which is what CI hits.
+
+Both triggers produced the identical kernel stack on the wedged isolate thread:
+
+```
+state=D  wchan=fuse_reverse_inval_entry
+[<0>] fuse_reverse_inval_entry+0x4c/0x210
+[<0>] fuse_notify_inval_entry
+[<0>] fuse_notify
+[<0>] fuse_dev_do_write
+[<0>] fuse_dev_write
+[<0>] ... vfs_writev ... __arm64_sys_writev
+```
+
+The counterpart probe was blocked waiting for the reply, holding the parent
+read lock:
+
+```
+state=D  wchan=request_wait_answer
+[<0>] request_wait_answer
+[<0>] fuse_simple_request
+[<0>] fuse_lookup_name
+[<0>] fuse_lookup
+[<0>] __lookup_slow          <- holds inode_lock_shared(parent) here
+[<0>] ... path_lookupat ... __arm64_sys_statx
+```
+
+Once wedged, the daemon could not be killed (uninterruptible sleep ignores
+`SIGKILL`) and the mount could not be unmounted. The only recovery was aborting
+the FUSE connection through `/sys/fs/fuse/connections/<id>/abort`, which is the
+documented last resort for a wedged mount. This matches the CI behavior, where
+the job ran to its step timeout and was cancelled.
+
+## The fix
+
+The two reverse-invalidation FFI symbols, `fuse_lowlevel_notify_inval_entry` and
+`fuse_lowlevel_notify_inval_inode`, are declared nonblocking in
+`packages/fuse/platform.ts`. A nonblocking FFI call runs on an FFI thread rather
+than the isolate thread and returns a promise. The daemon's flush in
+`packages/fuse/mod.ts` awaits each call.
+
+Now the invalidation blocks on the parent inode semaphore on an FFI thread. The
+isolate thread stays free, answers the in-flight lookup, and the lookup releases
+its read lock. The invalidation's write wait then completes on the FFI thread.
+The cycle is broken.
+
+The reply functions stay synchronous. They are called from inside the op
+callbacks on the isolate thread, they hand an answer to an outstanding request
+rather than waiting on a lock, and the reply-once contract depends on them
+running inline. Only the reverse-invalidation calls, which take a lock that a
+request can hold, needed to move off the isolate thread.
+
+One lifetime detail: because an invalidation can now still be running on an FFI
+thread when the daemon shuts down, `main()` awaits the last flush before it
+destroys the session, so a notify call cannot dereference freed session memory.
+By shutdown the session has been unmounted, which releases any blocked notify,
+so the wait resolves promptly.
+
+`packages/fuse/platform.test.ts` guards the invariant: the reverse-invalidation
+symbols must be nonblocking and the reply functions must not be, so a later edit
+cannot quietly move the invalidation back onto the request thread.
+
+### Verification
+
+Under the same forty-eight-worker `stat` storm that deadlocks the current
+daemon at once, the fixed daemon kept serving: it handled thousands of lookups
+and getattrs over twenty seconds while issuing invalidations continuously, and
+its isolate thread stayed in the normal event-loop wait (`ep_poll`) throughout.
+The deterministic inline trigger, which deadlocks every time before the fix,
+also completed the lookup and returned correct metadata after it.

--- a/packages/fuse/invalidation.test.ts
+++ b/packages/fuse/invalidation.test.ts
@@ -249,6 +249,51 @@ Deno.test("active() resolves before any flush and tracks the latest flush after"
   await flush;
 });
 
+Deno.test("close refuses further additions and reports closed", () => {
+  const { queue } = setup();
+  assert(!queue.closed);
+  queue.close();
+  assert(queue.closed);
+  assertEquals(queue.addEntry(1n, ["a"]), false);
+  assertEquals(queue.addInode(2n), false);
+});
+
+Deno.test("a flush after close is a no-op that issues nothing", async () => {
+  const { queue, rec } = setup();
+  queue.addEntry(1n, ["a"]);
+  queue.addInode(2n);
+  queue.close();
+  await queue.flush();
+  assertEquals(rec.entryCalls.length, 0);
+  assertEquals(rec.inodeCalls.length, 0);
+});
+
+Deno.test("close during an in-flight flush halts the remaining notifies", async () => {
+  const gate = deferred<number>();
+  let calls = 0;
+  const { queue, rec } = setup({
+    invalidateEntry: (parentIno, nameBuf, nameLen) => {
+      calls++;
+      const name = decoder.decode(nameBuf).replace(/\0$/, "");
+      rec.entryCalls.push({ parentIno, name, nameLen });
+      return calls === 1 ? gate.promise : 0;
+    },
+  });
+  queue.addEntry(1n, ["a", "b"]);
+  queue.addInode(9n);
+  const flush = queue.flush();
+  // Close while the first notify is still outstanding on the FFI thread.
+  queue.close();
+  gate.resolve(0);
+  await flush;
+  // Only the first name went out; "b" and the inode pass are skipped, and the
+  // queue is drained.
+  assertEquals(rec.entryCalls.map((c) => c.name), ["a"]);
+  assertEquals(rec.inodeCalls.length, 0);
+  assertEquals(queue.pendingEntryCount, 0);
+  assertEquals(queue.pendingInodeCount, 0);
+});
+
 Deno.test("both synchronous and asynchronous notify results are drained", async () => {
   const { queue, rec } = setup({
     invalidateEntry: (parentIno, nameBuf, nameLen) => {

--- a/packages/fuse/invalidation.test.ts
+++ b/packages/fuse/invalidation.test.ts
@@ -1,0 +1,263 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  type ReverseInvalidationDeps,
+  ReverseInvalidationQueue,
+} from "./invalidation.ts";
+
+const decoder = new TextDecoder();
+
+interface Recorder {
+  entryCalls: { parentIno: bigint; name: string; nameLen: bigint }[];
+  inodeCalls: bigint[];
+  logs: string[];
+  warns: string[];
+}
+
+function setup(overrides: Partial<ReverseInvalidationDeps> = {}) {
+  const rec: Recorder = { entryCalls: [], inodeCalls: [], logs: [], warns: [] };
+  const deps: ReverseInvalidationDeps = {
+    invalidateEntry: (parentIno, nameBuf, nameLen) => {
+      const name = decoder.decode(nameBuf).replace(/\0$/, "");
+      rec.entryCalls.push({ parentIno, name, nameLen });
+      return 0;
+    },
+    invalidateInode: (ino) => {
+      rec.inodeCalls.push(ino);
+      return 0;
+    },
+    isUnmounting: () => false,
+    debug: false,
+    log: (m) => rec.logs.push(m),
+    warn: (m) => rec.warns.push(m),
+    ...overrides,
+  };
+  const queue = new ReverseInvalidationQueue(deps);
+  return { queue, rec };
+}
+
+/** A promise plus its resolver, for holding a flush mid-await. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+Deno.test("flushes queued entry invalidations off-thread with the name length excluding NUL", async () => {
+  const { queue, rec } = setup();
+  assert(queue.addEntry(1n, ["alpha", "beta"]));
+  assertEquals(queue.pendingEntryCount, 1);
+  await queue.flush();
+  assertEquals(rec.entryCalls, [
+    { parentIno: 1n, name: "alpha", nameLen: 5n },
+    { parentIno: 1n, name: "beta", nameLen: 4n },
+  ]);
+  assertEquals(queue.pendingEntryCount, 0);
+});
+
+Deno.test("coalesces repeated names and parents before flushing", async () => {
+  const { queue, rec } = setup();
+  queue.addEntry(1n, ["a"]);
+  queue.addEntry(1n, ["a", "b"]);
+  queue.addEntry(2n, ["c"]);
+  assertEquals(queue.pendingEntryCount, 2);
+  await queue.flush();
+  assertEquals(
+    rec.entryCalls.map((c) => `${c.parentIno}:${c.name}`),
+    ["1:a", "1:b", "2:c"],
+  );
+});
+
+Deno.test("flushes queued inode invalidations", async () => {
+  const { queue, rec } = setup();
+  assert(queue.addInode(5n));
+  assert(queue.addInode(5n));
+  assert(queue.addInode(6n));
+  assertEquals(queue.pendingInodeCount, 2);
+  await queue.flush();
+  assertEquals(rec.inodeCalls, [5n, 6n]);
+  assertEquals(queue.pendingInodeCount, 0);
+});
+
+Deno.test("flush with nothing queued issues no notify calls", async () => {
+  const { queue, rec } = setup();
+  await queue.flush();
+  assertEquals(rec.entryCalls.length, 0);
+  assertEquals(rec.inodeCalls.length, 0);
+});
+
+Deno.test("queue additions are rejected while unmounting", () => {
+  const { queue } = setup({ isUnmounting: () => true });
+  assertEquals(queue.addEntry(1n, ["a"]), false);
+  assertEquals(queue.addInode(2n), false);
+  assertEquals(queue.pendingEntryCount, 0);
+  assertEquals(queue.pendingInodeCount, 0);
+});
+
+Deno.test("an unsupported entry notify disables further entry invalidation and logs once", async () => {
+  const { queue, rec } = setup({
+    invalidateEntry: () => -38, // -ENOSYS
+  });
+  queue.addEntry(1n, ["a", "b"]);
+  queue.addEntry(2n, ["c"]);
+  await queue.flush();
+  assertEquals(queue.entryNotifySupported, false);
+  assertEquals(
+    rec.logs,
+    ["notify_inval_entry not supported; skipping entry invalidation"],
+  );
+  // Later additions are refused now that the provider lacks the op.
+  assertEquals(queue.addEntry(3n, ["d"]), false);
+});
+
+Deno.test("an entry notify that throws disables entry invalidation and warns", async () => {
+  const { queue, rec } = setup({
+    invalidateEntry: () => {
+      throw new Error("boom");
+    },
+  });
+  queue.addEntry(1n, ["a"]);
+  await queue.flush();
+  assertEquals(queue.entryNotifySupported, false);
+  assertEquals(rec.warns.length, 1);
+  assert(rec.warns[0].includes("notify_inval_entry failed"));
+});
+
+Deno.test("an unsupported inode notify disables further inode invalidation without logging", async () => {
+  const { queue, rec } = setup({
+    invalidateInode: () => -38,
+  });
+  queue.addInode(9n);
+  await queue.flush();
+  assertEquals(queue.inodeNotifySupported, false);
+  assertEquals(rec.logs.length, 0);
+  assertEquals(queue.addInode(10n), false);
+});
+
+Deno.test("an inode notify that throws disables inode invalidation and warns", async () => {
+  const { queue, rec } = setup({
+    invalidateInode: () => {
+      throw new Error("nope");
+    },
+  });
+  queue.addInode(9n);
+  await queue.flush();
+  assertEquals(queue.inodeNotifySupported, false);
+  assert(rec.warns[0].includes("notify_inval_inode failed"));
+});
+
+Deno.test("debug logs a nonzero entry result but stays quiet on success", async () => {
+  const results = [7, 0];
+  const { queue, rec } = setup({
+    debug: true,
+    invalidateEntry: () => results.shift() ?? 0,
+  });
+  queue.addEntry(1n, ["a", "b"]);
+  await queue.flush();
+  assertEquals(rec.logs, ["notify_inval_entry(parent=1, name=a) => 7"]);
+});
+
+Deno.test("debug logs every inode result, including zero", async () => {
+  const { queue, rec } = setup({ debug: true });
+  queue.addInode(4n);
+  await queue.flush();
+  assertEquals(rec.logs, ["notify_inval_inode(ino=4) => 0"]);
+});
+
+Deno.test("the drain loop picks up work queued while an await is outstanding", async () => {
+  const rec: Recorder = { entryCalls: [], inodeCalls: [], logs: [], warns: [] };
+  const queue = new ReverseInvalidationQueue({
+    invalidateEntry: (parentIno, nameBuf, nameLen) => {
+      const name = decoder.decode(nameBuf).replace(/\0$/, "");
+      rec.entryCalls.push({ parentIno, name, nameLen });
+      // Enqueue more work during the first notify; the snapshot-and-clear loop
+      // must pick it up in a later pass rather than drop it.
+      if (rec.entryCalls.length === 1) queue.addEntry(2n, ["x"]);
+      return Promise.resolve(0);
+    },
+    invalidateInode: () => 0,
+    isUnmounting: () => false,
+    debug: false,
+  });
+  queue.addEntry(1n, ["a"]);
+  await queue.flush();
+  assertEquals(
+    rec.entryCalls.map((c) => `${c.parentIno}:${c.name}`),
+    ["1:a", "2:x"],
+  );
+});
+
+Deno.test("a re-entrant flush returns the running flush instead of starting a second", async () => {
+  const gate = deferred<number>();
+  let calls = 0;
+  const { queue, rec } = setup({
+    invalidateEntry: (parentIno, nameBuf, nameLen) => {
+      calls++;
+      const name = decoder.decode(nameBuf).replace(/\0$/, "");
+      rec.entryCalls.push({ parentIno, name, nameLen });
+      return calls === 1 ? gate.promise : 0;
+    },
+  });
+  queue.addEntry(1n, ["a"]);
+  const first = queue.flush();
+  const second = queue.flush();
+  assertEquals(first, second);
+  assertEquals(queue.active(), first);
+  gate.resolve(0);
+  await first;
+  assertEquals(calls, 1);
+});
+
+Deno.test("unmounting mid-flush stops issuing and clears the queue", async () => {
+  let unmounting = false;
+  const { queue, rec } = setup({
+    isUnmounting: () => unmounting,
+    invalidateEntry: (parentIno, nameBuf, nameLen) => {
+      const name = decoder.decode(nameBuf).replace(/\0$/, "");
+      rec.entryCalls.push({ parentIno, name, nameLen });
+      unmounting = true; // tear-down begins after the first notify
+      return Promise.resolve(0);
+    },
+  });
+  queue.addEntry(1n, ["a", "b"]);
+  queue.addEntry(3n, ["c"]);
+  await queue.flush();
+  // Only the first name went out; the remaining name, the second parent, and
+  // the inode pass are all skipped once unmounting is observed.
+  assertEquals(rec.entryCalls.map((c) => c.name), ["a"]);
+  assertEquals(queue.pendingEntryCount, 0);
+});
+
+Deno.test("a disabled entry kind is skipped while the inode kind still flushes", async () => {
+  const { queue, rec } = setup({ invalidateEntry: () => -38 });
+  queue.addEntry(1n, ["a"]);
+  await queue.flush();
+  assertEquals(queue.entryNotifySupported, false);
+  // A later inode flush must still run even though the entry op is disabled.
+  assert(queue.addInode(5n));
+  await queue.flush();
+  assertEquals(rec.inodeCalls, [5n]);
+});
+
+Deno.test("active() resolves before any flush and tracks the latest flush after", async () => {
+  const { queue } = setup();
+  await queue.active(); // the initial resolved promise
+  queue.addEntry(1n, ["a"]);
+  const flush = queue.flush();
+  assertEquals(queue.active(), flush);
+  await flush;
+});
+
+Deno.test("both synchronous and asynchronous notify results are drained", async () => {
+  const { queue, rec } = setup({
+    invalidateEntry: (parentIno, nameBuf, nameLen) => {
+      const name = decoder.decode(nameBuf).replace(/\0$/, "");
+      rec.entryCalls.push({ parentIno, name, nameLen });
+      return name === "sync" ? 0 : Promise.resolve(0);
+    },
+  });
+  queue.addEntry(1n, ["sync", "async"]);
+  await queue.flush();
+  assertEquals(rec.entryCalls.map((c) => c.name), ["sync", "async"]);
+});

--- a/packages/fuse/invalidation.ts
+++ b/packages/fuse/invalidation.ts
@@ -48,6 +48,7 @@ export class ReverseInvalidationQueue {
   readonly #encoder = new TextEncoder();
   #entrySupported = true;
   #inodeSupported = true;
+  #closed = false;
   readonly #pendingEntry = new Map<
     string,
     { parentIno: bigint; names: Set<string> }
@@ -76,12 +77,32 @@ export class ReverseInvalidationQueue {
     return this.#pendingInode.size;
   }
 
+  get closed(): boolean {
+    return this.#closed;
+  }
+
+  /**
+   * Permanently stop the queue: refuse further additions and issue no more
+   * notify calls, halting a flush already in progress at its next step.
+   *
+   * The daemon calls this during shutdown before the session is destroyed. The
+   * session loop can exit without going through the unmounting flag (an
+   * external unmount or a kernel abort), so closing here — not only in the
+   * signal handler — is what guarantees no flush scheduled just before the exit
+   * calls the notify FFI symbols against freed session memory.
+   */
+  close(): void {
+    this.#closed = true;
+  }
+
   /**
    * Queue an entry invalidation for `names` under `parentIno`. Returns whether
    * the work was accepted, so the caller can schedule a flush only when it was.
    */
   addEntry(parentIno: bigint, names: string[]): boolean {
-    if (!this.#entrySupported || this.#deps.isUnmounting()) return false;
+    if (this.#closed || !this.#entrySupported || this.#deps.isUnmounting()) {
+      return false;
+    }
     const key = parentIno.toString();
     let pending = this.#pendingEntry.get(key);
     if (!pending) {
@@ -96,7 +117,9 @@ export class ReverseInvalidationQueue {
 
   /** Queue an inode invalidation. Returns whether the work was accepted. */
   addInode(ino: bigint): boolean {
-    if (!this.#inodeSupported || this.#deps.isUnmounting()) return false;
+    if (this.#closed || !this.#inodeSupported || this.#deps.isUnmounting()) {
+      return false;
+    }
     this.#pendingInode.add(ino);
     return true;
   }
@@ -116,10 +139,14 @@ export class ReverseInvalidationQueue {
    * second one; that running flush drains anything queued during its awaits.
    */
   flush(): Promise<void> {
-    if (this.#flushing) return this.#activeFlush;
+    if (this.#closed || this.#flushing) return this.#activeFlush;
     this.#flushing = true;
     this.#activeFlush = this.#run();
     return this.#activeFlush;
+  }
+
+  #shuttingDown(): boolean {
+    return this.#closed || this.#deps.isUnmounting();
   }
 
   async #run(): Promise<void> {
@@ -128,7 +155,7 @@ export class ReverseInvalidationQueue {
       // queued while an await is outstanding are picked up by the next loop
       // iteration rather than lost.
       while (
-        !this.#deps.isUnmounting() &&
+        !this.#shuttingDown() &&
         (this.#pendingEntry.size > 0 || this.#pendingInode.size > 0)
       ) {
         const entryBatch = [...this.#pendingEntry.values()];
@@ -140,7 +167,7 @@ export class ReverseInvalidationQueue {
         if (this.#inodeSupported) await this.#flushInodes(inodeBatch);
       }
 
-      if (this.#deps.isUnmounting()) {
+      if (this.#shuttingDown()) {
         this.#pendingEntry.clear();
         this.#pendingInode.clear();
       }
@@ -155,9 +182,9 @@ export class ReverseInvalidationQueue {
     const log = this.#deps.log ?? console.log;
     const warn = this.#deps.warn ?? console.warn;
     for (const { parentIno, names } of batch) {
-      if (!this.#entrySupported || this.#deps.isUnmounting()) break;
+      if (!this.#entrySupported || this.#shuttingDown()) break;
       for (const name of names) {
-        if (!this.#entrySupported || this.#deps.isUnmounting()) break;
+        if (!this.#entrySupported || this.#shuttingDown()) break;
         const nameBuf = this.#encoder.encode(name + "\0");
         try {
           const rc = await this.#deps.invalidateEntry(
@@ -190,7 +217,7 @@ export class ReverseInvalidationQueue {
     const log = this.#deps.log ?? console.log;
     const warn = this.#deps.warn ?? console.warn;
     for (const ino of batch) {
-      if (!this.#inodeSupported || this.#deps.isUnmounting()) break;
+      if (!this.#inodeSupported || this.#shuttingDown()) break;
       try {
         const ret = await this.#deps.invalidateInode(ino);
         if (ret === NOTIFY_UNSUPPORTED) {

--- a/packages/fuse/invalidation.ts
+++ b/packages/fuse/invalidation.ts
@@ -21,11 +21,14 @@ export type NotifyResult = number | Promise<number>;
 export interface ReverseInvalidationDeps {
   /**
    * Issue notify_inval_entry off the isolate thread. `nameBuf` is the
-   * null-terminated entry name; `nameLen` excludes the terminator.
+   * null-terminated entry name; `nameLen` excludes the terminator. The buffer
+   * is typed as `ArrayBuffer`-backed (not the wider `ArrayBufferLike`) so it
+   * satisfies the FFI buffer parameter, which a nonblocking call pins and so
+   * rejects a possibly-shared buffer.
    */
   invalidateEntry(
     parentIno: bigint,
-    nameBuf: Uint8Array,
+    nameBuf: Uint8Array<ArrayBuffer>,
     nameLen: bigint,
   ): NotifyResult;
   /** Issue notify_inval_inode off the isolate thread (whole inode). */

--- a/packages/fuse/invalidation.ts
+++ b/packages/fuse/invalidation.ts
@@ -1,0 +1,210 @@
+// invalidation.ts — Reverse kernel-cache invalidation queue for the FUSE daemon.
+//
+// The daemon answers FUSE requests on the isolate thread. A reverse
+// invalidation (notify_inval_entry / notify_inval_inode) enters the Linux
+// kernel and takes the target directory's inode lock for write; a concurrent
+// lookup under that directory holds the same lock for read until the daemon
+// answers it. Issuing the invalidation on the isolate thread would block that
+// thread inside the kernel behind a lookup only it can answer, deadlocking the
+// mount. The daemon therefore hands the invalidation FFI calls to this queue,
+// which issues them off the isolate thread and awaits them, leaving the request
+// path free.
+//
+// The queue coalesces invalidations, snapshots and clears its pending sets each
+// pass so work queued during an await is not lost, and disables an invalidation
+// kind when libfuse reports it as unsupported (return code -ENOSYS; FUSE-T on
+// macOS accepts the call and does nothing instead).
+
+/** A reverse-invalidation FFI result: the libfuse return code, sync or async. */
+export type NotifyResult = number | Promise<number>;
+
+export interface ReverseInvalidationDeps {
+  /**
+   * Issue notify_inval_entry off the isolate thread. `nameBuf` is the
+   * null-terminated entry name; `nameLen` excludes the terminator.
+   */
+  invalidateEntry(
+    parentIno: bigint,
+    nameBuf: Uint8Array,
+    nameLen: bigint,
+  ): NotifyResult;
+  /** Issue notify_inval_inode off the isolate thread (whole inode). */
+  invalidateInode(ino: bigint): NotifyResult;
+  /** Whether the mount is tearing down; queued work is dropped once true. */
+  isUnmounting(): boolean;
+  /** Emit per-call diagnostics when set. */
+  debug: boolean;
+  /** Diagnostic sink; defaults to console.log. */
+  log?: (message: string) => void;
+  /** Failure sink; defaults to console.warn. */
+  warn?: (message: string) => void;
+}
+
+// libfuse returns -ENOSYS when a notify op is not implemented by the provider.
+const NOTIFY_UNSUPPORTED = -38;
+
+export class ReverseInvalidationQueue {
+  readonly #deps: ReverseInvalidationDeps;
+  readonly #encoder = new TextEncoder();
+  #entrySupported = true;
+  #inodeSupported = true;
+  readonly #pendingEntry = new Map<
+    string,
+    { parentIno: bigint; names: Set<string> }
+  >();
+  readonly #pendingInode = new Set<bigint>();
+  #flushing = false;
+  #activeFlush: Promise<void> = Promise.resolve();
+
+  constructor(deps: ReverseInvalidationDeps) {
+    this.#deps = deps;
+  }
+
+  get entryNotifySupported(): boolean {
+    return this.#entrySupported;
+  }
+
+  get inodeNotifySupported(): boolean {
+    return this.#inodeSupported;
+  }
+
+  get pendingEntryCount(): number {
+    return this.#pendingEntry.size;
+  }
+
+  get pendingInodeCount(): number {
+    return this.#pendingInode.size;
+  }
+
+  /**
+   * Queue an entry invalidation for `names` under `parentIno`. Returns whether
+   * the work was accepted, so the caller can schedule a flush only when it was.
+   */
+  addEntry(parentIno: bigint, names: string[]): boolean {
+    if (!this.#entrySupported || this.#deps.isUnmounting()) return false;
+    const key = parentIno.toString();
+    let pending = this.#pendingEntry.get(key);
+    if (!pending) {
+      pending = { parentIno, names: new Set<string>() };
+      this.#pendingEntry.set(key, pending);
+    }
+    for (const name of names) {
+      pending.names.add(name);
+    }
+    return true;
+  }
+
+  /** Queue an inode invalidation. Returns whether the work was accepted. */
+  addInode(ino: bigint): boolean {
+    if (!this.#inodeSupported || this.#deps.isUnmounting()) return false;
+    this.#pendingInode.add(ino);
+    return true;
+  }
+
+  /**
+   * The most recent flush. Await this before the session is destroyed so no
+   * notify call is still running on an FFI thread when the session memory it
+   * dereferences is freed.
+   */
+  active(): Promise<void> {
+    return this.#activeFlush;
+  }
+
+  /**
+   * Drain the queued invalidations off the isolate thread. A re-entrant call
+   * while a flush is running returns the running flush rather than starting a
+   * second one; that running flush drains anything queued during its awaits.
+   */
+  flush(): Promise<void> {
+    if (this.#flushing) return this.#activeFlush;
+    this.#flushing = true;
+    this.#activeFlush = this.#run();
+    return this.#activeFlush;
+  }
+
+  async #run(): Promise<void> {
+    try {
+      // Snapshot each pass and clear the pending sets first, so invalidations
+      // queued while an await is outstanding are picked up by the next loop
+      // iteration rather than lost.
+      while (
+        !this.#deps.isUnmounting() &&
+        (this.#pendingEntry.size > 0 || this.#pendingInode.size > 0)
+      ) {
+        const entryBatch = [...this.#pendingEntry.values()];
+        this.#pendingEntry.clear();
+        const inodeBatch = [...this.#pendingInode];
+        this.#pendingInode.clear();
+
+        if (this.#entrySupported) await this.#flushEntries(entryBatch);
+        if (this.#inodeSupported) await this.#flushInodes(inodeBatch);
+      }
+
+      if (this.#deps.isUnmounting()) {
+        this.#pendingEntry.clear();
+        this.#pendingInode.clear();
+      }
+    } finally {
+      this.#flushing = false;
+    }
+  }
+
+  async #flushEntries(
+    batch: { parentIno: bigint; names: Set<string> }[],
+  ): Promise<void> {
+    const log = this.#deps.log ?? console.log;
+    const warn = this.#deps.warn ?? console.warn;
+    for (const { parentIno, names } of batch) {
+      if (!this.#entrySupported || this.#deps.isUnmounting()) break;
+      for (const name of names) {
+        if (!this.#entrySupported || this.#deps.isUnmounting()) break;
+        const nameBuf = this.#encoder.encode(name + "\0");
+        try {
+          const rc = await this.#deps.invalidateEntry(
+            parentIno,
+            nameBuf,
+            BigInt(nameBuf.length - 1),
+          );
+          if (rc === NOTIFY_UNSUPPORTED) {
+            log(
+              "notify_inval_entry not supported; skipping entry invalidation",
+            );
+            this.#entrySupported = false;
+            break;
+          }
+          if (this.#deps.debug && rc !== 0) {
+            log(
+              `notify_inval_entry(parent=${parentIno}, name=${name}) => ${rc}`,
+            );
+          }
+        } catch (e) {
+          warn(`notify_inval_entry failed: ${e}`);
+          this.#entrySupported = false;
+          break;
+        }
+      }
+    }
+  }
+
+  async #flushInodes(batch: bigint[]): Promise<void> {
+    const log = this.#deps.log ?? console.log;
+    const warn = this.#deps.warn ?? console.warn;
+    for (const ino of batch) {
+      if (!this.#inodeSupported || this.#deps.isUnmounting()) break;
+      try {
+        const ret = await this.#deps.invalidateInode(ino);
+        if (ret === NOTIFY_UNSUPPORTED) {
+          this.#inodeSupported = false;
+          break;
+        }
+        if (this.#deps.debug) {
+          log(`notify_inval_inode(ino=${ino}) => ${ret}`);
+        }
+      } catch (e) {
+        warn(`notify_inval_inode failed: ${e}`);
+        this.#inodeSupported = false;
+        break;
+      }
+    }
+  }
+}

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -3380,10 +3380,13 @@ export async function main(argv: string[] = Deno.args) {
 
   let unmounting = false;
 
-  // The reverse-invalidation queue, when a bridge is present. Its active flush
-  // is awaited before the session is destroyed so no notify call is still
-  // running on an FFI thread when the session memory it dereferences is freed.
+  // The reverse-invalidation queue, when a bridge is present. It is closed and
+  // its active flush awaited before the session is destroyed, so no notify call
+  // is still running on an FFI thread when the session memory it dereferences is
+  // freed. `cancelInvalidationFlush` drops a pending flush timer during that
+  // shutdown.
   let invalidationQueue: ReverseInvalidationQueue | undefined;
+  let cancelInvalidationFlush: (() => void) | undefined;
 
   // Wire up kernel cache invalidation for subscriptions.
   //
@@ -3428,6 +3431,12 @@ export async function main(argv: string[] = Deno.args) {
       }, 0);
     };
     onPendingFuseRepliesDrained = scheduleInvalidationFlush;
+    cancelInvalidationFlush = () => {
+      if (invalidationTimer !== undefined) {
+        clearTimeout(invalidationTimer);
+        invalidationTimer = undefined;
+      }
+    };
 
     bridge.onInvalidate = (parentIno: bigint, names: string[]) => {
       if (queue.addEntry(parentIno, names)) scheduleInvalidationFlush();
@@ -3488,10 +3497,17 @@ export async function main(argv: string[] = Deno.args) {
     // Best effort during shutdown.
   });
 
-  // Let any reverse-invalidation flush still running on an FFI thread finish
-  // before the session is destroyed, so a notify call does not dereference
-  // freed session memory. The session is unmounted by now, so a blocked notify
-  // has been released by the torn-down connection and this resolves promptly.
+  // Stop the reverse-invalidation queue before the session is destroyed. The
+  // session loop can exit without a signal — an external unmount or a kernel
+  // abort — leaving `unmounting` false, so the queue is closed here rather than
+  // relying on the signal handler. Closing refuses further additions and halts
+  // an in-flight flush; dropping the reschedule hook and any pending timer stops
+  // a new flush from starting; the await lets a flush already on an FFI thread
+  // finish. Together these ensure no notify call runs against the session after
+  // it is destroyed.
+  invalidationQueue?.close();
+  onPendingFuseRepliesDrained = undefined;
+  cancelInvalidationFlush?.();
   await invalidationQueue?.active().catch(() => {});
 
   // Final cleanup

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -81,6 +81,7 @@ import {
   resolveMountCacheOptions,
 } from "./mount-options.ts";
 import { buildNodeStat, getMountOwnership, nodeMode } from "./stat.ts";
+import { ReverseInvalidationQueue } from "./invalidation.ts";
 
 const encoder = new TextEncoder();
 // Operation ring buffer — last 50 ops for crash diagnostics
@@ -3379,10 +3380,10 @@ export async function main(argv: string[] = Deno.args) {
 
   let unmounting = false;
 
-  // The most recent reverse-invalidation flush, awaited before the session is
-  // destroyed so no notify call is still running on an FFI thread when the
-  // session memory it dereferences is freed.
-  let activeInvalidationFlush: Promise<void> = Promise.resolve();
+  // The reverse-invalidation queue, when a bridge is present. Its active flush
+  // is awaited before the session is destroyed so no notify call is still
+  // running on an FFI thread when the session memory it dereferences is freed.
+  let invalidationQueue: ReverseInvalidationQueue | undefined;
 
   // Wire up kernel cache invalidation for subscriptions.
   //
@@ -3392,145 +3393,47 @@ export async function main(argv: string[] = Deno.args) {
   // the parent directory's inode lock for write, which a concurrent lookup
   // holds for read until the daemon answers it; the daemon answers on the
   // isolate thread, so a notify on that thread would block behind a lookup only
-  // that thread can complete. Queue notifications onto a timer, wait for tracked
-  // async replies to drain, and issue the notify calls off the isolate thread
-  // (they are nonblocking FFI symbols) so the request path stays free.
+  // that thread can complete. The queue coalesces notifications, and a timer
+  // gated on tracked async replies drains it off the isolate thread (the notify
+  // FFI symbols are nonblocking) so the request path stays free.
   if (bridge) {
-    let entryNotifySupported = true;
-    let inodeNotifySupported = true;
-    const pendingEntryInvalidations = new Map<
-      string,
-      { parentIno: bigint; names: Set<string> }
-    >();
-    const pendingInodeInvalidations = new Set<bigint>();
     let invalidationTimer: ReturnType<typeof setTimeout> | undefined;
+    const queue = new ReverseInvalidationQueue({
+      invalidateEntry: (parentIno, nameBuf, nameLen) =>
+        fuse.symbols.fuse_lowlevel_notify_inval_entry(
+          handle.notifyTarget,
+          parentIno,
+          nameBuf,
+          nameLen,
+        ),
+      // off=0, len=-1 invalidates all cached data for the inode.
+      invalidateInode: (ino) =>
+        fuse.symbols.fuse_lowlevel_notify_inval_inode(
+          handle.notifyTarget,
+          ino,
+          0n,
+          -1n,
+        ),
+      isUnmounting: () => unmounting,
+      debug,
+    });
+    invalidationQueue = queue;
 
     const scheduleInvalidationFlush = () => {
       if (invalidationTimer !== undefined) return;
       invalidationTimer = setTimeout(() => {
         invalidationTimer = undefined;
         if (pendingFuseReplies > 0) return;
-        activeInvalidationFlush = flushDeferredInvalidations();
+        queue.flush();
       }, 0);
     };
     onPendingFuseRepliesDrained = scheduleInvalidationFlush;
 
-    // Guards against a second flush starting while one is still awaiting its
-    // notify calls. The active flush drains anything queued during its awaits.
-    let flushingInvalidations = false;
-
-    const flushDeferredInvalidations = async (): Promise<void> => {
-      if (flushingInvalidations) return activeInvalidationFlush;
-      flushingInvalidations = true;
-      try {
-        // The notify calls run on an FFI thread and are awaited, so the isolate
-        // thread stays free to answer the FUSE requests whose inode locks the
-        // notify is blocked behind. Snapshot each pass and clear the pending
-        // sets first, so invalidations queued while an await is outstanding are
-        // picked up by the next loop iteration rather than lost.
-        while (
-          !unmounting &&
-          (pendingEntryInvalidations.size > 0 ||
-            pendingInodeInvalidations.size > 0)
-        ) {
-          const entryBatch = [...pendingEntryInvalidations.values()];
-          pendingEntryInvalidations.clear();
-          const inodeBatch = [...pendingInodeInvalidations];
-          pendingInodeInvalidations.clear();
-
-          if (entryNotifySupported) {
-            for (const { parentIno, names } of entryBatch) {
-              if (!entryNotifySupported || unmounting) break;
-              for (const name of names) {
-                if (!entryNotifySupported || unmounting) break;
-                const nameBuf = encoder.encode(name + "\0");
-                try {
-                  const rc = await fuse.symbols
-                    .fuse_lowlevel_notify_inval_entry(
-                      handle.notifyTarget,
-                      parentIno,
-                      nameBuf,
-                      BigInt(nameBuf.length - 1),
-                    );
-                  if (rc === -38) {
-                    // ENOSYS — this libfuse has no entry invalidation. FUSE-T
-                    // instead accepts the call and does nothing with it.
-                    console.log(
-                      "notify_inval_entry not supported; skipping entry invalidation",
-                    );
-                    entryNotifySupported = false;
-                    break;
-                  }
-                  if (debug && rc !== 0) {
-                    console.log(
-                      `notify_inval_entry(parent=${parentIno}, name=${name}) => ${rc}`,
-                    );
-                  }
-                } catch (e) {
-                  console.warn(`notify_inval_entry failed: ${e}`);
-                  entryNotifySupported = false;
-                  break;
-                }
-              }
-            }
-          }
-
-          if (inodeNotifySupported) {
-            for (const ino of inodeBatch) {
-              if (!inodeNotifySupported || unmounting) break;
-              try {
-                // Invalidate all cached data for this inode (off=0, len=-1 means all)
-                const ret = await fuse.symbols
-                  .fuse_lowlevel_notify_inval_inode(
-                    handle.notifyTarget,
-                    ino,
-                    0n,
-                    -1n,
-                  );
-                if (ret === -38) {
-                  // ENOSYS — this libfuse has no inode invalidation. FUSE-T
-                  // instead accepts the call and does nothing with it.
-                  inodeNotifySupported = false;
-                  break;
-                }
-                if (debug) {
-                  console.log(`notify_inval_inode(ino=${ino}) => ${ret}`);
-                }
-              } catch (e) {
-                console.warn(`notify_inval_inode failed: ${e}`);
-                inodeNotifySupported = false;
-                break;
-              }
-            }
-          }
-        }
-
-        if (unmounting) {
-          pendingEntryInvalidations.clear();
-          pendingInodeInvalidations.clear();
-        }
-      } finally {
-        flushingInvalidations = false;
-      }
-    };
-
     bridge.onInvalidate = (parentIno: bigint, names: string[]) => {
-      if (!entryNotifySupported || unmounting) return;
-      const key = parentIno.toString();
-      let pending = pendingEntryInvalidations.get(key);
-      if (!pending) {
-        pending = { parentIno, names: new Set<string>() };
-        pendingEntryInvalidations.set(key, pending);
-      }
-      for (const name of names) {
-        pending.names.add(name);
-      }
-      scheduleInvalidationFlush();
+      if (queue.addEntry(parentIno, names)) scheduleInvalidationFlush();
     };
     bridge.onInvalidateInode = (ino: bigint) => {
-      if (!inodeNotifySupported || unmounting) return;
-      pendingInodeInvalidations.add(ino);
-      scheduleInvalidationFlush();
+      if (queue.addInode(ino)) scheduleInvalidationFlush();
     };
   }
 
@@ -3589,7 +3492,7 @@ export async function main(argv: string[] = Deno.args) {
   // before the session is destroyed, so a notify call does not dereference
   // freed session memory. The session is unmounted by now, so a blocked notify
   // has been released by the torn-down connection and this resolves promptly.
-  await activeInvalidationFlush.catch(() => {});
+  await invalidationQueue?.active().catch(() => {});
 
   // Final cleanup
   platform.cleanup(fuse, handle, mountpointBuf, unmounting);

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -3379,14 +3379,22 @@ export async function main(argv: string[] = Deno.args) {
 
   let unmounting = false;
 
+  // The most recent reverse-invalidation flush, awaited before the session is
+  // destroyed so no notify call is still running on an FFI thread when the
+  // session memory it dereferences is freed.
+  let activeInvalidationFlush: Promise<void> = Promise.resolve();
+
   // Wire up kernel cache invalidation for subscriptions.
   //
   // libfuse reverse invalidation can block while the kernel answers the notify
   // request. Some bridge paths run while a FUSE request is still awaiting its
-  // reply (for example, lookup -> connectSpace -> syncPieceList). Calling
-  // notify inline from those paths can deadlock the daemon against the kernel's
-  // pending request. Queue notifications onto a timer and wait for all tracked
-  // async replies to drain before issuing reverse invalidations.
+  // reply (for example, lookup -> connectSpace -> syncPieceList). notify takes
+  // the parent directory's inode lock for write, which a concurrent lookup
+  // holds for read until the daemon answers it; the daemon answers on the
+  // isolate thread, so a notify on that thread would block behind a lookup only
+  // that thread can complete. Queue notifications onto a timer, wait for tracked
+  // async replies to drain, and issue the notify calls off the isolate thread
+  // (they are nonblocking FFI symbols) so the request path stays free.
   if (bridge) {
     let entryNotifySupported = true;
     let inodeNotifySupported = true;
@@ -3402,81 +3410,108 @@ export async function main(argv: string[] = Deno.args) {
       invalidationTimer = setTimeout(() => {
         invalidationTimer = undefined;
         if (pendingFuseReplies > 0) return;
-        flushDeferredInvalidations();
+        activeInvalidationFlush = flushDeferredInvalidations();
       }, 0);
     };
     onPendingFuseRepliesDrained = scheduleInvalidationFlush;
 
-    const flushDeferredInvalidations = () => {
-      if (unmounting) {
-        pendingEntryInvalidations.clear();
-        pendingInodeInvalidations.clear();
-        return;
-      }
+    // Guards against a second flush starting while one is still awaiting its
+    // notify calls. The active flush drains anything queued during its awaits.
+    let flushingInvalidations = false;
 
-      if (entryNotifySupported) {
-        for (const { parentIno, names } of pendingEntryInvalidations.values()) {
-          for (const name of names) {
-            const nameBuf = encoder.encode(name + "\0");
-            try {
-              const rc = fuse.symbols.fuse_lowlevel_notify_inval_entry(
-                handle.notifyTarget,
-                parentIno,
-                nameBuf,
-                BigInt(nameBuf.length - 1),
-              );
-              if (rc === -38) {
-                // ENOSYS — this libfuse has no entry invalidation. FUSE-T
-                // instead accepts the call and does nothing with it.
-                console.log(
-                  "notify_inval_entry not supported; skipping entry invalidation",
-                );
-                entryNotifySupported = false;
+    const flushDeferredInvalidations = async (): Promise<void> => {
+      if (flushingInvalidations) return activeInvalidationFlush;
+      flushingInvalidations = true;
+      try {
+        // The notify calls run on an FFI thread and are awaited, so the isolate
+        // thread stays free to answer the FUSE requests whose inode locks the
+        // notify is blocked behind. Snapshot each pass and clear the pending
+        // sets first, so invalidations queued while an await is outstanding are
+        // picked up by the next loop iteration rather than lost.
+        while (
+          !unmounting &&
+          (pendingEntryInvalidations.size > 0 ||
+            pendingInodeInvalidations.size > 0)
+        ) {
+          const entryBatch = [...pendingEntryInvalidations.values()];
+          pendingEntryInvalidations.clear();
+          const inodeBatch = [...pendingInodeInvalidations];
+          pendingInodeInvalidations.clear();
+
+          if (entryNotifySupported) {
+            for (const { parentIno, names } of entryBatch) {
+              if (!entryNotifySupported || unmounting) break;
+              for (const name of names) {
+                if (!entryNotifySupported || unmounting) break;
+                const nameBuf = encoder.encode(name + "\0");
+                try {
+                  const rc = await fuse.symbols
+                    .fuse_lowlevel_notify_inval_entry(
+                      handle.notifyTarget,
+                      parentIno,
+                      nameBuf,
+                      BigInt(nameBuf.length - 1),
+                    );
+                  if (rc === -38) {
+                    // ENOSYS — this libfuse has no entry invalidation. FUSE-T
+                    // instead accepts the call and does nothing with it.
+                    console.log(
+                      "notify_inval_entry not supported; skipping entry invalidation",
+                    );
+                    entryNotifySupported = false;
+                    break;
+                  }
+                  if (debug && rc !== 0) {
+                    console.log(
+                      `notify_inval_entry(parent=${parentIno}, name=${name}) => ${rc}`,
+                    );
+                  }
+                } catch (e) {
+                  console.warn(`notify_inval_entry failed: ${e}`);
+                  entryNotifySupported = false;
+                  break;
+                }
+              }
+            }
+          }
+
+          if (inodeNotifySupported) {
+            for (const ino of inodeBatch) {
+              if (!inodeNotifySupported || unmounting) break;
+              try {
+                // Invalidate all cached data for this inode (off=0, len=-1 means all)
+                const ret = await fuse.symbols
+                  .fuse_lowlevel_notify_inval_inode(
+                    handle.notifyTarget,
+                    ino,
+                    0n,
+                    -1n,
+                  );
+                if (ret === -38) {
+                  // ENOSYS — this libfuse has no inode invalidation. FUSE-T
+                  // instead accepts the call and does nothing with it.
+                  inodeNotifySupported = false;
+                  break;
+                }
+                if (debug) {
+                  console.log(`notify_inval_inode(ino=${ino}) => ${ret}`);
+                }
+              } catch (e) {
+                console.warn(`notify_inval_inode failed: ${e}`);
+                inodeNotifySupported = false;
                 break;
               }
-              if (debug && rc !== 0) {
-                console.log(
-                  `notify_inval_entry(parent=${parentIno}, name=${name}) => ${rc}`,
-                );
-              }
-            } catch (e) {
-              console.warn(`notify_inval_entry failed: ${e}`);
-              entryNotifySupported = false;
-              break;
             }
           }
-          if (!entryNotifySupported) break;
         }
-      }
-      pendingEntryInvalidations.clear();
 
-      if (inodeNotifySupported) {
-        for (const ino of pendingInodeInvalidations) {
-          try {
-            // Invalidate all cached data for this inode (off=0, len=-1 means all)
-            const ret = fuse.symbols.fuse_lowlevel_notify_inval_inode(
-              handle.notifyTarget,
-              ino,
-              0n,
-              -1n,
-            );
-            if (ret === -38) {
-              // ENOSYS — this libfuse has no inode invalidation. FUSE-T
-              // instead accepts the call and does nothing with it.
-              inodeNotifySupported = false;
-              break;
-            }
-            if (debug) {
-              console.log(`notify_inval_inode(ino=${ino}) => ${ret}`);
-            }
-          } catch (e) {
-            console.warn(`notify_inval_inode failed: ${e}`);
-            inodeNotifySupported = false;
-            break;
-          }
+        if (unmounting) {
+          pendingEntryInvalidations.clear();
+          pendingInodeInvalidations.clear();
         }
+      } finally {
+        flushingInvalidations = false;
       }
-      pendingInodeInvalidations.clear();
     };
 
     bridge.onInvalidate = (parentIno: bigint, names: string[]) => {
@@ -3549,6 +3584,12 @@ export async function main(argv: string[] = Deno.args) {
   await writeSupervisorStatus("exited", { exitCode: result }).catch(() => {
     // Best effort during shutdown.
   });
+
+  // Let any reverse-invalidation flush still running on an FFI thread finish
+  // before the session is destroyed, so a notify call does not dereference
+  // freed session memory. The session is unmounted by now, so a blocked notify
+  // has been released by the torn-down connection and this resolves promptly.
+  await activeInvalidationFlush.catch(() => {});
 
   // Final cleanup
   platform.cleanup(fuse, handle, mountpointBuf, unmounting);

--- a/packages/fuse/platform.test.ts
+++ b/packages/fuse/platform.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from "@std/assert";
+import { COMMON_SYMBOLS } from "./platform.ts";
+
+// The FUSE daemon runs fuse_session_loop on an FFI thread and answers every
+// request on the isolate thread. A reverse invalidation (notify_inval_entry /
+// notify_inval_inode) enters the Linux kernel and takes the parent directory's
+// inode lock for write; a concurrent lookup under that directory holds the same
+// lock for read until the daemon answers it. If a notify ran synchronously on
+// the isolate thread it would block there, inside the kernel, behind a lookup
+// only that thread can answer — a deadlock that wedges the mount before it
+// serves anything. The notify symbols must therefore be nonblocking so they run
+// off the isolate thread and leave the request path free.
+Deno.test("reverse-invalidation symbols are nonblocking", () => {
+  assertEquals(
+    COMMON_SYMBOLS.fuse_lowlevel_notify_inval_entry.nonblocking,
+    true,
+    "fuse_lowlevel_notify_inval_entry must run off the isolate thread",
+  );
+  assertEquals(
+    COMMON_SYMBOLS.fuse_lowlevel_notify_inval_inode.nonblocking,
+    true,
+    "fuse_lowlevel_notify_inval_inode must run off the isolate thread",
+  );
+});
+
+// The session loop owns one FFI thread for the mount's lifetime.
+Deno.test("session loop is nonblocking", () => {
+  assertEquals(COMMON_SYMBOLS.fuse_session_loop.nonblocking, true);
+});
+
+// Reply functions are called synchronously from inside the op callbacks, which
+// run on the isolate thread. They hand an answer back to an outstanding request
+// rather than waiting on a lock, so they stay blocking; making them nonblocking
+// would return an unawaited promise and break the reply-once contract.
+Deno.test("reply functions stay synchronous", () => {
+  const replySymbols = [
+    "fuse_reply_err",
+    "fuse_reply_entry",
+    "fuse_reply_attr",
+    "fuse_reply_buf",
+    "fuse_reply_open",
+    "fuse_reply_readlink",
+    "fuse_reply_write",
+    "fuse_reply_create",
+    "fuse_reply_xattr",
+    "fuse_reply_none",
+  ] as const;
+  for (const name of replySymbols) {
+    const sym = COMMON_SYMBOLS[name] as { nonblocking?: boolean };
+    assertEquals(
+      sym.nonblocking ?? false,
+      false,
+      `${name} must stay synchronous (called from within op callbacks)`,
+    );
+  }
+});

--- a/packages/fuse/platform.ts
+++ b/packages/fuse/platform.ts
@@ -117,13 +117,26 @@ export const COMMON_SYMBOLS = {
 
   // Kernel cache invalidation (FUSE 2.8+ / FUSE 3.x)
   // First param is channel (v2) or session (v3) — callers use MountHandle.notifyTarget.
+  //
+  // These run nonblocking, on an FFI thread rather than the isolate thread. On
+  // Linux, notify_inval_entry enters the kernel and takes the parent
+  // directory's inode lock for write; a concurrent lookup under that directory
+  // holds the same lock for read until the daemon answers it. The daemon
+  // answers requests on the isolate thread, so a synchronous notify would block
+  // that thread inside the kernel behind a lookup only that thread can complete,
+  // and the mount would stop serving. Running the notify off the isolate thread
+  // keeps the request path free to answer the lookup, which releases the read
+  // lock and lets the invalidation proceed. FUSE-T on macOS returns success
+  // from both without acting, so the thread choice is immaterial there.
   fuse_lowlevel_notify_inval_entry: {
     parameters: ["pointer", "u64", "buffer", "usize"],
     result: "i32",
+    nonblocking: true,
   },
   fuse_lowlevel_notify_inval_inode: {
     parameters: ["pointer", "u64", "i64", "i64"],
     result: "i32",
+    nonblocking: true,
   },
 } as const;
 


### PR DESCRIPTION
The FUSE daemon could deadlock itself on Linux and stop serving the mount entirely, before answering a single request. This flaked the CLI FUSE integration suite on a large fraction of CI runs, on branches unrelated to FUSE, because the trigger is a timing race that widens under load.

The daemon is single-threaded for request handling: fuse_session_loop runs on one FFI thread, and every operation callback plus every reverse cache invalidation ran on the one isolate thread. On Linux, notify_inval_entry enters the kernel and takes the target directory's inode lock for writing. A lookup already in flight under that directory holds the same lock for reading until the daemon answers it, and the daemon answers on the very thread now blocked inside the invalidation. The lookup can never be answered, its read lock is never released, and the invalidation's write wait never completes. The isolate thread sits in uninterruptible kernel sleep and the mount is dead.

The existing timer-plus-drain mitigation did not cover this. It defers the flush only while a reply is pending on the daemon side, but the deadlocking lookup has been accepted by the kernel, which already holds the read lock, before its callback starts, so the pending-reply counter is still zero and the flush proceeds.

Mark fuse_lowlevel_notify_inval_entry and fuse_lowlevel_notify_inval_inode as nonblocking FFI symbols so they run on an FFI thread, and await them from the flush. The invalidation now blocks on the inode lock off the isolate thread, which stays free to answer the in-flight lookup; the lookup releases its read lock and the invalidation completes. Reply functions stay synchronous, since they are called inline from op callbacks and hand back an answer rather than waiting on a lock.

Because an invalidation can now still be running on an FFI thread at shutdown, main() awaits the last flush before destroying the session so a notify call cannot dereference freed session memory.

The reproduction, root-cause analysis with captured kernel stacks, and the verified fix are recorded in
docs/history/packages/fuse/reverse-invalidation-deadlock.md. FUSE-T on macOS returns success from both notify calls without acting, which is why the deadlock is Linux-specific and never appeared in local macOS testing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Linux-only deadlock in the FUSE daemon by moving reverse cache invalidations off the request thread and hardening shutdown. Lookups stay responsive and the CLI FUSE integration in CI is stable.

- **Bug Fixes**
  - Dispatch reverse invalidations via nonblocking FFI (`fuse_lowlevel_notify_inval_entry`, `fuse_lowlevel_notify_inval_inode`) and await them in an off-thread flush, keeping the isolate thread free to reply and break the inode-lock cycle.
  - Coalesce names/parents and snapshot-and-clear between passes; skip when unmounting or closed; disable a kind on `-ENOSYS` or on errors.
  - Close the invalidation queue on all shutdown paths; detach the reschedule hook, cancel the pending timer, and await the active flush before destroying the session to prevent notify calls after free.
  - Keep reply functions synchronous; mark notify symbols nonblocking in `packages/fuse/platform.ts`; add `packages/fuse/platform.test.ts` to lock blocking modes.
  - Type the `invalidateEntry` name buffer as `Uint8Array<ArrayBuffer>` to satisfy nonblocking FFI pinning and fix type checks under the pinned Deno toolchain.
  - Add the root-cause record and correct the shutdown note in `docs/history/packages/fuse/reverse-invalidation-deadlock.md`.

- **Refactors**
  - Extract the reverse-invalidation queue into `packages/fuse/invalidation.ts` with `packages/fuse/invalidation.test.ts`; `main()` wires the bridge to the queue, keeps the reply-drain timer, and awaits `queue.active()` during teardown.

<sup>Written for commit 56a6833a27cd947a49f3f29b5df4deb486a1c3f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



NEW_PERF_BASELINE: job: Pattern Integration Tests (3/4) = 483s
NEW_PERF_BASELINE: step: patterns integration = 439s
NEW_PERF_BASELINE: job: Pattern Integration Tests = 483s
NEW_PERF_BASELINE: job: Pattern Integration Tests (1/4) = 267s
