### PR TITLE
fix(runner): ignore read-materialization touches in the idempotency r…

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -196,6 +196,8 @@ One line per archived document; each document's header carries the fuller
 
 - [settle-wave-2026-03-findings.md](development/debugging/settle-wave-2026-03-findings.md)
   — March 2026 settle-wave measurements.
+- [2026-07-group-chat-idempotency-false-positive.md](development/debugging/2026-07-group-chat-idempotency-false-positive.md)
+  — root cause of the group-chat idempotency false-positive CI flake, July 2026.
 - [default-app-note-create.md](development/performance/default-app-note-create.md),
   [two-browsers-cold-start.md](development/performance/two-browsers-cold-start.md),
   and

--- a/docs/history/development/debugging/2026-07-group-chat-idempotency-false-positive.md
+++ b/docs/history/development/debugging/2026-07-group-chat-idempotency-false-positive.md
@@ -1,0 +1,84 @@
+---
+status: historical
+created: 2026-07-18
+archived: 2026-07-18
+reason: "Root cause of the July 2026 group-chat idempotency false-positive CI flake and the fix that shipped."
+---
+
+# `cfc-group-chat-demo/multi-user.test.tsx` flagged non-idempotent (July 2026)
+
+A flaky failure in the `deno.yml` workflow. It is timing-sensitive and surfaces
+only under the parallelism and load of a CI runner; it reproduced at about 1 run
+in 150 under artificial load and not at all otherwise on a developer machine. A
+sibling flake investigated on the same branch is recorded in
+[2026-07-cf-profile-capture-exit-130.md](2026-07-cf-profile-capture-exit-130.md).
+
+## Symptom
+
+In a sharded "Pattern Unit Tests" job the test failed with:
+
+```
+✗ 1 non-idempotent computation(s):
+  [bob] cf:module/<hash>:__cfLift_9:<instance> (differing writes: <did>/<entity>/value)
+```
+
+The `__cfLift_9` in that module is bob's `assert_sees_alice_profile` computed —
+`profileNames(chat).includes("Alice")` — a pure boolean read of the shared,
+cross-runtime-synced profile roster. A `Can't load profile-create.tsx`
+connection-refused line appears nearby in the same job log, but it belongs to a
+different pattern (`lot-watch`, which passed) and is unrelated; the group-chat
+failure is the non-idempotency flag.
+
+## The idempotency recheck
+
+`cf test` enables an inline idempotency check. After a computation runs, the
+scheduler re-runs it once against post-commit state and compares the two runs'
+writes; differing writes with unchanged inputs signal non-determinism
+(`runIdempotencyRecheck` in `packages/runner/src/scheduler/diagnosis.ts`). A
+filter, `readInvariantMovedExternally`, suppresses the flag when an input the
+computation read changed between the two runs — which is what a cross-runtime
+sync landing between them looks like.
+
+## Root cause
+
+Instrumenting the recheck and reproducing under load (about 1 run in 150) showed,
+every time:
+
+- `inputsMoved = false` — the read values were identical across the two runs, so
+  the input-moved filter did not apply,
+- the original run captured **no** writes, and
+- the recheck run captured **one** write, to a cell the computation also reads,
+  whose read value is a user-scoped redirect link
+  (`{"/":{"link@1":{path:[],scope:"user",overwrite:"redirect"}}}`) and whose
+  captured write value is `undefined`.
+
+The `undefined` write value is the tell. `captureTransactionWrites` reads the
+transaction journal's novelty; an address that is in the reactivity write log but
+has no journal-novelty entry is recorded as `undefined`. So the recheck run's
+extra "write" is a **read-triggered materialization touch**: the first time a
+transaction reads through the redirect link, the read materializes it into the
+replica, and the reactivity log records that as a write even though it commits no
+value. The original run had already materialized the cell (no touch); the fresh
+recheck transaction had not (a touch). The lift's actual output — the boolean —
+is identical in both runs, so the result cell is not among the differing writes;
+only the materialization side-effect differs.
+
+This is a false positive. It is not specific to the test pattern: any multi-runtime
+pattern whose computation reads a cross-runtime cell reachable through a redirect
+link can hit it.
+
+## Fix
+
+`captureTransactionWrites` now records only value-carrying writes — those the
+transaction journal has novelty for — and drops write-log addresses with no
+novelty (no-op writes and read-triggered materialization touches). A materialization
+that happens in one run but not the other no longer registers as a differing
+write. Real non-idempotency still writes value novelty (a different result), so it
+is unaffected: the accumulator, shuffle, set-to-array, and timestamp
+non-idempotent fixtures all still flag, as do the existing inline-idempotency unit
+tests.
+
+The regression guard models the write-capture boundary directly: two recheck runs
+emit the same value-carrying output, but the fresh run additionally touches a cell
+it reads with no journal novelty; the captured writes must compare equal. The test
+fails against the pre-fix code (the touch is captured) and passes with the fix.

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -96,7 +96,17 @@ export function captureTransactionWrites(
         }
         writeDetailsBySpace.set(write.space, details);
       }
