### PR TITLE
data-model: move freeze-protocol plumbing off FabricInstance onto BaseFabricInstance

### DIFF
--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -328,7 +328,11 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
 
     seen.add(item);
 
-    if (BaseFabricInstance.isInstance(item)) {
+    if (BaseFabricPrimitive.isInstance(item)) {
+      // `FabricPrimitive`s are by definition frozen and have no outbound
+      // references.
+      return true;
+    } else if (BaseFabricInstance.isInstance(item)) {
       // Object.freeze() cannot prove that a fabric instance's private logical
       // contents will remain unchanged, so validate it but do not root-cache a
       // graph that reaches one.
@@ -368,14 +372,6 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
         }
         if (!checkValue(record[key])) return false;
       }
-      return true;
-    } else if (BaseFabricPrimitive.isInstance(item)) {
-      // `FabricPrimitive`s are by definition frozen and have no outbound
-      // references. This arm is checked after the array / plain-object arms
-      // (unlike the primitive-first ordering elsewhere): `BaseFabricPrimitive`'s
-      // instance type has no members, so this guard's negative narrowing would
-      // collapse `item` to `never` for any following branch -- keeping it last
-      // confines that to the unreachable-for-`item` final `else`.
       return true;
     } else {
       // It's an instance of a class that isn't covered by the `FabricValue`

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -1,12 +1,13 @@
 import { isPlainObject } from "@commonfabric/utils/types";
 import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
 
-import { FabricPrimitive, FabricValue } from "./interface.ts";
+import type { FabricValue } from "./interface.ts";
 import {
   BaseFabricInstance,
   DEEP_FREEZE,
   IS_DEEP_FROZEN,
 } from "./fabric-instances/BaseFabricInstance.ts";
+import { BaseFabricPrimitive } from "./fabric-primitives/BaseFabricPrimitive.ts";
 
 /**
  * Cache of confirmed deep-frozen objects.
@@ -121,18 +122,19 @@ export function isDeepFrozen(value: unknown): boolean {
 
     let result = true;
 
-    if (obj instanceof BaseFabricInstance) {
+    if (BaseFabricInstance.isInstance(obj)) {
       // A fabric instance's logical contents are not its enumerable own-props
       // (e.g. a `FabricError` keeps its custom properties in a private extras
       // `Map`), so it answers the deep-frozen question via its
       // `[IS_DEEP_FROZEN]` protocol member -- the side-effect-free sibling of
       // `[DEEP_FREEZE]` -- recursing into each nested `FabricValue` through
-      // `check`, which shares this call's cycle state. Gating on `instanceof`
-      // against `BaseFabricInstance` keeps this generic; the member is abstract
-      // on `BaseFabricInstance`, so every instance implements it. (A
-      // `FabricPrimitive` is necessarily frozen with no outbound references, so
-      // the `Object.values` arm below answers it correctly by accident -- its
-      // empty enumerable props yield `true`.)
+      // `check`, which shares this call's cycle state. Gating via
+      // `BaseFabricInstance.isInstance()` keeps this generic (and enforces the
+      // "every `FabricInstance` is a `BaseFabricInstance`" invariant); the
+      // member is abstract on `BaseFabricInstance`, so every instance implements
+      // it. (A `FabricPrimitive` is necessarily frozen with no outbound
+      // references, so the `Object.values` arm below answers it correctly by
+      // accident -- its empty enumerable props yield `true`.)
       result = obj[IS_DEEP_FROZEN](check);
     } else if (Array.isArray(obj)) {
       for (let i = 0; i < obj.length; i++) {
@@ -171,9 +173,9 @@ export function isDeepFrozen(value: unknown): boolean {
  *    at construction and have no outbound references.
  * 3. Fabric instance: delegate generically to its `[DEEP_FREEZE]` protocol
  *    member, handing recursion through as the `subFreeze` callback. The
- *    dispatch gates on `instanceof` against `BaseFabricInstance` (where the
- *    member is declared) -- it operates generically and does not enumerate
- *    concrete subclasses.
+ *    dispatch gates via `BaseFabricInstance.isInstance()` (where the member is
+ *    declared) -- it operates generically and does not enumerate concrete
+ *    subclasses.
  * 4. Plain object or array: recursively freeze children, then freeze the
  *    container.
  *
@@ -198,7 +200,7 @@ export function deepFreeze<T>(value: T): T {
   // construction) and have no outbound references. Handling arms 1 and 2 here,
   // before allocating the cycle-tracking set or the recursion closure below,
   // keeps primitives and `FabricPrimitive`s off the heavyweight path.
-  if (value instanceof FabricPrimitive) {
+  if (BaseFabricPrimitive.isInstance(value)) {
     return value;
   }
 
@@ -218,7 +220,7 @@ export function deepFreeze<T>(value: T): T {
     if (isNecessarilyOrKnownDeepFrozen(value)) {
       return value;
     }
-    if (value instanceof FabricPrimitive) {
+    if (BaseFabricPrimitive.isInstance(value)) {
       return value;
     }
 
@@ -238,7 +240,7 @@ export function deepFreeze<T>(value: T): T {
     // closes over `inProgress`, so the impl's recursion into nested
     // `FabricValue`s shares cycle state with this call -- the participating
     // instance doesn't need to be `inProgress`-aware in its own signature.
-    if (value instanceof BaseFabricInstance) {
+    if (BaseFabricInstance.isInstance(value)) {
       const result = value[DEEP_FREEZE](freeze) as U;
       // Cache the now-deep-frozen result so subsequent `isDeepFrozen()` checks
       // short-circuit in O(1), mirroring arm 4's cache-write below.
@@ -326,19 +328,16 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
 
     seen.add(item);
 
-    if (item instanceof FabricPrimitive) {
-      // `FabricPrimitive`s are by definition frozen and have no outbound
-      // references.
-      return true;
-    } else if (item instanceof BaseFabricInstance) {
+    if (BaseFabricInstance.isInstance(item)) {
       // Object.freeze() cannot prove that a fabric instance's private logical
       // contents will remain unchanged, so validate it but do not root-cache a
       // graph that reaches one.
       cacheableByIdentity = false;
       // Fabric instances answer the deep-frozen question via their
       // `[IS_DEEP_FROZEN]` protocol member (the side-effect-free sibling of
-      // `[DEEP_FREEZE]`), recursing through `checkValue`. Gating on
-      // `instanceof` against `BaseFabricInstance` keeps this guard generic; the
+      // `[DEEP_FREEZE]`), recursing through `checkValue`. Gating via
+      // `BaseFabricInstance.isInstance()` keeps this guard generic (and enforces
+      // the "every `FabricInstance` is a `BaseFabricInstance`" invariant); the
       // `[IS_DEEP_FROZEN]` member is abstract on `BaseFabricInstance`, so every
       // instance is guaranteed to implement it.
       return item[IS_DEEP_FROZEN](checkValue);
@@ -369,6 +368,14 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
         }
         if (!checkValue(record[key])) return false;
       }
+      return true;
+    } else if (BaseFabricPrimitive.isInstance(item)) {
+      // `FabricPrimitive`s are by definition frozen and have no outbound
+      // references. This arm is checked after the array / plain-object arms
+      // (unlike the primitive-first ordering elsewhere): `BaseFabricPrimitive`'s
+      // instance type has no members, so this guard's negative narrowing would
+      // collapse `item` to `never` for any following branch -- keeping it last
+      // confines that to the unreachable-for-`item` final `else`.
       return true;
     } else {
       // It's an instance of a class that isn't covered by the `FabricValue`

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -1,13 +1,12 @@
 import { isPlainObject } from "@commonfabric/utils/types";
 import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
 
+import { FabricPrimitive, FabricValue } from "./interface.ts";
 import {
+  BaseFabricInstance,
   DEEP_FREEZE,
-  FabricInstance,
-  FabricPrimitive,
-  FabricValue,
   IS_DEEP_FROZEN,
-} from "./interface.ts";
+} from "./fabric-instances/BaseFabricInstance.ts";
 
 /**
  * Cache of confirmed deep-frozen objects.
@@ -122,18 +121,18 @@ export function isDeepFrozen(value: unknown): boolean {
 
     let result = true;
 
-    if (obj instanceof FabricInstance) {
-      // A `FabricInstance`'s logical contents are not its enumerable own-props
+    if (obj instanceof BaseFabricInstance) {
+      // A fabric instance's logical contents are not its enumerable own-props
       // (e.g. a `FabricError` keeps its custom properties in a private extras
       // `Map`), so it answers the deep-frozen question via its
       // `[IS_DEEP_FROZEN]` protocol member -- the side-effect-free sibling of
       // `[DEEP_FREEZE]` -- recursing into each nested `FabricValue` through
       // `check`, which shares this call's cycle state. Gating on `instanceof`
-      // against the abstract base keeps this generic; the member is abstract on
-      // `FabricInstance`, so every instance implements it. (A `FabricPrimitive`
-      // is necessarily frozen with no outbound references, so the
-      // `Object.values` arm below answers it correctly by accident -- its empty
-      // enumerable props yield `true`.)
+      // against `BaseFabricInstance` keeps this generic; the member is abstract
+      // on `BaseFabricInstance`, so every instance implements it. (A
+      // `FabricPrimitive` is necessarily frozen with no outbound references, so
+      // the `Object.values` arm below answers it correctly by accident -- its
+      // empty enumerable props yield `true`.)
       result = obj[IS_DEEP_FROZEN](check);
     } else if (Array.isArray(obj)) {
       for (let i = 0; i < obj.length; i++) {
@@ -170,10 +169,10 @@ export function isDeepFrozen(value: unknown): boolean {
  *    objects): short-circuit unchanged.
  * 2. `FabricPrimitive` instance: short-circuit unchanged -- these self-freeze
  *    at construction and have no outbound references.
- * 3. `FabricInstance` (the abstract base): delegate generically to its
- *    `[DEEP_FREEZE]` protocol member, handing recursion through as the
- *    `subFreeze` callback. The dispatch gates on `instanceof` against the
- *    abstract base -- it operates generically and does not enumerate
+ * 3. Fabric instance: delegate generically to its `[DEEP_FREEZE]` protocol
+ *    member, handing recursion through as the `subFreeze` callback. The
+ *    dispatch gates on `instanceof` against `BaseFabricInstance` (where the
+ *    member is declared) -- it operates generically and does not enumerate
  *    concrete subclasses.
  * 4. Plain object or array: recursively freeze children, then freeze the
  *    container.
@@ -234,12 +233,12 @@ export function deepFreeze<T>(value: T): T {
     }
     inProgress.add(obj);
 
-    // Arm 3: a `FabricInstance` freezes itself in place via its `[DEEP_FREEZE]`
+    // Arm 3: a fabric instance freezes itself in place via its `[DEEP_FREEZE]`
     // protocol member. `freeze` is handed in as the `subFreeze` callback: it
     // closes over `inProgress`, so the impl's recursion into nested
     // `FabricValue`s shares cycle state with this call -- the participating
     // instance doesn't need to be `inProgress`-aware in its own signature.
-    if (value instanceof FabricInstance) {
+    if (value instanceof BaseFabricInstance) {
       const result = value[DEEP_FREEZE](freeze) as U;
       // Cache the now-deep-frozen result so subsequent `isDeepFrozen()` checks
       // short-circuit in O(1), mirroring arm 4's cache-write below.
@@ -331,16 +330,16 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
       // `FabricPrimitive`s are by definition frozen and have no outbound
       // references.
       return true;
-    } else if (item instanceof FabricInstance) {
-      // Object.freeze() cannot prove that a FabricInstance's private logical
+    } else if (item instanceof BaseFabricInstance) {
+      // Object.freeze() cannot prove that a fabric instance's private logical
       // contents will remain unchanged, so validate it but do not root-cache a
       // graph that reaches one.
       cacheableByIdentity = false;
-      // `FabricInstance`s answer the deep-frozen question via their
+      // Fabric instances answer the deep-frozen question via their
       // `[IS_DEEP_FROZEN]` protocol member (the side-effect-free sibling of
       // `[DEEP_FREEZE]`), recursing through `checkValue`. Gating on
-      // `instanceof` against the abstract base keeps this guard generic; the
-      // `[IS_DEEP_FROZEN]` member is abstract on `FabricInstance`, so every
+      // `instanceof` against `BaseFabricInstance` keeps this guard generic; the
+      // `[IS_DEEP_FROZEN]` member is abstract on `BaseFabricInstance`, so every
       // instance is guaranteed to implement it.
       return item[IS_DEEP_FROZEN](checkValue);
     } else if (Array.isArray(item)) {

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -47,41 +47,6 @@ export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
  */
 export abstract class BaseFabricInstance extends FabricInstance {
   //
-  // Static members
-  //
-
-  /**
-   * Type guard for `BaseFabricInstance`, which also enforces the invariant that
-   * every `FabricInstance` is in fact a `BaseFabricInstance`. Concrete
-   * fabric-instance classes are required to extend `BaseFabricInstance` (never
-   * `FabricInstance` directly), so a value that is a `FabricInstance` but not a
-   * `BaseFabricInstance` indicates a broken subclass. Use this in preference to
-   * a bare `instanceof BaseFabricInstance` where dispatch relies on the members
-   * declared here (e.g. the generic freeze machinery), so the invariant is
-   * actively enforced rather than silently skipped.
-   *
-   * This uses "death before confusion" on the mismatch: rather than quietly
-   * answer `false` for a direct `FabricInstance` subclass (which would let it
-   * bypass its freeze protocol and be cached as deep-frozen while only
-   * shallow-frozen), it throws, surfacing the broken subclass at the point of
-   * use. The throw is intentional despite the predicate-style name.
-   *
-   * @throws If `value` is a `FabricInstance` that is not a `BaseFabricInstance`
-   *   -- the "shouldn't happen" invariant violation.
-   */
-  static isInstance(value: unknown): value is BaseFabricInstance {
-    if (value instanceof BaseFabricInstance) {
-      return true;
-    } else if (value instanceof FabricInstance) {
-      throw new Error(
-        "Shouldn't happen: `FabricInstance` that is not a `BaseFabricInstance`.",
-      );
-    }
-
-    return false;
-  }
-
-  //
   // Instance members
   //
 
@@ -136,5 +101,40 @@ export abstract class BaseFabricInstance extends FabricInstance {
     // Cast needed: `Object.freeze()` returns `Readonly<T>`, which TS considers
     // incompatible with abstract class types due to protected members.
     return frozen ? Object.freeze(copy) as FabricInstance : copy;
+  }
+
+  //
+  // Static members
+  //
+
+  /**
+   * Type guard for `BaseFabricInstance`, which also enforces the invariant that
+   * every `FabricInstance` is in fact a `BaseFabricInstance`. Concrete
+   * fabric-instance classes are required to extend `BaseFabricInstance` (never
+   * `FabricInstance` directly), so a value that is a `FabricInstance` but not a
+   * `BaseFabricInstance` indicates a broken subclass. Use this in preference to
+   * a bare `instanceof BaseFabricInstance` where dispatch relies on the members
+   * declared here (e.g. the generic freeze machinery), so the invariant is
+   * actively enforced rather than silently skipped.
+   *
+   * This uses "death before confusion" on the mismatch: rather than quietly
+   * answer `false` for a direct `FabricInstance` subclass (which would let it
+   * bypass its freeze protocol and be cached as deep-frozen while only
+   * shallow-frozen), it throws, surfacing the broken subclass at the point of
+   * use. The throw is intentional despite the predicate-style name.
+   *
+   * @throws If `value` is a `FabricInstance` that is not a `BaseFabricInstance`
+   *   -- the "shouldn't happen" invariant violation.
+   */
+  static isInstance(value: unknown): value is BaseFabricInstance {
+    if (value instanceof BaseFabricInstance) {
+      return true;
+    } else if (value instanceof FabricInstance) {
+      throw new Error(
+        "Shouldn't happen: `FabricInstance` that is not a `BaseFabricInstance`.",
+      );
+    }
+
+    return false;
   }
 }

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -60,6 +60,12 @@ export abstract class BaseFabricInstance extends FabricInstance {
    * declared here (e.g. the generic freeze machinery), so the invariant is
    * actively enforced rather than silently skipped.
    *
+   * This uses "death before confusion" on the mismatch: rather than quietly
+   * answer `false` for a direct `FabricInstance` subclass (which would let it
+   * bypass its freeze protocol and be cached as deep-frozen while only
+   * shallow-frozen), it throws, surfacing the broken subclass at the point of
+   * use. The throw is intentional despite the predicate-style name.
+   *
    * @throws If `value` is a `FabricInstance` that is not a `BaseFabricInstance`
    *   -- the "shouldn't happen" invariant violation.
    */

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -47,6 +47,35 @@ export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
  */
 export abstract class BaseFabricInstance extends FabricInstance {
   //
+  // Static members
+  //
+
+  /**
+   * Type guard for `BaseFabricInstance`, which also enforces the invariant that
+   * every `FabricInstance` is in fact a `BaseFabricInstance`. Concrete
+   * fabric-instance classes are required to extend `BaseFabricInstance` (never
+   * `FabricInstance` directly), so a value that is a `FabricInstance` but not a
+   * `BaseFabricInstance` indicates a broken subclass. Use this in preference to
+   * a bare `instanceof BaseFabricInstance` where dispatch relies on the members
+   * declared here (e.g. the generic freeze machinery), so the invariant is
+   * actively enforced rather than silently skipped.
+   *
+   * @throws If `value` is a `FabricInstance` that is not a `BaseFabricInstance`
+   *   -- the "shouldn't happen" invariant violation.
+   */
+  static isInstance(value: unknown): value is BaseFabricInstance {
+    if (value instanceof BaseFabricInstance) {
+      return true;
+    } else if (value instanceof FabricInstance) {
+      throw new Error(
+        "Shouldn't happen: `FabricInstance` that is not a `BaseFabricInstance`.",
+      );
+    }
+
+    return false;
+  }
+
+  //
   // Instance members
   //
 

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -1,11 +1,44 @@
-import { FabricInstance } from "@/interface.ts";
+import { FabricInstance, type FabricValue } from "@/interface.ts";
+
+/**
+ * Well-known symbol for deeply freezing a fabric instance in place. The method
+ * freezes the instance's own internal slot(s) and recurses into any nested
+ * `FabricValue`s via the provided `subFreeze` callback. This is an abstract
+ * member of `BaseFabricInstance`, so the generic `deepFreeze()` operates on any
+ * fabric instance by gating on `instanceof` against `BaseFabricInstance` and
+ * invoking this member -- it does not enumerate concrete subclasses.
+ * Distinct from `deepClone()`: `[DEEP_FREEZE]` freezes the existing instance
+ * in place; `deepClone()` constructs a new instance.
+ */
+export const DEEP_FREEZE: unique symbol = Symbol.for("common.deepFreeze");
+
+/**
+ * Well-known symbol for checking whether a fabric instance is already deeply
+ * frozen, without mutating it. The sibling-of-`[DEEP_FREEZE]` *check*: it
+ * verifies the instance's own internal slot(s) are in canonical deep-frozen
+ * form and recurses into any nested `FabricValue`s via the provided
+ * `subIsDeepFrozen` callback, returning the boolean conjunction. This is an
+ * abstract member of `BaseFabricInstance`, so the generic deep-frozen type
+ * guard operates on any fabric instance by gating on `instanceof` against
+ * `BaseFabricInstance` and invoking this member -- it does not enumerate
+ * concrete subclasses.
+ *
+ * Unlike `[DEEP_FREEZE]`, this method is side-effect-free and never throws:
+ * a not-in-canonical-deep-frozen-form instance answers `false`, it does not
+ * crash. (`[DEEP_FREEZE]` is a mutator and uses "death before confusion" on
+ * a malformed internal slot; a status check must not.)
+ */
+export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
+  "common.isDeepFrozen",
+);
 
 /**
  * Abstract base class providing shared scaffolding for `FabricInstance`
  * subclasses. Concrete `FabricInstance` classes extend this, not
  * `FabricInstance` directly: `FabricInstance` is the pure abstract protocol
  * (the `instanceof`-able contract that external code is written against), while
- * `BaseFabricInstance` is where shared template-method implementations live.
+ * `BaseFabricInstance` is where shared template-method implementations and the
+ * freeze-protocol plumbing (`[DEEP_FREEZE]()`, `[IS_DEEP_FROZEN]()`) live.
  *
  * TODO(danfuzz): `deepClone()` should grow a base implementation here that
  * defers to a sibling `protected abstract` method (mirroring the
@@ -16,6 +49,37 @@ export abstract class BaseFabricInstance extends FabricInstance {
   //
   // Instance members
   //
+
+  /**
+   * Deeply freezes this instance in place: freezes this instance's own
+   * internal slot(s) and recurses into each nested `FabricValue` by calling
+   * the provided `subFreeze` callback on it. Implementations must NOT import
+   * or call `deepFreeze()` directly -- recursion is handed through the
+   * callback so that the freeze utility's caching / cycle-detection
+   * bookkeeping is preserved and no import cycle is introduced.
+   *
+   * Returns the (now deeply-frozen) value. Freeze-in-place implementations
+   * return `this`.
+   */
+  abstract [DEEP_FREEZE](
+    subFreeze: (value: FabricValue) => FabricValue,
+  ): FabricValue;
+
+  /**
+   * Indicates whether this instance is already deeply frozen, without
+   * mutating it. Checks this instance's own internal slot(s) are in
+   * canonical deep-frozen form and recurses into each nested `FabricValue`
+   * via the provided `subIsDeepFrozen` callback, returning the boolean
+   * conjunction. Implementations must NOT import or call the deep-frozen
+   * type guard directly -- recursion is handed through the callback,
+   * mirroring `[DEEP_FREEZE]`'s callback shape and avoiding an import cycle.
+   *
+   * Side-effect-free and must not throw: an instance that is not in
+   * canonical deep-frozen form returns `false`.
+   */
+  abstract [IS_DEEP_FROZEN](
+    subIsDeepFrozen: (value: FabricValue) => boolean,
+  ): boolean;
 
   /**
    * Returns a new unfrozen copy of this instance with the same data. Called

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -1,4 +1,5 @@
-import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
+import { DEEP_FREEZE, IS_DEEP_FROZEN } from "./BaseFabricInstance.ts";
 import {
   CODEC,
   type FabricCodec,

--- a/packages/data-model/src/fabric-instances/FabricLink.ts
+++ b/packages/data-model/src/fabric-instances/FabricLink.ts
@@ -4,13 +4,12 @@ import type {
 } from "@commonfabric/api";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
+import type { FabricPlainObject, FabricValue } from "@/interface.ts";
 import {
+  BaseFabricInstance,
   DEEP_FREEZE,
-  type FabricPlainObject,
-  type FabricValue,
   IS_DEEP_FROZEN,
-} from "@/interface.ts";
-import { BaseFabricInstance } from "./BaseFabricInstance.ts";
+} from "./BaseFabricInstance.ts";
 import { cloneIfNecessary } from "@/value-clone.ts";
 import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 import { BaseFabricCodec } from "@/codec-common/BaseFabricCodec.ts";

--- a/packages/data-model/src/fabric-instances/FabricMap.ts
+++ b/packages/data-model/src/fabric-instances/FabricMap.ts
@@ -1,4 +1,5 @@
-import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
+import { DEEP_FREEZE, IS_DEEP_FROZEN } from "./BaseFabricInstance.ts";
 import {
   CODEC,
   type FabricCodec,

--- a/packages/data-model/src/fabric-instances/FabricSet.ts
+++ b/packages/data-model/src/fabric-instances/FabricSet.ts
@@ -1,4 +1,5 @@
-import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
+import { DEEP_FREEZE, IS_DEEP_FROZEN } from "./BaseFabricInstance.ts";
 import {
   CODEC,
   type FabricCodec,

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -1,4 +1,5 @@
-import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
+import { DEEP_FREEZE, IS_DEEP_FROZEN } from "./BaseFabricInstance.ts";
 import {
   CODEC,
   type FabricCodec,

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -1,4 +1,5 @@
-import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
+import { DEEP_FREEZE, IS_DEEP_FROZEN } from "./BaseFabricInstance.ts";
 import {
   CODEC,
   type FabricCodec,

--- a/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
@@ -22,6 +22,11 @@ export abstract class BaseFabricPrimitive extends FabricPrimitive {
    * but not a `BaseFabricPrimitive` indicates a broken subclass. Mirrors
    * `BaseFabricInstance.isInstance()`.
    *
+   * Like its counterpart, this uses "death before confusion" on the mismatch:
+   * it throws rather than quietly answering `false`, so a broken subclass is
+   * surfaced at the point of use. The throw is intentional despite the
+   * predicate-style name.
+   *
    * @throws If `value` is a `FabricPrimitive` that is not a
    *   `BaseFabricPrimitive` -- the "shouldn't happen" invariant violation.
    */

--- a/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
@@ -1,13 +1,30 @@
 import { FabricPrimitive } from "@/interface.ts";
 
 /**
+ * Well-known symbol seeding `BaseFabricPrimitive`'s symbol-keyed member set.
+ *
+ * `BaseFabricPrimitive` is intended to accumulate symbol-keyed "implementation
+ * plumbing" members over time -- the same regular-name-for-clients /
+ * unique-symbol-for-plumbing pattern that `BaseFabricInstance` uses for
+ * `[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`. This is a deliberate placeholder seed:
+ * it gives the class one concrete member today so that its instance type is
+ * non-empty, which is what lets `BaseFabricPrimitive.isInstance()` narrow as an
+ * ordinary `value is` guard (a structurally-empty type makes such a guard's
+ * negative branch collapse to `never`). Replace it with the first real
+ * primitive-plumbing member once one is identified.
+ */
+export const EXAMPLE_METHOD: unique symbol = Symbol.for(
+  "data-model.exampleMethod",
+);
+
+/**
  * Abstract base class for `FabricPrimitive` subclasses. Concrete
  * `FabricPrimitive` classes extend this, not `FabricPrimitive` directly:
  * `FabricPrimitive` is the pure abstract contract that external code is written
  * against, while `BaseFabricPrimitive` is the designated home for shared
- * implementation. Beyond the static invariant guard below it currently adds no
- * members of its own (its counterpart `BaseFabricInstance` carries the
- * `shallowClone()` template method).
+ * implementation. Its counterpart `BaseFabricInstance` carries the
+ * `shallowClone()` template method; this class currently carries the static
+ * invariant guard and a placeholder seed member (see `[EXAMPLE_METHOD]`).
  */
 export abstract class BaseFabricPrimitive extends FabricPrimitive {
   //
@@ -40,5 +57,22 @@ export abstract class BaseFabricPrimitive extends FabricPrimitive {
     }
 
     return false;
+  }
+
+  //
+  // Instance members
+  //
+
+  /**
+   * Placeholder seed member (a throwing stub). Its only purpose today is to
+   * give `BaseFabricPrimitive` a non-empty instance type so `isInstance()`
+   * narrows normally; it has no callers and no real behavior yet, and is the
+   * first of the intended symbol-keyed primitive-plumbing members. Replace it
+   * with a real member once one is identified.
+   *
+   * @throws Always -- it is not implemented.
+   */
+  [EXAMPLE_METHOD](): never {
+    throw new Error("Not implemented: `[EXAMPLE_METHOD]` is a placeholder.");
   }
 }

--- a/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
@@ -5,8 +5,35 @@ import { FabricPrimitive } from "@/interface.ts";
  * `FabricPrimitive` classes extend this, not `FabricPrimitive` directly:
  * `FabricPrimitive` is the pure abstract contract that external code is written
  * against, while `BaseFabricPrimitive` is the designated home for shared
- * implementation. It currently adds no members of its own (its counterpart
- * `BaseFabricInstance` carries the `shallowClone()` template method).
+ * implementation. Beyond the static invariant guard below it currently adds no
+ * members of its own (its counterpart `BaseFabricInstance` carries the
+ * `shallowClone()` template method).
  */
 export abstract class BaseFabricPrimitive extends FabricPrimitive {
+  //
+  // Static members
+  //
+
+  /**
+   * Type guard for `BaseFabricPrimitive`, which also enforces the invariant
+   * that every `FabricPrimitive` is in fact a `BaseFabricPrimitive`. Concrete
+   * fabric-primitive classes are required to extend `BaseFabricPrimitive`
+   * (never `FabricPrimitive` directly), so a value that is a `FabricPrimitive`
+   * but not a `BaseFabricPrimitive` indicates a broken subclass. Mirrors
+   * `BaseFabricInstance.isInstance()`.
+   *
+   * @throws If `value` is a `FabricPrimitive` that is not a
+   *   `BaseFabricPrimitive` -- the "shouldn't happen" invariant violation.
+   */
+  static isInstance(value: unknown): value is BaseFabricPrimitive {
+    if (value instanceof BaseFabricPrimitive) {
+      return true;
+    } else if (value instanceof FabricPrimitive) {
+      throw new Error(
+        "Shouldn't happen: `FabricPrimitive` that is not a `BaseFabricPrimitive`.",
+      );
+    }
+
+    return false;
+  }
 }

--- a/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
@@ -28,6 +28,23 @@ export const EXAMPLE_METHOD: unique symbol = Symbol.for(
  */
 export abstract class BaseFabricPrimitive extends FabricPrimitive {
   //
+  // Instance members
+  //
+
+  /**
+   * Placeholder seed member (a throwing stub). Its only purpose today is to
+   * give `BaseFabricPrimitive` a non-empty instance type so `isInstance()`
+   * narrows normally; it has no callers and no real behavior yet, and is the
+   * first of the intended symbol-keyed primitive-plumbing members. Replace it
+   * with a real member once one is identified.
+   *
+   * @throws Always -- it is not implemented.
+   */
+  [EXAMPLE_METHOD](): never {
+    throw new Error("Not implemented: `[EXAMPLE_METHOD]` is a placeholder.");
+  }
+
+  //
   // Static members
   //
 
@@ -57,22 +74,5 @@ export abstract class BaseFabricPrimitive extends FabricPrimitive {
     }
 
     return false;
-  }
-
-  //
-  // Instance members
-  //
-
-  /**
-   * Placeholder seed member (a throwing stub). Its only purpose today is to
-   * give `BaseFabricPrimitive` a non-empty instance type so `isInstance()`
-   * narrows normally; it has no callers and no real behavior yet, and is the
-   * first of the intended symbol-keyed primitive-plumbing members. Replace it
-   * with a real member once one is identified.
-   *
-   * @throws Always -- it is not implemented.
-   */
-  [EXAMPLE_METHOD](): never {
-    throw new Error("Not implemented: `[EXAMPLE_METHOD]` is a placeholder.");
   }
 }

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -29,38 +29,6 @@ export abstract class FabricSpecialObject {}
 //
 
 /**
- * Well-known symbol for deeply freezing a fabric instance in place. The method
- * freezes the instance's own internal slot(s) and recurses into any nested
- * `FabricValue`s via the provided `subFreeze` callback. This is an abstract
- * member of `FabricInstance`, so the generic `deepFreeze()` operates on any
- * `FabricInstance` by gating on `instanceof` against the abstract base and
- * invoking this member -- it does not enumerate concrete subclasses.
- * Distinct from `deepClone()`: `[DEEP_FREEZE]` freezes the existing instance
- * in place; `deepClone()` constructs a new instance.
- */
-export const DEEP_FREEZE: unique symbol = Symbol.for("common.deepFreeze");
-
-/**
- * Well-known symbol for checking whether a fabric instance is already deeply
- * frozen, without mutating it. The sibling-of-`[DEEP_FREEZE]` *check*: it
- * verifies the instance's own internal slot(s) are in canonical deep-frozen
- * form and recurses into any nested `FabricValue`s via the provided
- * `subIsDeepFrozen` callback, returning the boolean conjunction. This is an
- * abstract member of `FabricInstance`, so the generic deep-frozen type guard
- * operates on any `FabricInstance` by gating on `instanceof` against the
- * abstract base and invoking this member -- it does not enumerate concrete
- * subclasses.
- *
- * Unlike `[DEEP_FREEZE]`, this method is side-effect-free and never throws:
- * a not-in-canonical-deep-frozen-form instance answers `false`, it does not
- * crash. (`[DEEP_FREEZE]` is a mutator and uses "death before confusion" on
- * a malformed internal slot; a status check must not.)
- */
-export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
-  "common.isDeepFrozen",
-);
-
-/**
  * Abstract base class for values that participate in the fabric protocol.
  * See Section 2.3 of the formal spec.
  *
@@ -70,42 +38,13 @@ export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
  * than this class directly; `BaseFabricInstance` is where shared
  * template-method scaffolding (such as `shallowClone()`) lives.
  *
- * Subclasses must implement `[DEEP_FREEZE]()`, `[IS_DEEP_FROZEN]()`,
- * `deepClone()`, and `shallowClone()` (the latter is normally inherited from
- * `BaseFabricInstance`).
+ * Subclasses must implement `deepClone()` and `shallowClone()` (the latter is
+ * normally inherited from `BaseFabricInstance`). The freeze-protocol members
+ * `[DEEP_FREEZE]()` and `[IS_DEEP_FROZEN]()` are declared on
+ * `BaseFabricInstance`, not here: they are implementation plumbing and are kept
+ * off this pure-protocol class.
  */
 export abstract class FabricInstance extends FabricSpecialObject {
-  /**
-   * Deeply freezes this instance in place: freezes this instance's own
-   * internal slot(s) and recurses into each nested `FabricValue` by calling
-   * the provided `subFreeze` callback on it. Implementations must NOT import
-   * or call `deepFreeze()` directly -- recursion is handed through the
-   * callback so that the freeze utility's caching / cycle-detection
-   * bookkeeping is preserved and no import cycle is introduced.
-   *
-   * Returns the (now deeply-frozen) value. Freeze-in-place implementations
-   * return `this`.
-   */
-  abstract [DEEP_FREEZE](
-    subFreeze: (value: FabricValue) => FabricValue,
-  ): FabricValue;
-
-  /**
-   * Indicates whether this instance is already deeply frozen, without
-   * mutating it. Checks this instance's own internal slot(s) are in
-   * canonical deep-frozen form and recurses into each nested `FabricValue`
-   * via the provided `subIsDeepFrozen` callback, returning the boolean
-   * conjunction. Implementations must NOT import or call the deep-frozen
-   * type guard directly -- recursion is handed through the callback,
-   * mirroring `[DEEP_FREEZE]`'s callback shape and avoiding an import cycle.
-   *
-   * Side-effect-free and must not throw: an instance that is not in
-   * canonical deep-frozen form returns `false`.
-   */
-  abstract [IS_DEEP_FROZEN](
-    subIsDeepFrozen: (value: FabricValue) => boolean,
-  ): boolean;
-
   /**
    * Returns a new deep clone of this instance with equivalent data but no
    * shared structure for any unfrozen data in the original. When `frozen ===

--- a/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
@@ -2,16 +2,15 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { JsonEncodingContext } from "@/codec-json/JsonEncodingContext.ts";
-import {
-  DEEP_FREEZE,
-  FabricInstance,
-  type FabricValue,
-  IS_DEEP_FROZEN,
-} from "@/interface.ts";
+import { FabricInstance, type FabricValue } from "@/interface.ts";
 import type { JsonWireValue } from "@/codec-json/interface.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
-import { BaseFabricInstance } from "@/fabric-instances/BaseFabricInstance.ts";
+import {
+  BaseFabricInstance,
+  DEEP_FREEZE,
+  IS_DEEP_FROZEN,
+} from "@/fabric-instances/BaseFabricInstance.ts";
 import { FabricEpochDays } from "@/fabric-primitives/FabricEpochDays.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";

--- a/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
+++ b/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
@@ -1,13 +1,12 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import { FabricInstance, type FabricValue } from "@/interface.ts";
 import {
+  BaseFabricInstance,
   DEEP_FREEZE,
-  FabricInstance,
-  type FabricValue,
   IS_DEEP_FROZEN,
-} from "@/interface.ts";
-import { BaseFabricInstance } from "@/fabric-instances/BaseFabricInstance.ts";
+} from "@/fabric-instances/BaseFabricInstance.ts";
 
 /**
  * Minimal `BaseFabricInstance` subclass used to exercise the template-method

--- a/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
+++ b/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
@@ -53,12 +53,47 @@ class Probe extends BaseFabricInstance {
   }
 }
 
+/**
+ * A rogue direct subclass of `FabricInstance` that bypasses
+ * `BaseFabricInstance` -- the shape the invariant forbids. Used only to witness
+ * `isInstance()`'s enforcement throw; no production class is built this way.
+ */
+class RogueInstance extends FabricInstance {
+  deepClone(_frozen: boolean): FabricInstance {
+    throw new Error("not exercised here");
+  }
+
+  shallowClone(_frozen: boolean): FabricInstance {
+    throw new Error("not exercised here");
+  }
+}
+
 describe("BaseFabricInstance", () => {
   describe("inheritance", () => {
     it("is a subclass of `FabricInstance`", () => {
       const probe = new Probe("t");
       expect(probe instanceof BaseFabricInstance).toBe(true);
       expect(probe instanceof FabricInstance).toBe(true);
+    });
+  });
+
+  describe("isInstance()", () => {
+    it("is `true` for a `BaseFabricInstance`", () => {
+      expect(BaseFabricInstance.isInstance(new Probe("t"))).toBe(true);
+    });
+
+    it("is `false` for non-fabric values", () => {
+      expect(BaseFabricInstance.isInstance(null)).toBe(false);
+      expect(BaseFabricInstance.isInstance(42)).toBe(false);
+      expect(BaseFabricInstance.isInstance("x")).toBe(false);
+      expect(BaseFabricInstance.isInstance({})).toBe(false);
+      expect(BaseFabricInstance.isInstance([])).toBe(false);
+    });
+
+    it("throws for a `FabricInstance` that is not a `BaseFabricInstance`", () => {
+      expect(() => BaseFabricInstance.isInstance(new RogueInstance())).toThrow(
+        "Shouldn't happen",
+      );
     });
   });
 

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -1,12 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import { FabricInstance, type FabricValue } from "@/interface.ts";
 import {
   DEEP_FREEZE,
-  FabricInstance,
-  type FabricValue,
   IS_DEEP_FROZEN,
-} from "@/interface.ts";
+} from "@/fabric-instances/BaseFabricInstance.ts";
 import { CODEC } from "@/codec-common/interface.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-common/EmptyReconstructionContext.ts";

--- a/packages/data-model/test/fabric-instances/FabricLink.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricLink.test.ts
@@ -1,12 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 import {
   DEEP_FREEZE,
-  FabricInstance,
-  FabricPrimitive,
   IS_DEEP_FROZEN,
-} from "@/interface.ts";
+} from "@/fabric-instances/BaseFabricInstance.ts";
 import { FabricLink } from "@/fabric-instances/FabricLink.ts";
 import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 import { subFreeze, subIsDeepFrozen } from "./fixtures.ts";

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -1,12 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import { FabricInstance, type FabricValue } from "@/interface.ts";
 import {
   DEEP_FREEZE,
-  FabricInstance,
-  type FabricValue,
   IS_DEEP_FROZEN,
-} from "@/interface.ts";
+} from "@/fabric-instances/BaseFabricInstance.ts";
 import { CODEC } from "@/codec-common/interface.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-common/EmptyReconstructionContext.ts";

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -1,12 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import { FabricInstance, type FabricValue } from "@/interface.ts";
 import {
   DEEP_FREEZE,
-  FabricInstance,
-  type FabricValue,
   IS_DEEP_FROZEN,
-} from "@/interface.ts";
+} from "@/fabric-instances/BaseFabricInstance.ts";
 import { CODEC } from "@/codec-common/interface.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-common/EmptyReconstructionContext.ts";

