### PR TITLE
fix(patterns): distinguish lunch poll voter displays

### DIFF
--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -12,8 +12,18 @@
  */
 
 import { action, computed, pattern, UI, wish } from "commonfabric";
-import { findNode, propsOf, readValue } from "../test/vnode-helpers.ts";
-import CozyPoll, { dayKeyOf, type Option, type Vote } from "./main.tsx";
+import {
+  findNode,
+  hasExactText,
+  propsOf,
+  readValue,
+} from "../test/vnode-helpers.ts";
+import CozyPoll, {
+  dayKeyOf,
+  type Option,
+  type User,
+  type Vote,
+} from "./main.tsx";
 
 const findNodeByProp = (
   root: unknown,
@@ -30,6 +40,111 @@ const SEEDED_OPTION: Option = {
   title: "Leftover Café",
   addedByName: "Stan",
 };
+
+const COLLIDING_INITIAL_OPTION: Option = {
+  id: "opt-colliding-initials",
+  title: "Initials Café",
+  addedByName: "Daffodil",
+};
+
+const COLLIDING_INITIAL_USERS: User[] = [
+  {
+    name: "Daffodil",
+    avatar: "",
+    color: "#2f6f4e",
+    joinedAt: 1,
+  },
+  {
+    name: "Dragonfly",
+    avatar: "",
+    color: "#c2573a",
+    joinedAt: 2,
+  },
+  {
+    name: "Dan",
+    avatar: "",
+    color: "#3b4a6b",
+    joinedAt: 3,
+  },
+  {
+    name: "Dana",
+    avatar: "",
+    color: "#a33b35",
+    joinedAt: 4,
+  },
+  {
+    name: "dan",
+    avatar: "",
+    color: "#b27722",
+    joinedAt: 5,
+  },
+  {
+    name: "A",
+    avatar: "",
+    color: "#7c3aed",
+    joinedAt: 6,
+  },
+  {
+    name: "a",
+    avatar: "",
+    color: "#2f6f4e",
+    joinedAt: 7,
+  },
+  {
+    name: "A1",
+    avatar: "",
+    color: "#c2573a",
+    joinedAt: 8,
+  },
+  {
+    name: "Bob Smith",
+    avatar: "",
+    color: "#3b4a6b",
+    joinedAt: 9,
+  },
+  {
+    name: "Bob  Smith",
+    avatar: "",
+    color: "#a33b35",
+    joinedAt: 10,
+  },
+  {
+    name: "👩🏽‍💻Alice",
+    avatar: "",
+    color: "#7c3aed",
+    joinedAt: 11,
+  },
+  {
+    name: "👩🏽‍💻Bob",
+    avatar: "",
+    color: "#2f6f4e",
+    joinedAt: 12,
+  },
+  {
+    name: "🇺🇸Alice",
+    avatar: "",
+    color: "#c2573a",
+    joinedAt: 13,
+  },
+  {
+    name: "🇺🇸Bob",
+    avatar: "",
+    color: "#3b4a6b",
+    joinedAt: 14,
+  },
+  {
+    name: "e\u0301Alice",
+    avatar: "",
+    color: "#a33b35",
+    joinedAt: 15,
+  },
+  {
+    name: "e\u0301Bob",
+    avatar: "",
+    color: "#b27722",
+    joinedAt: 16,
+  },
+];
 
 export default pattern(() => {
   const poll = CozyPoll({});
@@ -63,6 +178,112 @@ export default pattern(() => {
   const stalePoll = CozyPoll({
     options: [SEEDED_OPTION],
     votes: [STALE_VOTE],
+  });
+
+  // Participant names with shared prefixes use distinct current-day vote labels.
+  // Each label preserves complete displayed characters.
+  const collidingCastAt = computed(() => nowCell.result ?? undefined);
+  const initialsPoll = CozyPoll({
+    options: [COLLIDING_INITIAL_OPTION],
+    users: COLLIDING_INITIAL_USERS,
+    votes: [
+      {
+        voterName: "Daffodil",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "green",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "Dragonfly",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "yellow",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "Dan",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "red",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "Dana",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "green",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "dan",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "yellow",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "A",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "red",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "a",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "green",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "A1",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "yellow",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "Bob Smith",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "red",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "Bob  Smith",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "green",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "👩🏽‍💻Alice",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "yellow",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "👩🏽‍💻Bob",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "red",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "🇺🇸Alice",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "green",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "🇺🇸Bob",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "yellow",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "e\u0301Alice",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "red",
+        castAt: collidingCastAt,
+      },
+      {
+        voterName: "e\u0301Bob",
+        optionId: COLLIDING_INITIAL_OPTION.id,
+        voteType: "green",
+        castAt: collidingCastAt,
+      },
+    ],
   });
 
   // === Actions ===
@@ -311,6 +532,104 @@ export default pattern(() => {
     poll.todayDate === todayKey
   );
 
+  const assert_colliding_initials_are_disambiguated = computed(() => {
+    const ui = initialsPoll[UI];
+    const daffodil = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "Daffodil",
+    );
+    const dragonfly = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "Dragonfly",
+    );
+    const dan = findNodeByProp(ui, "data-vote-swatch-name", "Dan");
+    const dana = findNodeByProp(ui, "data-vote-swatch-name", "Dana");
+    const lowerDan = findNodeByProp(ui, "data-vote-swatch-name", "dan");
+    const upperA = findNodeByProp(ui, "data-vote-swatch-name", "A");
+    const lowerA = findNodeByProp(ui, "data-vote-swatch-name", "a");
+    const aOne = findNodeByProp(ui, "data-vote-swatch-name", "A1");
+    const bobSmith = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "Bob Smith",
+    );
+    const bobDoubleSpace = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "Bob  Smith",
+    );
+    const emojiAlice = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "👩🏽‍💻Alice",
+    );
+    const emojiBob = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "👩🏽‍💻Bob",
+    );
+    const flagAlice = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "🇺🇸Alice",
+    );
+    const flagBob = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "🇺🇸Bob",
+    );
+    const accentAlice = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "e\u0301Alice",
+    );
+    const accentBob = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "e\u0301Bob",
+    );
+    return todayKey !== "" &&
+      initialsPoll.todayDate === todayKey &&
+      hasExactText(daffodil, "DF") &&
+      hasExactText(dragonfly, "DR") &&
+      hasExactText(dan, "DAN1") &&
+      hasExactText(dana, "DANA") &&
+      hasExactText(lowerDan, "DAN2") &&
+      hasExactText(upperA, "A2") &&
+      hasExactText(lowerA, "A3") &&
+      hasExactText(aOne, "A1") &&
+      hasExactText(bobSmith, "BOBSMITH1") &&
+      hasExactText(bobDoubleSpace, "BOBSMITH2") &&
+      hasExactText(emojiAlice, "👩🏽‍💻A") &&
+      hasExactText(emojiBob, "👩🏽‍💻B") &&
+      hasExactText(flagAlice, "🇺🇸A") &&
+      hasExactText(flagBob, "🇺🇸B") &&
+      hasExactText(accentAlice, "E\u0301A") &&
+      hasExactText(accentBob, "E\u0301B");
+  });
+
+  const assert_vote_swatches_have_accessible_names = computed(() => {
+    const ui = initialsPoll[UI];
+    const daffodil = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "Daffodil",
+    );
+    const emojiBob = findNodeByProp(
+      ui,
+      "data-vote-swatch-name",
+      "👩🏽‍💻Bob",
+    );
+    return readValue(propsOf(daffodil)?.role) === "img" &&
+      readValue(propsOf(daffodil)?.["aria-label"]) ===
+        "Daffodil: green vote" &&
+      readValue(propsOf(emojiBob)?.role) === "img" &&
+      readValue(propsOf(emojiBob)?.["aria-label"]) ===
+        "👩🏽‍💻Bob: red vote";
+  });
+
   // The seeded stale vote is stored but hidden: absent from `todaysVotes`,
   // the count, and the rendered swatches. Guarded on both `#now` reads —
   // this pattern's (`todayKey`, which also resolves the seeded `castAt`) and
