### PR TITLE
test: fail fast after workspace package failures

### DIFF
--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -182,7 +182,9 @@ package-name list (`selectShardMembers`), and runs `deno task test` in every
 selected package, at most `TEST_CONCURRENCY` (default: half the cores) at a
 time to keep contention-sensitive tests stable. Each shard's wall time is set
 by the slowest package test task in the shard, plus the fixed setup and
-coverage report steps around it.
+coverage report steps around it. When a package fails, the runner prints that
+package's captured output immediately and stops starting new package tests.
+Package tests that are already running finish before the summary is printed.
 
 When a shard becomes the long pole, start with the `Package timings:` block
 printed by `tasks/test.ts`. The round-robin split carries no per-package

--- a/scripts/test-fast.ts
+++ b/scripts/test-fast.ts
@@ -7,4 +7,5 @@ const FAST_DISABLED = [
   "deno-web-test",
 ];
 
-await runTests(FAST_DISABLED);
+const passed = await runTests(FAST_DISABLED);
+if (!passed) Deno.exit(1);

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -172,10 +172,10 @@ Deno.test("readWorkspaceMembers reads the workspace list from a JSONC manifest",
 // Run `fn` with TEST_CONCURRENCY set (or cleared, on undefined), restoring
 // the caller's value afterwards. The CI test job itself sets the variable, so
 // tests must not read or leak the ambient value.
-async function withTestConcurrency(
+async function withTestConcurrency<T>(
   value: string | undefined,
-  fn: () => void | Promise<void>,
-): Promise<void> {
+  fn: () => T | Promise<T>,
+): Promise<T> {
   const saved = Deno.env.get("TEST_CONCURRENCY");
   if (value === undefined) {
     Deno.env.delete("TEST_CONCURRENCY");
@@ -183,7 +183,7 @@ async function withTestConcurrency(
     Deno.env.set("TEST_CONCURRENCY", value);
   }
   try {
-    await fn();
+    return await fn();
   } finally {
     if (saved === undefined) {
       Deno.env.delete("TEST_CONCURRENCY");
@@ -219,6 +219,49 @@ Deno.test("runTests drains every package with a concurrency limit of one", async
       assertEquals(passed, true);
     });
     assertEquals(await ranPackages(dir, ["a", "b", "c"]), ["a", "b", "c"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("runTests reports a failure and stops scheduling packages", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "ws-fail-fast-" });
+  try {
+    await makeWorkspace(dir, ["a", "b", "c"]);
+    await Deno.writeTextFile(
+      `${dir}/packages/a/deno.jsonc`,
+      JSON.stringify({
+        tasks: {
+          test:
+            "echo started > ran.txt && echo upstream package download failed >&2 && exit 1",
+        },
+      }),
+    );
+
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...values: unknown[]) => {
+      errors.push(values.map(String).join(" "));
+    };
+    let passed: boolean;
+    try {
+      passed = await withTestConcurrency(
+        "1",
+        () => runTests([], undefined, dir),
+      );
+    } finally {
+      console.error = originalError;
+    }
+
+    assertEquals(passed, false);
+    assertEquals(await ranPackages(dir, ["a", "b", "c"]), ["a"]);
+    const downloadErrorIndex = errors.findIndex((message) =>
+      message.includes("upstream package download failed")
+    );
+    const summaryIndex = errors.indexOf("One or more tests failed.");
+    assertEquals(downloadErrorIndex >= 0, true);
+    assertEquals(summaryIndex >= 0, true);
+    assertEquals(downloadErrorIndex < summaryIndex, true);
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -92,6 +92,14 @@ export async function testPackage(
   };
 }
 
+type PackageResult = Awaited<ReturnType<typeof testPackage>>;
+
+function reportPackageFailure(result: PackageResult): void {
+  console.error(`Failed ${result.packageName} (${result.packagePath})`);
+  console.log(decode(result.result.stdout));
+  console.error(decode(result.result.stderr));
+}
+
 // Read the workspace member list from the root manifest. Parsed with the JSONC
 // parser so a `deno.jsonc` carrying comments is read correctly.
 export async function readWorkspaceMembers(
@@ -201,7 +209,7 @@ export async function runTests(
   );
   if (units.length === 0) {
     console.error("No workspace packages selected to test.");
-    Deno.exit(1);
+    return false;
   }
   // Resolve to an absolute path: each package's test subprocess runs with its
   // own cwd, so a relative DENO_COVERAGE_DIR would land under
@@ -211,24 +219,27 @@ export async function runTests(
     ? path.resolve(workspaceCwd, coverageRootRaw)
     : undefined;
 
-  type PackageResult = Awaited<ReturnType<typeof testPackage>>;
   const results: PackageResult[] = [];
   let nextUnit = 0;
+  let failureSeen = false;
   const workerCount = Math.min(testConcurrency(), units.length);
   const workers = Array.from({ length: workerCount }, async () => {
-    while (nextUnit < units.length) {
+    while (!failureSeen && nextUnit < units.length) {
       const unit = units[nextUnit++];
       console.log(`Testing ${unit.packageName}...`);
       const packagePath = path.resolve(workspaceCwd, unit.memberPath);
-      results.push(
-        await testPackage(
-          unit.memberPath,
-          unit.packageName,
-          packagePath,
-          coverageRoot,
-          unit.env,
-        ),
+      const result = await testPackage(
+        unit.memberPath,
+        unit.packageName,
+        packagePath,
+        coverageRoot,
+        unit.env,
       );
+      results.push(result);
+      if (!result.result.success) {
+        failureSeen = true;
+        reportPackageFailure(result);
+      }
     }
   });
   await Promise.all(workers);
@@ -254,10 +265,7 @@ export async function runTests(
     console.error("Failed packages:");
     for (const result of failedPackages) {
       console.error(`- ${result.packageName} (${result.packagePath})`);
-      console.log(decode(result.result.stdout));
-      console.error(decode(result.result.stderr));
     }
-    Deno.exit(1);
   }
 
   return failedPackages.length === 0;
@@ -267,11 +275,12 @@ export async function main(): Promise<void> {
   const shardRaw = Deno.env.get("TEST_SHARD");
   const shard = shardRaw ? parseShard(shardRaw) : undefined;
   await initializeDb();
-  await runTests(
+  const passed = await runTests(
     [
       ...ALL_DISABLED,
       ...parseDisabledPackageList(Deno.env.get("TEST_DISABLED_PACKAGES")),
     ],
     shard,
   );
+  if (!passed) Deno.exit(1);
 }


### PR DESCRIPTION
The workspace test runner captured each package's output but deferred printing failures until every scheduled package had completed. With serial CI execution, this meant an actionable dependency resolution error could remain hidden while later packages continued running.

Print a failed package's captured output as soon as its task ends and stop workers from taking new queued packages after any failure. Let already-running tasks finish so parallel local runs remain orderly, then retain the summary and nonzero exit behavior at command entry points.

Add a regression test proving later packages do not start and the original error precedes the summary. Document the scheduling behavior for continuous integration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-fast the workspace test runner: print a failing package’s output immediately and stop starting new package tests after the first failure. CI now surfaces real errors sooner while running tasks finish to keep parallel runs orderly.

- **Bug Fixes**
  - `runTests` now returns pass/fail and stops scheduling new packages after any failure; active tasks finish.
  - `main` in `tasks/workspace-tests.ts` and `scripts/test-fast.ts` exit nonzero on failure.
  - Added a regression test that ensures later packages do not start and the failure logs appear before the summary.
  - Updated `docs/development/CI_PERFORMANCE.md` to document the fail-fast CI behavior.

<sup>Written for commit 7a97a13722c8c52a06c0c10f3829592853dc98aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

