### PR TITLE
fix(check-no-waitfor): stop flagging type-only imports of waitFor

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -292,7 +292,7 @@ The shape is always: settle the view, click once, then wait for the effect —
 never poll-and-pray, and never re-click.
 
 A CI check enforces this for the polling `waitFor`: `deno task check-no-waitfor`
-fails when an integration test imports `waitFor` from
+fails when an integration test imports `waitFor` as a value from
 `@commonfabric/integration`, whether through the bare specifier or a relative
 path to the package. See [`waiting-in-tests.md`](./waiting-in-tests.md) for the
 rationale, the full event-driven toolkit, and the allowlist of intentional

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -244,12 +244,15 @@ their teeth come from the wait being long enough to have seen an unwanted op.
 A check prevents new integration tests from importing the polling `waitFor`.
 `tasks/check-no-waitfor.ts` scans the `.ts` files under any `integration/`
 directory beneath `packages/` (excluding the `@commonfabric/integration` package,
-which defines `waitFor`) and fails when one names `waitFor` in an import of that
-package and is not on the check's allowlist. Two spellings reach it and both
-count: the bare `@commonfabric/integration` specifier, and a relative path ending
-at the package's `utils.ts` or `index.ts`. Commenting the import out clears the
-check, so it stays out of the way while a test is being migrated — text inside a
-comment or a string is not an import. Run it with `deno task check-no-waitfor`;
+which defines `waitFor`) and fails when one takes `waitFor` as a value from an
+import of that package and is not on the check's allowlist. Two spellings reach
+it and both count: the bare `@commonfabric/integration` specifier, and a relative
+path ending at the package's `utils.ts` or `index.ts`. Commenting the import out
+clears the check, so it stays out of the way while a test is being migrated —
+text inside a comment or a string is not an import. A type-only import, whether
+`import type { waitFor }` or an inline `{ type waitFor }`, is erased before the
+test runs and polls nothing, so it does not count either. Run it with
+`deno task check-no-waitfor`;
 the CI "Check" job runs it on every pull request. The error names the offending
 file and points at `waitForCondition`, `awaitViewSettled`, the in-process
 `defer()` replacement, and this report.

--- a/tasks/check-no-waitfor.test.ts
+++ b/tasks/check-no-waitfor.test.ts
@@ -69,6 +69,65 @@ Deno.test("importsPollingWaitFor detects an aliased import", () => {
   );
 });
 
