### PR TITLE
perf(ci): download coverage artifacts before performance check

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -858,8 +858,18 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
+      - name: 📥 Download coverage reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: coverage-profile-*
+          path: coverage-artifacts
+          merge-multiple: false
+          skip-decompress: false
+          digest-mismatch: error
+
       - name: 📊 Run performance check
         env:
+          COVERAGE_ARTIFACTS_DIR: coverage-artifacts
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -252,6 +252,13 @@ coverage artifact set during that reset cycle. Jobs with no reportable covered
 files upload an empty LCOV report so missing artifacts mean the report upload
 itself failed.
 
+The workflow downloads the current run's `coverage-profile-*` artifacts before
+starting `tasks/perf-check.ts`. `COVERAGE_ARTIFACTS_DIR` points the script at one
+subdirectory per artifact. The download step checks the artifact digests. The
+script separately checks the expected artifact names. It also rejects an
+artifact containing no coverage files. A manual run without the environment
+variable uses the GitHub API download path instead.
+
 ## Compile Cache State and Cold Runs
 
 The pattern test jobs restore a compile byte cache keyed on a fingerprint hash

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -68,11 +68,14 @@ all.
 
 ## How the two feed the coverage gate
 
-`tasks/perf-check.ts` downloads every `coverage-profile-*` artifact, joins all
-the LCOV files together, and hands them to `tasks/coverage-metrics.ts`. That
-code walks the tracked source files under `packages` and `tasks`, and for each
-file counts how many of its lines no test covered. The top-level `scripts`
-directory is excluded from this gate. The counts roll up into
+The Performance Check job downloads every `coverage-profile-*` artifact with
+`actions/download-artifact`. The action checks each artifact's recorded digest.
+`tasks/perf-check.ts` verifies that every expected artifact is present. It joins
+all the downloaded LCOV files together and hands them to
+`tasks/coverage-metrics.ts`. That code walks the tracked source files under
+`packages` and `tasks`. For each file, it counts how many lines no test covered.
+The top-level `scripts` directory is excluded from this gate. The counts roll up
+into
 `coverage-debt: <group> uncovered lines` metrics, for example
 `coverage-debt: packages/patterns uncovered lines`, and the performance check
 gates a pull request on them.

