### PR TITLE
fix(cli): stop a late stop-signal from failing the profiler capture

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -196,6 +196,8 @@ One line per archived document; each document's header carries the fuller
 
 - [settle-wave-2026-03-findings.md](development/debugging/settle-wave-2026-03-findings.md)
   — March 2026 settle-wave measurements.
+- [2026-07-cf-profile-capture-exit-130.md](development/debugging/2026-07-cf-profile-capture-exit-130.md)
+  — root cause of the cf-profile capture exit-130 CI flake, July 2026.
 - [2026-07-group-chat-idempotency-false-positive.md](development/debugging/2026-07-group-chat-idempotency-false-positive.md)
   — root cause of the group-chat idempotency false-positive CI flake, July 2026.
 - [default-app-note-create.md](development/performance/default-app-note-create.md),

--- a/docs/history/development/debugging/2026-07-cf-profile-capture-exit-130.md
+++ b/docs/history/development/debugging/2026-07-cf-profile-capture-exit-130.md
@@ -1,0 +1,99 @@
+---
+status: historical
+created: 2026-07-18
+archived: 2026-07-18
+reason: "Root cause of the July 2026 cf-profile capture exit-130 CI flake and the fix that shipped."
+---
+
+# `cf-profile.test.ts` "captures a CPU profile for CLI help" exits 130 (July 2026)
+
+A flaky failure in the `deno.yml` workflow. It is timing-sensitive and surfaces
+only under the parallelism and load of a CI runner; it did not reproduce on an
+unloaded developer machine at anything above a fraction of a percent. A sibling
+flake investigated on the same branch is recorded in
+[2026-07-group-chat-idempotency-false-positive.md](2026-07-group-chat-idempotency-false-positive.md).
+
+## Symptom
+
+In a sharded "Test" job the test failed with:
+
+```
+error: AssertionError: Values are not equal: cf-profile: writing CPU profile to /tmp/cf-profile-test-<hash>/profile.cpuprofile
+...
+    [Diff] Actual / Expected
+-   130
++   0
+```
+
+The CPU profile was written successfully (`profile: profile stop matched`, the
+metadata file, and the three `cf-profile:` summary lines all appear in the
+captured output). Only the process exit code was wrong: `assertEquals(result.code, 0)`
+saw `130`, which is `128 + 2`, a termination by SIGINT.
+
+## The three processes
+
+`cf-profile` (`packages/cli/support/profiling/cf-profile.ts`) drives two child
+processes:
+
+- the profiled CLI, run with `--inspect-wait` so it pauses until a debugger
+  connects, and
+- a one-shot capture process (`capture-deno-inspector-profile.ts`) that connects
+  to the CLI's inspector, starts the CPU profiler, watches the CLI's console
+  output for a stop pattern, then stops the profiler and writes the profile.
+
+When the profiled CLI finishes, it prints `Waiting for the debugger to
+disconnect...`. `cf-profile` watches for that line and sends a stop signal to the
+capture process to tell it to wrap up. That stop signal is essential for commands
+that never emit a stop pattern; it is the only signal that the CLI is done.
+
+## Root cause
+
+The 130 is the **capture** process being killed by that stop signal (SIGINT at
+the time of the failure).
+
+`captureDenoInspectorProfile` installs its own SIGINT/SIGTERM handlers so a
+signal drives a graceful stop, and it removes those handlers in its outer
+`finally` as it returns — the library is also called in-process by unit tests,
+which assert the handlers are unregistered, so it must clean them up. The
+entry point then calls `Deno.exit(exitCode)`.
+
+That leaves a small window: after the handlers are removed and before
+`Deno.exit` runs, the default signal disposition (terminate) is back in force.
+Under load, the CLI's `Waiting for the debugger to disconnect...` line can reach
+`cf-profile` late — after the capture has already matched the stop pattern via
+the inspector channel, written the profile, closed the inspector socket, and
+removed its handlers. The stop signal then lands in that window and terminates
+the capture with 130. `cf-profile` propagates a non-zero capture status as its
+own exit code, so a successful profiling run reports failure.
+
+This was confirmed by isolating the pieces: a Deno process under `--inspect-wait`
+exits 0 on both a clean and an abrupt inspector disconnect, and exits 130 only
+when it receives SIGINT directly; `ChildProcess.kill(pid, signal)` targets a
+single process, so the profiled CLI never receives the capture's signal.
+Two earlier commits (#4524, #4526) narrowed this same window; this residual
+window is the part they did not close.
+
+## Fix
+
+The capture handles SIGINT and SIGTERM identically, so cf-profile's stop signal
+was moved to SIGTERM (`CAPTURE_STOP_SIGNAL`), and `guardCaptureStopSignal`
+installs a no-op listener for that one signal in the capture entry point that
+stays for the whole process lifetime. A signal fires every registered listener,
+so the capture's own graceful-stop handler is unaffected while installed; once it
+is removed, the entry-point guard keeps the default terminate disposition
+disabled for SIGTERM, so a late stop signal cannot turn a written profile into a
+128+signal exit. The process always exits with the code the capture logic chose.
+
+SIGINT is deliberately left unguarded. Guarding it would swallow an interactive
+Ctrl-C for the whole run, so a user could not force-kill the process if it hung
+after the capture removed its own handlers. Sending the programmatic stop as
+SIGTERM keeps Ctrl-C as a manual escape hatch while still closing the flake's
+window.
+
+The exit window is between the library returning and `Deno.exit`, outside any
+seam the library exposes, so it cannot be driven deterministically from a test
+the way the earlier close-window race could. The regression guard is therefore a
+deterministic unit test of `guardCaptureStopSignal` (it registers a benign
+handler for the stop signal only — not SIGINT — and tolerates a platform without
+signal support), matching the earlier fixes' pattern of testing the mechanism
+rather than racing the window.

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
@@ -2,7 +2,9 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import {
+  CAPTURE_STOP_SIGNAL,
   captureDenoInspectorProfile,
+  guardCaptureStopSignal,
   markProfilerStarted,
   markProfileStoppedOnce,
   parseArg,
@@ -1459,5 +1461,30 @@ describe("capture-deno-inspector-profile helpers", () => {
       new TextDecoder().decode(result.stderr),
       "--output is required",
     );
+  });
+
+  it("guards only the capture stop signal, leaving SIGINT for Ctrl-C", () => {
+    const registered: Array<[Deno.Signal, () => void]> = [];
+    guardCaptureStopSignal((signal, handler) => {
+      registered.push([signal, handler]);
+    });
+
+    // Only the stop signal is guarded — SIGINT stays at its default disposition
+    // so an interactive Ctrl-C can still terminate the process.
+    assertEquals(registered.map(([signal]) => signal), [CAPTURE_STOP_SIGNAL]);
+    assertEquals(CAPTURE_STOP_SIGNAL, "SIGTERM");
+    // The guard handler is a no-op: it neither throws nor exits, so a stop
+    // signal arriving after the capture removed its own handlers cannot
+    // terminate the process.
+    for (const [, handler] of registered) {
+      handler();
+    }
+  });
+
+  it("tolerates platforms where signal listeners cannot be registered", () => {
+    // A throwing addSignalListener (signals unsupported) must not propagate.
+    guardCaptureStopSignal(() => {
+      throw new Error("signals unavailable");
+    });
   });
 });

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
@@ -351,6 +351,40 @@ export async function writeProfileCaptureFiles(
   }
 }
 