+// A type-only import binds the type of `waitFor` and is erased before the test
+// runs, so it cannot poll. The value forms below it still have to be caught.
+
+Deno.test("importsPollingWaitFor ignores a type-only import statement", () => {
+  assertEquals(
+    importsPollingWaitFor(
+      'import type { waitFor } from "@commonfabric/integration";',
+    ),
+    false,
+  );
+});
+
+Deno.test("importsPollingWaitFor ignores a type-only import by relative path", () => {
+  assertEquals(
+    importsPollingWaitFor(
+      'import type { waitFor } from "../../integration/utils.ts";',
+    ),
+    false,
+  );
+});
+
+Deno.test("importsPollingWaitFor ignores an inline type member", () => {
+  assertEquals(
+    importsPollingWaitFor(
+      'import { type waitFor } from "@commonfabric/integration";',
+    ),
+    false,
+  );
+});
+
+Deno.test("importsPollingWaitFor ignores an aliased inline type member", () => {
+  // The erased member binds the local name `waitFor`, so dropping only the
+  // `type` keyword would leave the name behind and flag this.
+  assertEquals(
+    importsPollingWaitFor(
+      'import { type Poll as waitFor } from "@commonfabric/integration";',
+    ),
+    false,
+  );
+});
+
+Deno.test("importsPollingWaitFor detects a value waitFor beside a type member", () => {
+  assert(
+    importsPollingWaitFor(
+      'import { type Page, waitFor } from "@commonfabric/integration";',
+    ),
+  );
+});
+
+Deno.test("importsPollingWaitFor detects a value waitFor after a type member on its own line", () => {
+  const source = [
+    "import {",
+    "  type Page,",
+    "  waitFor,",
+    '} from "@commonfabric/integration";',
+  ].join("\n");
+  assert(importsPollingWaitFor(source));
+});
+
 Deno.test("importsPollingWaitFor ignores waitFor-prefixed helpers", () => {
   assertEquals(
     importsPollingWaitFor(

--- a/tasks/check-no-waitfor.ts
+++ b/tasks/check-no-waitfor.ts
@@ -13,10 +13,11 @@
 // A file is in scope when it lives under an `integration/` directory somewhere
 // beneath `packages/`, excluding the `@commonfabric/integration` package itself,
 // which defines and re-exports `waitFor`. An in-scope file fails the check when
-// it names `waitFor` in an import of that package — either through the bare
-// specifier or through a relative path to the package's `utils.ts` or `index.ts`
-// — and is not on the ALLOWLIST below. Text inside a comment or a string is not
-// an import, so commenting the import out clears the check.
+// it takes `waitFor` as a value from an import of that package — either through
+// the bare specifier or through a relative path to the package's `utils.ts` or
+// `index.ts` — and is not on the ALLOWLIST below. Text inside a comment or a
+// string is not an import, so commenting the import out clears the check, and a
+// type-only import is erased before the test runs, so it polls nothing.
 //
 // The ALLOWLIST holds the files that are exempt from this check; the reason for
 // each is recorded in the "Where the polling `waitFor` stays" section of
@@ -55,9 +56,12 @@ export const ALLOWLIST: ReadonlySet<string> = new Set([
 ]);
 
 // Matches an import of the `@commonfabric/integration` package and captures the
-// named-imports clause between the braces. A leading default import and a
-// `type` modifier are tolerated, and `[^}]*` keeps the capture from bleeding
-// past the end of the clause.
+// named-imports clause between the braces. A leading default import is
+// tolerated, and `[^}]*` keeps the capture from bleeding past the end of the
+// clause.
+//
+// `import type { ... }` does not match. A type-only import binds the type of
+// `waitFor` and is erased before the test runs, so it polls nothing.
 //
 // Two spellings reach the package. The bare specifier names it directly; the
 // closing quote right after `integration` excludes its subpath exports
@@ -71,7 +75,7 @@ export const ALLOWLIST: ReadonlySet<string> = new Set([
 // "@commonfabric/integration"` with a later `I.waitFor(...)` passes the check.
 // Every import of this package in the repository uses the named form.
 const PACKAGE_IMPORT =
-  /import\s+(?:[\w$]+\s*,\s*)?(?:type\s+)?\{(?<clause>[^}]*)\}\s*from\s*["'](?:@commonfabric\/integration|\.[^"']*\/integration\/(?:utils|index)\.ts)["']/;
+  /import\s+(?:[\w$]+\s*,\s*)?\{(?<clause>[^}]*)\}\s*from\s*["'](?:@commonfabric\/integration|\.[^"']*\/integration\/(?:utils|index)\.ts)["']/;
 
 // The comment and literal forms that can hold import-shaped text. A `'` or `"`
 // opens a string only when its closing quote lands on the same line; a template
@@ -111,17 +115,29 @@ function stripComments(clause: string): string {
 }
 
 /**
- * Returns true when `source` imports the polling `waitFor` as a named import of
- * the `@commonfabric/integration` package. `waitForCondition`, `waitForText`,
- * and other `waitFor`-prefixed names do not count; neither does a `waitFor` on a
- * subpath specifier, a `harness.waitFor(...)` member call, or an import that is
- * commented out or quoted inside a string.
+ * Returns the members of a named-imports clause that a `type` modifier does not
+ * erase. A member is dropped whole rather than having its `type` deleted in
+ * place, so the local name an erased member binds — the `waitFor` in
+ * `{ type Poll as waitFor }` — goes with it.
+ */
+function valueMembers(clause: string): string[] {
+  return clause.split(",").filter((member) => !/^\s*type\s/.test(member));
+}
+
+/**
+ * Returns true when `source` imports the polling `waitFor` as a named value
+ * import of the `@commonfabric/integration` package. `waitForCondition`,
+ * `waitForText`, and other `waitFor`-prefixed names do not count; neither does a
+ * `waitFor` on a subpath specifier, a `harness.waitFor(...)` member call, a
+ * type-only import, or an import that is commented out or quoted inside a
+ * string.
  */
 export function importsPollingWaitFor(source: string): boolean {
   for (const match of source.matchAll(TOKEN_RE)) {
     const clause = match.groups?.clause;
     if (clause === undefined) continue;
-    if (/\bwaitFor\b/.test(stripComments(clause))) return true;
+    const members = valueMembers(stripComments(clause));
+    if (members.some((member) => /\bwaitFor\b/.test(member))) return true;
   }
   return false;
 }


### PR DESCRIPTION
The guard treats any named import of `waitFor` from `@commonfabric/integration` as a polling import. A type-only import is not one. `import type { waitFor }` binds the type of the function, and an inline `import { type waitFor }` binds the same thing for a single member. Both are erased before the test runs, so neither can poll. Flagging them fails the check for code that does nothing wrong, and a type-only import is idiomatic here because Deno compiles each module in isolation.

The statement form matched because the regex carried an optional `(?:type\s+)?` ahead of the braces, which let `import type {` through to the same clause test a value import gets. Drop it, and a type-only import statement stops matching at all, on the bare specifier and on the relative paths alike.

The member form needs the clause itself filtered. Split it on commas and drop the members a `type` modifier erases. A member is dropped whole rather than having its `type` keyword deleted where it stands, because the member carries the local name with it: `{ type Poll as waitFor }` binds `waitFor` to an erased type, and deleting only the keyword would leave the name behind and flag it. `{ type as waitFor }` is the inverse and is correctly dropped: it takes the export named `type`, not the polling helper.

No file in the repository type-imports `waitFor`, so this closes a latent false positive rather than one that is biting today. The check decides every file it scans exactly as before, and the allowlist is untouched.

Bring the one-line summaries in `waiting-in-tests.md` and `UI_TESTING.md` into step: the check fails when a test takes `waitFor` as a value, which a type-only import does not.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the check so it no longer flags type-only imports of `waitFor` from `@commonfabric/integration`. The check now only fails when `waitFor` is imported as a value.

- **Bug Fixes**
  - Stop matching `import type { ... }` by removing the optional `type` from the package import regex (bare and relative paths).
  - Filter named-import members to drop inline `type` entries, so `{ type waitFor }` and `{ type Poll as waitFor }` don’t count.
  - Behavior for value imports is unchanged; allowlist is unchanged. Docs clarified and tests added.

<sup>Written for commit 368b633f09787683415567afe86c83a6e0fa1783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

