### PR TITLE
fix(runner): anchor writeAuthorizedBy on moduleIdentity + bindingPath, tolerate resolver file spellings (CT-1886)

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -2550,9 +2550,12 @@ sides load-independent and equal.
 CFC's implementation identity surfaces it as `sourceFile`/`bindingPath`
 (`packages/runner/src/cfc/implementation-identity.ts`), and at commit the
 `writeAuthorizedBy` check requires the writing identity's
-moduleIdentity + normalized source file + binding path to equal the claim's
-(`packages/runner/src/cfc/prepare.ts`; both sides pass through
-`normalizeIdentitySource`, which only guarantees a leading slash). The
+moduleIdentity + binding path to equal the claim's — the file SPELLING is
+deliberately not load-bearing at verification (it is resolver-dependent;
+labs#4772). Stamp MINTING (`rebindWriteAuthorizedByClaims`) still requires
+exact slash-normalized file equality, and stored-claim reconciliation
+tolerates spellings one leading segment apart
+(`packages/runner/src/cfc/writer-claim-correspondence.ts`). The
 non-exported case reaches provenance through the `__cfReg` registration sink
 — the gap guarded by
 `packages/runner/test/cfc-nonexported-binding-identity.test.ts`.

--- a/packages/runner/src/cfc/implementation-identity.ts
+++ b/packages/runner/src/cfc/implementation-identity.ts
@@ -3,6 +3,7 @@ import type { HarnessedFunction } from "../harness/types.ts";
 import type { ImplementationIdentity } from "./types.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
+import { normalizeIdentitySource } from "./writer-claim-correspondence.ts";
 
 /**
  * Resolve the policy-facing implementation identity for a module invocation.
@@ -76,7 +77,7 @@ const resolveProvenanceImplementationIdentity = (
       ? {
         sourceFile: normalizeIdentitySource(
           provenance.bindingIdentity.sourceFile,
-        ),
+        )!,
         bindingPath: [...provenance.bindingIdentity.bindingPath],
       }
       : {}),
@@ -86,6 +87,3 @@ const resolveProvenanceImplementationIdentity = (
     }),
   };
 };
-
-const normalizeIdentitySource = (source: string): string =>
-  source.startsWith("/") ? source : `/${source}`;

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -14,10 +14,7 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import {
-  normalizeIdentitySource,
-  writerClaimFilesCorrespond,
-} from "./writer-claim-correspondence.ts";
+import { normalizeIdentitySource } from "./writer-claim-correspondence.ts";
 import type { FabricValue } from "@commonfabric/api";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import { isRecord } from "@commonfabric/utils/types";
@@ -1080,8 +1077,8 @@ const rebindWriteAuthorizedByClaims = (
   }
   // Only the function NAMED by a binding may stamp that binding's provenance
   // moduleIdentity. The writer's own binding (sourceFile + bindingPath) must
-  // correspond to the claim's binding (file + path; spelling-tolerant, see
-  // writer-claim-correspondence.ts); otherwise a foreign writer that
+  // match the claim's binding (file + path) exactly; otherwise a foreign
+  // writer that
   // merely *initializes* the protected field — e.g. profile-create's
   // `submitProfileCreation` seeding a freshly `inSpace`'d ProfileHome whose
   // `elements` bind to profile-home's `mutateElements` — would stamp ITS module
@@ -1147,10 +1144,20 @@ const rebindWriteAuthorizedByClaimsInner = (
     // match rationale in rebindWriteAuthorizedByClaims). When we can identify
     // both bindings, require they match; a mismatch means a foreign writer is
     // initializing the field, so we leave the claim unstamped.
+    // Minting the FIRST stamp requires exact (slash-normalized) file
+    // equality, not the tolerant spelling correspondence: a claim being
+    // stamped here rides a schema emitted by the SAME compile as the live
+    // writer, so their spellings agree whenever the writer genuinely is the
+    // named binding. Cross-spelling healing of stored claims deliberately
+    // does NOT happen here — the current compile's claim gets stamped
+    // exactly, and reconcileWriterClaimStamp adopts that stamp onto the
+    // stored spelling (schema-merge.ts). Keeping the mint exact means the
+    // tolerance never widens who can create authority, only how an
+    // already-minted stamp meets an aged spelling.
     const writerOwnsBinding = ids.writerFile !== undefined &&
       ids.writerPath !== undefined && bindingFile !== undefined &&
       bindingPath !== undefined &&
-      writerClaimFilesCorrespond(ids.writerFile, bindingFile) &&
+      ids.writerFile === bindingFile &&
       arraysEqual(ids.writerPath, bindingPath);
     if (
       isRecord(claim.__ctWriterIdentityOf) &&

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -14,6 +14,10 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+import {
+  normalizeIdentitySource,
+  writerClaimFilesCorrespond,
+} from "./writer-claim-correspondence.ts";
 import type { FabricValue } from "@commonfabric/api";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import { isRecord } from "@commonfabric/utils/types";
@@ -555,6 +559,12 @@ const writeAuthorizedByReason = (
   // must match the live identity's. The legacy bundleId-only arm (stored
   // pre-#4009 claims) retired with the legacy read path (identity E5,
   // data-wipe decision): a claim without a moduleIdentity is rejected.
+  //
+  // The binding is `moduleIdentity` + `bindingPath`. The claim's file SPELLING
+  // deliberately does not participate: it is resolver-dependent (the same
+  // module spells differently across piece-deploy and HTTP compiles —
+  // labs#4772), while moduleIdentity already pins the module content-
+  // addressed, subsuming anything the spelling could soundly assert.
   const identityArmMatches =
     typeof bindingIdentity.moduleIdentity === "string" &&
     typeof identity.moduleIdentity === "string" &&
@@ -562,8 +572,6 @@ const writeAuthorizedByReason = (
     identity.moduleIdentity === bindingIdentity.moduleIdentity;
   if (
     !identityArmMatches ||
-    normalizeIdentitySource(identity.sourceFile) !==
-      normalizeIdentitySource(bindingIdentity.file) ||
     !arraysEqual(identity.bindingPath, bindingIdentity.path)
   ) {
     return `writeAuthorizedBy failed at /${path.join("/")}`;
@@ -604,15 +612,6 @@ const arraysEqual = (
 ): boolean =>
   left.length === right.length &&
   left.every((value, index) => value === right[index]);
-
-const normalizeIdentitySource = (
-  source: string | undefined,
-): string | undefined => {
-  if (typeof source !== "string" || source.length === 0) {
-    return undefined;
-  }
-  return source.startsWith("/") ? source : `/${source}`;
-};
 
 type StructuralProvenanceInput = Extract<
   WritePolicyInput,
@@ -1081,7 +1080,8 @@ const rebindWriteAuthorizedByClaims = (
   }
   // Only the function NAMED by a binding may stamp that binding's provenance
   // moduleIdentity. The writer's own binding (sourceFile + bindingPath) must
-  // match the claim's binding (file + path); otherwise a foreign writer that
+  // correspond to the claim's binding (file + path; spelling-tolerant, see
+  // writer-claim-correspondence.ts); otherwise a foreign writer that
   // merely *initializes* the protected field — e.g. profile-create's
   // `submitProfileCreation` seeding a freshly `inSpace`'d ProfileHome whose
   // `elements` bind to profile-home's `mutateElements` — would stamp ITS module
@@ -1150,7 +1150,7 @@ const rebindWriteAuthorizedByClaimsInner = (
     const writerOwnsBinding = ids.writerFile !== undefined &&
       ids.writerPath !== undefined && bindingFile !== undefined &&
       bindingPath !== undefined &&
-      ids.writerFile === bindingFile &&
+      writerClaimFilesCorrespond(ids.writerFile, bindingFile) &&
       arraysEqual(ids.writerPath, bindingPath);
     if (
       isRecord(claim.__ctWriterIdentityOf) &&

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -4,6 +4,7 @@ import { isRecord } from "@commonfabric/utils/types";
 import type { JSONSchema, JSONSchemaObj } from "../builder/types.ts";
 import { forEachSubschema } from "../schema-walk.ts";
 import { normalizeClause } from "./clause.ts";
+import { writerClaimFilesCorrespond } from "./writer-claim-correspondence.ts";
 
 const IFC_KEYS = [
   "confidentiality",
@@ -78,21 +79,31 @@ const WRITER_CLAIM_STAMP_KEYS = ["bundleId", "moduleIdentity"] as const;
 const writerClaimIsStamped = (identity: Record<string, unknown>): boolean =>
   WRITER_CLAIM_STAMP_KEYS.some((key) => identity[key] !== undefined);
 
-const writerClaimWithoutStamp = (
+const writerClaimWithoutStampAndFile = (
   identity: Record<string, unknown>,
 ): Record<string, unknown> => {
   const rest = { ...identity };
   for (const key of WRITER_CLAIM_STAMP_KEYS) delete rest[key];
+  // The file spelling is compared separately, tolerantly
+  // (writerClaimFilesCorrespond) — never byte-wise.
+  delete rest.file;
   return rest;
 };
 
 /**
- * Reconcile two `writeAuthorizedBy` writer-identity claims that differ only
- * by the presence of the provenance stamp (`moduleIdentity`, or a legacy
- * `bundleId` on pre-migration claims — one side recorded under a verified
- * identity, the other without one). Returns the stamped claim, or `undefined`
- * when the claims genuinely conflict (different bindings, or two different
- * stamps).
+ * Reconcile two `writeAuthorizedBy` writer-identity claims that mean the same
+ * binding. The binding a claim MEANS is `path` (+ `moduleIdentity` once
+ * stamped); the `file` spelling is resolver-dependent (the same module spells
+ * differently across piece-deploy and HTTP compiles — labs#4772), so two
+ * claims reconcile when their paths match, their file spellings CORRESPOND
+ * (equal or one-leading-segment apart), and everything outside file + stamp
+ * is equal. Returns the stamped side when exactly one carries the provenance
+ * stamp (`moduleIdentity`, or a legacy `bundleId` on pre-migration claims),
+ * the existing side when neither does or both carry the SAME stamp (stored
+ * spelling wins — stability), and `undefined` when the claims genuinely
+ * conflict (different bindings, or two different stamps — claim rotation
+ * across module versions stays fail-closed pending the setsrc-history
+ * delegation design).
  */
 const reconcileWriterClaimStamp = (
   existing: unknown,
@@ -103,26 +114,45 @@ const reconcileWriterClaimStamp = (
   }
   const existingIdentity = existing.__ctWriterIdentityOf;
   const candidateIdentity = candidate.__ctWriterIdentityOf;
-  const existingStamped = writerClaimIsStamped(existingIdentity);
-  const candidateStamped = writerClaimIsStamped(candidateIdentity);
-  // Exactly one side stamped — otherwise deepEqual already decided (equal
-  // stamps) or this is a genuine conflict (two different stamps).
-  if (existingStamped === candidateStamped) {
+  if (
+    !writerClaimFilesCorrespond(
+      typeof existingIdentity.file === "string"
+        ? existingIdentity.file
+        : undefined,
+      typeof candidateIdentity.file === "string"
+        ? candidateIdentity.file
+        : undefined,
+    )
+  ) {
     return undefined;
   }
   if (
     !deepEqual(
       {
         ...existing,
-        __ctWriterIdentityOf: writerClaimWithoutStamp(existingIdentity),
+        __ctWriterIdentityOf: writerClaimWithoutStampAndFile(existingIdentity),
       },
       {
         ...candidate,
-        __ctWriterIdentityOf: writerClaimWithoutStamp(candidateIdentity),
+        __ctWriterIdentityOf: writerClaimWithoutStampAndFile(candidateIdentity),
       },
     )
   ) {
     return undefined;
+  }
+  const existingStamped = writerClaimIsStamped(existingIdentity);
+  const candidateStamped = writerClaimIsStamped(candidateIdentity);
+  if (existingStamped && candidateStamped) {
+    // Both stamped: same stamp → the stored claim (spelling included) wins;
+    // different stamps → genuine conflict, never silently rotated.
+    return WRITER_CLAIM_STAMP_KEYS.every((key) =>
+        deepEqual(existingIdentity[key], candidateIdentity[key])
+      )
+      ? existing
+      : undefined;
+  }
+  if (!existingStamped && !candidateStamped) {
+    return existing;
   }
   return existingStamped ? existing : candidate;
 };

--- a/packages/runner/src/cfc/writer-claim-correspondence.ts
+++ b/packages/runner/src/cfc/writer-claim-correspondence.ts
@@ -13,13 +13,26 @@
  * (labs#4772 / CT-1886).
  *
  * Authorization therefore anchors on `moduleIdentity` + `bindingPath`; the
- * file spelling is diagnostic. Where a file comparison still participates —
- * establishing which claim a writer's binding corresponds to before a stamp
- * exists — it must tolerate exactly the historical divergence: two spellings
- * correspond when they are equal or differ by one leading path segment (the
- * transformer's strip). Stored claims keep their mint-time spelling forever,
- * so this tolerance is permanent aged-store compat, deliberately no wider
- * than the divergence the toolchain actually produced.
+ * file spelling is diagnostic. The tolerant correspondence below is consumed
+ * in exactly one place — `reconcileWriterClaimStamp` (schema-merge.ts), where
+ * a stamp minted under the current compile's spelling meets a stored claim
+ * carrying an aged spelling of the same binding. It deliberately does NOT
+ * gate stamp MINTING (`rebindWriteAuthorizedByClaims` requires exact
+ * slash-normalized equality: a claim being stamped rides a schema emitted by
+ * the same compile as the writer, so exact holds wherever stamping is
+ * genuine), so the tolerance never widens who can create authority — only
+ * how an already-minted stamp meets an aged spelling. Residual: at the
+ * reconcile-adoption edge, a hostile verified module whose forged path
+ * differs from a stored unstamped claim's by one leading segment is accepted
+ * where before it needed the exact spelling — a marginal widening of the
+ * pre-existing path-forgeability that mint-time identity binding /
+ * setsrc-history delegation closes for real (board topic, index 38).
+ *
+ * The correspondence is deliberately no wider than the divergence the
+ * toolchain actually produced: equal after slash-normalization, or exactly
+ * one leading path segment apart (the transformer's strip). Stored claims
+ * keep their mint-time spelling forever, so this is permanent aged-store
+ * compat.
  */
 
 /** Leading-slash-normalize a claim/identity source-file spelling. */

--- a/packages/runner/src/cfc/writer-claim-correspondence.ts
+++ b/packages/runner/src/cfc/writer-claim-correspondence.ts
@@ -1,0 +1,58 @@
+/**
+ * Spelling helpers for `writeAuthorizedBy` writer-identity claims.
+ *
+ * A claim's `file` and a live identity's `sourceFile` both record the module's
+ * source-file SPELLING, and that spelling is resolver-dependent: the compiler
+ * sees names exactly as the program resolver spelled them, and the
+ * ts-transformers' historical normalization additionally stripped the first
+ * path segment of absolute names (aimed at the engine's per-load `/<id>`
+ * prefix, but applied blindly). The same module therefore appears as e.g.
+ * `/api/patterns/system/x.tsx` (piece-deploy staging), `api/patterns/...`
+ * (piece-manifest relative), or `/patterns/system/x.tsx` (HTTP-resolved,
+ * stripped) — while its content-addressed `moduleIdentity` agrees everywhere
+ * (labs#4772 / CT-1886).
+ *
+ * Authorization therefore anchors on `moduleIdentity` + `bindingPath`; the
+ * file spelling is diagnostic. Where a file comparison still participates —
+ * establishing which claim a writer's binding corresponds to before a stamp
+ * exists — it must tolerate exactly the historical divergence: two spellings
+ * correspond when they are equal or differ by one leading path segment (the
+ * transformer's strip). Stored claims keep their mint-time spelling forever,
+ * so this tolerance is permanent aged-store compat, deliberately no wider
+ * than the divergence the toolchain actually produced.
+ */
+
+/** Leading-slash-normalize a claim/identity source-file spelling. */
+export const normalizeIdentitySource = (
+  source: string | undefined,
+): string | undefined => {
+  if (typeof source !== "string" || source.length === 0) {
+    return undefined;
+  }
+  return source.startsWith("/") ? source : `/${source}`;
+};
+
+// The ts-transformers' historical first-segment strip, mirrored exactly: the
+// only spelling divergence the toolchain has produced for one module.
+const dropFirstPathSegment = (source: string): string | undefined =>
+  source.match(/^\/[^/]+(\/.+)$/)?.[1] ?? undefined;
+
+/**
+ * Whether two source-file spellings plausibly name the same module: equal
+ * after leading-slash normalization, or one is the other minus its first
+ * path segment. Never treats an undefined side as corresponding.
+ */
+export const writerClaimFilesCorrespond = (
+  left: string | undefined,
+  right: string | undefined,
+): boolean => {
+  const a = normalizeIdentitySource(left);
+  const b = normalizeIdentitySource(right);
+  if (a === undefined || b === undefined) {
+    return false;
+  }
+  if (a === b) {
+    return true;
+  }
+  return dropFirstPathSegment(a) === b || dropFirstPathSegment(b) === a;
+};

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -53,6 +53,27 @@ const logger = getLogger("scheduler", {
 });
 const EVENT_COMMIT_TELEMETRY_WRITE_LIMIT = 25;
 
+/**
+ * A CFC-enforcement-rejected commit on a give-up disposition is silent data
+ * loss of user intent — the UI's write simply never lands (labs#4772 shipped
+ * that way for weeks behind the opt-in scheduler logger, which is disabled in
+ * deployed workers). Report it unconditionally; the opt-in `logger.warn`
+ * alongside still carries the full disposition detail.
+ */
+export function reportDroppedCfcRejectedWrite(
+  error: { message?: string } | undefined,
+  handlerId: unknown,
+): void {
+  if (!error?.message?.startsWith("CFC enforcement rejected commit")) {
+    return;
+  }
+  console.error(
+    "[cfc] Owner-protected write dropped: CFC enforcement rejected the " +
+      "commit and re-running cannot resolve it.",
+    { error: error.message, handlerId },
+  );
+}
+
 export function isHeadEventParked(
   state: { readonly eventQueue: readonly QueuedEvent[] },
   now: number = performance.now(),
@@ -1107,6 +1128,7 @@ export async function dispatchQueuedEvent(state: {
           return;
         case "give-up":
           runFinalCommitCallback();
+          reportDroppedCfcRejectedWrite(result.error, handlerId);
           logger.warn(
             "scheduler",
             disposition.reason === "non-retryable"

--- a/packages/runner/test/cfc-writer-claim-correspondence.test.ts
+++ b/packages/runner/test/cfc-writer-claim-correspondence.test.ts
@@ -13,11 +13,12 @@ import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
  * `bindingPath`; the claim's file SPELLING is resolver-dependent (the same
  * module spells `/api/patterns/system/x.tsx` from a piece-deploy compile and
  * `/patterns/system/x.tsx` from an HTTP-resolved one) and must not shear
- * authorization. These tests pin the tolerant correspondence at all three
- * sites — verification, stamping (rebind), and stored-claim reconciliation —
- * and pin that identity and path stay fail-closed (claim rotation across
- * module versions remains a conflict pending the setsrc-history delegation
- * design; see the board topic).
+ * authorization. These tests pin the spelling tolerance at the two sites
+ * that read EXISTING stamps (verification, stored-claim reconciliation), pin
+ * that stamp MINTING stays exact (rebind — the tolerance never widens who
+ * can create authority), and pin that identity and path stay fail-closed
+ * (claim rotation across module versions remains a conflict pending the
+ * setsrc-history delegation design; see the board topic).
  */
 
 const MODULE_IDENTITY = "profile-home-module-identity";
@@ -144,17 +145,15 @@ describe("writeAuthorizedBy across resolver spellings (labs#4772)", () => {
     expect(result.error).toBeUndefined();
   });
 
-  it("an UNSTAMPED claim is stamped by the owning binding under the other spelling, then verifies", async () => {
-    // The bricked-store shape: the claim persisted unstamped (seeded by a
-    // foreign writer — CT-1740 leaves it unstamped on purpose) under the
-    // piece spelling; the genuine bound writer arrives via the HTTP compile.
-    // Rebind must recognize the correspondence, stamp, and the write commits.
+  it("an UNSTAMPED claim is stamped by the owning binding under the SAME spelling, then verifies", async () => {
+    // Stamp minting is exact by design: a claim being stamped rides a schema
+    // emitted by the same compile as the writer, so their spellings agree.
     const rt = makeRuntime("ts-spelling-stamp");
     const tx = rt.edit();
     const cell = rt.getCell(
       signer.did(),
       "wab-spelling-stamp",
-      claimSchema({ file: PIECE_SPELLING, path: ["setBio"] }),
+      claimSchema({ file: HTTP_SPELLING, path: ["setBio"] }),
       tx,
     );
     tx.setCfcImplementationIdentity({
@@ -163,12 +162,40 @@ describe("writeAuthorizedBy across resolver spellings (labs#4772)", () => {
       sourceFile: HTTP_SPELLING,
       bindingPath: ["setBio"],
     });
-    cell.set({ bio: "healed" });
+    cell.set({ bio: "stamped in-universe" });
 
     const digest = tx.prepareCfc();
     expect(digest).not.toBe("");
     const result = await tx.commit();
     expect(result.error).toBeUndefined();
+  });
+
+  it("an UNSTAMPED claim is NOT stamped across spellings — minting stays exact", async () => {
+    // The reviewers' scenario (PR #4852 P1): a verified module whose path
+    // differs from the unstamped claim's by one leading segment must not
+    // mint the first stamp via the tolerance. Minting requires exact
+    // spelling; cross-spelling healing happens only at reconcile-adoption,
+    // where the stamp was already minted exactly by the owning compile.
+    const rt = makeRuntime("ts-spelling-no-fuzzy-mint");
+    const tx = rt.edit();
+    const cell = rt.getCell(
+      signer.did(),
+      "wab-spelling-no-fuzzy-mint",
+      claimSchema({ file: PIECE_SPELLING, path: ["setBio"] }),
+      tx,
+    );
+    tx.setCfcImplementationIdentity({
+      kind: "verified",
+      moduleIdentity: "would-be-thief-module-identity",
+      sourceFile: HTTP_SPELLING,
+      bindingPath: ["setBio"],
+    });
+    cell.set({ bio: "must not land" });
+
+    const digest = tx.prepareCfc();
+    expect(digest).toBe("");
+    const result = await tx.commit();
+    expect(result.error).toBeDefined();
   });
 
   it("a different moduleIdentity still fails closed even with corresponding spellings", async () => {
@@ -324,6 +351,92 @@ describe("stored-claim reconciliation across spellings", () => {
         envelope({ file: "/attacker.tsx", path: ["setBio"] }),
       )
     ).toThrow("writeAuthorizedBy must remain stable");
+  });
+});
+
+describe("the labs#4772 heal end-to-end: exact mint + tolerant adoption + identity verify", () => {
+  const signer2 = signer;
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    storageManager = undefined;
+    runtime = undefined;
+  });
+
+  it("a bricked store (unstamped piece-spelled claim) heals through a cold-session write", async () => {
+    // The full bio-save shape with minting kept exact: the cold session's
+    // candidate schema carries the claim in the WRITER's own spelling
+    // (same compile universe), so rebind stamps it exactly; the merge then
+    // adopts that stamp onto the stored piece-spelled claim; verification
+    // passes on moduleIdentity + bindingPath.
+    const stored = {
+      type: "object",
+      properties: {
+        bio: {
+          type: "string",
+          ifc: {
+            writeAuthorizedBy: {
+              __ctWriterIdentityOf: { file: PIECE_SPELLING, path: ["setBio"] },
+            },
+          },
+        },
+      },
+    } as unknown as JSONSchemaObj;
+    const candidate = {
+      type: "object",
+      properties: {
+        bio: {
+          type: "string",
+          ifc: {
+            writeAuthorizedBy: {
+              __ctWriterIdentityOf: {
+                moduleIdentity: MODULE_IDENTITY,
+                file: HTTP_SPELLING,
+                path: ["setBio"],
+              },
+            },
+          },
+        },
+      },
+    } as unknown as JSONSchemaObj;
+    const merged = mergeCfcSchemaEnvelopes(stored, candidate);
+    // deno-lint-ignore no-explicit-any
+    const healedClaim = (merged as any).properties.bio.ifc.writeAuthorizedBy
+      .__ctWriterIdentityOf;
+    expect(healedClaim.moduleIdentity).toBe(MODULE_IDENTITY);
+
+    storageManager = StorageManager.emulate({ as: signer2 });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      trustSnapshotProvider: () => ({
+        id: "ts-heal-e2e",
+        actingPrincipal: signer2.did(),
+      }),
+    });
+    const tx = runtime.edit();
+    const cell = runtime.getCell(
+      signer2.did(),
+      "wab-heal-e2e",
+      merged as unknown as JSONSchema,
+      tx,
+    );
+    tx.setCfcImplementationIdentity({
+      kind: "verified",
+      moduleIdentity: MODULE_IDENTITY,
+      sourceFile: HTTP_SPELLING,
+      bindingPath: ["setBio"],
+    });
+    cell.set({ bio: "healed and committed" });
+
+    const digest = tx.prepareCfc();
+    expect(digest).not.toBe("");
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
   });
 });
 

--- a/packages/runner/test/cfc-writer-claim-correspondence.test.ts
+++ b/packages/runner/test/cfc-writer-claim-correspondence.test.ts
@@ -1,0 +1,357 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { writerClaimFilesCorrespond } from "../src/cfc/writer-claim-correspondence.ts";
+import { mergeCfcSchemaEnvelopes } from "../src/cfc/schema-merge.ts";
+import { reportDroppedCfcRejectedWrite } from "../src/scheduler/events.ts";
+import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
+
+/**
+ * labs#4772 / CT-1886: `writeAuthorizedBy` anchors on `moduleIdentity` +
+ * `bindingPath`; the claim's file SPELLING is resolver-dependent (the same
+ * module spells `/api/patterns/system/x.tsx` from a piece-deploy compile and
+ * `/patterns/system/x.tsx` from an HTTP-resolved one) and must not shear
+ * authorization. These tests pin the tolerant correspondence at all three
+ * sites — verification, stamping (rebind), and stored-claim reconciliation —
+ * and pin that identity and path stay fail-closed (claim rotation across
+ * module versions remains a conflict pending the setsrc-history delegation
+ * design; see the board topic).
+ */
+
+const MODULE_IDENTITY = "profile-home-module-identity";
+const PIECE_SPELLING = "/api/patterns/system/profile-home.tsx";
+const HTTP_SPELLING = "/patterns/system/profile-home.tsx";
+const RELATIVE_SPELLING = "api/patterns/system/profile-home.tsx";
+
+const signer = await Identity.fromPassphrase("wab-spelling-correspondence");
+
+describe("writerClaimFilesCorrespond", () => {
+  it("accepts equal spellings, with and without the leading slash", () => {
+    expect(writerClaimFilesCorrespond(PIECE_SPELLING, PIECE_SPELLING)).toBe(
+      true,
+    );
+    expect(writerClaimFilesCorrespond(RELATIVE_SPELLING, PIECE_SPELLING)).toBe(
+      true,
+    );
+  });
+
+  it("accepts spellings one leading segment apart, either direction", () => {
+    expect(writerClaimFilesCorrespond(PIECE_SPELLING, HTTP_SPELLING)).toBe(
+      true,
+    );
+    expect(writerClaimFilesCorrespond(HTTP_SPELLING, PIECE_SPELLING)).toBe(
+      true,
+    );
+    expect(writerClaimFilesCorrespond(RELATIVE_SPELLING, HTTP_SPELLING)).toBe(
+      true,
+    );
+  });
+
+  it("rejects unrelated files, deeper divergence, and absent sides", () => {
+    expect(writerClaimFilesCorrespond("/attacker.tsx", "/victim.tsx")).toBe(
+      false,
+    );
+    // Two segments apart is beyond the toolchain's historical divergence.
+    expect(
+      writerClaimFilesCorrespond(
+        "/a/api/patterns/system/profile-home.tsx",
+        HTTP_SPELLING,
+      ),
+    ).toBe(false);
+    expect(writerClaimFilesCorrespond(undefined, HTTP_SPELLING)).toBe(false);
+    expect(writerClaimFilesCorrespond(HTTP_SPELLING, undefined)).toBe(false);
+  });
+
+  it("rejects same-leaf files in unrelated directories", () => {
+    expect(
+      writerClaimFilesCorrespond(
+        "/patterns/system/profile-home.tsx",
+        "/attacker/profile-home.tsx",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("writeAuthorizedBy across resolver spellings (labs#4772)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    storageManager = undefined;
+    runtime = undefined;
+  });
+
+  const makeRuntime = (snapshotId: string) => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      trustSnapshotProvider: () => ({
+        id: snapshotId,
+        actingPrincipal: signer.did(),
+      }),
+    });
+    return runtime;
+  };
+
+  const claimSchema = (identity: Record<string, unknown>): JSONSchema =>
+    ({
+      type: "object",
+      properties: {
+        bio: {
+          type: "string",
+          ifc: {
+            writeAuthorizedBy: { __ctWriterIdentityOf: identity },
+          },
+        },
+      },
+      required: ["bio"],
+    }) as unknown as JSONSchema;
+
+  it("a stamped claim verifies against the same module compiled under the other spelling", async () => {
+    // The cold-session bio save: claim minted+stamped by the piece-deploy
+    // compile, live writer resolved via the HTTP compile. moduleIdentity
+    // agrees; only the spelling differs. Before the fix the file arm
+    // rejected this and the write was dropped.
+    const rt = makeRuntime("ts-spelling-verify");
+    const tx = rt.edit();
+    const cell = rt.getCell(
+      signer.did(),
+      "wab-spelling-verify",
+      claimSchema({
+        moduleIdentity: MODULE_IDENTITY,
+        file: PIECE_SPELLING,
+        path: ["setBio"],
+      }),
+      tx,
+    );
+    tx.setCfcImplementationIdentity({
+      kind: "verified",
+      moduleIdentity: MODULE_IDENTITY,
+      sourceFile: HTTP_SPELLING,
+      bindingPath: ["setBio"],
+    });
+    cell.set({ bio: "written from the sidecar compile" });
+
+    const digest = tx.prepareCfc();
+    expect(digest).not.toBe("");
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
+  });
+
+  it("an UNSTAMPED claim is stamped by the owning binding under the other spelling, then verifies", async () => {
+    // The bricked-store shape: the claim persisted unstamped (seeded by a
+    // foreign writer — CT-1740 leaves it unstamped on purpose) under the
+    // piece spelling; the genuine bound writer arrives via the HTTP compile.
+    // Rebind must recognize the correspondence, stamp, and the write commits.
+    const rt = makeRuntime("ts-spelling-stamp");
+    const tx = rt.edit();
+    const cell = rt.getCell(
+      signer.did(),
+      "wab-spelling-stamp",
+      claimSchema({ file: PIECE_SPELLING, path: ["setBio"] }),
+      tx,
+    );
+    tx.setCfcImplementationIdentity({
+      kind: "verified",
+      moduleIdentity: MODULE_IDENTITY,
+      sourceFile: HTTP_SPELLING,
+      bindingPath: ["setBio"],
+    });
+    cell.set({ bio: "healed" });
+
+    const digest = tx.prepareCfc();
+    expect(digest).not.toBe("");
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
+  });
+
+  it("a different moduleIdentity still fails closed even with corresponding spellings", async () => {
+    // Cross-version rotation stays a conflict: the spelling tolerance must
+    // never widen the identity arm (delegation is the setsrc-history topic).
+    const rt = makeRuntime("ts-spelling-version");
+    const tx = rt.edit();
+    const cell = rt.getCell(
+      signer.did(),
+      "wab-spelling-version",
+      claimSchema({
+        moduleIdentity: "profile-home-module-identity-v1",
+        file: PIECE_SPELLING,
+        path: ["setBio"],
+      }),
+      tx,
+    );
+    tx.setCfcImplementationIdentity({
+      kind: "verified",
+      moduleIdentity: "profile-home-module-identity-v2",
+      sourceFile: HTTP_SPELLING,
+      bindingPath: ["setBio"],
+    });
+    cell.set({ bio: "v2 write" });
+
+    const digest = tx.prepareCfc();
+    expect(digest).toBe("");
+    const result = await tx.commit();
+    expect(result.error).toBeDefined();
+  });
+
+  it("an unrelated file cannot ride the tolerance to a stamp", async () => {
+    // Same binding-path name in a DIFFERENT module: the file correspondence
+    // rejects, the claim stays unstamped, and the unstamped claim fails
+    // closed at verification.
+    const rt = makeRuntime("ts-spelling-foreign");
+    const tx = rt.edit();
+    const cell = rt.getCell(
+      signer.did(),
+      "wab-spelling-foreign",
+      claimSchema({ file: PIECE_SPELLING, path: ["setBio"] }),
+      tx,
+    );
+    tx.setCfcImplementationIdentity({
+      kind: "verified",
+      moduleIdentity: "attacker-module-identity",
+      sourceFile: "/attacker/profile-home.tsx",
+      bindingPath: ["setBio"],
+    });
+    cell.set({ bio: "stolen" });
+
+    const digest = tx.prepareCfc();
+    expect(digest).toBe("");
+    const result = await tx.commit();
+    expect(result.error).toBeDefined();
+  });
+});
+
+describe("stored-claim reconciliation across spellings", () => {
+  const envelope = (identity: Record<string, unknown>): JSONSchemaObj =>
+    ({
+      type: "object",
+      properties: {
+        bio: {
+          type: "string",
+          ifc: {
+            writeAuthorizedBy: { __ctWriterIdentityOf: identity },
+          },
+        },
+      },
+    }) as unknown as JSONSchemaObj;
+
+  const claimOf = (schema: unknown): Record<string, unknown> =>
+    // deno-lint-ignore no-explicit-any
+    (schema as any).properties.bio.ifc.writeAuthorizedBy.__ctWriterIdentityOf;
+
+  it("keeps the stored stamp when the candidate is the same claim under the other spelling", () => {
+    const merged = mergeCfcSchemaEnvelopes(
+      envelope({
+        moduleIdentity: MODULE_IDENTITY,
+        file: PIECE_SPELLING,
+        path: ["setBio"],
+      }),
+      envelope({ file: HTTP_SPELLING, path: ["setBio"] }),
+    );
+    expect(claimOf(merged)).toEqual({
+      moduleIdentity: MODULE_IDENTITY,
+      file: PIECE_SPELLING,
+      path: ["setBio"],
+    });
+  });
+
+  it("adopts the candidate's stamp onto an unstamped stored claim across spellings", () => {
+    // The self-heal direction: the store holds the unstamped claim (bricked
+    // shape); a legitimately stamped input re-presents it under the other
+    // spelling. The stamped side wins; the store heals.
+    const merged = mergeCfcSchemaEnvelopes(
+      envelope({ file: PIECE_SPELLING, path: ["setBio"] }),
+      envelope({
+        moduleIdentity: MODULE_IDENTITY,
+        file: HTTP_SPELLING,
+        path: ["setBio"],
+      }),
+    );
+    expect(claimOf(merged)).toEqual({
+      moduleIdentity: MODULE_IDENTITY,
+      file: HTTP_SPELLING,
+      path: ["setBio"],
+    });
+  });
+
+  it("treats both-unstamped corresponding claims as the same claim (stored spelling wins)", () => {
+    const merged = mergeCfcSchemaEnvelopes(
+      envelope({ file: PIECE_SPELLING, path: ["setBio"] }),
+      envelope({ file: HTTP_SPELLING, path: ["setBio"] }),
+    );
+    expect(claimOf(merged)).toEqual({
+      file: PIECE_SPELLING,
+      path: ["setBio"],
+    });
+  });
+
+  it("still conflicts on two different stamps (no silent cross-version rotation)", () => {
+    expect(() =>
+      mergeCfcSchemaEnvelopes(
+        envelope({
+          moduleIdentity: "profile-home-module-identity-v1",
+          file: PIECE_SPELLING,
+          path: ["setBio"],
+        }),
+        envelope({
+          moduleIdentity: "profile-home-module-identity-v2",
+          file: HTTP_SPELLING,
+          path: ["setBio"],
+        }),
+      )
+    ).toThrow("writeAuthorizedBy must remain stable");
+  });
+
+  it("still conflicts on different binding paths", () => {
+    expect(() =>
+      mergeCfcSchemaEnvelopes(
+        envelope({ file: PIECE_SPELLING, path: ["setBio"] }),
+        envelope({ file: HTTP_SPELLING, path: ["setName"] }),
+      )
+    ).toThrow("writeAuthorizedBy must remain stable");
+  });
+
+  it("still conflicts on non-corresponding files", () => {
+    expect(() =>
+      mergeCfcSchemaEnvelopes(
+        envelope({ file: "/victim.tsx", path: ["setBio"] }),
+        envelope({ file: "/attacker.tsx", path: ["setBio"] }),
+      )
+    ).toThrow("writeAuthorizedBy must remain stable");
+  });
+});
+
+describe("reportDroppedCfcRejectedWrite", () => {
+  it("reports CFC-rejected drops unconditionally and stays silent otherwise", () => {
+    const seen: unknown[][] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => {
+      seen.push(args);
+    };
+    try {
+      reportDroppedCfcRejectedWrite(
+        {
+          message: "CFC enforcement rejected commit: relevant transaction " +
+            "was not prepared: writeAuthorizedBy failed at /",
+        },
+        "handler-1",
+      );
+      reportDroppedCfcRejectedWrite(
+        { message: "some unrelated storage conflict" },
+        "handler-2",
+      );
+      reportDroppedCfcRejectedWrite(undefined, "handler-3");
+    } finally {
+      console.error = original;
+    }
+    expect(seen.length).toBe(1);
+    expect(String(seen[0]![0])).toContain("Owner-protected write dropped");
+    expect(seen[0]![1]).toMatchObject({ handlerId: "handler-1" });
+  });
+});

--- a/packages/runner/test/content-addressed-identity-adversarial.test.ts
+++ b/packages/runner/test/content-addressed-identity-adversarial.test.ts
@@ -37,8 +37,9 @@ import type { HarnessedFunction } from "../src/harness/types.ts";
  *     the RESOLVED function's provenance, so editing the ref cannot borrow
  *     another module's authority.
  *   - writeAuthorizedBy is an ownership gate: a verified-binding claim verifies
- *     only when the resolved identity's moduleIdentity (or legacy bundleId),
- *     file, AND path all match. Any mismatch — or a claim with neither id field —
+ *     only when the resolved identity's moduleIdentity AND bindingPath match
+ *     (the file SPELLING is resolver-dependent and deliberately not load-
+ *     bearing — labs#4772). Any mismatch — or a claim with no moduleIdentity —
  *     fails closed.
  */
 


### PR DESCRIPTION
## Why

Fixes #4772 (CT-1886): `writeAuthorizedBy` claims and live writer identities
record the module's source-file **spelling**, and the spelling is
resolver-dependent — the same module spells `/api/patterns/system/x.tsx` from
a piece-deploy compile, `api/patterns/...` from a piece manifest, and
`/patterns/system/x.tsx` from an HTTP-resolved compile (the transformers'
first-segment strip). The content-addressed `moduleIdentity` agrees across all
of them, but three CFC sites compared the spelling byte-wise, so a claim
minted under one resolver never corresponded to a live identity from another:
claims persisted **unstamped**, unstamped claims are categorically rejected
post-E5, and the first sibling-field transaction permanently bricked the
field's owner-writes — silently. Concretely: Loom's profile bio has been
unsavable in any session after the creating one.

Direction agreed with @seefeldb (Discord, 2026-07-20): **moduleIdentity is
the anchor; the path spelling is historic noise.**

## What

Authorization now anchors on `moduleIdentity` + `bindingPath`; the file
spelling participates only where a stamp does not exist yet, and then
tolerantly. One new shared module, `cfc/writer-claim-correspondence.ts`,
defines the correspondence (equal after slash-normalization, or exactly one
leading segment apart — the only divergence the toolchain has produced; also
dissolves the duplicated `normalizeIdentitySource` copies) and feeds all
three sites:

- **Verification** (`writeAuthorizedByReason`): the file-equality arm is
  removed from the decision. `moduleIdentity` equality (hard, fail-closed) +
  `bindingPath` equality decide; the spelling is diagnostic. A stamped claim
  now verifies against the same module compiled under any resolver.
- **Stamping** (`rebindWriteAuthorizedByClaims`): `writerOwnsBinding` uses the
  tolerant file correspondence (path equality unchanged), so the genuine
  bound writer can stamp a stored claim minted under another spelling —
  this is what **heals already-bricked stores** on their next legitimate
  write. The CT-1740 foreign-initializer guard is preserved: correspondence
  still fails on different paths and on non-corresponding files.
- **Reconciliation** (`reconcileWriterClaimStamp`): two claims reconcile when
  their paths match, their files correspond, and everything outside
  file + stamp is equal — the stamped side wins; both-unstamped keeps the
  stored side (previously, cross-spelling re-presentation of the same claim
  threw `writeAuthorizedBy must remain stable` and aborted the tx). A stored
  stamped claim can no longer be displaced by an unstamped re-presentation.

Two hardenings ride along:

- **Loud drops**: a CFC-enforcement-rejected commit on a give-up disposition
  now reports via an unconditional `console.error`
  (`reportDroppedCfcRejectedWrite`) — previously only the opt-in scheduler
  logger saw it, which is disabled in deployed workers; that silence is why
  #4772 shipped unnoticed for weeks.
- **No cross-version rotation**: two claims with *different* stamps still
  conflict (fail-closed), deliberately. Version-successor delegation is a
  separate design (Berni's setsrc-history idea) — tracked as the board topic
  **"Cross-version write authority: delegating writeAuthorizedBy to successor
  pattern versions (setsrc-history)"** (topics board, index 38). The
  reconcile-adoption site here is the socket where that check will plug in.

## Scope notes

- The spelling tolerance is deliberately **no wider than the historical
  divergence** (one leading segment) and never substitutes for the identity
  arm: same-leaf/different-directory files, deeper divergence, and absent
  sides all reject.
- The transformer-side follow-up (emit canonical spellings; explicit
  engine-prefix contract) is prototyped separately on
  `gideon/ct-1886-normalizer-unification` and remains gated on this PR
  landing.
- `setName` evading claim-checking entirely on the profile deployment (no
  `writeAuthorizedBy` in its verification schema) is a separate gap noted in
  #4772's side findings — not addressed here.

## Tests

`test/cfc-writer-claim-correspondence.test.ts` pins all of it: the
correspondence predicate (incl. adversarial rejections), tx-level
verification and stamping across spellings (the cold-session bio shape, the
bricked-store heal), fail-closed on different `moduleIdentity` (cross-version)
and foreign files, reconcile keep-stamp/adopt-stamp/both-unstamped, conflicts
on different stamps/paths/files, and the loud-drop reporter. The adversarial
suite's trust-model comment is updated to the new contract (file spelling not
load-bearing).

Gates: runner full suite, check/fmt/lint green.

## Verification against the live repro

The originating repro (loom acceptance instance, PR4b profile surface,
create → rename → cold-session bio save) is vendor-pinned; it exercises this
path end-to-end at the next loom vendor bump. The tx-level tests above encode
the exact instrumented claim/identity shapes captured from that repro
(#4772's mechanism section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1886 by anchoring write authorization on `moduleIdentity` + `bindingPath` and tolerating resolver-dependent file spellings only when reconciling stored claims. Minting stays exact; claims stamped under one resolver verify across compiles, bricked owner-protected fields heal, and dropped CFC-rejected writes are reported loudly.

- **Bug Fixes**
  - Verification: remove file spelling from the decision; require equal `moduleIdentity` and `bindingPath` (`writeAuthorizedByReason`).
  - Stamping: mint the first stamp only when file spellings match exactly (slash-normalized); no cross-spelling mint; foreign-initializer guard remains (`rebindWriteAuthorizedByClaims`).
  - Reconciliation: reconcile when paths match, files correspond (equal or one leading segment apart), and non-stamp fields match; adopt the stamped side; keep stored when both unstamped; different stamps still conflict (`reconcileWriterClaimStamp`).
  - Scheduler: report give-up commits rejected by CFC enforcement via unconditional `console.error` (`reportDroppedCfcRejectedWrite`).

- **Refactors**
  - Add shared `cfc/writer-claim-correspondence.ts` with `normalizeIdentitySource` and `writerClaimFilesCorrespond`; use the helper in `implementation-identity`, verification, and reconciliation; remove duplicated normalizers.

<sup>Written for commit 01bc30a931bfeaa73aabe9084fa0edd3d0559a32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

