### PR TITLE
fix(patterns): migrate default-app and notebook read-then-push appends

### DIFF
--- a/packages/patterns/notes/notebook-drop.test.tsx
+++ b/packages/patterns/notes/notebook-drop.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Test: dropping onto a note row keeps memberships stable.
+ *
+ * Every row's drop zone binds handleDropOntoNotebook with the notebook's own
+ * SELF as the target, so target and current alias the same notes collection.
+ * The handler adds with addUnique (dedup by link identity, no whole-list
+ * read of the target) and must skip the remove-from-current step when the
+ * lists alias — otherwise an in-notebook drop of an existing note turns into
+ * a move-to-tail reorder, and a multi-select drop strips the selected notes
+ * from the notebook entirely (the pre-addUnique code had exactly that
+ * data-loss bug). These tests drive the drop stream bound to a row and pin:
+ * order stability for an in-notebook re-drop, membership survival for a
+ * multi-select re-drop, and a plain add for a note from outside.
+ *
+ * Run: deno task cf test packages/patterns/notes/notebook-drop.test.tsx --root packages/patterns --verbose
+ */
+import { action, computed, pattern, UI } from "commonfabric";
+import { findNode, propsOf, readValue } from "../test/vnode-helpers.ts";
+import Notebook from "./notebook.tsx";
+import Note from "./note.tsx";
+
+type DropStream = {
+  send: (event: { detail: { sourceCell: unknown } }) => void;
+};
+
+// A row's title lives in its cf-chip's `label` prop, which textContent
+// (a children walk) never sees — so locate the row zone as the
+// note,notebook-accepting cf-drop-zone whose subtree holds the chip with
+// that label. Module scope: SES callbacks may not capture callables from
+// enclosing function scopes.
+const isElement = (
+  value: unknown,
+  name: string,
+): value is Record<PropertyKey, unknown> =>
+  typeof value === "object" && value !== null &&
+  (value as { name?: unknown }).name === name;
+
+const sendDropOntoRow = (
+  subject: { [UI]: unknown },
+  rowText: string,
+  sourceCell: unknown,
+) => {
+  const zone = findNode(subject[UI], (node) => {
+    if (!isElement(readValue(node), "cf-drop-zone")) return false;
+    // Prop values arrive as link proxies, so resolve before comparing.
+    if (
+      String(readValue(propsOf(node)?.accept) ?? "") !== "note,notebook"
+    ) return false;
+    // Labels carry the note NAME ("📝 <title>"), so match by inclusion.
+    const chip = findNode(
+      node,
+      (inner) =>
+        isElement(readValue(inner), "cf-chip") &&
+        String(readValue(propsOf(inner)?.label) ?? "").includes(rowText),
+    );
+    return chip !== undefined;
+  });
+  const stream = propsOf(zone)?.["oncf-drop"];
+  if (typeof stream === "object" && stream !== null && "send" in stream) {
+    (stream as DropStream).send({ detail: { sourceCell } });
+  }
+};
+
+const noteTitlesOf = (subject: { notes?: unknown }): string[] =>
+  [...((subject.notes as { title?: string }[] | undefined) ?? [])]
+    .map((n) => n?.title ?? "");
+
+export default pattern(() => {
+  const firstNote = Note({
+    title: "First Note",
+    content: "",
+    isHidden: true,
+  });
+  const secondNote = Note({
+    title: "Second Note",
+    content: "",
+    isHidden: true,
+  });
+  // Lives outside the notebook until a drop pulls it in.
+  const looseNote = Note({
+    title: "Loose Note",
+    content: "",
+    isHidden: false,
+  });
+
+  const subject = Notebook({
+    title: "Drop Test Notebook",
+    notes: [firstNote, secondNote],
+    isHidden: false,
+  });
+
+  const action_drop_existing_note_onto_row = action(() =>
+    sendDropOntoRow(subject, "Second Note", firstNote)
+  );
+  const action_select_all = action(() => {
+    subject.selectAllNotes.send();
+  });
+  const action_drop_selected_onto_row = action(() =>
+    sendDropOntoRow(subject, "Second Note", firstNote)
+  );
+  const action_drop_loose_note_onto_row = action(() =>
+    sendDropOntoRow(subject, "Second Note", looseNote)
+  );
+
+  const assert_initial_order = computed(() => {
+    const titles = noteTitlesOf(subject);
+    return titles.length === 2 && titles[0] === "First Note" &&
+      titles[1] === "Second Note";
+  });
+
+  // An in-notebook drop of an already-present note is a no-op: same
+  // memberships, same order. (Removing then re-adding would file the note
+  // back at the tail.)
+  const assert_re_drop_keeps_order = computed(() => {
+    const titles = noteTitlesOf(subject);
+    return titles.length === 2 && titles[0] === "First Note" &&
+      titles[1] === "Second Note";
+  });
+
+  // A multi-select drop within the notebook must not remove the selection
+  // from the notebook it is already in.
+  const assert_multi_drop_keeps_notes = computed(() => {
+    const titles = noteTitlesOf(subject);
+    return titles.length === 2 && titles[0] === "First Note" &&
+      titles[1] === "Second Note";
+  });
+
+  // The selection is consumed by the drop either way.
+  const assert_multi_drop_clears_selection = computed(() =>
+    [...(subject.selectedNoteIndices ?? [])].length === 0
+  );
+
+  // A note from outside the notebook is added once and hidden from the
+  // space-wide list.
+  const assert_loose_note_added = computed(() => {
+    const titles = noteTitlesOf(subject);
+    return titles.length === 3 && titles[2] === "Loose Note";
+  });
+  const assert_loose_note_hidden = computed(() => looseNote.isHidden === true);
+
+  return {
+    tests: [
+      { assertion: assert_initial_order },
+
+      { action: action_drop_existing_note_onto_row },
+      { assertion: assert_re_drop_keeps_order },
+
+      { action: action_select_all },
+      { action: action_drop_selected_onto_row },
+      { assertion: assert_multi_drop_keeps_notes },
+      { assertion: assert_multi_drop_clears_selection },
+
+      { action: action_drop_loose_note_onto_row },
+      { assertion: assert_loose_note_added },
+      { assertion: assert_loose_note_hidden },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -143,12 +143,13 @@ const handleDropOntoCurrentNotebook = handler<
     // Remove from all notebooks
     removeFromAllNotebooks(notebooks, itemsToMove);
 
-    // Add all to this notebook (deduplicated)
+    // Add all to this notebook, deduplicated by link identity on the server.
+    // The whole-list read above genuinely has to stay (it resolves the dragged
+    // index against the selection), so this write still contends on concurrent
+    // notes changes; addUnique keeps a re-add a no-op instead of a duplicate.
     for (const item of itemsToMove) {
-      if (!notesList.some((n) => equals(item, n))) {
-        notes.push(item);
-        item.key("isHidden").set(true);
-      }
+      notes.addUnique(item);
+      item.key("isHidden").set(true);
     }
     selectedNoteIndices.set([]);
   } else {
@@ -157,7 +158,9 @@ const handleDropOntoCurrentNotebook = handler<
 
     removeFromAllNotebooks(notebooks, [sourceCell]);
     sourceCell.key("isHidden").set(true);
-    notes.push(sourceCell);
+    // Deduplicated by link identity; the early return above already covers the
+    // common already-present case, and the retained read keeps this contended.
+    notes.addUnique(sourceCell);
   }
 });
 
@@ -182,7 +185,6 @@ const handleDropOntoNotebook = handler<
   if (!targetNotebook.key("isNotebook").get()) return;
 
   const targetNotesCell = targetNotebook.key("notes");
-  const targetNotesList = targetNotesCell.get() ?? [];
   const currentList = currentNotes.get();
   const selected = selectedNoteIndices.get();
 
@@ -197,12 +199,12 @@ const handleDropOntoNotebook = handler<
       Boolean,
     );
 