--- a/tasks/perf-check.test.ts
+++ b/tasks/perf-check.test.ts
@@ -1,4 +1,9 @@
-import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import * as path from "@std/path";
 import {
   type Artifact,
@@ -17,6 +22,7 @@ import {
   buildBaselineRunContexts,
   buildExtraBackfillContexts,
   collectCurrentCacheStates,
+  copyCoverageArtifactFiles,
   currentWorkflowRunFromEvent,
   evaluateTimingMetric,
   fetchArtifactsForRunBestEffort,
@@ -101,6 +107,140 @@ function makeSample(run = makeRun(1)): TimingSample {
     durationSeconds: 1.5,
   };
 }
+
+Deno.test("copyCoverageArtifactFiles reads a pre-downloaded artifact in place", async () => {
+  const root = await Deno.makeTempDir({ prefix: "perf-coverage-artifact-" });
+  const artifact = makeArtifact(17, "coverage-profile-workspace-1");
+  const artifactsDir = path.join(root, "artifacts");
+  const sourceDir = path.join(artifactsDir, artifact.name);
+  const nestedSourceDir = path.join(sourceDir, "pattern-runtime");
+  const profileDir = path.join(root, "profiles");
+  const lcovDir = path.join(root, "lcov");
+
+  try {
+    await Promise.all([
+      Deno.mkdir(nestedSourceDir, { recursive: true }),
+      Deno.mkdir(profileDir),
+      Deno.mkdir(lcovDir),
+    ]);
+    await Promise.all([
+      Deno.writeTextFile(path.join(sourceDir, "runtime.lcov"), "runtime"),
+      Deno.writeTextFile(
+        path.join(nestedSourceDir, "pattern.pattern-coverage.lcov"),
+        "pattern",
+      ),
+      Deno.writeTextFile(path.join(sourceDir, "profile.json"), "profile"),
+      Deno.writeTextFile(path.join(sourceDir, "ignored.txt"), "ignored"),
+    ]);
+
+    assertEquals(
+      await copyCoverageArtifactFiles(
+        artifact,
+        profileDir,
+        lcovDir,
+        artifactsDir,
+      ),
+      { profileFiles: 1, lcovFiles: 2 },
+    );
+
+    const copiedLcov: string[] = [];
+    for await (const entry of Deno.readDir(lcovDir)) {
+      copiedLcov.push(await Deno.readTextFile(path.join(lcovDir, entry.name)));
+    }
+    assertEquals(copiedLcov.sort(), ["pattern", "runtime"]);
+    assertEquals(
+      await Deno.readTextFile(path.join(profileDir, "17-0-profile.json")),
+      "profile",
+    );
+    assert((await Deno.stat(sourceDir)).isDirectory);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("copyCoverageArtifactFiles rejects a missing pre-downloaded artifact", async () => {
+  const root = await Deno.makeTempDir({ prefix: "perf-coverage-missing-" });
+  const profileDir = path.join(root, "profiles");
+  const lcovDir = path.join(root, "lcov");
+  await Promise.all([Deno.mkdir(profileDir), Deno.mkdir(lcovDir)]);
+
+  try {
+    await assertRejects(
+      () =>
+        copyCoverageArtifactFiles(
+          makeArtifact(18, "coverage-profile-workspace-2"),
+          profileDir,
+          lcovDir,
+          path.join(root, "artifacts"),
+        ),
+      Error,
+      "Pre-downloaded coverage profile artifact coverage-profile-workspace-2 (18) was not found",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("copyCoverageArtifactFiles rejects an empty pre-downloaded artifact", async () => {
+  const root = await Deno.makeTempDir({ prefix: "perf-coverage-empty-" });
+  const artifact = makeArtifact(19, "coverage-profile-workspace-3");
+  const artifactsDir = path.join(root, "artifacts");
+  const sourceDir = path.join(artifactsDir, artifact.name);
+  const profileDir = path.join(root, "profiles");
+  const lcovDir = path.join(root, "lcov");
+  await Promise.all([
+    Deno.mkdir(sourceDir, { recursive: true }),
+    Deno.mkdir(profileDir),
+    Deno.mkdir(lcovDir),
+  ]);
+
+  try {
+    await assertRejects(
+      () =>
+        copyCoverageArtifactFiles(
+          artifact,
+          profileDir,
+          lcovDir,
+          artifactsDir,
+        ),
+      Error,
+      "contained no profile or LCOV files",
+    );
+    assert((await Deno.stat(sourceDir)).isDirectory);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("performance check pre-downloads coverage with strict integrity checks", async () => {
+  const workflow = await Deno.readTextFile(
+    new URL("../.github/workflows/deno.yml", import.meta.url),
+  );
+  const start = workflow.indexOf("  perf-check:\n");
+  const end = workflow.indexOf("\n  attest-binaries:", start);
+  assert(start >= 0 && end > start, "Performance Check job not found");
+
+  const job = workflow.slice(start, end);
+  const downloadStart = job.indexOf("- name: 📥 Download coverage reports");
+  const checkStart = job.indexOf("- name: 📊 Run performance check");
+  assert(
+    downloadStart >= 0 && checkStart > downloadStart,
+    "coverage reports must be downloaded before Performance Check runs",
+  );
+
+  const downloadStep = job.slice(downloadStart, checkStart);
+  assertStringIncludes(downloadStep, "uses: actions/download-artifact@v8");
+  assertStringIncludes(downloadStep, "pattern: coverage-profile-*");
+  assertStringIncludes(downloadStep, "path: coverage-artifacts");
+  assertStringIncludes(downloadStep, "merge-multiple: false");
+  assertStringIncludes(downloadStep, "skip-decompress: false");
+  assertStringIncludes(downloadStep, "digest-mismatch: error");
+  assertEquals(downloadStep.includes("continue-on-error"), false);
+  assertStringIncludes(
+    job.slice(checkStart),
+    "COVERAGE_ARTIFACTS_DIR: coverage-artifacts",
+  );
+});
 
 function makePR(number: number, mergedAt: string | null = null): PRInfo {
   return {

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -13,6 +13,8 @@
  *   GITHUB_REPOSITORY   - Optional, defaults to "commontoolsinc/labs".
  *   GITHUB_RUN_ID       - Required. Current workflow run ID.
  *   PR_NUMBER           - Required. Pull request number.
+ *   COVERAGE_ARTIFACTS_DIR - Optional. Directory containing downloaded
+ *                            coverage artifacts, one subdirectory per name.
  */
 
 import {
@@ -746,25 +748,51 @@ function sampleForRun(run: WorkflowRun, value: number): TimingSample {
   };
 }
 
-async function copyCoverageArtifactFiles(
+export async function copyCoverageArtifactFiles(
   artifact: Artifact,
   profileDir: string,
   lcovDir: string,
+  coverageArtifactsDir?: string,
 ): Promise<{ profileFiles: number; lcovFiles: number }> {
-  const extractedDir = await downloadAndExtractArtifact(
-    artifact.id,
-    "coverage-profile-",
-  );
-  if (!extractedDir) {
-    throw new Error(
-      `Failed to download or extract coverage profile artifact ${artifact.name} (${artifact.id}).`,
+  let sourceDir: string;
+  let removeSourceDir = false;
+  if (coverageArtifactsDir) {
+    sourceDir = path.join(coverageArtifactsDir, artifact.name);
+    let sourceStat: Deno.FileInfo;
+    try {
+      sourceStat = await Deno.stat(sourceDir);
+    } catch (error) {
+      const problem = error instanceof Deno.errors.NotFound
+        ? "was not found"
+        : "could not be read";
+      throw new Error(
+        `Pre-downloaded coverage profile artifact ${artifact.name} (${artifact.id}) ${problem} at ${sourceDir}.`,
+        { cause: error },
+      );
+    }
+    if (!sourceStat.isDirectory) {
+      throw new Error(
+        `Pre-downloaded coverage profile artifact ${artifact.name} (${artifact.id}) is not a directory: ${sourceDir}.`,
+      );
+    }
+  } else {
+    const extractedDir = await downloadAndExtractArtifact(
+      artifact.id,
+      "coverage-profile-",
     );
+    if (!extractedDir) {
+      throw new Error(
+        `Failed to download or extract coverage profile artifact ${artifact.name} (${artifact.id}).`,
+      );
+    }
+    sourceDir = extractedDir;
+    removeSourceDir = true;
   }
 
   let profileFiles = 0;
   let lcovFiles = 0;
   try {
-    for await (const file of walkFiles(extractedDir)) {
+    for await (const file of walkFiles(sourceDir)) {
       const isProfile = file.endsWith(".json");
       const isLcov = file.endsWith(".lcov");
       if (!isProfile && !isLcov) continue;
@@ -785,9 +813,11 @@ async function copyCoverageArtifactFiles(
       );
     }
   } finally {
-    try {
-      await Deno.remove(extractedDir, { recursive: true });
-    } catch { /* ignore cleanup errors */ }
+    if (removeSourceDir) {
+      try {
+        await Deno.remove(sourceDir, { recursive: true });
+      } catch { /* ignore cleanup errors */ }
+    }
   }
 
   return { profileFiles, lcovFiles };
@@ -1055,6 +1085,7 @@ export function evaluateTimingMetric(
 async function extractCoverageDebtSamples(
   run: WorkflowRun,
   artifacts: Artifact[],
+  coverageArtifactsDir?: string,
 ): Promise<{ samples: Map<string, TimingSample>; lcov: string }> {
   const metrics = new Map<string, TimingSample>();
   const coverageArtifacts = newestArtifactsByName(artifacts.filter(
@@ -1086,6 +1117,7 @@ async function extractCoverageDebtSamples(
         artifact,
         profileDir,
         lcovDir,
+        coverageArtifactsDir,
       );
       profileFileCount += copied.profileFiles;
       lcovFileCount += copied.lcovFiles;
@@ -1490,6 +1522,7 @@ export async function main() {
     const coverage = await extractCoverageDebtSamples(
       currentRunInfo,
       currentArtifacts,
+      Deno.env.get("COVERAGE_ARTIFACTS_DIR"),
     );
     for (const [name, sample] of coverage.samples) {
       currentMetrics.set(name, sample);


### PR DESCRIPTION
The Performance Check downloaded every coverage artifact through the GitHub REST API in sequence. A typical run produces dozens of artifacts, so request and extraction overhead delayed coverage analysis. The custom download path also did not validate artifact digests.

Use actions/download-artifact to fetch the coverage artifacts into separate directories before the checker starts. Require digest validation and pass the resulting root to the checker. Preserve expected artifact and nonempty file validation, and retain the existing API download path for manual runs that do not provide a local artifact directory.

Add tests for local artifact consumption, missing and empty artifacts, and workflow configuration. Update the CI performance and coverage documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-download coverage artifacts in CI to speed up the Performance Check and enforce artifact integrity. The checker now reads from a provided artifacts directory, with API fallback for manual runs.

- New Features
  - Pre-download `coverage-profile-*` using `actions/download-artifact@v8` into separate dirs with digest verification.
  - Use `COVERAGE_ARTIFACTS_DIR` to locate artifacts; validate expected names; reject empty artifacts; keep API path when unset.
  - Added tests for pre-downloaded, missing, and empty artifacts; updated CI performance and coverage docs.

- Dependencies
  - Introduced `actions/download-artifact@v8` in CI.

<sup>Written for commit d447c161e15c95afba8d3ebe98c98e9852af43f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

