### PR TITLE
data-model: standardize freeze-symbol registry keys on the data-model. prefix

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1216,7 +1216,7 @@ export const CODEC: unique symbol = Symbol.for('data-model.codec');
  * into any nested `FabricValue`s via a `subFreeze` callback supplied by the
  * generic `deepFreeze()` utility. See Section 8.6.
  */
-export const DEEP_FREEZE = Symbol.for('common.deepFreeze');
+export const DEEP_FREEZE = Symbol.for('data-model.deepFreeze');
 
 /**
  * Well-known symbol for checking whether a fabric instance is already
@@ -1226,7 +1226,7 @@ export const DEEP_FREEZE = Symbol.for('common.deepFreeze');
  * via a `subIsDeepFrozen` callback, returning the boolean conjunction.
  * See Section 8.6.
  */
-export const IS_DEEP_FROZEN = Symbol.for('common.isDeepFrozen');
+export const IS_DEEP_FROZEN = Symbol.for('data-model.isDeepFrozen');
 
 // Protocol evolution: Symbol.for('data-model.codec@2'), etc.
 ```

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -325,8 +325,8 @@ well-known symbols:
 ```typescript
 // Shown inside a pattern body.
 const CODEC = Symbol.for('data-model.codec');
-const DEEP_FREEZE = Symbol.for('common.deepFreeze');
-const IS_DEEP_FROZEN = Symbol.for('common.isDeepFrozen');
+const DEEP_FREEZE = Symbol.for('data-model.deepFreeze');
+const IS_DEEP_FROZEN = Symbol.for('data-model.isDeepFrozen');
 // If protocol evolution is needed: Symbol.for('data-model.codec@2')
 
 // Instance protocol: "here's how to freeze me deeply, and here's how to

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -10,7 +10,7 @@ import { FabricInstance, type FabricValue } from "@/interface.ts";
  * Distinct from `deepClone()`: `[DEEP_FREEZE]` freezes the existing instance
  * in place; `deepClone()` constructs a new instance.
  */
-export const DEEP_FREEZE: unique symbol = Symbol.for("common.deepFreeze");
+export const DEEP_FREEZE: unique symbol = Symbol.for("data-model.deepFreeze");
 
 /**
  * Well-known symbol for checking whether a fabric instance is already deeply
@@ -29,7 +29,7 @@ export const DEEP_FREEZE: unique symbol = Symbol.for("common.deepFreeze");
  * a malformed internal slot; a status check must not.)
  */
 export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
-  "common.isDeepFrozen",
+  "data-model.isDeepFrozen",
 );
 
 /**


### PR DESCRIPTION
## What

Standardizes the freeze-protocol well-known symbol registry keys on the
`data-model.` prefix, dropping the two remaining `common.` outliers:

- `DEEP_FREEZE`: `Symbol.for("common.deepFreeze")` → `Symbol.for("data-model.deepFreeze")`
- `IS_DEEP_FROZEN`: `Symbol.for("common.isDeepFrozen")` → `Symbol.for("data-model.isDeepFrozen")`

Plus the matching illustrative-block updates in the two spec docs that show these
keys (`space-model-formal-spec/1-fabric-values.md`, `space-model/1-data-model.md`),
keeping the docs in step with the code.

## Why

The fabric-instance well-known symbols should share one uniform registry-key
prefix. `[CODEC]` and `[SHALLOW_UNFROZEN_CLONE]` already use `data-model.`;
`DEEP_FREEZE` and `IS_DEEP_FROZEN` were the last two on the older `common.`
prefix. This flip makes the family consistent.

## Scope / safety

This is a registry-key rename only. It is identity-uniform: every consumer
references the exported `DEEP_FREEZE` / `IS_DEEP_FROZEN` const (not the string
literal), so all `[DEEP_FREEZE]()` / `[IS_DEEP_FROZEN]()` member accesses continue
to resolve to the same symbol object — the key string is an internal registry
detail. The serialization boundary was traced clear: nothing persists these
`Symbol.for()` keys, so there is no stored-data or wire-format impact. Behavior-
preserving; the data-model suite and `deno task check-docs` pass unchanged.

Co-Authored-By: coder-cedar (Claude Opus 4.8) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.8) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the freeze-protocol well-known symbol keys to the `data-model.` prefix for consistency across the data model. Renamed `Symbol.for('common.deepFreeze')` to `Symbol.for('data-model.deepFreeze')` and `Symbol.for('common.isDeepFrozen')` to `Symbol.for('data-model.isDeepFrozen')`, and updated spec docs; behavior is unchanged.

<sup>Written for commit 556ec3b7769b57a49e471d6c3932851b8ed33fc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

