### PR TITLE
cf view: focus, select, and animate the modal dialog buttons

### DIFF
--- a/packages/cli/lib/view/pager.ts
+++ b/packages/cli/lib/view/pager.ts
@@ -29,6 +29,11 @@ const REPARSE_DEBOUNCE_MS = 150;
 /** Gap between frames while the lines a Ctrl-L revealed land, one per frame. */
 const REVEAL_FRAME_MS = 16;
 
+/** How long a prompt button stays drawn pushed after it is activated, before
+ * its action's result shows. Long enough to register as a press, short enough
+ * not to hold up the answer. */
+const PUSH_FRAME_MS = 90;
+
 /** How long a status message that takes itself away stands before it goes. Long
  * enough to read twice over, short enough not to outstay what prompted it. */
 const MESSAGE_LINGER_MS = 2000;
@@ -56,6 +61,10 @@ export interface PagerDeps {
   exit(code: number): never;
   /** Schedule `handler` after `ms`; returns a function that cancels it. */
   setTimer(handler: () => void, ms: number): () => void;
+  /** Resolve after `ms`. Used to hold a frame on screen for a moment on a path
+   * that then tears the screen down, where a cancellable timer has nothing left
+   * to run in. */
+  delay(ms: number): Promise<void>;
 }
 
 /** The real terminal and process operations. */
@@ -74,6 +83,7 @@ export function realPagerDeps(): PagerDeps {
       const id = setTimeout(handler, ms);
       return () => clearTimeout(id);
     },
+    delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   };
 }
 
@@ -171,6 +181,29 @@ export async function runPager(
     return true;
   };
 
+  // A prompt button press shows the button pushed for a moment before its result
+  // lands. The captured pushed frame is painted now; a timer then draws the real
+  // state (the dialog closed, or the next prompt up). Any key drops the wait.
+  let cancelPush: (() => void) | undefined;
+  const stopPush = () => {
+    if (cancelPush) {
+      cancelPush();
+      cancelPush = undefined;
+    }
+  };
+  const startPush = (): boolean => {
+    const push = session.pendingPush;
+    if (!push) return false;
+    paint(push.doc, push.view);
+    cancelPush = deps.setTimer(() => {
+      cancelPush = undefined;
+      session.pendingPush = null;
+      draw();
+      startExpiry();
+    }, PUSH_FRAME_MS);
+    return true;
+  };
+
   // Ctrl-L pressed where the bar does not offer it says why, and the key changed
   // nothing else. The reason has served its purpose once it has been read, so it
   // stands for a moment and then goes rather than sitting in the bar describing
