### PR TITLE
feat(dashboard): add historical performance views

### DIFF
--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,7 +1,7 @@
 # Dev/company dashboard image — serves packages/dashboard over HTTP.
 #
-# Build context is the labs repo ROOT: the "/ci" Gantt drill-down shells out to
-# scripts/ci-gantt.ts, so the repo source must be in the image (modeled on
+# Build context is the labs repo ROOT: the "/bench?view=gantt" drill-down shells
+# out to scripts/ci-gantt.ts, so the repo source must be in the image (modeled on
 # Dockerfile.toolshed). Every backend is reached over its REST API — the GitHub
 # tiles with GH_TOKEN, the cloud-spend tile via BigQuery using the workload's own
 # service account (Workload Identity) — so no cloud CLI is installed.

--- a/deno.lock
+++ b/deno.lock
@@ -14,6 +14,7 @@
     "jsr:@deno/loader@~0.3.10": "0.3.14",
     "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@denosaurs/plug@^1.1.0": "1.1.0",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/async@^1.4.0": "1.5.0",
     "jsr:@std/async@^1.5.0": "1.5.0",
@@ -246,7 +247,7 @@
     "@std/expect@1.0.20": {
       "integrity": "ffc4f3c33f732417e3e9acf3d995818c89984313c37d933b9ebbb4571d2887e9",
       "dependencies": [
-        "jsr:@std/assert",
+        "jsr:@std/assert@^1.0.19",
         "jsr:@std/internal@^1.0.14",
         "jsr:@std/path@^1.1.6"
       ]
@@ -320,7 +321,7 @@
     "@std/testing@1.0.19": {
       "integrity": "f4236172365b216728dc3cc8b5e80a9f4c33083d1e4ede7613d5b25b4014898e",
       "dependencies": [
-        "jsr:@std/assert",
+        "jsr:@std/assert@^1.0.19",
         "jsr:@std/async@^1.4.0",
         "jsr:@std/data-structures@^1.1.0",
         "jsr:@std/fs@^1.0.24",

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -85,6 +85,16 @@ Jobs and steps for a run:
 `GET /repos/commontoolsinc/labs/actions/runs/<run-id>/jobs?per_page=100` — each
 job and step carries `started_at` and `completed_at`.
 
+The team ops dashboard's `/bench?view=ci` page provides repeated-run analysis
+for labs and loom. It reports overall workflow duration and individual job
+duration. Matrix jobs are grouped using the trailing-parenthesis base names from
+`scripts/ci-gantt.ts`, with the slowest shard tracked across runs to expose
+persistent imbalance.
+
+For a requested history window, the collector retains every successful main
+push build when there are at most 90. Larger sets are reduced to about 90 time
+buckets, keeping the newest build in each bucket.
+
 ## Step Phase Markers
 
 `scripts/ci-gantt.ts` draws each job as a bar and splits that bar into three

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -148,13 +148,16 @@ surveillance tool.
 | labs ci, labs ci trust, labs ci duration | GitHub Actions (`deno.yml` on main in `commontoolsinc/labs`), via the REST API | `GH_TOKEN` (or `GITHUB_TOKEN`) |
 | loom ci, loom ci trust, loom ci duration | the same three tiles for `commontoolsinc/loom` (`test-fast.yml` on main) | `GH_TOKEN` (read access to loom); optional `DASHBOARD_LOOM_REPO` |
 | recent main runs | labs + loom main runs interleaved chronologically, each row tagged with its repo | `GH_TOKEN` |
-| labs ci duration → `/ci` | runs `scripts/ci-gantt.ts` with live controls (labs only) | — |
+| commit CI Gantt → `/ci-gantt` | job and step timing for every successful main workflow run attached to one commit, linked from run durations in recent main runs | `GH_TOKEN` |
+| CI duration history → `/bench?view=ci` | labs and loom job, shard-group, and end-to-end workflow duration trends. The duration tiles open their matching repository view | `GH_TOKEN` |
+| CI run Gantt → `/bench?view=gantt` | detailed labs or loom job phases from `scripts/ci-gantt.ts`, backed by the CI history cache | `GH_TOKEN` |
 | production | synthetic HTTP check of the production server: `/_health` on `PROD_URL`'s origin, which answers only while the server is really serving. Defaults to estuary, the production toolshed. Estuary is on the tailnet, so a dashboard that cannot reach the tailnet needs `PROD_URL` pointed at something it can | `PROD_URL` (optional) |
 | common.tools | synthetic HTTP check of the public site | `COMMON_TOOLS_URL` (optional; defaults to `https://common.tools`) |
 | prod errors | SigNoz trace error rate for one service (errored spans / all spans): last-12h headline, with a per-hour sparkline over the retained trace history (~2 weeks) and the last-12h slice that feeds the headline highlighted. Scoped to `PROD_SERVICE` — the same SigNoz holds staging and one-off perf runs, whose rates are not production's. Gray (not red) when SigNoz is unreachable. Pops out to the SigNoz logs explorer | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `SIGNOZ_UI_URL` for the pop-out |
 | cloud spend | BigQuery billing export, via the REST API | `GCP_BILLING_TABLE` (+ Workload Identity, or `GCP_SA_KEY` locally), optional `GCP_DAILY_BUDGET` |
 | ci spend | GitHub Actions billing, projected to month-end (USD), with a 45-day daily-spend sparkline. Month-to-date sits in the header (the `aside` slot); the sub shows the GitHub-configured budget when there is one; the span the sparkline covers is in its bottom-left corner (the `duration` slot) | `GH_TOKEN` (with org billing read); optional `GH_BILLING_ORG` |
 | benchmark | a runtime benchmark's ~45-day trend, from the `benchmarks.yml` deno-bench artifacts on main | `GH_TOKEN`; optional `BENCH_METRIC` |
+| performance history → `/bench?view=runtime` | runtime benchmark trends, labs or loom CI duration history, and a detailed CI run Gantt. Historical views support windows from 1 through 45 days, date axes, and duration sorting. CI includes end-to-end workflow time, every job, and slowest-shard group lines | `GH_TOKEN` |
 | model spend | OpenAI + Anthropic + OpenRouter usage APIs. Headline is the projected full-month spend (extrapolated from the recent daily rate, spilling into last month when this month is under two weeks old), summed across providers. OpenAI and Anthropic (which expose per-day cost) are charted as one line each over ~45 days, dimmed except for the current-month slice that feeds the headline, with each line's MTD in the right gutter; OpenRouter (monthly total only, abbreviated "OR") is folded into the totals. The subtitle is the bullet-separated key (`OpenAI • Anthropic • OR $0`); the combined MTD sits in the header (the `aside` slot); the span the chart covers is in its bottom-left corner (the `duration` slot). A provider we can't read shows `$???` and drops the tile to gray, but the rest still chart and total | any of `OPENAI_ADMIN_KEY`, `ANTHROPIC_ADMIN_KEY`, `OPENROUTER_KEY`; optional `MODEL_MONTHLY_BUDGET` |
 | discord online | Discord gateway presence, team vs visitors over time | `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID` (Server Members + Presence intents) |
 | dau | distinct identities active per UTC day on one named service, counted from the `user.did` attribute on the `memory.transact` and `memory.subscriber.sync` spans in SigNoz. The headline is the last day that ran to the end (today is still filling, and a part-day always reads as a drop); the sparkline is the retained history. Gray while the named service has no such spans — which is the resting state until a deployment's tracing is switched on. It counts keypairs rather than people; see [dau](#dau) below | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `DAU_EXCLUDE_DIDS`, `SIGNOZ_UI_URL` |
@@ -318,8 +321,7 @@ it.
 | `PROD_URL` | production | the production **server**, as an origin — the tile checks `/_health` on it and links to it. Defaults to estuary, the production toolshed. Note `production.commontools.dev` is the shell, a static site in a GCS bucket: it has no health endpoint, and its index page answers 200 whether or not the server behind it is serving, so it cannot see an outage. |
 | `COMMON_TOOLS_URL` | common.tools | override the public-site URL (e.g. the `www` host if the apex redirects). |
 | `DASHBOARD_REPO` | CI tiles, github users | which repo the CI tiles read. Its owner is the organization the **github users** tile reads (default `commontoolsinc/labs`). |
-| `DISCORD_HISTORY_FILE` | discord online | where the team/visitors history is persisted (default: a file in the temp dir). |
-| `GITHUB_MEMBERS_HISTORY_FILE` | github users | where the Members/Collaborators history is persisted (default: an organization-specific file in the temp dir). |
+| `DASHBOARD_CACHE_DIR` | server caches | directory for all persistent dashboard cache files (default: the platform temp directory). |
 | `BENCH_METRIC` | benchmark | substring that pins which benchmark the grid tile shows; unset, it rotates hourly through all of them (see the note below). |
 | `SIGNOZ_UI_URL` | prod errors | browser-facing SigNoz URL for the "logs" pop-out. Defaults to `SIGNOZ_URL` when that is a public `https://` URL; set it when the server reaches SigNoz over an in-cluster URL a browser can't. |
 | `PROD_SERVICE` | prod errors, dau | the `service.name` production reports under in SigNoz, which both trace-reading tiles scope to. Defaults to `toolshed-production`. A name outside `[A-Za-z0-9._-]` is ignored, since it lands inside a query expression. |
@@ -374,9 +376,10 @@ Notes:
   `benchmarks.yml` job on main runs `deno bench --json` over the runner, cache,
   and deep-equal benchmarks and uploads the report as a `bench-results` artifact
   (90-day retention; there is no committed history). The tile lists benchmark runs
-  on main, samples one run per 4-hour window, downloads that artifact, unzips it
-  in-process, and reads each benchmark's timings; per-run results are cached, so
-  only new runs are fetched after the first fill. The grid tile plots **p99**. With
+  on main, samples one run per shortest-view bucket, downloads that artifact, unzips it
+  in-process, and reads each benchmark's timings. Each completed artifact check is
+  persisted before it is counted as finished, so only new runs and new attempts are
+  fetched after the first fill or a server restart. The grid tile plots **p99**. With
   `BENCH_METRIC` set it pins to the benchmark whose `<file> > <group>/<name>` key
   contains that substring; otherwise it **rotates** — showing one benchmark per
   clock-hour, chosen deterministically from the hour so a fresh dashboard on any
@@ -391,19 +394,98 @@ Notes:
   days being outliers, and working per calendar day (not per sample or per
   millisecond) keeps it time-aware without letting two noisy runs a few hours apart
   blow up the slope — which is what naive per-millisecond weighting does. A
-  benchmark with fewer than 7 distinct days in the window is reported as flat: too
-  little data to claim a trend. The window is capped by the 90-day artifact
-  retention, so it shows at most ~45 days and only as far back as the job has run.
-  (4-hour sampling means many more points than daily, so the first cache fill
-  downloads correspondingly more artifacts.)
-  - Its **`/bench` drill-down** shows a sparkline for **every** benchmark on a
-    shared calendar-time axis, so a late-starting benchmark sits at the right and a
-    stale one visibly ends short of it. Selectors choose which measurement to plot
-    (a percentile ladder — **p0** = min, **p50** = the mean, **p75**, **p99**,
-    **p99.5**, **p99.9**, **p100** = max) and whether to sort by source **file** or
-    by **trend** (biggest rise first); a "hide green" checkbox drops the steady
-    ones. Each row is coloured by its own trend, and the page reads from the tile's
-    cache so it re-renders instantly.
+  benchmark with fewer than 7 distinct days in the window is marked as new and
+  left gray: there is too little data to claim a trend. The window is capped by
+  the 90-day artifact retention, so it shows at most ~45 days and only as far
+  back as the job has run.
+  (The shortest-view buckets are about 16 minutes wide, so the first cache fill
+  can download correspondingly more artifacts.)
+  - Its **runtime benchmarks** view at `/bench?view=runtime` shows a sparkline
+    for **every** benchmark on a shared calendar-time axis, so a late-starting
+    benchmark sits at the right and a stale one visibly ends short of it.
+    Selectors choose which measurement to plot (a percentile ladder — **p0** =
+    min, **p50** = the mean, **p75**, **p99**, **p99.5**, **p99.9**, **p100** =
+    max) and whether to group by source **file** or sort by latest **duration**
+    or **trend**. A "hide green" checkbox drops the steady ones. A slider from 1
+    through 45 days changes the visible calendar range. The displayed samples
+    are spread across at most 90 time buckets, so a shorter window uses more of
+    the collected samples per day. Keyboard arrows adjust the window without
+    moving focus. Enter applies the range immediately. Another selector carries
+    the range into its own navigation, and leaving the controls applies it
+    directly. Each row is coloured by its own trend, and the page reads from the
+    server cache so it re-renders instantly. Its progress panel stays visible as
+    Idle between collections. During collection it shows cached, queued, requested,
+    responded, outstanding, and failed artifact checks. Changing the range leaves
+    the server collection running and joins it from the new page.
+  - The **CI duration history** view at `/bench?view=ci` selects either labs
+    `deno.yml` or loom `test-fast.yml`. It charts every job's start-to-finish
+    duration on one calendar-time axis. An overall row measures the workflow
+    from the first job
+    start to the last job completion. Jobs that share the trailing-parenthesis
+    base name used by `scripts/ci-gantt.ts` are shown together. Each group starts
+    with a slowest-shard line, followed by the individual shard lines. The
+    slider covers 1 through 45 days. It keeps every successful main build when
+    there are at most 90, then uses about 90 time buckets and keeps the newest
+    build in each bucket for larger sets. A coverage label compares the sampled
+    builds shown with every successful main build in the selected range. The
+    view can group by job or sort every line by latest duration or robust trend.
+    It renders cached history immediately. The progress panel remains visible
+    as Idle between collections, then shows live collection progress with
+    cached, queued, requested, responded, outstanding, and failed run counts.
+    Open runtime benchmark and CI history pages check for newer server data once
+    a minute. An open Gantt regenerates every 30 minutes and whenever its tab
+    becomes visible. CI refreshes share a 30-minute GitHub freshness window, so
+    multiple pages do not repeat the same API reads. Moving the window slider
+    starts or joins the matching collection without cancelling wider-window
+    work already in progress.
+  - Every GitHub API request made by the three performance views reserves rate
+    capacity before it starts. Each guarded request batch reads GitHub's current
+    rate-limit status before reserving. Collection stops before projected
+    in-flight requests would pass 80% of the token's hourly core limit. It also
+    stops at 720 REST request points in a rolling minute, which is 80% of
+    GitHub's documented 900-point limit. The page reports either boundary as a
+    rate limit hit. It does not wait or retry there. Reservations and request
+    times are locked and stored in the fixed
+    `fabric-wall-github-rate-limit.json` file in the dashboard cache directory, so
+    overlapping dashboard processes and restarts share the same budget. Tokens
+    are represented by SHA-256 hashes in that file. Only `/bench` collection
+    reserves capacity or can be stopped by the ledger. Other dashboard GitHub
+    requests do not read or update it and proceed normally.
+  - Completed workflow-attempt run, job, and step timings are written
+    atomically to the fixed `fabric-wall-ci-job-history.json` file in the
+    dashboard cache directory.
+    CI history and the detailed `/bench?view=gantt` view use the same entries.
+    The three performance views share one selector and preserve the applicable
+    repository, range, sort, and runtime statistic while moving between them.
+    The next collection loads those timings before reading GitHub, so it only
+    fetches jobs for new sampled runs, uncached Gantt runs, and new attempts.
+    Cached history remains visible when no GitHub token is configured or a
+    refresh fails. Each completed response is placed in the shared cache and
+    persisted while the rest of its collection continues, including responses
+    from a window the browser has since left.
+    The cache also stores each window's exact sampled run attempts, partial-read
+    state, last completed refresh, and the complete set of successful-run
+    timestamps used by its coverage label. A new dashboard process therefore
+    renders the same chart, warning, and coverage while honoring the remaining
+    part of the 30-minute freshness window without querying GitHub. Dashboard
+    processes that share the file lock it while merging and atomically replacing
+    entries. Attempts referenced by the last completed chart remain in the
+    cache while a rerun is being collected. An interrupted or rate-limited
+    collection records that its earlier manifest is no longer fresh, so a
+    restart keeps the completed chart visible but resumes collection.
+  - Runtime benchmark artifact results are written atomically to
+    the fixed `fabric-wall-benchmark-history.json` file in the dashboard cache
+    directory.
+    Successful reads and definitive empty results are retained for 60 days. A
+    failed read remains uncached so a later scheduled collection can establish
+    whether the artifact exists. Dashboard processes that share the file lock it
+    while merging and replacing the stored run attempts. The exact run attempts
+    behind the last completed refresh, including the reason for a definitive
+    empty result, are stored in the same file. Attempts used by that completed
+    refresh remain available while a rerun is incomplete. Restarting the
+    dashboard therefore reconstructs the same chart without immediately
+    rediscovering benchmark runs that are still within the 30-minute freshness
+    window. An interrupted replacement is persisted as stale and is retried.
 - **Deploying these gated tiles** follows the same pattern as the existing ones:
   add the value to Secret Manager, wire an ExternalSecret in
   `dashboard-secrets.yaml`, and add the env to `03-deployment.yaml` (see the

--- a/packages/dashboard/benchmark-history-cache.test.ts
+++ b/packages/dashboard/benchmark-history-cache.test.ts
@@ -1,0 +1,549 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import {
+  BENCHMARK_HISTORY_CACHE_DAYS,
+  BenchmarkHistoryStore,
+  type BenchmarkStats,
+} from "./benchmark-history-cache.ts";
+
+const DAY_MS = 86_400_000;
+
+const stats = (p99: number): BenchmarkStats => ({
+  min: p99 / 4,
+  avg: p99 / 2,
+  max: p99 * 2,
+  p75: p99 * 0.75,
+  p99,
+  p995: p99 * 1.05,
+  p999: p99 * 1.1,
+});
+
+Deno.test("runtime benchmark history persists usable and empty artifacts", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now();
+  try {
+    const writer = new BenchmarkHistoryStore(file);
+    await writer.load();
+    writer.set({
+      runId: 101,
+      runAttempt: 1,
+      at: now - DAY_MS,
+      metrics: new Map([["packages/a.bench.ts > works", stats(1_000)]]),
+    });
+    writer.set({
+      runId: 101,
+      runAttempt: 2,
+      at: now - DAY_MS,
+      metrics: new Map([["packages/a.bench.ts > works", stats(1_500)]]),
+    });
+    writer.set({
+      runId: 102,
+      runAttempt: 1,
+      at: now,
+      metrics: new Map(),
+    });
+    writer.markRefreshed(now - 1_000, writer.list());
+    await writer.save(now);
+
+    const reader = new BenchmarkHistoryStore(file);
+    await reader.load();
+    assertEquals(reader.list().map((run) => run.runId), [101, 102]);
+    assertEquals(
+      reader.get(101)?.metrics.get("packages/a.bench.ts > works")?.p99,
+      1_500,
+    );
+    assertEquals(reader.get(101)?.runAttempt, 2);
+    assertEquals(reader.get(102)?.metrics.size, 0);
+    assertEquals(reader.refreshedAt, now - 1_000);
+    assertEquals(
+      reader.refreshedRuns()?.map((run) => [run.runId, run.runAttempt]),
+      [[101, 2], [102, 1]],
+    );
+    assertEquals(
+      await Deno.stat(`${file}.tmp`).then(
+        () => true,
+        () => false,
+      ),
+      false,
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history preserves a definitive empty refresh", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now();
+  try {
+    const writer = new BenchmarkHistoryStore(file);
+    await writer.load();
+    writer.set({
+      runId: 150,
+      runAttempt: 1,
+      at: now,
+      metrics: new Map([["old", stats(1_000)]]),
+    });
+    writer.markRefreshed(now, []);
+    await writer.save(now);
+
+    const reader = new BenchmarkHistoryStore(file);
+    await reader.load();
+    assertEquals(reader.list().map((run) => run.runId), [150]);
+    assertEquals(reader.refreshedRuns(), []);
+    assertEquals(reader.refresh?.result, "no-runs");
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history retains the completed attempt while a rerun is incomplete", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now();
+  try {
+    const writer = new BenchmarkHistoryStore(file);
+    await writer.load();
+    const first = writer.set({
+      runId: 160,
+      runAttempt: 1,
+      at: now,
+      metrics: new Map([["first", stats(1_000)]]),
+    });
+    writer.markRefreshed(now - 1_000, [first], "data");
+    await writer.save(now);
+
+    writer.set({
+      runId: 160,
+      runAttempt: 2,
+      at: now,
+      metrics: new Map([["second", stats(2_000)]]),
+    });
+    await writer.save(now);
+
+    const reader = new BenchmarkHistoryStore(file);
+    await reader.load();
+    assertEquals(reader.refreshedAt, 0);
+    assertEquals(reader.get(160)?.runAttempt, 2);
+    assertEquals(reader.get(160, 1)?.metrics.has("first"), true);
+    assertEquals(
+      reader.refreshedRuns()?.map((run) => run.runAttempt),
+      [1],
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history can replace an in-process future refresh", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now();
+  try {
+    const store = new BenchmarkHistoryStore(file);
+    await store.load();
+    const run = store.set({
+      runId: 170,
+      runAttempt: 1,
+      at: now,
+      metrics: new Map([["current", stats(1_000)]]),
+    });
+    store.markRefreshed(now + DAY_MS, [run], "data");
+    await store.save(now);
+
+    assertEquals(store.quarantineFuture(now), true);
+    await store.save(now);
+    store.markRefreshed(now, [run], "data");
+    await store.save(now);
+
+    const reader = new BenchmarkHistoryStore(file);
+    await reader.load();
+    assertEquals(reader.refreshedAt, now);
+    assertEquals(reader.refreshedRuns()?.[0].runAttempt, 1);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history drops freshness with a malformed run", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now();
+  try {
+    const writer = new BenchmarkHistoryStore(file);
+    await writer.load();
+    writer.set({
+      runId: 175,
+      runAttempt: 1,
+      at: now,
+      metrics: new Map([["valid", stats(1_000)]]),
+    });
+    writer.markRefreshed(now, writer.list());
+    await writer.save(now);
+    const persisted = JSON.parse(await Deno.readTextFile(file));
+    persisted.runs.push({ runId: "invalid" });
+    await Deno.writeTextFile(file, JSON.stringify(persisted));
+
+    const reader = new BenchmarkHistoryStore(file);
+    await reader.load();
+    assertEquals(reader.list().map((run) => run.runId), [175]);
+    assertEquals(reader.refreshedAt, 0);
+    assertEquals(reader.refreshedRuns(), null);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history prunes entries outside its retention window", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now();
+  try {
+    const store = new BenchmarkHistoryStore(file);
+    await store.load();
+    store.set({
+      runId: 201,
+      runAttempt: 1,
+      at: now - (BENCHMARK_HISTORY_CACHE_DAYS + 1) * DAY_MS,
+      metrics: new Map([["old", stats(2_000)]]),
+    });
+    store.set({
+      runId: 202,
+      runAttempt: 1,
+      at: now,
+      metrics: new Map([["current", stats(3_000)]]),
+    });
+    await store.save(now - BENCHMARK_HISTORY_CACHE_DAYS * DAY_MS);
+
+    const loaded = new BenchmarkHistoryStore(file);
+    await loaded.load();
+    assertEquals(loaded.list().map((run) => run.runId), [201, 202]);
+    await loaded.save(now);
+
+    const reader = new BenchmarkHistoryStore(file);
+    await reader.load();
+    assertEquals(reader.list().map((run) => run.runId), [202]);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history merges writes from concurrent stores", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now();
+  try {
+    const first = new BenchmarkHistoryStore(file);
+    const second = new BenchmarkHistoryStore(file);
+    await Promise.all([first.load(), second.load()]);
+    first.set({
+      runId: 301,
+      runAttempt: 1,
+      at: now - DAY_MS,
+      metrics: new Map([["first", stats(4_000)]]),
+    });
+    second.set({
+      runId: 302,
+      runAttempt: 1,
+      at: now,
+      metrics: new Map([["second", stats(5_000)]]),
+    });
+
+    await Promise.all([first.save(now), second.save(now)]);
+
+    const reader = new BenchmarkHistoryStore(file);
+    await reader.load();
+    assertEquals(reader.list().map((run) => run.runId), [301, 302]);
+    assertEquals(
+      (await Array.fromAsync(Deno.readDir(directory))).filter((entry) =>
+        entry.name.endsWith(".tmp")
+      ),
+      [],
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history coalesces concurrent saves from one store", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  try {
+    const store = new BenchmarkHistoryStore(file);
+    await store.load();
+    store.set({
+      runId: 350,
+      runAttempt: 1,
+      at: Date.now(),
+      metrics: new Map([["current", stats(5_000)]]),
+    });
+    await Promise.all([store.save(), store.save()]);
+    assertEquals(store.dirty, false);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history does not replace an unreadable cache", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const malformed = "{not json";
+  try {
+    const store = new BenchmarkHistoryStore(file);
+    await store.load();
+    store.set({
+      runId: 401,
+      runAttempt: 1,
+      at: Date.now(),
+      metrics: new Map([["local", stats(6_000)]]),
+    });
+    await Deno.writeTextFile(file, malformed);
+
+    await assertRejects(() => store.save());
+    assertEquals(await Deno.readTextFile(file), malformed);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history rejects malformed cache structures before merging", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const now = Date.now();
+  const localRun = {
+    runId: 501,
+    runAttempt: 1,
+    at: now,
+    metrics: new Map([["local", stats(1_000)]]),
+  };
+  const cases: { value: unknown; message: string }[] = [
+    { value: null, message: "Invalid runtime benchmark history cache" },
+    {
+      value: { version: 2, runs: [] },
+      message: "Unsupported runtime benchmark history cache format",
+    },
+    {
+      value: {
+        version: 1,
+        runs: [{ runId: 1, runAttempt: 1, at: now, metrics: { bad: null } }],
+      },
+      message: "Invalid runtime benchmark history cache entry",
+    },
+    {
+      value: { version: 1, runs: [], invalidatedAt: -1 },
+      message: "Invalid runtime benchmark refresh invalidation",
+    },
+    {
+      value: {
+        version: 1,
+        runs: [],
+        refresh: { refreshedAt: now, runs: [null] },
+      },
+      message: "Invalid runtime benchmark refresh manifest",
+    },
+    {
+      value: { version: 1, runs: [null] },
+      message: "Invalid runtime benchmark history cache entry",
+    },
+    {
+      value: { version: 1, runs: [], refresh: null },
+      message: "Invalid runtime benchmark refresh manifest",
+    },
+    {
+      value: {
+        version: 1,
+        runs: [],
+        refresh: {
+          refreshedAt: now,
+          runs: [{ runId: 999, runAttempt: 1 }],
+          result: "data",
+        },
+      },
+      message: "references a missing run",
+    },
+  ];
+  try {
+    for (const [index, testCase] of cases.entries()) {
+      const file = `${directory}/${index}.json`;
+      await Deno.writeTextFile(file, JSON.stringify(testCase.value));
+      const store = new BenchmarkHistoryStore(file);
+      await store.load();
+      assertEquals(store.list(), []);
+      store.set(localRun);
+      await assertRejects(() => store.save(now), Error, testCase.message);
+    }
+
+    const futureFile = `${directory}/future-strict.json`;
+    const futureStore = new BenchmarkHistoryStore(futureFile);
+    await futureStore.load();
+    futureStore.set(localRun);
+    await Deno.writeTextFile(
+      futureFile,
+      JSON.stringify({
+        version: 1,
+        invalidatedAt: now + DAY_MS,
+        runs: [],
+      }),
+    );
+    await assertRejects(
+      () => futureStore.save(now),
+      Error,
+      "Invalid runtime benchmark refresh invalidation",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history reads manifests written before result labels", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now();
+  try {
+    await Deno.writeTextFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        runs: [{
+          runId: 550,
+          runAttempt: 1,
+          at: now,
+          metrics: { current: stats(1_000) },
+        }],
+        refresh: {
+          refreshedAt: now,
+          runs: [{ runId: 550, runAttempt: 1 }],
+        },
+      }),
+    );
+    const store = new BenchmarkHistoryStore(file);
+    await store.load();
+    assertEquals(store.refresh?.result, "data");
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history validates refresh state transitions", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now();
+  try {
+    const store = new BenchmarkHistoryStore(file);
+    await store.load();
+    const run = store.set({
+      runId: 601,
+      runAttempt: 1,
+      at: now,
+      metrics: new Map([["current", stats(2_000)]]),
+    });
+    assertEquals(store.set(run), run);
+    assertEquals(store.list(now + 1), []);
+    assertEquals(store.markRefreshed(Number.NaN, [run]), null);
+    assertThrows(
+      () => {
+        store.markRefreshed(now, [{ ...run, runId: 999 }]);
+      },
+      Error,
+      "contains an uncached run",
+    );
+
+    store.markRefreshed(now, [run], "data");
+    const refresh = store.refresh!;
+    assertEquals(store.markRefreshed(now - 1, [run]), refresh);
+    store.restoreRefresh(null);
+    assertEquals(store.refresh, null);
+    store.restoreRefresh(refresh);
+    assertEquals(store.refreshedRuns()?.map((value) => value.runId), [601]);
+
+    store.invalidateRefresh(now + DAY_MS);
+    store.invalidateRefresh(now);
+    assertEquals(store.quarantineFuture(now), true);
+    assertEquals(store.quarantineFuture(now), true);
+    await store.save(now);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history drops a refresh whose retained run is pruned", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now();
+  try {
+    const store = new BenchmarkHistoryStore(file);
+    await store.load();
+    const old = store.set({
+      runId: 701,
+      runAttempt: 1,
+      at: now - (BENCHMARK_HISTORY_CACHE_DAYS + 1) * DAY_MS,
+      metrics: new Map([["old", stats(3_000)]]),
+    });
+    store.markRefreshed(now - DAY_MS, [old]);
+    await store.save(now);
+    assertEquals(store.refresh, null);
+    assertEquals(store.refreshedRuns(), null);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history removes a temporary file after rename fails", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const rename = Deno.rename;
+  try {
+    const store = new BenchmarkHistoryStore(file);
+    await store.load();
+    store.set({
+      runId: 801,
+      runAttempt: 1,
+      at: Date.now(),
+      metrics: new Map([["current", stats(4_000)]]),
+    });
+    Deno.rename = (() =>
+      Promise.reject(new Error("rename failed"))) as typeof Deno.rename;
+    await assertRejects(() => store.save(), Error, "rename failed");
+    assertEquals(
+      [...Deno.readDirSync(directory)].some((entry) =>
+        entry.name.endsWith(".tmp")
+      ),
+      false,
+    );
+  } finally {
+    Deno.rename = rename;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history preserves a write error when temporary cleanup fails", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const rename = Deno.rename;
+  const remove = Deno.remove;
+  try {
+    const store = new BenchmarkHistoryStore(file);
+    await store.load();
+    store.set({
+      runId: 802,
+      runAttempt: 1,
+      at: Date.now(),
+      metrics: new Map([["current", stats(4_000)]]),
+    });
+    Deno.rename = (() =>
+      Promise.reject(new Error("rename failed"))) as typeof Deno.rename;
+    Deno.remove = ((path, options) =>
+      String(path).endsWith(".tmp")
+        ? Promise.reject(new Error("remove failed"))
+        : remove(path, options)) as typeof Deno.remove;
+    await assertRejects(
+      () =>
+        store.save(),
+      Error,
+      "rename failed",
+    );
+  } finally {
+    Deno.rename = rename;
+    Deno.remove = remove;
+    await Deno.remove(directory, { recursive: true });
+  }
+});

--- a/packages/dashboard/benchmark-history-cache.ts
+++ b/packages/dashboard/benchmark-history-cache.ts
@@ -1,0 +1,488 @@
+// Completed runtime benchmark artifacts persisted across dashboard restarts.
+// One workflow run attempt is immutable, including the absence of a usable artifact.
+
+import { dashboardCacheFile } from "./history-files.ts";
+
+export const BENCHMARK_HISTORY_CACHE_DAYS = 60;
+
+const DAY_MS = 86_400_000;
+const STORE_VERSION = 1;
+
+export interface BenchmarkStats {
+  min: number;
+  avg: number;
+  max: number;
+  p75: number;
+  p99: number;
+  p995: number;
+  p999: number;
+}
+
+export interface CachedBenchmarkRun {
+  runId: number;
+  runAttempt: number;
+  at: number;
+  metrics: Map<string, BenchmarkStats>;
+}
+
+interface StoredBenchmarkRun {
+  runId: number;
+  runAttempt: number;
+  at: number;
+  metrics: Record<string, BenchmarkStats>;
+}
+
+interface BenchmarkRunReference {
+  runId: number;
+  runAttempt: number;
+}
+
+export interface BenchmarkRefreshManifest {
+  refreshedAt: number;
+  runs: BenchmarkRunReference[];
+  result: BenchmarkRefreshResult;
+}
+
+export type BenchmarkRefreshResult =
+  | "data"
+  | "no-runs"
+  | "data-unavailable"
+  | "no-metric";
+
+interface StoredBenchmarkHistory {
+  version: number;
+  refresh?: BenchmarkRefreshManifest;
+  invalidatedAt?: number;
+  runs: StoredBenchmarkRun[];
+}
+
+interface BenchmarkHistoryContents {
+  refresh: BenchmarkRefreshManifest | null;
+  invalidatedAt: number;
+  futureState: boolean;
+  runs: CachedBenchmarkRun[];
+}
+
+const defaultFile = (): string =>
+  dashboardCacheFile("fabric-wall-benchmark-history.json");
+
+const isStats = (value: unknown): value is BenchmarkStats => {
+  if (typeof value !== "object" || value === null) return false;
+  const stats = value as BenchmarkStats;
+  return [
+    stats.min,
+    stats.avg,
+    stats.max,
+    stats.p75,
+    stats.p99,
+    stats.p995,
+    stats.p999,
+  ].every((number) => Number.isFinite(number));
+};
+
+const isStoredRun = (value: unknown): value is StoredBenchmarkRun => {
+  if (typeof value !== "object" || value === null) return false;
+  const run = value as StoredBenchmarkRun;
+  return Number.isInteger(run.runId) && run.runId > 0 &&
+    Number.isInteger(run.runAttempt) && run.runAttempt > 0 &&
+    Number.isFinite(run.at) && typeof run.metrics === "object" &&
+    run.metrics !== null && !Array.isArray(run.metrics) &&
+    Object.values(run.metrics).every(isStats);
+};
+
+const isRunReference = (value: unknown): value is BenchmarkRunReference => {
+  if (typeof value !== "object" || value === null) return false;
+  const run = value as BenchmarkRunReference;
+  return Number.isInteger(run.runId) && run.runId > 0 &&
+    Number.isInteger(run.runAttempt) && run.runAttempt > 0;
+};
+
+const isRefreshManifest = (
+  value: unknown,
+): value is BenchmarkRefreshManifest => {
+  if (typeof value !== "object" || value === null) return false;
+  const refresh = value as BenchmarkRefreshManifest;
+  return Number.isFinite(refresh.refreshedAt) && refresh.refreshedAt >= 0 &&
+    Array.isArray(refresh.runs) && refresh.runs.every(isRunReference) &&
+    (refresh.result === undefined ||
+      ["data", "no-runs", "data-unavailable", "no-metric"].includes(
+        refresh.result,
+      ));
+};
+
+const runKey = (runId: number, runAttempt: number): string =>
+  `${runId}:${runAttempt}`;
+
+export class BenchmarkHistoryStore {
+  #file: string | undefined;
+  #loadRequest: Promise<void> | null = null;
+  #runs = new Map<string, CachedBenchmarkRun>();
+  #refresh: BenchmarkRefreshManifest | null = null;
+  #invalidatedAt = 0;
+  #allowFutureCleanup = false;
+  #write: Promise<void> = Promise.resolve();
+  #revision = 0;
+  #persistedRevision = 0;
+
+  constructor(file?: string) {
+    this.#file = file;
+  }
+
+  async #read(strict = false): Promise<BenchmarkHistoryContents> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await Deno.readTextFile(this.file));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound || !strict) {
+        return {
+          refresh: null,
+          invalidatedAt: 0,
+          futureState: false,
+          runs: [],
+        };
+      }
+      throw error;
+    }
+    if (typeof parsed !== "object" || parsed === null) {
+      if (strict) throw new Error("Invalid runtime benchmark history cache.");
+      return {
+        refresh: null,
+        invalidatedAt: 0,
+        futureState: false,
+        runs: [],
+      };
+    }
+    const value = parsed as Partial<StoredBenchmarkHistory>;
+    if (value.version !== STORE_VERSION || !Array.isArray(value.runs)) {
+      if (strict) {
+        throw new Error("Unsupported runtime benchmark history cache format.");
+      }
+      return {
+        refresh: null,
+        invalidatedAt: 0,
+        futureState: false,
+        runs: [],
+      };
+    }
+    const invalidInvalidation = value.invalidatedAt !== undefined &&
+      (!Number.isFinite(value.invalidatedAt) || value.invalidatedAt < 0);
+    const futureInvalidation = value.invalidatedAt !== undefined &&
+      Number.isFinite(value.invalidatedAt) && value.invalidatedAt >= 0 &&
+      value.invalidatedAt > Date.now();
+    const rejectedInvalidation = invalidInvalidation || futureInvalidation;
+    const futureRefresh = value.refresh !== undefined &&
+      isRefreshManifest(value.refresh) &&
+      value.refresh.refreshedAt > Date.now();
+    const futureState = futureInvalidation || futureRefresh;
+    if (
+      strict &&
+      (invalidInvalidation ||
+        (futureInvalidation && !this.#allowFutureCleanup))
+    ) {
+      throw new Error("Invalid runtime benchmark refresh invalidation.");
+    }
+    const runs: CachedBenchmarkRun[] = [];
+    let rejectedRun = false;
+    for (const run of value.runs) {
+      if (!isStoredRun(run)) {
+        if (strict) {
+          throw new Error("Invalid runtime benchmark history cache entry.");
+        }
+        rejectedRun = true;
+        continue;
+      }
+      runs.push({
+        runId: run.runId,
+        runAttempt: run.runAttempt,
+        at: run.at,
+        metrics: new Map(Object.entries(run.metrics)),
+      });
+    }
+    let refresh: BenchmarkRefreshManifest | null = null;
+    if (value.refresh !== undefined) {
+      if (!isRefreshManifest(value.refresh)) {
+        if (strict) {
+          throw new Error("Invalid runtime benchmark refresh manifest.");
+        }
+      } else if (
+        !rejectedRun && !rejectedInvalidation &&
+        value.refresh.refreshedAt <= Date.now()
+      ) {
+        const available = new Set(
+          runs.map((run) => `${run.runId}:${run.runAttempt}`),
+        );
+        if (
+          value.refresh.runs.every((run) =>
+            available.has(`${run.runId}:${run.runAttempt}`)
+          )
+        ) {
+          refresh = {
+            refreshedAt: value.refresh.refreshedAt,
+            runs: value.refresh.runs.map((run) => ({ ...run })),
+            result: value.refresh.result ??
+              (value.refresh.runs.length ? "data" : "no-runs"),
+          };
+        } else if (strict) {
+          throw new Error(
+            "Runtime benchmark refresh manifest references a missing run.",
+          );
+        }
+      }
+    }
+    return {
+      refresh,
+      invalidatedAt: !rejectedInvalidation &&
+          Number.isFinite(value.invalidatedAt)
+        ? value.invalidatedAt!
+        : 0,
+      futureState,
+      runs,
+    };
+  }
+
+  #merge(contents: BenchmarkHistoryContents): void {
+    for (const run of contents.runs) {
+      const key = runKey(run.runId, run.runAttempt);
+      if (!this.#runs.has(key)) this.#runs.set(key, run);
+    }
+    this.#invalidatedAt = Math.max(
+      this.#invalidatedAt,
+      contents.invalidatedAt,
+    );
+    if (contents.futureState && !this.#allowFutureCleanup) {
+      this.#allowFutureCleanup = true;
+      this.#revision++;
+    }
+    if (
+      contents.refresh &&
+      (!this.#refresh ||
+        this.#refresh.refreshedAt < contents.refresh.refreshedAt)
+    ) {
+      this.#refresh = contents.refresh;
+    }
+    this.#invalidateSupersededRefresh();
+  }
+
+  #invalidateSupersededRefresh(at?: number): void {
+    if (!this.#refresh) return;
+    const superseded = this.#refresh.runs.some((reference) => {
+      const latest = this.get(reference.runId);
+      return latest && latest.runAttempt > reference.runAttempt;
+    });
+    if (superseded) {
+      this.#invalidatedAt = Math.max(
+        this.#invalidatedAt,
+        at ?? this.#refresh.refreshedAt,
+      );
+    }
+  }
+
+  #resolve(refresh: BenchmarkRefreshManifest): CachedBenchmarkRun[] | null {
+    const runs: CachedBenchmarkRun[] = [];
+    for (const reference of refresh.runs) {
+      const run = this.#runs.get(runKey(reference.runId, reference.runAttempt));
+      if (!run) return null;
+      runs.push(run);
+    }
+    return runs.sort((a, b) => a.at - b.at);
+  }
+
+  #prune(now: number): void {
+    const cutoff = now - BENCHMARK_HISTORY_CACHE_DAYS * DAY_MS;
+    let pruned = false;
+    for (const [key, run] of this.#runs) {
+      if (run.at < cutoff) {
+        this.#runs.delete(key);
+        pruned = true;
+      }
+    }
+    if (this.#refresh && !this.#resolve(this.#refresh)) {
+      this.#refresh = null;
+      pruned = true;
+    }
+    if (pruned) this.#revision++;
+  }
+
+  get file(): string {
+    return this.#file ??= defaultFile();
+  }
+
+  load(): Promise<void> {
+    if (!this.#loadRequest) {
+      this.#loadRequest = (async () => {
+        this.#merge(await this.#read());
+      })();
+    }
+    return this.#loadRequest;
+  }
+
+  get(runId: number, runAttempt?: number): CachedBenchmarkRun | undefined {
+    if (runAttempt !== undefined) {
+      return this.#runs.get(runKey(runId, runAttempt));
+    }
+    let latest: CachedBenchmarkRun | undefined;
+    for (const run of this.#runs.values()) {
+      if (
+        run.runId === runId &&
+        (!latest || latest.runAttempt < run.runAttempt)
+      ) latest = run;
+    }
+    return latest;
+  }
+
+  get refreshedAt(): number {
+    return this.#refresh && this.#refresh.refreshedAt > this.#invalidatedAt &&
+        this.#refresh.refreshedAt <= Date.now()
+      ? this.#refresh.refreshedAt
+      : 0;
+  }
+
+  get refresh(): BenchmarkRefreshManifest | null {
+    if (!this.#refresh || !this.#resolve(this.#refresh)) return null;
+    return {
+      refreshedAt: this.#refresh.refreshedAt,
+      runs: this.#refresh.runs.map((run) => ({ ...run })),
+      result: this.#refresh.result,
+    };
+  }
+
+  refreshedRuns(): CachedBenchmarkRun[] | null {
+    return this.#refresh ? this.#resolve(this.#refresh) : null;
+  }
+
+  markRefreshed(
+    at: number,
+    runs: CachedBenchmarkRun[],
+    result: BenchmarkRefreshResult = runs.length ? "data" : "no-runs",
+  ): BenchmarkRefreshManifest | null {
+    const previous = this.refresh;
+    if (!Number.isFinite(at) || at < (this.#refresh?.refreshedAt ?? 0)) {
+      return previous;
+    }
+    const references = runs.map((run) => ({
+      runId: run.runId,
+      runAttempt: run.runAttempt,
+    }));
+    const refresh = { refreshedAt: at, runs: references, result };
+    if (!this.#resolve(refresh)) {
+      throw new Error("Runtime benchmark refresh contains an uncached run.");
+    }
+    this.#refresh = refresh;
+    this.#revision++;
+    return previous;
+  }
+
+  restoreRefresh(refresh: BenchmarkRefreshManifest | null): void {
+    this.#refresh = refresh && this.#resolve(refresh) ? refresh : null;
+    this.#revision++;
+  }
+
+  quarantineFuture(now = Date.now()): boolean {
+    let changed = this.#allowFutureCleanup;
+    if (this.#refresh && this.#refresh.refreshedAt > now) {
+      this.#refresh = null;
+      changed = true;
+    }
+    if (this.#invalidatedAt > now) {
+      this.#invalidatedAt = 0;
+      changed = true;
+    }
+    if (changed && !this.#allowFutureCleanup) this.#revision++;
+    this.#allowFutureCleanup = changed;
+    return changed;
+  }
+
+  invalidateRefresh(at = Date.now()): void {
+    if (!Number.isFinite(at) || at <= this.#invalidatedAt) return;
+    this.#invalidatedAt = at;
+    this.#revision++;
+  }
+
+  set(run: CachedBenchmarkRun): CachedBenchmarkRun {
+    const key = runKey(run.runId, run.runAttempt);
+    const current = this.#runs.get(key);
+    if (current) return current;
+    const stored = {
+      runId: run.runId,
+      runAttempt: run.runAttempt,
+      at: run.at,
+      metrics: new Map(run.metrics),
+    };
+    this.#runs.set(key, stored);
+    this.#invalidateSupersededRefresh(Date.now());
+    this.#revision++;
+    return stored;
+  }
+
+  list(cutoff = -Infinity): CachedBenchmarkRun[] {
+    const latest = new Map<number, CachedBenchmarkRun>();
+    for (const run of this.#runs.values()) {
+      if (run.at < cutoff) continue;
+      const current = latest.get(run.runId);
+      if (!current || current.runAttempt < run.runAttempt) {
+        latest.set(run.runId, run);
+      }
+    }
+    return [...latest.values()].sort((a, b) => a.at - b.at);
+  }
+
+  get dirty(): boolean {
+    return this.#revision > this.#persistedRevision;
+  }
+
+  async save(now = Date.now()): Promise<void> {
+    this.#prune(now);
+    if (!this.dirty) return;
+    const write = async () => {
+      if (!this.dirty) return;
+      const lock = await Deno.open(`${this.file}.lock`, {
+        create: true,
+        write: true,
+      });
+      let locked = false;
+      try {
+        await lock.lock(true);
+        locked = true;
+        this.#merge(await this.#read(true));
+        this.#prune(now);
+
+        const revision = this.#revision;
+        const value: StoredBenchmarkHistory = {
+          version: STORE_VERSION,
+          refresh: this.refresh ?? undefined,
+          invalidatedAt: this.#invalidatedAt || undefined,
+          runs: [...this.#runs.values()].sort((a, b) => a.at - b.at).map((
+            run,
+          ) => ({
+            runId: run.runId,
+            runAttempt: run.runAttempt,
+            at: run.at,
+            metrics: Object.fromEntries(run.metrics),
+          })),
+        };
+        const temporary = `${this.file}.${crypto.randomUUID()}.tmp`;
+        try {
+          await Deno.writeTextFile(temporary, JSON.stringify(value));
+          await Deno.rename(temporary, this.file);
+        } catch (error) {
+          try {
+            await Deno.remove(temporary);
+          } catch {
+            // Ignore cleanup when no temporary file remains.
+          }
+          throw error;
+        }
+        this.#persistedRevision = Math.max(
+          this.#persistedRevision,
+          revision,
+        );
+        this.#allowFutureCleanup = false;
+      } finally {
+        if (locked) await lock.unlock();
+        lock.close();
+      }
+    };
+    this.#write = this.#write.then(write, write);
+    await this.#write;
+  }
+}

--- a/packages/dashboard/ci-job-cache.test.ts
+++ b/packages/dashboard/ci-job-cache.test.ts
@@ -1,0 +1,458 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import {
+  type CachedCiHistoryRefresh,
+  type CachedCiRun,
+  CI_JOB_CACHE_DAYS,
+  CiJobHistoryStore,
+} from "./ci-job-cache.ts";
+
+const DAY_MS = 86_400_000;
+const NOW = Date.UTC(2026, 6, 20);
+const REPO = "owner/repo";
+const WORKFLOW = "ci.yml";
+
+function cachedRun(
+  runId: number,
+  runAttempt = 1,
+  at = NOW,
+  repo = REPO,
+  workflow = WORKFLOW,
+): CachedCiRun {
+  const startedAt = new Date(at).toISOString();
+  const completedAt = new Date(at + 60_000).toISOString();
+  return {
+    repo,
+    workflow,
+    runId,
+    runAttempt,
+    runUrl: `https://github.com/${repo}/actions/runs/${runId}`,
+    at,
+    overallSeconds: 60,
+    jobs: [{ name: "test", seconds: 60 }],
+    gantt: {
+      status: "completed",
+      conclusion: "success",
+      event: "push",
+      headBranch: "main",
+      workflowName: "CI",
+      startedAt,
+      jobs: [{
+        name: "test",
+        status: "completed",
+        conclusion: "success",
+        started_at: startedAt,
+        completed_at: completedAt,
+        steps: [{
+          name: "run",
+          number: 1,
+          conclusion: "success",
+          started_at: startedAt,
+          completed_at: completedAt,
+        }],
+      }],
+    },
+  };
+}
+
+Deno.test("CI job cache rejects malformed persisted structures before merging", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-cache-" });
+  const valid = cachedRun(1);
+  const invalidStep = structuredClone(valid);
+  invalidStep.gantt.jobs[0].steps = [null] as never;
+  const invalidJob = structuredClone(valid);
+  invalidJob.gantt.jobs = [null] as never;
+  const invalidGantt = { ...valid, gantt: null };
+  const invalidSha = { ...valid, headSha: "not-a-commit" };
+  const cases: { value: unknown; message: string }[] = [
+    { value: null, message: "Invalid CI job history cache" },
+    {
+      value: { version: 2, runs: [] },
+      message: "Unsupported CI job history cache format",
+    },
+    {
+      value: { version: 1, runs: [null] },
+      message: "Invalid CI job history cache entry",
+    },
+    {
+      value: { version: 1, runs: [invalidGantt] },
+      message: "Invalid CI job history cache entry",
+    },
+    {
+      value: { version: 1, runs: [invalidJob] },
+      message: "Invalid CI job history cache entry",
+    },
+    {
+      value: { version: 1, runs: [invalidStep] },
+      message: "Invalid CI job history cache entry",
+    },
+    {
+      value: { version: 1, runs: [invalidSha] },
+      message: "Invalid CI job history cache entry",
+    },
+    {
+      value: { version: 1, runs: [], refreshes: {} },
+      message: "Invalid CI job history refresh entry",
+    },
+    {
+      value: { version: 1, runs: [], refreshes: [null] },
+      message: "Invalid CI job history refresh entry",
+    },
+    {
+      value: { version: 1, runs: [], invalidations: {} },
+      message: "Invalid CI job history refresh invalidation",
+    },
+    {
+      value: { version: 1, runs: [], invalidations: [null] },
+      message: "Invalid CI job history refresh invalidation",
+    },
+    {
+      value: {
+        version: 1,
+        runs: [],
+        refreshes: [{
+          repo: REPO,
+          workflow: WORKFLOW,
+          days: 7,
+          refreshedAt: NOW,
+          successfulRunTimes: [NOW],
+          sampledRuns: [{ runId: 999, runAttempt: 1 }],
+          failedRunCount: 0,
+          failedRunTimes: [],
+          stale: false,
+        }],
+      },
+      message: "references a missing run",
+    },
+  ];
+
+  try {
+    for (const [index, testCase] of cases.entries()) {
+      const file = `${directory}/${index}.json`;
+      await Deno.writeTextFile(file, JSON.stringify(testCase.value));
+      const store = new CiJobHistoryStore(file);
+      await store.load();
+      store.set(cachedRun(100 + index));
+      await assertRejects(() => store.save(NOW), Error, testCase.message);
+    }
+
+    const file = `${directory}/future-strict.json`;
+    const store = new CiJobHistoryStore(file);
+    await store.load();
+    store.set(cachedRun(200));
+    const future = Date.now() + DAY_MS;
+    await Deno.writeTextFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        runs: [],
+        invalidations: [{
+          repo: REPO,
+          workflow: WORKFLOW,
+          days: 7,
+          invalidatedAt: future,
+        }],
+      }),
+    );
+    await assertRejects(
+      () => store.save(NOW),
+      Error,
+      "Invalid CI job history refresh invalidation",
+    );
+
+    const malformedFile = `${directory}/malformed.json`;
+    await Deno.writeTextFile(malformedFile, "{not json");
+    const malformedStore = new CiJobHistoryStore(malformedFile);
+    await malformedStore.load();
+    malformedStore.set(cachedRun(201));
+    await assertRejects(() => malformedStore.save(NOW), SyntaxError);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job cache records a validated commit on an exact run attempt", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-cache-" });
+  try {
+    const store = new CiJobHistoryStore(`${directory}/history.json`);
+    await store.load();
+    const run = store.set(cachedRun(250));
+    const revision = store.revision;
+    assertEquals(store.setHeadSha(REPO, WORKFLOW, 999, 1, "a".repeat(40)), undefined);
+    const tagged = store.setHeadSha(
+      REPO,
+      WORKFLOW,
+      run.runId,
+      run.runAttempt,
+      "A".repeat(40),
+    );
+    assertEquals(tagged, { ...run, headSha: "a".repeat(40) });
+    assertEquals(store.revision, revision + 1);
+    assertEquals(
+      store.setHeadSha(
+        REPO,
+        WORKFLOW,
+        run.runId,
+        run.runAttempt,
+        "a".repeat(40),
+      ),
+      tagged,
+    );
+    assertEquals(store.revision, revision + 1);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job cache quarantines future persisted refresh state", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-cache-" });
+  const file = `${directory}/history.json`;
+  const run = cachedRun(301);
+  const observedNow = Date.now();
+  const future = observedNow + DAY_MS;
+  try {
+    await Deno.writeTextFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        runs: [run],
+        refreshes: [{
+          repo: REPO,
+          workflow: WORKFLOW,
+          days: 7,
+          refreshedAt: future,
+          successfulRunTimes: [NOW],
+          sampledRuns: [{ runId: run.runId, runAttempt: run.runAttempt }],
+          failedRunCount: 0,
+          failedRunTimes: [],
+          stale: false,
+        }],
+        invalidations: [{
+          repo: REPO,
+          workflow: WORKFLOW,
+          days: 7,
+          invalidatedAt: future,
+        }],
+      }),
+    );
+
+    const store = new CiJobHistoryStore(file);
+    await store.load();
+    assertEquals(store.refresh(REPO, WORKFLOW, 7), undefined);
+    assertEquals(
+      store.quarantineFutureRefresh(REPO, WORKFLOW, 7, observedNow),
+      true,
+    );
+    await store.save(observedNow);
+    const persisted = JSON.parse(await Deno.readTextFile(file));
+    assertEquals(persisted.refreshes, []);
+    assertEquals(persisted.invalidations, []);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job cache validates refresh changes and isolates source revisions", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-cache-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now;
+  Date.now = () => NOW;
+  try {
+    const store = new CiJobHistoryStore(file);
+    await store.load();
+    const first = store.set(cachedRun(401));
+    assertEquals(store.set(first), first);
+    const second = store.set(cachedRun(401, 2));
+    store.set(cachedRun(402, 1, NOW, "other/repo"));
+    store.set(cachedRun(403, 1, NOW, REPO, "other.yml"));
+    assertEquals(store.get(REPO, WORKFLOW, 401, 1), first);
+    assertEquals(store.latest(REPO, WORKFLOW, 401), second);
+    assertEquals(store.list(REPO, WORKFLOW).map((run) => run.runId), [401]);
+    assertEquals(store.list(REPO, WORKFLOW, NOW + 1), []);
+
+    store.markRefreshed(
+      REPO,
+      WORKFLOW,
+      7,
+      Number.NaN,
+      [],
+      [],
+      0,
+      [],
+      false,
+    );
+    assertThrows(
+      () => {
+        store.markRefreshed(REPO, WORKFLOW, 7, NOW, [], [], -1, [], false);
+      },
+      Error,
+      "invalid failure count",
+    );
+    assertThrows(
+      () => {
+        store.markRefreshed(
+          REPO,
+          WORKFLOW,
+          7,
+          NOW,
+          [],
+          [{ runId: 999, runAttempt: 1 }],
+          0,
+          [],
+          false,
+        );
+      },
+      Error,
+      "contains an uncached run",
+    );
+
+    store.markRefreshed(
+      REPO,
+      WORKFLOW,
+      7,
+      NOW,
+      [Number.NaN, NOW, NOW - 1],
+      [{ runId: 401, runAttempt: 2 }],
+      2,
+      [Number.NaN, NOW - 2],
+      true,
+    );
+    const refresh = store.refresh(REPO, WORKFLOW, 7)!;
+    assertEquals(refresh.successfulRunTimes, [NOW - 1, NOW]);
+    assertEquals(refresh.failedRunTimes, [NOW - 2]);
+    store.markRefreshed(
+      REPO,
+      WORKFLOW,
+      7,
+      NOW - 1,
+      [],
+      [],
+      0,
+      [],
+      false,
+    );
+    assertEquals(store.refresh(REPO, WORKFLOW, 7), refresh);
+    assertEquals(store.refreshedRuns(REPO, WORKFLOW, 7)?.[0], second);
+
+    const superseded = store.set(cachedRun(404, 1));
+    store.markRefreshed(
+      REPO,
+      WORKFLOW,
+      8,
+      NOW,
+      [NOW],
+      [{ runId: superseded.runId, runAttempt: superseded.runAttempt }],
+      0,
+      [],
+      false,
+    );
+    store.set(cachedRun(404, 2));
+    assertEquals(store.freshRefresh(REPO, WORKFLOW, 8), undefined);
+
+    store.restoreRefresh(REPO, WORKFLOW, 7, undefined);
+    assertEquals(store.refresh(REPO, WORKFLOW, 7), undefined);
+    store.restoreRefresh(REPO, WORKFLOW, 7, refresh);
+    assertEquals(store.refresh(REPO, WORKFLOW, 7), refresh);
+    store.invalidateRefresh(REPO, WORKFLOW, 7);
+    const revision = store.revision;
+    store.invalidateRefresh(REPO, WORKFLOW, 7);
+    assertEquals(store.revision, revision);
+    assertEquals(store.freshRefresh(REPO, WORKFLOW, 7), undefined);
+
+    const futureRefresh: CachedCiHistoryRefresh = {
+      ...refresh,
+      refreshedAt: NOW + 2 * DAY_MS,
+    };
+    store.restoreRefresh(REPO, WORKFLOW, 7, futureRefresh);
+    Date.now = () => NOW + 2 * DAY_MS;
+    store.invalidateRefresh(REPO, WORKFLOW, 7);
+    assertEquals(store.quarantineFutureRefresh(REPO, WORKFLOW, 7, NOW), true);
+    assertEquals(store.revisionFor(REPO, WORKFLOW) > 0, true);
+    await store.save(NOW);
+    await store.save(NOW);
+  } finally {
+    Date.now = now;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job cache drops a refresh whose retained run is pruned", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-cache-" });
+  const file = `${directory}/history.json`;
+  try {
+    const store = new CiJobHistoryStore(file);
+    await store.load();
+    const old = store.set(cachedRun(
+      501,
+      1,
+      NOW - (CI_JOB_CACHE_DAYS + 1) * DAY_MS,
+    ));
+    store.markRefreshed(
+      REPO,
+      WORKFLOW,
+      7,
+      NOW - DAY_MS,
+      [old.at],
+      [{ runId: old.runId, runAttempt: old.runAttempt }],
+      0,
+      [],
+      false,
+    );
+    const revision = store.revisionFor(REPO, WORKFLOW);
+    await store.save(NOW);
+    assertEquals(store.refresh(REPO, WORKFLOW, 7), undefined);
+    assertEquals(store.revisionFor(REPO, WORKFLOW), revision + 1);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job cache removes a temporary file after rename fails", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-cache-" });
+  const file = `${directory}/history.json`;
+  const rename = Deno.rename;
+  try {
+    const store = new CiJobHistoryStore(file);
+    await store.load();
+    store.set(cachedRun(601));
+    Deno.rename = (() =>
+      Promise.reject(new Error("rename failed"))) as typeof Deno.rename;
+    await assertRejects(() => store.save(NOW), Error, "rename failed");
+    assertEquals(
+      [...Deno.readDirSync(directory)].some((entry) =>
+        entry.name.endsWith(".tmp")
+      ),
+      false,
+    );
+  } finally {
+    Deno.rename = rename;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job cache preserves a write error when temporary cleanup fails", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-cache-" });
+  const file = `${directory}/history.json`;
+  const rename = Deno.rename;
+  const remove = Deno.remove;
+  try {
+    const store = new CiJobHistoryStore(file);
+    await store.load();
+    store.set(cachedRun(602));
+    Deno.rename = (() =>
+      Promise.reject(new Error("rename failed"))) as typeof Deno.rename;
+    Deno.remove = ((path, options) =>
+      String(path).endsWith(".tmp")
+        ? Promise.reject(new Error("remove failed"))
+        : remove(path, options)) as typeof Deno.remove;
+    await assertRejects(
+      () =>
+        store.save(NOW),
+      Error,
+      "rename failed",
+    );
+  } finally {
+    Deno.rename = rename;
+    Deno.remove = remove;
+    await Deno.remove(directory, { recursive: true });
+  }
+});

--- a/packages/dashboard/ci-job-cache.ts
+++ b/packages/dashboard/ci-job-cache.ts
@@ -1,0 +1,744 @@
+// Completed CI run, job, and step timings persisted across dashboard restarts.
+// Timings are stable for one workflow attempt and are retained for the widest
+// history window the dashboard can display.
+
+import { dashboardCacheFile } from "./history-files.ts";
+
+export const CI_JOB_CACHE_DAYS = 60;
+
+const DAY_MS = 86_400_000;
+const STORE_VERSION = 1;
+
+export interface CachedCiJob {
+  name: string;
+  seconds: number;
+}
+
+export interface CachedCiGanttStep {
+  name: string;
+  number: number;
+  conclusion: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+export interface CachedCiGanttJob {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  steps: CachedCiGanttStep[];
+}
+
+export interface CachedCiGanttRun {
+  status: string;
+  conclusion: string | null;
+  event: string;
+  headBranch?: string;
+  startedAt: string;
+  workflowName?: string;
+  jobs: CachedCiGanttJob[];
+}
+
+export interface CachedCiRun {
+  repo: string;
+  workflow: string;
+  runId: number;
+  runAttempt: number;
+  headSha?: string;
+  runUrl: string;
+  at: number;
+  overallSeconds: number;
+  jobs: CachedCiJob[];
+  gantt: CachedCiGanttRun;
+}
+
+export interface CachedCiRunReference {
+  runId: number;
+  runAttempt: number;
+}
+
+export interface CachedCiHistoryRefresh {
+  repo: string;
+  workflow: string;
+  days: number;
+  refreshedAt: number;
+  successfulRunTimes: number[];
+  sampledRuns: CachedCiRunReference[];
+  failedRunCount: number;
+  failedRunTimes: number[];
+  stale: boolean;
+}
+
+interface CachedCiHistoryInvalidation {
+  repo: string;
+  workflow: string;
+  days: number;
+  invalidatedAt: number;
+}
+
+interface StoredCiJobHistory {
+  version: number;
+  refreshes?: CachedCiHistoryRefresh[];
+  invalidations?: CachedCiHistoryInvalidation[];
+  runs: CachedCiRun[];
+}
+
+const defaultFile = (): string =>
+  dashboardCacheFile("fabric-wall-ci-job-history.json");
+
+const runKey = (
+  repo: string,
+  workflow: string,
+  runId: number,
+  runAttempt: number,
+): string => `${repo}:${workflow}:${runId}:${runAttempt}`;
+
+const sourceKey = (repo: string, workflow: string): string =>
+  `${repo}:${workflow}`;
+
+const refreshKey = (repo: string, workflow: string, days: number): string =>
+  `${sourceKey(repo, workflow)}:${days}`;
+
+const isCachedJob = (value: unknown): value is CachedCiJob =>
+  typeof value === "object" && value !== null &&
+  typeof (value as CachedCiJob).name === "string" &&
+  Number.isFinite((value as CachedCiJob).seconds) &&
+  (value as CachedCiJob).seconds > 0;
+
+const isNullableString = (value: unknown): value is string | null =>
+  value === null || typeof value === "string";
+
+const isCachedGanttStep = (value: unknown): value is CachedCiGanttStep => {
+  if (typeof value !== "object" || value === null) return false;
+  const step = value as CachedCiGanttStep;
+  return typeof step.name === "string" && Number.isInteger(step.number) &&
+    isNullableString(step.conclusion) && isNullableString(step.started_at) &&
+    isNullableString(step.completed_at);
+};
+
+const isCachedGanttJob = (value: unknown): value is CachedCiGanttJob => {
+  if (typeof value !== "object" || value === null) return false;
+  const job = value as CachedCiGanttJob;
+  return typeof job.name === "string" && typeof job.status === "string" &&
+    isNullableString(job.conclusion) && isNullableString(job.started_at) &&
+    isNullableString(job.completed_at) && Array.isArray(job.steps) &&
+    job.steps.every(isCachedGanttStep);
+};
+
+const isCachedGanttRun = (value: unknown): value is CachedCiGanttRun => {
+  if (typeof value !== "object" || value === null) return false;
+  const run = value as CachedCiGanttRun;
+  return typeof run.status === "string" &&
+    isNullableString(run.conclusion) && typeof run.event === "string" &&
+    (run.headBranch === undefined || typeof run.headBranch === "string") &&
+    typeof run.startedAt === "string" &&
+    (run.workflowName === undefined || typeof run.workflowName === "string") &&
+    Array.isArray(run.jobs) && run.jobs.every(isCachedGanttJob);
+};
+
+const isCachedRun = (value: unknown): value is CachedCiRun => {
+  if (typeof value !== "object" || value === null) return false;
+  const run = value as CachedCiRun;
+  return typeof run.repo === "string" && typeof run.workflow === "string" &&
+    Number.isInteger(run.runId) && run.runId > 0 &&
+    Number.isInteger(run.runAttempt) && run.runAttempt > 0 &&
+    (run.headSha === undefined || /^[0-9a-f]{40}$/i.test(run.headSha)) &&
+    typeof run.runUrl === "string" && Number.isFinite(run.at) &&
+    Number.isFinite(run.overallSeconds) && run.overallSeconds >= 0 &&
+    Array.isArray(run.jobs) && run.jobs.every(isCachedJob) &&
+    isCachedGanttRun(run.gantt);
+};
+
+const isCachedRefresh = (
+  value: unknown,
+): value is CachedCiHistoryRefresh => {
+  if (typeof value !== "object" || value === null) return false;
+  const refresh = value as CachedCiHistoryRefresh;
+  return typeof refresh.repo === "string" &&
+    typeof refresh.workflow === "string" &&
+    Number.isInteger(refresh.days) && refresh.days > 0 &&
+    Number.isFinite(refresh.refreshedAt) && refresh.refreshedAt >= 0 &&
+    Array.isArray(refresh.successfulRunTimes) &&
+    refresh.successfulRunTimes.every(Number.isFinite) &&
+    Array.isArray(refresh.sampledRuns) &&
+    refresh.sampledRuns.every((run) =>
+      Number.isInteger(run.runId) && run.runId > 0 &&
+      Number.isInteger(run.runAttempt) && run.runAttempt > 0
+    ) &&
+    Number.isInteger(refresh.failedRunCount) && refresh.failedRunCount >= 0 &&
+    Array.isArray(refresh.failedRunTimes) &&
+    refresh.failedRunTimes.every(Number.isFinite) &&
+    refresh.failedRunTimes.length <= refresh.failedRunCount &&
+    typeof refresh.stale === "boolean";
+};
+
+const isCachedInvalidation = (
+  value: unknown,
+): value is CachedCiHistoryInvalidation => {
+  if (typeof value !== "object" || value === null) return false;
+  const invalidation = value as CachedCiHistoryInvalidation;
+  return typeof invalidation.repo === "string" &&
+    typeof invalidation.workflow === "string" &&
+    Number.isInteger(invalidation.days) && invalidation.days > 0 &&
+    Number.isFinite(invalidation.invalidatedAt) &&
+    invalidation.invalidatedAt >= 0;
+};
+
+interface CiJobHistoryContents {
+  refreshes: CachedCiHistoryRefresh[];
+  invalidations: CachedCiHistoryInvalidation[];
+  futureKeys: string[];
+  runs: CachedCiRun[];
+}
+
+export class CiJobHistoryStore {
+  #file: string | undefined;
+  #loadRequest: Promise<void> | null = null;
+  #runs = new Map<string, CachedCiRun>();
+  #refreshes = new Map<string, CachedCiHistoryRefresh>();
+  #invalidations = new Map<string, CachedCiHistoryInvalidation>();
+  #futureQuarantines = new Set<string>();
+  #write: Promise<void> = Promise.resolve();
+  #revision = 0;
+  #persistedRevision = 0;
+  #sourceRevisions = new Map<string, number>();
+
+  constructor(file?: string) {
+    this.#file = file;
+  }
+
+  get file(): string {
+    return this.#file ??= defaultFile();
+  }
+
+  async #read(strict = false): Promise<CiJobHistoryContents> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await Deno.readTextFile(this.file));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound || !strict) {
+        return { refreshes: [], invalidations: [], futureKeys: [], runs: [] };
+      }
+      throw error;
+    }
+    if (typeof parsed !== "object" || parsed === null) {
+      if (strict) throw new Error("Invalid CI job history cache.");
+      return { refreshes: [], invalidations: [], futureKeys: [], runs: [] };
+    }
+    const value = parsed as Partial<StoredCiJobHistory>;
+    if (value.version !== STORE_VERSION || !Array.isArray(value.runs)) {
+      if (strict) throw new Error("Unsupported CI job history cache format.");
+      return { refreshes: [], invalidations: [], futureKeys: [], runs: [] };
+    }
+    if (strict && value.runs.some((run) => !isCachedRun(run))) {
+      throw new Error("Invalid CI job history cache entry.");
+    }
+    if (
+      strict && value.refreshes !== undefined &&
+      (!Array.isArray(value.refreshes) ||
+        value.refreshes.some((refresh) => !isCachedRefresh(refresh)))
+    ) {
+      throw new Error("Invalid CI job history refresh entry.");
+    }
+    if (
+      strict && value.invalidations !== undefined &&
+      (!Array.isArray(value.invalidations) ||
+        value.invalidations.some((entry) =>
+          !isCachedInvalidation(entry) ||
+          (entry.invalidatedAt > Date.now() &&
+            !this.#futureQuarantines.has(
+              refreshKey(entry.repo, entry.workflow, entry.days),
+            ))
+        ))
+    ) {
+      throw new Error("Invalid CI job history refresh invalidation.");
+    }
+    const rejectedRun = value.runs.some((run) => !isCachedRun(run));
+    const rejectedRefresh = value.refreshes !== undefined &&
+      (!Array.isArray(value.refreshes) ||
+        value.refreshes.some((refresh) => !isCachedRefresh(refresh)));
+    const rejectedInvalidation = value.invalidations !== undefined &&
+      (!Array.isArray(value.invalidations) ||
+        value.invalidations.some((entry) => !isCachedInvalidation(entry)));
+    const futureKeys = new Set<string>();
+    if (Array.isArray(value.refreshes)) {
+      for (const refresh of value.refreshes.filter(isCachedRefresh)) {
+        if (refresh.refreshedAt > Date.now()) {
+          futureKeys.add(
+            refreshKey(refresh.repo, refresh.workflow, refresh.days),
+          );
+        }
+      }
+    }
+    if (Array.isArray(value.invalidations)) {
+      for (
+        const invalidation of value.invalidations.filter(
+          isCachedInvalidation,
+        )
+      ) {
+        if (invalidation.invalidatedAt > Date.now()) {
+          futureKeys.add(refreshKey(
+            invalidation.repo,
+            invalidation.workflow,
+            invalidation.days,
+          ));
+        }
+      }
+    }
+    const runs = value.runs.filter(isCachedRun);
+    const available = new Set(
+      runs.map((run) =>
+        `${run.repo}:${run.workflow}:${run.runId}:${run.runAttempt}`
+      ),
+    );
+    const eligibleRefreshes = Array.isArray(value.refreshes)
+      ? value.refreshes.filter(isCachedRefresh).filter((refresh) =>
+        refresh.refreshedAt <= Date.now()
+      )
+      : [];
+    const trustedEligibleRefreshes = eligibleRefreshes.filter((refresh) =>
+      !futureKeys.has(refreshKey(refresh.repo, refresh.workflow, refresh.days))
+    );
+    const refreshes = !rejectedRun && !rejectedRefresh &&
+        !rejectedInvalidation
+      ? trustedEligibleRefreshes.filter((refresh) =>
+        refresh.sampledRuns.every((run) =>
+          available.has(
+            `${refresh.repo}:${refresh.workflow}:${run.runId}:${run.runAttempt}`,
+          )
+        )
+      )
+      : [];
+    if (
+      strict && refreshes.length !== trustedEligibleRefreshes.length
+    ) {
+      throw new Error("CI job history refresh references a missing run.");
+    }
+    return {
+      runs,
+      refreshes,
+      invalidations: Array.isArray(value.invalidations) &&
+          !rejectedInvalidation
+        ? value.invalidations.filter(isCachedInvalidation).filter((entry) =>
+          entry.invalidatedAt <= Date.now()
+        )
+        : [],
+      futureKeys: [...futureKeys],
+    };
+  }
+
+  #merge(contents: CiJobHistoryContents): void {
+    for (const run of contents.runs) {
+      if (this.#put(run) === run) this.#bumpSource(run.repo, run.workflow);
+    }
+    for (const invalidation of contents.invalidations) {
+      const key = refreshKey(
+        invalidation.repo,
+        invalidation.workflow,
+        invalidation.days,
+      );
+      const current = this.#invalidations.get(key);
+      if (!current || current.invalidatedAt < invalidation.invalidatedAt) {
+        this.#invalidations.set(key, invalidation);
+        this.#bumpSource(invalidation.repo, invalidation.workflow);
+      }
+    }
+    for (const refresh of contents.refreshes) {
+      const key = refreshKey(refresh.repo, refresh.workflow, refresh.days);
+      const current = this.#refreshes.get(key);
+      if (!current || current.refreshedAt < refresh.refreshedAt) {
+        this.#refreshes.set(key, refresh);
+        this.#bumpSource(refresh.repo, refresh.workflow);
+      }
+    }
+    for (const key of contents.futureKeys) {
+      if (!this.#futureQuarantines.has(key)) {
+        this.#futureQuarantines.add(key);
+        this.#revision++;
+      }
+    }
+    this.#invalidateSupersededRefreshes();
+  }
+
+  #recordInvalidation(
+    repo: string,
+    workflow: string,
+    days: number,
+    invalidatedAt: number,
+  ): boolean {
+    const key = refreshKey(repo, workflow, days);
+    const current = this.#invalidations.get(key);
+    if (current && current.invalidatedAt >= invalidatedAt) return false;
+    this.#invalidations.set(key, {
+      repo,
+      workflow,
+      days,
+      invalidatedAt,
+    });
+    return true;
+  }
+
+  #invalidateSupersededRefreshes(at?: number): boolean {
+    let changed = false;
+    for (const refresh of this.#refreshes.values()) {
+      const superseded = refresh.sampledRuns.some((reference) => {
+        const latest = this.latest(
+          refresh.repo,
+          refresh.workflow,
+          reference.runId,
+        );
+        return latest && latest.runAttempt > reference.runAttempt;
+      });
+      if (
+        superseded && this.#recordInvalidation(
+          refresh.repo,
+          refresh.workflow,
+          refresh.days,
+          at ?? refresh.refreshedAt,
+        )
+      ) changed = true;
+    }
+    return changed;
+  }
+
+  #resolveRefresh(refresh: CachedCiHistoryRefresh): CachedCiRun[] | null {
+    const runs: CachedCiRun[] = [];
+    for (const reference of refresh.sampledRuns) {
+      const run = this.#runs.get(
+        runKey(
+          refresh.repo,
+          refresh.workflow,
+          reference.runId,
+          reference.runAttempt,
+        ),
+      );
+      if (!run) return null;
+      runs.push(run);
+    }
+    return runs.sort((a, b) => a.at - b.at);
+  }
+
+  #dropUnresolvedRefreshes(): boolean {
+    let dropped = false;
+    for (const [key, refresh] of this.#refreshes) {
+      if (!this.#resolveRefresh(refresh)) {
+        this.#refreshes.delete(key);
+        dropped = true;
+      }
+    }
+    return dropped;
+  }
+
+  load(): Promise<void> {
+    if (!this.#loadRequest) {
+      this.#loadRequest = (async () => {
+        this.#merge(await this.#read());
+      })();
+    }
+    return this.#loadRequest;
+  }
+
+  get(
+    repo: string,
+    workflow: string,
+    runId: number,
+    runAttempt: number,
+  ): CachedCiRun | undefined {
+    return this.#runs.get(runKey(repo, workflow, runId, runAttempt));
+  }
+
+  setHeadSha(
+    repo: string,
+    workflow: string,
+    runId: number,
+    runAttempt: number,
+    headSha: string,
+  ): CachedCiRun | undefined {
+    const key = runKey(repo, workflow, runId, runAttempt);
+    const current = this.#runs.get(key);
+    if (!current) return undefined;
+    const normalized = headSha.toLowerCase();
+    if (current.headSha === normalized) return current;
+    const updated = { ...current, headSha: normalized };
+    this.#runs.set(key, updated);
+    this.#revision++;
+    this.#bumpSource(repo, workflow);
+    return updated;
+  }
+
+  latest(
+    repo: string,
+    workflow: string,
+    runId: number,
+  ): CachedCiRun | undefined {
+    let latest: CachedCiRun | undefined;
+    for (const run of this.#runs.values()) {
+      if (
+        run.repo === repo && run.workflow === workflow && run.runId === runId
+      ) {
+        if (!latest || run.runAttempt > latest.runAttempt) latest = run;
+      }
+    }
+    return latest;
+  }
+
+  refresh(
+    repo: string,
+    workflow: string,
+    days: number,
+  ): CachedCiHistoryRefresh | undefined {
+    const refresh = this.#refreshes.get(refreshKey(repo, workflow, days));
+    if (!refresh || !this.#resolveRefresh(refresh)) return undefined;
+    return {
+      ...refresh,
+      successfulRunTimes: [...refresh.successfulRunTimes],
+      sampledRuns: refresh.sampledRuns.map((run) => ({ ...run })),
+      failedRunTimes: [...refresh.failedRunTimes],
+    };
+  }
+
+  freshRefresh(
+    repo: string,
+    workflow: string,
+    days: number,
+  ): CachedCiHistoryRefresh | undefined {
+    const refresh = this.refresh(repo, workflow, days);
+    const invalidation = this.#invalidations.get(
+      refreshKey(repo, workflow, days),
+    );
+    return refresh && refresh.refreshedAt <= Date.now() &&
+        (!invalidation || refresh.refreshedAt > invalidation.invalidatedAt)
+      ? refresh
+      : undefined;
+  }
+
+  refreshedRuns(
+    repo: string,
+    workflow: string,
+    days: number,
+  ): CachedCiRun[] | null {
+    const refresh = this.#refreshes.get(refreshKey(repo, workflow, days));
+    return refresh ? this.#resolveRefresh(refresh) : null;
+  }
+
+  markRefreshed(
+    repo: string,
+    workflow: string,
+    days: number,
+    refreshedAt: number,
+    successfulRunTimes: number[],
+    sampledRuns: CachedCiRunReference[],
+    failedRunCount: number,
+    failedRunTimes: number[],
+    stale: boolean,
+  ): void {
+    if (!Number.isFinite(refreshedAt) || refreshedAt < 0) return;
+    if (!Number.isInteger(failedRunCount) || failedRunCount < 0) {
+      throw new Error("CI job history refresh has an invalid failure count.");
+    }
+    const key = refreshKey(repo, workflow, days);
+    const current = this.#refreshes.get(key);
+    if (current && current.refreshedAt > refreshedAt) return;
+    this.#refreshes.set(key, {
+      repo,
+      workflow,
+      days,
+      refreshedAt,
+      successfulRunTimes: successfulRunTimes.filter(Number.isFinite).sort(
+        (a, b) => a - b,
+      ),
+      sampledRuns: sampledRuns.map((run) => ({ ...run })),
+      failedRunCount,
+      failedRunTimes: failedRunTimes.filter(Number.isFinite).sort(
+        (a, b) => a - b,
+      ),
+      stale,
+    });
+    if (!this.#resolveRefresh(this.#refreshes.get(key)!)) {
+      this.#refreshes.delete(key);
+      throw new Error("CI job history refresh contains an uncached run.");
+    }
+    this.#revision++;
+  }
+
+  restoreRefresh(
+    repo: string,
+    workflow: string,
+    days: number,
+    refresh: CachedCiHistoryRefresh | undefined,
+  ): void {
+    const key = refreshKey(repo, workflow, days);
+    if (refresh && this.#resolveRefresh(refresh)) {
+      this.#refreshes.set(key, refresh);
+    } else this.#refreshes.delete(key);
+    this.#revision++;
+  }
+
+  invalidateRefresh(repo: string, workflow: string, days: number): void {
+    if (!this.#recordInvalidation(repo, workflow, days, Date.now())) return;
+    this.#revision++;
+    this.#bumpSource(repo, workflow);
+  }
+
+  quarantineFutureRefresh(
+    repo: string,
+    workflow: string,
+    days: number,
+    now = Date.now(),
+  ): boolean {
+    const key = refreshKey(repo, workflow, days);
+    let changed = this.#futureQuarantines.has(key);
+    const refresh = this.#refreshes.get(key);
+    if (refresh && refresh.refreshedAt > now) {
+      this.#refreshes.delete(key);
+      changed = true;
+    }
+    const invalidation = this.#invalidations.get(key);
+    if (invalidation && invalidation.invalidatedAt > now) {
+      this.#invalidations.delete(key);
+      changed = true;
+    }
+    if (changed && !this.#futureQuarantines.has(key)) this.#revision++;
+    if (changed) this.#futureQuarantines.add(key);
+    return changed;
+  }
+
+  get dirty(): boolean {
+    return this.#revision > this.#persistedRevision;
+  }
+
+  get revision(): number {
+    return this.#revision;
+  }
+
+  revisionFor(repo: string, workflow: string): number {
+    return this.#sourceRevisions.get(sourceKey(repo, workflow)) ?? 0;
+  }
+
+  #bumpSource(repo: string, workflow: string): void {
+    const key = sourceKey(repo, workflow);
+    this.#sourceRevisions.set(key, (this.#sourceRevisions.get(key) ?? 0) + 1);
+  }
+
+  #prune(now: number): void {
+    const cutoff = now - CI_JOB_CACHE_DAYS * DAY_MS;
+    let pruned = false;
+    const prunedSources = new Set<string>();
+    for (const [key, run] of this.#runs) {
+      if (run.at < cutoff) {
+        this.#runs.delete(key);
+        pruned = true;
+        prunedSources.add(sourceKey(run.repo, run.workflow));
+      }
+    }
+    if (this.#dropUnresolvedRefreshes()) pruned = true;
+    if (!pruned) return;
+    this.#revision++;
+    for (const key of prunedSources) {
+      this.#sourceRevisions.set(
+        key,
+        (this.#sourceRevisions.get(key) ?? 0) + 1,
+      );
+    }
+  }
+
+  #put(run: CachedCiRun): CachedCiRun {
+    const key = runKey(run.repo, run.workflow, run.runId, run.runAttempt);
+    const current = this.#runs.get(key);
+    if (current) return current;
+    this.#runs.set(key, run);
+    return run;
+  }
+
+  set(run: CachedCiRun): CachedCiRun {
+    const stored = this.#put(run);
+    if (stored === run) {
+      this.#invalidateSupersededRefreshes(Date.now());
+      this.#revision++;
+      this.#bumpSource(run.repo, run.workflow);
+    }
+    return this.latest(run.repo, run.workflow, run.runId) ?? stored;
+  }
+
+  replace(run: CachedCiRun): CachedCiRun {
+    const key = runKey(run.repo, run.workflow, run.runId, run.runAttempt);
+    this.#runs.set(key, run);
+    this.#invalidateSupersededRefreshes(Date.now());
+    this.#revision++;
+    this.#bumpSource(run.repo, run.workflow);
+    return this.latest(run.repo, run.workflow, run.runId) ?? run;
+  }
+
+  list(repo: string, workflow: string, cutoff = -Infinity): CachedCiRun[] {
+    const latest = new Map<number, CachedCiRun>();
+    for (const run of this.#runs.values()) {
+      if (
+        run.repo !== repo || run.workflow !== workflow || run.at < cutoff
+      ) continue;
+      const current = latest.get(run.runId);
+      if (!current || current.runAttempt < run.runAttempt) {
+        latest.set(run.runId, run);
+      }
+    }
+    return [...latest.values()].sort((a, b) => a.at - b.at);
+  }
+
+  async save(now = Date.now()): Promise<void> {
+    this.#prune(now);
+    if (!this.dirty) return;
+    const write = async () => {
+      if (!this.dirty) return;
+      const lock = await Deno.open(`${this.file}.lock`, {
+        create: true,
+        write: true,
+      });
+      let locked = false;
+      try {
+        await lock.lock(true);
+        locked = true;
+        this.#merge(await this.#read(true));
+        this.#prune(now);
+
+        const revision = this.#revision;
+        const value: StoredCiJobHistory = {
+          version: STORE_VERSION,
+          invalidations: [...this.#invalidations.values()].sort((a, b) =>
+            refreshKey(a.repo, a.workflow, a.days).localeCompare(
+              refreshKey(b.repo, b.workflow, b.days),
+            )
+          ),
+          refreshes: [...this.#refreshes.values()].sort((a, b) =>
+            refreshKey(a.repo, a.workflow, a.days).localeCompare(
+              refreshKey(b.repo, b.workflow, b.days),
+            )
+          ),
+          runs: [...this.#runs.values()].sort((a, b) => a.at - b.at),
+        };
+        const temporary = `${this.file}.${crypto.randomUUID()}.tmp`;
+        try {
+          await Deno.writeTextFile(temporary, JSON.stringify(value));
+          await Deno.rename(temporary, this.file);
+        } catch (error) {
+          try {
+            await Deno.remove(temporary);
+          } catch {
+            // Ignore cleanup when no temporary file remains.
+          }
+          throw error;
+        }
+        this.#persistedRevision = Math.max(
+          this.#persistedRevision,
+          revision,
+        );
+        this.#futureQuarantines.clear();
+      } finally {
+        if (locked) await lock.unlock();
+        lock.close();
+      }
+    };
+    this.#write = this.#write.then(write, write);
+    await this.#write;
+  }
+}

--- a/packages/dashboard/ci-job-history.test.ts
+++ b/packages/dashboard/ci-job-history.test.ts
@@ -1,0 +1,5143 @@
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+
+import {
+  baseJobName,
+  buildCiJobHistory,
+  CI_HISTORY_DAYS,
+  CI_HISTORY_MIN_DAYS,
+  CI_HISTORY_POINT_TARGET,
+  CI_HISTORY_SOURCES,
+  ciFetchProgressPanel,
+  type CiGanttInput,
+  ciGanttOptions,
+  ciGanttProgressResponse,
+  ciHistoryDays,
+  type CiHistorySample,
+  type CiHistorySource,
+  type CiJobFetchProgress,
+  ciJobHistoryCheckResponse,
+  CiJobHistoryCollector as RateLimitedCiJobHistoryCollector,
+  ciJobHistoryPage,
+  ciJobHistoryProgressResponse,
+  ciJobHistoryResponse,
+  ciJobHistorySnapshotVersion,
+  collectCiGanttInput,
+  sampleWorkflowRuns,
+  type WorkflowRun,
+} from "./ci-job-history.ts";
+import {
+  type CachedCiHistoryRefresh,
+  CI_JOB_CACHE_DAYS,
+  CiJobHistoryStore,
+} from "./ci-job-cache.ts";
+import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "./config.ts";
+import { github } from "./lib.ts";
+import { GitHubRateLimitBudgetError } from "./github-rate-limit.ts";
+
+// Existing collector tests exercise history and persistence behavior against
+// precise request stubs. The rate-budget implementation has its own tests.
+class CiJobHistoryCollector extends RateLimitedCiJobHistoryCollector {
+  constructor(store = new CiJobHistoryStore()) {
+    super(store, github);
+  }
+}
+
+const DAY = 86_400_000;
+const HOUR = 3_600_000;
+const NOW = Date.parse("2026-06-20T18:00:00Z");
+const HEAD_SHA = "a".repeat(40);
+
+function workflowRun(
+  id: number,
+  at: number,
+  overrides: Partial<WorkflowRun> = {},
+): WorkflowRun {
+  return {
+    id,
+    status: "completed",
+    conclusion: "success",
+    event: "push",
+    head_branch: "main",
+    run_attempt: 1,
+    run_started_at: new Date(at).toISOString(),
+    html_url: `https://github.com/${REPO}/actions/runs/${id}`,
+    ...overrides,
+  };
+}
+
+function historySamples(): CiHistorySample[] {
+  return Array.from({ length: 8 }, (_, day) => ({
+    runId: 100 + day,
+    runUrl: `https://example.test/runs/${100 + day}`,
+    at: NOW - (7 - day) * DAY,
+    overallSeconds: 300 + day * 15,
+    jobs: [
+      { name: "Test (1/2)", seconds: 100 + day * 2 },
+      { name: "Test (2/2)", seconds: 120 + day * 12 },
+      { name: "Check", seconds: 200 - day * 5 },
+      { name: "One platform (linux)", seconds: 60 },
+      ...(day === 0 ? [{ name: "Test (1/2)", seconds: 10 }] : []),
+    ],
+  }));
+}
+
+Deno.test("CI job history keeps every eligible build below the point target", () => {
+  const sameWindowOld = workflowRun(1, NOW - HOUR * 2);
+  const sameWindowNew = workflowRun(2, NOW - HOUR);
+  const previousWindow = workflowRun(3, NOW - HOUR * 14);
+  const runs = [
+    sameWindowOld,
+    previousWindow,
+    workflowRun(4, NOW, { conclusion: "failure" }),
+    workflowRun(5, NOW, { event: "pull_request" }),
+    workflowRun(6, NOW, { head_branch: "release" }),
+    workflowRun(7, NOW - (CI_HISTORY_DAYS + 1) * DAY),
+    sameWindowNew,
+  ];
+
+  assertEquals(
+    sampleWorkflowRuns(runs, NOW).map((run) => run.id),
+    [3, 1, 2],
+  );
+});
+
+Deno.test("CI Gantt options retain valid selected run attempts", () => {
+  const parameters = new URLSearchParams();
+  parameters.append("run", "8101:1");
+  parameters.append("run", "not-a-run");
+  parameters.append("run", "8102:3");
+  parameters.set("limit", "2");
+  parameters.set("mainOnly", "1");
+  parameters.set("sha", HEAD_SHA.toUpperCase());
+  assertEquals(ciGanttOptions(parameters), {
+    limit: 2,
+    mainOnly: true,
+    allConclusions: false,
+    headSha: HEAD_SHA,
+    selectedRuns: [
+      { runId: 8101, runAttempt: 1 },
+      { runId: 8102, runAttempt: 3 },
+    ],
+  });
+});
+
+Deno.test("CI Gantt limits exact run selections before collecting", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selection-limit-test-",
+  });
+  const requested: number[] = [];
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>(path: string): Promise<T> => {
+      const match = path.match(/\/actions\/runs\/(\d+)\/attempts\/1$/);
+      if (!match) throw new Error(`unexpected selected-run request: ${path}`);
+      const id = Number(match[1]);
+      requested.push(id);
+      return Promise.resolve(workflowRun(id, NOW, {
+        status: "in_progress",
+        conclusion: null,
+        head_sha: HEAD_SHA,
+        path: `.github/workflows/${CI_WORKFLOW}`,
+      }) as T);
+    },
+  );
+  try {
+    await assertRejects(
+      () =>
+        collector.gantt(
+          "selection-limit-token",
+          CI_HISTORY_SOURCES.labs,
+          {
+            limit: 1,
+            mainOnly: true,
+            headSha: HEAD_SHA,
+            selectedRuns: Array.from({ length: 151 }, (_, index) => ({
+              runId: 20_000 + index,
+              runAttempt: 1,
+            })),
+          },
+          NOW,
+        ),
+      Error,
+      "Every selected CI run must be a completed successful main push",
+    );
+    assertEquals(requested.length, 150);
+    assertEquals(requested.includes(20_150), false);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history keeps every eligible build at the point target", () => {
+  const runs = Array.from(
+    { length: CI_HISTORY_POINT_TARGET },
+    (_, index) => workflowRun(2_000 + index, NOW - HOUR - index * 1_000),
+  );
+
+  assertEquals(
+    sampleWorkflowRuns(runs, NOW).map((run) => run.id).sort((a, b) => a - b),
+    runs.map((run) => run.id),
+  );
+});
+
+Deno.test("CI job history samples the newest build per bucket above the point target", () => {
+  const clustered = Array.from(
+    { length: CI_HISTORY_POINT_TARGET + 1 },
+    (_, index) => workflowRun(1_000 + index, NOW - HOUR - index * 1_000),
+  );
+
+  assertEquals(
+    sampleWorkflowRuns(clustered, NOW).map((run) => run.id),
+    [1_000],
+  );
+});
+
+Deno.test("CI job history keeps a similar point count when the window gets shorter", () => {
+  const denseRuns = (days: number, firstId: number) =>
+    Array.from(
+      { length: CI_HISTORY_POINT_TARGET * 2 + 1 },
+      (_, sample) =>
+        workflowRun(
+          firstId + sample,
+          NOW - sample * days * DAY / (CI_HISTORY_POINT_TARGET * 2),
+        ),
+    );
+  const full = sampleWorkflowRuns(
+    denseRuns(CI_HISTORY_DAYS, 20_000),
+    NOW,
+    CI_HISTORY_DAYS,
+  );
+  const short = sampleWorkflowRuns(
+    denseRuns(CI_HISTORY_MIN_DAYS, 30_000),
+    NOW,
+    CI_HISTORY_MIN_DAYS,
+  );
+
+  assert(full.length <= CI_HISTORY_POINT_TARGET + 1);
+  assert(short.length <= CI_HISTORY_POINT_TARGET + 1);
+  assert(full.length >= CI_HISTORY_POINT_TARGET - 1);
+  assert(short.length >= CI_HISTORY_POINT_TARGET - 1);
+  assert(
+    short.every((run) =>
+      Date.parse(run.run_started_at) >= NOW - CI_HISTORY_MIN_DAYS * DAY
+    ),
+  );
+  assertEquals(ciHistoryDays(null), CI_HISTORY_DAYS);
+  assertEquals(ciHistoryDays("0"), CI_HISTORY_MIN_DAYS);
+  assertEquals(ciHistoryDays("2"), 2);
+  assertEquals(ciHistoryDays("100"), CI_HISTORY_DAYS);
+});
+
+Deno.test("CI job history groups concurrent suffix jobs and keeps every shard", () => {
+  const snapshot = buildCiJobHistory(historySamples());
+
+  assertEquals(snapshot.runCount, 8);
+  assertEquals(snapshot.successfulRunTimes, null);
+  assertEquals(snapshot.stale, false);
+  assertEquals(snapshot.axisStart, NOW - 7 * DAY);
+  assertEquals(snapshot.axisEnd, NOW);
+  assertEquals(snapshot.overall?.kind, "overall");
+  assertEquals(
+    snapshot.overall?.points.map((point) => point.seconds),
+    Array.from({ length: 8 }, (_, day) => 300 + day * 15),
+  );
+  assertEquals(snapshot.groups.length, 1);
+  assertEquals(snapshot.groups[0].base, "Test");
+  assertEquals(snapshot.groups[0].maxConcurrent, 2);
+  assertEquals(
+    snapshot.groups[0].shards.map((series) => series.name),
+    ["Test (1/2)", "Test (2/2)"],
+  );
+  assertEquals(
+    snapshot.groups[0].aggregate.points.map((point) => point.seconds),
+    Array.from({ length: 8 }, (_, day) => 120 + day * 12),
+  );
+  assertEquals(
+    snapshot.groups[0].shards[0].points[0].seconds,
+    100,
+  );
+  assertEquals(
+    snapshot.jobs.map((series) => series.name),
+    ["Check", "One platform (linux)"],
+  );
+  assertEquals(
+    baseJobName("Package Integration Tests (runner)"),
+    "Package Integration Tests",
+  );
+});
+
+Deno.test("CI job history preserves changing shard layouts and labels maximum concurrency", () => {
+  const snapshot = buildCiJobHistory([
+    {
+      runId: 1,
+      runUrl: "https://example.test/runs/1",
+      at: NOW - DAY,
+      jobs: [
+        { name: "Test (1/3)", seconds: 40 },
+        { name: "Test (2/3)", seconds: 45 },
+        { name: "Test (3/3)", seconds: 60 },
+      ],
+    },
+    {
+      runId: 2,
+      runUrl: "https://example.test/runs/2",
+      at: NOW,
+      jobs: [
+        { name: "Test (1/2)", seconds: 50 },
+        { name: "Test (2/2)", seconds: 55 },
+      ],
+    },
+  ]);
+
+  assertEquals(snapshot.groups[0].maxConcurrent, 3);
+  assertEquals(snapshot.groups[0].shards.length, 5);
+  assertStringIncludes(
+    ciJobHistoryPage(snapshot, "job"),
+    "up to 3 concurrent · 5 historical variants",
+  );
+  assertStringIncludes(
+    ciJobHistoryPage(snapshot, "job"),
+    "Individual shard · last seen Jun 19",
+  );
+});
+
+Deno.test("CI job history page shows the slowest shard, every shard, and unsharded jobs", () => {
+  const html = ciJobHistoryPage(
+    buildCiJobHistory(
+      historySamples(),
+      0,
+      undefined,
+      [],
+      Array.from({ length: 418 }, (_, index) => NOW - index),
+    ),
+    "job",
+  );
+
+  assertStringIncludes(html, "<title>CI job history</title>");
+  assertStringIncludes(
+    html,
+    'href="/bench?view=ci&amp;repo=labs&amp;days=45&amp;sort=job&amp;stat=p99" aria-current="page"',
+  );
+  assertStringIncludes(html, '<select id="repo" name="repo">');
+  assertStringIncludes(
+    html,
+    'type="range" id="days" name="days" min="1" max="45"',
+  );
+  assertStringIncludes(html, '<span class="cname">Overall CI</span>');
+  assertStringIncludes(html, "First job start to last job completion");
+  assertStringIncludes(html, "<h2>Test <span>up to 2 concurrent</span></h2>");
+  assertStringIncludes(html, 'data-kind="group"');
+  assertStringIncludes(
+    html,
+    '<span class="cname">longest-running shard</span>',
+  );
+  assertStringIncludes(html, '<span class="cname">1/2</span>');
+  assertStringIncludes(html, '<span class="cname">2/2</span>');
+  assertStringIncludes(html, '<span class="cname">Check</span>');
+  assertStringIncludes(html, '<span class="cname">One platform (linux)</span>');
+  assertStringIncludes(html, "3m 24s");
+  assertStringIncludes(html, "<svg");
+  assertStringIncludes(html, "Jun 13");
+  assertStringIncludes(html, "Jun 20");
+  assertStringIncludes(html, "longest-running shard in each run");
+  assertStringIncludes(
+    html,
+    "Coverage: 8 sampled builds shown out of 418 successful main builds.",
+  );
+  assert(
+    html.indexOf('id="fetch-progress"') < html.indexOf('class="coverage"'),
+    "coverage follows the progress panel",
+  );
+  assert(
+    html.indexOf('class="coverage"') < html.indexOf('class="legend"'),
+    "the duration explanation follows coverage",
+  );
+  assertStringIncludes(html, "Slowest shard duration · last seen Jun 20");
+  assertStringIncludes(
+    html,
+    "Every successful main run is sampled when the selected window contains at most 90",
+  );
+  assertStringIncludes(
+    html,
+    'href="/bench?view=gantt&amp;repo=labs&amp;days=45&amp;sort=job&amp;stat=p99">CI run Gantt</a>',
+  );
+  assertStringIncludes(html, '<strong id="fetch-title">Idle</strong>');
+  assertStringIncludes(html, "0 outstanding");
+  assertEquals([...html.matchAll(/class="crow /g)].length, 6);
+});
+
+Deno.test("CI job history trend sort is flat and includes groups and exact job names", () => {
+  const html = ciJobHistoryPage(buildCiJobHistory(historySamples()), "trend");
+
+  assert(!html.includes("<h2>"));
+  assertStringIncludes(html, "Test — slowest of up to 2 shards");
+  assertStringIncludes(html, '<span class="cname">Test (1/2)</span>');
+  assertStringIncludes(html, '<span class="cname">Test (2/2)</span>');
+  assertStringIncludes(
+    html,
+    'href="/bench?view=ci&amp;repo=labs&amp;days=45&amp;sort=trend"',
+  );
+});
+
+Deno.test("CI job history duration sort puts the longest latest value first", () => {
+  const html = ciJobHistoryPage(
+    buildCiJobHistory(historySamples()),
+    "duration",
+  );
+  const names = [...html.matchAll(/<span class="cname">([^<]*)<\/span>/g)]
+    .map((match) => match[1]);
+
+  assertEquals(names[0], "Overall CI");
+  assertStringIncludes(
+    html,
+    'href="/bench?view=ci&amp;repo=labs&amp;days=45&amp;sort=duration"',
+  );
+  assertStringIncludes(html, 'aria-label="Sort CI history"');
+  assertStringIncludes(html, 'aria-current="true">duration</a>');
+
+  const fromRuntime = ciJobHistoryPage(
+    buildCiJobHistory(historySamples()),
+    "duration",
+    undefined,
+    { runtimeStat: "p75" },
+  );
+  assertStringIncludes(
+    fromRuntime,
+    'href="/bench?view=runtime&amp;repo=labs&amp;days=45&amp;sort=duration&amp;stat=p75">Runtime benchmarks</a>',
+  );
+  assertStringIncludes(fromRuntime, 'name="stat" value="p75"');
+  assertStringIncludes(
+    fromRuntime,
+    "repo=labs&amp;days=45&amp;sort=duration&amp;stat=p75",
+  );
+});
+
+Deno.test("CI job history page can select the loom workflow", () => {
+  const html = ciJobHistoryPage(
+    buildCiJobHistory(historySamples()),
+    "job",
+    undefined,
+    {
+      source: CI_HISTORY_SOURCES.loom,
+      days: 14,
+    },
+  );
+
+  assertStringIncludes(html, `${LOOM_REPO} · ${LOOM_CI_WORKFLOW}`);
+  assertStringIncludes(html, '<option value="loom" selected>loom</option>');
+  assertStringIncludes(html, 'value="14"');
+  assertStringIncludes(html, "selected 14-day trend");
+  assertStringIncludes(
+    html,
+    'href="/bench?view=gantt&amp;repo=loom&amp;days=14&amp;sort=job&amp;stat=p99">CI run Gantt</a>',
+  );
+});
+
+Deno.test("CI job history page exposes live collection progress without disabling controls", () => {
+  const progress: CiJobFetchProgress = {
+    id: "labs-14-progress",
+    source: "labs",
+    days: 14,
+    phase: "fetching",
+    discoveryRequestsMade: 4,
+    discoveryResponsesReceived: 4,
+    discoveryOutstandingRequests: 0,
+    totalRuns: 30,
+    cachedRuns: 8,
+    requestsMade: 12,
+    responsesReceived: 7,
+    sharedRequests: 2,
+    sharedResponses: 1,
+    successfulResponses: 6,
+    failedResponses: 1,
+    completedRuns: 16,
+    queuedRuns: 8,
+    outstandingRequests: 6,
+    needsReload: true,
+    updatedAt: NOW,
+  };
+  const html = ciJobHistoryPage(null, "job", undefined, {
+    days: 14,
+    progress,
+  });
+
+  assertStringIncludes(html, 'id="fetch-progress"');
+  assertStringIncludes(html, '<progress id="fetch-bar" max="30" value="16"');
+  assertStringIncludes(
+    html,
+    "12 run requests made · 2 shared · 8 responded",
+  );
+  assertStringIncludes(html, 'state.sharedRequests + " shared');
+  assertStringIncludes(
+    html,
+    "state.responsesReceived + state.sharedResponses",
+  );
+  assertStringIncludes(html, "6 outstanding · 8 queued");
+  assertStringIncludes(html, 'data-refresh-on-complete="1"');
+  assertStringIncludes(html, "const stream = new EventSource(url)");
+  assertStringIncludes(html, 'id="days" name="days"');
+  assert(!html.includes('id="days" name="days" disabled'));
+  assertStringIncludes(html, 'controls.addEventListener("submit"');
+  assertStringIncludes(html, '<div id="range-content">');
+  assertStringIncludes(html, 'days.addEventListener("keydown"');
+  assertStringIncludes(html, "syncDayLinks()");
+  assertStringIncludes(html, 'days.addEventListener("change", applyDays)');
+  assert(!html.includes("keyboardEditing"));
+  assertStringIncludes(html, "new DOMParser().parseFromString");
+  assertStringIncludes(html, "rangeContent.replaceWith(replacement)");
+  assertStringIncludes(html, "history.pushState(null");
+  assertStringIncludes(html, 'window.addEventListener("popstate"');
+  assertStringIncludes(html, 'void loadRange("pop")');
+  assertStringIncludes(html, 'void loadRange("restore")');
+  assertStringIncludes(html, 'if (mode === "refresh")');
+  assertStringIncludes(html, "rangeRequestDays !== days.value");
+  assertStringIncludes(html, "if (loaded && pendingRefresh)");
+  assertStringIncludes(html, "days.value !== appliedDays ||");
+  assertStringIncludes(
+    html,
+    "if (!Number.isFinite(value)) return DEFAULT_DAYS",
+  );
+  assertStringIncludes(html, "rangeRequest.abort()");
+  assertStringIncludes(html, "refreshRangeWhenIdle()");
+  assert(!html.includes("location.reload()"));
+  assert(!html.includes("ciJobsRestoreDaysFocus"));
+  assertStringIncludes(html, "setInterval(checkForUpdates, 60000)");
+  assertStringIncludes(
+    html,
+    'fetchProgress.dataset.refreshOnComplete === "1"',
+  );
+  assertStringIncludes(
+    html,
+    'collectionFailed = state.phase === "error"',
+  );
+  assertStringIncludes(
+    html,
+    "if (!eventStream && !collectionFailed && !transportFailed) renderIdle()",
+  );
+  assertStringIncludes(html, "transportFailed = true");
+  assert(
+    !html.includes(
+      "No completed CI job timings were found in the history window.",
+    ),
+  );
+  assertStringIncludes(
+    html,
+    'data-check-url="/bench/check?view=ci&amp;repo=labs&amp;days=14"',
+  );
+  assert(
+    !html.includes(
+      ".views a.on,.controls a.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11;font-weight",
+    ),
+  );
+  assertStringIncludes(
+    html,
+    "section:has(.clist):not(:has(.crow:not(.good)))",
+  );
+  assert(!html.includes("section:not(:has(.crow:not(.good)))"));
+});
+
+Deno.test("CI job history page reports workflow discovery requests", () => {
+  const progress: CiJobFetchProgress = {
+    id: "loom-discovery",
+    source: "loom",
+    days: 45,
+    phase: "discovering",
+    discoveryRequestsMade: 3,
+    discoveryResponsesReceived: 2,
+    discoveryOutstandingRequests: 1,
+    totalRuns: 0,
+    cachedRuns: 0,
+    requestsMade: 0,
+    responsesReceived: 0,
+    sharedRequests: 0,
+    sharedResponses: 0,
+    successfulResponses: 0,
+    failedResponses: 0,
+    completedRuns: 0,
+    queuedRuns: 0,
+    outstandingRequests: 0,
+    needsReload: false,
+    updatedAt: NOW,
+  };
+  const html = ciJobHistoryPage(null, "job", undefined, {
+    source: CI_HISTORY_SOURCES.loom,
+    days: 45,
+    progress,
+  });
+
+  assertStringIncludes(
+    html,
+    '<strong id="fetch-title">Finding workflow runs…</strong>',
+  );
+  assertStringIncludes(html, '<span id="fetch-total">1 outstanding</span>');
+  assertStringIncludes(
+    html,
+    "3 workflow requests made · 2 responded · 1 outstanding",
+  );
+  assertStringIncludes(
+    html,
+    'state.discoveryRequestsMade + " workflow requests made',
+  );
+});
+
+Deno.test("CI fetch progress panel retains a completed collection warning", () => {
+  const html = ciFetchProgressPanel({
+    id: "gantt-cached-warning",
+    source: "loom",
+    days: 45,
+    phase: "complete",
+    discoveryRequestsMade: 1,
+    discoveryResponsesReceived: 1,
+    discoveryOutstandingRequests: 0,
+    totalRuns: 12,
+    cachedRuns: 11,
+    requestsMade: 1,
+    responsesReceived: 1,
+    sharedRequests: 0,
+    sharedResponses: 0,
+    successfulResponses: 0,
+    failedResponses: 1,
+    completedRuns: 12,
+    queuedRuns: 0,
+    outstandingRequests: 0,
+    needsReload: false,
+    updatedAt: NOW,
+    warning: "Showing cached runs because GitHub reported rate limit hit.",
+  });
+
+  assertStringIncludes(html, 'class="fetch-progress warning"');
+  assertStringIncludes(html, '<strong id="fetch-title">Idle</strong>');
+  assertStringIncludes(
+    html,
+    "Showing cached runs because GitHub reported rate limit hit.",
+  );
+});
+
+Deno.test("CI job history response uses a refresh that completed after its cache read", async () => {
+  const cached = buildCiJobHistory([{
+    runId: 7_101,
+    runUrl: "https://example.test/runs/7101",
+    at: NOW,
+    jobs: [{ name: "Old only", seconds: 20 }],
+  }]);
+  const refreshed = buildCiJobHistory([{
+    runId: 7_102,
+    runUrl: "https://example.test/runs/7102",
+    at: NOW,
+    jobs: [{ name: "Fresh result", seconds: 30 }],
+  }]);
+  const provider = {
+    cached: () => Promise.resolve(cached),
+    startRefresh: () => ({
+      progress: null,
+      result: Promise.resolve(refreshed),
+    }),
+  };
+
+  const response = await ciJobHistoryResponse(
+    new URL("http://x/bench?view=ci"),
+    provider,
+    "response-token",
+  );
+  const html = await response.text();
+
+  assertStringIncludes(html, "Fresh result");
+  assert(!html.includes("Old only"));
+  assertStringIncludes(html, 'id="fetch-progress"');
+  assertStringIncludes(html, '<strong id="fetch-title">Idle</strong>');
+
+  const fragmentResponse = await ciJobHistoryResponse(
+    new URL("http://x/bench?view=ci&days=7&fragment=range"),
+    provider,
+    "",
+  );
+  const fragment = await fragmentResponse.text();
+  assert(fragment.startsWith('<div id="range-content">'));
+  assertStringIncludes(fragment, "selected 7-day trend");
+  assert(!fragment.includes("<!doctype html>"));
+  assert(!fragment.includes('<form class="controls"'));
+});
+
+Deno.test("CI job history update check uses the selected repository and window", async () => {
+  const cached = buildCiJobHistory(historySamples());
+  const progress: CiJobFetchProgress = {
+    id: "loom-9-check",
+    source: "loom",
+    days: 9,
+    phase: "discovering",
+    discoveryRequestsMade: 0,
+    discoveryResponsesReceived: 0,
+    discoveryOutstandingRequests: 0,
+    totalRuns: 0,
+    cachedRuns: 0,
+    requestsMade: 0,
+    responsesReceived: 0,
+    sharedRequests: 0,
+    sharedResponses: 0,
+    successfulResponses: 0,
+    failedResponses: 0,
+    completedRuns: 0,
+    queuedRuns: 0,
+    outstandingRequests: 0,
+    needsReload: false,
+    updatedAt: NOW,
+  };
+  let selected: { source: CiHistorySource; days: number } | undefined;
+  const provider = {
+    cached: (_source: CiHistorySource, _days: number) =>
+      Promise.resolve(cached),
+    startRefresh: (
+      _token: string,
+      source: CiHistorySource,
+      days: number,
+    ) => {
+      selected = { source, days };
+      return { progress, result: Promise.resolve(cached) };
+    },
+  };
+
+  const response = await ciJobHistoryCheckResponse(
+    new URL("http://x/bench/check?view=ci&repo=loom&days=9"),
+    provider,
+    "check-token",
+  );
+  const state = await response.json();
+
+  assertEquals(selected?.source, CI_HISTORY_SOURCES.loom);
+  assertEquals(selected?.days, 9);
+  assertEquals(state.progress, progress);
+  assertEquals(typeof state.version, "string");
+  assertEquals(response.headers.get("cache-control"), "no-store");
+});
+
+Deno.test("CI job history update checks freshness-gate a failed collection", async () => {
+  const test = await temporaryCollector();
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = () => {
+    calls++;
+    return Promise.resolve(new Response("unavailable", { status: 503 }));
+  };
+
+  try {
+    const first = test.collector.startRefreshForCheck(
+      "check-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    assert(first);
+    await assertRejects(() => first.result);
+
+    assertEquals(
+      test.collector.startRefreshForCheck(
+        "check-token",
+        CI_HISTORY_SOURCES.labs,
+        14,
+      ),
+      null,
+    );
+    assertEquals(calls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history page escapes job names and labels a short series as new", () => {
+  const snapshot = buildCiJobHistory([{
+    runId: 999,
+    runUrl: "https://example.test/?a=1&b=2",
+    at: NOW,
+    jobs: [{ name: "Check <unsafe>", seconds: 42 }],
+  }]);
+  const html = ciJobHistoryPage(snapshot, "job");
+
+  assertStringIncludes(
+    html,
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+  );
+  assertStringIncludes(html, "Check &lt;unsafe&gt;");
+  assertStringIncludes(html, 'href="https://example.test/?a=1&amp;b=2"');
+  assertStringIncludes(html, "new · 1 runs");
+  assertStringIncludes(html, 'class="crow unknown"');
+  assert(!html.includes('class="crow good"'));
+  assertStringIncludes(
+    ciJobHistoryPage(null, "job", "Refresh failed: <unsafe>."),
+    "Refresh failed: &lt;unsafe&gt;.",
+  );
+});
+
+function apiJob(
+  name: string,
+  seconds: number,
+  conclusion: string | null = "success",
+) {
+  const start = NOW - HOUR;
+  return {
+    name,
+    conclusion,
+    started_at: new Date(start).toISOString(),
+    completed_at: new Date(start + seconds * 1_000).toISOString(),
+  };
+}
+
+async function temporaryCollector(): Promise<{
+  collector: CiJobHistoryCollector;
+  file: string;
+  cleanup: () => Promise<void>;
+}> {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const file = `${directory}/history.json`;
+  return {
+    collector: new CiJobHistoryCollector(new CiJobHistoryStore(file)),
+    file,
+    cleanup: () => Deno.remove(directory, { recursive: true }),
+  };
+}
+
+Deno.test("CI job history reports shared workflow discovery progress", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-job-discovery-test-",
+  });
+  const now = Date.now();
+  let releaseFirst!: (value: unknown) => void;
+  let releaseSecond!: (value: unknown) => void;
+  let markFirstStarted!: () => void;
+  let markSecondStarted!: () => void;
+  const firstResponse = new Promise<unknown>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const secondResponse = new Promise<unknown>((resolve) => {
+    releaseSecond = resolve;
+  });
+  const firstStarted = new Promise<void>((resolve) => {
+    markFirstStarted = resolve;
+  });
+  const secondStarted = new Promise<void>((resolve) => {
+    markSecondStarted = resolve;
+  });
+  let requests = 0;
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>() => {
+      requests++;
+      if (requests === 1) {
+        markFirstStarted();
+        return firstResponse as Promise<T>;
+      }
+      if (requests === 2) {
+        markSecondStarted();
+        return secondResponse as Promise<T>;
+      }
+      throw new Error(`unexpected workflow request ${requests}`);
+    },
+  );
+  let stopShort: (() => void) | null = null;
+  let wideResult: Promise<unknown> | undefined;
+  let shortResult: Promise<unknown> | undefined;
+  try {
+    const wide = collector.startRefresh(
+      "discovery-token",
+      CI_HISTORY_SOURCES.labs,
+      45,
+    );
+    assert(wide.progress);
+    wideResult = wide.result;
+    await firstStarted;
+    assertEquals(
+      [
+        collector.progress(wide.progress.id)?.discoveryRequestsMade,
+        collector.progress(wide.progress.id)?.discoveryResponsesReceived,
+        collector.progress(wide.progress.id)?.discoveryOutstandingRequests,
+        collector.progress(wide.progress.id)?.requestsMade,
+      ],
+      [1, 0, 1, 0],
+    );
+
+    const short = collector.startRefresh(
+      "discovery-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    assert(short.progress);
+    shortResult = short.result;
+    let markShortJoined!: () => void;
+    const shortJoined = new Promise<void>((resolve) => {
+      markShortJoined = resolve;
+    });
+    stopShort = collector.subscribeProgress(short.progress.id, (state) => {
+      if (state.discoveryRequestsMade === 1) markShortJoined();
+    });
+    assert(stopShort);
+    await shortJoined;
+
+    releaseFirst({
+      total_count: 101,
+      workflow_runs: Array.from(
+        { length: 100 },
+        (_, index) =>
+          workflowRun(11_000 + index, now - index * 1_000, {
+            conclusion: "failure",
+          }),
+      ),
+    });
+    await secondStarted;
+    for (const progress of [wide.progress, short.progress]) {
+      assertEquals(
+        [
+          collector.progress(progress.id)?.discoveryRequestsMade,
+          collector.progress(progress.id)?.discoveryResponsesReceived,
+          collector.progress(progress.id)?.discoveryOutstandingRequests,
+        ],
+        [2, 1, 1],
+      );
+    }
+
+    releaseSecond({
+      workflow_runs: [workflowRun(11_100, now, { conclusion: "failure" })],
+    });
+    await Promise.all([wide.result, short.result]);
+    for (const progress of [wide.progress, short.progress]) {
+      assertEquals(
+        [
+          collector.progress(progress.id)?.phase,
+          collector.progress(progress.id)?.discoveryRequestsMade,
+          collector.progress(progress.id)?.discoveryResponsesReceived,
+          collector.progress(progress.id)?.discoveryOutstandingRequests,
+          collector.progress(progress.id)?.requestsMade,
+        ],
+        ["complete", 2, 2, 0, 0],
+      );
+    }
+    assertEquals(requests, 2);
+  } finally {
+    stopShort?.();
+    releaseFirst({ workflow_runs: [] });
+    releaseSecond({ workflow_runs: [] });
+    await Promise.allSettled(
+      [wideResult, shortResult].filter(
+        (result): result is Promise<unknown> => result !== undefined,
+      ),
+    );
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history reports progress and persists wider-window responses after a slider change", async () => {
+  const test = await temporaryCollector();
+  const now = Date.now();
+  const oldRun = workflowRun(8_901, now - 30 * DAY);
+  const recentRun = workflowRun(8_902, now - DAY);
+  let releaseOld!: (response: Response) => void;
+  let releaseRecent!: (response: Response) => void;
+  const oldResponse = new Promise<Response>((resolve) => releaseOld = resolve);
+  const recentResponse = new Promise<Response>((resolve) => {
+    releaseRecent = resolve;
+  });
+  let markRequestsStarted!: () => void;
+  const requestsStarted = new Promise<void>((resolve) => {
+    markRequestsStarted = resolve;
+  });
+  let actualJobRequests = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({
+        workflow_runs: [recentRun, oldRun],
+      }));
+    }
+    const runId = Number(
+      url.match(/\/actions\/runs\/(\d+)\/attempts\/1\/jobs/)?.[1],
+    );
+    if (runId === oldRun.id || runId === recentRun.id) {
+      actualJobRequests++;
+      if (actualJobRequests === 2) markRequestsStarted();
+      return runId === oldRun.id ? oldResponse : recentResponse;
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  let stopWide: (() => void) | null = null;
+  let stopShort: (() => void) | null = null;
+  try {
+    const wide = test.collector.startRefresh(
+      "progress-token",
+      CI_HISTORY_SOURCES.labs,
+      45,
+    );
+    assert(wide.progress);
+    const progressUrl = new URL(
+      `http://x/bench/ci-progress?id=${wide.progress.id}`,
+    );
+    const progressResponse = ciJobHistoryProgressResponse(
+      progressUrl,
+      test.collector,
+    );
+    assertEquals(
+      progressResponse.headers.get("content-type"),
+      "text/event-stream",
+    );
+    const progressReader = progressResponse.body!.getReader();
+    const firstProgressEvent = await progressReader.read();
+    assertStringIncludes(
+      new TextDecoder().decode(firstProgressEvent.value),
+      'event: progress\ndata: {"id":',
+    );
+    await progressReader.cancel();
+    const widePhases: string[] = [];
+    let markWideResponse!: () => void;
+    const wideResponded = new Promise<void>((resolve) => {
+      markWideResponse = resolve;
+    });
+    stopWide = test.collector.subscribeProgress(wide.progress.id, (state) => {
+      widePhases.push(state.phase);
+      if (state.responsesReceived === 1) markWideResponse();
+    });
+    assert(stopWide);
+
+    await requestsStarted;
+    assertEquals(test.collector.progress(wide.progress.id)?.requestsMade, 2);
+    assertEquals(
+      test.collector.progress(wide.progress.id)?.outstandingRequests,
+      2,
+    );
+
+    const short = test.collector.startRefresh(
+      "progress-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    assert(short.progress);
+    let markShortStarted!: () => void;
+    const shortStarted = new Promise<void>((resolve) => {
+      markShortStarted = resolve;
+    });
+    stopShort = test.collector.subscribeProgress(short.progress.id, (state) => {
+      if (state.sharedRequests === 1) markShortStarted();
+    });
+    assert(stopShort);
+    await shortStarted;
+
+    releaseOld(Response.json({ jobs: [apiJob("Old check", 100)] }));
+    await wideResponded;
+    const partiallyPersisted = JSON.parse(await Deno.readTextFile(test.file));
+    assertEquals(
+      partiallyPersisted.runs.map((run: { runId: number }) => run.runId),
+      [oldRun.id],
+    );
+
+    releaseRecent(Response.json({ jobs: [apiJob("Recent check", 80)] }));
+    const [wideSnapshot, shortSnapshot] = await Promise.all([
+      wide.result,
+      short.result,
+    ]);
+    assertEquals(wideSnapshot.runCount, 2);
+    assertEquals(shortSnapshot.runCount, 1);
+    const wideDone = test.collector.progress(wide.progress.id);
+    assertEquals(
+      [
+        wideDone?.phase,
+        wideDone?.completedRuns,
+        wideDone?.responsesReceived,
+        wideDone?.outstandingRequests,
+        wideDone?.queuedRuns,
+      ],
+      ["complete", 2, 2, 0, 0],
+    );
+    assert(widePhases.includes("discovering"));
+    assert(widePhases.includes("fetching"));
+    assert(widePhases.includes("saving"));
+    assert(widePhases.includes("complete"));
+    const cachedWindow = test.collector.startRefresh(
+      "progress-token",
+      CI_HISTORY_SOURCES.labs,
+      14,
+    );
+    assert(cachedWindow.progress);
+    await cachedWindow.result;
+    const cachedDone = test.collector.progress(cachedWindow.progress.id);
+    assertEquals(
+      [
+        cachedDone?.phase,
+        cachedDone?.totalRuns,
+        cachedDone?.cachedRuns,
+        cachedDone?.requestsMade,
+        cachedDone?.needsReload,
+      ],
+      ["complete", 1, 1, 0, false],
+    );
+    const persisted = JSON.parse(await Deno.readTextFile(test.file));
+    assertEquals(
+      persisted.runs.map((run: { runId: number }) => run.runId),
+      [oldRun.id, recentRun.id],
+    );
+    assertEquals(actualJobRequests, 2);
+  } finally {
+    stopWide?.();
+    stopShort?.();
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history reloads a short page when a wider collection populated its cache", async () => {
+  const test = await temporaryCollector();
+  const now = Date.now();
+  const firstRun = workflowRun(8_911, now - 2 * DAY);
+  const addedRun = workflowRun(8_912, now - DAY);
+  let jobCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({
+        workflow_runs: [addedRun, firstRun],
+      }));
+    }
+    const runId = Number(
+      url.match(/\/actions\/runs\/(\d+)\/attempts\/1\/jobs/)?.[1],
+    );
+    if (runId === firstRun.id || runId === addedRun.id) {
+      jobCalls++;
+      return Promise.resolve(Response.json({
+        jobs: [apiJob(`Check ${runId}`, runId === firstRun.id ? 60 : 70)],
+      }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const initial = await test.collector.collect(
+      "baseline-token",
+      now,
+      CI_HISTORY_SOURCES.labs,
+      7,
+      [firstRun],
+    );
+    assertEquals(initial.runCount, 1);
+
+    const baseline = test.collector.snapshot(CI_HISTORY_SOURCES.labs, 7);
+    assert(baseline);
+    const wide = await test.collector.collect(
+      "baseline-token",
+      now,
+      CI_HISTORY_SOURCES.labs,
+      45,
+      [firstRun, addedRun],
+    );
+    assertEquals(wide.runCount, 2);
+
+    const refresh = test.collector.startRefresh(
+      "baseline-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+      baseline,
+    );
+    assert(refresh.progress);
+    const updated = await refresh.result;
+    const progress = test.collector.progress(refresh.progress.id);
+
+    assertEquals(updated.runCount, 2);
+    assertEquals(progress?.requestsMade, 0);
+    assertEquals(progress?.needsReload, true);
+    assertEquals(jobCalls, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history rebuilds a fresh short range after a wider range repairs its cache", async () => {
+  const test = await temporaryCollector();
+  const now = Date.now();
+  const stableRun = workflowRun(8_916, now - 2 * DAY);
+  const repairedRun = workflowRun(8_917, now - DAY);
+  let repairAvailable = false;
+  const jobCalls = new Map<number, number>();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({
+        workflow_runs: [repairedRun, stableRun],
+      }));
+    }
+    const runId = Number(
+      url.match(/\/actions\/runs\/(\d+)\/attempts\/1\/jobs/)?.[1],
+    );
+    if (runId === stableRun.id) {
+      jobCalls.set(runId, (jobCalls.get(runId) ?? 0) + 1);
+      return Promise.resolve(Response.json({ jobs: [apiJob("Stable", 60)] }));
+    }
+    if (runId === repairedRun.id) {
+      jobCalls.set(runId, (jobCalls.get(runId) ?? 0) + 1);
+      return repairAvailable
+        ? Promise.resolve(Response.json({ jobs: [apiJob("Repaired", 70)] }))
+        : Promise.resolve(new Response("unavailable", { status: 503 }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const short = test.collector.startRefresh(
+      "repair-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    const partial = await short.result;
+    assertEquals([partial.runCount, partial.failedRunCount], [1, 1]);
+
+    repairAvailable = true;
+    const wide = await test.collector.startRefresh(
+      "repair-token",
+      CI_HISTORY_SOURCES.labs,
+      45,
+    ).result;
+    assertEquals([wide.runCount, wide.failedRunCount], [2, 0]);
+
+    const rebuilt = test.collector.startRefresh(
+      "repair-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    assert(rebuilt.progress);
+    const complete = await rebuilt.result;
+    assertEquals([complete.runCount, complete.failedRunCount], [2, 0]);
+    assertEquals(jobCalls.get(stableRun.id), 1);
+    assertEquals(jobCalls.get(repairedRun.id), 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history joins a wider repair before taking the short-range freshness path", async () => {
+  const test = await temporaryCollector();
+  const now = Date.now();
+  const stableRun = workflowRun(8_918, now - 2 * DAY);
+  const repairedRun = workflowRun(8_919, now - DAY);
+  let repairCalls = 0;
+  let stableCalls = 0;
+  let markRepairStarted!: () => void;
+  const repairStarted = new Promise<void>((resolve) =>
+    markRepairStarted = resolve
+  );
+  let releaseRepair!: (response: Response) => void;
+  const repairResponse = new Promise<Response>((resolve) =>
+    releaseRepair = resolve
+  );
+  let repairReleased = false;
+  const unblockRepair = () => {
+    if (repairReleased) return;
+    repairReleased = true;
+    releaseRepair(Response.json({ jobs: [apiJob("Repaired", 70)] }));
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({
+        workflow_runs: [repairedRun, stableRun],
+      }));
+    }
+    const runId = Number(
+      url.match(/\/actions\/runs\/(\d+)\/attempts\/1\/jobs/)?.[1],
+    );
+    if (runId === stableRun.id) {
+      stableCalls++;
+      return Promise.resolve(Response.json({ jobs: [apiJob("Stable", 60)] }));
+    }
+    if (runId === repairedRun.id) {
+      repairCalls++;
+      if (repairCalls === 1) {
+        return Promise.resolve(new Response("unavailable", { status: 503 }));
+      }
+      markRepairStarted();
+      return repairResponse;
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  const pending: Promise<unknown>[] = [];
+  try {
+    const partial = await test.collector.startRefresh(
+      "active-repair-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    ).result;
+    assertEquals([partial.runCount, partial.failedRunCount], [1, 1]);
+
+    const wide = test.collector.startRefresh(
+      "active-repair-token",
+      CI_HISTORY_SOURCES.labs,
+      45,
+    );
+    pending.push(wide.result);
+    await repairStarted;
+
+    const lateShort = test.collector.startRefresh(
+      "active-repair-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+      partial,
+    );
+    assert(lateShort.progress);
+    pending.push(lateShort.result);
+    unblockRepair();
+    const [wideResult, shortResult] = await Promise.all([
+      wide.result,
+      lateShort.result,
+    ]);
+
+    assertEquals([wideResult.runCount, wideResult.failedRunCount], [2, 0]);
+    assertEquals([shortResult.runCount, shortResult.failedRunCount], [2, 0]);
+    assertEquals(
+      test.collector.progress(lateShort.progress.id)?.needsReload,
+      true,
+    );
+    assertEquals([stableCalls, repairCalls], [1, 2]);
+  } finally {
+    unblockRepair();
+    await Promise.allSettled(pending);
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history keeps labs fresh while loom has a pending cache write", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-job-history-source-cache-test-",
+  });
+  const file = `${directory}/history.json`;
+  let markLoomSaveStarted!: () => void;
+  const loomSaveStarted = new Promise<void>((resolve) =>
+    markLoomSaveStarted = resolve
+  );
+  let releaseLoomSave!: () => void;
+  const loomSaveGate = new Promise<void>((resolve) =>
+    releaseLoomSave = resolve
+  );
+  let loomSaveReleased = false;
+  const unblockLoomSave = () => {
+    if (loomSaveReleased) return;
+    loomSaveReleased = true;
+    releaseLoomSave();
+  };
+  class SourceStore extends CiJobHistoryStore {
+    saveCalls = 0;
+
+    override async save(now = Date.now()): Promise<void> {
+      this.saveCalls++;
+      if (this.saveCalls === 3) {
+        markLoomSaveStarted();
+        await loomSaveGate;
+        throw new Error("loom save failed");
+      }
+      await super.save(now);
+    }
+  }
+  const store = new SourceStore(file);
+  const collector = new CiJobHistoryCollector(store);
+  const labsRun = workflowRun(8_926, Date.now() - DAY);
+  const loomRun = workflowRun(8_927, Date.now() - DAY, {
+    html_url: `https://github.com/${LOOM_REPO}/actions/runs/8927`,
+  });
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.includes(`/repos/${REPO}/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({ workflow_runs: [labsRun] }));
+    }
+    if (
+      url.includes(
+        `/repos/${LOOM_REPO}/actions/workflows/${LOOM_CI_WORKFLOW}/runs?`,
+      )
+    ) {
+      return Promise.resolve(Response.json({ workflow_runs: [loomRun] }));
+    }
+    if (
+      url.includes(
+        `/repos/${REPO}/actions/runs/${labsRun.id}/attempts/1/jobs`,
+      )
+    ) {
+      return Promise.resolve(Response.json({ jobs: [apiJob("Labs", 60)] }));
+    }
+    if (
+      url.includes(
+        `/repos/${LOOM_REPO}/actions/runs/${loomRun.id}/attempts/1/jobs`,
+      )
+    ) {
+      return Promise.resolve(Response.json({ jobs: [apiJob("Loom", 70)] }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  const pending: Promise<unknown>[] = [];
+  try {
+    const labs = await collector.startRefresh(
+      "source-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    ).result;
+    assertEquals(labs.runCount, 1);
+
+    const loom = collector.startRefresh(
+      "source-token",
+      CI_HISTORY_SOURCES.loom,
+      7,
+    );
+    pending.push(loom.result);
+    await loomSaveStarted;
+
+    const labsDuringLoom = collector.startRefresh(
+      "source-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    assertEquals(labsDuringLoom.progress, null);
+    assertEquals((await labsDuringLoom.result).runCount, 1);
+    assertEquals(store.saveCalls, 3);
+
+    unblockLoomSave();
+    await assertRejects(() => loom.result, Error, "loom save failed");
+    const labsAfterFailure = collector.startRefresh(
+      "source-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    assertEquals(labsAfterFailure.progress, null);
+    assertEquals((await labsAfterFailure.result).runCount, 1);
+    assertEquals(store.saveCalls, 3);
+    assertEquals(
+      calls.filter((url) => url.includes(`/repos/${REPO}/`)).length,
+      2,
+    );
+  } finally {
+    unblockLoomSave();
+    await Promise.allSettled(pending);
+    globalThis.fetch = originalFetch;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history persists a shared job response once across active windows", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-job-history-save-test-",
+  });
+  const file = `${directory}/history.json`;
+  class CountingStore extends CiJobHistoryStore {
+    saveCalls = 0;
+
+    override async save(now = Date.now()): Promise<void> {
+      this.saveCalls++;
+      await super.save(now);
+    }
+  }
+  const store = new CountingStore(file);
+  const collector = new CiJobHistoryCollector(store);
+  const run = workflowRun(8_921, Date.now() - DAY);
+  let releaseJob!: (response: Response) => void;
+  const jobResponse = new Promise<Response>((resolve) => releaseJob = resolve);
+  let jobCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({ workflow_runs: [run] }));
+    }
+    if (url.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+      jobCalls++;
+      return jobResponse;
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  const stops: (() => void)[] = [];
+  try {
+    const refreshes = [7, 8, 9, 10, 11].map((days) =>
+      collector.startRefresh(
+        "shared-save-token",
+        CI_HISTORY_SOURCES.labs,
+        days,
+        null,
+      )
+    );
+    await Promise.all(refreshes.map((refresh) => {
+      assert(refresh.progress);
+      return new Promise<void>((resolve) => {
+        const stop = collector.subscribeProgress(
+          refresh.progress!.id,
+          (state) => {
+            if (state.requestsMade + state.sharedRequests === 1) resolve();
+          },
+        );
+        assert(stop);
+        stops.push(stop);
+      });
+    }));
+
+    releaseJob(Response.json({ jobs: [apiJob("Shared check", 90)] }));
+    await Promise.all(refreshes.map((refresh) => refresh.result));
+
+    assertEquals(jobCalls, 1);
+    assertEquals(store.saveCalls, 6);
+    assertEquals(
+      refreshes.reduce(
+        (total, refresh) =>
+          total + (collector.progress(refresh.progress!.id)?.requestsMade ?? 0),
+        0,
+      ),
+      1,
+    );
+    assertEquals(
+      refreshes.reduce(
+        (total, refresh) =>
+          total +
+          (collector.progress(refresh.progress!.id)?.sharedRequests ?? 0),
+        0,
+      ),
+      4,
+    );
+  } finally {
+    for (const stop of stops) stop();
+    globalThis.fetch = originalFetch;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history joins persistence when a range starts after the response", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-job-history-late-range-test-",
+  });
+  const file = `${directory}/history.json`;
+  let markSaveStarted!: () => void;
+  const saveStarted = new Promise<void>((resolve) => markSaveStarted = resolve);
+  let releaseSave!: () => void;
+  const saveGate = new Promise<void>((resolve) => releaseSave = resolve);
+  let saveReleased = false;
+  const unblockSave = () => {
+    if (saveReleased) return;
+    saveReleased = true;
+    releaseSave();
+  };
+  class BlockingStore extends CiJobHistoryStore {
+    saveCalls = 0;
+
+    override async save(now = Date.now()): Promise<void> {
+      this.saveCalls++;
+      markSaveStarted();
+      await saveGate;
+      await super.save(now);
+    }
+  }
+  const store = new BlockingStore(file);
+  const collector = new CiJobHistoryCollector(store);
+  const run = workflowRun(8_931, Date.now() - DAY);
+  let jobCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({ workflow_runs: [run] }));
+    }
+    if (url.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+      jobCalls++;
+      return Promise.resolve(
+        Response.json({ jobs: [apiJob("Late check", 90)] }),
+      );
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  const results: Promise<unknown>[] = [];
+  const stops: (() => void)[] = [];
+  try {
+    const wide = collector.startRefresh(
+      "late-range-token",
+      CI_HISTORY_SOURCES.labs,
+      45,
+      null,
+    );
+    results.push(wide.result);
+    await saveStarted;
+
+    const short = collector.startRefresh(
+      "late-range-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+      null,
+    );
+    results.push(short.result);
+    assert(short.progress);
+    await new Promise<void>((resolve) => {
+      const stop = collector.subscribeProgress(short.progress!.id, (state) => {
+        if (state.sharedRequests === 1) resolve();
+      });
+      assert(stop);
+      stops.push(stop);
+    });
+    const waiting = collector.progress(short.progress.id);
+    assertEquals(waiting?.cachedRuns, 0);
+    assertEquals(waiting?.completedRuns, 0);
+    assertEquals(waiting?.outstandingRequests, 1);
+    assertEquals(store.saveCalls, 1);
+
+    unblockSave();
+    await Promise.all(results);
+    assertEquals(jobCalls, 1);
+    assertEquals(store.saveCalls, 3);
+    assertEquals(collector.progress(short.progress.id)?.phase, "complete");
+  } finally {
+    for (const stop of stops) stop();
+    unblockSave();
+    await Promise.allSettled(results);
+    globalThis.fetch = originalFetch;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history fetches selected runs once and filters unusable jobs", async () => {
+  const test = await temporaryCollector();
+  const runs = [
+    workflowRun(9_001, NOW - 2 * DAY),
+    workflowRun(9_002, NOW - DAY),
+    workflowRun(9_003, NOW),
+    workflowRun(9_004, NOW - HOUR, { conclusion: "failure" }),
+    workflowRun(9_005, NOW - DAY),
+  ];
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input, init) => {
+    const url = String(input);
+    calls.push(url);
+    assertEquals(
+      new Headers(init?.headers).get("authorization"),
+      "Bearer test-token",
+    );
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      const parsed = new URL(url);
+      assertEquals(parsed.searchParams.get("branch"), "main");
+      assertEquals(parsed.searchParams.get("event"), "push");
+      assertEquals(parsed.searchParams.get("status"), "success");
+      assert(parsed.searchParams.get("created")?.includes(".."));
+      return Promise.resolve(Response.json({ workflow_runs: runs }));
+    }
+    const match = url.match(/\/actions\/runs\/(\d+)\/attempts\/1\/jobs/);
+    if (match) {
+      const id = Number(match[1]);
+      return Promise.resolve(Response.json({
+        jobs: [
+          apiJob("Check", 100 + id - 9_001),
+          apiJob("Test (1/2)", 120 + id - 9_001),
+          apiJob("Test (2/2)", 140 + id - 9_001),
+          apiJob("Cancelled", 300, "cancelled"),
+          {
+            name: "No timing",
+            conclusion: "success",
+            started_at: null,
+            completed_at: null,
+          },
+        ],
+      }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const first = await test.collector.collect("test-token", NOW);
+    assertEquals(first.runCount, 4);
+    assertEquals(first.successfulRunTimes, [
+      NOW - 2 * DAY,
+      NOW - DAY,
+      NOW - DAY,
+      NOW,
+    ]);
+    assertEquals(first.failedRunCount, 0);
+    assertEquals(first.axisStart, NOW - CI_HISTORY_DAYS * DAY);
+    assertEquals(first.axisEnd, NOW);
+    assertEquals(
+      first.overall?.points.map((point) => point.seconds),
+      [140, 141, 144, 142],
+    );
+    assertEquals(first.groups[0].aggregate.points.length, 4);
+    assertEquals(first.jobs.map((series) => series.name), ["Check"]);
+    assertEquals(
+      first.groups[0].aggregate.points.map((point) => point.seconds),
+      [140, 141, 144, 142],
+    );
+    assert(!JSON.stringify(first).includes("Cancelled"));
+    assert(!JSON.stringify(first).includes("No timing"));
+
+    const firstJobCalls = calls.filter((call) =>
+      call.includes("/jobs?")
+    ).length;
+    assertEquals(firstJobCalls, 4);
+    await test.collector.collect("test-token", NOW);
+    const secondJobCalls = calls.filter((call) =>
+      call.includes("/jobs?")
+    ).length;
+    assertEquals(secondJobCalls, firstJobCalls);
+
+    const runCallsBeforeRefresh =
+      calls.filter((call) =>
+        call.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)
+      ).length;
+    await test.collector.refresh("test-token");
+    await test.collector.refresh("test-token");
+    const runCallsAfterRefresh =
+      calls.filter((call) =>
+        call.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)
+      ).length;
+    assertEquals(runCallsAfterRefresh, runCallsBeforeRefresh + 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history reloads completed attempts from its server cache", async () => {
+  const test = await temporaryCollector();
+  const run = workflowRun(9_101, NOW);
+  let runCalls = 0;
+  let jobCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      runCalls++;
+      return Promise.resolve(Response.json({ workflow_runs: [run] }));
+    }
+    if (url.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+      jobCalls++;
+      return Promise.resolve(Response.json({
+        jobs: [apiJob("Check", 90), apiJob("Test", 120)],
+      }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const first = await test.collector.collect("cache-token", NOW);
+    assertEquals(first.overall?.points[0].seconds, 120);
+    assertEquals([runCalls, jobCalls], [1, 1]);
+
+    const persisted = JSON.parse(await Deno.readTextFile(test.file));
+    assertEquals(persisted.version, 1);
+    assertEquals(persisted.runs[0].repo, REPO);
+    assertEquals(persisted.runs[0].runAttempt, 1);
+
+    const restarted = new CiJobHistoryCollector(
+      new CiJobHistoryStore(test.file),
+    );
+    const cached = await restarted.cached(CI_HISTORY_SOURCES.labs, 45, NOW);
+    assertEquals(cached?.jobs.map((series) => series.name), ["Check", "Test"]);
+    assertEquals([runCalls, jobCalls], [1, 1]);
+
+    const short = await restarted.cached(CI_HISTORY_SOURCES.labs, 7, NOW);
+    assertEquals(short?.runCount, 1);
+    const expired = await restarted.cached(
+      CI_HISTORY_SOURCES.labs,
+      7,
+      NOW + 8 * DAY,
+    );
+    assertEquals(expired?.runCount, 0);
+    assertEquals(expired?.overall, null);
+    assertEquals(expired?.groups, []);
+    assertEquals(expired?.jobs, []);
+    assertEquals(expired?.axisStart, NOW + DAY);
+    assertEquals(expired?.axisEnd, NOW + 8 * DAY);
+
+    await restarted.collect("cache-token", NOW);
+    assertEquals(runCalls, 2);
+    assertEquals(jobCalls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history reuses a fresh completed collection after a dashboard restart", async () => {
+  const test = await temporaryCollector();
+  const now = Date.now();
+  const run = workflowRun(9_103, now);
+  let runCalls = 0;
+  let jobCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      runCalls++;
+      return Promise.resolve(Response.json({ workflow_runs: [run] }));
+    }
+    if (url.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+      jobCalls++;
+      return Promise.resolve(Response.json({
+        jobs: [apiJob("Check", 90)],
+      }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const first = test.collector.startRefresh(
+      "restart-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+    );
+    assert(first.progress);
+    await first.result;
+    assertEquals([runCalls, jobCalls], [1, 1]);
+
+    const persisted = JSON.parse(await Deno.readTextFile(test.file));
+    assertEquals(persisted.refreshes.length, 1);
+    assertEquals(persisted.refreshes[0].days, CI_HISTORY_DAYS);
+    assertEquals(persisted.refreshes[0].successfulRunTimes, [now]);
+    assertEquals(persisted.refreshes[0].sampledRuns, [{
+      runId: run.id,
+      runAttempt: 1,
+    }]);
+    assertEquals(persisted.refreshes[0].failedRunCount, 0);
+
+    const restarted = new CiJobHistoryCollector(
+      new CiJobHistoryStore(test.file),
+    );
+    const cached = await restarted.cached(
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      Date.now(),
+    );
+    assertEquals(cached?.successfulRunTimes, [now]);
+    const refresh = restarted.startRefresh(
+      "restart-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      cached,
+    );
+    assertEquals(refresh.progress, null);
+    assertEquals((await refresh.result).runCount, 1);
+    assertEquals([runCalls, jobCalls], [1, 1]);
+    assertEquals(
+      (await restarted.cached(
+        CI_HISTORY_SOURCES.labs,
+        CI_HISTORY_DAYS,
+        now + (CI_HISTORY_DAYS + 1) * DAY,
+      ))?.runCount,
+      0,
+    );
+
+    const validCache = await Deno.readTextFile(test.file);
+    const malformed = JSON.parse(validCache);
+    malformed.runs.push({ runId: "invalid" });
+    await Deno.writeTextFile(test.file, JSON.stringify(malformed));
+    const damaged = new CiJobHistoryStore(test.file);
+    await damaged.load();
+    assertEquals(
+      damaged.refresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS),
+      undefined,
+    );
+    await Deno.writeTextFile(test.file, validCache);
+
+    const emptyStore = new CiJobHistoryStore(test.file);
+    await emptyStore.load();
+    emptyStore.invalidateRefresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS);
+    emptyStore.markRefreshed(
+      REPO,
+      CI_WORKFLOW,
+      CI_HISTORY_DAYS,
+      Date.now(),
+      [],
+      [],
+      0,
+      [],
+      false,
+    );
+    await emptyStore.save();
+    const emptyRestart = new CiJobHistoryCollector(
+      new CiJobHistoryStore(test.file),
+    );
+    assertEquals(
+      (await emptyRestart.cached(
+        CI_HISTORY_SOURCES.labs,
+        CI_HISTORY_DAYS,
+        Date.now(),
+      ))?.runCount,
+      0,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history preserves an all-failed refresh warning after restart", async () => {
+  const test = await temporaryCollector();
+  const now = Date.now();
+  const run = workflowRun(9_104, now - HOUR);
+  let failing = false;
+  let calls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    calls++;
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({
+        workflow_runs: [{ ...run, run_attempt: failing ? 2 : 1 }],
+      }));
+    }
+    if (url.includes(`/actions/runs/${run.id}/`)) {
+      return failing
+        ? Promise.resolve(new Response("unavailable", { status: 503 }))
+        : Promise.resolve(Response.json({ jobs: [apiJob("Check", 90)] }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    await test.collector.startRefresh(
+      "restart-failure-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+    ).result;
+    failing = true;
+
+    const second = new CiJobHistoryCollector(
+      new CiJobHistoryStore(test.file),
+    );
+    const baseline = await second.cached(CI_HISTORY_SOURCES.labs, 7, now);
+    assertEquals(baseline?.runCount, 1);
+    const failed = await second.startRefresh(
+      "restart-failure-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+      baseline,
+    ).result;
+    assertEquals(failed.runCount, 1);
+    assertEquals(failed.failedRunCount, 1);
+    assertEquals(failed.stale, true);
+
+    const callsBeforeRestart = calls;
+    const restarted = new CiJobHistoryCollector(
+      new CiJobHistoryStore(test.file),
+    );
+    const cached = await restarted.cached(
+      CI_HISTORY_SOURCES.labs,
+      7,
+      Date.now(),
+    );
+    assertEquals(cached?.runCount, 1);
+    assertEquals(cached?.failedRunCount, 1);
+    assertEquals(cached?.failedRunTimes, [Date.parse(run.run_started_at)]);
+    assertEquals(cached?.stale, true);
+    const refresh = restarted.startRefresh(
+      "restart-failure-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+      cached,
+    );
+    assertEquals(refresh.progress, null);
+    assertEquals((await refresh.result).stale, true);
+    assertEquals(calls, callsBeforeRestart);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history does not mark a rate-limited collection fresh", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-rate-limited-" });
+  const file = `${directory}/history.json`;
+  const store = new CiJobHistoryStore(file);
+  const run = workflowRun(9_105, Date.now() - HOUR);
+  const warmed = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T = unknown>(path: string): Promise<T> => {
+      if (path.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+        return Promise.resolve({ workflow_runs: [run] } as T);
+      }
+      return Promise.resolve({ jobs: [apiJob("Check", 90)] } as T);
+    },
+  );
+  await warmed.startRefresh(
+    "rate-limited-token",
+    CI_HISTORY_SOURCES.labs,
+    CI_HISTORY_DAYS,
+  ).result;
+  const rerun = { ...run, run_attempt: 2 };
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T = unknown>(path: string): Promise<T> => {
+      if (path.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+        return Promise.resolve({ workflow_runs: [rerun] } as T);
+      }
+      return Promise.reject(
+        new GitHubRateLimitBudgetError(
+          "GitHub rate limit has been hit at the 80% performance-history safety threshold.",
+        ),
+      );
+    },
+  );
+  try {
+    const refresh = collector.startRefresh(
+      "rate-limited-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+    );
+    await assertRejects(
+      () => refresh.result,
+      GitHubRateLimitBudgetError,
+    );
+    assertEquals(
+      store.freshRefresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS),
+      undefined,
+    );
+    assertEquals(
+      store.refresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS)?.sampledRuns,
+      [{ runId: run.id, runAttempt: 1 }],
+    );
+    assertEquals(collector.snapshot()?.failedRunCount, 1);
+    assertEquals(collector.progress(refresh.progress!.id)?.phase, "error");
+
+    const restartedStore = new CiJobHistoryStore(file);
+    await restartedStore.load();
+    assertEquals(
+      restartedStore.freshRefresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS),
+      undefined,
+    );
+    assertEquals(
+      restartedStore.get(REPO, CI_WORKFLOW, run.id, 1)?.runAttempt,
+      1,
+    );
+    let discoveryCalls = 0;
+    const restarted = new RateLimitedCiJobHistoryCollector(
+      restartedStore,
+      <T = unknown>(path: string): Promise<T> => {
+        if (path.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+          discoveryCalls++;
+          return Promise.resolve({ workflow_runs: [rerun] } as T);
+        }
+        return Promise.reject(
+          new GitHubRateLimitBudgetError("rate limit still reserved"),
+        );
+      },
+    );
+    await restarted.cached(CI_HISTORY_SOURCES.labs, CI_HISTORY_DAYS);
+    const retry = restarted.startRefresh(
+      "rate-limited-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+    );
+    assert(retry.progress);
+    await assertRejects(() => retry.result, GitHubRateLimitBudgetError);
+    assertEquals(discoveryCalls, 1);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history can replace an in-process future refresh", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-future-refresh-" });
+  const file = `${directory}/history.json`;
+  const store = new CiJobHistoryStore(file);
+  const run = workflowRun(9_106, Date.now() - HOUR);
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T = unknown>(path: string): Promise<T> => {
+      if (path.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+        return Promise.resolve({ workflow_runs: [run] } as T);
+      }
+      return Promise.resolve({ jobs: [apiJob("Check", 90)] } as T);
+    },
+  );
+  try {
+    await collector.startRefresh(
+      "future-refresh-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+    ).result;
+    const completed = store.refresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS)!;
+    store.markRefreshed(
+      REPO,
+      CI_WORKFLOW,
+      CI_HISTORY_DAYS,
+      Date.now() + DAY,
+      completed.successfulRunTimes,
+      completed.sampledRuns,
+      completed.failedRunCount,
+      completed.failedRunTimes,
+      completed.stale,
+    );
+    await store.save();
+
+    assertEquals(
+      store.quarantineFutureRefresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS),
+      true,
+    );
+    await store.save();
+    const replacementAt = Date.now();
+    store.markRefreshed(
+      REPO,
+      CI_WORKFLOW,
+      CI_HISTORY_DAYS,
+      replacementAt,
+      completed.successfulRunTimes,
+      completed.sampledRuns,
+      completed.failedRunCount,
+      completed.failedRunTimes,
+      completed.stale,
+    );
+    await store.save();
+
+    const restarted = new CiJobHistoryStore(file);
+    await restarted.load();
+    assertEquals(
+      restarted.freshRefresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS)?.refreshedAt,
+      replacementAt,
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt reuses and reloads the CI history job cache", async () => {
+  const test = await temporaryCollector();
+  const now = Date.now();
+  const run = workflowRun(9_105, now, { name: "CI" });
+  let runCalls = 0;
+  let jobCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      runCalls++;
+      return Promise.resolve(Response.json({ workflow_runs: [run] }));
+    }
+    if (url.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+      jobCalls++;
+      return Promise.resolve(Response.json({
+        jobs: [{
+          ...apiJob("Check", 90),
+          status: "completed",
+          steps: [{
+            name: "🔎 Check",
+            number: 1,
+            conclusion: "success",
+            started_at: new Date(now - HOUR).toISOString(),
+            completed_at: new Date(now - HOUR + 90_000).toISOString(),
+          }],
+        }],
+      }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    await test.collector.startRefresh(
+      "shared-cache-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+    ).result;
+    const gantt = await test.collector.gantt(
+      "shared-cache-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 10, mainOnly: true },
+      now,
+    );
+    assertEquals(runCalls, 1);
+    assertEquals(jobCalls, 1);
+    assertEquals(gantt.runs[0].run.databaseId, run.id);
+    assertEquals(gantt.runs[0].jobs[0].steps[0].name, "🔎 Check");
+
+    const persisted = JSON.parse(await Deno.readTextFile(test.file));
+    assertEquals(persisted.runs[0].gantt.workflowName, "CI");
+    assertEquals(persisted.runs[0].gantt.jobs[0].name, "Check");
+
+    const restarted = new CiJobHistoryCollector(
+      new CiJobHistoryStore(test.file),
+    );
+    const reloaded = await restarted.gantt(
+      undefined,
+      CI_HISTORY_SOURCES.labs,
+      { limit: 10, mainOnly: true },
+      now,
+    );
+    assertEquals(reloaded, gantt);
+    assertEquals(jobCalls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("a selected-run Gantt reads only its run and then reuses the disk cache", async () => {
+  const test = await temporaryCollector();
+  const run = workflowRun(9_115, NOW, {
+    name: "CI",
+    head_sha: HEAD_SHA,
+    path: `.github/workflows/${CI_WORKFLOW}`,
+  });
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = new URL(String(input));
+    calls.push(url.pathname);
+    if (
+      url.pathname.endsWith(
+        `/actions/runs/${run.id}/attempts/${run.run_attempt}`,
+      )
+    ) {
+      return Promise.resolve(Response.json(run));
+    }
+    if (
+      url.pathname.endsWith(
+        `/actions/runs/${run.id}/attempts/${run.run_attempt}/jobs`,
+      )
+    ) {
+      return Promise.resolve(Response.json({ jobs: [apiJob("Check", 75)] }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+  const options = {
+    limit: 1,
+    mainOnly: true,
+    headSha: HEAD_SHA,
+    selectedRuns: [
+      { runId: 0, runAttempt: 1 },
+      { runId: run.id, runAttempt: 0 },
+      { runId: run.id, runAttempt: run.run_attempt },
+    ],
+  };
+
+  try {
+    const first = await test.collector.gantt(
+      "selected-run-token",
+      CI_HISTORY_SOURCES.labs,
+      options,
+      NOW,
+    );
+    assertEquals(first.runs.map(({ run }) => run.databaseId), [run.id]);
+    assertEquals(
+      calls.filter((path) =>
+        path.endsWith(
+          `/actions/runs/${run.id}/attempts/${run.run_attempt}`,
+        )
+      ).length,
+      1,
+    );
+    assertEquals(
+      calls.some((path) => path.includes(`/workflows/${CI_WORKFLOW}/runs`)),
+      false,
+    );
+
+    const restarted = new CiJobHistoryCollector(
+      new CiJobHistoryStore(test.file),
+    );
+    globalThis.fetch = () => {
+      throw new Error("a cached selected-run Gantt contacted GitHub");
+    };
+    assertEquals(
+      await restarted.gantt(
+        undefined,
+        CI_HISTORY_SOURCES.labs,
+        options,
+        NOW,
+      ),
+      first,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("a selected-run Gantt reuses fresh run metadata after a job failure", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selected-metadata-test-",
+  });
+  const run = workflowRun(9_116, NOW, {
+    name: "CI",
+    head_sha: HEAD_SHA,
+    path: `.github/workflows/${CI_WORKFLOW}`,
+  });
+  let metadataCalls = 0;
+  let jobCalls = 0;
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>(path: string): Promise<T> => {
+      if (
+        path.endsWith(
+          `/actions/runs/${run.id}/attempts/${run.run_attempt}`,
+        )
+      ) {
+        metadataCalls++;
+        return Promise.resolve(run as T);
+      }
+      if (
+        path.includes(
+          `/actions/runs/${run.id}/attempts/${run.run_attempt}/jobs`,
+        )
+      ) {
+        jobCalls++;
+        return jobCalls === 1
+          ? Promise.reject(new Error("job response failed"))
+          : Promise.resolve({ jobs: [apiJob("Check", 75)] } as T);
+      }
+      throw new Error(`unexpected selected-run request: ${path}`);
+    },
+  );
+  const options = {
+    limit: 1,
+    mainOnly: true,
+    headSha: HEAD_SHA,
+    selectedRuns: [{ runId: run.id, runAttempt: run.run_attempt }],
+  };
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    await assertRejects(
+      () =>
+        collector.gantt(
+          "selected-run-token",
+          CI_HISTORY_SOURCES.labs,
+          options,
+          NOW,
+        ),
+      Error,
+      "job response failed",
+    );
+    const result = await collector.gantt(
+      "selected-run-token",
+      CI_HISTORY_SOURCES.labs,
+      options,
+      NOW,
+    );
+    assertEquals(result.runs.map(({ run }) => run.databaseId), [run.id]);
+    assertEquals(metadataCalls, 1);
+    assertEquals(jobCalls, 2);
+  } finally {
+    console.error = originalError;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("selected-run metadata keeps only the most recent Gantt selection", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selected-metadata-limit-test-",
+  });
+  const metadataCalls = new Map<number, number>();
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>(path: string): Promise<T> => {
+      const metadata = path.match(/\/actions\/runs\/(\d+)\/attempts\/1$/);
+      if (metadata) {
+        const id = Number(metadata[1]);
+        metadataCalls.set(id, (metadataCalls.get(id) ?? 0) + 1);
+        return Promise.resolve(workflowRun(id, NOW, {
+          head_sha: HEAD_SHA,
+          path: `.github/workflows/${CI_WORKFLOW}`,
+        }) as T);
+      }
+      if (path.includes("/attempts/1/jobs")) {
+        return Promise.reject(new Error("jobs unavailable"));
+      }
+      throw new Error(`unexpected selected-run request: ${path}`);
+    },
+  );
+  const selections = Array.from({ length: 150 }, (_, index) => ({
+    runId: 20_000 + index,
+    runAttempt: 1,
+  }));
+  const options = (selectedRuns: typeof selections) => ({
+    limit: selectedRuns.length,
+    mainOnly: true,
+    headSha: HEAD_SHA,
+    selectedRuns,
+  });
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    await assertRejects(
+      () =>
+        collector.gantt(
+          "selected-run-token",
+          CI_HISTORY_SOURCES.labs,
+          options(selections),
+          NOW,
+        ),
+      Error,
+      "jobs unavailable",
+    );
+    await assertRejects(
+      () =>
+        collector.gantt(
+          "selected-run-token",
+          CI_HISTORY_SOURCES.labs,
+          options([{ runId: 30_000, runAttempt: 1 }]),
+          NOW,
+        ),
+      Error,
+      "jobs unavailable",
+    );
+    await assertRejects(
+      () =>
+        collector.gantt(
+          "selected-run-token",
+          CI_HISTORY_SOURCES.labs,
+          options([selections[1]]),
+          NOW,
+        ),
+      Error,
+      "jobs unavailable",
+    );
+    assertEquals(metadataCalls.get(selections[1].runId), 1);
+    await assertRejects(
+      () =>
+        collector.gantt(
+          "selected-run-token",
+          CI_HISTORY_SOURCES.labs,
+          options([selections[0]]),
+          NOW,
+        ),
+      Error,
+      "jobs unavailable",
+    );
+    assertEquals(metadataCalls.get(selections[0].runId), 2);
+  } finally {
+    console.error = originalError;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt retains a bounded set of completed progress records", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-progress-limit-test-",
+  });
+  let releaseMetadata!: () => void;
+  const metadataGate = new Promise<void>((resolve) => {
+    releaseMetadata = resolve;
+  });
+  let metadataStarted = 0;
+  let markAllMetadataStarted!: () => void;
+  const allMetadataStarted = new Promise<void>((resolve) => {
+    markAllMetadataStarted = resolve;
+  });
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    async <T>(path: string): Promise<T> => {
+      const metadata = path.match(/\/actions\/runs\/(\d+)\/attempts\/1$/);
+      if (metadata) {
+        const id = Number(metadata[1]);
+        metadataStarted++;
+        if (metadataStarted === 257) markAllMetadataStarted();
+        await metadataGate;
+        return workflowRun(id, NOW, {
+          head_sha: HEAD_SHA,
+          path: `.github/workflows/${CI_WORKFLOW}`,
+        }) as T;
+      }
+      if (path.includes("/attempts/1/jobs")) {
+        throw new Error("jobs unavailable");
+      }
+      throw new Error(`unexpected selected-run request: ${path}`);
+    },
+  );
+  const ids: string[] = [];
+  const results: Promise<CiGanttInput>[] = [];
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    for (let index = 0; index < 257; index++) {
+      const refresh = collector.startGantt(
+        "selected-run-token",
+        CI_HISTORY_SOURCES.labs,
+        {
+          limit: 1,
+          mainOnly: true,
+          headSha: HEAD_SHA,
+          selectedRuns: [{ runId: 40_000 + index, runAttempt: 1 }],
+        },
+        NOW,
+      );
+      ids.push(refresh.progress.id);
+      results.push(refresh.result);
+    }
+    await allMetadataStarted;
+    assertEquals(collector.progress(ids[0])?.phase, "discovering");
+    assertEquals(collector.progress(ids[256])?.phase, "discovering");
+    releaseMetadata();
+    const outcomes = await Promise.allSettled(results);
+    assert(outcomes.every((outcome) => outcome.status === "rejected"));
+    assertEquals(collector.progress(ids[0]), null);
+    assertEquals(collector.progress(ids[1])?.phase, "error");
+    assertEquals(collector.progress(ids[256])?.phase, "error");
+  } finally {
+    releaseMetadata();
+    await Promise.allSettled(results);
+    console.error = originalError;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("a selected-run Gantt repairs cached responses with no drawable jobs", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selected-empty-jobs-test-",
+  });
+  const file = `${directory}/history.json`;
+  const run = workflowRun(9_117, NOW, {
+    name: "CI",
+    head_sha: HEAD_SHA,
+    path: `.github/workflows/${CI_WORKFLOW}`,
+  });
+  const store = new CiJobHistoryStore(file);
+  let metadataCalls = 0;
+  let jobCalls = 0;
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T>(path: string): Promise<T> => {
+      if (
+        path.endsWith(
+          `/actions/runs/${run.id}/attempts/${run.run_attempt}`,
+        )
+      ) {
+        metadataCalls++;
+        return Promise.resolve(run as T);
+      }
+      if (path.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+        jobCalls++;
+        return Promise.resolve({
+          jobs: jobCalls === 1 ? [] : [apiJob("Recovered", 45)],
+        } as T);
+      }
+      throw new Error(`unexpected selected-run request: ${path}`);
+    },
+  );
+  const options = {
+    limit: 1,
+    mainOnly: true,
+    headSha: HEAD_SHA,
+    selectedRuns: [{ runId: run.id, runAttempt: run.run_attempt }],
+  };
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    await assertRejects(
+      () =>
+        collector.gantt(
+          "selected-run-token",
+          CI_HISTORY_SOURCES.labs,
+          options,
+          NOW,
+        ),
+      Error,
+      "No completed CI job timings were returned",
+    );
+    assertEquals(store.get(REPO, CI_WORKFLOW, run.id, 1), undefined);
+
+    store.set({
+      repo: REPO,
+      workflow: CI_WORKFLOW,
+      runId: run.id,
+      runAttempt: run.run_attempt,
+      headSha: HEAD_SHA,
+      runUrl: run.html_url,
+      at: NOW,
+      overallSeconds: 0,
+      jobs: [],
+      gantt: {
+        status: run.status,
+        conclusion: run.conclusion,
+        event: run.event,
+        headBranch: run.head_branch ?? undefined,
+        startedAt: run.run_started_at,
+        workflowName: run.name,
+        jobs: [],
+      },
+    });
+    await store.save(NOW);
+
+    const repaired = await collector.gantt(
+      "selected-run-token",
+      CI_HISTORY_SOURCES.labs,
+      options,
+      NOW,
+    );
+    assertEquals(repaired.runs[0].jobs[0].name, "Recovered");
+    assertEquals(metadataCalls, 1);
+    assertEquals(jobCalls, 2);
+    assertEquals(
+      store.get(REPO, CI_WORKFLOW, run.id, 1)?.gantt.jobs[0].name,
+      "Recovered",
+    );
+
+    const restarted = new RateLimitedCiJobHistoryCollector(
+      new CiJobHistoryStore(file),
+      () => {
+        throw new Error("a repaired selection contacted GitHub");
+      },
+    );
+    assertEquals(
+      await restarted.gantt(
+        undefined,
+        CI_HISTORY_SOURCES.labs,
+        options,
+        NOW,
+      ),
+      repaired,
+    );
+  } finally {
+    console.error = originalError;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("a selected-run Gantt validates the commit and workflow before fetching jobs", async () => {
+  const mismatches = [
+    { head_sha: "b".repeat(40), path: `.github/workflows/${CI_WORKFLOW}` },
+    { head_sha: HEAD_SHA, path: ".github/workflows/other.yml" },
+  ];
+  for (const [index, mismatch] of mismatches.entries()) {
+    const directory = await Deno.makeTempDir({
+      prefix: "ci-gantt-selected-validation-test-",
+    });
+    const run = workflowRun(9_120 + index, NOW, {
+      ...mismatch,
+      name: "CI",
+    });
+    let jobCalls = 0;
+    const store = new CiJobHistoryStore(`${directory}/history.json`);
+    const collector = new RateLimitedCiJobHistoryCollector(
+      store,
+      <T>(path: string): Promise<T> => {
+        if (
+          path.endsWith(
+            `/actions/runs/${run.id}/attempts/${run.run_attempt}`,
+          )
+        ) {
+          return Promise.resolve(run as T);
+        }
+        if (path.includes(`/actions/runs/${run.id}/attempts/`)) {
+          jobCalls++;
+          return Promise.resolve({ jobs: [apiJob("Check", 75)] } as T);
+        }
+        throw new Error(`unexpected selected-run request: ${path}`);
+      },
+    );
+    try {
+      await assertRejects(
+        () =>
+          collector.gantt(
+            "selected-run-token",
+            CI_HISTORY_SOURCES.labs,
+            {
+              limit: 1,
+              mainOnly: true,
+              headSha: HEAD_SHA,
+              selectedRuns: [{
+                runId: run.id,
+                runAttempt: run.run_attempt,
+              }],
+            },
+            NOW,
+          ),
+        Error,
+        "does not match the requested commit and workflow",
+      );
+      assertEquals(jobCalls, 0);
+      assertEquals(store.list(REPO, CI_WORKFLOW), []);
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  }
+});
+
+Deno.test("a selected-run Gantt requires a valid commit SHA", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selected-sha-test-",
+  });
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    () => {
+      throw new Error("an invalid selection contacted GitHub");
+    },
+  );
+  try {
+    await assertRejects(
+      () =>
+        collector.gantt(
+          "selected-run-token",
+          CI_HISTORY_SOURCES.labs,
+          {
+            limit: 1,
+            mainOnly: true,
+            headSha: "invalid",
+            selectedRuns: [{ runId: 9_125, runAttempt: 1 }],
+          },
+          NOW,
+        ),
+      Error,
+      "Selected CI runs require a commit SHA",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("a selected-run Gantt enriches a shared cached attempt with its commit", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selected-cache-commit-test-",
+  });
+  const file = `${directory}/history.json`;
+  const run = workflowRun(9_126, NOW, { name: "CI" });
+  const selectedRun = {
+    ...run,
+    head_sha: HEAD_SHA,
+    path: `.github/workflows/${CI_WORKFLOW}`,
+  };
+  let immutableJobCalls = 0;
+  const store = new CiJobHistoryStore(file);
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T>(path: string): Promise<T> => {
+      if (
+        path.endsWith(
+          `/actions/runs/${run.id}/attempts/${run.run_attempt}`,
+        )
+      ) {
+        return Promise.resolve(selectedRun as T);
+      }
+      if (path.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+        immutableJobCalls++;
+        return Promise.resolve({ jobs: [apiJob("Cached", 30)] } as T);
+      }
+      throw new Error(`unexpected selected-run request: ${path}`);
+    },
+  );
+  const options = {
+    limit: 1,
+    mainOnly: true,
+    headSha: HEAD_SHA,
+    selectedRuns: [{ runId: run.id, runAttempt: run.run_attempt }],
+  };
+  try {
+    await collector.gantt(
+      "selected-run-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 1, mainOnly: true },
+      NOW,
+      [run],
+    );
+    const selected = await collector.gantt(
+      "selected-run-token",
+      CI_HISTORY_SOURCES.labs,
+      options,
+      NOW,
+    );
+    assertEquals(selected.runs[0].jobs[0].name, "Cached");
+    assertEquals(immutableJobCalls, 1);
+    assertEquals(
+      store.get(REPO, CI_WORKFLOW, run.id, run.run_attempt)?.headSha,
+      HEAD_SHA,
+    );
+
+    const restarted = new RateLimitedCiJobHistoryCollector(
+      new CiJobHistoryStore(file),
+      () => {
+        throw new Error("the enriched cache contacted GitHub");
+      },
+    );
+    assertEquals(
+      await restarted.gantt(
+        undefined,
+        CI_HISTORY_SOURCES.labs,
+        options,
+        NOW,
+      ),
+      selected,
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("selected and aggregate Gantt requests do not join different job queries", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selected-request-mode-test-",
+  });
+  const run = workflowRun(9_127, NOW, { name: "CI" });
+  const selectedRun = {
+    ...run,
+    head_sha: HEAD_SHA,
+    path: `.github/workflows/${CI_WORKFLOW}`,
+  };
+  let releaseAggregate!: (value: { jobs: ReturnType<typeof apiJob>[] }) => void;
+  let markAggregateStarted!: () => void;
+  const aggregateResponse = new Promise<{ jobs: ReturnType<typeof apiJob>[] }>(
+    (resolve) => {
+      releaseAggregate = resolve;
+    },
+  );
+  const aggregateStarted = new Promise<void>((resolve) => {
+    markAggregateStarted = resolve;
+  });
+  let attemptJobCalls = 0;
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>(path: string): Promise<T> => {
+      if (
+        path.endsWith(
+          `/actions/runs/${run.id}/attempts/${run.run_attempt}`,
+        )
+      ) return Promise.resolve(selectedRun as T);
+      if (path.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+        attemptJobCalls++;
+        if (attemptJobCalls === 1) {
+          markAggregateStarted();
+          return aggregateResponse as Promise<T>;
+        }
+        return Promise.resolve({ jobs: [apiJob("Exact", 20)] } as T);
+      }
+      throw new Error(`unexpected Gantt request: ${path}`);
+    },
+  );
+  let aggregate: Promise<CiGanttInput> | undefined;
+  try {
+    aggregate = collector.gantt(
+      "gantt-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 1, mainOnly: true },
+      NOW,
+      [run],
+    );
+    await aggregateStarted;
+    const exact = await collector.gantt(
+      "gantt-token",
+      CI_HISTORY_SOURCES.labs,
+      {
+        limit: 1,
+        mainOnly: true,
+        headSha: HEAD_SHA,
+        selectedRuns: [{ runId: run.id, runAttempt: run.run_attempt }],
+      },
+      NOW,
+    );
+    assertEquals(exact.runs[0].jobs[0].name, "Exact");
+    releaseAggregate({ jobs: [apiJob("Aggregate", 30)] });
+    await aggregate;
+  } finally {
+    releaseAggregate({ jobs: [] });
+    if (aggregate) await Promise.allSettled([aggregate]);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("a selected-run Gantt rejects timings outside cache retention", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selected-retention-test-",
+  });
+  const run = workflowRun(
+    9_128,
+    NOW - (CI_JOB_CACHE_DAYS + 1) * DAY,
+    {
+      name: "CI",
+      head_sha: HEAD_SHA,
+      path: `.github/workflows/${CI_WORKFLOW}`,
+    },
+  );
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>(path: string): Promise<T> => {
+      if (
+        path.endsWith(
+          `/actions/runs/${run.id}/attempts/${run.run_attempt}`,
+        )
+      ) return Promise.resolve(run as T);
+      if (path.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+        return Promise.resolve({ jobs: [apiJob("Old", 20)] } as T);
+      }
+      throw new Error(`unexpected selected-run request: ${path}`);
+    },
+  );
+  try {
+    await assertRejects(
+      () =>
+        collector.gantt(
+          "selected-run-token",
+          CI_HISTORY_SOURCES.labs,
+          {
+            limit: 1,
+            mainOnly: true,
+            headSha: HEAD_SHA,
+            selectedRuns: [{ runId: run.id, runAttempt: run.run_attempt }],
+          },
+          NOW,
+        ),
+      Error,
+      "Not every selected CI run has cached job timings",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("a selected-run Gantt keeps each workflow attempt distinct", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selected-attempt-test-",
+  });
+  const file = `${directory}/history.json`;
+  const runId = 9_130;
+  const requestedJobAttempts: number[] = [];
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(file),
+    <T>(path: string): Promise<T> => {
+      const metadata = path.match(
+        new RegExp(`/actions/runs/${runId}/attempts/(\\d+)$`),
+      );
+      if (metadata) {
+        const attempt = Number(metadata[1]);
+        return Promise.resolve(workflowRun(runId, NOW, {
+          run_attempt: attempt,
+          name: "CI",
+          head_sha: HEAD_SHA,
+          path: `.github/workflows/${CI_WORKFLOW}`,
+        }) as T);
+      }
+      const jobs = path.match(
+        new RegExp(`/actions/runs/${runId}/attempts/(\\d+)/jobs`),
+      );
+      if (jobs) {
+        requestedJobAttempts.push(Number(jobs[1]));
+        return Promise.resolve({
+          jobs: [apiJob(`Attempt ${jobs[1]}`, Number(jobs[1]) * 10)],
+        } as T);
+      }
+      throw new Error(`unexpected selected-run request: ${path}`);
+    },
+  );
+  const options = (runAttempt: number) => ({
+    limit: 1,
+    mainOnly: true,
+    headSha: HEAD_SHA,
+    selectedRuns: [{ runId, runAttempt }],
+  });
+  try {
+    await collector.gantt(
+      "selected-run-token",
+      CI_HISTORY_SOURCES.labs,
+      options(1),
+      NOW,
+    );
+    await collector.gantt(
+      "selected-run-token",
+      CI_HISTORY_SOURCES.labs,
+      options(2),
+      NOW,
+    );
+    assertEquals(requestedJobAttempts, [1, 1, 2]);
+
+    const restarted = new RateLimitedCiJobHistoryCollector(
+      new CiJobHistoryStore(file),
+      () => {
+        throw new Error("an exact cached attempt contacted GitHub");
+      },
+    );
+    const firstAttempt = await restarted.gantt(
+      undefined,
+      CI_HISTORY_SOURCES.labs,
+      options(1),
+      NOW,
+    );
+    assertEquals(firstAttempt.runs[0].run.attempt, 1);
+    assertEquals(firstAttempt.runs[0].jobs[0].name, "Attempt 1");
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("a selected-run Gantt does not render an incomplete cached selection", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selected-partial-cache-test-",
+  });
+  const file = `${directory}/history.json`;
+  const first = workflowRun(9_140, NOW, {
+    name: "CI",
+    head_sha: HEAD_SHA,
+    path: `.github/workflows/${CI_WORKFLOW}`,
+  });
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(file),
+    <T>(path: string): Promise<T> => {
+      if (
+        path.endsWith(
+          `/actions/runs/${first.id}/attempts/${first.run_attempt}`,
+        )
+      ) {
+        return Promise.resolve(first as T);
+      }
+      if (path.includes(`/actions/runs/${first.id}/attempts/1/jobs`)) {
+        return Promise.resolve({ jobs: [apiJob("Check", 75)] } as T);
+      }
+      throw new Error(`unexpected selected-run request: ${path}`);
+    },
+  );
+  try {
+    await collector.gantt(
+      "selected-run-token",
+      CI_HISTORY_SOURCES.labs,
+      {
+        limit: 1,
+        mainOnly: true,
+        headSha: HEAD_SHA,
+        selectedRuns: [{ runId: first.id, runAttempt: first.run_attempt }],
+      },
+      NOW,
+    );
+    const restarted = new RateLimitedCiJobHistoryCollector(
+      new CiJobHistoryStore(file),
+      () => {
+        throw new Error("a credential-free request contacted GitHub");
+      },
+    );
+    await assertRejects(
+      () =>
+        restarted.gantt(
+          undefined,
+          CI_HISTORY_SOURCES.labs,
+          {
+            limit: 2,
+            mainOnly: true,
+            headSha: HEAD_SHA,
+            selectedRuns: [
+              { runId: first.id, runAttempt: first.run_attempt },
+              { runId: 9_141, runAttempt: 1 },
+            ],
+          },
+          NOW,
+        ),
+      Error,
+      "Set GH_TOKEN",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("selected-run discovery settles a failed batch before stopping", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selected-discovery-batch-test-",
+  });
+  const file = `${directory}/history.json`;
+  const runs = Array.from(
+    { length: 9 },
+    (_, index) =>
+      workflowRun(9_150 + index, NOW - index, {
+        name: "CI",
+        head_sha: HEAD_SHA,
+        path: `.github/workflows/${CI_WORKFLOW}`,
+      }),
+  );
+  const deferred = Array.from({ length: 8 }, () => {
+    let resolve!: (run: WorkflowRun) => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<WorkflowRun>((accept, decline) => {
+      resolve = accept;
+      reject = decline;
+    });
+    return { promise, resolve, reject };
+  });
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const requested: number[] = [];
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(file),
+    <T>(path: string): Promise<T> => {
+      if (path.includes("/jobs")) {
+        return Promise.resolve({ jobs: [apiJob("Check", 30)] } as T);
+      }
+      const match = path.match(/\/actions\/runs\/(\d+)\/attempts\/1$/);
+      if (!match) throw new Error(`unexpected selected-run request: ${path}`);
+      requested.push(Number(match[1]));
+      if (requested.length === 8) markStarted();
+      return deferred[requested.length - 1].promise as Promise<T>;
+    },
+  );
+  const active = collector.startGantt(
+    "selected-run-token",
+    CI_HISTORY_SOURCES.labs,
+    {
+      limit: runs.length,
+      mainOnly: true,
+      headSha: HEAD_SHA,
+      selectedRuns: runs.map((run) => ({
+        runId: run.id,
+        runAttempt: run.run_attempt,
+      })),
+    },
+    NOW,
+  );
+  const rejected = assertRejects(
+    () => active.result,
+    Error,
+    "selected metadata failed",
+  );
+  try {
+    await started;
+    assertEquals(requested, runs.slice(0, 8).map((run) => run.id));
+    assertEquals(
+      [
+        collector.progress(active.progress.id)?.discoveryRequestsMade,
+        collector.progress(active.progress.id)?.discoveryResponsesReceived,
+        collector.progress(active.progress.id)?.discoveryOutstandingRequests,
+      ],
+      [8, 0, 8],
+    );
+    deferred[0].reject(new Error("selected metadata failed"));
+    for (let index = 1; index < deferred.length; index++) {
+      deferred[index].resolve(runs[index]);
+    }
+    await rejected;
+    assertEquals(requested.length, 8);
+    assertEquals(
+      [
+        collector.progress(active.progress.id)?.phase,
+        collector.progress(active.progress.id)?.discoveryResponsesReceived,
+        collector.progress(active.progress.id)?.discoveryOutstandingRequests,
+      ],
+      ["error", 8, 0],
+    );
+
+    const restartedRequests: number[] = [];
+    const restarted = new RateLimitedCiJobHistoryCollector(
+      new CiJobHistoryStore(file),
+      <T>(path: string): Promise<T> => {
+        if (path.includes("/jobs")) {
+          return Promise.resolve({ jobs: [apiJob("Recovered", 40)] } as T);
+        }
+        const match = path.match(/\/actions\/runs\/(\d+)\/attempts\/1$/);
+        if (!match) throw new Error(`unexpected recovery request: ${path}`);
+        const run = runs.find((candidate) => candidate.id === Number(match[1]));
+        if (!run) throw new Error(`unknown recovery run: ${match[1]}`);
+        restartedRequests.push(run.id);
+        return Promise.resolve(run as T);
+      },
+    );
+    const recovered = await restarted.gantt(
+      "selected-run-token",
+      CI_HISTORY_SOURCES.labs,
+      {
+        limit: runs.length,
+        mainOnly: true,
+        headSha: HEAD_SHA,
+        selectedRuns: runs.map((run) => ({
+          runId: run.id,
+          runAttempt: run.run_attempt,
+        })),
+      },
+      NOW,
+    );
+    assertEquals(recovered.runs.length, runs.length);
+    assertEquals(restartedRequests, [runs[0].id, runs[8].id]);
+  } finally {
+    for (const [index, response] of deferred.entries()) {
+      response.resolve(runs[index]);
+    }
+    await Promise.allSettled([active.result]);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt reports shared discovery and job-fetch progress", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-progress-test-",
+  });
+  const run = workflowRun(9_106, NOW);
+  let releaseWorkflow!: (value: unknown) => void;
+  let releaseJobs!: (value: unknown) => void;
+  let markWorkflowStarted!: () => void;
+  let markJobsStarted!: () => void;
+  const workflowResponse = new Promise<unknown>((resolve) => {
+    releaseWorkflow = resolve;
+  });
+  const jobsResponse = new Promise<unknown>((resolve) => {
+    releaseJobs = resolve;
+  });
+  const workflowStarted = new Promise<void>((resolve) => {
+    markWorkflowStarted = resolve;
+  });
+  const jobsStarted = new Promise<void>((resolve) => {
+    markJobsStarted = resolve;
+  });
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>(path: string) => {
+      if (path.includes("/runs?")) {
+        markWorkflowStarted();
+        return workflowResponse as Promise<T>;
+      }
+      if (path.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+        markJobsStarted();
+        return jobsResponse as Promise<T>;
+      }
+      throw new Error(`unexpected Gantt request: ${path}`);
+    },
+  );
+  const options = { limit: 1, mainOnly: false, allConclusions: true };
+  let firstResult: Promise<CiGanttInput> | undefined;
+  try {
+    const first = collector.startGantt(
+      "gantt-progress-token",
+      CI_HISTORY_SOURCES.labs,
+      options,
+      NOW,
+    );
+    firstResult = first.result;
+    const joined = collector.startGantt(
+      "gantt-progress-token",
+      CI_HISTORY_SOURCES.labs,
+      options,
+      NOW,
+    );
+    assertEquals(joined.progress.id, first.progress.id);
+    assertEquals(joined.result, first.result);
+
+    await workflowStarted;
+    assertEquals(
+      [
+        collector.progress(first.progress.id)?.phase,
+        collector.progress(first.progress.id)?.discoveryRequestsMade,
+        collector.progress(first.progress.id)?.discoveryResponsesReceived,
+        collector.progress(first.progress.id)?.discoveryOutstandingRequests,
+      ],
+      ["discovering", 1, 0, 1],
+    );
+
+    releaseWorkflow({ workflow_runs: [run] });
+    await jobsStarted;
+    assertEquals(
+      [
+        collector.progress(first.progress.id)?.phase,
+        collector.progress(first.progress.id)?.totalRuns,
+        collector.progress(first.progress.id)?.cachedRuns,
+        collector.progress(first.progress.id)?.requestsMade,
+        collector.progress(first.progress.id)?.responsesReceived,
+        collector.progress(first.progress.id)?.outstandingRequests,
+      ],
+      ["fetching", 1, 0, 1, 0, 1],
+    );
+
+    releaseJobs({ jobs: [apiJob("Check", 30)] });
+    const result = await first.result;
+    assertEquals(result.runs[0].run.databaseId, run.id);
+    assertEquals(
+      [
+        collector.progress(first.progress.id)?.phase,
+        collector.progress(first.progress.id)?.completedRuns,
+        collector.progress(first.progress.id)?.successfulResponses,
+        collector.progress(first.progress.id)?.outstandingRequests,
+      ],
+      ["complete", 1, 1, 0],
+    );
+
+    const cached = collector.startGantt(
+      "gantt-progress-token",
+      CI_HISTORY_SOURCES.labs,
+      { ...options, limit: 2 },
+      NOW,
+    );
+    await cached.result;
+    assertEquals(
+      [
+        collector.progress(cached.progress.id)?.phase,
+        collector.progress(cached.progress.id)?.totalRuns,
+        collector.progress(cached.progress.id)?.cachedRuns,
+        collector.progress(cached.progress.id)?.requestsMade,
+      ],
+      ["complete", 1, 1, 0],
+    );
+  } finally {
+    releaseWorkflow({ workflow_runs: [] });
+    releaseJobs({ jobs: [] });
+    if (firstResult) await Promise.allSettled([firstResult]);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt reuses a run cached while collection is starting", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-concurrent-cache-test-",
+  });
+  const store = new CiJobHistoryStore(`${directory}/history.json`);
+  const run = workflowRun(9_110, NOW);
+  let jobRequests = 0;
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T>(path: string) => {
+      if (path.includes("/runs?")) {
+        return Promise.resolve({ workflow_runs: [run] } as T);
+      }
+      if (path.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+        jobRequests++;
+        return Promise.resolve({ jobs: [apiJob("Check", 30)] } as T);
+      }
+      throw new Error(`unexpected Gantt request: ${path}`);
+    },
+  );
+  try {
+    const refresh = collector.startGantt(
+      "concurrent-cache-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 1, mainOnly: false, allConclusions: true },
+      NOW,
+    );
+    let populated = false;
+    const unsubscribe = collector.subscribeProgress(
+      refresh.progress.id,
+      (progress) => {
+        if (populated || progress.phase !== "fetching") return;
+        populated = true;
+        store.set({
+          repo: REPO,
+          workflow: CI_WORKFLOW,
+          runId: run.id,
+          runAttempt: run.run_attempt,
+          runUrl: run.html_url,
+          at: NOW,
+          overallSeconds: 30,
+          jobs: [{ name: "Check", seconds: 30 }],
+          gantt: {
+            status: run.status,
+            conclusion: run.conclusion,
+            event: run.event,
+            headBranch: run.head_branch ?? undefined,
+            startedAt: run.run_started_at,
+            workflowName: "CI",
+            jobs: [],
+          },
+        });
+      },
+    );
+    const result = await refresh.result;
+    unsubscribe?.();
+
+    assert(populated);
+    assertEquals(jobRequests, 0);
+    assertEquals(result.runs[0].run.databaseId, run.id);
+    assertEquals(result.runs[0].jobs, []);
+    assertEquals(
+      [
+        collector.progress(refresh.progress.id)?.cachedRuns,
+        collector.progress(refresh.progress.id)?.requestsMade,
+        collector.progress(refresh.progress.id)?.responsesReceived,
+        collector.progress(refresh.progress.id)?.sharedRequests,
+        collector.progress(refresh.progress.id)?.sharedResponses,
+        collector.progress(refresh.progress.id)?.outstandingRequests,
+      ],
+      [1, 0, 0, 0, 0, 0],
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt progress endpoint streams collection failures", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-progress-response-test-",
+  });
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+  );
+  try {
+    const response = ciGanttProgressResponse(
+      new Request("http://dashboard/bench/gantt-progress"),
+      new URL(
+        "http://dashboard/bench/gantt-progress?repo=loom&limit=12&mainOnly=1&allConclusions=1",
+      ),
+      collector,
+      "",
+    );
+    assertEquals(response.headers.get("content-type"), "text/event-stream");
+    const events = await response.text();
+    assertStringIncludes(events, "event: progress");
+    assertStringIncludes(events, '"source":"loom"');
+    assertStringIncludes(events, '"phase":"error"');
+    assertStringIncludes(events, '"error":"set GH_TOKEN"');
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt progress reports a cached discovery fallback", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-cached-warning-test-",
+  });
+  const store = new CiJobHistoryStore(`${directory}/history.json`);
+  await store.load();
+  const run = workflowRun(9_107, NOW);
+  store.set({
+    repo: REPO,
+    workflow: CI_WORKFLOW,
+    runId: run.id,
+    runAttempt: run.run_attempt,
+    runUrl: run.html_url,
+    at: NOW,
+    overallSeconds: 30,
+    jobs: [{ name: "Check", seconds: 30 }],
+    gantt: {
+      status: run.status,
+      conclusion: run.conclusion,
+      event: run.event,
+      headBranch: run.head_branch ?? undefined,
+      startedAt: run.run_started_at,
+      workflowName: "CI",
+      jobs: [],
+    },
+  });
+  await store.save(NOW);
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    () => Promise.reject(new Error("workflow source unreachable")),
+  );
+  try {
+    const refresh = collector.startGantt(
+      "cached-warning-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 1, mainOnly: false, allConclusions: true },
+      NOW,
+    );
+    const result = await refresh.result;
+    const progress = collector.progress(refresh.progress.id);
+    assertEquals(result.runs[0].run.databaseId, run.id);
+    assertEquals(progress?.phase, "complete");
+    assertEquals(
+      [
+        progress?.discoveryRequestsMade,
+        progress?.discoveryResponsesReceived,
+        progress?.discoveryOutstandingRequests,
+      ],
+      [1, 1, 0],
+    );
+    assertStringIncludes(progress?.warning ?? "", "Showing cached runs");
+    assertStringIncludes(progress?.warning ?? "", "source unreachable");
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt progress reports partial job responses and rate limits", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-partial-warning-test-",
+  });
+  const successful = workflowRun(9_108, NOW);
+  const unavailable = workflowRun(9_109, NOW - 1_000);
+  const limited = workflowRun(9_110, NOW - 2_000);
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>(path: string) => {
+      if (path.includes("/runs?")) {
+        return Promise.resolve({
+          workflow_runs: [successful, unavailable, limited],
+        } as T);
+      }
+      if (path.includes(`/actions/runs/${successful.id}/attempts/1/jobs`)) {
+        return Promise.resolve({ jobs: [apiJob("Check", 30)] } as T);
+      }
+      if (path.includes(`/actions/runs/${unavailable.id}/attempts/1/jobs`)) {
+        return Promise.reject(new Error("workflow source unreachable"));
+      }
+      if (path.includes(`/actions/runs/${limited.id}/attempts/1/jobs`)) {
+        return Promise.reject(
+          new GitHubRateLimitBudgetError(
+            "GitHub rate limit has been hit at the 80% performance-history safety threshold.",
+          ),
+        );
+      }
+      throw new Error(`unexpected Gantt request: ${path}`);
+    },
+  );
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    const refresh = collector.startGantt(
+      "partial-warning-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 3, mainOnly: false, allConclusions: true },
+      NOW,
+    );
+    const result = await refresh.result;
+    const progress = collector.progress(refresh.progress.id);
+    assertEquals(result.runs.map(({ run }) => run.databaseId), [successful.id]);
+    assertEquals(
+      [
+        progress?.phase,
+        progress?.totalRuns,
+        progress?.successfulResponses,
+        progress?.failedResponses,
+        progress?.outstandingRequests,
+      ],
+      ["complete", 3, 1, 2, 0],
+    );
+    assertStringIncludes(progress?.warning ?? "", "2 run checks");
+    assertStringIncludes(progress?.warning ?? "", "rate limit hit");
+    assert(!(progress?.warning ?? "").includes("source unreachable"));
+  } finally {
+    console.error = originalError;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt preserves the quota error when no run can be rendered", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-quota-error-test-",
+  });
+  const first = workflowRun(9_111, NOW);
+  const second = workflowRun(9_112, NOW - 1_000);
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>(path: string) => {
+      if (path.includes("/runs?")) {
+        return Promise.resolve({ workflow_runs: [first, second] } as T);
+      }
+      if (path.includes("/jobs")) {
+        return Promise.reject(
+          new GitHubRateLimitBudgetError(
+            "GitHub rate limit has been hit at the 80% performance-history safety threshold.",
+          ),
+        );
+      }
+      throw new Error(`unexpected Gantt request: ${path}`);
+    },
+  );
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    const refresh = collector.startGantt(
+      "quota-error-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 2, mainOnly: false, allConclusions: true },
+      NOW,
+    );
+    await assertRejects(
+      () => refresh.result,
+      GitHubRateLimitBudgetError,
+      "80% performance-history safety threshold",
+    );
+    assertEquals(collector.progress(refresh.progress.id)?.phase, "error");
+    assertEquals(
+      collector.progress(refresh.progress.id)?.error,
+      "rate limit hit",
+    );
+  } finally {
+    console.error = originalError;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt preserves a specific job error when no run can be rendered", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-job-error-test-",
+  });
+  const run = workflowRun(9_113, NOW);
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>(path: string) => {
+      if (path.includes("/runs?")) {
+        return Promise.resolve({ workflow_runs: [run] } as T);
+      }
+      if (path.includes("/jobs")) {
+        return Promise.reject(new Error("job network unreachable"));
+      }
+      throw new Error(`unexpected Gantt request: ${path}`);
+    },
+  );
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    const refresh = collector.startGantt(
+      "job-error-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 1, mainOnly: false, allConclusions: true },
+      NOW,
+    );
+    await assertRejects(
+      () => refresh.result,
+      Error,
+      "job network unreachable",
+    );
+    assertEquals(collector.progress(refresh.progress.id)?.phase, "error");
+    assertEquals(
+      collector.progress(refresh.progress.id)?.error,
+      "source unreachable",
+    );
+    assertEquals(collector.progress(refresh.progress.id)?.warning, undefined);
+  } finally {
+    console.error = originalError;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt persists a completed response before a discovery fallback reuses it", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-cache-write-test-",
+  });
+  const file = `${directory}/history.json`;
+  class FailOnceStore extends CiJobHistoryStore {
+    saveCalls = 0;
+
+    override async save(now = Date.now()): Promise<void> {
+      this.saveCalls++;
+      if (this.saveCalls === 1) throw new Error("cache unavailable");
+      await super.save(now);
+    }
+  }
+  const store = new FailOnceStore(file);
+  const collector = new CiJobHistoryCollector(store);
+  const run = workflowRun(9_107, NOW);
+  let jobCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+      jobCalls++;
+      return Promise.resolve(Response.json({ jobs: [apiJob("Check", 90)] }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    await assertRejects(
+      () =>
+        collector.gantt(
+          "shared-cache-token",
+          CI_HISTORY_SOURCES.labs,
+          { limit: 10, mainOnly: true },
+          NOW,
+          [run],
+        ),
+      Error,
+      "Could not persist CI job history",
+    );
+    assertEquals([jobCalls, store.saveCalls, store.dirty], [1, 1, true]);
+
+    const cached = await collector.gantt(
+      "shared-cache-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 10, mainOnly: true },
+      NOW,
+    );
+    assertEquals(cached.runs[0].run.databaseId, run.id);
+    assertEquals([jobCalls, store.saveCalls, store.dirty], [1, 2, false]);
+    assertEquals(
+      JSON.parse(await Deno.readTextFile(file)).runs[0].runId,
+      run.id,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt includes failed main pushes when all conclusions are selected", async () => {
+  const test = await temporaryCollector();
+  const failed = workflowRun(9_108, NOW, { conclusion: "failure" });
+  const runQueries: URL[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = new URL(String(input));
+    if (url.pathname.includes(`/actions/workflows/${CI_WORKFLOW}/runs`)) {
+      runQueries.push(url);
+      return Promise.resolve(Response.json({ workflow_runs: [failed] }));
+    }
+    if (
+      url.pathname.includes(`/actions/runs/${failed.id}/attempts/1/jobs`)
+    ) {
+      return Promise.resolve(Response.json({
+        jobs: [apiJob("Failed check", 90, "failure")],
+      }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const gantt = await test.collector.gantt(
+      "all-conclusions-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 10, mainOnly: true, allConclusions: true },
+      NOW,
+    );
+    assertEquals(gantt.runs[0].run.conclusion, "failure");
+    assertEquals(gantt.runs[0].jobs[0].conclusion, "failure");
+    assertEquals(runQueries.length, 1);
+    assertEquals(runQueries[0].searchParams.get("branch"), "main");
+    assertEquals(runQueries[0].searchParams.get("event"), "push");
+    assertEquals(runQueries[0].searchParams.get("status"), null);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI Gantt keeps a constant page size while collecting 150 runs", async () => {
+  const test = await temporaryCollector();
+  const runs = Array.from(
+    { length: 200 },
+    (_, index) =>
+      workflowRun(20_000 + index, NOW - index * 60_000, {
+        status: index === 149 ? "completed" : "in_progress",
+        conclusion: index === 149 ? "success" : null,
+      }),
+  );
+  const pageSizes: number[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = new URL(String(input));
+    if (url.pathname.includes(`/actions/workflows/${CI_WORKFLOW}/runs`)) {
+      const perPage = Number(url.searchParams.get("per_page"));
+      const page = Number(url.searchParams.get("page"));
+      pageSizes.push(perPage);
+      const start = (page - 1) * perPage;
+      return Promise.resolve(Response.json({
+        workflow_runs: runs.slice(start, start + perPage),
+      }));
+    }
+    if (
+      url.pathname.includes(`/actions/runs/${runs[149].id}/attempts/1/jobs`)
+    ) {
+      return Promise.resolve(Response.json({ jobs: [apiJob("Check", 90)] }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const gantt = await test.collector.gantt(
+      "paging-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 150, mainOnly: false },
+      NOW,
+    );
+    assertEquals(pageSizes, [100, 100]);
+    assertEquals(gantt.runs.map(({ run }) => run.databaseId), [runs[149].id]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI history rejects cache rows without run provenance", async () => {
+  const test = await temporaryCollector();
+  await Deno.writeTextFile(
+    test.file,
+    JSON.stringify({
+      version: 1,
+      runs: [{
+        repo: REPO,
+        workflow: CI_WORKFLOW,
+        runId: 9_109,
+        runAttempt: 1,
+        runUrl: "https://example.test/runs/9109",
+        at: NOW,
+        overallSeconds: 90,
+        jobs: [{ name: "Check", seconds: 90 }],
+      }],
+    }),
+  );
+  const collector = new CiJobHistoryCollector(
+    new CiJobHistoryStore(test.file),
+  );
+
+  try {
+    assertEquals(
+      await collector.cached(CI_HISTORY_SOURCES.labs, 45, NOW),
+      null,
+    );
+  } finally {
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI history excludes pull request runs cached by the Gantt", async () => {
+  const test = await temporaryCollector();
+  const pullRequest = workflowRun(9_106, NOW, {
+    event: "pull_request",
+    head_branch: "feature",
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/runs/${pullRequest.id}/attempts/1/jobs`)) {
+      return Promise.resolve(Response.json({ jobs: [apiJob("Check", 90)] }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const gantt = await test.collector.gantt(
+      "shared-cache-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 10, mainOnly: false },
+      NOW,
+      [pullRequest],
+    );
+    assertEquals(gantt.runs.length, 1);
+    assertEquals(
+      await test.collector.cached(
+        CI_HISTORY_SOURCES.labs,
+        CI_HISTORY_DAYS,
+        NOW,
+      ),
+      null,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history recomputes shard concurrency as layouts age out", async () => {
+  const test = await temporaryCollector();
+  const oldRun = workflowRun(9_111, NOW - 6 * DAY);
+  const recentRun = workflowRun(9_112, NOW);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/runs/${oldRun.id}/attempts/1/jobs`)) {
+      return Promise.resolve(Response.json({
+        jobs: Array.from(
+          { length: 8 },
+          (_, shard) => apiJob(`Test (${shard + 1}/8)`, 100 + shard),
+        ),
+      }));
+    }
+    if (url.includes(`/actions/runs/${recentRun.id}/attempts/1/jobs`)) {
+      return Promise.resolve(Response.json({
+        jobs: Array.from(
+          { length: 4 },
+          (_, shard) => apiJob(`Test (${shard + 1}/4)`, 100 + shard),
+        ),
+      }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const initial = await test.collector.collect(
+      "layout-token",
+      NOW,
+      CI_HISTORY_SOURCES.labs,
+      7,
+      [oldRun, recentRun],
+    );
+    assertEquals(initial.groups[0].maxConcurrent, 8);
+
+    const aged = await test.collector.cached(
+      CI_HISTORY_SOURCES.labs,
+      7,
+      NOW + 2 * DAY,
+    );
+    assertEquals(aged?.runCount, 1);
+    assertEquals(aged?.groups[0].maxConcurrent, 4);
+    assertEquals(aged?.groups[0].shards.length, 4);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history keeps a newer partial refresh ahead of its disk cache", async () => {
+  const test = await temporaryCollector();
+  const runId = 9_121;
+  const stableRun = workflowRun(9_122, NOW - DAY);
+  let attempt = 1;
+  let failedCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/runs/${runId}/`)) {
+      if (attempt === 2) {
+        failedCalls++;
+        return Promise.resolve(new Response("unavailable", { status: 503 }));
+      }
+      return Promise.resolve(Response.json({ jobs: [apiJob("Changing", 80)] }));
+    }
+    if (url.includes(`/actions/runs/${stableRun.id}/attempts/1/jobs`)) {
+      return Promise.resolve(Response.json({ jobs: [apiJob("Stable", 70)] }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const initial = await test.collector.collect(
+      "partial-cache-token",
+      NOW,
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      [workflowRun(runId, NOW), stableRun],
+    );
+    assertEquals([initial.runCount, initial.failedRunCount], [2, 0]);
+
+    attempt = 2;
+    const partial = await test.collector.collect(
+      "partial-cache-token",
+      NOW,
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      [workflowRun(runId, NOW, { run_attempt: 2 }), stableRun],
+    );
+    assertEquals([partial.runCount, partial.failedRunCount, partial.stale], [
+      1,
+      1,
+      false,
+    ]);
+
+    const cached = await test.collector.cached(
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      NOW,
+    );
+    assertEquals(
+      [cached?.runCount, cached?.failedRunCount, cached?.stale],
+      [1, 1, false],
+    );
+    assertEquals(failedCalls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history reports a cache write failure and retries without refetching jobs", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-job-history-write-test-",
+  });
+  const parent = `${directory}/later`;
+  const file = `${parent}/history.json`;
+  let releaseRetrySave!: () => void;
+  const retrySave = new Promise<void>((resolve) => releaseRetrySave = resolve);
+  class CountingStore extends CiJobHistoryStore {
+    saveCalls = 0;
+
+    override async save(now = Date.now()): Promise<void> {
+      this.saveCalls++;
+      if (this.saveCalls === 2) await retrySave;
+      await super.save(now);
+    }
+  }
+  const store = new CountingStore(file);
+  const collector = new CiJobHistoryCollector(store);
+  const run = workflowRun(9_131, Date.now());
+  let jobCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({ workflow_runs: [run] }));
+    }
+    if (url.includes(`/actions/runs/${run.id}/attempts/1/jobs`)) {
+      jobCalls++;
+      return Promise.resolve(Response.json({ jobs: [apiJob("Check", 90)] }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const first = collector.startRefresh(
+      "write-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+    );
+    assert(first.progress);
+    await assertRejects(
+      () => first.result,
+      Error,
+      "Could not persist CI job history",
+    );
+    const failed = collector.progress(first.progress.id);
+    assertEquals(failed?.phase, "error");
+    assertEquals(failed?.failedResponses, 1);
+    assertEquals(store.dirty, true);
+    assertEquals(jobCalls, 1);
+
+    await Deno.mkdir(parent);
+    const retries = [7, 14, 21, 30, 45].map((days) =>
+      collector.startRefresh(
+        "write-token",
+        CI_HISTORY_SOURCES.labs,
+        days,
+      )
+    );
+    const stops: (() => void)[] = [];
+    await Promise.all(retries.map((retry) => {
+      assert(retry.progress);
+      return new Promise<void>((resolve) => {
+        const stop = collector.subscribeProgress(
+          retry.progress!.id,
+          (state) => {
+            if (state.phase === "saving") resolve();
+          },
+        );
+        assert(stop);
+        stops.push(stop);
+      });
+    }));
+    assertEquals(store.saveCalls, 2);
+    releaseRetrySave();
+    await Promise.all(retries.map((retry) => retry.result));
+    for (const stop of stops) stop();
+    for (const retry of retries) {
+      assert(retry.progress);
+      assertEquals(collector.progress(retry.progress.id)?.phase, "complete");
+      assertEquals(collector.progress(retry.progress.id)?.requestsMade, 0);
+    }
+    assertEquals(store.dirty, false);
+    assertEquals(store.saveCalls, 7);
+    assertEquals(jobCalls, 1);
+
+    const restarted = new CiJobHistoryCollector(new CiJobHistoryStore(file));
+    assertEquals(
+      (await restarted.cached(
+        CI_HISTORY_SOURCES.labs,
+        CI_HISTORY_DAYS,
+        Date.now(),
+      ))
+        ?.runCount,
+      1,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history reads loom when that repository is selected", async () => {
+  const test = await temporaryCollector();
+  const run = workflowRun(9_151, NOW, {
+    html_url: `https://github.com/${LOOM_REPO}/actions/runs/9151`,
+  });
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    calls.push(url);
+    if (
+      url.includes(
+        `/repos/${LOOM_REPO}/actions/workflows/${LOOM_CI_WORKFLOW}/runs?`,
+      )
+    ) {
+      return Promise.resolve(Response.json({ workflow_runs: [run] }));
+    }
+    if (
+      url.includes(
+        `/repos/${LOOM_REPO}/actions/runs/${run.id}/attempts/1/jobs`,
+      )
+    ) {
+      return Promise.resolve(Response.json({ jobs: [apiJob("Tests", 75)] }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const snapshot = await test.collector.collect(
+      "loom-token",
+      NOW,
+      CI_HISTORY_SOURCES.loom,
+    );
+    assertEquals(snapshot.jobs[0].name, "Tests");
+    assert(calls.every((call) => call.includes(`/repos/${LOOM_REPO}/`)));
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history splits a saturated workflow-run search", async () => {
+  const test = await temporaryCollector();
+  const ranges: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = new URL(String(input));
+    assertStringIncludes(
+      url.pathname,
+      `/actions/workflows/${CI_WORKFLOW}/runs`,
+    );
+    ranges.push(url.searchParams.get("created") ?? "");
+    return Promise.resolve(Response.json({
+      total_count: ranges.length === 1 ? 1_000 : 0,
+      workflow_runs: [],
+    }));
+  };
+
+  try {
+    const snapshot = await test.collector.collect("split-token", NOW);
+    assertEquals(snapshot.runCount, 0);
+    assertEquals(ranges.length, 3);
+    assert(ranges.every((range) => range.includes("..")));
+    assert(ranges[1] !== ranges[2]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history refreshes the complete latest job set after a subset rerun", async () => {
+  const test = await temporaryCollector();
+  const runId = 9_201;
+  let attempt = 1;
+  const jobCalls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({
+        workflow_runs: [
+          workflowRun(runId, NOW, { run_attempt: attempt }),
+        ],
+      }));
+    }
+    const attempted = url.match(/\/actions\/runs\/\d+\/attempts\/(\d+)\/jobs/);
+    if (attempted) {
+      jobCalls.push(url);
+      const attemptedNumber = Number(attempted[1]);
+      return Promise.resolve(Response.json({
+        jobs: attemptedNumber === 1
+          ? [apiJob("Check", 100), apiJob("Retried job", 100)]
+          : attemptedNumber === 2
+          ? [apiJob("Retried job", 200)]
+          : [apiJob("Check", 300)],
+      }));
+    }
+    if (url.includes(`/actions/runs/${runId}/`)) {
+      jobCalls.push(url);
+      return Promise.resolve(Response.json({
+        jobs: [apiJob("Check", 100), apiJob("Retried job", 100)],
+      }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const first = await test.collector.collect("rerun-token", NOW);
+    attempt = 2;
+    const second = await test.collector.collect("rerun-token", NOW);
+    attempt = 3;
+    const third = await test.collector.collect("rerun-token", NOW);
+    await test.collector.collect("rerun-token", NOW);
+    assertEquals(
+      first.jobs.map((series) => [series.name, series.points[0].seconds]),
+      [["Check", 100], ["Retried job", 100]],
+    );
+    assertEquals(
+      second.jobs.map((series) => [series.name, series.points[0].seconds]),
+      [["Check", 100], ["Retried job", 200]],
+    );
+    assertEquals(
+      third.jobs.map((series) => [series.name, series.points[0].seconds]),
+      [["Check", 300], ["Retried job", 200]],
+    );
+    assertEquals(jobCalls.length, 6);
+    assertStringIncludes(jobCalls[0], `/attempts/1/jobs`);
+    assertStringIncludes(jobCalls[1], `/attempts/1/jobs`);
+    assertStringIncludes(jobCalls[2], `/attempts/2/jobs`);
+    assertStringIncludes(jobCalls[5], `/attempts/3/jobs`);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI Gantt keeps rerun jobs on the first attempt timeline", async () => {
+  const test = await temporaryCollector();
+  const runId = 9_205;
+  const firstStart = NOW - HOUR;
+  const retryStart = NOW + 6 * HOUR;
+  const jobAt = (name: string, seconds: number, start: number) => ({
+    ...apiJob(name, seconds),
+    started_at: new Date(start).toISOString(),
+    completed_at: new Date(start + seconds * 1_000).toISOString(),
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/runs/${runId}/attempts/1/jobs`)) {
+      return Promise.resolve(Response.json({
+        jobs: [
+          jobAt("Check", 100, firstStart),
+          jobAt("Retried job", 100, firstStart + 120_000),
+        ],
+      }));
+    }
+    if (url.includes(`/actions/runs/${runId}/attempts/2/jobs`)) {
+      return Promise.resolve(Response.json({
+        jobs: [jobAt("Retried job", 200, retryStart)],
+      }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const run = workflowRun(runId, NOW, { run_attempt: 2 });
+    const history = await test.collector.collect(
+      "rerun-gantt-token",
+      NOW,
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      [run],
+    );
+    assertEquals(
+      history.jobs.find((series) => series.name === "Retried job")?.points[0]
+        .seconds,
+      200,
+    );
+
+    const gantt = await test.collector.gantt(
+      "rerun-gantt-token",
+      CI_HISTORY_SOURCES.labs,
+      { limit: 1, mainOnly: true },
+      NOW,
+      [run],
+    );
+    const retried = gantt.runs[0].jobs.find((job) =>
+      job.name === "Retried job"
+    );
+    assertEquals(
+      retried?.started_at,
+      new Date(firstStart + 120_000).toISOString(),
+    );
+    assertEquals(
+      retried?.completed_at,
+      new Date(firstStart + 220_000).toISOString(),
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history keeps the higher attempt when requests finish out of order", async () => {
+  const test = await temporaryCollector();
+  const runId = 9_211;
+  let releaseLower!: (response: Response) => void;
+  let markLowerRequested!: () => void;
+  const lowerResponse = new Promise<Response>((resolve) => {
+    releaseLower = resolve;
+  });
+  const lowerRequested = new Promise<void>((resolve) => {
+    markLowerRequested = resolve;
+  });
+  const calls: string[] = [];
+  let attemptOneCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.includes(`/actions/runs/${runId}/attempts/1/jobs`)) {
+      attemptOneCalls++;
+      if (attemptOneCalls === 1) {
+        markLowerRequested();
+        return lowerResponse;
+      }
+      return Promise.resolve(Response.json({
+        jobs: [apiJob("Check", 100)],
+      }));
+    }
+    const attempted = url.match(/\/actions\/runs\/\d+\/attempts\/(\d+)\/jobs/);
+    if (attempted) {
+      return Promise.resolve(Response.json({
+        jobs: [apiJob("Check", Number(attempted[1]) * 100)],
+      }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const lowerRequest = test.collector.collect(
+      "ordering-token",
+      NOW,
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      [workflowRun(runId, NOW)],
+    );
+    await lowerRequested;
+    const higher = await test.collector.collect(
+      "ordering-token",
+      NOW,
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      [workflowRun(runId, NOW, { run_attempt: 2 })],
+    );
+    releaseLower(Response.json({ jobs: [apiJob("Check", 100)] }));
+    const lower = await lowerRequest;
+
+    assertEquals(higher.jobs[0].points[0].seconds, 200);
+    assertEquals(lower.jobs[0].points[0].seconds, 200);
+    const callsBeforeCachedLower = calls.length;
+    const cachedLower = await test.collector.collect(
+      "ordering-token",
+      NOW,
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      [workflowRun(runId, NOW)],
+    );
+    assertEquals(cachedLower.jobs[0].points[0].seconds, 200);
+    assertEquals(calls.length, callsBeforeCachedLower);
+
+    const persisted = JSON.parse(await Deno.readTextFile(test.file));
+    assertEquals(
+      persisted.runs.map((run: { runAttempt: number }) => run.runAttempt)
+        .sort(),
+      [1, 2],
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history keeps successful samples when another run cannot be read", async () => {
+  const test = await temporaryCollector();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({
+        workflow_runs: [
+          workflowRun(9_301, NOW),
+          workflowRun(9_302, NOW - 6 * DAY),
+        ],
+      }));
+    }
+    if (url.includes(`/actions/runs/9301/attempts/1/jobs`)) {
+      return Promise.resolve(Response.json({ jobs: [apiJob("Check", 90)] }));
+    }
+    if (url.includes(`/actions/runs/9302/attempts/1/jobs`)) {
+      return Promise.resolve(new Response("unavailable", { status: 503 }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const snapshot = await test.collector.collect(
+      "partial-token",
+      NOW,
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    assertEquals(snapshot.runCount, 1);
+    assertEquals(snapshot.successfulRunTimes, [NOW - 6 * DAY, NOW]);
+    assertEquals(snapshot.failedRunCount, 1);
+    assertEquals(snapshot.failedRunTimes, [NOW - 6 * DAY]);
+    assertEquals(snapshot.stale, false);
+    assertEquals(snapshot.jobs.map((series) => series.name), ["Check"]);
+    const html = ciJobHistoryPage(snapshot, "job");
+    assertStringIncludes(html, "Showing partial data.");
+    assertStringIncludes(html, "1 sampled run could not be read.");
+    assertStringIncludes(
+      html,
+      "Coverage: 1 sampled build shown out of 2 successful main builds.",
+    );
+    assertStringIncludes(html, '<span class="cname">Check</span>');
+    assertStringIncludes(
+      ciJobHistoryPage(buildCiJobHistory([], 2), "job"),
+      "CI job timings could not be read for 2 sampled runs.",
+    );
+    assertStringIncludes(
+      ciJobHistoryPage(buildCiJobHistory([], 1), "job"),
+      "CI job timings could not be read for 1 sampled run.",
+    );
+    assertEquals(buildCiJobHistory([], 1).stale, true);
+
+    const aged = await test.collector.cached(
+      CI_HISTORY_SOURCES.labs,
+      7,
+      NOW + 2 * DAY,
+    );
+    assertEquals(aged?.runCount, 1);
+    assertEquals(aged?.successfulRunTimes, [NOW]);
+    assertEquals(aged?.failedRunCount, 0);
+    assertEquals(aged?.failedRunTimes, []);
+    assertEquals(aged?.jobs.map((series) => series.name), ["Check"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history keeps the last snapshot when every refreshed attempt fails", async () => {
+  const test = await temporaryCollector();
+  const previousRunId = 9_400;
+  const runId = 9_401;
+  let attempt = 1;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({
+        workflow_runs: attempt === 1
+          ? [
+            workflowRun(previousRunId, NOW - 6 * DAY),
+            workflowRun(runId, NOW),
+          ]
+          : [workflowRun(runId, NOW, { run_attempt: attempt })],
+      }));
+    }
+    if (url.includes(`/actions/runs/${previousRunId}/`)) {
+      return Promise.resolve(Response.json({ jobs: [apiJob("Check", 80)] }));
+    }
+    if (url.includes(`/actions/runs/${runId}/`)) {
+      return attempt === 1
+        ? Promise.resolve(Response.json({ jobs: [apiJob("Check", 90)] }))
+        : Promise.resolve(new Response("unavailable", { status: 503 }));
+    }
+    if (url.includes("/actions/runs/9402/")) {
+      return Promise.resolve(new Response("unavailable", { status: 503 }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    const first = await test.collector.collect(
+      "stale-token",
+      NOW,
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    attempt = 2;
+    const stale = await test.collector.collect(
+      "stale-token",
+      NOW,
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    assertEquals(first.jobs[0].points.map((point) => point.seconds), [80, 90]);
+    assertEquals(stale.jobs[0].points.map((point) => point.seconds), [80, 90]);
+    assertEquals(first.successfulRunTimes, [NOW - 6 * DAY, NOW]);
+    assertEquals(stale.successfulRunTimes, [NOW - 6 * DAY, NOW]);
+    assertEquals(stale.runCount, 2);
+    assertEquals(stale.failedRunCount, 1);
+    assertEquals(stale.failedRunTimes, [NOW]);
+    assertEquals(stale.stale, true);
+    const html = ciJobHistoryPage(stale, "job");
+    assertStringIncludes(
+      html,
+      "Coverage: 2 sampled builds shown out of 2 successful main builds.",
+    );
+    assertStringIncludes(html, "Showing the last collected data.");
+    assert(!html.includes("Showing partial data."));
+
+    const expired = await test.collector.collect(
+      "stale-token",
+      NOW + 8 * DAY,
+      CI_HISTORY_SOURCES.labs,
+      7,
+      [workflowRun(9_402, NOW + 8 * DAY)],
+    );
+    assertEquals(expired.runCount, 0);
+    assertEquals(expired.failedRunCount, 1);
+    assertEquals(expired.failedRunTimes, [NOW + 8 * DAY]);
+    assertEquals(expired.stale, true);
+    assertEquals(expired.overall, null);
+    assertEquals(expired.groups, []);
+    assertEquals(expired.jobs, []);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history sorts named shard suffixes and formats hour-long jobs", () => {
+  const snapshot = buildCiJobHistory([{
+    runId: 9_501,
+    runUrl: "https://example.test/runs/9501",
+    at: NOW,
+    jobs: [
+      { name: "Build (windows)", seconds: 3_700 },
+      { name: "Build (linux)", seconds: 3_600 },
+    ],
+  }]);
+
+  assertEquals(
+    snapshot.groups[0].shards.map((series) => series.name),
+    ["Build (linux)", "Build (windows)"],
+  );
+  assertStringIncludes(ciJobHistoryPage(snapshot, "job"), "1h 01m");
+});
+
+Deno.test("CI job history rejects a one-second workflow search with over 1,000 runs", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>() => Promise.resolve({ total_count: 1_000, workflow_runs: [] } as T),
+  );
+  try {
+    await assertRejects(
+      () => collector.collect("token", NOW),
+      Error,
+      "exceeded 1,000 results in one second",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history paginates workflow searches and honors the reported total", async () => {
+  for (const reportsTotal of [false, true]) {
+    const directory = await Deno.makeTempDir({
+      prefix: "ci-job-history-test-",
+    });
+    const pages: number[] = [];
+    const runs = Array.from(
+      { length: 100 },
+      (_, index) =>
+        workflowRun(10_000 + index, NOW - index, { conclusion: "failure" }),
+    );
+    const collector = new RateLimitedCiJobHistoryCollector(
+      new CiJobHistoryStore(`${directory}/history.json`),
+      <T>(path: string) => {
+        const page = Number(
+          new URL(`https://example.test/${path}`).searchParams.get("page"),
+        );
+        pages.push(page);
+        return Promise.resolve({
+          ...(reportsTotal ? { total_count: 100 } : {}),
+          workflow_runs: page === 1 ? runs : [
+            workflowRun(10_101, NOW - 101, { conclusion: "failure" }),
+          ],
+        } as T);
+      },
+    );
+    try {
+      assertEquals((await collector.collect("token", NOW)).runCount, 0);
+      assertEquals(pages, reportsTotal ? [1] : [1, 2]);
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  }
+});
+
+Deno.test("CI job history ignores invalid job times and uses a timed rerun in the Gantt", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const run = workflowRun(10_200, NOW, { run_attempt: 2 });
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>(path: string) => {
+      const jobs = path.includes("attempts/1")
+        ? [{
+          name: "Retry",
+          status: "completed",
+          conclusion: "failure",
+          started_at: null,
+          completed_at: null,
+        }, {
+          name: "Invalid clock",
+          status: "completed",
+          conclusion: "success",
+          started_at: "not-a-date",
+          completed_at: new Date(NOW).toISOString(),
+        }]
+        : [{ ...apiJob("Retry", 30), status: "completed" }];
+      return Promise.resolve({ jobs } as T);
+    },
+  );
+  try {
+    const snapshot = await collector.collect("token", NOW, undefined, 45, [
+      run,
+    ]);
+    assertEquals(snapshot.jobs.map((series) => series.name), ["Retry"]);
+    const gantt = await collector.gantt(
+      undefined,
+      CI_HISTORY_SOURCES.labs,
+      { limit: 1, mainOnly: true, allConclusions: false },
+      NOW,
+    );
+    assertEquals(gantt.runs[0].jobs[0].conclusion, "success");
+    assertEquals(
+      gantt.runs[0].jobs[0].started_at,
+      apiJob("Retry", 30).started_at,
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history removes progress listeners that throw", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  let resolveRuns: (value: unknown) => void = () => {};
+  const pending = new Promise<unknown>((resolve) => resolveRuns = resolve);
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>() => pending as Promise<T>,
+  );
+  try {
+    const refresh = collector.startRefresh("token");
+    assert(refresh.progress);
+    assertEquals(collector.subscribeProgress("missing", () => {}), null);
+    assertEquals(
+      collector.subscribeProgress(refresh.progress.id, () => {
+        throw new Error("initial listener failed");
+      }),
+      null,
+    );
+    let calls = 0;
+    assert(collector.subscribeProgress(refresh.progress.id, () => {
+      calls++;
+      if (calls > 1) throw new Error("update listener failed");
+    }));
+    resolveRuns({ workflow_runs: [] });
+    await refresh.result;
+    assertEquals(calls, 2);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history quarantines a future refresh when reading cached data", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const file = `${directory}/history.json`;
+  const store = new CiJobHistoryStore(file);
+  const now = Date.now();
+  try {
+    await store.load();
+    const run = store.set({
+      repo: REPO,
+      workflow: CI_WORKFLOW,
+      runId: 10_300,
+      runAttempt: 1,
+      runUrl: `https://github.com/${REPO}/actions/runs/10300`,
+      at: now,
+      overallSeconds: 30,
+      jobs: [{ name: "Check", seconds: 30 }],
+      gantt: {
+        status: "completed",
+        conclusion: "success",
+        event: "push",
+        headBranch: "main",
+        workflowName: "CI",
+        startedAt: new Date(now).toISOString(),
+        jobs: [],
+      },
+    });
+    store.markRefreshed(
+      REPO,
+      CI_WORKFLOW,
+      45,
+      now + DAY,
+      [now],
+      [{ runId: run.runId, runAttempt: run.runAttempt }],
+      0,
+      [],
+      false,
+    );
+    await store.save(now);
+
+    const collector = new RateLimitedCiJobHistoryCollector(store);
+    assertEquals((await collector.cached(undefined, 45, now))?.runCount, 1);
+    const persisted = JSON.parse(await Deno.readTextFile(file));
+    assertEquals(persisted.refreshes, []);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt reports missing credentials and includes cached failed main runs", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const store = new CiJobHistoryStore(`${directory}/history.json`);
+  const collector = new RateLimitedCiJobHistoryCollector(store);
+  try {
+    await assertRejects(
+      () =>
+        collector.gantt(undefined, CI_HISTORY_SOURCES.labs, {
+          limit: 1,
+          mainOnly: true,
+          allConclusions: true,
+        }),
+      Error,
+      "Set GH_TOKEN",
+    );
+    const failed = workflowRun(10_400, NOW, { conclusion: "failure" });
+    store.set({
+      repo: REPO,
+      workflow: CI_WORKFLOW,
+      runId: failed.id,
+      runAttempt: 1,
+      runUrl: failed.html_url,
+      at: NOW,
+      overallSeconds: 0,
+      jobs: [],
+      gantt: {
+        status: "completed",
+        conclusion: "failure",
+        event: "push",
+        headBranch: "main",
+        workflowName: "CI",
+        startedAt: failed.run_started_at,
+        jobs: [],
+      },
+    });
+    await store.save(NOW);
+    const cachedRefresh = collector.startGantt(
+      undefined,
+      CI_HISTORY_SOURCES.labs,
+      { limit: 1, mainOnly: true, allConclusions: true },
+      NOW,
+    );
+    const cached = await cachedRefresh.result;
+    assertEquals(cached.runs[0].run.conclusion, "failure");
+    assertEquals(
+      collector.progress(cachedRefresh.progress.id)?.warning,
+      "Showing cached runs; set GH_TOKEN to check for newer attempts.",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("the production CI Gantt wrapper forwards a source with no cached data", async () => {
+  const source: CiHistorySource = {
+    ...CI_HISTORY_SOURCES.labs,
+    repo: `uncached/repo-${crypto.randomUUID()}`,
+  };
+  await assertRejects(
+    () =>
+      collectCiGanttInput(source, {
+        limit: 1,
+        mainOnly: true,
+        allConclusions: false,
+      }, ""),
+    Error,
+    "Set GH_TOKEN",
+  );
+});
+
+Deno.test("CI job history detects when its exact stale snapshot cannot be retained", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const store = new CiJobHistoryStore(`${directory}/history.json`);
+  let failJobs = false;
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T>() =>
+      failJobs
+        ? Promise.reject(new Error("jobs unavailable"))
+        : Promise.resolve({ jobs: [apiJob("Check", 30)] } as T),
+  );
+  const run = workflowRun(10_500, NOW);
+  try {
+    assertEquals(
+      (await collector.collect("token", NOW, undefined, 45, [run])).runCount,
+      1,
+    );
+    await store.save(NOW + 100 * DAY);
+    failJobs = true;
+    await assertRejects(
+      () => collector.collect("token", NOW, undefined, 45, [run]),
+      Error,
+      "could not preserve the exact previous run set",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt reuses recent discovery and reports discovery failure without cache", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const run = workflowRun(10_600, NOW);
+  let workflowRequests = 0;
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>(path: string) => {
+      if (path.includes("/runs?")) {
+        workflowRequests++;
+        return Promise.resolve({ workflow_runs: [run] } as T);
+      }
+      return Promise.resolve({ jobs: [apiJob("Check", 30)] } as T);
+    },
+  );
+  const options = { limit: 1, mainOnly: false, allConclusions: true };
+  try {
+    assertEquals(
+      (await collector.gantt("token", CI_HISTORY_SOURCES.labs, options, NOW))
+        .runs.length,
+      1,
+    );
+    assertEquals(
+      (await collector.gantt("token", CI_HISTORY_SOURCES.labs, options, NOW))
+        .runs.length,
+      1,
+    );
+    assertEquals(workflowRequests, 1);
+
+    const failed = new RateLimitedCiJobHistoryCollector(
+      new CiJobHistoryStore(`${directory}/failed.json`),
+      () => Promise.reject(new Error("discovery failed")),
+    );
+    await assertRejects(
+      () => failed.gantt("token", CI_HISTORY_SOURCES.labs, options, NOW),
+      Error,
+      "discovery failed",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI Gantt reports job failures and falls back to an older cached attempt", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const options = { limit: 1, mainOnly: true, allConclusions: false };
+  try {
+    const noRuns = new RateLimitedCiJobHistoryCollector(
+      new CiJobHistoryStore(`${directory}/no-runs.json`),
+    );
+    await assertRejects(
+      () =>
+        noRuns.gantt(
+          "token",
+          CI_HISTORY_SOURCES.labs,
+          options,
+          NOW,
+          [],
+        ),
+      Error,
+      "No completed CI runs with cached job timings",
+    );
+
+    const empty = new RateLimitedCiJobHistoryCollector(
+      new CiJobHistoryStore(`${directory}/empty.json`),
+      () => Promise.reject("job request failed"),
+    );
+    await assertRejects(
+      () =>
+        empty.gantt(
+          "token",
+          CI_HISTORY_SOURCES.labs,
+          options,
+          NOW,
+          [workflowRun(10_700, NOW)],
+        ),
+      Error,
+      "job request failed",
+    );
+
+    const store = new CiJobHistoryStore(`${directory}/cached.json`);
+    await store.load();
+    const oldRun = workflowRun(10_701, NOW);
+    store.set({
+      repo: REPO,
+      workflow: CI_WORKFLOW,
+      runId: oldRun.id,
+      runAttempt: 1,
+      runUrl: oldRun.html_url,
+      at: NOW,
+      overallSeconds: 30,
+      jobs: [{ name: "Old check", seconds: 30 }],
+      gantt: {
+        status: "completed",
+        conclusion: "success",
+        event: "push",
+        headBranch: "main",
+        workflowName: "CI",
+        startedAt: oldRun.run_started_at,
+        jobs: [],
+      },
+    });
+    await store.save(NOW);
+    const cached = new RateLimitedCiJobHistoryCollector(
+      store,
+      () => Promise.reject(new Error("new attempt failed")),
+    );
+    const result = await cached.gantt(
+      "token",
+      CI_HISTORY_SOURCES.labs,
+      options,
+      NOW,
+      [{ ...oldRun, run_attempt: 2 }],
+    );
+    assertEquals(result.runs[0].run.attempt, 1);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history joins an active refresh for the same window", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  let resolveRuns: (value: unknown) => void = () => {};
+  const runs = new Promise<unknown>((resolve) => resolveRuns = resolve);
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>() => runs as Promise<T>,
+  );
+  try {
+    const first = collector.startRefresh("token", CI_HISTORY_SOURCES.labs, 7);
+    const second = collector.startRefresh(
+      "token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+      buildCiJobHistory([]),
+    );
+    assert(first.progress);
+    assertEquals(second.progress?.id, first.progress.id);
+    assertEquals(second.result, first.result);
+    resolveRuns({ workflow_runs: [] });
+    await second.result;
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history restores its prior manifest when the manifest write fails", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  class FailManifestSaveStore extends CiJobHistoryStore {
+    saveCalls = 0;
+    failManifestSave = false;
+
+    override markRefreshed(
+      ...args: Parameters<CiJobHistoryStore["markRefreshed"]>
+    ): void {
+      super.markRefreshed(...args);
+      this.failManifestSave = true;
+    }
+
+    override async save(now = Date.now()): Promise<void> {
+      this.saveCalls++;
+      if (this.failManifestSave) throw new Error("manifest write failed");
+      await super.save(now);
+    }
+  }
+  const store = new FailManifestSaveStore(`${directory}/history.json`);
+  const run = workflowRun(10_800, Date.now() - 1_000);
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T>(path: string) =>
+      Promise.resolve(
+        (path.includes("/runs?")
+          ? { workflow_runs: [run] }
+          : { jobs: [apiJob("Check", 30)] }) as T,
+      ),
+  );
+  try {
+    await assertRejects(
+      () => collector.startRefresh("token").result,
+      Error,
+      "manifest write failed",
+    );
+    assertEquals(store.saveCalls, 2);
+    assertEquals(
+      store.refresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS),
+      undefined,
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history rejects a missing persisted refresh manifest", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const store = new CiJobHistoryStore(`${directory}/history.json`);
+  store.refresh = (() => undefined) as typeof store.refresh;
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T>() => Promise.resolve({ workflow_runs: [] } as T),
+  );
+  try {
+    await assertRejects(
+      () => collector.startRefresh("token").result,
+      Error,
+      "refresh manifest was not persisted",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history reloads when concurrent persistence changes its manifest", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const store = new CiJobHistoryStore(`${directory}/history.json`);
+  const readRefresh = store.refresh.bind(store);
+  let reads = 0;
+  store.refresh = ((...args): CachedCiHistoryRefresh | undefined => {
+    const refresh = readRefresh(...args);
+    reads++;
+    return refresh && reads >= 2
+      ? { ...refresh, stale: !refresh.stale }
+      : refresh;
+  }) as typeof store.refresh;
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T>() => Promise.resolve({ workflow_runs: [] } as T),
+  );
+  try {
+    assertEquals((await collector.startRefresh("token").result).runCount, 0);
+    assertEquals(reads >= 2, true);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history completes when a persisted manifest is immediately invalidated", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const store = new CiJobHistoryStore(`${directory}/history.json`);
+  store.freshRefresh = (() => undefined) as typeof store.freshRefresh;
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T>() => Promise.resolve({ workflow_runs: [] } as T),
+  );
+  try {
+    assertEquals((await collector.startRefresh("token").result).runCount, 0);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history reports persistence failure while recording a rate limit", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const store = new CiJobHistoryStore(`${directory}/missing/history.json`);
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    () => Promise.reject(new GitHubRateLimitBudgetError("limited")),
+  );
+  try {
+    const error = await assertRejects(
+      () => collector.startRefresh("token").result,
+      Error,
+    );
+    assertStringIncludes(error.message, "No such file or directory");
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history progress responses close completed streams", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  const collector = new RateLimitedCiJobHistoryCollector(
+    new CiJobHistoryStore(`${directory}/history.json`),
+    <T>() => Promise.resolve({ workflow_runs: [] } as T),
+  );
+  try {
+    assertEquals(
+      ciJobHistoryProgressResponse(
+        new URL("http://x/bench/ci-progress"),
+        collector,
+      ).status,
+      400,
+    );
+    assertEquals(
+      ciJobHistoryProgressResponse(
+        new URL("http://x/bench/ci-progress?id=missing"),
+        collector,
+      ).status,
+      404,
+    );
+    const refresh = collector.startRefresh("token");
+    assert(refresh.progress);
+    await refresh.result;
+    const response = ciJobHistoryProgressResponse(
+      new URL(`http://x/bench/ci-progress?id=${refresh.progress.id}`),
+      collector,
+    );
+    const body = await response.text();
+    assertStringIncludes(body, '"phase":"complete"');
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history progress streams ignore duplicate terminal updates", async () => {
+  const complete: CiJobFetchProgress = {
+    id: "duplicate-terminal",
+    source: "labs",
+    days: 45,
+    phase: "complete",
+    discoveryRequestsMade: 1,
+    discoveryResponsesReceived: 1,
+    discoveryOutstandingRequests: 0,
+    totalRuns: 0,
+    cachedRuns: 0,
+    requestsMade: 0,
+    responsesReceived: 0,
+    sharedRequests: 0,
+    sharedResponses: 0,
+    successfulResponses: 0,
+    failedResponses: 0,
+    completedRuns: 0,
+    queuedRuns: 0,
+    outstandingRequests: 0,
+    needsReload: false,
+    updatedAt: NOW,
+  };
+  const collector = {
+    progress: () => complete,
+    subscribeProgress: (
+      _id: string,
+      listener: (progress: CiJobFetchProgress) => void,
+    ) => {
+      listener(complete);
+      listener(complete);
+      return () => {};
+    },
+  } as unknown as RateLimitedCiJobHistoryCollector;
+  const response = ciJobHistoryProgressResponse(
+    new URL("http://x/bench/ci-progress?id=duplicate-terminal"),
+    collector,
+  );
+  assertStringIncludes(await response.text(), '"phase":"complete"');
+});
+
+Deno.test("CI history endpoints handle immediate and background refreshes", async () => {
+  const cached = buildCiJobHistory(historySamples());
+  const progress: CiJobFetchProgress = {
+    id: "background",
+    source: "labs",
+    days: 45,
+    phase: "discovering",
+    discoveryRequestsMade: 0,
+    discoveryResponsesReceived: 0,
+    discoveryOutstandingRequests: 0,
+    totalRuns: 0,
+    cachedRuns: 0,
+    requestsMade: 0,
+    responsesReceived: 0,
+    sharedRequests: 0,
+    sharedResponses: 0,
+    successfulResponses: 0,
+    failedResponses: 0,
+    completedRuns: 0,
+    queuedRuns: 0,
+    outstandingRequests: 0,
+    needsReload: false,
+    updatedAt: NOW,
+  };
+  const immediate = {
+    cached: () => Promise.resolve(null),
+    startRefresh: () => ({ progress: null, result: Promise.resolve(cached) }),
+  };
+  const checked = await ciJobHistoryCheckResponse(
+    new URL("http://x/bench/check?view=ci"),
+    immediate,
+    "token",
+  );
+  assertEquals(
+    (await checked.json()).version,
+    ciJobHistorySnapshotVersion(cached),
+  );
+
+  const background = {
+    cached: () => Promise.resolve(cached),
+    startRefresh: () => ({
+      progress,
+      result: Promise.reject(new Error("background failed")),
+    }),
+  };
+  const response = await ciJobHistoryResponse(
+    new URL("http://x/bench?view=ci"),
+    background,
+    "token",
+  );
+  assertStringIncludes(
+    await response.text(),
+    'data-progress-url="/bench/ci-progress?id=background"',
+  );
+});

--- a/packages/dashboard/ci-job-history.ts
+++ b/packages/dashboard/ci-job-history.ts
@@ -1,0 +1,3284 @@
+// Historical wall-clock duration for every job in the labs and loom CI
+// workflows. The page samples successful main runs, persists each completed
+// attempt's jobs, and uses the same trailing-parenthesis grouping as
+// scripts/ci-gantt.ts.
+import {
+  type CachedCiGanttJob,
+  type CachedCiRun,
+  type CachedCiRunReference,
+  CiJobHistoryStore,
+} from "./ci-job-cache.ts";
+import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "./config.ts";
+import {
+  clampInt,
+  durationTag,
+  escapeHtml,
+  friendlyError,
+  github,
+  performanceGithub,
+  SPARK_FADE,
+  sparkline,
+} from "./lib.ts";
+import { GitHubRateLimitBudgetError } from "./github-rate-limit.ts";
+import {
+  distinctTrendDays,
+  trendPct,
+  trendPctLabel,
+  trendStatus,
+} from "./trend.ts";
+import {
+  PERFORMANCE_CHECK_MS,
+  performanceViewNav,
+} from "./performance-views.ts";
+
+export const CI_HISTORY_DAYS = 45;
+export const CI_HISTORY_MIN_DAYS = 1;
+export const CI_HISTORY_POINT_TARGET = 90;
+export const CI_HISTORY_BUCKET_HOURS = CI_HISTORY_DAYS * 24 /
+  CI_HISTORY_POINT_TARGET;
+
+const DAY_MS = 86_400_000;
+const JOBS_PER_PAGE = 100;
+const JOB_FETCH_CONCURRENCY = 8;
+const REFRESH_MS = 30 * 60_000;
+const GITHUB_SEARCH_LIMIT = 1_000;
+export const GANTT_MAX_RUNS = 150;
+const SELECTED_WORKFLOW_RUN_CACHE_MAX = GANTT_MAX_RUNS;
+const PROGRESS_RECORD_MAX = 256;
+
+type GitHubRequest = <T = unknown>(
+  path: string,
+  token?: string,
+) => Promise<T>;
+
+export interface WorkflowRun {
+  id: number;
+  status: string;
+  conclusion: string | null;
+  event: string;
+  head_branch?: string | null;
+  head_sha?: string;
+  path?: string;
+  run_attempt: number;
+  run_started_at: string;
+  html_url: string;
+  name?: string;
+}
+
+interface ApiStep {
+  name: string;
+  number: number;
+  conclusion: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+interface ApiJob {
+  name: string;
+  status?: string;
+  conclusion: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  steps?: ApiStep[];
+}
+
+export interface CiGanttInputRun {
+  run: {
+    attempt: number;
+    databaseId: number;
+    status: string;
+    conclusion: string;
+    event: string;
+    headBranch?: string;
+    startedAt: string;
+    workflowName?: string;
+  };
+  jobs: CachedCiGanttJob[];
+}
+
+export interface CiGanttInput {
+  runs: CiGanttInputRun[];
+}
+
+export interface CiGanttOptions {
+  limit: number;
+  mainOnly: boolean;
+  allConclusions?: boolean;
+  selectedRuns?: CiGanttRunSelection[];
+  headSha?: string;
+}
+
+export interface CiGanttRunSelection {
+  runId: number;
+  runAttempt: number;
+}
+
+export interface CiGanttRefresh {
+  progress: CiJobFetchProgress;
+  result: Promise<CiGanttInput>;
+}
+
+export interface CiTimedJob {
+  name: string;
+  seconds: number;
+}
+
+export interface CiHistorySample {
+  runId: number;
+  runUrl: string;
+  at: number;
+  overallSeconds?: number;
+  jobs: CiTimedJob[];
+}
+
+export interface CiJobPoint {
+  at: number;
+  seconds: number;
+  runId: number;
+  runUrl: string;
+}
+
+export interface CiJobSeries {
+  kind: "job" | "group" | "overall";
+  name: string;
+  base: string;
+  points: CiJobPoint[];
+}
+
+export interface CiShardGroup {
+  base: string;
+  maxConcurrent: number;
+  aggregate: CiJobSeries;
+  shards: CiJobSeries[];
+}
+
+export interface CiJobHistorySnapshot {
+  runCount: number;
+  successfulRunTimes: number[] | null;
+  failedRunCount: number;
+  failedRunTimes: number[];
+  stale: boolean;
+  axisStart: number;
+  axisEnd: number;
+  overall: CiJobSeries | null;
+  groups: CiShardGroup[];
+  jobs: CiJobSeries[];
+}
+
+export type CiJobFetchPhase =
+  | "discovering"
+  | "fetching"
+  | "saving"
+  | "complete"
+  | "error";
+
+export interface CiJobFetchProgress {
+  id: string;
+  source: CiHistorySourceKey;
+  days: number;
+  phase: CiJobFetchPhase;
+  discoveryRequestsMade: number;
+  discoveryResponsesReceived: number;
+  discoveryOutstandingRequests: number;
+  totalRuns: number;
+  cachedRuns: number;
+  requestsMade: number;
+  responsesReceived: number;
+  sharedRequests: number;
+  sharedResponses: number;
+  successfulResponses: number;
+  failedResponses: number;
+  completedRuns: number;
+  queuedRuns: number;
+  outstandingRequests: number;
+  needsReload: boolean;
+  updatedAt: number;
+  error?: string;
+  warning?: string;
+}
+
+export interface CiJobRefresh {
+  progress: CiJobFetchProgress | null;
+  result: Promise<CiJobHistorySnapshot>;
+}
+
+type CiJobProgressListener = (progress: CiJobFetchProgress) => void;
+
+interface CiJobProgressRecord {
+  state: CiJobFetchProgress;
+  listeners: Set<CiJobProgressListener>;
+  baselines: Set<string>;
+}
+
+interface CiWorkflowDiscovery<Result = WorkflowRun[]> {
+  progresses: Set<CiJobProgressRecord>;
+  requestsMade: number;
+  responsesReceived: number;
+  result: Promise<Result>;
+}
+
+interface SelectedWorkflowRuns {
+  runs: WorkflowRun[];
+  failure?: { error: unknown };
+}
+
+interface CiGanttRequest {
+  progress: CiJobProgressRecord;
+  result: Promise<CiGanttInput>;
+}
+
+type CiJobFetchOutcome =
+  | { run: WorkflowRun; entry: CachedCiRun }
+  | { run: WorkflowRun; error: unknown; persistence: boolean };
+
+interface CiJobLoad {
+  kind: "cached" | "joined" | "requested";
+  result: Promise<CachedCiRun>;
+}
+
+class CiJobCacheWriteError extends Error {
+  constructor(error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    super(`Could not persist CI job history: ${message}`, { cause: error });
+    this.name = "CiJobCacheWriteError";
+  }
+}
+
+export type CiHistorySourceKey = "labs" | "loom";
+
+export interface CiHistorySource {
+  key: CiHistorySourceKey;
+  label: string;
+  repo: string;
+  workflow: string;
+}
+
+export const CI_HISTORY_SOURCES: Record<CiHistorySourceKey, CiHistorySource> = {
+  labs: { key: "labs", label: "labs", repo: REPO, workflow: CI_WORKFLOW },
+  loom: {
+    key: "loom",
+    label: "loom",
+    repo: LOOM_REPO,
+    workflow: LOOM_CI_WORKFLOW,
+  },
+};
+
+export function baseJobName(name: string): string {
+  return name.replace(/\s*\([^)]*\)\s*$/, "");
+}
+
+function shardKey(name: string): string {
+  const fraction = name.match(/\((\d+)\/(\d+)\)/);
+  if (fraction) return String(Number(fraction[1])).padStart(4, "0");
+  const suffix = name.match(/\(([^)]*)\)\s*$/);
+  return suffix ? suffix[1] : "";
+}
+
+function runTime(run: WorkflowRun): number {
+  return Date.parse(run.run_started_at);
+}
+
+function validateSelectedWorkflowRun(
+  run: WorkflowRun,
+  selected: CiGanttRunSelection,
+  source: CiHistorySource,
+  headSha: string,
+): WorkflowRun {
+  const workflowPath = run.path?.split("@", 1)[0];
+  const expectedWorkflowPath = `.github/workflows/${source.workflow}`;
+  if (
+    run.id !== selected.runId || run.run_attempt !== selected.runAttempt ||
+    run.head_sha?.toLowerCase() !== headSha ||
+    workflowPath !== expectedWorkflowPath
+  ) {
+    throw new Error(
+      `Selected CI run ${selected.runId} attempt ${selected.runAttempt} does not match the requested commit and workflow.`,
+    );
+  }
+  return {
+    id: run.id,
+    status: run.status,
+    conclusion: run.conclusion,
+    event: run.event,
+    head_branch: run.head_branch,
+    head_sha: run.head_sha,
+    path: run.path,
+    run_attempt: run.run_attempt,
+    run_started_at: run.run_started_at,
+    html_url: run.html_url,
+    name: run.name,
+  };
+}
+
+export function ciHistoryDays(value: string | null): number {
+  return clampInt(
+    value,
+    CI_HISTORY_DAYS,
+    CI_HISTORY_MIN_DAYS,
+    CI_HISTORY_DAYS,
+  );
+}
+
+export function ciHistorySource(value: string | null): CiHistorySource {
+  return value === "loom" ? CI_HISTORY_SOURCES.loom : CI_HISTORY_SOURCES.labs;
+}
+
+export function ciGanttOptions(
+  parameters: URLSearchParams,
+): CiGanttOptions {
+  const selectedRuns = parameters.getAll("run").flatMap((value) => {
+    const match = value.match(/^(\d+):(\d+)$/);
+    if (!match) return [];
+    const runId = Number(match[1]);
+    const runAttempt = Number(match[2]);
+    return Number.isSafeInteger(runId) && runId > 0 &&
+        Number.isSafeInteger(runAttempt) && runAttempt > 0
+      ? [{ runId, runAttempt }]
+      : [];
+  });
+  const options: CiGanttOptions = {
+    limit: clampInt(parameters.get("limit"), 60, 1, GANTT_MAX_RUNS),
+    mainOnly: parameters.get("mainOnly") === "1",
+    allConclusions: parameters.get("allConclusions") === "1",
+  };
+  if (selectedRuns.length) options.selectedRuns = selectedRuns;
+  const headSha = parameters.get("sha") ?? "";
+  if (selectedRuns.length && /^[0-9a-f]{40}$/i.test(headSha)) {
+    options.headSha = headSha.toLowerCase();
+  }
+  return options;
+}
+
+function normalizedGanttOptions(
+  options: CiGanttOptions,
+): Required<CiGanttOptions> {
+  const requestedLimit = Number.isFinite(options.limit)
+    ? Math.floor(options.limit)
+    : GANTT_MAX_RUNS;
+  const selectedRuns = new Map<number, CiGanttRunSelection>();
+  for (const selected of options.selectedRuns ?? []) {
+    if (
+      !Number.isSafeInteger(selected.runId) || selected.runId <= 0 ||
+      !Number.isSafeInteger(selected.runAttempt) || selected.runAttempt <= 0
+    ) continue;
+    const current = selectedRuns.get(selected.runId);
+    if (!current || current.runAttempt < selected.runAttempt) {
+      selectedRuns.set(selected.runId, { ...selected });
+    }
+    if (selectedRuns.size >= GANTT_MAX_RUNS) break;
+  }
+  const headSha = options.headSha?.toLowerCase() ?? "";
+  if (selectedRuns.size && !/^[0-9a-f]{40}$/.test(headSha)) {
+    throw new Error("Selected CI runs require a commit SHA.");
+  }
+  return {
+    limit: selectedRuns.size ||
+      Math.max(1, Math.min(GANTT_MAX_RUNS, requestedLimit)),
+    mainOnly: options.mainOnly,
+    allConclusions: options.allConclusions === true,
+    selectedRuns: [...selectedRuns.values()],
+    headSha,
+  };
+}
+
+export function ciHistoryBucketMs(days: number): number {
+  return days * DAY_MS / CI_HISTORY_POINT_TARGET;
+}
+
+function sampleNewestPerBucket<T>(
+  values: T[],
+  at: (value: T) => number,
+  cutoff: number,
+  bucketMs: number,
+): T[] {
+  const eligible = values.filter((value) => {
+    const time = at(value);
+    return Number.isFinite(time) && time >= cutoff;
+  });
+  if (eligible.length <= CI_HISTORY_POINT_TARGET) {
+    return eligible.sort((a, b) => at(a) - at(b));
+  }
+  const buckets = new Map<number, T>();
+  for (const value of eligible) {
+    const time = at(value);
+    const bucket = Math.floor((time - cutoff) / bucketMs);
+    const current = buckets.get(bucket);
+    if (!current || time > at(current)) buckets.set(bucket, value);
+  }
+  return [...buckets.values()].sort((a, b) => at(a) - at(b));
+}
+
+export function sampleWorkflowRuns(
+  runs: WorkflowRun[],
+  now = Date.now(),
+  days = CI_HISTORY_DAYS,
+): WorkflowRun[] {
+  const eligible = successfulMainWorkflowRuns(runs, now, days);
+  const cutoff = now - days * DAY_MS;
+  return sampleNewestPerBucket(
+    eligible,
+    runTime,
+    cutoff,
+    ciHistoryBucketMs(days),
+  );
+}
+
+function successfulMainWorkflowRuns(
+  runs: WorkflowRun[],
+  now: number,
+  days: number,
+): WorkflowRun[] {
+  const cutoff = now - days * DAY_MS;
+  const eligible = new Map<number, WorkflowRun>();
+  for (const run of runs) {
+    const at = runTime(run);
+    if (
+      run.status !== "completed" || run.conclusion !== "success" ||
+      run.event !== "push" ||
+      (run.head_branch !== undefined && run.head_branch !== null &&
+        run.head_branch !== "main") ||
+      !Number.isFinite(at) || at < cutoff || at > now
+    ) continue;
+    const current = eligible.get(run.id);
+    if (!current || run.run_attempt > current.run_attempt) {
+      eligible.set(run.id, run);
+    }
+  }
+  return [...eligible.values()];
+}
+
+async function fetchWorkflowRuns(
+  token: string,
+  now: number,
+  source: CiHistorySource,
+  request: GitHubRequest,
+): Promise<WorkflowRun[]> {
+  const cutoff = now - CI_HISTORY_DAYS * DAY_MS;
+  // GitHub caps every filtered workflow-run search at 1,000 results. Query the
+  // complete window first, then divide only a saturated range. The one-day
+  // buffer covers runs that were created before the cutoff but started after it.
+  const searchRange = async (
+    start: number,
+    end: number,
+  ): Promise<WorkflowRun[]> => {
+    const requestPage = (page: number) => {
+      const created = `${new Date(start).toISOString()}..${
+        new Date(end).toISOString()
+      }`;
+      const params = new URLSearchParams({
+        branch: "main",
+        event: "push",
+        status: "success",
+        created,
+        per_page: "100",
+        page: String(page),
+      });
+      return request<{
+        total_count?: number;
+        workflow_runs?: WorkflowRun[];
+      }>(
+        `repos/${source.repo}/actions/workflows/${source.workflow}/runs?${params}`,
+        token,
+      );
+    };
+
+    const first = await requestPage(1);
+    const firstBatch = first.workflow_runs ?? [];
+    if ((first.total_count ?? firstBatch.length) >= GITHUB_SEARCH_LIMIT) {
+      if (end - start <= 1_000) {
+        throw new Error(
+          "GitHub workflow-run search exceeded 1,000 results in one second",
+        );
+      }
+      const midpoint = Math.floor((start + end) / 2);
+      return [
+        ...await searchRange(start, midpoint),
+        ...await searchRange(midpoint, end),
+      ];
+    }
+
+    const runs = [...firstBatch];
+    for (let page = 2; firstBatch.length === 100; page++) {
+      if (first.total_count !== undefined && runs.length >= first.total_count) {
+        break;
+      }
+      const response = await requestPage(page);
+      const batch = response.workflow_runs ?? [];
+      runs.push(...batch);
+      if (batch.length < 100) break;
+    }
+    return runs;
+  };
+
+  const runs = await searchRange(cutoff - DAY_MS, now);
+  const unique = new Map<number, WorkflowRun>();
+  for (const run of runs) {
+    const current = unique.get(run.id);
+    if (!current || run.run_attempt > current.run_attempt) {
+      unique.set(run.id, run);
+    }
+  }
+  return [...unique.values()];
+}
+
+async function fetchRecentWorkflowRuns(
+  token: string,
+  source: CiHistorySource,
+  mainOnly: boolean,
+  request: GitHubRequest,
+): Promise<WorkflowRun[]> {
+  const runs: WorkflowRun[] = [];
+  for (let page = 1; runs.length < GANTT_MAX_RUNS; page++) {
+    const params = new URLSearchParams({
+      per_page: "100",
+      page: String(page),
+    });
+    if (mainOnly) {
+      params.set("branch", "main");
+      params.set("event", "push");
+    }
+    const response = await request<{ workflow_runs?: WorkflowRun[] }>(
+      `repos/${source.repo}/actions/workflows/${source.workflow}/runs?${params}`,
+      token,
+    );
+    const batch = response.workflow_runs ?? [];
+    runs.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return runs.slice(0, GANTT_MAX_RUNS);
+}
+
+interface TimedApiJob {
+  timing: CiTimedJob;
+  start: number;
+  end: number;
+}
+
+interface CiRunTiming {
+  jobs: CiTimedJob[];
+  overallSeconds: number;
+  ganttJobs: CachedCiGanttJob[];
+}
+
+function timedJob(job: ApiJob): TimedApiJob | null {
+  if (
+    job.conclusion !== "success" || !job.started_at || !job.completed_at
+  ) {
+    return null;
+  }
+  const start = Date.parse(job.started_at);
+  const end = Date.parse(job.completed_at);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    return null;
+  }
+  return {
+    timing: { name: job.name, seconds: (end - start) / 1_000 },
+    start,
+    end,
+  };
+}
+
+function hasJobTiming(job: ApiJob): boolean {
+  if (!job.started_at || !job.completed_at) return false;
+  const start = Date.parse(job.started_at);
+  const end = Date.parse(job.completed_at);
+  return Number.isFinite(start) && Number.isFinite(end) && end > start;
+}
+
+function isDrawableGanttJob(job: ApiJob | CachedCiGanttJob): boolean {
+  return job.conclusion !== "skipped" && hasJobTiming(job);
+}
+
+function ganttJob(job: ApiJob): CachedCiGanttJob {
+  return {
+    name: job.name,
+    status: job.status ?? "completed",
+    conclusion: job.conclusion,
+    started_at: job.started_at,
+    completed_at: job.completed_at,
+    steps: (job.steps ?? []).map((step) => ({
+      name: step.name,
+      number: step.number,
+      conclusion: step.conclusion,
+      started_at: step.started_at,
+      completed_at: step.completed_at,
+    })),
+  };
+}
+
+async function fetchJobPage(
+  path: string,
+  token: string,
+  source: CiHistorySource,
+  request: GitHubRequest,
+): Promise<ApiJob[]> {
+  const jobs: ApiJob[] = [];
+  for (let page = 1;; page++) {
+    const response = await request<{ jobs?: ApiJob[] }>(
+      `repos/${source.repo}/${path}${
+        path.includes("?") ? "&" : "?"
+      }per_page=${JOBS_PER_PAGE}&page=${page}`,
+      token,
+    );
+    const batch = response.jobs ?? [];
+    jobs.push(...batch);
+    if (batch.length < JOBS_PER_PAGE) break;
+  }
+  return jobs;
+}
+
+async function fetchRunJobs(
+  run: WorkflowRun,
+  token: string,
+  source: CiHistorySource,
+  request: GitHubRequest,
+): Promise<CiRunTiming> {
+  let jobs: ApiJob[];
+  let ganttJobs: ApiJob[];
+  if (run.run_attempt > 1) {
+    const complete = new Map<string, ApiJob>();
+    let firstAttempt: ApiJob[] = [];
+    for (let attempt = 1; attempt <= run.run_attempt; attempt++) {
+      const attempted = await fetchJobPage(
+        `actions/runs/${run.id}/attempts/${attempt}/jobs`,
+        token,
+        source,
+        request,
+      );
+      if (attempt === 1) firstAttempt = attempted;
+      for (const job of attempted) complete.set(job.name, job);
+    }
+    jobs = [...complete.values()];
+    ganttJobs = firstAttempt.map((job) => {
+      const latest = complete.get(job.name)!;
+      if (!hasJobTiming(job) && hasJobTiming(latest)) return latest;
+      return {
+        ...job,
+        status: latest.status,
+        conclusion: latest.conclusion,
+      };
+    });
+  } else {
+    jobs = await fetchJobPage(
+      `actions/runs/${run.id}/attempts/1/jobs`,
+      token,
+      source,
+      request,
+    );
+    ganttJobs = jobs;
+  }
+  if (!ganttJobs.some(isDrawableGanttJob)) {
+    throw new Error(
+      `No completed CI job timings were returned for run ${run.id} attempt ${run.run_attempt}.`,
+    );
+  }
+  const timed = jobs.flatMap((job) => {
+    const value = timedJob(job);
+    return value ? [value] : [];
+  });
+  const start = timed.length ? Math.min(...timed.map((job) => job.start)) : 0;
+  const end = timed.length ? Math.max(...timed.map((job) => job.end)) : 0;
+  return {
+    jobs: timed.map((job) => job.timing),
+    overallSeconds: start && end > start ? (end - start) / 1_000 : 0,
+    ganttJobs: ganttJobs.map(ganttJob),
+  };
+}
+
+export function buildCiJobHistory(
+  samples: CiHistorySample[],
+  failedRunCount = 0,
+  axis?: { start: number; end: number },
+  failedRunTimes: number[] = [],
+  successfulRunTimes: number[] | null = null,
+): CiJobHistorySnapshot {
+  const jobSeries = new Map<string, CiJobSeries>();
+  const groupPoints = new Map<string, CiJobPoint[]>();
+  const overallPoints: CiJobPoint[] = [];
+  const shardedBases = new Set<string>();
+  const maxConcurrent = new Map<string, number>();
+
+  for (const sample of samples) {
+    if (
+      sample.overallSeconds !== undefined &&
+      Number.isFinite(sample.overallSeconds) && sample.overallSeconds > 0
+    ) {
+      overallPoints.push({
+        at: sample.at,
+        seconds: sample.overallSeconds,
+        runId: sample.runId,
+        runUrl: sample.runUrl,
+      });
+    }
+    // A re-run can return two records with the same job name. Keep the longer
+    // successful record so one run contributes one point to each series.
+    const jobsByName = new Map<string, CiTimedJob>();
+    for (const job of sample.jobs) {
+      const current = jobsByName.get(job.name);
+      if (!current || job.seconds > current.seconds) {
+        jobsByName.set(job.name, job);
+      }
+    }
+    const jobsByBase = new Map<string, CiTimedJob[]>();
+    for (const job of jobsByName.values()) {
+      const base = baseJobName(job.name);
+      let series = jobSeries.get(job.name);
+      if (!series) {
+        series = { kind: "job", name: job.name, base, points: [] };
+        jobSeries.set(job.name, series);
+      }
+      const point = {
+        at: sample.at,
+        seconds: job.seconds,
+        runId: sample.runId,
+        runUrl: sample.runUrl,
+      };
+      series.points.push(point);
+      const siblings = jobsByBase.get(base);
+      if (siblings) siblings.push(job);
+      else jobsByBase.set(base, [job]);
+    }
+    for (const [base, jobs] of jobsByBase) {
+      if (jobs.length > 1) shardedBases.add(base);
+      maxConcurrent.set(
+        base,
+        Math.max(maxConcurrent.get(base) ?? 0, jobs.length),
+      );
+      const slowest = jobs.reduce((a, b) => a.seconds >= b.seconds ? a : b);
+      const points = groupPoints.get(base);
+      const point = {
+        at: sample.at,
+        seconds: slowest.seconds,
+        runId: sample.runId,
+        runUrl: sample.runUrl,
+      };
+      if (points) points.push(point);
+      else groupPoints.set(base, [point]);
+    }
+  }
+
+  const groups = [...shardedBases].sort().map((base): CiShardGroup => {
+    const shards = [...jobSeries.values()]
+      .filter((series) => series.base === base)
+      .sort((a, b) =>
+        shardKey(a.name).localeCompare(shardKey(b.name)) ||
+        a.name.localeCompare(b.name)
+      );
+    return {
+      base,
+      maxConcurrent: maxConcurrent.get(base) ?? shards.length,
+      aggregate: {
+        kind: "group",
+        name: base,
+        base,
+        points: groupPoints.get(base)!,
+      },
+      shards,
+    };
+  });
+  const jobs = [...jobSeries.values()]
+    .filter((series) => !shardedBases.has(series.base))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const times = samples.map((sample) => sample.at).filter(Number.isFinite);
+  return {
+    runCount: samples.length,
+    successfulRunTimes,
+    failedRunCount,
+    failedRunTimes,
+    stale: samples.length === 0 && failedRunCount > 0,
+    axisStart: axis?.start ?? (times.length ? Math.min(...times) : 0),
+    axisEnd: axis?.end ?? (times.length ? Math.max(...times) : 0),
+    overall: overallPoints.length
+      ? {
+        kind: "overall",
+        name: "Overall CI",
+        base: "Overall CI",
+        points: overallPoints,
+      }
+      : null,
+    groups,
+    jobs,
+  };
+}
+
+const snapshotKey = (source: CiHistorySource, days: number): string =>
+  `${source.key}:${days}`;
+
+function snapshotFingerprint(
+  snapshot: CiJobHistorySnapshot | null,
+): string {
+  if (!snapshot) return "none";
+  return JSON.stringify([
+    snapshot.runCount,
+    snapshot.successfulRunTimes,
+    snapshot.failedRunCount,
+    snapshot.failedRunTimes,
+    snapshot.stale,
+    snapshot.overall,
+    snapshot.groups,
+    snapshot.jobs,
+  ]);
+}
+
+export function ciJobHistorySnapshotVersion(
+  snapshot: CiJobHistorySnapshot | null,
+): string {
+  const value = snapshotFingerprint(snapshot);
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function inRequestedWindow(
+  snapshot: CiJobHistorySnapshot,
+  now: number,
+  days: number,
+): CiJobHistorySnapshot {
+  const axisStart = now - days * DAY_MS;
+  const samples = new Map<number, CiHistorySample>();
+  const sampleFor = (point: CiJobPoint): CiHistorySample | null => {
+    if (point.at < axisStart || point.at > now) return null;
+    let sample = samples.get(point.runId);
+    if (!sample) {
+      sample = {
+        runId: point.runId,
+        runUrl: point.runUrl,
+        at: point.at,
+        jobs: [],
+      };
+      samples.set(point.runId, sample);
+    }
+    return sample;
+  };
+  for (const point of snapshot.overall?.points ?? []) {
+    const sample = sampleFor(point);
+    if (sample) sample.overallSeconds = point.seconds;
+  }
+  const jobs = [
+    ...snapshot.jobs,
+    ...snapshot.groups.flatMap((group) => group.shards),
+  ];
+  for (const series of jobs) {
+    for (const point of series.points) {
+      const sample = sampleFor(point);
+      if (sample) {
+        sample.jobs.push({ name: series.name, seconds: point.seconds });
+      }
+    }
+  }
+  const failedRunTimes = snapshot.failedRunTimes.filter((at) =>
+    at >= axisStart && at <= now
+  );
+  const successfulRunTimes =
+    snapshot.successfulRunTimes?.filter((at) => at >= axisStart && at <= now) ??
+      null;
+  const untimedFailureCount = Math.max(
+    0,
+    snapshot.failedRunCount - snapshot.failedRunTimes.length,
+  );
+  const overlapsOriginalWindow = snapshot.axisEnd >= axisStart &&
+    snapshot.axisStart <= now;
+  const failedRunCount = failedRunTimes.length +
+    (overlapsOriginalWindow ? untimedFailureCount : 0);
+  const filtered = buildCiJobHistory(
+    [...samples.values()].sort((a, b) => a.at - b.at),
+    failedRunCount,
+    { start: axisStart, end: now },
+    failedRunTimes,
+    successfulRunTimes,
+  );
+  return {
+    ...filtered,
+    stale: filtered.runCount > 0 ? snapshot.stale : filtered.stale,
+  };
+}
+
+function sampleFromCache(run: CachedCiRun): CiHistorySample {
+  return {
+    runId: run.runId,
+    runUrl: run.runUrl,
+    at: run.at,
+    overallSeconds: run.overallSeconds,
+    jobs: run.jobs,
+  };
+}
+
+function isSuccessfulMainCachedRun(run: CachedCiRun): boolean {
+  return run.gantt.status === "completed" &&
+    run.gantt.conclusion === "success" && run.gantt.event === "push" &&
+    (run.gantt.headBranch === undefined || run.gantt.headBranch === "main");
+}
+
+function isMainCachedRun(run: CachedCiRun): boolean {
+  return run.gantt.status === "completed" &&
+    run.gantt.event === "push" &&
+    (run.gantt.headBranch === undefined || run.gantt.headBranch === "main");
+}
+
+function hasDrawableGanttTiming(run: CachedCiRun): boolean {
+  return run.gantt.jobs.some(isDrawableGanttJob);
+}
+
+function workflowRunFromCache(
+  run: CachedCiRun,
+  source: CiHistorySource,
+): WorkflowRun {
+  return {
+    id: run.runId,
+    status: run.gantt.status,
+    conclusion: run.gantt.conclusion,
+    event: run.gantt.event,
+    head_branch: run.gantt.headBranch,
+    head_sha: run.headSha,
+    path: `.github/workflows/${source.workflow}`,
+    run_attempt: run.runAttempt,
+    run_started_at: run.gantt.startedAt,
+    html_url: run.runUrl,
+    name: run.gantt.workflowName,
+  };
+}
+
+function ganttInputRun(run: CachedCiRun): CiGanttInputRun {
+  return {
+    run: {
+      attempt: run.runAttempt,
+      databaseId: run.runId,
+      status: run.gantt.status,
+      conclusion: run.gantt.conclusion ?? "",
+      event: run.gantt.event,
+      headBranch: run.gantt.headBranch,
+      startedAt: run.gantt.startedAt,
+      workflowName: run.gantt.workflowName,
+    },
+    jobs: run.gantt.jobs,
+  };
+}
+
+export class CiJobHistoryCollector {
+  #store: CiJobHistoryStore;
+  #github: GitHubRequest;
+  #cacheSaves = new Map<number, Promise<void>>();
+  #jobRequests = new Map<string, Promise<CachedCiRun>>();
+  #latest = new Map<string, CiJobHistorySnapshot>();
+  #sampledRuns = new Map<string, CachedCiRunReference[]>();
+  #snapshotRevisions = new Map<string, number>();
+  #progressById = new Map<string, CiJobProgressRecord>();
+  #progressByKey = new Map<string, CiJobProgressRecord>();
+  #progressSequence = 0;
+  #refreshedAt = new Map<string, { at: number; revision: number }>();
+  #refreshFailureAt = new Map<CiHistorySourceKey, number>();
+  #refreshRequests = new Map<string, Promise<CiJobHistorySnapshot>>();
+  #recentWorkflowRuns = new Map<string, { at: number; runs: WorkflowRun[] }>();
+  #selectedWorkflowRuns = new Map<
+    string,
+    { at: number; run: WorkflowRun }
+  >();
+  #recentWorkflowRequests = new Map<string, CiWorkflowDiscovery>();
+  #selectedWorkflowRequests = new Map<
+    string,
+    CiWorkflowDiscovery<SelectedWorkflowRuns>
+  >();
+  #workflowRuns = new Map<
+    CiHistorySourceKey,
+    { at: number; runs: WorkflowRun[] }
+  >();
+  #workflowRequests = new Map<CiHistorySourceKey, CiWorkflowDiscovery>();
+  #ganttRequests = new Map<string, CiGanttRequest>();
+
+  constructor(
+    store = new CiJobHistoryStore(),
+    request: GitHubRequest = performanceGithub,
+  ) {
+    this.#store = store;
+    this.#github = request;
+  }
+
+  #newProgress(
+    source: CiHistorySource,
+    days: number,
+    baseline?: CiJobHistorySnapshot | null,
+    key = snapshotKey(source, days),
+  ): CiJobProgressRecord {
+    const previous = this.#progressByKey.get(key);
+    if (previous) {
+      this.#progressByKey.delete(key);
+      this.#progressById.delete(previous.state.id);
+    }
+    const now = Date.now();
+    const state: CiJobFetchProgress = {
+      id: `${source.key}-${days}-${now.toString(36)}-${++this
+        .#progressSequence}`,
+      source: source.key,
+      days,
+      phase: "discovering",
+      discoveryRequestsMade: 0,
+      discoveryResponsesReceived: 0,
+      discoveryOutstandingRequests: 0,
+      totalRuns: 0,
+      cachedRuns: 0,
+      requestsMade: 0,
+      responsesReceived: 0,
+      sharedRequests: 0,
+      sharedResponses: 0,
+      successfulResponses: 0,
+      failedResponses: 0,
+      completedRuns: 0,
+      queuedRuns: 0,
+      outstandingRequests: 0,
+      needsReload: false,
+      updatedAt: now,
+    };
+    const record = {
+      state,
+      listeners: new Set<CiJobProgressListener>(),
+      baselines: new Set(
+        baseline === undefined ? [] : [snapshotFingerprint(baseline)],
+      ),
+    };
+    this.#progressByKey.set(key, record);
+    this.#progressById.set(state.id, record);
+    this.#trimProgressRecords(record);
+    return record;
+  }
+
+  #trimProgressRecords(preserve: CiJobProgressRecord): void {
+    if (this.#progressByKey.size <= PROGRESS_RECORD_MAX) return;
+    for (const [key, record] of this.#progressByKey) {
+      if (this.#progressByKey.size <= PROGRESS_RECORD_MAX) break;
+      const terminal = record.state.phase === "complete" ||
+        record.state.phase === "error";
+      if (record !== preserve && terminal) {
+        this.#progressByKey.delete(key);
+        this.#progressById.delete(record.state.id);
+      }
+    }
+  }
+
+  #updateProgress(
+    record: CiJobProgressRecord,
+    update: Partial<CiJobFetchProgress>,
+  ): void {
+    Object.assign(record.state, update);
+    record.state.completedRuns = Math.min(
+      record.state.totalRuns,
+      record.state.cachedRuns + record.state.responsesReceived +
+        record.state.sharedResponses,
+    );
+    record.state.queuedRuns = Math.max(
+      0,
+      record.state.totalRuns - record.state.cachedRuns -
+        record.state.requestsMade - record.state.sharedRequests,
+    );
+    record.state.outstandingRequests = Math.max(
+      0,
+      record.state.requestsMade + record.state.sharedRequests -
+        record.state.responsesReceived - record.state.sharedResponses,
+    );
+    record.state.updatedAt = Date.now();
+    const value = { ...record.state };
+    for (const listener of record.listeners) {
+      try {
+        listener(value);
+      } catch {
+        record.listeners.delete(listener);
+      }
+    }
+    if (update.phase === "complete" || update.phase === "error") {
+      this.#trimProgressRecords(record);
+    }
+  }
+
+  #startJobLoadProgress(
+    progress: CiJobProgressRecord,
+    kind: CiJobLoad["kind"],
+  ): void {
+    if (kind === "requested") {
+      this.#updateProgress(progress, {
+        requestsMade: progress.state.requestsMade + 1,
+      });
+    } else if (kind === "joined") {
+      this.#updateProgress(progress, {
+        sharedRequests: progress.state.sharedRequests + 1,
+      });
+    }
+  }
+
+  #finishJobLoadProgress(
+    progress: CiJobProgressRecord,
+    kind: CiJobLoad["kind"],
+    succeeded: boolean,
+  ): void {
+    if (kind === "cached") {
+      this.#updateProgress(progress, {
+        cachedRuns: progress.state.cachedRuns + 1,
+      });
+      return;
+    }
+    this.#updateProgress(progress, {
+      responsesReceived: progress.state.responsesReceived +
+        (kind === "requested" ? 1 : 0),
+      sharedResponses: progress.state.sharedResponses +
+        (kind === "joined" ? 1 : 0),
+      successfulResponses: progress.state.successfulResponses +
+        (succeeded ? 1 : 0),
+      failedResponses: progress.state.failedResponses + (succeeded ? 0 : 1),
+    });
+  }
+
+  progress(id: string): CiJobFetchProgress | null {
+    const record = this.#progressById.get(id);
+    return record ? { ...record.state } : null;
+  }
+
+  subscribeProgress(
+    id: string,
+    listener: CiJobProgressListener,
+  ): (() => void) | null {
+    const record = this.#progressById.get(id);
+    if (!record) return null;
+    record.listeners.add(listener);
+    try {
+      listener({ ...record.state });
+    } catch {
+      record.listeners.delete(listener);
+      return null;
+    }
+    return () => record.listeners.delete(listener);
+  }
+
+  snapshot(
+    source = CI_HISTORY_SOURCES.labs,
+    days = CI_HISTORY_DAYS,
+  ): CiJobHistorySnapshot | null {
+    return this.#latest.get(snapshotKey(source, days)) ?? null;
+  }
+
+  async cached(
+    source = CI_HISTORY_SOURCES.labs,
+    days = CI_HISTORY_DAYS,
+    now = Date.now(),
+  ): Promise<CiJobHistorySnapshot | null> {
+    await this.#store.load();
+    const key = snapshotKey(source, days);
+    if (
+      this.#store.quarantineFutureRefresh(
+        source.repo,
+        source.workflow,
+        days,
+      )
+    ) {
+      this.#refreshedAt.delete(key);
+      await this.#saveCache(now);
+    }
+    const refresh = this.#store.refresh(
+      source.repo,
+      source.workflow,
+      days,
+    );
+    const current = this.snapshot(source, days);
+    const sourceRevision = this.#store.revisionFor(
+      source.repo,
+      source.workflow,
+    );
+    if (current && this.#snapshotRevisions.get(key) === sourceRevision) {
+      return inRequestedWindow(current, now, days);
+    }
+    const cutoff = now - days * DAY_MS;
+    const successfulRunTimes =
+      refresh?.successfulRunTimes.filter((at) => at >= cutoff && at <= now) ??
+        null;
+    const resolvedRefreshRuns = this.#store.refreshedRuns(
+      source.repo,
+      source.workflow,
+      days,
+    );
+    const refreshedRuns =
+      resolvedRefreshRuns?.filter((run) => run.at >= cutoff && run.at <= now) ??
+        resolvedRefreshRuns;
+    const runs = refreshedRuns ?? sampleNewestPerBucket(
+      this.#store.list(source.repo, source.workflow, cutoff).filter(
+        isSuccessfulMainCachedRun,
+      ),
+      (run) => run.at,
+      cutoff,
+      ciHistoryBucketMs(days),
+    );
+    if (!runs.length && !refresh) {
+      return current ? inRequestedWindow(current, now, days) : null;
+    }
+    const failedRunTimes =
+      refresh?.failedRunTimes.filter((at) => at >= cutoff && at <= now) ?? [];
+    const untimedFailureCount = refresh
+      ? Math.max(0, refresh.failedRunCount - refresh.failedRunTimes.length)
+      : 0;
+    const built = buildCiJobHistory(
+      runs.map(sampleFromCache),
+      failedRunTimes.length + untimedFailureCount,
+      { start: cutoff, end: now },
+      failedRunTimes,
+      successfulRunTimes,
+    );
+    const value = refresh?.stale && built.runCount
+      ? { ...built, stale: true }
+      : built;
+    this.#sampledRuns.set(
+      key,
+      runs.map((run) => ({
+        runId: run.runId,
+        runAttempt: run.runAttempt,
+      })),
+    );
+    this.#latest.set(key, value);
+    this.#snapshotRevisions.set(
+      key,
+      this.#store.revisionFor(source.repo, source.workflow),
+    );
+    const freshRefresh = this.#store.freshRefresh(
+      source.repo,
+      source.workflow,
+      days,
+    );
+    if (freshRefresh) {
+      this.#refreshedAt.set(key, {
+        at: freshRefresh.refreshedAt,
+        revision: this.#store.revisionFor(source.repo, source.workflow),
+      });
+    }
+    return value;
+  }
+
+  #jobsForRun(
+    run: WorkflowRun,
+    token: string,
+    source: CiHistorySource,
+    now: number,
+    exactAttempt = false,
+    expectedHeadSha = "",
+  ): CiJobLoad {
+    const pending = this.#pendingJobsForRun(run, source, exactAttempt);
+    if (pending) return { kind: "joined", result: pending };
+    let cached = exactAttempt
+      ? this.#store.get(
+        source.repo,
+        source.workflow,
+        run.id,
+        run.run_attempt,
+      )
+      : this.#store.latest(source.repo, source.workflow, run.id);
+    if (exactAttempt && cached && run.head_sha) {
+      cached = this.#store.setHeadSha(
+        source.repo,
+        source.workflow,
+        run.id,
+        run.run_attempt,
+        run.head_sha,
+      );
+    }
+    const repairCachedEntry = exactAttempt && cached !== undefined &&
+      !hasDrawableGanttTiming(cached);
+    if (
+      cached &&
+      (exactAttempt
+        ? cached.runAttempt === run.run_attempt &&
+          cached.headSha === expectedHeadSha &&
+          hasDrawableGanttTiming(cached)
+        : cached.runAttempt >= run.run_attempt)
+    ) {
+      return { kind: "cached", result: Promise.resolve(cached) };
+    }
+
+    const key =
+      `${source.repo}:${source.workflow}:${run.id}:${run.run_attempt}:${
+        exactAttempt ? "exact" : "aggregate"
+      }`;
+    let request = this.#jobRequests.get(key);
+    if (!request) {
+      request = fetchRunJobs(run, token, source, this.#github)
+        .then(async (timing): Promise<CachedCiRun> => {
+          const entry = {
+            repo: source.repo,
+            workflow: source.workflow,
+            runId: run.id,
+            runAttempt: run.run_attempt,
+            headSha: run.head_sha?.toLowerCase(),
+            runUrl: run.html_url,
+            at: runTime(run),
+            overallSeconds: timing.overallSeconds,
+            jobs: timing.jobs,
+            gantt: {
+              status: run.status,
+              conclusion: run.conclusion,
+              event: run.event,
+              headBranch: run.head_branch ?? undefined,
+              startedAt: run.run_started_at,
+              workflowName: run.name ?? source.workflow,
+              jobs: timing.ganttJobs,
+            },
+          };
+          if (repairCachedEntry) this.#store.replace(entry);
+          else this.#store.set(entry);
+          const cached = exactAttempt
+            ? this.#store.get(
+              source.repo,
+              source.workflow,
+              run.id,
+              run.run_attempt,
+            )!
+            : this.#store.latest(source.repo, source.workflow, run.id)!;
+          try {
+            await this.#saveCache(now);
+          } catch (error) {
+            throw new CiJobCacheWriteError(error);
+          }
+          return cached;
+        })
+        .finally(() => this.#jobRequests.delete(key));
+      this.#jobRequests.set(key, request);
+    }
+    return { kind: "requested", result: request };
+  }
+
+  #jobRequestPrefix(run: WorkflowRun, source: CiHistorySource): string {
+    return `${source.repo}:${source.workflow}:${run.id}:`;
+  }
+
+  #pendingJobsForRun(
+    run: WorkflowRun,
+    source: CiHistorySource,
+    exactAttempt = false,
+  ): Promise<CachedCiRun> | null {
+    const prefix = this.#jobRequestPrefix(run, source);
+    let newestAttempt = -1;
+    let pending: Promise<CachedCiRun> | null = null;
+    for (const [key, request] of this.#jobRequests) {
+      if (!key.startsWith(prefix)) continue;
+      const [attemptValue, mode] = key.slice(prefix.length).split(":", 2);
+      if (mode !== (exactAttempt ? "exact" : "aggregate")) continue;
+      const attempt = Number(attemptValue);
+      if (
+        (exactAttempt
+          ? attempt === run.run_attempt
+          : attempt >= run.run_attempt) &&
+        attempt > newestAttempt
+      ) {
+        newestAttempt = attempt;
+        pending = request;
+      }
+    }
+    return pending;
+  }
+
+  async #saveCache(now: number): Promise<void> {
+    if (!this.#store.dirty) return;
+    const revision = this.#store.revision;
+    let request = this.#cacheSaves.get(revision);
+    if (!request) {
+      const save = this.#store.save(now);
+      const saveRevision = this.#store.revision;
+      request = save.finally(() => {
+        this.#cacheSaves.delete(revision);
+        this.#cacheSaves.delete(saveRevision);
+      });
+      this.#cacheSaves.set(revision, request);
+      this.#cacheSaves.set(saveRevision, request);
+    }
+    await request;
+  }
+
+  async collect(
+    token: string,
+    now = Date.now(),
+    source = CI_HISTORY_SOURCES.labs,
+    days = CI_HISTORY_DAYS,
+    workflowRuns?: WorkflowRun[],
+    progress?: CiJobProgressRecord,
+  ): Promise<CiJobHistorySnapshot> {
+    await this.#store.load();
+    const previous = this.snapshot(source, days) ??
+      await this.cached(source, days, now);
+    const workflowRunHistory = workflowRuns ??
+      await fetchWorkflowRuns(token, now, source, this.#github);
+    const successfulRuns = successfulMainWorkflowRuns(
+      workflowRunHistory,
+      now,
+      days,
+    );
+    const successfulRunTimes = successfulRuns.map(runTime).sort((a, b) =>
+      a - b
+    );
+    const runs = sampleNewestPerBucket(
+      successfulRuns,
+      runTime,
+      now - days * DAY_MS,
+      ciHistoryBucketMs(days),
+    );
+    const priorRefresh = this.#store.refresh(
+      source.repo,
+      source.workflow,
+      days,
+    );
+    const desiredRuns = runs.map((run) => ({
+      runId: run.id,
+      runAttempt: run.run_attempt,
+    }));
+    if (
+      priorRefresh &&
+      JSON.stringify(priorRefresh.sampledRuns) !== JSON.stringify(desiredRuns)
+    ) {
+      this.#store.invalidateRefresh(source.repo, source.workflow, days);
+      this.#refreshedAt.delete(snapshotKey(source, days));
+      await this.#saveCache(now);
+    }
+    const entries = new Map<number, CachedCiRun>();
+    for (const run of runs) {
+      const cached = this.#store.latest(source.repo, source.workflow, run.id);
+      if (
+        cached && cached.runAttempt >= run.run_attempt &&
+        !this.#pendingJobsForRun(run, source)
+      ) {
+        entries.set(run.id, cached);
+      }
+    }
+    const missing = runs.filter((run) => !entries.has(run.id));
+    if (progress) {
+      this.#updateProgress(progress, {
+        phase: "fetching",
+        totalRuns: runs.length,
+        cachedRuns: entries.size,
+        needsReload: missing.length > 0,
+      });
+    }
+    const failed = new Map<number, unknown>();
+    for (let i = 0; i < missing.length; i += JOB_FETCH_CONCURRENCY) {
+      const batch = missing.slice(i, i + JOB_FETCH_CONCURRENCY);
+      const outcomes = await Promise.all(
+        batch.map(async (run): Promise<CiJobFetchOutcome> => {
+          const load = this.#jobsForRun(run, token, source, now);
+          if (progress) this.#startJobLoadProgress(progress, load.kind);
+          try {
+            const entry = await load.result;
+            if (progress) {
+              this.#finishJobLoadProgress(progress, load.kind, true);
+            }
+            return { run, entry };
+          } catch (error) {
+            if (progress) {
+              this.#finishJobLoadProgress(progress, load.kind, false);
+            }
+            return {
+              run,
+              error,
+              persistence: error instanceof CiJobCacheWriteError,
+            };
+          }
+        }),
+      );
+      const persistenceFailure = outcomes.find((outcome) =>
+        "error" in outcome && outcome.persistence
+      );
+      if (persistenceFailure && "error" in persistenceFailure) {
+        throw persistenceFailure.error;
+      }
+      for (const outcome of outcomes) {
+        if ("entry" in outcome) entries.set(outcome.run.id, outcome.entry);
+        else failed.set(outcome.run.id, outcome.error);
+      }
+    }
+    if (progress) this.#updateProgress(progress, { phase: "saving" });
+    await this.#saveCache(now);
+    const samples = runs.flatMap((run) => {
+      const entry = entries.get(run.id);
+      return entry ? [sampleFromCache(entry)] : [];
+    });
+    const failures = runs.flatMap((run) => {
+      return failed.has(run.id) ? [{ run, error: failed.get(run.id) }] : [];
+    });
+    if (failures.length) {
+      const first = failures[0];
+      const message = first.error instanceof Error
+        ? first.error.message
+        : String(first.error);
+      console.error(
+        `CI job history could not read ${failures.length} sampled run(s); ` +
+          `first was ${first.run.id} attempt ${first.run.run_attempt}: ${message}`,
+      );
+    }
+    const key = snapshotKey(source, days);
+    const failedRunTimes = failures.map(({ run }) => runTime(run)).filter(
+      Number.isFinite,
+    );
+    const previousInWindow = previous
+      ? inRequestedWindow(previous, now, days)
+      : null;
+    const preservePrevious = !samples.length && failures.length &&
+      Boolean(previousInWindow?.runCount);
+    const value = preservePrevious
+      ? {
+        ...previousInWindow!,
+        successfulRunTimes: [
+          ...new Set([
+            ...successfulRunTimes,
+            ...(previousInWindow!.successfulRunTimes ?? []),
+          ]),
+        ].sort((a, b) => a - b),
+        failedRunCount: failures.length,
+        failedRunTimes,
+        stale: true,
+      }
+      : buildCiJobHistory(
+        samples,
+        failures.length,
+        {
+          start: now - days * DAY_MS,
+          end: now,
+        },
+        failedRunTimes,
+        successfulRunTimes,
+      );
+    const sampledRuns = preservePrevious
+      ? (this.#sampledRuns.get(key) ?? []).filter((reference) => {
+        const run = this.#store.get(
+          source.repo,
+          source.workflow,
+          reference.runId,
+          reference.runAttempt,
+        );
+        return Boolean(
+          run && run.at >= now - days * DAY_MS && run.at <= now,
+        );
+      })
+      : runs.flatMap((run) => {
+        const entry = entries.get(run.id);
+        return entry
+          ? [{ runId: entry.runId, runAttempt: entry.runAttempt }]
+          : [];
+      });
+    if (preservePrevious && sampledRuns.length !== value.runCount) {
+      throw new Error(
+        "CI job history could not preserve the exact previous run set.",
+      );
+    }
+    this.#sampledRuns.set(key, sampledRuns);
+    this.#latest.set(key, value);
+    this.#snapshotRevisions.set(
+      key,
+      this.#store.revisionFor(source.repo, source.workflow),
+    );
+    const rateLimitFailure = failures.find(({ error }) =>
+      error instanceof GitHubRateLimitBudgetError
+    );
+    if (rateLimitFailure) throw rateLimitFailure.error;
+    return value;
+  }
+
+  async #discoverWorkflowRuns<Key, Result>(
+    requests: Map<Key, CiWorkflowDiscovery<Result>>,
+    key: Key,
+    load: (request: GitHubRequest) => Promise<Result>,
+    progress?: CiJobProgressRecord,
+  ): Promise<Result> {
+    let discovery = requests.get(key);
+    if (!discovery) {
+      const activeDiscovery: CiWorkflowDiscovery<Result> = {
+        progresses: new Set(progress ? [progress] : []),
+        requestsMade: 0,
+        responsesReceived: 0,
+        result: Promise.resolve(undefined as Result),
+      };
+      const updateProgress = () => {
+        for (const progress of activeDiscovery.progresses) {
+          this.#updateProgress(progress, {
+            discoveryRequestsMade: activeDiscovery.requestsMade,
+            discoveryResponsesReceived: activeDiscovery.responsesReceived,
+            discoveryOutstandingRequests: Math.max(
+              0,
+              activeDiscovery.requestsMade -
+                activeDiscovery.responsesReceived,
+            ),
+          });
+        }
+      };
+      const request: GitHubRequest = async <T>(
+        path: string,
+        token?: string,
+      ) => {
+        activeDiscovery.requestsMade++;
+        updateProgress();
+        try {
+          return await this.#github<T>(path, token);
+        } finally {
+          activeDiscovery.responsesReceived++;
+          updateProgress();
+        }
+      };
+      activeDiscovery.result = Promise.resolve()
+        .then(() => load(request))
+        .finally(() => {
+          if (requests.get(key) === activeDiscovery) {
+            requests.delete(key);
+          }
+        });
+      discovery = activeDiscovery;
+      requests.set(key, activeDiscovery);
+    } else if (progress) {
+      discovery.progresses.add(progress);
+      this.#updateProgress(progress, {
+        discoveryRequestsMade: discovery.requestsMade,
+        discoveryResponsesReceived: discovery.responsesReceived,
+        discoveryOutstandingRequests: Math.max(
+          0,
+          discovery.requestsMade - discovery.responsesReceived,
+        ),
+      });
+    }
+    return await discovery.result;
+  }
+
+  async #runsForRefresh(
+    token: string,
+    source: CiHistorySource,
+    now: number,
+    progress?: CiJobProgressRecord,
+  ): Promise<WorkflowRun[]> {
+    const cached = this.#workflowRuns.get(source.key);
+    if (cached && Date.now() - cached.at < REFRESH_MS) return cached.runs;
+    return await this.#discoverWorkflowRuns(
+      this.#workflowRequests,
+      source.key,
+      (request) =>
+        fetchWorkflowRuns(token, now, source, request).then((runs) => {
+          this.#workflowRuns.set(source.key, { at: Date.now(), runs });
+          return runs;
+        }),
+      progress,
+    );
+  }
+
+  #selectedWorkflowRunKey(
+    source: CiHistorySource,
+    headSha: string,
+    selected: CiGanttRunSelection,
+  ): string {
+    return `${source.key}:selected:${headSha}:${selected.runId}:${selected.runAttempt}`;
+  }
+
+  #cacheSelectedWorkflowRun(key: string, run: WorkflowRun): void {
+    this.#selectedWorkflowRuns.delete(key);
+    this.#selectedWorkflowRuns.set(key, { at: Date.now(), run });
+    if (
+      this.#selectedWorkflowRuns.size > SELECTED_WORKFLOW_RUN_CACHE_MAX
+    ) {
+      const oldest = this.#selectedWorkflowRuns.keys().next();
+      if (!oldest.done) this.#selectedWorkflowRuns.delete(oldest.value);
+    }
+  }
+
+  async #selectedRunsForGantt(
+    token: string,
+    source: CiHistorySource,
+    options: Required<CiGanttOptions>,
+    progress?: CiJobProgressRecord,
+  ): Promise<SelectedWorkflowRuns> {
+    const resolved = new Map<number, WorkflowRun>();
+    const missing: CiGanttRunSelection[] = [];
+    for (const selected of options.selectedRuns) {
+      const persisted = this.#store.get(
+        source.repo,
+        source.workflow,
+        selected.runId,
+        selected.runAttempt,
+      );
+      if (
+        persisted?.headSha === options.headSha &&
+        hasDrawableGanttTiming(persisted)
+      ) {
+        resolved.set(selected.runId, workflowRunFromCache(persisted, source));
+        continue;
+      }
+      const key = this.#selectedWorkflowRunKey(
+        source,
+        options.headSha,
+        selected,
+      );
+      const cached = this.#selectedWorkflowRuns.get(key);
+      if (cached && Date.now() - cached.at < REFRESH_MS) {
+        resolved.set(selected.runId, cached.run);
+      } else {
+        missing.push(selected);
+      }
+    }
+
+    let failure: SelectedWorkflowRuns["failure"];
+    if (missing.length) {
+      const key = `${source.key}:selected:${options.headSha}:${
+        missing.map(({ runId, runAttempt }) => `${runId}:${runAttempt}`).join(
+          ",",
+        )
+      }`;
+      const discovered = await this.#discoverWorkflowRuns(
+        this.#selectedWorkflowRequests,
+        key,
+        async (request): Promise<SelectedWorkflowRuns> => {
+          const runs: WorkflowRun[] = [];
+          let failure: SelectedWorkflowRuns["failure"];
+          for (
+            let index = 0;
+            index < missing.length;
+            index += JOB_FETCH_CONCURRENCY
+          ) {
+            const batch = missing.slice(index, index + JOB_FETCH_CONCURRENCY);
+            const outcomes = await Promise.allSettled(
+              batch.map(async (selected) =>
+                validateSelectedWorkflowRun(
+                  await request<WorkflowRun>(
+                    `repos/${source.repo}/actions/runs/${selected.runId}/attempts/${selected.runAttempt}`,
+                    token,
+                  ),
+                  selected,
+                  source,
+                  options.headSha,
+                )
+              ),
+            );
+            for (const [outcomeIndex, outcome] of outcomes.entries()) {
+              if (outcome.status === "rejected") {
+                failure ??= { error: outcome.reason };
+                continue;
+              }
+              const selected = batch[outcomeIndex];
+              runs.push(outcome.value);
+              this.#cacheSelectedWorkflowRun(
+                this.#selectedWorkflowRunKey(
+                  source,
+                  options.headSha,
+                  selected,
+                ),
+                outcome.value,
+              );
+            }
+            if (failure) break;
+          }
+          return { runs, failure };
+        },
+        progress,
+      );
+      failure = discovered.failure;
+      for (const run of discovered.runs) resolved.set(run.id, run);
+    }
+
+    return {
+      runs: options.selectedRuns.flatMap((selected) => {
+        const run = resolved.get(selected.runId);
+        return run ? [run] : [];
+      }),
+      failure,
+    };
+  }
+
+  async #runsForGantt(
+    token: string,
+    source: CiHistorySource,
+    options: Required<CiGanttOptions>,
+    now: number,
+    progress?: CiJobProgressRecord,
+  ): Promise<SelectedWorkflowRuns> {
+    if (options.selectedRuns.length) {
+      return await this.#selectedRunsForGantt(
+        token,
+        source,
+        options,
+        progress,
+      );
+    }
+    if (options.mainOnly && !options.allConclusions) {
+      return {
+        runs: successfulMainWorkflowRuns(
+          await this.#runsForRefresh(token, source, now, progress),
+          now,
+          CI_HISTORY_DAYS,
+        ),
+      };
+    }
+    const key = `${source.key}:${options.mainOnly ? "main" : "all"}`;
+    const cached = this.#recentWorkflowRuns.get(key);
+    if (cached && Date.now() - cached.at < REFRESH_MS) {
+      return { runs: cached.runs };
+    }
+    return {
+      runs: await this.#discoverWorkflowRuns(
+        this.#recentWorkflowRequests,
+        key,
+        (request) =>
+          fetchRecentWorkflowRuns(token, source, options.mainOnly, request)
+            .then(
+              (runs) => {
+                this.#recentWorkflowRuns.set(key, {
+                  at: Date.now(),
+                  runs,
+                });
+                return runs;
+              },
+            ),
+        progress,
+      ),
+    };
+  }
+
+  #cachedGanttInput(
+    source: CiHistorySource,
+    options: CiGanttOptions,
+  ): CiGanttInput {
+    const selectedRuns = options.selectedRuns ?? [];
+    const candidates = selectedRuns.length
+      ? selectedRuns.flatMap(({ runId, runAttempt }) => {
+        const run = this.#store.get(
+          source.repo,
+          source.workflow,
+          runId,
+          runAttempt,
+        );
+        if (
+          !run || run.headSha !== options.headSha ||
+          !hasDrawableGanttTiming(run)
+        ) return [];
+        return [run];
+      })
+      : this.#store.list(source.repo, source.workflow);
+    const runs = candidates
+      .filter((run) =>
+        !options.mainOnly ||
+        (options.allConclusions
+          ? isMainCachedRun(run)
+          : isSuccessfulMainCachedRun(run))
+      )
+      .sort((a, b) => b.at - a.at)
+      .slice(0, options.limit)
+      .map(ganttInputRun);
+    return { runs };
+  }
+
+  async gantt(
+    token: string | undefined,
+    source: CiHistorySource,
+    options: CiGanttOptions,
+    now = Date.now(),
+    workflowRuns?: WorkflowRun[],
+  ): Promise<CiGanttInput> {
+    return await this.#collectGantt(
+      token,
+      source,
+      normalizedGanttOptions(options),
+      now,
+      workflowRuns,
+    );
+  }
+
+  async #collectGantt(
+    token: string | undefined,
+    source: CiHistorySource,
+    normalized: Required<CiGanttOptions>,
+    now: number,
+    workflowRuns?: WorkflowRun[],
+    progress?: CiJobProgressRecord,
+  ): Promise<CiGanttInput> {
+    await this.#store.load();
+    await this.#saveCache(now);
+    const cached = this.#cachedGanttInput(source, normalized);
+    const exactSelection = normalized.selectedRuns.length > 0;
+    const hasEverySelectedRun = exactSelection &&
+      normalized.selectedRuns.every(({ runId, runAttempt }) =>
+        cached.runs.some((entry) =>
+          entry.run.databaseId === runId &&
+          (entry.run.attempt ?? 1) === runAttempt
+        )
+      );
+    if (hasEverySelectedRun) return cached;
+    if (!token) {
+      if (!exactSelection && cached.runs.length) {
+        if (progress) {
+          this.#updateProgress(progress, {
+            warning:
+              "Showing cached runs; set GH_TOKEN to check for newer attempts.",
+          });
+        }
+        return cached;
+      }
+      throw new Error("Set GH_TOKEN to collect CI Gantt data.");
+    }
+
+    let discovery: SelectedWorkflowRuns;
+    try {
+      discovery = workflowRuns
+        ? { runs: workflowRuns }
+        : await this.#runsForGantt(
+          token,
+          source,
+          normalized,
+          now,
+          progress,
+        );
+    } catch (error) {
+      if (!exactSelection && cached.runs.length) {
+        if (progress) {
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
+          this.#updateProgress(progress, {
+            warning: `Showing cached runs because workflow discovery reported ${
+              friendlyError(message)
+            }.`,
+          });
+        }
+        return cached;
+      }
+      throw error;
+    }
+    const history = discovery.runs;
+    const selectionFailure = discovery.failure;
+    const latest = new Map<number, WorkflowRun>();
+    for (const run of history) {
+      const current = latest.get(run.id);
+      if (!current || run.run_attempt > current.run_attempt) {
+        latest.set(run.id, run);
+      }
+    }
+    const requestedRuns = new Map(
+      normalized.selectedRuns.map((run) => [run.runId, run.runAttempt]),
+    );
+    const selected = [...latest.values()]
+      .filter((run) =>
+        (!requestedRuns.size ||
+          (requestedRuns.has(run.id) &&
+            run.run_attempt === requestedRuns.get(run.id)!)) &&
+        (!normalized.mainOnly ||
+          (run.event === "push" &&
+            (run.head_branch === undefined || run.head_branch === null ||
+              run.head_branch === "main") &&
+            (normalized.allConclusions ||
+              (run.status === "completed" && run.conclusion === "success"))))
+      )
+      .sort((a, b) => runTime(b) - runTime(a))
+      .slice(0, normalized.limit)
+      .filter((run) => run.status === "completed");
+    const missing = selected.filter((run) => {
+      const entry = exactSelection
+        ? this.#store.get(
+          source.repo,
+          source.workflow,
+          run.id,
+          run.run_attempt,
+        )
+        : this.#store.latest(source.repo, source.workflow, run.id);
+      return !entry ||
+        (exactSelection
+          ? entry.headSha !== normalized.headSha ||
+            !hasDrawableGanttTiming(entry)
+          : entry.runAttempt < run.run_attempt) ||
+        Boolean(this.#pendingJobsForRun(run, source, exactSelection));
+    });
+    if (progress) {
+      this.#updateProgress(progress, {
+        phase: "fetching",
+        totalRuns: exactSelection
+          ? normalized.selectedRuns.length
+          : selected.length,
+        cachedRuns: selected.length - missing.length,
+      });
+    }
+    const failures: { run: WorkflowRun; error: unknown }[] = [];
+    for (let i = 0; i < missing.length; i += JOB_FETCH_CONCURRENCY) {
+      const batch = missing.slice(i, i + JOB_FETCH_CONCURRENCY);
+      const outcomes = await Promise.all(
+        batch.map(async (run): Promise<
+          | { run: WorkflowRun; entry: CachedCiRun }
+          | { run: WorkflowRun; error: unknown }
+        > => {
+          const load = this.#jobsForRun(
+            run,
+            token,
+            source,
+            now,
+            exactSelection,
+            normalized.headSha,
+          );
+          if (progress) this.#startJobLoadProgress(progress, load.kind);
+          try {
+            const outcome = {
+              run,
+              entry: await load.result,
+            };
+            if (progress) {
+              this.#finishJobLoadProgress(progress, load.kind, true);
+            }
+            return outcome;
+          } catch (error) {
+            if (progress) {
+              this.#finishJobLoadProgress(progress, load.kind, false);
+            }
+            return { run, error };
+          }
+        }),
+      );
+      for (const outcome of outcomes) {
+        if ("error" in outcome) failures.push(outcome);
+      }
+    }
+    const persistenceFailure = failures.find(({ error }) =>
+      error instanceof CiJobCacheWriteError
+    );
+    if (persistenceFailure) throw persistenceFailure.error;
+    const quotaFailure = failures.find(({ error }) =>
+      error instanceof GitHubRateLimitBudgetError
+    );
+    const reportedFailure = quotaFailure ?? failures[0];
+    if (progress) this.#updateProgress(progress, { phase: "saving" });
+    await this.#saveCache(now);
+    if (reportedFailure) {
+      const message = reportedFailure.error instanceof Error
+        ? reportedFailure.error.message
+        : String(reportedFailure.error);
+      console.error(
+        `CI Gantt could not read ${failures.length} run(s); ` +
+          `reported run ${reportedFailure.run.id} attempt ${reportedFailure.run.run_attempt}: ${message}`,
+      );
+    }
+    const runs = selected.flatMap((run) => {
+      const entry = exactSelection
+        ? this.#store.get(
+          source.repo,
+          source.workflow,
+          run.id,
+          run.run_attempt,
+        )
+        : this.#store.latest(source.repo, source.workflow, run.id);
+      if (
+        !entry ||
+        (exactSelection
+          ? entry.headSha !== normalized.headSha ||
+            !hasDrawableGanttTiming(entry)
+          : entry.runAttempt < run.run_attempt)
+      ) return [];
+      return [ganttInputRun(entry)];
+    });
+    if (exactSelection) {
+      if (selectionFailure) {
+        throw selectionFailure.error instanceof Error
+          ? selectionFailure.error
+          : new Error(String(selectionFailure.error));
+      }
+      if (reportedFailure) {
+        throw reportedFailure.error instanceof Error
+          ? reportedFailure.error
+          : new Error(String(reportedFailure.error));
+      }
+      if (selected.length !== normalized.selectedRuns.length) {
+        throw new Error(
+          "Every selected CI run must be a completed successful main push.",
+        );
+      }
+      if (runs.length !== selected.length) {
+        throw new Error("Not every selected CI run has cached job timings.");
+      }
+    }
+    const available = runs.length
+      ? { runs }
+      : cached.runs.length
+      ? cached
+      : null;
+    if (!available) {
+      if (reportedFailure) {
+        throw reportedFailure.error instanceof Error
+          ? reportedFailure.error
+          : new Error(String(reportedFailure.error));
+      }
+      throw new Error(
+        "No completed CI runs with cached job timings were available.",
+      );
+    }
+    if (progress && reportedFailure) {
+      const message = reportedFailure.error instanceof Error
+        ? reportedFailure.error.message
+        : String(reportedFailure.error);
+      this.#updateProgress(progress, {
+        warning: `${failures.length} run check${
+          failures.length === 1 ? "" : "s"
+        } reported ${
+          friendlyError(message)
+        }; the chart uses available cached responses.`,
+      });
+    }
+    return available;
+  }
+
+  startGantt(
+    token: string | undefined,
+    source: CiHistorySource,
+    options: CiGanttOptions,
+    now = Date.now(),
+  ): CiGanttRefresh {
+    const normalized = normalizedGanttOptions(options);
+    const key = `gantt:${source.key}:${normalized.limit}:${
+      normalized.mainOnly ? "main" : "all"
+    }:${
+      normalized.allConclusions ? "all-conclusions" : "successful"
+    }:${normalized.headSha}:${
+      normalized.selectedRuns.map(({ runId, runAttempt }) =>
+        `${runId}:${runAttempt}`
+      ).join(",")
+    }`;
+    const active = this.#ganttRequests.get(key);
+    if (active) {
+      return {
+        progress: { ...active.progress.state },
+        result: active.result,
+      };
+    }
+
+    const progress = this.#newProgress(
+      source,
+      CI_HISTORY_DAYS,
+      undefined,
+      key,
+    );
+    const request: CiGanttRequest = {
+      progress,
+      result: Promise.resolve({ runs: [] }),
+    };
+    request.result = Promise.resolve()
+      .then(() =>
+        this.#collectGantt(
+          token,
+          source,
+          normalized,
+          now,
+          undefined,
+          progress,
+        )
+      )
+      .then((result) => {
+        this.#updateProgress(progress, { phase: "complete" });
+        return result;
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        this.#updateProgress(progress, {
+          phase: "error",
+          error: friendlyError(message),
+        });
+        throw error;
+      })
+      .finally(() => {
+        if (this.#ganttRequests.get(key) === request) {
+          this.#ganttRequests.delete(key);
+        }
+      });
+    this.#ganttRequests.set(key, request);
+    return { progress: { ...progress.state }, result: request.result };
+  }
+
+  startRefresh(
+    token: string,
+    source = CI_HISTORY_SOURCES.labs,
+    days = CI_HISTORY_DAYS,
+    baseline?: CiJobHistorySnapshot | null,
+  ): CiJobRefresh {
+    const key = snapshotKey(source, days);
+    const latest = this.snapshot(source, days);
+    const persistedRefresh = this.#store.freshRefresh(
+      source.repo,
+      source.workflow,
+      days,
+    );
+    const refreshed = this.#refreshedAt.get(key) ??
+      (persistedRefresh
+        ? {
+          at: persistedRefresh.refreshedAt,
+          revision: this.#store.revisionFor(
+            source.repo,
+            source.workflow,
+          ),
+        }
+        : undefined);
+    const sourceRefreshActive = [...this.#refreshRequests.keys()].some(
+      (refreshKey) => refreshKey.startsWith(`${source.key}:`),
+    );
+    if (
+      latest && refreshed && !sourceRefreshActive &&
+      refreshed.revision === this.#store.revisionFor(
+          source.repo,
+          source.workflow,
+        ) &&
+      Date.now() - refreshed.at >= 0 &&
+      Date.now() - refreshed.at < REFRESH_MS
+    ) {
+      return {
+        progress: null,
+        result: Promise.resolve(inRequestedWindow(latest, Date.now(), days)),
+      };
+    }
+    let request = this.#refreshRequests.get(key);
+    if (request) {
+      const progress = this.#progressByKey.get(key);
+      if (progress && baseline !== undefined) {
+        progress.baselines.add(snapshotFingerprint(baseline));
+      }
+      return {
+        progress: progress ? { ...progress.state } : null,
+        result: request,
+      };
+    }
+    const now = Date.now();
+    const progress = this.#newProgress(source, days, baseline);
+    request = this.#runsForRefresh(token, source, now, progress)
+      .then((runs) => this.collect(token, now, source, days, runs, progress))
+      .then(async (collectedValue) => {
+        let value = collectedValue;
+        this.#refreshFailureAt.delete(source.key);
+        const refreshedAt = Date.now();
+        const previousRefresh = this.#store.refresh(
+          source.repo,
+          source.workflow,
+          days,
+        );
+        const expectedRefresh = {
+          repo: source.repo,
+          workflow: source.workflow,
+          days,
+          refreshedAt,
+          successfulRunTimes: [...(value.successfulRunTimes ?? [])].filter(
+            Number.isFinite,
+          ).sort((a, b) => a - b),
+          sampledRuns: (this.#sampledRuns.get(key) ?? []).map((run) => ({
+            ...run,
+          })),
+          failedRunCount: value.failedRunCount,
+          failedRunTimes: [...value.failedRunTimes].filter(Number.isFinite)
+            .sort((a, b) => a - b),
+          stale: value.stale,
+        };
+        this.#store.markRefreshed(
+          source.repo,
+          source.workflow,
+          days,
+          refreshedAt,
+          value.successfulRunTimes ?? [],
+          this.#sampledRuns.get(key) ?? [],
+          value.failedRunCount,
+          value.failedRunTimes,
+          value.stale,
+        );
+        try {
+          await this.#saveCache(now);
+        } catch (error) {
+          this.#store.restoreRefresh(
+            source.repo,
+            source.workflow,
+            days,
+            previousRefresh,
+          );
+          throw error;
+        }
+        const persistedRefresh = this.#store.refresh(
+          source.repo,
+          source.workflow,
+          days,
+        );
+        if (!persistedRefresh) {
+          throw new Error("CI job history refresh manifest was not persisted.");
+        }
+        if (
+          JSON.stringify(persistedRefresh) !== JSON.stringify(expectedRefresh)
+        ) {
+          this.#snapshotRevisions.delete(key);
+          value = await this.cached(source, days, Date.now()) ?? value;
+        }
+        const persistedFreshRefresh = this.#store.freshRefresh(
+          source.repo,
+          source.workflow,
+          days,
+        );
+        if (persistedFreshRefresh) {
+          this.#refreshedAt.set(key, {
+            at: persistedFreshRefresh.refreshedAt,
+            revision: this.#store.revisionFor(source.repo, source.workflow),
+          });
+        } else this.#refreshedAt.delete(key);
+        const fingerprint = snapshotFingerprint(value);
+        this.#updateProgress(progress, {
+          phase: "complete",
+          needsReload: [...progress.baselines].some((value) =>
+            value !== fingerprint
+          ),
+        });
+        return value;
+      })
+      .catch(async (error) => {
+        let reportedError = error;
+        if (error instanceof GitHubRateLimitBudgetError) {
+          this.#store.invalidateRefresh(
+            source.repo,
+            source.workflow,
+            days,
+          );
+          this.#refreshedAt.delete(key);
+          try {
+            await this.#saveCache(Date.now());
+          } catch (persistenceError) {
+            reportedError = persistenceError;
+          }
+        }
+        this.#refreshFailureAt.set(source.key, Date.now());
+        const message = reportedError instanceof Error
+          ? reportedError.message
+          : String(reportedError);
+        console.error(
+          `CI job history refresh failed for ${source.repo}:`,
+          message,
+        );
+        this.#updateProgress(progress, {
+          phase: "error",
+          error: friendlyError(message),
+        });
+        throw reportedError;
+      })
+      .finally(() => this.#refreshRequests.delete(key));
+    this.#refreshRequests.set(key, request);
+    return { progress: { ...progress.state }, result: request };
+  }
+
+  startRefreshForCheck(
+    token: string,
+    source = CI_HISTORY_SOURCES.labs,
+    days = CI_HISTORY_DAYS,
+    baseline?: CiJobHistorySnapshot | null,
+  ): CiJobRefresh | null {
+    const failedAt = this.#refreshFailureAt.get(source.key);
+    if (failedAt && Date.now() - failedAt < REFRESH_MS) return null;
+    return this.startRefresh(token, source, days, baseline);
+  }
+
+  async refresh(
+    token: string,
+    source = CI_HISTORY_SOURCES.labs,
+    days = CI_HISTORY_DAYS,
+  ): Promise<CiJobHistorySnapshot> {
+    return await this.startRefresh(token, source, days).result;
+  }
+}
+
+const productionStore = new CiJobHistoryStore();
+const productionCollector = new CiJobHistoryCollector(
+  productionStore,
+  performanceGithub,
+);
+const commitGanttCollector = new CiJobHistoryCollector(
+  productionStore,
+  github,
+);
+
+export function collectCiGanttInput(
+  source: CiHistorySource,
+  options: CiGanttOptions,
+  token = Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN"),
+): Promise<CiGanttInput> {
+  return productionCollector.startGantt(token, source, options).result;
+}
+
+export function collectCommitCiGanttInput(
+  source: CiHistorySource,
+  options: CiGanttOptions,
+  token = Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN"),
+): Promise<CiGanttInput> {
+  return commitGanttCollector.startGantt(token, source, options).result;
+}
+
+function formatDuration(seconds: number): string {
+  const rounded = Math.round(seconds);
+  if (rounded < 60) return `${rounded}s`;
+  const minutes = Math.floor(rounded / 60);
+  const remainder = rounded % 60;
+  if (minutes < 60) {
+    return `${minutes}m ${String(remainder).padStart(2, "0")}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${String(minutes % 60).padStart(2, "0")}m`;
+}
+
+function shortShardName(series: CiJobSeries): string {
+  const prefix = `${series.base} (`;
+  return series.name.startsWith(prefix) && series.name.endsWith(")")
+    ? series.name.slice(prefix.length, -1)
+    : series.name;
+}
+
+interface RenderedSeries {
+  series: CiJobSeries;
+  pct: number;
+  status: ReturnType<typeof trendStatus>;
+  spark: string;
+  span: string;
+  latest: CiJobPoint;
+  trend: string;
+}
+
+function renderSeries(
+  series: CiJobSeries,
+  axisStart: number,
+  axisEnd: number,
+): RenderedSeries {
+  const times = series.points.map((point) => point.at);
+  const values = series.points.map((point) => point.seconds);
+  const pct = trendPct(times, values);
+  const trendDays = distinctTrendDays(times, values);
+  const status = trendDays >= 7 ? trendStatus(pct) : "unknown";
+  const axisSpan = axisEnd - axisStart || 1;
+  const xs = times.map((at) => (at - axisStart) / axisSpan);
+  const spark = sparkline(
+    values,
+    "#727882",
+    undefined,
+    SPARK_FADE[status],
+    xs,
+  );
+  const pointSpan = times.length > 1 ? times[times.length - 1] - times[0] : 0;
+  return {
+    series,
+    pct,
+    status,
+    spark,
+    span: pointSpan > 0 ? durationTag(pointSpan) : "",
+    latest: series.points[series.points.length - 1],
+    trend: trendDays >= 7 ? trendPctLabel(pct) : "new",
+  };
+}
+
+function rowHtml(
+  row: RenderedSeries,
+  label: string,
+  detail: string,
+): string {
+  const latest = row.latest;
+  const summary = `${label}: ${formatDuration(latest.seconds)} in its latest ` +
+    `available sample on ${dateLabel(latest.at)}, ${row.trend} over ` +
+    `${row.series.points.length} sampled runs.`;
+  return `<div class="crow ${row.status}${
+    row.series.kind === "group"
+      ? " aggregate"
+      : row.series.kind === "overall"
+      ? " overall"
+      : ""
+  }" data-kind="${row.series.kind}">` +
+    `<div class="cspark">${row.spark}${row.span}</div>` +
+    `<div class="cmeta"><span class="cname">${escapeHtml(label)}</span>` +
+    `<span class="cdetail">${escapeHtml(detail)} · last seen ${
+      escapeHtml(dateLabel(latest.at))
+    }</span></div>` +
+    `<a class="cval" href="${escapeHtml(latest.runUrl)}" target="_blank" ` +
+    `rel="noopener">${formatDuration(latest.seconds)}` +
+    `<span class="ctrend">${
+      escapeHtml(row.trend)
+    } · ${row.series.points.length} runs</span></a>` +
+    `<span class="sr-only">${escapeHtml(summary)}</span></div>`;
+}
+
+const dateLabel = (at: number): string =>
+  new Date(at).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+
+interface CiHistoryPageOptions {
+  source?: CiHistorySource;
+  days?: number;
+  runtimeStat?: string;
+  progress?: CiJobFetchProgress;
+  fragment?: boolean;
+}
+
+export const CI_FETCH_PROGRESS_STYLES = `
+  .fetch-progress{background:#16181d;border:1px solid #2f333c;border-radius:10px;padding:10px 12px;margin:0 0 12px}
+  .fetch-progress.error,.fetch-progress.warning{border-color:rgba(224,168,82,.42)}
+  .fetch-head{display:flex;justify-content:space-between;gap:12px;align-items:baseline;font-size:12px;color:#c7ccd4}
+  .fetch-head strong{font-weight:600}.fetch-head span,#fetch-detail{font-variant-numeric:tabular-nums;color:#878d97}
+  .fetch-progress progress{display:block;width:100%;height:7px;margin:7px 0 6px;accent-color:#6ea8fe}
+  #fetch-detail{font-size:11px;margin:0}`;
+
+interface CiFetchProgressPanelOptions {
+  ariaLabel?: string;
+  checkUrl?: string;
+  snapshotVersion?: string;
+  refreshOnComplete?: boolean;
+  progressUrl?: string;
+}
+
+export function ciFetchProgressPanel(
+  progress?: CiJobFetchProgress | null,
+  options: CiFetchProgressPanelOptions = {},
+): string {
+  const progressIdle = !progress || progress.phase === "complete" ||
+    progress.phase === "error";
+  const progressTitle = progressIdle
+    ? "Idle"
+    : progress.phase === "discovering"
+    ? "Finding workflow runs…"
+    : `${progress.completedRuns} of ${progress.totalRuns} run checks complete`;
+  const progressTotal = progressIdle
+    ? "0 outstanding"
+    : progress.phase === "discovering"
+    ? `${progress.discoveryOutstandingRequests} outstanding`
+    : `${progress.completedRuns} / ${progress.totalRuns || "?"}`;
+  const progressDetail = progress?.phase === "error"
+    ? `Last collection stopped: ${
+      escapeHtml(progress.error ?? "unknown error")
+    }`
+    : progressIdle && progress?.warning
+    ? escapeHtml(progress.warning)
+    : !progressIdle && progress?.phase === "discovering"
+    ? `${progress.discoveryRequestsMade} workflow requests made · ${progress.discoveryResponsesReceived} responded · ${progress.discoveryOutstandingRequests} outstanding`
+    : !progressIdle && progress
+    ? `${progress.cachedRuns} cached · ${progress.requestsMade} run requests made · ${progress.sharedRequests} shared · ${
+      progress.responsesReceived + progress.sharedResponses
+    } responded · ${progress.outstandingRequests} outstanding · ${progress.queuedRuns} queued`
+    : "No requests in progress.";
+  const attributes = [
+    options.checkUrl ? `data-check-url="${escapeHtml(options.checkUrl)}"` : "",
+    options.snapshotVersion !== undefined
+      ? `data-snapshot-version="${escapeHtml(options.snapshotVersion)}"`
+      : "",
+    options.refreshOnComplete !== undefined
+      ? `data-refresh-on-complete="${options.refreshOnComplete ? "1" : "0"}"`
+      : "",
+    options.progressUrl
+      ? `data-progress-url="${escapeHtml(options.progressUrl)}"`
+      : "",
+  ].filter(Boolean).join(" ");
+  return `<section class="fetch-progress${
+    progressIdle && progress?.warning ? " warning" : ""
+  }" id="fetch-progress" aria-live="polite"${
+    attributes ? ` ${attributes}` : ""
+  }><div class="fetch-head"><strong id="fetch-title">${progressTitle}</strong><span id="fetch-total">${progressTotal}</span></div><progress id="fetch-bar" max="${
+    progressIdle ? 1 : Math.max(1, progress?.totalRuns ?? 1)
+  }"${
+    !progressIdle && progress && !progress.totalRuns
+      ? ""
+      : ` value="${progressIdle ? 0 : progress?.completedRuns ?? 0}"`
+  } aria-label="${
+    escapeHtml(options.ariaLabel ?? "CI history fetch progress")
+  }"></progress><p id="fetch-detail">${progressDetail}</p></section>`;
+}
+
+function ciPageHref(
+  source: CiHistorySource,
+  days: number,
+  sort: string,
+  runtimeStat?: string,
+): string {
+  const params = new URLSearchParams({
+    view: "ci",
+    repo: source.key,
+    days: String(days),
+    sort,
+  });
+  if (runtimeStat) params.set("stat", runtimeStat);
+  return `/bench?${escapeHtml(params.toString())}`;
+}
+
+export function ciJobHistoryPage(
+  snapshot: CiJobHistorySnapshot | null,
+  sortMode: string,
+  refreshError?: string,
+  options: CiHistoryPageOptions = {},
+): string {
+  const source = options.source ?? CI_HISTORY_SOURCES.labs;
+  const days = options.days ?? CI_HISTORY_DAYS;
+  const runtimeStat = options.runtimeStat;
+  const progress = options.progress;
+  const progressActive = progress && progress.phase !== "complete" &&
+    progress.phase !== "error";
+  const sort = sortMode === "trend" || sortMode === "duration"
+    ? sortMode
+    : "job";
+  let body: string;
+  const hasSeries = snapshot &&
+    (snapshot.overall || snapshot.groups.length > 0 ||
+      snapshot.jobs.length > 0);
+  if (!snapshot || snapshot.runCount === 0 || !hasSeries) {
+    if (progressActive) {
+      body = "";
+    } else {
+      const message = refreshError ??
+        (snapshot?.failedRunCount
+          ? `CI job timings could not be read for ${snapshot.failedRunCount} sampled run${
+            snapshot.failedRunCount === 1 ? "" : "s"
+          }.`
+          : "No completed CI job timings were found in the history window.");
+      body = `<p class="empty">${escapeHtml(message)}</p>`;
+    }
+  } else {
+    const rendered = new Map<CiJobSeries, RenderedSeries>();
+    const get = (series: CiJobSeries) => {
+      let row = rendered.get(series);
+      if (!row) {
+        row = renderSeries(series, snapshot.axisStart, snapshot.axisEnd);
+        rendered.set(series, row);
+      }
+      return row;
+    };
+    const axis = `<div class="axisrow"><div class="timeaxis"><span>${
+      dateLabel(snapshot.axisStart)
+    }</span><span>${dateLabel(snapshot.axisEnd)}</span></div></div>`;
+    if (sort === "trend" || sort === "duration") {
+      const rows = [
+        ...(snapshot.overall ? [get(snapshot.overall)] : []),
+        ...snapshot.groups.flatMap((group) => [
+          get(group.aggregate),
+          ...group.shards.map(get),
+        ]),
+        ...snapshot.jobs.map(get),
+      ].sort((a, b) => {
+        const difference = sort === "duration"
+          ? b.latest.seconds - a.latest.seconds
+          : b.pct - a.pct;
+        return difference || a.series.name.localeCompare(b.series.name);
+      });
+      body = `${axis}<div class="clist">${
+        rows.map((row) => {
+          const group = snapshot.groups.find((item) =>
+            item.base === row.series.base
+          );
+          const label = row.series.kind === "overall"
+            ? "Overall CI"
+            : row.series.kind === "group"
+            ? `${row.series.base} — slowest of up to ${
+              group?.maxConcurrent ?? 0
+            } shards`
+            : row.series.name;
+          return rowHtml(
+            row,
+            label,
+            row.series.kind === "overall"
+              ? "First job start to last job completion"
+              : row.series.kind === "group"
+              ? "Slowest shard duration"
+              : "Individual job",
+          );
+        }).join("")
+      }</div>`;
+    } else {
+      const overall = snapshot.overall
+        ? `<section class="overall-section"><h2>Workflow <span>end-to-end wall time</span></h2><div class="clist">${
+          rowHtml(
+            get(snapshot.overall),
+            "Overall CI",
+            "First job start to last job completion",
+          )
+        }</div></section>`
+        : "";
+      const sections = snapshot.groups.map((group) =>
+        `<section><h2>${
+          escapeHtml(group.base)
+        } <span>up to ${group.maxConcurrent} concurrent${
+          group.shards.length === group.maxConcurrent
+            ? ""
+            : ` · ${group.shards.length} historical variants`
+        }</span></h2>` +
+        `<div class="clist">${
+          rowHtml(
+            get(group.aggregate),
+            "longest-running shard",
+            "Slowest shard duration",
+          )
+        }${
+          group.shards.map((series) =>
+            rowHtml(get(series), shortShardName(series), "Individual shard")
+          ).join("")
+        }</div></section>`
+      ).join("");
+      const jobs = snapshot.jobs.length
+        ? `<section><h2>Unsharded jobs <span>${snapshot.jobs.length} jobs</span></h2>` +
+          `<div class="clist">${
+            snapshot.jobs.map((series) =>
+              rowHtml(get(series), series.name, "Individual job")
+            ).join("")
+          }</div></section>`
+        : "";
+      body = `${axis}${overall}${sections}${jobs}`;
+    }
+  }
+
+  const notices: string[] = [];
+  if (refreshError && snapshot?.runCount) {
+    notices.push(`Showing the last collected data. ${refreshError}`);
+  }
+  if (snapshot?.failedRunCount && snapshot.runCount) {
+    notices.push(
+      `${
+        snapshot.stale
+          ? "Showing the last collected data"
+          : "Showing partial data"
+      }. ` +
+        `${snapshot.failedRunCount} sampled run${
+          snapshot.failedRunCount === 1 ? "" : "s"
+        } could not be read.`,
+    );
+  }
+  const refreshNotice = notices.map((notice) =>
+    `<p class="refresh-error">${escapeHtml(notice)}</p>`
+  ).join("");
+  const bucketHours = ciHistoryBucketMs(days) / 3_600_000;
+  const bucketLabel = bucketHours >= 10
+    ? String(Math.round(bucketHours))
+    : bucketHours.toFixed(1).replace(/\.0$/, "");
+  const viewNav = performanceViewNav("ci", {
+    repo: source.key,
+    days,
+    sort,
+    stat: runtimeStat ?? "p99",
+  });
+  const workflowUrl =
+    `https://github.com/${source.repo}/actions/workflows/${source.workflow}?query=branch%3Amain`;
+  const version = ciJobHistorySnapshotVersion(snapshot);
+  const checkParams = new URLSearchParams({
+    view: "ci",
+    repo: source.key,
+    days: String(days),
+  });
+  const checkUrl = `/bench/check?${checkParams.toString()}`;
+  const progressUrl = progress
+    ? `/bench/ci-progress?id=${encodeURIComponent(progress.id)}`
+    : "";
+  const progressHtml = ciFetchProgressPanel(progress, {
+    checkUrl,
+    snapshotVersion: version,
+    refreshOnComplete: Boolean(
+      progressActive && (!snapshot || snapshot.runCount === 0 || !hasSeries),
+    ),
+    progressUrl,
+  });
+  const coverageHtml = snapshot
+    ? `<p class="coverage">Coverage: ${snapshot.runCount} sampled build${
+      snapshot.runCount === 1 ? "" : "s"
+    } shown${
+      snapshot.successfulRunTimes === null
+        ? ""
+        : ` out of ${snapshot.successfulRunTimes.length} successful main build${
+          snapshot.successfulRunTimes.length === 1 ? "" : "s"
+        }`
+    }.</p>`
+    : "";
+  const rangeContent = `<div id="range-content">
+    ${progressHtml}${coverageHtml}
+    <p class="legend">Job start-to-finish duration. Overall CI runs from the first job start to the last job completion. A shard group's line is the longest-running shard in each run. Lower is faster; colour follows the selected ${days}-day trend. Duration sort uses the latest sample.</p>
+    ${refreshNotice}${body}
+    <p class="note">Every successful main run is sampled when the selected window contains at most ${CI_HISTORY_POINT_TARGET}. Larger sets keep the newest run per ${bucketLabel}-hour bucket from <a href="${
+    escapeHtml(workflowUrl)
+  }" target="_blank" rel="noopener">${
+    escapeHtml(source.workflow)
+  } runs ↗</a>. The window adjusts its sampling interval to keep about ${CI_HISTORY_POINT_TARGET} points. Values come from GitHub's job start and completion times. The detailed Gantt uses the same cached runs.</p>
+  </div>`;
+  if (options.fragment) return rangeContent;
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>CI job history</title>
+<style>
+  body{box-sizing:border-box;width:100%;margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
+  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:12px;flex-wrap:wrap}
+  .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:#6f757f}
+  a.back,.note a{color:#6ea8fe;text-decoration:none;font-size:13px}
+  .views{display:flex;gap:6px;margin:0 0 14px}
+  .views a,.controls a{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:4px 10px}
+  .views a.on,.controls a.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11}
+  .controls{display:flex;flex-wrap:wrap;align-items:center;gap:6px;background:#16181d;border:1px solid #23262d;border-radius:12px;padding:12px 14px;margin-bottom:8px}
+  .controls .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#878d97;margin-right:6px}
+  .controls .field{display:flex;align-items:center;gap:7px;font-size:12px;color:#9aa0ab;margin-right:8px}
+  .controls .choice-group{display:flex;align-items:center;gap:6px}
+  .controls select{background:#0d0e11;color:#c7ccd4;border:1px solid #2f333c;border-radius:6px;padding:4px 7px}
+  .controls input[type=range]{width:150px}.controls output{color:#c7ccd4;min-width:46px;font-variant-numeric:tabular-nums}
+  .legend{font-size:11px;color:#777d87;margin:0 0 12px}.coverage{font-size:11px;color:#c7ccd4;font-variant-numeric:tabular-nums;margin:0 0 12px}
+  ${CI_FETCH_PROGRESS_STYLES}
+  .axisrow{display:flex;gap:18px;margin:0 14px 4px}.timeaxis{flex:0 0 42%;display:flex;justify-content:space-between;color:#666c76;font-size:10px}
+  h2{font-size:12px;letter-spacing:.04em;color:#878d97;font-weight:600;margin:20px 0 8px;font-family:ui-monospace,Menlo,monospace}
+  h2 span{font-family:-apple-system,Segoe UI,Roboto,sans-serif;font-weight:400;color:#666c76;margin-left:6px}
+  .clist{display:flex;flex-direction:column;gap:7px}
+  .crow{display:flex;align-items:center;gap:18px;background:#16181d;border:1px solid #23262d;border-radius:10px;padding:8px 14px}
+  .crow.good{border-color:rgba(67,197,116,.34);background:rgba(67,197,116,.06)}
+  .crow.warn{border-color:rgba(224,168,82,.42);background:rgba(224,168,82,.07)}
+  .crow.bad{border-color:rgba(226,80,74,.5);background:rgba(226,80,74,.09)}
+  .crow.aggregate{border-left-width:4px}
+  .crow.overall{border-left:4px solid #6ea8fe}.overall-section{margin-bottom:20px}
+  .cspark{flex:0 0 42%;min-width:0;position:relative}.cspark>div,.cspark>svg{margin-top:0!important}
+  .cmeta{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:2px}
+  .cname{font-size:13px;color:#c7ccd4;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .cdetail{font-size:11px;color:#777d87}
+  .cval{flex:none;display:flex;flex-direction:column;align-items:flex-end;color:#e7e9ee;text-decoration:none;font-size:18px;font-weight:600;font-variant-numeric:tabular-nums}
+  .ctrend{font-size:11px;font-weight:400;color:#9aa0ab}
+  .empty,.refresh-error{color:#9aa0ab;font-size:14px}.refresh-error{color:#e0a852}
+  .note{font-size:11px;color:#666c76;margin-top:22px}.note a{font-size:11px}
+  label.chk{font-size:13px;color:#c7ccd4;display:inline-flex;align-items:center;gap:6px;margin-left:auto;cursor:pointer;user-select:none}
+  body.hide-green .crow.good{display:none}body.hide-green section:has(.clist):not(:has(.crow:not(.good))){display:none}
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+  @media(max-width:640px){.timeaxis{flex:1}.crow{align-items:stretch;gap:7px;flex-wrap:wrap}.cspark{flex:1 0 100%}.cmeta{flex:1 1 55%}.cval{font-size:16px}.controls label.chk{margin-left:0}.controls .field{flex:1 1 100%}.controls input[type=range]{flex:1;width:auto}}
+</style></head><body>
+  <div class="top"><a class="back" href="/">← dashboard</a><b>Performance history</b><span>${
+    escapeHtml(source.repo)
+  } · ${escapeHtml(source.workflow)}</span></div>
+  ${viewNav}
+  <form class="controls" method="get" action="/bench"><input type="hidden" name="view" value="ci"><input type="hidden" name="sort" value="${sort}">${
+    runtimeStat
+      ? `<input type="hidden" name="stat" value="${escapeHtml(runtimeStat)}">`
+      : ""
+  }<label class="field">repository <select id="repo" name="repo"><option value="labs"${
+    source.key === "labs" ? " selected" : ""
+  }>labs</option><option value="loom"${
+    source.key === "loom" ? " selected" : ""
+  }>loom</option></select></label><label class="field" for="days">window <output id="daysv" for="days">${days} day${
+    days === 1 ? "" : "s"
+  }</output><input type="range" id="days" name="days" min="${CI_HISTORY_MIN_DAYS}" max="${CI_HISTORY_DAYS}" step="1" value="${days}"></label><nav class="choice-group" aria-label="Sort CI history"><span class="lbl">sort</span><a class="${
+    sort === "job" ? "on" : ""
+  }" href="${ciPageHref(source, days, "job", runtimeStat)}"${
+    sort === "job" ? ' aria-current="true"' : ""
+  }>job</a><a class="${sort === "duration" ? "on" : ""}" href="${
+    ciPageHref(source, days, "duration", runtimeStat)
+  }"${
+    sort === "duration" ? ' aria-current="true"' : ""
+  }>duration</a><a class="${sort === "trend" ? "on" : ""}" href="${
+    ciPageHref(source, days, "trend", runtimeStat)
+  }"${
+    sort === "trend" ? ' aria-current="true"' : ""
+  }>trend</a></nav><label class="chk"><input type="checkbox" id="hg"> hide green</label></form>
+  ${rangeContent}
+<script>
+  const hg = document.getElementById("hg"), days = document.getElementById("days"), daysv = document.getElementById("daysv"), repo = document.getElementById("repo"), controls = days.form, KEY = "ciJobsHideGreen", DEFAULT_DAYS = days.value;
+  let rangeContent = document.getElementById("range-content"), fetchProgress = document.getElementById("fetch-progress"), title = document.getElementById("fetch-title"), total = document.getElementById("fetch-total"), detail = document.getElementById("fetch-detail"), bar = document.getElementById("fetch-bar"), pageVersion = fetchProgress.dataset.snapshotVersion, appliedDays = days.value;
+  let navigating = false, pendingRefresh = false, checking = false, eventStream = null, connectedProgressUrl = "", serverVersionChanged = false, collectionFailed = false, transportFailed = false, rangeRequest = null, rangeRequestDays = "", rangeSequence = 0, viewRevision = 0;
+  const apply = () => document.body.classList.toggle("hide-green", hg.checked);
+  hg.checked = sessionStorage.getItem(KEY) === "1";
+  apply();
+  hg.addEventListener("change", () => {
+    sessionStorage.setItem(KEY, hg.checked ? "1" : "0");
+    apply();
+  });
+  const syncDayLinks = () => {
+    for (const link of document.querySelectorAll('a[href^="/bench?"]')) {
+      const target = new URL(link.href);
+      target.searchParams.set("days", days.value);
+      link.href = target.pathname + "?" + target.searchParams.toString();
+    }
+  };
+  days.addEventListener("input", () => {
+    daysv.value = days.value + (days.value === "1" ? " day" : " days");
+    syncDayLinks();
+  });
+  const applyDays = () => {
+    if (days.value !== appliedDays) {
+      if (!rangeRequest || rangeRequestDays !== days.value) void loadRange("push");
+    } else if (rangeRequest && rangeRequestDays !== days.value) {
+      void loadRange("restore");
+    } else if (pendingRefresh && !rangeRequest) {
+      pendingRefresh = false;
+      void loadRange("refresh");
+    }
+  };
+  days.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      applyDays();
+    }
+  });
+  days.addEventListener("change", applyDays);
+  const isSameTabLink = (event, link) =>
+    link.target !== "_blank" && event.button === 0 && !event.metaKey &&
+    !event.ctrlKey && !event.shiftKey && !event.altKey;
+  document.addEventListener("click", (event) => {
+    const link = event.target.closest?.("a[href]");
+    if (link && isSameTabLink(event, link)) navigating = true;
+  }, true);
+  controls.addEventListener("submit", () => navigating = true);
+  window.addEventListener("pagehide", () => {
+    navigating = true;
+    rangeRequest?.abort();
+    eventStream?.close();
+  });
+  repo.addEventListener("change", () => repo.form.requestSubmit());
+
+  const renderIdle = () => {
+    collectionFailed = false;
+    transportFailed = false;
+    fetchProgress.classList.remove("error");
+    title.textContent = "Idle";
+    total.textContent = "0 outstanding";
+    bar.max = 1;
+    bar.value = 0;
+    detail.textContent = "No requests in progress.";
+  };
+  const refreshRangeWhenIdle = () => {
+    if (navigating) return;
+    if (
+      days.value !== appliedDays || rangeContent.contains(document.activeElement) ||
+      rangeRequest
+    ) {
+      pendingRefresh = true;
+      return;
+    }
+    void loadRange("refresh");
+  };
+  document.addEventListener("focusout", () => {
+    requestAnimationFrame(() => {
+      if (
+        pendingRefresh && !navigating && !rangeRequest &&
+        !rangeContent.contains(document.activeElement)
+      ) {
+        pendingRefresh = false;
+        refreshRangeWhenIdle();
+      }
+    });
+  });
+  const renderProgress = (state) => {
+    collectionFailed = state.phase === "error";
+    transportFailed = false;
+    fetchProgress.classList.remove("error");
+    if (state.phase === "discovering") {
+      title.textContent = "Finding workflow runs…";
+      total.textContent = state.discoveryOutstandingRequests + " outstanding";
+      bar.removeAttribute("value");
+      detail.textContent = state.discoveryRequestsMade + " workflow requests made · " +
+        state.discoveryResponsesReceived + " responded · " +
+        state.discoveryOutstandingRequests + " outstanding";
+    } else {
+      title.textContent = state.phase === "saving"
+        ? "Saving completed responses…"
+        : state.completedRuns + " of " + state.totalRuns + " run checks complete";
+      total.textContent = state.completedRuns + " / " + state.totalRuns;
+      bar.max = Math.max(1, state.totalRuns);
+      bar.value = state.completedRuns;
+      detail.textContent = state.cachedRuns + " cached · " +
+        state.requestsMade + " run requests made · " +
+        state.sharedRequests + " shared · " +
+        (state.responsesReceived + state.sharedResponses) + " responded · " +
+        state.outstandingRequests + " outstanding · " +
+        state.queuedRuns + " queued" +
+        (state.failedResponses ? " · " + state.failedResponses + " failed" : "");
+    }
+    if (state.phase === "error") {
+      fetchProgress.classList.add("error");
+      title.textContent = "Idle";
+      total.textContent = "0 outstanding";
+      bar.max = 1;
+      bar.value = 0;
+      detail.textContent = "Last collection stopped: " + (state.error || "unknown error");
+      eventStream?.close();
+      eventStream = null;
+      connectedProgressUrl = "";
+    } else if (state.phase === "complete") {
+      eventStream?.close();
+      eventStream = null;
+      connectedProgressUrl = "";
+      if (state.needsReload || serverVersionChanged || fetchProgress.dataset.refreshOnComplete === "1") refreshRangeWhenIdle();
+      else renderIdle();
+    }
+  };
+  const connectProgress = (url) => {
+    if (!url || connectedProgressUrl === url) return;
+    eventStream?.close();
+    connectedProgressUrl = url;
+    const stream = new EventSource(url);
+    eventStream = stream;
+    stream.addEventListener("progress", (event) => {
+      if (eventStream !== stream) return;
+      try {
+        renderProgress(JSON.parse(event.data));
+      } catch {
+        stream.close();
+        eventStream = null;
+        connectedProgressUrl = "";
+        transportFailed = true;
+        fetchProgress.classList.add("error");
+        title.textContent = "Could not read collection progress";
+      }
+    });
+    stream.onerror = () => {
+      if (eventStream !== stream) return;
+      stream.close();
+      eventStream = null;
+      connectedProgressUrl = "";
+      transportFailed = true;
+      fetchProgress.classList.add("error");
+      title.textContent = "Progress connection closed; collection continues on the server";
+    };
+  };
+  const checkForUpdates = async () => {
+    if (checking || navigating || document.visibilityState === "hidden") return;
+    checking = true;
+    const revision = viewRevision;
+    try {
+      const response = await fetch(fetchProgress.dataset.checkUrl, { headers: { accept: "application/json" } });
+      if (!response.ok) throw new Error("HTTP " + response.status);
+      const state = await response.json();
+      if (revision !== viewRevision) return;
+      serverVersionChanged ||= state.version !== pageVersion;
+      if (state.progress) {
+        connectProgress("/bench/ci-progress?id=" + encodeURIComponent(state.progress.id));
+        renderProgress(state.progress);
+      } else if (serverVersionChanged) refreshRangeWhenIdle();
+      else if (!collectionFailed) renderIdle();
+    } catch {
+      if (!eventStream && !collectionFailed && !transportFailed) renderIdle();
+    } finally {
+      checking = false;
+    }
+  };
+  const bindRangeContent = () => {
+    viewRevision++;
+    fetchProgress = rangeContent.querySelector("#fetch-progress");
+    title = rangeContent.querySelector("#fetch-title");
+    total = rangeContent.querySelector("#fetch-total");
+    detail = rangeContent.querySelector("#fetch-detail");
+    bar = rangeContent.querySelector("#fetch-bar");
+    pageVersion = fetchProgress.dataset.snapshotVersion;
+    serverVersionChanged = false;
+    collectionFailed = false;
+    transportFailed = false;
+    connectedProgressUrl = "";
+    if (fetchProgress.dataset.progressUrl) connectProgress(fetchProgress.dataset.progressUrl);
+    else renderIdle();
+  };
+  const showRangeLoading = (requestedDays) => {
+    rangeContent.setAttribute("aria-busy", "true");
+    fetchProgress.classList.remove("error");
+    title.textContent = "Loading " + requestedDays + "-day view…";
+    total.textContent = "updating";
+    bar.removeAttribute("value");
+    detail.textContent = "Reading cached history and checking for new CI data.";
+  };
+  const loadRange = async (mode) => {
+    if (navigating) return;
+    if (rangeRequest) {
+      if (mode === "refresh") {
+        pendingRefresh = true;
+        return;
+      }
+      rangeRequest.abort();
+    }
+    const requestedDays = days.value;
+    const url = new URL(location.href);
+    url.searchParams.set("days", requestedDays);
+    const sequence = ++rangeSequence;
+    const controller = new AbortController();
+    rangeRequest = controller;
+    rangeRequestDays = requestedDays;
+    let loaded = false;
+    showRangeLoading(requestedDays);
+    try {
+      const requestUrl = new URL(url);
+      requestUrl.searchParams.set("fragment", "range");
+      const response = await fetch(requestUrl.pathname + requestUrl.search, {
+        cache: "no-store",
+        headers: { accept: "text/html" },
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error("HTTP " + response.status);
+      const page = new DOMParser().parseFromString(await response.text(), "text/html");
+      const replacement = page.getElementById("range-content");
+      if (!replacement) throw new Error("Range content was missing from the response.");
+      if (sequence !== rangeSequence || navigating) return;
+      eventStream?.close();
+      eventStream = null;
+      connectedProgressUrl = "";
+      rangeContent.replaceWith(replacement);
+      rangeContent = replacement;
+      appliedDays = requestedDays;
+      const target = url.pathname + url.search;
+      if (mode === "push" && target !== location.pathname + location.search) {
+        history.pushState(null, "", target);
+      }
+      bindRangeContent();
+      syncDayLinks();
+      loaded = true;
+    } catch (error) {
+      if (controller.signal.aborted || sequence !== rangeSequence) return;
+      pendingRefresh = false;
+      rangeContent.removeAttribute("aria-busy");
+      fetchProgress.classList.add("error");
+      title.textContent = "Could not update the history window";
+      total.textContent = "0 outstanding";
+      bar.max = 1;
+      bar.value = 0;
+      detail.textContent = error instanceof Error ? error.message : String(error);
+    } finally {
+      if (sequence === rangeSequence) {
+        rangeRequest = null;
+        rangeRequestDays = "";
+        if (loaded && pendingRefresh) {
+          pendingRefresh = false;
+          refreshRangeWhenIdle();
+        }
+      }
+    }
+  };
+  const daysFromLocation = () => {
+    const parameter = new URL(location.href).searchParams.get("days");
+    if (parameter === null || parameter.trim() === "") return DEFAULT_DAYS;
+    const value = Number(parameter);
+    if (!Number.isFinite(value)) return DEFAULT_DAYS;
+    return String(Math.max(Number(days.min), Math.min(Number(days.max), Math.floor(value))));
+  };
+  window.addEventListener("popstate", () => {
+    days.value = daysFromLocation();
+    daysv.value = days.value + (days.value === "1" ? " day" : " days");
+    syncDayLinks();
+    void loadRange("pop");
+  });
+  bindRangeContent();
+  setInterval(checkForUpdates, ${PERFORMANCE_CHECK_MS});
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") void checkForUpdates();
+  });
+</script></body></html>`;
+}
+
+export function ciJobHistoryProgressResponse(
+  url: URL,
+  collector = productionCollector,
+): Response {
+  const id = url.searchParams.get("id");
+  if (!id) return new Response("missing progress id", { status: 400 });
+  if (!collector.progress(id)) {
+    return new Response("unknown progress id", { status: 404 });
+  }
+  const encoder = new TextEncoder();
+  let unsubscribe: (() => void) | undefined;
+  let closed = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const send = (progress: CiJobFetchProgress) => {
+        if (closed) return;
+        controller.enqueue(encoder.encode(
+          `event: progress\ndata: ${JSON.stringify(progress)}\n\n`,
+        ));
+        if (progress.phase === "complete" || progress.phase === "error") {
+          closed = true;
+          controller.close();
+          unsubscribe?.();
+        }
+      };
+      unsubscribe = collector.subscribeProgress(id, send) ??
+        undefined;
+      if (closed) unsubscribe?.();
+    },
+    cancel() {
+      closed = true;
+      unsubscribe?.();
+    },
+  });
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+    },
+  });
+}
+
+function ganttProgressResponse(
+  _request: Request,
+  url: URL,
+  collector: CiJobHistoryCollector,
+  token: string | undefined,
+): Response {
+  const refresh = collector.startGantt(
+    token,
+    ciHistorySource(url.searchParams.get("repo")),
+    ciGanttOptions(url.searchParams),
+  );
+  void refresh.result.catch(() => {});
+  const progressUrl = new URL("http://dashboard/bench/ci-progress");
+  progressUrl.searchParams.set("id", refresh.progress.id);
+  return ciJobHistoryProgressResponse(progressUrl, collector);
+}
+
+export function ciGanttProgressResponse(
+  request: Request,
+  url: URL,
+  collector = productionCollector,
+  token = Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN"),
+): Response {
+  return ganttProgressResponse(request, url, collector, token);
+}
+
+export function ciCommitGanttProgressResponse(
+  request: Request,
+  url: URL,
+  collector = commitGanttCollector,
+  token = Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN"),
+): Response {
+  return ganttProgressResponse(request, url, collector, token);
+}
+
+type CiJobHistoryProvider =
+  & Pick<
+    CiJobHistoryCollector,
+    "cached" | "startRefresh"
+  >
+  & Partial<Pick<CiJobHistoryCollector, "startRefreshForCheck">>;
+
+export async function ciJobHistoryCheckResponse(
+  url: URL,
+  collector: CiJobHistoryProvider = productionCollector,
+  token = Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN"),
+): Promise<Response> {
+  const source = ciHistorySource(url.searchParams.get("repo"));
+  const days = ciHistoryDays(url.searchParams.get("days"));
+  let snapshot = await collector.cached(source, days);
+  let progress: CiJobFetchProgress | null = null;
+  if (token) {
+    const refresh = collector.startRefreshForCheck
+      ? collector.startRefreshForCheck(token, source, days, snapshot)
+      : collector.startRefresh(token, source, days, snapshot);
+    if (refresh) {
+      progress = refresh.progress;
+      if (progress) void refresh.result.catch(() => {});
+      else snapshot = await refresh.result;
+    }
+  }
+  return Response.json(
+    { version: ciJobHistorySnapshotVersion(snapshot), progress },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
+
+export async function ciJobHistoryResponse(
+  url: URL,
+  collector: CiJobHistoryProvider = productionCollector,
+  token = Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN"),
+): Promise<Response> {
+  const source = ciHistorySource(url.searchParams.get("repo"));
+  const days = ciHistoryDays(url.searchParams.get("days"));
+  let snapshot = await collector.cached(source, days);
+  let refreshError: string | undefined;
+  let progress: CiJobFetchProgress | undefined;
+  if (!token) {
+    refreshError = snapshot?.runCount
+      ? "Set GH_TOKEN to refresh CI job history."
+      : "Set GH_TOKEN to collect CI job history.";
+  } else {
+    const refresh = collector.startRefresh(token, source, days, snapshot);
+    progress = refresh.progress ?? undefined;
+    if (progress) void refresh.result.catch(() => {});
+    else snapshot = await refresh.result;
+  }
+  return new Response(
+    ciJobHistoryPage(
+      snapshot,
+      url.searchParams.get("sort") ?? "job",
+      refreshError,
+      {
+        source,
+        days,
+        runtimeStat: url.searchParams.get("stat") ?? undefined,
+        progress,
+        fragment: url.searchParams.get("fragment") === "range",
+      },
+    ),
+    { headers: { "content-type": "text/html; charset=utf-8" } },
+  );
+}

--- a/packages/dashboard/deno.jsonc
+++ b/packages/dashboard/deno.jsonc
@@ -4,7 +4,7 @@
   },
   "tasks": {
     "watch": "deno run --watch --allow-net --allow-run=deno --allow-read --allow-write --allow-env server.ts",
-    "test": "deno test --allow-env --ignore=favicon-client.browser.test.ts --ignore=favicon-raster.test.ts --ignore=regenerate-favicons.test.ts && deno task test-favicon-raster && deno task test-browser",
+    "test": "deno run --allow-env --allow-read --allow-write --allow-run test/runner.ts",
     // Resvg's Linux loader checks the C library through Node's process report,
     // which reads CPU, network-interface, and hostname information.
     "test-favicon-raster": "deno test --allow-read --allow-write --allow-run=deno --allow-ffi --allow-sys=cpus,networkInterfaces,hostname favicon-raster.test.ts regenerate-favicons.test.ts",

--- a/packages/dashboard/github-rate-limit.test.ts
+++ b/packages/dashboard/github-rate-limit.test.ts
@@ -1,0 +1,1234 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
+import {
+  type GitHubPrimaryRateLimit,
+  GitHubRateLimitBudget,
+  GitHubRateLimitBudgetError,
+  type GitHubRateLimitLedgerLock,
+} from "./github-rate-limit.ts";
+import { dashboardCacheFile } from "./history-files.ts";
+import {
+  friendlyError,
+  github,
+  githubDownload,
+  performanceGithub,
+  performanceGithubDownload,
+} from "./lib.ts";
+
+const RESET = 2_000_000_000;
+
+function primary(
+  used: number,
+  limit = 100,
+  reset = RESET,
+): GitHubPrimaryRateLimit {
+  return { limit, used, remaining: limit - used, reset };
+}
+
+function rateHeaders(used: number, limit = 100, reset = RESET): HeadersInit {
+  return {
+    "x-ratelimit-resource": "core",
+    "x-ratelimit-limit": String(limit),
+    "x-ratelimit-used": String(used),
+    "x-ratelimit-remaining": String(limit - used),
+    "x-ratelimit-reset": String(reset),
+  };
+}
+
+function ledgerLock(overrides: Partial<GitHubRateLimitLedgerLock> = {}) {
+  return {
+    lock: () => Promise.resolve(),
+    unlock: () => Promise.resolve(),
+    close: () => {},
+    ...overrides,
+  };
+}
+
+function fakeLease(overrides: Record<string, unknown> = {}): Deno.FsFile {
+  return {
+    lock: () => Promise.resolve(),
+    unlock: () => Promise.resolve(),
+    tryLock: () => Promise.resolve(true),
+    close: () => {},
+    ...overrides,
+  } as unknown as Deno.FsFile;
+}
+
+async function tokenKey(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(token),
+  );
+  return [...new Uint8Array(digest)].map((byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("");
+}
+
+Deno.test("GitHub performance budget rejects invalid configuration", () => {
+  for (const fraction of [0, 1.1, Number.NaN]) {
+    assertThrows(
+      () => new GitHubRateLimitBudget({ fraction }),
+      RangeError,
+      "fraction must be above 0 and at most 1",
+    );
+  }
+  for (const restPointsPerMinute of [0, 1.5]) {
+    assertThrows(
+      () => new GitHubRateLimitBudget({ restPointsPerMinute }),
+      RangeError,
+      "REST points per minute must be a positive integer",
+    );
+  }
+});
+
+Deno.test("GitHub performance budget rejects every malformed primary field", async () => {
+  const malformed: GitHubPrimaryRateLimit[] = [
+    { limit: 0, used: 0, remaining: 0, reset: RESET },
+    { limit: 100, used: -1, remaining: 100, reset: RESET },
+    { limit: 100, used: 0, remaining: -1, reset: RESET },
+    { limit: 100, used: 0, remaining: 101, reset: RESET },
+    { limit: 100, used: 0, remaining: 100, reset: 0 },
+  ];
+  for (const [index, value] of malformed.entries()) {
+    const budget = new GitHubRateLimitBudget();
+    await assertRejects(
+      () => budget.reserve(`invalid-${index}`, () => Promise.resolve(value)),
+      GitHubRateLimitBudgetError,
+      "rate limit status was invalid",
+    );
+  }
+});
+
+Deno.test("GitHub performance budget reports rejected in-memory probes", async () => {
+  for (
+    const [index, reason] of [new Error("offline"), "disconnected"].entries()
+  ) {
+    const budget = new GitHubRateLimitBudget();
+    await assertRejects(
+      () => budget.reserve(`rejected-${index}`, () => Promise.reject(reason)),
+      GitHubRateLimitBudgetError,
+      String(reason instanceof Error ? reason.message : reason),
+    );
+  }
+});
+
+Deno.test("GitHub performance budget handles incomplete and older response headers", async () => {
+  const budget = new GitHubRateLimitBudget({ now: () => 1_900_000_000_000 });
+  const first = await budget.reserve(
+    "token",
+    () => Promise.resolve(primary(0, 100, RESET + 10)),
+  );
+  await first.complete(new Response(null));
+  await first.complete(new Response(null));
+
+  const second = await budget.reserve(
+    "token",
+    () => Promise.resolve(primary(0, 100, RESET + 10)),
+  );
+  await second.complete(
+    new Response(null, {
+      headers: rateHeaders(1, 100, RESET),
+    }),
+  );
+  const third = await budget.reserve(
+    "token",
+    () => Promise.resolve(primary(0, 100, RESET + 10)),
+  );
+  await third.complete(
+    new Response(null, {
+      headers: {
+        "x-ratelimit-resource": "core",
+        "x-ratelimit-limit": "",
+      },
+    }),
+  );
+});
+
+Deno.test("GitHub performance budget rejects malformed stored ledgers", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const key = "a".repeat(64);
+  const cases: unknown[] = [
+    null,
+    { version: 2, tokens: [] },
+    { version: 1, tokens: {} },
+    { version: 1, tokens: [null] },
+    {
+      version: 1,
+      tokens: [{ key, primary: null, reservations: [], requestTimes: [] }],
+    },
+    {
+      version: 1,
+      tokens: [{ key, reservations: [null], requestTimes: [] }],
+    },
+    {
+      version: 1,
+      tokens: [
+        { key, reservations: [], requestTimes: [] },
+        { key, reservations: [], requestTimes: [] },
+      ],
+    },
+  ];
+  try {
+    for (const [index, value] of cases.entries()) {
+      const file = `${directory}/${index}.json`;
+      await Deno.writeTextFile(file, JSON.stringify(value));
+      const budget = new GitHubRateLimitBudget({ file });
+      await assertRejects(
+        () => budget.reserve("token", () => Promise.resolve(primary(0))),
+        GitHubRateLimitBudgetError,
+        "ledger was invalid",
+      );
+    }
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance budget rejects an invalid stored probe", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  try {
+    const budget = new GitHubRateLimitBudget({
+      file: `${directory}/ledger.json`,
+    });
+    await assertRejects(
+      () => budget.reserve("token", () => Promise.resolve(primary(0, 0))),
+      GitHubRateLimitBudgetError,
+      "rate limit status was invalid",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance ledger preserves write failures during cleanup", async () => {
+  for (const cleanupFails of [false, true]) {
+    const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+    const file = `${directory}/ledger.json`;
+    const rename = Deno.rename;
+    const remove = Deno.remove;
+    try {
+      Deno.rename = (() =>
+        Promise.reject(new Error("rename failed"))) as typeof Deno.rename;
+      Deno.remove = ((path, options) =>
+        cleanupFails && String(path).endsWith(".tmp")
+          ? Promise.reject(new Error("remove failed"))
+          : remove(path, options)) as typeof Deno.remove;
+      const budget = new GitHubRateLimitBudget({ file });
+      await assertRejects(
+        () =>
+          budget.reserve("token", () =>
+            Promise.resolve(primary(0))),
+        GitHubRateLimitBudgetError,
+        "rename failed",
+      );
+    } finally {
+      Deno.rename = rename;
+      Deno.remove = remove;
+      await Deno.remove(directory, { recursive: true });
+    }
+  }
+});
+
+Deno.test("GitHub performance ledger reports lock cleanup failures", async () => {
+  for (const stage of ["unlock", "close"] as const) {
+    const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+    try {
+      const budget = new GitHubRateLimitBudget({
+        file: `${directory}/ledger.json`,
+        openLedgerLock: () =>
+          Promise.resolve(ledgerLock({
+            unlock: () =>
+              stage === "unlock"
+                ? Promise.reject(new Error("unlock failed"))
+                : Promise.resolve(),
+            close: () => {
+              if (stage === "close") throw new Error("close failed");
+            },
+          })),
+      });
+      await assertRejects(
+        () => budget.reserve("token", () => Promise.resolve(primary(0))),
+        GitHubRateLimitBudgetError,
+        `${stage} failed`,
+      );
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  }
+});
+
+Deno.test("GitHub performance ledger cleans up a reservation lease that cannot lock", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const open = Deno.open;
+  try {
+    Deno.open = (() =>
+      Promise.resolve(fakeLease({
+        lock: () => Promise.reject(new Error("lease lock failed")),
+      }))) as typeof Deno.open;
+    const budget = new GitHubRateLimitBudget({
+      file: `${directory}/ledger.json`,
+      openLedgerLock: () => Promise.resolve(ledgerLock()),
+    });
+    await assertRejects(
+      () => budget.reserve("token", () => Promise.resolve(primary(0))),
+      GitHubRateLimitBudgetError,
+      "lease lock failed",
+    );
+  } finally {
+    Deno.open = open;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance ledger reports reservation close failures", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const open = Deno.open;
+  const remove = Deno.remove;
+  try {
+    Deno.open = (() =>
+      Promise.resolve(fakeLease({
+        unlock: () => Promise.reject(new Error("lease unlock failed")),
+        close: () => {
+          throw new Error("lease close failed");
+        },
+      }))) as typeof Deno.open;
+    Deno.remove = ((path, options) =>
+      String(path).endsWith(".reservation.lock")
+        ? Promise.reject(new Error("lease remove failed"))
+        : remove(path, options)) as typeof Deno.remove;
+    const budget = new GitHubRateLimitBudget({
+      file: `${directory}/ledger.json`,
+      openLedgerLock: () =>
+        Promise.resolve(ledgerLock()),
+    });
+    const reservation = await budget.reserve(
+      "token",
+      () => Promise.resolve(primary(0)),
+    );
+    await assertRejects(
+      () => Promise.resolve(reservation.complete()),
+      GitHubRateLimitBudgetError,
+      "lease unlock failed",
+    );
+  } finally {
+    Deno.open = open;
+    Deno.remove = remove;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance ledger reports failed rejected-reservation cleanup", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const open = Deno.open;
+  try {
+    Deno.open = (() =>
+      Promise.resolve(fakeLease({
+        unlock: () => Promise.reject(new Error("lease unlock failed")),
+      }))) as typeof Deno.open;
+    const budget = new GitHubRateLimitBudget({
+      file: `${directory}/ledger.json`,
+      openLedgerLock: () => Promise.resolve(ledgerLock()),
+    });
+    await assertRejects(
+      () => budget.reserve("token", () => Promise.resolve(primary(80))),
+      GitHubRateLimitBudgetError,
+      "lease unlock failed",
+    );
+  } finally {
+    Deno.open = open;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance ledger reports failed abandoned-reservation cleanup", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  const open = Deno.open;
+  try {
+    Deno.open = (() =>
+      Promise.resolve(fakeLease({
+        unlock: () => Promise.reject(new Error("lease unlock failed")),
+        close: () => {
+          throw new Error("lease close failed");
+        },
+      }))) as typeof Deno.open;
+    const budget = new GitHubRateLimitBudget({
+      file,
+      openLedgerLock: () => Promise.resolve(ledgerLock()),
+    });
+    const reservation = await budget.reserve(
+      "token",
+      () => Promise.resolve(primary(0)),
+    );
+    await Deno.writeTextFile(file, "{invalid");
+    await assertRejects(
+      () => Promise.resolve(reservation.complete()),
+      GitHubRateLimitBudgetError,
+      "lease unlock failed",
+    );
+  } finally {
+    Deno.open = open;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance ledger closes a lease after its write rolls back", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  const rename = Deno.rename;
+  let renames = 0;
+  try {
+    Deno.rename = ((oldpath, newpath) => {
+      renames++;
+      return renames === 3
+        ? Promise.reject(new Error("reservation write failed"))
+        : rename(oldpath, newpath);
+    }) as typeof Deno.rename;
+    const budget = new GitHubRateLimitBudget({ file });
+    await assertRejects(
+      () => budget.reserve("token", () => Promise.resolve(primary(0))),
+      GitHubRateLimitBudgetError,
+      "reservation write failed",
+    );
+    assertEquals(
+      [...Deno.readDirSync(directory)].some((entry) =>
+        entry.name.endsWith(".reservation.lock")
+      ),
+      false,
+    );
+  } finally {
+    Deno.rename = rename;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance ledger reports reservation liveness failures", async () => {
+  for (const stage of ["open", "lock"] as const) {
+    const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+    const file = `${directory}/ledger.json`;
+    const token = `token-${stage}`;
+    const open = Deno.open;
+    try {
+      await Deno.writeTextFile(
+        file,
+        JSON.stringify({
+          version: 1,
+          tokens: [{
+            key: await tokenKey(token),
+            reservations: [{ id: "expired", resetAt: 1 }],
+            requestTimes: [],
+          }],
+        }),
+      );
+      Deno.open = (() =>
+        stage === "open"
+          ? Promise.reject(new Error("lease open failed"))
+          : Promise.resolve(fakeLease({
+            tryLock: () =>
+              Promise.reject(new Error("lease lock failed")),
+          }))) as typeof Deno.open;
+      const budget = new GitHubRateLimitBudget({
+        file,
+        now: () => 2,
+        openLedgerLock: () => Promise.resolve(ledgerLock()),
+      });
+      await assertRejects(
+        () => budget.reserve(token, () => Promise.resolve(primary(0))),
+        GitHubRateLimitBudgetError,
+        `lease ${stage} failed`,
+      );
+    } finally {
+      Deno.open = open;
+      await Deno.remove(directory, { recursive: true });
+    }
+  }
+});
+
+Deno.test("GitHub performance ledger treats a missing reservation lease as expired", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  const token = "missing-lease";
+  const open = Deno.open;
+  try {
+    await Deno.writeTextFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        tokens: [{
+          key: await tokenKey(token),
+          reservations: [{ id: "expired", resetAt: 1 }],
+          requestTimes: [],
+        }],
+      }),
+    );
+    Deno.open = (() =>
+      Promise.reject(new Deno.errors.NotFound())) as typeof Deno.open;
+    const budget = new GitHubRateLimitBudget({
+      file,
+      now: () => 2,
+      openLedgerLock: () => Promise.resolve(ledgerLock()),
+    });
+    await assertRejects(
+      () => budget.reserve(token, () => Promise.resolve(primary(0))),
+      GitHubRateLimitBudgetError,
+    );
+  } finally {
+    Deno.open = open;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance ledger reports an expired-lease removal failure", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  const token = "expired-removal";
+  const open = Deno.open;
+  const remove = Deno.remove;
+  try {
+    await Deno.writeTextFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        tokens: [{
+          key: await tokenKey(token),
+          reservations: [{ id: "expired", resetAt: 1 }],
+          requestTimes: [],
+        }],
+      }),
+    );
+    Deno.open = (() => Promise.resolve(fakeLease())) as typeof Deno.open;
+    Deno.remove = ((path, options) =>
+      String(path).endsWith(".reservation.lock")
+        ? Promise.reject(new Error("lease remove failed"))
+        : remove(path, options)) as typeof Deno.remove;
+    const budget = new GitHubRateLimitBudget({
+      file,
+      now: () =>
+        2,
+      openLedgerLock: () => Promise.resolve(ledgerLock()),
+    });
+    await assertRejects(
+      () => budget.reserve(token, () => Promise.resolve(primary(0))),
+      GitHubRateLimitBudgetError,
+      "lease remove failed",
+    );
+  } finally {
+    Deno.open = open;
+    Deno.remove = remove;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance budget rejects a primary window that expires during its probe", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  let now = 1_900_000_000_000;
+  try {
+    const budget = new GitHubRateLimitBudget({
+      file: `${directory}/ledger.json`,
+      now: () => now,
+    });
+    await assertRejects(
+      () =>
+        budget.reserve("token", () => {
+          now = RESET * 1_000;
+          return Promise.resolve(primary(0));
+        }),
+      GitHubRateLimitBudgetError,
+      "rate limit status expired before the request started",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance reservation completion is idempotent", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  try {
+    const budget = new GitHubRateLimitBudget({
+      file: `${directory}/ledger.json`,
+    });
+    const reservation = await budget.reserve(
+      "token",
+      () => Promise.resolve(primary(0)),
+    );
+    await reservation.complete();
+    await reservation.complete();
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance ledger serializes concurrent reservations before taking file locks", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  let held = false;
+  let overlapping = false;
+  let lockCount = 0;
+  const budget = new GitHubRateLimitBudget({
+    file,
+    now: () => 1_900_000_000_000,
+    openLedgerLock: () =>
+      Promise.resolve({
+        async lock() {
+          lockCount++;
+          if (held) {
+            overlapping = true;
+            throw new Error("concurrent ledger lock attempt");
+          }
+          held = true;
+          await Promise.resolve();
+        },
+        unlock() {
+          held = false;
+          return Promise.resolve();
+        },
+        close() {},
+      }),
+  });
+  const probe = () => Promise.resolve(primary(0, 5_000));
+  try {
+    const reservations = await Promise.all(
+      Array.from({ length: 48 }, () => budget.reserve("token", probe)),
+    );
+    await Promise.all(
+      reservations.map((reservation) => reservation.complete()),
+    );
+    assertEquals(overlapping, false);
+    assertEquals(held, false);
+    assertEquals(lockCount > 48, true);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+async function readLine(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let value = "";
+  try {
+    while (!value.includes("\n")) {
+      const next = await reader.read();
+      if (next.done) {
+        throw new Error("child process closed before it was ready");
+      }
+      value += decoder.decode(next.value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return value.slice(0, value.indexOf("\n"));
+}
+
+Deno.test("GitHub performance budget reserves concurrent requests below the 80% ceiling", async () => {
+  const budget = new GitHubRateLimitBudget({ now: () => 1_900_000_000_000 });
+  let probes = 0;
+  const probe = () => {
+    probes++;
+    return Promise.resolve(primary(78));
+  };
+
+  const first = await budget.reserve("token", probe);
+  const second = await budget.reserve("token", probe);
+  const error = await assertRejects(
+    () => budget.reserve("token", probe),
+    GitHubRateLimitBudgetError,
+  );
+  assertStringIncludes(
+    error.message,
+    "80% performance-history safety threshold",
+  );
+  assertEquals(probes, 3);
+
+  await second.complete(new Response(null, { headers: rateHeaders(80) }));
+  await first.complete(new Response(null, { headers: rateHeaders(79) }));
+  await assertRejects(
+    () => budget.reserve("token", probe),
+    GitHubRateLimitBudgetError,
+  );
+});
+
+Deno.test("GitHub performance budget reads a new primary window after reset", async () => {
+  let now = 1_900_000_000_000;
+  const budget = new GitHubRateLimitBudget({ now: () => now });
+  let probes = 0;
+  const reservation = await budget.reserve("token", () => {
+    probes++;
+    return Promise.resolve(primary(0, 100, 1_900_000_001));
+  });
+  await reservation.complete(
+    new Response(null, { headers: rateHeaders(1, 100, 1_900_000_001) }),
+  );
+
+  now = 1_900_000_001_000;
+  const next = await budget.reserve("token", () => {
+    probes++;
+    return Promise.resolve(primary(0, 200, 1_900_000_100));
+  });
+  await next.complete(
+    new Response(null, { headers: rateHeaders(1, 200, 1_900_000_100) }),
+  );
+  assertEquals(probes, 2);
+});
+
+Deno.test("GitHub performance budget also keeps REST request points below 80% per minute", async () => {
+  const budget = new GitHubRateLimitBudget({
+    now: () => 1_900_000_000_000,
+    restPointsPerMinute: 5,
+  });
+  const probe = () => Promise.resolve(primary(0));
+
+  for (let request = 0; request < 2; request++) {
+    const reservation = await budget.reserve("token", probe);
+    await reservation.complete(
+      new Response(null, { headers: rateHeaders(request + 1) }),
+    );
+  }
+  const error = await assertRejects(
+    () => budget.reserve("token", probe),
+    GitHubRateLimitBudgetError,
+  );
+  assertStringIncludes(error.message, "REST request points");
+});
+
+Deno.test("GitHub performance budget uses the most conservative primary fields", async () => {
+  const budget = new GitHubRateLimitBudget({ now: () => 1_900_000_000_000 });
+  await assertRejects(
+    () =>
+      budget.reserve("token", () =>
+        Promise.resolve({
+          limit: 100,
+          used: 0,
+          remaining: 0,
+          reset: RESET,
+        })),
+    GitHubRateLimitBudgetError,
+    "80% performance-history safety threshold",
+  );
+});
+
+Deno.test("GitHub performance reservations are shared by budget instances", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  const options = { now: () => 1_900_000_000_000, file };
+  const firstBudget = new GitHubRateLimitBudget(options);
+  const secondBudget = new GitHubRateLimitBudget(options);
+  let probes = 0;
+  const probe = () => {
+    probes++;
+    return Promise.resolve(primary(78));
+  };
+  try {
+    const first = await firstBudget.reserve("shared-token", probe);
+    const second = await secondBudget.reserve("shared-token", probe);
+    await assertRejects(
+      () => secondBudget.reserve("shared-token", probe),
+      GitHubRateLimitBudgetError,
+      "80% performance-history safety threshold",
+    );
+    assertEquals(probes, 3);
+    assertEquals(
+      (await Deno.readTextFile(file)).includes("shared-token"),
+      false,
+    );
+    await Promise.all([
+      first.complete(new Response(null, { headers: rateHeaders(79) })),
+      second.complete(new Response(null, { headers: rateHeaders(80) })),
+    ]);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance reservations are shared by dashboard processes", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  const module = new URL("./github-rate-limit.ts", import.meta.url).href;
+  const token = `process-token-${crypto.randomUUID()}`;
+  const now = 1_900_000_000_000;
+  const childCode = `
+    const { GitHubRateLimitBudget } = await import(${JSON.stringify(module)});
+    const budget = new GitHubRateLimitBudget({
+      file: ${JSON.stringify(file)},
+      now: () => ${now},
+    });
+    const reservation = await budget.reserve(
+      ${JSON.stringify(token)},
+      () => Promise.resolve({
+        limit: 100,
+        used: 79,
+        remaining: 21,
+        reset: ${RESET},
+      }),
+    );
+    console.log("reserved");
+    await Deno.stdin.readable.getReader().read();
+    await reservation.complete();
+  `;
+  const child = new Deno.Command(Deno.execPath(), {
+    args: ["eval", childCode],
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  }).spawn();
+  const childError = new Response(child.stderr).text();
+  let inputError: unknown;
+  let status: Deno.CommandStatus | undefined;
+  let stderr = "";
+  try {
+    assertEquals(await readLine(child.stdout), "reserved");
+    const budget = new GitHubRateLimitBudget({ file, now: () => now });
+    await assertRejects(
+      () => budget.reserve(token, () => Promise.resolve(primary(79))),
+      GitHubRateLimitBudgetError,
+      "80% performance-history safety threshold",
+    );
+  } finally {
+    try {
+      const childInput = child.stdin.getWriter();
+      await childInput.write(new Uint8Array([10]));
+      await childInput.close();
+    } catch (error) {
+      inputError = error;
+    }
+    [status, stderr] = await Promise.all([child.status, childError]);
+    await Deno.remove(directory, { recursive: true });
+  }
+  if (inputError) throw inputError;
+  assertEquals(status?.success, true, stderr);
+});
+
+Deno.test("GitHub performance reservations stay counted across a primary reset", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  let now = 1_900_000_000_000;
+  const options = { now: () => now, file };
+  const firstBudget = new GitHubRateLimitBudget(options);
+  const secondBudget = new GitHubRateLimitBudget(options);
+  try {
+    const crossing = await firstBudget.reserve(
+      "shared-token",
+      () => Promise.resolve(primary(79, 100, 1_900_000_001)),
+    );
+    now = 1_900_000_001_000;
+    await assertRejects(
+      () =>
+        secondBudget.reserve(
+          "shared-token",
+          () => Promise.resolve(primary(79, 100, 1_900_000_100)),
+        ),
+      GitHubRateLimitBudgetError,
+      "80% performance-history safety threshold",
+    );
+    await crossing.complete(
+      new Response(null, {
+        headers: rateHeaders(80, 100, 1_900_000_100),
+      }),
+    );
+    await assertRejects(
+      () =>
+        secondBudget.reserve(
+          "shared-token",
+          () => Promise.resolve(primary(80, 100, 1_900_000_100)),
+        ),
+      GitHubRateLimitBudgetError,
+      "80% performance-history safety threshold",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub REST point history survives a dashboard restart", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  const options = {
+    now: () => 1_900_000_000_000,
+    file,
+    restPointsPerMinute: 5,
+  };
+  const probe = () => Promise.resolve(primary(0));
+  try {
+    const firstBudget = new GitHubRateLimitBudget(options);
+    const first = await firstBudget.reserve("shared-token", probe);
+    await first.complete(new Response(null, { headers: rateHeaders(1) }));
+
+    const restarted = new GitHubRateLimitBudget(options);
+    const reservation = await restarted.reserve("shared-token", probe);
+    await reservation.complete(
+      new Response(null, { headers: rateHeaders(2) }),
+    );
+    await assertRejects(
+      () => restarted.reserve("shared-token", probe),
+      GitHubRateLimitBudgetError,
+      "REST request points",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance reservations become recoverable when completion cannot update the ledger", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  let now = 1_900_000_000_000;
+  const options = { now: () => now, file };
+  const budget = new GitHubRateLimitBudget(options);
+  try {
+    const reservation = await budget.reserve(
+      "shared-token",
+      () => Promise.resolve(primary(0, 100, 1_900_000_001)),
+    );
+    const validLedger = await Deno.readTextFile(file);
+    await Deno.writeTextFile(file, "{invalid");
+    await assertRejects(
+      async () => await reservation.complete(),
+      GitHubRateLimitBudgetError,
+      "ledger could not be read",
+    );
+    await Deno.writeTextFile(file, validLedger);
+
+    now = 1_900_000_001_000;
+    const restarted = new GitHubRateLimitBudget(options);
+    const next = await restarted.reserve(
+      "shared-token",
+      () => Promise.resolve(primary(0, 100, 1_900_000_100)),
+    );
+    await next.complete(
+      new Response(null, {
+        headers: rateHeaders(1, 100, 1_900_000_100),
+      }),
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance requests preserve an unreadable shared ledger", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  const malformed = "{not json";
+  await Deno.writeTextFile(file, malformed);
+  let probes = 0;
+  const budget = new GitHubRateLimitBudget({ file });
+  try {
+    await assertRejects(
+      () =>
+        budget.reserve("shared-token", () => {
+          probes++;
+          return Promise.resolve(primary(0));
+        }),
+      GitHubRateLimitBudgetError,
+      "ledger could not be read",
+    );
+    assertEquals(probes, 0);
+    assertEquals(await Deno.readTextFile(file), malformed);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("GitHub performance requests fail closed when the ledger cannot be locked", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/missing/ledger.json`;
+  const budget = new GitHubRateLimitBudget({ file });
+  try {
+    await assertRejects(
+      () => budget.reserve("shared-token", () => Promise.resolve(primary(0))),
+      GitHubRateLimitBudgetError,
+      "ledger could not be updated",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("a rejected performance reservation removes its unused lease", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  const budget = new GitHubRateLimitBudget({
+    file,
+    now: () => 1_900_000_000_000,
+  });
+  try {
+    await assertRejects(
+      () => budget.reserve("shared-token", () => Promise.resolve(primary(80))),
+      GitHubRateLimitBudgetError,
+      "80% performance-history safety threshold",
+    );
+    const leases: string[] = [];
+    for await (const entry of Deno.readDir(directory)) {
+      if (entry.name.endsWith(".reservation.lock")) leases.push(entry.name);
+    }
+    assertEquals(leases, []);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("expired reservation leases remain until their ledger removal commits", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "github-rate-limit-" });
+  const file = `${directory}/ledger.json`;
+  const reset = 1_900_000_001;
+  const firstBudget = new GitHubRateLimitBudget({
+    file,
+    now: () => 1_900_000_000_000,
+  });
+  try {
+    const abandoned = await firstBudget.reserve(
+      "shared-token",
+      () => Promise.resolve(primary(0, 100, reset)),
+    );
+    const validLedger = await Deno.readTextFile(file);
+    await Deno.writeTextFile(file, "{invalid");
+    await assertRejects(
+      async () => await abandoned.complete(),
+      GitHubRateLimitBudgetError,
+      "ledger could not be read",
+    );
+    const saturated = JSON.parse(validLedger) as {
+      tokens: { requestTimes: number[] }[];
+    };
+    saturated.tokens[0].requestTimes = Array(4).fill(reset * 1_000);
+    await Deno.writeTextFile(file, JSON.stringify(saturated));
+
+    const restarted = new GitHubRateLimitBudget({
+      file,
+      now: () => reset * 1_000,
+      restPointsPerMinute: 5,
+    });
+    await assertRejects(
+      () =>
+        restarted.reserve("shared-token", () => Promise.resolve(primary(0))),
+      GitHubRateLimitBudgetError,
+      "REST request points",
+    );
+    const stored = JSON.parse(await Deno.readTextFile(file)) as {
+      tokens: { reservations: unknown[]; requestTimes: number[] }[];
+    };
+    assertEquals(stored.tokens[0].reservations.length, 1);
+    assertEquals(
+      [...Deno.readDirSync(directory)].filter((entry) =>
+        entry.name.endsWith(".reservation.lock")
+      ).length,
+      1,
+    );
+
+    stored.tokens[0].requestTimes = [];
+    await Deno.writeTextFile(file, JSON.stringify(stored));
+
+    const recovered = await restarted.reserve(
+      "shared-token",
+      () => Promise.resolve(primary(0, 100, reset + 100)),
+    );
+    await recovered.complete(
+      new Response(null, { headers: rateHeaders(1, 100, reset + 100) }),
+    );
+    assertEquals(
+      [...Deno.readDirSync(directory)].filter((entry) =>
+        entry.name.endsWith(".reservation.lock")
+      ).length,
+      0,
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("ordinary dashboard GitHub requests stay outside the ledger while the next performance probe refreshes the primary total", async () => {
+  const token = `ordinary-request-${crypto.randomUUID()}`;
+  const ledgerFile = dashboardCacheFile(
+    "fabric-wall-github-rate-limit.json",
+  );
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  let probes = 0;
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    calls.push(url.pathname);
+    if (url.pathname === "/rate_limit") {
+      probes++;
+      return Promise.resolve(Response.json({
+        resources: { core: primary(probes === 1 ? 0 : 1) },
+      }));
+    }
+    if (url.pathname === "/repos/o/performance-first") {
+      return Promise.resolve(Response.json({ performance: true }, {
+        headers: rateHeaders(1),
+      }));
+    }
+    if (url.pathname === "/repos/o/ordinary") {
+      return Promise.resolve(Response.json({ ordinary: true }, {
+        headers: rateHeaders(80),
+      }));
+    }
+    if (url.pathname === "/repos/o/performance") {
+      return Promise.resolve(Response.json({ performance: true }, {
+        headers: rateHeaders(2),
+      }));
+    }
+    return Promise.resolve(Response.json({ shouldNotBeRead: true }));
+  }) as typeof fetch;
+
+  try {
+    assertEquals(
+      await performanceGithub<{ performance: boolean }>(
+        "repos/o/performance-first",
+        token,
+      ),
+      { performance: true },
+    );
+    const ledgerBeforeOrdinary = await Deno.readTextFile(ledgerFile);
+    assertEquals(
+      await github<{ ordinary: boolean }>("repos/o/ordinary", token),
+      { ordinary: true },
+    );
+    assertEquals(await Deno.readTextFile(ledgerFile), ledgerBeforeOrdinary);
+    assertEquals(
+      await performanceGithub<{ performance: boolean }>(
+        "repos/o/performance",
+        token,
+      ),
+      { performance: true },
+    );
+    assertEquals(calls, [
+      "/rate_limit",
+      "/repos/o/performance-first",
+      "/repos/o/ordinary",
+      "/rate_limit",
+      "/repos/o/performance",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("performance GitHub requests stop after the rate probe reaches 80%", async () => {
+  const token = `rate-limit-test-${crypto.randomUUID()}`;
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    calls.push(url.pathname);
+    if (url.pathname === "/rate_limit") {
+      return Promise.resolve(Response.json({
+        resources: { core: primary(80) },
+      }));
+    }
+    return Promise.resolve(Response.json({ shouldNotBeRead: true }));
+  }) as typeof fetch;
+
+  try {
+    const error = await assertRejects(
+      () => performanceGithub("repos/o/r", token),
+      GitHubRateLimitBudgetError,
+    );
+    assertStringIncludes(
+      error.message,
+      "80% performance-history safety threshold",
+    );
+    assertEquals(friendlyError(error.message), "rate limit hit");
+    assertEquals(calls, ["/rate_limit"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("performance GitHub requests can consume the request that reaches 80%", async () => {
+  const token = `rate-limit-test-${crypto.randomUUID()}`;
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  let probes = 0;
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    calls.push(url.pathname);
+    if (url.pathname === "/rate_limit") {
+      probes++;
+      return Promise.resolve(Response.json({
+        resources: { core: primary(probes === 1 ? 79 : 80) },
+      }));
+    }
+    return Promise.resolve(Response.json({ ok: true }, {
+      headers: rateHeaders(80),
+    }));
+  }) as typeof fetch;
+
+  try {
+    assertEquals(
+      await performanceGithub<{ ok: boolean }>("repos/o/r", token),
+      { ok: true },
+    );
+    assertEquals(calls, ["/rate_limit", "/repos/o/r"]);
+    await assertRejects(
+      () => performanceGithub("repos/o/r", token),
+      GitHubRateLimitBudgetError,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("performance GitHub requests report unusable rate-limit responses", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    for (
+      const response of [
+        new Response("unavailable", { status: 503 }),
+        Response.json({ resources: {} }),
+      ]
+    ) {
+      const token = `rate-probe-${crypto.randomUUID()}`;
+      globalThis.fetch = (() =>
+        Promise.resolve(response.clone())) as typeof fetch;
+      await assertRejects(
+        () => performanceGithub("repos/o/r", token),
+        GitHubRateLimitBudgetError,
+        "rate limit status could not be read",
+      );
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("GitHub download helpers return response bodies without JSON decoding", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: { path: string; signal: AbortSignal | null | undefined }[] = [];
+  const token = `download-${crypto.randomUUID()}`;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    calls.push({ path: url.pathname, signal: init?.signal });
+    if (url.pathname === "/rate_limit") {
+      return Promise.resolve(Response.json({
+        resources: { core: primary(0, 5_000) },
+      }));
+    }
+    return Promise.resolve(
+      new Response("archive", {
+        headers: rateHeaders(1, 5_000),
+      }),
+    );
+  }) as typeof fetch;
+
+  try {
+    assertEquals(
+      await (await githubDownload("repos/o/archive", token)).text(),
+      "archive",
+    );
+    assertEquals(
+      await (await performanceGithubDownload("repos/o/archive", token)).text(),
+      "archive",
+    );
+    assertEquals(calls.map((call) => call.path), [
+      "/repos/o/archive",
+      "/rate_limit",
+      "/repos/o/archive",
+    ]);
+    assertEquals(calls.every((call) => call.signal == null), true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/dashboard/github-rate-limit.ts
+++ b/packages/dashboard/github-rate-limit.ts
@@ -1,0 +1,735 @@
+// A shared budget for GitHub requests made by the performance history views.
+// GitHub reports the primary core budget in every API response. Each guarded
+// request batch reads /rate_limit so the token-wide spend is known before
+// collection starts.
+
+import { dashboardCacheFile } from "./history-files.ts";
+
+export const GITHUB_RATE_LIMIT_FRACTION = 0.8;
+export const GITHUB_REST_POINTS_PER_MINUTE = 900;
+
+const LEDGER_VERSION = 1;
+const ledgerOperationTails = new Map<string, Promise<void>>();
+
+async function withGitHubRateLimitLedgerTurn<T>(
+  file: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = ledgerOperationTails.get(file) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const tail = previous.then(() => current);
+  ledgerOperationTails.set(file, tail);
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (ledgerOperationTails.get(file) === tail) {
+      ledgerOperationTails.delete(file);
+    }
+  }
+}
+
+export interface GitHubPrimaryRateLimit {
+  limit: number;
+  used: number;
+  remaining: number;
+  reset: number;
+}
+
+interface GitHubRateLimitState {
+  limit: number;
+  used: number;
+  resetAt: number;
+  inFlight: number;
+}
+
+interface StoredPrimaryRateLimit {
+  limit: number;
+  used: number;
+  resetAt: number;
+}
+
+interface StoredReservation {
+  id: string;
+  resetAt: number;
+}
+
+interface StoredTokenBudget {
+  key: string;
+  primary?: StoredPrimaryRateLimit;
+  reservations: StoredReservation[];
+  requestTimes: number[];
+}
+
+interface StoredRateLimitLedger {
+  version: number;
+  tokens: StoredTokenBudget[];
+}
+
+export interface GitHubRateLimitReservation {
+  complete(response?: Response): void | Promise<void>;
+}
+
+export interface GitHubRateLimitLedgerLock {
+  lock(exclusive?: boolean): Promise<void>;
+  unlock(): Promise<void>;
+  close(): void;
+}
+
+export interface GitHubRateLimitBudgetOptions {
+  fraction?: number;
+  restPointsPerMinute?: number;
+  now?: () => number;
+  file?: string | null;
+  openLedgerLock?: (file: string) => Promise<GitHubRateLimitLedgerLock>;
+}
+
+export class GitHubRateLimitBudgetError extends Error {
+  readonly resetAt?: number;
+
+  constructor(message: string, resetAt?: number) {
+    super(message);
+    this.name = "GitHubRateLimitBudgetError";
+    this.resetAt = resetAt;
+  }
+}
+
+function finiteInteger(value: string | null): number | null {
+  if (value === null || value.trim() === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) && Number.isInteger(number) ? number : null;
+}
+
+function normalizePrimary(
+  value: GitHubPrimaryRateLimit,
+): GitHubPrimaryRateLimit | null {
+  if (
+    !Number.isInteger(value.limit) || value.limit <= 0 ||
+    !Number.isInteger(value.used) || value.used < 0 ||
+    !Number.isInteger(value.remaining) || value.remaining < 0 ||
+    value.remaining > value.limit ||
+    !Number.isInteger(value.reset) || value.reset <= 0
+  ) return null;
+  return {
+    ...value,
+    used: Math.max(value.used, value.limit - value.remaining),
+  };
+}
+
+function primaryFromHeaders(response: Response): GitHubPrimaryRateLimit | null {
+  if (response.headers.get("x-ratelimit-resource") !== "core") return null;
+  const limit = finiteInteger(response.headers.get("x-ratelimit-limit"));
+  const remaining = finiteInteger(
+    response.headers.get("x-ratelimit-remaining"),
+  );
+  const reset = finiteInteger(response.headers.get("x-ratelimit-reset"));
+  const reportedUsed = finiteInteger(response.headers.get("x-ratelimit-used"));
+  if (limit === null || remaining === null || reset === null) return null;
+  return normalizePrimary({
+    limit,
+    used: reportedUsed ?? limit - remaining,
+    remaining,
+    reset,
+  });
+}
+
+function storedPrimary(
+  primary: GitHubPrimaryRateLimit,
+): StoredPrimaryRateLimit {
+  return {
+    limit: primary.limit,
+    used: primary.used,
+    resetAt: primary.reset * 1_000,
+  };
+}
+
+function mergePrimary(
+  current: StoredPrimaryRateLimit | undefined,
+  incoming: GitHubPrimaryRateLimit,
+): StoredPrimaryRateLimit {
+  const next = storedPrimary(incoming);
+  if (!current || next.resetAt > current.resetAt) return next;
+  if (next.resetAt < current.resetAt) return current;
+  return {
+    limit: Math.min(current.limit, next.limit),
+    used: Math.max(current.used, next.used),
+    resetAt: current.resetAt,
+  };
+}
+
+function isStoredPrimary(value: unknown): value is StoredPrimaryRateLimit {
+  if (typeof value !== "object" || value === null) return false;
+  const primary = value as StoredPrimaryRateLimit;
+  return Number.isInteger(primary.limit) && primary.limit > 0 &&
+    Number.isInteger(primary.used) && primary.used >= 0 &&
+    Number.isInteger(primary.resetAt) && primary.resetAt > 0;
+}
+
+function isStoredReservation(value: unknown): value is StoredReservation {
+  if (typeof value !== "object" || value === null) return false;
+  const reservation = value as StoredReservation;
+  return typeof reservation.id === "string" && reservation.id.length > 0 &&
+    Number.isInteger(reservation.resetAt) && reservation.resetAt > 0;
+}
+
+function isStoredTokenBudget(value: unknown): value is StoredTokenBudget {
+  if (typeof value !== "object" || value === null) return false;
+  const budget = value as StoredTokenBudget;
+  return typeof budget.key === "string" && /^[0-9a-f]{64}$/.test(budget.key) &&
+    (budget.primary === undefined || isStoredPrimary(budget.primary)) &&
+    Array.isArray(budget.reservations) &&
+    budget.reservations.every(isStoredReservation) &&
+    Array.isArray(budget.requestTimes) &&
+    budget.requestTimes.every((at) => Number.isFinite(at) && at >= 0);
+}
+
+const defaultFile = (): string =>
+  dashboardCacheFile("fabric-wall-github-rate-limit.json");
+
+export class GitHubRateLimitBudget {
+  #fraction: number;
+  #restPointsPerMinute: number;
+  #now: () => number;
+  #file: string | null;
+  #openLedgerLock: (file: string) => Promise<GitHubRateLimitLedgerLock>;
+  #states = new Map<string, GitHubRateLimitState>();
+  #probes = new Map<string, Promise<void>>();
+  #requestTimes = new Map<string, number[]>();
+  #tokenKeys = new Map<string, Promise<string>>();
+
+  constructor(options: GitHubRateLimitBudgetOptions = {}) {
+    const fraction = options.fraction ?? GITHUB_RATE_LIMIT_FRACTION;
+    if (!(fraction > 0 && fraction <= 1)) {
+      throw new RangeError(
+        "GitHub rate limit fraction must be above 0 and at most 1.",
+      );
+    }
+    const restPoints = options.restPointsPerMinute ??
+      GITHUB_REST_POINTS_PER_MINUTE;
+    if (!Number.isInteger(restPoints) || restPoints <= 0) {
+      throw new RangeError(
+        "GitHub REST points per minute must be a positive integer.",
+      );
+    }
+    this.#fraction = fraction;
+    this.#restPointsPerMinute = restPoints;
+    this.#now = options.now ?? Date.now;
+    this.#file = options.file ?? null;
+    this.#openLedgerLock = options.openLedgerLock ??
+      ((file) =>
+        Deno.open(file, {
+          create: true,
+          write: true,
+        }));
+  }
+
+  #primaryCeiling(limit: number): number {
+    return Math.floor(limit * this.#fraction);
+  }
+
+  #secondaryCeiling(): number {
+    return Math.floor(this.#restPointsPerMinute * this.#fraction);
+  }
+
+  #primaryError(limit: number, resetAt: number): GitHubRateLimitBudgetError {
+    const ceiling = this.#primaryCeiling(limit);
+    return new GitHubRateLimitBudgetError(
+      `GitHub rate limit has been hit at the ${
+        Math.round(this.#fraction * 100)
+      }% performance-history safety threshold (${ceiling} of ${limit} primary requests).`,
+      resetAt,
+    );
+  }
+
+  #secondaryError(): GitHubRateLimitBudgetError {
+    return new GitHubRateLimitBudgetError(
+      `GitHub rate limit has been hit at the ${
+        Math.round(this.#fraction * 100)
+      }% performance-history safety threshold for REST request points.`,
+    );
+  }
+
+  #normalizeProbe(primary: GitHubPrimaryRateLimit): GitHubPrimaryRateLimit {
+    const normalized = normalizePrimary(primary);
+    if (!normalized) {
+      throw new GitHubRateLimitBudgetError(
+        "GitHub rate limit status was invalid; performance history made no request.",
+      );
+    }
+    return normalized;
+  }
+
+  #reserveMemoryPoint(token: string): void {
+    const now = this.#now();
+    const cutoff = now - 60_000;
+    const recent = (this.#requestTimes.get(token) ?? []).filter((at) =>
+      at > cutoff
+    );
+    if (recent.length + 1 > this.#secondaryCeiling()) {
+      throw this.#secondaryError();
+    }
+    recent.push(now);
+    this.#requestTimes.set(token, recent);
+  }
+
+  #setMemoryPrimary(token: string, primary: GitHubPrimaryRateLimit): void {
+    const normalized = this.#normalizeProbe(primary);
+    const current = this.#states.get(token);
+    const merged = mergePrimary(
+      current && {
+        limit: current.limit,
+        used: current.used,
+        resetAt: current.resetAt,
+      },
+      normalized,
+    );
+    this.#states.set(token, {
+      ...merged,
+      inFlight: current?.inFlight ?? 0,
+    });
+  }
+
+  async #ensureMemoryPrimary(
+    token: string,
+    probe: () => Promise<GitHubPrimaryRateLimit>,
+  ): Promise<void> {
+    let request = this.#probes.get(token);
+    if (!request) {
+      request = (async () => {
+        this.#reserveMemoryPoint(token);
+        let primary: GitHubPrimaryRateLimit;
+        try {
+          primary = await probe();
+        } catch (error) {
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
+          throw new GitHubRateLimitBudgetError(
+            `GitHub rate limit status could not be read: ${message}`,
+          );
+        }
+        this.#setMemoryPrimary(token, primary);
+      })().finally(() => this.#probes.delete(token));
+      this.#probes.set(token, request);
+    }
+    await request;
+  }
+
+  async #reserveMemory(
+    token: string,
+    probe: () => Promise<GitHubPrimaryRateLimit>,
+  ): Promise<GitHubRateLimitReservation> {
+    await this.#ensureMemoryPrimary(token, probe);
+    const state = this.#states.get(token)!;
+    if (
+      state.used + state.inFlight + 1 > this.#primaryCeiling(state.limit)
+    ) {
+      throw this.#primaryError(state.limit, state.resetAt);
+    }
+    this.#reserveMemoryPoint(token);
+    state.inFlight++;
+    let completed = false;
+    return {
+      complete: (response?: Response) => {
+        if (completed) return;
+        completed = true;
+        const current = this.#states.get(token)!;
+        current.inFlight = Math.max(0, current.inFlight - 1);
+        const primary = response && primaryFromHeaders(response);
+        if (primary) this.#setMemoryPrimary(token, primary);
+        else current.used++;
+      },
+    };
+  }
+
+  #tokenKey(token: string): Promise<string> {
+    let key = this.#tokenKeys.get(token);
+    if (!key) {
+      key = crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(token),
+      ).then((digest) =>
+        [...new Uint8Array(digest)].map((byte) =>
+          byte.toString(16).padStart(2, "0")
+        ).join("")
+      );
+      this.#tokenKeys.set(token, key);
+    }
+    return key;
+  }
+
+  async #readLedger(): Promise<StoredRateLimitLedger> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await Deno.readTextFile(this.#file!));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return { version: LEDGER_VERSION, tokens: [] };
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new GitHubRateLimitBudgetError(
+        `GitHub rate limit ledger could not be read: ${message}`,
+      );
+    }
+    const ledger = parsed as StoredRateLimitLedger;
+    if (
+      typeof parsed !== "object" || parsed === null ||
+      ledger.version !== LEDGER_VERSION ||
+      !Array.isArray(ledger.tokens) ||
+      !ledger.tokens.every(isStoredTokenBudget) ||
+      new Set(ledger.tokens.map((token) => token.key)).size !==
+        ledger.tokens.length
+    ) {
+      throw new GitHubRateLimitBudgetError(
+        "GitHub rate limit ledger was invalid; performance history made no request.",
+      );
+    }
+    return ledger;
+  }
+
+  async #writeLedger(ledger: StoredRateLimitLedger): Promise<void> {
+    const temporary = `${this.#file!}.${crypto.randomUUID()}.tmp`;
+    try {
+      await Deno.writeTextFile(temporary, JSON.stringify(ledger));
+      await Deno.rename(temporary, this.#file!);
+    } catch (error) {
+      try {
+        await Deno.remove(temporary);
+      } catch {
+        // Ignore cleanup when no temporary file remains.
+      }
+      throw error;
+    }
+  }
+
+  #ledgerError(error: unknown): GitHubRateLimitBudgetError {
+    if (error instanceof GitHubRateLimitBudgetError) return error;
+    const message = error instanceof Error ? error.message : String(error);
+    return new GitHubRateLimitBudgetError(
+      `GitHub rate limit ledger could not be updated: ${message}`,
+    );
+  }
+
+  async #withLedger<T>(
+    update: (ledger: StoredRateLimitLedger) => T | Promise<T>,
+  ): Promise<T> {
+    return await withGitHubRateLimitLedgerTurn(this.#file!, async () => {
+      let lock: GitHubRateLimitLedgerLock | undefined;
+      let locked = false;
+      let result: T | undefined;
+      let failed = false;
+      let failure: unknown;
+      try {
+        lock = await this.#openLedgerLock(`${this.#file!}.lock`);
+        await lock.lock(true);
+        locked = true;
+        const ledger = await this.#readLedger();
+        result = await update(ledger);
+        await this.#writeLedger(ledger);
+      } catch (error) {
+        failed = true;
+        failure = error;
+      } finally {
+        let cleanupFailure: unknown;
+        if (locked) {
+          try {
+            await lock!.unlock();
+          } catch (error) {
+            cleanupFailure = error;
+          }
+        }
+        try {
+          lock?.close();
+        } catch (error) {
+          cleanupFailure ??= error;
+        }
+        if (!failed && cleanupFailure !== undefined) {
+          failed = true;
+          failure = cleanupFailure;
+        }
+      }
+      if (failed) throw this.#ledgerError(failure);
+      return result as T;
+    });
+  }
+
+  #storedToken(
+    ledger: StoredRateLimitLedger,
+    key: string,
+  ): StoredTokenBudget {
+    let state = ledger.tokens.find((value) => value.key === key);
+    if (!state) {
+      state = { key, reservations: [], requestTimes: [] };
+      ledger.tokens.push(state);
+    }
+    return state;
+  }
+
+  #reservationLease(id: string): string {
+    return `${this.#file!}.${id}.reservation.lock`;
+  }
+
+  async #openReservationLease(id: string): Promise<Deno.FsFile> {
+    const path = this.#reservationLease(id);
+    let lease: Deno.FsFile | undefined;
+    try {
+      lease = await Deno.open(path, {
+        createNew: true,
+        read: true,
+        write: true,
+      });
+      await lease.lock(true);
+      return lease;
+    } catch (error) {
+      await Promise.resolve().then(() => lease?.close()).catch(() => undefined);
+      await Promise.resolve().then(() => Deno.remove(path)).catch(() =>
+        undefined
+      );
+      throw this.#ledgerError(error);
+    }
+  }
+
+  async #closeReservationLease(id: string, lease: Deno.FsFile): Promise<void> {
+    let failure: unknown;
+    try {
+      await lease.unlock();
+    } catch (error) {
+      failure = error;
+    }
+    try {
+      lease.close();
+    } catch (error) {
+      failure ??= error;
+    }
+    try {
+      await Deno.remove(this.#reservationLease(id));
+    } catch (error) {
+      failure ??= error;
+    }
+    if (failure !== undefined) throw this.#ledgerError(failure);
+  }
+
+  async #abandonReservationLease(lease: Deno.FsFile): Promise<void> {
+    let failure: unknown;
+    try {
+      await lease.unlock();
+    } catch (error) {
+      failure = error;
+    }
+    try {
+      lease.close();
+    } catch (error) {
+      failure ??= error;
+    }
+    if (failure !== undefined) throw this.#ledgerError(failure);
+  }
+
+  async #releaseFailedReservation(
+    id: string,
+    lease: Deno.FsFile,
+    mayBeStored: boolean,
+  ): Promise<void> {
+    if (!mayBeStored) {
+      await this.#closeReservationLease(id, lease);
+      return;
+    }
+    let stored = true;
+    try {
+      const ledger = await this.#readLedger();
+      stored = ledger.tokens.some((token) =>
+        token.reservations.some((reservation) => reservation.id === id)
+      );
+    } catch {
+      // Keep the lease when the ledger cannot establish whether it references it.
+    }
+    if (stored) await this.#abandonReservationLease(lease);
+    else await this.#closeReservationLease(id, lease);
+  }
+
+  async #reservationIsLive(id: string): Promise<boolean> {
+    let lease: Deno.FsFile;
+    try {
+      lease = await Deno.open(this.#reservationLease(id), {
+        read: true,
+        write: true,
+      });
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return false;
+      throw this.#ledgerError(error);
+    }
+    let acquired = false;
+    try {
+      acquired = await lease.tryLock(true);
+      if (acquired) await lease.unlock();
+      return !acquired;
+    } catch (error) {
+      throw this.#ledgerError(error);
+    } finally {
+      lease.close();
+    }
+  }
+
+  async #pruneStored(
+    state: StoredTokenBudget,
+    now: number,
+  ): Promise<string[]> {
+    const cutoff = now - 60_000;
+    state.requestTimes = state.requestTimes.filter((at) => at > cutoff);
+    const retained: StoredReservation[] = [];
+    const expired: string[] = [];
+    for (const reservation of state.reservations) {
+      if (
+        reservation.resetAt > now ||
+        await this.#reservationIsLive(reservation.id)
+      ) {
+        retained.push(reservation);
+      } else {
+        expired.push(reservation.id);
+      }
+    }
+    state.reservations = retained;
+    return expired;
+  }
+
+  async #removeReservationLeases(ids: string[]): Promise<void> {
+    for (const id of ids) {
+      try {
+        await Deno.remove(this.#reservationLease(id));
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw this.#ledgerError(error);
+        }
+      }
+    }
+  }
+
+  #reserveStoredPoint(state: StoredTokenBudget, now: number): void {
+    if (state.requestTimes.length + 1 > this.#secondaryCeiling()) {
+      throw this.#secondaryError();
+    }
+    state.requestTimes.push(now);
+  }
+
+  async #ensureStoredPrimary(
+    token: string,
+    key: string,
+    probe: () => Promise<GitHubPrimaryRateLimit>,
+  ): Promise<void> {
+    let request = this.#probes.get(token);
+    if (!request) {
+      request = (async () => {
+        let expiredLeases: string[] = [];
+        await this.#withLedger(async (ledger) => {
+          const now = this.#now();
+          const state = this.#storedToken(ledger, key);
+          expiredLeases = await this.#pruneStored(state, now);
+          this.#reserveStoredPoint(state, now);
+        });
+        await this.#removeReservationLeases(expiredLeases);
+        let primary: GitHubPrimaryRateLimit;
+        try {
+          primary = this.#normalizeProbe(await probe());
+        } catch (error) {
+          if (error instanceof GitHubRateLimitBudgetError) throw error;
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
+          throw new GitHubRateLimitBudgetError(
+            `GitHub rate limit status could not be read: ${message}`,
+          );
+        }
+        await this.#withLedger((ledger) => {
+          const state = this.#storedToken(ledger, key);
+          state.primary = mergePrimary(state.primary, primary);
+        });
+      })().finally(() => this.#probes.delete(token));
+      this.#probes.set(token, request);
+    }
+    await request;
+  }
+
+  async #reserveStored(
+    token: string,
+    probe: () => Promise<GitHubPrimaryRateLimit>,
+  ): Promise<GitHubRateLimitReservation> {
+    const key = await this.#tokenKey(token);
+    await this.#ensureStoredPrimary(token, key, probe);
+    const id = crypto.randomUUID();
+    const lease = await this.#openReservationLease(id);
+    let reservationAdded = false;
+    try {
+      let expiredLeases: string[] = [];
+      await this.#withLedger(async (ledger) => {
+        const now = this.#now();
+        const state = this.#storedToken(ledger, key);
+        expiredLeases = await this.#pruneStored(state, now);
+        const primary = state.primary;
+        if (!primary || now >= primary.resetAt) {
+          throw new GitHubRateLimitBudgetError(
+            "GitHub rate limit status expired before the request started; performance history made no request.",
+          );
+        }
+        const inFlight = state.reservations.length;
+        if (
+          primary.used + inFlight + 1 > this.#primaryCeiling(primary.limit)
+        ) {
+          throw this.#primaryError(primary.limit, primary.resetAt);
+        }
+        this.#reserveStoredPoint(state, now);
+        state.reservations.push({ id, resetAt: primary.resetAt });
+        reservationAdded = true;
+      });
+      await this.#removeReservationLeases(expiredLeases);
+    } catch (error) {
+      try {
+        await this.#releaseFailedReservation(id, lease, reservationAdded);
+      } catch (cleanupError) {
+        throw this.#ledgerError(cleanupError);
+      }
+      throw error;
+    }
+    let completed = false;
+    return {
+      complete: async (response?: Response) => {
+        if (completed) return;
+        completed = true;
+        const primary = response && primaryFromHeaders(response);
+        try {
+          await this.#withLedger((ledger) => {
+            const state = this.#storedToken(ledger, key);
+            state.reservations = state.reservations.filter((reservation) =>
+              reservation.id !== id
+            );
+            if (primary) state.primary = mergePrimary(state.primary, primary);
+            else if (state.primary) state.primary.used++;
+          });
+        } catch (error) {
+          try {
+            await this.#releaseFailedReservation(id, lease, true);
+          } catch (cleanupError) {
+            throw this.#ledgerError(cleanupError);
+          }
+          throw error;
+        }
+        await this.#closeReservationLease(id, lease);
+      },
+    };
+  }
+
+  reserve(
+    token: string,
+    probe: () => Promise<GitHubPrimaryRateLimit>,
+  ): Promise<GitHubRateLimitReservation> {
+    return this.#file
+      ? this.#reserveStored(token, probe)
+      : this.#reserveMemory(token, probe);
+  }
+}
+
+export const performanceGitHubRateLimit = new GitHubRateLimitBudget({
+  file: defaultFile(),
+});

--- a/packages/dashboard/history-files.test.ts
+++ b/packages/dashboard/history-files.test.ts
@@ -1,0 +1,83 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import {
+  dashboardCacheDirectory,
+  dashboardCacheFile,
+} from "./history-files.ts";
+
+function environment(
+  values: Record<string, string>,
+): (name: string) => string | undefined {
+  return (name) => values[name];
+}
+
+Deno.test("dashboard cache files use fixed names in one configured directory", () => {
+  const directory = "configured-dashboard-cache";
+  const env = environment({
+    DASHBOARD_CACHE_DIR: directory,
+  });
+
+  assertEquals(
+    dashboardCacheDirectory(env),
+    directory,
+  );
+  assertEquals(
+    dashboardCacheFile("fabric-wall-discord-history.json", env),
+    join(directory, "fabric-wall-discord-history.json"),
+  );
+  assertEquals(
+    dashboardCacheFile("fabric-wall-ci-job-history.json", env),
+    join(directory, "fabric-wall-ci-job-history.json"),
+  );
+  assertEquals(
+    dashboardCacheFile("fabric-wall-benchmark-history.json", env),
+    join(directory, "fabric-wall-benchmark-history.json"),
+  );
+  assertEquals(
+    dashboardCacheFile("fabric-wall-github-rate-limit.json", env),
+    join(directory, "fabric-wall-github-rate-limit.json"),
+  );
+  assertEquals(
+    dashboardCacheFile(
+      "fabric-wall-github-members-commontoolsinc-history.json",
+      env,
+    ),
+    join(
+      directory,
+      "fabric-wall-github-members-commontoolsinc-history.json",
+    ),
+  );
+});
+
+Deno.test("dashboard cache files default to the temp directory", () => {
+  const directory = "platform-temp";
+  const env = environment({ TMPDIR: directory });
+  assertEquals(dashboardCacheDirectory(env), directory);
+  assertEquals(
+    dashboardCacheFile("fabric-wall-ci-job-history.json", env),
+    join(directory, "fabric-wall-ci-job-history.json"),
+  );
+});
+
+Deno.test("dashboard cache files recognize Windows temp variables", () => {
+  assertEquals(
+    dashboardCacheDirectory(environment({ TEMP: "windows-temp" })),
+    "windows-temp",
+  );
+  assertEquals(
+    dashboardCacheDirectory(environment({ TMP: "windows-tmp" })),
+    "windows-tmp",
+  );
+  assertEquals(
+    dashboardCacheDirectory(environment({
+      TMPDIR: "posix-temp",
+      TEMP: "windows-temp",
+      TMP: "windows-tmp",
+    })),
+    "posix-temp",
+  );
+  assertEquals(
+    dashboardCacheDirectory(environment({})),
+    Deno.build.os === "windows" ? "." : "/tmp",
+  );
+});

--- a/packages/dashboard/history-files.ts
+++ b/packages/dashboard/history-files.ts
@@ -1,0 +1,17 @@
+import { join } from "@std/path";
+
+type Environment = (name: string) => string | undefined;
+
+export function dashboardCacheDirectory(
+  env: Environment = Deno.env.get,
+): string {
+  return env("DASHBOARD_CACHE_DIR") ?? env("TMPDIR") ?? env("TEMP") ??
+    env("TMP") ?? (Deno.build.os === "windows" ? "." : "/tmp");
+}
+
+export function dashboardCacheFile(
+  basename: string,
+  env: Environment = Deno.env.get,
+): string {
+  return join(dashboardCacheDirectory(env), basename);
+}

--- a/packages/dashboard/lib-extra.test.ts
+++ b/packages/dashboard/lib-extra.test.ts
@@ -61,7 +61,7 @@ Deno.test("github: non-OK -> throws with the status; the error body is not retur
     await withFetch(() => Response.json({}, { status: 429 }), async () => {
       const e = await assertRejects(() => github("rate/limited"), Error);
       assertEquals(e.message, "GitHub API rate/limited failed: HTTP 429");
-      assertEquals(friendlyError(e.message), "rate-limited");
+      assertEquals(friendlyError(e.message), "rate limit hit");
     });
     await withFetch(
       () =>
@@ -75,7 +75,7 @@ Deno.test("github: non-OK -> throws with the status; the error body is not retur
           e.message,
           "GitHub API rate/limited failed: HTTP 403 (rate-limited)",
         );
-        assertEquals(friendlyError(e.message), "rate-limited");
+        assertEquals(friendlyError(e.message), "rate limit hit");
       },
     );
   });

--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -67,7 +67,7 @@ Deno.test("friendlyError: raw errors become short calm phrases", () => {
   );
   assertEquals(friendlyError("error sending request for url"), "source unreachable");
   assertEquals(friendlyError("HTTP 404: Not Found"), "not found");
-  assertEquals(friendlyError("HTTP 403: rate limit exceeded"), "rate-limited");
+  assertEquals(friendlyError("HTTP 403: rate limit exceeded"), "rate limit hit");
   assertEquals(friendlyError("Bad credentials"), "auth failed");
   assertEquals(friendlyError("GitHub API x: set GH_TOKEN or GITHUB_TOKEN"), "set GH_TOKEN");
   assertEquals(friendlyError("something weird"), "temporarily unavailable");

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -1,6 +1,10 @@
 // Shared helpers used across tiles and the core.
 import type { Status } from "./types.ts";
 import { PROD_SERVICE } from "./config.ts";
+import {
+  type GitHubPrimaryRateLimit,
+  performanceGitHubRateLimit,
+} from "./github-rate-limit.ts";
 
 // The service.name to scope a SigNoz query to. The name lands inside a query
 // expression, so anything outside the shape a service name has falls back to the
@@ -13,17 +17,70 @@ export const serviceName = (env: (k: string) => string | undefined): string => {
 // Call the GitHub REST API and return parsed JSON. Pass an explicit `token` (e.g.
 // a higher-privilege org-billing token); otherwise it reads GH_TOKEN or
 // GITHUB_TOKEN from the environment. One of those must be set.
-export async function github<T = unknown>(path: string, token?: string): Promise<T> {
+function githubToken(path: string, token?: string): string {
   const t = token ?? Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN");
   if (!t) throw new Error(`GitHub API ${path}: set GH_TOKEN or GITHUB_TOKEN`);
-  const res = await fetch(`https://api.github.com/${path.replace(/^\//, "")}`, {
+  return t;
+}
+
+function githubRequest(path: string, token: string, withTimeout: boolean): Promise<Response> {
+  const init: RequestInit = {
     headers: {
-      authorization: `Bearer ${t}`,
+      authorization: `Bearer ${token}`,
       accept: "application/vnd.github+json",
       "x-github-api-version": "2022-11-28",
     },
-    signal: AbortSignal.timeout(15_000),
-  });
+  };
+  if (withTimeout) init.signal = AbortSignal.timeout(15_000);
+  return fetch(
+    `https://api.github.com/${path.replace(/^\//, "")}`,
+    init,
+  );
+}
+
+async function githubPrimaryRateLimit(
+  token: string,
+): Promise<GitHubPrimaryRateLimit> {
+  const response = await githubRequest("rate_limit", token, false);
+  if (!response.ok) {
+    throw new Error(`GitHub API rate_limit failed: HTTP ${response.status}`);
+  }
+  const value = await response.json() as {
+    resources?: { core?: GitHubPrimaryRateLimit };
+  };
+  if (!value.resources?.core) {
+    throw new Error("GitHub API rate_limit did not report the core budget");
+  }
+  return value.resources.core;
+}
+
+async function githubResponse(
+  path: string,
+  token: string,
+  performance: boolean,
+  withTimeout: boolean,
+): Promise<Response> {
+  const reservation = performance
+    ? await performanceGitHubRateLimit.reserve(
+      token,
+      () => githubPrimaryRateLimit(token),
+    )
+    : null;
+  let response: Response | undefined;
+  try {
+    response = await githubRequest(path, token, withTimeout);
+    return response;
+  } finally {
+    if (reservation) await reservation.complete(response);
+  }
+}
+
+async function githubJson<T>(
+  path: string,
+  token: string,
+  performance: boolean,
+): Promise<T> {
+  const res = await githubResponse(path, token, performance, true);
   if (!res.ok) {
     let rateLimited = false;
     if (res.status === 403) {
@@ -37,6 +94,38 @@ export async function github<T = unknown>(path: string, token?: string): Promise
     );
   }
   return await res.json() as T;
+}
+
+export async function github<T = unknown>(
+  path: string,
+  token?: string,
+): Promise<T> {
+  const t = githubToken(path, token);
+  return await githubJson<T>(path, t, false);
+}
+
+export async function githubDownload(
+  path: string,
+  token?: string,
+): Promise<Response> {
+  const t = githubToken(path, token);
+  return await githubResponse(path, t, false, false);
+}
+
+export async function performanceGithub<T = unknown>(
+  path: string,
+  token?: string,
+): Promise<T> {
+  const t = githubToken(path, token);
+  return await githubJson<T>(path, t, true);
+}
+
+export async function performanceGithubDownload(
+  path: string,
+  token?: string,
+): Promise<Response> {
+  const t = githubToken(path, token);
+  return await githubResponse(path, t, true, false);
 }
 
 // Cache an async result for ttlMs; a rejection is not cached (so it retries).
@@ -110,7 +199,7 @@ export function friendlyError(msg: string): string {
   if (/connect|sending request|network|dns|refused|unreachable|timed ?out|timeout|econn/.test(m)) {
     return "source unreachable";
   }
-  if (/rate.?limit|\b429\b/.test(m)) return "rate-limited";
+  if (/rate.?limit|\b429\b/.test(m)) return "rate limit hit";
   if (/\b404\b|not found/.test(m)) return "not found";
   if (/\b401\b|\b403\b|unauthor|forbidden|bad credentials/.test(m)) return "auth failed";
   if (/gh_token|github_token/.test(m)) return "set GH_TOKEN";

--- a/packages/dashboard/performance-views.test.ts
+++ b/packages/dashboard/performance-views.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  performanceViewHref,
+  performanceViewNav,
+} from "./performance-views.ts";
+
+const state = {
+  repo: "loom" as const,
+  days: 14,
+  sort: "job",
+  stat: "p99",
+};
+
+Deno.test("performance view URLs share one canonical route and translate sort modes", () => {
+  assertEquals(
+    performanceViewHref("runtime", state),
+    "/bench?view=runtime&amp;repo=loom&amp;days=14&amp;sort=file&amp;stat=p99",
+  );
+  assertEquals(
+    performanceViewHref("ci", { ...state, sort: "file" }),
+    "/bench?view=ci&amp;repo=loom&amp;days=14&amp;sort=job&amp;stat=p99",
+  );
+  assertEquals(
+    performanceViewHref("gantt", state),
+    "/bench?view=gantt&amp;repo=loom&amp;days=14&amp;sort=job&amp;stat=p99",
+  );
+});
+
+Deno.test("performance view navigation marks one stable-size selector active", () => {
+  const html = performanceViewNav("ci", state);
+
+  assertStringIncludes(html, ">Runtime benchmarks</a>");
+  assertStringIncludes(
+    html,
+    'aria-current="page">CI duration history</a>',
+  );
+  assertStringIncludes(html, ">CI run Gantt</a>");
+});

--- a/packages/dashboard/performance-views.ts
+++ b/packages/dashboard/performance-views.ts
@@ -1,0 +1,53 @@
+import { escapeHtml } from "./lib.ts";
+
+export type PerformanceView = "runtime" | "ci" | "gantt";
+
+export interface PerformanceViewState {
+  repo: "labs" | "loom";
+  days: number;
+  sort: string;
+  stat: string;
+}
+
+export const PERFORMANCE_CHECK_MS = 60_000;
+
+const labels: Record<PerformanceView, string> = {
+  runtime: "Runtime benchmarks",
+  ci: "CI duration history",
+  gantt: "CI run Gantt",
+};
+
+const runtimeSort = (sort: string): string =>
+  sort === "duration" || sort === "trend" ? sort : "file";
+
+const ciSort = (sort: string): string =>
+  sort === "duration" || sort === "trend" ? sort : "job";
+
+export function performanceViewHref(
+  view: PerformanceView,
+  state: PerformanceViewState,
+): string {
+  const params = new URLSearchParams({ view });
+  params.set("repo", state.repo);
+  params.set("days", String(state.days));
+  params.set(
+    "sort",
+    view === "runtime" ? runtimeSort(state.sort) : ciSort(state.sort),
+  );
+  params.set("stat", state.stat);
+  return `/bench?${escapeHtml(params.toString())}`;
+}
+
+export function performanceViewNav(
+  active: PerformanceView,
+  state: PerformanceViewState,
+): string {
+  const views: PerformanceView[] = ["runtime", "ci", "gantt"];
+  return `<nav class="views" aria-label="Performance view">${
+    views.map((view) =>
+      `<a${view === active ? ' class="on"' : ""} href="${
+        performanceViewHref(view, state)
+      }"${view === active ? ' aria-current="page"' : ""}>${labels[view]}</a>`
+    ).join("")
+  }</nav>`;
+}

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -18,7 +18,12 @@ function view(over: Partial<TileView> = {}): TileView {
 }
 
 Deno.test("renderTile: status drives the tile class, the dot color and the headline color", () => {
-  const dots: Record<Status, string> = { good: "green", warn: "amber", bad: "red", unknown: "grey" };
+  const dots: Record<Status, string> = {
+    good: "green",
+    warn: "amber",
+    bad: "red",
+    unknown: "grey",
+  };
   for (const [status, dot] of Object.entries(dots) as [Status, string][]) {
     const html = renderTile(view({ status, value: "passing" }));
     assertStringIncludes(html, `class="tile ${status}"`);
@@ -45,21 +50,36 @@ Deno.test("renderTile: a server-supplied id becomes the stable update key", () =
 
 Deno.test("renderTile: an http href is an anchor that opens a new tab; a local one stays in place", () => {
   const external = renderTile(view({ href: "https://github.com/o/r/actions" }));
-  assertStringIncludes(external, `<a class="tile good link" href="https://github.com/o/r/actions" target="_blank" rel="noopener">`);
+  assertStringIncludes(
+    external,
+    `<a class="tile good link" href="https://github.com/o/r/actions" target="_blank" rel="noopener">`,
+  );
   const local = renderTile(view({ href: "/bench" }));
   assertStringIncludes(local, `<a class="tile good link" href="/bench">`);
-  assert(!local.includes("target="), "a drill-down on this server replaces the page");
+  assert(
+    !local.includes("target="),
+    "a drill-down on this server replaces the page",
+  );
 });
 
 Deno.test("renderTile: wide adds the class the shell lays out below the grid", () => {
-  assertStringIncludes(renderTile(view(), undefined, true), `class="tile good wide"`);
-  assertStringIncludes(renderTile(view({ href: "/x" }), undefined, true), `class="tile good link wide"`);
+  assertStringIncludes(
+    renderTile(view(), undefined, true),
+    `class="tile good wide"`,
+  );
+  assertStringIncludes(
+    renderTile(view({ href: "/x" }), undefined, true),
+    `class="tile good link wide"`,
+  );
   assert(!renderTile(view()).includes("wide"));
 });
 
 Deno.test("renderTile: an absent value/sub/hint/aside renders nothing rather than an empty element", () => {
   const html = renderTile(view());
-  assertEquals(html, `<div class="tile good"><p class="lbl"><span class="dot green"></span> labs ci<span class="spacer"></span></p></div>`);
+  assertEquals(
+    html,
+    `<div class="tile good"><p class="lbl"><span class="dot green"></span> labs ci<span class="spacer"></span></p></div>`,
+  );
 });
 
 Deno.test("renderTile: label and sub are escaped — a hostile label cannot inject markup", () => {
@@ -70,7 +90,10 @@ Deno.test("renderTile: label and sub are escaped — a hostile label cannot inje
   assert(!html.includes("<img"), "the label's tag is defanged");
   assert(!html.includes("<script>"), "the sub line's tag is defanged");
   assertStringIncludes(html, "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;");
-  assertStringIncludes(html, `<p class="sub">a &amp; b &quot;quoted&quot; &lt;script&gt;</p>`);
+  assertStringIncludes(
+    html,
+    `<p class="sub">a &amp; b &quot;quoted&quot; &lt;script&gt;</p>`,
+  );
 });
 
 Deno.test("renderTile: value, extra and aside are trusted html; hint is escaped", () => {
@@ -85,7 +108,10 @@ Deno.test("renderTile: value, extra and aside are trusted html; hint is escaped"
   assertStringIncludes(html, `<span class="hmtd">$12</span>`);
   assertStringIncludes(html, `<svg viewBox="0 0 1 1"></svg>`);
   // The hint is plain text from the tile, so the renderer escapes it.
-  assertStringIncludes(html, `<span class="drill">commits ↗ &lt;not a tag&gt;</span>`);
+  assertStringIncludes(
+    html,
+    `<span class="drill">commits ↗ &lt;not a tag&gt;</span>`,
+  );
 });
 
 Deno.test("renderTile: the aside and hint sit after the label, separated by the spacer", () => {
@@ -97,7 +123,9 @@ Deno.test("renderTile: the aside and hint sit after the label, separated by the 
 });
 
 Deno.test("renderTile: a duration wraps the chart so the span can be pinned to its corner", () => {
-  const html = renderTile(view({ extra: "<svg></svg>", duration: 25 * 86_400_000 }));
+  const html = renderTile(
+    view({ extra: "<svg></svg>", duration: 25 * 86_400_000 }),
+  );
   assertStringIncludes(html, `<div style="position:relative"><svg></svg>`);
   // The corner tag is the auto-formatted span, and it is inside the wrapper.
   assertStringIncludes(html, ">25 days</span></div>");
@@ -107,7 +135,10 @@ Deno.test("renderTile: a duration wraps the chart so the span can be pinned to i
 Deno.test("renderTile: no duration leaves extra unwrapped", () => {
   const html = renderTile(view({ extra: "<svg></svg>" }));
   assertStringIncludes(html, "<svg></svg>");
-  assert(!html.includes("position:relative"), "nothing to position, so no wrapper");
+  assert(
+    !html.includes("position:relative"),
+    "nothing to position, so no wrapper",
+  );
 });
 
 Deno.test("renderTile: a duration with no chart draws nothing to label", () => {
@@ -115,13 +146,18 @@ Deno.test("renderTile: a duration with no chart draws nothing to label", () => {
   // the label would sit on top of the sub line. A tile whose series is too short to
   // plot still reports a span, so this happens: dau's first day, for one.
   const html = renderTile(view({ sub: "things", duration: 90 * 60_000 }));
-  assert(!html.includes("position:relative"), "nothing to position, so no wrapper");
+  assert(
+    !html.includes("position:relative"),
+    "nothing to position, so no wrapper",
+  );
   assert(!html.includes(humanSpan(90 * 60_000)), "and no orphaned span label");
   assertStringIncludes(html, `<p class="sub">things</p>`); // the sub is left alone
 });
 
 Deno.test("renderTile: the body order is label, headline, sub, chart", () => {
-  const html = renderTile(view({ value: "42", sub: "things", extra: "<svg></svg>" }));
+  const html = renderTile(
+    view({ value: "42", sub: "things", extra: "<svg></svg>" }),
+  );
   const at = (needle: string) => html.indexOf(needle);
   assert(at(`class="lbl"`) < at(`class="big`), "label first");
   assert(at(`class="big`) < at(`class="sub"`), "headline above the sub line");
@@ -137,8 +173,14 @@ Deno.test("shell: the grid and the wide tiles land in their own slots", () => {
     SHELL_VERSION,
     "bad",
   );
-  assertStringIncludes(html, `<div class="grid" id="dashboard-grid"><div class="tile good">g</div></div>`);
-  assertStringIncludes(html, `<div id="dashboard-wide"><div class="tile bad wide">w</div></div>`);
+  assertStringIncludes(
+    html,
+    `<div class="grid" id="dashboard-grid"><div class="tile good">g</div></div>`,
+  );
+  assertStringIncludes(
+    html,
+    `<div id="dashboard-wide"><div class="tile bad wide">w</div></div>`,
+  );
   // Wide tiles sit after the grid, not inside it.
   assert(html.indexOf(`class="grid"`) < html.indexOf(`tile bad wide`));
   assert(html.startsWith("<!doctype html>"), "a whole page, not a fragment");
@@ -169,8 +211,13 @@ Deno.test("shell: the freshness age and the refresh interval reach both the text
     `if (update.shellVersion !== SHELL_VERSION) { location.reload(); return; }`,
   );
   assertEquals(html.match(/location\.reload\(\)/g)?.length, 2);
-  assertStringIncludes(html, `if (current.outerHTML === next.outerHTML) return current;`);
+  assertStringIncludes(
+    html,
+    `if (current.outerHTML === next.outerHTML) return current;`,
+  );
   assertStringIncludes(html, `nextScroller.scrollTop = scrollTop`);
+  assertStringIncludes(html, `active.dataset.focusKey ?? null`);
+  assertStringIncludes(html, `link.dataset.focusKey === focusedKey`);
 });
 
 Deno.test("formatViewerTimes: the viewer's formatter replaces the UTC fallback", () => {
@@ -189,13 +236,18 @@ Deno.test("shell: the browser runs the viewer-time formatter", () => {
   const html = shell("", "", 0, 30_000, SHELL_VERSION, "good");
   const source = formatViewerTimes.toString();
   assertStringIncludes(source, `time[data-viewer-time][datetime]`);
-  assert(!source.includes("timeZone"), "the default formatter must use the viewer's timezone");
+  assert(
+    !source.includes("timeZone"),
+    "the default formatter must use the viewer's timezone",
+  );
   assertStringIncludes(html, source);
   assertStringIncludes(html, "formatViewerTimes();");
   const localizeUpdate = html.indexOf(
     `formatViewerTimes(template.content.querySelectorAll('time[data-viewer-time][datetime]'));`,
   );
-  const compareMarkup = html.indexOf("if (current.outerHTML === next.outerHTML)");
+  const compareMarkup = html.indexOf(
+    "if (current.outerHTML === next.outerHTML)",
+  );
   assert(localizeUpdate >= 0, "live updates localize their timestamps");
   assert(
     localizeUpdate < compareMarkup,

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -24,14 +24,19 @@ type ViewerTimeElement = Pick<HTMLTimeElement, "dateTime" | "textContent">;
 
 /** Replace marked absolute timestamps with the viewer's local wall-clock time. */
 export function formatViewerTimes(
-  times: Iterable<ViewerTimeElement> = document.querySelectorAll<HTMLTimeElement>(
+  times: Iterable<ViewerTimeElement> = document.querySelectorAll<
+    HTMLTimeElement
+  >(
     "time[data-viewer-time][datetime]",
   ),
-  formatter: { format(value: number): string } = new Intl.DateTimeFormat(undefined, {
-    hour: "2-digit",
-    minute: "2-digit",
-    hourCycle: "h23",
-  }),
+  formatter: { format(value: number): string } = new Intl.DateTimeFormat(
+    undefined,
+    {
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    },
+  ),
 ): void {
   for (const time of times) {
     const at = Date.parse(time.dateTime);
@@ -44,8 +49,12 @@ export function renderTile(v: TileView, id?: string, wide = false): string {
   const key = id ? ` data-tile-id="${escapeHtml(id)}"` : "";
   const dot = `<span class="dot ${STATUS_DOT[v.status]}"></span>`;
   const hint = v.hint ? `<span class="drill">${escapeHtml(v.hint)}</span>` : "";
-  const header = `<p class="lbl">${dot} ${escapeHtml(v.label)}<span class="spacer"></span>${v.aside ?? ""}${hint}</p>`;
-  const big = v.value !== undefined ? `<p class="big ${v.status}">${v.value}</p>` : "";
+  const header = `<p class="lbl">${dot} ${
+    escapeHtml(v.label)
+  }<span class="spacer"></span>${v.aside ?? ""}${hint}</p>`;
+  const big = v.value !== undefined
+    ? `<p class="big ${v.status}">${v.value}</p>`
+    : "";
   const sub = v.sub ? `<p class="sub">${escapeHtml(v.sub)}</p>` : "";
   // The chart plus its duration label (bottom-left corner, auto-formatted). The
   // relative wrapper positions the duration; a tile with no duration renders extra
@@ -54,12 +63,16 @@ export function renderTile(v: TileView, id?: string, wide = false): string {
   // top of the sub line. A tile whose series is too short to plot still reports a
   // span, so this is reachable.
   const body = v.duration && v.extra
-    ? `<div style="position:relative">${v.extra}${durationTag(v.duration)}</div>`
+    ? `<div style="position:relative">${v.extra}${
+      durationTag(v.duration)
+    }</div>`
     : (v.extra ?? "");
   const inner = `${header}${big}${sub}${body}`;
   if (!v.href) return `<div class="${cls}"${key}>${inner}</div>`;
   const tgt = /^https?:/.test(v.href) ? ` target="_blank" rel="noopener"` : "";
-  return `<a class="${cls}"${key} href="${escapeHtml(v.href)}"${tgt}>${inner}</a>`;
+  return `<a class="${cls}"${key} href="${
+    escapeHtml(v.href)
+  }"${tgt}>${inner}</a>`;
 }
 
 export function shell(
@@ -107,16 +120,20 @@ ${faviconLink(status)}
   .evscroll{max-height:340px;overflow:auto}
   .ev{display:flex;align-items:center;gap:11px;padding:6px 0;font-size:13px;border-top:1px solid #1c2026}.ev:first-child{border-top:0}
   .ev .t{color:#7d838e;min-width:54px;flex:none}
-  .evtxt{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-  a.ev{color:inherit;text-decoration:none;transition:color .1s}
-  a.ev:hover{color:#fff}a.ev:hover .evarrow{color:#8a93a5}
-  .evarrow{flex:none;color:#33373f;font-size:11px}
+  .evtxt{color:inherit;text-decoration:none;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;transition:color .1s}
+  .evtxt:hover{color:#fff}
+  .evdur{color:#9aa0ab;text-decoration:none;text-align:right;min-width:64px;flex:none;font-variant-numeric:tabular-nums}
+  a.evdur:hover{color:#6ea8fe}
+  .evarrow{color:#33373f;text-decoration:none;flex:none;font-size:11px;transition:color .1s}
+  .evarrow:hover{color:#8a93a5}
   .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;vertical-align:middle}
   .note{font-size:11px;color:#666c76;margin-top:14px}
   code{background:#1b1e24;padding:1px 5px;border-radius:4px}
 </style></head><body>
   <div class="top">
-    <div class="brand"><b>Fabric wall</b><span class="badge" id="livebadge">● LIVE</span><span>${escapeHtml(REPO)}</span></div>
+    <div class="brand"><b>Fabric wall</b><span class="badge" id="livebadge">● LIVE</span><span>${
+    escapeHtml(REPO)
+  }</span></div>
     <div class="live"><span class="dot green" id="freshdot"></span> <span id="agotext">updated ${ago}s ago</span></div>
   </div>
   <div class="grid" id="dashboard-grid">${gridHtml}</div>
@@ -176,12 +193,19 @@ ${faviconLink(status)}
       const active = document.activeElement;
       const rootFocused = active === current;
       const focusedHref = current.contains(active) && active instanceof HTMLAnchorElement ? active.href : null;
+      const focusedKey = current.contains(active) && active instanceof HTMLAnchorElement
+        ? active.dataset.focusKey ?? null
+        : null;
       current.replaceWith(next);
       const nextScroller = next.querySelector('.evscroll');
       if (scrollTop !== undefined && nextScroller) nextScroller.scrollTop = scrollTop;
       if (rootFocused) next.focus({ preventScroll: true });
       else if (focusedHref) {
-        Array.from(next.querySelectorAll('a')).find((link) => link.href === focusedHref)?.focus({ preventScroll: true });
+        const links = Array.from(next.querySelectorAll('a'));
+        const replacement = focusedKey
+          ? links.find((link) => link.dataset.focusKey === focusedKey)
+          : undefined;
+        (replacement ?? links.find((link) => link.href === focusedHref))?.focus({ preventScroll: true });
       }
       return next;
     });

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -13,7 +13,7 @@ import {
   start,
   tick,
 } from "./server.ts";
-import { PORT } from "./config.ts";
+import { LOOM_CI_WORKFLOW, LOOM_REPO, PORT } from "./config.ts";
 import { TILES } from "./registry.ts";
 import type { Tile, TileView } from "./types.ts";
 
@@ -259,6 +259,65 @@ Deno.test("each completed collection is published while slower tiles are still r
   assertStringIncludes(updateFromEvent(messages[1]).gridHtml, "slow");
 });
 
+Deno.test("a tile can publish cached data while its collection is still running", async () => {
+  const messages: string[] = [];
+  const client = {
+    enqueue(value: Uint8Array) {
+      messages.push(dec.decode(value));
+    },
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+  let releaseCollection!: (view: TileView) => void;
+  const finalView = new Promise<TileView>((resolve) => {
+    releaseCollection = resolve;
+  });
+  let cachedPublished!: () => void;
+  const sawCached = new Promise<void>((resolve) => {
+    cachedPublished = resolve;
+  });
+  let publishIntermediate = (_view: TileView) => {};
+  let collection: Promise<void> | undefined;
+  clients.add(client);
+  try {
+    collection = tick([{
+      id: "benchmark",
+      intervalMs: 0,
+      async collect(_ctx, publish) {
+        publishIntermediate = publish ?? publishIntermediate;
+        publish?.({ label: "benchmark", status: "good", value: "cached" });
+        cachedPublished();
+        return await finalView;
+      },
+    }]);
+    await sawCached;
+    assertEquals(messages.length, 1);
+    assertStringIncludes(updateFromEvent(messages[0]).gridHtml, "cached");
+
+    releaseCollection({
+      label: "benchmark",
+      status: "good",
+      value: "refreshed",
+    });
+    await collection;
+    assertEquals(messages.length, 2);
+    assertStringIncludes(updateFromEvent(messages[1]).gridHtml, "refreshed");
+    publishIntermediate({
+      label: "benchmark",
+      status: "bad",
+      value: "late cached value",
+    });
+    assertEquals(messages.length, 2);
+    assertStringIncludes(tileHtml("benchmark"), "refreshed");
+  } finally {
+    releaseCollection({
+      label: "benchmark",
+      status: "unknown",
+      value: "stopped",
+    });
+    await collection;
+    clients.delete(client);
+  }
+});
+
 Deno.test("sse: /events opens a stream, tick pushes new tile markup, disconnect drops the client", async () => {
   const res = await handle(req("/events"));
   assertEquals(res.headers.get("content-type"), "text/event-stream");
@@ -305,11 +364,21 @@ Deno.test("broadcast: a client whose stream is gone is dropped rather than throw
 });
 
 Deno.test("routes: a tile's drill-down path wins over the page; anything else is the page", async () => {
-  // ci-duration declares /ci, so the generic runtime serves it without knowing the tile.
-  const drill = await handle(req("/ci"));
-  assertEquals(drill.status, 200);
-  const html = await drill.text();
-  assertStringIncludes(html, "<title>CI Gantt — configurable</title>");
+  const gantt = await handle(req("/bench?view=gantt&repo=loom"));
+  assertEquals(gantt.status, 200);
+  const html = await gantt.text();
+  assertStringIncludes(html, "<title>CI run Gantt</title>");
+  assertStringIncludes(html, `${LOOM_REPO} · ${LOOM_CI_WORKFLOW}`);
+
+  const sha = "c".repeat(40);
+  const commitGantt = await handle(
+    req(`/ci-gantt?repo=labs&sha=${sha}&limit=1&mainOnly=1&run=901:1`),
+  );
+  assertEquals(commitGantt.status, 200);
+  assertStringIncludes(
+    await commitGantt.text(),
+    `<title>CI Gantt · ${sha.slice(0, 7)}</title>`,
+  );
 
   const fallback = await handle(req("/not-a-route"));
   assertEquals(fallback.status, 200);

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -122,8 +122,19 @@ export async function tick(tiles: Tile[] = TILES) {
     let remaining = due.length;
     await Promise.all(due.map(async (t) => {
       let view: TileView;
+      let acceptingIntermediate = true;
       try {
-        view = await t.collect(ctx);
+        try {
+          view = await t.collect(ctx, (intermediate) => {
+            if (!acceptingIntermediate) return;
+            views.set(t.id, intermediate);
+            lastChange = Date.now();
+            updateFaviconRedSince(lastChange, false);
+            broadcast(dashboardUpdate());
+          });
+        } finally {
+          acceptingIntermediate = false;
+        }
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         console.error(`tile ${t.id} failed:`, msg); // full detail to the log

--- a/packages/dashboard/test-runner.test.ts
+++ b/packages/dashboard/test-runner.test.ts
@@ -1,0 +1,180 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { runDashboardTests, TEST_COMMANDS } from "./test/runner.ts";
+
+Deno.test("dashboard test runner isolates caches and stops after a failure", async () => {
+  const calls: { args: readonly string[]; env: Record<string, string> }[] = [];
+  const removed: string[] = [];
+  const code = await runDashboardTests({
+    interrupts: [],
+    makeTempDirectory: () => Promise.resolve("dashboard-test-cache"),
+    removeDirectory: (directory) => {
+      removed.push(directory);
+      return Promise.resolve();
+    },
+    spawn: (args, env) => {
+      calls.push({ args, env });
+      return {
+        status: Promise.resolve({ code: calls.length === 2 ? 7 : 0 }),
+        kill: () => {},
+      };
+    },
+  });
+
+  assertEquals(code, 7);
+  assertEquals(calls, [
+    {
+      args: TEST_COMMANDS[0],
+      env: {
+        TMPDIR: "dashboard-test-cache",
+        DASHBOARD_CACHE_DIR: "dashboard-test-cache",
+      },
+    },
+    {
+      args: TEST_COMMANDS[1],
+      env: {
+        TMPDIR: "dashboard-test-cache",
+        DASHBOARD_CACHE_DIR: "dashboard-test-cache",
+      },
+    },
+  ]);
+  assertEquals(removed, ["dashboard-test-cache"]);
+});
+
+Deno.test("dashboard test runner stops its child before interruption cleanup", async () => {
+  const handlers = new Map<Deno.Signal, () => void>();
+  const removed: string[] = [];
+  const events: string[] = [];
+  let finishChild: (status: { code: number }) => void = () => {};
+  let childStarted: () => void = () => {};
+  const started = new Promise<void>((resolve) => childStarted = resolve);
+
+  const result = runDashboardTests({
+    interrupts: [{ signal: "SIGINT", status: 130 }],
+    addSignalListener: (signal, handler) => handlers.set(signal, handler),
+    removeSignalListener: (signal, handler) => {
+      assertEquals(handlers.get(signal), handler);
+      handlers.delete(signal);
+    },
+    makeTempDirectory: () => Promise.resolve("dashboard-test-cache"),
+    removeDirectory: (directory) => {
+      events.push("remove");
+      removed.push(directory);
+      return Promise.resolve();
+    },
+    spawn: () => {
+      const status = new Promise<{ code: number }>((resolve) => {
+        finishChild = resolve;
+      });
+      childStarted();
+      return {
+        status,
+        kill: () => {
+          events.push("kill");
+          finishChild({ code: 143 });
+        },
+      };
+    },
+  });
+
+  await started;
+  handlers.get("SIGINT")!();
+  assertEquals(await result, 130);
+  assertEquals(events, ["kill", "remove"]);
+  assertEquals(removed, ["dashboard-test-cache"]);
+  assertEquals(handlers.size, 0);
+});
+
+Deno.test("dashboard test runner handles signals received before a child starts", async () => {
+  let spawned = false;
+  const result = await runDashboardTests({
+    interrupts: [{ signal: "SIGINT", status: 130 }],
+    addSignalListener: (_signal, handler) => handler(),
+    removeSignalListener: () => {},
+    makeTempDirectory: () => Promise.resolve("dashboard-test-cache"),
+    removeDirectory: () => Promise.resolve(),
+    spawn: () => {
+      spawned = true;
+      return { status: Promise.resolve({ code: 0 }), kill: () => {} };
+    },
+  });
+
+  assertEquals(result, 130);
+  assertEquals(spawned, false);
+});
+
+Deno.test("dashboard test runner gives an interrupt precedence over a child error", async () => {
+  const handlers = new Map<Deno.Signal, () => void>();
+  let rejectChild: (error: unknown) => void = () => {};
+  let started: () => void = () => {};
+  const childStarted = new Promise<void>((resolve) => started = resolve);
+  const result = runDashboardTests({
+    interrupts: [{ signal: "SIGTERM", status: 143 }],
+    addSignalListener: (signal, handler) => handlers.set(signal, handler),
+    removeSignalListener: () => {},
+    makeTempDirectory: () => Promise.resolve("dashboard-test-cache"),
+    removeDirectory: () => Promise.resolve(),
+    spawn: () => {
+      const status = new Promise<{ code: number }>((_resolve, reject) => {
+        rejectChild = reject;
+      });
+      started();
+      return {
+        status,
+        kill: () => {
+          throw new Error("child already exited");
+        },
+      };
+    },
+  });
+
+  await childStarted;
+  handlers.get("SIGTERM")!();
+  handlers.get("SIGTERM")!();
+  rejectChild(new Error("child failed"));
+  assertEquals(await result, 143);
+});
+
+Deno.test("dashboard test runner propagates a child process error", async () => {
+  await assertRejects(
+    () =>
+      runDashboardTests({
+        interrupts: [],
+        makeTempDirectory: () => Promise.resolve("dashboard-test-cache"),
+        removeDirectory: () => Promise.resolve(),
+        spawn: () => ({
+          status: Promise.reject(new Error("spawned process failed")),
+          kill: () => {},
+        }),
+      }),
+    Error,
+    "spawned process failed",
+  );
+});
+
+Deno.test("dashboard test runner completes every configured suite", async () => {
+  const commands: string[][] = [];
+  const result = await runDashboardTests({
+    interrupts: [],
+    makeTempDirectory: () => Promise.resolve("dashboard-test-cache"),
+    removeDirectory: () => Promise.resolve(),
+    spawn: (args) => {
+      commands.push([...args]);
+      return { status: Promise.resolve({ code: 0 }), kill: () => {} };
+    },
+  });
+
+  assertEquals(result, 0);
+  assertEquals(commands, TEST_COMMANDS.map((args) => [...args]));
+});
+
+Deno.test("dashboard browser tests disable the Chromium sandbox in CI", async () => {
+  const previous = Deno.env.get("CI");
+  try {
+    Deno.env.set("CI", "1");
+    const config = (await import("./deno-web-test.config.ts?ci-test")).default;
+    assertEquals(config.args, ["--no-sandbox"]);
+  } finally {
+    if (previous === undefined) Deno.env.delete("CI");
+    else Deno.env.set("CI", previous);
+  }
+});

--- a/packages/dashboard/test/runner.ts
+++ b/packages/dashboard/test/runner.ts
@@ -1,0 +1,124 @@
+import { fromFileUrl } from "@std/path";
+
+const DASHBOARD_DIRECTORY = fromFileUrl(new URL("../", import.meta.url));
+
+export const TEST_COMMANDS = [
+  [
+    "test",
+    "--allow-env",
+    "--allow-read",
+    "--allow-write",
+    `--allow-run=${Deno.execPath()}`,
+    "--ignore=favicon-client.browser.test.ts",
+    "--ignore=favicon-raster.test.ts",
+    "--ignore=regenerate-favicons.test.ts",
+  ],
+  ["task", "test-favicon-raster"],
+  ["task", "test-browser"],
+] as const;
+
+interface RunningCommand {
+  status: Promise<{ code: number }>;
+  kill(): void;
+}
+
+type SpawnCommand = (
+  args: readonly string[],
+  env: Record<string, string>,
+) => RunningCommand;
+
+function spawnCommand(
+  args: readonly string[],
+  env: Record<string, string>,
+): RunningCommand {
+  const child = new Deno.Command(Deno.execPath(), {
+    args: [...args],
+    cwd: DASHBOARD_DIRECTORY,
+    env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  }).spawn();
+  return child;
+}
+
+interface Interrupt {
+  signal: Deno.Signal;
+  status: number;
+}
+
+const INTERRUPTS: readonly Interrupt[] = Deno.build.os === "windows"
+  ? [{ signal: "SIGINT", status: 130 }, { signal: "SIGBREAK", status: 131 }]
+  : [
+    { signal: "SIGHUP", status: 129 },
+    { signal: "SIGINT", status: 130 },
+    { signal: "SIGTERM", status: 143 },
+  ];
+
+export async function runDashboardTests(options: {
+  spawn?: SpawnCommand;
+  makeTempDirectory?: () => Promise<string>;
+  removeDirectory?: (directory: string) => Promise<void>;
+  interrupts?: readonly Interrupt[];
+  addSignalListener?: typeof Deno.addSignalListener;
+  removeSignalListener?: typeof Deno.removeSignalListener;
+} = {}): Promise<number> {
+  const spawn = options.spawn ?? spawnCommand;
+  const directory = await (options.makeTempDirectory ??
+    (() => Deno.makeTempDir({ prefix: "commontools-dashboard-tests-" })))();
+  const removeDirectory = options.removeDirectory ??
+    ((path) => Deno.remove(path, { recursive: true }));
+  const env = { TMPDIR: directory, DASHBOARD_CACHE_DIR: directory };
+  const interrupts = options.interrupts ?? INTERRUPTS;
+  const addSignalListener = options.addSignalListener ?? Deno.addSignalListener;
+  const removeSignalListener = options.removeSignalListener ??
+    Deno.removeSignalListener;
+  const handlers = new Map<Deno.Signal, () => void>();
+  let interrupted: Interrupt | undefined;
+  let active: RunningCommand | undefined;
+  const receivedInterrupt = (): Interrupt | undefined => interrupted;
+
+  for (const interrupt of interrupts) {
+    const handler = () => {
+      if (interrupted) return;
+      interrupted = interrupt;
+      try {
+        active?.kill();
+      } catch {
+        // The child completed between receiving the signal and forwarding it.
+      }
+    };
+    handlers.set(interrupt.signal, handler);
+    addSignalListener(interrupt.signal, handler);
+  }
+
+  try {
+    for (const args of TEST_COMMANDS) {
+      const beforeSpawn = receivedInterrupt();
+      if (beforeSpawn) return beforeSpawn.status;
+      active = spawn(args, env);
+      try {
+        const code = (await active.status).code;
+        const afterStatus = receivedInterrupt();
+        if (afterStatus) return afterStatus.status;
+        if (code !== 0) return code;
+      } catch (error) {
+        const afterError = receivedInterrupt();
+        if (afterError) return afterError.status;
+        throw error;
+      } finally {
+        active = undefined;
+      }
+    }
+    return 0;
+  } finally {
+    for (const [signal, handler] of handlers) {
+      removeSignalListener(signal, handler);
+    }
+    await removeDirectory(directory);
+  }
+}
+
+if (import.meta.main) {
+  Deno.exitCode = await runDashboardTests();
+}

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -7,21 +7,36 @@ import { LOOM_REPO, REPO, TRUST_COLS } from "./config.ts";
 import { labsCi, loomCi } from "./tiles/main-build.ts";
 import { labsCiTrust, loomCiTrust } from "./tiles/ci-trust.ts";
 import { labsCiDuration, loomCiDuration } from "./tiles/ci-duration.ts";
-import { recentRuns } from "./tiles/recent-runs.ts";
+import { commitGanttHref, recentRuns } from "./tiles/recent-runs.ts";
 import { dau, foldSeries, parseExcludes } from "./tiles/dau.ts";
 import { githubMembers } from "./tiles/github-members.ts";
 import { buildSnapshot, discordOnline } from "./tiles/discord-online.ts";
 import { gcpSpend } from "./tiles/gcp-spend.ts";
 import { prodErrors } from "./tiles/prod-errors.ts";
-import { githubCiSpend, GITHUB_LAG_DAYS, projectMonthly, settled } from "./tiles/github-ci-spend.ts";
+import {
+  GITHUB_LAG_DAYS,
+  githubCiSpend,
+  projectMonthly,
+  settled,
+} from "./tiles/github-ci-spend.ts";
 import { modelSpend } from "./tiles/model-spend.ts";
-import { benchmark, formatNs, trendPct, trendStatus } from "./tiles/benchmark.ts";
+import {
+  benchmark,
+  formatNs,
+  trendPct,
+  trendStatus,
+} from "./tiles/benchmark.ts";
 import { TILES } from "./registry.ts";
 
-function ctx(runs: Run[], env: Record<string, string> = {}, runsByRepo?: (repo: string) => Run[]): Ctx {
+function ctx(
+  runs: Run[],
+  env: Record<string, string> = {},
+  runsByRepo?: (repo: string) => Run[],
+): Ctx {
   return {
     runs: () => Promise.resolve(runs),
-    runsFor: (repo: string) => Promise.resolve(runsByRepo ? runsByRepo(repo) : runs),
+    runsFor: (repo: string) =>
+      Promise.resolve(runsByRepo ? runsByRepo(repo) : runs),
     env: (k) => env[k],
   };
 }
@@ -56,7 +71,9 @@ Deno.test("labs ci:failing tip -> bad (shows the raw conclusion)", async () => {
 });
 
 Deno.test("labs ci:no completed runs -> unknown", async () => {
-  const v = await labsCi.collect(ctx([run({ status: "in_progress", conclusion: null })]));
+  const v = await labsCi.collect(
+    ctx([run({ status: "in_progress", conclusion: null })]),
+  );
   assertEquals(v.status, "unknown");
   assertEquals(v.value, "—");
 });
@@ -74,9 +91,17 @@ Deno.test("labs ci trust: first-try-green rate drives status", async () => {
 });
 
 Deno.test("labs ci trust grid: cell count is a whole number of rows (no half-empty final row)", async () => {
-  const runs = Array.from({ length: 130 }, () => run({ conclusion: "success" }));
-  const cells = ((await labsCiTrust.collect(ctx(runs))).extra ?? "").match(/class="cell"/g)?.length ?? 0;
-  assert(cells > 0 && cells % TRUST_COLS === 0, `expected a multiple of ${TRUST_COLS}, got ${cells}`);
+  const runs = Array.from(
+    { length: 130 },
+    () => run({ conclusion: "success" }),
+  );
+  const cells =
+    ((await labsCiTrust.collect(ctx(runs))).extra ?? "").match(/class="cell"/g)
+      ?.length ?? 0;
+  assert(
+    cells > 0 && cells % TRUST_COLS === 0,
+    `expected a multiple of ${TRUST_COLS}, got ${cells}`,
+  );
   assertEquals(cells, 120); // floor(130 / 40) * 40
 });
 
@@ -89,13 +114,19 @@ Deno.test("ci-duration window: the 6h window when it has >= 20 runs, else the mo
     });
   // 25 runs within the last ~25 min -> the 6h window wins (25 >= 20).
   const busy = Array.from({ length: 25 }, (_, i) => at(i));
-  assertStringIncludes((await labsCiDuration.collect(ctx(busy))).sub ?? "", "25 passing runs in the last 6h");
+  assertStringIncludes(
+    (await labsCiDuration.collect(ctx(busy))).sub ?? "",
+    "25 passing runs in the last 6h",
+  );
   // 5 recent + 30 from two days ago -> only 5 in 6h (< 20) -> fall back to the last 20.
   const quiet = [
     ...Array.from({ length: 5 }, (_, i) => at(i)),
     ...Array.from({ length: 30 }, () => at(60 * 48)),
   ];
-  assertStringIncludes((await labsCiDuration.collect(ctx(quiet))).sub ?? "", "last 20 passing runs");
+  assertStringIncludes(
+    (await labsCiDuration.collect(ctx(quiet))).sub ?? "",
+    "last 20 passing runs",
+  );
 });
 
 Deno.test("ci-duration: only runs that passed end to end count", async () => {
@@ -114,11 +145,18 @@ Deno.test("ci-duration: only runs that passed end to end count", async () => {
     at(3, { status: "in_progress", conclusion: null }),
   ];
   // Only the 20 successful runs are counted; the rest are ignored.
-  assertStringIncludes((await labsCiDuration.collect(ctx(runs))).sub ?? "", "20 passing runs in the last 6h");
+  assertStringIncludes(
+    (await labsCiDuration.collect(ctx(runs))).sub ?? "",
+    "20 passing runs in the last 6h",
+  );
 });
 
 Deno.test("recent-runs: wide, failure tip -> bad, rows link to the landing PR", async () => {
-  const v = await recentRuns.collect(ctx([run({ conclusion: "failure", head_commit: { message: "oops (#42)" } })]));
+  const v = await recentRuns.collect(
+    ctx([
+      run({ conclusion: "failure", head_commit: { message: "oops (#42)" } }),
+    ]),
+  );
   assertEquals(recentRuns.wide, true);
   assertEquals(v.status, "bad");
   assertStringIncludes(v.extra ?? "", "/pull/42");
@@ -126,12 +164,98 @@ Deno.test("recent-runs: wide, failure tip -> bad, rows link to the landing PR", 
 
 Deno.test("recent runs: timestamps have a UTC fallback and a viewer-local marker", async () => {
   const startedAt = "2024-01-02T17:05:00Z";
-  const runsByRepo = (repo: string) => repo === REPO ? [run({ run_started_at: startedAt })] : [];
+  const runsByRepo = (repo: string) =>
+    repo === REPO ? [run({ run_started_at: startedAt })] : [];
   const v = await recentRuns.collect(ctx([], {}, runsByRepo));
   assertStringIncludes(
     v.extra ?? "",
     `<time class="t" datetime="${startedAt}" data-viewer-time>17:05 UTC</time>`,
   );
+});
+
+Deno.test("recent runs: duration opens every successful run for the commit", async () => {
+  const sha = "a".repeat(40);
+  const start = Date.parse("2026-07-21T18:00:00Z");
+  const first = run({
+    id: 41,
+    head_sha: sha,
+    run_started_at: new Date(start).toISOString(),
+    updated_at: new Date(start + 185_000).toISOString(),
+  });
+  const second = run({
+    id: 42,
+    head_sha: sha,
+    run_attempt: 2,
+    run_started_at: new Date(start - 60_000).toISOString(),
+    updated_at: new Date(start + 120_000).toISOString(),
+  });
+  const failed = run({ id: 43, head_sha: sha, conclusion: "failure" });
+  const loom = run({ id: 44, repo: LOOM_REPO, head_sha: sha });
+  const dispatched = run({
+    id: 45,
+    event: "workflow_dispatch",
+    head_sha: sha,
+  });
+  const running = run({
+    id: 46,
+    status: "in_progress",
+    conclusion: null,
+    head_sha: "b".repeat(40),
+    run_started_at: new Date(start - 120_000).toISOString(),
+  });
+  const untimed = run({
+    id: 47,
+    head_sha: "c".repeat(40),
+    run_started_at: new Date(start - 180_000).toISOString(),
+    updated_at: "not-a-timestamp",
+  });
+  const brief = run({
+    id: 48,
+    head_sha: "d".repeat(40),
+    run_started_at: new Date(start - 240_000).toISOString(),
+    updated_at: new Date(start - 198_000).toISOString(),
+  });
+
+  const href = commitGanttHref(first, [
+    first,
+    second,
+    failed,
+    loom,
+    dispatched,
+  ]);
+  assert(href);
+  const target = new URL(href, "http://dashboard");
+  assertEquals(target.pathname, "/ci-gantt");
+  assertEquals(target.searchParams.get("repo"), "labs");
+  assertEquals(target.searchParams.get("sha"), sha);
+  assertEquals(target.searchParams.getAll("run"), ["41:1", "42:2"]);
+  assertEquals(commitGanttHref({ ...first, head_sha: "" }, [first]), null);
+  assertEquals(commitGanttHref(failed, [first, failed]), null);
+  const tooMany = Array.from(
+    { length: 151 },
+    (_, index) => run({ id: 1_000 + index, head_sha: sha }),
+  );
+  assertEquals(commitGanttHref(tooMany[0], tooMany), null);
+
+  const runsByRepo = (repo: string) =>
+    repo === REPO
+      ? [first, second, failed, dispatched, running, untimed, brief]
+      : [loom];
+  const html = (await recentRuns.collect(ctx([], {}, runsByRepo))).extra ?? "";
+  assertStringIncludes(
+    html,
+    `class="evdur" data-focus-key="gantt-41" href="${
+      href.replaceAll("&", "&amp;")
+    }"`,
+  );
+  assertStringIncludes(html, 'class="evtxt" data-focus-key="pr-title-41"');
+  assertStringIncludes(
+    html,
+    '>3m 05s</a><a class="evarrow" data-focus-key="pr-arrow-41"',
+  );
+  assertStringIncludes(html, '<span class="evdur">running</span>');
+  assertStringIncludes(html, '<span class="evdur">—</span>');
+  assertStringIncludes(html, '>42s</a><a class="evarrow"');
 });
 
 Deno.test("tile labels: the labs/loom ci family is renamed and paired", async () => {
@@ -151,20 +275,32 @@ Deno.test("labs ci: an in-flight build renders at the bottom (extra), not the he
   ];
   const v = await labsCi.collect(ctx(runs));
   assertStringIncludes(v.extra ?? "", "next build running");
-  assert(!(v.aside ?? "").includes("next build running"), "the badge is no longer in the header aside");
+  assert(
+    !(v.aside ?? "").includes("next build running"),
+    "the badge is no longer in the header aside",
+  );
 });
 
 Deno.test("recent runs: labs and loom runs interleave chronologically, each tagged", async () => {
   const now = Date.now();
   const mk = (repo: string, minsAgo: number, msg: string) =>
-    run({ repo, run_started_at: new Date(now - minsAgo * 60_000).toISOString(), head_commit: { message: msg } });
+    run({
+      repo,
+      run_started_at: new Date(now - minsAgo * 60_000).toISOString(),
+      head_commit: { message: msg },
+    });
   const byRepo = (repo: string) =>
     repo === LOOM_REPO
       ? [mk(LOOM_REPO, 10, "loom c (#7)"), mk(LOOM_REPO, 30, "loom b (#6)")]
       : [mk(REPO, 5, "labs c (#3)"), mk(REPO, 20, "labs a (#2)")];
   const v = await recentRuns.collect(ctx([], {}, byRepo));
   // Newest-first interleave across repos: labs 5m, loom 10m, labs 20m, loom 30m.
-  const order = [...(v.extra ?? "").matchAll(/\/pull\/(\d+)/g)].map((m) => m[1]);
+  const order = [
+    ...(v.extra ?? "").matchAll(
+      /class="evtxt" data-focus-key="pr-title-\d+" href="[^"]*\/pull\/(\d+)/g,
+    ),
+  ]
+    .map((match) => match[1]);
   assertEquals(order, ["3", "7", "2", "6"]);
   assertStringIncludes(v.extra ?? "", "labs · ");
   assertStringIncludes(v.extra ?? "", "loom · ");
@@ -190,11 +326,17 @@ Deno.test("dau: distinct identities per UTC day, excluding the DIDs we name", ()
   assertEquals(human.get(day1)?.size, 1);
   assertEquals(human.get(day2)?.size, 2);
   // A bucket carrying no spans for an identity is not that identity being active.
-  assertEquals(foldSeries([ser("did:key:alice", [[day1, 0]])], new Set()).size, 0);
+  assertEquals(
+    foldSeries([ser("did:key:alice", [[day1, 0]])], new Set()).size,
+    0,
+  );
 });
 
 Deno.test("dau: the exclusion list is read defensively", () => {
-  assertEquals([...parseExcludes("did:key:a, did:key:b ,, ")], ["did:key:a", "did:key:b"]);
+  assertEquals([...parseExcludes("did:key:a, did:key:b ,, ")], [
+    "did:key:a",
+    "did:key:b",
+  ]);
   assertEquals(parseExcludes(undefined).size, 0);
   assertEquals(parseExcludes("").size, 0);
 });
@@ -252,7 +394,9 @@ Deno.test("projectMonthly: >=2-week (or month-to-date) window, spilling into las
   assertEquals(projectMonthly(2000, 20, 30, lastMonth), 3000);
   // < 2 weeks -> 14-day window = 6 days this month + last 8 of last month.
   //   window = 1200 + 8*100 = 2000 over 14 days -> (2000/14)*30.
-  assert(Math.abs(projectMonthly(1200, 6, 30, lastMonth) - (2000 / 14) * 30) < 1e-6);
+  assert(
+    Math.abs(projectMonthly(1200, 6, 30, lastMonth) - (2000 / 14) * 30) < 1e-6,
+  );
   // No data this month yet -> window is the last 14 days of last month.
   assertEquals(projectMonthly(0, 0, 31, lastMonth), 100 * 31);
   // No data anywhere -> falls back to mtd.
@@ -263,12 +407,24 @@ Deno.test("settled: a day is known once it has a figure, or once billing has had
   const L = GITHUB_LAG_DAYS; // 2
   // Day 15 of the month. Spend every day through the 15th: the last two days have
   // figures, so they are known despite being inside the lag.
-  assertEquals(settled(Array.from({ length: 31 }, (_, i) => (i < 15 ? 10 : 0)), 15, L).length, 15);
+  assertEquals(
+    settled(Array.from({ length: 31 }, (_, i) => (i < 15 ? 10 : 0)), 15, L)
+      .length,
+    15,
+  );
   // Nothing since the 5th. The days that carried spend stop at 5, but by the 15th
   // billing has settled everything up to the 13th, so those quiet days are known.
-  assertEquals(settled(Array.from({ length: 31 }, (_, i) => (i < 5 ? 10 : 0)), 15, L).length, 13);
+  assertEquals(
+    settled(Array.from({ length: 31 }, (_, i) => (i < 5 ? 10 : 0)), 15, L)
+      .length,
+    13,
+  );
   // The window keeps growing as the month goes on rather than stalling at 5.
-  assertEquals(settled(Array.from({ length: 31 }, (_, i) => (i < 5 ? 10 : 0)), 31, L).length, 29);
+  assertEquals(
+    settled(Array.from({ length: 31 }, (_, i) => (i < 5 ? 10 : 0)), 31, L)
+      .length,
+    29,
+  );
   // Nothing at all this month: still only what billing has settled.
   assertEquals(settled(new Array(31).fill(0), 15, L).length, 13);
   // Day 1: nothing is settled yet and nothing has a figure.
@@ -296,7 +452,10 @@ Deno.test("projectMonthly: the window keeps up with the calendar once spend stop
   assert(projectMonthly(1.01, 2, 31, []) / rate(15) > 6);
   // By the end of the month the projection has converged on what was actually spent,
   // instead of stalling at the 14th and claiming double.
-  assert(rate(31) < 1.15, `end-of-month projection should approach $1.01, got ${rate(31)}`);
+  assert(
+    rate(31) < 1.15,
+    `end-of-month projection should approach $1.01, got ${rate(31)}`,
+  );
   assert(rate(31) < rate(15), "the rate falls as quiet days accumulate");
   // The same money landing early is rated over the same elapsed fortnight, not over
   // the two days at the start of it.
@@ -316,13 +475,25 @@ Deno.test("projectMonthly: a borrowed tail is settled before it is borrowed", ()
   // On the 1st, with a 2-day lag, last month's final day is not known yet.
   const unsettledTail = [...steady.slice(0, 29), 0];
   assertEquals(settled(unsettledTail, 30 + 1, GITHUB_LAG_DAYS).length, 29);
-  assertEquals(projectMonthly(30, 3, 31, settled(unsettledTail, 30 + 1, GITHUB_LAG_DAYS)), truth);
+  assertEquals(
+    projectMonthly(30, 3, 31, settled(unsettledTail, 30 + 1, GITHUB_LAG_DAYS)),
+    truth,
+  );
   // Borrowed raw, that one zero drags the rate down.
-  assert(projectMonthly(30, 3, 31, unsettledTail) < truth, "an unsettled tail under-projects");
+  assert(
+    projectMonthly(30, 3, 31, unsettledTail) < truth,
+    "an unsettled tail under-projects",
+  );
   // A prior month with no data at all borrows nothing rather than a month of zeros.
-  assertEquals(settled(new Array(30).fill(0), 30 + 1, GITHUB_LAG_DAYS).length, 29);
+  assertEquals(
+    settled(new Array(30).fill(0), 30 + 1, GITHUB_LAG_DAYS).length,
+    29,
+  );
   // But by mid-month a genuinely quiet prior month is known, and counts as quiet.
-  assertEquals(settled(new Array(30).fill(0), 30 + 15, GITHUB_LAG_DAYS).length, 30);
+  assertEquals(
+    settled(new Array(30).fill(0), 30 + 15, GITHUB_LAG_DAYS).length,
+    30,
+  );
 });
 
 Deno.test("benchmark: trend classification — flat/down good, up warn, steep up bad", () => {
@@ -359,5 +530,7 @@ Deno.test("benchmark: formatNs picks a readable unit", () => {
 Deno.test("registry: unique ids and positive intervals", () => {
   const ids = TILES.map((t) => t.id);
   assertEquals(new Set(ids).size, ids.length, "tile ids must be unique");
-  for (const t of TILES) assert(t.intervalMs > 0, `${t.id} needs a positive intervalMs`);
+  for (const t of TILES) {
+    assert(t.intervalMs > 0, `${t.id} needs a positive intervalMs`);
+  }
 });

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -3,20 +3,38 @@
 // the per-run artifact listings and the artifact zips (real zip bytes, really
 // deflated) are all canned. No network, no files, no subprocess.
 //
-// The tile keeps a per-process cache of each run's results and a module-level
-// snapshot for the drill-down page, so these tests share state: every test uses
-// its own run ids, and the tests that read the snapshot follow the collect that
-// filled it. They run in declaration order.
+// The tile keeps a persistent cache of each run's results and a module-level
+// snapshot for the drill-down page. The dashboard test runner gives this module
+// a temporary server-data directory. These tests share that state, use distinct
+// run ids, and read snapshots after the collection that filled them.
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
-import type { Ctx } from "../types.ts";
+import type { Ctx, TileView } from "../types.ts";
 import { REPO } from "../config.ts";
-import { benchmark, formatNs, jsonFromZip, trendPct, trendStatus } from "./benchmark.ts";
+import { BenchmarkHistoryStore } from "../benchmark-history-cache.ts";
+import {
+  benchmark,
+  type BenchmarkFetchProgress,
+  benchmarkHistoryCheckResponse,
+  benchmarkHistoryProgressResponse,
+  benchmarkTrend,
+  benchPage,
+  formatNs,
+  jsonFromZip,
+  pointsForWindow,
+  sampleBenchmarkRuns,
+  trendPct,
+  trendStatus,
+} from "./benchmark.ts";
+import { CI_HISTORY_MIN_DAYS, ciHistoryBucketMs } from "../ci-job-history.ts";
 
 const DAY = 86_400_000;
 const HOUR = 3_600_000;
-// Midnight UTC yesterday plus two hours: half way through a 4-hour sampling
-// window, so a run an hour either side of it lands in the same window.
+// Midnight UTC yesterday plus two hours keeps test data inside the live window.
 const BASE = Math.floor(Date.now() / DAY) * DAY - DAY + 2 * HOUR;
+const COLLECTION_BUCKET = ciHistoryBucketMs(CI_HISTORY_MIN_DAYS);
+const SAMPLED_BASE = Math.floor(BASE / COLLECTION_BUCKET) *
+    COLLECTION_BUCKET +
+  COLLECTION_BUCKET * 0.75;
 
 function ctx(env: Record<string, string> = {}): Ctx {
   return {
@@ -48,7 +66,10 @@ interface Member {
 // directory and the end-of-central-directory record. CRCs are left zero — the
 // reader takes its sizes and offsets from the central directory and checks
 // neither. `entryCount` overrides the count the EOCD advertises.
-function makeZip(members: Member[], entryCount = members.length): Uint8Array<ArrayBuffer> {
+function makeZip(
+  members: Member[],
+  entryCount = members.length,
+): Uint8Array<ArrayBuffer> {
   const enc = new TextEncoder();
   const local: Uint8Array[] = [];
   const central: Uint8Array[] = [];
@@ -113,12 +134,19 @@ async function benchZip(json: string): Promise<Uint8Array<ArrayBuffer>> {
 
 interface GhRun {
   id: number;
+  run_attempt: number;
   created_at: string;
   conclusion: string | null;
 }
 
-const ghRun = (id: number, at: number, conclusion: string | null = "success"): GhRun => ({
+const ghRun = (
+  id: number,
+  at: number,
+  conclusion: string | null = "success",
+  runAttempt = 1,
+): GhRun => ({
   id,
+  run_attempt: runAttempt,
   created_at: new Date(at).toISOString(),
   conclusion,
 });
@@ -126,7 +154,10 @@ const ghRun = (id: number, at: number, conclusion: string | null = "success"): G
 interface Api {
   pages?: Record<number, GhRun[]>;
   // runId -> its artifact listing, or an HTTP status to fail with.
-  artifacts?: Record<number, { id: number; name: string; expired: boolean }[] | number>;
+  artifacts?: Record<
+    number,
+    { id: number; name: string; expired: boolean }[] | number
+  >;
   // artifactId -> the zip bytes, or an HTTP status to fail with.
   zips?: Record<number, Uint8Array<ArrayBuffer> | number>;
   // Thrown instead of answering, standing in for a dead network.
@@ -138,10 +169,24 @@ interface Api {
 // A stand-in GitHub Actions API answering exactly the three calls the tile makes.
 function serve(api: Api): (url: URL) => Response {
   return (url) => {
+    if (url.pathname === "/rate_limit") {
+      return Response.json({
+        resources: {
+          core: {
+            limit: 5_000,
+            used: 0,
+            remaining: 5_000,
+            reset: Math.ceil(Date.now() / 1_000) + 3_600,
+          },
+        },
+      });
+    }
     if (api.throws) throw api.throws;
     if (api.status) return new Response("no", { status: api.status });
     if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
-      return Response.json({ workflow_runs: api.pages?.[Number(url.searchParams.get("page"))] ?? [] });
+      return Response.json({
+        workflow_runs: api.pages?.[Number(url.searchParams.get("page"))] ?? [],
+      });
     }
     const runId = url.pathname.match(/\/actions\/runs\/(\d+)\/artifacts$/)?.[1];
     if (runId) {
@@ -152,7 +197,9 @@ function serve(api: Api): (url: URL) => Response {
     const artId = url.pathname.match(/\/actions\/artifacts\/(\d+)\/zip$/)?.[1];
     if (artId) {
       const v = api.zips?.[Number(artId)];
-      if (v === undefined || typeof v === "number") return new Response("no", { status: typeof v === "number" ? v : 404 });
+      if (v === undefined || typeof v === "number") {
+        return new Response("no", { status: typeof v === "number" ? v : 404 });
+      }
       return new Response(v);
     }
     throw new Error(`unexpected request ${url.pathname}`);
@@ -161,7 +208,10 @@ function serve(api: Api): (url: URL) => Response {
 
 // Swap in the stub api for one test, recording every path requested, and put the
 // real fetch back afterwards so no state leaks into the rest of the process.
-async function withApi(api: Api, fn: (calls: string[]) => Promise<void>): Promise<void> {
+async function withApi(
+  api: Api,
+  fn: (calls: string[]) => Promise<void>,
+): Promise<void> {
   const real = globalThis.fetch;
   const handler = serve(api);
   const calls: string[] = [];
@@ -178,7 +228,10 @@ async function withApi(api: Api, fn: (calls: string[]) => Promise<void>): Promis
 }
 
 const runsPath = `/repos/${REPO}/actions/workflows/benchmarks.yml/runs`;
-const artifactCalls = (calls: string[]) => calls.filter((c) => c.includes("/artifacts"));
+const artifactCalls = (calls: string[]) =>
+  calls.filter((c) => c.includes("/artifacts"));
+const apiCalls = (calls: string[]) =>
+  calls.filter((call) => !call.startsWith("/rate_limit"));
 
 // ------------------------------------------------------------ bench json
 
@@ -204,7 +257,12 @@ const timings = (p99: number): Timings => ({
   p999: p99 * 1.2,
 });
 
-const bench = (origin: string, group: string | null, name: string, ok: Timings | undefined) => ({
+const bench = (
+  origin: string,
+  group: string | null,
+  name: string,
+  ok: Timings | undefined,
+) => ({
   origin: `file:///w/${origin}`,
   group,
   name,
@@ -213,7 +271,8 @@ const bench = (origin: string, group: string | null, name: string, ok: Timings |
 
 // The deno bench report. `noise` stands in for a benchmark's own console output
 // landing on stdout ahead of the JSON.
-const report = (benches: unknown[], noise = "") => noise + JSON.stringify({ version: 1, runtime: "deno", benches });
+const report = (benches: unknown[], noise = "") =>
+  noise + JSON.stringify({ version: 1, runtime: "deno", benches });
 
 // ----------------------------------------------------------------- the tests
 
@@ -223,40 +282,556 @@ Deno.test("benchmark: no token -> gray, and nothing is fetched", async () => {
     assertEquals(v.status, "unknown");
     assertEquals(v.value, "—");
     assertEquals(v.sub, "set GH_TOKEN");
-    assertEquals(v.href, undefined); // no drill-down offered when there is nothing behind it
+    assertEquals(v.href, "/bench?view=runtime&repo=labs");
+    assertEquals(v.hint, "all metrics ↗");
     assertEquals(calls, []);
   });
+});
+
+Deno.test("dashboard and /bench benchmark refreshes keep separate request scopes", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-scope-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const isolated = await import(
+    `./benchmark.ts?scope=${crypto.randomUUID()}`
+  );
+  const originalFetch = globalThis.fetch;
+  const token = `benchmark-scope-${crypto.randomUUID()}`;
+  const calls: string[] = [];
+  let workflowCalls = 0;
+  let dashboardReleased = false;
+  let requestsOverlapped = false;
+  let releaseDashboard!: (response: Response) => void;
+  let markDashboardStarted!: () => void;
+  let releasePerformance!: (response: Response) => void;
+  let markPerformanceStarted!: () => void;
+  const dashboardResponse = new Promise<Response>((resolve) => {
+    releaseDashboard = resolve;
+  });
+  const dashboardStarted = new Promise<void>((resolve) => {
+    markDashboardStarted = resolve;
+  });
+  const performanceResponse = new Promise<Response>((resolve) => {
+    releasePerformance = resolve;
+  });
+  const performanceStarted = new Promise<void>((resolve) => {
+    markPerformanceStarted = resolve;
+  });
+  const handler = serve({ pages: {} });
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    calls.push(url.pathname + url.search);
+    if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
+      workflowCalls++;
+      if (workflowCalls === 1) {
+        markDashboardStarted();
+        return dashboardResponse;
+      }
+      requestsOverlapped ||= !dashboardReleased;
+      markPerformanceStarted();
+      return performanceResponse;
+    }
+    return Promise.resolve(handler(url));
+  }) as typeof fetch;
+
+  let dashboardResult: Promise<TileView> | undefined;
+  try {
+    dashboardResult = isolated.benchmark.collect(ctx({ GH_TOKEN: token }));
+    await dashboardStarted;
+
+    const url = new URL("http://x/bench?view=runtime");
+    const page = await isolated.benchmarkHistoryResponse(
+      url,
+      ctx({ GH_TOKEN: token }),
+    );
+    const html = await page.text();
+    const progressMatch = html.match(/data-progress-url="([^"]+)"/);
+    assert(progressMatch);
+    const progressResponse = isolated.benchmarkHistoryProgressResponse(
+      new URL(progressMatch[1], url),
+    );
+    const progressText = progressResponse.text();
+
+    dashboardReleased = true;
+    releaseDashboard(new Response("unavailable", { status: 503 }));
+    await dashboardResult;
+    await performanceStarted;
+    releasePerformance(Response.json({ workflow_runs: [] }));
+    const events = await progressText;
+    assertStringIncludes(events, '"phase":"complete"');
+    assertEquals(events.includes('"phase":"error"'), false);
+
+    assertEquals(workflowCalls, 2);
+    assertEquals(requestsOverlapped, false);
+    assertEquals(calls.includes("/rate_limit"), true);
+  } finally {
+    dashboardReleased = true;
+    releaseDashboard(new Response("unavailable", { status: 503 }));
+    releasePerformance(Response.json({ workflow_runs: [] }));
+    await dashboardResult?.catch(() => {});
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
 });
 
 Deno.test("benchmark: GITHUB_TOKEN stands in for GH_TOKEN", async () => {
   await withApi({ pages: {} }, async (calls) => {
     const v = await benchmark.collect(ctx({ GITHUB_TOKEN: "t" }));
     assertEquals(v.sub, "no benchmark runs"); // it got past the token gate and asked
-    assertEquals(calls.length, 1);
-    assertStringIncludes(calls[0], runsPath);
+    assertEquals(apiCalls(calls).length, 1);
+    assertStringIncludes(apiCalls(calls)[0], runsPath);
+    assertEquals(calls.includes("/rate_limit"), false);
   });
 });
 
-Deno.test("/bench before any data: says it is still collecting, rather than drawing an empty chart", () => {
-  const url = new URL("http://x/bench");
-  const res = benchmark.routes![0].handler(new Request(url), url) as Response;
-  assertEquals(benchmark.routes![0].path, "/bench");
-  assertEquals(res.headers.get("content-type"), "text/html; charset=utf-8");
+Deno.test("benchmark: a fresh disk cache prevents discovery after a dashboard restart", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-restart-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  const token = `benchmark-restart-${crypto.randomUUID()}`;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    calls.push(url.pathname);
+    if (url.pathname === "/rate_limit") {
+      return Promise.resolve(serve({})(url));
+    }
+    if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
+      return Promise.resolve(Response.json({ workflow_runs: [] }));
+    }
+    throw new Error(`unexpected request ${url.pathname}`);
+  }) as typeof fetch;
+
+  try {
+    const first = await import(`./benchmark.ts?restart=${crypto.randomUUID()}`);
+    await first.benchmark.collect(ctx({ GH_TOKEN: token }));
+    assert(calls.some((call) => call.endsWith("/benchmarks.yml/runs")));
+
+    calls.length = 0;
+    const restarted = await import(
+      `./benchmark.ts?restart=${crypto.randomUUID()}`
+    );
+    const restartedView = await restarted.benchmark.collect(ctx({
+      GH_TOKEN: token,
+    }));
+    assertEquals(calls, []);
+    assertEquals(restartedView.sub, "no benchmark runs");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
 });
 
-Deno.test("/bench before any data: the body is the collecting notice", async () => {
-  const url = new URL("http://x/bench");
-  const html = await (benchmark.routes![0].handler(new Request(url), url) as Response).text();
-  assertStringIncludes(html, `<p class="empty">Collecting benchmark data from CI artifacts`);
+Deno.test("fresh runtime history serves the page and update check without discovery", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    calls.push(input instanceof Request ? input.url : String(input));
+    throw new Error("fresh runtime history must not request GitHub");
+  }) as typeof fetch;
+
+  try {
+    const store = new BenchmarkHistoryStore();
+    await store.load();
+    store.markRefreshed(Date.now(), [], "no-runs");
+    await store.save();
+
+    const isolated = await import(
+      `./benchmark.ts?fresh-history=${crypto.randomUUID()}`
+    );
+    const tokenContext = ctx({ GH_TOKEN: "fresh-history-token" });
+    const page = await isolated.benchmarkHistoryResponse(
+      new URL("http://x/bench?view=runtime"),
+      tokenContext,
+    );
+    assertStringIncludes(await page.text(), "Idle");
+
+    const checkIsolated = await import(
+      `./benchmark.ts?fresh-check=${crypto.randomUUID()}`
+    );
+    const check = await checkIsolated.benchmarkHistoryCheckResponse(
+      tokenContext,
+    );
+    assertEquals(await check.json(), {
+      version: checkIsolated.benchmarkSnapshotVersion(),
+      progress: null,
+    });
+    assertEquals(calls, []);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: a stale disk cache is published while startup checks GitHub", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-startup-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  const token = `benchmark-startup-${crypto.randomUUID()}`;
+  const key = "packages/a/startup.bench.ts > cached";
+  const stats = {
+    min: 400,
+    avg: 500,
+    max: 1_500,
+    p75: 800,
+    p99: 1_000,
+    p995: 1_050,
+    p999: 1_200,
+  };
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const store = new BenchmarkHistoryStore();
+  await store.load();
+  const cachedRuns = [
+    { runId: 81_001, runAttempt: 1, at: Date.now() - 2 * DAY },
+    { runId: 81_002, runAttempt: 1, at: Date.now() - DAY },
+  ].map((run) => ({ ...run, metrics: new Map([[key, stats]]) }));
+  for (const run of cachedRuns) store.set(run);
+  store.markRefreshed(Date.now() - 31 * 60_000, cachedRuns);
+  await store.save();
+
+  let releaseDiscovery!: (response: Response) => void;
+  const discovery = new Promise<Response>((resolve) => {
+    releaseDiscovery = resolve;
+  });
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
+      return discovery;
+    }
+    throw new Error(`unexpected request ${url.pathname}`);
+  }) as typeof fetch;
+
+  let published!: TileView;
+  let markPublished!: () => void;
+  const publishedResult = new Promise<void>((resolve) => {
+    markPublished = resolve;
+  });
+  let collection: Promise<TileView> | undefined;
+  try {
+    const isolated = await import(
+      `./benchmark.ts?startup=${crypto.randomUUID()}`
+    );
+    const activeCollection = isolated.benchmark.collect(
+      ctx({ GH_TOKEN: token, BENCH_METRIC: key }),
+      (view: TileView) => {
+        published = view;
+        markPublished();
+      },
+    );
+    collection = activeCollection;
+    let settled = false;
+    const observedCollection = activeCollection.then((view: TileView) => {
+      settled = true;
+      return view;
+    });
+    await publishedResult;
+    assertEquals(published.value, "1.0µs");
+    assertEquals(settled, false);
+
+    releaseDiscovery(Response.json({ workflow_runs: [] }));
+    await observedCollection;
+  } finally {
+    releaseDiscovery(Response.json({ workflow_runs: [] }));
+    await collection?.catch(() => {});
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: a future refresh marker cannot suppress discovery", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-future-" });
+  const file = `${directory}/fabric-wall-benchmark-history.json`;
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const store = new BenchmarkHistoryStore(file);
+  await store.load();
+  store.markRefreshed(Date.now() + DAY, []);
+  await store.save();
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    calls.push(url.pathname);
+    if (url.pathname === "/rate_limit") {
+      return Promise.resolve(serve({})(url));
+    }
+    return Promise.resolve(Response.json({ workflow_runs: [] }));
+  }) as typeof fetch;
+
+  try {
+    const restarted = await import(
+      `./benchmark.ts?future=${crypto.randomUUID()}`
+    );
+    await restarted.benchmark.collect(ctx({
+      GH_TOKEN: `benchmark-future-${crypto.randomUUID()}`,
+    }));
+    assert(calls.some((call) => call.endsWith("/benchmarks.yml/runs")));
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("/bench requires an explicit performance view", () => {
+  const missing = new URL("http://x/bench?days=5");
+  const res = benchmark.routes![0].handler(
+    new Request(missing),
+    missing,
+  ) as Response;
+  assertEquals(benchmark.routes![0].path, "/bench");
+  assertEquals(res.status, 400);
+  assertEquals(res.headers.get("location"), null);
+
+  const unknown = new URL("http://x/bench?view=summary");
+  assertEquals(
+    (benchmark.routes![0].handler(
+      new Request(unknown),
+      unknown,
+    ) as Response).status,
+    400,
+  );
+});
+
+Deno.test("/bench?view=runtime serves the runtime history page", async () => {
+  const url = new URL("http://x/bench?view=runtime");
+  const res = await benchmark.routes![0].handler(new Request(url), url);
+  assertEquals(res.headers.get("content-type"), "text/html; charset=utf-8");
+
+  const fragmentUrl = new URL(
+    "http://x/bench?view=runtime&days=7&fragment=range",
+  );
+  const fragmentResponse = await benchmark.routes![0].handler(
+    new Request(fragmentUrl),
+    fragmentUrl,
+  );
+  const fragment = await fragmentResponse.text();
+  assert(fragment.startsWith('<div id="range-content">'));
+  assertStringIncludes(fragment, "selected 7-day trend");
+  assert(!fragment.includes("<!doctype html>"));
+  assert(!fragment.includes('<form class="controls"'));
+});
+
+Deno.test("/bench CI progress route rejects an unknown collection", async () => {
+  const route = benchmark.routes![2];
+  const url = new URL("http://x/bench/ci-progress?id=missing");
+  const response = await route.handler(new Request(url), url);
+  assertEquals(route.path, "/bench/ci-progress");
+  assertEquals(response.status, 404);
+});
+
+Deno.test("/bench update check returns an uncached runtime snapshot version", async () => {
+  const route = benchmark.routes![1];
+  const url = new URL("http://x/bench/check?view=runtime");
+  const response = await route.handler(new Request(url), url);
+  const state = await response.json();
+  assertEquals(route.path, "/bench/check");
+  assertEquals(typeof state.version, "string");
+  assertEquals(response.headers.get("cache-control"), "no-store");
+});
+
+Deno.test("/bench update check requires an explicit supported view", async () => {
+  const route = benchmark.routes![1];
+  for (const query of ["", "?view=summary", "?view=gantt"]) {
+    const url = new URL(`http://x/bench/check${query}`);
+    const response = await route.handler(new Request(url), url);
+    assertEquals(response.status, 400);
+  }
+});
+
+Deno.test("runtime history shows live artifact progress and keeps collection running", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-progress-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const isolated = await import(
+    `./benchmark.ts?progress=${crypto.randomUUID()}`
+  );
+  const originalFetch = globalThis.fetch;
+  let releaseArtifact = (_response: Response) => {};
+  let artifactRequested = () => {};
+  const sawArtifact = new Promise<void>((resolve) =>
+    artifactRequested = resolve
+  );
+  const artifactResponse = new Promise<Response>((resolve) => {
+    releaseArtifact = resolve;
+  });
+  const runId = 39_001;
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.pathname === "/rate_limit") return Promise.resolve(serve({})(url));
+    if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
+      return Promise.resolve(Response.json({
+        workflow_runs: [ghRun(runId, BASE)],
+      }));
+    }
+    if (url.pathname.endsWith(`/actions/runs/${runId}/artifacts`)) {
+      artifactRequested();
+      return artifactResponse;
+    }
+    throw new Error(`unexpected request ${url.pathname}`);
+  }) as typeof fetch;
+
+  const tokenContext = ctx({ GH_TOKEN: "progress-token" });
+  try {
+    await isolated.benchmarkHistoryResponse(
+      new URL("http://x/bench?view=runtime&days=7"),
+      tokenContext,
+    );
+    await sawArtifact;
+
+    const check = await isolated.benchmarkHistoryCheckResponse(tokenContext);
+    const state = await check.json();
+    assertEquals(state.progress.phase, "fetching");
+    assertEquals(state.progress.requestsMade, 1);
+    assertEquals(state.progress.responsesReceived, 0);
+    assertEquals(state.progress.outstandingRequests, 1);
+
+    const pageResponse = await isolated.benchmarkHistoryResponse(
+      new URL("http://x/bench?view=runtime&days=7"),
+      tokenContext,
+    );
+    const html = await pageResponse.text();
+    assertStringIncludes(html, "0 of 1 artifact checks complete");
+    assertStringIncludes(html, "1 artifact checks made · 0 responded");
+    assertStringIncludes(html, "1 outstanding · 0 queued");
+    assertStringIncludes(html, 'data-refresh-on-complete="1"');
+    assertStringIncludes(
+      html,
+      `/bench/runtime-progress?id=${state.progress.id}`,
+    );
+    assert(!html.includes("reload in a moment"));
+    assert(!html.includes('id="days" name="days" disabled'));
+    assertStringIncludes(
+      html,
+      'fetchProgress.dataset.refreshOnComplete === "1"',
+    );
+    assertStringIncludes(
+      html,
+      'collectionFailed = state.phase === "error"',
+    );
+    assertStringIncludes(
+      html,
+      "if (!eventStream && !collectionFailed && !transportFailed) renderIdle()",
+    );
+    assertStringIncludes(html, "transportFailed = true");
+
+    const progressUrl = new URL(
+      `http://x/bench/runtime-progress?id=${state.progress.id}`,
+    );
+    const progressResponse = isolated.benchmarkHistoryProgressResponse(
+      progressUrl,
+    );
+    const reader = progressResponse.body!.getReader();
+    const first = new TextDecoder().decode((await reader.read()).value);
+    assertStringIncludes(first, '"outstandingRequests":1');
+
+    releaseArtifact(Response.json({ artifacts: [] }));
+    let completed = first;
+    while (!completed.includes('"phase":"complete"')) {
+      const next = await reader.read();
+      if (next.done) break;
+      completed += new TextDecoder().decode(next.value);
+    }
+    assertStringIncludes(completed, '"phase":"complete"');
+    assertStringIncludes(completed, '"responsesReceived":1');
+    assertStringIncludes(completed, '"outstandingRequests":0');
+  } finally {
+    releaseArtifact(Response.json({ artifacts: [] }));
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("/bench before any data shows an idle progress panel", async () => {
+  const isolated = await import(
+    `./benchmark.ts?idle=${crypto.randomUUID()}`
+  );
+  const html = isolated.benchPage("p99", "file", 45, BASE, "labs");
+  assertStringIncludes(html, '<section class="fetch-progress"');
+  assertStringIncludes(html, '<strong id="fetch-title">Idle</strong>');
+  assertStringIncludes(
+    html,
+    "No runtime benchmark samples were found in the history window.",
+  );
+  assert(!html.includes("reload in a moment"));
+  assertStringIncludes(
+    html,
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+  );
   assertStringIncludes(html, "<title>Benchmarks — p99</title>"); // p99 is the default measurement
-  assert(!html.includes('class="brow'), "no rows are drawn with nothing to draw");
+  assertStringIncludes(
+    html,
+    'href="/bench?view=ci&amp;repo=labs&amp;days=45&amp;sort=job&amp;stat=p99">CI duration history</a>',
+  );
+  assertStringIncludes(
+    html,
+    'href="/bench?view=gantt&amp;repo=labs&amp;days=45&amp;sort=job&amp;stat=p99">CI run Gantt</a>',
+  );
+  assert(
+    !html.includes('class="brow'),
+    "no rows are drawn with nothing to draw",
+  );
+});
+
+Deno.test("/bench?view=ci serves CI job history through the same drill-down", async () => {
+  const gh = Deno.env.get("GH_TOKEN");
+  const github = Deno.env.get("GITHUB_TOKEN");
+  const cacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  Deno.env.delete("GH_TOKEN");
+  Deno.env.delete("GITHUB_TOKEN");
+  Deno.env.set(
+    "DASHBOARD_CACHE_DIR",
+    `/tmp/ci-job-history-missing-${crypto.randomUUID()}`,
+  );
+  try {
+    const url = new URL("http://x/bench?view=ci");
+    const response = await benchmark.routes![0].handler(new Request(url), url);
+    const html = await response.text();
+    assertEquals(
+      response.headers.get("content-type"),
+      "text/html; charset=utf-8",
+    );
+    assertStringIncludes(html, "<title>CI job history</title>");
+    assertStringIncludes(html, "Set GH_TOKEN to collect CI job history.");
+  } finally {
+    if (gh === undefined) Deno.env.delete("GH_TOKEN");
+    else Deno.env.set("GH_TOKEN", gh);
+    if (github === undefined) Deno.env.delete("GITHUB_TOKEN");
+    else Deno.env.set("GITHUB_TOKEN", github);
+    if (cacheDirectory === undefined) Deno.env.delete("DASHBOARD_CACHE_DIR");
+    else Deno.env.set("DASHBOARD_CACHE_DIR", cacheDirectory);
+  }
 });
 
 Deno.test("benchmark: paging stops at the 45-day cutoff; failures and out-of-window runs are not sampled", async () => {
   // One full page whose oldest run is past the window: the loop stops there rather
   // than asking for page 2. Nothing on it is both successful and in-window.
   const page1 = [
-    ...Array.from({ length: 99 }, (_, i) => ghRun(1_000 + i, BASE - i * HOUR, "failure")),
+    ...Array.from(
+      { length: 99 },
+      (_, i) => ghRun(1_000 + i, BASE - i * HOUR, "failure"),
+    ),
     ghRun(1_099, BASE - 50 * DAY, "success"), // in date order last, and older than the cutoff
   ];
   await withApi({ pages: { 1: page1 } }, async (calls) => {
@@ -264,20 +839,26 @@ Deno.test("benchmark: paging stops at the 45-day cutoff; failures and out-of-win
     assertEquals(v.status, "unknown");
     assertEquals(v.value, "—");
     assertEquals(v.sub, "no benchmark runs");
-    assertEquals(v.href, "/bench");
+    assertEquals(v.href, "/bench?view=runtime&repo=labs");
     assertEquals(v.hint, "all metrics ↗");
-    assertEquals(calls.length, 1); // page 2 was never asked for
+    assertEquals(apiCalls(calls).length, 1); // page 2 was never asked for
     assertEquals(artifactCalls(calls), []); // and no artifact was downloaded
   });
 });
 
 Deno.test("benchmark: an empty page ends the paging", async () => {
-  const page1 = Array.from({ length: 100 }, (_, i) => ghRun(2_000 + i, BASE - i * HOUR, "failure"));
+  const page1 = Array.from(
+    { length: 100 },
+    (_, i) => ghRun(2_000 + i, BASE - i * HOUR, "failure"),
+  );
   await withApi({ pages: { 1: page1, 2: [] } }, async (calls) => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
     assertEquals(v.sub, "no benchmark runs");
     // A full page still inside the window is followed; the empty page 2 stops it.
-    assertEquals(calls.map((c) => c.match(/[?&]page=(\d+)/)![1]), ["1", "2"]);
+    assertEquals(
+      apiCalls(calls).map((c) => c.match(/[?&]page=(\d+)/)![1]),
+      ["1", "2"],
+    );
   });
 });
 
@@ -289,7 +870,11 @@ Deno.test("benchmark: unusable artifacts -> gray, never a false green", async ()
     ghRun(403, BASE - 1 * DAY),
     ghRun(404, BASE),
   ];
-  const art = (id: number, name = "bench-results", expired = false) => ({ id, name, expired });
+  const art = (id: number, name = "bench-results", expired = false) => ({
+    id,
+    name,
+    expired,
+  });
   await withApi({
     pages: { 1: runs },
     artifacts: {
@@ -300,14 +885,18 @@ Deno.test("benchmark: unusable artifacts -> gray, never a false green", async ()
     },
     zips: {
       4_020: 404,
-      4_030: makeZip([{ name: "notes.txt", method: 0, data: bytes("nothing useful") }]),
+      4_030: makeZip([{
+        name: "notes.txt",
+        method: 0,
+        data: bytes("nothing useful"),
+      }]),
     },
   }, async (calls) => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
     assertEquals(v.status, "unknown");
     assertEquals(v.value, "—");
     assertEquals(v.sub, "benchmark data unavailable");
-    assertEquals(v.href, "/bench");
+    assertEquals(v.href, "/bench?view=runtime&repo=labs");
     // The expired artifact and the coverage artifact are never downloaded.
     assert(!calls.some((c) => c.includes("/artifacts/4010/zip")));
     assert(!calls.some((c) => c.includes("/artifacts/4011/zip")));
@@ -327,7 +916,9 @@ Deno.test("benchmark: a read that blipped is retried; a run with a definite answ
     ghRun(403, BASE - 1 * DAY),
     ghRun(404, BASE),
   ];
-  const json = report([bench("packages/a/x.bench.ts", null, "tick", timings(1_000))]);
+  const json = report([
+    bench("packages/a/x.bench.ts", null, "tick", timings(1_000)),
+  ]);
   await withApi({
     pages: { 1: runs },
     // The source is healthy again, and now answers for the two that blipped.
@@ -341,19 +932,131 @@ Deno.test("benchmark: a read that blipped is retried; a run with a definite answ
     // The blips are asked again, so the tile recovers rather than staying dark for
     // the life of the process.
     assertEquals(v.value, "1.0µs");
-    assert(calls.some((c) => c.includes("/runs/402/artifacts")), "the failed zip download is retried");
-    assert(calls.some((c) => c.includes("/runs/404/artifacts")), "the failed listing is retried");
+    assert(
+      calls.some((c) => c.includes("/runs/402/artifacts")),
+      "the failed zip download is retried",
+    );
+    assert(
+      calls.some((c) => c.includes("/runs/404/artifacts")),
+      "the failed listing is retried",
+    );
     // The settled runs are answered from the cache; the healthy source is not asked.
-    assert(!calls.some((c) => c.includes("/runs/401/artifacts")), "a run with no usable artifact is settled");
-    assert(!calls.some((c) => c.includes("/runs/403/artifacts")), "a zip with no report is settled");
+    assert(
+      !calls.some((c) => c.includes("/runs/401/artifacts")),
+      "a run with no usable artifact is settled",
+    );
+    assert(
+      !calls.some((c) => c.includes("/runs/403/artifacts")),
+      "a zip with no report is settled",
+    );
   });
 });
 
-Deno.test("benchmark: one benchmark, one run sampled per 4-hour window (the newest in the window wins)", async () => {
+Deno.test("benchmark: a failed newer attempt stays stale and reports an error", async () => {
+  const firstRun = ghRun(40_101, BASE - DAY);
+  const secondRun = ghRun(40_102, BASE);
+  const key = "packages/a/rerun.bench.ts";
+  await withApi({
+    pages: { 1: [firstRun, secondRun] },
+    artifacts: {
+      40_101: [{
+        id: 401_010,
+        name: "bench-results",
+        expired: false,
+      }],
+      40_102: [{
+        id: 401_020,
+        name: "bench-results",
+        expired: false,
+      }],
+    },
+    zips: {
+      401_010: await benchZip(
+        report([bench(key, null, "work", timings(1_000))]),
+      ),
+      401_020: await benchZip(
+        report([bench(key, null, "work", timings(2_000))]),
+      ),
+    },
+  }, async () => {
+    const view = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(view.value, "2.0µs");
+  });
+
+  const originalFetch = globalThis.fetch;
+  let releaseAttempt = (_response: Response) => {};
+  let attemptRequested = () => {};
+  const sawAttempt = new Promise<void>((resolve) => attemptRequested = resolve);
+  const attemptResponse = new Promise<Response>((resolve) => {
+    releaseAttempt = resolve;
+  });
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.pathname === "/rate_limit") {
+      return Promise.resolve(serve({})(url));
+    }
+    if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
+      return Promise.resolve(Response.json({
+        workflow_runs: [
+          ghRun(firstRun.id, BASE - DAY, "success", 2),
+          secondRun,
+        ],
+      }));
+    }
+    if (url.pathname.endsWith(`/actions/runs/${firstRun.id}/artifacts`)) {
+      attemptRequested();
+      return attemptResponse;
+    }
+    throw new Error(`unexpected request ${url.pathname}`);
+  }) as typeof fetch;
+
+  try {
+    const collection = benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    await sawAttempt;
+    const check = await benchmarkHistoryCheckResponse(ctx({ GH_TOKEN: "t" }));
+    const state = await check.json();
+    const progress = benchmarkHistoryProgressResponse(
+      new URL(`http://x/bench/runtime-progress?id=${state.progress.id}`),
+    );
+    const reader = progress.body!.getReader();
+    let events = new TextDecoder().decode((await reader.read()).value);
+
+    releaseAttempt(new Response("unavailable", { status: 503 }));
+    const view = await collection;
+    assertEquals(view.value, "2.0µs");
+    while (!events.includes('"phase":"error"')) {
+      const next = await reader.read();
+      if (next.done) break;
+      events += new TextDecoder().decode(next.value);
+    }
+    assertStringIncludes(events, '"phase":"error"');
+    assertStringIncludes(events, '"failedResponses":1');
+
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
+        return Promise.resolve(Response.json({ workflow_runs: [] }));
+      }
+      throw new Error(`unexpected request ${url.pathname}`);
+    }) as typeof fetch;
+    await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(
+      benchmarkHistoryProgressResponse(
+        new URL(`http://x/bench/runtime-progress?id=${state.progress.id}`),
+      ).status,
+      404,
+    );
+  } finally {
+    releaseAttempt(new Response("unavailable", { status: 503 }));
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("benchmark: one benchmark per shortest-view bucket (the newest in the bucket wins)", async () => {
   // Twelve days, one run a day, all at 1µs. Two runs share the last window: the
   // older one is wildly slow, so if the wrong one were sampled the headline would
   // read 10ms and the tile would turn red.
-  const at = (d: number) => BASE - (11 - d) * DAY;
+  const at = (d: number) => SAMPLED_BASE - (11 - d) * DAY;
   const key = "packages/runner/solo.bench.ts";
   const runs: GhRun[] = [];
   const artifacts: Api["artifacts"] = {};
@@ -364,14 +1067,24 @@ Deno.test("benchmark: one benchmark, one run sampled per 4-hour window (the newe
     artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
     // No "version" key here: the report is parsed whole when there is no console
     // output to skip past.
-    zips[id * 10] = await benchZip(JSON.stringify({ benches: [bench(key, null, "tick", timings(1_000))] }));
+    zips[id * 10] = await benchZip(
+      JSON.stringify({ benches: [bench(key, null, "tick", timings(1_000))] }),
+    );
   }
   // The stale twin, listed before its window's winner so the newer one displaces it.
-  runs.push(ghRun(599, at(11) - HOUR));
+  runs.push(ghRun(599, at(11) - COLLECTION_BUCKET / 2));
   artifacts[599] = [{ id: 5_990, name: "bench-results", expired: false }];
-  zips[5_990] = await benchZip(JSON.stringify({ benches: [bench(key, null, "tick", timings(9_999_999))] }));
+  zips[5_990] = await benchZip(
+    JSON.stringify({ benches: [bench(key, null, "tick", timings(9_999_999))] }),
+  );
 
-  await withApi({ pages: { 1: [ghRun(599, at(11) - HOUR), ...runs.slice(0, 12)] }, artifacts, zips }, async () => {
+  await withApi({
+    pages: {
+      1: [ghRun(599, at(11) - COLLECTION_BUCKET / 2), ...runs.slice(0, 12)],
+    },
+    artifacts,
+    zips,
+  }, async () => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
     assertEquals(v.value, "1.0µs"); // the newest run in the window, not the 10ms twin
     assertEquals(v.status, "good"); // flat p99 over 45 days
@@ -385,8 +1098,11 @@ Deno.test("benchmark: one benchmark, one run sampled per 4-hour window (the newe
 });
 
 Deno.test("benchmark: a run's results are immutable, so a cached run is not refetched", async () => {
-  const at = (d: number) => BASE - (11 - d) * DAY;
-  const runs = [ghRun(599, at(11) - HOUR), ...Array.from({ length: 12 }, (_, d) => ghRun(501 + d, at(d)))];
+  const at = (d: number) => SAMPLED_BASE - (11 - d) * DAY;
+  const runs = [
+    ghRun(599, at(11) - COLLECTION_BUCKET / 2),
+    ...Array.from({ length: 12 }, (_, d) => ghRun(501 + d, at(d))),
+  ];
   // Every artifact call would 500; the cache from the previous test answers instead.
   await withApi({ pages: { 1: runs } }, async (calls) => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
@@ -405,12 +1121,18 @@ Deno.test("jsonFromZip: reads a stored json member, ignoring a text member besid
 });
 
 Deno.test("jsonFromZip: inflates a deflated json member", async () => {
-  const json = report([bench("packages/a/x.bench.ts", null, "tick", timings(5))]);
+  const json = report([
+    bench("packages/a/x.bench.ts", null, "tick", timings(5)),
+  ]);
   assertEquals(await jsonFromZip(await benchZip(json)), json);
 });
 
 Deno.test("jsonFromZip: a zip with no json member -> null", async () => {
-  const zip = makeZip([{ name: "notes.txt", method: 0, data: bytes("nothing") }]);
+  const zip = makeZip([{
+    name: "notes.txt",
+    method: 0,
+    data: bytes("nothing"),
+  }]);
   assertEquals(await jsonFromZip(zip), null);
 });
 
@@ -425,13 +1147,21 @@ Deno.test("jsonFromZip: a central directory shorter than its own count stops ins
 });
 
 Deno.test("jsonFromZip: a member whose local header the central directory does not point at -> null", async () => {
-  const zip = makeZip([{ name: "results.json", method: 0, data: bytes(`{"benches":[]}`) }]);
+  const zip = makeZip([{
+    name: "results.json",
+    method: 0,
+    data: bytes(`{"benches":[]}`),
+  }]);
   new DataView(zip.buffer).setUint32(0, 0xdeadbeef, true); // clobber the local file header signature
   assertEquals(await jsonFromZip(zip), null);
 });
 
 Deno.test("jsonFromZip: a compression method we cannot read -> null, not garbage", async () => {
-  const zip = makeZip([{ name: "results.json", method: 99, data: bytes(`{"benches":[]}`) }]);
+  const zip = makeZip([{
+    name: "results.json",
+    method: 99,
+    data: bytes(`{"benches":[]}`),
+  }]);
   assertEquals(await jsonFromZip(zip), null);
 });
 
@@ -439,8 +1169,20 @@ Deno.test("jsonFromZip: a compression method we cannot read -> null, not garbage
 // series ends at exactly `fold` times where it started.
 const SHAPES = [
   // origin, group, name, p99 on day 0, end/start ratio
-  ["packages/runner/scheduler-persistent-state.bench.ts", null, "commit", 1_000, 1.12],
-  ["packages/runner/scheduler-persistent-state.bench.ts", "hot", "steep", 1_000_000, 20],
+  [
+    "packages/runner/scheduler-persistent-state.bench.ts",
+    null,
+    "commit",
+    1_000,
+    1.12,
+  ],
+  [
+    "packages/runner/scheduler-persistent-state.bench.ts",
+    "hot",
+    "steep",
+    1_000_000,
+    20,
+  ],
   ["packages/memory/query.bench.ts", null, "fivefold", 10_000, 5],
   ["packages/memory/query.bench.ts", null, "quarter", 400_000_000, 0.25],
   ["packages/html/render.bench.ts", null, "easing", 1_000, 0.9],
@@ -463,10 +1205,17 @@ async function fillVaried(): Promise<Api> {
       bench("packages/html/render.bench.ts", null, "flat", { avg: 2_500_000 }),
       // Neither of these is a measurement, so neither reaches the page.
       bench("packages/x/skip.bench.ts", null, "no-ok", undefined),
-      bench("packages/x/skip.bench.ts", null, "not-a-number", { avg: "quick" } as unknown as Timings),
+      bench(
+        "packages/x/skip.bench.ts",
+        null,
+        "not-a-number",
+        { avg: "quick" } as unknown as Timings,
+      ),
     ];
     // A benchmark's own console output precedes the report on stdout.
-    zips[id * 10] = await benchZip(report(benches, "running 7 benchmarks\ncpu: apple m2\n"));
+    zips[id * 10] = await benchZip(
+      report(benches, "running 7 benchmarks\ncpu: apple m2\n"),
+    );
   }
   return { pages: { 1: runs }, artifacts, zips };
 }
@@ -479,13 +1228,17 @@ function rows(html: string) {
 }
 
 const page = async (query: string): Promise<string> => {
-  const url = new URL(`http://x/bench${query}`);
-  return await (benchmark.routes![0].handler(new Request(url), url) as Response).text();
+  const suffix = query ? `&${query.replace(/^\?/, "")}` : "";
+  const url = new URL(`http://x/bench?view=runtime${suffix}`);
+  return await (await benchmark.routes![0].handler(new Request(url), url))
+    .text();
 };
 
 Deno.test("benchmark: BENCH_METRIC pins the grid tile to a named benchmark", async () => {
   await withApi(await fillVaried(), async () => {
-    const v = await benchmark.collect(ctx({ GH_TOKEN: "t", BENCH_METRIC: "steep" }));
+    const v = await benchmark.collect(
+      ctx({ GH_TOKEN: "t", BENCH_METRIC: "steep" }),
+    );
     assertEquals(v.value, "20ms"); // 1ms rising twenty-fold over the 45 days
     assertEquals(v.status, "bad"); // past RAPID_PCT -> trending up rapidly
     assertEquals(v.duration, 11 * DAY);
@@ -498,7 +1251,11 @@ Deno.test("/bench: grouped by source file, each benchmark coloured by its own tr
   const html = await page("?stat=p99&sort=file");
   assertEquals(
     [...html.matchAll(/<h2>([^<]*)<\/h2>/g)].map((m) => m[1]),
-    ["packages/html/render.bench.ts", "packages/memory/query.bench.ts", "packages/runner/scheduler-persistent-state.bench.ts"],
+    [
+      "packages/html/render.bench.ts",
+      "packages/memory/query.bench.ts",
+      "packages/runner/scheduler-persistent-state.bench.ts",
+    ],
   );
   assertEquals(rows(html), [
     { status: "good", name: "easing", value: "900ns", trend: "▼10%" },
@@ -512,10 +1269,75 @@ Deno.test("/bench: grouped by source file, each benchmark coloured by its own tr
   // measurement and never reaches the page.
   assert(!html.includes("no-ok"), "a result with no ok block is dropped");
   assert(!html.includes("not-a-number"), "a non-numeric average is dropped");
-  assertStringIncludes(html, `<a class="stat on" href="/bench?stat=p99&sort=file">p99</a>`);
-  assertStringIncludes(html, `<a class="stat" href="/bench?stat=p75&sort=file">p75</a>`);
-  assertStringIncludes(html, `<a class="stat on" href="/bench?stat=p99&sort=file">file</a>`);
-  assertStringIncludes(html, `<a class="stat" href="/bench?stat=p99&sort=trend">trend</a>`);
+  assertStringIncludes(
+    html,
+    `<a class="stat on" href="/bench?view=runtime&amp;repo=labs&amp;days=45&amp;sort=file&amp;stat=p99" aria-current="true">p99</a>`,
+  );
+  assertStringIncludes(
+    html,
+    `<a class="stat" href="/bench?view=runtime&amp;repo=labs&amp;days=45&amp;sort=file&amp;stat=p75">p75</a>`,
+  );
+  assertStringIncludes(
+    html,
+    `<a class="stat on" href="/bench?view=runtime&amp;repo=labs&amp;days=45&amp;sort=file&amp;stat=p99" aria-current="true">file</a>`,
+  );
+  assertStringIncludes(
+    html,
+    `<a class="stat" href="/bench?view=runtime&amp;repo=labs&amp;days=45&amp;sort=duration&amp;stat=p99">duration</a>`,
+  );
+  assertStringIncludes(html, 'aria-label="Benchmark metric"');
+  assertStringIncludes(html, 'aria-label="Sort benchmarks"');
+  assertStringIncludes(
+    html,
+    'href="/bench?view=runtime&amp;repo=labs&amp;days=45&amp;sort=file&amp;stat=p99" aria-current="page">Runtime benchmarks</a>',
+  );
+  assertStringIncludes(
+    html,
+    'href="/bench?view=gantt&amp;repo=labs&amp;days=45&amp;sort=job&amp;stat=p99">CI run Gantt</a>',
+  );
+  assertStringIncludes(
+    html,
+    '<input type="hidden" name="view" value="runtime">',
+  );
+  assertStringIncludes(html, '<input type="hidden" name="repo" value="labs">');
+  assertStringIncludes(html, '<div id="range-content">');
+  assertStringIncludes(html, 'days.addEventListener("keydown"');
+  assertStringIncludes(html, "syncDayLinks()");
+  assertStringIncludes(html, 'days.addEventListener("change", applyDays)');
+  assert(!html.includes("keyboardEditing"));
+  assertStringIncludes(html, "new DOMParser().parseFromString");
+  assertStringIncludes(html, "rangeContent.replaceWith(replacement)");
+  assertStringIncludes(html, "history.pushState(null");
+  assertStringIncludes(html, 'window.addEventListener("popstate"');
+  assertStringIncludes(html, 'void loadRange("pop")');
+  assertStringIncludes(html, 'void loadRange("restore")');
+  assertStringIncludes(html, 'if (mode === "refresh")');
+  assertStringIncludes(html, "rangeRequestDays !== days.value");
+  assertStringIncludes(html, "if (loaded && pendingRefresh)");
+  assertStringIncludes(html, "days.value !== appliedDays ||");
+  assertStringIncludes(
+    html,
+    "if (!Number.isFinite(value)) return DEFAULT_DAYS",
+  );
+  assertStringIncludes(html, "rangeRequest.abort()");
+  assertStringIncludes(html, "refreshRangeWhenIdle()");
+  assert(!html.includes("location.reload()"));
+  assert(!html.includes("benchRestoreDaysFocus"));
+  assertStringIncludes(html, "setInterval(checkForUpdates, 60000)");
+  assert(
+    !html.includes(
+      ".views a.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11;font-weight",
+    ),
+  );
+  assert(
+    !html.includes(
+      "a.stat.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11;font-weight",
+    ),
+  );
+  assertStringIncludes(
+    html,
+    '<div class="axisrow"><div class="timeaxis"><span>',
+  );
 });
 
 Deno.test("/bench?sort=trend: a flat list, biggest rise first, showing the full key", async () => {
@@ -530,7 +1352,61 @@ Deno.test("/bench?sort=trend: a flat list, biggest rise first, showing the full 
     "packages/memory/query.bench.ts &gt; quarter",
   ]);
   assert(!html.includes("<h2>"), "a flat list has no file headings");
-  assertStringIncludes(html, `<a class="stat on" href="/bench?stat=p99&sort=trend">trend</a>`);
+  assertStringIncludes(
+    html,
+    `<a class="stat on" href="/bench?view=runtime&amp;repo=labs&amp;days=45&amp;sort=trend&amp;stat=p99" aria-current="true">trend</a>`,
+  );
+});
+
+Deno.test("/bench?sort=duration lists the longest current benchmark first", async () => {
+  const html = await page("?stat=p99&sort=duration");
+  assertEquals(rows(html).map((row) => row.name).slice(0, 3), [
+    "packages/memory/query.bench.ts &gt; quarter",
+    "packages/runner/scheduler-persistent-state.bench.ts &gt; hot/steep",
+    "packages/html/render.bench.ts &gt; flat",
+  ]);
+  assertStringIncludes(
+    html,
+    'href="/bench?view=ci&amp;repo=labs&amp;days=45&amp;sort=duration&amp;stat=p99">CI duration history</a>',
+  );
+});
+
+Deno.test("/bench history windows keep about the same chart point count", () => {
+  const now = 45 * DAY;
+  const step = 10 * 60_000;
+  const points = Array.from(
+    { length: Math.floor(45 * DAY / step) + 1 },
+    (_, index) => ({ at: now - index * step }),
+  );
+  const full = pointsForWindow(points, 0, ciHistoryBucketMs(45));
+  const short = pointsForWindow(
+    points,
+    now - CI_HISTORY_MIN_DAYS * DAY,
+    ciHistoryBucketMs(CI_HISTORY_MIN_DAYS),
+  );
+
+  assert(full.length >= 89 && full.length <= 91);
+  assert(short.length >= 89 && short.length <= 91);
+});
+
+Deno.test("benchmark collection retains enough runs for the shortest history window", () => {
+  const now = 45 * DAY;
+  const step = 10 * 60_000;
+  const runs = Array.from(
+    { length: Math.floor(45 * DAY / step) + 1 },
+    (_, index) => ghRun(30_000 + index, now - index * step),
+  );
+  const collected = sampleBenchmarkRuns(runs, 0).map((run) => ({
+    at: Date.parse(run.created_at),
+  }));
+  const short = pointsForWindow(
+    collected,
+    now - CI_HISTORY_MIN_DAYS * DAY,
+    ciHistoryBucketMs(CI_HISTORY_MIN_DAYS),
+    now,
+  );
+
+  assert(short.length >= 89 && short.length <= 91);
 });
 
 Deno.test("/bench: the measurement selector changes what is plotted", async () => {
@@ -538,26 +1414,145 @@ Deno.test("/bench: the measurement selector changes what is plotted", async () =
   assertEquals(p50.find((r) => r.name === "hot/steep")?.value, "10ms"); // the mean, half the p99
   // A benchmark that reported only an average reads the same at every percentile.
   assertEquals(p50.find((r) => r.name === "flat")?.value, "2.5ms");
-  assertEquals(rows(await page("?stat=p0")).find((r) => r.name === "flat")?.value, "2.5ms");
-  assertStringIncludes(await page("?stat=p50"), "<title>Benchmarks — p50</title>");
+  assertEquals(
+    rows(await page("?stat=p0")).find((r) => r.name === "flat")?.value,
+    "2.5ms",
+  );
+  assertStringIncludes(
+    await page("?stat=p50"),
+    "<title>Benchmarks — p50</title>",
+  );
   // An unknown measurement falls back to the default rather than blanking the page.
-  assertStringIncludes(await page("?stat=nonsense"), "<title>Benchmarks — p99</title>");
-  assertEquals(rows(await page("?stat=nonsense")).find((r) => r.name === "hot/steep")?.value, "20ms");
+  assertStringIncludes(
+    await page("?stat=nonsense"),
+    "<title>Benchmarks — p99</title>",
+  );
+  assertEquals(
+    rows(await page("?stat=nonsense")).find((r) => r.name === "hot/steep")
+      ?.value,
+    "20ms",
+  );
   // So does an unknown sort.
-  assertStringIncludes(await page("?sort=nonsense"), "<h2>packages/html/render.bench.ts</h2>");
+  assertStringIncludes(
+    await page("?sort=nonsense"),
+    "<h2>packages/html/render.bench.ts</h2>",
+  );
+});
+
+Deno.test("/bench: the history slider selects and clamps the displayed days", async () => {
+  const short = await page("?days=1");
+  assertStringIncludes(
+    short,
+    'id="days" name="days" min="1" max="45" step="1" value="1"',
+  );
+  assertStringIncludes(short, "selected 1-day trend");
+  assertStringIncludes(
+    await page("?days=7"),
+    '<div class="axisrow"><div class="timeaxis"><span>',
+  );
+  assertStringIncludes(await page("?days=0"), ">1 day</output>");
+  assertStringIncludes(await page("?days=100"), ">45 days</output>");
+
+  const requestedEnd = BASE + DAY;
+  const anchored = benchPage("p99", "file", 7, requestedEnd);
+  const date = (at: number) =>
+    new Date(at).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    });
+  assertStringIncludes(
+    anchored,
+    `<div class="timeaxis"><span>${date(requestedEnd - 7 * DAY)}</span><span>${
+      date(requestedEnd)
+    }</span>`,
+  );
+
+  const stale = benchPage("p99", "file", 7, BASE + 20 * DAY);
+  assertStringIncludes(
+    stale,
+    "No benchmark samples were found in the selected window.",
+  );
+  assert(!stale.includes('class="brow'));
 });
 
 Deno.test("/bench: the page names the repo and workflow it read", async () => {
   const html = await page("");
   assertStringIncludes(html, `${REPO} · benchmarks.yml`);
-  assertStringIncludes(html, `https://github.com/${REPO}/actions/workflows/benchmarks.yml`);
+  assertStringIncludes(
+    html,
+    `https://github.com/${REPO}/actions/workflows/benchmarks.yml`,
+  );
+});
+
+Deno.test("/bench runtime preserves the selected CI repository across its links", () => {
+  const html = benchPage("p75", "duration", 9, BASE, "loom");
+
+  assertStringIncludes(html, '<input type="hidden" name="repo" value="loom">');
+  assertStringIncludes(
+    html,
+    'href="/bench?view=ci&amp;repo=loom&amp;days=9&amp;sort=duration&amp;stat=p75">CI duration history</a>',
+  );
+  assertStringIncludes(
+    html,
+    'href="/bench?view=gantt&amp;repo=loom&amp;days=9&amp;sort=duration&amp;stat=p75">CI run Gantt</a>',
+  );
+});
+
+Deno.test("benchmark: a pinned metric that disappeared yields to the current default", async () => {
+  const runs = Array.from(
+    { length: 4 },
+    (_, index) => ghRun(38_100 + index, BASE - (3 - index) * DAY),
+  );
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  for (let index = 0; index < runs.length; index++) {
+    const run = runs[index];
+    artifacts[run.id] = [{
+      id: run.id * 10,
+      name: "bench-results",
+      expired: false,
+    }];
+    const benches = [
+      bench(
+        "packages/runner/scheduler-persistent-state.bench.ts",
+        null,
+        "current",
+        timings(2_000),
+      ),
+      ...(index < 2
+        ? [
+          bench(
+            "packages/old/removed.bench.ts",
+            null,
+            "removed",
+            timings(9_000),
+          ),
+        ]
+        : []),
+    ];
+    zips[run.id * 10] = await benchZip(report(benches));
+  }
+
+  await withApi({ pages: { 1: runs }, artifacts, zips }, async () => {
+    const view = await benchmark.collect(ctx({
+      GH_TOKEN: "t",
+      BENCH_METRIC: "removed",
+    }));
+    assertEquals(view.value, "2.0µs");
+    assertStringIncludes(view.extra ?? "", "current");
+    assert(!view.extra?.includes("removed"));
+  });
 });
 
 Deno.test("benchmark: a BENCH_METRIC that names nothing falls back to the default benchmark", async () => {
   // Runs 601-612 are cached from the fill above; only the pick changes.
   const at = (d: number) => BASE - (11 - d) * DAY;
-  await withApi({ pages: { 1: Array.from({ length: 12 }, (_, d) => ghRun(601 + d, at(d))) } }, async () => {
-    const v = await benchmark.collect(ctx({ GH_TOKEN: "t", BENCH_METRIC: "no-such-benchmark" }));
+  await withApi({
+    pages: { 1: Array.from({ length: 12 }, (_, d) => ghRun(601 + d, at(d))) },
+  }, async () => {
+    const v = await benchmark.collect(
+      ctx({ GH_TOKEN: "t", BENCH_METRIC: "no-such-benchmark" }),
+    );
     // DEFAULT_METRIC is scheduler-persistent-state.bench.ts; "commit" is its first.
     assertEquals(v.value, "1.1µs");
     assertEquals(v.status, "warn");
@@ -580,7 +1575,9 @@ Deno.test("benchmark: with neither the named nor the default benchmark present, 
     ]));
   }
   await withApi({ pages: { 1: runs }, artifacts, zips }, async () => {
-    const v = await benchmark.collect(ctx({ GH_TOKEN: "t", BENCH_METRIC: "nothing-matches-this" }));
+    const v = await benchmark.collect(
+      ctx({ GH_TOKEN: "t", BENCH_METRIC: "nothing-matches-this" }),
+    );
     assertEquals(v.value, "500ms"); // the slowest benchmark by p99, not the 1µs one
     assertEquals(v.status, "good"); // flat
     assertEquals(v.duration, 7 * DAY);
@@ -588,12 +1585,16 @@ Deno.test("benchmark: with neither the named nor the default benchmark present, 
 });
 
 Deno.test("benchmark: an unreachable source grays out with a calm reason, and never reads red", async () => {
-  await withApi({ throws: new TypeError("error sending request for url (https://api.github.com/...)") }, async () => {
+  await withApi({
+    throws: new TypeError(
+      "error sending request for url (https://api.github.com/...)",
+    ),
+  }, async () => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
     assertEquals(v.status, "unknown"); // gray, not bad
     assertEquals(v.value, "—");
     assertEquals(v.sub, "source unreachable"); // not a stack trace or an api path
-    assertEquals(v.href, "/bench");
+    assertEquals(v.href, "/bench?view=runtime&repo=labs");
   });
 });
 
@@ -617,15 +1618,21 @@ Deno.test("benchmark: benchmarks seen in only one run give no trend to draw", as
       802: [{ id: 8_020, name: "bench-results", expired: false }],
     },
     zips: {
-      8_010: await benchZip(report([bench("packages/a/one.bench.ts", null, "a", timings(10))])),
-      8_020: await benchZip(report([bench("packages/a/two.bench.ts", null, "b", timings(20))])),
+      8_010: await benchZip(
+        report([bench("packages/a/one.bench.ts", null, "a", timings(10))]),
+      ),
+      8_020: await benchZip(
+        report([bench("packages/a/two.bench.ts", null, "b", timings(20))]),
+      ),
     },
   }, async () => {
-    const v = await benchmark.collect(ctx({ GH_TOKEN: "t", BENCH_METRIC: "a" }));
+    const v = await benchmark.collect(
+      ctx({ GH_TOKEN: "t", BENCH_METRIC: "a" }),
+    );
     assertEquals(v.status, "unknown");
     assertEquals(v.value, "—");
     assertEquals(v.sub, "no metric");
-    assertEquals(v.href, "/bench");
+    assertEquals(v.href, "/bench?view=runtime&repo=labs");
   });
 });
 
@@ -655,6 +1662,13 @@ Deno.test("benchmark: a whole day's samples collapse to that day's median before
 
 Deno.test("benchmark: fewer than a week of days claims no trend", () => {
   assertEquals(trendPct([0, DAY, 2 * DAY], [100, 500, 2_000]), 0);
+  assertEquals(
+    benchmarkTrend(
+      Array.from({ length: 12 }, (_, hour) => hour * HOUR),
+      Array.from({ length: 12 }, (_, hour) => 2 ** hour),
+    ),
+    { pct: 0, status: "unknown", label: "new" },
+  );
 });
 
 Deno.test("benchmark: an even number of days takes the mean of the two middle slopes", () => {
@@ -683,4 +1697,384 @@ Deno.test("benchmark: the trend thresholds", () => {
   assertEquals(trendStatus(0.20), "warn"); // exactly at RAPID_PCT
   assertEquals(trendStatus(0.21), "bad");
   assertEquals(trendStatus(-1), "good");
+});
+
+Deno.test("benchmark routes serve the Gantt and both progress endpoints", async () => {
+  const gantt = new URL("http://x/bench?view=gantt");
+  const ganttResponse = await benchmark.routes![0].handler(
+    new Request(gantt),
+    gantt,
+  );
+  assertStringIncludes(
+    await ganttResponse.text(),
+    "<title>CI run Gantt</title>",
+  );
+
+  const gh = Deno.env.get("GH_TOKEN");
+  const github = Deno.env.get("GITHUB_TOKEN");
+  Deno.env.delete("GH_TOKEN");
+  Deno.env.delete("GITHUB_TOKEN");
+  try {
+    const check = new URL("http://x/bench/check?view=ci");
+    assertEquals(
+      (await benchmark.routes![1].handler(new Request(check), check)).status,
+      200,
+    );
+  } finally {
+    if (gh === undefined) Deno.env.delete("GH_TOKEN");
+    else Deno.env.set("GH_TOKEN", gh);
+    if (github === undefined) Deno.env.delete("GITHUB_TOKEN");
+    else Deno.env.set("GITHUB_TOKEN", github);
+  }
+
+  const progress = new URL("http://x/bench/runtime-progress");
+  const progressResponse = await benchmark.routes![3].handler(
+    new Request(progress),
+    progress,
+  );
+  assertEquals(benchmark.routes![3].path, "/bench/runtime-progress");
+  assertEquals(progressResponse.status, 400);
+});
+
+Deno.test("benchmark defaults a missing workflow run attempt to one", async () => {
+  const runId = 80_001;
+  const run = {
+    id: runId,
+    created_at: new Date(BASE).toISOString(),
+    conclusion: "success",
+  } as GhRun;
+  await withApi({
+    pages: { 1: [run] },
+    artifacts: { [runId]: [] },
+  }, async () => {
+    await benchmark.collect(ctx({ GH_TOKEN: "token" }));
+    const store = new BenchmarkHistoryStore();
+    await store.load();
+    assertEquals(store.get(runId, 1)?.runAttempt, 1);
+  });
+});
+
+Deno.test("runtime benchmark progress removes failed listeners and closes cleanly", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-progress-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  let resolveRuns: (response: Response) => void = () => {};
+  const runs = new Promise<Response>((resolve) => resolveRuns = resolve);
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.pathname === "/rate_limit") return Promise.resolve(serve({})(url));
+    return runs;
+  }) as typeof fetch;
+  try {
+    const isolated = await import(
+      `./benchmark.ts?listener=${crypto.randomUUID()}`
+    );
+    const response = await isolated.benchmarkHistoryResponse(
+      new URL("http://x/bench?view=runtime"),
+      ctx({ GH_TOKEN: `listener-${crypto.randomUUID()}` }),
+    );
+    const html = await response.text();
+    const id = html.match(/runtime-progress\?id=([^"&]+)/)?.[1];
+    assert(id);
+    assertEquals(
+      isolated.subscribeBenchmarkProgress("missing", () => {}),
+      null,
+    );
+    assertEquals(
+      isolated.subscribeBenchmarkProgress(id, () => {
+        throw new Error("initial listener failed");
+      }),
+      null,
+    );
+    let listenerCalls = 0;
+    assert(isolated.subscribeBenchmarkProgress(id, () => {
+      listenerCalls++;
+      if (listenerCalls > 1) throw new Error("updated listener failed");
+    }));
+
+    assertEquals(
+      isolated.benchmarkHistoryProgressResponse(
+        new URL("http://x/bench/runtime-progress"),
+      ).status,
+      400,
+    );
+    const progressUrl = new URL(`http://x/bench/runtime-progress?id=${id}`);
+    const completion = isolated.benchmarkHistoryProgressResponse(progressUrl)
+      .text();
+    const canceled = isolated.benchmarkHistoryProgressResponse(progressUrl);
+    const reader = canceled.body!.getReader();
+    await reader.read();
+    await reader.cancel();
+
+    resolveRuns(Response.json({ workflow_runs: [] }));
+    assertStringIncludes(await completion, '"phase":"complete"');
+    assertEquals(listenerCalls, 2);
+    assertStringIncludes(
+      await isolated.benchmarkHistoryProgressResponse(progressUrl).text(),
+      '"phase":"complete"',
+    );
+  } finally {
+    resolveRuns(Response.json({ workflow_runs: [] }));
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark progress ignores duplicate terminal updates", async () => {
+  const progress: BenchmarkFetchProgress = {
+    id: "duplicate-terminal",
+    phase: "complete",
+    totalRuns: 0,
+    cachedRuns: 0,
+    requestsMade: 0,
+    responsesReceived: 0,
+    successfulResponses: 0,
+    failedResponses: 0,
+    completedRuns: 0,
+    queuedRuns: 0,
+    outstandingRequests: 0,
+    needsReload: false,
+    updatedAt: BASE,
+  };
+  let unsubscribed = false;
+  const response = benchmarkHistoryProgressResponse(
+    new URL("http://x/bench/runtime-progress?id=duplicate-terminal"),
+    {
+      progress: () => progress,
+      subscribe: (_id, listener) => {
+        listener(progress);
+        listener(progress);
+        return () => unsubscribed = true;
+      },
+    },
+  );
+  assertStringIncludes(await response.text(), '"phase":"complete"');
+  assertEquals(unsubscribed, true);
+});
+
+Deno.test("runtime history reconstructs unmanifested cache data before asking for a token", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-cache-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const stats = {
+    min: 400,
+    avg: 500,
+    max: 1_500,
+    p75: 800,
+    p99: 1_000,
+    p995: 1_050,
+    p999: 1_200,
+  };
+  try {
+    const store = new BenchmarkHistoryStore();
+    await store.load();
+    store.set({
+      runId: 81_001,
+      runAttempt: 1,
+      at: BASE - DAY,
+      metrics: new Map([["packages/a/cache.bench.ts > cached", stats]]),
+    });
+    store.set({
+      runId: 81_002,
+      runAttempt: 1,
+      at: BASE,
+      metrics: new Map([["packages/a/cache.bench.ts > cached", stats]]),
+    });
+    await store.save(BASE);
+    const isolated = await import(
+      `./benchmark.ts?cache=${crypto.randomUUID()}`
+    );
+    const response = await isolated.benchmarkHistoryResponse(
+      new URL("http://x/bench?view=runtime"),
+      ctx(),
+    );
+    const html = await response.text();
+    assertStringIncludes(
+      html,
+      "Set GH_TOKEN to refresh runtime benchmark history.",
+    );
+    assertStringIncludes(html, "cache.bench.ts");
+  } finally {
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("empty runtime history asks for a token to collect data", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-cache-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  try {
+    const isolated = await import(
+      `./benchmark.ts?empty=${crypto.randomUUID()}`
+    );
+    const response = await isolated.benchmarkHistoryResponse(
+      new URL("http://x/bench?view=runtime"),
+      ctx(),
+    );
+    assertStringIncludes(
+      await response.text(),
+      "Set GH_TOKEN to collect runtime benchmark history.",
+    );
+  } finally {
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark collection reports cache writes that fail during a run or manifest", async () => {
+  const archive = await benchZip(report([
+    bench("packages/a/write.bench.ts", null, "write", timings(1_000)),
+  ]));
+  for (const failedRename of [1, 2]) {
+    const directory = await Deno.makeTempDir({ prefix: "benchmark-write-" });
+    const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+    const originalFetch = globalThis.fetch;
+    const rename = Deno.rename;
+    let renames = 0;
+    Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+    try {
+      const isolated = await import(
+        `./benchmark.ts?write=${failedRename}-${crypto.randomUUID()}`
+      );
+      const runId = 82_000 + failedRename;
+      const handler = serve({
+        pages: { 1: [ghRun(runId, BASE)] },
+        artifacts: {
+          [runId]: [{
+            id: runId * 10,
+            name: "bench-results",
+            expired: false,
+          }],
+        },
+        zips: { [runId * 10]: archive },
+      });
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = new URL(
+          input instanceof Request ? input.url : String(input),
+        );
+        return Promise.resolve(handler(url));
+      }) as typeof fetch;
+      Deno.rename = ((oldpath, newpath) => {
+        renames++;
+        return renames === failedRename
+          ? Promise.reject(new Error(`rename ${failedRename} failed`))
+          : rename(oldpath, newpath);
+      }) as typeof Deno.rename;
+
+      const view = await isolated.benchmark.collect(ctx({ GH_TOKEN: "token" }));
+      assertEquals(view.status, "unknown");
+      assertEquals(renames, failedRename);
+    } finally {
+      Deno.rename = rename;
+      globalThis.fetch = originalFetch;
+      if (previousCacheDirectory === undefined) {
+        Deno.env.delete("DASHBOARD_CACHE_DIR");
+      } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+      await Deno.remove(directory, { recursive: true });
+    }
+  }
+});
+
+Deno.test("a queued runtime history refresh reuses a dashboard refresh that just completed", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-queue-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  let resolveRuns: (response: Response) => void = () => {};
+  const runs = new Promise<Response>((resolve) => resolveRuns = resolve);
+  let workflowRequests = 0;
+  let rateRequests = 0;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.pathname === "/rate_limit") {
+      rateRequests++;
+      return Promise.resolve(serve({})(url));
+    }
+    workflowRequests++;
+    return runs;
+  }) as typeof fetch;
+  let dashboard: Promise<TileView> | undefined;
+  try {
+    const isolated = await import(
+      `./benchmark.ts?queue=${crypto.randomUUID()}`
+    );
+    const tokenContext = ctx({ GH_TOKEN: `queue-${crypto.randomUUID()}` });
+    dashboard = isolated.benchmark.collect(tokenContext);
+    const page = await isolated.benchmarkHistoryResponse(
+      new URL("http://x/bench?view=runtime"),
+      tokenContext,
+    );
+    const html = await page.text();
+    const id = html.match(/runtime-progress\?id=([^"&]+)/)?.[1];
+    assert(id);
+    const completion = isolated.benchmarkHistoryProgressResponse(
+      new URL(`http://x/bench/runtime-progress?id=${id}`),
+    ).text();
+
+    resolveRuns(Response.json({ workflow_runs: [] }));
+    await dashboard;
+    assertStringIncludes(await completion, '"phase":"complete"');
+    assertEquals(workflowRequests, 1);
+    assertEquals(rateRequests, 0);
+  } finally {
+    resolveRuns(Response.json({ workflow_runs: [] }));
+    await dashboard?.catch(() => {});
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime history reports a recent failed collection without starting another", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-failure-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.pathname === "/rate_limit") return Promise.resolve(serve({})(url));
+    return Promise.resolve(new Response("unavailable", { status: 503 }));
+  }) as typeof fetch;
+  try {
+    const isolated = await import(
+      `./benchmark.ts?failure=${crypto.randomUUID()}`
+    );
+    const tokenContext = ctx({ GH_TOKEN: `failure-${crypto.randomUUID()}` });
+    const first = await isolated.benchmarkHistoryResponse(
+      new URL("http://x/bench?view=runtime"),
+      tokenContext,
+    );
+    const firstHtml = await first.text();
+    const id = firstHtml.match(/runtime-progress\?id=([^"&]+)/)?.[1];
+    assert(id);
+    assertStringIncludes(
+      await isolated.benchmarkHistoryProgressResponse(
+        new URL(`http://x/bench/runtime-progress?id=${id}`),
+      ).text(),
+      '"phase":"error"',
+    );
+
+    const second = await isolated.benchmarkHistoryResponse(
+      new URL("http://x/bench?view=runtime"),
+      tokenContext,
+    );
+    assertStringIncludes(await second.text(), "Last collection stopped:");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
 });

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -2,37 +2,95 @@
 // results the benchmarks.yml job publishes on main. That job runs
 // `deno bench --json` and uploads the output as a `bench-results` artifact (90-day
 // retention); there is no committed history, so this tile lists recent benchmark
-// runs on main, downloads one artifact per 4-hour window, unzips it in-process,
-// and reads every benchmark's timings. Results per run are immutable, so they are
-// cached and only new runs are fetched after the first fill.
+// runs on main, keeps one artifact per shortest-view time bucket, unzips it
+// in-process, and reads every benchmark's timings. Results per run attempt are
+// immutable and persisted, so only new runs and attempts are fetched later.
 //
 // The grid tile shows one benchmark (BENCH_METRIC, default DEFAULT_METRIC; else
 // the slowest). Its /bench drill-down shows every benchmark, with a selector for
 // which measurement to plot. Colour follows the 45-day trend: green while flat or
 // falling, orange past UP_PCT, red past RAPID_PCT ("trending up rapidly").
-import type { Route, Status, Tile, TileView } from "../types.ts";
-import { durationTag, escapeHtml, friendlyError, github, SPARK_FADE, sparkline } from "../lib.ts";
+import type { Ctx, Route, Status, Tile, TileView } from "../types.ts";
+import {
+  BenchmarkHistoryStore,
+  type BenchmarkRefreshResult,
+  type BenchmarkStats,
+  type CachedBenchmarkRun,
+} from "../benchmark-history-cache.ts";
+import {
+  CI_HISTORY_DAYS,
+  CI_HISTORY_MIN_DAYS,
+  CI_HISTORY_POINT_TARGET,
+  ciHistoryBucketMs,
+  ciHistoryDays,
+  ciHistorySource,
+  type CiHistorySourceKey,
+  ciJobHistoryCheckResponse,
+  ciJobHistoryProgressResponse,
+  ciJobHistoryResponse,
+} from "../ci-job-history.ts";
+import {
+  durationTag,
+  escapeHtml,
+  friendlyError,
+  github,
+  githubDownload,
+  performanceGithub,
+  performanceGithubDownload,
+  SPARK_FADE,
+  sparkline,
+} from "../lib.ts";
 import { REPO } from "../config.ts";
+import {
+  PERFORMANCE_CHECK_MS,
+  performanceViewHref,
+  performanceViewNav,
+} from "../performance-views.ts";
+import {
+  distinctTrendDays,
+  trendPct,
+  trendPctLabel,
+  trendStatus,
+} from "../trend.ts";
+import { ciGanttPage } from "./ci-duration.ts";
+
+export { trendPct, trendStatus } from "../trend.ts";
+
+export function benchmarkTrend(
+  times: number[],
+  values: number[],
+): { pct: number; status: Status; label: string } {
+  if (distinctTrendDays(times, values) < 7) {
+    return { pct: 0, status: "unknown", label: "new" };
+  }
+  const pct = trendPct(times, values);
+  return { pct, status: trendStatus(pct), label: trendPctLabel(pct) };
+}
 
 const WORKFLOW = "benchmarks.yml";
 const ARTIFACT = "bench-results";
-const SPARK_DAYS = 45;
-const BUCKET_MS = 4 * 3_600_000; // sample one run per 4-hour window
-const UP_PCT = 0.05; // 45-day rise past this -> orange (trending up)
-const RAPID_PCT = 0.20; // ...past this -> red (trending up rapidly)
-const MIN_TREND_DAYS = 7; // fewer distinct days than this -> no trend claim (too little data)
+const SPARK_DAYS = CI_HISTORY_DAYS;
+const COLLECTION_BUCKET_MS = ciHistoryBucketMs(CI_HISTORY_MIN_DAYS);
 const DEFAULT_METRIC = "scheduler-persistent-state.bench.ts";
+const BENCHMARK_REFRESH_MS = 30 * 60_000;
+const BENCHMARK_FETCH_CONCURRENCY = 8;
+
+interface BenchmarkGitHub {
+  json<T>(path: string, token: string): Promise<T>;
+  download(path: string, token: string): Promise<Response>;
+}
+
+const ordinaryBenchmarkGitHub: BenchmarkGitHub = {
+  json: github,
+  download: githubDownload,
+};
+const performanceBenchmarkGitHub: BenchmarkGitHub = {
+  json: performanceGithub,
+  download: performanceGithubDownload,
+};
 
 // deno bench reports these seven timings per benchmark (all nanoseconds).
-interface Stats {
-  min: number;
-  avg: number;
-  max: number;
-  p75: number;
-  p99: number;
-  p995: number;
-  p999: number;
-}
+type Stats = BenchmarkStats;
 // Shown as one percentile ladder: min is p0, the average stands in for p50, max is
 // p100. (avg is the mean, not a true median, but reads consistently here.)
 const STATS: { label: string; field: keyof Stats }[] = [
@@ -49,6 +107,7 @@ const DEFAULT_LABEL = "p99";
 
 interface Run {
   id: number;
+  run_attempt?: number;
   created_at: string;
   conclusion: string | null;
 }
@@ -64,16 +123,182 @@ interface Bench {
   results: { ok?: Partial<Stats> }[];
 }
 
-// runId -> { benchmark key -> timings }. A completed run's results never change,
-// so this is a permanent per-process cache; a run with no usable artifact caches
-// an empty map so it isn't retried every refresh.
-const cache = new Map<number, Map<string, Stats>>();
+const benchmarkStore = new BenchmarkHistoryStore();
 // Assembled by collect() for the /bench drill-down: each benchmark key with its
 // timings over the covered days (oldest -> newest).
-let snapshot: { key: string; points: { at: number; stats: Stats }[] }[] = [];
+interface BenchmarkSeries {
+  key: string;
+  points: { at: number; stats: Stats }[];
+}
+
+let snapshot: BenchmarkSeries[] = [];
+let benchmarkEmptyReason: string | undefined;
+
+export type BenchmarkFetchPhase =
+  | "discovering"
+  | "fetching"
+  | "saving"
+  | "complete"
+  | "error";
+
+export interface BenchmarkFetchProgress {
+  id: string;
+  phase: BenchmarkFetchPhase;
+  totalRuns: number;
+  cachedRuns: number;
+  requestsMade: number;
+  responsesReceived: number;
+  successfulResponses: number;
+  failedResponses: number;
+  completedRuns: number;
+  queuedRuns: number;
+  outstandingRequests: number;
+  needsReload: boolean;
+  updatedAt: number;
+  error?: string;
+}
+
+interface BenchmarkProgressRecord {
+  state: BenchmarkFetchProgress;
+  listeners: Set<(progress: BenchmarkFetchProgress) => void>;
+  baselines: Set<string>;
+}
+
+interface BenchmarkRefresh {
+  progress: BenchmarkFetchProgress | null;
+  result: Promise<TileView>;
+}
+
+type BenchmarkRefreshScope = "bench" | "dashboard";
+
+const activeBenchmarkRefreshes = new Map<BenchmarkRefreshScope, {
+  progress: BenchmarkProgressRecord;
+  result: Promise<TileView>;
+}>();
+let benchmarkCollectionTail: Promise<void> = Promise.resolve();
+let benchmarkProgressSequence = 0;
+let benchmarkRefreshedAt = 0;
+let benchmarkRefreshFailedAt = 0;
+let benchmarkRefreshError = "";
+let benchmarkInitialCollection = true;
+const benchmarkProgressById = new Map<string, BenchmarkProgressRecord>();
+
+function benchmarkVersion(value: BenchmarkSeries[]): string {
+  const serialized = JSON.stringify(value);
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < serialized.length; index++) {
+    hash ^= serialized.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function benchmarkSnapshotVersion(): string {
+  return benchmarkVersion(snapshot);
+}
+
+function newBenchmarkProgress(baseline?: string): BenchmarkProgressRecord {
+  for (const [id, record] of benchmarkProgressById) {
+    if (record.state.phase === "complete" || record.state.phase === "error") {
+      benchmarkProgressById.delete(id);
+    }
+  }
+  const now = Date.now();
+  const record: BenchmarkProgressRecord = {
+    state: {
+      id: `runtime-${now.toString(36)}-${++benchmarkProgressSequence}`,
+      phase: "discovering",
+      totalRuns: 0,
+      cachedRuns: 0,
+      requestsMade: 0,
+      responsesReceived: 0,
+      successfulResponses: 0,
+      failedResponses: 0,
+      completedRuns: 0,
+      queuedRuns: 0,
+      outstandingRequests: 0,
+      needsReload: false,
+      updatedAt: now,
+    },
+    listeners: new Set(),
+    baselines: new Set(baseline === undefined ? [] : [baseline]),
+  };
+  benchmarkProgressById.set(record.state.id, record);
+  return record;
+}
+
+function updateBenchmarkProgress(
+  record: BenchmarkProgressRecord,
+  update: Partial<BenchmarkFetchProgress>,
+): void {
+  Object.assign(record.state, update);
+  record.state.completedRuns = Math.min(
+    record.state.totalRuns,
+    record.state.cachedRuns + record.state.responsesReceived,
+  );
+  record.state.queuedRuns = Math.max(
+    0,
+    record.state.totalRuns - record.state.cachedRuns -
+      record.state.requestsMade,
+  );
+  record.state.outstandingRequests = Math.max(
+    0,
+    record.state.requestsMade - record.state.responsesReceived,
+  );
+  record.state.updatedAt = Date.now();
+  const value = { ...record.state };
+  for (const listener of record.listeners) {
+    try {
+      listener(value);
+    } catch {
+      record.listeners.delete(listener);
+    }
+  }
+}
+
+function benchmarkProgress(id: string): BenchmarkFetchProgress | null {
+  const record = benchmarkProgressById.get(id);
+  return record ? { ...record.state } : null;
+}
+
+export function subscribeBenchmarkProgress(
+  id: string,
+  listener: (progress: BenchmarkFetchProgress) => void,
+): (() => void) | null {
+  const record = benchmarkProgressById.get(id);
+  if (!record) return null;
+  record.listeners.add(listener);
+  try {
+    listener({ ...record.state });
+  } catch {
+    record.listeners.delete(listener);
+    return null;
+  }
+  return () => record.listeners.delete(listener);
+}
 
 const benchKey = (b: Bench): string =>
-  `${b.origin.replace(/^file:\/\/.*\/packages\//, "packages/")} > ${b.group ? b.group + "/" : ""}${b.name}`;
+  `${b.origin.replace(/^file:\/\/.*\/packages\//, "packages/")} > ${
+    b.group ? b.group + "/" : ""
+  }${b.name}`;
+
+function pickKey(stats: Map<string, Stats>, want: string): string | undefined {
+  const has = (needle: string) =>
+    [...stats.keys()].find((key) =>
+      key.toLowerCase().includes(needle.toLowerCase())
+    );
+  const match = has(want) ?? has(DEFAULT_METRIC);
+  if (match) return match;
+  let best: string | undefined;
+  let bestValue = -Infinity;
+  for (const [key, value] of stats) {
+    if (value.p99 > bestValue) {
+      best = key;
+      bestValue = value.p99;
+    }
+  }
+  return best;
+}
 
 // Deterministic, well-spread hash of a small integer. Used to rotate the grid
 // tile's benchmark by clock-hour: the same hour yields the same index on any
@@ -85,59 +310,6 @@ function hashInt(n: number): number {
   x = Math.imul(x ^ (x >>> 16), 0x45d9f3b) >>> 0;
   return (x ^ (x >>> 16)) >>> 0;
 }
-
-const median = (a: number[]): number => {
-  const s = [...a].sort((x, y) => x - y);
-  const m = s.length >> 1;
-  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
-};
-
-// Overall trend as the fractional change of a robust fit across the displayed
-// range (+0.2 ≈ the fit ends 20% higher than it starts; negative when improving).
-//
-// Collapse the sub-daily samples to one median value per calendar day, then take
-// the Theil–Sen slope (median of pairwise log-slopes per day) across days, and
-// project it over the day span. Three robustness layers: the daily median absorbs
-// within-day spikes; the median-of-slopes tolerates ~29% outlier days (versus 0%
-// for least squares, which one point can swing); and working per day — not per
-// sample or per millisecond — makes it time-aware without letting two noisy points
-// a few hours apart blow up the slope (a big Δlog over a tiny Δt), which naive
-// per-millisecond weighting does. `times` must be ascending. Exported for tests.
-export function trendPct(times: number[], values: number[]): number {
-  const byDay = new Map<number, number[]>();
-  for (let i = 0; i < values.length; i++) {
-    if (values[i] <= 0) continue;
-    const d = Math.floor(times[i] / 86_400_000);
-    const arr = byDay.get(d);
-    if (arr) arr.push(values[i]);
-    else byDay.set(d, [values[i]]);
-  }
-  const days = [...byDay.keys()].sort((a, b) => a - b);
-  if (days.length < MIN_TREND_DAYS) return 0; // too few days to claim a trend
-  const daily = days.map((d) => median(byDay.get(d)!));
-  const slopes: number[] = [];
-  for (let i = 0; i < days.length; i++) {
-    for (let j = i + 1; j < days.length; j++) {
-      slopes.push((Math.log(daily[j]) - Math.log(daily[i])) / (days[j] - days[i]));
-    }
-  }
-  return Math.expm1(median(slopes) * (days[days.length - 1] - days[0]));
-}
-
-export function trendStatus(pct: number): Status {
-  return pct <= UP_PCT ? "good" : pct <= RAPID_PCT ? "warn" : "bad";
-}
-
-// A percent for modest moves; a fold multiplier once it passes 4x either way, so a
-// real step-change regression reads "▲44×" rather than "▲4297%".
-const trendPctLabel = (pct: number): string => {
-  const up = pct + 1; // end / start
-  const fold = (f: number) => f >= 10 ? f.toFixed(0) : f.toFixed(1);
-  if (up >= 4) return `▲${fold(up)}×`;
-  if (up > 0 && 1 / up >= 4) return `▼${fold(1 / up)}×`;
-  const p = Math.round(pct * 100);
-  return p > 0 ? `▲${p}%` : p < 0 ? `▼${-p}%` : "flat";
-};
 
 // Wall-clock span of a series (first to last point), in milliseconds.
 const spanMs = (points: { at: number }[]): number =>
@@ -152,27 +324,19 @@ export function formatNs(ns: number): string {
   return `${(ns / 1e9).toFixed(2)}s`;
 }
 
-// Pick the key to plot on the grid tile: first containing `want`, else containing
-// DEFAULT_METRIC, else the slowest single benchmark (by p99).
-function pickKey(stats: Map<string, Stats>, want: string): string | undefined {
-  const has = (needle: string) => [...stats.keys()].find((k) => k.toLowerCase().includes(needle.toLowerCase()));
-  const match = has(want) ?? has(DEFAULT_METRIC);
-  if (match) return match;
-  let best: string | undefined, bestV = -Infinity;
-  for (const [k, s] of stats) if (s.p99 > bestV) [best, bestV] = [k, s.p99];
-  return best;
-}
-
 // deno bench --json -> { benchmark key -> timings }. A benchmark's own console
 // output can precede the JSON report on stdout, so parse from the report object.
 function benchMetrics(json: string): Map<string, Stats> {
   const at = json.match(/\{\s*"version"\s*:/);
-  const data = JSON.parse(at ? json.slice(at.index) : json) as { benches?: Bench[] };
+  const data = JSON.parse(at ? json.slice(at.index) : json) as {
+    benches?: Bench[];
+  };
   const m = new Map<string, Stats>();
   for (const b of data.benches ?? []) {
     const ok = b.results?.[0]?.ok;
     if (!ok || typeof ok.avg !== "number") continue;
-    const n = (v: number | undefined, d: number) => typeof v === "number" ? v : d;
+    const n = (v: number | undefined, d: number) =>
+      typeof v === "number" ? v : d;
     m.set(benchKey(b), {
       min: n(ok.min, ok.avg),
       avg: ok.avg,
@@ -198,7 +362,9 @@ async function inflateRaw(data: Uint8Array<ArrayBuffer>): Promise<Uint8Array> {
 
 // Extract the first *.json file from a zip via its central directory (which holds
 // the true sizes even when a streamed zip leaves them out of the local headers).
-export async function jsonFromZip(buf: Uint8Array<ArrayBuffer>): Promise<string | null> {
+export async function jsonFromZip(
+  buf: Uint8Array<ArrayBuffer>,
+): Promise<string | null> {
   const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
   const u16 = (o: number) => dv.getUint16(o, true);
   const u32 = (o: number) => dv.getUint32(o, true);
@@ -216,68 +382,525 @@ export async function jsonFromZip(buf: Uint8Array<ArrayBuffer>): Promise<string 
     if (u32(p) !== 0x02014b50) break; // central-directory file header signature
     const method = u16(p + 10);
     const compSize = u32(p + 20);
-    const nameLen = u16(p + 28), extraLen = u16(p + 30), commentLen = u16(p + 32);
+    const nameLen = u16(p + 28),
+      extraLen = u16(p + 30),
+      commentLen = u16(p + 32);
     const lho = u32(p + 42); // local header offset
-    const name = new TextDecoder().decode(buf.subarray(p + 46, p + 46 + nameLen));
+    const name = new TextDecoder().decode(
+      buf.subarray(p + 46, p + 46 + nameLen),
+    );
     p += 46 + nameLen + extraLen + commentLen;
     if (!name.endsWith(".json")) continue;
     if (u32(lho) !== 0x04034b50) return null; // local file header signature
     const dataStart = lho + 30 + u16(lho + 26) + u16(lho + 28);
     const comp = buf.subarray(dataStart, dataStart + compSize);
-    const bytes = method === 0 ? comp : method === 8 ? await inflateRaw(comp) : null;
+    const bytes = method === 0
+      ? comp
+      : method === 8
+      ? await inflateRaw(comp)
+      : null;
     return bytes ? new TextDecoder().decode(bytes) : null;
   }
   return null;
 }
 
-async function fetchZip(artifactId: number, token: string): Promise<Uint8Array<ArrayBuffer>> {
+async function fetchZip(
+  artifactId: number,
+  token: string,
+  github: BenchmarkGitHub,
+): Promise<Uint8Array<ArrayBuffer>> {
   // GitHub 302s to a pre-signed blob URL; fetch follows it and drops the
   // Authorization header on the cross-origin hop, which the signed URL expects.
-  const res = await fetch(`https://api.github.com/repos/${REPO}/actions/artifacts/${artifactId}/zip`, {
-    headers: {
-      authorization: `Bearer ${token}`,
-      accept: "application/vnd.github+json",
-      "x-github-api-version": "2022-11-28",
-    },
-    signal: AbortSignal.timeout(20_000),
-  });
+  const res = await github.download(
+    `repos/${REPO}/actions/artifacts/${artifactId}/zip`,
+    token,
+  );
   if (!res.ok) throw new Error(`artifact ${artifactId}: HTTP ${res.status}`);
   return new Uint8Array(await res.arrayBuffer());
 }
 
-// Populate the cache for one run (best-effort; caches empty on any failure so an
-// expired or missing artifact isn't retried every refresh).
-async function loadRun(runId: number, token: string): Promise<void> {
+// Populate and persist one run. A response that establishes there is no usable
+// artifact is cached as an empty map. A failed read remains unknown.
+async function loadRun(
+  run: Run,
+  token: string,
+  github: BenchmarkGitHub,
+): Promise<{ cached: boolean; error?: unknown }> {
   let metrics = new Map<string, Stats>();
   try {
-    const arts = await github<{ artifacts?: Artifact[] }>(`repos/${REPO}/actions/runs/${runId}/artifacts`, token);
-    const art = (arts.artifacts ?? []).find((a) => a.name === ARTIFACT && !a.expired);
+    const arts = await github.json<{ artifacts?: Artifact[] }>(
+      `repos/${REPO}/actions/runs/${run.id}/artifacts`,
+      token,
+    );
+    const art = (arts.artifacts ?? []).find((a) =>
+      a.name === ARTIFACT && !a.expired
+    );
     if (art) {
-      const json = await jsonFromZip(await fetchZip(art.id, token));
+      const json = await jsonFromZip(await fetchZip(art.id, token, github));
       if (json) metrics = benchMetrics(json);
     }
-  } catch {
+  } catch (error) {
     // The read failed, so whether this run has usable results is still unknown.
     // Caching the empty map here would answer that question with "no" and never ask
     // again: the run is only ever fetched once, so a single blip would drop the run
     // from the trend for the life of the process. Record nothing and retry on the
     // next refresh.
-    return;
+    return { cached: false, error };
   }
-  // A run that reached a definite answer — no artifact, an expired one, or one
-  // holding no readable JSON — is settled. Its results cannot change, so cache the
-  // empty map and stop asking.
-  cache.set(runId, metrics);
+  benchmarkStore.set({
+    runId: run.id,
+    runAttempt: run.run_attempt ?? 1,
+    at: Date.parse(run.created_at),
+    metrics,
+  });
+  await benchmarkStore.save();
+  return { cached: true };
 }
 
 // The stats series (oldest -> newest) for one benchmark key across the given runs.
 function seriesFor(key: string, runs: Run[]): { at: number; stats: Stats }[] {
   const out: { at: number; stats: Stats }[] = [];
   for (const r of runs) {
-    const s = cache.get(r.id)?.get(key);
+    const s = currentRunMetrics(r)?.get(key);
     if (s) out.push({ at: Date.parse(r.created_at), stats: s });
   }
   return out;
+}
+
+function currentRunMetrics(run: Run): Map<string, Stats> | undefined {
+  const cached = benchmarkStore.get(run.id);
+  return cached && cached.runAttempt >= (run.run_attempt ?? 1)
+    ? cached.metrics
+    : undefined;
+}
+
+function assembleBenchmarkSnapshot(runs: Run[]): BenchmarkSeries[] {
+  const withData = runs.filter((run) =>
+    (currentRunMetrics(run)?.size ?? 0) > 0
+  );
+  const keys = new Set<string>();
+  for (const run of withData) {
+    for (const key of currentRunMetrics(run)!.keys()) keys.add(key);
+  }
+  return [...keys]
+    .map((key) => ({ key, points: seriesFor(key, withData) }))
+    .filter((series) => series.points.length >= 2)
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function assembleCachedBenchmarkSnapshot(
+  runs: CachedBenchmarkRun[],
+): BenchmarkSeries[] {
+  const keys = new Set(runs.flatMap((run) => [...run.metrics.keys()]));
+  return [...keys]
+    .map((key) => ({
+      key,
+      points: runs.flatMap((run) => {
+        const stats = run.metrics.get(key);
+        return stats ? [{ at: run.at, stats }] : [];
+      }),
+    }))
+    .filter((series) => series.points.length >= 2)
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+async function loadCachedBenchmarkSnapshot(now = Date.now()): Promise<void> {
+  await benchmarkStore.load();
+  if (benchmarkStore.quarantineFuture(now)) {
+    await benchmarkStore.save(now);
+  }
+  benchmarkRefreshedAt = benchmarkStore.refreshedAt;
+  const refresh = benchmarkStore.refresh;
+  benchmarkEmptyReason = refresh?.result === "no-runs"
+    ? "no benchmark runs"
+    : refresh?.result === "data-unavailable"
+    ? "benchmark data unavailable"
+    : refresh?.result === "no-metric"
+    ? "no metric"
+    : undefined;
+  const cutoff = now - SPARK_DAYS * 86_400_000;
+  const refreshedRuns = benchmarkStore.refreshedRuns();
+  const cachedRuns = refreshedRuns ?? benchmarkStore.list(cutoff);
+  if (refreshedRuns === null) {
+    const available = cachedRuns.map((run) => ({
+      id: run.runId,
+      run_attempt: run.runAttempt,
+      created_at: new Date(run.at).toISOString(),
+      conclusion: "success",
+    }));
+    snapshot = assembleBenchmarkSnapshot(
+      sampleBenchmarkRuns(available, cutoff),
+    );
+  } else {
+    snapshot = assembleCachedBenchmarkSnapshot(refreshedRuns);
+  }
+}
+
+async function markBenchmarkRefreshed(
+  runs: Run[],
+  result: BenchmarkRefreshResult,
+): Promise<void> {
+  const cachedRuns = runs.map((run) => benchmarkStore.get(run.id)!);
+  const previous = benchmarkStore.markRefreshed(
+    Date.now(),
+    cachedRuns,
+    result,
+  );
+  await benchmarkStore.save().catch((error) => {
+    benchmarkStore.restoreRefresh(previous);
+    throw error;
+  });
+  const refreshedRuns = benchmarkStore.refreshedRuns();
+  if (refreshedRuns !== null) {
+    snapshot = assembleCachedBenchmarkSnapshot(refreshedRuns);
+  }
+  const refresh = benchmarkStore.refresh;
+  benchmarkEmptyReason = refresh?.result === "no-runs"
+    ? "no benchmark runs"
+    : refresh?.result === "data-unavailable"
+    ? "benchmark data unavailable"
+    : refresh?.result === "no-metric"
+    ? "no metric"
+    : undefined;
+  benchmarkRefreshedAt = benchmarkStore.refreshedAt;
+}
+
+export function sampleBenchmarkRuns<
+  T extends { created_at: string; conclusion: string | null },
+>(runs: T[], cutoff: number): T[] {
+  const perBucket = new Map<number, T>();
+  for (const run of runs) {
+    const at = Date.parse(run.created_at);
+    if (run.conclusion !== "success" || at < cutoff) continue;
+    const bucket = Math.floor(at / COLLECTION_BUCKET_MS);
+    const current = perBucket.get(bucket);
+    if (!current || at > Date.parse(current.created_at)) {
+      perBucket.set(bucket, run);
+    }
+  }
+  return [...perBucket.values()].sort((a, b) =>
+    Date.parse(a.created_at) - Date.parse(b.created_at)
+  );
+}
+
+const benchmarkDrill = {
+  href: "/bench?view=runtime&repo=labs",
+  hint: "all metrics ↗",
+};
+
+function benchmarkUnavailable(sub: string): TileView {
+  return {
+    ...benchmarkDrill,
+    label: "benchmark",
+    status: "unknown",
+    value: "—",
+    sub,
+  };
+}
+
+function benchmarkTileView(
+  ctx: Ctx,
+  currentMetrics?: Map<string, Stats>,
+): TileView {
+  const pinned = ctx.env("BENCH_METRIC");
+  let series: BenchmarkSeries | undefined;
+  if (pinned) {
+    const latest = currentMetrics ?? benchmarkStore.refreshedRuns()
+      ?.findLast((run) => run.metrics.size > 0)?.metrics;
+    const key = latest ? pickKey(latest, pinned) : undefined;
+    series = snapshot.find((item) => item.key === key) ?? snapshot[0];
+  } else {
+    series = snapshot[
+      hashInt(Math.floor(Date.now() / 3_600_000)) % snapshot.length
+    ];
+  }
+  if (!series) return benchmarkUnavailable(benchmarkEmptyReason ?? "no metric");
+
+  const points = series.points.map((point) => point.stats[TILE_STAT]);
+  const trend = benchmarkTrend(
+    series.points.map((point) => point.at),
+    points,
+  );
+  const name = series.key.split(" > ").slice(1).join(" > ") || series.key;
+  const line =
+    `<div style="display:flex;align-items:baseline;gap:6px;font-size:13px;margin:5px 0 0">` +
+    `<span style="flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#9aa0ab">${
+      escapeHtml(name)
+    }</span>` +
+    `<span style="flex:none;color:#c7ccd4">${DEFAULT_LABEL} ${
+      escapeHtml(trend.label)
+    }</span></div>`;
+  return {
+    ...benchmarkDrill,
+    label: "benchmark",
+    status: trend.status,
+    value: formatNs(points[points.length - 1]),
+    extra: `${line}${
+      sparkline(points, "#727882", undefined, SPARK_FADE[trend.status])
+    }`,
+    duration: spanMs(series.points),
+  };
+}
+
+interface BenchmarkCollectionOutcome {
+  view: TileView;
+  error?: unknown;
+}
+
+async function collectBenchmark(
+  ctx: Ctx,
+  token: string,
+  progress: BenchmarkProgressRecord,
+  github: BenchmarkGitHub,
+): Promise<BenchmarkCollectionOutcome> {
+  const now = Date.now();
+  const cutoff = now - SPARK_DAYS * 86_400_000;
+
+  try {
+    await benchmarkStore.load();
+    const runs: Run[] = [];
+    for (let page = 1; page <= 12; page++) {
+      const response = await github.json<{ workflow_runs?: Run[] }>(
+        `repos/${REPO}/actions/workflows/${WORKFLOW}/runs?branch=main&per_page=100&page=${page}`,
+        token,
+      );
+      const batch = response.workflow_runs ?? [];
+      if (!batch.length) break;
+      runs.push(...batch);
+      if (
+        batch.length < 100 ||
+        Date.parse(batch[batch.length - 1].created_at) < cutoff
+      ) break;
+    }
+
+    const chosen = sampleBenchmarkRuns(runs, cutoff);
+    const priorRefresh = benchmarkStore.refresh;
+    const chosenReferences = chosen.map((run) => ({
+      runId: run.id,
+      runAttempt: run.run_attempt ?? 1,
+    }));
+    if (
+      priorRefresh &&
+      JSON.stringify(priorRefresh.runs) !== JSON.stringify(chosenReferences)
+    ) {
+      benchmarkStore.invalidateRefresh(now);
+      await benchmarkStore.save(now);
+      benchmarkRefreshedAt = benchmarkStore.refreshedAt;
+    }
+    const isCached = (run: Run) => currentRunMetrics(run) !== undefined;
+    const cachedRuns = chosen.filter(isCached);
+    const missing = chosen.filter((run) => !isCached(run));
+    updateBenchmarkProgress(progress, {
+      phase: "fetching",
+      totalRuns: chosen.length,
+      cachedRuns: cachedRuns.length,
+      needsReload: missing.length > 0,
+    });
+    if (!chosen.length) {
+      snapshot = [];
+      await markBenchmarkRefreshed([], "no-runs");
+      return { view: benchmarkTileView(ctx) };
+    }
+
+    let firstReadError: unknown;
+    for (
+      let index = 0;
+      index < missing.length;
+      index += BENCHMARK_FETCH_CONCURRENCY
+    ) {
+      const batch = missing.slice(index, index + BENCHMARK_FETCH_CONCURRENCY);
+      const outcomes = await Promise.all(batch.map(async (run) => {
+        updateBenchmarkProgress(progress, {
+          requestsMade: progress.state.requestsMade + 1,
+        });
+        let cached = false;
+        try {
+          const outcome = await loadRun(run, token, github);
+          cached = outcome.cached;
+          return outcome.error === undefined
+            ? null
+            : { readError: outcome.error };
+        } catch (error) {
+          return { persistenceError: error };
+        } finally {
+          updateBenchmarkProgress(progress, {
+            responsesReceived: progress.state.responsesReceived + 1,
+            successfulResponses: progress.state.successfulResponses +
+              (cached ? 1 : 0),
+            failedResponses: progress.state.failedResponses +
+              (cached ? 0 : 1),
+          });
+        }
+      }));
+      const persistenceFailure = outcomes.find((outcome) =>
+        outcome && "persistenceError" in outcome
+      );
+      if (persistenceFailure && "persistenceError" in persistenceFailure) {
+        throw persistenceFailure.persistenceError;
+      }
+      const readFailure = outcomes.find((outcome) =>
+        outcome && "readError" in outcome
+      );
+      if (
+        firstReadError === undefined && readFailure &&
+        "readError" in readFailure
+      ) firstReadError = readFailure.readError;
+    }
+
+    updateBenchmarkProgress(progress, { phase: "saving" });
+    await benchmarkStore.save(now);
+    const withData = chosen.filter((run) =>
+      (currentRunMetrics(run)?.size ?? 0) > 0
+    );
+    if (!withData.length) {
+      if (firstReadError === undefined) snapshot = [];
+      if (firstReadError === undefined) {
+        await markBenchmarkRefreshed(chosen, "data-unavailable");
+      }
+      return {
+        view: firstReadError === undefined
+          ? benchmarkTileView(ctx)
+          : benchmarkUnavailable("benchmark data unavailable"),
+        error: firstReadError,
+      };
+    }
+    const collectedSnapshot = assembleBenchmarkSnapshot(withData);
+    if (collectedSnapshot.length || firstReadError === undefined) {
+      snapshot = collectedSnapshot;
+    }
+    if (firstReadError === undefined) {
+      await markBenchmarkRefreshed(
+        chosen,
+        collectedSnapshot.length ? "data" : "no-metric",
+      );
+    }
+    return {
+      view: benchmarkTileView(
+        ctx,
+        firstReadError === undefined
+          ? undefined
+          : currentRunMetrics(withData[withData.length - 1]),
+      ),
+      error: firstReadError,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      view: benchmarkUnavailable(friendlyError(message)),
+      error,
+    };
+  }
+}
+
+function startBenchmarkRefresh(
+  ctx: Ctx,
+  baseline?: string,
+  snapshotIsFresh = false,
+  scope: BenchmarkRefreshScope = "bench",
+): BenchmarkRefresh {
+  const github = scope === "bench"
+    ? performanceBenchmarkGitHub
+    : ordinaryBenchmarkGitHub;
+  const token = (ctx.env("GH_TOKEN") ?? ctx.env("GITHUB_TOKEN"))!;
+  const activeBenchmarkRefresh = activeBenchmarkRefreshes.get(scope);
+  if (activeBenchmarkRefresh) {
+    if (baseline !== undefined) {
+      activeBenchmarkRefresh.progress.baselines.add(baseline);
+    }
+    return {
+      progress: { ...activeBenchmarkRefresh.progress.state },
+      result: activeBenchmarkRefresh.result,
+    };
+  }
+  if (snapshotIsFresh) {
+    return {
+      progress: null,
+      result: Promise.resolve(benchmarkTileView(ctx)),
+    };
+  }
+
+  const progress = newBenchmarkProgress(baseline);
+  const queuedBehindOtherScope = activeBenchmarkRefreshes.size > 0;
+  const previousCollection = benchmarkCollectionTail;
+  let finishCollection!: () => void;
+  benchmarkCollectionTail = new Promise<void>((resolve) => {
+    finishCollection = resolve;
+  });
+  const collection = async (): Promise<BenchmarkCollectionOutcome> => {
+    await previousCollection;
+    if (
+      queuedBehindOtherScope && benchmarkRefreshedAt &&
+      Date.now() - benchmarkRefreshedAt >= 0 &&
+      Date.now() - benchmarkRefreshedAt < BENCHMARK_REFRESH_MS
+    ) {
+      return { view: benchmarkTileView(ctx) };
+    }
+    return await collectBenchmark(ctx, token, progress, github);
+  };
+  let refreshFinished = false;
+  const finishRefresh = () => {
+    if (refreshFinished) return;
+    refreshFinished = true;
+    finishCollection();
+    if (activeBenchmarkRefreshes.get(scope)?.progress === progress) {
+      activeBenchmarkRefreshes.delete(scope);
+    }
+  };
+  const result = collection().then((outcome) => {
+    finishRefresh();
+    if (outcome.error) {
+      const message = outcome.error instanceof Error
+        ? outcome.error.message
+        : String(outcome.error);
+      if (scope === "bench") {
+        benchmarkRefreshFailedAt = Date.now();
+        benchmarkRefreshError = friendlyError(message);
+      }
+      const version = benchmarkSnapshotVersion();
+      updateBenchmarkProgress(progress, {
+        phase: "error",
+        error: friendlyError(message),
+        needsReload: [...progress.baselines].some((value) => value !== version),
+      });
+    } else {
+      if (scope === "bench") {
+        benchmarkRefreshFailedAt = 0;
+        benchmarkRefreshError = "";
+      }
+      benchmarkRefreshedAt = benchmarkStore.refreshedAt;
+      const version = benchmarkSnapshotVersion();
+      updateBenchmarkProgress(progress, {
+        phase: "complete",
+        needsReload: [...progress.baselines].some((value) => value !== version),
+      });
+    }
+    return outcome.view;
+  }).finally(finishRefresh);
+  activeBenchmarkRefreshes.set(scope, { progress, result });
+  return { progress: { ...progress.state }, result };
+}
+
+function benchmarkSnapshotIsFresh(now = Date.now()): boolean {
+  const age = now - benchmarkRefreshedAt;
+  return Boolean(
+    benchmarkRefreshedAt && age >= 0 && age < BENCHMARK_REFRESH_MS,
+  );
+}
+
+function benchmarkRefreshRecentlyFailed(now = Date.now()): boolean {
+  const age = now - benchmarkRefreshFailedAt;
+  return Boolean(
+    benchmarkRefreshFailedAt && !activeBenchmarkRefreshes.has("bench") &&
+      age >= 0 && age < BENCHMARK_REFRESH_MS,
+  );
+}
+
+function benchmarkServerContext(): Ctx {
+  return {
+    runs: () => Promise.resolve([]),
+    runsFor: () => Promise.resolve([]),
+    env: (key) => Deno.env.get(key),
+  };
 }
 
 export const benchmark: Tile = {
@@ -286,150 +909,356 @@ export const benchmark: Tile = {
   routes: [
     {
       path: "/bench",
-      handler: (_req, url) =>
-        new Response(
-          benchPage(url.searchParams.get("stat") ?? DEFAULT_LABEL, url.searchParams.get("sort") ?? "file"),
-          { headers: { "content-type": "text/html; charset=utf-8" } },
-        ),
+      handler: (_req, url) => {
+        const view = url.searchParams.get("view");
+        if (view === "ci") {
+          return ciJobHistoryResponse(url);
+        }
+        if (view === "gantt") {
+          return new Response(ciGanttPage(url), {
+            headers: { "content-type": "text/html; charset=utf-8" },
+          });
+        }
+        if (view !== "runtime") {
+          return new Response("unknown performance view", { status: 400 });
+        }
+        return benchmarkHistoryResponse(url);
+      },
+    },
+    {
+      path: "/bench/check",
+      handler: (_req, url) => {
+        const view = url.searchParams.get("view");
+        if (view === "ci") {
+          return ciJobHistoryCheckResponse(url);
+        }
+        if (view === "runtime") return benchmarkHistoryCheckResponse();
+        return new Response("unknown performance view", { status: 400 });
+      },
+    },
+    {
+      path: "/bench/ci-progress",
+      handler: (_req, url) => ciJobHistoryProgressResponse(url),
+    },
+    {
+      path: "/bench/runtime-progress",
+      handler: (_req, url) => benchmarkHistoryProgressResponse(url),
     },
   ] satisfies Route[],
-  async collect(ctx): Promise<TileView> {
-    const label = "benchmark";
+  async collect(ctx, publish): Promise<TileView> {
     const token = ctx.env("GH_TOKEN") ?? ctx.env("GITHUB_TOKEN");
-    if (!token) return { label, status: "unknown", value: "—", sub: "set GH_TOKEN" };
-    const drill = { href: "/bench", hint: "all metrics ↗" };
-    const cutoff = Date.now() - SPARK_DAYS * 86_400_000;
-
-    try {
-      // Recent benchmark runs on main, paging back until past the window. The job
-      // runs on both pushes to main and a 4-hourly schedule, which carry different
-      // event types (push vs schedule) but the same bench-results artifact, so this
-      // is not filtered by event — a push-only filter misses every scheduled run.
-      // Enough pages to reach ~45 days back; the 4-hour bucketing below still caps
-      // artifact downloads at one per bucket.
-      const runs: Run[] = [];
-      for (let page = 1; page <= 12; page++) {
-        const r = await github<{ workflow_runs?: Run[] }>(
-          `repos/${REPO}/actions/workflows/${WORKFLOW}/runs?branch=main&per_page=100&page=${page}`,
-          token,
-        );
-        const batch = r.workflow_runs ?? [];
-        if (!batch.length) break;
-        runs.push(...batch);
-        if (batch.length < 100 || Date.parse(batch[batch.length - 1].created_at) < cutoff) break;
-      }
-
-      // Newest successful run per 4-hour window within the range, oldest -> newest.
-      const perBucket = new Map<number, Run>();
-      for (const run of runs) {
-        const t = Date.parse(run.created_at);
-        if (run.conclusion !== "success" || t < cutoff) continue;
-        const bucket = Math.floor(t / BUCKET_MS);
-        const cur = perBucket.get(bucket);
-        if (!cur || t > Date.parse(cur.created_at)) perBucket.set(bucket, run);
-      }
-      const chosen = [...perBucket.values()].sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
-      if (!chosen.length) return { ...drill, label, status: "unknown", value: "—", sub: "no benchmark runs" };
-
-      // Fill the cache for any new runs, a few artifacts at a time. 4-hour
-      // sampling means more buckets, so the first fill downloads more.
-      const missing = chosen.filter((r) => !cache.has(r.id));
-      for (let i = 0; i < missing.length; i += 8) {
-        await Promise.all(missing.slice(i, i + 8).map((r) => loadRun(r.id, token)));
-      }
-
-      const withData = chosen.filter((r) => (cache.get(r.id)?.size ?? 0) > 0);
-      if (!withData.length) return { ...drill, label, status: "unknown", value: "—", sub: "benchmark data unavailable" };
-
-      // Assemble every benchmark's series for the drill-down page.
-      const keys = new Set<string>();
-      for (const r of withData) for (const k of cache.get(r.id)!.keys()) keys.add(k);
-      snapshot = [...keys]
-        .map((key) => ({ key, points: seriesFor(key, withData) }))
-        .filter((s) => s.points.length >= 2)
-        .sort((a, b) => (a.key < b.key ? -1 : 1));
-
-      // The grid tile plots one benchmark's p99. BENCH_METRIC pins it to a
-      // specific benchmark; otherwise it rotates — one benchmark per clock-hour,
-      // chosen deterministically so a fresh dashboard on another machine shows the
-      // same one for the same hour.
-      const pinned = ctx.env("BENCH_METRIC");
-      const series = pinned
-        ? (snapshot.find((s) => s.key === pickKey(cache.get(withData[withData.length - 1].id)!, pinned)) ??
-          snapshot[0])
-        : snapshot[hashInt(Math.floor(Date.now() / 3_600_000)) % snapshot.length];
-      if (!series) return { ...drill, label, status: "unknown", value: "—", sub: "no metric" };
-      const pts = series.points.map((p) => p.stats[TILE_STAT]);
-      const pct = trendPct(series.points.map((p) => p.at), pts);
-      const status = trendStatus(pct);
-      // Test name and its p99 trend on one line, the name ellipsized when long.
-      const name = series.key.split(" > ").slice(1).join(" > ") || series.key;
-      const line = `<div style="display:flex;align-items:baseline;gap:6px;font-size:13px;margin:5px 0 0">` +
-        `<span style="flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#9aa0ab">${escapeHtml(name)}</span>` +
-        `<span style="flex:none;color:#c7ccd4">${DEFAULT_LABEL} ${escapeHtml(trendPctLabel(pct))}</span></div>`;
-      return {
-        ...drill,
-        label,
-        status,
-        value: formatNs(pts[pts.length - 1]),
-        extra: `${line}${sparkline(pts, "#727882", undefined, SPARK_FADE[status])}`,
-        duration: spanMs(series.points),
-      };
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      return { ...drill, label, status: "unknown", value: "—", sub: friendlyError(msg) };
+    if (!token) return benchmarkUnavailable("set GH_TOKEN");
+    await loadCachedBenchmarkSnapshot();
+    const initialCollection = benchmarkInitialCollection;
+    benchmarkInitialCollection = false;
+    const snapshotIsFresh = initialCollection && benchmarkSnapshotIsFresh();
+    if (
+      publish && initialCollection &&
+      (snapshot.length > 0 || benchmarkEmptyReason !== undefined) &&
+      !snapshotIsFresh
+    ) {
+      publish(benchmarkTileView(ctx));
     }
+    return await startBenchmarkRefresh(
+      ctx,
+      undefined,
+      snapshotIsFresh,
+      "dashboard",
+    ).result;
   },
 };
 
+export async function benchmarkHistoryResponse(
+  url: URL,
+  ctx = benchmarkServerContext(),
+): Promise<Response> {
+  await loadCachedBenchmarkSnapshot();
+  const token = ctx.env("GH_TOKEN") ?? ctx.env("GITHUB_TOKEN");
+  const baseline = benchmarkSnapshotVersion();
+  let progress: BenchmarkFetchProgress | undefined;
+  let refreshError: string | undefined;
+  if (!token) {
+    refreshError = snapshot.length
+      ? "Set GH_TOKEN to refresh runtime benchmark history."
+      : "Set GH_TOKEN to collect runtime benchmark history.";
+  }
+  if (token && benchmarkRefreshRecentlyFailed()) {
+    refreshError = `Last collection stopped: ${benchmarkRefreshError}`;
+  }
+  if (token && !refreshError) {
+    const refresh = startBenchmarkRefresh(
+      ctx,
+      baseline,
+      benchmarkSnapshotIsFresh(),
+    );
+    progress = refresh.progress ?? undefined;
+    if (progress) void refresh.result;
+    else await refresh.result;
+  }
+  return new Response(
+    benchPage(
+      url.searchParams.get("stat") ?? DEFAULT_LABEL,
+      url.searchParams.get("sort") ?? "file",
+      ciHistoryDays(url.searchParams.get("days")),
+      Date.now(),
+      ciHistorySource(url.searchParams.get("repo")).key,
+      {
+        progress,
+        refreshError,
+        fragment: url.searchParams.get("fragment") === "range",
+      },
+    ),
+    { headers: { "content-type": "text/html; charset=utf-8" } },
+  );
+}
+
+export async function benchmarkHistoryCheckResponse(
+  ctx = benchmarkServerContext(),
+): Promise<Response> {
+  await loadCachedBenchmarkSnapshot();
+  const token = ctx.env("GH_TOKEN") ?? ctx.env("GITHUB_TOKEN");
+  let progress: BenchmarkFetchProgress | null = null;
+  if (
+    token &&
+    (!benchmarkRefreshFailedAt || activeBenchmarkRefreshes.has("bench") ||
+      Date.now() - benchmarkRefreshFailedAt >= BENCHMARK_REFRESH_MS)
+  ) {
+    const refresh = startBenchmarkRefresh(
+      ctx,
+      benchmarkSnapshotVersion(),
+      benchmarkSnapshotIsFresh(),
+    );
+    progress = refresh.progress;
+    if (progress) void refresh.result;
+    else await refresh.result;
+  }
+  return Response.json(
+    { version: benchmarkSnapshotVersion(), progress },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
+
+interface BenchmarkProgressProvider {
+  progress(id: string): BenchmarkFetchProgress | null;
+  subscribe(
+    id: string,
+    listener: (progress: BenchmarkFetchProgress) => void,
+  ): (() => void) | null;
+}
+
+const defaultBenchmarkProgressProvider: BenchmarkProgressProvider = {
+  progress: benchmarkProgress,
+  subscribe: subscribeBenchmarkProgress,
+};
+
+export function benchmarkHistoryProgressResponse(
+  url: URL,
+  provider = defaultBenchmarkProgressProvider,
+): Response {
+  const id = url.searchParams.get("id");
+  if (!id) return new Response("missing progress id", { status: 400 });
+  if (!provider.progress(id)) {
+    return new Response("unknown progress id", { status: 404 });
+  }
+  const encoder = new TextEncoder();
+  let unsubscribe: (() => void) | undefined;
+  let closed = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const send = (progress: BenchmarkFetchProgress) => {
+        if (closed) return;
+        controller.enqueue(encoder.encode(
+          `event: progress\ndata: ${JSON.stringify(progress)}\n\n`,
+        ));
+        if (progress.phase === "complete" || progress.phase === "error") {
+          closed = true;
+          controller.close();
+          unsubscribe?.();
+        }
+      };
+      unsubscribe = provider.subscribe(id, send) ?? undefined;
+      if (closed) unsubscribe?.();
+    },
+    cancel() {
+      closed = true;
+      unsubscribe?.();
+    },
+  });
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+    },
+  });
+}
+
+export function pointsForWindow<T extends { at: number }>(
+  points: T[],
+  axisStart: number,
+  bucketMs: number,
+  axisEnd = Infinity,
+): T[] {
+  const buckets = new Map<number, T>();
+  for (const point of points) {
+    if (point.at < axisStart || point.at > axisEnd) continue;
+    const bucket = Math.floor(point.at / bucketMs);
+    const current = buckets.get(bucket);
+    if (!current || point.at > current.at) buckets.set(bucket, point);
+  }
+  return [...buckets.values()].sort((a, b) => a.at - b.at);
+}
+
+const dateLabel = (at: number): string =>
+  new Date(at).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+
 // The /bench drill-down: every benchmark's sparkline for the chosen measurement,
 // grouped by source file, each coloured by its own trend.
-function benchPage(statLabel: string, sortMode: string): string {
-  const stat = STATS.find((s) => s.label === statLabel) ?? STATS.find((s) => s.label === DEFAULT_LABEL)!;
-  const sort = sortMode === "trend" ? "trend" : "file";
-  const href = (st: string, so: string) => `/bench?stat=${encodeURIComponent(st)}&sort=${so}`;
+interface BenchmarkPageOptions {
+  progress?: BenchmarkFetchProgress;
+  refreshError?: string;
+  fragment?: boolean;
+}
+
+export function benchPage(
+  statLabel: string,
+  sortMode: string,
+  days: number,
+  now = Date.now(),
+  repo: CiHistorySourceKey = "labs",
+  options: BenchmarkPageOptions = {},
+): string {
+  const stat = STATS.find((s) => s.label === statLabel) ??
+    STATS.find((s) => s.label === DEFAULT_LABEL)!;
+  const sort = sortMode === "trend" || sortMode === "duration"
+    ? sortMode
+    : "file";
+  const href = (st: string, so: string) =>
+    performanceViewHref("runtime", {
+      repo,
+      days,
+      sort: so,
+      stat: st,
+    });
   const statSel = STATS.map((s) =>
-    `<a class="stat${s.label === stat.label ? " on" : ""}" href="${href(s.label, sort)}">${s.label}</a>`
+    `<a class="stat${s.label === stat.label ? " on" : ""}" href="${
+      href(s.label, sort)
+    }"${s.label === stat.label ? ' aria-current="true"' : ""}>${s.label}</a>`
   ).join("");
-  const sortSel = (["file", "trend"] as const).map((so) =>
-    `<a class="stat${sort === so ? " on" : ""}" href="${href(stat.label, so)}">${so}</a>`
+  const sortSel = (["file", "duration", "trend"] as const).map((so) =>
+    `<a class="stat${sort === so ? " on" : ""}" href="${href(stat.label, so)}"${
+      sort === so ? ' aria-current="true"' : ""
+    }>${so}</a>`
   ).join("");
+  const viewNav = performanceViewNav("runtime", {
+    repo,
+    days,
+    sort,
+    stat: stat.label,
+  });
+  const version = benchmarkSnapshotVersion();
+  const progress = options.progress;
+  const progressIdle = !progress || progress.phase === "complete" ||
+    progress.phase === "error";
+  const progressTitle = progressIdle
+    ? "Idle"
+    : progress.phase === "discovering"
+    ? "Finding benchmark runs…"
+    : `${progress.completedRuns} of ${progress.totalRuns} artifact checks complete`;
+  const progressTotal = progressIdle
+    ? "0 outstanding"
+    : `${progress.completedRuns} / ${progress.totalRuns || "?"}`;
+  const progressDetail = progress?.phase === "error"
+    ? `Last collection stopped: ${
+      escapeHtml(progress.error ?? "unknown error")
+    }`
+    : !progressIdle && progress
+    ? `${progress.cachedRuns} cached · ${progress.requestsMade} artifact checks made · ${progress.responsesReceived} responded · ${progress.outstandingRequests} outstanding · ${progress.queuedRuns} queued`
+    : "No requests in progress.";
+  const progressUrl = progress
+    ? `/bench/runtime-progress?id=${
+      escapeHtml(encodeURIComponent(progress.id))
+    }`
+    : "";
+  const progressHtml =
+    `<section class="fetch-progress" id="fetch-progress" aria-live="polite" data-check-url="/bench/check?view=runtime" data-snapshot-version="${
+      escapeHtml(version)
+    }" data-refresh-on-complete="${
+      progress && !progressIdle && !snapshot.length ? "1" : "0"
+    }"${
+      progressUrl ? ` data-progress-url="${progressUrl}"` : ""
+    }><div class="fetch-head"><strong id="fetch-title">${progressTitle}</strong><span id="fetch-total">${progressTotal}</span></div><progress id="fetch-bar" max="${
+      progressIdle ? 1 : Math.max(1, progress?.totalRuns ?? 1)
+    }"${
+      !progressIdle && progress && !progress.totalRuns
+        ? ""
+        : ` value="${progressIdle ? 0 : progress?.completedRuns ?? 0}"`
+    } aria-label="Runtime benchmark fetch progress"></progress><p id="fetch-detail">${progressDetail}</p></section>`;
+  const refreshNotice = options.refreshError && snapshot.length
+    ? `<p class="refresh-error">${escapeHtml(options.refreshError)}</p>`
+    : "";
 
   let body: string;
   if (!snapshot.length) {
-    body = `<p class="empty">Collecting benchmark data from CI artifacts — reload in a moment.</p>`;
+    body = progress && !progressIdle ? "" : `<p class="empty">${
+      escapeHtml(
+        options.refreshError ??
+          "No runtime benchmark samples were found in the history window.",
+      )
+    }</p>`;
   } else {
-    // A shared calendar-time axis for every graph: points sit at their real time,
-    // so a late-starting benchmark sits at the right and a stale one visibly ends
-    // short of it. (A benchmark with no data in the range never reaches snapshot —
-    // it requires >= 2 in-window points — so nothing empty is drawn.)
-    let axisStart = Infinity, axisEnd = -Infinity;
-    for (const s of snapshot) {
-      for (const p of s.points) {
-        if (p.at < axisStart) axisStart = p.at;
-        if (p.at > axisEnd) axisEnd = p.at;
-      }
-    }
+    const axisEnd = now;
+    const axisStart = axisEnd - days * 86_400_000;
     const axisSpan = axisEnd - axisStart || 1;
-    // Per-benchmark render data; the trend is computed once, for the colour, the
-    // label, and the trend sort.
-    const rows = snapshot.map((s) => {
-      const pts = s.points.map((p) => p.stats[stat.field]);
-      const pct = trendPct(s.points.map((p) => p.at), pts);
-      const st = trendStatus(pct);
-      const xs = s.points.map((p) => (p.at - axisStart) / axisSpan);
-      const spark = sparkline(pts, "#727882", undefined, SPARK_FADE[st], xs);
-      return { key: s.key, file: s.key.split(" > ")[0], pct, st, spark, dur: durationTag(spanMs(s.points)), latest: pts[pts.length - 1] };
+    const bucketMs = ciHistoryBucketMs(days);
+    const rows = snapshot.flatMap((s) => {
+      const points = pointsForWindow(s.points, axisStart, bucketMs, axisEnd);
+      if (points.length < 2) return [];
+      const pts = points.map((p) => p.stats[stat.field]);
+      const trend = benchmarkTrend(points.map((p) => p.at), pts);
+      const xs = points.map((p) => (p.at - axisStart) / axisSpan);
+      const spark = sparkline(
+        pts,
+        "#727882",
+        undefined,
+        SPARK_FADE[trend.status],
+        xs,
+      );
+      return [{
+        key: s.key,
+        file: s.key.split(" > ")[0],
+        pct: trend.pct,
+        st: trend.status,
+        trend: trend.label,
+        spark,
+        dur: durationTag(spanMs(points)),
+        latest: pts[pts.length - 1],
+      }];
     });
     const rowHtml = (r: (typeof rows)[number], label: string) =>
       `<div class="brow ${r.st}"><div class="bspark">${r.spark}${r.dur}</div><div class="bmeta">` +
       `<span class="bname">${escapeHtml(label)}</span>` +
-      `<span class="bval">${formatNs(r.latest)}<span class="btrend">${escapeHtml(trendPctLabel(r.pct))}</span></span>` +
+      `<span class="bval">${formatNs(r.latest)}<span class="btrend">${
+        escapeHtml(r.trend)
+      }</span></span>` +
       `</div></div>`;
-    if (sort === "trend") {
-      // Flat list, biggest rise first; show the full key since there's no heading.
-      body = `<div class="blist">${
-        [...rows].sort((a, b) => b.pct - a.pct).map((r) => rowHtml(r, r.key)).join("")
+    const axis = `<div class="axisrow"><div class="timeaxis"><span>${
+      dateLabel(axisStart)
+    }</span><span>${dateLabel(axisEnd)}</span></div></div>`;
+    if (!rows.length) {
+      body =
+        `<p class="empty">No benchmark samples were found in the selected window.</p>`;
+    } else if (sort === "trend" || sort === "duration") {
+      const sorted = [...rows].sort((a, b) => {
+        const difference = sort === "duration"
+          ? b.latest - a.latest
+          : b.pct - a.pct;
+        return difference || a.key.localeCompare(b.key);
+      });
+      body = `${axis}<div class="blist">${
+        sorted.map((r) => rowHtml(r, r.key)).join("")
       }</div>`;
     } else {
       // Grouped by source file, in the snapshot's alphabetical order.
@@ -439,26 +1268,52 @@ function benchPage(statLabel: string, sortMode: string): string {
         if (arr) arr.push(r);
         else groups.set(r.file, [r]);
       }
-      body = [...groups.entries()].map(([file, rs]) =>
-        `<section><h2>${escapeHtml(file)}</h2><div class="blist">${
-          rs.map((r) => rowHtml(r, r.key.split(" > ").slice(1).join(" > ") || r.key)).join("")
-        }</div></section>`
-      ).join("");
+      body = axis +
+        [...groups.entries()].map(([file, rs]) =>
+          `<section><h2>${escapeHtml(file)}</h2><div class="blist">${
+            rs.map((r) =>
+              rowHtml(r, r.key.split(" > ").slice(1).join(" > ") || r.key)
+            ).join("")
+          }</div></section>`
+        ).join("");
     }
   }
 
-  return `<!doctype html><html><head><meta charset="utf-8"><title>Benchmarks — ${escapeHtml(stat.label)}</title>
+  const rangeContent = `<div id="range-content">
+    ${progressHtml}${refreshNotice}
+    <p class="legend">Percentile of per-op time across a run's samples — p0 = min, p50 = mean, p100 = max. Lower is faster; the grid tile tracks p99. Coloured by the selected ${days}-day trend; fewer than seven distinct days are marked new. Duration sort uses the latest sample.</p>
+    ${body}
+    <p class="note">Successful main runs come from the <a href="https://github.com/${REPO}/actions/workflows/${WORKFLOW}" target="_blank" rel="noopener">${WORKFLOW} runs ↗</a> (deno bench artifacts). Collection keeps enough samples for the shortest window, and charts reduce longer windows to about ${CI_HISTORY_POINT_TARGET} evenly spaced points.</p>
+  </div>`;
+  if (options.fragment) return rangeContent;
+
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Benchmarks — ${
+    escapeHtml(stat.label)
+  }</title>
 <style>
-  body{margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
-  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:14px}
+  body{box-sizing:border-box;width:100%;margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
+  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:14px;flex-wrap:wrap}
   .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:#6f757f}
   a.back{color:#6ea8fe;text-decoration:none;font-size:13px}
+  .views{display:flex;gap:6px;margin:0 0 14px}
+  .views a{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:4px 10px}
+  .views a.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11}
   .controls{display:flex;flex-wrap:wrap;align-items:center;gap:6px;background:#16181d;border:1px solid #23262d;border-radius:12px;padding:12px 14px;margin-bottom:8px}
   .controls .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#878d97;margin-right:6px}
+  .controls .field{display:flex;align-items:center;gap:7px;font-size:12px;color:#9aa0ab;margin-right:8px}
+  .controls .choice-group{display:flex;flex-wrap:wrap;align-items:center;gap:6px}
+  .controls input[type=range]{width:150px}.controls output{color:#c7ccd4;min-width:46px;font-variant-numeric:tabular-nums}
   a.stat{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:3px 9px;font-variant-numeric:tabular-nums}
   a.stat:hover{border-color:#3a4150}
-  a.stat.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11;font-weight:600}
+  a.stat.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11}
   .legend{font-size:11px;color:#666c76;margin:0 0 16px}
+  .fetch-progress{background:#16181d;border:1px solid #2f333c;border-radius:10px;padding:10px 12px;margin:0 0 12px}
+  .fetch-progress.error{border-color:rgba(224,168,82,.42)}
+  .fetch-head{display:flex;justify-content:space-between;gap:12px;align-items:baseline;font-size:12px;color:#c7ccd4}
+  .fetch-head strong{font-weight:600}.fetch-head span,#fetch-detail{font-variant-numeric:tabular-nums;color:#878d97}
+  .fetch-progress progress{display:block;width:100%;height:7px;margin:7px 0 6px;accent-color:#6ea8fe}
+  #fetch-detail{font-size:11px;margin:0}
+  .axisrow{display:flex;gap:18px;margin:0 14px 4px}.timeaxis{flex:0 0 42%;display:flex;justify-content:space-between;color:#666c76;font-size:10px}
   h2{font-size:12px;letter-spacing:.04em;color:#878d97;font-weight:600;margin:20px 0 8px;font-family:ui-monospace,Menlo,monospace}
   .blist{display:flex;flex-direction:column;gap:7px}
   .brow{display:flex;align-items:center;gap:18px;background:#16181d;border:1px solid #23262d;border-radius:10px;padding:8px 14px}
@@ -471,26 +1326,304 @@ function benchPage(statLabel: string, sortMode: string): string {
   .btrend{font-size:12px;font-weight:400;color:#9aa0ab;margin-left:8px}
   .bspark{flex:0 0 42%;min-width:0;position:relative}
   .bspark>div,.bspark>svg{margin-top:0!important}
-  .empty{color:#9aa0ab;font-size:14px}
+  .empty,.refresh-error{color:#9aa0ab;font-size:14px}.refresh-error{color:#e0a852}
   .note{font-size:11px;color:#666c76;margin-top:22px}
   .note a{color:#6ea8fe;text-decoration:none}
   label.chk{font-size:13px;color:#c7ccd4;display:inline-flex;align-items:center;gap:6px;margin-left:auto;cursor:pointer;user-select:none}
   body.hide-green .brow.good{display:none}
   body.hide-green section:not(:has(.brow:not(.good))){display:none}
-</style></head><body>
-  <div class="top"><a class="back" href="/">← dashboard</a><b>Benchmarks</b><span>${escapeHtml(REPO)} · ${WORKFLOW}</span></div>
-  <div class="controls"><span class="lbl">metric</span>${statSel}<span class="lbl">sort</span>${sortSel}<label class="chk"><input type="checkbox" id="hg"> hide green</label></div>
-  <p class="legend">Percentile of per-op time across a run's samples — p0 = min, p50 = mean, p100 = max. Lower is faster; the grid tile tracks p99. Coloured by the ~45-day trend.</p>
-  ${body}
-  <p class="note">One CI run sampled per 4-hour window on main, from the <a href="https://github.com/${REPO}/actions/workflows/${WORKFLOW}" target="_blank" rel="noopener">${WORKFLOW} runs ↗</a> (deno bench artifacts).</p>
+  @media(max-width:640px){.timeaxis{flex:1}.brow{align-items:stretch;gap:7px;flex-wrap:wrap}.bspark{flex:1 0 100%}.controls .field,.controls .choice-group{flex:1 1 100%}.controls input[type=range]{flex:1;width:auto}.controls label.chk{margin-left:0}}
+</style></head><body data-snapshot-version="${escapeHtml(version)}">
+  <div class="top"><a class="back" href="/">← dashboard</a><b>Performance history</b><span>${
+    escapeHtml(REPO)
+  } · ${WORKFLOW}</span></div>
+  ${viewNav}
+  <form class="controls" method="get" action="/bench"><input type="hidden" name="view" value="runtime"><input type="hidden" name="repo" value="${repo}"><input type="hidden" name="stat" value="${
+    escapeHtml(stat.label)
+  }"><input type="hidden" name="sort" value="${sort}"><label class="field" for="days">window <output id="daysv" for="days">${days} day${
+    days === 1 ? "" : "s"
+  }</output><input type="range" id="days" name="days" min="${CI_HISTORY_MIN_DAYS}" max="${CI_HISTORY_DAYS}" step="1" value="${days}"></label><nav class="choice-group" aria-label="Benchmark metric"><span class="lbl">metric</span>${statSel}</nav><nav class="choice-group" aria-label="Sort benchmarks"><span class="lbl">sort</span>${sortSel}</nav><label class="chk"><input type="checkbox" id="hg"> hide green</label></form>
+  ${rangeContent}
 <script>
-  const hg = document.getElementById("hg"), KEY = "benchHideGreen";
+  const hg = document.getElementById("hg"), days = document.getElementById("days"), daysv = document.getElementById("daysv"), controls = days.form, KEY = "benchHideGreen", DEFAULT_DAYS = days.value;
+  let rangeContent = document.getElementById("range-content"), fetchProgress = document.getElementById("fetch-progress"), title = document.getElementById("fetch-title"), total = document.getElementById("fetch-total"), detail = document.getElementById("fetch-detail"), bar = document.getElementById("fetch-bar"), pageVersion = fetchProgress.dataset.snapshotVersion, appliedDays = days.value;
+  let navigating = false, pendingRefresh = false, checking = false, eventStream = null, connectedProgressUrl = "", serverVersionChanged = false, collectionFailed = false, transportFailed = false, rangeRequest = null, rangeRequestDays = "", rangeSequence = 0, viewRevision = 0;
   const apply = () => document.body.classList.toggle("hide-green", hg.checked);
   hg.checked = sessionStorage.getItem(KEY) === "1";
   apply();
   hg.addEventListener("change", () => {
     sessionStorage.setItem(KEY, hg.checked ? "1" : "0");
     apply();
+  });
+  const syncDayLinks = () => {
+    for (const link of document.querySelectorAll('a[href^="/bench?"]')) {
+      const target = new URL(link.href);
+      target.searchParams.set("days", days.value);
+      link.href = target.pathname + "?" + target.searchParams.toString();
+    }
+  };
+  days.addEventListener("input", () => {
+    daysv.value = days.value + (days.value === "1" ? " day" : " days");
+    syncDayLinks();
+  });
+  const applyDays = () => {
+    if (days.value !== appliedDays) {
+      if (!rangeRequest || rangeRequestDays !== days.value) void loadRange("push");
+    } else if (rangeRequest && rangeRequestDays !== days.value) {
+      void loadRange("restore");
+    } else if (pendingRefresh && !rangeRequest) {
+      pendingRefresh = false;
+      void loadRange("refresh");
+    }
+  };
+  days.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      applyDays();
+    }
+  });
+  days.addEventListener("change", applyDays);
+  const isSameTabLink = (event, link) =>
+    link.target !== "_blank" && event.button === 0 && !event.metaKey &&
+    !event.ctrlKey && !event.shiftKey && !event.altKey;
+  document.addEventListener("click", (event) => {
+    const link = event.target.closest?.("a[href]");
+    if (link && isSameTabLink(event, link)) navigating = true;
+  }, true);
+  controls.addEventListener("submit", () => navigating = true);
+  window.addEventListener("pagehide", () => {
+    navigating = true;
+    rangeRequest?.abort();
+    eventStream?.close();
+  });
+  const renderIdle = () => {
+    collectionFailed = false;
+    transportFailed = false;
+    fetchProgress.classList.remove("error");
+    title.textContent = "Idle";
+    total.textContent = "0 outstanding";
+    bar.max = 1;
+    bar.value = 0;
+    detail.textContent = "No requests in progress.";
+  };
+  const refreshRangeWhenIdle = () => {
+    if (navigating) return;
+    if (
+      days.value !== appliedDays || rangeContent.contains(document.activeElement) ||
+      rangeRequest
+    ) {
+      pendingRefresh = true;
+      return;
+    }
+    void loadRange("refresh");
+  };
+  document.addEventListener("focusout", () => {
+    requestAnimationFrame(() => {
+      if (
+        pendingRefresh && !navigating && !rangeRequest &&
+        !rangeContent.contains(document.activeElement)
+      ) {
+        pendingRefresh = false;
+        refreshRangeWhenIdle();
+      }
+    });
+  });
+  const renderProgress = (state) => {
+    collectionFailed = state.phase === "error";
+    transportFailed = false;
+    fetchProgress.classList.remove("error");
+    if (state.phase === "discovering") {
+      title.textContent = "Finding benchmark runs…";
+      total.textContent = "starting";
+      bar.removeAttribute("value");
+    } else {
+      title.textContent = state.phase === "saving"
+        ? "Saving completed responses…"
+        : state.completedRuns + " of " + state.totalRuns + " artifact checks complete";
+      total.textContent = state.completedRuns + " / " + state.totalRuns;
+      bar.max = Math.max(1, state.totalRuns);
+      bar.value = state.completedRuns;
+    }
+    detail.textContent = state.cachedRuns + " cached · " +
+      state.requestsMade + " artifact checks made · " +
+      state.responsesReceived + " responded · " +
+      state.outstandingRequests + " outstanding · " +
+      state.queuedRuns + " queued" +
+      (state.failedResponses ? " · " + state.failedResponses + " failed" : "");
+    if (state.phase === "error") {
+      fetchProgress.classList.add("error");
+      title.textContent = "Idle";
+      total.textContent = "0 outstanding";
+      bar.max = 1;
+      bar.value = 0;
+      detail.textContent = "Last collection stopped: " + (state.error || "unknown error");
+      eventStream?.close();
+      eventStream = null;
+      connectedProgressUrl = "";
+    } else if (state.phase === "complete") {
+      eventStream?.close();
+      eventStream = null;
+      connectedProgressUrl = "";
+      if (state.needsReload || serverVersionChanged || fetchProgress.dataset.refreshOnComplete === "1") refreshRangeWhenIdle();
+      else renderIdle();
+    }
+  };
+  const connectProgress = (url) => {
+    if (!url || connectedProgressUrl === url) return;
+    eventStream?.close();
+    connectedProgressUrl = url;
+    const stream = new EventSource(url);
+    eventStream = stream;
+    stream.addEventListener("progress", (event) => {
+      if (eventStream !== stream) return;
+      try {
+        renderProgress(JSON.parse(event.data));
+      } catch {
+        stream.close();
+        eventStream = null;
+        connectedProgressUrl = "";
+        transportFailed = true;
+        fetchProgress.classList.add("error");
+        title.textContent = "Could not read collection progress";
+      }
+    });
+    stream.onerror = () => {
+      if (eventStream !== stream) return;
+      stream.close();
+      eventStream = null;
+      connectedProgressUrl = "";
+      transportFailed = true;
+      fetchProgress.classList.add("error");
+      title.textContent = "Progress connection closed; collection continues on the server";
+    };
+  };
+  const checkForUpdates = async () => {
+    if (checking || navigating || document.visibilityState === "hidden") return;
+    checking = true;
+    const revision = viewRevision;
+    try {
+      const response = await fetch(fetchProgress.dataset.checkUrl, { headers: { accept: "application/json" } });
+      if (!response.ok) throw new Error("HTTP " + response.status);
+      const state = await response.json();
+      if (revision !== viewRevision) return;
+      serverVersionChanged ||= state.version !== pageVersion;
+      if (state.progress) {
+        connectProgress("/bench/runtime-progress?id=" + encodeURIComponent(state.progress.id));
+        renderProgress(state.progress);
+      } else if (serverVersionChanged) refreshRangeWhenIdle();
+      else if (!collectionFailed) renderIdle();
+    } catch {
+      if (!eventStream && !collectionFailed && !transportFailed) renderIdle();
+    } finally {
+      checking = false;
+    }
+  };
+  const bindRangeContent = () => {
+    viewRevision++;
+    fetchProgress = rangeContent.querySelector("#fetch-progress");
+    title = rangeContent.querySelector("#fetch-title");
+    total = rangeContent.querySelector("#fetch-total");
+    detail = rangeContent.querySelector("#fetch-detail");
+    bar = rangeContent.querySelector("#fetch-bar");
+    pageVersion = fetchProgress.dataset.snapshotVersion;
+    document.body.dataset.snapshotVersion = pageVersion;
+    serverVersionChanged = false;
+    collectionFailed = false;
+    transportFailed = false;
+    connectedProgressUrl = "";
+    if (fetchProgress.dataset.progressUrl) connectProgress(fetchProgress.dataset.progressUrl);
+    else renderIdle();
+  };
+  const showRangeLoading = (requestedDays) => {
+    rangeContent.setAttribute("aria-busy", "true");
+    fetchProgress.classList.remove("error");
+    title.textContent = "Loading " + requestedDays + "-day view…";
+    total.textContent = "updating";
+    bar.removeAttribute("value");
+    detail.textContent = "Reading cached history and checking for new benchmark data.";
+  };
+  const loadRange = async (mode) => {
+    if (navigating) return;
+    if (rangeRequest) {
+      if (mode === "refresh") {
+        pendingRefresh = true;
+        return;
+      }
+      rangeRequest.abort();
+    }
+    const requestedDays = days.value;
+    const url = new URL(location.href);
+    url.searchParams.set("days", requestedDays);
+    const sequence = ++rangeSequence;
+    const controller = new AbortController();
+    rangeRequest = controller;
+    rangeRequestDays = requestedDays;
+    let loaded = false;
+    showRangeLoading(requestedDays);
+    try {
+      const requestUrl = new URL(url);
+      requestUrl.searchParams.set("fragment", "range");
+      const response = await fetch(requestUrl.pathname + requestUrl.search, {
+        cache: "no-store",
+        headers: { accept: "text/html" },
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error("HTTP " + response.status);
+      const page = new DOMParser().parseFromString(await response.text(), "text/html");
+      const replacement = page.getElementById("range-content");
+      if (!replacement) throw new Error("Range content was missing from the response.");
+      if (sequence !== rangeSequence || navigating) return;
+      eventStream?.close();
+      eventStream = null;
+      connectedProgressUrl = "";
+      rangeContent.replaceWith(replacement);
+      rangeContent = replacement;
+      appliedDays = requestedDays;
+      const target = url.pathname + url.search;
+      if (mode === "push" && target !== location.pathname + location.search) {
+        history.pushState(null, "", target);
+      }
+      bindRangeContent();
+      syncDayLinks();
+      loaded = true;
+    } catch (error) {
+      if (controller.signal.aborted || sequence !== rangeSequence) return;
+      pendingRefresh = false;
+      rangeContent.removeAttribute("aria-busy");
+      fetchProgress.classList.add("error");
+      title.textContent = "Could not update the history window";
+      total.textContent = "0 outstanding";
+      bar.max = 1;
+      bar.value = 0;
+      detail.textContent = error instanceof Error ? error.message : String(error);
+    } finally {
+      if (sequence === rangeSequence) {
+        rangeRequest = null;
+        rangeRequestDays = "";
+        if (loaded && pendingRefresh) {
+          pendingRefresh = false;
+          refreshRangeWhenIdle();
+        }
+      }
+    }
+  };
+  const daysFromLocation = () => {
+    const parameter = new URL(location.href).searchParams.get("days");
+    if (parameter === null || parameter.trim() === "") return DEFAULT_DAYS;
+    const value = Number(parameter);
+    if (!Number.isFinite(value)) return DEFAULT_DAYS;
+    return String(Math.max(Number(days.min), Math.min(Number(days.max), Math.floor(value))));
+  };
+  window.addEventListener("popstate", () => {
+    days.value = daysFromLocation();
+    daysv.value = days.value + (days.value === "1" ? " day" : " days");
+    syncDayLinks();
+    void loadRange("pop");
+  });
+  bindRangeContent();
+  setInterval(checkForUpdates, ${PERFORMANCE_CHECK_MS});
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") void checkForUpdates();
   });
 </script>
 </body></html>`;

--- a/packages/dashboard/tiles/ci-duration.test.ts
+++ b/packages/dashboard/tiles/ci-duration.test.ts
@@ -1,14 +1,26 @@
-// ci-duration's drill-down: the /ci page and the /ci-gantt.png image behind it.
-// The image handler shells out to scripts/ci-gantt.ts and writes a temp file,
-// neither of which the test permissions allow, so the subprocess and the three
-// filesystem calls around it are replaced with stubs that record what the
-// handler asked for and hand back a canned result.
+// ci-duration's drill-down: the Gantt page and the /bench/gantt.png image behind it.
+// The image handler shells out to scripts/ci-gantt.ts and writes a temp file.
+// The subprocess and the filesystem calls around it are replaced with
+// stubs that record what the handler asked for and hand back a canned result.
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
-import type { Ctx, Route, Run } from "../types.ts";
+import type { Ctx, Run } from "../types.ts";
 import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "../config.ts";
-import { labsCiDuration, loomCiDuration, median } from "./ci-duration.ts";
+import type {
+  CiGanttInput,
+  CiGanttOptions,
+  CiHistorySource,
+} from "../ci-job-history.ts";
+import {
+  ciCommitGanttPage,
+  ciGanttPage,
+  labsCiDuration,
+  loomCiDuration,
+  median,
+  renderGantt,
+  renderGanttRoute,
+} from "./ci-duration.ts";
 
-const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // enough to tell the bytes apart
+const PNG = Uint8Array.from([137, 80, 78, 71]);
 
 function ctx(runs: Run[]): Ctx {
   return {
@@ -35,16 +47,12 @@ function run(over: Partial<Run>): Run {
   };
 }
 
-function route(path: string): Route {
-  const r = labsCiDuration.routes?.find((x) => x.path === path);
-  assert(r, `ci-duration should own a ${path} route`);
-  return r;
-}
-
 interface Fake {
   success?: boolean; // what the ci-gantt run reports
   stderr?: string; // what it printed on the way out
   throws?: Error; // the spawn itself blowing up
+  abortOnOutput?: AbortController;
+  abortAfterOutput?: AbortController;
 }
 
 interface Result {
@@ -52,23 +60,48 @@ interface Result {
   args: string[]; // the argv the handler built for scripts/ci-gantt.ts
   logged: string; // everything the handler wrote to console.error
   leftover: string[]; // temp files still on disk once the handler returned
+  input: CiGanttInput;
+  requested: { source: CiHistorySource; options: CiGanttOptions };
 }
 
-async function gantt(query: string, fake: Fake = {}): Promise<Result> {
-  const origTemp = Deno.makeTempFile, origRead = Deno.readFile, origRemove = Deno.remove;
+async function gantt(
+  query: string,
+  fake: Fake = {},
+  signal?: AbortSignal,
+): Promise<Result> {
+  const origTemp = Deno.makeTempFile;
+  const origRead = Deno.readFile;
+  const origWrite = Deno.writeTextFile;
+  const origRemove = Deno.remove;
   const origCommand = Object.getOwnPropertyDescriptor(Deno, "Command")!;
   const origError = console.error;
   const live = new Set<string>();
   const logged: string[] = [];
   let args: string[] = [];
   let seq = 0;
+  let written = "";
+  let commandSignal: AbortSignal | undefined;
+  let requested!: Result["requested"];
   try {
     Deno.makeTempFile = (opts?: Deno.MakeTempOptions) => {
-      const path = `/fake-tmp/${opts?.prefix ?? ""}${++seq}${opts?.suffix ?? ""}`;
+      const path = `/fake-tmp/${opts?.prefix ?? ""}${++seq}${
+        opts?.suffix ?? ""
+      }`;
       live.add(path);
       return Promise.resolve(path);
     };
-    Deno.readFile = (path: string | URL) => live.has(String(path)) ? Promise.resolve(PNG) : Promise.reject(new Deno.errors.NotFound(String(path)));
+    Deno.readFile = (path: string | URL) =>
+      live.has(String(path))
+        ? Promise.resolve(PNG)
+        : Promise.reject(new Deno.errors.NotFound(String(path)));
+    Deno.writeTextFile = (
+      _path: string | URL,
+      data: string | ReadableStream<string>,
+    ) => {
+      assert(typeof data === "string");
+      written = data;
+      return Promise.resolve();
+    };
     Deno.remove = (path: string | URL) => {
       live.delete(String(path));
       return Promise.resolve();
@@ -76,10 +109,23 @@ async function gantt(query: string, fake: Fake = {}): Promise<Result> {
     Object.defineProperty(Deno, "Command", {
       configurable: true,
       value: class {
-        constructor(_cmd: string, opts: { args: string[] }) {
+        constructor(
+          _cmd: string,
+          opts: { args: string[]; signal?: AbortSignal },
+        ) {
           args = opts.args;
+          commandSignal = opts.signal;
         }
         output() {
+          if (fake.abortOnOutput) {
+            assertEquals(commandSignal, fake.abortOnOutput.signal);
+            fake.abortOnOutput.abort();
+            return Promise.reject(fake.abortOnOutput.signal.reason);
+          }
+          if (fake.abortAfterOutput) {
+            assertEquals(commandSignal, fake.abortAfterOutput.signal);
+            fake.abortAfterOutput.abort();
+          }
           if (fake.throws) return Promise.reject(fake.throws);
           return Promise.resolve({
             success: fake.success ?? true,
@@ -89,13 +135,46 @@ async function gantt(query: string, fake: Fake = {}): Promise<Result> {
         }
       },
     });
-    console.error = (...parts: unknown[]) => void logged.push(parts.map(String).join(" "));
-    const url = new URL(`http://d/ci-gantt.png${query}`);
-    const res = await route("/ci-gantt.png").handler(new Request(url), url);
-    return { res, args, logged: logged.join("\n"), leftover: [...live] };
+    console.error = (...parts: unknown[]) =>
+      void logged.push(parts.map(String).join(" "));
+    const url = new URL(`http://d/bench/gantt.png${query}`);
+    const res = await renderGantt(
+      url.searchParams,
+      (source, options) => {
+        requested = { source, options };
+        return Promise.resolve({
+          runs: Array.from(
+            { length: Math.min(options.limit, 60) },
+            (_, index) => ({
+              run: {
+                attempt: 1,
+                databaseId: index + 1,
+                status: "completed",
+                conclusion: "success",
+                event: "push",
+                headBranch: "main",
+                startedAt: "2026-06-20T18:00:00Z",
+                workflowName: source.workflow,
+              },
+              jobs: [],
+            }),
+          ),
+        });
+      },
+      signal,
+    );
+    return {
+      res,
+      args,
+      logged: logged.join("\n"),
+      leftover: [...live],
+      input: written ? JSON.parse(written) as CiGanttInput : { runs: [] },
+      requested,
+    };
   } finally {
     Deno.makeTempFile = origTemp;
     Deno.readFile = origRead;
+    Deno.writeTextFile = origWrite;
     Deno.remove = origRemove;
     Object.defineProperty(Deno, "Command", origCommand);
     console.error = origError;
@@ -108,33 +187,218 @@ function opt(args: string[], flag: string): string | undefined {
   return i < 0 ? undefined : args[i + 1];
 }
 
-Deno.test("/ci serves the gantt page for the repo and workflow the tile charts", async () => {
-  const url = new URL("http://d/ci");
-  const res = await route("/ci").handler(new Request(url), url);
-  assertEquals(res.status, 200);
-  assertEquals(res.headers.get("content-type"), "text/html; charset=utf-8");
-  const html = await res.text();
+Deno.test("the Gantt page shares the performance view selector", async () => {
+  const url = new URL("http://d/bench?view=gantt");
+  const html = ciGanttPage(url);
+  assertStringIncludes(
+    html,
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+  );
+  assertStringIncludes(html, "<title>CI run Gantt</title>");
   assertStringIncludes(html, `${REPO} · ${CI_WORKFLOW}`);
   assertStringIncludes(html, `href="/"`); // a way back to the dashboard
-  assertStringIncludes(html, "/ci-gantt.png?"); // the controls point at the image route
+  assertStringIncludes(
+    html,
+    'href="/bench?view=runtime&amp;repo=labs&amp;days=45&amp;sort=file&amp;stat=p99">Runtime benchmarks</a>',
+  );
+  assertStringIncludes(
+    html,
+    'href="/bench?view=ci&amp;repo=labs&amp;days=45&amp;sort=job&amp;stat=p99">CI duration history</a>',
+  );
+  assertStringIncludes(
+    html,
+    'href="/bench?view=gantt&amp;repo=labs&amp;days=45&amp;sort=job&amp;stat=p99" aria-current="page">CI run Gantt</a>',
+  );
+  assertStringIncludes(html, '<option value="labs" selected>labs</option>');
+  assertStringIncludes(html, "/bench/gantt.png?"); // the controls point at the image route
+  assertStringIncludes(html, 'id="fetch-progress"');
+  assertStringIncludes(html, 'id="fetch-title">Idle</strong>');
+  assertStringIncludes(html, 'aria-label="CI Gantt fetch progress"');
+  assertStringIncludes(html, "/bench/gantt-progress?");
+  assertStringIncludes(html, "new EventSource(progressUrl())");
+  assertStringIncludes(
+    html,
+    "state.discoveryRequestsMade + ' workflow requests made",
+  );
+  assertStringIncludes(html, "state.cachedRuns + ' cached");
+  assertStringIncludes(html, "state.sharedRequests + ' shared");
+  assertStringIncludes(html, "title.textContent = 'Generating chart image…'");
+  assertStringIncludes(html, "collectionError || text");
+  assertStringIncludes(html, "g.removeAttribute('src')");
+  assertStringIncludes(html, "const controller = new AbortController()");
+  assertStringIncludes(html, "signal: controller.signal");
+  assertStringIncludes(html, "sequence !== renderSequence");
+  assertStringIncludes(html, "controller.signal.aborted");
+  assert(!html.includes('class="spinner"'));
+  assert(!html.includes("min runs per job"));
+  assert(!html.includes("minRuns"));
   // The runs slider offers only what the image route will honour, so dragging it
   // to either end can't ask for a limit that comes back silently clamped.
   assertStringIncludes(html, `id="limit" min="1" max="150"`);
   assertEquals((await gantt("?limit=150")).args.indexOf("150") >= 0, true);
+  assertStringIncludes(html, "setInterval(() => {");
+  assertStringIncludes(html, "}, 1800000)");
+  assert(!html.includes("pendingRender"));
+  assertStringIncludes(html, "location.href = '/bench?' + params.toString()");
+  assert(
+    !html.includes(
+      ".views a.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11;font-weight",
+    ),
+  );
+  assert(
+    labsCiDuration.routes?.some((route) =>
+      route.path === "/bench/gantt-progress"
+    ),
+  );
+  for (const path of ["/ci-gantt", "/ci-gantt.png", "/ci-gantt-progress"]) {
+    assert(labsCiDuration.routes?.some((route) => route.path === path));
+  }
+  for (const path of ["/ci-gantt.png", "/ci-gantt-progress"]) {
+    const route = labsCiDuration.routes?.find((route) => route.path === path);
+    assert(route);
+    const invalid = new URL(`http://d${path}?sha=invalid`);
+    assertEquals(
+      (await route.handler(new Request(invalid), invalid)).status,
+      400,
+    );
+
+    const tooMany = new URL(`http://d${path}`);
+    tooMany.searchParams.set("sha", "f".repeat(40));
+    for (let index = 0; index < 151; index++) {
+      tooMany.searchParams.append("run", `${1_000 + index}:1`);
+    }
+    assertEquals(
+      (await route.handler(new Request(tooMany), tooMany)).status,
+      400,
+    );
+  }
+
+  const loomHtml = ciGanttPage(
+    new URL(
+      "http://d/bench?view=gantt&repo=loom&days=9&sort=duration&stat=p75",
+    ),
+  );
+  assertStringIncludes(loomHtml, `${LOOM_REPO} · ${LOOM_CI_WORKFLOW}`);
+  assertStringIncludes(
+    loomHtml,
+    'href="/bench?view=runtime&amp;repo=loom&amp;days=9&amp;sort=duration&amp;stat=p75">Runtime benchmarks</a>',
+  );
+  assertStringIncludes(
+    loomHtml,
+    'href="/bench?view=ci&amp;repo=loom&amp;days=9&amp;sort=duration&amp;stat=p75">CI duration history</a>',
+  );
+  assertStringIncludes(loomHtml, '<option value="loom" selected>loom</option>');
 });
 
-Deno.test("loom ci duration links out to loom's run list and owns no drill-down route", async () => {
+Deno.test("the commit Gantt page contains only one commit selection", () => {
+  const sha = "b".repeat(40);
+  const url = new URL(
+    `http://d/ci-gantt?repo=loom&sha=${sha}&limit=2&mainOnly=1&run=701:1&run=702:3`,
+  );
+  const html = ciCommitGanttPage(url);
+  assertStringIncludes(html, `<title>CI Gantt · ${sha.slice(0, 7)}</title>`);
+  assertStringIncludes(html, `${LOOM_REPO} · `);
+  assertStringIncludes(
+    html,
+    `href="https://github.com/${LOOM_REPO}/commit/${sha}"`,
+  );
+  assertStringIncludes(html, 'aria-label="Commit CI Gantt fetch progress"');
+  assertStringIncludes(html, "/ci-gantt.png?");
+  assertStringIncludes(html, "/ci-gantt-progress?");
+  assertStringIncludes(
+    html,
+    "Chart includes 2 successful runs for this commit.",
+  );
+  assertStringIncludes(html, "const image = new Image()");
+  assertStringIncludes(html, "image.onerror = () =>");
+  assertStringIncludes(html, "URL.revokeObjectURL(src)");
+  assertStringIncludes(html, "if (chartSrc) URL.revokeObjectURL(chartSrc)");
+  assertStringIncludes(html, "if (chartSettled) return");
+  assertStringIncludes(html, "chartSettled = true");
+  assertStringIncludes(html, "stream.close();\n    chartSrc = src");
+  assert(!html.includes('class="controls"'));
+  assert(!html.includes('aria-label="Performance view"'));
+
+  const empty = ciCommitGanttPage(
+    new URL(`http://d/ci-gantt?repo=loom&sha=${sha}`),
+  );
+  assertStringIncludes(
+    empty,
+    "No successful main CI runs were supplied for this commit.",
+  );
+  assert(!empty.includes("/ci-gantt.png?"));
+});
+
+Deno.test("commit Gantt data routes start the exact selected collection", async () => {
+  const previousGhToken = Deno.env.get("GH_TOKEN");
+  const previousGitHubToken = Deno.env.get("GITHUB_TOKEN");
+  const originalError = console.error;
+  Deno.env.delete("GH_TOKEN");
+  Deno.env.delete("GITHUB_TOKEN");
+  console.error = () => {};
+  const selection = `repo=labs&sha=${
+    "e".repeat(40)
+  }&limit=1&mainOnly=1&run=9007199254740991:1`;
+  try {
+    const imageRoute = labsCiDuration.routes?.find((route) =>
+      route.path === "/ci-gantt.png"
+    );
+    assert(imageRoute);
+    const imageUrl = new URL(`http://d/ci-gantt.png?${selection}`);
+    const image = await imageRoute.handler(new Request(imageUrl), imageUrl);
+    assertEquals(image.status, 500);
+    assertEquals(await image.text(), "set GH_TOKEN");
+
+    const progressRoute = labsCiDuration.routes?.find((route) =>
+      route.path === "/ci-gantt-progress"
+    );
+    assert(progressRoute);
+    const progressUrl = new URL(`http://d/ci-gantt-progress?${selection}`);
+    const progress = await progressRoute.handler(
+      new Request(progressUrl),
+      progressUrl,
+    );
+    assertEquals(progress.status, 200);
+    const events = await progress.text();
+    assertStringIncludes(events, '"phase":"error"');
+    assertStringIncludes(events, "set GH_TOKEN");
+  } finally {
+    console.error = originalError;
+    if (previousGhToken === undefined) Deno.env.delete("GH_TOKEN");
+    else Deno.env.set("GH_TOKEN", previousGhToken);
+    if (previousGitHubToken === undefined) Deno.env.delete("GITHUB_TOKEN");
+    else Deno.env.set("GITHUB_TOKEN", previousGitHubToken);
+  }
+});
+
+Deno.test("CI duration tiles link to their repository histories", async () => {
   assertEquals(loomCiDuration.routes, undefined);
-  const v = await loomCiDuration.collect(ctx([run({})]));
-  assertStringIncludes(v.href ?? "", `github.com/${LOOM_REPO}/actions/workflows/${LOOM_CI_WORKFLOW}`);
-  assertStringIncludes(v.href ?? "", "branch%3Amain"); // main only, matching what the tile measures
-  assertEquals(v.hint, "runs ↗");
-  // The labs tile is the one that drills into the local gantt view.
-  assertEquals((await labsCiDuration.collect(ctx([run({})]))).href, "/ci");
+  const loom = await loomCiDuration.collect(ctx([run({})]));
+  assertEquals(loom.href, "/bench?view=ci&repo=loom");
+  assertEquals(loom.hint, "history ↗");
+  const labs = await labsCiDuration.collect(ctx([run({})]));
+  assertEquals(labs.href, "/bench?view=ci&repo=labs");
+  assertEquals(labs.hint, "history ↗");
+
+  const unavailable: Ctx = {
+    runs: () => Promise.resolve([]),
+    runsFor: () => Promise.reject(new Error("set GH_TOKEN to use GitHub")),
+    env: () => undefined,
+  };
+  const coldLabs = await labsCiDuration.collect(unavailable);
+  const coldLoom = await loomCiDuration.collect(unavailable);
+  assertEquals(
+    [coldLabs.href, coldLabs.hint, coldLabs.sub],
+    ["/bench?view=ci&repo=labs", "history ↗", "set GH_TOKEN"],
+  );
+  assertEquals(
+    [coldLoom.href, coldLoom.hint, coldLoom.sub],
+    ["/bench?view=ci&repo=loom", "history ↗", "set GH_TOKEN"],
+  );
 });
 
-Deno.test("/ci-gantt.png: a successful render returns the png bytes uncached", async () => {
-  const { res, args, leftover } = await gantt("?limit=30");
+Deno.test("/bench/gantt.png: a successful render returns the PNG bytes uncached", async () => {
+  const { res, args, input, leftover, requested } = await gantt("?limit=30");
   assertEquals(res.status, 200);
   assertEquals(res.headers.get("content-type"), "image/png");
   assertEquals(res.headers.get("cache-control"), "no-store");
@@ -142,64 +406,230 @@ Deno.test("/ci-gantt.png: a successful render returns the png bytes uncached", a
   assertEquals(opt(args, "--repo"), REPO);
   assertEquals(opt(args, "--workflow"), CI_WORKFLOW);
   assertEquals(opt(args, "--limit"), "30");
-  assert(args.includes("--allow-sys=cpus,networkInterfaces,hostname"));
   assertEquals(opt(args, "--out"), "/fake-tmp/ci-gantt-1.png"); // the bytes come from where it was told to write
+  assertEquals(opt(args, "--input"), "/fake-tmp/ci-gantt-input-2.json");
+  assert(!args.includes("--allow-net"));
+  assert(!args.includes("--allow-env"));
+  assert(args.includes("--allow-read"));
+  assert(!args.includes("--allow-write"));
+  assert(args.includes("--allow-ffi"));
+  assert(args.includes("--allow-sys=cpus,networkInterfaces,hostname"));
+  assert(!args.includes("--allow-read=/fake-tmp/ci-gantt-input-2.json"));
+  assert(args.includes("--allow-write=/fake-tmp/ci-gantt-1.png"));
+  assertEquals(opt(args, "--scale"), "2");
+  assertEquals(input.runs.length, 30);
+  assertEquals(requested.source.key, "labs");
+  assertEquals(requested.options, {
+    limit: 30,
+    mainOnly: false,
+    allConclusions: false,
+  });
   assertEquals(leftover, []); // the temp file is cleaned up on the way out
 });
 
-Deno.test("/ci-gantt.png: limit is clamped to the slider's range, junk falls back to 60", async () => {
+Deno.test("/bench/gantt.png finishes collection but skips an abandoned render", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const request = new Request("http://d/bench/gantt.png?limit=12", {
+    signal: controller.signal,
+  });
+  const url = new URL(request.url);
+  const originalTemp = Deno.makeTempFile;
+  let collected = false;
+  try {
+    Deno.makeTempFile = () => {
+      throw new Error("abandoned render created a temporary file");
+    };
+    const response = await renderGanttRoute(request, url, () => {
+      collected = true;
+      return Promise.resolve({ runs: [] });
+    });
+    assert(collected);
+    assertEquals(response.status, 204);
+    assertEquals(response.headers.get("cache-control"), "no-store");
+  } finally {
+    Deno.makeTempFile = originalTemp;
+  }
+});
+
+Deno.test("/bench/gantt.png stops rasterizing when its request is abandoned", async () => {
+  const controller = new AbortController();
+  const result = await gantt(
+    "?limit=12",
+    { abortOnOutput: controller },
+    controller.signal,
+  );
+  assertEquals(result.res.status, 204);
+  assertEquals(result.res.headers.get("cache-control"), "no-store");
+  assert(result.args.includes("12"));
+  assertEquals(result.leftover, []);
+});
+
+Deno.test("/bench/gantt.png drops an image completed after abandonment", async () => {
+  const controller = new AbortController();
+  const result = await gantt(
+    "?limit=12",
+    { abortAfterOutput: controller },
+    controller.signal,
+  );
+  assertEquals(result.res.status, 204);
+  assertEquals(result.res.headers.get("cache-control"), "no-store");
+  assertEquals(result.leftover, []);
+});
+
+Deno.test("/bench/gantt.png selects loom for both cached data and rendering", async () => {
+  const { args, requested, input } = await gantt(
+    "?repo=loom&limit=12&mainOnly=1",
+  );
+  assertEquals(requested.source.key, "loom");
+  assertEquals(requested.options, {
+    limit: 12,
+    mainOnly: true,
+    allConclusions: false,
+  });
+  assertEquals(opt(args, "--repo"), LOOM_REPO);
+  assertEquals(opt(args, "--workflow"), LOOM_CI_WORKFLOW);
+  assertEquals(input.runs[0].run.workflowName, LOOM_CI_WORKFLOW);
+});
+
+Deno.test("a commit Gantt image requests the selected run attempts", async () => {
+  const sha = "c".repeat(40);
+  const selected = await gantt(
+    `?sha=${sha}&limit=2&mainOnly=1&run=501:1&run=502:4`,
+  );
+  assertEquals(selected.requested.options, {
+    limit: 2,
+    mainOnly: true,
+    allConclusions: false,
+    headSha: sha,
+    selectedRuns: [
+      { runId: 501, runAttempt: 1 },
+      { runId: 502, runAttempt: 4 },
+    ],
+  });
+  assertEquals(
+    selected.args.flatMap((arg, index) =>
+      arg === "--run-id" ? [selected.args[index + 1]] : []
+    ),
+    ["501", "502"],
+  );
+  assertEquals(opt(selected.args, "--min-runs"), "1");
+});
+
+Deno.test("/bench/gantt.png: limit is clamped to the slider's range, junk falls back to 60", async () => {
   assertEquals(opt((await gantt("?limit=500")).args, "--limit"), "150");
   assertEquals(opt((await gantt("?limit=0")).args, "--limit"), "1");
   assertEquals(opt((await gantt("?limit=abc")).args, "--limit"), "60");
   assertEquals(opt((await gantt("")).args, "--limit"), "60");
 });
 
-Deno.test("/ci-gantt.png: the checkboxes are off unless set to 1", async () => {
-  const off = (await gantt("?mainOnly=0&allConclusions=yes")).args;
+Deno.test("/bench/gantt.png: the checkboxes are off unless set to 1", async () => {
+  const offResult = await gantt("?mainOnly=0&allConclusions=yes");
+  const off = offResult.args;
   assert(!off.includes("--main-only"), "mainOnly=0 is not main-only");
   assert(!off.includes("--all-conclusions"));
-  assert(!off.includes("--min-runs"), "without main-only, ci-gantt's own threshold stands");
-  const on = (await gantt("?mainOnly=1&allConclusions=1")).args;
+  assertEquals(offResult.requested.options.allConclusions, false);
+  assertEquals(opt(off, "--min-runs"), "6");
+  const onResult = await gantt("?mainOnly=1&allConclusions=1");
+  const on = onResult.args;
   assert(on.includes("--main-only"));
   assert(on.includes("--all-conclusions"));
+  assertEquals(onResult.requested.options.allConclusions, true);
 });
 
-Deno.test("/ci-gantt.png: main-only drops the min-runs floor to fit the window; a typed value wins", async () => {
+Deno.test("/bench/gantt.png: automatic min-runs fits every window", async () => {
   // A main-only window can be thin. The floor is capped at the run count so even a
   // one-run window still draws instead of having every job dropped.
   assertEquals(opt((await gantt("?mainOnly=1")).args, "--min-runs"), "2");
-  assertEquals(opt((await gantt("?mainOnly=1&limit=1")).args, "--min-runs"), "1");
-  // Anything the user typed is passed through, over the floor and without main-only.
-  assertEquals(opt((await gantt("?mainOnly=1&minRuns=9")).args, "--min-runs"), "9");
-  assertEquals(opt((await gantt("?minRuns=9")).args, "--min-runs"), "9");
-  // Only digits count as typed; the rest leave the floor (or nothing) in place.
-  assertEquals(opt((await gantt("?mainOnly=1&minRuns=-3")).args, "--min-runs"), "2");
-  assertEquals(opt((await gantt("?minRuns=x")).args, "--min-runs"), undefined);
-  assertEquals(opt((await gantt("?minRuns=")).args, "--min-runs"), undefined);
+  assertEquals(
+    opt((await gantt("?mainOnly=1&limit=1")).args, "--min-runs"),
+    "1",
+  );
+  assertEquals(opt((await gantt("?limit=1")).args, "--min-runs"), "1");
+  assertEquals(opt((await gantt("?limit=4")).args, "--min-runs"), "4");
 });
 
-Deno.test("/ci-gantt.png: a failing ci-gantt is a 500, with its stderr in the server log only", async () => {
-  const { res, logged, leftover } = await gantt("?limit=5", { success: false, stderr: "no runs matched --min-runs" });
+Deno.test("/bench/gantt.png ignores the removed minRuns parameter", async () => {
+  assertEquals(
+    opt((await gantt("?mainOnly=1&minRuns=9")).args, "--min-runs"),
+    "2",
+  );
+});
+
+Deno.test("/bench/gantt.png: a failing ci-gantt is a 500, with its stderr in the server log only", async () => {
+  const { res, logged, leftover } = await gantt("?limit=5", {
+    success: false,
+    stderr: "no runs matched --min-runs",
+  });
   assertEquals(res.status, 500);
   assertEquals(await res.text(), "ci-gantt failed (see server log)"); // the raw stderr stays server-side
   assertStringIncludes(logged, "no runs matched --min-runs");
   assertEquals(leftover, []);
 });
 
-Deno.test("/ci-gantt.png: a spawn that throws is a 500, not an unhandled rejection", async () => {
-  const { res, logged, leftover } = await gantt("", { throws: new Error("deno: command not found") });
+Deno.test("/bench/gantt.png: a spawn that throws is a 500, not an unhandled rejection", async () => {
+  const { res, logged, leftover } = await gantt("", {
+    throws: new Error("deno: command not found"),
+  });
   assertEquals(res.status, 500);
-  assertEquals(await res.text(), "ci-gantt render error (see server log)");
+  assertEquals(await res.text(), "not found");
+  assertEquals(res.headers.get("cache-control"), "no-store");
   assertStringIncludes(logged, "deno: command not found");
   assertEquals(leftover, []); // the temp file is removed even on the error path
 });
 
+Deno.test("/bench/gantt.png reports the performance-history boundary as a rate limit hit", async () => {
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    const response = await renderGantt(
+      new URLSearchParams(),
+      () =>
+        Promise.reject(
+          new Error(
+            "GitHub rate limit has been hit at the 80% performance-history safety threshold.",
+          ),
+        ),
+    );
+    assertEquals(response.status, 429);
+    assertEquals(response.headers.get("cache-control"), "no-store");
+    assertEquals(await response.text(), "rate limit hit");
+  } finally {
+    console.error = originalError;
+  }
+});
+
+Deno.test("/bench/gantt.png returns a safe collection error to the page", async () => {
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    const response = await renderGantt(
+      new URLSearchParams(),
+      () =>
+        Promise.reject(new Error("GitHub API secret/path failed: HTTP 401")),
+    );
+    assertEquals(response.status, 500);
+    assertEquals(response.headers.get("cache-control"), "no-store");
+    assertEquals(await response.text(), "auth failed");
+  } finally {
+    console.error = originalError;
+  }
+});
+
 Deno.test("ci-duration: no passing runs is gray, never a false green", async () => {
-  const v = await labsCiDuration.collect(ctx([run({ conclusion: "failure" }), run({ status: "in_progress", conclusion: null })]));
+  const v = await labsCiDuration.collect(
+    ctx([
+      run({ conclusion: "failure" }),
+      run({ status: "in_progress", conclusion: null }),
+    ]),
+  );
   assertEquals(v.status, "unknown");
   assertEquals(v.value, "—"); // no data, like every other tile — not a zero-minute build
   assertEquals(v.duration, 0); // no span to label
-  assertEquals(await labsCiDuration.collect(ctx([])).then((x) => x.status), "unknown");
+  assertEquals(
+    await labsCiDuration.collect(ctx([])).then((x) => x.status),
+    "unknown",
+  );
 });
 
 Deno.test("ci-duration: the median minutes set the status against the thresholds", async () => {
@@ -208,9 +638,24 @@ Deno.test("ci-duration: the median minutes set the status against the thresholds
       run_started_at: new Date(Date.now() - m * 60_000).toISOString(),
       updated_at: new Date().toISOString(),
     });
-  assertEquals(await labsCiDuration.collect(ctx([mins(10)])).then((v) => [v.status, v.value]), ["good", "10m"]);
-  assertEquals(await labsCiDuration.collect(ctx([mins(16)])).then((v) => [v.status, v.value]), ["warn", "16m"]);
-  assertEquals(await labsCiDuration.collect(ctx([mins(45)])).then((v) => [v.status, v.value]), ["bad", "45m"]);
+  assertEquals(
+    await labsCiDuration.collect(ctx([mins(10)])).then((
+      v,
+    ) => [v.status, v.value]),
+    ["good", "10m"],
+  );
+  assertEquals(
+    await labsCiDuration.collect(ctx([mins(16)])).then((
+      v,
+    ) => [v.status, v.value]),
+    ["warn", "16m"],
+  );
+  assertEquals(
+    await labsCiDuration.collect(ctx([mins(45)])).then((
+      v,
+    ) => [v.status, v.value]),
+    ["bad", "45m"],
+  );
   // The median, not the mean: one long run among short ones doesn't move it.
   const v = await labsCiDuration.collect(ctx([mins(10), mins(10), mins(180)]));
   assertEquals([v.status, v.value], ["good", "10m"]);

--- a/packages/dashboard/tiles/ci-duration.ts
+++ b/packages/dashboard/tiles/ci-duration.ts
@@ -1,145 +1,660 @@
 // ci duration: median wall-clock of recent completed runs, with a trend
 // sparkline. One factory builds both the labs and loom instances against their
-// own repo + workflow. The labs instance drills down to /ci, an interactive view
-// of the real scripts/ci-gantt.ts with its arguments exposed as controls; the
-// loom instance drills to loom's Actions run list.
+// own repo + workflow. Both instances drill down to their repository's history
+// on /bench. The labs instance owns the Gantt image route. The Gantt view
+// exposes scripts/ci-gantt.ts controls for both repositories.
 import { fromFileUrl } from "@std/path";
 import type { Route, Run, Status, Tile, TileView } from "../types.ts";
-import { clampInt, sparkline, SPARK_FADE } from "../lib.ts";
-import { CI_WORKFLOW, DUR_GOOD, DUR_MAX_AGE_HOURS, DUR_MIN_RUNS, DUR_WARN, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "../config.ts";
+import { escapeHtml, friendlyError, SPARK_FADE, sparkline } from "../lib.ts";
+import {
+  CI_WORKFLOW,
+  DUR_GOOD,
+  DUR_MAX_AGE_HOURS,
+  DUR_MIN_RUNS,
+  DUR_WARN,
+  LOOM_CI_WORKFLOW,
+  LOOM_REPO,
+  REPO,
+} from "../config.ts";
+import {
+  CI_FETCH_PROGRESS_STYLES,
+  ciCommitGanttProgressResponse,
+  ciFetchProgressPanel,
+  type CiGanttInput,
+  type CiGanttOptions,
+  ciGanttOptions,
+  ciGanttProgressResponse,
+  ciHistoryDays,
+  type CiHistorySource,
+  ciHistorySource,
+  collectCiGanttInput,
+  collectCommitCiGanttInput,
+  GANTT_MAX_RUNS,
+} from "../ci-job-history.ts";
+import { performanceViewNav } from "../performance-views.ts";
 
-const CIGANTT = fromFileUrl(new URL("../../../scripts/ci-gantt.ts", import.meta.url));
+const CIGANTT = fromFileUrl(
+  new URL("../../../scripts/ci-gantt.ts", import.meta.url),
+);
+const GANTT_REFRESH_MS = 30 * 60_000;
 
-async function renderGantt(p: URLSearchParams): Promise<Response> {
-  const limit = clampInt(p.get("limit"), 60, 1, 150);
-  const mainOnly = p.get("mainOnly") === "1";
-  const minRunsRaw = p.get("minRuns");
-  const hasMin = !!(minRunsRaw && /^\d+$/.test(minRunsRaw));
-  const out = await Deno.makeTempFile({ prefix: "ci-gantt-", suffix: ".png" });
-  const args = [
-    "run", "--allow-net", "--allow-read", "--allow-write", "--allow-env", "--allow-ffi",
-    "--allow-sys=cpus,networkInterfaces,hostname",
-    CIGANTT, "--repo", REPO, "--workflow", CI_WORKFLOW, "--limit", String(limit), "--scale", "2", "--theme", "dark", "--out", out,
-  ];
-  if (mainOnly) args.push("--main-only");
-  if (p.get("allConclusions") === "1") args.push("--all-conclusions");
-  // A user value wins; else a low floor, capped at the run count, so a thin
-  // main-only window — down to a single run — still draws (ci-gantt exits
-  // non-zero when its default threshold drops every job).
-  if (hasMin) args.push("--min-runs", minRunsRaw!);
-  else if (mainOnly) args.push("--min-runs", String(Math.min(2, limit)));
+export type CiGanttDataProvider = (
+  source: CiHistorySource,
+  options: CiGanttOptions,
+) => Promise<CiGanttInput>;
+
+export async function renderGantt(
+  p: URLSearchParams,
+  dataProvider: CiGanttDataProvider = collectCiGanttInput,
+  signal?: AbortSignal,
+): Promise<Response> {
+  const source = ciHistorySource(p.get("repo"));
+  const options = ciGanttOptions(p);
+  const { limit, mainOnly, allConclusions } = options;
+  let out: string | undefined;
+  let input: string | undefined;
   try {
+    const data = await dataProvider(source, options);
+    if (signal?.aborted) {
+      return new Response(null, {
+        status: 204,
+        headers: { "cache-control": "no-store" },
+      });
+    }
+    out = await Deno.makeTempFile({ prefix: "ci-gantt-", suffix: ".png" });
+    input = await Deno.makeTempFile({
+      prefix: "ci-gantt-input-",
+      suffix: ".json",
+    });
+    await Deno.writeTextFile(input, JSON.stringify(data));
+    const args = [
+      "run",
+      "--allow-read",
+      `--allow-write=${out}`,
+      "--allow-ffi",
+      "--allow-sys=cpus,networkInterfaces,hostname",
+      CIGANTT,
+      "--input",
+      input,
+      "--repo",
+      source.repo,
+      "--workflow",
+      source.workflow,
+      "--limit",
+      String(limit),
+      "--scale",
+      "2",
+      "--theme",
+      "dark",
+      "--out",
+      out,
+    ];
+    if (mainOnly) args.push("--main-only");
+    if (allConclusions) args.push("--all-conclusions");
+    for (const { runId } of options.selectedRuns ?? []) {
+      args.push("--run-id", String(runId));
+    }
+    const defaultMinimum = options.selectedRuns?.length
+      ? 1
+      : mainOnly
+      ? 2
+      : Math.max(5, Math.round(0.1 * data.runs.length));
+    args.push(
+      "--min-runs",
+      String(Math.min(defaultMinimum, Math.max(1, data.runs.length))),
+    );
     const { success, stderr } = await new Deno.Command("deno", {
       args,
       stdout: "piped",
       stderr: "piped",
-      signal: AbortSignal.timeout(120_000),
+      signal,
     }).output();
+    if (signal?.aborted) {
+      return new Response(null, {
+        status: 204,
+        headers: { "cache-control": "no-store" },
+      });
+    }
     if (!success) {
       console.error("ci-gantt failed:", new TextDecoder().decode(stderr));
       return new Response("ci-gantt failed (see server log)", { status: 500 });
     }
-    return new Response(await Deno.readFile(out), { headers: { "content-type": "image/png", "cache-control": "no-store" } });
+    return new Response(await Deno.readFile(out), {
+      headers: {
+        "content-type": "image/png",
+        "cache-control": "no-store",
+      },
+    });
   } catch (e) {
-    console.error("ci-gantt render error:", e instanceof Error ? e.message : e);
-    return new Response("ci-gantt render error (see server log)", { status: 500 });
+    if (signal?.aborted) {
+      return new Response(null, {
+        status: 204,
+        headers: { "cache-control": "no-store" },
+      });
+    }
+    const message = e instanceof Error ? e.message : String(e);
+    console.error("ci-gantt render error:", message);
+    const safeMessage = friendlyError(message);
+    if (safeMessage === "rate limit hit") {
+      return new Response("rate limit hit", {
+        status: 429,
+        headers: { "cache-control": "no-store" },
+      });
+    }
+    return new Response(safeMessage, {
+      status: 500,
+      headers: { "cache-control": "no-store" },
+    });
   } finally {
-    await Deno.remove(out).catch(() => {});
+    if (out) await Deno.remove(out).catch(() => {});
+    if (input) await Deno.remove(input).catch(() => {});
   }
 }
 
-function ciGanttPage(): string {
-  return `<!doctype html><html><head><meta charset="utf-8"><title>CI Gantt — configurable</title>
+export function renderGanttRoute(
+  request: Request,
+  url: URL,
+  dataProvider: CiGanttDataProvider = collectCiGanttInput,
+): Promise<Response> {
+  return renderGantt(url.searchParams, dataProvider, request.signal);
+}
+
+export function ciGanttPage(url: URL): string {
+  const source = ciHistorySource(url.searchParams.get("repo"));
+  const days = ciHistoryDays(url.searchParams.get("days"));
+  const sort = url.searchParams.get("sort") ?? "job";
+  const stat = url.searchParams.get("stat") ?? "p99";
+  const viewNav = performanceViewNav("gantt", {
+    repo: source.key,
+    days,
+    sort,
+    stat,
+  });
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>CI run Gantt</title>
 <style>
   body{margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
-  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:16px}
+  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:12px;flex-wrap:wrap}
   .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:#6f757f}
   a.back{color:#6ea8fe;text-decoration:none;font-size:13px}
+  .views{display:flex;gap:6px;margin:0 0 14px}
+  .views a{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:4px 10px}
+  .views a.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11}
   .controls{display:flex;flex-wrap:wrap;gap:20px;align-items:center;background:#16181d;border:1px solid #23262d;border-radius:12px;padding:14px 16px;margin-bottom:14px}
-  .controls label{font-size:13px;color:#c7ccd4;display:flex;align-items:center;gap:8px}
+  .controls label{font-size:13px;color:#c7ccd4;display:flex;align-items:center;gap:8px;flex:none}
   .controls input[type=range]{width:200px}
-  .controls input[type=number]{width:64px;background:#0d0e11;color:#e7e9ee;border:1px solid #2f333c;border-radius:6px;padding:3px 6px}
-  .statusrow{display:flex;align-items:center;font-size:12px;color:#8a93a5;margin:0 0 12px;min-height:18px}
-  .statusrow.busy{color:#6ea8fe}.statusrow.err{color:#f0726c}
-  .spinner{width:15px;height:15px;border:2px solid #2f333c;border-top-color:#6ea8fe;border-radius:50%;animation:spin .8s linear infinite;display:none;margin-right:8px;flex:none}
-  .spinner.on{display:inline-block}
-  @keyframes spin{to{transform:rotate(360deg)}}
+  .controls select{background:#0d0e11;color:#e7e9ee;border:1px solid #2f333c;border-radius:6px;padding:3px 6px}
+  ${CI_FETCH_PROGRESS_STYLES}
   .imgwrap{background:#0c0d11;border:1px solid #23262d;border-radius:12px;padding:10px;overflow:auto;min-height:60px}
   #g{width:100%;height:auto;display:none}
   .hint{font-size:11px;color:#666c76;margin-top:12px}
+  @media(max-width:640px){.controls{gap:14px}.controls label{flex:1 1 100%}.controls input[type=range]{width:auto;min-width:0;flex:1}}
 </style></head><body>
-  <div class="top"><a class="back" href="/">← dashboard</a><b>CI Gantt</b><span>${REPO} · ${CI_WORKFLOW} · live from scripts/ci-gantt.ts</span></div>
+  <div class="top"><a class="back" href="/">← dashboard</a><b>Performance history</b><span>${
+    escapeHtml(source.repo)
+  } · ${escapeHtml(source.workflow)} · scripts/ci-gantt.ts</span></div>
+  ${viewNav}
   <div class="controls">
+    <label>repository <select id="repo"><option value="labs"${
+    source.key === "labs" ? " selected" : ""
+  }>labs</option><option value="loom"${
+    source.key === "loom" ? " selected" : ""
+  }>loom</option></select></label>
     <label>runs to include <input type="range" id="limit" min="1" max="150" step="1" value="60"><b id="limitv">60</b></label>
     <label><input type="checkbox" id="mainOnly" checked> main pushes only</label>
     <label><input type="checkbox" id="allConcl"> include failed/cancelled in timing</label>
-    <label>min runs per job <input type="number" id="minRuns" min="1" placeholder="auto"></label>
   </div>
-  <div class="statusrow"><span class="spinner" id="spin"></span><span id="status"></span></div>
+  ${ciFetchProgressPanel(undefined, { ariaLabel: "CI Gantt fetch progress" })}
   <div class="imgwrap"><img id="g" alt="CI Gantt chart"></div>
-  <p class="hint">Each change re-runs scripts/ci-gantt.ts against GitHub, so regeneration takes a few seconds (longer for larger run counts). Changes are debounced; the last setting wins.</p>
+  <p class="hint">Run, job, and step timings share the persistent server cache used by CI history. Regeneration reads cached past runs and fetches only missing runs or newer attempts.</p>
 <script>
   const $ = (id) => document.getElementById(id);
-  const status = $('status'), g = $('g'), spin = $('spin'), row = document.querySelector('.statusrow');
-  function query(){
+  const g = $('g'), fetchProgress = $('fetch-progress'), title = $('fetch-title'), total = $('fetch-total'), detail = $('fetch-detail'), bar = $('fetch-bar');
+  function parameters(){
     const p = new URLSearchParams();
+    p.set('repo', $('repo').value);
     p.set('limit', $('limit').value);
     if ($('mainOnly').checked) p.set('mainOnly', '1');
     if ($('allConcl').checked) p.set('allConclusions', '1');
-    if ($('minRuns').value) p.set('minRuns', $('minRuns').value);
+    return p;
+  }
+  function imageUrl(){
+    const p = parameters();
     p.set('t', Date.now());
-    return '/ci-gantt.png?' + p.toString();
+    return '/bench/gantt.png?' + p.toString();
   }
-  let seq = 0;
-  function regen(){
-    const mine = ++seq;
-    spin.classList.add('on');
-    row.className = 'statusrow busy';
-    status.textContent = 'regenerating… fetching ' + $('limit').value + ' runs from GitHub';
-    const img = new Image();
-    const done = (kind, text, src) => {
-      if (mine !== seq) return;
-      clearTimeout(to);
-      spin.classList.remove('on');
-      if (kind === 'ok') { g.src = src; g.style.display = 'block'; row.className = 'statusrow'; }
-      else { row.className = 'statusrow err'; }
-      status.textContent = text;
+  function progressUrl(){
+    return '/bench/gantt-progress?' + parameters().toString();
+  }
+  let renderSequence = 0, imageRequest = null, chartSrc = '', eventStream = null, collectionError = '', collectionWarning = '';
+  const closeProgress = () => {
+    eventStream?.close();
+    eventStream = null;
+  };
+  const renderIdle = (message = 'No requests in progress.', warning = '') => {
+    fetchProgress.classList.remove('error', 'warning');
+    if (warning) fetchProgress.classList.add('warning');
+    title.textContent = 'Idle';
+    total.textContent = '0 outstanding';
+    bar.max = 1;
+    bar.value = 0;
+    detail.textContent = message + (warning ? ' ' + warning : '');
+  };
+  const renderProgress = (state) => {
+    fetchProgress.classList.remove('error', 'warning');
+    collectionWarning = state.warning || '';
+    if (state.phase === 'discovering') {
+      title.textContent = 'Finding workflow runs…';
+      total.textContent = state.discoveryOutstandingRequests + ' outstanding';
+      bar.removeAttribute('value');
+      detail.textContent = state.discoveryRequestsMade + ' workflow requests made · ' +
+        state.discoveryResponsesReceived + ' responded · ' +
+        state.discoveryOutstandingRequests + ' outstanding';
+    } else {
+      title.textContent = state.phase === 'saving'
+        ? 'Saving completed responses…'
+        : state.completedRuns + ' of ' + state.totalRuns + ' run checks complete';
+      total.textContent = state.completedRuns + ' / ' + state.totalRuns;
+      bar.max = Math.max(1, state.totalRuns);
+      bar.value = state.completedRuns;
+      detail.textContent = state.cachedRuns + ' cached · ' +
+        state.requestsMade + ' run requests made · ' +
+        state.sharedRequests + ' shared · ' +
+        (state.responsesReceived + state.sharedResponses) + ' responded · ' +
+        state.outstandingRequests + ' outstanding · ' +
+        state.queuedRuns + ' queued' +
+        (state.failedResponses ? ' · ' + state.failedResponses + ' failed' : '') +
+        (collectionWarning ? ' · ' + collectionWarning : '');
+    }
+    if (state.phase === 'error') {
+      closeProgress();
+      collectionError = state.error || 'unknown error';
+      collectionWarning = '';
+      fetchProgress.classList.add('error');
+      title.textContent = 'Idle';
+      total.textContent = '0 outstanding';
+      bar.max = 1;
+      bar.value = 0;
+      detail.textContent = 'Last collection stopped: ' + collectionError;
+    } else if (state.phase === 'complete') {
+      closeProgress();
+      if (collectionWarning) fetchProgress.classList.add('warning');
+      title.textContent = 'Generating chart image…';
+      total.textContent = '0 outstanding';
+      detail.textContent = (collectionWarning ? collectionWarning + ' ' : 'CI data is ready. ') +
+        'Rendering the chart image.';
+    }
+  };
+  const connectProgress = () => {
+    closeProgress();
+    const stream = new EventSource(progressUrl());
+    eventStream = stream;
+    stream.addEventListener('progress', (event) => {
+      if (eventStream !== stream) return;
+      try {
+        renderProgress(JSON.parse(event.data));
+      } catch {
+        stream.close();
+        eventStream = null;
+        fetchProgress.classList.add('error');
+        title.textContent = 'Could not read collection progress';
+      }
+    });
+    stream.onerror = () => {
+      if (eventStream !== stream) return;
+      stream.close();
+      eventStream = null;
+      fetchProgress.classList.add('error');
+      title.textContent = 'Progress connection closed; collection continues on the server';
     };
-    const to = setTimeout(() => done('err', 'timed out generating (check the server log)'), 135000);
-    img.onload = () => done('ok', 'updated · ' + $('limit').value + ' runs', img.src);
-    img.onerror = () => done('err', 'failed to generate (check the server log)');
-    img.src = query();
+  };
+  function regen(){
+    const sequence = ++renderSequence;
+    imageRequest?.abort();
+    const controller = new AbortController();
+    imageRequest = controller;
+    const requestedLimit = $('limit').value;
+    collectionError = '';
+    collectionWarning = '';
+    fetchProgress.classList.remove('error', 'warning');
+    title.textContent = 'Starting CI Gantt collection…';
+    total.textContent = 'starting';
+    bar.removeAttribute('value');
+    detail.textContent = 'Reading cached runs and checking GitHub for newer attempts.';
+    connectProgress();
+    const done = (kind, text, src) => {
+      if (sequence !== renderSequence) {
+        if (src) URL.revokeObjectURL(src);
+        return;
+      }
+      imageRequest = null;
+      closeProgress();
+      if (chartSrc) URL.revokeObjectURL(chartSrc);
+      chartSrc = kind === 'ok' ? src : '';
+      if (kind === 'ok') {
+        g.src = src;
+        g.style.display = 'block';
+        renderIdle(text, collectionWarning);
+      } else {
+        g.removeAttribute('src');
+        g.style.display = 'none';
+        fetchProgress.classList.add('error');
+        title.textContent = 'Idle';
+        total.textContent = '0 outstanding';
+        bar.max = 1;
+        bar.value = 0;
+        detail.textContent = 'Last collection stopped: ' + (collectionError || text);
+      }
+    };
+    fetch(imageUrl(), { cache: 'no-store', signal: controller.signal }).then(async (response) => {
+      if (!response.ok) {
+        throw new Error((await response.text()).trim());
+      }
+      const src = URL.createObjectURL(await response.blob());
+      return await new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => resolve(src);
+        img.onerror = () => {
+          URL.revokeObjectURL(src);
+          reject(new Error('invalid chart image'));
+        };
+        img.src = src;
+      });
+    }).then((src) => {
+      done(
+        'ok',
+        'No requests in progress. Chart updated with up to ' + requestedLimit + ' runs.',
+        src,
+      );
+    }).catch((error) => {
+      if (controller.signal.aborted || sequence !== renderSequence) return;
+      const message = error instanceof Error && error.message
+        ? error.message
+        : 'failed to generate (check the server log)';
+      done('err', message);
+    });
   }
-  let timer;
-  const debounced = () => { clearTimeout(timer); timer = setTimeout(regen, 500); };
-  $('limit').addEventListener('input', () => { $('limitv').textContent = $('limit').value; debounced(); });
-  ['mainOnly','allConcl','minRuns'].forEach((id) => $(id).addEventListener('change', debounced));
+  $('repo').addEventListener('change', () => {
+    const params = new URLSearchParams(location.search);
+    params.set('view', 'gantt');
+    params.set('repo', $('repo').value);
+    location.href = '/bench?' + params.toString();
+  });
+  $('limit').addEventListener('input', () => { $('limitv').textContent = $('limit').value; });
+  $('limit').addEventListener('change', regen);
+  ['mainOnly','allConcl'].forEach((id) => $(id).addEventListener('change', regen));
   regen();
+  setInterval(() => {
+    if (document.visibilityState === 'visible') regen();
+  }, ${GANTT_REFRESH_MS});
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') regen();
+  });
+  window.addEventListener('pagehide', () => {
+    renderSequence++;
+    imageRequest?.abort();
+    closeProgress();
+  });
 </script></body></html>`;
 }
 
+function commitGanttParameters(url: URL): URLSearchParams | null {
+  const sha = url.searchParams.get("sha") ?? "";
+  if (!/^[0-9a-f]{40}$/i.test(sha)) return null;
+  const selected = new Map<number, { runId: number; runAttempt: number }>();
+  for (const run of ciGanttOptions(url.searchParams).selectedRuns ?? []) {
+    const current = selected.get(run.runId);
+    if (!current || current.runAttempt < run.runAttempt) {
+      selected.set(run.runId, run);
+    }
+  }
+  if (!selected.size || selected.size > GANTT_MAX_RUNS) return null;
+  const parameters = new URLSearchParams({
+    repo: ciHistorySource(url.searchParams.get("repo")).key,
+    sha: sha.toLowerCase(),
+    limit: String(selected.size),
+    mainOnly: "1",
+  });
+  for (const { runId, runAttempt } of selected.values()) {
+    parameters.append("run", `${runId}:${runAttempt}`);
+  }
+  return parameters;
+}
+
+export function ciCommitGanttPage(url: URL): string {
+  const source = ciHistorySource(url.searchParams.get("repo"));
+  const parameters = commitGanttParameters(url);
+  const sha = parameters?.get("sha") ?? url.searchParams.get("sha") ?? "";
+  const shortSha = sha.slice(0, 7) || "unknown commit";
+  const runCount = parameters?.getAll("run").length ?? 0;
+  const commitUrl = `https://github.com/${source.repo}/commit/${sha}`;
+  const imageUrl = parameters ? `/ci-gantt.png?${parameters}` : "";
+  const progressUrl = parameters ? `/ci-gantt-progress?${parameters}` : "";
+  const chart = parameters
+    ? `<div class="imgwrap"><img id="g" alt="CI Gantt for ${
+      escapeHtml(shortSha)
+    }"></div>`
+    : `<div class="empty">No successful main CI runs were supplied for this commit.</div>`;
+  const script = parameters
+    ? `<script>
+  const fetchProgress = document.getElementById('fetch-progress');
+  const title = document.getElementById('fetch-title');
+  const total = document.getElementById('fetch-total');
+  const detail = document.getElementById('fetch-detail');
+  const bar = document.getElementById('fetch-bar');
+  const chart = document.getElementById('g');
+  let collectionWarning = '';
+  let chartSettled = false;
+  const stream = new EventSource(${JSON.stringify(progressUrl)});
+  const idle = (message, warning = '', error = false) => {
+    fetchProgress.classList.remove('error', 'warning');
+    if (error) fetchProgress.classList.add('error');
+    if (warning) fetchProgress.classList.add('warning');
+    title.textContent = 'Idle';
+    total.textContent = '0 outstanding';
+    bar.max = 1;
+    bar.value = 0;
+    detail.textContent = message + (warning ? ' ' + warning : '');
+  };
+  stream.addEventListener('progress', (event) => {
+    if (chartSettled) return;
+    const state = JSON.parse(event.data);
+    fetchProgress.classList.remove('error', 'warning');
+    collectionWarning = state.warning || '';
+    if (state.phase === 'discovering') {
+      title.textContent = 'Finding selected workflow runs…';
+      total.textContent = state.discoveryOutstandingRequests + ' outstanding';
+      bar.removeAttribute('value');
+      detail.textContent = state.discoveryRequestsMade + ' workflow requests made · ' +
+        state.discoveryResponsesReceived + ' responded · ' +
+        state.discoveryOutstandingRequests + ' outstanding';
+    } else {
+      title.textContent = state.phase === 'saving'
+        ? 'Saving completed responses…'
+        : state.completedRuns + ' of ' + state.totalRuns + ' run checks complete';
+      total.textContent = state.completedRuns + ' / ' + state.totalRuns;
+      bar.max = Math.max(1, state.totalRuns);
+      bar.value = state.completedRuns;
+      detail.textContent = state.cachedRuns + ' cached · ' +
+        state.requestsMade + ' run requests made · ' +
+        state.sharedRequests + ' shared · ' +
+        (state.responsesReceived + state.sharedResponses) + ' responded · ' +
+        state.outstandingRequests + ' outstanding · ' +
+        state.queuedRuns + ' queued' +
+        (state.failedResponses ? ' · ' + state.failedResponses + ' failed' : '') +
+        (collectionWarning ? ' · ' + collectionWarning : '');
+    }
+    if (state.phase === 'error') {
+      stream.close();
+      idle('Last collection stopped: ' + (state.error || 'unknown error'), '', true);
+    } else if (state.phase === 'complete') {
+      stream.close();
+      if (collectionWarning) fetchProgress.classList.add('warning');
+      title.textContent = 'Generating chart image…';
+      total.textContent = '0 outstanding';
+      detail.textContent = (collectionWarning ? collectionWarning + ' ' : 'CI data is ready. ') +
+        'Rendering the chart image.';
+    }
+  });
+  stream.onerror = () => {
+    if (chartSettled) return;
+    stream.close();
+    idle('Progress connection closed; collection continues on the server.', '', true);
+  };
+  let chartSrc = '';
+  fetch(${
+      JSON.stringify(imageUrl)
+    }, { cache: 'no-store' }).then(async (response) => {
+    if (!response.ok) throw new Error((await response.text()).trim());
+    const src = URL.createObjectURL(await response.blob());
+    return await new Promise((resolve, reject) => {
+      const image = new Image();
+      image.onload = () => resolve(src);
+      image.onerror = () => {
+        URL.revokeObjectURL(src);
+        reject(new Error('The chart image could not be decoded.'));
+      };
+      image.src = src;
+    });
+  }).then((src) => {
+    chartSettled = true;
+    stream.close();
+    chartSrc = src;
+    chart.src = src;
+    chart.style.display = 'block';
+    idle('Chart includes ${runCount} successful run${
+      runCount === 1 ? "" : "s"
+    } for this commit.', collectionWarning);
+  }).catch((error) => {
+    chartSettled = true;
+    stream.close();
+    idle('Last collection stopped: ' + (error.message || 'failed to generate chart'), '', true);
+  });
+  window.addEventListener('pagehide', () => {
+    stream.close();
+    if (chartSrc) URL.revokeObjectURL(chartSrc);
+  });
+</script>`
+    : "";
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>CI Gantt · ${
+    escapeHtml(shortSha)
+  }</title>
+<style>
+  body{margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1400px;margin:0 auto}
+  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:14px;flex-wrap:wrap}
+  .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:#6f757f}
+  a{color:#6ea8fe;text-decoration:none}.back{font-size:13px}.commit{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+  ${CI_FETCH_PROGRESS_STYLES}
+  .imgwrap{background:#0c0d11;border:1px solid #23262d;border-radius:12px;padding:10px;overflow:auto;min-height:60px}
+  #g{width:100%;height:auto;display:none}
+  .empty{background:#16181d;border:1px solid #2f333c;border-radius:12px;padding:18px;color:#9aa0ab}
+</style></head><body>
+  <div class="top"><a class="back" href="/">← dashboard</a><b>CI Gantt</b><span>${
+    escapeHtml(source.repo)
+  } · <a class="commit" href="${
+    escapeHtml(commitUrl)
+  }" target="_blank" rel="noopener">${escapeHtml(shortSha)} ↗</a></span></div>
+  ${
+    ciFetchProgressPanel(undefined, {
+      ariaLabel: "Commit CI Gantt fetch progress",
+    })
+  }
+  ${chart}
+  ${script}
+</body></html>`;
+}
+
+function commitGanttUrl(url: URL): URL | null {
+  const parameters = commitGanttParameters(url);
+  if (!parameters) return null;
+  const normalized = new URL(url);
+  normalized.search = parameters.toString();
+  return normalized;
+}
+
 const ganttRoutes: Route[] = [
-  { path: "/ci", handler: () => new Response(ciGanttPage(), { headers: { "content-type": "text/html; charset=utf-8" } }) },
-  { path: "/ci-gantt.png", handler: (_req, url) => renderGantt(url.searchParams) },
+  {
+    path: "/ci-gantt",
+    handler(_request, url) {
+      return new Response(ciCommitGanttPage(url), {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    },
+  },
+  {
+    path: "/ci-gantt.png",
+    handler(request, url) {
+      const normalized = commitGanttUrl(url);
+      return normalized
+        ? renderGanttRoute(request, normalized, collectCommitCiGanttInput)
+        : Promise.resolve(
+          new Response("invalid commit Gantt selection", {
+            status: 400,
+            headers: { "cache-control": "no-store" },
+          }),
+        );
+    },
+  },
+  {
+    path: "/ci-gantt-progress",
+    handler(request, url) {
+      const normalized = commitGanttUrl(url);
+      return normalized
+        ? ciCommitGanttProgressResponse(request, normalized)
+        : new Response("invalid commit Gantt selection", { status: 400 });
+    },
+  },
+  {
+    path: "/bench/gantt.png",
+    handler: renderGanttRoute,
+  },
+  {
+    path: "/bench/gantt-progress",
+    handler: ciGanttProgressResponse,
+  },
 ];
 
 function makeCiDuration(
-  opts: { id: string; label: string; repo: string; workflow: string; href: string; hint: string; routes?: Route[] },
+  opts: {
+    id: string;
+    label: string;
+    repo: string;
+    workflow: string;
+    href: string;
+    hint: string;
+    routes?: Route[];
+  },
 ): Tile {
   return {
     id: opts.id,
     intervalMs: 30_000,
     routes: opts.routes,
     async collect(ctx): Promise<TileView> {
-      const runs = await ctx.runsFor(opts.repo, opts.workflow);
+      let runs: Run[];
+      try {
+        runs = await ctx.runsFor(opts.repo, opts.workflow);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          label: opts.label,
+          status: "unknown",
+          value: "—",
+          sub: friendlyError(message),
+          href: opts.href,
+          hint: opts.hint,
+        };
+      }
       // Only runs that passed end to end: a failed/cancelled/timed-out run's
       // wall-clock time isn't a representative CI duration.
-      const passed = runs.filter((r) => r.status === "completed" && r.conclusion === "success");
-      const durMins = (r: Run) => (Date.parse(r.updated_at) - Date.parse(r.run_started_at)) / 60000;
+      const passed = runs.filter((r) =>
+        r.status === "completed" && r.conclusion === "success"
+      );
+      const durMins = (r: Run) =>
+        (Date.parse(r.updated_at) - Date.parse(r.run_started_at)) / 60000;
       // Median window = the successful runs in the last DUR_MAX_AGE_HOURS, or the
       // most recent DUR_MIN_RUNS — whichever has more runs.
       const cutoff = Date.now() - DUR_MAX_AGE_HOURS * 3_600_000;
-      const inTimeCount = passed.filter((r) => Date.parse(r.run_started_at) >= cutoff).length;
+      const inTimeCount =
+        passed.filter((r) => Date.parse(r.run_started_at) >= cutoff).length;
       const usingTime = inTimeCount >= DUR_MIN_RUNS; // time window wins when it has enough runs
       // A count-based prefix (not the filter set itself) so the median runs are
       // always the newest slice of passed — which is what the sparkline
@@ -154,11 +669,19 @@ function makeCiDuration(
       // trend.
       const series = [...passed].reverse().map(durMins);
       // How long the sparkline spans (oldest to newest run), for the corner label.
-      const times = passed.map((r) => Date.parse(r.run_started_at)).filter((t) => !Number.isNaN(t));
-      const spanMs = times.length >= 2 ? Math.max(...times) - Math.min(...times) : 0;
+      const times = passed.map((r) => Date.parse(r.run_started_at)).filter((
+        t,
+      ) => !Number.isNaN(t));
+      const spanMs = times.length >= 2
+        ? Math.max(...times) - Math.min(...times)
+        : 0;
       const s: Status = window.length === 0
         ? "unknown"
-        : medianMins <= DUR_GOOD ? "good" : medianMins <= DUR_WARN ? "warn" : "bad";
+        : medianMins <= DUR_GOOD
+        ? "good"
+        : medianMins <= DUR_WARN
+        ? "warn"
+        : "bad";
       return {
         label: opts.label,
         status: s,
@@ -166,7 +689,10 @@ function makeCiDuration(
         sub: usingTime
           ? `median · ${window.length} passing runs in the last ${DUR_MAX_AGE_HOURS}h`
           : `median · last ${window.length} passing runs`,
-        extra: sparkline(series, "#727882", { count: window.length, color: "#c7ccd4" }, SPARK_FADE[s]),
+        extra: sparkline(series, "#727882", {
+          count: window.length,
+          color: "#c7ccd4",
+        }, SPARK_FADE[s]),
         duration: spanMs,
         href: opts.href,
         hint: opts.hint,
@@ -175,9 +701,6 @@ function makeCiDuration(
   };
 }
 
-const loomRunsUrl = `https://github.com/${LOOM_REPO}/actions/workflows/${LOOM_CI_WORKFLOW}?query=branch%3Amain`;
-
-
 // The middle of a sorted series. An even count has no single middle run, so it is
 // the mean of the two: taking the upper one alone reports a duration no run had,
 // and always the higher of the pair. The default window is 20 runs, so even is the
@@ -185,7 +708,9 @@ const loomRunsUrl = `https://github.com/${LOOM_REPO}/actions/workflows/${LOOM_CI
 export function median(sorted: number[]): number {
   if (sorted.length === 0) return 0;
   const mid = sorted.length / 2;
-  return sorted.length % 2 ? sorted[Math.floor(mid)] : (sorted[mid - 1] + sorted[mid]) / 2;
+  return sorted.length % 2
+    ? sorted[Math.floor(mid)]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
 export const labsCiDuration = makeCiDuration({
@@ -193,8 +718,8 @@ export const labsCiDuration = makeCiDuration({
   label: "labs ci duration",
   repo: REPO,
   workflow: CI_WORKFLOW,
-  href: "/ci",
-  hint: "gantt ↗",
+  href: "/bench?view=ci&repo=labs",
+  hint: "history ↗",
   routes: ganttRoutes,
 });
 export const loomCiDuration = makeCiDuration({
@@ -202,6 +727,6 @@ export const loomCiDuration = makeCiDuration({
   label: "loom ci duration",
   repo: LOOM_REPO,
   workflow: LOOM_CI_WORKFLOW,
-  href: loomRunsUrl,
-  hint: "runs ↗",
+  href: "/bench?view=ci&repo=loom",
+  hint: "history ↗",
 });

--- a/packages/dashboard/tiles/discord-online.ts
+++ b/packages/dashboard/tiles/discord-online.ts
@@ -10,6 +10,7 @@
 // closes with 4014.
 import type { Status, Tile, TileView } from "../types.ts";
 import { escapeHtml, multiSparkline, thin } from "../lib.ts";
+import { dashboardCacheFile } from "../history-files.ts";
 
 const GATEWAY = "wss://gateway.discord.gg/?v=10&encoding=json";
 const SNAPSHOT_TIMEOUT_MS = 12_000;
@@ -27,15 +28,14 @@ const VISITOR_COLOR = "#7c828c";
 const LINE_FADE = "#0e1915";
 
 // A rolling series of timestamped samples, charted as two lines. Samples are
-// retained for up to HISTORY_MAX_AGE_DAYS (~2 months) and persisted to disk
-// (DISCORD_HISTORY_FILE, else a file in the temp dir), reloaded on start so a
-// relaunch keeps the chart.
+// retained for up to HISTORY_MAX_AGE_DAYS (~2 months) and persisted to disk in
+// the dashboard cache directory, reloaded on start so a relaunch keeps the
+// chart.
 const HISTORY_MAX_AGE_DAYS = 60; // ~2 months
 // Cap the plotted points so a long window still renders as a small SVG; the full
 // history feeds the timestamps and span, this only thins the polyline.
 const PLOT_POINTS = 500;
-const HISTORY_FILE = Deno.env.get("DISCORD_HISTORY_FILE") ??
-  `${Deno.env.get("TMPDIR") ?? "/tmp"}/fabric-wall-discord-history.json`;
+const HISTORY_FILE = dashboardCacheFile("fabric-wall-discord-history.json");
 type Point = { t: number; team: number; visitors: number };
 const history: Point[] = [];
 

--- a/packages/dashboard/tiles/github-members.test.ts
+++ b/packages/dashboard/tiles/github-members.test.ts
@@ -3,6 +3,7 @@
 // history, and the gray states for unavailable data.
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { REPO } from "../config.ts";
+import { dashboardCacheFile } from "../history-files.ts";
 import type { Ctx } from "../types.ts";
 import { createGithubMembers, organizationUserIds } from "./github-members.ts";
 
@@ -10,6 +11,12 @@ const DAY = 86_400_000;
 const HOUR = 3_600_000;
 const T0 = Date.UTC(2026, 6, 1);
 const ORG = REPO.split("/")[0];
+
+function historyFile(): string {
+  return dashboardCacheFile(
+    `fabric-wall-github-members-${ORG.toLowerCase()}-history.json`,
+  );
+}
 
 let clock = T0;
 
@@ -135,11 +142,11 @@ Deno.test("github users: organization rosters read every page and deduplicate id
   });
 });
 
-Deno.test("github users: configured history loads once across collections", async () => {
-  const key = "GITHUB_MEMBERS_HISTORY_FILE";
+Deno.test("github users: shared history cache loads once across collections", async () => {
+  const key = "DASHBOARD_CACHE_DIR";
   const saved = Deno.env.get(key);
-  const configured = "/configured/github-users-history.json";
-  Deno.env.set(key, configured);
+  const directory = "/configured/dashboard-cache";
+  Deno.env.set(key, directory);
   clock = T0;
 
   try {
@@ -154,18 +161,20 @@ Deno.test("github users: configured history loads once across collections", asyn
       clock += HOUR;
       await tile.collect(ctx({ GH_TOKEN: "token" }));
 
-      assertEquals(wire.reads, [configured]);
+      const file =
+        `${directory}/fabric-wall-github-members-${ORG.toLowerCase()}-history.json`;
+      assertEquals(wire.reads, [file]);
       assertEquals(wire.writes.map((write) => write.path), [
-        `${configured}.tmp`,
-        `${configured}.tmp`,
+        `${file}.tmp`,
+        `${file}.tmp`,
       ]);
       assertEquals(JSON.parse(wire.writes[1].data), [
         { t: T0, members: 2, collaborators: 1 },
         { t: T0 + HOUR, members: 2, collaborators: 1 },
       ]);
       assertEquals(wire.renames, [
-        { from: `${configured}.tmp`, to: configured },
-        { from: `${configured}.tmp`, to: configured },
+        { from: `${file}.tmp`, to: file },
+        { from: `${file}.tmp`, to: file },
       ]);
     });
   } finally {
@@ -214,12 +223,7 @@ Deno.test("github users: transitional overlap counts once and draws retained his
         `/orgs/${ORG}/outside_collaborators`,
       ]),
     );
-    assertEquals(wire.reads, [
-      Deno.env.get("GITHUB_MEMBERS_HISTORY_FILE") ??
-        `${
-          Deno.env.get("TMPDIR") ?? "/tmp"
-        }/fabric-wall-github-members-${ORG.toLowerCase()}-history.json`,
-    ]);
+    assertEquals(wire.reads, [historyFile()]);
     assertEquals(JSON.parse(wire.writes[0].data), [
       { t: T0 - 2 * DAY, members: 11, collaborators: 1 },
       { t: T0, members: 12, collaborators: 2 },
@@ -327,7 +331,7 @@ Deno.test("github users: unavailable or malformed organization data stays gray",
             headers: { "x-ratelimit-remaining": "0" },
           })
           : [],
-      sub: "rate-limited",
+      sub: "rate limit hit",
       log:
         `github users: could not read organization users: GitHub API orgs/${ORG}/outside_collaborators?per_page=100&page=1 failed: HTTP 403 (rate-limited)`,
     },

--- a/packages/dashboard/tiles/github-members.ts
+++ b/packages/dashboard/tiles/github-members.ts
@@ -3,6 +3,7 @@
 // history of each roster's size and chart them as two lines.
 import { REPO } from "../config.ts";
 import type { Tile, TileView } from "../types.ts";
+import { dashboardCacheFile } from "../history-files.ts";
 import {
   escapeHtml,
   friendlyError,
@@ -43,13 +44,11 @@ const isUser = (value: unknown): value is User =>
   Number.isSafeInteger((value as User).id) && (value as User).id > 0;
 
 function historyFile(org: string): string {
-  const configured = Deno.env.get("GITHUB_MEMBERS_HISTORY_FILE");
-  if (configured) return configured;
   const fileOrg = org.toLowerCase().replace(/[^a-z0-9.-]/g, "_") ||
     "unknown";
-  return `${
-    Deno.env.get("TMPDIR") ?? "/tmp"
-  }/fabric-wall-github-members-${fileOrg}-history.json`;
+  return dashboardCacheFile(
+    `fabric-wall-github-members-${fileOrg}-history.json`,
+  );
 }
 
 async function loadHistory(

--- a/packages/dashboard/tiles/recent-runs.ts
+++ b/packages/dashboard/tiles/recent-runs.ts
@@ -6,12 +6,74 @@
 // recovered, else good.
 import type { Run, Status, Tile, TileView } from "../types.ts";
 import { concDot, escapeHtml, landingHref } from "../lib.ts";
-import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, RECENT_DISPLAY, RECENT_WINDOW, REPO } from "../config.ts";
+import {
+  CI_WORKFLOW,
+  LOOM_CI_WORKFLOW,
+  LOOM_REPO,
+  RECENT_DISPLAY,
+  RECENT_WINDOW,
+  REPO,
+} from "../config.ts";
+import { GANTT_MAX_RUNS } from "../ci-job-history.ts";
 
 const utcFallback = (iso: string): string => {
   const at = Date.parse(iso);
-  return Number.isFinite(at) ? `${new Date(at).toISOString().slice(11, 16)} UTC` : iso;
+  return Number.isFinite(at)
+    ? `${new Date(at).toISOString().slice(11, 16)} UTC`
+    : iso;
 };
+
+const repoOf = (run: Run): string => run.repo ?? REPO;
+
+function runDuration(run: Run): string | null {
+  if (run.status !== "completed") return null;
+  const start = Date.parse(run.run_started_at);
+  const end = Date.parse(run.updated_at);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    return null;
+  }
+  const seconds = Math.round((end - start) / 1_000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${String(remainder).padStart(2, "0")}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${String(minutes % 60).padStart(2, "0")}m`;
+}
+
+export function commitGanttHref(run: Run, candidates: Run[]): string | null {
+  if (
+    !run.head_sha || run.status !== "completed" ||
+    run.conclusion !== "success" || run.event !== "push"
+  ) return null;
+  const selected = new Map<number, Run>();
+  for (const candidate of candidates) {
+    if (
+      repoOf(candidate) !== repoOf(run) ||
+      candidate.head_sha !== run.head_sha ||
+      candidate.status !== "completed" ||
+      candidate.conclusion !== "success" || candidate.event !== "push"
+    ) continue;
+    const current = selected.get(candidate.id);
+    if (!current || current.run_attempt < candidate.run_attempt) {
+      selected.set(candidate.id, candidate);
+    }
+  }
+  if (!selected.size || selected.size > GANTT_MAX_RUNS) return null;
+  const parameters = new URLSearchParams({
+    repo: repoOf(run) === LOOM_REPO ? "loom" : "labs",
+    sha: run.head_sha,
+    limit: String(selected.size),
+    mainOnly: "1",
+  });
+  for (const selectedRun of selected.values()) {
+    parameters.append(
+      "run",
+      `${selectedRun.id}:${selectedRun.run_attempt}`,
+    );
+  }
+  return `/ci-gantt?${parameters}`;
+}
 
 export const recentRuns: Tile = {
   id: "recent-runs",
@@ -24,11 +86,15 @@ export const recentRuns: Tile = {
       ctx.runsFor(REPO, CI_WORKFLOW),
       ctx.runsFor(LOOM_REPO, LOOM_CI_WORKFLOW),
     ]);
-    const runs = [...labs, ...loom]
-      .sort((a, b) => Date.parse(b.run_started_at) - Date.parse(a.run_started_at))
-      .slice(0, RECENT_DISPLAY);
+    const allRuns = [...labs, ...loom]
+      .sort((a, b) =>
+        Date.parse(b.run_started_at) - Date.parse(a.run_started_at)
+      );
+    const runs = allRuns.slice(0, RECENT_DISPLAY);
 
-    const completedOutcomes = [...runs].filter((r) => r.status === "completed" && r.conclusion).reverse()
+    const completedOutcomes = [...runs].filter((r) =>
+      r.status === "completed" && r.conclusion
+    ).reverse()
       .map((r) => concDot(r.conclusion, r.run_attempt));
     const status: Status = completedOutcomes.length === 0
       ? "unknown"
@@ -38,7 +104,6 @@ export const recentRuns: Tile = {
       ? "warn"
       : "good";
 
-    const repoOf = (r: Run) => r.repo ?? REPO;
     const shortRepo = (r: Run) => repoOf(r).split("/")[1] ?? repoOf(r);
     const rows = runs.map((r) => {
       const running = r.status !== "completed";
@@ -48,12 +113,31 @@ export const recentRuns: Tile = {
         : r.conclusion === "success"
         ? (r.run_attempt > 1 ? `green on retry #${r.run_attempt}` : "green")
         : (r.conclusion ?? "done");
-      const title = (r.head_commit?.message ?? r.display_title).split("\n", 1)[0];
+      const title =
+        (r.head_commit?.message ?? r.display_title).split("\n", 1)[0];
       const href = landingHref(title, r.head_sha, repoOf(r));
+      const ganttHref = commitGanttHref(r, allRuns);
+      const duration = runDuration(r);
       const startedAt = escapeHtml(r.run_started_at);
       const fallback = escapeHtml(utcFallback(r.run_started_at));
-      return `<a class="ev" href="${escapeHtml(href)}" target="_blank" rel="noopener"><time class="t" datetime="${startedAt}" data-viewer-time>${fallback}</time><span class="dot ${dot}"></span><span class="evtxt">${escapeHtml(`${shortRepo(r)} · ${label} · ${title}`)}</span><span class="evarrow">↗</span></a>`;
-    }).join("") || `<div class="ev"><span class="dot grey"></span><span>waiting for first poll…</span></div>`;
+      const durationHtml = ganttHref && duration
+        ? `<a class="evdur" data-focus-key="gantt-${r.id}" href="${
+          escapeHtml(ganttHref)
+        }" title="View CI Gantt for ${escapeHtml(r.head_sha.slice(0, 7))}">${
+          escapeHtml(duration)
+        }</a>`
+        : `<span class="evdur">${
+          escapeHtml(duration ?? (running ? "running" : "—"))
+        }</span>`;
+      return `<div class="ev"><time class="t" datetime="${startedAt}" data-viewer-time>${fallback}</time><span class="dot ${dot}"></span><a class="evtxt" data-focus-key="pr-title-${r.id}" href="${
+        escapeHtml(href)
+      }" target="_blank" rel="noopener">${
+        escapeHtml(`${shortRepo(r)} · ${label} · ${title}`)
+      }</a>${durationHtml}<a class="evarrow" data-focus-key="pr-arrow-${r.id}" href="${
+        escapeHtml(href)
+      }" target="_blank" rel="noopener" aria-label="Open landed change on GitHub">↗</a></div>`;
+    }).join("") ||
+      `<div class="ev"><span class="dot grey"></span><span>waiting for first poll…</span></div>`;
 
     return {
       label: `recent main runs · ${runs.length} in window`,

--- a/packages/dashboard/trend.ts
+++ b/packages/dashboard/trend.ts
@@ -1,0 +1,69 @@
+import type { Status } from "./types.ts";
+
+const DAY_MS = 86_400_000;
+const MIN_TREND_DAYS = 7;
+const UP_PCT = 0.05;
+const RAPID_PCT = 0.20;
+
+const median = (values: number[]): number => {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = sorted.length >> 1;
+  return sorted.length % 2
+    ? sorted[middle]
+    : (sorted[middle - 1] + sorted[middle]) / 2;
+};
+
+export function distinctTrendDays(times: number[], values: number[]): number {
+  const days = new Set<number>();
+  for (let i = 0; i < values.length; i++) {
+    if (values[i] > 0) days.add(Math.floor(times[i] / DAY_MS));
+  }
+  return days.size;
+}
+
+// Overall trend as the fractional change of a robust fit across the displayed
+// range (+0.2 means the fit ends 20% higher than it starts).
+//
+// Sub-daily samples become one median value per calendar day. The fit is the
+// median of every pairwise log slope between those daily values, projected over
+// the complete day span. `times` must be ascending.
+export function trendPct(times: number[], values: number[]): number {
+  const byDay = new Map<number, number[]>();
+  for (let i = 0; i < values.length; i++) {
+    if (values[i] <= 0) continue;
+    const day = Math.floor(times[i] / DAY_MS);
+    const samples = byDay.get(day);
+    if (samples) samples.push(values[i]);
+    else byDay.set(day, [values[i]]);
+  }
+  const days = [...byDay.keys()].sort((a, b) => a - b);
+  if (days.length < MIN_TREND_DAYS) return 0;
+  const daily = days.map((day) => median(byDay.get(day)!));
+  const slopes: number[] = [];
+  for (let i = 0; i < days.length; i++) {
+    for (let j = i + 1; j < days.length; j++) {
+      slopes.push(
+        (Math.log(daily[j]) - Math.log(daily[i])) / (days[j] - days[i]),
+      );
+    }
+  }
+  return Math.expm1(
+    median(slopes) * (days[days.length - 1] - days[0]),
+  );
+}
+
+export function trendStatus(pct: number): Status {
+  return pct <= UP_PCT ? "good" : pct <= RAPID_PCT ? "warn" : "bad";
+}
+
+// A percent for modest moves; a fold multiplier once it passes four times in
+// either direction.
+export function trendPctLabel(pct: number): string {
+  const ratio = pct + 1;
+  const fold = (value: number) =>
+    value >= 10 ? value.toFixed(0) : value.toFixed(1);
+  if (ratio >= 4) return `▲${fold(ratio)}×`;
+  if (ratio > 0 && 1 / ratio >= 4) return `▼${fold(1 / ratio)}×`;
+  const percent = Math.round(pct * 100);
+  return percent > 0 ? `▲${percent}%` : percent < 0 ? `▼${-percent}%` : "flat";
+}

--- a/packages/dashboard/types.ts
+++ b/packages/dashboard/types.ts
@@ -28,7 +28,7 @@ export interface Tile {
   id: string; // unique, stable key for this tile's scheduling + latest-view state
   intervalMs: number; // how often collect() runs
   wide?: boolean; // render full-width below the grid, including before collection
-  collect(ctx: Ctx): Promise<TileView>;
+  collect(ctx: Ctx, publish?: (view: TileView) => void): Promise<TileView>; // publish usable data before slower work completes
   routes?: Route[]; // optional drill-down routes this tile owns
 }
 

--- a/packages/test-support/src/isolated-deno.ts
+++ b/packages/test-support/src/isolated-deno.ts
@@ -56,7 +56,7 @@ export async function runDenoCommandWithTemporaryLock(
     if (options.env) {
       commandOptions.env = options.env;
     }
-    return await new Deno.Command(Deno.execPath(), commandOptions).output();
+    return await new Deno.Command("deno", commandOptions).output();
   } finally {
     await removeIfPresent(tempDir, { recursive: true });
   }

--- a/scripts/ci-gantt.ts
+++ b/scripts/ci-gantt.ts
@@ -27,12 +27,14 @@
 //     --repo OWNER/REPO     default commontoolsinc/labs
 //     --workflow FILE       default deno.yml
 //     --limit N             runs to fetch, default 100
+//     --input PATH          cached run and job JSON; skips GitHub requests
 //     --out PATH            output file, default ci-gantt.png; a .svg path
 //                           writes the raw SVG instead of a rasterized PNG
 //     --scale N             raster scale factor, default 2
 //     --concurrency N       parallel job fetches, default 8
 //     --min-runs N          drop jobs seen in fewer than N runs (default: 10% of runs)
 //     --main-only           only fetch pushes to main, skipping pre-land PR runs
+//     --all-conclusions     include failed and cancelled jobs with timing
 //     --run-id ID           chart this workflow run ID, repeatable
 //     --theme NAME          color palette: "default" (light) or "dark"
 //     --colors JSON         override palette keys, e.g. '{"work":"#6ea8fe"}'
@@ -56,7 +58,8 @@ function numOpt(
 if (args.includes("--help") || args.includes("-h")) {
   console.log(
     "Usage: scripts/ci-gantt.ts [--repo OWNER/REPO] [--workflow FILE] [--limit N]\n" +
-      "       [--out PATH] [--scale N] [--concurrency N] [--min-runs N] [--main-only]\n" +
+      "       [--input PATH] [--out PATH] [--scale N] [--concurrency N] [--min-runs N]\n" +
+      "       [--main-only] [--all-conclusions]\n" +
       "       [--run-id ID] [--theme default|dark] [--colors '<json>']",
   );
   Deno.exit(0);
@@ -65,6 +68,7 @@ if (args.includes("--help") || args.includes("-h")) {
 const REPO = opt("repo", "commontoolsinc/labs");
 const WORKFLOW = opt("workflow", "deno.yml");
 const LIMIT = numOpt("limit", 100, { min: 1, integer: true });
+const INPUT = opt("input", "");
 const OUT = opt("out", "ci-gantt.png");
 const SCALE = numOpt("scale", 2, { min: 0.1 });
 const CONCURRENCY = numOpt("concurrency", 8, { min: 1, integer: true });
@@ -81,12 +85,14 @@ const SUCCESS_ONLY = !RUN_IDS.length && !args.includes("--all-conclusions");
 const MAIN_ONLY = args.includes("--main-only");
 
 // ---------------------------------------------------------------------------
-// Data fetching: calls the GitHub REST API directly, authenticated with
-// GH_TOKEN or GITHUB_TOKEN. One of those must be set.
+// Data fetching: without --input, calls the GitHub REST API directly,
+// authenticated with GH_TOKEN or GITHUB_TOKEN. One of those must be set.
 // ---------------------------------------------------------------------------
 
-const TOKEN = Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN");
-if (!TOKEN) {
+const TOKEN = INPUT
+  ? undefined
+  : Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN");
+if (!INPUT && !TOKEN) {
   console.error(
     "Set GH_TOKEN or GITHUB_TOKEN (a GitHub token with repo read).",
   );
@@ -125,7 +131,6 @@ async function githubApi<T>(path: string): Promise<T> {
       accept: "application/vnd.github+json",
       "x-github-api-version": "2022-11-28",
     },
-    signal: AbortSignal.timeout(15_000),
   });
   if (!res.ok) throw new Error(`GitHub API ${path} failed: HTTP ${res.status}`);
   return await res.json() as T;
@@ -205,6 +210,10 @@ interface Job {
   started_at: string | null;
   completed_at: string | null;
   steps?: Step[];
+}
+
+interface GanttInput {
+  runs: { run: Run; jobs: Job[] }[];
 }
 
 function hasTiming(job: Job): boolean {
@@ -364,49 +373,70 @@ function esc(s: string): string {
 // Main
 // ---------------------------------------------------------------------------
 
-console.error(
-  RUN_IDS.length
-    ? `Fetching ${RUN_IDS.length} selected run(s) on ${REPO} ...`
-    : `Fetching last ${LIMIT} ${WORKFLOW} runs on ${REPO}${
-      MAIN_ONLY ? " (main pushes only)" : ""
-    } ...`,
-);
-const runs: Run[] = RUN_IDS.length
-  ? await pool(
-    RUN_IDS,
-    CONCURRENCY,
-    async (runId) =>
-      toRun(await githubApi<RestRun>(`/repos/${REPO}/actions/runs/${runId}`)),
-  )
-  : await fetchRuns();
-
-const completed = runs.filter((r) => r.status === "completed");
-console.error(
-  `Got ${runs.length} runs (${completed.length} completed); fetching jobs ...`,
-);
-
-const jobsPerRun = await pool(completed, CONCURRENCY, async (run, i) => {
-  if ((i + 1) % 10 === 0) console.error(`  ${i + 1}/${completed.length}`);
-  let jobs = await fetchJobs(
-    `/repos/${REPO}/actions/runs/${run.databaseId}/attempts/1/jobs`,
-  );
-  if ((run.attempt ?? 1) > 1) {
-    const latestJobs = await fetchJobs(
-      `/repos/${REPO}/actions/runs/${run.databaseId}/jobs`,
-    );
-    const latestByName = new Map(
-      latestJobs.map((job) => [job.name, job]),
-    );
-    jobs = jobs.map((job) => {
-      const latest = latestByName.get(job.name);
-      if (latest && !hasTiming(job) && hasTiming(latest)) return latest;
-      return latest
-        ? { ...job, status: latest.status, conclusion: latest.conclusion }
-        : job;
-    });
+let runs: Run[];
+let jobsPerRun: GanttInput["runs"];
+if (INPUT) {
+  const input = JSON.parse(await Deno.readTextFile(INPUT)) as GanttInput;
+  if (!Array.isArray(input.runs)) {
+    throw new Error("CI Gantt input must contain a runs array.");
   }
-  return { run, jobs };
-});
+  jobsPerRun = input.runs;
+  runs = jobsPerRun.map(({ run }) => run);
+  console.error(`Loaded ${runs.length} cached run(s) for ${REPO}.`);
+} else {
+  console.error(
+    RUN_IDS.length
+      ? `Fetching ${RUN_IDS.length} selected run(s) on ${REPO} ...`
+      : `Fetching last ${LIMIT} ${WORKFLOW} runs on ${REPO}${
+        MAIN_ONLY ? " (main pushes only)" : ""
+      } ...`,
+  );
+  runs = RUN_IDS.length
+    ? await pool(
+      RUN_IDS,
+      CONCURRENCY,
+      async (runId) =>
+        toRun(
+          await githubApi<RestRun>(`/repos/${REPO}/actions/runs/${runId}`),
+        ),
+    )
+    : await fetchRuns();
+  const completedRuns = runs.filter((run) => run.status === "completed");
+  console.error(
+    `Got ${runs.length} runs (${completedRuns.length} completed); fetching jobs ...`,
+  );
+  jobsPerRun = await pool(
+    completedRuns,
+    CONCURRENCY,
+    async (run, i) => {
+      if ((i + 1) % 10 === 0) {
+        console.error(`  ${i + 1}/${completedRuns.length}`);
+      }
+      let jobs = await fetchJobs(
+        `/repos/${REPO}/actions/runs/${run.databaseId}/attempts/1/jobs`,
+      );
+      if ((run.attempt ?? 1) > 1) {
+        const latestJobs = await fetchJobs(
+          `/repos/${REPO}/actions/runs/${run.databaseId}/jobs`,
+        );
+        const latestByName = new Map(
+          latestJobs.map((job) => [job.name, job]),
+        );
+        jobs = jobs.map((job) => {
+          const latest = latestByName.get(job.name);
+          if (latest && !hasTiming(job) && hasTiming(latest)) return latest;
+          return latest
+            ? { ...job, status: latest.status, conclusion: latest.conclusion }
+            : job;
+        });
+      }
+      return { run, jobs };
+    },
+  );
+}
+
+const completed = runs.filter((run) => run.status === "completed");
+jobsPerRun = jobsPerRun.filter(({ run }) => run.status === "completed");
 
 // Accumulate timings keyed by exact job name (each shard is its own key).
 const acc = new Map<


### PR DESCRIPTION
The dashboard showed current CI summaries but did not make repeated-run timing changes easy to inspect. Add one performance area for runtime benchmarks, CI job durations, and detailed CI run Gantt charts. Support labs and loom, one-day through 45-day windows, shared date legends, duration and trend sorting, overall workflow duration, and individual or grouped shard series.

Collect successful main builds and benchmark artifacts while reporting live request progress. Keep every successful build when a window has at most 90, then sample the newest build in each time bucket for denser ranges. Keep controls usable during collection, retain responses after navigation, and check open views for newer completed runs.

Update Runtime benchmark and CI duration windows in place instead of reloading the page. Preserve focus, browser history, request cancellation, queued refreshes, and rapid range reversals. Commit native range changes immediately so cursor-key adjustments fetch their selected window while pointer drags commit at the browser's normal change boundary.

Persist Discord history, CI timings, benchmark artifacts, and the GitHub request ledger under fixed filenames in DASHBOARD_CACHE_DIR. Share CI timing data between history charts and Gantt rendering. Guard only performance collection and stop before it passes 80% of GitHub's primary or request-point limits.

Serialize quota-ledger operations within each dashboard process before taking the cross-process filesystem lock. This prevents concurrent performance requests from exhausting Deno's filesystem workers and deadlocking Gantt rendering. Keep persisted reservation leases for coordination across dashboard processes.

Allow the Gantt renderer to read its dynamically loaded Resvg module and system fonts while retaining scoped output writes and denying network and environment access.

Link duration tiles to the matching history pages, keep the performance view selector and URLs consistent, trim implementation detail from the CI performance guide, and remove unused root dashboard task aliases. Run dashboard tests through an isolated cache directory so they cannot modify a developer or deployment cache.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add historical performance views to the dashboard: runtime benchmarks, CI job duration trends, a CI run Gantt for labs and loom, and a standalone commit Gantt page linked from Recent Main Runs. Shows cached data during refresh, guards GitHub limits for performance-only requests, and persists history across restarts.

- **New Features**
  - New `/bench` views: `runtime`, `ci`, and `gantt` for labs and loom; 1–45 day windows; sort by duration or trend; shared date legends; overall workflow and per-job/shard series; stable selector and URLs.
  - Collects successful main runs; keeps all when ≤90, else samples newest per time bucket; validates exact run attempts; shows live progress; updates in place; shares CI timings with Gantt; `scripts/ci-gantt.ts` adds `--input` and `--all-conclusions`; adds commit Gantt at `/ci-gantt` and links it from Recent Main Runs durations.
  - Persists history in `DASHBOARD_CACHE_DIR`: Discord samples, GitHub member history, benchmark artifacts, CI jobs/timings, and a GitHub request ledger. Applies the 80% budget only to performance-history traffic and serializes reservations across processes; portable cache paths; Gantt renderer loads Resvg and system fonts while denying network/env.
  - Duration tiles link to `/bench?view=ci`; Gantt is `/bench?view=gantt`; Recent Main Runs durations link to `/ci-gantt`. Tiles can publish an intermediate cached view during collection to avoid blank states.
  - Docs updated; Deno test runner isolates caches and works on Windows.

- **Migration**
  - Optional: set `DASHBOARD_CACHE_DIR` to persist history across restarts.
  - Update any bookmarks to `/bench?view=ci`, `/bench?view=gantt`, or `/ci-gantt`.
  - `GITHUB_MEMBERS_HISTORY_FILE` is removed; use `DASHBOARD_CACHE_DIR`.

<sup>Written for commit bbb9d4955cc1e403f3a53ee9243805b89c72d6ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

