### PR TITLE
ci: split binary builds and artifact downloads

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -12,11 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Define the list of binaries we're building
-# This makes it easy to add more binaries in the future
-env:
-  BINARIES: "toolshed bg-piece-service cf"
-
 # Every step name must begin with a phase-marker emoji (setup / work / shutdown).
 # scripts/ci-gantt.ts reads that emoji to split each job bar by phase. See the
 # "Step phase markers" table in docs/development/CI_PERFORMANCE.md for the
@@ -210,8 +205,8 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
-  build-binaries:
-    name: "Build Binaries"
+  build-toolshed:
+    name: "Build Binary (toolshed)"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -224,20 +219,69 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 🏗️ Build application binaries
-        run: deno task build-binaries
+      - name: 🏗️ Build toolshed binary
+        run: deno task build-binaries toolshed
         env:
           COMMIT_SHA: ${{ github.sha }}
 
-      # Upload binaries as artifacts for the integration tests
-      - name: 📤 Upload binaries for integration tests
+      - name: 📤 Upload toolshed binary
         uses: actions/upload-artifact@v7
         with:
-          name: common-binaries
-          path: |
-            ./dist/toolshed
-            ./dist/bg-piece-service
-            ./dist/cf
+          name: binary-toolshed
+          path: ./dist/toolshed
+          if-no-files-found: error
+
+  build-bg-piece-service:
+    name: "Build Binary (bg-piece-service)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
+
+      - name: 🏗️ Build bg-piece-service binary
+        run: deno task build-binaries bg-piece-service
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+
+      - name: 📤 Upload bg-piece-service binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: binary-bg-piece-service
+          path: ./dist/bg-piece-service
+          if-no-files-found: error
+
+  build-cf:
+    name: "Build Binary (cf)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
+
+      - name: 🏗️ Build cf binary
+        run: deno task build-binaries cf
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+
+      - name: 📤 Upload cf binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: binary-cf
+          path: ./dist/cf
+          if-no-files-found: error
 
   generated-patterns-integration-test:
     name: "Generated Patterns Integration Tests (${{ matrix.shard }}/${{ matrix.total }})"
@@ -326,7 +370,7 @@ jobs:
     name: "Package Integration Tests (${{ matrix.suite_name }})"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: ["build-binaries"]
+    needs: ["build-toolshed"]
     strategy:
       fail-fast: false
       matrix:
@@ -356,10 +400,10 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 📥 Download built binaries
+      - name: 📥 Download toolshed binary
         uses: actions/download-artifact@v8
         with:
-          name: common-binaries
+          name: binary-toolshed
           path: common-binaries
 
       - name: 🔌 Start Toolshed server for testing
@@ -418,7 +462,7 @@ jobs:
     name: "CLI Integration Tests (${{ matrix.suite_name }})"
     runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout_minutes }}
-    needs: ["build-binaries"]
+    needs: ["build-toolshed", "build-cf"]
     strategy:
       fail-fast: false
       matrix:
@@ -457,10 +501,16 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 📥 Download built binaries
+      - name: 📥 Download toolshed binary
         uses: actions/download-artifact@v8
         with:
-          name: common-binaries
+          name: binary-toolshed
+          path: common-binaries
+
+      - name: 📥 Download cf binary
+        uses: actions/download-artifact@v8
+        with:
+          name: binary-cf
           path: common-binaries
 
       - name: 🔌 Start Toolshed server for testing
@@ -571,7 +621,7 @@ jobs:
     name: "Pattern Integration Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: ["build-binaries"]
+    needs: ["build-toolshed"]
     strategy:
       fail-fast: false
       matrix:
