### PR TITLE
data-model: rename shallowUnfrozenClone() to the symbol [SHALLOW_UNFROZEN_CLONE]

### DIFF
--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -33,6 +33,18 @@ export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
 );
 
 /**
+ * Well-known symbol for producing a new unfrozen copy of a fabric instance with
+ * the same data. This is the `protected` template-method primitive that the
+ * concrete `shallowClone()` calls when it needs a fresh instance; each concrete
+ * subclass implements it. Symbol-keyed as implementation plumbing (matching
+ * `[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`), while `shallowClone()` stays a
+ * regular-named client method.
+ */
+export const SHALLOW_UNFROZEN_CLONE: unique symbol = Symbol.for(
+  "data-model.shallowUnfrozenClone",
+);
+
+/**
  * Abstract base class providing shared scaffolding for `FabricInstance`
  * subclasses. Concrete `FabricInstance` classes extend this, not
  * `FabricInstance` directly: `FabricInstance` is the pure abstract protocol
@@ -42,7 +54,7 @@ export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
  *
  * TODO(danfuzz): `deepClone()` should grow a base implementation here that
  * defers to a sibling `protected abstract` method (mirroring the
- * `shallowClone()`/`shallowUnfrozenClone()` template-method split), at which
+ * `shallowClone()`/`[SHALLOW_UNFROZEN_CLONE]()` template-method split), at which
  * point individual subclasses stop implementing `deepClone()` directly.
  */
 export abstract class BaseFabricInstance extends FabricInstance {
@@ -85,19 +97,19 @@ export abstract class BaseFabricInstance extends FabricInstance {
    * Returns a new unfrozen copy of this instance with the same data. Called
    * by `shallowClone()` when a new instance is needed.
    */
-  protected abstract shallowUnfrozenClone(): FabricInstance;
+  protected abstract [SHALLOW_UNFROZEN_CLONE](): FabricInstance;
 
   /**
    * Returns a shallow clone of this instance with the requested frozenness.
    *
    * When `frozen` is `true` and this instance is already frozen, returns
    * `this` (identity optimization -- freezing is idempotent). In all other
-   * cases, creates a new instance via `shallowUnfrozenClone()` and freezes
+   * cases, creates a new instance via `[SHALLOW_UNFROZEN_CLONE]()` and freezes
    * it if requested.
    */
   shallowClone(frozen: boolean): FabricInstance {
     if (frozen && Object.isFrozen(this)) return this;
-    const copy = this.shallowUnfrozenClone();
+    const copy = this[SHALLOW_UNFROZEN_CLONE]();
     // Cast needed: `Object.freeze()` returns `Readonly<T>`, which TS considers
     // incompatible with abstract class types due to protected members.
     return frozen ? Object.freeze(copy) as FabricInstance : copy;

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -1,5 +1,9 @@
 import type { FabricValue } from "@/interface.ts";
-import { DEEP_FREEZE, IS_DEEP_FROZEN } from "./BaseFabricInstance.ts";
+import {
+  DEEP_FREEZE,
+  IS_DEEP_FROZEN,
+  SHALLOW_UNFROZEN_CLONE,
+} from "./BaseFabricInstance.ts";
 import {
   CODEC,
   type FabricCodec,
@@ -258,7 +262,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
   }
 
   /** @inheritDoc */
-  protected shallowUnfrozenClone(): FabricError {
+  protected [SHALLOW_UNFROZEN_CLONE](): FabricError {
     return new FabricError({
       type: this.type,
       name: this.name,

--- a/packages/data-model/src/fabric-instances/FabricLink.ts
+++ b/packages/data-model/src/fabric-instances/FabricLink.ts
@@ -9,6 +9,7 @@ import {
   BaseFabricInstance,
   DEEP_FREEZE,
   IS_DEEP_FROZEN,
+  SHALLOW_UNFROZEN_CLONE,
 } from "./BaseFabricInstance.ts";
 import { cloneIfNecessary } from "@/value-clone.ts";
 import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
@@ -87,7 +88,7 @@ export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
   }
 
   /** @inheritDoc */
-  protected shallowUnfrozenClone(): FabricLink {
+  protected [SHALLOW_UNFROZEN_CLONE](): FabricLink {
     return new FabricLink(this.#payload);
   }
 

--- a/packages/data-model/src/fabric-instances/FabricMap.ts
+++ b/packages/data-model/src/fabric-instances/FabricMap.ts
@@ -1,5 +1,9 @@
 import type { FabricValue } from "@/interface.ts";
-import { DEEP_FREEZE, IS_DEEP_FROZEN } from "./BaseFabricInstance.ts";
+import {
+  DEEP_FREEZE,
+  IS_DEEP_FROZEN,
+  SHALLOW_UNFROZEN_CLONE,
+} from "./BaseFabricInstance.ts";
 import {
   CODEC,
   type FabricCodec,
@@ -43,7 +47,7 @@ export class FabricMap
   }
 
   /** @inheritDoc */
-  protected shallowUnfrozenClone(): FabricMap {
+  protected [SHALLOW_UNFROZEN_CLONE](): FabricMap {
     return new FabricMap(this.map);
   }
 

--- a/packages/data-model/src/fabric-instances/FabricSet.ts
+++ b/packages/data-model/src/fabric-instances/FabricSet.ts
@@ -1,5 +1,9 @@
 import type { FabricValue } from "@/interface.ts";
-import { DEEP_FREEZE, IS_DEEP_FROZEN } from "./BaseFabricInstance.ts";
+import {
+  DEEP_FREEZE,
+  IS_DEEP_FROZEN,
+  SHALLOW_UNFROZEN_CLONE,
+} from "./BaseFabricInstance.ts";
 import {
   CODEC,
   type FabricCodec,
@@ -42,7 +46,7 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
   }
 
   /** @inheritDoc */
-  protected shallowUnfrozenClone(): FabricSet {
+  protected [SHALLOW_UNFROZEN_CLONE](): FabricSet {
     return new FabricSet(this.set);
   }
 

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -1,5 +1,9 @@
 import type { FabricValue } from "@/interface.ts";
-import { DEEP_FREEZE, IS_DEEP_FROZEN } from "./BaseFabricInstance.ts";
+import {
+  DEEP_FREEZE,
+  IS_DEEP_FROZEN,
+  SHALLOW_UNFROZEN_CLONE,
+} from "./BaseFabricInstance.ts";
 import {
   CODEC,
   type FabricCodec,
@@ -60,7 +64,7 @@ export class ProblematicValue extends ExplicitTagValue {
     throw new Error("Cannot yet handle deep cloning of `ProblematicValue`.");
   }
 
-  protected shallowUnfrozenClone(): ProblematicValue {
+  protected [SHALLOW_UNFROZEN_CLONE](): ProblematicValue {
     return new ProblematicValue(this.wireTypeTag, this.state, this.error);
   }
 

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -1,5 +1,9 @@
 import type { FabricValue } from "@/interface.ts";
-import { DEEP_FREEZE, IS_DEEP_FROZEN } from "./BaseFabricInstance.ts";
+import {
+  DEEP_FREEZE,
+  IS_DEEP_FROZEN,
+  SHALLOW_UNFROZEN_CLONE,
+} from "./BaseFabricInstance.ts";
 import {
   CODEC,
   type FabricCodec,
@@ -45,7 +49,7 @@ export class UnknownValue extends ExplicitTagValue {
     throw new Error("Cannot yet handle deep cloning of `UnknownValue`.");
   }
 
-  protected shallowUnfrozenClone(): UnknownValue {
+  protected [SHALLOW_UNFROZEN_CLONE](): UnknownValue {
     return new UnknownValue(this.wireTypeTag, this.state);
   }
 

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -55,7 +55,7 @@ export abstract class FabricInstance extends FabricSpecialObject {
    *
    * TODO(danfuzz): This method should grow a base implementation on
    * `BaseFabricInstance` which defers to a `protected abstract` sibling,
-   * mirroring the `shallowClone()`/`shallowUnfrozenClone()` split.
+   * mirroring the `shallowClone()`/`[SHALLOW_UNFROZEN_CLONE]()` split.
    */
   abstract deepClone(frozen: boolean): FabricInstance;
 

--- a/packages/data-model/test/cloneForMutation.test.ts
+++ b/packages/data-model/test/cloneForMutation.test.ts
@@ -62,7 +62,7 @@ describe("cloneForMutation", () => {
       expect(value).toBeInstanceOf(FabricError);
       expect(Object.isFrozen(value)).toBe(false);
       expect(pathValue).toBe(value);
-      // `shallowUnfrozenClone` preserves the FabricValue-shaped state.
+      // `[SHALLOW_UNFROZEN_CLONE]` preserves the FabricValue-shaped state.
       const cloned = value as unknown as FabricError;
       expect(cloned.type).toBe(err.type);
       expect(cloned.name).toBe(err.name);

--- a/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
@@ -10,6 +10,7 @@ import {
   BaseFabricInstance,
   DEEP_FREEZE,
   IS_DEEP_FROZEN,
+  SHALLOW_UNFROZEN_CLONE,
 } from "@/fabric-instances/BaseFabricInstance.ts";
 import { FabricEpochDays } from "@/fabric-primitives/FabricEpochDays.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
@@ -42,7 +43,7 @@ class UnregisteredInstance extends BaseFabricInstance {
     return "Unregistered@1";
   }
 
-  protected shallowUnfrozenClone(): FabricInstance {
+  protected [SHALLOW_UNFROZEN_CLONE](): FabricInstance {
     return new UnregisteredInstance();
   }
 

--- a/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
+++ b/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
@@ -6,12 +6,13 @@ import {
   BaseFabricInstance,
   DEEP_FREEZE,
   IS_DEEP_FROZEN,
+  SHALLOW_UNFROZEN_CLONE,
 } from "@/fabric-instances/BaseFabricInstance.ts";
 
 /**
  * Minimal `BaseFabricInstance` subclass used to exercise the template-method
  * behavior in isolation, independent of any production concrete subclass.
- * Counts `shallowUnfrozenClone()` invocations via a constructor-supplied
+ * Counts `[SHALLOW_UNFROZEN_CLONE]()` invocations via a constructor-supplied
  * counter (kept off the instance so freezing doesn't block bookkeeping).
  */
 class Probe extends BaseFabricInstance {
@@ -47,7 +48,7 @@ class Probe extends BaseFabricInstance {
     throw new Error("not exercised here");
   }
 
-  protected shallowUnfrozenClone(): Probe {
+  protected [SHALLOW_UNFROZEN_CLONE](): Probe {
     this.counter.calls += 1;
     return new Probe(this.#tag, this.counter);
   }

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -24,6 +24,7 @@ import {
   BaseFabricInstance,
   DEEP_FREEZE,
   IS_DEEP_FROZEN,
+  SHALLOW_UNFROZEN_CLONE,
 } from "@/fabric-instances/BaseFabricInstance.ts";
 import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 import { DummyReconstructionContext } from "./fabric-instances/fixtures.ts";
@@ -360,7 +361,7 @@ describe("native-conversion", () => {
         deepClone(_frozen: boolean): CustomFabInst {
           return new CustomFabInst();
         }
-        protected shallowUnfrozenClone(): CustomFabInst {
+        protected [SHALLOW_UNFROZEN_CLONE](): CustomFabInst {
           return new CustomFabInst();
         }
       }


### PR DESCRIPTION
## What

Renames the `protected abstract` template-method primitive
`BaseFabricInstance.shallowUnfrozenClone()` to a `unique symbol`,
`[SHALLOW_UNFROZEN_CLONE]`. Pure rename, no behavior change.

## Why

This completes the "regular name for client use, unique symbol for implementation
plumbing" split on the fabric-instance base. `shallowUnfrozenClone()` was the last
regular-named plumbing member: it's the `protected` primitive that `shallowClone()`
calls when it needs a fresh instance. Converting it to a symbol means all three
plumbing symbols — `[DEEP_FREEZE]`, `[IS_DEEP_FROZEN]`, and now
`[SHALLOW_UNFROZEN_CLONE]` — sit uniformly on `BaseFabricInstance`, while the
client-facing `shallowClone()` keeps its regular name.

## What changes

- New `SHALLOW_UNFROZEN_CLONE: unique symbol` on `BaseFabricInstance`, keyed
  `data-model.shallowUnfrozenClone`.
- The abstract declaration and the single `shallowClone()` call site are converted
  to the symbol.
- All six concrete subclass implementations are re-pointed: `FabricError`,
  `FabricLink`, `FabricSet`, `FabricMap`, `UnknownValue`, `ProblematicValue`.
- Three test fixtures and the doc/comment references are updated.

## Scope / behavior

The member stays `protected` — the symbol only keys it; access is unchanged, and
only `shallowClone()` calls it. Nothing outside `data-model` references it (it's
`protected`), so there is no external contract change. Behavior-preserving; the
data-model suite passes unchanged.

Co-Authored-By: coder-cedar (Claude Opus 4.8) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.8) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the protected template method `BaseFabricInstance.shallowUnfrozenClone()` to the unique symbol `[SHALLOW_UNFROZEN_CLONE]` to align with other plumbing symbols. No behavior or public API change; `shallowClone()` still calls it internally.

- **Refactors**
  - Added `[SHALLOW_UNFROZEN_CLONE]` (`unique symbol`, key: `data-model.shallowUnfrozenClone`) on `BaseFabricInstance`.
  - Switched the abstract declaration and the `shallowClone()` call site to use the symbol.
  - Updated implementations in `FabricError`, `FabricLink`, `FabricSet`, `FabricMap`, `UnknownValue`, and `ProblematicValue`.
  - Refreshed related tests and comments; remains `protected` and internal to `data-model`.

<sup>Written for commit 336a47e1155f4909bceb431a4da7fb9f8f09027c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

