### PR TITLE
ci: shard pattern capability sweeps across integration jobs

### DIFF
--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -56,6 +56,24 @@ per-pattern CFC compile, not by storage or sync — see
 [the profiling snapshot](../history/development/performance/pattern-integration-compile-bound.md)
 before optimizing there.
 
+### Pattern Integration Sharding
+
+Pattern Integration runs four jobs. Most integration test files run in exactly
+one job. Tests that sweep a pattern list run in every job and divide their own
+cases with `PATTERN_INTEGRATION_SHARD`. An unset variable selects every case, so
+the ordinary local command remains unsharded.
+
+`INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES` in
+`tasks/select-pattern-integration-files.ts` is the list of files that run in
+every job. Those files select their cases through
+`packages/patterns/integration/pattern-integration-shard.ts`. The selector tests
+verify that every real integration file follows one of these two contracts.
+
+Use internal sharding for a single file with many independent, expensive cases.
+Moving that file intact between jobs moves the delay without dividing it. Keep
+independent end-to-end files in the measured assignment table when their run
+times are large enough that count-based round-robin cannot balance them.
+
 ## Pulling Timing Data
 
 The labs repository is public, so the GitHub Actions REST API returns run, job,

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -214,6 +214,9 @@ One line per archived document; each document's header carries the fuller
   and
   [pattern-integration-compile-bound.md](development/performance/pattern-integration-compile-bound.md)
   — June 2026 profiling snapshots.
+- [2026-07-pattern-capability-ci-duration-increase.md](development/performance/2026-07-pattern-capability-ci-duration-increase.md)
+  — root cause of the July 2026 labs CI duration increase: two unsharded
+  pattern time-capability sweeps, especially the 56-pattern sweep on shard 3.
 - [scoped-cells-field-notes.md](development/scoped-cells-field-notes.md) —
   field journal from the first scoped-cell patterns.
 - [2026-07-02-convergence-evidence-appendix.md](plans/2026-07-02-convergence-evidence-appendix.md)

