### PR TITLE
refactor(data-model,runner)!: move the `data:` URI codec into `data-model`

### DIFF
--- a/packages/data-model/deno.jsonc
+++ b/packages/data-model/deno.jsonc
@@ -36,6 +36,7 @@
     "./frozen-builtins": "./src/frozen-builtins.ts",
     "./interface": "./src/interface.ts",
     "./codec-json": "./src/codec-json/index.ts",
+    "./data-uri-codec": "./src/data-uri-codec.ts",
     "./native-type-tags": "./src/native-type-tags.ts",
     "./schema-hash": "./src/schema-hash.ts",
     "./schema-utils": "./src/schema-utils.ts",

--- a/packages/data-model/src/data-uri-codec.ts
+++ b/packages/data-model/src/data-uri-codec.ts
@@ -3,22 +3,27 @@
  * facts, the mint half ({@link dataUriFromValue}), and the read half
  * ({@link valueFromDataUri}, {@link extractDataUriPayloadText},
  * {@link valueFromDataUriPayloadText}). This is a leaf module -- its only
- * dependencies are `data-model`, `utils`, and type imports -- so any
+ * dependencies are sibling `data-model` modules and `utils` -- so any
  * module, however graph-entangled, can use the codec without importing
  * the cell/link machinery. (That leafness is load-bearing: see the
- * `data-uri.ts` module doc for the dividing line, and #4846 for the
- * module-evaluation bug that a cycle-cluster import edge can trip.)
+ * runner's `data-uri.ts` module doc for the dividing line, and #4846 for
+ * the module-evaluation bug that a cycle-cluster import edge can trip.)
  */
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { jsonFromValue } from "@commonfabric/data-model/codec-json";
 import {
   fromBase64url,
   toUnpaddedBase64url,
 } from "@commonfabric/utils/base64url";
-import { valueFromJson } from "@commonfabric/data-model/codec-json";
-import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
-import type { URI } from "@commonfabric/memory/interface";
+import { EmptyReconstructionContext } from "./codec-common/index.ts";
+import { jsonFromValue, valueFromJson } from "./codec-json/index.ts";
+import type { FabricValue } from "./fabric-value.ts";
+
+/**
+ * A URI in string form. Structurally identical to (and hence
+ * interchangeable with) the `URI` type in `memory/interface`, which this
+ * package does not depend on.
+ */
+type UriString = `${string}:${string}`;
 
 /** The media type minted for `data:` URIs. */
 export const DATA_URI_MEDIA_TYPE = "application/vnd.common-fabric.data";