@@ -226,6 +259,7 @@ export async function runPager(
     const s = consoleSize(deps);
     stopReveal(); // the frames left were laid out for the old size
     stopExpiry();
+    stopPush(); // the captured pushed frame was laid out for the old size
     session.resize(s.width, s.height);
     draw();
     // A message that takes itself away is still up after the redraw, so start
@@ -243,6 +277,7 @@ export async function runPager(
   const onInterrupt = () => {
     stopReveal();
     stopExpiry();
+    stopPush();
     if (session.requestQuitFromSignal()) draw();
     else terminate(130);
   };
@@ -280,20 +315,36 @@ export async function runPager(
         session.handleKey(key);
         if (session.quit) break;
       }
-      if (!session.quit) {
+      if (session.quit) {
         stopReveal();
         stopExpiry();
-        // A reveal draws its own frames, ending on the finished one.
-        if (!startReveal()) {
-          draw();
-          startExpiry(); // starts the clock on the message the draw put up
+        stopPush();
+        // A committing button (Save / Discard, and amend-Yes) sets quit as its
+        // action. Hold its pressed frame on screen for the press moment before
+        // the screen is torn down, so it depresses like any other button rather
+        // than vanishing. A bare `q` has nothing pushed and exits at once.
+        const push = session.pendingPush;
+        if (push) {
+          paint(push.doc, push.view);
+          await deps.delay(PUSH_FRAME_MS);
         }
-        if (session.needsReparse) scheduleReparse();
+        break;
       }
+      stopReveal();
+      stopExpiry();
+      stopPush();
+      // A reveal or a button press draws its own frames, ending on the finished
+      // one; otherwise draw the new state now.
+      if (!startReveal() && !startPush()) {
+        draw();
+        startExpiry(); // starts the clock on the message the draw put up
+      }
+      if (session.needsReparse) scheduleReparse();
     }
   } finally {
     stopReveal();
     stopExpiry();
+    stopPush();
     if (cancelReparse) {
       cancelReparse();
     }

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -135,9 +135,9 @@ export interface OverlayState {
   readonly sourceView?: boolean;
 }
 
-/** A push-button in a modal dialog. Its {@link kind} decides how Enter and Esc
- * behave (default and cancel), and its first letter matching {@link hotkey} is
- * drawn highlighted. */
+/** A push-button in a modal dialog. Its {@link kind} sets where the Tab focus
+ * starts ("default") and which button Esc activates ("cancel"); its first letter
+ * matching {@link hotkey} is drawn highlighted and activates it directly. */
 export interface DialogButton {
   readonly label: string;
   readonly hotkey: string;
@@ -149,6 +149,12 @@ export interface DialogState {
   readonly title: string;
   readonly body: readonly string[];
   readonly buttons: readonly DialogButton[];
+  /** Index of the focused button — the one Space and Enter activate, drawn
+   * highlighted. When absent, the default button (if any) is highlighted. */
+  readonly focus?: number;
+  /** Index of a button drawn mid-press: shifted one column right with its
+   * shadow hidden, for the brief animation after it is activated. */
+  readonly pushed?: number;
 }
 
 interface Cell {
@@ -654,6 +660,10 @@ function darkenSpan(
 /** Blank columns between adjacent buttons in a dialog's button row. */
 const BUTTON_GAP = 3;
 
+/** Blank columns of margin inside each side border of a dialog, between the
+ * border and the widest line of content. */
+const DIALOG_HMARGIN = 2;
+
 /** The drawn face of a button: its label with one space of padding each side. */
 function faceText(b: DialogButton): string {
   return ` ${b.label} `;
@@ -690,11 +700,14 @@ export function dialogBox(view: ViewState, dialog: DialogState): DialogBox {
   const titleW = cpLen(dialog.title) + 4; // the padding spaces and some fill
   const bodyW = dialog.body.reduce((m, l) => Math.max(m, cpLen(l)), 0);
   const btnW = buttonsWidth(dialog.buttons);
-  // One blank margin column each side, then the two borders.
   const contentW = Math.max(titleW, bodyW, btnW);
+  // The margin columns each side, then the two borders.
   // Inner rows: a blank under the title, the body, a blank, the buttons, and the
   // buttons' shadow.
-  const boxW = Math.max(0, Math.min(contentW + 4, view.width - 2));
+  const boxW = Math.max(
+    0,
+    Math.min(contentW + 2 * DIALOG_HMARGIN + 2, view.width - 2),
+  );
   const boxH = Math.max(0, Math.min(dialog.body.length + 6, view.height - 1));
   return {
     x: Math.max(0, Math.floor((view.width - boxW) / 2)),
@@ -768,6 +781,11 @@ function applyDialog(
   const layout = layoutButtons(dialog.buttons, innerW);
   const buttonRow = innerH - 2;
   const shadowRow = innerH - 1;
+  // The focused button is drawn highlighted; without an explicit focus, the
+  // default button is. A pushed button is drawn mid-press.
+  const focusIdx = dialog.focus ??
+    dialog.buttons.findIndex((b) => b.kind === "default");
+  const pushedIdx = dialog.pushed ?? -1;
   for (let i = 0; i < innerH; i++) {
     const cells: Cell[] = new Array(innerW);
     for (let c = 0; c < innerW; c++) cells[c] = { ch: " ", style: panelBg };
@@ -775,9 +793,9 @@ function applyDialog(
     if (bodyIdx >= 0 && bodyIdx < dialog.body.length) {
       placeCentered(cells, dialog.body[bodyIdx], textStyle);
     } else if (i === buttonRow) {
-      placeButtonFaces(cells, layout, view.color, panelBg);
+      placeButtonFaces(cells, layout, view.color, panelBg, focusIdx, pushedIdx);
     } else if (i === shadowRow && view.color) {
-      placeButtonShadows(cells, layout, panelBg);
+      placeButtonShadows(cells, layout, panelBg, pushedIdx);
     }
     const rowText = paintIf("║", border, view.color) +
       cellsToAnsi(cells, view.color) + paintIf("║", border, view.color);
@@ -803,24 +821,30 @@ function placeButtonFaces(
   layout: ButtonPos[],
   color: boolean,
   panelBg: Style,
+  focus: number,
+  pushed: number,
 ): void {
-  for (const { b, start, faceW } of layout) {
+  layout.forEach(({ b, start, faceW }, idx) => {
     const chars = [...faceText(b)];
     const face = !color
       ? panelBg
-      : b.kind === "default"
+      : idx === focus
       ? ui.buttonDefault
       : ui.button;
     const keyStyle = color ? ui.buttonKey : panelBg;
     const hk = hotkeyFaceIndex(b);
+    // A pressed button slides one column right, into the space its shadow held.
+    const shift = idx === pushed ? 1 : 0;
     for (let j = 0; j < chars.length; j++) {
-      const col = start + j;
+      const col = start + shift + j;
       if (col >= 0 && col < cells.length) {
         cells[col] = { ch: chars[j], style: j === hk ? keyStyle : face };
       }
     }
     const rightShadow = start + faceW;
-    if (color && rightShadow >= 0 && rightShadow < cells.length) {
+    if (
+      color && idx !== pushed && rightShadow >= 0 && rightShadow < cells.length
+    ) {
       // A lower half-block in the column beside the face, matching the band
       // beneath, so the shadow reads as a thin edge along the bottom.
       cells[rightShadow] = {
@@ -828,7 +852,7 @@ function placeButtonFaces(
         style: mergeBg(ui.buttonShadow, panelBg),
       };
     }
-  }
+  });
 }
 
 /** The buttons' drop shadow row: an upper half-block band under each face,
@@ -837,16 +861,18 @@ function placeButtonShadows(
   cells: Cell[],
   layout: ButtonPos[],
   panelBg: Style,
+  pushed: number,
 ): void {
   const style = mergeBg(ui.buttonShadow, panelBg);
-  for (const { start, faceW } of layout) {
+  layout.forEach(({ start, faceW }, idx) => {
+    if (idx === pushed) return; // a pressed button casts no shadow
     for (let k = 0; k < faceW; k++) {
       const col = start + 1 + k;
       if (col >= 0 && col < cells.length) {
         cells[col] = { ch: "▀", style };
       }
     }
-  }
+  });
 }
 
 /** Splice `insert` into `base` starting at visible column `x`. */

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -163,6 +163,11 @@ export class Session {
    * the viewport holds still) or below it (so it slides as they land). The next
    * key clears it. */
   pendingReveal: { row: number; count: number; up: boolean } | null = null;
+  /** A prompt button was just activated. Holds the frame that shows it pushed —
+   * the dialog with that button drawn mid-press — so the driver can play the
+   * press for a moment before the action's result appears. The next key clears
+   * it. */
+  pendingPush: { doc: Document; view: ViewState } | null = null;
   /** The last key set a message that takes itself away again rather than sitting
    * in the bar — Ctrl-L pressed where it is not offered, which changed nothing
    * else. The driver leaves it up for a moment and then calls
@@ -185,6 +190,10 @@ export class Session {
   private cursorOn = false;
   /** Pending C-x prefix (Emacs chord), reset by the next key. */
   private chord: "ctrl-x" | null = null;
+  /** Which button the active prompt's Tab focus rests on — an index into its
+   * button row. Space and Enter activate it; it is reset to the default button
+   * each time a prompt opens. */
+  private dialogFocus = 0;
   /** What the active save prompt does on confirm. */
   private savePromptThen: "quit" | null = null;
   /** Set once the user confirms amending the commit message, so the save that
@@ -461,10 +470,25 @@ export class Session {
   /** The modal dialog for whichever confirmation prompt is open, or null when no
    * prompt is up. Rebuilt each frame from the current buffer and source. */
   private promptDialog(): DialogState | null {
-    if (this.mode === "savePrompt") return this.saveDialog();
-    if (this.mode === "amendPrompt") return this.amendDialog();
-    if (this.mode === "revertPrompt") return this.revertDialog();
-    return null;
+    let dialog: DialogState | null = null;
+    if (this.mode === "savePrompt") dialog = this.saveDialog();
+    else if (this.mode === "amendPrompt") dialog = this.amendDialog();
+    else if (this.mode === "revertPrompt") dialog = this.revertDialog();
+    if (!dialog) return null;
+    // -1 means no button is focused (a prompt with no default, before Tab).
+    const focus = this.dialogFocus < 0
+      ? -1
+      : clamp(this.dialogFocus, 0, Math.max(0, dialog.buttons.length - 1));
+    return { ...dialog, focus };
+  }
+
+  /** Rest the current prompt's Tab focus on its default button, called as each
+   * prompt opens. A prompt with no default button (the diff revert) starts with
+   * no focus — an index of -1 — so Space and Enter do nothing until Tab picks a
+   * button, keeping a stray Enter from reverting. */
+  private focusDefaultButton(): void {
+    const buttons = this.promptDialog()?.buttons ?? [];
+    this.dialogFocus = buttons.findIndex((b) => b.kind === "default");
   }
 
   /** The save-changes confirmation: names what a save writes, lists the files
@@ -546,17 +570,13 @@ export class Session {
     // itself away goes now rather than waiting out its moment, before this key
     // has the chance to set one of its own.
     this.pendingReveal = null;
+    this.pendingPush = null;
     this.expireMessage();
-    if (this.mode === "savePrompt") {
-      this.handleSavePrompt(key);
-      return;
-    }
-    if (this.mode === "amendPrompt") {
-      this.handleAmendPrompt(key);
-      return;
-    }
-    if (this.mode === "revertPrompt") {
-      this.handleRevertPrompt(key);
+    if (
+      this.mode === "savePrompt" || this.mode === "amendPrompt" ||
+      this.mode === "revertPrompt"
+    ) {
+      this.handleDialogKey(key);
       return;
     }
     if (this.mode === "filePicker") {
@@ -2030,6 +2050,7 @@ export class Session {
         return false;
       }
       this.mode = "amendPrompt";
+      this.focusDefaultButton();
       this.message = "";
       return false;
     }
@@ -2054,16 +2075,15 @@ export class Session {
     }
   }
 
-  private handleAmendPrompt(key: Key): void {
-    const k = (key.char ?? key.name).toLowerCase();
-    if (k === "y" || key.name === "enter") {
+  private applyAmendButton(button: DialogButton): void {
+    if (button.hotkey === "y") {
       this.amendConfirmed = true;
       const ok = this.requestSave();
       this.mode = "normal";
       this.editedFiles = [];
       if (ok && this.savePromptThen === "quit") this.quit = true;
       this.savePromptThen = null;
-    } else if (k === "n" || key.name === "escape") {
+    } else if (button.kind === "cancel") {
       this.mode = "normal";
       this.amendConfirmed = false;
       this.savePromptThen = null;
@@ -2082,6 +2102,7 @@ export class Session {
       this.mode = "savePrompt";
       this.savePromptThen = "quit";
       this.editedFiles = this.computeEditedFiles();
+      this.focusDefaultButton();
       this.message = "";
     } else {
       this.quit = true;
@@ -2115,10 +2136,65 @@ export class Session {
     return willPrompt;
   }
 
-  private handleSavePrompt(key: Key): void {
-    const k = (key.char ?? key.name).toLowerCase();
-    // Save is the default button, so Enter and either shortcut trigger it.
-    if (k === "s" || key.name === "enter") {
+  /** Keys while a modal prompt (save / amend / revert) is up. Tab and Shift-Tab
+   * move the focus ring between buttons, wrapping around; Space and Enter
+   * activate the focused button; Esc activates the cancel button; a button's
+   * shortcut letter activates it directly. Any other key leaves the prompt up. */
+  private handleDialogKey(key: Key): void {
+    const dialog = this.promptDialog();
+    if (!dialog) return;
+    const buttons = dialog.buttons;
+    const n = buttons.length;
+    if (n === 0) return;
+
+    // Tab moves the ring forward, Shift-Tab back, both wrapping around. From no
+    // focus (-1) Tab lands on the first button and Shift-Tab on the last.
+    if (key.name === "tab") {
+      this.dialogFocus = this.dialogFocus < 0 ? 0 : (this.dialogFocus + 1) % n;
+      return;
+    }
+    if (key.name === "shift-tab") {
+      this.dialogFocus = this.dialogFocus < 0
+        ? n - 1
+        : (this.dialogFocus - 1 + n) % n;
+      return;
+    }
+
+    let index = -1;
+    if (key.name === "enter" || key.name === "space" || key.char === " ") {
+      // The clamped focus the dialog was drawn with, so Enter always activates
+      // the highlighted button. -1 means nothing is focused: a no-op.
+      index = dialog.focus ?? -1;
+    } else if (key.name === "escape") {
+      index = buttons.findIndex((b) => b.kind === "cancel");
+    } else {
+      const k = (key.char ?? key.name).toLowerCase();
+      index = buttons.findIndex((b) => b.hotkey.toLowerCase() === k);
+    }
+    if (index < 0 || index >= n) return; // an unbound key leaves the prompt up
+    this.activateButton(index);
+  }
+
+  /** Run a prompt button's action, first capturing the frame that shows it
+   * pushed so the driver can play the press before the result appears. The
+   * activated button also takes the focus ring, so a shortcut-key press draws
+   * the pressed button highlighted rather than leaving the highlight behind. */
+  private activateButton(index: number): void {
+    this.dialogFocus = index;
+    const dialog = this.promptDialog();
+    if (!dialog) return;
+    this.pendingPush = {
+      doc: this.displayDoc(),
+      view: { ...this.view(), dialog: { ...dialog, pushed: index } },
+    };
+    const button = dialog.buttons[index];
+    if (this.mode === "savePrompt") this.applySaveButton(button);
+    else if (this.mode === "amendPrompt") this.applyAmendButton(button);
+    else if (this.mode === "revertPrompt") this.applyRevertButton(button);
+  }
+
+  private applySaveButton(button: DialogButton): void {
+    if (button.hotkey === "s") {
       const ok = this.requestSave();
       // The save may need to confirm a commit amend first; leave that prompt up
       // (keeping the quit intent) instead of forcing back to normal mode.
@@ -2127,12 +2203,12 @@ export class Session {
       this.editedFiles = [];
       if (ok && this.savePromptThen === "quit") this.quit = true;
       this.savePromptThen = null;
-    } else if (k === "d") {
+    } else if (button.hotkey === "d") {
       this.mode = "normal";
       this.editedFiles = [];
       if (this.savePromptThen === "quit") this.quit = true;
       this.savePromptThen = null;
-    } else if (k === "c" || key.name === "escape") {
+    } else if (button.kind === "cancel") {
       this.mode = "normal";
       this.savePromptThen = null;
       this.editedFiles = [];
@@ -2149,6 +2225,7 @@ export class Session {
       return;
     }
     this.mode = "revertPrompt";
+    this.focusDefaultButton();
     this.message = "";
   }
 
@@ -2173,29 +2250,32 @@ export class Session {
     return { chunk, file, message };
   }
 
-  private handleRevertPrompt(key: Key): void {
-    const k = (key.char ?? key.name).toLowerCase();
+  private applyRevertButton(button: DialogButton): void {
+    // The dialog only offers the scopes that apply where the cursor sits, so a
+    // scope button that reached here is always valid.
     let scope: RevertScope | null = null;
-    if (this.source?.policy) {
-      // A diff offers the scopes that apply at the cursor plus Cancel; there is
-      // no default button, so Enter (and any unlisted key) does nothing.
-      const s = this.revertScopesAt();
-      if (k === "h" && s.chunk) scope = "chunk";
-      else if (k === "f" && s.file) scope = "file";
-      else if (k === "m" && s.message) scope = "message";
-      else if (k === "a") scope = "all";
-    } else if (k === "y" || key.name === "enter") {
-      // A plain file has a single scope, so Yes is the default button.
-      scope = "all";
+    switch (button.hotkey) {
+      case "h":
+        scope = "chunk";
+        break;
+      case "f":
+        scope = "file";
+        break;
+      case "m":
+        scope = "message";
+        break;
+      case "a": // a diff's all
+      case "y": // a plain file's single scope
+        scope = "all";
+        break;
     }
     if (scope) {
       this.performRevert(scope);
       this.mode = "normal";
-    } else if (k === "c" || key.name === "escape") {
+    } else if (button.kind === "cancel") {
       this.message = "Cancelled";
       this.mode = "normal";
     }
-    // Any other key does nothing: the prompt stays up.
   }
 
   /** Restore the chosen scope to its original form, keeping the dirty baseline

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -2141,11 +2141,11 @@ export class Session {
    * activate the focused button; Esc activates the cancel button; a button's
    * shortcut letter activates it directly. Any other key leaves the prompt up. */
   private handleDialogKey(key: Key): void {
-    const dialog = this.promptDialog();
-    if (!dialog) return;
+    // Reached only from the prompt modes, each of which builds a dialog with at
+    // least two buttons, so the dialog is present and its row is non-empty.
+    const dialog = this.promptDialog()!;
     const buttons = dialog.buttons;
     const n = buttons.length;
-    if (n === 0) return;
 
     // Tab moves the ring forward, Shift-Tab back, both wrapping around. From no
     // focus (-1) Tab lands on the first button and Shift-Tab on the last.
@@ -2172,20 +2172,21 @@ export class Session {
       index = buttons.findIndex((b) => b.hotkey.toLowerCase() === k);
     }
     if (index < 0 || index >= n) return; // an unbound key leaves the prompt up
-    this.activateButton(index);
+    this.activateButton(dialog, index);
   }
 
   /** Run a prompt button's action, first capturing the frame that shows it
    * pushed so the driver can play the press before the result appears. The
-   * activated button also takes the focus ring, so a shortcut-key press draws
-   * the pressed button highlighted rather than leaving the highlight behind. */
-  private activateButton(index: number): void {
+   * pressed button is drawn focused as well, so a shortcut-key press shows it
+   * highlighted rather than leaving the highlight on whatever Tab last chose. */
+  private activateButton(dialog: DialogState, index: number): void {
     this.dialogFocus = index;
-    const dialog = this.promptDialog();
-    if (!dialog) return;
     this.pendingPush = {
       doc: this.displayDoc(),
-      view: { ...this.view(), dialog: { ...dialog, pushed: index } },
+      view: {
+        ...this.view(),
+        dialog: { ...dialog, focus: index, pushed: index },
+      },
     };
     const button = dialog.buttons[index];
     if (this.mode === "savePrompt") this.applySaveButton(button);

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -1940,6 +1940,44 @@ Deno.test("revert: Enter does nothing on a diff revert (no default button)", () 
   }
 });
 
+Deno.test("revert: with no default button, Tab focuses the first scope, Shift-Tab the last", () => {
+  const { ws, done } = tempWorkspace();
+  const fg = fakeGit(SHOW_SHA);
+  try {
+    const s = diffSessionFrom(ws, GIT_SHOW, 30, fg.git);
+    toLine(s, 17);
+    press(s, "end");
+    type(s, " X");
+
+    press(s, "ctrl-r");
+    assertEquals(
+      s.view().dialog?.focus,
+      -1,
+      "no button is focused without a default",
+    );
+    const n = s.view().dialog!.buttons.length;
+
+    // From no focus, Tab lands on the first button (a scope).
+    press(s, "tab");
+    assertEquals(s.view().dialog?.focus, 0, "Tab focused the first scope");
+    press(s, "escape"); // close it via Cancel
+
+    // Reopen and go the other way: Shift-Tab from no focus lands on the last,
+    // which is Cancel; Enter then activates it.
+    press(s, "ctrl-r");
+    press(s, "shift-tab");
+    assertEquals(
+      s.view().dialog?.focus,
+      n - 1,
+      "Shift-Tab focused the last button",
+    );
+    press(s, "enter");
+    assertEquals(s.view().message, "Cancelled");
+  } finally {
+    done();
+  }
+});
+
 Deno.test("revert: on a file header offers file but not hunk", () => {
   const { ws, done } = tempWorkspace();
   const fg = fakeGit(SHOW_SHA);

--- a/packages/cli/test/view-editor.test.ts
+++ b/packages/cli/test/view-editor.test.ts
@@ -230,6 +230,67 @@ Deno.test("editor: the save prompt ignores keys that are not its buttons", () =>
   assertEquals(saved(), "Zabc\n");
 });
 
+Deno.test("editor: the save prompt focuses its default button; Space activates it", () => {
+  const { src, saved } = memSource();
+  const s = editSession("abc\n", src);
+  press(s, "e");
+  type(s, "Z");
+  press(s, "escape", "q");
+  assertEquals(
+    s.view().dialog?.focus,
+    0,
+    "Save, the default button, is focused",
+  );
+  press(s, "space"); // Space activates the focused button, like Enter
+  assert(s.quit, "quits after saving");
+  assertEquals(saved(), "Zabc\n");
+});
+
+Deno.test("editor: Tab moves the focus ring; Enter activates the focused button", () => {
+  const { src, saved } = memSource();
+  const s = editSession("abc\n", src);
+  press(s, "e");
+  type(s, "Z");
+  press(s, "escape", "q");
+  press(s, "tab"); // Save → Discard
+  assertEquals(s.view().dialog?.focus, 1, "Tab advanced the focus to Discard");
+  press(s, "enter"); // Enter activates whichever button is focused
+  assert(s.quit, "quits after discarding");
+  assertEquals(saved(), null, "Discard was activated, not Save");
+});
+
+Deno.test("editor: Shift-Tab wraps the focus ring to the last button", () => {
+  const { src } = memSource();
+  const s = editSession("abc\n", src);
+  press(s, "e");
+  type(s, "Z");
+  press(s, "escape", "q");
+  press(s, "shift-tab"); // Save → Cancel, wrapping backwards
+  assertEquals(s.view().dialog?.focus, 2, "Shift-Tab wrapped to Cancel");
+  press(s, "enter");
+  assertEquals(s.view().message, "Cancelled");
+});
+
+Deno.test("editor: activating a button captures the pushed frame for its press", () => {
+  const { src } = memSource();
+  const s = editSession("abc\n", src);
+  press(s, "e");
+  type(s, "Z");
+  press(s, "escape", "q");
+  press(s, "shift-tab"); // focus Cancel (index 2)
+  press(s, "enter"); // activate it
+  const push = s.pendingPush;
+  assert(push, "the press captured a pushed frame");
+  assertEquals(
+    push!.view.dialog?.pushed,
+    2,
+    "the pushed frame shows Cancel pressed",
+  );
+  assertEquals(s.view().message, "Cancelled", "and the button's action ran");
+  press(s, "s"); // any following key clears the pending press
+  assertEquals(s.pendingPush, null, "the next key drops the pending press");
+});
+
 Deno.test("editor: quitting dirty, d discards and quits", () => {
   const { src, saved } = memSource();
   const s = editSession("abc\n", src);

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -117,6 +117,9 @@ function makeFake(opts: FakeOpts = {}) {
       timers.set(id, h);
       return () => timers.delete(id);
     },
+    // Resolve at once: a test drives frames with `fireTimers`, so a real wait
+    // here would only stall the run.
+    delay: () => Promise.resolve(),
   };
   return { deps, writes, signals, removed, timers, exited };
 }
@@ -561,6 +564,64 @@ Deno.test("pager: what a reveal says takes itself away once the lines have lande
     assert(gone, "and it was taken away again");
   } finally {
     done();
+  }
+});
+
+Deno.test("pager: a prompt button's result waits for the press animation to finish", async () => {
+  // Open the revert prompt, then Esc to activate its Cancel button. The press
+  // is drawn at once; its result ("Cancelled") is what the push timer draws, so
+  // without the timer firing the result never reaches the screen.
+  const run = (steps: Step[]) => {
+    const { doc, source, dir } = editableDoc();
+    const { deps, writes } = makeFake({ steps });
+    return runPager(doc, OPTS, undefined, source, deps).then(() => {
+      Deno.removeSync(dir, { recursive: true });
+      return writes;
+    });
+  };
+  const openRevert: Step[] = [
+    { bytes: enc("e") }, // edit mode
+    { bytes: enc("X") }, // dirty the buffer
+    { bytes: enc("\x12") }, // Ctrl-R: open the revert prompt
+    { bytes: enc("\x1b") }, // Esc: activate Cancel — paints the pressed frame
+  ];
+
+  const held = await run([...openRevert, { eof: true }]);
+  assert(
+    held.some((w) => w.includes("Revert all edits?")),
+    "the prompt (and its pressed frame) was drawn",
+  );
+  assert(
+    !held.some((w) => w.includes("Cancelled")),
+    "the result waited for the press timer, so it never drew",
+  );
+
+  const fired = await run([...openRevert, { fireTimers: true }, { eof: true }]);
+  assert(
+    fired.some((w) => w.includes("Cancelled")),
+    "the press timer drew the result",
+  );
+});
+
+Deno.test("pager: a committing button plays its press before the pager quits", async () => {
+  const { doc, source, dir } = editableDoc();
+  try {
+    const { deps, writes } = makeFake({
+      steps: [
+        { bytes: enc("e") }, // edit mode
+        { bytes: enc("X") }, // dirty the buffer
+        { bytes: enc("\x03") }, // Ctrl-C: raise the save-and-quit prompt
+        { bytes: enc("d") }, // Discard: quits, but plays its press first
+      ],
+    });
+    await runPager(doc, OPTS, undefined, source, deps);
+    // The save dialog is drawn once as it opens and once more as the pressed
+    // frame the Discard key paints on its way out. Without the press animation
+    // the quit would tear the screen down after the single opening frame.
+    const dialogFrames = writes.filter((w) => w.includes("Save changes to"));
+    assertEquals(dialogFrames.length, 2, "the press was drawn before quitting");
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
   }
 });
 

--- a/packages/cli/test/view-render-cov.test.ts
+++ b/packages/cli/test/view-render-cov.test.ts
@@ -599,6 +599,128 @@ Deno.test("dialog: collapses on a terminal too narrow to frame", () => {
   );
 });
 
+Deno.test("dialog: body sits two columns inside each border", () => {
+  const rows = renderFrame(
+    parseDocument("x\n"),
+    baseView({
+      width: 40,
+      height: 12,
+      color: false,
+      dialog: { title: "T", body: ["hello world"], buttons: [] },
+    }),
+  );
+  const bodyRow = rows.map(stripAnsi).find((r) => r.includes("hello world"))!;
+  const left = bodyRow.indexOf("║");
+  const right = bodyRow.indexOf("║", left + 1);
+  // Two blank margin columns separate the border from the content on each side.
+  assertEquals(
+    bodyRow.slice(left + 1, left + 3),
+    "  ",
+    "two blank columns after the left border",
+  );
+  assertEquals(
+    bodyRow.slice(left + 3, left + 3 + "hello world".length),
+    "hello world",
+    "content begins after the margin",
+  );
+  assertEquals(
+    bodyRow.slice(right - 2, right),
+    "  ",
+    "two blank columns before the right border",
+  );
+});
+
+Deno.test("dialog: the focused button — not just the default — is highlighted", () => {
+  const dlg: DialogState = {
+    title: "Pick",
+    body: ["Which one?"],
+    buttons: [
+      { label: "One", hotkey: "o" },
+      { label: "Two", hotkey: "t" },
+    ],
+  };
+  const render = (focus?: number) =>
+    renderFrame(
+      parseDocument("x\n"),
+      baseView({
+        width: 40,
+        height: 12,
+        color: true,
+        dialog: { ...dlg, focus },
+      }),
+    );
+  // The bright face is the default-button colour on the button-face background;
+  // it only appears where a button is highlighted.
+  const brightFace = fgCode(ui.buttonDefault.fg!) + ";" + bgCode(ui.button.bg!);
+
+  // No focus and no default kind: no button is brightened.
+  assert(
+    !render(-1).join("").includes(brightFace),
+    "nothing highlighted without focus",
+  );
+
+  // Focusing a button brightens that button, and moving focus moves the bright
+  // face to the newly focused label.
+  for (const [focus, label] of [[0, "One"], [1, "Two"]] as const) {
+    const btnRow = render(focus).find((r) => stripAnsi(r).includes("One"))!;
+    assert(btnRow.includes(brightFace), `button ${focus} is highlighted`);
+    // Read past the rest of the bright face's escape (its closing `m`) to the
+    // label text that follows it.
+    const sgrEnd = btnRow.indexOf("m", btnRow.indexOf(brightFace)) + 1;
+    const after = stripAnsi(btnRow.slice(sgrEnd)).trimStart();
+    assert(
+      after.startsWith(label),
+      `the highlight sits on ${label}: ${after}`,
+    );
+  }
+});
+
+Deno.test("dialog: a pushed button loses its shadow and shifts one column right", () => {
+  const dlg: DialogState = {
+    title: "T",
+    body: ["Go?"],
+    buttons: [{ label: "Ok", hotkey: "o", kind: "default" }],
+  };
+  const render = (over: Partial<DialogState>) =>
+    renderFrame(
+      parseDocument("x\n"),
+      baseView({
+        width: 40,
+        height: 12,
+        color: true,
+        dialog: { ...dlg, ...over },
+      }),
+    ).map(stripAnsi);
+
+  const normal = render({});
+  const pushed = render({ pushed: 0 });
+  // The half-block shadow glyphs come only from the button; a press drops them.
+  assert(
+    normal.join("\n").includes("▀"),
+    "a resting button casts a shadow band",
+  );
+  assert(
+    normal.join("\n").includes("▄"),
+    "a resting button casts a right edge",
+  );
+  assert(
+    !pushed.join("\n").includes("▀"),
+    "a pushed button casts no shadow band",
+  );
+  assert(
+    !pushed.join("\n").includes("▄"),
+    "a pushed button casts no right edge",
+  );
+  // The face slides one column into the space its shadow held.
+  const normalRow = normal.find((r) => r.includes("Ok"))!;
+  const pushedRow = pushed.find((r) => r.includes("Ok"))!;
+  assertEquals(
+    pushedRow.indexOf("Ok"),
+    normalRow.indexOf("Ok") + 1,
+    "the pressed face shifts right by one column",
+  );
+});
+
 Deno.test("renderFrame: the guide rail is blank on lines outside the selected node", () => {
   const ln = (text: string) => ({
     text,


### PR DESCRIPTION
The save, amend, and revert confirmation dialogs had no keyboard focus model. The default button was hard-highlighted, Enter always triggered it, and every other button was reachable only by its shortcut letter. This adds a focus ring the reader can move, a way to activate the focused button without knowing its letter, a press animation, and a little more breathing room around the box.

Horizontal margin: dialogs now leave two blank columns inside each side border instead of one, widening the box by one column on each side. The change lives in the dialog geometry alone; the overlay/peek window keeps its own margin.

Focus ring: a focused-button index, reset to the default button as each prompt opens. Tab moves it forward and Shift-Tab back, both wrapping. The focused button is drawn highlighted, so the highlight follows the ring rather than staying fixed on the default button. A dialog with no default button — the diff revert, whose scopes have no single primary action — starts with no focus, so a stray Space or Enter does nothing until Tab picks a scope, keeping the prior guard against an accidental revert.

Activation: Space and Enter both activate the focused button, alongside the existing shortcut letters and Esc for cancel. The three separate prompt key handlers collapse into one navigation-and-activation handler plus a small action method per dialog.

Press animation: activating a button briefly draws it pushed — shifted one column right, into the space its shadow held, with the shadow hidden. The driver holds that frame for a moment and then draws the result, mirroring how the Ctrl-L reveal paces its own frames. A button that quits the pager (Save or Discard on the quit prompt) still plays its press before the screen is torn down, through a newly injected delay so the behavior stays exercisable in tests without a real wait.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyboard focus, selection, and a short press animation to modal dialog buttons. Quitting actions now play their press before exit, and dialogs have wider inner margins.

- New Features
  - Tab/Shift-Tab move focus; Space/Enter activate; Esc cancels; letter hotkeys still work.
  - Highlight follows focus; the diff revert prompt starts unfocused (Tab picks first, Shift‑Tab from no focus picks last).
  - Press animates (~90ms): shifts right and hides shadow; Save/Discard and amend‑Yes animate before exit.
  - Dialogs keep two inner margin columns on each side.

- Refactors
  - Unified save/amend/revert into one dialog key handler with small per‑dialog action methods.
  - Added pendingPush and a short hold to display pressed frames; resize/interrupt clear it. Removed unreachable guards and threaded the active dialog into activateButton so shortcut presses highlight the pressed button.

<sup>Written for commit 62b470f1b9be4f9d370fdf0c69603d86e874f25e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