-    // Add all to target (deduplicated)
+    // Add all to target, deduplicated by link identity on the server —
+    // addUnique needs no read of the target list, so concurrent drops onto the
+    // same notebook merge instead of conflicting.
     for (const item of itemsToMove) {
-      if (!targetNotesList.some((n) => equals(item, n))) {
-        targetNotesCell.push(item);
-        item.key("isHidden").set(true);
-      }
+      targetNotesCell.addUnique(item);
+      item.key("isHidden").set(true);
     }
 
     // Find target notebook index to skip it during removal
@@ -223,8 +225,6 @@ const handleDropOntoNotebook = handler<
     selectedNoteIndices.set([]);
   } else {
     // Single-item move
-    if (targetNotesList.some((n) => equals(sourceCell, n))) return;
-
     // Remove from current notebook if present
     const indexInCurrent = currentList.findIndex((n) => equals(sourceCell, n));
     if (indexInCurrent !== -1) {
@@ -234,7 +234,11 @@ const handleDropOntoNotebook = handler<
     }
 
     sourceCell.key("isHidden").set(true);
-    targetNotesCell.push(sourceCell);
+    // Deduplicated by link identity on the server, so a note the target
+    // already holds is a no-op there while still moving out of the current
+    // notebook. (The old whole-list guard skipped the move entirely in that
+    // case, leaving the note in both notebooks.)
+    targetNotesCell.addUnique(sourceCell);
   }
 });
 
