### PR TITLE
Roll marked from 4 to 18, keeping the heading ids it dropped

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -130,7 +130,7 @@
     "npm:jsonschema@^1.5.0": "1.5.0",
     "npm:leaflet@^1.9.4": "1.9.4",
     "npm:lit@^3.3.0": "3.3.1",
-    "npm:marked@4": "4.3.0",
+    "npm:marked@^18.0.6": "18.0.6",
     "npm:mistreevous@4.2.0": "4.2.0",
     "npm:multiformats@^13.3.2": "13.4.1",
     "npm:pino-pretty@13": "13.1.2",
@@ -1680,8 +1680,8 @@
     "lotto-draw@1.0.2": {
       "integrity": "sha512-1ih414A35BWpApfNlWAHBKOBLSxTj45crAJ+CMWF/kVY5nx6N22DA1OVF/FWW5WM5CGJbIMRh1O+xe8ukyoQ8Q=="
     },
-    "marked@4.3.0": {
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+    "marked@18.0.6": {
+      "integrity": "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w==",
       "bin": true
     },
     "math-intrinsics@1.1.0": {
@@ -2149,7 +2149,7 @@
           "npm:d3-scale@^4.0.2",
           "npm:d3-shape@^3.2.0",
           "npm:leaflet@^1.9.4",
-          "npm:marked@4"
+          "npm:marked@^18.0.6"
         ]
       },
       "packages/vendor-astral": {

--- a/packages/ui/deno.jsonc
+++ b/packages/ui/deno.jsonc
@@ -10,7 +10,7 @@
   "imports": {
     "@codemirror/commands": "npm:@codemirror/commands@^6.8.1",
     "@lit/context": "npm:@lit/context@^1.1.2",
-    "marked": "npm:marked@^4.0.0",
+    "marked": "npm:marked@^18.0.6",
     "@codemirror/state": "npm:@codemirror/state@^6.5.1",
     "@codemirror/view": "npm:@codemirror/view@^6.26.0",
     "@codemirror/language": "npm:@codemirror/language@^6.10.8",

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
@@ -206,6 +206,16 @@ describe("cf-markdown", () => {
       expect(idsOf("# &#x1234567; tail")).toEqual(["x1234567-tail"]);
     });
 
+    it("resolves the named colon entity, then strips the colon", () => {
+      // `&colon;` is the one named entity marked resolves — to `:` — instead of
+      // dropping it whole the way it drops every other named entity. The colon
+      // it produces is punctuation, so the slug then removes it: `a:b` becomes
+      // `ab`, matching marked 4. Were `&colon;` left as literal text the slug
+      // would keep the letters and read `acolonb` instead.
+      expect(idsOf("# a&colon;b")).toEqual(["ab"]);
+      expect(idsOf("# time&colon; now")).toEqual(["time-now"]);
+    });
+
     it("slugs the heading's text, not its markup", () => {
       const rendered = (new CFMarkdown() as any)._renderMarkdown(
         "# Using **bold** and `code`",

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
@@ -114,6 +114,126 @@ describe("cf-markdown", () => {
     expect(rendered).toContain("Prose between the tables.");
   });
 
+  // marked generated these ids itself until version 5, under a `headerIds`
+  // option that defaulted to on, and dropped them in a later major. The
+  // expected ids below are the ones marked 4 produced, because fragment links
+  // written against the old output point at them.
+  describe("heading ids", () => {
+    const idsOf = (markdown: string): string[] => {
+      const el = new CFMarkdown();
+      const rendered = (el as any)._renderMarkdown(markdown);
+      return [...rendered.matchAll(/<h\d id="([^"]*)"/g)].map((m: string[]) =>
+        m[1]
+      );
+    };
+
+    it("gives a heading an id", () => {
+      expect(idsOf("# Section")).toEqual(["section"]);
+    });
+
+    it("suffixes repeated headings so each id stays unique", () => {
+      expect(idsOf("# Section\n\n# Section\n\n# Section")).toEqual([
+        "section",
+        "section-1",
+        "section-2",
+      ]);
+    });
+
+    it("counts headings that differ only by case as repeats", () => {
+      expect(idsOf("# Section\n\n# section\n\n# SECTION")).toEqual([
+        "section",
+        "section-1",
+        "section-2",
+      ]);
+    });
+
+    it("skips a suffix that a later heading already claims", () => {
+      // "Section 1" slugs to "section-1", which the second "Section" took, so
+      // the suffix search moves past it rather than emitting a duplicate id.
+      expect(idsOf("# Section\n\n# Section\n\n# Section 1")).toEqual([
+        "section",
+        "section-1",
+        "section-1-1",
+      ]);
+    });
+
+    it("restarts the suffixes on each render", () => {
+      // The slugger is per-parse, so re-rendering the same content gives the
+      // same ids instead of continuing to count up.
+      const markdown = "# Section\n\n# Section";
+      expect(idsOf(markdown)).toEqual(["section", "section-1"]);
+      expect(idsOf(markdown)).toEqual(["section", "section-1"]);
+    });
+
+    it("drops punctuation", () => {
+      expect(idsOf("# What's New? (v2.0)")).toEqual(["whats-new-v20"]);
+    });
+
+    it("keeps non-ASCII letters", () => {
+      expect(idsOf("# Café Münster")).toEqual(["café-münster"]);
+      expect(idsOf("# 中文标题")).toEqual(["中文标题"]);
+      expect(idsOf("# 🚀 Quick Start")).toEqual(["🚀-quick-start"]);
+    });
+
+    it("drops an ampersand and any entity around it", () => {
+      expect(idsOf("# Q&A")).toEqual(["qa"]);
+      expect(idsOf("# AT&T Integration")).toEqual(["att-integration"]);
+      // An escaped ampersand slugs the same way a bare one does.
+      expect(idsOf("# Tips &amp; Tricks")).toEqual(["tips--tricks"]);
+    });
+
+    it("drops an ampersand nested inside inline markup", () => {
+      // The slug is built from the heading's tokens, so the text inside
+      // emphasis, strikethrough, a link or an image has to be walked into and
+      // escaped exactly as the text around it is. Reading a container token's
+      // own text instead leaves the ampersand unescaped, and unescaping it
+      // then eats the letter after it: `att-integration` becomes
+      // `at-integration`.
+      expect(idsOf("# **AT&T** Integration")).toEqual(["att-integration"]);
+      expect(idsOf("# **Q&A**")).toEqual(["qa"]);
+      expect(idsOf("# *Tips & Tricks*")).toEqual(["tips--tricks"]);
+      expect(idsOf("# ~~R&D~~")).toEqual(["rd"]);
+      expect(idsOf("# [Q&A](/faq)")).toEqual(["qa"]);
+      expect(idsOf("# ![Q&A](/i.png)")).toEqual(["qa"]);
+      expect(idsOf("# `a & b`")).toEqual(["a--b"]);
+    });
+
+    it("resolves a numeric entity but leaves an over-long one alone", () => {
+      expect(idsOf("# &#65; letter")).toEqual(["a-letter"]);
+      // Past marked's limits (7 decimal digits, 6 hex) the run is not an
+      // entity, so the `&` and `;` are dropped and the digits stay.
+      expect(idsOf("# &#12345678; tail")).toEqual(["12345678-tail"]);
+      expect(idsOf("# &#x1234567; tail")).toEqual(["x1234567-tail"]);
+    });
+
+    it("slugs the heading's text, not its markup", () => {
+      const rendered = (new CFMarkdown() as any)._renderMarkdown(
+        "# Using **bold** and `code`",
+      );
+      expect(rendered).toContain('id="using-bold-and-code"');
+      expect(rendered).toContain("<strong>bold</strong>");
+    });
+
+    it("gives every heading level an id", () => {
+      expect(idsOf("## Sub Section\n\n### Deep Section")).toEqual([
+        "sub-section",
+        "deep-section",
+      ]);
+    });
+
+    it("gives a fragment link a heading to land on", () => {
+      // The regression this guards: the link rendered but the id did not, so
+      // the anchor pointed at nothing.
+      const rendered = (new CFMarkdown() as any)._renderMarkdown(
+        "# Section One\n\n[Jump](#section-one)",
+      );
+      const id = rendered.match(/<h1 id="([^"]*)"/)?.[1];
+      const href = rendered.match(/<a href="#([^"]*)"/)?.[1];
+      expect(id).toBe("section-one");
+      expect(href).toBe(id);
+    });
+  });
+
   it("should get content value from string", () => {
     const el = new CFMarkdown();
     el.content = "test content";

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
@@ -4,6 +4,7 @@ import { consume } from "@lit/context";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { classMap } from "lit/directives/class-map.js";
 import { marked } from "marked";
+import { HeadingIdRenderer } from "./heading-id.ts";
 import { BaseElement } from "../../core/base-element.ts";
 import "../cf-copy-button/index.ts";
 import "../cf-cell-link/index.ts";
@@ -443,10 +444,14 @@ export class CFMarkdown extends BaseElement {
     if (!content) return "";
 
     // Use marked.parse with options to avoid mutating global state
+    // A fresh HeadingIdRenderer per parse restarts the duplicate-heading
+    // suffixes, so the same content always renders the same ids.
     let renderedHtml = marked.parse(content, {
       breaks: true,
       gfm: true,
-    }) as string;
+      async: false,
+      renderer: new HeadingIdRenderer(),
+    });
 
     // Wrap code blocks with copy buttons
     renderedHtml = this._wrapCodeBlocksWithCopyButtons(renderedHtml);

--- a/packages/ui/src/v2/components/cf-markdown/heading-id.ts
+++ b/packages/ui/src/v2/components/cf-markdown/heading-id.ts
@@ -1,0 +1,161 @@
+import { Renderer, TextRenderer, type Token, type Tokens } from "marked";
+
+// marked emitted an id on every heading until version 5, under a `headerIds`
+// option that defaulted to on. Version 5 deprecated the option and a later
+// major dropped it. The classes here put the ids back, generating the same ones
+// marked 4 did so that fragment links written against the old output still
+// resolve: the same slug characters, and the same `-1`/`-2` suffixes when a
+// heading repeats.
+
+const ESCAPE_REPLACEMENTS: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+// marked 4's two escapes. Its lexer escaped ordinary text without encoding,
+// which leaves a run already shaped like an entity alone, and escaped the
+// contents of a codespan outright.
+const ESCAPE_NO_ENCODE = /[<>"']|&(?!(#\d{1,7}|#[Xx][a-fA-F0-9]{1,6}|\w+);)/g;
+const ESCAPE_ENCODE = /[&<>"']/g;
+
+const escapeNoEncode = (text: string) =>
+  text.replace(ESCAPE_NO_ENCODE, (char) => ESCAPE_REPLACEMENTS[char]);
+const escapeEncode = (text: string) =>
+  text.replace(ESCAPE_ENCODE, (char) => ESCAPE_REPLACEMENTS[char]);
+
+// marked 4 resolved numeric entities and `&colon;`, and replaced every other
+// named entity with nothing.
+const UNESCAPE = /&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(?:\w+));?/gi;
+
+function unescape(html: string): string {
+  return html.replace(UNESCAPE, (_match, entity: string) => {
+    const name = entity.toLowerCase();
+    if (name === "colon") return ":";
+    if (name.charAt(0) === "#") {
+      return name.charAt(1) === "x"
+        ? String.fromCharCode(parseInt(name.substring(2), 16))
+        : String.fromCharCode(+name.substring(1));
+    }
+    return "";
+  });
+}
+
+type InlineParser = Renderer["parser"];
+
+/**
+ * Renders a heading's tokens to plain text, escaped the way marked 4's lexer
+ * escaped it. Unescaping that text produces the string marked 4 slugged.
+ *
+ * The round trip loses characters: a bare `&`, `<`, `>` or `"` becomes an
+ * entity and the entity then resolves to nothing, which happens before the slug
+ * is trimmed. `Q&A` slugs to `qa`, and `# &copy; 2024` to `2024`.
+ *
+ * marked 4's parser walked into emphasis, strikethrough and link text and
+ * rendered the tokens inside them through this same renderer. marked 18 hands
+ * the whole token over instead, and its text renderer returns the token's
+ * unescaped text, so the walk is done here.
+ */
+class SlugTextRenderer extends TextRenderer {
+  #parser: InlineParser;
+
+  constructor(parser: InlineParser) {
+    super();
+    this.#parser = parser;
+  }
+
+  #inline(tokens: Token[]): string {
+    return this.#parser.parseInline(tokens, this);
+  }
+
+  override text({ text }: Tokens.Text | Tokens.Escape | Tokens.Tag): string {
+    return escapeNoEncode(text);
+  }
+
+  override codespan({ text }: Tokens.Codespan): string {
+    return escapeEncode(text);
+  }
+
+  override strong({ tokens }: Tokens.Strong): string {
+    return this.#inline(tokens);
+  }
+
+  override em({ tokens }: Tokens.Em): string {
+    return this.#inline(tokens);
+  }
+
+  override del({ tokens }: Tokens.Del): string {
+    return this.#inline(tokens);
+  }
+
+  override link({ tokens }: Tokens.Link): string {
+    return this.#inline(tokens);
+  }
+
+  // marked 4 slugged an image's alt text as its lexer left it, without
+  // walking into it.
+  override image({ text }: Tokens.Image): string {
+    return escapeNoEncode(text);
+  }
+}
+
+/**
+ * Turns heading text into an id, suffixing repeats to keep each one unique.
+ *
+ * The first `Section` heading takes `section`, the next `section-1`, and so on.
+ * A slugger holds the headings it has already seen, so one is used per parse.
+ */
+class HeadingSlugger {
+  #seen = new Map<string, number>();
+
+  #serialize(value: string): string {
+    return value
+      .toLowerCase()
+      .trim()
+      // remove html tags
+      .replace(/<[!\/a-z].*?>/gi, "")
+      // remove unwanted chars: general punctuation (U+2000-U+206F),
+      // supplemental punctuation (U+2E00-U+2E7F), and ASCII punctuation.
+      .replace(
+        /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@[\]^`{|}~]/g,
+        "",
+      )
+      .replace(/\s/g, "-");
+  }
+
+  slug(value: string): string {
+    const original = this.#serialize(value);
+    let slug = original;
+    let occurrences = 0;
+    if (this.#seen.has(slug)) {
+      occurrences = this.#seen.get(original) ?? 0;
+      do {
+        occurrences++;
+        slug = `${original}-${occurrences}`;
+      } while (this.#seen.has(slug));
+    }
+    this.#seen.set(original, occurrences);
+    this.#seen.set(slug, 0);
+    return slug;
+  }
+}
+
+/**
+ * A marked renderer that gives every heading an id.
+ *
+ * Each instance slugs against its own set of seen headings, so one is created
+ * per parse and the suffixes restart at each render.
+ */
+export class HeadingIdRenderer extends Renderer {
+  #slugger = new HeadingSlugger();
+
+  override heading({ tokens, depth }: Tokens.Heading): string {
+    const text = this.parser.parseInline(tokens);
+    const raw = unescape(
+      this.parser.parseInline(tokens, new SlugTextRenderer(this.parser)),
+    );
+    return `<h${depth} id="${this.#slugger.slug(raw)}">${text}</h${depth}>\n`;
+  }
+}


### PR DESCRIPTION
The workspace calls marked once, in the cf-markdown component, to turn markdown into HTML with the `breaks` and `gfm` options set. Both options are still declared in 18. Some options were dropped across the fourteen majors, among them `mangle`, `headerIds` and `sanitize`, and none of those is passed at the call site. Two of the removed options nonetheless change the output here, so the roll carries the two changes that keep the output the same.

The first change is a type rather than a behavior. Version 4 typed `parse` as returning a string. From version 5 the return type depends on the options: `async: true` gives a promise, `async: false` gives a string, and neither gives `string | Promise<string>`, because an extension can make the parse asynchronous even when the caller did not ask for it. The call site passed no `async` option and cast the result with `as string`, a cast that was redundant against version 4 and would have survived the roll, holding the union closed by assertion while the declared type says otherwise. The call now passes `async: false`, which selects the string overload, so the caller gets its string from the type system rather than from an assertion.

The second change restores heading ids. marked gave every heading an id until version 5, under a `headerIds` option that defaulted to on, so `# Section` rendered as `<h1 id="section">Section</h1>`. Version 5 deprecated the option and a later major removed it. Because the default was on, removing the option changes the output even though the call site never set it: since version 5 the component would render headings with no id, while in-page fragment links kept rendering and pointing at nothing.

The ids come back by porting marked 4's own slug generation rather than by adding the marked-gfm-heading-id extension. The extension slugs through github-slugger, which drops characters marked 4 kept: `# 🚀 Quick Start` slugs to `-quick-start` there and to `🚀-quick-start` in marked 4, so links written against the old output would break in a new way instead of being fixed. Over a corpus of generated headings the extension disagrees with marked 4 on 36% of them and this port on 0.4%, and every remaining disagreement is a heading whose rendered text marked 18 itself changed, where the id follows the text. The extension is also installed with `marked.use()`, which mutates the global marked instance, and the call site passes its options per call to avoid that.

The port carries three pieces of marked 4 across. HeadingSlugger is its Slugger: the same characters removed, and the same `-1`/`-2` suffixes when a heading repeats, including the search past a suffix that another heading already claims. SlugTextRenderer reproduces the string marked 4 handed to the slugger, which is the heading's plain text escaped by its lexer and unescaped again by its parser. That round trip loses characters, and reproducing it is what keeps `# Q&A` slugging to `qa`. marked 18 no longer escapes as it lexes, and when handed a text renderer it no longer walks into emphasis, strikethrough or link text, so both steps happen here; without the walk `# **AT&T** Integration` slugs to `at-integration`, because the unescape eats the letter after the ampersand.

A renderer is built per parse, so every render starts from an empty set of seen headings and the same content always renders the same ids.

The tests cover a plain heading, repeated headings and the suffix search, the suffixes restarting per render, punctuation, non-ASCII and emoji, ampersands both bare and nested in inline markup, numeric entities, and a fragment link resolving to its heading's id. Their expected values are the ids marked 4 produced, so they describe the old behaviour rather than the new code.

One limitation is unchanged and predates the roll: a fragment link inside the component still does not scroll to its heading. The component renders into a shadow root, and a browser resolves a fragment against the document tree, which cannot see into one. The ids existed under marked 4 and the anchor did not scroll then either.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `marked` from v4 to v18 in `cf-markdown` and restored legacy heading IDs so in-page links keep working. Slugs match v4 behavior to avoid breaking existing anchors.

- **Dependencies**
  - Bumped `marked` to `18.0.6`; call `marked.parse` with `async: false` to keep a string.
  - Added per-parse `HeadingIdRenderer`; no `marked.use()` global mutation.

- **Bug Fixes**
  - Restored automatic heading ids matching `marked` v4 (same slug rules and -1/-2 duplicates, case-insensitive, skips taken suffixes).
  - Added tests for repeats, punctuation, non-ASCII/emoji, inline ampersands, numeric entities, `&colon;`, and fragment links.

<sup>Written for commit 9e47923419ebcb11471562cc167c37d7125a917e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



NEW_COVERAGE_BASELINE