### PR TITLE
fix(test-support): freeze nested Deno checks

### DIFF
--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -15,6 +15,24 @@ deno task test
 
 **Important:** Always use `deno task test` from the root, NOT `deno test`, as the task includes necessary flags.
 
+### Tests that start Deno
+
+Dependency installation and verification are separate parts of CI. Installation
+may fetch registry metadata and package contents. Verification must use the
+dependency graph recorded in `deno.lock` without resolving package versions
+again.
+
+Use `@commonfabric/test-support/isolated-deno` when a test starts another Deno
+process. Its check helper copies the lockfile and runs `deno check` with frozen
+dependency resolution. A generated config may change compiler options, but it
+must preserve the root config's imports and workspace members. Package imports
+already come from each workspace member's config and must not be copied into
+the generated root config.
+
+This boundary keeps a verification test independent of mutable registry
+metadata. It also makes an accidental dependency graph change fail as an
+out-of-date lockfile instead of silently resolving a different graph.
+
 ### Test Structure
 
 - **Unit tests**: Use `@std/testing/bdd` (`describe`/`it`) with `@std/expect` for assertions

--- a/packages/shell/test/standard-decorators-entrypoint.test.ts
+++ b/packages/shell/test/standard-decorators-entrypoint.test.ts
@@ -13,16 +13,8 @@ function decode(bytes: Uint8Array): string {
 
 Deno.test("shell entrypoint type-checks under standard decorators", async () => {
   const rootConfig = await readDenoConfig(join(ROOT, "deno.jsonc"));
-  const packageConfig = await readDenoConfig(
-    join(ROOT, "packages", "shell", "deno.jsonc"),
-  );
-
   rootConfig.compilerOptions ??= {};
   rootConfig.compilerOptions.experimentalDecorators = false;
-  rootConfig.imports = {
-    ...(rootConfig.imports ?? {}),
-    ...(packageConfig.imports ?? {}),
-  };
 
   const output = await runDenoCheckWithTemporaryConfig({
     root: ROOT,

--- a/packages/test-support/deno.jsonc
+++ b/packages/test-support/deno.jsonc
@@ -8,7 +8,7 @@
     "./isolated-deno": "./src/isolated-deno.ts"
   },
   "tasks": {
-    "test": "deno test --allow-env=CF_COMPILE_CACHE_FILE --allow-read --allow-write src/*.test.ts",
+    "test": "deno test --frozen=true --allow-env=CF_COMPILE_CACHE_FILE --allow-read --allow-write --allow-run=deno src/*.test.ts",
     "check": "deno check src/**/*.ts",
     "fmt": "deno fmt src/",
     "lint": "deno lint src/"

--- a/packages/test-support/src/isolated-deno.test.ts
+++ b/packages/test-support/src/isolated-deno.test.ts
@@ -1,0 +1,60 @@
+import { assert, assertEquals, assertMatch } from "@std/assert";
+import { join } from "@std/path";
+import {
+  readDenoConfig,
+  runDenoCheckWithTemporaryConfig,
+} from "./isolated-deno.ts";
+
+const ROOT = join(import.meta.dirname!, "..", "..", "..");
+
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+Deno.test("nested checks use the checked-in dependency graph", async () => {
+  const lockPath = join(ROOT, "deno.lock");
+  const lockBefore = await Deno.readTextFile(lockPath);
+  const rootConfig = await readDenoConfig(join(ROOT, "deno.jsonc"));
+
+  rootConfig.compilerOptions ??= {};
+  rootConfig.compilerOptions.experimentalDecorators = false;
+
+  const output = await runDenoCheckWithTemporaryConfig({
+    root: ROOT,
+    config: rootConfig,
+    files: ["packages/test-support/src/mod.ts"],
+    tempConfigPrefix: "deno.test-support.frozen-check",
+  });
+
+  assert(
+    output.success,
+    `nested check failed:\n${decode(output.stdout)}\n${decode(output.stderr)}`,
+  );
+  assertEquals(await Deno.readTextFile(lockPath), lockBefore);
+});
+
+Deno.test("nested checks reject dependency graph changes", async () => {
+  const rootConfig = await readDenoConfig(join(ROOT, "deno.jsonc"));
+  const shellConfig = await readDenoConfig(
+    join(ROOT, "packages", "shell", "deno.jsonc"),
+  );
+  const rootImports = rootConfig.imports ?? {};
+  const packageImport = Object.entries(shellConfig.imports ?? {}).find(
+    ([name]) => !(name in rootImports),
+  );
+
+  assert(packageImport, "shell config should contain a package-only import");
+  const [name, specifier] = packageImport;
+  rootConfig.imports = { ...rootImports, [name]: specifier };
+
+  const output = await runDenoCheckWithTemporaryConfig({
+    root: ROOT,
+    config: rootConfig,
+    files: ["packages/test-support/src/mod.ts"],
+    tempConfigPrefix: "deno.test-support.changed-dependencies",
+  });
+  const stderr = decode(output.stderr);
+
+  assert(!output.success, "a changed dependency graph should fail the check");
+  assertMatch(stderr, /lockfile is out of date/i);
+});

--- a/packages/test-support/src/isolated-deno.ts
+++ b/packages/test-support/src/isolated-deno.ts
@@ -10,6 +10,10 @@ export interface DenoCommandWithTemporaryLockOptions {
 
 export interface DenoCheckWithTemporaryConfigOptions {
   root: string;
+  /**
+   * A copy of the root config with the same workspace dependency graph.
+   * Compiler options may differ for the check.
+   */
   config: unknown;
   files: string[];
   tempConfigPrefix: string;
@@ -85,6 +89,8 @@ export async function runDenoCheckWithTemporaryConfig(
         tempConfig,
         "--lock",
         tempLock,
+        // Verification uses the dependency graph pinned by the checked-in lock.
+        "--frozen=true",
         ...options.files,
       ],
     });

--- a/packages/ui/test/standard-decorators-entrypoint.test.ts
+++ b/packages/ui/test/standard-decorators-entrypoint.test.ts
@@ -13,16 +13,8 @@ function decode(bytes: Uint8Array): string {
 
 Deno.test("ui entrypoint type-checks under standard decorators", async () => {
   const rootConfig = await readDenoConfig(join(ROOT, "deno.jsonc"));
-  const packageConfig = await readDenoConfig(
-    join(ROOT, "packages", "ui", "deno.jsonc"),
-  );
-
   rootConfig.compilerOptions ??= {};
   rootConfig.compilerOptions.experimentalDecorators = false;
-  rootConfig.imports = {
-    ...(rootConfig.imports ?? {}),
-    ...(packageConfig.imports ?? {}),
-  };
 
   const output = await runDenoCheckWithTemporaryConfig({
     root: ROOT,

--- a/skills/isolated-test-processes/SKILL.md
+++ b/skills/isolated-test-processes/SKILL.md
@@ -27,7 +27,11 @@ That helper keeps the generated Deno workspace config in the repository root,
 where Deno requires workspace members to be nested under the config directory.
 It points Deno at a temporary copy of `deno.lock`, so dependency metadata writes
 do not touch the real lockfile. It also removes the generated root config in a
-`finally` block.
+`finally` block. The nested check uses frozen dependency resolution, so its
+generated config must preserve the dependency graph in the checked-in lockfile.
+Start with the root config and change only the compiler settings needed by the
+test. Workspace member imports already come from their package configs. Do not
+copy them into the generated root config.
 
 For nested Deno commands that do not need a generated config:
 
@@ -43,6 +47,10 @@ command's `--lock` flag.
 ## Values
 
 - A verification test must not change `deno.lock` or repository files.
+- A verification test must use the dependency graph already recorded in
+  `deno.lock`. Dependency fetching belongs in setup before the test runs.
+- A generated config may change compiler options. It must preserve imports,
+  workspace members, and other dependency declarations.
 - If a test needs mutable inputs or outputs, put them under `Deno.makeTempDir()`
   or an explicit test fixture copy.
 - If a generated file must briefly live in the repository root for tool


### PR DESCRIPTION
Nested verification checks generated root configs and copied deno.lock files, but allowed Deno to update the copied lock. Deno could therefore resolve workspace dependency ranges again against registry metadata restored from the CI cache. If that metadata omitted a locked version, an unrelated package failed before type checking began.

Run generated-config checks and their regression harness with frozen dependency resolution. Keep the standard-decorator entrypoint configs equivalent to the root workspace instead of copying imports already supplied by member configs. Limit the harness subprocess permission to Deno, add behavioral regression coverage, and document the setup and verification boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freeze nested Deno checks to use the checked-in lockfile and prevent dependency re-resolution from cached registry metadata. Keeps generated configs aligned with the workspace so unrelated packages don’t fail before type checking.

- Bug Fixes
  - Run nested checks with `--frozen=true` using a temp `deno.lock`.
  - Keep generated configs equivalent to the root; remove package import merging in entrypoint tests.
  - Restrict harness permissions to `--allow-run=deno`.
  - Add regression tests verifying lockfile is unchanged and changed graphs fail; document usage of `@commonfabric/test-support/isolated-deno` and the setup/verification boundary.

<sup>Written for commit fd626e61bc863959a964750b7e5c35890c99155c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