@@ -623,10 +673,10 @@ jobs:
           cache-file: ${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json
           exact-hit: ${{ steps.compile-cache.outputs.cache-hit }}
 
-      - name: 📥 Download built binaries
+      - name: 📥 Download toolshed binary
         uses: actions/download-artifact@v8
         with:
-          name: common-binaries
+          name: binary-toolshed
           path: common-binaries
 
       - name: 🔌 Start Toolshed server for testing
@@ -748,7 +798,7 @@ jobs:
     name: "Pattern Unit Tests (${{ matrix.chunk }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: ["build-binaries"]
+    needs: ["build-cf"]
     strategy:
       matrix:
         chunk: [1, 2, 3, 4, 5]
@@ -783,10 +833,10 @@ jobs:
           cache-file: ${{ github.workspace }}/.compile-cache/pattern-unit-coverage-${{ matrix.chunk }}.json
           exact-hit: ${{ steps.compile-cache.outputs.cache-hit }}
 
-      - name: 📥 Download built binaries
+      - name: 📥 Download cf binary
         uses: actions/download-artifact@v8
         with:
-          name: common-binaries
+          name: binary-cf
           path: common-binaries
 
       - name: 🧪 Run pattern unit tests
@@ -833,7 +883,9 @@ jobs:
     needs:
       - check
       - test
-      - build-binaries
+      - build-toolshed
+      - build-bg-piece-service
+      - build-cf
       - package-integration-test
       - cli-integration-test
       - pattern-integration-test
@@ -901,6 +953,9 @@ jobs:
       [
         "test",
         "check",
+        "build-toolshed",
+        "build-bg-piece-service",
+        "build-cf",
         "runner-test",
         "pattern-integration-test",
         "pattern-reload-integration-test",
@@ -919,10 +974,22 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
 
-      - name: 📥 Download built binaries
+      - name: 📥 Download toolshed binary
         uses: actions/download-artifact@v8
         with:
-          name: common-binaries
+          name: binary-toolshed
+          path: common-binaries
+
+      - name: 📥 Download bg-piece-service binary
+        uses: actions/download-artifact@v8
+        with:
+          name: binary-bg-piece-service
+          path: common-binaries
+
+      - name: 📥 Download cf binary
+        uses: actions/download-artifact@v8
+        with:
+          name: binary-cf
           path: common-binaries
 
       - name: 🦕 Setup Deno

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -358,7 +358,7 @@ shell expansion to forward extra `deno test` flags (e.g. `--filter`).
 | `check` | Type-check all packages (`./tasks/check.sh`). |
 | `test` | Run all package tests (`./tasks/test.ts`). |
 | `integration` | Run integration tests (`./tasks/integration.ts`). |
-| `build-binaries` | Build all standalone binaries, or only the named targets passed after the task (`toolshed`, `bg-piece-service`, or `cf`). |
+| `build-binaries` | Build all standalone binaries, build only the named targets passed after the task (`toolshed`, `bg-piece-service`, or `cf`), or use the legacy `deno task build-binaries --cli-only` alias to build only `cf`. |
 | `cf` | Run the CLI via the launcher. |
 | `initialize-db` | Initialize the local development database. |
 | `install-hooks` | Install git pre-commit hooks. |

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -358,7 +358,7 @@ shell expansion to forward extra `deno test` flags (e.g. `--filter`).
 | `check` | Type-check all packages (`./tasks/check.sh`). |
 | `test` | Run all package tests (`./tasks/test.ts`). |
 | `integration` | Run integration tests (`./tasks/integration.ts`). |
-| `build-binaries` | Build standalone binaries (`cf`, `bg-piece-service`, etc.). |
+| `build-binaries` | Build all standalone binaries, or only the named targets passed after the task (`toolshed`, `bg-piece-service`, or `cf`). |
 | `cf` | Run the CLI via the launcher. |
 | `initialize-db` | Initialize the local development database. |
 | `install-hooks` | Install git pre-commit hooks. |

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -220,6 +220,9 @@ One line per archived document; each document's header carries the fuller
 - [2026-07-ci-duration-profile.md](development/performance/2026-07-ci-duration-profile.md)
   — July 2026 Deno Workflow profile, including compile-cache validation,
   duplicate work, workspace shard balance, and follow-up experiments.
+- [2026-07-binary-artifact-transfer.md](development/performance/2026-07-binary-artifact-transfer.md)
+  — binary artifact file and byte transfer snapshot before the per-binary
+  workflow split, July 2026.
 - [scoped-cells-field-notes.md](development/scoped-cells-field-notes.md) —
   field journal from the first scoped-cell patterns.
 - [2026-07-02-convergence-evidence-appendix.md](plans/2026-07-02-convergence-evidence-appendix.md)

--- a/docs/history/development/performance/2026-07-binary-artifact-transfer.md
+++ b/docs/history/development/performance/2026-07-binary-artifact-transfer.md
@@ -1,0 +1,75 @@
+---
+status: historical
+created: 2026-07-20
+archived: 2026-07-20
+reason: "Transfer snapshot used to evaluate splitting the Deno Workflow binary artifact."
+---
+
+# Binary artifact transfer snapshot, July 20, 2026
+
+## Result
+
+The latest successful `main` Deno Workflow run was
+[`29765072099`](https://github.com/commontoolsinc/labs/actions/runs/29765072099)
+for commit `b480270dd5d8f246e70b9b50d7e0cba26d14f399`. Its
+`common-binaries` artifact was 252,900,276 bytes.
+
+On a `main` run, downstream jobs currently download 51 binary files in 17
+artifact downloads. Those downloads transfer 4,299,304,692 bytes. Separate
+artifacts reduce this to 23 binary files in 23 artifact downloads and
+2,025,452,983 bytes. The change removes 28 unnecessary binary-file transfers
+and 2,273,851,709 bytes, or 52.89 percent of the downstream binary download
+traffic.
+
+Including the build upload, a `main` run currently transfers 54 binary files
+and 4,552,204,968 artifact bytes. The split workflow transfers 26 binary files
+and 2,278,353,303 artifact bytes. That full-run comparison saves 28 file
+transfers and 2,273,851,665 bytes, or 49.95 percent. The 44-byte difference
+between the downstream and full-run savings is the extra ZIP framing needed
+for three upload artifacts instead of one.
+
+## Artifact sizes
+
+The file count in this report counts binary payloads crossing the artifact
+boundary. The byte count is the compressed artifact archive size transferred
+over the network, not the expanded size on the runner.
+
+| Binary | Expanded bytes | Compressed ZIP entry bytes | Separate artifact bytes |
+| --- | ---: | ---: | ---: |
+| `toolshed` | 369,717,265 | 96,633,927 | 96,634,057 |
+| `bg-piece-service` | 279,351,903 | 77,424,113 | 77,424,259 |
+| `cf` | 285,838,024 | 78,841,886 | 78,842,004 |
+| **Total** | **934,907,192** | **252,899,926** | **252,900,320** |
+
+The current combined artifact adds 350 bytes of ZIP framing to its compressed
+entries. The three separate artifacts add 394 bytes in total. The separate
+artifact sizes therefore model the same binaries and compression from today's
+run with the filenames and ZIP layout that the split workflow will use.
+
+## Downstream transfer calculation
+
+| Consumer | Job copies | Current files | Current bytes | Split files | Split bytes |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Package integration | 3 | 9 | 758,700,828 | 3 | 289,902,171 |
+| CLI integration | 4 | 12 | 1,011,601,104 | 8 | 701,904,244 |
+| Pattern integration | 4 | 12 | 1,011,601,104 | 4 | 386,536,228 |
+| Pattern unit | 5 | 15 | 1,264,501,380 | 5 | 394,210,020 |
+| Binary attestation | 1 | 3 | 252,900,276 | 3 | 252,900,320 |
+| **`main` total** | **17** | **51** | **4,299,304,692** | **23** | **2,025,452,983** |
+
+Package integration and pattern integration use only `toolshed`. Pattern unit
+uses only `cf`. CLI integration uses `toolshed` and `cf`. Binary attestation
+uses all three binaries.
+
+A pull request does not run binary attestation. Its downstream comparison is
+48 files and 4,046,404,416 bytes today, versus 20 files and 1,772,552,663
+bytes after the split. Including the upload changes those pull request totals
+to 51 files and 4,299,304,692 bytes today, versus 23 files and 2,025,452,983
+bytes after the split.
+
+The artifact request count rises because consumers that need two or three
+binaries make one request per binary. On `main`, downloads rise from 17 to 23,
+while uploads rise from one to three. The lower payload size is the intended
+trade-off. Future binary content changes will change the byte totals, while
+the file counts remain fixed until the job matrices or binary dependencies
+change.

--- a/tasks/build-binaries.test.ts
+++ b/tasks/build-binaries.test.ts
@@ -10,12 +10,15 @@ import { exists } from "@std/fs";
 import { fromFileUrl, join } from "@std/path";
 
 import {
+  build,
   BuildConfig,
+  type BuildDependencies,
   type BuildSignalApi,
   installBuildSignalCleanup,
   prepareWorkspace,
   requestedBinaries,
   revertWorkspace,
+  runBuildBinaries,
   runBuildWithSignalCleanup,
 } from "./build-binaries.ts";
 import {
@@ -76,6 +79,26 @@ function makeFakeSignalApi(): {
         throw new FakeExit(code);
       },
     },
+  };
+}
+
+function recordingBuildDependencies(
+  calls: string[],
+  overrides: Partial<BuildDependencies> = {},
+): BuildDependencies {
+  const record = (name: string) => (_config: BuildConfig) => {
+    calls.push(name);
+    return Promise.resolve();
+  };
+  return {
+    ensureDistDir: record("ensureDistDir"),
+    buildShell: record("buildShell"),
+    prepareWorkspace: record("prepareWorkspace"),
+    buildToolshed: record("buildToolshed"),
+    buildBgPieceService: record("buildBgPieceService"),
+    buildCli: record("buildCli"),
+    revertWorkspace: record("revertWorkspace"),
+    ...overrides,
   };
 }
 
@@ -231,6 +254,151 @@ Deno.test("requestedBinaries rejects unknown build targets", () => {
     Error,
     'Unknown binary "--cli-only"',
   );
+});
+
+Deno.test("runBuildBinaries preserves the legacy CLI-only entry point", async () => {
+  const root = await makeFakeRepo();
+  try {
+    const configs: BuildConfig[] = [];
+    await runBuildBinaries(["--cli-only"], {
+      root,
+      runBuild: (config) => {
+        configs.push(config);
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(configs.length, 1);
+    assertEquals(configs[0].root, root);
+    assertEquals(configs[0].binaries, ["cf"]);
+    assertEquals(configs[0].cliOnly, true);
+    assertEquals(configs[0].toolshedFlags, [
+      "--allow-env",
+      "--allow-sys",
+      "--allow-read",
+      "--allow-ffi",
+      "--allow-net",
+      "--allow-write",
+    ]);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("BuildConfig selects named binaries and rejects conflicting options", async () => {
+  const root = await makeFakeRepo();
+  try {
+    const config = new BuildConfig({
+      root,
+      toolshedFlags: [],
+      binaries: ["toolshed", "cf"],
+    });
+
+    assertEquals(config.binaries, ["toolshed", "cf"]);
+    assertEquals(config.cliOnly, false);
+    assertEquals(config.builds("toolshed"), true);
+    assertEquals(config.builds("bg-piece-service"), false);
+    assertEquals(config.builds("cf"), true);
+
+    const duplicateCliConfig = new BuildConfig({
+      root,
+      toolshedFlags: [],
+      binaries: ["cf", "cf"],
+    });
+    assertEquals(duplicateCliConfig.binaries, ["cf"]);
+    assertEquals(duplicateCliConfig.cliOnly, true);
+
+    assertThrows(
+      () => new BuildConfig({ root, toolshedFlags: [], binaries: [] }),
+      Error,
+      "At least one binary must be selected",
+    );
+    assertThrows(
+      () =>
+        new BuildConfig({
+          root,
+          toolshedFlags: [],
+          binaries: ["cf"],
+          cliOnly: true,
+        }),
+      Error,
+      "cliOnly and binaries cannot be combined",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("build runs only the steps required by each binary", async () => {
+  const root = await makeFakeRepo();
+  try {
+    const cases = [
+      {
+        binaries: ["toolshed"] as const,
+        expected: [
+          "ensureDistDir",
+          "buildShell",
+          "prepareWorkspace",
+          "buildToolshed",
+          "revertWorkspace",
+        ],
+      },
+      {
+        binaries: ["bg-piece-service"] as const,
+        expected: [
+          "ensureDistDir",
+          "prepareWorkspace",
+          "buildBgPieceService",
+          "revertWorkspace",
+        ],
+      },
+      {
+        binaries: ["cf"] as const,
+        expected: [
+          "ensureDistDir",
+          "prepareWorkspace",
+          "buildCli",
+          "revertWorkspace",
+        ],
+      },
+    ];
+
+    for (const { binaries, expected } of cases) {
+      const calls: string[] = [];
+      const config = new BuildConfig({ root, toolshedFlags: [], binaries });
+      await build(config, recordingBuildDependencies(calls));
+      assertEquals(calls, expected);
+    }
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("build reverts the workspace after a build step fails", async () => {
+  const root = await makeFakeRepo();
+  try {
+    const calls: string[] = [];
+    const config = new BuildConfig({
+      root,
+      toolshedFlags: [],
+      binaries: ["toolshed"],
+    });
+    const dependencies = recordingBuildDependencies(calls, {
+      buildShell: () => {
+        calls.push("buildShell");
+        return Promise.reject(new Error("shell build failed"));
+      },
+    });
+
+    await assertRejects(
+      () => build(config, dependencies),
+      Error,
+      "shell build failed",
+    );
+    assertEquals(calls, ["ensureDistDir", "buildShell", "revertWorkspace"]);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
 });
 
 Deno.test("manifest() returns an independent parsed copy each call", async () => {

--- a/tasks/build-binaries.test.ts
+++ b/tasks/build-binaries.test.ts
@@ -4,6 +4,7 @@ import {
   assertNotEquals,
   assertRejects,
   assertStringIncludes,
+  assertThrows,
 } from "@std/assert";
 import { exists } from "@std/fs";
 import { fromFileUrl, join } from "@std/path";
@@ -13,6 +14,7 @@ import {
   type BuildSignalApi,
   installBuildSignalCleanup,
   prepareWorkspace,
+  requestedBinaries,
   revertWorkspace,
   runBuildWithSignalCleanup,
 } from "./build-binaries.ts";
@@ -136,6 +138,7 @@ Deno.test("BuildConfig resolves workspace paths against the root", async () => {
     const config = new BuildConfig({ root, toolshedFlags: [], cliOnly: true });
 
     assertEquals(config.root, root);
+    assertEquals(config.binaries, ["cf"]);
     assertEquals(config.cliOnly, true);
     assertEquals(config.workspaceManifestPath(), join(root, "deno.jsonc"));
     assertEquals(config.workspaceLockPath(), join(root, "deno.lock"));
@@ -207,6 +210,27 @@ Deno.test("BuildConfig resolves workspace paths against the root", async () => {
   } finally {
     await Deno.remove(root, { recursive: true });
   }
+});
+
+Deno.test("requestedBinaries selects all binaries or named subsets", () => {
+  assertEquals(requestedBinaries([]), ["toolshed", "bg-piece-service", "cf"]);
+  assertEquals(requestedBinaries(["toolshed"]), ["toolshed"]);
+  assertEquals(requestedBinaries(["cf", "toolshed"]), ["toolshed", "cf"]);
+  assertEquals(requestedBinaries(["cf", "cf"]), ["cf"]);
+  assertEquals(requestedBinaries(["--cli-only"]), ["cf"]);
+});
+
+Deno.test("requestedBinaries rejects unknown build targets", () => {
+  assertThrows(
+    () => requestedBinaries(["unknown"]),
+    Error,
+    'Unknown binary "unknown". Expected one or more of: toolshed, bg-piece-service, cf',
+  );
+  assertThrows(
+    () => requestedBinaries(["--cli-only", "toolshed"]),
+    Error,
+    'Unknown binary "--cli-only"',
+  );
 });
 
 Deno.test("manifest() returns an independent parsed copy each call", async () => {

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -10,12 +10,35 @@ import {
 export interface BuildConfigInitializer {
   root: string;
   toolshedFlags: string[];
+  binaries?: readonly BinaryName[];
   cliOnly?: boolean;
+}
+
+export const BINARY_NAMES = ["toolshed", "bg-piece-service", "cf"] as const;
+export type BinaryName = (typeof BINARY_NAMES)[number];
+
+export function requestedBinaries(args: readonly string[]): BinaryName[] {
+  if (args.length === 0) return [...BINARY_NAMES];
+  if (args.length === 1 && args[0] === "--cli-only") return ["cf"];
+
+  const requested = new Set<BinaryName>();
+  for (const arg of args) {
+    if (!BINARY_NAMES.includes(arg as BinaryName)) {
+      throw new Error(
+        `Unknown binary "${arg}". Expected one or more of: ${
+          BINARY_NAMES.join(", ")
+        }`,
+      );
+    }
+    requested.add(arg as BinaryName);
+  }
+  return BINARY_NAMES.filter((binary) => requested.has(binary));
 }
 
 export class BuildConfig {
   readonly root: string;
   readonly toolshedFlags: string[];
+  readonly binaries: readonly BinaryName[];
   readonly cliOnly: boolean;
   private _manifestOriginal: string;
   private _compileCacheVersionOriginal: string;
@@ -23,7 +46,13 @@ export class BuildConfig {
   constructor(options: BuildConfigInitializer) {
     this.root = options.root;
     this.toolshedFlags = options.toolshedFlags;
-    this.cliOnly = !!options.cliOnly;
+    if (options.cliOnly && options.binaries) {
+      throw new Error("cliOnly and binaries cannot be combined");
+    }
+    this.binaries = options.cliOnly
+      ? ["cf"]
+      : [...(options.binaries ?? BINARY_NAMES)];
+    this.cliOnly = this.binaries.length === 1 && this.binaries[0] === "cf";
     this._manifestOriginal = Deno.readTextFileSync(
       this.workspaceManifestPath(),
     );
@@ -145,6 +174,10 @@ export class BuildConfig {
   distPath(binary: string) {
     return this.path("dist", binary);
   }
+
+  builds(binary: BinaryName): boolean {
+    return this.binaries.includes(binary);
+  }
 }
 
 async function build(config: BuildConfig): Promise<void> {
@@ -153,11 +186,13 @@ async function build(config: BuildConfig): Promise<void> {
     // Ensure dist directory exists
     await ensureDistDir(config);
 
-    if (!config.cliOnly) await buildShell(config);
+    if (config.builds("toolshed")) await buildShell(config);
     await prepareWorkspace(config);
-    if (!config.cliOnly) await buildToolshed(config);
-    if (!config.cliOnly) await buildBgPieceService(config);
-    await buildCli(config);
+    if (config.builds("toolshed")) await buildToolshed(config);
+    if (config.builds("bg-piece-service")) {
+      await buildBgPieceService(config);
+    }
+    if (config.builds("cf")) await buildCli(config);
   } catch (e: unknown) {
     buildError = e as Error;
   }
@@ -485,7 +520,7 @@ if (import.meta.main) {
       "--allow-net",
       "--allow-write",
     ],
-    cliOnly: Deno.args.includes("--cli-only"),
+    binaries: requestedBinaries(Deno.args),
   });
 
   await runBuildWithSignalCleanup(config);

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -49,9 +49,12 @@ export class BuildConfig {
     if (options.cliOnly && options.binaries) {
       throw new Error("cliOnly and binaries cannot be combined");
     }
+    if (options.binaries?.length === 0) {
+      throw new Error("At least one binary must be selected");
+    }
     this.binaries = options.cliOnly
       ? ["cf"]
-      : [...(options.binaries ?? BINARY_NAMES)];
+      : requestedBinaries(options.binaries ?? []);
     this.cliOnly = this.binaries.length === 1 && this.binaries[0] === "cf";
     this._manifestOriginal = Deno.readTextFileSync(
       this.workspaceManifestPath(),
@@ -180,23 +183,46 @@ export class BuildConfig {
   }
 }
 
-async function build(config: BuildConfig): Promise<void> {
+export type BuildDependencies = {
+  ensureDistDir(config: BuildConfig): Promise<void>;
+  buildShell(config: BuildConfig): Promise<void>;
+  prepareWorkspace(config: BuildConfig): Promise<void>;
+  buildToolshed(config: BuildConfig): Promise<void>;
+  buildBgPieceService(config: BuildConfig): Promise<void>;
+  buildCli(config: BuildConfig): Promise<void>;
+  revertWorkspace(config: BuildConfig): Promise<void>;
+};
+
+export const defaultBuildDependencies: BuildDependencies = {
+  ensureDistDir,
+  buildShell,
+  prepareWorkspace,
+  buildToolshed,
+  buildBgPieceService,
+  buildCli,
+  revertWorkspace,
+};
+
+export async function build(
+  config: BuildConfig,
+  dependencies: BuildDependencies = defaultBuildDependencies,
+): Promise<void> {
   let buildError: Error | void;
   try {
     // Ensure dist directory exists
-    await ensureDistDir(config);
+    await dependencies.ensureDistDir(config);
 
-    if (config.builds("toolshed")) await buildShell(config);
-    await prepareWorkspace(config);
-    if (config.builds("toolshed")) await buildToolshed(config);
+    if (config.builds("toolshed")) await dependencies.buildShell(config);
+    await dependencies.prepareWorkspace(config);
+    if (config.builds("toolshed")) await dependencies.buildToolshed(config);
     if (config.builds("bg-piece-service")) {
-      await buildBgPieceService(config);
+      await dependencies.buildBgPieceService(config);
     }
-    if (config.builds("cf")) await buildCli(config);
+    if (config.builds("cf")) await dependencies.buildCli(config);
   } catch (e: unknown) {
     buildError = e as Error;
   }
-  await revertWorkspace(config);
+  await dependencies.revertWorkspace(config);
   // @ts-ignore This is used after being assigned.
   if (buildError) {
     throw buildError;
@@ -506,12 +532,17 @@ export async function runBuildWithSignalCleanup(
   }
 }
 
-// Only run the build when invoked directly (`deno task build-binaries`), not
-// when imported by tests, which exercise BuildConfig / prepareWorkspace /
-// revertWorkspace against a temporary tree.
-if (import.meta.main) {
+export interface RunBuildBinariesOptions {
+  root?: string;
+  runBuild?: (config: BuildConfig) => Promise<void>;
+}
+
+export async function runBuildBinaries(
+  args: readonly string[],
+  options: RunBuildBinariesOptions = {},
+): Promise<void> {
   const config = new BuildConfig({
-    root: Deno.cwd(),
+    root: options.root ?? Deno.cwd(),
     toolshedFlags: [
       "--allow-env",
       "--allow-sys",
@@ -520,8 +551,15 @@ if (import.meta.main) {
       "--allow-net",
       "--allow-write",
     ],
-    binaries: requestedBinaries(Deno.args),
+    binaries: requestedBinaries(args),
   });
 
-  await runBuildWithSignalCleanup(config);
+  await (options.runBuild ?? runBuildWithSignalCleanup)(config);
+}
+
+// Only run the build when invoked directly (`deno task build-binaries`), not
+// when imported by tests, which exercise BuildConfig / prepareWorkspace /
+// revertWorkspace against a temporary tree.
+if (import.meta.main) {
+  await runBuildBinaries(Deno.args);
 }

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -452,6 +452,71 @@ Deno.test("extractMetrics aggregates workspace test matrix shards", () => {
   assertEquals(metrics.get("step: workspace tests")?.durationSeconds, 180);
 });
 
+Deno.test("extractMetrics records separate binary builds and their critical path", () => {
+  const metrics = extractMetrics(makeRun(), [
+    makeJob(
+      1,
+      "Build Binary (toolshed)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:03:20Z",
+      [
+        makeStep(
+          "🏗️ Build toolshed binary",
+          "2026-01-01T00:00:20Z",
+          "2026-01-01T00:03:00Z",
+        ),
+      ],
+    ),
+    makeJob(
+      2,
+      "Build Binary (bg-piece-service)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:40Z",
+      [
+        makeStep(
+          "🏗️ Build bg-piece-service binary",
+          "2026-01-01T00:00:20Z",
+          "2026-01-01T00:01:20Z",
+        ),
+      ],
+    ),
+    makeJob(
+      3,
+      "Build Binary (cf)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:02:30Z",
+      [
+        makeStep(
+          "🏗️ Build cf binary",
+          "2026-01-01T00:00:20Z",
+          "2026-01-01T00:02:10Z",
+        ),
+      ],
+    ),
+  ]);
+
+  assertEquals(
+    metrics.get("job: Build Binary (toolshed)")?.durationSeconds,
+    200,
+  );
+  assertEquals(
+    metrics.get("job: Build Binary (bg-piece-service)")?.durationSeconds,
+    100,
+  );
+  assertEquals(metrics.get("job: Build Binary (cf)")?.durationSeconds, 150);
+  assertEquals(metrics.get("job: Build Binaries")?.durationSeconds, 200);
+  assertEquals(
+    metrics.get("step: Build toolshed binary")?.durationSeconds,
+    160,
+  );
+  assertEquals(
+    metrics.get("step: Build bg-piece-service binary")?.durationSeconds,
+    60,
+  );
+  assertEquals(metrics.get("step: Build cf binary")?.durationSeconds, 110);
+  assertEquals(metrics.get("step: Build application")?.durationSeconds, 160);
+});
+
 Deno.test("timingArtifactLabel normalizes matrix shard artifacts", () => {
   assertEquals(
     timingArtifactLabel("test-timing-package-integration-runner"),

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -928,6 +928,9 @@ const JOB_METRIC_NAMES: Record<string, string> = {
   "Generated Patterns Integration Tests":
     "job: Generated Patterns Integration Tests",
   "Runner Tests": "job: Runner Tests",
+  "Build Binary (toolshed)": "job: Build Binary (toolshed)",
+  "Build Binary (bg-piece-service)": "job: Build Binary (bg-piece-service)",
+  "Build Binary (cf)": "job: Build Binary (cf)",
   "Build Binaries": "job: Build Binaries",
   "Test": "job: Test",
   "Check": "job: Check",
@@ -1028,7 +1031,24 @@ const STEP_METRIC_MATCHERS: StepMetricMatcher[] = [
     stepKeyword: "build application",
     metricName: "step: Build application",
   },
+  {
+    jobName: "Build Binary (toolshed)",
+    stepKeyword: "build toolshed binary",
+    metricName: "step: Build toolshed binary",
+  },
+  {
+    jobName: "Build Binary (bg-piece-service)",
+    stepKeyword: "build bg-piece-service binary",
+    metricName: "step: Build bg-piece-service binary",
+  },
+  {
+    jobName: "Build Binary (cf)",
+    stepKeyword: "build cf binary",
+    metricName: "step: Build cf binary",
+  },
 ];
+
+const BUILD_BINARY_RE = /^Build Binary \((toolshed|bg-piece-service|cf)\)$/;
 
 export function extractMetrics(
   run: WorkflowRun,
@@ -1056,10 +1076,15 @@ export function extractMetrics(
     if (jobDuration <= 0) continue;
 
     const normalizedJobName = normalizeName(job.name);
+    const buildBinaryMatch = BUILD_BINARY_RE.exec(normalizedJobName);
 
     const jobMetricName = JOB_METRIC_NAMES[normalizedJobName];
     if (jobMetricName) {
-      metrics.set(jobMetricName, makeSample(jobDuration));
+      const sample = makeSample(jobDuration);
+      metrics.set(jobMetricName, sample);
+      if (buildBinaryMatch) {
+        setMaxMetric("job: Build Binaries", sample);
+      }
     }
 
     const packageIntegrationMatch = PACKAGE_INTEGRATION_RE.exec(
@@ -1168,6 +1193,12 @@ export function extractMetrics(
       if (stepDuration <= 0) continue;
 
       const normalizedStepName = normalizeName(step.name).toLowerCase();
+      if (
+        buildBinaryMatch && normalizedStepName.includes("build") &&
+        normalizedStepName.includes("binary")
+      ) {
+        setMaxMetric("step: Build application", makeSample(stepDuration));
+      }
       for (const matcher of STEP_METRIC_MATCHERS) {
         if (
           matcher.jobName === matcherJobName &&


### PR DESCRIPTION
Build toolshed, bg-piece-service, and cf in independent jobs so each consumer can wait for and download only the executables it uses. Extend the build task with named targets while preserving its all-binaries default and legacy CLI-only entry point.

Upload one artifact per binary, merge all three only in release attestation, and retain the existing aggregate performance metric as the slowest concurrent binary build. Record the measured main and pull-request transfer counts and compressed byte totals from the current main artifact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split CI binary builds and artifacts per executable (`toolshed`, `bg-piece-service`, `cf`) so jobs download only what they use. This cuts downstream binary artifact transfer by ~50% on `main` while keeping the aggregate “Build Binaries” metric as the slowest concurrent build.

- **New Features**
  - `deno task build-binaries` accepts named targets and still defaults to all; legacy `--cli-only` builds only `cf`.
  - CI adds `build-toolshed`, `build-bg-piece-service`, and `build-cf` jobs with one artifact per binary; release attestation downloads all three.
  - Integration jobs depend only on the binaries they need and download those specific artifacts.
  - Added a history snapshot documenting pre-split artifact file and byte transfer totals.
  - Stricter target parsing and entry point: normalize duplicates, reject unknown/empty selections, export `runBuildBinaries`, make build steps injectable, and always revert the workspace on failure.

- **Performance**
  - Downstream downloads drop from 51 files and ~4.30 GB to 23 files and ~2.03 GB on `main` (about 53% fewer bytes); full run saves ~50%.
  - Perf metrics record each binary build separately and keep the aggregate as the max duration across builds.
  - More artifact requests, but smaller payloads; net transfer is lower.

<sup>Written for commit e12b46cbd413a548dceff0797decf4784e99ae54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

