### PR TITLE
Ci duration reduction

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -52,10 +52,6 @@ jobs:
       - name: 🔎 Type check codebase
         run: deno task check
 
-      # --no-check: the type-check step above covers tasks/ (tasks/check.sh).
-      - name: 🧪 Run tasks/ unit tests
-        run: deno test --no-check --allow-read --allow-write --allow-env --allow-run tasks/
-
       - name: 🧭 Check skill facts
         run: deno task check-skill-facts
 
@@ -131,9 +127,6 @@ jobs:
           packages: pkg-config gcc libfuse3-dev fuse3
           cache-key: cfc-pattern-check
 
-      - name: 📥 Download Deno dependency binaries
-        run: deno task initialize-db
-
       # For deno-web-test browser tests
       # https://github.com/lino-levan/astral/blob/f5ef833b2c5bde3783564a6b925073d5d46bb4b8/README.md#no-usable-sandbox-with-user-namespace-cloning-enabled
       - name: 🛡️ Disable AppArmor for browser tests
@@ -145,11 +138,6 @@ jobs:
           DENO_COVERAGE_DIR: coverage/raw/workspace-${{ matrix.shard }}
           TEST_DISABLED_PACKAGES: runner
           TEST_SHARD: "${{ matrix.shard }}/${{ matrix.total }}"
-          # One package at a time: a package's own test task already
-          # parallelizes across all of this runner's cores, and cross-package
-          # concurrency destabilizes the timing-sensitive CLI pseudo-terminal
-          # tests (see docs/development/CI_PERFORMANCE.md).
-          TEST_CONCURRENCY: "1"
 
       - name: 🧾 Write coverage report
         if: always()
@@ -613,15 +601,17 @@ jobs:
       # This input list mirrors COMPILE_FINGERPRINT_INPUTS in
       # packages/runner/src/compilation-cache/compiler-fingerprint.deno.ts, which
       # fingerprints the same set for the durable runtime cache; the
-      # compiler-fingerprint test fails if the two drift. The pattern-source hash
-      # rolls the key while `restore-keys` still seeds from the most recent prior
-      # cache.
+      # compiler-fingerprint test fails if the two drift. The pattern-source and
+      # integration-harness hash rolls the key while `restore-keys` still seeds
+      # from the most recent prior cache. Hash both TypeScript extensions. An
+      # exact actions/cache entry is immutable; newly compiled bytes are saved
+      # under a rotated key.
       - name: ♻️ Restore/save compile byte cache
         id: compile-cache
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json
-          key: cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-${{ hashFiles('packages/patterns/**/*.tsx') }}
+          key: cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-${{ hashFiles('packages/patterns/**/*.ts', 'packages/patterns/**/*.tsx') }}
           restore-keys: |
             cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-
 

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -179,20 +179,23 @@ its packages with `DENO_COVERAGE_DIR` and uploads it as
 The root task is `tasks/test.ts`. It reads the workspace list from
 `deno.jsonc`, selects this shard's packages by round-robin over the sorted
 package-name list (`selectShardMembers`), and runs `deno task test` in every
-selected package, at most `TEST_CONCURRENCY` (default: half the cores) at a
-time to keep contention-sensitive tests stable. Each shard's wall time is set
-by the slowest package test task in the shard, plus the fixed setup and
-coverage report steps around it. When a package fails, the runner prints that
-package's captured output immediately and stops starting new package tests.
-Package tests that are already running finish before the summary is printed.
+selected package. The test runner uses half the available cores for package
+workers. This is two package workers on the standard four-core CI runner.
+`TEST_CONCURRENCY` can override that default for a diagnostic run. Each shard's
+test time follows the longest chain of package tasks assigned to one worker,
+plus initialization inside the root task. Fixed workflow setup and coverage
+reporting sit outside that test step. When a package fails, the runner prints
+that package's captured output immediately and stops starting new package
+tests. Package tests that are already running finish before the summary is
+printed.
 
 When a shard becomes the long pole, start with the `Package timings:` block
 printed by `tasks/test.ts`. The round-robin split carries no per-package
