### PR TITLE
fix(claude-hooks): only block a real --amend flag in git commit commands

### DIFF
--- a/.claude/scripts/block-git-amend.ts
+++ b/.claude/scripts/block-git-amend.ts
@@ -21,73 +21,24 @@ try {
   Deno.exit(0);
 }
 
-/**
- * Split a command into shell-like words, honoring single quotes, double
- * quotes, and backslash escapes. Quoting joins characters into the current
- * word (so a message passed as -m "mentions --amend" stays one word), while
- * a quoted-but-real argument like "--amend" still surfaces as its own word.
- * Unterminated quotes swallow the rest of the string into the current word,
- * which errs toward blocking.
- */
-function shellWords(command: string): string[] {
-  const words: string[] = [];
-  let current = "";
-  let inWord = false;
-  let i = 0;
-  while (i < command.length) {
-    const ch = command[i];
-    if (ch === "'") {
-      inWord = true;
-      const end = command.indexOf("'", i + 1);
-      current += end === -1
-        ? command.slice(i + 1)
-        : command.slice(i + 1, end);
-      i = end === -1 ? command.length : end + 1;
-    } else if (ch === '"') {
-      inWord = true;
-      i++;
-      while (i < command.length && command[i] !== '"') {
-        if (command[i] === "\\" && i + 1 < command.length) {
-          current += command[i + 1];
-          i += 2;
-        } else {
-          current += command[i];
-          i++;
-        }
-      }
-      i++; // skip closing quote
-    } else if (ch === "\\" && i + 1 < command.length) {
-      inWord = true;
-      current += command[i + 1];
-      i += 2;
-    } else if (/\s/.test(ch)) {
-      if (inWord) {
-        words.push(current);
-        current = "";
-        inWord = false;
-      }
-      i++;
-    } else {
-      inWord = true;
-      current += ch;
-      i++;
-    }
-  }
-  if (inWord) words.push(current);
-  return words;
-}
+// Drop quoted segments so only actual shell words are inspected — a commit
+// message that merely mentions the flag must not trip the block. Double-quoted
+// segments can span newlines (e.g. -m "$(cat <<'EOF' ... EOF)").
+//
+// Known gap, accepted: a deliberately quoted flag (git commit "--amend") is
+// erased along with the message text and slips through. This hook is a
+// guardrail against accidental amends, not a security boundary — a deliberate
+// bypass has routes no string check can catch (FLAG=--amend, sh -c, a script
+// file), so shell-aware parsing would add complexity without closing anything.
+const bareWords = cmd
+  .replace(/"(?:\\.|[^"\\])*"/gs, '""')
+  .replace(/'[^']*'/g, "''");
 
