### PR TITLE
docs(specs): align space-model formal spec to shipped data-model behavior

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1068,7 +1068,62 @@ class, it hosts its own `[CODEC]` (tag `Bytes@1`), the same shape as
 `FabricEpochNsec` and `FabricEpochDays`. The hashing system uses the
 dedicated `TAG_BYTES` primitive tag (Section 6.3).
 
-#### 1.4.11 `bigint` — Not Wrapped
+#### 1.4.11 `FabricLink`
+
+`FabricLink` is a fabric-native `FabricInstance` — like the wrapper classes of
+Sections 1.4.2–1.4.4, but not wrapping any native JS type — that represents a
+**link**: the modern, object-shaped form of a reference to fabric data. It
+wraps a single **payload**, a plain object (`FabricPlainObject`) of addressing
+fields, as its sole nested `FabricValue`.
+
+A link is a `FabricInstance` rather than a `FabricPrimitive` because its
+payload is an **outgoing reference**, not leaf data: the payload may itself
+carry nested `FabricValue`s (for example a schema filter), so a link is a
+small object graph rather than an immutable scalar. Like every instance, a
+`FabricLink` is mutable until frozen and immutable thereafter, and its protocol
+members (`[DEEP_FREEZE]`, `[IS_DEEP_FROZEN]`, `deepClone()`, and the inherited
+`shallowClone()`; Section 2.3) recurse through the payload as their one nested
+value.
+
+**The data-model does not constrain the payload's field set.** The value
+definition here is deliberately general: the data-model requires only that the
+payload be a plain object with no prototype-polluting keys, and treats its
+entries as arbitrary `FabricValue`s. Which fields a link carries — and what
+they mean — is a **consumer concern**: a module that uses links (for example a
+runner's cell references) defines its own payload shape on top of this general
+form. Keeping the field set unconstrained is what lets `FabricLink` be reused
+across consumers, each specializing the general link value in its own way.
+
+Like every fabric class, `FabricLink` hosts a static `[CODEC]` (Section 2.4)
+with wire tag `Link@1`. Its encoded state **is** the payload object: the
+codec's `encode()` returns the payload directly, and `decode()` reconstructs a
+`FabricLink` from it (or a `ProblematicValue`, Section 3.5, if the payload is
+malformed). The JSON wire form is the `/Link@1`-tagged envelope
+`{ "/Link@1": <payload> }`; see Section 3 of `3-json-encoding.md` for the wire
+encoding, and the migration table in Section 4 for how legacy link forms
+(the IPLD sigil `{ "/": { "link@1": … } }` and `$alias`) map onto it.
+
+```typescript
+// Shown for illustration only.
+// file: packages/data-model/fabric-instances/FabricLink.ts
+
+/**
+ * A link value: a `FabricInstance` wrapping a plain-object addressing
+ * `payload` as its sole nested `FabricValue`. The data-model does not
+ * constrain the payload's fields; consumers define their own payload shape.
+ */
+export class FabricLink extends BaseFabricInstance {
+  constructor(payload: FabricPlainObject);
+
+  /** The wrapped addressing payload. */
+  get payload(): FabricPlainObject;
+
+  /** The codec for instances of this class; wire tag `Link@1`. */
+  static get [CODEC](): FabricCodec;
+}
+```
+
+#### 1.4.12 `bigint` — Not Wrapped
 
 `bigint` is a JavaScript primitive (`typeof x === 'bigint'`), not an object. It
 rides through the `FabricValue` layer directly, like `undefined`. No
@@ -1077,7 +1132,7 @@ rides through the `FabricValue` layer directly, like `undefined`. No
 `UndefinedCodec` — there is no owned class to host a `[CODEC]`); see
 Section 4.5.
 
-#### 1.4.12 Design Notes
+#### 1.4.13 Design Notes
 
 > **Why wrapper classes instead of inline serializer branches?** Each wrapper
 > genuinely implements `FabricInstance` and hosts its own `[CODEC]`, so the

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -486,7 +486,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
   extraEntries(): IterableIterator<[string, FabricValue]>;
 
   // ([DEEP_FREEZE] / [IS_DEEP_FROZEN] freeze `this` and recurse into
-  // `cause` + the extras-bag values; `shallowUnfrozenClone()` copies the
+  // `cause` + the extras-bag values; `[SHALLOW_UNFROZEN_CLONE]()` copies the
   // slots + bag; `wrappedValue` / `toNativeFrozen()` / `toNativeThawed()`
   // build the native `Error` projection on demand. `deepClone(frozen)`
   // round-trips through the codec: `codec.decode(tag,
