### PR TITLE
fix(runner): FabricInstance fails loudly at the value-type dispatch and plain-schema fast path

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -3519,20 +3519,28 @@ export class SchemaObjectTraverser<V extends FabricValue>
       // an array element under `items: true` still decomposes via
       // `traverseArrayWithSchema`'s `createDataCellURI` path (pre-existing;
       // not addressed here).
-    } else if (doc.value instanceof FabricSpecialObject) {
-      // A `FabricSpecialObject` (e.g. `FabricBytes`) is an opaque host value
-      // the fabric type system treats like a primitive — always frozen,
-      // passing through conversion unchanged — so it materializes as a LEAF:
-      // its `typeof` is "object", so this arm must precede the record branch
-      // below, which would otherwise decompose it via `Object.entries` over
-      // its own props (empty for e.g. `FabricBytes`, whose surface lives on
-      // the prototype). Type-validate as "object" — the shape the
+    } else if (doc.value instanceof FabricPrimitive) {
+      // A `FabricPrimitive` (e.g. `FabricBytes`) is a fully-opaque host
+      // value — always frozen, passing through conversion unchanged — so it
+      // materializes as a LEAF: its `typeof` is "object", so this arm must
+      // precede the record branch below, which would otherwise decompose it
+      // via `Object.entries` over its own props (empty — its state lives in
+      // private `#fields`). Type-validate as "object" — the shape the
       // schema-generator emits for these types today — but do not consult
-      // the schema's structural details: leaves are not property-walked
-      // (CT-1836).
+      // the schema's structural details: leaves are not property-walked.
       return this.isValidType(schemaObj, "object") !== TypeValidity.False
         ? { ok: this.traversePrimitive(doc, schemaObj) }
         : fail(TRAVERSE_FAILURES.invalidType);
+    } else if (doc.value instanceof FabricInstance) {
+      // A `FabricInstance` is not a fully-opaque leaf: it can have
+      // model-visible outgoing references, so neither the generic record
+      // rebuild below (which strips its class and codec identity) nor
+      // leafing it whole traverses it correctly. Correct traversal descends
+      // it by its codec contents; fail loudly until that exists.
+      throw new Error(
+        `Cannot yet handle \`${doc.value.constructor.name}\` (a ` +
+          "`FabricInstance`) in schema traversal.",
+      );
     } else if (isRecord(doc.value)) {
       if (isSigilLink(doc.value)) {
         this.tx.read(doc.address, READ_FOR_SCHEDULING);
@@ -3692,7 +3700,20 @@ export class SchemaObjectTraverser<V extends FabricValue>
         : fail(TRAVERSE_FAILURES.invalidArray);
     }
 
-    if (doc.value instanceof FabricSpecialObject) return { ok: doc.value };
+    if (doc.value instanceof FabricSpecialObject) {
+      // A `FabricPrimitive` is a fully-opaque leaf; see the value-type
+      // dispatch's arm for the rationale (the plan compiles from the same
+      // schema family, so the same posture applies here).
+      if (doc.value instanceof FabricPrimitive) return { ok: doc.value };
+      // The other subclass, `FabricInstance`, is not a fully-opaque leaf
+      // (it can have model-visible outgoing references): fail loudly rather
+      // than leaf it whole or let it fall into the record copy below. See
+      // the dispatch's `FabricInstance` arm.
+      throw new Error(
+        `Cannot yet handle \`${doc.value.constructor.name}\` (a ` +
+          "`FabricInstance`) in plain-schema traversal.",
+      );
+    }
     if (!isRecord(doc.value)) return fail(TRAVERSE_FAILURES.invalidType);
 
     const newValue: Record<string, Immutable<FabricValue>> = {};

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -3520,23 +3520,19 @@ export class SchemaObjectTraverser<V extends FabricValue>
       // `traverseArrayWithSchema`'s `createDataCellURI` path (pre-existing;
       // not addressed here).
     } else if (doc.value instanceof FabricPrimitive) {
-      // A `FabricPrimitive` (e.g. `FabricBytes`) is a fully-opaque host
-      // value — always frozen, passing through conversion unchanged — so it
-      // materializes as a LEAF: its `typeof` is "object", so this arm must
-      // precede the record branch below, which would otherwise decompose it
-      // via `Object.entries` over its own props (empty — its state lives in
-      // private `#fields`). Type-validate as "object" — the shape the
-      // schema-generator emits for these types today — but do not consult
-      // the schema's structural details: leaves are not property-walked.
+      // An opaque leaf whose `typeof` is "object": this arm must precede the
+      // record branch below, which would otherwise decompose it.
+      // Type-validate as "object" — the shape the schema-generator emits for
+      // these types today — but do not consult the schema's structural
+      // details: leaves are not property-walked.
       return this.isValidType(schemaObj, "object") !== TypeValidity.False
         ? { ok: this.traversePrimitive(doc, schemaObj) }
         : fail(TRAVERSE_FAILURES.invalidType);
     } else if (doc.value instanceof FabricInstance) {
-      // A `FabricInstance` is not a fully-opaque leaf: it can have
-      // model-visible outgoing references, so neither the generic record
-      // rebuild below (which strips its class and codec identity) nor
-      // leafing it whole traverses it correctly. Correct traversal descends
-      // it by its codec contents; fail loudly until that exists.
+      // TODO(danfuzz): a `FabricInstance` (which can have model-visible
+      // outgoing references) is not yet handled by schema traversal; correct
+      // traversal descends it by its codec contents. Fail loudly until that
+      // exists.
       throw new Error(
         `Cannot yet handle \`${doc.value.constructor.name}\` (a ` +
           "`FabricInstance`) in schema traversal.",
@@ -3701,14 +3697,12 @@ export class SchemaObjectTraverser<V extends FabricValue>
     }
 
     if (doc.value instanceof FabricSpecialObject) {
-      // A `FabricPrimitive` is a fully-opaque leaf; see the value-type
-      // dispatch's arm for the rationale (the plan compiles from the same
-      // schema family, so the same posture applies here).
+      // A `FabricPrimitive` is an opaque leaf; see the value-type dispatch's
+      // arm (the plan compiles from the same schema family, so the same
+      // posture applies here).
       if (doc.value instanceof FabricPrimitive) return { ok: doc.value };
-      // The other subclass, `FabricInstance`, is not a fully-opaque leaf
-      // (it can have model-visible outgoing references): fail loudly rather
-      // than leaf it whole or let it fall into the record copy below. See
-      // the dispatch's `FabricInstance` arm.
+      // TODO(danfuzz): a `FabricInstance` is not yet handled here either —
+      // see the dispatch's `FabricInstance` arm. Fail loudly until it is.
       throw new Error(
         `Cannot yet handle \`${doc.value.constructor.name}\` (a ` +
           "`FabricInstance`) in plain-schema traversal.",

--- a/packages/runner/test/schema-dispatch-fabric-instance.test.ts
+++ b/packages/runner/test/schema-dispatch-fabric-instance.test.ts
@@ -1,0 +1,151 @@
+// fabric-safety (#4527): the schema traversal's special-object handling must
+// distinguish the two direct subclasses of `FabricSpecialObject`. A
+// `FabricPrimitive` (state in private `#fields`, zero enumerable own-props)
+// is a fully-opaque leaf. A `FabricInstance` — which can have model-visible
+// outgoing references — must fail loudly rather than be silently leafed
+// whole or rebuilt as a plain record (stripping its class and codec
+// identity), until it can be descended by its codec contents. Covers the
+// value-type dispatch's leaf arm and the plain-schema fast path's
+// special-object check.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type {
+  Entity,
+  Revision,
+  State,
+  URI,
+} from "@commonfabric/memory/interface";
+import type { SchemaPathSelector } from "@commonfabric/api";
+
+import {
+  createDefaultTraversalContext,
+  type IMemorySpaceValueAttestation,
+  ManagedStorageTransaction,
+  SchemaObjectTraverser,
+} from "../src/traverse.ts";
+import { StoreObjectManager } from "../src/storage/query.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+
+const traverserOver = (
+  uri: string,
+  value: FabricValue,
+  selector: SchemaPathSelector,
+  // `includeMeta: false` (the query path's setting) enables the plain-schema
+  // fast path (`traverseCells` gates it off otherwise).
+  includeMeta = true,
+) => {
+  const store = new Map<string, Revision<State>>();
+  const type = "application/json" as const;
+  const entity = uri as URI as Entity;
+  store.set(`${entity}/${type}`, {
+    the: type,
+    of: entity,
+    is: { value },
+    cause: hashOf({ the: type, of: entity }),
+    since: 1,
+  });
+  const manager = new StoreObjectManager(store);
+  const managedTx = new ManagedStorageTransaction(manager);
+  const storeTx = new ExtendedStorageTransaction(managedTx);
+  const traverser = new SchemaObjectTraverser(
+    storeTx,
+    selector,
+    createDefaultTraversalContext(includeMeta),
+  );
+  const doc: IMemorySpaceValueAttestation = {
+    address: {
+      space: "did:null:null",
+      id: uri as URI,
+      type,
+      path: ["value"],
+    },
+    value,
+  };
+  return { traverser, doc };
+};
+
+describe("value-type dispatch: FabricSpecialObject subclasses", () => {
+  const objectSelector: SchemaPathSelector = {
+    path: ["value"],
+    schema: {
+      type: "object",
+      properties: { field: { type: "object" } },
+    },
+  };
+
+  it("materializes a FabricPrimitive as an opaque leaf (regression pin)", () => {
+    const blob = new FabricBytes(new Uint8Array([1, 2, 3]));
+    const { traverser, doc } = traverserOver(
+      "of:dispatch-primitive",
+      { field: blob } as unknown as FabricValue,
+      objectSelector,
+    );
+
+    const { ok: result } = traverser.traverse(doc);
+    expect((result as Record<string, unknown>).field).toBeInstanceOf(
+      FabricBytes,
+    );
+  });
+
+  it("fails loudly on a FabricInstance (not yet handled)", () => {
+    // A `FabricInstance` is not a fully-opaque leaf: leafing it whole (as
+    // this arm did for any `FabricSpecialObject`) silently hides that its
+    // contents were never descended or validated. Fail loudly until
+    // codec-contents descent exists.
+    const failure = FabricError.fromNativeError(new Error("loud"));
+    const { traverser, doc } = traverserOver(
+      "of:dispatch-instance",
+      { field: failure } as unknown as FabricValue,
+      objectSelector,
+    );
+
+    expect(() => traverser.traverse(doc)).toThrow(/Cannot yet handle/);
+  });
+});
+
+describe("plain-schema fast path: FabricSpecialObject subclasses", () => {
+  // An array whose item schema compiles to a plain-schema plan (`type` +
+  // `properties` with primitive-typed leaves only) routes each element
+  // through `traversePlainSchemaWithReads`.
+  const planSelector: SchemaPathSelector = {
+    path: ["value"],
+    schema: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { name: { type: "string" } },
+      },
+    },
+  };
+
+  it("materializes a FabricPrimitive element as an opaque leaf (regression pin)", () => {
+    const blob = new FabricBytes(new Uint8Array([7, 7]));
+    const { traverser, doc } = traverserOver(
+      "of:plan-primitive",
+      [blob] as unknown as FabricValue,
+      planSelector,
+      false,
+    );
+
+    const { ok: result } = traverser.traverse(doc);
+    expect((result as unknown[])[0]).toBeInstanceOf(FabricBytes);
+  });
+
+  it("fails loudly on a FabricInstance element (not yet handled)", () => {
+    const failure = FabricError.fromNativeError(new Error("loud"));
+    const { traverser, doc } = traverserOver(
+      "of:plan-instance",
+      [failure] as unknown as FabricValue,
+      planSelector,
+      false,
+    );
+
+    expect(() => traverser.traverse(doc)).toThrow(/Cannot yet handle/);
+  });
+});


