### PR TITLE
test(runner): make scheduler coverage deterministic

### DIFF
--- a/packages/runner/test/scheduler-execution.test.ts
+++ b/packages/runner/test/scheduler-execution.test.ts
@@ -1,0 +1,36 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import {
+  planEventInvalidDependencyScheduling,
+  pushBoundedHistory,
+} from "../src/scheduler/execution.ts";
+import type { Action } from "../src/scheduler/types.ts";
+
+describe("scheduler execution planning", () => {
+  it("parks debounced invalid dependencies until their scheduled run", () => {
+    const debounced: Action = () => {};
+    const runnable: Action = () => {};
+
+    const plan = planEventInvalidDependencyScheduling({
+      invalidDeps: [debounced, runnable],
+      isDebouncedComputationWaiting: (action) => action === debounced,
+      getNextDebounceRunTime: (action) =>
+        action === debounced ? 1_250 : undefined,
+      getNextEligibleRunTime: () => undefined,
+      now: 1_000,
+    });
+
+    expect(plan).toEqual({
+      runnableDeps: [runnable],
+      nextEligibleAt: 1_250,
+    });
+  });
+
+  it("discards the oldest entry when bounded history is full", () => {
+    const history = [1, 2];
+
+    pushBoundedHistory(history, 3, 2);
+
+    expect(history).toEqual([2, 3]);
+  });
+});


### PR DESCRIPTION
## Summary

- add a direct unit test for debounced invalid-dependency scheduling
- add a direct unit test for bounded scheduler-history eviction
- replace incidental pattern-integration coverage with deterministic unit coverage

## Why

The runner coverage ratchet could depend on whether a pattern integration shard happened to exercise scheduler timing branches. The same main revision produced different uncovered-line totals between its PR and post-merge runs. These focused tests exercise the relevant pure scheduler helpers directly, making ten previously incidental lines deterministic without changing runtime behavior.

## Impact

Test-only change. Runtime behavior is unchanged.

## Validation

- `deno fmt --check packages/runner/test/scheduler-execution.test.ts`
- `deno lint packages/runner/test/scheduler-execution.test.ts`
- `deno check packages/runner/test/scheduler-execution.test.ts`
- `DENO_COVERAGE_DIR=<temp> deno test packages/runner/test/scheduler-execution.test.ts`
- LCOV confirms hits on all ten targeted lines
- combined with the previously failing CI artifact, runner coverage debt is `7205`, below its `7207` gate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `packages/runner/test/scheduler-execution.test.ts` with focused unit tests for scheduler planning to make coverage deterministic and stabilize the runner coverage gate. Tests cover debounced invalid-dependency scheduling and bounded history eviction; runtime behavior is unchanged.

<sup>Written for commit a0fc8b77275e948397cdc3698f26cd2812bfb930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

