### PR TITLE
fix(dashboard): update tiles without reloading the page

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1,8 +1,8 @@
 # Fabric wall — modular dev/company dashboard
 
 A small Deno server that renders a dark, glanceable wall of status tiles and
-refreshes browsers over Server-Sent Events. Every tile is one file with a fixed
-interface; a single file registers them.
+updates their markup in place over Server-Sent Events. Every tile is one file
+with a fixed interface; a single file registers them.
 
 ## Run
 
@@ -35,11 +35,17 @@ dashboard/
 
 `server.ts` knows nothing about individual tiles. It runs a single ticker,
 collects each tile that is due (respecting its `intervalMs`), renders the
-results uniformly, mounts any drill-down routes a tile declares, and pushes an
-SSE reload when anything changes. A tile whose `collect()` throws is desaturated
-to a gray "unknown" — it keeps its last-known value and shows a short reason
-(e.g. "source unreachable"), with the full error in the server log — so one
-unreachable source never blanks or breaks the board.
+results uniformly, mounts any drill-down routes a tile declares, and pushes the
+new tile markup when anything changes. A tile whose `collect()` throws is
+desaturated to a gray "unknown" — it keeps its last-known value and shows a
+short reason (e.g. "source unreachable"), with the full error in the server log
+— so one unreachable source never blanks or breaks the board.
+
+Each event connection receives the current tile snapshot before it waits for
+new collections. The browser reconciles that snapshot by tile ID, leaving
+unchanged elements, focus, and scroll positions in place. Routine data updates
+never navigate the page. A changed shell version reloads once so an unattended
+display picks up new CSS or client code after a dashboard deployment.
 
 ## Add a tile
 

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -2,7 +2,7 @@
 // in the page. Pure string work — no server, no network, no subprocess.
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Status, TileView } from "./types.ts";
-import { renderTile, shell } from "./render.ts";
+import { renderTile, shell, SHELL_VERSION } from "./render.ts";
 import { humanSpan } from "./lib.ts";
 import { REPO } from "./config.ts";
 