--- a/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
+++ b/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
+import {
+  DEEP_FREEZE,
+  IS_DEEP_FROZEN,
+} from "@/fabric-instances/BaseFabricInstance.ts";
 import { CODEC } from "@/codec-common/interface.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { ExplicitTagValue } from "@/fabric-instances/ExplicitTagValue.ts";

--- a/packages/data-model/test/fabric-instances/UnknownValue.test.ts
+++ b/packages/data-model/test/fabric-instances/UnknownValue.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
+import {
+  DEEP_FREEZE,
+  IS_DEEP_FROZEN,
+} from "@/fabric-instances/BaseFabricInstance.ts";
 import { CODEC } from "@/codec-common/interface.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ExplicitTagValue } from "@/fabric-instances/ExplicitTagValue.ts";

--- a/packages/data-model/test/fabric-primitives/BaseFabricPrimitive.test.ts
+++ b/packages/data-model/test/fabric-primitives/BaseFabricPrimitive.test.ts
@@ -2,7 +2,10 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { FabricPrimitive } from "@/interface.ts";
-import { BaseFabricPrimitive } from "@/fabric-primitives/BaseFabricPrimitive.ts";
+import {
+  BaseFabricPrimitive,
+  EXAMPLE_METHOD,
+} from "@/fabric-primitives/BaseFabricPrimitive.ts";
 
 /**
  * Minimal `BaseFabricPrimitive` subclass for exercising the static guard in
@@ -45,6 +48,14 @@ describe("BaseFabricPrimitive", () => {
         .toThrow(
           "Shouldn't happen",
         );
+    });
+  });
+
+  describe("`[EXAMPLE_METHOD]` (placeholder seed)", () => {
+    it("throws when invoked (unimplemented stub)", () => {
+      expect(() => new ProbePrimitive()[EXAMPLE_METHOD]()).toThrow(
+        "Not implemented",
+      );
     });
   });
 });

--- a/packages/data-model/test/fabric-primitives/BaseFabricPrimitive.test.ts
+++ b/packages/data-model/test/fabric-primitives/BaseFabricPrimitive.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { FabricPrimitive } from "@/interface.ts";
+import { BaseFabricPrimitive } from "@/fabric-primitives/BaseFabricPrimitive.ts";
+
+/**
+ * Minimal `BaseFabricPrimitive` subclass for exercising the static guard in
+ * isolation, independent of any production primitive.
+ */
+class ProbePrimitive extends BaseFabricPrimitive {}
+
+/**
+ * A rogue direct subclass of `FabricPrimitive` that bypasses
+ * `BaseFabricPrimitive` -- the shape the invariant forbids. Used only to
+ * witness `isInstance()`'s enforcement throw; no production class is built this
+ * way.
+ */
+class RoguePrimitive extends FabricPrimitive {}
+
+describe("BaseFabricPrimitive", () => {
+  describe("inheritance", () => {
+    it("is a subclass of `FabricPrimitive`", () => {
+      const probe = new ProbePrimitive();
+      expect(probe instanceof BaseFabricPrimitive).toBe(true);
+      expect(probe instanceof FabricPrimitive).toBe(true);
+    });
+  });
+
+  describe("isInstance()", () => {
+    it("is `true` for a `BaseFabricPrimitive`", () => {
+      expect(BaseFabricPrimitive.isInstance(new ProbePrimitive())).toBe(true);
+    });
+
+    it("is `false` for non-fabric values", () => {
+      expect(BaseFabricPrimitive.isInstance(null)).toBe(false);
+      expect(BaseFabricPrimitive.isInstance(42)).toBe(false);
+      expect(BaseFabricPrimitive.isInstance("x")).toBe(false);
+      expect(BaseFabricPrimitive.isInstance({})).toBe(false);
+      expect(BaseFabricPrimitive.isInstance([])).toBe(false);
+    });
+
+    it("throws for a `FabricPrimitive` that is not a `BaseFabricPrimitive`", () => {
+      expect(() => BaseFabricPrimitive.isInstance(new RoguePrimitive()))
+        .toThrow(
+          "Shouldn't happen",
+        );
+    });
+  });
+});

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -1,12 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import {
-  DEEP_FREEZE,
-  FabricInstance,
-  type FabricValue,
-  IS_DEEP_FROZEN,
-} from "@/interface.ts";
+import { FabricInstance, type FabricValue } from "@/interface.ts";
 import { CODEC } from "@/codec-common/interface.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