-weighting, so first check whether one shard simply drew several slow packages;
-changing the shard count in the workflow matrix reshuffles the assignment.
-A shard-count change must also update the `coverage-profile-workspace-*`
-entries in `EXPECTED_COVERAGE_ARTIFACT_NAMES` in `tasks/perf-check.ts`, which
-the Performance Check gate uses to require every shard's coverage artifact.
+weighting, so first check whether one shard simply drew several slow packages.
+Changing the shard count in the workflow matrix reshuffles the assignment. A
+shard-count change must also update the `coverage-profile-workspace-*` entries
+in `EXPECTED_COVERAGE_ARTIFACT_NAMES` in `tasks/perf-check.ts`, which the
+Performance Check gate uses to require every shard's coverage artifact.
 
 A package too heavy for any single shard can be split internally: the cli
 package runs as three units via `CLI_TEST_SHARD` (see
@@ -258,6 +261,14 @@ timing gate would trip against warm baselines. The other direction is just as
 bad: a cold main run covers compile branches that only execute on a cold cache,
 which lowers the coverage-debt baseline, so later warm PRs fail the coverage
 ratchet with phantom uncovered lines.
+
+The pattern-integration process owns one shared cache in
+`packages/patterns/integration/pieces-controller.ts`. Its controller helper and
+the capability-gate controller both inject that cache into every runtime they
+create. A custom runtime in this suite must do the same. Setting
+`CF_COMPILE_CACHE_FILE` only tells the test-support cache where to persist its
+bytes; a runtime uses those bytes only when it receives the cache through its
+`moduleByteCache` option.
 
 To compare like with like, each pattern job uploads a small `cache-state-*`
 artifact recording its cache restore result. Performance Check aggregates those

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -217,6 +217,9 @@ One line per archived document; each document's header carries the fuller
 - [2026-07-pattern-capability-ci-duration-increase.md](development/performance/2026-07-pattern-capability-ci-duration-increase.md)
   — root cause of the July 2026 labs CI duration increase: two unsharded
   pattern time-capability sweeps, especially the 56-pattern sweep on shard 3.
+- [2026-07-ci-duration-profile.md](development/performance/2026-07-ci-duration-profile.md)
+  — July 2026 Deno Workflow profile, including compile-cache validation,
+  duplicate work, workspace shard balance, and follow-up experiments.
 - [scoped-cells-field-notes.md](development/scoped-cells-field-notes.md) —
   field journal from the first scoped-cell patterns.
 - [2026-07-02-convergence-evidence-appendix.md](plans/2026-07-02-convergence-evidence-appendix.md)

--- a/docs/history/development/performance/2026-07-ci-duration-profile.md
+++ b/docs/history/development/performance/2026-07-ci-duration-profile.md
@@ -1,0 +1,357 @@
+---
+status: historical
+created: 2026-07-18
+archived: 2026-07-18
+reason: "Profiling snapshot and remediation record for the July 2026 Deno Workflow CI duration audit."
+---
+
+# Deno Workflow CI duration profile, July 2026
+
+## Conclusion
+
+The starting `main` run was
+[`29671969142`](https://github.com/commontoolsinc/labs/actions/runs/29671969142).
+It took 9 minutes 28 seconds. Pull request
+[`4832`](https://github.com/commontoolsinc/labs/pull/4832) then ran commit
+`cc5b1e659` twice. The retry used the same source and completed successfully.
+
+| Run | Workflow elapsed | Slowest pattern integration job | Slowest workspace job | Slowest runner job | Check job |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Starting `main` | 9m 28s | 5m 01s | 4m 20s | 3m 55s | 2m 15s |
+| PR attempt 1 | 6m 39s | 4m 57s | 4m 06s | 3m 55s | 2m 06s |
+| PR attempt 2 | 6m 59s | 5m 02s | 3m 36s | 4m 04s | 2m 14s |
+
+Setup was not the main cost. Most test jobs spent 20 to 40 seconds outside
+their main test step. Pattern compilation, transformer tests, schema-generator
+tests, and runner tests accounted for most of the useful work.
+
+The branch CI validated these results:
+
+- Removing the duplicate `tasks/` test step removed 14 seconds of Check-job
+  work. The whole Check job still varied from 126 to 134 seconds.
+- Removing the duplicate dependency initializer saved no measurable time. Its
+  visible step took zero or one second.
+- The package shard pins shortened the workspace maximum by 17.7 seconds in
+  attempt 1 and 6.0 seconds in attempt 2. They saved no workflow time because
+  pattern integration remained slower. The pins and their contract test were
+  removed after this result.
+- Injecting the compile cache into the capability tests did not shorten either
+  CI attempt. The restored cache key did not include pattern `.ts` files, so an
+  exact immutable Actions cache could not learn the branch's new compiled
+  modules. The key now covers `.ts` and `.tsx` sources.
+
+Attempt 1 failed only the coverage-debt gate. It reported 238,065 uncovered
+`packages/patterns` lines. Attempt 2 reported 238,061 lines from the same commit
+and passed. The four-line change came from coverage collection rather than a
+source change, so the coverage gate has a small nondeterministic boundary.
+
+The CI results led to four follow-up changes that were not present in
+`cc5b1e659`: repair the pattern-integration cache key, use two workspace package
+workers, rebalance pattern integration from the uploaded per-file timings, and
+move transformer type checking from the workspace shard to the concurrent
+Check job. A later CI run must measure those follow-up changes directly.
+
+## What was measured
+
+GitHub's Actions API supplied job and step durations for the starting run and
+its recent predecessors. The PR logs supplied exact workspace package timings.
+The PR's JUnit and performance artifacts supplied the per-test timings and
+cache state for both attempts.
+
+The local measurements included:
+
+- all five runner shards with JUnit output and without coverage;
+- all six workspace shards with coverage and one package worker, matching CI's
+  serial scheduling;
+- every pattern capability shard with an empty compile cache and then with the
+  cache produced by that first run; and
+- a V8 CPU sample of a capability shard.
+
+The workspace profiles used the local Deno 2.8.3 installation while the
+repository pinned 2.8.1. Restricted loopback or storage access ended `shell`
+early on shard 1, `ui` and `background-piece-service` on shard 2, `static` on
+shard 3, and the first CLI slice and one coverage fixture in `tasks` on shard
+4. The moved `fuse` and `cf-harness` packages completed. The aggregate shard
+figures below are useful assignment weights, not successful end-to-end
+benchmarks.
+
+The CPU sample's JavaScript frames were concentrated in TypeScript scanning and
+name resolution, the compiled-module parser, and the JSX expression-site
+transformer. The native symbols did not match the local V8 build, so they were
+not used. This agrees with the earlier
+[pattern-integration compiler profile](pattern-integration-compile-bound.md):
+compilation is the useful optimization target, not emulated storage or runtime
+synchronization.
+
+## The capability sweeps did not use the restored cache
+
+The workflow restored a per-shard compile-cache file and set
+`CF_COMPILE_CACHE_FILE`. The two capability test files constructed `Runtime`
+directly without passing the shared `moduleByteCache`. Setting the environment
+variable selected a persistence file, but no runtime read or wrote it. Before
+the fix, a complete capability shard did not create the configured cache file.
+
+The Performance Check still called the pattern-integration family warm when
+the Actions cache had restored a file. Its cache-state artifact records whether
+the file was restored, not whether every runtime in the test process used it.
+Other integration tests populated the file, so this looked healthy from the
+workflow level while the new expensive sweeps compiled every pattern again.
+
+Both sweeps now use one capability-gate controller helper. That helper injects
+the same process-wide byte cache used by the other pattern-integration
+controllers. All four shards then produced cache files of about 3.3 MB.
+
+| Capability shard | Empty cache | Reused cache | Reduction |
+| --- | ---: | ---: | ---: |
+| 1 | 14s | 5s | 64% |
+| 2 | 14s | 6s | 57% |
+| 3 | 8s | 3s | 63% |
+| 4 | 11s | 4s | 64% |
+
+The two PR attempts did not reproduce that local reduction. All four cache
+state artifacts reported exact hits in both attempts, but the capability suite
+times remained in the same range:
+
+| Suite maximum | Attempt 1 | Attempt 2 |
+| --- | ---: | ---: |
+| Full discovered-pattern sweep | 106.1s | 101.5s |
+| Curated allowed-and-rejected suite | 35.6s | 36.6s |
+
+The source-side cache key hashed only `packages/patterns/**/*.tsx`. The branch
+changed capability controllers and tests in `.ts` files. Actions caches cannot
+replace an existing exact-key entry, so each job restored the old cache, added
+the missing modules in its workspace, and then could not save the augmented
+file under that key. The key now hashes both TypeScript extensions. Its prefix
+still restores the preceding cache as a starting point. A new commit can save
+the augmented cache under the new exact key.
+
+The previously shipped
+[`d0c5264d2`](https://github.com/commontoolsinc/labs/commit/d0c5264d2750a2c9fff7a8f08e15c730c4977d0c)
+change that divides the capability sweeps across all four jobs is useful. It
+removed the earlier concentration of the full sweep in one job. The cache
+injection fixes a separate problem inside each divided slice.
+
+## The Check job repeated the workspace task tests
+
+The standalone `tasks/` test step predated `tasks` becoming a root workspace
+member. Once it became a member, workspace shard 4 ran the same tests again and
+collected their coverage. The latest Check job spent 14 seconds on the
+standalone copy. Removing that step preserves both execution and coverage in
+the workspace job.
+
+No individual behavioral test was removed. The audit did not find evidence
+that the full capability sweep or the curated capability suite was useless.
+The full sweep protects every discovered pattern. The curated suite keeps
+explicit allowed and rejected examples. Their duplicated compilation was the
+waste.
+
+The curated suite also repeats the battleship, card-piles, and scrabble cases
+from the full sweep. They consumed about 16.5 seconds of aggregate CI test time
+in attempt 2. They did not extend the slowest shard, and they make a direct run
+of the curated file cover the handler-only game cases. They were retained. The
+compile cache should make their second compilation inexpensive once the cache
+key repair has run.
+
+## Workspace package pins did not improve the workflow
+
+The first local profile suggested moving `fuse` from shard 1 to shard 5 and
+`cf-harness` from shard 3 to shard 2. The PR logs made it possible to replay the
+round-robin assignment with the exact package times from each CI attempt.
+
+| Attempt | Maximum with pins | Round-robin maximum | Workspace-only gain | Workflow gain |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 212.7s | 230.4s | 17.7s, or 7.7% | 0s |
+| 2 | 191.8s | 197.8s | 6.0s, or 3.0% | 0s |
+
+The `cf-harness` move did not change the maximum in either attempt. The `fuse`
+move produced all of the workspace-only gain. Pattern integration was still at
+least 51 seconds slower than the workspace matrix, so neither pin shortened the
+workflow. The fixed six-shard table, its topology-specific name, and its
+36-line contract test were removed. Workspace packages again use the ordinary
+sorted round-robin rule.
+
+## The serial workspace override protected a test that was already fixed
+
+An earlier six-shard trial ran two packages concurrently. Five workspace jobs
+passed. Shard 3 failed the task-runner test named `runTests passes internal
+shard environment to expanded packages`. Two mock CLI commands appended their
+markers to the same file. The failing assertion received
+`shard=3/3shard=1/3` when it expected two separate lines. The failure was in the
+test's assumption about concurrent file writes, not in a package under test.
+
+The six workspace test steps in that CI run took 90, 58, 43, 138, 96, and 143
+seconds in shard order. Shard 3 stopped at 43 seconds on the test failure. The
+other five completed successfully with two package workers. These durations
+come from an earlier revision, so they establish that two-worker CI operates
+successfully but are not a direct speed comparison with this pull request.
+
+The merged test already selects a workspace shard containing one CLI slice and
+uses one writer. No recorded CI package failure therefore supports keeping
+`TEST_CONCURRENCY=1`. Scheduling the two PR attempts' package timings through
+two workers gives these estimates after removing the package pins:
+
+| Attempt | Serial round-robin maximum | Two-worker estimate | Estimated gain |
+| --- | ---: | ---: | ---: |
+| 1 | 230.4s | 180.8s | 49.6s |
+| 2 | 197.8s | 153.6s | 44.2s |
+
+CI now uses the package runner's half-core default. That is two workers on a
+standard four-core runner. `TEST_CONCURRENCY` remains available for a diagnostic
+override.
+
+## The four-shard pattern table has repeatable critical-path value
+
+The pattern assignment table was evaluated with the same counterfactual used
+for the workspace table. The observed per-file JUnit durations were kept fixed.
+The files were then assigned by the old table, the current table, or sorted
+round-robin with no table. Each shard kept its observed internally sharded work
+and non-test job overhead.
+
+| Run | Observed old-table maximum | Current-table model | No-table model | Current table versus no table |
+| --- | ---: | ---: | ---: | ---: |
+| Starting `main` | 301.0s | 281.9s | 295.7s | 13.8s, or 4.7% |
+| PR attempt 1 | 297.0s | 276.0s | 291.6s | 15.5s, or 5.3% |
+| PR attempt 2 | 302.0s | 281.4s | 296.3s | 14.9s, or 5.0% |
+
+Pattern integration remained the critical job after each modeled assignment.
+The current table therefore has an estimated workflow benefit of 13.8 to 15.5
+seconds when downstream work is unchanged. These are counterfactuals built
+from actual CI timings, not separate workflow runs.
+
+Three earlier timing-artifact sets from runs
+[`29667152509`](https://github.com/commontoolsinc/labs/actions/runs/29667152509),
+[`29662362384`](https://github.com/commontoolsinc/labs/actions/runs/29662362384),
+and
+[`29661808609`](https://github.com/commontoolsinc/labs/actions/runs/29661808609)
+provided an out-of-sample check. The current table reduced their slowest test
+step by 13.4, 8.3, and 3.3 seconds compared with no table. The last run was
+dominated by about 380 seconds of internally sharded work on shard 3, so
+ordinary file placement had little leverage. The table did not lose to sorted
+round-robin in any of the six measured timing sets.
+
+Three ordinary files appeared among the four heaviest in every recent run:
+`cf-code-editor`, `home-profile`, and `convergence-storm`. The remaining
+top-four member alternated between `default-app` and
+`home-rehydration-churn`. Sorted round-robin puts `cf-code-editor` and
+`convergence-storm` together on shard 1. That shard also has the consistently
+heaviest internally sharded slice. The table separates that collision. It
+keeps every known assignment stable when a new unlisted file is added.
+
+The old table's comments no longer described the expensive files. That table
+was 5.3, 5.4, and 5.7 seconds slower than deleting the table in the three
+principal timing sets. Moving `profile-embed` from shard 1 to shard 3 and
+`cfc-authorized-save` from shard 1 to shard 4 shortened the modeled critical job
+by 19.1 seconds on starting `main`, 21.0 seconds on PR attempt 1, and 20.6
+seconds on PR attempt 2. The changes turned the table from a regression into a
+repeatable critical-path improvement.
+
+Every currently measured ordinary integration file is now fixed in the
+assignment table. A new file falls back to round-robin over the unlisted files
+until a later profile supplies its weight.
+
+`FOUR_SHARD_ASSIGNMENTS` accurately names the table's validity constraint. The
+partition has no measured meaning for another shard count, and the selector
+consults it only when the total is four. The module name already supplies the
+pattern-integration context. A generic name would suggest that the assignments
+remain valid at other counts. If CI gains another profiled shard count, the
+representation should become a map keyed by the count before the name becomes
+generic.
+
+The explicit table is maintenance work, but unlike the removed workspace table
+it reduces the workflow's critical path. Its contract tests verify that the
+profiled round-robin collision remains separated, explicit entries still name
+real files, every ordinary file appears exactly once, and each internally
+sharded file runs on all four shards. A heuristic retune could improve the three
+principal runs by another 5.3 to 11.3 seconds. The same retune made the slowest
+test step in an earlier cold run 19.2 seconds slower, so it was rejected as an
+overfit rather than added to this branch.
+
+## Transformer setup is repeated hundreds of times
+
+`ts-transformers` was the largest workspace package in both attempts. It took
+162.4 seconds and 135.1 seconds. A coverage-enabled local run took 27.7 seconds
+with Deno's pre-test type check and 23.9 seconds without it. Checking the source
+and all test entry points directly took 1.3 seconds. Those paths now run in the
+concurrent Check job, and the package test uses `--no-check`.
+
+The transformer tests contain 307 calls or helper definitions named
+`createProgram`. The slow local files repeatedly construct a fresh TypeScript
+program for small source snippets. The largest file totals were 10.7 seconds
+for `destructuring-lowering-coverage`, 9.5 seconds for
+`array-method-utils-coverage`, and 9.3 seconds for `ast/utils-coverage`.
+Grouping independent snippets into shared virtual programs is the next
+runtime-code experiment. It needs a separate correctness review because some
+tests intentionally depend on isolated compiler state.
+
+## Runner sharding is already adequate
+
+The five local runner shards took 38.0, 35.8, 41.4, 44.3, and 32.9 seconds.
+The slowest test-file totals were 30.4 seconds on shard 4 and 21.0 seconds on
+shard 5. Moving files could save only several local seconds, and the existing
+CI policy stops when the expected gain is under about 30 seconds. More runner
+sharding would add setup and coverage artifacts without addressing the common
+compiler cost. No runner assignment changed.
+
+## Redundant workspace initialization was neutral machinery
+
+Each workspace job had a visible `deno task initialize-db` step. The root
+`deno task test` entry point then invoked the same task before selecting
+packages. The visible step took zero or one second in each measured job. The
+root entry point remains responsible for initialization, so local and CI test
+runs keep one self-contained contract.
+
+## Binary distribution is the next setup experiment
+
+The build job uploads `toolshed`, `bg-piece-service`, and `cf` as one
+`common-binaries` artifact. The measured artifact was 254,598,871 bytes.
+Downstream jobs always download all three binaries even when they use only
+one.
+
+Local binary sizes were 333 MB for `toolshed`, 253 MB for `cf`, and 247 MB for
+`bg-piece-service`. Their individual gzip sizes were about 91 MB, 72 MB, and
+71 MB. Pattern integration and package integration need only `toolshed`.
+Pattern unit tests need only `cf`. CLI integration needs `toolshed` and `cf`.
+The measured download step took 10 to 16 seconds on pattern-integration jobs,
+and one CLI job took 43 seconds.
+
+A useful next experiment is to build and upload one artifact per binary in
+parallel jobs. Each consumer could depend only on the binaries it uses. The
+experiment must include upload and job-start overhead because three serial
+upload steps in the existing build job could erase the download gain. Another
+option is to run the source Toolshed in most integration shards and retain one
+built-binary smoke test. That would remove the build dependency from those
+shards, but it changes what those tests cover and needs a direct comparison.
+
+## Further improvements
+
+The next CI run should measure the cache-key repair, two-worker workspace
+schedule, pattern-integration rebalance, and transformer `--no-check` change as
+separate step and package timings. The cache repair needs two observations: a
+new commit that saves an augmented key and a rerun that restores that exact
+key.
+
+Further experiments supported by the current data are:
+
+- Record compile-cache reads, writes, and misses for every test process. Mark a
+  job family warm only when its expensive runtimes report cache use.
+- Upload workspace package timings as structured data rather than recovering
+  them from logs. Keep accepted fixed assignments in source only when they
+  reduce the workflow's critical path across repeated runs.
+- Reuse TypeScript programs across compatible transformer test cases. The
+  repeated program construction is both runtime work and test setup work.
+- Split `common-binaries` by consumer and run the build paths concurrently.
+  Compare the current 25-second artifact upload and 6-to-14-second downstream
+  downloads against the extra job-start and upload costs.
+- Make the coverage-debt gate tolerate or eliminate the observed four-line
+  collection variance without allowing actual uncovered source growth.
+- Profile the shared TypeScript and transformer pipeline with matching V8
+  symbols. Improvements there apply to pattern integration, runner tests,
+  generated patterns, pattern unit tests, and `cf check`.
+
+There are also polling waits and retry sleeps in CI support code, including
+`.github/actions/deno-install/action.yml`,
+`.github/actions/wait-for-toolshed/action.yml`, and `tasks/perf-lib.ts`. They
+either delay failure or make progress depend on elapsed time. A focused follow-up
+should replace them with observable readiness or a single surfaced failure.
+Start a dedicated agent for that change because it needs its own failure-mode
+review; it was not mixed into these duration changes.

--- a/packages/patterns/integration/capability-gate-controller.ts
+++ b/packages/patterns/integration/capability-gate-controller.ts
@@ -1,0 +1,28 @@
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { PieceManager } from "@commonfabric/piece";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { moduleByteCache } from "./pieces-controller.ts";
+
+export async function initializeCapabilityGateController(
+  spaceName: string,
+): Promise<PiecesController> {
+  const identity = await Identity.generate({ implementation: "noble" });
+  const session = await createSession({ identity, spaceName });
+  const runtime = new Runtime({
+    apiUrl: new URL(
+      Deno.env.get("API_URL") ?? "http://localhost:8000/",
+    ),
+    storageManager: StorageManager.emulate({ as: session.as }),
+    moduleByteCache,
+    cfcEnforcementMode: "enforce-explicit",
+    trustSnapshotProvider: () => ({
+      id: `principal:${session.as.did()}`,
+      actingPrincipal: session.as.did(),
+    }),
+  });
+  const manager = new PieceManager(session, runtime);
+  await manager.synced();
+  return new PiecesController(manager);
+}

--- a/packages/patterns/integration/time-capability-full.test.ts
+++ b/packages/patterns/integration/time-capability-full.test.ts
@@ -14,16 +14,12 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { join } from "@std/path";
-import { createSession, Identity } from "@commonfabric/identity";
-import { Runtime } from "@commonfabric/runner";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { PieceManager } from "@commonfabric/piece";
-import { PiecesController } from "@commonfabric/piece/ops";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import {
   currentPatternIntegrationShard,
   selectPatternIntegrationShard,
 } from "./pattern-integration-shard.ts";
+import { initializeCapabilityGateController } from "./capability-gate-controller.ts";
 
 const ROOT = join(import.meta.dirname!, "..");
 
@@ -67,23 +63,6 @@ function discoverPatterns(): string[] {
   return hits.sort();
 }
 
-async function gatedController(spaceName: string): Promise<PiecesController> {
-  const identity = await Identity.generate({ implementation: "noble" });
-  const session = await createSession({ identity, spaceName });
-  const runtime = new Runtime({
-    apiUrl: new URL("http://localhost:8000/"),
-    storageManager: StorageManager.emulate({ as: session.as }),
-    cfcEnforcementMode: "enforce-explicit",
-    trustSnapshotProvider: () => ({
-      id: `principal:${session.as.did()}`,
-      actingPrincipal: session.as.did(),
-    }),
-  });
-  const manager = new PieceManager(session, runtime);
-  await manager.synced();
-  return new PiecesController(manager);
-}
-
 interface Outcome {
   timeCapabilityErrors: string[];
   skipReason?: string;
@@ -92,7 +71,9 @@ interface Outcome {
 // Instantiate the pattern under the gate, materialize lifts, then fire every
 // top-level result stream to exercise handler-context clock reads too.
 async function checkPattern(rel: string): Promise<Outcome> {
-  const cc = await gatedController(`${rel}-${crypto.randomUUID()}`);
+  const cc = await initializeCapabilityGateController(
+    `${rel}-${crypto.randomUUID()}`,
+  );
   const errors: string[] = [];
   cc.manager().runtime.scheduler.onError((err) => {
     if (err?.name === "TimeCapabilityError") errors.push(err.message);

--- a/packages/patterns/integration/time-capability.test.ts
+++ b/packages/patterns/integration/time-capability.test.ts
@@ -18,42 +18,22 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { join } from "@std/path";
-import { createSession, Identity } from "@commonfabric/identity";
-import { Runtime } from "@commonfabric/runner";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { PieceManager } from "@commonfabric/piece";
-import { PiecesController } from "@commonfabric/piece/ops";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import {
   currentPatternIntegrationShard,
   selectPatternIntegrationShard,
 } from "./pattern-integration-shard.ts";
+import { initializeCapabilityGateController } from "./capability-gate-controller.ts";
+import { moduleByteCache } from "./pieces-controller.ts";
 
 const ROOT = join(import.meta.dirname!, "..");
-
-// Mirror of PiecesController.initialize() but with in-memory (offline) storage
-// and the time gate enabled — initialize() exposes no experimental hook.
-async function gatedController(spaceName: string): Promise<PiecesController> {
-  const identity = await Identity.generate({ implementation: "noble" });
-  const session = await createSession({ identity, spaceName });
-  const runtime = new Runtime({
-    apiUrl: new URL("http://localhost:8000/"),
-    storageManager: StorageManager.emulate({ as: session.as }),
-    cfcEnforcementMode: "enforce-explicit",
-    trustSnapshotProvider: () => ({
-      id: `principal:${session.as.did()}`,
-      actingPrincipal: session.as.did(),
-    }),
-  });
-  const manager = new PieceManager(session, runtime);
-  await manager.synced();
-  return new PiecesController(manager);
-}
 
 // Instantiate a pattern with the gate on, materialize its lifts, and return the
 // messages of any TimeCapabilityErrors the scheduler reported.
 async function timeCapabilityErrors(rel: string): Promise<string[]> {
-  const cc = await gatedController(`${rel}-${crypto.randomUUID()}`);
+  const cc = await initializeCapabilityGateController(
+    `${rel}-${crypto.randomUUID()}`,
+  );
   const errors: string[] = [];
   cc.manager().runtime.scheduler.onError((err) => {
     if (err?.name === "TimeCapabilityError") errors.push(err.message);
@@ -153,6 +133,19 @@ const CAPABILITY_CASES: CapabilityCase[] = [
       expect(errors).toEqual([]);
     },
   })),
+  {
+    name: "uses the process-wide pattern integration compile cache",
+    run: async () => {
+      const cc = await initializeCapabilityGateController(
+        `compile-cache-${crypto.randomUUID()}`,
+      );
+      try {
+        expect(cc.manager().runtime.moduleByteCache).toBe(moduleByteCache);
+      } finally {
+        await cc.dispose();
+      }
+    },
+  },
 ];
 
 describe("capability gate (W1): patterns read the clock only in handlers", () => {

--- a/packages/ts-transformers/deno.jsonc
+++ b/packages/ts-transformers/deno.jsonc
@@ -13,7 +13,7 @@
     "typescript": "npm:typescript@6.0.3"
   },
   "tasks": {
-    "test": "deno test --parallel --allow-read --allow-write --allow-env test/**/*.test.ts",
+    "test": "deno test --no-check --parallel --allow-read --allow-write --allow-env test/**/*.test.ts",
     "check": "deno check src/**/*.ts",
     "fmt": "deno fmt src/ test/**/*.test.ts",
     "lint": "deno lint src/ test/"

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -98,6 +98,7 @@ DIRS=(
   "packages/static/scripts"
   "packages/static/test"
   "packages/toolshed"
+  "packages/ts-transformers/src"
   "packages/utils"
   "packages/patterns/battleship"
   "packages/patterns/budget-tracker"
@@ -124,6 +125,10 @@ FILES_TO_CHECK+=(packages/cli/*.ts)
 FILES_TO_CHECK+=(packages/static/*.ts)
 FILES_TO_CHECK+=(packages/patterns/*.ts)
 FILES_TO_CHECK+=(packages/patterns/*.tsx)
+
+while IFS= read -r testFile; do
+  FILES_TO_CHECK+=("${testFile}")
+done < <(find packages/ts-transformers/test -type f -name '*.test.ts' -print)
 
 # Google patterns (previously checked individually to avoid OOM, now included
 # with increased heap limit)

--- a/tasks/perf-cache-state.test.ts
+++ b/tasks/perf-cache-state.test.ts
@@ -147,6 +147,23 @@ Deno.test("COMPILE_CACHE_KEY_GLOBS matches the cc-* cache keys in deno.yml", asy
   }
 });
 
+Deno.test("pattern integration cache rotates for .ts and .tsx changes", async () => {
+  const workflow = await Deno.readTextFile(
+    new URL("../.github/workflows/deno.yml", import.meta.url),
+  );
+  const start = workflow.indexOf("  pattern-integration-test:\n");
+  const end = workflow.indexOf("\n  pattern-reload-integration-test:", start);
+  assert(start >= 0 && end > start, "pattern integration job not found");
+
+  const job = workflow.slice(start, end);
+  assert(
+    job.includes(
+      "hashFiles('packages/patterns/**/*.ts', 'packages/patterns/**/*.tsx')",
+    ),
+    "pattern integration cache must rotate when either TypeScript extension changes",
+  );
+});
+
 Deno.test("changedPathsOf surfaces both sides of a rename", () => {
   const paths = changedPathsOf([
     {

--- a/tasks/select-pattern-integration-files.test.ts
+++ b/tasks/select-pattern-integration-files.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import {
   assignPatternIntegrationShards,
+  FOUR_SHARD_ASSIGNMENTS,
   INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES,
   listPatternIntegrationTests,
   selectPatternIntegrationFiles,
@@ -130,37 +131,38 @@ Deno.test("pattern integration shard rejects unsafe integer values", () => {
   }
 });
 
-Deno.test("pattern integration four-way shard keeps the heaviest tests apart", () => {
-  const heavy = [
-    "parking-coordinator-admin-view.test.ts",
-    "cfc-group-chat-demo-two-browsers.test.ts",
-    "cfc-spec-gallery.test.ts",
-    "cfc-group-chat-demo.test.ts",
-  ];
-  const assignment = assignPatternIntegrationShards(heavy, TOTAL_SHARDS);
-  const shardOf = (file: string) => assignment.get(file);
-
-  // The two group-chat browser tests are the heaviest end-to-end tests on CI
-  // (~41s for two-browsers, ~29s for the single-browser one). They must not
-  // share a shard, or that shard carries ~70s of group-chat work alone.
-  assertEquals(
-    shardOf("cfc-group-chat-demo-two-browsers.test.ts") !==
-      shardOf("cfc-group-chat-demo.test.ts"),
-    true,
-    "the two group-chat browser tests must be on different shards",
+Deno.test("pattern integration profile separates the round-robin shard-one collision", async () => {
+  const files = (await listPatternIntegrationTests()).filter((name) =>
+    !INTERNALLY_SHARDED_FILE_NAMES.has(name)
   );
-
-  // The three heaviest single files land on distinct shards.
-  const top = [
-    "parking-coordinator-admin-view.test.ts",
-    "cfc-group-chat-demo-two-browsers.test.ts",
-    "cfc-spec-gallery.test.ts",
-  ].map(shardOf);
-  assertEquals(
-    new Set(top).size,
-    3,
-    "the three heaviest tests should be on distinct shards",
+  const roundRobin = new Map(
+    files.toSorted().map((name, index) => [name, index % TOTAL_SHARDS + 1]),
   );
+  const assignment = assignPatternIntegrationShards(files, TOTAL_SHARDS);
+  const cfCodeEditor = "cf-code-editor.test.ts";
+  const convergenceStorm = "convergence-storm.test.ts";
+
+  assertEquals(
+    roundRobin.get(cfCodeEditor),
+    roundRobin.get(convergenceStorm),
+    "the sorted round-robin control should reproduce the profiled collision",
+  );
+  assertEquals(
+    assignment.get(cfCodeEditor) === assignment.get(convergenceStorm),
+    false,
+    "the profiled assignment should separate the two expensive files",
+  );
+});
+
+Deno.test("profiled pattern integration assignments name real files", async () => {
+  const files = new Set(await listPatternIntegrationTests());
+  for (const name of Object.keys(FOUR_SHARD_ASSIGNMENTS)) {
+    assertEquals(
+      files.has(name),
+      true,
+      `profiled assignment ${name} should name a real integration test`,
+    );
+  }
 });
 
 Deno.test("internally sharded files run in every shard", () => {

--- a/tasks/select-pattern-integration-files.ts
+++ b/tasks/select-pattern-integration-files.ts
@@ -15,44 +15,52 @@ const INTERNALLY_SHARDED_FILE_SET = new Set<string>(
   INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES,
 );
 
-// Explicit assignments balance the four browser-integration shards by
-// wall-time, using observed CI per-file timings. The heaviest end-to-end tests
-// are parking-coordinator (~43s), cfc-group-chat-demo-two-browsers (~41s),
-// cfc-spec-gallery (~33s), cfc-group-chat-demo (~29s), and default-app (~26s);
-// they are spread so no shard carries two of them. The two group-chat browser
-// tests in particular go on different shards (they alone sum to ~70s). Each
-// shard also runs slices of the internally sharded files above. These weights
-// span ~100x, so a count-based split (hash or plain round-robin) cannot balance
-// them; the table is what keeps the shards even. Files not listed here fall back
-// to round-robin over the unlisted files.
-const FOUR_SHARD_ASSIGNMENTS: Record<string, number> = {
+// Explicit assignments balance the canonical four browser-integration shards
+// using observed CI per-file timings. Files added after the latest profile fall
+// back to round-robin over the unlisted files.
+export const FOUR_SHARD_ASSIGNMENTS: Readonly<Record<string, number>> = {
   // shard 1
   "parking-coordinator-admin-view.test.ts": 1,
-  "cfc-authorized-save.test.ts": 1,
   "nested-counter.test.ts": 1,
   "chat-note.test.ts": 1,
   "fetch-json.test.ts": 1,
-  "profile-embed.test.ts": 1,
+  "cell-flip-shaping.test.ts": 1,
+  "cf-code-editor.test.ts": 1,
+  "home-profile-reload-durability.test.ts": 1,
+  "sqlite-db-owner-multi-runtime.test.ts": 1,
 
   // shard 2
   "cfc-group-chat-demo-two-browsers.test.ts": 2,
   "cfc-staged-publish.test.ts": 2,
   "cfc-group-chat-demo-multi-runtime.test.ts": 2,
   "cfc-authorship-chat.test.ts": 2,
+  "cellset-lww-lost-update.test.ts": 2,
+  "cf-render.test.ts": 2,
+  "home-rehydration-churn.test.ts": 2,
+  "sqlite-read-clearance-multi-runtime.test.ts": 2,
 
   // shard 3
   "cfc-spec-gallery.test.ts": 3,
   "shared-profile.test.ts": 3,
   "cfc-render-policy-demo.test.ts": 3,
   "counter.test.ts": 3,
+  "cellset-lww.test.ts": 3,
+  "convergence-storm.test.ts": 3,
+  "lunch-poll-vote.test.ts": 3,
+  "profile-embed.test.ts": 3,
+  "time-capability-intrinsics.test.ts": 3,
 
   // shard 4
+  "cfc-authorized-save.test.ts": 4,
   "cfc-group-chat-demo.test.ts": 4,
   "default-app.test.ts": 4,
   "home-profile.test.ts": 4,
   "instantiate-pattern.test.ts": 4,
   "llm.test.ts": 4,
   "chatbot.test.ts": 4,
+  "cf-checkbox.test.ts": 4,
+  "group-chat-adoption-bench.test.ts": 4,
+  "note-append-link.test.ts": 4,
 };
 
 // Assign each file without internal sharding to one shard: the explicit table

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -1,5 +1,6 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import {
+  assertTaskTestsIncluded,
   initializeDb,
   parseDisabledPackageList,
   readWorkspaceMembers,
@@ -169,9 +170,17 @@ Deno.test("readWorkspaceMembers reads the workspace list from a JSONC manifest",
   }
 });
 
-// Run `fn` with TEST_CONCURRENCY set (or cleared, on undefined), restoring
-// the caller's value afterwards. The CI test job itself sets the variable, so
-// tests must not read or leak the ambient value.
+Deno.test("assertTaskTestsIncluded requires tasks in the root workspace", () => {
+  assertTaskTestsIncluded(["./packages/api", "./tasks"]);
+  assertThrows(
+    () => assertTaskTestsIncluded(["./packages/api"]),
+    Error,
+    "workspace must include tasks",
+  );
+});
+
+// Run `fn` with TEST_CONCURRENCY set or cleared, then restore the caller's
+// value. This keeps each test independent of the ambient environment.
 async function withTestConcurrency<T>(
   value: string | undefined,
   fn: () => T | Promise<T>,

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -103,12 +103,21 @@ function reportPackageFailure(result: PackageResult): void {
 // Read the workspace member list from the root manifest. Parsed with the JSONC
 // parser so a `deno.jsonc` carrying comments is read correctly.
 export async function readWorkspaceMembers(
-  configPath = "./deno.jsonc",
+  configPath: string | URL = "./deno.jsonc",
 ): Promise<string[]> {
   const manifest = parseJsonc(await Deno.readTextFile(configPath)) as {
     workspace: string[];
   };
   return manifest.workspace;
+}
+
+export function assertTaskTestsIncluded(members: string[]): void {
+  if (members.some((memberPath) => getPackageName(memberPath) === "tasks")) {
+    return;
+  }
+  throw new Error(
+    "The root workspace must include tasks so the workspace test job runs the task tests.",
+  );
 }
 
 // One `deno task test` invocation: a workspace member, plus environment
@@ -133,11 +142,8 @@ const INTERNALLY_SHARDED_PACKAGES: Record<
 };
 
 // Enabled workspace members are split across shards by round-robin over the
-// unit list sorted by package name, matching the other shard selectors. There
-// is no per-package weighting; rebalance by adjusting the shard count only
-// when the imbalance shows up on the critical path (see
-// docs/development/CI_PERFORMANCE.md). Without a shard, every enabled member
-// is selected as a single unit.
+// unit list sorted by package name, matching the other shard selectors. Without
+// a shard, every enabled member is selected as a single unit.
 export function selectShardMembers(
   members: string[],
   disabledPackages: string[],
@@ -175,12 +181,9 @@ export function selectShardMembers(
     .filter((_, i) => i % shard.total === shard.index - 1);
 }
 
-// Cap on concurrently running package test tasks. Each package's own test
-// task parallelizes across the machine's cores, so running every package at
-// once mostly adds contention, and timing-sensitive tests flake under that
-// load (see the known serial CLI tests in docs/development/CI_PERFORMANCE.md).
-// Half the cores balances throughput against contention; TEST_CONCURRENCY
-// overrides it.
+// Cap on concurrently running package test tasks. Individual packages may also
+// parallelize their tests. Half the cores limits that nested concurrency while
+// allowing independent packages to overlap. TEST_CONCURRENCY overrides it.
 export function testConcurrency(
   raw = Deno.env.get("TEST_CONCURRENCY"),
 ): number {
@@ -274,6 +277,7 @@ export async function runTests(
 export async function main(): Promise<void> {
   const shardRaw = Deno.env.get("TEST_SHARD");
   const shard = shardRaw ? parseShard(shardRaw) : undefined;
+  assertTaskTestsIncluded(await readWorkspaceMembers());
   await initializeDb();
   const passed = await runTests(
     [


### PR DESCRIPTION
A variety of changes to improve timings on CI.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts CI wall time by fixing the pattern compile cache usage/keying, removing duplicate steps, enabling two concurrent workspace package tests, and rebalancing pattern-integration shards. Pattern and workspace jobs should run faster with no loss of coverage.

- **Refactors**
  - Pattern capability tests now use the shared compile cache via a new controller; added a test that the runtime receives `moduleByteCache` and honors `API_URL`. The compile-cache key now rotates on `.ts` and `.tsx` changes; added a guard test.
  - Workspace tests run with two package workers (half the cores). Removed the forced `TEST_CONCURRENCY=1` override and the workspace shard pins; added an assertion that the root workspace includes `tasks` so its tests run in the workspace job.
  - Removed duplicate work: dropped the standalone `tasks/` unit-test step from the Check job and the extra workflow DB init (the root test task still initializes).
  - Rebalanced the four pattern-integration shards from recent CI timings; added tests to separate a known round-robin collision, ensure every ordinary file is assigned once, ensure profiled entries name real files, and keep internally sharded files on all shards.
  - `packages/ts-transformers` tests now run with `--no-check`; type checking for its sources and test entry points moved to the concurrent Check job.
  - Docs: updated the CI performance guide and added the July 2026 duration profile.

<sup>Written for commit c4d5c1318ce24f1602a1a57b64fd44022c6c3963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



NEW_COVERAGE_BASELINE