### PR TITLE
fix(cli): --log-level stops at "--"; piece link validation failures are data errors

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,7 +48,9 @@ standard error and continues searching that piece and the rest of the space.
 - `piece call` accepts its payload as an inline JSON argument, `-` for stdin, an
   implicit pipe (no payload argument), or schema-derived flags after `--`.
 - A `piece get` path that doesn't resolve prints a one-line error on stderr and
-  exits 1 — it is a data error, not a usage error.
+  exits 1 — it is a data error, not a usage error. A `piece link` that fails
+  validation (a source/target piece or path that doesn't exist) reports the same
+  way.
 - The launcher spawns the child CLI with `deno run --quiet` so Deno's own
   warnings (npm "Ignored build scripts" banner) never reach users.
 

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -188,6 +188,48 @@ export function pieceGetDataErrorReport(
   };
 }
 
+/**
+ * Build the stderr report for a `piece link` validation failure. Returns null
+ * when the error is not a LinkValidationError (the caller should rethrow).
+ * Link validation fails on data conditions — a source/target piece or path
+ * that doesn't exist, read over the network — so it reports like `piece get`'s
+ * unresolved-path data error rather than as a Cliffy usage error.
+ */
+export function pieceLinkDataErrorReport(
+  error: unknown,
+  opts: { sourcePieceId: string; targetPieceId: string },
+): { message: string; hint: string } | null {
+  if (!(error instanceof LinkValidationError)) return null;
+  return {
+    message: error.message,
+    hint: cliText(
+      `TIP: Run 'cf piece inspect --piece ${opts.sourcePieceId} ...' and '--piece ${opts.targetPieceId} ...' to see the fields each piece actually has.`,
+    ),
+  };
+}
+
+/**
+ * Print a data-error report — message plus optional hint — to stderr and exit
+ * 1. The single exit path for the `piece get` / `piece link` data errors
+ * above. The `deps` seam lets unit tests observe the wiring without a real
+ * process exit; runtime callers use the defaults.
+ */
+export function exitWithDataError(
+  report: { message: string; hint?: string },
+  deps?: {
+    printError?: (message: string) => void;
+    printHint?: (message: string) => void;
+    exit?: (code: number) => never;
+  },
+): never {
+  const printError = deps?.printError ?? console.error;
+  const printHint = deps?.printHint ?? hint;
+  const exit = deps?.exit ?? Deno.exit;
+  printError(report.message);
+  if (report.hint) printHint(report.hint);
+  return exit(1);
+}
+
 export function pieceCallRawArgs(
   tail: string[],
   literalArgs: string[],
@@ -828,9 +870,15 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
         },
       );
     } catch (error) {
-      if (error instanceof LinkValidationError) {
-        throw new ValidationError(error.message, { exitCode: 1 });
-      }
+      // A link that fails validation is a data error (the pieces/paths read
+      // over the network don't support the link), not a usage error — report
+      // it like `piece get` does instead of letting Cliffy dump the help
+      // screen over it.
+      const report = pieceLinkDataErrorReport(error, {
+        sourcePieceId: source.pieceId,
+        targetPieceId: target.pieceId,
+      });
+      if (report) exitWithDataError(report);
       throw error;
     }
 
@@ -899,11 +947,7 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
         input: options.input,
         piece: pieceConfig.piece,
       });
-      if (report) {
-        console.error(report.message);
-        if (report.hint) hint(report.hint);
-        Deno.exit(1);
-      }
+      if (report) exitWithDataError(report);
       throw error;
     }
   })

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -398,9 +398,23 @@ run_piece_links() {
   PIECE_ID3=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $PATTERN_SRC)
   echo "Created third piece: $PIECE_ID3"
 
-  # Linking from invented piece should fail without --allow-non-existing
-  if cf piece link $SPACE_ARGS $INVENTED_ID/value $PIECE_ID3/value 2>/dev/null; then
+  # Linking from invented piece should fail without --allow-non-existing —
+  # and as a DATA error: message (with the --allow-non-existing next step) and
+  # TIP on stderr, nothing on stdout, no usage screen (regression guard for
+  # the LinkValidationError → Cliffy usage-dump path).
+  LINK_ERR_FILE=$(mktemp)
+  if LINK_OUT=$(cf piece link $SPACE_ARGS $INVENTED_ID/value $PIECE_ID3/value 2>"$LINK_ERR_FILE"); then
     error "Linking from invented piece should have failed without --allow-non-existing"
+  fi
+  if [ -n "$LINK_OUT" ]; then
+    error "Link data error should print nothing to stdout, got: $LINK_OUT"
+  fi
+  grep -q -- "--allow-non-existing" "$LINK_ERR_FILE" ||
+    error "Link data error should carry the --allow-non-existing next step on stderr"
+  grep -q "TIP:" "$LINK_ERR_FILE" ||
+    error "Link data error should print the inspect hint on stderr"
+  if grep -q "Usage:" "$LINK_ERR_FILE"; then
+    error "Link data error must not dump the usage screen"
   fi
 
   # Now link with --allow-non-existing