@@ -453,6 +772,9 @@ export default pattern(() => {
       // === Current-day vote filter ===
       // Header date + exposed day key.
       { assertion: assert_today_header_renders },
+      // Same-first-letter participant names get stable, distinct swatches.
+      { assertion: assert_colliding_initials_are_disambiguated },
+      { assertion: assert_vote_swatches_have_accessible_names },
       // Seeded stale (yesterday) vote: stored but hidden everywhere.
       { assertion: assert_stale_vote_hidden },
       // Same-color click on the stale vote re-casts it for today…

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -249,13 +249,135 @@ const clearVoteEntity = (votes: VotesCell, key: string): void => {
   vote.set(undefined);
 };
 
-const getInitials = (name: string): string => {
+const COMBINING_MARK = /^\p{Mark}$/u;
+const EMOJI_MODIFIER = /^\p{Emoji_Modifier}$/u;
+const REGIONAL_INDICATOR = /^\p{Regional_Indicator}$/u;
+const ZERO_WIDTH_JOINER = "\u200D";
+
+// Groups combining marks, emoji modifiers, joined emoji, and regional-indicator
+// pairs into the characters displayed in participant labels.
+const displayCharactersOf = (value: string): string[] => {
+  const codePoints = Array.from(value);
+  const characters: string[] = [];
+  for (let index = 0; index < codePoints.length; index += 1) {
+    let character = codePoints[index] ?? "";
+    const next = codePoints[index + 1] ?? "";
+    if (
+      REGIONAL_INDICATOR.test(character) && REGIONAL_INDICATOR.test(next)
+    ) {
+      character += next;
+      index += 1;
+    }
+    while (index + 1 < codePoints.length) {
+      const continuation = codePoints[index + 1] ?? "";
+      if (
+        COMBINING_MARK.test(continuation) ||
+        EMOJI_MODIFIER.test(continuation)
+      ) {
+        character += continuation;
+        index += 1;
+        continue;
+      }
+      if (
+        continuation === ZERO_WIDTH_JOINER && index + 2 < codePoints.length
+      ) {
+        character += continuation + (codePoints[index + 2] ?? "");
+        index += 2;
+        continue;
+      }
+      break;
+    }
+    characters.push(character);
+  }
+  return characters;
+};
+
+const getDefaultInitials = (name: string): string => {
   const trimmed = name.trim();
   if (!trimmed) return "?";
-  return trimmed.split(/\s+/).map((w) => w[0]).join("").toUpperCase().slice(
-    0,
-    2,
+  const initials = trimmed.split(/\s+/).map((word) =>
+    displayCharactersOf(word)[0] ?? ""
+  ).join("").toUpperCase();
+  return displayCharactersOf(initials).slice(0, 2).join("");
+};
+
+const compactName = (name: string): string =>
+  name.trim().split(/\s+/).join("").toUpperCase();
+
+const getInitials = (
+  name: string,
+  participantNames: readonly string[],
+): string => {
+  const compact = compactName(name);
+  const characters = displayCharactersOf(compact);
+  if (characters.length === 0) return "?";
+  const peers = participantNames
+    .map(compactName)
+    .filter((candidate) =>
+      candidate !== compact &&
+      displayCharactersOf(candidate)[0] === characters[0]
+    );
+  if (peers.length === 0) return getDefaultInitials(name);
+
+  const distinguishingIndex = characters.findIndex((_, index) =>
+    index > 0 &&
+    peers.every((peer) =>
+      !peer.startsWith(characters.slice(0, index + 1).join(""))
+    )
   );
+  const secondInitial = distinguishingIndex >= 1
+    ? characters[distinguishingIndex]
+    : characters[1];
+  return `${characters[0]}${secondInitial ?? ""}`;
+};
+
+const getInitialsByName = (
+  participantNames: readonly string[],
+): Map<string, string> => {
+  const provisionalByName = new Map<string, string>();
+  const countByInitials = new Map<string, number>();
+  for (const name of participantNames) {
+    const initials = getInitials(name, participantNames);
+    provisionalByName.set(name, initials);
+    countByInitials.set(initials, (countByInitials.get(initials) ?? 0) + 1);
+  }
+
+  const expandedByName = new Map<string, string>();
+  const countByExpanded = new Map<string, number>();
+  for (const name of participantNames) {
+    const initials = provisionalByName.get(name) ?? getDefaultInitials(name);
+    const expanded = (countByInitials.get(initials) ?? 0) > 1
+      ? compactName(name)
+      : initials;
+    expandedByName.set(name, expanded);
+    countByExpanded.set(expanded, (countByExpanded.get(expanded) ?? 0) + 1);
+  }
+
+  const result = new Map<string, string>();
+  const usedLabels = new Set<string>();
+  for (const name of participantNames) {
+    const expanded = expandedByName.get(name) ?? getDefaultInitials(name);
+    if ((countByExpanded.get(expanded) ?? 0) <= 1) {
+      result.set(name, expanded);
+      usedLabels.add(expanded);
+    }
+  }
+
+  const nextSuffixByExpanded = new Map<string, number>();
+  for (const name of participantNames) {
+    const expanded = expandedByName.get(name) ?? getDefaultInitials(name);
+    if ((countByExpanded.get(expanded) ?? 0) <= 1) continue;
+    let suffix = nextSuffixByExpanded.get(expanded) ?? 1;
+    let label = `${expanded}${suffix}`;
+    while (usedLabels.has(label)) {
+      suffix += 1;
+      label = `${expanded}${suffix}`;
+    }
+    nextSuffixByExpanded.set(expanded, suffix + 1);
+    result.set(name, label);
+    usedLabels.add(label);
+  }
+  return result;
 };
 
 const DAY_NAMES = [
@@ -587,7 +709,12 @@ interface OptionTally {
   green: number;
   yellow: number;
   red: number;
-  voters: Array<{ name: string; voteType: VoteColor; color: string }>;
+  voters: Array<{
+    name: string;
+    voteType: VoteColor;
+    color: string;
+    initials: string;
+  }>;
 }
 
 const tallyOptions = (
@@ -596,6 +723,8 @@ const tallyOptions = (
   users: readonly User[],
 ): OptionTally[] => {
   const colorByName = new Map(users.map((u) => [u.name, u.color]));
+  const participantNames = users.map((u) => u.name);
+  const initialsByName = getInitialsByName(participantNames);
   const tallies = options.map((option): OptionTally => {
     const optionVotes = votes.filter((v) => v.optionId === option.id);
     return {
@@ -607,6 +736,8 @@ const tallyOptions = (
         name: v.voterName,
         voteType: v.voteType,
         color: colorByName.get(v.voterName) ?? "#888",
+        initials: initialsByName.get(v.voterName) ??
+          getInitials(v.voterName, participantNames),
       })),
     };
   });
@@ -748,9 +879,11 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // different schema default per runtime and churn the built graph.
     const today = Writable.perSession.of<number>(0);
     // Two-step confirmation for destructive actions. Stores the optionId
-    // pending remove-confirm (null = nothing pending). Same idiom as
+    // pending remove-confirm (null or undefined = nothing pending). Same idiom as
     // parking-coordinator's `removePersonConfirmTarget`.
-    const removeConfirmTarget = Writable.perSession.of<string | null>(null);
+    const removeConfirmTarget = Writable.perSession.of<
+      string | null | undefined
+    >(null);
     const resetConfirmPending = Writable.perSession.of<boolean>(false);
     const clearHistoryConfirmPending = Writable.perSession.of<boolean>(false);
     const participantIdentity = ParticipantIdentityCard({
@@ -1149,6 +1282,8 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                                 {tally.voters.map((voter) => (
                                   <span
                                     title={voter.name}
+                                    role="img"
+                                    aria-label={`${voter.name}: ${voter.voteType} vote`}
                                     data-vote-swatch-name={voter.name}
                                     style={{
                                       display: "inline-flex",
@@ -1168,7 +1303,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                                         : "none",
                                     }}
                                   >
-                                    {getInitials(voter.name)}
+                                    {voter.initials}
                                   </span>
                                 ))}
                               </div>
@@ -1231,7 +1366,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                     const idx = ranked.findIndex(
                       (t) => t.option.id === oid,
                     );
-                    return idx >= 0 ? idx + 1 : 0;
+                    return idx >= 0 ? idx + 1 : undefined;
                   });
                   return (
                     <PollOptionCard

--- a/packages/patterns/lunch-poll/poll-option-card.test.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.test.tsx
@@ -1,4 +1,5 @@
 import {
+  action,
   computed,
   handler,
   pattern,
@@ -6,7 +7,13 @@ import {
   UI,
   Writable,
 } from "commonfabric";
-import { findNode, propsOf, readValue } from "../test/vnode-helpers.ts";
+import {
+  findElementByExactText,
+  findNode,
+  hasText,
+  propsOf,
+  readValue,
+} from "../test/vnode-helpers.ts";
 import PollOptionCard from "./poll-option-card.tsx";
 import type {
   CastVoteEvent,
@@ -52,7 +59,11 @@ const votes: Vote[] = [
 ];
 
 export default pattern(() => {
-  const removeConfirmTarget = new Writable<string | null>(null);
+  const removeConfirmTarget = new Writable<string | null | undefined>(
+    undefined,
+  );
+  const rank = new Writable<number | undefined>(undefined);
+  const reactiveRank = computed(() => rank.get());
 
   const castVote: Stream<CastVoteEvent> = noopCastVote({});
   const removeOption: Stream<RemoveOptionEvent> = noopRemoveOption({});
@@ -60,7 +71,7 @@ export default pattern(() => {
 
   const card = PollOptionCard({
     option: STORED_OPTION,
-    rank: 1,
+    rank: reactiveRank,
     me: "Alex",
     isJoined: true,
     isAdmin: true,
@@ -77,6 +88,22 @@ export default pattern(() => {
       "aria-label",
       "Clear my green vote",
     ) !== undefined
+  );
+
+  const assert_unset_rank_renders_placeholder = computed(() =>
+    hasText(card[UI], "—") && !hasText(card[UI], "#0")
+  );
+
+  const action_resolve_rank = action(() => rank.set(1));
+
+  const assert_resolved_rank_renders = computed(() =>
+    hasText(card[UI], "#1") && !hasText(card[UI], "—")
+  );
+
+  const action_set_zero_rank = action(() => rank.set(0));
+
+  const assert_zero_rank_renders_placeholder = computed(() =>
+    hasText(card[UI], "—") && !hasText(card[UI], "#0")
   );
 
   const assert_my_green_vote_styles_buttons = computed(() => {
@@ -97,25 +124,70 @@ export default pattern(() => {
       propValue(red, "style") === "opacity: 0.4;";
   });
 
-  const assert_host_controls_render = computed(() => {
-    const remove = findNodeByProp(
-      card[UI],
-      "aria-label",
-      "Remove option (host)",
-    );
-    const logVisit = findNodeByProp(
+  const assert_remove_control_contains_only_link_text = computed(() => {
+    const remove = findElementByExactText(card[UI], "button", "remove");
+    return remove !== undefined &&
+      propValue(remove, "aria-label") === "Remove option (host)";
+  });
+
+  const assert_remove_control_is_clickable = computed(() => {
+    const remove = findElementByExactText(card[UI], "button", "remove");
+    return propsOf(remove)?.onClick !== undefined;
+  });
+
+  const assert_remove_control_is_underlined = computed(() => {
+    const remove = findElementByExactText(card[UI], "button", "remove");
+    const removeStyle = propValue(remove, "style");
+    return typeof removeStyle === "object" && removeStyle !== null &&
+      readValue(
+          (removeStyle as Record<PropertyKey, unknown>).textDecoration,
+        ) === "underline";
+  });
+
+  const assert_remove_separator_is_plain = computed(() => {
+    const separator = findElementByExactText(card[UI], "span", "·");
+    const separatorAriaHidden = propValue(separator, "aria-hidden");
+    const separatorStyle = propValue(separator, "style");
+    const separatorStyleRecord =
+      typeof separatorStyle === "object" && separatorStyle !== null
+        ? separatorStyle as Record<PropertyKey, unknown>
+        : undefined;
+    const separatorTextDecoration = separatorStyleRecord
+      ? readValue(separatorStyleRecord.textDecoration)
+      : undefined;
+    const separatorTextDecorationLine = separatorStyleRecord
+      ? readValue(separatorStyleRecord.textDecorationLine)
+      : undefined;
+    return separator !== undefined &&
+      (separatorAriaHidden === true || separatorAriaHidden === "true") &&
+      propsOf(separator)?.onClick === undefined &&
+      separatorTextDecoration === "none" &&
+      (separatorTextDecorationLine === undefined ||
+        separatorTextDecorationLine === "none");
+  });
+
+  const assert_log_visit_control_renders = computed(() =>
+    findNodeByProp(
       card[UI],
       "aria-label",
       "Log that we went here (host)",
-    );
-    return remove !== undefined && logVisit !== undefined;
-  });
+    ) !== undefined
+  );
 
   return {
     tests: [
       { assertion: assert_my_green_vote_label_renders },
+      { assertion: assert_unset_rank_renders_placeholder },
+      { action: action_resolve_rank },
+      { assertion: assert_resolved_rank_renders },
+      { action: action_set_zero_rank },
+      { assertion: assert_zero_rank_renders_placeholder },
       { assertion: assert_my_green_vote_styles_buttons },
-      { assertion: assert_host_controls_render },
+      { assertion: assert_remove_control_contains_only_link_text },
+      { assertion: assert_remove_control_is_clickable },
+      { assertion: assert_remove_control_is_underlined },
+      { assertion: assert_remove_separator_is_plain },
+      { assertion: assert_log_visit_control_renders },
     ],
     card,
   };

--- a/packages/patterns/lunch-poll/poll-option-card.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.tsx
@@ -1,5 +1,6 @@
 import {
   computed,
+  lift,
   NAME,
   pattern,
   type Stream,
@@ -17,7 +18,7 @@ import type {
 } from "./main.tsx";
 
 /** Shared per-session target cell used for one open option editor at a time. */
-export type PollOptionLinkTargetCell = Writable<string | null>;
+export type PollOptionLinkTargetCell = Writable<string | null | undefined>;
 
 const myVoteFor = (
   votes: readonly Vote[],
@@ -29,6 +30,10 @@ const myVoteFor = (
     (v) => v.voterName === me && v.optionId === optionId,
   )?.voteType;
 };
+
+const formatRank = lift<{ rank: number | undefined }, string>(({ rank }) =>
+  rank === undefined || rank <= 0 ? "—" : `#${rank}`
+);
 
 /**
  * PollOptionCard renders one complete ranked restaurant option row.
@@ -52,8 +57,8 @@ export interface PollOptionCardInput {
   /** Option record to render. */
   option: Option;
 
-  /** One-based display rank supplied by the parent's ranking computation. */
-  rank: number;
+  /** One-based display rank, or undefined while the parent ranking settles. */
+  rank: number | undefined;
 
   /** Resolved current viewer name; required for per-option vote styling. */
   me: string;
@@ -110,6 +115,7 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
   ) => {
     const oid = option.id;
     const optionTitle = option.title;
+    const displayRank = formatRank({ rank });
     const myVote = computed(() => myVoteFor(votes, me, oid));
     const isRemoveConfirm = computed(() => removeConfirmTarget.get() === oid);
 
@@ -143,7 +149,7 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
               fontWeight: 700,
             }}
           >
-            #{rank}
+            {displayRank}
           </span>
           <div style={{ flex: 1, minWidth: 0 }}>
             <div
@@ -167,22 +173,30 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
               <span>added by {option.addedByName}</span>
               {isAdmin
                 ? (
-                  <button
-                    type="button"
-                    aria-label="Remove option (host)"
-                    style={{
-                      background: "none",
-                      border: "none",
-                      padding: 0,
-                      color: "#9ca3af",
-                      fontSize: "11px",
-                      textDecoration: "underline",
-                      cursor: "pointer",
-                    }}
-                    onClick={() => removeConfirmTarget.set(oid)}
-                  >
-                    · remove
-                  </button>
+                  <>
+                    <span
+                      aria-hidden="true"
+                      style={{ textDecoration: "none" }}
+                    >
+                      ·
+                    </span>
+                    <button
+                      type="button"
+                      aria-label="Remove option (host)"
+                      style={{
+                        background: "none",
+                        border: "none",
+                        padding: 0,
+                        color: "#9ca3af",
+                        fontSize: "11px",
+                        textDecoration: "underline",
+                        cursor: "pointer",
+                      }}
+                      onClick={() => removeConfirmTarget.set(oid)}
+                    >
+                      remove
+                    </button>
+                  </>
                 )
                 : null}
               {isAdmin

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -1003,8 +1003,8 @@ describe("Cell Static Methods", () => {
       });
     });
 
-    // TODO(danfuzz): the `Cell.of(new Date(...))` cases (top-level and nested)
-    // are intentionally absent: unlike `set()`, the `Cell.of` initial-value path
+    // The `Cell.of(new Date(...))` cases (top-level and nested) are absent.
+    // Unlike `set()`, the `Cell.of` initial-value path
     // doesn't normalize native values (see the TODO in `createWithDefault` in
     // `cell.ts`), so the raw `Date` reaches encode and throws under the strict
     // codec. `get()` *appears* to convert (read-side projection), but the


### PR DESCRIPTION
Participant vote swatches derived short labels independently, so people with similar names could receive the same visible label. The label extraction could also split combining marks, emoji modifiers, joined emoji, and flag pairs. Swatches exposed the participant name only through a tooltip, leaving assistive technology without the vote meaning.

Generate participant labels as a group so collisions expand deterministically, preserve complete displayed characters, and provide an accessible name that includes both participant and vote. Accept transient undefined option-card state while reactive values settle, render an unresolved rank as a neutral dash, and keep separator punctuation outside the remove button.

Use fictional participant names in the collision fixtures and remove personal attribution from runner test commentary. Expand coverage for label collisions, composed Unicode, accessible swatches, reactive rank settling, vote styling, and the remove-control boundary. Verified repository-wide with deno fmt --check and deno lint.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make lunch poll voter swatches deterministic and accessible. Labels are unique across similar names, preserve full Unicode, and swatches announce the vote.

- **Bug Fixes**
  - Preserve full displayed characters when deriving labels (combining marks, emoji modifiers, ZWJ emoji, flag pairs).
  - Disambiguate collisions and expand to stable, unique labels; add numeric suffixes when needed.
  - Keep the separator "·" outside the remove button, set it `aria-hidden`, and only "remove" is clickable/underlined.

- **New Features**
  - Accessible vote swatches with `role="img"` and `aria-label` like "Name: color vote".
  - Accept transient undefined and zero ranks; show a neutral "—" until rank resolves.

<sup>Written for commit a4b61ac8ae5af0bbe013ebc9763acd7b617c2523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



NEW_COVERAGE_BASELINE