+/**
+ * The signal cf-profile sends to stop this one-shot capture once the profiled
+ * command finishes. SIGTERM rather than SIGINT, so an interactive Ctrl-C
+ * (SIGINT) is left at its default disposition and can still terminate the
+ * process if it hangs after the capture has removed its own signal handlers.
+ */
+export const CAPTURE_STOP_SIGNAL: Deno.Signal = "SIGTERM";
+
+/**
+ * Install a no-op listener for CAPTURE_STOP_SIGNAL that stays for the whole
+ * process lifetime, so a late stop signal never terminates this process with
+ * 128+signal.
+ *
+ * captureDenoInspectorProfile installs and then removes its own stop-signal
+ * handlers as it runs, which leaves a window between that removal and the
+ * process reaching Deno.exit. The parent (cf-profile) sends CAPTURE_STOP_SIGNAL
+ * to stop this capture once the profiled command finishes; a signal landing in
+ * that window would exit with 128+signal and report a failure even though the
+ * profile was already written. This listener keeps the default terminate
+ * disposition disabled for that one signal across the whole run, and fires
+ * alongside the capture's own handler, so graceful stop is unaffected. SIGINT
+ * stays unguarded, so an interactive Ctrl-C can still terminate the process
+ * after its own handlers are gone.
+ */
+export function guardCaptureStopSignal(
+  addSignalListener: (signal: Deno.Signal, handler: () => void) => void,
+): void {
+  try {
+    addSignalListener(CAPTURE_STOP_SIGNAL, () => {});
+  } catch {
+    // Signals are unavailable on some platforms; nothing to guard.
+  }
+}
+
 export async function captureDenoInspectorProfile(
   args: string[],
   runtime: ProfileCaptureRuntime,

--- a/packages/cli/support/profiling/capture-deno-inspector-profile.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile.ts
@@ -1,7 +1,16 @@
 import { Celestial } from "../../../../packages/vendor-astral/bindings/celestial.ts";
-import { captureDenoInspectorProfile } from "./capture-deno-inspector-profile-lib.ts";
+import {
+  captureDenoInspectorProfile,
+  guardCaptureStopSignal,
+} from "./capture-deno-inspector-profile-lib.ts";
 
 if (import.meta.main) {
+  // captureDenoInspectorProfile removes its own stop-signal handlers as it
+  // returns; keep an exit-time guard for the parent's stop signal installed for
+  // the whole process so a late stop signal never terminates this one-shot
+  // capture with 128+signal after the profile has been written. Ctrl-C (SIGINT)
+  // stays unguarded as a manual escape hatch.
+  guardCaptureStopSignal(Deno.addSignalListener);
   const exitCode = await captureDenoInspectorProfile(Deno.args, {
     addSignalListener: Deno.addSignalListener,
     createCelestial: (ws) => new Celestial(ws),

--- a/packages/cli/support/profiling/cf-profile.ts
+++ b/packages/cli/support/profiling/cf-profile.ts
@@ -1,4 +1,5 @@
 import { dirname, fromFileUrl, join, resolve } from "@std/path";
+import { CAPTURE_STOP_SIGNAL } from "./capture-deno-inspector-profile-lib.ts";
 import {
   DEBUGGER_WAITING_MESSAGE,
   DEFAULT_SUMMARY_PATTERN,
@@ -84,7 +85,10 @@ let inspectorUrlFound = false;
 const captureRef: { current?: Deno.ChildProcess } = {};
 const stopCapture = () => {
   if (captureRef.current) {
-    stopCaptureOnce(captureStopState, captureRef.current);
+    // SIGTERM, not SIGINT, so an interactive Ctrl-C stays available to the user;
+    // the capture handles both identically, and its exit-time guard covers this
+    // signal (see guardCaptureStopSignal).
+    stopCaptureOnce(captureStopState, captureRef.current, CAPTURE_STOP_SIGNAL);
   }
 };
 


### PR DESCRIPTION
The CLI profiler wrapper (cf-profile) drives the profiled command under --inspect-wait and a separate one-shot capture process that connects to the command's inspector, records a CPU profile, and stops when the command finishes. When the command finishes it prints "Waiting for the debugger to disconnect...", and cf-profile sends a stop signal to the capture process to tell it to wrap up. That signal is the only stop for commands that never emit a console stop pattern, so it cannot be removed.

captureDenoInspectorProfile installs its own SIGINT/SIGTERM handlers for a graceful stop and removes them in its outer finally as it returns — the library is also called in-process by unit tests, which assert the handlers are unregistered. That removal leaves a brief window before the entry point calls Deno.exit where the default terminate disposition is back in force. Under CI load the command's disconnect line can reach cf-profile late, after the capture has already matched its stop pattern over the inspector channel, written the profile, and removed its handlers; the signal then lands in that window and terminates the capture with a 128+signal exit. cf-profile propagates the non-zero capture status, so a run that captured a valid profile reports failure and the "captures a CPU profile for CLI help" test fails asserting exit code 0.

A Deno process under --inspect-wait exits 0 on both clean and abrupt inspector disconnects and exits 130 only on a direct SIGINT, and kill targets a single pid, so the profiled command never receives this signal — the failure is always the capture process. Two earlier fixes narrowed the same window; this is the residual part between handler removal and Deno.exit.

The capture handles SIGINT and SIGTERM identically, so route the programmatic stop through SIGTERM (the shared CAPTURE_STOP_SIGNAL constant, so the sender and the guard cannot drift) and install a no-op guard for that one signal in the capture entry point that stays for the whole process lifetime. A signal fires every registered listener, so the capture's own graceful-stop handler keeps working while installed; once it is removed, the guard keeps the default terminate disposition disabled for SIGTERM, so a late stop signal can no longer turn a written profile into a 128+signal exit. SIGINT is left unguarded so an interactive Ctrl-C can still terminate the process if it hangs after its own handlers are gone. Add a unit test that the guard registers a benign handler for the stop signal only — not SIGINT — and tolerates a platform without signal support.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a late stop signal from killing the profiler capture. Successful runs no longer exit 130 after the profile is written, fixing the CI flake in the CPU profiler test.

- **Bug Fixes**
  - Switched the programmatic stop to SIGTERM via `CAPTURE_STOP_SIGNAL`.
  - Added `guardCaptureStopSignal` to install a no-op SIGTERM listener for the capture’s entire lifetime.
  - Left SIGINT unguarded so Ctrl-C still works for users.
  - Updated `cf-profile` to send `CAPTURE_STOP_SIGNAL`; added unit tests that verify only the stop signal is guarded and that platforms without signal support are tolerated.
  - Added a history note documenting the root cause and fix.

<sup>Written for commit a4e954721ac1d2fe93cb13a1160cb2ce76796334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



NEW_PERF_BASELINE: job: Pattern Integration Tests (3/4) = 521s
NEW_PERF_BASELINE: step: patterns integration = 474s
NEW_PERF_BASELINE: job: Pattern Integration Tests = 521s