### PR DESCRIPTION
Applies the subclass ruling from your #4531 review to the two main-side special-object leaf sites that rework doesn't own: the value-type dispatch's leaf arm (landed via #4510 / CT-1836) and the plain-schema fast path's special-object check (landed via #4693). Kept as its own PR so each review stays self-contained.

Part of the fabric-safety series — tracking issue #4527.

### Shape

Both sites previously leafed any `FabricSpecialObject`. Now:

- **`FabricPrimitive`** leafs exactly as before — the dispatch arm keeps its type-validate-as-"object" + `traversePrimitive` materialization; the plan walk keeps its identity return. Pinned by regression tests on both routes.
- **`FabricInstance`** throws (`Cannot yet handle … in schema traversal.` / `… in plain-schema traversal.`), per the fail-loud posture from your #4531 review: silently leafing an instance hides that its contents were never descended or validated.
- The plan walk keeps its outer `instanceof FabricSpecialObject` chokepoint (downstream typing relies on the union subtraction) and splits primitive/instance inside it.
- The dispatch's `TODO(danfuzz)` narrows to the codec-contents-descent residual plus the pre-existing `items: true` array-element residual — the same final text as #4531's rework, so the two PRs converge textually; whichever lands second takes a trivial adjacent-hunk rebase.

### Verification