@@ -44,15 +49,15 @@ export function isDataUri(id: string): boolean {
 /**
  * Assembles a `data:` URI carrying (the encoding of) `value` -- the
  * single place the URI shape is put together: scheme, media type, and the
- * base64url-of-UTF-8 `fvj1:` payload. Unlike
- * `data-uri.ts`'s `dataUriFromValueWithResolvedLinks()`, this does no link rewriting or
+ * base64url-of-UTF-8 `fvj1:` payload. Unlike the runner's
+ * `dataUriFromValueWithResolvedLinks()`, this does no link rewriting or
  * other preparation of `value`; callers hand it a ready `FabricValue`.
  */
-export function dataUriFromValue(value: FabricValue): URI {
+export function dataUriFromValue(value: FabricValue): UriString {
   const payload = toUnpaddedBase64url(
     new TextEncoder().encode(jsonFromValue(value)),
   );
-  return `data:${DATA_URI_MEDIA_TYPE},${payload}` as URI;
+  return `data:${DATA_URI_MEDIA_TYPE},${payload}` as UriString;
 }
 
 /** Shared text decoder, created once. */
@@ -150,7 +155,7 @@ export function valueFromDataUriPayloadText(text: string): FabricValue {
  *   payload is not a valid encoded `FabricValue` (which includes the empty
  *   payload and bare JSON).
  */
-export function valueFromDataUri(uri: URI | string): any {
+export function valueFromDataUri(uri: UriString | string): any {
   const { mediaType, text } = extractDataUriPayloadText(uri);
   if (!isDataUriMediaType(mediaType)) {
     throw new Error(`Invalid URI: ${uri}`);

--- a/packages/data-model/src/data-uri-codec.ts
+++ b/packages/data-model/src/data-uri-codec.ts
@@ -2,12 +2,7 @@
  * The `data:` URI codec, complete and self-contained: the media-type
  * facts, the mint half ({@link dataUriFromValue}), and the read half
  * ({@link valueFromDataUri}, {@link extractDataUriPayloadText},
- * {@link valueFromDataUriPayloadText}). This is a leaf module -- its only
- * dependencies are sibling `data-model` modules and `utils` -- so any
- * module, however graph-entangled, can use the codec without importing
- * the cell/link machinery. (That leafness is load-bearing: see the
- * runner's `data-uri.ts` module doc for the dividing line, and #4846 for
- * the module-evaluation bug that a cycle-cluster import edge can trip.)
+ * {@link valueFromDataUriPayloadText}).
  */
 
 import {
@@ -20,8 +15,7 @@ import type { FabricValue } from "./fabric-value.ts";
 
 /**
  * A URI in string form. Structurally identical to (and hence
- * interchangeable with) the `URI` type in `memory/interface`, which this
- * package does not depend on.
+ * interchangeable with) the `URI` type in `memory/interface`.
  */
 type UriString = `${string}:${string}`;
 

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -1,0 +1,237 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  fromBase64url,
+  toUnpaddedBase64url,
+} from "@commonfabric/utils/base64url";
+import { jsonFromValue } from "@/codec-json/index.ts";
+import {
+  DATA_URI_MEDIA_TYPE,
+  dataUriFromValue,
+  isDataUri,
+  isDataUriMediaType,
+  valueFromDataUri,
+  valueFromDataUriPayloadText,
+} from "@/data-uri-codec.ts";
+
+describe("data-uri-codec", () => {
+  describe("media-type predicates", () => {
+    it("accepts exactly the data-cell media type", () => {
+      expect(isDataUriMediaType(DATA_URI_MEDIA_TYPE)).toBe(true);
+      expect(isDataUriMediaType("application/json")).toBe(false);
+      expect(isDataUriMediaType(`${DATA_URI_MEDIA_TYPE};charset=utf-8`))
+        .toBe(false);
+    });
+
+    it("recognizes only this codec's `data:` URIs", () => {
+      expect(isDataUri(dataUriFromValue({ a: 1 }))).toBe(true);
+      expect(isDataUri("data:image/png;base64,aGVsbG8")).toBe(false);
+      expect(isDataUri("of:xyz")).toBe(false);
+    });
+  });
+
+  describe("dataUriFromValue", () => {
+    it("mints the data-cell media type and the standard encoding", () => {
+      const uri = dataUriFromValue({ x: 1 });
+      // Deliberately a literal (not the imported constant): changing the
+      // minted media type must be a conscious test change.
+      expect(uri.startsWith("data:application/vnd.common-fabric.data,"))
+        .toBe(true);
+      const payload = new TextDecoder().decode(
+        fromBase64url(uri.slice(uri.indexOf(",") + 1)),
+      );
+      expect(payload.startsWith("fvj1:")).toBe(true);
+    });
+
+    // The standard encoding canonicalizes key order, so the minted id is a
+    // function of content alone.
+    it("mints the same URI regardless of key insertion order", () => {
+      const inOrder = { alpha: 1, beta: [2, 3], gamma: { delta: 4 } };
+      const scrambled = { gamma: { delta: 4 }, beta: [2, 3], alpha: 1 };
+      expect(dataUriFromValue(scrambled)).toBe(dataUriFromValue(inOrder));
+    });
+
+    it("round-trips an `undefined` value", () => {
+      expect(valueFromDataUri(dataUriFromValue(undefined))).toBeUndefined();
+    });
+
+    it("round-trips non-finite numbers and negative zero", () => {
+      const parsed = valueFromDataUri(
+        dataUriFromValue({ n: NaN, z: -0, i: -Infinity }),
+      );
+      expect(Object.is(parsed.n, NaN)).toBe(true);
+      expect(Object.is(parsed.z, -0)).toBe(true);
+      expect(Object.is(parsed.i, -Infinity)).toBe(true);
+    });
+  });
+
+  describe("valueFromDataUriPayloadText", () => {
+    it("decodes encoded payload text of every top-level shape", () => {
+      expect(valueFromDataUriPayloadText(jsonFromValue({ b: 1, a: [true] })))
+        .toEqual({ b: 1, a: [true] });
+      expect(valueFromDataUriPayloadText(jsonFromValue([1, 2, 3])))
+        .toEqual([1, 2, 3]);
+      expect(valueFromDataUriPayloadText(jsonFromValue("plain"))).toBe(
+        "plain",
+      );
+      expect(valueFromDataUriPayloadText(jsonFromValue(null))).toBe(null);
+    });
+
+    it("rejects historical bare-JSON payload text", () => {
+      expect(() => valueFromDataUriPayloadText('{"value":{"x":1}}')).toThrow();
+      expect(() => valueFromDataUriPayloadText("[1,2,3]")).toThrow();
+    });
+
+    it("rejects invalid payload text", () => {
+      expect(() => valueFromDataUriPayloadText("{nope")).toThrow();
+    });
+
+    it("rejects empty payload text", () => {
+      expect(() => valueFromDataUriPayloadText("")).toThrow();
+    });
+
+    it("decodes encoded-`FabricValue` (`fvj1:`) payload text", () => {
+      const value = { value: { b: 1, a: [true, null, "x"] } };
+      expect(valueFromDataUriPayloadText(jsonFromValue(value))).toEqual(value);
+    });
+
+    it("rejects invalid payload text past the `fvj1:` tag", () => {
+      expect(() => valueFromDataUriPayloadText("fvj1:{nope")).toThrow();
+    });
+  });
+
+  describe("valueFromDataUri", () => {
+    /** `data:` cell URI (base64url payload) with the given payload text. */
+    const uriOf = (payload: string): string =>
+      `data:${DATA_URI_MEDIA_TYPE},${
+        toUnpaddedBase64url(new TextEncoder().encode(payload))
+      }`;
+
+    it("rejects a URI whose media type is not the data-cell type", () => {
+      expect(() => valueFromDataUri("data:text/plain,aGVsbG8")).toThrow(
+        /Invalid URI/,
+      );
+    });
+
+    // Exactly one media type is accepted; the historical `application/json`
+    // form is not.
+    it("rejects the `application/json` media type", () => {
+      const payload = toUnpaddedBase64url(
+        new TextEncoder().encode(jsonFromValue({ a: 1 })),
+      );
+      expect(() => valueFromDataUri(`data:application/json,${payload}`))
+        .toThrow(/Invalid URI/);
+    });
+
+    // There are no header parameters in this format; a header carrying any
+    // fails the media-type check.
+    it("rejects header parameters (charset, base64)", () => {
+      const payload = toUnpaddedBase64url(
+        new TextEncoder().encode(jsonFromValue({})),
+      );
+      expect(() =>
+        valueFromDataUri(
+          `data:${DATA_URI_MEDIA_TYPE};charset=utf-8,${payload}`,
+        )
+      ).toThrow(/Invalid URI/);
+      expect(() =>
+        valueFromDataUri(
+          `data:${DATA_URI_MEDIA_TYPE};base64,${payload}`,
+        )
+      ).toThrow(/Invalid URI/);
+    });
+
+    it("rejects a URI with no comma", () => {
+      expect(() => valueFromDataUri(`data:${DATA_URI_MEDIA_TYPE}`))
+        .toThrow(
+          /Invalid data URI format/,
+        );
+    });
+
+    it("rejects a percent-encoded payload", () => {
+      const payload = encodeURIComponent(jsonFromValue({ a: 1 }));
+      expect(() =>
+        valueFromDataUri(
+          `data:${DATA_URI_MEDIA_TYPE},${payload}`,
+        )
+      ).toThrow(/not base64url/);
+    });
+
+    // Both `data:` URI payload readers (this one and attestation `load()`)
+    // reject an empty payload uniformly; see `valueFromDataUriPayloadText()`.
+    it("rejects an empty payload", () => {
+      expect(() => valueFromDataUri(`data:${DATA_URI_MEDIA_TYPE},`))
+        .toThrow();
+    });
+
+    describe("historical bare-JSON payloads", () => {
+      it("rejects one", () => {
+        expect(() => valueFromDataUri(uriOf('{"value":{"b":1}}')))
+          .toThrow();
+      });
+    });
+
+    describe("encoded-`FabricValue` (`fvj1:`) payloads", () => {
+      it("decodes a payload", () => {
+        const value = { value: { b: 1, a: [true, null, "x"] } };
+        expect(valueFromDataUri(uriOf(jsonFromValue(value)))).toEqual(
+          value,
+        );
+      });
+
+      it("decodes non-ASCII text", () => {
+        const value = { value: "città" };
+        expect(valueFromDataUri(uriOf(jsonFromValue(value))))
+          .toEqual(value);
+      });
+
+      it("decodes a non-object payload", () => {
+        expect(valueFromDataUri(uriOf(jsonFromValue([1, 2, 3]))))
+          .toEqual([1, 2, 3]);
+        expect(valueFromDataUri(uriOf(jsonFromValue("plain"))))
+          .toBe("plain");
+      });
+
+      it("preserves non-finite numbers and negative zero", () => {
+        const uri = uriOf(jsonFromValue({ value: [NaN, -0, Infinity] }));
+        const result = valueFromDataUri(uri);
+        expect(Object.is(result.value[0], NaN)).toBe(true);
+        expect(Object.is(result.value[1], -0)).toBe(true);
+        expect(Object.is(result.value[2], Infinity)).toBe(true);
+      });
+
+      // Sigil links are plain objects with a `/`-prefixed key, which the codec
+      // escapes on encode (spec section 5.6); they must come back as the same
+      // plain objects, since link recognition downstream depends on that shape.
+      it("round-trips a plain object with a `/`-prefixed key", () => {
+        const value = {
+          value: { "/": { "link@1": { id: "of:xyz", path: ["a"] } } },
+        };
+        expect(valueFromDataUri(uriOf(jsonFromValue(value)))).toEqual(
+          value,
+        );
+      });
+
+      it("returns deep-frozen results", () => {
+        const uri = uriOf(jsonFromValue({ value: { nested: { deep: [1] } } }));
+        const result = valueFromDataUri(uri);
+        expect(Object.isFrozen(result)).toBe(true);
+        expect(Object.isFrozen(result.value)).toBe(true);
+        expect(Object.isFrozen(result.value.nested.deep)).toBe(true);
+      });
+
+      it("stops the payload at a raw query or fragment delimiter", () => {
+        // base64url never contains `?` or `#`; raw ones delimit a
+        // query/fragment per the URL grammar.
+        const uri = uriOf(jsonFromValue({ a: 1 }));
+        expect(valueFromDataUri(`${uri}#frag`)).toEqual({ a: 1 });
+        expect(valueFromDataUri(`${uri}?q=1`)).toEqual({ a: 1 });
+      });
+
+      it("rejects a malformed payload past the tag", () => {
+        expect(() => valueFromDataUri(uriOf("fvj1:{nope"))).toThrow();
+      });
+    });
+  });
+});

--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -3,7 +3,10 @@ import type { CellScope, JSONSchema } from "../builder/types.ts";
 import { type NormalizedFullLink, parseLink } from "../link-utils.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { findAndInlineDataUriLinks } from "../data-uri.ts";
-import { isDataUri, valueFromDataUri } from "../data-uri-codec.ts";
+import {
+  isDataUri,
+  valueFromDataUri,
+} from "@commonfabric/data-model/data-uri-codec";
 import { ContextualFlowControl } from "../cfc.ts";
 import type { CfcAddress } from "./types.ts";
 import { isNormalizedFullLink } from "../link-types.ts";

--- a/packages/runner/src/data-uri.ts
+++ b/packages/runner/src/data-uri.ts
@@ -1,9 +1,9 @@
 /**
  * Cell-side integration of the `data:` cell URI codec. The dividing line
- * between this module and `data-uri-codec.ts` is the need for the
- * cell/link machinery: everything that can be expressed against
- * `data-model` alone lives in the codec (a leaf module); this module holds
- * the two operations that cannot -- {@link dataUriFromValueWithResolvedLinks},
+ * between this module and `data-model`'s `data-uri-codec.ts` is the need
+ * for the cell/link machinery: everything that can be expressed against
+ * `data-model` alone lives in the codec (in that package); this module
+ * holds the two operations that cannot -- {@link dataUriFromValueWithResolvedLinks},
  * which rewrites relative links against a base before encoding, and
  * {@link findAndInlineDataUriLinks}, which dissolves `data:` URI links
  * back into the values they carry.
@@ -39,7 +39,10 @@ import {
 } from "./link-utils.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import type { URI } from "./sigil-types.ts";
-import { dataUriFromValue, valueFromDataUri } from "./data-uri-codec.ts";
+import {
+  dataUriFromValue,
+  valueFromDataUri,
+} from "@commonfabric/data-model/data-uri-codec";
 
 /**
  * Makes a `data:` URI that names a cell whose content is carried in the id

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -5,7 +5,7 @@ import {
 } from "@commonfabric/static";
 import { RuntimeTelemetry } from "@commonfabric/runner";
 import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
-import { dataUriFromValue } from "./data-uri-codec.ts";
+import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
 import type { NonIdempotentReport } from "./telemetry.ts";
 import type {
   AnyCell,

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -28,7 +28,7 @@ import {
   isDataUri,
   isDataUriMediaType,
   valueFromDataUriPayloadText,
-} from "../../data-uri-codec.ts";
+} from "@commonfabric/data-model/data-uri-codec";
 
 const logger = getLogger("attestation", {
   enabled: false,

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -55,7 +55,7 @@ import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
-import { valueFromDataUri } from "../data-uri-codec.ts";
+import { valueFromDataUri } from "@commonfabric/data-model/data-uri-codec";
 import {
   isPrimitiveCellLink,
   type NormalizedLink,

--- a/packages/runner/test/attestation-data-uri.test.ts
+++ b/packages/runner/test/attestation-data-uri.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { jsonFromValue } from "@commonfabric/data-model/codec-json";
 import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
-import { DATA_URI_MEDIA_TYPE } from "../src/data-uri-codec.ts";
+import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
 import { load } from "../src/storage/transaction/attestation.ts";
 import type { URI } from "../src/sigil-types.ts";
 

--- a/packages/runner/test/cell-arrays.test.ts
+++ b/packages/runner/test/cell-arrays.test.ts
@@ -1,7 +1,7 @@
 // Cell array tests: element conversion plus optimized plain-schema traversal.
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
-import { DATA_URI_MEDIA_TYPE } from "../src/data-uri-codec.ts";
+import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
 import { expect } from "@std/expect";
 import "@commonfabric/utils/equal-ignoring-symbols";
 

--- a/packages/runner/test/cell-callbacks.test.ts
+++ b/packages/runner/test/cell-callbacks.test.ts
@@ -2,7 +2,7 @@
 // after cell writes reach a final commit result.
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
-import { DATA_URI_MEDIA_TYPE } from "../src/data-uri-codec.ts";
+import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
 import { expect } from "@std/expect";
 import "@commonfabric/utils/equal-ignoring-symbols";
 

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
-import { dataUriFromValue } from "../src/data-uri-codec.ts";
+import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";

--- a/packages/runner/test/data-uri.test.ts
+++ b/packages/runner/test/data-uri.test.ts
@@ -19,7 +19,7 @@ import {
   DATA_URI_MEDIA_TYPE,
   valueFromDataUri,
   valueFromDataUriPayloadText,
-} from "../src/data-uri-codec.ts";
+} from "@commonfabric/data-model/data-uri-codec";
 import { isSigilLink, type NormalizedLink } from "../src/link-utils.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";

--- a/packages/runner/test/data-uri.test.ts
+++ b/packages/runner/test/data-uri.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { jsonFromValue } from "@commonfabric/data-model/codec-json";
-import {
-  fromBase64url,
-  toUnpaddedBase64url,
-} from "@commonfabric/utils/base64url";
+import { fromBase64url } from "@commonfabric/utils/base64url";
 import {
   linkRefFrom,
   linkRefPayload,
@@ -15,11 +11,7 @@ import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 import { UnknownValue } from "@commonfabric/data-model/fabric-instances";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
-import {
-  DATA_URI_MEDIA_TYPE,
-  valueFromDataUri,
-  valueFromDataUriPayloadText,
-} from "@commonfabric/data-model/data-uri-codec";
+import { valueFromDataUri } from "@commonfabric/data-model/data-uri-codec";
 import { isSigilLink, type NormalizedLink } from "../src/link-utils.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
@@ -333,175 +325,6 @@ describe("data-uri", () => {
       } finally {
         resetModernCellRepConfig();
       }
-    });
-  });
-
-  describe("valueFromDataUriPayloadText", () => {
-    it("decodes encoded payload text of every top-level shape", () => {
-      expect(valueFromDataUriPayloadText(jsonFromValue({ b: 1, a: [true] })))
-        .toEqual({ b: 1, a: [true] });
-      expect(valueFromDataUriPayloadText(jsonFromValue([1, 2, 3])))
-        .toEqual([1, 2, 3]);
-      expect(valueFromDataUriPayloadText(jsonFromValue("plain"))).toBe(
-        "plain",
-      );
-      expect(valueFromDataUriPayloadText(jsonFromValue(null))).toBe(null);
-    });
-
-    it("rejects historical bare-JSON payload text", () => {
-      expect(() => valueFromDataUriPayloadText('{"value":{"x":1}}')).toThrow();
-      expect(() => valueFromDataUriPayloadText("[1,2,3]")).toThrow();
-    });
-
-    it("rejects invalid payload text", () => {
-      expect(() => valueFromDataUriPayloadText("{nope")).toThrow();
-    });
-
-    it("rejects empty payload text", () => {
-      expect(() => valueFromDataUriPayloadText("")).toThrow();
-    });
-
-    it("decodes encoded-`FabricValue` (`fvj1:`) payload text", () => {
-      const value = { value: { b: 1, a: [true, null, "x"] } };
-      expect(valueFromDataUriPayloadText(jsonFromValue(value))).toEqual(value);
-    });
-
-    it("rejects invalid payload text past the `fvj1:` tag", () => {
-      expect(() => valueFromDataUriPayloadText("fvj1:{nope")).toThrow();
-    });
-  });
-
-  describe("valueFromDataUri", () => {
-    /** `data:` cell URI (base64url payload) with the given payload text. */
-    const uriOf = (payload: string): string =>
-      `data:${DATA_URI_MEDIA_TYPE},${
-        toUnpaddedBase64url(new TextEncoder().encode(payload))
-      }`;
-
-    it("rejects a URI whose media type is not the data-cell type", () => {
-      expect(() => valueFromDataUri("data:text/plain,aGVsbG8")).toThrow(
-        /Invalid URI/,
-      );
-    });
-
-    // Exactly one media type is accepted; the historical `application/json`
-    // form is not.
-    it("rejects the `application/json` media type", () => {
-      const payload = toUnpaddedBase64url(
-        new TextEncoder().encode(jsonFromValue({ a: 1 })),
-      );
-      expect(() => valueFromDataUri(`data:application/json,${payload}`))
-        .toThrow(/Invalid URI/);
-    });
-
-    // There are no header parameters in this format; a header carrying any
-    // fails the media-type check.
-    it("rejects header parameters (charset, base64)", () => {
-      const payload = toUnpaddedBase64url(
-        new TextEncoder().encode(jsonFromValue({})),
-      );
-      expect(() =>
-        valueFromDataUri(
-          `data:${DATA_URI_MEDIA_TYPE};charset=utf-8,${payload}`,
-        )
-      ).toThrow(/Invalid URI/);
-      expect(() =>
-        valueFromDataUri(
-          `data:${DATA_URI_MEDIA_TYPE};base64,${payload}`,
-        )
-      ).toThrow(/Invalid URI/);
-    });
-
-    it("rejects a URI with no comma", () => {
-      expect(() => valueFromDataUri(`data:${DATA_URI_MEDIA_TYPE}`))
-        .toThrow(
-          /Invalid data URI format/,
-        );
-    });
-
-    it("rejects a percent-encoded payload", () => {
-      const payload = encodeURIComponent(jsonFromValue({ a: 1 }));
-      expect(() =>
-        valueFromDataUri(
-          `data:${DATA_URI_MEDIA_TYPE},${payload}`,
-        )
-      ).toThrow(/not base64url/);
-    });
-
-    // Both `data:` URI payload readers (this one and attestation `load()`)
-    // reject an empty payload uniformly; see `valueFromDataUriPayloadText()`.
-    it("rejects an empty payload", () => {
-      expect(() => valueFromDataUri(`data:${DATA_URI_MEDIA_TYPE},`))
-        .toThrow();
-    });
-
-    describe("historical bare-JSON payloads", () => {
-      it("rejects one", () => {
-        expect(() => valueFromDataUri(uriOf('{"value":{"b":1}}')))
-          .toThrow();
-      });
-    });
-
-    describe("encoded-`FabricValue` (`fvj1:`) payloads", () => {
-      it("decodes a payload", () => {
-        const value = { value: { b: 1, a: [true, null, "x"] } };
-        expect(valueFromDataUri(uriOf(jsonFromValue(value)))).toEqual(
-          value,
-        );
-      });
-
-      it("decodes non-ASCII text", () => {
-        const value = { value: "città" };
-        expect(valueFromDataUri(uriOf(jsonFromValue(value))))
-          .toEqual(value);
-      });
-
-      it("decodes a non-object payload", () => {
-        expect(valueFromDataUri(uriOf(jsonFromValue([1, 2, 3]))))
-          .toEqual([1, 2, 3]);
-        expect(valueFromDataUri(uriOf(jsonFromValue("plain"))))
-          .toBe("plain");
-      });
-
-      it("preserves non-finite numbers and negative zero", () => {
-        const uri = uriOf(jsonFromValue({ value: [NaN, -0, Infinity] }));
-        const result = valueFromDataUri(uri);
-        expect(Object.is(result.value[0], NaN)).toBe(true);
-        expect(Object.is(result.value[1], -0)).toBe(true);
-        expect(Object.is(result.value[2], Infinity)).toBe(true);
-      });
-
-      // Sigil links are plain objects with a `/`-prefixed key, which the codec
-      // escapes on encode (spec section 5.6); they must come back as the same
-      // plain objects, since link recognition downstream depends on that shape.
-      it("round-trips a plain object with a `/`-prefixed key", () => {
-        const value = {
-          value: { "/": { "link@1": { id: "of:xyz", path: ["a"] } } },
-        };
-        expect(valueFromDataUri(uriOf(jsonFromValue(value)))).toEqual(
-          value,
-        );
-      });
-
-      it("returns deep-frozen results", () => {
-        const uri = uriOf(jsonFromValue({ value: { nested: { deep: [1] } } }));
-        const result = valueFromDataUri(uri);
-        expect(Object.isFrozen(result)).toBe(true);
-        expect(Object.isFrozen(result.value)).toBe(true);
-        expect(Object.isFrozen(result.value.nested.deep)).toBe(true);
-      });
-
-      it("stops the payload at a raw query or fragment delimiter", () => {
-        // base64url never contains `?` or `#`; raw ones delimit a
-        // query/fragment per the URL grammar.
-        const uri = uriOf(jsonFromValue({ a: 1 }));
-        expect(valueFromDataUri(`${uri}#frag`)).toEqual({ a: 1 });
-        expect(valueFromDataUri(`${uri}?q=1`)).toEqual({ a: 1 });
-      });
-
-      it("rejects a malformed payload past the tag", () => {
-        expect(() => valueFromDataUri(uriOf("fvj1:{nope"))).toThrow();
-      });
     });
   });
 });

--- a/packages/runner/test/memory-v2-read-compaction.test.ts
+++ b/packages/runner/test/memory-v2-read-compaction.test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals } from "@std/assert";
-import { dataUriFromValue } from "../src/data-uri-codec.ts";
+import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/traverse-replay.test.ts
+++ b/packages/runner/test/traverse-replay.test.ts
@@ -9,7 +9,7 @@
  * PR.
  */
 import { assert } from "@std/assert";
