### PR TITLE
fix(runner): complete LLM-derived schema stamping

### DIFF
--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -136,11 +136,15 @@ function mergeLlmDerivedIntoNode(
 }
 
 /**
- * Deep-merge the `LlmDerived` stamp into a generateObject result schema's
- * `ifc.addIntegrity` at EVERY node — the root AND every nested property / item /
- * `$defs` / compound-branch node — so it rides the (possibly custom /
- * injection-safe) resultSchema write to wherever the model bytes land, whether
- * inline at `["result"]` or in a SPLIT CHILD DOCUMENT.
+ * Deep-merge the `LlmDerived` stamp into every object subschema in a
+ * generateObject result schema. Storage-addressable nodes (properties,
+ * additional properties, items / prefix items, compound branches, and `$defs`
+ * targets) need the stamp so it rides the possibly custom / injection-safe
+ * resultSchema to wherever the model bytes land, whether inline at `["result"]`
+ * or in a SPLIT CHILD DOCUMENT. The shared walker's complete vocabulary is
+ * stamped too: this runs once per model result, so defensive completeness for
+ * caller-supplied schemas has no noticeable cost and preserves provenance if
+ * more keywords become storage-addressable later.
  *
  * A root-only merge is not enough: when a nested value redirects/splits into its
  * own document (an `asCell` field, an ID-anchored array item), the child write
@@ -158,17 +162,14 @@ function mergeLlmDerivedIntoNode(
  * An absent resultSchema defaults to a plain object schema.
  */
 function withLlmDerivedStamp(schema: JSONSchema | undefined): JSONSchema {
-  // Stamp this node, then every structural subschema. The descent is the shared
-  // vocabulary (`$defs` included): the previous hand-listed set covered
-  // properties/$defs/patternProperties/items/additionalProperties/prefixItems/
-  // anyOf/oneOf/allOf but skipped not/if/then/else/contains/propertyNames/
-  // dependentSchemas/contentSchema, leaving those nodes unstamped. `$ref` is a
-  // string, not a subschema, so a `$defs` self-reference stays a leaf.
+  // Stamp this node, then every structural subschema, including `$defs` and the
+  // keywords our generators do not currently emit. `$ref` is a string, not a
+  // subschema, so a `$defs` self-reference stays a leaf.
   const stampNode = (node: Record<string, unknown>): JSONSchema =>
     mapSubschemas(
       mergeLlmDerivedIntoNode(node) as JSONSchemaObj,
       (child) => (isRecord(child) ? stampNode(child) : child),
-      { includeDefs: true },
+      { includeDefs: true, includeUnused: true },
     );
 
   const base: Record<string, unknown> = isRecord(schema)

--- a/packages/runner/src/schema-walk.ts
+++ b/packages/runner/src/schema-walk.ts
@@ -194,7 +194,14 @@ export function forEachSubschema(
     const record = node[keyword];
     if (isRecord(record)) {
       for (const key of Object.keys(record)) {
-        if (visit((record as Record<string, JSONSchema>)[key], keyword, key, undefined)) {
+        if (
+          visit(
+            (record as Record<string, JSONSchema>)[key],
+            keyword,
+            key,
+            undefined,
+          )
+        ) {
           return true;
         }
       }
@@ -409,7 +416,9 @@ export function walkSchema(
       if (stopped) return;
       // `$ref` target (opt-in): walked at the ref site's own path so a label on
       // the target counts. The on-path guard above covers ref cycles.
-      if (opts.resolveRef && typeof (schema as JSONSchemaObj).$ref === "string") {
+      if (
+        opts.resolveRef && typeof (schema as JSONSchemaObj).$ref === "string"
+      ) {
         const resolved = opts.resolveRef(schema as JSONSchemaObj);
         if (resolved !== undefined && resolved !== schema) {
           recurse(resolved, path, { viaRef: true }, schema as JSONSchemaObj);

--- a/packages/runner/test/schema-walk.test.ts
+++ b/packages/runner/test/schema-walk.test.ts
@@ -7,9 +7,10 @@ import {
   ARRAY_SUBSCHEMA_KEYS,
   findSchema,
   forEachSubschema,
+  mapSubschemas,
   RECORD_SUBSCHEMA_KEYS,
-  SINGLE_SUBSCHEMA_KEYS,
   type SchemaNode,
+  SINGLE_SUBSCHEMA_KEYS,
   subschemaEdges,
   type SubschemaKeyword,
   walkSchema,
@@ -148,7 +149,9 @@ describe("subschemaEdges (generator form)", () => {
     const cb = edgesOf(schema);
     expect(gen.length).toBe(cb.length);
     expect(gen.map((e) => `${e.keyword}:${e.key ?? e.index ?? ""}`).toSorted())
-      .toEqual(cb.map((e) => `${e.keyword}:${e.key ?? e.index ?? ""}`).toSorted());
+      .toEqual(
+        cb.map((e) => `${e.keyword}:${e.key ?? e.index ?? ""}`).toSorted(),
+      );
   });
 
   it("honors includeDefs / includeUnused like the callback", () => {
@@ -171,6 +174,35 @@ describe("subschemaEdges (generator form)", () => {
       break;
     }
     expect(count).toBe(1);
+  });
+});
+
+describe("mapSubschemas", () => {
+  it("maps definitions and unused keywords when both tiers are enabled", () => {
+    const patternChild: JSONSchema = { type: "string" };
+    const conditionalChild: JSONSchema = { type: "number" };
+    const definitionChild: JSONSchema = { type: "boolean" };
+    const schema = {
+      patternProperties: { ".*": patternChild },
+      if: conditionalChild,
+      $defs: { Flag: definitionChild },
+    } as const;
+    const mapped = mapSubschemas(
+      schema,
+      (child) =>
+        typeof child === "boolean" ? child : { ...child, title: "mapped" },
+      { includeDefs: true, includeUnused: true },
+    );
+
+    expect(mapped.patternProperties?.[".*"]).toEqual({
+      type: "string",
+      title: "mapped",
+    });
+    expect(mapped.if).toEqual({ type: "number", title: "mapped" });
+    expect(mapped.$defs?.Flag).toEqual({
+      type: "boolean",
+      title: "mapped",
+    });
   });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Complete LLM-derived schema stamping across generateObject result schemas. We now stamp every storage-addressable object subschema, including `$defs`, so nested writes keep provenance even when split into child documents.

- **Bug Fixes**
  - Apply stamp via `mapSubschemas(..., { includeDefs: true, includeUnused: true })` to cover properties, items, compound branches, and rarely emitted keywords.
  - Add tests for `mapSubschemas` to ensure definitions and “unused” keywords are mapped when enabled.

<sup>Written for commit 519f34b2d83e0e68c1c8f4cba3005eb3180c0808. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