@@ -26,6 +26,14 @@ Deno.test("renderTile: no href -> a plain div, not a link", () => {
   assert(html.endsWith("</div>"));
   assert(!html.includes("<a "), "nothing to drill into, so no anchor");
   assert(!html.includes(" link"), "the link class is only for tiles that link");
+});
+
+Deno.test("renderTile: a server-supplied id becomes the stable update key", () => {
+  assertStringIncludes(renderTile(view(), "labs-ci"), `data-tile-id="labs-ci"`);
+  assertStringIncludes(
+    renderTile(view({ href: "/ci" }), "labs-ci-duration"),
+    `data-tile-id="labs-ci-duration"`,
+  );
 });
 
 Deno.test("renderTile: an http href is an anchor that opens a new tab; a local one stays in place", () => {
@@ -114,8 +122,15 @@ Deno.test("renderTile: the body order is label, headline, sub, chart", () => {
 });
 
 Deno.test("shell: the grid and the wide tiles land in their own slots", () => {
-  const html = shell(`<div class="tile good">g</div>`, `<div class="tile bad wide">w</div>`, 3, 30_000);
-  assertStringIncludes(html, `<div class="grid"><div class="tile good">g</div></div>`);
+  const html = shell(
+    `<div class="tile good">g</div>`,
+    `<div class="tile bad wide">w</div>`,
+    3,
+    30_000,
+    SHELL_VERSION,
+  );
+  assertStringIncludes(html, `<div class="grid" id="dashboard-grid"><div class="tile good">g</div></div>`);
+  assertStringIncludes(html, `<div id="dashboard-wide"><div class="tile bad wide">w</div></div>`);
   // Wide tiles sit after the grid, not inside it.
   assert(html.indexOf(`class="grid"`) < html.indexOf(`tile bad wide`));
   assert(html.startsWith("<!doctype html>"), "a whole page, not a fragment");
@@ -124,14 +139,31 @@ Deno.test("shell: the grid and the wide tiles land in their own slots", () => {
 });
 
 Deno.test("shell: the freshness age and the refresh interval reach both the text and the script", () => {
-  const html = shell("", "", 7, 45_000);
+  const html = shell("", "", 7, 45_000, SHELL_VERSION);
   assertStringIncludes(html, `<span id="agotext">updated 7s ago</span>`);
   assertStringIncludes(html, "const REFRESH = 45000;");
-  assertStringIncludes(html, "const base = 7;");
-  // The client re-reads the stream rather than polling the page.
+  assertStringIncludes(html, `const SHELL_VERSION = ${SHELL_VERSION};`);
+  assertStringIncludes(html, "let base = 7;");
   assertStringIncludes(html, `new EventSource('/events')`);
+  assertStringIncludes(
+    html,
+    `es.onmessage = (e) => { if (e.data === 'reload') location.reload(); };`,
+  );
+  assertStringIncludes(html, `es.addEventListener('update'`);
+  assertStringIncludes(html, `reconcileTiles(grid, update.gridHtml)`);
+  assertStringIncludes(html, `reconcileTiles(wide, update.wideHtml)`);
+  assertStringIncludes(
+    html,
+    `if (update.shellVersion !== SHELL_VERSION) { location.reload(); return; }`,
+  );
+  assertEquals(html.match(/location\.reload\(\)/g)?.length, 2);
+  assertStringIncludes(html, `if (current.outerHTML === next.outerHTML) return current;`);
+  assertStringIncludes(html, `nextScroller.scrollTop = scrollTop`);
 });
 
 Deno.test("shell: the repo name in the header is escaped", () => {
-  assertStringIncludes(shell("", "", 0, 1000), `<span>${REPO.replace(/&/g, "&amp;")}</span>`);
+  assertStringIncludes(
+    shell("", "", 0, 1000, SHELL_VERSION),
+    `<span>${REPO.replace(/&/g, "&amp;")}</span>`,
+  );
 });

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -4,8 +4,13 @@ import type { TileView } from "./types.ts";
 import { durationTag, escapeHtml, STATUS_DOT } from "./lib.ts";
 import { REPO } from "./config.ts";
 
-export function renderTile(v: TileView): string {
+// Open dashboards reload when this changes. Increment it with shell markup,
+// styles, client code, or the update payload shape.
+export const SHELL_VERSION = 2;
+
+export function renderTile(v: TileView, id?: string): string {
   const cls = `tile ${v.status}${v.href ? " link" : ""}${v.wide ? " wide" : ""}`;
+  const key = id ? ` data-tile-id="${escapeHtml(id)}"` : "";
   const dot = `<span class="dot ${STATUS_DOT[v.status]}"></span>`;
   const hint = v.hint ? `<span class="drill">${escapeHtml(v.hint)}</span>` : "";
   const header = `<p class="lbl">${dot} ${escapeHtml(v.label)}<span class="spacer"></span>${v.aside ?? ""}${hint}</p>`;
@@ -21,12 +26,18 @@ export function renderTile(v: TileView): string {
     ? `<div style="position:relative">${v.extra}${durationTag(v.duration)}</div>`
     : (v.extra ?? "");
   const inner = `${header}${big}${sub}${body}`;
-  if (!v.href) return `<div class="${cls}">${inner}</div>`;
+  if (!v.href) return `<div class="${cls}"${key}>${inner}</div>`;
   const tgt = /^https?:/.test(v.href) ? ` target="_blank" rel="noopener"` : "";
-  return `<a class="${cls}" href="${escapeHtml(v.href)}"${tgt}>${inner}</a>`;
+  return `<a class="${cls}"${key} href="${escapeHtml(v.href)}"${tgt}>${inner}</a>`;
 }
 
-export function shell(gridHtml: string, wideHtml: string, ago: number, refreshMs: number): string {
+export function shell(
+  gridHtml: string,
+  wideHtml: string,
+  ago: number,
+  refreshMs: number,
+  shellVersion: number,
+): string {
   return `<!doctype html><html><head><meta charset="utf-8"><title>Fabric wall — LIVE</title>
 <style>
   body{margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
@@ -73,19 +84,19 @@ export function shell(gridHtml: string, wideHtml: string, ago: number, refreshMs
     <div class="brand"><b>Fabric wall</b><span class="badge" id="livebadge">● LIVE</span><span>${escapeHtml(REPO)}</span></div>
     <div class="live"><span class="dot green" id="freshdot"></span> <span id="agotext">updated ${ago}s ago</span></div>
   </div>
-  <div class="grid">${gridHtml}</div>
-  ${wideHtml}
+  <div class="grid" id="dashboard-grid">${gridHtml}</div>
+  <div id="dashboard-wide">${wideHtml}</div>
 <script>
   const REFRESH = ${refreshMs};
+  const SHELL_VERSION = ${shellVersion};
   const COL = { green: '#43c574', amber: '#e0a852', red: '#e2504a' };
   const badge = document.getElementById('livebadge');
   const dot = document.getElementById('freshdot');
   const agotext = document.getElementById('agotext');
-  let last = Date.now();
-  const es = new EventSource('/events');
-  es.onmessage = (e) => { last = Date.now(); if (e.data === 'reload') location.reload(); };
-  const base = ${ago};
-  const t0 = Date.now();
+  const grid = document.getElementById('dashboard-grid');
+  const wide = document.getElementById('dashboard-wide');
+  let base = ${ago};
+  let t0 = Date.now();
   function paint() {
     const ago = base + Math.floor((Date.now() - t0) / 1000);
     agotext.textContent = 'updated ' + ago + 's ago';
@@ -99,8 +110,47 @@ export function shell(gridHtml: string, wideHtml: string, ago: number, refreshMs
     if (state !== 'green') { badge.style.borderColor = COL[state]; badge.style.color = '#7c828c'; }
     else if (anyGray) { badge.style.borderColor = '#7c828c'; badge.style.color = '#7c828c'; }
     else { badge.style.borderColor = '#62d18d'; badge.style.color = '#62d18d'; }
-    if (Date.now() - last > 70000) location.reload();
   }
+  function reconcileTiles(container, html) {
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    const currentById = new Map(Array.from(container.children).map((tile) => [tile.dataset.tileId, tile]));
+    const desired = Array.from(template.content.children).map((next) => {
+      const current = currentById.get(next.dataset.tileId);
+      if (!current) return next;
+      currentById.delete(next.dataset.tileId);
+      if (current.outerHTML === next.outerHTML) return current;
+
+      const scrollTop = current.querySelector('.evscroll')?.scrollTop;
+      const active = document.activeElement;
+      const rootFocused = active === current;
+      const focusedHref = current.contains(active) && active instanceof HTMLAnchorElement ? active.href : null;
+      current.replaceWith(next);
+      const nextScroller = next.querySelector('.evscroll');
+      if (scrollTop !== undefined && nextScroller) nextScroller.scrollTop = scrollTop;
+      if (rootFocused) next.focus({ preventScroll: true });
+      else if (focusedHref) {
+        Array.from(next.querySelectorAll('a')).find((link) => link.href === focusedHref)?.focus({ preventScroll: true });
+      }
+      return next;
+    });
+    for (const obsolete of currentById.values()) obsolete.remove();
+    desired.forEach((tile, index) => {
+      const atIndex = container.children[index];
+      if (atIndex !== tile) container.insertBefore(tile, atIndex ?? null);
+    });
+  }
+  const es = new EventSource('/events');
+  es.onmessage = (e) => { if (e.data === 'reload') location.reload(); };
+  es.addEventListener('update', (e) => {
+    const update = JSON.parse(e.data);
+    if (update.shellVersion !== SHELL_VERSION) { location.reload(); return; }
+    reconcileTiles(grid, update.gridHtml);
+    reconcileTiles(wide, update.wideHtml);
+    base = update.ageSeconds;
+    t0 = Date.now();
+    paint();
+  });
   paint();
   setInterval(paint, 1000);
 </script></body></html>`;

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -23,6 +23,18 @@ async function chunk(r: ReadableStreamDefaultReader<Uint8Array>): Promise<string
   return dec.decode(value);
 }
 
+interface TestUpdate {
+  gridHtml: string;
+  wideHtml: string;
+  ageSeconds: number;
+  shellVersion: number;
+}
+
+function updateFromEvent(event: string): TestUpdate {
+  assertStringIncludes(event, "event: update\n");
+  return JSON.parse(event.match(/^data: (.*)$/m)?.[1] ?? "") as TestUpdate;
+}
+
 // The rendered markup for one tile, keyed off its header label. The returned
 // string starts with the tile's status classes.
 function tileHtml(label: string): string {
@@ -45,7 +57,7 @@ Deno.test("a tile that has never succeeded falls back to a gray tile labelled wi
     throw new Error("HTTP 404: Not Found");
   })]);
   const html = tileHtml("labs-ci"); // no view to keep, so the id stands in for the label
-  assertStringIncludes(html, `unknown">`); // gray, never a color it hasn't earned
+  assert(html.startsWith(`unknown" data-tile-id="labs-ci">`)); // gray, never a color it hasn't earned
   assertStringIncludes(html, `<p class="big unknown">—</p>`);
   assertStringIncludes(html, `<p class="sub">not found</p>`); // the short reason, not the raw error
 });
@@ -53,13 +65,13 @@ Deno.test("a tile that has never succeeded falls back to a gray tile labelled wi
 Deno.test("a tile whose collect throws keeps its last good view, desaturated to gray", async () => {
   const good: TileView = { label: "recent main runs", status: "good", value: "passing", sub: "10 runs", wide: true };
   await tick([fake("recent-runs", () => good)]);
-  assertStringIncludes(tileHtml("recent main runs"), `good wide">`);
+  assert(tileHtml("recent main runs").startsWith(`good wide" data-tile-id="recent-runs">`));
 
   await tick([fake("recent-runs", () => {
     throw new Error("error sending request for url");
   })]);
   const html = tileHtml("recent main runs");
-  assertStringIncludes(html, `unknown wide">`); // gray, and still full-width
+  assert(html.startsWith(`unknown wide" data-tile-id="recent-runs">`)); // gray, and still full-width
   assertStringIncludes(html, `<p class="big unknown">passing</p>`); // the last-known value stays on the wall
   assertStringIncludes(html, `<p class="sub">source unreachable</p>`); // and says why it can't tell
 });
@@ -95,16 +107,23 @@ Deno.test("a tick that is still running makes the next tick a no-op", async () =
   await slow;
 });
 
-Deno.test("sse: /events opens a stream, tick pushes a reload, disconnect drops the client", async () => {
+Deno.test("sse: /events opens a stream, tick pushes new tile markup, disconnect drops the client", async () => {
   const res = await handle(req("/events"));
   assertEquals(res.headers.get("content-type"), "text/event-stream");
   assertEquals(res.headers.get("cache-control"), "no-cache");
   const reader = res.body!.getReader();
   assertEquals(await chunk(reader), ": connected\n\n");
   assertEquals(clients.size, 1);
+  const initial = updateFromEvent(await chunk(reader));
+  assert(initial.shellVersion > 0);
+  assert(initial.ageSeconds >= 0);
 
-  await tick([fake("labs-ci", () => ({ label: "labs ci", status: "good", value: "passing" }))]);
-  assertEquals(await chunk(reader), "data: reload\n\n");
+  await tick([fake("labs-ci", () => ({ label: "labs ci", status: "good", value: "live update" }))]);
+  const update = updateFromEvent(await chunk(reader));
+  assertStringIncludes(update.gridHtml, `data-tile-id="labs-ci"`);
+  assertStringIncludes(update.gridHtml, "live update");
+  assert(update.ageSeconds >= 0);
+  assertEquals(update.shellVersion, initial.shellVersion);
 
   await reader.cancel();
   assertEquals(clients.size, 0, "a disconnected browser is not kept as a client");
@@ -115,7 +134,7 @@ Deno.test("broadcast: a client whose stream is gone is dropped rather than throw
   const dead = [...clients].at(-1)!;
   await res.body!.cancel(); // closes the stream, so enqueueing to it now throws
   clients.add(dead); // back in the set, standing for a disconnect that went unnoticed
-  broadcast("reload");
+  broadcast({ gridHtml: "", wideHtml: "", ageSeconds: 0, shellVersion: 1 });
   assertEquals(clients.size, 0);
 });
 

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -3,7 +3,7 @@
 //
 // Each tile lives in tiles/ and is registered once in registry.ts. This file is
 // generic: it schedules every tile's collect() on its own interval, renders the
-// results uniformly, serves the page, pushes SSE reloads, and mounts any
+// results uniformly, serves the page, pushes SSE updates, and mounts any
 // drill-down routes a tile declares. It knows nothing about individual tiles.
 //
 //   cd <repo root>
@@ -21,7 +21,7 @@ import { PORT } from "./config.ts";
 import { TILES } from "./registry.ts";
 import { makeCtx } from "./ctx.ts";
 import { friendlyError } from "./lib.ts";
-import { renderTile, shell } from "./render.ts";
+import { renderTile, shell, SHELL_VERSION } from "./render.ts";
 import type { Tile, TileView } from "./types.ts";
 
 const ctx = makeCtx();
@@ -29,12 +29,41 @@ const views = new Map<string, TileView>();
 const lastRun = new Map<string, number>();
 let lastChange = 0;
 
+interface DashboardUpdate {
+  gridHtml: string;
+  wideHtml: string;
+  ageSeconds: number;
+  shellVersion: number;
+}
+
+function dashboardUpdate(): DashboardUpdate {
+  const grid: string[] = [];
+  const wide: string[] = [];
+  for (const t of TILES) {
+    const v = views.get(t.id);
+    if (!v) continue;
+    (v.wide ? wide : grid).push(renderTile(v, t.id));
+  }
+  const ageSeconds = lastChange
+    ? Math.max(0, Math.floor((Date.now() - lastChange) / 1000))
+    : 0;
+  return {
+    gridHtml: grid.join(""),
+    wideHtml: wide.join(""),
+    ageSeconds,
+    shellVersion: SHELL_VERSION,
+  };
+}
+
 export const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
 const enc = new TextEncoder();
-export const broadcast = (kind: string) => {
+const encodeUpdate = (update: DashboardUpdate) =>
+  enc.encode(`event: update\ndata: ${JSON.stringify(update)}\n\n`);
+export const broadcast = (update: DashboardUpdate) => {
+  const event = encodeUpdate(update);
   for (const c of clients) {
     try {
-      c.enqueue(enc.encode(`data: ${kind}\n\n`));
+      c.enqueue(event);
     } catch {
       clients.delete(c); // drop a dead controller so the set can't grow forever
     }
@@ -72,7 +101,7 @@ export async function tick(tiles: Tile[] = TILES) {
       lastRun.set(t.id, Date.now());
     }));
     lastChange = Date.now();
-    broadcast("reload");
+    broadcast(dashboardUpdate());
   } finally {
     ticking = false;
   }
@@ -81,24 +110,23 @@ export async function tick(tiles: Tile[] = TILES) {
 // Collect drill-down routes declared by tiles.
 const routes = TILES.flatMap((t) => t.routes ?? []);
 
-// How often the page actually reloads, which the client colors the "updated"
-// indicator against (fresh up to this, then stale). The server re-broadcasts a
-// reload when a tile is due, but the 15s ticker only notices a tile is due on the
-// tick after its interval elapses (and collection latency pushes that to the tick
-// after that), so the real cadence for the fastest tile is its interval plus a
-// tick, not the bare interval.
+// How often the page actually updates, which the client colors the "updated"
+// indicator against (fresh up to this, then stale). The server broadcasts when a
+// tile is due, but the 15s ticker only notices a tile is due on the tick after its
+// interval elapses (and collection latency pushes that to the tick after that), so
+// the real cadence for the fastest tile is its interval plus a tick, not the bare
+// interval.
 const REFRESH_MS = Math.min(...TILES.map((t) => t.intervalMs)) + TICK_MS;
 
 export function page(): string {
-  const ago = Math.floor((Date.now() - (lastChange || Date.now())) / 1000);
-  const grid: string[] = [];
-  const wide: string[] = [];
-  for (const t of TILES) {
-    const v = views.get(t.id);
-    if (!v) continue;
-    (v.wide ? wide : grid).push(renderTile(v));
-  }
-  return shell(grid.join(""), wide.join(""), ago, REFRESH_MS);
+  const update = dashboardUpdate();
+  return shell(
+    update.gridHtml,
+    update.wideHtml,
+    update.ageSeconds,
+    REFRESH_MS,
+    update.shellVersion,
+  );
 }
 
 export async function handle(req: Request): Promise<Response> {
@@ -110,6 +138,7 @@ export async function handle(req: Request): Promise<Response> {
         controller = c;
         clients.add(c);
         c.enqueue(enc.encode(": connected\n\n"));
+        c.enqueue(encodeUpdate(dashboardUpdate()));
       },
       cancel() {
         if (controller) clients.delete(controller);


### PR DESCRIPTION
Dashboard refresh events navigated the whole page with location.reload(), briefly exposing an empty document while the replacement page painted. Routine status updates therefore produced a distracting flash and discarded focus and the recent-runs scroll position.

Send rendered dashboard snapshots through the existing Server-Sent Event stream and reconcile tiles by stable ID in the browser. Leave unchanged elements in place, preserve focus and scroll state when changed tiles are replaced, reset the freshness clock from the server snapshot, and send the current snapshot as soon as each stream connects.

Carry an explicit shell version so unattended displays reload once when CSS, client code, or the update protocol changes. Continue accepting the previous server's reload message so deployment rollbacks refresh correctly.

Update the dashboard documentation and tests to cover connection snapshots, keyed reconciliation, shell-version transitions, legacy rollback compatibility, and the absence of routine page navigation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update dashboard tiles in place over Server‑Sent Events to remove page reloads. This eliminates the flash and preserves focus and scroll positions.

- New Features
  - Stream rendered snapshots via `update` SSE events; send the current snapshot on connect; reconcile into `#dashboard-grid` and `#dashboard-wide`.
  - Key tiles by `data-tile-id` (server passes ids to `renderTile(id)`); skip unchanged tiles, remove obsolete ones, and keep order stable.
  - Preserve focus and `.evscroll` scrollTop on replacement; reset the freshness timer from `ageSeconds`.
  - Add `SHELL_VERSION`; reload once on version mismatch; still accept legacy `'reload'` messages for rollback compatibility.
  - Update docs and tests for snapshot-on-connect, keyed reconciliation, version transitions, and no routine navigation.

<sup>Written for commit 03087279d3bf191c3bf3463909b6fe43707c5e5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