-import { DATA_URI_MEDIA_TYPE } from "../src/data-uri-codec.ts";
+import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {


### PR DESCRIPTION
## What

Moves `data-uri-codec.ts` from the runner into `data-model`, exported as
`@commonfabric/data-model/data-uri-codec`. Follow-on to #4857, which
carved the codec out as a leaf module precisely because it needs nothing
from the runner; this PR moves it to the package that reality already
placed it in.

- The module's imports become package-internal (`./codec-json/`,
  `./codec-common/`, `./fabric-value.ts`); the `utils/base64url` import
  stays. `data-model` already depends on `utils`.
- The pure-codec unit tests (`valueFromDataUriPayloadText`,
  `valueFromDataUri` describes) move to
  `packages/data-model/test/data-uri-codec.test.ts`, joined by direct
  tests for the mint half and the two predicates. The runner keeps the
  cell-side `dataUriFromValueWithResolvedLinks` suite, which exercises
  the codec through the wrapper.
- Runner call sites (5 src, 7 test files) repoint their imports; no
  behavior change anywhere.

## The `URI` type

The codec previously typed its URI values with `memory/interface`'s
`URI`, an unbranded backtick-template `${string}:${string}`. `data-model`
must not depend on `memory`, so the codec defines a local `UriString`
with the same definition, used only in that file. TS aliases are
transparent: `UriString` and `URI` are the same type to the checker, so
every runner call site keeps its `URI` typing untouched.

