### PR TITLE
fix(dashboard): localize run timestamps in the browser

### DIFF
--- a/packages/dashboard/lib-extra.test.ts
+++ b/packages/dashboard/lib-extra.test.ts
@@ -1,7 +1,7 @@
-// Unit tests for the helpers lib.test.ts does not reach: the GitHub API wrapper,
-// the memo cache, and hhmm. No real network — fetch is stubbed and restored.
+// Unit tests for the helpers lib.test.ts does not reach: the GitHub API wrapper
+// and the memo cache. No real network — fetch is stubbed and restored.
 import { assert, assertEquals, assertRejects } from "@std/assert";
-import { friendlyError, github, hhmm, memo } from "./lib.ts";
+import { friendlyError, github, memo } from "./lib.ts";
 
 // Run `fn` with fetch replaced by `stub`, handing `fn` the calls made so far.
 async function withFetch(
@@ -135,10 +135,4 @@ Deno.test("memo: concurrent callers share the one in-flight call", async () => {
   assertEquals(await a, "v");
   assertEquals(await b, "v");
   assertEquals(n, 1);
-});
-
-Deno.test("hhmm: local wall-clock time, zero-padded, 24-hour", () => {
-  assertEquals(hhmm(new Date(2024, 0, 2, 9, 5).toISOString()), "09:05");
-  assertEquals(hhmm(new Date(2024, 0, 2, 13, 45).toISOString()), "13:45");
-  assertEquals(hhmm(new Date(2024, 0, 2, 0, 0).toISOString()), "00:00");
 });

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -50,11 +50,6 @@ export const STATUS_DOT: Record<Status, string> = { good: "green", warn: "amber"
 export const escapeHtml = (s: string) =>
   s.replace(/[<>&"]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;" }[c]!));
 
-export const hhmm = (iso: string) => {
-  const d = new Date(iso);
-  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
-};
-
 // Per-status left edge for a sparkline's fade gradient — a shade just below the
 // tile's own (status-tinted) background, so the line fades up out of the tile.
 export const SPARK_FADE: Record<Status, string> = {

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -2,7 +2,7 @@
 // in the page. Pure string work — no server, no network, no subprocess.
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Status, TileView } from "./types.ts";
-import { renderTile, shell, SHELL_VERSION } from "./render.ts";
+import { formatViewerTimes, renderTile, shell, SHELL_VERSION } from "./render.ts";
 import { humanSpan } from "./lib.ts";
 import { REPO } from "./config.ts";
 
@@ -159,6 +159,31 @@ Deno.test("shell: the freshness age and the refresh interval reach both the text
   assertEquals(html.match(/location\.reload\(\)/g)?.length, 2);
   assertStringIncludes(html, `if (current.outerHTML === next.outerHTML) return current;`);
   assertStringIncludes(html, `nextScroller.scrollTop = scrollTop`);
+});
+
+Deno.test("formatViewerTimes: the viewer's formatter replaces the UTC fallback", () => {
+  const time = { dateTime: "2024-01-02T17:05:00Z", textContent: "17:05 UTC" };
+  const viewerTime = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "America/Los_Angeles",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+  formatViewerTimes([time], viewerTime);
+  assertEquals(time.textContent, "09:05");
+});
+
+Deno.test("shell: the browser runs the viewer-time formatter", () => {
+  const html = shell("", "", 0, 30_000, SHELL_VERSION);
+  const source = formatViewerTimes.toString();
+  assertStringIncludes(source, `time[data-viewer-time][datetime]`);
+  assert(!source.includes("timeZone"), "the default formatter must use the viewer's timezone");
+  assertStringIncludes(html, source);
+  assertStringIncludes(html, "formatViewerTimes();");
+  assertStringIncludes(
+    html,
+    `formatViewerTimes(template.content.querySelectorAll('time[data-viewer-time][datetime]'));`,
+  );
 });
 
 Deno.test("shell: the repo name in the header is escaped", () => {

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -180,9 +180,14 @@ Deno.test("shell: the browser runs the viewer-time formatter", () => {
   assert(!source.includes("timeZone"), "the default formatter must use the viewer's timezone");
   assertStringIncludes(html, source);
   assertStringIncludes(html, "formatViewerTimes();");
-  assertStringIncludes(
-    html,
+  const localizeUpdate = html.indexOf(
     `formatViewerTimes(template.content.querySelectorAll('time[data-viewer-time][datetime]'));`,
+  );
+  const compareMarkup = html.indexOf("if (current.outerHTML === next.outerHTML)");
+  assert(localizeUpdate >= 0, "live updates localize their timestamps");
+  assert(
+    localizeUpdate < compareMarkup,
+    "live updates are localized before their markup is compared",
   );
 });
 

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -6,7 +6,26 @@ import { REPO } from "./config.ts";
 
 // Open dashboards reload when this changes. Increment it with shell markup,
 // styles, client code, or the update payload shape.
-export const SHELL_VERSION = 2;
+export const SHELL_VERSION = 3;
+
+type ViewerTimeElement = Pick<HTMLTimeElement, "dateTime" | "textContent">;
+
+/** Replace marked absolute timestamps with the viewer's local wall-clock time. */
+export function formatViewerTimes(
+  times: Iterable<ViewerTimeElement> = document.querySelectorAll<HTMLTimeElement>(
+    "time[data-viewer-time][datetime]",
+  ),
+  formatter: { format(value: number): string } = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }),
+): void {
+  for (const time of times) {
+    const at = Date.parse(time.dateTime);
+    if (Number.isFinite(at)) time.textContent = formatter.format(at);
+  }
+}
 
 export function renderTile(v: TileView, id?: string): string {
   const cls = `tile ${v.status}${v.href ? " link" : ""}${v.wide ? " wide" : ""}`;
@@ -93,6 +112,8 @@ export function shell(
   const badge = document.getElementById('livebadge');
   const dot = document.getElementById('freshdot');
   const agotext = document.getElementById('agotext');
+  ${formatViewerTimes.toString()}
+  formatViewerTimes();
   const grid = document.getElementById('dashboard-grid');
   const wide = document.getElementById('dashboard-wide');
   let base = ${ago};
@@ -114,6 +135,7 @@ export function shell(
   function reconcileTiles(container, html) {
     const template = document.createElement('template');
     template.innerHTML = html;
+    formatViewerTimes(template.content.querySelectorAll('time[data-viewer-time][datetime]'));
     const currentById = new Map(Array.from(container.children).map((tile) => [tile.dataset.tileId, tile]));
     const desired = Array.from(template.content.children).map((next) => {
       const current = currentById.get(next.dataset.tileId);

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -124,6 +124,16 @@ Deno.test("recent-runs: wide, failure tip -> bad, rows link to the landing PR", 
   assertStringIncludes(v.extra ?? "", "/pull/42");
 });
 
+Deno.test("recent runs: timestamps have a UTC fallback and a viewer-local marker", async () => {
+  const startedAt = "2024-01-02T17:05:00Z";
+  const runsByRepo = (repo: string) => repo === REPO ? [run({ run_started_at: startedAt })] : [];
+  const v = await recentRuns.collect(ctx([], {}, runsByRepo));
+  assertStringIncludes(
+    v.extra ?? "",
+    `<time class="t" datetime="${startedAt}" data-viewer-time>17:05 UTC</time>`,
+  );
+});
+
 Deno.test("tile labels: the labs/loom ci family is renamed and paired", async () => {
   const one = ctx([run({ conclusion: "success" })]);
   assertEquals((await labsCi.collect(one)).label, "labs ci");

--- a/packages/dashboard/tiles/recent-runs.ts
+++ b/packages/dashboard/tiles/recent-runs.ts
@@ -5,8 +5,13 @@
 // failed, concerning if a failure sits within the recent window but the tip
 // recovered, else good.
 import type { Run, Status, Tile, TileView } from "../types.ts";
-import { concDot, escapeHtml, hhmm, landingHref } from "../lib.ts";
+import { concDot, escapeHtml, landingHref } from "../lib.ts";
 import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, RECENT_DISPLAY, RECENT_WINDOW, REPO } from "../config.ts";
+
+const utcFallback = (iso: string): string => {
+  const at = Date.parse(iso);
+  return Number.isFinite(at) ? `${new Date(at).toISOString().slice(11, 16)} UTC` : iso;
+};
 
 export const recentRuns: Tile = {
   id: "recent-runs",
@@ -44,7 +49,9 @@ export const recentRuns: Tile = {
         : (r.conclusion ?? "done");
       const title = (r.head_commit?.message ?? r.display_title).split("\n", 1)[0];
       const href = landingHref(title, r.head_sha, repoOf(r));
-      return `<a class="ev" href="${escapeHtml(href)}" target="_blank" rel="noopener"><span class="t">${hhmm(r.run_started_at)}</span><span class="dot ${dot}"></span><span class="evtxt">${escapeHtml(`${shortRepo(r)} · ${label} · ${title}`)}</span><span class="evarrow">↗</span></a>`;
+      const startedAt = escapeHtml(r.run_started_at);
+      const fallback = escapeHtml(utcFallback(r.run_started_at));
+      return `<a class="ev" href="${escapeHtml(href)}" target="_blank" rel="noopener"><time class="t" datetime="${startedAt}" data-viewer-time>${fallback}</time><span class="dot ${dot}"></span><span class="evtxt">${escapeHtml(`${shortRepo(r)} · ${label} · ${title}`)}</span><span class="evarrow">↗</span></a>`;
     }).join("") || `<div class="ev"><span class="dot grey"></span><span>waiting for first poll…</span></div>`;
 
     return {


### PR DESCRIPTION
The recent-runs tile formatted run start times while rendering the page, so the host machine's timezone determined what every viewer saw.

Keep the absolute ISO value in semantic time markup and format marked values with Intl.DateTimeFormat in the browser. Provide an explicit UTC fallback when client code does not run, scope localization to marked clock labels, and cover the server markup plus viewer-local conversion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localize recent-run timestamps to each viewer’s timezone in the browser. Keep ISO datetimes in `<time datetime="">` and show “HH:MM UTC” if JS doesn’t run.

- **Bug Fixes**
  - Render `<time class="t" datetime="…" data-viewer-time>HH:MM UTC</time>` and localize only these labels.
  - Add `formatViewerTimes()`; call on load and for live updates (before the outerHTML compare) using `Intl.DateTimeFormat` in the viewer’s timezone.
  - Remove `hhmm`; add tests for UTC fallback, viewer-local formatting, and update-time localization order.

<sup>Written for commit 8ca95b32e4bff577dab6cc753bac148fc0ce91e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

