### PR TITLE
fix(dashboard): render tiles during initial collection

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -35,11 +35,14 @@ dashboard/
 
 `server.ts` knows nothing about individual tiles. It runs a single ticker,
 collects each tile that is due (respecting its `intervalMs`), renders the
-results uniformly, mounts any drill-down routes a tile declares, and pushes the
-new tile markup when anything changes. A tile whose `collect()` throws is
-desaturated to a gray "unknown" — it keeps its last-known value and shows a
-short reason (e.g. "source unreachable"), with the full error in the server log
-— so one unreachable source never blanks or breaks the board.
+results uniformly, mounts any drill-down routes a tile declares, and pushes new
+tile markup as each collection completes. Every registered tile has a gray
+placeholder labelled with its id in its registered position until its first
+collection completes, so slow collectors do not leave holes in the board. A
+tile whose `collect()` throws is desaturated to a gray "unknown" — it keeps its
+last-known value and shows a short reason (e.g. "source unreachable"), with the
+full error in the server log — so one unreachable source never blanks or breaks
+the board.
 
 Each event connection receives the current tile snapshot before it waits for
 new collections. The browser reconciles that snapshot by tile ID, leaving
@@ -57,6 +60,7 @@ import type { Status, Tile, TileView } from "../types.ts";
 export const myTile: Tile = {
   id: "my-tile",          // unique, stable
   intervalMs: 60_000,     // how often collect() runs
+  // wide: true,           // optional full-width placement
   async collect(ctx): Promise<TileView> {
     // ctx.runs() -> shared CI runs; ctx.env("KEY") -> env var.
     // If a required env var is missing, return a gray "unknown" view — don't throw.
@@ -109,7 +113,6 @@ surveillance tool.
 | `aside` | trusted inline HTML minor header facet (e.g. an MTD or a "running" badge) |
 | `href` | makes the whole tile a link (an `http…` link opens a new tab) |
 | `hint` | small drill affordance, e.g. `"commits ↗"` |
-| `wide` | render full-width below the grid instead of as a grid cell |
 
 ## Tiles
 

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -45,8 +45,8 @@ Deno.test("renderTile: an http href is an anchor that opens a new tab; a local o
 });
 
 Deno.test("renderTile: wide adds the class the shell lays out below the grid", () => {
-  assertStringIncludes(renderTile(view({ wide: true })), `class="tile good wide"`);
-  assertStringIncludes(renderTile(view({ wide: true, href: "/x" })), `class="tile good link wide"`);
+  assertStringIncludes(renderTile(view(), undefined, true), `class="tile good wide"`);
+  assertStringIncludes(renderTile(view({ href: "/x" }), undefined, true), `class="tile good link wide"`);
   assert(!renderTile(view()).includes("wide"));
 });
 

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -8,8 +8,8 @@ import { REPO } from "./config.ts";
 // styles, client code, or the update payload shape.
 export const SHELL_VERSION = 2;
 
-export function renderTile(v: TileView, id?: string): string {
-  const cls = `tile ${v.status}${v.href ? " link" : ""}${v.wide ? " wide" : ""}`;
+export function renderTile(v: TileView, id?: string, wide = false): string {
+  const cls = `tile ${v.status}${v.href ? " link" : ""}${wide ? " wide" : ""}`;
   const key = id ? ` data-tile-id="${escapeHtml(id)}"` : "";
   const dot = `<span class="dot ${STATUS_DOT[v.status]}"></span>`;
   const hint = v.hint ? `<span class="drill">${escapeHtml(v.hint)}</span>` : "";

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -37,8 +37,8 @@ function updateFromEvent(event: string): TestUpdate {
 
 // The rendered markup for one tile, keyed off its header label. The returned
 // string starts with the tile's status classes.
-function tileHtml(label: string): string {
-  const parts = page().split(`<div class="tile `);
+function tileHtml(label: string, html = page()): string {
+  const parts = html.split(`<div class="tile `);
   const hit = parts.filter((p) => p.includes(`</span> ${label}<span class="spacer">`));
   assertEquals(hit.length, 1, `expected exactly one tile labelled "${label}"`);
   return hit[0];
@@ -52,18 +52,27 @@ Deno.test("healthz: not ok until the board has collected something", async () =>
   assertEquals(await res.json(), { ok: false, at: 0 });
 });
 
-Deno.test("a tile that has never succeeded falls back to a gray tile labelled with its id", async () => {
-  await tick([fake("labs-ci", () => {
-    throw new Error("HTTP 404: Not Found");
-  })]);
-  const html = tileHtml("labs-ci"); // no view to keep, so the id stands in for the label
-  assert(html.startsWith(`unknown" data-tile-id="labs-ci">`)); // gray, never a color it hasn't earned
-  assertStringIncludes(html, `<p class="big unknown">—</p>`);
-  assertStringIncludes(html, `<p class="sub">not found</p>`); // the short reason, not the raw error
+Deno.test("registered tiles render before their first collection completes", () => {
+  const html = page(new Map());
+  for (const tile of TILES) {
+    assertStringIncludes(
+      html,
+      `</span> ${tile.id}<span class="spacer"></span>`,
+    );
+  }
+  assert(tileHtml("recent-runs", html).startsWith(`unknown wide" data-tile-id="recent-runs">`));
 });
 
-Deno.test("a tile whose collect throws keeps its last good view, desaturated to gray", async () => {
-  const good: TileView = { label: "recent main runs", status: "good", value: "passing", sub: "10 runs", wide: true };
+Deno.test("a tile stays wide through failures and keeps its last good view", async () => {
+  await tick([fake("recent-runs", () => {
+    throw new Error("HTTP 404: Not Found");
+  })]);
+  const firstFailure = tileHtml("recent-runs");
+  assert(firstFailure.startsWith(`unknown wide" data-tile-id="recent-runs">`));
+  assertStringIncludes(firstFailure, `<p class="big unknown">—</p>`);
+  assertStringIncludes(firstFailure, `<p class="sub">not found</p>`);
+
+  const good: TileView = { label: "recent main runs", status: "good", value: "passing", sub: "10 runs" };
   await tick([fake("recent-runs", () => good)]);
   assert(tileHtml("recent main runs").startsWith(`good wide" data-tile-id="recent-runs">`));
 
@@ -71,9 +80,9 @@ Deno.test("a tile whose collect throws keeps its last good view, desaturated to 
     throw new Error("error sending request for url");
   })]);
   const html = tileHtml("recent main runs");
-  assert(html.startsWith(`unknown wide" data-tile-id="recent-runs">`)); // gray, and still full-width
-  assertStringIncludes(html, `<p class="big unknown">passing</p>`); // the last-known value stays on the wall
-  assertStringIncludes(html, `<p class="sub">source unreachable</p>`); // and says why it can't tell
+  assert(html.startsWith(`unknown wide" data-tile-id="recent-runs">`));
+  assertStringIncludes(html, `<p class="big unknown">passing</p>`);
+  assertStringIncludes(html, `<p class="sub">source unreachable</p>`);
 });
 
 Deno.test("the ticker leaves a tile alone until its interval has elapsed", async () => {
@@ -105,6 +114,33 @@ Deno.test("a tick that is still running makes the next tick a no-op", async () =
   assertEquals(collects, 0, "the overlapping tick collected nothing");
   release({ label: "labs ci", status: "good", value: "passing" });
   await slow;
+});
+
+Deno.test("each completed collection is published while slower tiles are still running", async () => {
+  const messages: string[] = [];
+  const client = {
+    enqueue(value: Uint8Array) {
+      messages.push(dec.decode(value));
+    },
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+  clients.add(client);
+  let beforeSlow: string[] = [];
+  try {
+    await tick([
+      fake("labs-ci", () => ({ label: "fast", status: "good" })),
+      fake("loom-ci", async () => {
+        await Promise.resolve();
+        beforeSlow = [...messages];
+        return { label: "slow", status: "good" };
+      }),
+    ]);
+  } finally {
+    clients.delete(client);
+  }
+  assertEquals(beforeSlow.length, 1);
+  assertStringIncludes(updateFromEvent(beforeSlow[0]).gridHtml, "fast");
+  assertEquals(messages.length, 2);
+  assertStringIncludes(updateFromEvent(messages[1]).gridHtml, "slow");
 });
 
 Deno.test("sse: /events opens a stream, tick pushes new tile markup, disconnect drops the client", async () => {

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -36,13 +36,15 @@ interface DashboardUpdate {
   shellVersion: number;
 }
 
-function dashboardUpdate(): DashboardUpdate {
+function dashboardUpdate(currentViews: ReadonlyMap<string, TileView> = views): DashboardUpdate {
   const grid: string[] = [];
   const wide: string[] = [];
   for (const t of TILES) {
-    const v = views.get(t.id);
-    if (!v) continue;
-    (v.wide ? wide : grid).push(renderTile(v, t.id));
+    const v = currentViews.get(t.id) ?? {
+      label: t.id,
+      status: "unknown" as const,
+    };
+    (t.wide ? wide : grid).push(renderTile(v, t.id, t.wide));
   }
   const ageSeconds = lastChange
     ? Math.max(0, Math.floor((Date.now() - lastChange) / 1000))
@@ -87,9 +89,8 @@ export async function tick(tiles: Tile[] = TILES) {
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         console.error(`tile ${t.id} failed:`, msg); // full detail to the log
-        // Keep the last good view but desaturate it to gray and show a short
-        // reason, so a blip leaves the last-known values on the wall (and keeps a
-        // wide tile wide) instead of blanking everything to "—".
+        // A failed collection preserves the previous view in gray and shows a
+        // short error.
         const prev = views.get(t.id);
         views.set(
           t.id,
@@ -99,9 +100,9 @@ export async function tick(tiles: Tile[] = TILES) {
         );
       }
       lastRun.set(t.id, Date.now());
+      lastChange = Date.now();
+      broadcast(dashboardUpdate());
     }));
-    lastChange = Date.now();
-    broadcast(dashboardUpdate());
   } finally {
     ticking = false;
   }
@@ -118,8 +119,8 @@ const routes = TILES.flatMap((t) => t.routes ?? []);
 // interval.
 const REFRESH_MS = Math.min(...TILES.map((t) => t.intervalMs)) + TICK_MS;
 
-export function page(): string {
-  const update = dashboardUpdate();
+export function page(currentViews: ReadonlyMap<string, TileView> = views): string {
+  const update = dashboardUpdate(currentViews);
   return shell(
     update.gridHtml,
     update.wideHtml,

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -119,7 +119,7 @@ Deno.test("ci-duration: only runs that passed end to end count", async () => {
 
 Deno.test("recent-runs: wide, failure tip -> bad, rows link to the landing PR", async () => {
   const v = await recentRuns.collect(ctx([run({ conclusion: "failure", head_commit: { message: "oops (#42)" } })]));
-  assertEquals(v.wide, true);
+  assertEquals(recentRuns.wide, true);
   assertEquals(v.status, "bad");
   assertStringIncludes(v.extra ?? "", "/pull/42");
 });

--- a/packages/dashboard/tiles/recent-runs.ts
+++ b/packages/dashboard/tiles/recent-runs.ts
@@ -11,6 +11,7 @@ import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, RECENT_DISPLAY, RECENT_WINDOW
 export const recentRuns: Tile = {
   id: "recent-runs",
   intervalMs: 30_000,
+  wide: true,
   async collect(ctx): Promise<TileView> {
     // Two shared bases (labs + loom), merged newest-first and cut to the most
     // recent RECENT_DISPLAY across both.
@@ -50,7 +51,6 @@ export const recentRuns: Tile = {
     return {
       label: `recent main runs · ${runs.length} in window`,
       status,
-      wide: true,
       extra: `<div class="evscroll">${rows}</div>`,
     };
   },

--- a/packages/dashboard/types.ts
+++ b/packages/dashboard/types.ts
@@ -17,7 +17,6 @@ export interface TileView {
   aside?: string; // trusted inline html minor header facet (e.g. an MTD or "running" badge)
   href?: string; // if set, the whole tile becomes a link (external opens a new tab)
   hint?: string; // small drill affordance text, e.g. "commits ↗"
-  wide?: boolean; // render full-width below the grid instead of as a grid cell
 }
 
 export interface Route {
@@ -28,6 +27,7 @@ export interface Route {
 export interface Tile {
   id: string; // unique, stable key for this tile's scheduling + latest-view state
   intervalMs: number; // how often collect() runs
+  wide?: boolean; // render full-width below the grid, including before collection
   collect(ctx: Ctx): Promise<TileView>;
   routes?: Route[]; // optional drill-down routes this tile owns
 }


### PR DESCRIPTION
The dashboard omitted registered tiles until their first collection completed. Slow collectors left holes in the layout, and a full-width tile could move after startup or its first failed collection.

Render gray placeholders from the tile registry in both the page and Server-Sent Event snapshots. Store full-width placement on the tile definition so it is available before collection. Publish a keyed snapshot after each collector settles so faster tiles update without waiting for slower collectors.

Add coverage for startup placeholders, first-failure placement, retained data after later failures, and per-collector publication. Update the dashboard documentation and tile layout types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render all registered dashboard tiles immediately with gray placeholders and keep full-width placement stable by defining `wide` on the tile. Stream per-collector updates so fast tiles update without waiting for slow ones.

- **Bug Fixes**
  - Show a gray placeholder for each registered tile before first `collect()` finishes (initial page and SSE snapshots).
  - Publish a keyed snapshot after each collector settles; faster tiles update independently.
  - On failures, keep the last good view desaturated with a short reason; wide tiles remain wide.

- **Migration**
  - Move `wide` from `TileView` to `Tile` (set `wide: true` on the tile; do not return it from views).

<sup>Written for commit 630ed31978d3662c2dca2663935bd83ae44ab264. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