-      writeValues.set(key, details.has(key) ? details.get(key) : undefined);
+      // Record only value-carrying writes — those the transaction journal has
+      // novelty for. An address that is in the reactivity write log but produced
+      // no novelty is a no-op write or a read-triggered materialization touch
+      // (for example, resolving a redirect link into a replica the first time it
+      // is read). Such a touch happens in a fresh recheck run but not in the
+      // original run, which already materialized it; recording it would make the
+      // idempotency comparison see a differing write where the computation's
+      // output did not actually change.
+      if (details.has(key)) {
+        writeValues.set(key, details.get(key));
+      }
     } catch (error) {
       if (!("errorValue" in options)) throw error;
       writeValues.set(key, options.errorValue);

--- a/packages/runner/test/scheduler-pull-idempotency.test.ts
+++ b/packages/runner/test/scheduler-pull-idempotency.test.ts
@@ -1,6 +1,10 @@
 // Inline scheduler idempotency check tests.
 
-import { findDifferingWriteKeys } from "../src/scheduler/diagnosis.ts";
+import {
+  captureTransactionWrites,
+  findDifferingWriteKeys,
+  makeAddressKey,
+} from "../src/scheduler/diagnosis.ts";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   afterEach,
@@ -232,5 +236,55 @@ describe("inline idempotency check mode", () => {
     expect(findDifferingWriteKeys(previousWrites, latestWrites)).toEqual([
       "missing-output",
     ]);
+  });
+
+  it("ignores a recheck's no-novelty materialization touch", () => {
+    // Model the multi-user `cf test` flake at the write-capture boundary. Both
+    // runs of the idempotency recheck emit the same value-carrying output, but
+    // the fresh recheck run additionally touches a cell it reads — resolving a
+    // redirect link into the replica the first time that transaction reads it.
+    // The reactivity log records that touch as a write, yet the transaction
+    // journal has no novelty for it (the read did not change committed state).
+    // The original run, which already materialized the cell, does not touch it.
+    // captureTransactionWrites must keep value-carrying writes and drop the
+    // touch, so the two runs compare equal instead of flagging a spurious
+    // non-idempotency.
+    const valueCell = runtime.getCell<number>(
+      space,
+      "novelty-value-write",
+      undefined,
+      tx,
+    );
+    const touchCell = runtime.getCell<number>(
+      space,
+      "materialization-touch",
+      undefined,
+      tx,
+    );
+    const valueAddr = toMemorySpaceAddress(valueCell.getAsNormalizedFullLink());
+    const touchAddr = toMemorySpaceAddress(touchCell.getAsNormalizedFullLink());
+
+    // Both transaction journals have novelty for the value write only; the
+    // touch never appears in journal novelty.
+    const journalWithValueOnly = {
+      getWriteDetails: (querySpace: unknown) =>
+        querySpace === space ? [{ address: valueAddr, value: 7 }] : [],
+    } as unknown as IExtendedStorageTransaction;
+
+    const originalWrites = captureTransactionWrites(journalWithValueOnly, [
+      valueAddr,
+    ]);
+    const recheckWrites = captureTransactionWrites(journalWithValueOnly, [
+      valueAddr,
+      touchAddr,
+    ]);
+
+    expect(recheckWrites.get(makeAddressKey(valueAddr))).toBe(7);
+    expect(recheckWrites.has(makeAddressKey(touchAddr))).toBe(false);
+    expect(
+      findDifferingWriteKeys(originalWrites, recheckWrites, {
+        keySet: "latest",
+      }),
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
…echeck

The inline idempotency check that cf test enables re-runs each computation once against post-commit state and flags it as non-idempotent when the two runs produce differing writes over unchanged inputs. The multi-user group-chat pattern test flaked in CI (about 1 run in 150 under load) with a lift that reads the shared, cross-runtime-synced profile roster being flagged, even though it is a pure boolean read.

Instrumenting the recheck showed the same shape every time: the inputs did not move between the two runs, the original run captured no writes, and the recheck run captured a single write to a cell the lift also reads. The read value there is a redirect link and the captured write value is undefined. captureTransaction Writes reads the transaction journal's novelty, and an address that is in the reactivity write log but has no novelty entry is recorded as undefined. So that extra write is a read-triggered materialization touch: the first time a fresh transaction reads through the redirect link it materializes the target into the replica, which the reactivity log records as a write even though it commits no value. The original run had already materialized the cell, so it did not touch it; the fresh recheck transaction had not. The lift's actual output — the boolean — is identical in both runs, so only the materialization side-effect differs. This is a false positive, and it is not specific to the test: any multi-runtime pattern whose computation reads a cross-runtime cell reachable through a redirect link can hit it.

Record only value-carrying writes — the ones the transaction journal has novelty for — and drop write-log addresses with no novelty (no-op writes and read-triggered materialization touches). A materialization that happens in one run but not the other no longer registers as a differing write. Real non-idempotency still writes value novelty (a different result), so it is unaffected: the accumulator, shuffle, set-to-array, and timestamp non-idempotent fixtures still flag, as do the existing inline-idempotency unit tests. Add a unit test at the write-capture boundary that a recheck run's no-novelty touch is dropped so the two runs compare equal; it fails against the pre-fix code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore read-triggered materialization touches in the inline idempotency recheck to remove false-positive non-idempotency flags in multi-runtime patterns. We now record only value-carrying writes from the transaction journal.

- **Bug Fixes**
  - Updated `captureTransactionWrites` to include only writes with journal novelty. Drops write-log addresses without novelty (no-ops and redirect-link materialization).
  - Real non-idempotency is unaffected. Existing fixtures still flag as expected.
  - Added a unit test to confirm the recheck ignores a no-novelty materialization touch. Documented the root cause and fix in `docs/history`.

<sup>Written for commit f3c715c80a119bf418373e48d7719e041ddec760. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: job: Pattern Integration Tests (3/4) = 477s
NEW_PERF_BASELINE: step: patterns integration = 445s
NEW_PERF_BASELINE: job: Pattern Integration Tests = 477s
NEW_PERF_BASELINE: job: Pattern Integration Tests (1/4) = 269s