@@ -25,7 +20,11 @@ import {
 import { FrozenMap, FrozenSet } from "@/frozen-builtins.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
-import { BaseFabricInstance } from "@/fabric-instances/BaseFabricInstance.ts";
+import {
+  BaseFabricInstance,
+  DEEP_FREEZE,
+  IS_DEEP_FROZEN,
+} from "@/fabric-instances/BaseFabricInstance.ts";
 import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 import { DummyReconstructionContext } from "./fabric-instances/fixtures.ts";
 


### PR DESCRIPTION
## What

Structural refactor within `packages/data-model`: move the freeze-protocol
plumbing off the pure `FabricInstance` protocol interface and down onto the
concrete `BaseFabricInstance` base class. No runtime behavior change.

## Why

The `[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]` symbol-keyed members are implementation
plumbing — the machinery the generic freeze routines dispatch through — not part
of the pure, `instanceof`-able protocol that external code is written against.
`FabricInstance` (in `interface.ts`) is the dependency-free protocol leaf;
`BaseFabricInstance` is where the concrete instance machinery already lives. Keeping
the freeze plumbing off the protocol class leaves the interface as a clean
client-facing surface and co-locates the plumbing with the base that actually
implements around it.

## The member split

- **Moved down to `BaseFabricInstance`:** the `[DEEP_FREEZE]` and `[IS_DEEP_FROZEN]`
  `unique symbol` consts and their abstract member declarations. (The symbol consts
  travel with their declarations, for cohesion.)
- **Stays on `FabricInstance`:** `deepClone()` and `shallowClone()` — these remain
  the client-facing surface.

## The gate flip

The generic freeze machinery in `deep-freeze.ts` gated on
`instanceof FabricInstance` before invoking those symbols. Since the members no
longer type against `FabricInstance`, the three dispatch sites (`isDeepFrozen`,
`deepFreeze`, `isDeepFrozenFabricValue`) now narrow on
`instanceof BaseFabricInstance`. Every concrete instance already extends
`BaseFabricInstance`, so each gate is runtime-equivalent.

## Behavior-preserving

This is a structural move with no external contract change — everything is within
`data-model`. Importers of the two symbols (subclass impls, `deep-freeze.ts`, and
tests) are re-pointed to the new home; the only test changes are import-path
re-points. The data-model suite passes unchanged.

Co-Authored-By: coder-cedar (Claude Opus 4.8) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.8) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the freeze-protocol members off `FabricInstance` onto `BaseFabricInstance` in `packages/data-model`, added `isInstance()` invariant guards for instances/primitives, and seeded `BaseFabricPrimitive` so its guard narrows normally. No external behavior changes.

- **Refactors**
  - Declared `[DEEP_FREEZE]` and `[IS_DEEP_FROZEN]` on `BaseFabricInstance`; `deep-freeze.ts` now gates via `BaseFabricInstance.isInstance()` and `BaseFabricPrimitive.isInstance()` (not `instanceof`); JSDoc clarifies the invariant-guard throw.
  - Added `BaseFabricInstance.isInstance()` and `BaseFabricPrimitive.isInstance()` to enforce “every subclass extends the base.”
  - Seeded `BaseFabricPrimitive` with `[EXAMPLE_METHOD]` (placeholder) so its instance type is non-empty; added unit test for the stub.
  - Restored primitive-first order in `isDeepFrozenFabricValue()`; repointed imports across subclasses and tests; `deepClone()`/`shallowClone()` stay on `FabricInstance`.
  - Placed static `isInstance()` after instance members on both bases per data-model convention; reorder only.

<sup>Written for commit 36682cf4bb10dd24d5465b97f58382d836fd06a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