@@ -602,7 +602,7 @@ export class FabricMap
   }
 
   // ([DEEP_FREEZE] / [IS_DEEP_FROZEN] freeze `this` and recurse into the
-  // entries; `shallowUnfrozenClone()` copies `map` into a new wrapper;
+  // entries; `[SHALLOW_UNFROZEN_CLONE]()` copies `map` into a new wrapper;
   // `wrappedValue` / `toNativeFrozen()` (-> `FrozenMap`) /
   // `toNativeThawed()` are the native-projection members.)
 
@@ -952,17 +952,18 @@ export class FabricHash extends FabricPrimitive {
 
   /**
    * Parse an instance from its string representation
-   * (`<tag>:<base64urlHash>`). Splits at the LAST colon: the hash segment
-   * is base64url and never contains one, while the tag segment may in
-   * principle. Entity KINDS do not ride the tag — they ride a URI scheme
-   * OUTSIDE the tagged-hash string (`computed:fid1:<hash>`), so a kinded
-   * id's hash portion parses here as a plain `fid1` hash. Callers must
-   * strip the URI scheme before parsing; the scheme is part of the entity's
-   * identity and must be carried alongside, never inferred back from the
-   * bare hash.
+   * (`<tag>:<base64urlHash>`). Splits at the FIRST colon: the tag segment is
+   * a colon-free identifier (e.g. `fid1`) and the hash segment is base64url
+   * (which never contains a colon), so the first colon is the tag/hash
+   * boundary. Entity URI schemes (`of:`, `computed:`) are NOT part of this
+   * string — a caller must strip the scheme before parsing and carry it
+   * alongside, since the scheme is part of the entity's identity. An input
+   * that still carries a scheme leaves a colon in what would be the hash
+   * segment, which is not valid base64url, so parsing fails loudly rather
+   * than silently mis-splitting.
    */
   static fromString(source: string): FabricHash {
-    const colonIndex = source.lastIndexOf(":");
+    const colonIndex = source.indexOf(":");
     if (colonIndex === -1) {
       throw new ReferenceError(`Invalid content hash string: ${source}`);
     }
@@ -982,7 +983,7 @@ The hash bytes are private (`#hash`). The public API provides:
 - `.copyInto(target)` — copies hash bytes into a caller-provided buffer.
 - `.toString()` — `<tag>:<base64urlHash>`.
 - `FabricHash.fromString(s)` — parse from `<tag>:<base64urlHash>` (splits at
-  the last colon; entity URI schemes like `of:`/`computed:` are NOT part of
+  the first colon; entity URI schemes like `of:`/`computed:` are NOT part of
   this string and must be stripped — and preserved — by the caller).
 
 The `tag` field (formerly `algorithmTag`) is an opaque string identifier.
@@ -1251,7 +1252,9 @@ discussion in Section 2.4).
 ### 2.2 Symbols
 
 The serialization symbol lives with the codec vocabulary; the in-process
-lifecycle symbols live in the dependency-free `interface.ts`.
+lifecycle symbols live on the implementation base class `BaseFabricInstance`
+(Section 2.3), kept off the pure-protocol `FabricInstance` interface as
+implementation plumbing.
 
 ```typescript
 // file: packages/data-model/codec-common/interface.ts
@@ -1265,7 +1268,7 @@ export const CODEC: unique symbol = Symbol.for('data-model.codec');
 ```
 
 ```typescript
-// file: packages/data-model/interface.ts
+// file: packages/data-model/fabric-instances/BaseFabricInstance.ts
 
 /**
  * Well-known symbol for deeply freezing a fabric instance in place. The
@@ -1284,6 +1287,17 @@ export const DEEP_FREEZE = Symbol.for('data-model.deepFreeze');
  * See Section 8.6.
  */
 export const IS_DEEP_FROZEN = Symbol.for('data-model.isDeepFrozen');
+
+/**
+ * Well-known symbol for the **internal** shallow-clone hook: a `protected`
+ * template-method member that returns a new unfrozen copy of a fabric
+ * instance. Unlike `[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`, which the generic
+ * freeze utility invokes externally, this member is not part of the external
+ * protocol surface — concrete subclasses implement it, and the
+ * `shallowClone()` template method on `BaseFabricInstance` is its only caller
+ * (Section 2.3).
+ */
+export const SHALLOW_UNFROZEN_CLONE = Symbol.for('data-model.shallowUnfrozenClone');
 
 // Protocol evolution: Symbol.for('data-model.codec@2'), etc.
 ```
@@ -1324,7 +1338,7 @@ class-side `[CODEC]` (Section 2.4).
  *   frozenness.
  * - `shallowClone(frozen)` -- returns a shallow clone with the requested
  *   frozenness. Concrete subclasses normally inherit this from
- *   `BaseFabricInstance` and instead implement `shallowUnfrozenClone()`
+ *   `BaseFabricInstance` and instead implement `[SHALLOW_UNFROZEN_CLONE]()`
  *   (see below).
  *
  * Subclasses that participate in serialization also host a static
@@ -1403,14 +1417,14 @@ export abstract class BaseFabricInstance extends FabricInstance {
    * Returns a new unfrozen copy of this instance with the same data. Called
    * by `shallowClone()` when a new instance is needed.
    */
-  protected abstract shallowUnfrozenClone(): FabricInstance;
+  protected abstract [SHALLOW_UNFROZEN_CLONE](): FabricInstance;
 
   /**
    * Returns a shallow clone of this instance with the requested frozenness.
    *
    * When `frozen` is `true` and this instance is already frozen, returns
    * `this` (identity optimization -- freezing is idempotent). In all other
-   * cases, creates a new instance via `shallowUnfrozenClone()` and freezes
+   * cases, creates a new instance via `[SHALLOW_UNFROZEN_CLONE]()` and freezes
    * it if requested.
    *
    * This effectively-final template method manages the frozenness
@@ -1423,7 +1437,7 @@ export abstract class BaseFabricInstance extends FabricInstance {
    */
   shallowClone(frozen: boolean): FabricInstance {
     if (frozen && Object.isFrozen(this)) return this;
-    const copy = this.shallowUnfrozenClone();
+    const copy = this[SHALLOW_UNFROZEN_CLONE]();
     return frozen ? Object.freeze(copy) as FabricInstance : copy;
   }
 }
@@ -1435,7 +1449,7 @@ export abstract class BaseFabricInstance extends FabricInstance {
 > an effectively-final template method (on `BaseFabricInstance`),
 > encapsulating the frozenness-management contract (clone-if-necessary,
 > freeze-if-requested) in one place. Concrete subclasses implement only
-> `shallowUnfrozenClone()` (the type-specific copy logic) plus the
+> `[SHALLOW_UNFROZEN_CLONE]()` (the type-specific copy logic) plus the
 > deep-freeze pair; serialization lives on the class's `[CODEC]`
 > (Section 2.4). Brand detection uses `instanceof FabricInstance` directly
 > — no type guard function is needed (see Section 2.6).
@@ -1692,7 +1706,7 @@ class Temperature extends BaseFabricInstance {
     super();
   }
 
-  protected shallowUnfrozenClone(): Temperature {
+  protected [SHALLOW_UNFROZEN_CLONE](): Temperature {
     return new Temperature(this.value, this.unit);
   }
 
@@ -1917,7 +1931,7 @@ export class UnknownValue extends ExplicitTagValue {
   }
 
   // ([DEEP_FREEZE] / [IS_DEEP_FROZEN] freeze `this` and recurse into
-  // `state`; `shallowUnfrozenClone()` copies the two fields. Omitted for
+  // `state`; `[SHALLOW_UNFROZEN_CLONE]()` copies the two fields. Omitted for
   // brevity; see §2.3 and §8.6 for the pattern.)
 
   static #codec = Object.freeze(
@@ -2018,7 +2032,7 @@ export class ProblematicValue extends ExplicitTagValue {
   }
 
   // ([DEEP_FREEZE] / [IS_DEEP_FROZEN] freeze `this` and recurse into
-  // `state`; `shallowUnfrozenClone()` copies the three fields. Omitted
+  // `state`; `[SHALLOW_UNFROZEN_CLONE]()` copies the three fields. Omitted
   // for brevity; see §2.3 and §8.6 for the pattern.)
 
   static #codec = Object.freeze(

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -3266,15 +3266,19 @@ produces a `FabricValue` that is structurally equivalent to `sv`.
 
 `FabricValue` trees produced by reconstruction at boundary-crossings are
 deep-frozen by default. This is enforced via a small protocol on
-`FabricInstance` together with a generic top-level utility that dispatches
+`BaseFabricInstance` together with a generic top-level utility that dispatches
 across the four kinds of values that can appear in a `FabricValue` tree.
 
-#### Protocol members on `FabricInstance`
+#### Instance protocol members
 
-Every `FabricInstance` subclass implements three protocol members
-(Section 2.3) — these, plus the inherited `shallowClone()`, are the whole
-instance protocol (serialization lives on the class-side `[CODEC]`;
-Section 2.4):
+Every concrete `FabricInstance` provides the three members below
+(Section 2.3). Their declarations are split by concern: the freeze-protocol
+members `[DEEP_FREEZE]` and `[IS_DEEP_FROZEN]` are declared on
+`BaseFabricInstance` — the abstract base that concrete instance classes extend
+— keeping this implementation plumbing off the pure-protocol `FabricInstance`
+interface, while `deepClone()` and the inherited `shallowClone()` are declared
+on `FabricInstance` itself. These members, plus the class-side `[CODEC]`
+(serialization; Section 2.4), are the whole instance protocol:
 
 - **`[DEEP_FREEZE](subFreeze)`** — Deeply freezes this instance in place
   and returns it. The implementation freezes the instance's own internal

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -226,7 +226,9 @@ member of `FabricValue`.
 > (`Object.is(result, -0) === true`), and `NaN` / `±Infinity` round-trip
 > through hashing and JSON encoding via the byte-level forms in
 > `2-hash-byte-format.md` Section 4.3 and the `SpecialNumber@1` envelope in
-> `3-json-encoding.md` Section 3.
+> `3-json-encoding.md` Section 3. Value-equality among these values follows
+> `Object.is()` — `-0` is distinct from `+0` while all `NaN`s are equal — as
+> specified in Section 6.7.
 
 > **Interned vs. unique symbols.** The hashing layer (Section 6.4 and
 > `2-hash-byte-format.md` Section 4.6) and the JSON wire format
@@ -2730,6 +2732,48 @@ Hashing is used for:
 Entity IDs remain stable addresses (analogous to IPNS names) pointing to the
 most current version of the data. Hashes are not used as entity addresses.
 
+### 6.7 Value Equality
+
+`FabricValue`s are compared for logical (content) equality by
+`valueEqual(a: FabricValue, b: FabricValue): boolean`. This is the equality
+the reactive system's change-detection and no-op gates depend on, and the
+equality that `Map` / `Set` key behavior over fabric values is expected to
+follow.
+
+**Governing principle.** Value-equality follows `Object.is()` at the primitive
+level, and content-hash equality (Section 6.4) is defined to agree with it —
+equivalently, two `FabricValue`s are value-equal exactly when their content
+hashes are equal. `Object.is()`, not `===`, is the operator the contract
+names, and the two disagree in exactly the two cases the hashing layer already
+distinguishes:
+
+- **`-0` ≠ `+0`.** `Object.is(-0, +0)` is `false`, so `-0` and `+0` are
+  distinct fabric values and hash distinctly (Section 6.4;
+  `2-hash-byte-format.md` Section 4.3). (`===` would conflate them, treating
+  `-0 === +0` as `true`.)
+- **All `NaN`s are value-equal.** `Object.is(NaN, NaN)` is `true`, so every
+  `NaN` is value-equal to every other `NaN` — including bitwise-distinct
+  payloads, which the hashing layer canonicalizes to a single quiet `NaN`
+  (Section 6.4; `2-hash-byte-format.md` Section 4.3) — and all `NaN`s hash
+  identically. (`===` would report `NaN !== NaN`.)
+
+Every other primitive falls through to ordinary same-value equality:
+`+Infinity`, `-Infinity`, and each finite number equals itself and nothing
+else, and likewise for `string`, `boolean`, `bigint`, interned `symbol`,
+`null`, and `undefined`.
+
+**Objects, arrays, and instances.** Non-primitive fabric values are compared
+by canonical content hash: `valueEqual(a, b)` holds exactly when
+`hashStringOf(a) === hashStringOf(b)` (Section 6.4). Because the content hash
+reflects logical content and carries the primitive-leaf distinctions above, a
+`-0`, `NaN`, or any other value nested arbitrarily deep inside a plain object,
+array, `FabricMap`, `FabricSet`, or other `FabricInstance` inherits the same
+equality. Deciding object equality by content hash (rather than by a naive
+property walk) is also what lets structurally distinct values be told apart —
+a sparse array hole vs. a stored `undefined`, a present `undefined` vs. an
+absent key (Section 6.4), and two distinct `FabricInstance`s of the same class
+that carry no enumerable own-properties.
+
 ---
 
 ## 7. Implementation Guidance
@@ -3341,13 +3385,6 @@ values cross from internal serialization machinery to callers:
 
 These questions may need resolution during implementation but do not block the
 spec from being implementable.
-
-- **Comparison semantics for modern types**: Should equality be by identity, by
-  encoded state (or as if by encoded state — an implementation need
-  not actually run a codec), or configurable? This affects both runtime
-  comparisons (e.g., in reactive system change detection) and `Map`/`Set` key
-  behavior. Recommendation: start with identity semantics (the JS default) and
-  revisit if structural equality is needed for specific use cases.
 
 - **Type registry management**: How are serialization contexts configured? Static
   registration? Dynamic discovery? Who owns the registry? The isolation

--- a/docs/specs/space-model-formal-spec/2-hash-byte-format.md
+++ b/docs/specs/space-model-formal-spec/2-hash-byte-format.md
@@ -127,10 +127,11 @@ four special values that JSON cannot represent natively (`-0`, `NaN`,
 - **`NaN`** is canonicalized to a single representation: the **quiet NaN**
   payload `7F F8 00 00 00 00 00 00`. Any input NaN bit pattern (signaling,
   quiet, with arbitrary payload bits) hashes via this canonical 8-byte
-  sequence. This ensures all NaN values produce identical hashes,
-  consistent with JavaScript semantics where every NaN compares unequal
-  to itself but is observationally indistinguishable from every other NaN
-  at the language level.
+  sequence. This ensures all NaN values produce identical hashes, matching
+  fabric value-equality, under which all `NaN`s are equal (`Object.is(NaN,
+  NaN)` is `true`; see `1-fabric-values.md` Section 6.7). Note this is
+  distinct from the `===` operator, under which a `NaN` compares unequal even
+  to itself.
 
 > **Conversion-gate cross-reference.** Whether `-0`, `NaN`, or `±Infinity`
 > reach this layer depends on the fabric-value conversion gate; see


### PR DESCRIPTION
## What

Documentation-only spec-alignment pass on the space-model formal spec, bringing
it into agreement with the shipped `data-model` behavior and settled design
intent. Touches two files: `1-fabric-values.md` and `2-hash-byte-format.md`.

## Changes

- **§6.7 — value equality.** States the `Object.is()` value-equality principle
  for fabric values explicitly (all `NaN`s equal; `-0` and `+0` distinct), and
  removes the now-stale open-decision bullet from Appendix A that this settles.
- **§2 (hash byte format) — NaN note.** Clarifies that NaN canonicalization to a
  single hash matches fabric value-equality (`Object.is(NaN, NaN)` is `true`),
  explicitly distinguished from `===` (under which `NaN` is unequal even to
  itself), cross-referencing §6.7.
- **§1.4.11 — `FabricLink`.** Adds `FabricLink` to the Section 1.4 type catalog
  (`Link@1`).
- **§8.6 and §2.2 — freeze protocol attribution.** Attributes the freeze-protocol
  members to `BaseFabricInstance` (rather than the pure `FabricInstance`
  interface), matching the implementation.
- **Symbol bracketing.** Updates `shallowUnfrozenClone()` references to the
  symbol form `[SHALLOW_UNFROZEN_CLONE]`, matching the shipped rename.
- **§1.4.9 — `FabricHash`.** Documents the first-colon split behavior.

## Scope

Docs-only; no code changes. `deno task check-docs` passes.

Co-Authored-By: spec-writer-sage (Claude Opus 4.8) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.8) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the space-model formal spec with shipped `data-model` behavior. Clarifies value equality, hashing, and instance protocol; adds `FabricLink`.

- **Refactors**
  - Define value equality: `Object.is()` for primitives; value-equal iff content hashes match; remove the stale appendix note.
  - Update the NaN canonicalization note and cross-reference the new equality section.
  - Add `FabricLink` (`Link@1`) to the type catalog with a payload-only codec.
  - Attribute `[DEEP_FREEZE]` and `[IS_DEEP_FROZEN]` to `BaseFabricInstance` and retitle the protocol section.
  - Use the `[SHALLOW_UNFROZEN_CLONE]` symbol consistently and declare it in the symbols list.
  - Parse `FabricHash.fromString` at the first colon; clarify that URI schemes must be stripped.

<sup>Written for commit 12f3c8e2da0b38ab8dde593bd9d4220961ba2c40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