@@ -455,8 +459,11 @@ const createNotebookFromPrompt = handler<
       newNotebook,
     ]);
   } else {
-    // For add: just add the new notebook as sibling
-    notes.push(newNotebook);
+    // For add: append the new notebook as sibling. Its contents derive from
+    // the notes snapshot read above, so write the whole list from that same
+    // snapshot; the read stays in the conflict set and a concurrent change
+    // rejects this commit and retries against fresh state.
+    notes.set([...notesList, newNotebook]);
   }
 
   // Clean up state

--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -188,6 +188,12 @@ const handleDropOntoNotebook = handler<
   const currentList = currentNotes.get();
   const selected = selectedNoteIndices.get();
 
+  // The only binding today passes the notebook's own SELF as the target, so
+  // target and current usually alias the same notes collection. In that case
+  // there is nothing to remove from "current": removing would strip or
+  // reorder the very memberships addUnique confirms below.
+  const targetIsCurrent = equals(targetNotesCell, currentNotes);
+
   // Check if dragged item is in the selection
   const draggedIndex = currentList.findIndex((n) => equals(sourceCell, n));
   const isDraggedInSelection = draggedIndex >= 0 &&
@@ -216,28 +222,39 @@ const handleDropOntoNotebook = handler<
     // Remove from all notebooks except target
     removeFromAllNotebooks(notebooks, itemsToMove, targetIndex);
 
-    // Remove from current notebook
-    currentNotes.set(
-      currentList.filter(
-        (n) => !itemsToMove.some((item) => equals(n, item)),
-      ),
-    );
+    // Remove from current notebook — unless current IS the target, where
+    // "removing" would strip the memberships this drop just confirmed. (The
+    // pre-addUnique code ran this unconditionally, so a same-notebook
+    // multi-drop silently dropped the selected notes from the notebook.)
+    if (!targetIsCurrent) {
+      currentNotes.set(
+        currentList.filter(
+          (n) => !itemsToMove.some((item) => equals(n, item)),
+        ),
+      );
+    }
     selectedNoteIndices.set([]);
   } else {
     // Single-item move
-    // Remove from current notebook if present
-    const indexInCurrent = currentList.findIndex((n) => equals(sourceCell, n));
-    if (indexInCurrent !== -1) {
-      const copy = [...currentList];
-      copy.splice(indexInCurrent, 1);
-      currentNotes.set(copy);
+    // Remove from current notebook if present — unless current IS the
+    // target, where the removal would turn addUnique's no-op below into a
+    // move-to-tail reorder of an already-present note.
+    if (!targetIsCurrent) {
+      const indexInCurrent = currentList.findIndex((n) =>
+        equals(sourceCell, n)
+      );
+      if (indexInCurrent !== -1) {
+        const copy = [...currentList];
+        copy.splice(indexInCurrent, 1);
+        currentNotes.set(copy);
+      }
     }
 
     sourceCell.key("isHidden").set(true);
     // Deduplicated by link identity on the server, so a note the target
-    // already holds is a no-op there while still moving out of the current
-    // notebook. (The old whole-list guard skipped the move entirely in that
-    // case, leaving the note in both notebooks.)
+    // already holds keeps a single membership with no whole-list read. For a
+    // genuinely distinct target this completes the move (the old guard
+    // skipped it entirely, leaving the note in both notebooks).
     targetNotesCell.addUnique(sourceCell);
   }
 });