## Testing

- `deno check` clean on `data-model` and `runner`.
- `data-model` and affected `runner` suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkQwRxCmaYNC7tQ3E949is

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the `data:` URI codec from the runner to `@commonfabric/data-model`, exported as `@commonfabric/data-model/data-uri-codec`. No behavior changes; imports and tests updated, and codec docs simplified.

- **Refactors**
  - Relocated `data-uri-codec.ts` to `data-model` and added export in `deno.jsonc`.
  - Switched codec imports to package-internal modules; kept `@commonfabric/utils/base64url`.
  - Replaced `memory/interface`’s `URI` with a local `UriString` in the codec (same template type).
  - Simplified codec module comments; removed leaf-module rationale.
  - Moved pure codec tests to `packages/data-model`; kept cell-side integration tests in the runner.
  - Updated runner sources and tests to import from `@commonfabric/data-model/data-uri-codec`.

- **Migration**
  - Update imports to `@commonfabric/data-model/data-uri-codec`.
  - Existing `URI` annotations remain valid; the codec’s `UriString` is structurally identical.

<sup>Written for commit 7b76cbc58b67d175aa869af3cfb58b5208d42ea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
## Coverage override

```
NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7206 lines
```

Justification: the +7 is unrelated to this diff. Per-file LCOV diff
against the latest main run pins it to `scheduler/facade.ts:1247` (the
wall-clock-gated scheduler-telemetry family, a known nondeterministic
flapper) and `traverse.ts:2207-2213` (the warn-and-continue branch for
malformed `internal` manifest entries — code this PR does not touch,
exercised only nondeterministically). This PR is a pure module move plus
import repoints; `packages/data-model` absorbed the codec at +0 debt.

