### PR TITLE
fix(toolshed): describe the streamed LLM response and guard /doc gene…

### DIFF
--- a/packages/toolshed/lib/configure-open-api.test.ts
+++ b/packages/toolshed/lib/configure-open-api.test.ts
@@ -1,15 +1,19 @@
 import { assert, assertEquals } from "@std/assert";
 
 import env from "@/env.ts";
-import createApp from "@/lib/create-app.ts";
+import app from "@/app.ts";
+import { createRouter } from "@/lib/create-app.ts";
 import configureOpenAPI from "@/lib/configure-open-api.ts";
+import { DESCRIPTORS } from "@/routes/integrations/provider-registry.ts";
+import { createOAuth2Routes } from "@/routes/integrations/oauth2-common/oauth2-common.routes.ts";
 
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
 }
 
-const app = createApp();
-configureOpenAPI(app);
+// `@/app.ts` is the app the server serves: `configureOpenAPI` plus every
+// router. The document is generated per request from the schemas of the routes
+// mounted on it.
 
 Deno.test("openapi reference", async (t) => {
   await t.step("GET /doc serves the OpenAPI document", async () => {
@@ -19,6 +23,70 @@ Deno.test("openapi reference", async (t) => {
     const json = await response.json();
     assertEquals(json.openapi, "3.0.0");
     assertEquals(json.info.title, "Toolshed API");
+  });
+
+  // Generation walks the schemas of the mounted routes, so these four paths,
+  // from four separate routers, stand as evidence that the walk reached real
+  // route schemas and not an empty app.
+  await t.step("the document covers the mounted routes", async () => {
+    const doc = await (await app.request("/doc")).json();
+
+    for (
+      const path of [
+        "/_health",
+        "/api/ai/llm",
+        "/api/storage/memory",
+        "/api/whoami",
+      ]
+    ) {
+      assert(path in doc.paths, `${path} is missing from the document`);
+    }
+  });
+
+  // `buildProviderRouters` mounts an OAuth2 provider only when that provider's
+  // credentials are set, and the test environment sets none, so the app above
+  // carries no provider paths. A deployment that configures them generates a
+  // document from these schemas too. Registering the route definitions against
+  // a throwaway router puts them through the generator here, without the
+  // credentials — and the network calls — that mounting them for real needs.
+  await t.step("the OAuth2 provider route schemas serialize", async () => {
+    const probe = createRouter();
+    configureOpenAPI(probe);
+
+    for (const descriptor of DESCRIPTORS) {
+      for (const route of Object.values(createOAuth2Routes(descriptor.name))) {
+        probe.openapi(route, (c) => c.json({}, 200) as never);
+      }
+    }
+
+    const response = await probe.request("/doc");
+    assertEquals(response.status, 200);
+
+    const doc = await response.json();
+    for (const descriptor of DESCRIPTORS) {
+      const path = `/api/integrations/${descriptor.name}-oauth/login`;
+      assert(path in doc.paths, `${path} is missing from the document`);
+    }
+  });
+
+  // `POST /api/ai/llm` answers with JSON or with a stream depending on the
+  // request's `stream` flag. The streamed body is UTF-8 text carrying one JSON
+  // event per line, which the document states as a string with a description.
+  await t.step("the streamed LLM response is described", async () => {
+    const doc = await (await app.request("/doc")).json();
+    const content = doc.paths["/api/ai/llm"].post.responses["200"].content;
+
+    assertEquals(Object.keys(content).sort(), [
+      "application/json",
+      "text/event-stream",
+    ]);
+
+    const streamed = content["text/event-stream"].schema;
+    assertEquals(streamed.type, "string");
+    assert(
+      streamed.description.includes("Newline-delimited JSON events"),
+      `the streamed body is undescribed: ${JSON.stringify(streamed)}`,
+    );
   });
 
   // Scalar renders the configuration it is handed into the page without

--- a/packages/toolshed/routes/ai/llm/llm.routes.ts
+++ b/packages/toolshed/routes/ai/llm/llm.routes.ts
@@ -119,9 +119,18 @@ export const ModelInfoSchema = z.object({
 
 export const ModelsResponseSchema = z.record(ModelInfoSchema);
 
-const StreamResponse = z.object({
-  type: z.literal("stream"),
-  body: z.instanceof(ReadableStream),
+// The streamed branch of this route writes one JSON event per line straight to
+// the response body, with no envelope around the sequence. The events are
+// `text-delta`, `tool-call`, `tool-result`, `finish` and `error`, each tagged by
+// its own `type` field. The body is UTF-8 text, so it is a plain string; the
+// line-delimited structure inside it is beyond what JSON Schema can state, and
+// the description carries it.
+const StreamResponse = z.string().openapi({
+  description:
+    'Newline-delimited JSON events, one per line, each tagged by a "type" ' +
+    'field: "text-delta" carries the next piece of text in "textDelta", ' +
+    '"tool-call" and "tool-result" report tool activity, "finish" ends a ' +
+    'complete response, and "error" reports a failure mid-stream.',
 });
 
 const JsonResponse = z.object({
@@ -230,7 +239,7 @@ export const generateText = createRoute({
         },
       },
       description:
-        "Generated text response. NOTE: If you make a request with `stream: true`, the server response will just be a stream of newline separated strings returned from the LLM, without a structured message object.",
+        "Generated text response. NOTE: If you make a request with `stream: true`, the server answers with a `text/event-stream` of newline-delimited JSON events instead of a single message object; the message is assembled from the `text-delta` events as they arrive.",
     },
     [HttpStatusCodes.BAD_REQUEST]: {
       content: {


### PR DESCRIPTION
…ration

The OpenAPI document served at `/doc` is generated in one pass from the schemas of every mounted route. The streamed branch of `POST /api/ai/llm` was described as an object `{type: "stream", body: z.instanceof(ReadableStream)}`. An instanceof check has no JSON Schema representation. The current converter (@hono/zod-openapi 0.18) quietly emits an empty schema for it, so the document generates but describes the streamed body as nothing; the zod 4 converter (@hono/zod-openapi 1.x) refuses instead, and because generation is all-or- nothing, that refusal turns the whole `/doc` response into a 500. Removing the instanceof check closes that hazard before it can land.

The `{type, body}` envelope was fiction regardless of the converter. The handler answers a streaming request with the model's events written straight to the response body, one `JSON.stringify(...) + "\n"` per event, and a non-streaming request with the bare message as JSON. The client reads the raw body in the first case and parses the message in the second. Neither branch has ever carried a `type` discriminator. Describe the streamed body as what it is: newline- delimited JSON events tagged `text-delta`, `tool-call`, `tool-result`, `finish` and `error`, which is a plain string whose internal structure JSON Schema has no vocabulary for, so the description carries it. `format: "binary"` is dropped, because in OpenAPI 3.0 that marks a body of raw octets, the file-download idiom, and this body is UTF-8 text. The route's own note is corrected the same way; it had called the stream a sequence of newline separated strings, a format the client now only keeps a legacy branch for.

The existing `/doc` test could not catch any of this. It built its own app from `createApp()` with no routers mounted, so it asked for a document generated from an empty set of schemas, which succeeds no matter how broken a route schema is. Point the test at the assembled app the server actually serves and assert that routes from four separate routers reach the document; one unserializable schema fails the whole document, so those paths stand as evidence for every mounted route's schemas.

That still leaves a blind spot exactly where the fault is most likely to reappear. `buildProviderRouters` mounts an OAuth2 provider only when that provider's credentials are configured, and no test environment configures any, so all eight contribute nothing to the document under test while a configured deployment serves their paths. Credentials cannot simply be supplied, because mounting a provider for real fetches its metadata document over the network. The route definitions need neither, so register those against a throwaway router and generate a document from them. Injecting `z.instanceof(ReadableStream)` into the shared OAuth2 login schema now fails this step and no other.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `/doc` OpenAPI generation by accurately describing the streamed `POST /api/ai/llm` response and removing an unserializable `ReadableStream` schema. Adds tests that use the real app and OAuth2 route schemas to prevent `/doc` 500s, including with `@hono/zod-openapi` upgrades.

- **Bug Fixes**
  - Describe stream as a `string` with newline-delimited JSON events (`text-delta`, `tool-call`, `tool-result`, `finish`, `error`); drop `format: binary`.
  - Remove `z.instanceof(ReadableStream)` to ensure JSON Schema serializes (avoids empty schema in `@hono/zod-openapi` 0.18 and hard failure in 1.x).
  - Update route docs to match actual streaming behavior (no `{type, body}` envelope).

- **Refactors**
  - Generate `/doc` from the real app (`@/app.ts`) and assert paths for `/_health`, `/api/ai/llm`, `/api/storage/memory`, `/api/whoami`.
  - Build a throwaway router and register OAuth2 login routes from `DESCRIPTORS` via `createOAuth2Routes`; verify schemas serialize without credentials or network calls.
  - Assert `text/event-stream` appears alongside `application/json` with the expected description.

<sup>Written for commit 7dec8eda4b9d859cf734d4d89e792f83f43ed0b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: job: Pattern Integration Tests (3/4) = 501s
NEW_PERF_BASELINE: step: patterns integration = 461s
NEW_PERF_BASELINE: job: Pattern Integration Tests = 501s
NEW_PERF_BASELINE: job: Pattern Integration Tests (1/4) = 251s