--- a/docs/history/development/performance/2026-07-pattern-capability-ci-duration-increase.md
+++ b/docs/history/development/performance/2026-07-pattern-capability-ci-duration-increase.md
@@ -1,0 +1,128 @@
+---
+status: historical
+created: 2026-07-18
+archived: 2026-07-18
+reason: "Investigation snapshot of the July 2026 CI duration increase caused by the pattern time-capability sweeps."
+---
+
+# Why labs CI duration increased in July 2026
+
+## Conclusion
+
+Commit
+[`72df6bce1`](https://github.com/commontoolsinc/labs/commit/72df6bce116bebbc334d0d7e7c277a161d299e52),
+"Timing side-channel mitigations and the reactive #now clock," added four
+pattern-integration test files. Three cover the new time-capability rules. The
+fourth covers cell-flip shaping. The largest file,
+`time-capability-full.test.ts`, discovers 56 patterns and exercises every one
+serially. It creates a new identity, session, runtime, and controller for each
+pattern. It then resolves and starts the pattern, makes its result reactive,
+waits for the runtime to settle and synchronize, fires every top-level result
+stream, waits again, and disposes the controller.
+
+That full sweep is assigned as one ordinary test file to Pattern Integration
+Tests shard 3. It does not use `PATTERN_INTEGRATION_SHARD` to divide its 56
+patterns. On a warm compile cache the sweep takes about 5 minutes 28 seconds by
+itself. It accounts for about 72 percent of shard 3's test step.
+
+The compile cache made the first affected run slower still, but a cache miss is
+not the persistent cause. A later warm run still took 8 minutes 10 seconds for
+shard 3, compared with 1 minute 56 seconds immediately before the commit.
+
+## The change boundary
+
+The first slow commit is the direct child of the last fast commit, so no other
+change is mixed into this comparison.
+
+| State | Main run | Compile cache | Whole workflow | Shard 3 job | Shard 3 test step |
+| --- | --- | --- | ---: | ---: | ---: |
+| Before | [`29635744508`](https://github.com/commontoolsinc/labs/actions/runs/29635744508), `d7a5243e7` | warm | 8m 08s | 1m 56s | 1m 25s |
+| First affected | [`29636904390`](https://github.com/commontoolsinc/labs/actions/runs/29636904390), `72df6bce1` | cold | 13m 42s | 9m 42s | 8m 57s |
+| Later comparison | [`29641431325`](https://github.com/commontoolsinc/labs/actions/runs/29641431325), `a88a29d6a` | warm | 12m 39s | 8m 10s | 7m 37s |
+
+The warm comparison shows that the whole workflow remained 4 minutes 31
+seconds slower than the run before the change. The Performance Check reported
+that required non-deploy jobs occupied 9 minutes 6 seconds in the warm run. The
+last fast run's required jobs completed in about 4 minutes 51 seconds.
+
+## Per-test evidence
+
+The JUnit timing artifacts make the new work visible inside the test step.
+
+| Shard 3 measurement | Before | Warm after |
+| --- | ---: | ---: |
+| Reported tests | 34 | 98 |
+| Total test time | 84.421s | 456.265s |
+| `all.test.ts`: Compile all patterns | 16.296s | 16.344s |
+| `time-capability-full.test.ts` | absent | 327.899s |
+
+The unchanged warm time for `all.test.ts` rules out a slowdown in its existing
+warm-cache compile-and-create workload as the main cause. That test creates
+patterns without starting them, so it does not exercise every runtime operation
+in the full sweep. The new full capability sweep alone contributes 327.899
+seconds. Its 56 individual pattern cases account for 327.876 seconds of that
+total.
+
+The smaller `time-capability.test.ts` sweep also adds 84.261 seconds to shard 1.
+In the same warm run the four pattern-integration jobs took:
+
+| Shard | Job duration | New capability work |
+| --- | ---: | --- |
+| 1 | 4m 32s | the 11-case curated capability suite |
+| 2 | 2m 41s | none of the two large sweeps |
+| 3 | 8m 10s | the 56-case full-pattern sweep |
+| 4 | 2m 44s | the intrinsic behavior tests |
+
+## Why all 56 cases landed in one shard
+
+`tasks/select-pattern-integration-files.ts` includes `all.test.ts` in every
+shard because that file divides its own pattern list with
+`PATTERN_INTEGRATION_SHARD`. Every other integration file is assigned to one
+shard. Known expensive files have explicit assignments. New unlisted files use
+round-robin assignment by filename.
+
+The timing-side-channel commit added `time-capability-full.test.ts`,
+`time-capability.test.ts`, and `time-capability-intrinsics.test.ts` without
+changing the selector. The fallback placed the full sweep on shard 3 and the
+curated capability suite on shard 1. The full sweep does not divide its
+discovered pattern list by the CI shard value.
+
+Moving the full test file intact to another shard would move the delay rather
+than reduce it. The independent pattern cases are the useful split boundary.
+
+## Why Performance Check did not stop the increase
+
+The first affected run changed the compile fingerprint and missed every pattern
+compile cache. Performance Check classified the pattern-integration timing as
+`COLD`, which deliberately does not fail against warm baselines. It did emit all
+three wall-time revisit signals:
+
+- the slowest required job exceeded 3 minutes;
+- shard 3 was much slower than nearby jobs; and
+- required non-deploy checks exceeded the 8-minute budget.
+
+The later warm run emitted the same revisit signals. Its shard 1 and shard 3
+timings had fewer than five comparable samples, so Performance Check reported
+them as `n/a` instead of comparing them with a threshold. The guard therefore
+identified the wall-time problem in its informational section but had no gated
+timing result that could fail.
+
+## Remediation direction
+
+The lowest-risk first change is to give the full sweep the same internal
+sharding contract as `all.test.ts` and select it in every pattern-integration
+job. A plain sorted, modulo-four division of the measured 56 cases would put
+between 50 and 117 seconds of this sweep on each shard, instead of 328 seconds
+on shard 3. The 84-second curated capability suite on shard 1 should then be
+split or reassigned while comparing all four resulting job times.
+
+The selector should explicitly distinguish internally sharded files that run in
+every job from expensive files pinned to one job. The full sweep belongs in the
+first group. The curated suite can be split or pinned after measuring the new
+balance. Leaving either file to the fallback changes the placement of other
+unlisted files whenever a new filename is inserted, which makes an already
+measured balance unstable.
+
+This investigation does not recommend weakening or removing the capability
+checks. It recommends running the independent checks across the four workers
+that CI already starts.

--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -5,37 +5,18 @@ import { assert } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { initializePiecesController } from "./pieces-controller.ts";
+import {
+  currentPatternIntegrationShard,
+  selectPatternIntegrationShard,
+} from "./pattern-integration-shard.ts";
 
 const { API_URL } = env;
-
-// Optional sharding for CI fan-out: PATTERN_INTEGRATION_SHARD="i/n" (1-based)
-// runs only the patterns where (sorted index % n) == (i - 1), so the pattern
-// compiles spread across the n parallel "Pattern Integration Tests (i/n)" jobs
-// instead of all landing in one. Mirrors the CFCHECK_SHARD fan-out in
-// tasks/cfcheck.ts. Unset (local dev) runs every pattern.
-function parsePatternShard(): { index: number; count: number } {
-  const raw = Deno.env.get("PATTERN_INTEGRATION_SHARD");
-  if (!raw) return { index: 0, count: 1 };
-  const match = raw.match(/^(\d+)\/(\d+)$/);
-  if (!match) {
-    throw new Error(
-      `Invalid PATTERN_INTEGRATION_SHARD "${raw}"; expected "i/n" (1-based).`,
-    );
-  }
-  const index = Number(match[1]) - 1;
-  const count = Number(match[2]);
-  if (count < 1 || index < 0 || index >= count) {
-    throw new Error(`PATTERN_INTEGRATION_SHARD "${raw}" out of range.`);
-  }
-  return { index, count };
-}
 
 describe("Compile all patterns", () => {
   const skippedPatterns = [
     "system/link-tool.tsx", // Utility handlers, not a standalone pattern
   ];
 
-  const shard = parsePatternShard();
   const patterns = [...Deno.readDirSync(join(import.meta.dirname!, ".."))]
     .filter((file) => file.name.endsWith(".tsx"))
     .map((file) => file.name)
@@ -48,11 +29,13 @@ describe("Compile all patterns", () => {
     .filter((name) => !name.endsWith(".test.tsx") && !name.endsWith(".test.ts"))
     .filter((name) => !skippedPatterns.includes(name))
     .sort();
+  const selectedPatterns = selectPatternIntegrationShard(
+    patterns,
+    currentPatternIntegrationShard(),
+  );
 
   // Add a test for each pattern in this shard's slice.
-  for (const [i, name] of patterns.entries()) {
-    if (i % shard.count !== shard.index) continue;
-
+  for (const name of selectedPatterns) {
     it(`Executes: ${name}`, async () => {
       // Heap monitoring for bisection experiments (CT-1148)
       const heapBefore = Deno.memoryUsage().heapUsed;

--- a/packages/patterns/integration/pattern-integration-shard.ts
+++ b/packages/patterns/integration/pattern-integration-shard.ts
@@ -1,0 +1,40 @@
+export interface PatternIntegrationShard {
+  index: number;
+  total: number;
+}
+
+export function parsePatternIntegrationShard(
+  raw: string | undefined,
+): PatternIntegrationShard {
+  if (!raw) return { index: 1, total: 1 };
+
+  const match = raw.match(/^([1-9][0-9]*)\/([1-9][0-9]*)$/);
+  if (!match) {
+    throw new Error(
+      `Invalid PATTERN_INTEGRATION_SHARD "${raw}"; expected "i/n" (1-based).`,
+    );
+  }
+
+  const index = Number(match[1]);
+  const total = Number(match[2]);
+  if (index > total) {
+    throw new Error(`PATTERN_INTEGRATION_SHARD "${raw}" out of range.`);
+  }
+
+  return { index, total };
+}
+
+export function currentPatternIntegrationShard(): PatternIntegrationShard {
+  return parsePatternIntegrationShard(
+    Deno.env.get("PATTERN_INTEGRATION_SHARD"),
+  );
+}
+
+export function selectPatternIntegrationShard<T>(
+  items: readonly T[],
+  shard: PatternIntegrationShard,
+): T[] {
+  return items.filter((_, itemIndex) =>
+    itemIndex % shard.total === shard.index - 1
+  );
+}

--- a/packages/patterns/integration/pattern-integration-shard.ts
+++ b/packages/patterns/integration/pattern-integration-shard.ts
@@ -6,7 +6,7 @@ export interface PatternIntegrationShard {
 export function parsePatternIntegrationShard(
   raw: string | undefined,
 ): PatternIntegrationShard {
-  if (!raw) return { index: 1, total: 1 };
+  if (raw === undefined) return { index: 1, total: 1 };
 
   const match = raw.match(/^([1-9][0-9]*)\/([1-9][0-9]*)$/);
   if (!match) {
@@ -17,6 +17,11 @@ export function parsePatternIntegrationShard(
 
   const index = Number(match[1]);
   const total = Number(match[2]);
+  if (!Number.isSafeInteger(index) || !Number.isSafeInteger(total)) {
+    throw new Error(
+      `Invalid PATTERN_INTEGRATION_SHARD "${raw}"; shard values must be safe integers.`,
+    );
+  }
   if (index > total) {
     throw new Error(`PATTERN_INTEGRATION_SHARD "${raw}" out of range.`);
   }

--- a/packages/patterns/integration/time-capability-full.test.ts
+++ b/packages/patterns/integration/time-capability-full.test.ts
@@ -20,6 +20,10 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { PieceManager } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import {
+  currentPatternIntegrationShard,
+  selectPatternIntegrationShard,
+} from "./pattern-integration-shard.ts";
 
 const ROOT = join(import.meta.dirname!, "..");
 
@@ -142,7 +146,10 @@ async function checkPattern(rel: string): Promise<Outcome> {
   }
 }
 
-const PATTERNS = discoverPatterns();
+const PATTERNS = selectPatternIntegrationShard(
+  discoverPatterns(),
+  currentPatternIntegrationShard(),
+);
 
 describe("capability gate (W1): full pattern-set gate verification", () => {
   for (const rel of PATTERNS) {

--- a/packages/patterns/integration/time-capability.test.ts
+++ b/packages/patterns/integration/time-capability.test.ts
@@ -24,6 +24,10 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { PieceManager } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import {
+  currentPatternIntegrationShard,
+  selectPatternIntegrationShard,
+} from "./pattern-integration-shard.ts";
 
 const ROOT = join(import.meta.dirname!, "..");
 
@@ -117,26 +121,46 @@ const MIGRATED_OFFLINE_PATTERNS = [
 //   the in-memory store), which is unrelated to the time gate. It needs a
 //   verified-module environment to behaviorally verify.
 
-describe("capability gate (W1): patterns read the clock only in handlers", () => {
-  it("catches a lift-context clock read (negative control)", async () => {
-    const errors = await timeCapabilityErrors(
-      "integration/fixtures/lift-clock-violation.tsx",
-    );
-    expect(errors.length).toBeGreaterThan(0);
-    expect(errors[0]).toContain("ambient clock");
-  });
+interface CapabilityCase {
+  name: string;
+  run: () => Promise<void>;
+}
 
-  it("allows the #now reactive clock in a computed (positive control)", async () => {
-    const errors = await timeCapabilityErrors(
-      "integration/fixtures/lift-now-wish-ok.tsx",
-    );
-    expect(errors).toEqual([]);
-  });
-
-  for (const rel of MIGRATED_OFFLINE_PATTERNS) {
-    it(`materializes ${rel} with no lift-context clock read`, async () => {
+const CAPABILITY_CASES: CapabilityCase[] = [
+  {
+    name: "catches a lift-context clock read (negative control)",
+    run: async () => {
+      const errors = await timeCapabilityErrors(
+        "integration/fixtures/lift-clock-violation.tsx",
+      );
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0]).toContain("ambient clock");
+    },
+  },
+  {
+    name: "allows the #now reactive clock in a computed (positive control)",
+    run: async () => {
+      const errors = await timeCapabilityErrors(
+        "integration/fixtures/lift-now-wish-ok.tsx",
+      );
+      expect(errors).toEqual([]);
+    },
+  },
+  ...MIGRATED_OFFLINE_PATTERNS.map((rel): CapabilityCase => ({
+    name: `materializes ${rel} with no lift-context clock read`,
+    run: async () => {
       const errors = await timeCapabilityErrors(rel);
       expect(errors).toEqual([]);
-    });
+    },
+  })),
+];
+
+describe("capability gate (W1): patterns read the clock only in handlers", () => {
+  const cases = selectPatternIntegrationShard(
+    CAPABILITY_CASES,
+    currentPatternIntegrationShard(),
+  );
+  for (const testCase of cases) {
+    it(testCase.name, testCase.run);
   }
 });

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -46,7 +46,7 @@ import {
   downloadAndParsePerfMetricsDetailed,
   dropColdSamples,
   extractMetrics,
-  extractTestFileMetrics,
+  extractTimingArtifactMetrics,
   fetchArtifactsForRun,
   fetchCurrentPRBody,
   fetchJobsForRun,
@@ -62,9 +62,11 @@ import {
   MIN_REGRESSION_PCT,
   MIN_SAMPLES,
   newestArtifactsByName,
+  newestTimingArtifacts,
   parseAddedLinesFromPatch,
   parseBaselineOverrides,
   parseCacheStateFiles,
+  type ParsedTimingArtifact,
   PERF_METRICS_ARTIFACT_NAME,
   PERF_METRICS_BACKFILL_ARTIFACT_NAME,
   PERF_METRICS_BACKFILL_FILE,
@@ -76,7 +78,6 @@ import {
   REPO,
   shouldGateCoverageDebtMetric,
   STDDEV_FACTOR,
-  timingArtifactLabel,
   type TimingSample,
   walkFiles,
   WORKFLOW_FILE,
@@ -1454,27 +1455,27 @@ export async function main() {
   });
   fillMissingFamiliesFromFingerprint(currentCacheStates, inferredRunState);
 
-  // Extract per-test metrics from JUnit artifacts
+  // Extract per-test metrics from JUnit artifacts.
+  const parsedTimingArtifacts: ParsedTimingArtifact[] = [];
   try {
     // Newest per name: a re-run of a flagged test job must refresh its metric.
-    const timingArtifacts = newestArtifactsByName(currentArtifacts.filter(
-      (a) => a.name.startsWith("test-timing-") && !a.expired,
-    ));
+    const timingArtifacts = newestTimingArtifacts(currentArtifacts);
     for (const artifact of timingArtifacts) {
       const suites = await downloadAndParseJUnit(artifact.id);
-      const testMetrics = extractTestFileMetrics(
-        currentRunInfo,
-        timingArtifactLabel(artifact.name),
-        suites,
-      );
-      for (const [name, sample] of testMetrics) {
-        currentMetrics.set(name, sample);
-      }
+      parsedTimingArtifacts.push({ name: artifact.name, suites });
     }
   } catch (e) {
     console.warn(
       `  Warning: could not extract timing metrics from current run artifacts: ${e}`,
     );
+  }
+  for (
+    const [name, sample] of extractTimingArtifactMetrics(
+      currentRunInfo,
+      parsedTimingArtifacts,
+    )
+  ) {
+    currentMetrics.set(name, sample);
   }
 
   // Extract coverage debt metrics from coverage profile artifacts.
@@ -1672,29 +1673,28 @@ export async function main() {
 
         // Fetch per-test timing artifacts
         let canBackfill = true;
+        const parsedTimingArtifacts: ParsedTimingArtifact[] = [];
         try {
-          const timingArtifacts = artifacts.filter(
-            (a) => a.name.startsWith("test-timing-") && !a.expired,
-          );
+          const timingArtifacts = newestTimingArtifacts(artifacts);
           for (const artifact of timingArtifacts) {
             const suites = await downloadAndParseJUnit(artifact.id);
             if (suites.length === 0) {
               canBackfill = false;
               continue;
             }
-            const testMetrics = extractTestFileMetrics(
-              run,
-              timingArtifactLabel(artifact.name),
-              suites,
-            );
-            for (const [name, sample] of testMetrics) {
-              metrics.set(name, sample);
-              addSample(timelines, name, sample);
-            }
+            parsedTimingArtifacts.push({ name: artifact.name, suites });
           }
         } catch {
           // Artifacts may not exist for older runs
           canBackfill = false;
+        }
+        const testMetrics = extractTimingArtifactMetrics(
+          run,
+          parsedTimingArtifacts,
+        );
+        for (const [name, sample] of testMetrics) {
+          metrics.set(name, sample);
+          addSample(timelines, name, sample);
         }
 
         if (metrics.size > 0 && canBackfill) {

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -25,6 +25,7 @@ import {
   downloadAndExtractArtifact,
   dropColdSamples,
   extractMetrics,
+  extractTimingArtifactMetrics,
   fetchArtifactsForRun,
   fetchCurrentPRBody,
   fetchPRBody,
@@ -37,6 +38,7 @@ import {
   type Job,
   latestNonColdSample,
   newestArtifactsByName,
+  newestTimingArtifacts,
   parseAddedLinesFromPatch,
   parseBaselineOverrides,
   parseCacheStateFiles,
@@ -471,6 +473,47 @@ Deno.test("timingArtifactLabel normalizes matrix shard artifacts", () => {
     timingArtifactLabel("test-timing-package-integration"),
     "package-integration",
   );
+});
+
+Deno.test("timing artifacts combine internally sharded suites once per run", () => {
+  const suiteName =
+    "packages/patterns/integration/time-capability-full.test.ts";
+  const metrics = extractTimingArtifactMetrics(makeRun(), [
+    {
+      name: "test-timing-pattern-integration-1",
+      suites: [{
+        name: suiteName,
+        time: 117,
+        tests: [{ name: "case a", time: 30 }],
+      }],
+    },
+    {
+      name: "test-timing-pattern-integration-2",
+      suites: [{
+        name: suiteName,
+        time: 50,
+        tests: [{ name: "case b", time: 20 }],
+      }],
+    },
+  ]);
+
+  assertEquals(
+    metrics.get(`test: pattern-integration/${suiteName}`)?.durationSeconds,
+    117,
+  );
+  assertEquals(
+    metrics.get(
+      `subtest: pattern-integration/${suiteName} > case a`,
+    )?.durationSeconds,
+    30,
+  );
+  assertEquals(
+    metrics.get(
+      `subtest: pattern-integration/${suiteName} > case b`,
+    )?.durationSeconds,
+    20,
+  );
+  assertEquals(metrics.size, 3);
 });
 
 Deno.test("perf metrics files round-trip stable metric samples", () => {
@@ -1697,6 +1740,34 @@ Deno.test("newestArtifactsByName keeps the latest re-run upload per name", () =>
     [
       ["test-timing-pattern-unit-1", 150],
       ["test-timing-pattern-unit-4", 200],
+    ],
+  );
+});
+
+Deno.test("newestTimingArtifacts drops stale, expired, and unrelated artifacts", () => {
+  const artifact = (
+    id: number,
+    name: string,
+    expired = false,
+  ): Artifact => ({
+    id,
+    name,
+    size_in_bytes: 1,
+    expired,
+  });
+  const result = newestTimingArtifacts([
+    artifact(200, "test-timing-pattern-integration-3"),
+    artifact(150, "test-timing-pattern-integration-1"),
+    artifact(100, "test-timing-pattern-integration-3"),
+    artifact(300, "test-timing-pattern-integration-4", true),
+    artifact(400, "coverage-profile-pattern-integration-2"),
+  ]);
+
+  assertEquals(
+    result.map((item) => [item.name, item.id]).sort(),
+    [
+      ["test-timing-pattern-integration-1", 150],
+      ["test-timing-pattern-integration-3", 200],
     ],
   );
 });

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -234,6 +234,11 @@ export interface JUnitTestSuite {
   tests: { name: string; time: number }[];
 }
 
+export interface ParsedTimingArtifact {
+  name: string;
+  suites: JUnitTestSuite[];
+}
+
 export interface PRInfo {
   number: number;
   title: string;
@@ -498,6 +503,14 @@ export function newestArtifactsByName(artifacts: Artifact[]): Artifact[] {
     }
   }
   return [...byName.values()];
+}
+
+export function newestTimingArtifacts(artifacts: Artifact[]): Artifact[] {
+  return newestArtifactsByName(
+    artifacts.filter((artifact) =>
+      artifact.name.startsWith("test-timing-") && !artifact.expired
+    ),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -1202,6 +1215,30 @@ export function extractTestFileMetrics(
       if (test.time <= 0) continue;
       const testKey = `subtest: ${artifactName}/${suite.name} > ${test.name}`;
       metrics.set(testKey, makeSample(test.time));
+    }
+  }
+
+  return metrics;
+}
+
+/** Keeps the longest slice when normalized artifact labels share a metric. */
+export function extractTimingArtifactMetrics(
+  run: WorkflowRun,
+  artifacts: Iterable<ParsedTimingArtifact>,
+): Map<string, TimingSample> {
+  const metrics = new Map<string, TimingSample>();
+
+  for (const artifact of artifacts) {
+    const artifactMetrics = extractTestFileMetrics(
+      run,
+      timingArtifactLabel(artifact.name),
+      artifact.suites,
+    );
+    for (const [name, sample] of artifactMetrics) {
+      const existing = metrics.get(name);
+      if (!existing || sample.durationSeconds > existing.durationSeconds) {
+        metrics.set(name, sample);
+      }
     }
   }
 

--- a/tasks/select-pattern-integration-files.test.ts
+++ b/tasks/select-pattern-integration-files.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import {
   assignPatternIntegrationShards,
   INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES,
@@ -18,6 +18,10 @@ const INTERNALLY_SHARDED_FILE_NAMES = new Set<string>(
 
 Deno.test("parseShard parses shard notation", () => {
   assertEquals(parseShard("2/4"), { index: 2, total: 4 });
+  assertEquals(parseShard("9007199254740991/9007199254740991"), {
+    index: Number.MAX_SAFE_INTEGER,
+    total: Number.MAX_SAFE_INTEGER,
+  });
 });
 
 Deno.test("parseShard rejects invalid shard notation", () => {
@@ -32,6 +36,20 @@ Deno.test("parseShard rejects invalid shard notation", () => {
   }
 });
 
+Deno.test("parseShard rejects unsafe integer values", () => {
+  const enormous = "9".repeat(400);
+  for (
+    const raw of [
+      "1/9007199254740992",
+      "9007199254740992/9007199254740992",
+      "9007199254740993/9007199254740992",
+      `${enormous}/${enormous}`,
+    ]
+  ) {
+    assertThrows(() => parseShard(raw), Error, "safe integers");
+  }
+});
+
 Deno.test("pattern integration shard defaults local runs to every item", () => {
   const shard = parsePatternIntegrationShard(undefined);
   assertEquals(shard, { index: 1, total: 1 });
@@ -40,6 +58,14 @@ Deno.test("pattern integration shard defaults local runs to every item", () => {
     "b",
     "c",
   ]);
+});
+
+Deno.test("pattern integration shard rejects an explicitly empty setting", () => {
+  assertThrows(
+    () => parsePatternIntegrationShard(""),
+    Error,
+    'Invalid PATTERN_INTEGRATION_SHARD ""',
+  );
 });
 
 Deno.test("pattern integration shard divides items exactly once", () => {
@@ -76,6 +102,31 @@ Deno.test("pattern integration shard rejects invalid notation", () => {
         true,
       );
     }
+  }
+});
+
+Deno.test("pattern integration shard rejects unsafe integer values", () => {
+  assertEquals(
+    parsePatternIntegrationShard("9007199254740991/9007199254740991"),
+    {
+      index: Number.MAX_SAFE_INTEGER,
+      total: Number.MAX_SAFE_INTEGER,
+    },
+  );
+  const enormous = "9".repeat(400);
+  for (
+    const raw of [
+      "1/9007199254740992",
+      "9007199254740992/9007199254740992",
+      "9007199254740993/9007199254740992",
+      `${enormous}/${enormous}`,
+    ]
+  ) {
+    assertThrows(
+      () => parsePatternIntegrationShard(raw),
+      Error,
+      "shard values must be safe integers",
+    );
   }
 });
 

--- a/tasks/select-pattern-integration-files.test.ts
+++ b/tasks/select-pattern-integration-files.test.ts
@@ -1,13 +1,20 @@
 import { assertEquals } from "@std/assert";
 import {
   assignPatternIntegrationShards,
+  INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES,
   listPatternIntegrationTests,
   selectPatternIntegrationFiles,
 } from "./select-pattern-integration-files.ts";
 import { parseShard } from "./shard-utils.ts";
+import {
+  parsePatternIntegrationShard,
+  selectPatternIntegrationShard,
+} from "../packages/patterns/integration/pattern-integration-shard.ts";
 
 const TOTAL_SHARDS = 4;
-const ALL_PATTERNS_FILE = "all.test.ts";
+const INTERNALLY_SHARDED_FILE_NAMES = new Set<string>(
+  INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES,
+);
 
 Deno.test("parseShard parses shard notation", () => {
   assertEquals(parseShard("2/4"), { index: 2, total: 4 });
@@ -22,6 +29,53 @@ Deno.test("parseShard rejects invalid shard notation", () => {
       (error as Error).message,
       "Shard index 5 exceeds total shard count 4",
     );
+  }
+});
+
+Deno.test("pattern integration shard defaults local runs to every item", () => {
+  const shard = parsePatternIntegrationShard(undefined);
+  assertEquals(shard, { index: 1, total: 1 });
+  assertEquals(selectPatternIntegrationShard(["a", "b", "c"], shard), [
+    "a",
+    "b",
+    "c",
+  ]);
+});
+
+Deno.test("pattern integration shard divides items exactly once", () => {
+  const items = ["a", "b", "c", "d", "e", "f", "g"];
+  const selections = Array.from(
+    { length: TOTAL_SHARDS },
+    (_, index) =>
+      selectPatternIntegrationShard(
+        items,
+        parsePatternIntegrationShard(`${index + 1}/${TOTAL_SHARDS}`),
+      ),
+  );
+  assertEquals(selections, [
+    ["a", "e"],
+    ["b", "f"],
+    ["c", "g"],
+    ["d"],
+  ]);
+  assertEquals(selections.flat().sort(), items);
+});
+
+Deno.test("pattern integration shard rejects invalid notation", () => {
+  for (const raw of ["0/4", "1/0", "5/4", "2", "2/4/6"]) {
+    try {
+      parsePatternIntegrationShard(raw);
+      throw new Error(`expected ${raw} to be rejected`);
+    } catch (error) {
+      assertEquals(
+        (error as Error).message.startsWith(
+          `Invalid PATTERN_INTEGRATION_SHARD "${raw}"`,
+        ) ||
+          (error as Error).message ===
+            `PATTERN_INTEGRATION_SHARD "${raw}" out of range.`,
+        true,
+      );
+    }
   }
 });
 
@@ -58,26 +112,28 @@ Deno.test("pattern integration four-way shard keeps the heaviest tests apart", (
   );
 });
 
-Deno.test("all.test.ts runs in every shard", () => {
+Deno.test("internally sharded files run in every shard", () => {
   const files = [
-    "all.test.ts",
+    ...INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES,
     "counter.test.ts",
     "default-app.test.ts",
     "parking-coordinator-admin-view.test.ts",
   ];
   for (let index = 1; index <= 4; index++) {
     const selected = selectPatternIntegrationFiles(files, { index, total: 4 });
-    assertEquals(
-      selected.includes("./integration/all.test.ts"),
-      true,
-      `shard ${index} should include all.test.ts`,
-    );
+    for (const name of INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES) {
+      assertEquals(
+        selected.includes(`./integration/${name}`),
+        true,
+        `shard ${index} should include ${name}`,
+      );
+    }
   }
 });
 
-Deno.test("every non-all file is assigned to exactly one shard", () => {
+Deno.test("every file without internal sharding is assigned to one shard", () => {
   const files = [
-    "all.test.ts",
+    ...INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES,
     "parking-coordinator-admin-view.test.ts",
     "cfc-spec-gallery.test.ts",
     "default-app.test.ts",
@@ -89,12 +145,13 @@ Deno.test("every non-all file is assigned to exactly one shard", () => {
   for (let index = 1; index <= 4; index++) {
     const selected = selectPatternIntegrationFiles(files, { index, total: 4 });
     for (const path of selected) {
-      if (path === "./integration/all.test.ts") continue;
+      const name = path.replace("./integration/", "");
+      if (INTERNALLY_SHARDED_FILE_NAMES.has(name)) continue;
       counts.set(path, (counts.get(path) ?? 0) + 1);
     }
   }
   for (const file of files) {
-    if (file === "all.test.ts") continue;
+    if (INTERNALLY_SHARDED_FILE_NAMES.has(file)) continue;
     assertEquals(
       counts.get(`./integration/${file}`),
       1,
@@ -103,18 +160,20 @@ Deno.test("every non-all file is assigned to exactly one shard", () => {
   }
 });
 
-Deno.test("every real integration file is covered exactly once across shards", async () => {
+Deno.test("every real integration file follows its sharding contract", async () => {
   // Read the actual integration directory so a file that silently falls out of
   // every shard fails here — CI itself would run green, because a dropped file
   // is simply never executed.
   const files = await listPatternIntegrationTests();
 
   // Guard against the test passing vacuously if the listing breaks.
-  assertEquals(
-    files.includes(ALL_PATTERNS_FILE),
-    true,
-    `expected ${ALL_PATTERNS_FILE} in the integration directory`,
-  );
+  for (const name of INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES) {
+    assertEquals(
+      files.includes(name),
+      true,
+      `expected ${name} in the integration directory`,
+    );
+  }
 
   const shardOf = new Map<string, number[]>();
   for (let index = 1; index <= TOTAL_SHARDS; index++) {
@@ -132,7 +191,7 @@ Deno.test("every real integration file is covered exactly once across shards", a
 
   for (const name of files) {
     const shards = shardOf.get(name) ?? [];
-    if (name === ALL_PATTERNS_FILE) {
+    if (INTERNALLY_SHARDED_FILE_NAMES.has(name)) {
       assertEquals(
         shards,
         [1, 2, 3, 4],

--- a/tasks/select-pattern-integration-files.ts
+++ b/tasks/select-pattern-integration-files.ts
@@ -3,13 +3,17 @@
 import { parseShard } from "./shard-utils.ts";
 export { parseShard };
 
-// `all.test.ts` compiles and instantiates every authored pattern, so its cost
-// grows with the pattern catalog. It runs in EVERY shard and splits its own
-// pattern list by PATTERN_INTEGRATION_SHARD (see
-// packages/patterns/integration/all.test.ts), spreading the compile work across
-// shards instead of pinning it to one. It is therefore excluded from the
-// per-file shard assignment below.
-const ALL_PATTERNS_FILE = "all.test.ts";
+// These files run in every shard and divide their own independent cases by
+// PATTERN_INTEGRATION_SHARD. They are excluded from the per-file assignment
+// below.
+export const INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES = [
+  "all.test.ts",
+  "time-capability-full.test.ts",
+  "time-capability.test.ts",
+] as const;
+const INTERNALLY_SHARDED_FILE_SET = new Set<string>(
+  INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES,
+);
 
 // Explicit assignments balance the four browser-integration shards by
 // wall-time, using observed CI per-file timings. The heaviest end-to-end tests
@@ -17,10 +21,10 @@ const ALL_PATTERNS_FILE = "all.test.ts";
 // cfc-spec-gallery (~33s), cfc-group-chat-demo (~29s), and default-app (~26s);
 // they are spread so no shard carries two of them. The two group-chat browser
 // tests in particular go on different shards (they alone sum to ~70s). Each
-// shard also runs its slice of `all.test.ts` (see above). These weights span
-// ~100x, so a count-based split (hash or plain round-robin) cannot balance them;
-// the table is what keeps the shards even. Files not listed here fall back to
-// round-robin over the unlisted files.
+// shard also runs slices of the internally sharded files above. These weights
+// span ~100x, so a count-based split (hash or plain round-robin) cannot balance
+// them; the table is what keeps the shards even. Files not listed here fall back
+// to round-robin over the unlisted files.
 const FOUR_SHARD_ASSIGNMENTS: Record<string, number> = {
   // shard 1
   "parking-coordinator-admin-view.test.ts": 1,
@@ -51,9 +55,9 @@ const FOUR_SHARD_ASSIGNMENTS: Record<string, number> = {
   "chatbot.test.ts": 4,
 };
 
-// Assign each end-to-end file (everything except `all.test.ts`) to a shard:
-// the explicit table when running the canonical four-way split, else round-robin
-// over the unlisted files so a newly added file still lands somewhere even.
+// Assign each file without internal sharding to one shard: the explicit table
+// when running the canonical four-way split, else round-robin over the unlisted
+// files so a newly added file still lands somewhere even.
 export function assignPatternIntegrationShards(
   files: string[],
   total: number,
@@ -61,7 +65,8 @@ export function assignPatternIntegrationShards(
   const assignment = new Map<string, number>();
   let roundRobin = 0;
   for (
-    const name of files.filter((name) => name !== ALL_PATTERNS_FILE).sort()
+    const name of files.filter((name) => !INTERNALLY_SHARDED_FILE_SET.has(name))
+      .sort()
   ) {
     const pinned = total === 4 ? FOUR_SHARD_ASSIGNMENTS[name] : undefined;
     assignment.set(name, pinned ?? (roundRobin++ % total) + 1);
@@ -69,9 +74,8 @@ export function assignPatternIntegrationShards(
   return assignment;
 }
 
-// Select the files for one shard. `all.test.ts` is included in every shard (it
-// shards its own pattern list internally); the remaining files are assigned to
-// exactly one shard each.
+// Select the files for one shard. Internally sharded files are included in
+// every shard; the remaining files are assigned to exactly one shard each.
 export function selectPatternIntegrationFiles(
   files: string[],
   shard: { index: number; total: number },
@@ -83,11 +87,11 @@ export function selectPatternIntegrationFiles(
     if (assigned === shard.index) selected.push(`./integration/${name}`);
   }
 
-  if (files.includes(ALL_PATTERNS_FILE)) {
-    selected.unshift(`./integration/${ALL_PATTERNS_FILE}`);
-  }
+  const internallySharded = INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES
+    .filter((name) => files.includes(name))
+    .map((name) => `./integration/${name}`);
 
-  return selected;
+  return [...internallySharded, ...selected];
 }
 
 export async function listPatternIntegrationTests(): Promise<string[]> {

--- a/tasks/shard-utils.ts
+++ b/tasks/shard-utils.ts
@@ -11,6 +11,9 @@ export function parseShard(raw: string): Shard {
 
   const index = Number(match[1]);
   const total = Number(match[2]);
+  if (!Number.isSafeInteger(index) || !Number.isSafeInteger(total)) {
+    throw new Error(`Shard values must be safe integers, got: ${raw}`);
+  }
   if (index > total) {
     throw new Error(`Shard index ${index} exceeds total shard count ${total}`);
   }


### PR DESCRIPTION
The full time-capability integration suite runs 56 independent pattern cases. The file selector assigned the entire suite to one Pattern Integration worker. A smaller 11-case capability suite created a second serial block on another worker. Together these additions raised required CI wall time even with warm compile caches.

Introduce a shared PATTERN_INTEGRATION_SHARD parser and item selector. Use it for the existing all-pattern compilation suite and both capability suites. Run those internally sharded files in each of the four existing Pattern Integration jobs, while an unset variable continues to run every case locally.

Extend selector tests to prove that internally sharded files run in every job, ordinary files run in exactly one job, shard slices cover their item list exactly once, and malformed shard notation fails. Document the sharding contract and preserve the investigation evidence in the CI performance history.

Combine equal suite timing metrics from normalized shard artifacts once per workflow run. Keep the longest shard slice as the suite's critical-path duration and retain distinct subtest metrics from every slice. Apply the same aggregation to current runs and historical backfills. Select only the newest unexpired timing artifact for each exact name so rerun attempts cannot contaminate the result.

Verified with repository-wide formatting, linting, and type checking; selector and performance tests; all four real capability shard invocations; and forward-and-reverse adversarial reviews.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shard the pattern capability sweeps across all four Pattern Integration jobs to eliminate single-shard bottlenecks and cut CI wall time. Tighten timing metric aggregation and artifact selection so Performance Check reports stable, accurate suite durations.

- **New Features**
  - Added shared shard parser/selector in `packages/patterns/integration/pattern-integration-shard.ts` using `PATTERN_INTEGRATION_SHARD` ("i/n").
  - Applied internal sharding to `all.test.ts`, `time-capability-full.test.ts`, and `time-capability.test.ts`; they now run in every job, while an unset env runs all cases locally.
  - Updated file selector to always include internally sharded files via `INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES`; other files are assigned to exactly one job. Expanded tests and added sharding docs and the July 2026 CI duration investigation.

- **Bug Fixes**
  - Combined equal suite timing metrics from sharded artifacts once per run, keeping the longest slice as the suite duration and preserving all subtest timings; applied to current runs and backfills.
  - Selected only the newest unexpired `test-timing-*` artifacts per exact name to avoid rerun contamination.
  - Rejected ambiguous shard settings: empty `PATTERN_INTEGRATION_SHARD` now fails, and both shard values must be safe integers (enforced in both the integration and selector parsers), with regression tests added.

<sup>Written for commit 563154d38b57a6da84d627f99e52d8a4e3e3037a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



NEW_PERF_BASELINE: job: Pattern Integration Tests (2/4) = 251s
NEW_PERF_BASELINE: job: Pattern Integration Tests (4/4) = 264s