- **Red-first:** against unmodified `main`, both instance cases pass a leafed instance through intact (failing runs captured); the primitive pins pass before and after.
- **Routing verified by mutation:** temporarily restoring the plan walk's old leaf flipped ONLY the plan-path test while the dispatch test stayed green — each test pins its own site. The plan-path tests run with `includeMeta: false` (the query path's setting); the fast path is gated off otherwise.
- **Gates:** fmt/lint/`deno check` clean; full `packages/runner` suite **971 passed / 0 failed** with the throws in place.
- **Contrast with `traverseDAG` (#4531):** the equivalent instance arm there had to back off to leafing — the fetch builtins store a `FabricError` result value that the tracked-query refresh reads back through `traverseDAG`, so throwing broke fetch reactivity (uncaught rejection in the refresh loop). No unit-suite traffic routes instances through the two sites here.

### Needs Dan's judgment

1. Throw-vs-leaf on these two sites if the pattern-integration suites (the broader canary) surface live instance traffic the runner unit suite doesn't — the same back-off #4531's `traverseDAG` took would apply.
2. The message texts, matched to #4531's reworked sites.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split schema traversal to leaf `FabricPrimitive` and fail loudly on `FabricInstance` in both value-type dispatch and the plain-schema fast path. Prevents silently skipping instance contents during validation (fabric-safety #4527).

- **Bug Fixes**
  - Value-type dispatch: leaf `FabricPrimitive`; throw "Cannot yet handle … (a `FabricInstance`) in schema traversal."
  - Plain-schema fast path: leaf `FabricPrimitive`; throw "Cannot yet handle … (a `FabricInstance`) in plain-schema traversal."
  - Tests pin primitive leafing and assert throws for instances; runner suite stays green.

- **Refactors**
  - Add `TODO(danfuzz)` on both `FabricInstance` arms; trim `FabricPrimitive` guard comments.

<sup>Written for commit 89e1facde082d983ccd5b5370db3ca0ed1dbf70b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