--- a/packages/patterns/system/default-app.test.tsx
+++ b/packages/patterns/system/default-app.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Test: registering a piece is idempotent by identity.
+ *
+ * addPiece dedups with addUnique on the piece cell rather than a
+ * read-then-push guard. That only works because the event field is declared
+ * as a cell: a plain-typed event would arrive as a query-result proxy, which
+ * addUnique compares by deep equality against the stored link and never
+ * matches — every registration would append a duplicate and nothing would
+ * report it. These tests pin the two halves: re-sending the same piece cell
+ * leaves one entry, and distinct pieces still land.
+ *
+ * Run: deno task cf test packages/patterns/system/default-app.test.tsx --root packages/patterns --verbose
+ */
+import { action, computed, pattern } from "commonfabric";
+import DefaultApp from "./default-app.tsx";
+import Note from "../notes/note.tsx";
+
+type AddPieceStream = { send: (event: { piece: unknown }) => void };
+
+// Module scope: SES callbacks may not capture callables from enclosing
+// function scopes.
+const addPieceOf = (subject: Record<string, unknown>, piece: unknown) =>
+  (subject.addPiece as AddPieceStream).send({ piece });
+
+const piecesLengthOf = (subject: Record<string, unknown>) =>
+  [...((subject.allPieces as unknown[]) ?? [])].length;
+
+export default pattern(() => {
+  const subject = DefaultApp();
+
+  const note = Note({
+    title: "Registered Note",
+    content: "",
+  });
+  const otherNote = Note({
+    title: "Other Note",
+    content: "",
+  });
+
+  const action_register_note = action(() => addPieceOf(subject, note));
+  const action_register_note_again = action(() => addPieceOf(subject, note));
+  const action_register_other_note = action(() =>
+    addPieceOf(subject, otherNote)
+  );
+
+  const assert_starts_empty = computed(() => piecesLengthOf(subject) === 0);
+
+  const assert_first_registration_lands = computed(() =>
+    piecesLengthOf(subject) === 1
+  );
+
+  // The same piece cell again must resolve to the same membership entry.
+  const assert_duplicate_registration_is_noop = computed(() =>
+    piecesLengthOf(subject) === 1
+  );
+
+  // Dedup is by identity, not a cap: a distinct piece still lands.
+  const assert_distinct_piece_lands = computed(() =>
+    piecesLengthOf(subject) === 2
+  );
+
+  return {
+    tests: [
+      { assertion: assert_starts_empty },
+
+      { action: action_register_note },
+      { assertion: assert_first_registration_lands },
+
+      { action: action_register_note_again },
+      { assertion: assert_duplicate_registration_is_noop },
+
+      { action: action_register_other_note },
+      { assertion: assert_distinct_piece_lands },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/system/default-app.tsx
+++ b/packages/patterns/system/default-app.tsx
@@ -72,18 +72,15 @@ const dropOntoNotebook = handler<
   { notebook: Writable<{ notes?: NotePiece[] }> }
 >((event, { notebook }) => {
   const sourceCell = event.detail.sourceCell;
-  const notesCell = notebook.key("notes");
-  const notesList = notesCell.get() ?? [];
 
-  // Prevent duplicates using Writable.equals
-  const alreadyExists = notesList.some((n) => equals(sourceCell, n));
-  if (alreadyExists) return;
-
-  // Hide from Patterns list
+  // Hide from Patterns list. Idempotent on a re-drop: a note already in the
+  // notebook is already hidden.
   sourceCell.key("isHidden").set(true);
 
-  // Add to notebook - push cell reference, not value, to maintain piece identity
-  notesCell.push(sourceCell);
+  // Add to notebook by piece identity. addUnique compares a cell argument by
+  // link, so re-dropping the same note resolves to one membership entry and
+  // drops of distinct notes merge, without reading the whole list.
+  notebook.key("notes").addUnique(sourceCell);
 });
 
 // Toggle dropdown menu
@@ -117,17 +114,18 @@ const menuNewNotebook = handler<void, { menuOpen: Writable<boolean> }>(
   },
 );
 
-// Handler: Add piece to allPieces if not already present
+// Handler: Add piece to allPieces if not already present. The event field is
+// declared as a cell so it arrives as one (the shell sends a piece cell);
+// addUnique then dedups by link, so concurrent registrations of the same
+// piece resolve to one entry and adds of distinct pieces merge, without
+// reading the whole list.
 const addPiece = handler<
-  { piece: MentionablePiece },
+  { piece: Writable<MentionablePiece> },
   { allPieces: Writable<MentionablePiece[]> }
 >((event, { allPieces }) => {
   const piece = event?.piece;
   if (!piece) return;
-  const current = allPieces.get();
-  if (!current.some((c) => equals(c, piece))) {
-    allPieces.push(piece);
-  }
+  allPieces.addUnique(piece);
 });
 
 // Handler: Track piece as recently used (add to front, maintain max)

--- a/packages/patterns/system/default-app.tsx
+++ b/packages/patterns/system/default-app.tsx
@@ -5,6 +5,7 @@ import {
   NAME,
   navigateTo,
   pattern,
+  Stream,
   UI,
   Writable,
 } from "commonfabric";
@@ -33,6 +34,11 @@ export interface PiecesListOutput {
     mentionable: MentionablePiece[] | undefined;
   };
   sidebarUI?: unknown;
+  // Declared (not just index-signature) so the schema surfaces them to
+  // external callers and tests: the runtime reads outputs through the
+  // declared type.
+  allPieces: MentionablePiece[];
+  addPiece: Stream<{ piece: Writable<MentionablePiece> }>;
 }
 
 const _visit = handler<

--- a/packages/shell/public/index.html
+++ b/packages/shell/public/index.html
@@ -21,6 +21,7 @@
     <link rel="stylesheet" href="/styles/index.css" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#f3f3f3" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Common Fabric" />


### PR DESCRIPTION
## Why

Every cold compile of the space root logs five `mergeable-push:read-then-push` transformer warnings to the browser console (reported from a production mobile session on Estuary — they fire on every load, on any deployment, since the flagged code ships at HEAD). The five appends are dedup-guarded pushes of piece cells, or a snapshot-derived append, in `system/default-app.tsx` and `notes/notebook.tsx`. Beyond the console noise, the shape they warn about is real: the whole-list read keeps each append in the conflict set, so writes contend and retry instead of merging, and concurrent adds of the same piece rely on conflict-retry rather than identity to avoid duplicates.

#4736 migrated this class in `record`, `map-demo`, and the JSX reactivity demo and wrote `docs/development/migrating-collection-writes.md`; this PR applies that guide to the two system-surface patterns it didn't cover.

## What Changed

- **`default-app.tsx` — `dropOntoNotebook`, `addPiece`:** replace guard+push with `addUnique` on the piece cell, which dedups by link on the server, so re-adds are no-ops and disjoint adds merge — no whole-list read. `addPiece`'s event field is now declared `Writable<MentionablePiece>` so it arrives as a cell: the shell's `registerNavigatedPiece` already sends a piece cell, and with the old plain event type it would arrive as a query-result proxy, which `addUnique` silently fails to dedup (this handler is the worked example in the migration guide's "Event data is a cell only if its type says so").
- **`notebook.tsx` — `handleDropOntoNotebook`:** drops its whole-list read of the target notebook entirely; both branches `addUnique` into the target, so concurrent drops onto the same notebook merge. Deliberate behavior change: dropping a note the target already holds still moves it out of the current notebook — the old guard early-returned, leaving the note in **both** notebooks.
- **`notebook.tsx` — `handleDropOntoCurrentNotebook`:** `addUnique` for both branches, keeping the list read (it resolves the dragged index against the selection) with comments per the guide's "keep it deliberately and say so".
- **`notebook.tsx` — `createNotebookFromPrompt`:** the add branch appends a notebook whose contents derive from the notes snapshot — a content-dependent append — so it becomes a read-modify-write `set` over that snapshot, mirroring its own move branch.
- **`shell/public/index.html`:** add the non-Apple `<meta name="mobile-web-app-capable">` beside the deprecated Apple-only tag Chrome warns about.

## Test plan

- `cf check` on the **pre-change** files reproduces exactly the five warnings (2 in default-app, 3 in notebook); on the migrated files both patterns compile with **zero** transformer diagnostics.
- `cf test` on `notes/notebook.test.tsx` (31 assertions) and `system/` (34 assertions) passes.
- `deno task integration patterns default-app` (browser-driven) passes, including the rapid notebook-note creation/reload regression — exercises `addPiece` end-to-end through `registerNavigatedPiece`, the surface CT-1838 bricked.
- Full workspace `deno task test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes read-then-push appends in `system/default-app` and `notes/notebook` to eliminate five `mergeable-push:read-then-push` warnings and let concurrent adds merge by identity. Also fixes same-notebook drop edge cases and adds a mobile-web-app meta tag to clear a Chrome console warning.

- **Bug Fixes**
  - Default app: `dropOntoNotebook` and `addPiece` now use `addUnique`; `addPiece` event is `Writable<MentionablePiece>`; `PiecesListOutput` now declares `allPieces` and `addPiece` so callers/tests can access them.
  - Notebook: both drop handlers use `addUnique`; when target and current alias, skip removal to avoid reorder/data-loss on in-notebook drops; cross-notebook drops still move already-present notes; `createNotebookFromPrompt` add path becomes a snapshot `set`. Tests added to pin these semantics.
  - Shell: add `<meta name="mobile-web-app-capable" content="yes">`.

<sup>Written for commit 935d67eae30564d0494c5e94417208bd88c3437a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