-// Block git commit --amend (including abbreviated forms: --am, --ame, --amen,
-// --amend). Matching whole words means a quoted flag ("--amend") is still
-// caught, while a commit message that merely mentions the flag is not — the
-// message is a single word containing more than the flag itself.
-const words = shellWords(cmd);
-const invokesGitCommit = words.some((word, i) =>
-  word === "git" && words[i + 1] === "commit"
-);
-const hasAmendFlag = words.some((word) => /^--am(e(nd?)?)?$/.test(word));
-
-if (invokesGitCommit && hasAmendFlag) {
+// Block git commit --amend (including abbreviated forms: --am, --ame, --amen, --amend)
+if (
+  /\bgit\s+commit\b/.test(bareWords) &&
+  /(^|\s)--am(e(nd?)?)?\b/.test(bareWords)
+) {
   console.error(
     "git commit --amend is not allowed. Create a new commit instead.",
   );

--- a/.claude/scripts/block-git-amend.ts
+++ b/.claude/scripts/block-git-amend.ts
@@ -21,18 +21,73 @@ try {
   Deno.exit(0);
 }
 
-// Drop quoted segments so only actual shell words are inspected — a commit
-// message that merely mentions the flag must not trip the block. Double-quoted
-// segments can span newlines (e.g. -m "$(cat <<'EOF' ... EOF)").
-const bareWords = cmd
-  .replace(/"(?:\\.|[^"\\])*"/gs, '""')
-  .replace(/'[^']*'/g, "''");
+/**
+ * Split a command into shell-like words, honoring single quotes, double
+ * quotes, and backslash escapes. Quoting joins characters into the current
+ * word (so a message passed as -m "mentions --amend" stays one word), while
+ * a quoted-but-real argument like "--amend" still surfaces as its own word.
+ * Unterminated quotes swallow the rest of the string into the current word,
+ * which errs toward blocking.
+ */
+function shellWords(command: string): string[] {
+  const words: string[] = [];
+  let current = "";
+  let inWord = false;
+  let i = 0;
+  while (i < command.length) {
+    const ch = command[i];
+    if (ch === "'") {
+      inWord = true;
+      const end = command.indexOf("'", i + 1);
+      current += end === -1
+        ? command.slice(i + 1)
+        : command.slice(i + 1, end);
+      i = end === -1 ? command.length : end + 1;
+    } else if (ch === '"') {
+      inWord = true;
+      i++;
+      while (i < command.length && command[i] !== '"') {
+        if (command[i] === "\\" && i + 1 < command.length) {
+          current += command[i + 1];
+          i += 2;
+        } else {
+          current += command[i];
+          i++;
+        }
+      }
+      i++; // skip closing quote
+    } else if (ch === "\\" && i + 1 < command.length) {
+      inWord = true;
+      current += command[i + 1];
+      i += 2;
+    } else if (/\s/.test(ch)) {
+      if (inWord) {
+        words.push(current);
+        current = "";
+        inWord = false;
+      }
+      i++;
+    } else {
+      inWord = true;
+      current += ch;
+      i++;
+    }
+  }
+  if (inWord) words.push(current);
+  return words;
+}
 
-// Block git commit --amend (including abbreviated forms: --am, --ame, --amen, --amend)
-if (
-  /\bgit\s+commit\b/.test(bareWords) &&
-  /(^|\s)--am(e(nd?)?)?\b/.test(bareWords)
-) {
+// Block git commit --amend (including abbreviated forms: --am, --ame, --amen,
+// --amend). Matching whole words means a quoted flag ("--amend") is still
+// caught, while a commit message that merely mentions the flag is not — the
+// message is a single word containing more than the flag itself.
+const words = shellWords(cmd);
+const invokesGitCommit = words.some((word, i) =>
+  word === "git" && words[i + 1] === "commit"
+);
+const hasAmendFlag = words.some((word) => /^--am(e(nd?)?)?$/.test(word));
+
+if (invokesGitCommit && hasAmendFlag) {
   console.error(
     "git commit --amend is not allowed. Create a new commit instead.",
   );

--- a/.claude/scripts/block-git-amend.ts
+++ b/.claude/scripts/block-git-amend.ts
@@ -21,8 +21,18 @@ try {
   Deno.exit(0);
 }
 
+// Drop quoted segments so only actual shell words are inspected — a commit
+// message that merely mentions the flag must not trip the block. Double-quoted
+// segments can span newlines (e.g. -m "$(cat <<'EOF' ... EOF)").
+const bareWords = cmd
+  .replace(/"(?:\\.|[^"\\])*"/gs, '""')
+  .replace(/'[^']*'/g, "''");
+
 // Block git commit --amend (including abbreviated forms: --am, --ame, --amen, --amend)
-if (/\bgit\s+commit\b/.test(cmd) && /--am(e(nd?)?)?\b/.test(cmd)) {
+if (
+  /\bgit\s+commit\b/.test(bareWords) &&
+  /(^|\s)--am(e(nd?)?)?\b/.test(bareWords)
+) {
   console.error(
     "git commit --amend is not allowed. Create a new commit instead.",
   );


### PR DESCRIPTION
## Summary

The `block-git-amend` PreToolUse hook tested the entire Bash command string for `--am(end)`, so any `git commit` whose quoted message merely mentioned the flag was blocked — including the common heredoc form `-m "$(cat <<'EOF' ... )"`. The hook now strips single- and double-quoted segments (double-quoted spanning newlines) before matching, and requires the flag to start a shell word, so only an actual `--amend` argument (or its unique abbreviations `--am`/`--ame`/`--amen`) trips the block.

## Testing

Fed sample `tool_input` payloads to the hook script directly:

- Still blocked: `git commit --amend`, abbreviated forms, and `--amend` alongside an innocent `-m` message.
- Now allowed: messages mentioning `--amend` in double quotes, single quotes, or a heredoc; plain commits unchanged.
- The commit on this branch is itself an end-to-end test: its message mentions the flag in a heredoc and the updated hook allowed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `block-git-amend` hook to block only a real `--amend` flag (including `--am`, `--ame`, `--amen`) in `git commit`; message text that mentions the flag, including heredoc `-m`, now passes. A deliberately quoted flag (e.g. `"--amend"`) is not blocked by design.

- **Bug Fixes**
  - Strip single- and double-quoted segments (double quotes may span newlines) before matching and require the flag to start a shell word.
  - Document the accepted gap so the hook remains a guardrail against accidental amends, not a security boundary.

<sup>Written for commit 7df9fe2830ad085d4781f1c122be2d4212ea16df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