--- a/packages/cli/lib/log-level.ts
+++ b/packages/cli/lib/log-level.ts
@@ -11,24 +11,33 @@ const VALID_LOG_LEVELS = new Set([
 /**
  * Extract --log-level <level> from args before Cliffy sees them.
  * Returns the level (if found) and the cleaned args array.
+ *
+ * Scanning stops at the first `--`: everything after it is a payload for the
+ * target command (e.g. a schema-derived handler flag named `--log-level`),
+ * and silently eating it would drop handler input. Mirrors extractNoColor in
+ * color-mode.ts. Use `cf --log-level error <cmd> -- --log-level error` to set
+ * both.
  */
 export function extractLogLevel(
   args: string[],
 ): { level: string | undefined; args: string[] } {
+  const end = args.indexOf("--");
+  const scanned = end === -1 ? args : args.slice(0, end);
+  const passthrough = end === -1 ? [] : args.slice(end);
   const cleaned: string[] = [];
   let level: string | undefined;
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--log-level" && i + 1 < args.length) {
-      const candidate = args[i + 1];
+  for (let i = 0; i < scanned.length; i++) {
+    if (scanned[i] === "--log-level" && i + 1 < scanned.length) {
+      const candidate = scanned[i + 1];
       if (VALID_LOG_LEVELS.has(candidate)) {
         level = candidate;
         i++; // skip the value
         continue;
       }
     }
-    cleaned.push(args[i]);
+    cleaned.push(scanned[i]);
   }
-  return { level, args: cleaned };
+  return { level, args: [...cleaned, ...passthrough] };
 }
 
 /**

--- a/packages/cli/test/log-level.test.ts
+++ b/packages/cli/test/log-level.test.ts
@@ -63,3 +63,41 @@ Deno.test("extractLogLevel ignores an invalid --log-level value", () => {
   assertEquals(level, undefined);
   assertEquals(args, ["--log-level", "bogus", "check"]);
 });
+
+Deno.test("extractLogLevel leaves payload args after -- untouched", () => {
+  // `--log-level error` after `--` is a schema-derived flag for the target
+  // handler, not a CLI directive; eating it would silently drop handler input.
+  const { level, args } = extractLogLevel([
+    "piece",
+    "call",
+    "h",
+    "--",
+    "--log-level",
+    "error",
+  ]);
+  assertEquals(level, undefined);
+  assertEquals(args, ["piece", "call", "h", "--", "--log-level", "error"]);
+});
+
+Deno.test("extractLogLevel consumes the leading flag and keeps the payload one", () => {
+  const { level, args } = extractLogLevel([
+    "--log-level",
+    "debug",
+    "piece",
+    "call",
+    "h",
+    "--",
+    "--log-level",
+    "error",
+  ]);
+  assertEquals(level, "debug");
+  assertEquals(args, ["piece", "call", "h", "--", "--log-level", "error"]);
+});
+
+Deno.test("extractLogLevel does not pair a flag with a value across --", () => {
+  // `--log-level` as the last token before `--` has no in-bounds value; it
+  // stays put rather than consuming the payload boundary.
+  const { level, args } = extractLogLevel(["--log-level", "--", "error"]);
+  assertEquals(level, undefined);
+  assertEquals(args, ["--log-level", "--", "error"]);
+});

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -7,10 +7,13 @@ import {
   PieceResultProjectionError,
 } from "../lib/piece.ts";
 import {
+  exitWithDataError,
   isPieceGetDataError,
   pieceCallRawArgs,
   pieceGetDataErrorReport,
+  pieceLinkDataErrorReport,
 } from "../commands/piece.ts";
+import { LinkValidationError } from "../lib/piece.ts";
 
 describe("executePieceCallable", () => {
   it("invokes handlers from schema-derived flags", async () => {
@@ -1019,5 +1022,67 @@ describe("piece get data errors", () => {
     expect(report?.message).toMatch(/schema could not resolve/);
     expect(report?.message).toMatch(/--step/);
     expect(report?.hint).toBeUndefined();
+  });
+});
+
+describe("piece link data errors", () => {
+  it("reports a validation failure with an inspect hint for both pieces", () => {
+    const report = pieceLinkDataErrorReport(
+      new LinkValidationError(
+        'Target path "config/email" does not exist on piece fid1:target-1\n\nUse --allow-non-existing to link anyway.',
+      ),
+      { sourcePieceId: "fid1:source-1", targetPieceId: "fid1:target-1" },
+    );
+    // The runtime's message survives verbatim — it carries its own
+    // --allow-non-existing next step — and the hint adds the inspect pointer.
+    expect(report?.message).toMatch(/does not exist on piece fid1:target-1/);
+    expect(report?.message).toMatch(/--allow-non-existing/);
+    expect(report?.hint).toMatch(/piece inspect/);
+    expect(report?.hint).toMatch(/fid1:source-1/);
+    expect(report?.hint).toMatch(/fid1:target-1/);
+  });
+
+  it("returns null for a non-validation error (caller rethrows)", () => {
+    expect(
+      pieceLinkDataErrorReport(new Error("network unreachable"), {
+        sourcePieceId: "fid1:source-1",
+        targetPieceId: "fid1:target-1",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("exitWithDataError", () => {
+  const exitSentinel = (exited: number[]) => (code: number): never => {
+    exited.push(code);
+    throw new Error("exit-sentinel");
+  };
+
+  it("prints message then hint to stderr sinks and exits 1", () => {
+    const printed: string[] = [];
+    const exited: number[] = [];
+    expect(() =>
+      exitWithDataError({ message: "boom", hint: "TIP: look closer" }, {
+        printError: (m) => printed.push(`error:${m}`),
+        printHint: (m) => printed.push(`hint:${m}`),
+        exit: exitSentinel(exited),
+      })
+    ).toThrow("exit-sentinel");
+    expect(printed).toEqual(["error:boom", "hint:TIP: look closer"]);
+    expect(exited).toEqual([1]);
+  });
+
+  it("omits the hint line when the report has none", () => {
+    const printed: string[] = [];
+    const exited: number[] = [];
+    expect(() =>
+      exitWithDataError({ message: "boom" }, {
+        printError: (m) => printed.push(`error:${m}`),
+        printHint: (m) => printed.push(`hint:${m}`),
+        exit: exitSentinel(exited),
+      })
+    ).toThrow("exit-sentinel");
+    expect(printed).toEqual(["error:boom"]);
+    expect(exited).toEqual([1]);
   });
 });

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -60,7 +60,8 @@ Three equivalent ways to run the CLI, in order of preference for agents:
   (`echo '{...}' | cf piece call ... handler -`), a bare pipe with no payload
   argument, or schema-derived flags after `--`. Empty stdin fails loudly.
 - A `piece get` path that doesn't resolve is a data error: one-line message on
-  stderr, exit 1 (no usage screen).
+  stderr, exit 1 (no usage screen). A `piece link` that fails validation
+  (missing source/target piece or path) reports the same way.
 
 ## Environment Setup
 


### PR DESCRIPTION
## Summary

Two follow-up burrs from the [#4771](https://github.com/commontoolsinc/labs/pull/4771) review, same philosophy as that PR
(no silent no-ops; data errors are not usage errors):

**`--log-level` extraction now stops at `--`.** `extractLogLevel` scanned the
whole argv, so a schema-derived handler flag literally named `--log-level`
(with a valid level as its value) after `--` was silently consumed — the exact
payload-eating hazard #4771 hardened `--no-color` against. It now mirrors
`extractNoColor`: scanning stops at the first `--`, everything after passes
through untouched. `cf --log-level error <cmd> -- --log-level error` sets both.

**`piece link` validation failures are data errors.** A `LinkValidationError`
(source/target piece or path that doesn't exist — a condition read over the
network) was wrapped in a Cliffy `ValidationError`, dumping the colorized
usage screen exactly like the `piece get` bug #4771 fixed. It now prints the
runtime's message (which carries its own `--allow-non-existing` next step)
plus an inspect TIP on stderr and exits 1. Genuine argument-shape errors
(missing target path, bad refs) still get the usage treatment.

**Shared exit path, unit-covered.** The get/link stderr-and-exit wiring is
deduplicated into one exported `exitWithDataError` with an injected-deps seam,
so both catch sites shrink to a call and the wiring itself is unit-tested
rather than reachable only through a real process exit. Measured
`packages/cli` coverage debt: **−5 lines vs base** (tasks/coverage-metrics.ts
over the full package suite; base 4167 → this branch 4162).

**Stacked on #4771**: branched from its current head (79c86ec43), to be
rebased onto `main` once it lands. Draft until then — only the last commit is
this PR's change.

## Review response (@willkelly)

- 🟡 coverage: adopted, two ways — the suggested integration case now runs in
  `run_piece_links` (invented-source link without `--allow-non-existing`
  asserts exit 1, empty stdout, message + `--allow-non-existing` + TIP on
  stderr, and no usage screen), and the action wiring became unit-coverable
  via the `exitWithDataError` seam, which is what actually feeds the debt gate
  (the CLI integration job collects no V8 coverage — it drives the compiled
  binary).
- docs `null` bullet: resolved by restacking onto 79c86ec43, which carries the
  #4771 fix; this PR's bullet extends the corrected wording.
- hint asymmetry (link always hints): kept as-is, per review.

## Tests

- `test/log-level.test.ts`: `--` boundary cases, including `--log-level`
  immediately before `--` not pairing across the boundary.
- `test/piece-call.test.ts`: `pieceLinkDataErrorReport` (message passthrough,
  inspect hint naming both pieces, null for non-validation errors) and
  `exitWithDataError` (message+hint order, hint omitted when absent, exit 1).
- `integration/integration.sh` (`piece-links` section): failure-shape
  assertions as above. Verified end-to-end against a local toolshed:
  full section green.
- Full `packages/cli` suite green; `deno fmt`/`lint`/`check` clean on touched
  files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
