### PR TITLE
cf view: honor the capitalization of displayed shortcuts

### DIFF
--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -1047,6 +1047,13 @@ export class Session {
       case "q":
         this.closeOverlay();
         break;
+      case "Q":
+        this.requestQuit();
+        break;
+      case "t":
+        this.mode = "deflookup";
+        this.input = overlay.node?.name ?? this.selectedNode()?.name ?? "";
+        break;
       case "enter":
         // Follow the selected reference, pushing this card so Esc returns to it:
         // open the referenced node's card, or — when the definition lives in
@@ -1069,7 +1076,8 @@ export class Session {
           this.closeOverlay();
         }
         break;
-      case "z": {
+      case "z":
+      case "Z": {
         // Reveal the target: an external file opens in place; an in-blob target
         // closes the card and centres the main view on it. A "… N more" line has
         // no destination to reveal.
@@ -1093,11 +1101,13 @@ export class Session {
         break;
       case "down":
       case "j":
+      case "J":
         if (hasTargets) this.moveCardSelection(1);
         else this.overlayScroll = clamp(this.overlayScroll + 1, 0, maxScroll);
         break;
       case "up":
       case "k":
+      case "K":
         if (hasTargets) this.moveCardSelection(-1);
         else this.overlayScroll = clamp(this.overlayScroll - 1, 0, maxScroll);
         break;
@@ -1105,6 +1115,8 @@ export class Session {
       case "space":
         this.overlayScroll = clamp(this.overlayScroll + 10, 0, maxScroll);
         break;
+      case "b":
+      case "B":
       case "pageup":
         this.overlayScroll = clamp(this.overlayScroll - 10, 0, maxScroll);
         break;
@@ -1142,6 +1154,7 @@ export class Session {
     const lastTop = maxTop(this.displayCount(), this.height);
     switch (key.name) {
       case "q":
+      case "Q":
       case "ctrl-c":
         this.requestQuit();
         return;
@@ -1169,15 +1182,19 @@ export class Session {
         this.stepMatch(false);
         return;
       case "j":
+      case "J":
         this.top = clamp(this.top + 1, 0, lastTop);
         return;
       case "k":
+      case "K":
         this.top = clamp(this.top - 1, 0, lastTop);
         return;
       case "h":
+      case "H":
         this.left = clamp(this.left - HORIZONTAL_STEP, 0, this.maxLineLen);
         return;
       case "l":
+      case "L":
         this.left = clamp(this.left + HORIZONTAL_STEP, 0, this.maxLineLen);
         return;
       case "space":
@@ -1186,6 +1203,7 @@ export class Session {
         this.top = clamp(this.top + rows - 1, 0, lastTop);
         return;
       case "b":
+      case "B":
       case "pageup":
       case "ctrl-b":
         this.top = clamp(this.top - rows + 1, 0, lastTop);
@@ -1209,15 +1227,19 @@ export class Session {
         this.performExpand();
         return;
       case "w":
+      case "W":
         this.navigateTree(treePrevSibling);
         return;
       case "s":
+      case "S":
         this.navigateTree(treeNextSibling);
         return;
       case "a":
+      case "A":
         this.navigateTree(treeParent);
         return;
       case "d":
+      case "D":
         this.navigateTree(treeChild);
         return;
       case "tab":
@@ -1235,7 +1257,8 @@ export class Session {
         }
         return;
       }
-      case "z": {
+      case "z":
+      case "Z": {
         const node = this.selectedNode();
         if (node) {
           this.top = frameTop(
@@ -1251,6 +1274,7 @@ export class Session {
         this.cycleLineNumbers();
         return;
       case "c":
+      case "C":
         this.cycleDisplayMode();
         return;
       case "f":
@@ -1424,9 +1448,11 @@ export class Session {
     if (key.alt) {
       switch (key.name) {
         case "f":
+        case "F":
           b.moveWordForward();
           return this.afterMove();
         case "b":
+        case "B":
           b.moveWordBackward();
           return this.afterMove();
         case "v":
@@ -1451,18 +1477,21 @@ export class Session {
           b.yankPop();
           return this.afterEdit();
         case "l":
+        case "L":
           if (this.allowEdit(false)) {
             b.lowercaseWord();
             this.afterEdit();
           }
           return;
         case "u":
+        case "U":
           if (this.allowEdit(false)) {
             b.uppercaseWord();
             this.afterEdit();
           }
           return;
         case "c":
+        case "C":
           if (this.allowEdit(false)) {
             b.capitalizeWord();
             this.afterEdit();

--- a/packages/cli/test/view-editor.test.ts
+++ b/packages/cli/test/view-editor.test.ts
@@ -215,6 +215,17 @@ Deno.test("editor: quitting dirty prompts, s saves and quits", () => {
   assertEquals(saved(), "Zabc\n");
 });
 
+Deno.test("editor: dialog shortcut letters accept either case", () => {
+  const { src, saved } = memSource();
+  const s = editSession("abc\n", src);
+  press(s, "e");
+  type(s, "Z");
+  press(s, "escape", "q");
+  press(s, "S");
+  assert(s.quit, "uppercase S activated Save");
+  assertEquals(saved(), "Zabc\n");
+});
+
 Deno.test("editor: the save prompt ignores keys that are not its buttons", () => {
   const { src, saved } = memSource();
   const s = editSession("abc\n", src);

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -17,6 +17,7 @@ import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { diffSource } from "../lib/view/diffedit.ts";
 import { overlayBox, type ViewState } from "../lib/view/render.ts";
 import type { Document } from "../lib/view/model.ts";
+import { frameTop } from "../lib/view/actions.ts";
 
 // --- key helpers -----------------------------------------------------------
 
@@ -445,6 +446,77 @@ Deno.test("session: overlay paging keys scroll the card", () => {
   assertEquals(s.view().overlay, null, "q closed the overlay");
 });
 
+Deno.test("session: overlay letter shortcuts match the help text", () => {
+  const s = makeSession(60, 8);
+  press(s, "?");
+  press(s, "J");
+  assert(s.view().overlay!.scroll > 0, "J scrolled the help overlay");
+  press(s, "K");
+  assertEquals(s.view().overlay!.scroll, 0, "K scrolled back");
+  press(s, "q");
+  assertEquals(s.view().overlay, null, "lowercase q closed the overlay");
+
+  press(s, "?");
+  press(s, "Q");
+  assertEquals(s.quit, true, "uppercase Q requested quit");
+
+  for (const pageUp of ["b", "B"]) {
+    const paging = makeSession(60, 8);
+    press(paging, "?", "space");
+    const afterPageDown = paging.view().overlay!.scroll;
+    assert(afterPageDown > 0, "Space paged down");
+    press(paging, pageUp);
+    assert(
+      paging.view().overlay!.scroll < afterPageDown,
+      `${pageUp} paged up`,
+    );
+  }
+});
+
+Deno.test("session: info-card letter shortcuts match the help text", () => {
+  for (const reveal of ["z", "Z"]) {
+    const s = makeSession();
+    selectByLabel(s, "pattern myPattern");
+    const subject = s.view().selected!;
+    const beforeTop = s.view().top;
+    press(s, "enter");
+    assert(s.view().overlay, "the info card opened");
+    press(s, reveal);
+    assertEquals(s.view().overlay, null, `${reveal} revealed the card subject`);
+    const expectedTop = frameTop(
+      subject.startLine,
+      subject.endLine,
+      s.view().height,
+      s.doc.lines.length,
+    );
+    assert(expectedTop !== beforeTop, "the fixture requires reframing");
+    assertEquals(
+      s.view().top,
+      expectedTop,
+      `${reveal} framed the card subject`,
+    );
+    assertEquals(
+      s.view().selected?.startOffset,
+      subject.startOffset,
+      `${reveal} kept the card subject selected`,
+    );
+  }
+
+  const s = makeSession();
+  selectByLabel(s, "pattern myPattern");
+  press(s, "enter", "down", "down", "down", "enter");
+  assert(s.view().overlay?.title.includes("lift __cfLift_1"));
+  assertEquals(s.view().selected?.label, "pattern myPattern");
+  press(s, "t");
+  assertEquals(
+    s.view().inputLine,
+    "definition: __cfLift_1",
+    "t used the active followed card rather than the main-view selection",
+  );
+  press(s, "enter");
+  assert(s.view().overlay?.title.includes("__cfLift_1"));
+});
+
 Deno.test("session: overlay scrolling stops once the last line reaches the bottom", () => {
   const doc = parseDocument(SAMPLE);
   const s = new Session(
@@ -563,6 +635,100 @@ Deno.test("session: paging, half-paging and home/end via the keymap", () => {
   assertEquals(s.view().top, 0);
 });
 
+Deno.test("session: capital keycap shortcuts accept either letter case", () => {
+  const cases: Array<{
+    lower: string;
+    upper: string;
+    setup?: readonly string[];
+  }> = [
+    { lower: "q", upper: "Q" },
+    { lower: "j", upper: "J" },
+    { lower: "k", upper: "K", setup: ["j"] },
+    { lower: "h", upper: "H", setup: ["l"] },
+    { lower: "l", upper: "L" },
+    { lower: "b", upper: "B", setup: ["space"] },
+    { lower: "c", upper: "C" },
+  ];
+  for (const { lower, upper, setup = [] } of cases) {
+    const lowerSession = makeSession(30, 8);
+    const upperSession = makeSession(30, 8);
+    press(lowerSession, ...setup, lower);
+    press(upperSession, ...setup, upper);
+    assertEquals(
+      upperSession.view(),
+      lowerSession.view(),
+      `${upper} matches ${lower}`,
+    );
+    assertEquals(
+      upperSession.quit,
+      lowerSession.quit,
+      `${upper} and ${lower} have the same quit state`,
+    );
+  }
+});
+
+Deno.test("session: capital WASD keycaps navigate to the same tree nodes", () => {
+  const cases = [
+    {
+      lower: "w",
+      upper: "W",
+      from: "pattern myPattern",
+      to: "lift __cfLift_1",
+    },
+    {
+      lower: "s",
+      upper: "S",
+      from: "lift __cfLift_1",
+      to: "pattern myPattern",
+    },
+    { lower: "a", upper: "A", from: "pattern myPattern", to: "▸ /app.ts" },
+    { lower: "d", upper: "D", from: "pattern myPattern", to: "λ(input)" },
+  ];
+  for (const { lower, upper, from, to } of cases) {
+    const lowerSession = makeSession();
+    const upperSession = makeSession();
+    selectByLabel(lowerSession, from);
+    selectByLabel(upperSession, from);
+    press(lowerSession, lower);
+    press(upperSession, upper);
+    assertEquals(
+      lowerSession.view().selected?.label,
+      to,
+      `${lower} reached ${to}`,
+    );
+    assertEquals(
+      upperSession.view(),
+      lowerSession.view(),
+      `${upper} matches ${lower}`,
+    );
+  }
+});
+
+Deno.test("session: capital Z keycap frames the selected node", () => {
+  const height = 8;
+  const lowerSession = makeSession(80, height);
+  const upperSession = makeSession(80, height);
+  selectByLabel(lowerSession, "pattern myPattern");
+  selectByLabel(upperSession, "pattern myPattern");
+  const node = lowerSession.view().selected!;
+  press(lowerSession, "g");
+  press(upperSession, "g");
+  assertEquals(lowerSession.view().top, 0);
+  assertEquals(upperSession.view().top, 0);
+
+  press(lowerSession, "z");
+  press(upperSession, "Z");
+  const expected = frameTop(
+    node.startLine,
+    node.endLine,
+    height,
+    lowerSession.doc.lines.length,
+  );
+  assert(expected > 0, "the fixture requires reframing from the top");
+  assertEquals(lowerSession.view().top, expected, "z framed the node");
+  assertEquals(upperSession.view(), lowerSession.view(), "Z matches z");
+});
+
 Deno.test("session: Enter with no selection prompts to select a node", () => {
   const s = makeSession();
   press(s, "enter");
@@ -572,8 +738,14 @@ Deno.test("session: Enter with no selection prompts to select a node", () => {
 Deno.test("session: 'z' in pager mode frames the selected node", () => {
   const s = makeSession(80, 8);
   selectByLabel(s, "pattern myPattern");
+  press(s, "g");
   press(s, "z");
-  assert(s.view().top >= 0, "z framed the node");
+  const node = s.view().selected!;
+  assertEquals(
+    s.view().top,
+    frameTop(node.startLine, node.endLine, 8, s.doc.lines.length),
+    "z framed the node",
+  );
 });
 
 Deno.test("session: '#' toggles line numbers and escape clears selection & search", () => {
@@ -759,6 +931,39 @@ Deno.test("session: typing, tab, space, kill-line, yank and word-case edits in a
   press(s, "ctrl-a");
   s.handleKey(alt("c")); // capitalize word
   assert(s.doc.lines[0].text.startsWith("Hello"), s.doc.lines[0].text);
+});
+
+Deno.test("session: displayed Alt-letter shortcuts accept either case", () => {
+  const cases: Array<{
+    lower: string;
+    upper: string;
+    text: string;
+    setup?: readonly string[];
+  }> = [
+    { lower: "f", upper: "F", text: "hello world\n" },
+    { lower: "b", upper: "B", text: "hello world\n", setup: ["end"] },
+    { lower: "l", upper: "L", text: "HELLO world\n" },
+    { lower: "u", upper: "U", text: "hello world\n" },
+    { lower: "c", upper: "C", text: "hello world\n" },
+  ];
+  for (const { lower, upper, text, setup = [] } of cases) {
+    const lowerSession = fileSession(text).s;
+    const upperSession = fileSession(text).s;
+    press(lowerSession, "e", ...setup);
+    press(upperSession, "e", ...setup);
+    lowerSession.handleKey(alt(lower));
+    upperSession.handleKey(alt(upper));
+    assertEquals(
+      upperSession.doc.text,
+      lowerSession.doc.text,
+      `Alt-${upper} edits like Alt-${lower}`,
+    );
+    assertEquals(
+      upperSession.view().cursor,
+      lowerSession.view().cursor,
+      `Alt-${upper} moves like Alt-${lower}`,
+    );
+  }
 });
 
 Deno.test("session: delete-forward, backspace, kill-word forward/back, newline and mark/region", () => {


### PR DESCRIPTION
The pager displays several letter shortcuts as uppercase keycaps, but normal, overlay, and editing handlers accepted only lowercase terminal events. Pressing the displayed form therefore did nothing.

Accept both cases for commands whose uppercase form has no distinct meaning. Preserve lowercase q for closing overlays and uppercase Q for quitting, along with every existing case-sensitive command pair. Make info-card definition lookup available where help advertises it, and let b or B page upward in help overlays.

Add behavioral coverage for displayed shortcut forms, info cards, tree navigation, Alt editing commands, and case-insensitive dialog buttons. Each navigation test starts from a state where the command must produce a distinct result.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor the capitalization of displayed shortcuts in `cf view`. Uppercase keycaps now work across pager, overlays, and editor; case-sensitive pairs keep their meaning.

- **Bug Fixes**
  - Accept both cases where uppercase has no special meaning: J/K/H/L, W/A/S/D, Z, C; Alt-F/B/L/U/C; B for page up.
  - Preserve q vs Q semantics: q closes overlays; Q quits.
  - Help and info cards: J/K scroll; b/B page up; z/Z reveal and reframe; t starts definition lookup from the active card.
  - Add behavioral tests for overlay shortcuts, info cards, tree navigation, Alt edits, and case-insensitive editor dialog buttons.

<sup>Written for commit 6b16068450b088dcbaebb00eb3ccd53b691e3be0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 150s
