### PR TITLE
fix(piece): restore system-pattern auto-update repair

### DIFF
--- a/docs/common/conventions/HOME_SPACE.md
+++ b/docs/common/conventions/HOME_SPACE.md
@@ -219,10 +219,11 @@ Both the home pattern and the default app pattern follow the same mechanism:
    which also stamps `patternSource`, or a custom `RuntimeProgram` (used by
    `cf piece set-home`), which remains untracked by the URL updater and may carry
    a separate repository locator
-5. Before an existing eligible root starts, it is reconciled in place. A legacy
-   sourceless root is eligible only when its verified stored source closure
-   names the exact official system entry for that space; custom roots remain
-   pinned
+5. Before an existing eligible root starts, it is reconciled in place. A root
+   with stored `patternSource` tracks that source. A pre-provenance root is
+   admitted only when its stored `{ identity, symbol }` exactly matches the
+   build-attested current official entry for that space; stale, custom, and
+   repository-pinned sourceless roots remain pinned
 
 
 Runtime internals (ACL initialization, PieceManager home-space detection) are

--- a/docs/common/conventions/HOME_SPACE.md
+++ b/docs/common/conventions/HOME_SPACE.md
@@ -213,9 +213,16 @@ Both the home pattern and the default app pattern follow the same mechanism:
      `/api/patterns/system/profile-home.tsx`
    - **Other spaces**: reads `defaultAppUrl` from the home space; falls back to
      `/api/patterns/system/default-app.tsx`
-3. The pattern is compiled, run, and linked as `spaceCell.defaultPattern`
-4. `recreateDefaultPattern()` can replace it — either with a URL-based system
-   pattern or a custom `RuntimeProgram` (used by `cf piece set-home`)
+3. The pattern is compiled, run, linked as `spaceCell.defaultPattern`, and its
+   source URL is stamped as `patternSource` for future updates
+4. `recreateDefaultPattern()` can replace it — either with a URL-based pattern,
+   which also stamps `patternSource`, or a custom `RuntimeProgram` (used by
+   `cf piece set-home`), which remains untracked by the URL updater and may carry
+   a separate repository locator
+5. Before an existing eligible root starts, it is reconciled in place. A legacy
+   sourceless root is eligible only when its verified stored source closure
+   names the exact official system entry for that space; custom roots remain
+   pinned
 
 
 Runtime internals (ACL initialization, PieceManager home-space detection) are

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -218,8 +218,8 @@ Off by default; flip `OTEL_ENABLED=true` to start exporting.
 
 | Var | Default | Notes |
 |---|---|---|
-| `TOOLSHED_GIT_SHA` | _(auto-detected)_ | Deployed commit SHA, surfaced via `lib/build-info.ts`. Takes priority over the build-baked SHA. |
-| `COMMIT_SHA` | _(unset)_ | Shared Labs build attestation. A source-run toolshed exposes it through `/api/meta`; shell and headless runtimes use it as `clientVersion` for the system-pattern update gate. On a compiled toolshed, baked metadata takes priority over this fallback. |
+| `TOOLSHED_GIT_SHA` | _(auto-detected)_ | Deployed commit SHA, surfaced via `lib/build-info.ts`. Takes priority over the build-baked SHA for `/api/meta`, pattern-response attestations, and the toolshed Runtime. |
+| `COMMIT_SHA` | _(unset)_ | Shared Labs build attestation. A source-run toolshed exposes it through `/api/meta` and pattern responses; shell and headless runtimes use it as `clientVersion` for the system-pattern update gate. On a compiled toolshed, baked metadata takes priority over this fallback. |
 
 Set `COMMIT_SHA` to the same exact Labs revision in every process that belongs
 to one deployment. It is an operator attestation, not source auto-detection:
@@ -269,7 +269,7 @@ Most shell config is **build-time**: esbuild injects defines in
 |---|---|---|---|
 | `PRODUCTION` | `$ENVIRONMENT` (`"production"` if set, else `"development"`) | _(unset = dev)_ | Triggers minified bundle and disables sourcemaps. |
 | `API_URL` | `$API_URL` | falls back to `location.origin` | Backend the shell calls. |
-| `COMMIT_SHA` | `$COMMIT_SHA` | _(unset)_ | Surfaced for debugging and passed to the browser runtime as its build version. |
+| `COMMIT_SHA` | `$COMMIT_SHA` | _(unset)_ | Surfaced for debugging and passed to the browser runtime as its build version. In development it does not change the worker route from `/scripts/worker-runtime.js` to the deployed `/builds/<sha>` namespace. |
 | `EXPERIMENTAL_MODERN_CELL_REP` | `EXPERIMENTAL.modernCellRep` | _(unset)_ | See experimental flags. |
 | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | `EXPERIMENTAL.persistentSchedulerState` | _(unset)_ | See experimental flags. |
 | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` | `EXPERIMENTAL.eagerSourceAnnotation` | on in dev builds, off in production | See experimental flags. |

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -219,6 +219,12 @@ Off by default; flip `OTEL_ENABLED=true` to start exporting.
 | Var | Default | Notes |
 |---|---|---|
 | `TOOLSHED_GIT_SHA` | _(auto-detected)_ | Deployed commit SHA, surfaced via `lib/build-info.ts`. Takes priority over the build-baked SHA. |
+| `COMMIT_SHA` | _(unset)_ | Shared Labs build attestation. A source-run toolshed exposes it through `/api/meta`; shell and headless runtimes use it as `clientVersion` for the system-pattern update gate. On a compiled toolshed, baked metadata takes priority over this fallback. |
+
+Set `COMMIT_SHA` to the same exact Labs revision in every process that belongs
+to one deployment. It is an operator attestation, not source auto-detection:
+only stamp a revision when the launched sources correspond to it. The explicit
+toolshed-only `TOOLSHED_GIT_SHA` override remains highest priority.
 
 The compilation cache for compiled patterns is the content-addressed cell
 cache (always on under an enforcing CFC mode; see
@@ -263,7 +269,7 @@ Most shell config is **build-time**: esbuild injects defines in
 |---|---|---|---|
 | `PRODUCTION` | `$ENVIRONMENT` (`"production"` if set, else `"development"`) | _(unset = dev)_ | Triggers minified bundle and disables sourcemaps. |
 | `API_URL` | `$API_URL` | falls back to `location.origin` | Backend the shell calls. |
-| `COMMIT_SHA` | `$COMMIT_SHA` | _(unset)_ | Surfaced for debugging. |
+| `COMMIT_SHA` | `$COMMIT_SHA` | _(unset)_ | Surfaced for debugging and passed to the browser runtime as its build version. |
 | `EXPERIMENTAL_MODERN_CELL_REP` | `EXPERIMENTAL.modernCellRep` | _(unset)_ | See experimental flags. |
 | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | `EXPERIMENTAL.persistentSchedulerState` | _(unset)_ | See experimental flags. |
 | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` | `EXPERIMENTAL.eagerSourceAnnotation` | on in dev builds, off in production | See experimental flags. |
@@ -287,6 +293,7 @@ the labs checkout and dispatches to `packages/cli/mod.ts`.
 | `CF_CLI_NAME` | `cf` | Override the displayed CLI name (for branded builds). |
 | `CF_CLI_TRACE_TIMINGS` | `0` | Set to `1` for detailed timing traces. |
 | `CF_CLI_INTEGRATION_USE_LOCAL` | _(unset)_ | Used by integration tests to dispatch through local source rather than a built binary. |
+| `COMMIT_SHA` | _(unset)_ | Labs revision passed to remote client runtimes as `clientVersion`. Use the same value as the target source-run toolshed. |
 
 ### Global args
 
@@ -322,6 +329,7 @@ Passed before the CLI args; rarely needed:
 | `OPERATOR_PASS` | `"implicit trust"` | Passphrase for implicit identity. Must match toolshed's identity in dev. |
 | `IDENTITY` | _(unset)_ | Path to keyfile; takes precedence over `OPERATOR_PASS`. |
 | `API_URL` | `http://localhost:8000` | Toolshed URL the service calls. |
+| `COMMIT_SHA` | _(unset)_ | Labs revision passed through the main runtime and worker IPC as `clientVersion`. Use the same value as the target source-run toolshed. |
 | `EXPERIMENTAL_MODERN_CELL_REP` | _(unset)_ | See experimental flags. |
 | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | _(unset)_ | See experimental flags. |
 | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` | _(unset)_ | See experimental flags. |

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -222,15 +222,16 @@ propagate](#how-flags-propagate).
   identity. A loadable root uses the client/toolshed version gate and cached
   `?identity` comparison before an in-place `patternIdentity` swap. An
   unloadable tracked root instead compiles its source directly under the current
-  runtime, so CLI/daemon and source-run toolsheds can repair it without build
-  metadata; a failed compile performs no metadata write. Persisted roots are
+  runtime after that same version gate; a failed compile performs no metadata
+  write. Source-run toolsheds, CLI, and daemon processes can receive the shared
+  Labs revision through `COMMIT_SHA`. Persisted roots are
   resolved without starting, and a verified legacy root whose content-addressed
   source closure names the official entry can have missing `patternSource`
   provenance back-filled. Custom sourceless roots remain pinned. URL-based
   creation and recreation stamp provenance; custom `RuntimeProgram` recreation
   does not. The check remains best-effort; if repair is unavailable, the
   subsequent root start retains its normal loud failure behavior. For a
-  loadable root, an unknown build SHA skips silently; the `versionSkew` IPC
+  root, an unknown build SHA skips silently; the `versionSkew` IPC
   signal—which raises the shell's reload banner—fires only on a proven mismatch
   (both SHAs known and different). See
   [`docs/specs/pattern-imports/pattern-updates.md`](../specs/pattern-imports/pattern-updates.md).

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -219,19 +219,19 @@ propagate](#how-flags-propagate).
   #4619 (2026-07-09).
 - **Purpose.** At space open, rolls a space's **non-home** root system pattern
   (default-app) forward in place when its toolshed serves a newer content
-  identity. A loadable root uses the client/toolshed version gate and cached
-  `?identity` comparison before an in-place `patternIdentity` swap. An
-  unloadable tracked root instead compiles its source directly under the current
-  runtime after that same version gate; a failed compile performs no metadata
-  write. Source-run toolsheds, CLI, and daemon processes can receive the shared
-  Labs revision through `COMMIT_SHA`. Persisted roots are
-  resolved without starting, and a verified legacy root whose content-addressed
-  source closure names the official entry can have missing `patternSource`
-  provenance back-filled. Custom sourceless roots remain pinned. URL-based
-  creation and recreation stamp provenance; custom `RuntimeProgram` recreation
-  does not. The check remains best-effort; if repair is unavailable, the
-  subsequent root start retains its normal loud failure behavior. For a
-  root, an unknown build SHA skips silently; the `versionSkew` IPC
+  identity. Every tracked root uses the client/toolshed version gate and cached
+  `?identity` comparison before an in-place `patternIdentity` swap. The check
+  does not load the persisted identity, so an unloadable stale root can still
+  be replaced before bootstrap through that same path. Source-run toolsheds,
+  CLI, and daemon processes can receive the shared Labs revision through
+  `COMMIT_SHA`. Persisted roots are resolved without starting, and a verified
+  legacy root whose content-addressed source closure names the official entry
+  can have missing `patternSource` provenance back-filled. Custom sourceless
+  roots remain pinned. URL-based creation and recreation stamp provenance;
+  custom `RuntimeProgram` recreation does not. The check remains best-effort;
+  if identity lookup or replacement compilation is unavailable, the subsequent
+  root start retains its normal loud failure behavior. An unknown build SHA
+  skips silently; the `versionSkew` IPC
   signal—which raises the shell's reload banner—fires only on a proven mismatch
   (both SHAs known and different). See
   [`docs/specs/pattern-imports/pattern-updates.md`](../specs/pattern-imports/pattern-updates.md).

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -219,16 +219,20 @@ propagate](#how-flags-propagate).
   #4619 (2026-07-09).
 - **Purpose.** At space open, rolls a space's **non-home** root system pattern
   (default-app) forward in place when its toolshed serves a newer content
-  identity: version gate (client vs toolshed build sha) → cached `?identity`
-  compare → in-place `patternIdentity` swap. Persisted roots are resolved
-  without starting; the check is awaited and the reconciled identity is
-  committed before root bootstrap, so an unloadable obsolete root cannot block
-  its own repair. The check remains best-effort and converts its own failures
-  to a no-op; if repair is unavailable, the subsequent root start retains its
-  normal loud failure behavior. When either build sha is unknown (dev/source
-  servers carry none) the check skips silently; the `versionSkew` IPC signal —
-  which raises the shell's reload banner — fires only on a proven mismatch
-  (both shas known and different). See
+  identity. A loadable root uses the client/toolshed version gate and cached
+  `?identity` comparison before an in-place `patternIdentity` swap. An
+  unloadable tracked root instead compiles its source directly under the current
+  runtime, so CLI/daemon and source-run toolsheds can repair it without build
+  metadata; a failed compile performs no metadata write. Persisted roots are
+  resolved without starting, and a verified legacy root whose content-addressed
+  source closure names the official entry can have missing `patternSource`
+  provenance back-filled. Custom sourceless roots remain pinned. URL-based
+  creation and recreation stamp provenance; custom `RuntimeProgram` recreation
+  does not. The check remains best-effort; if repair is unavailable, the
+  subsequent root start retains its normal loud failure behavior. For a
+  loadable root, an unknown build SHA skips silently; the `versionSkew` IPC
+  signal—which raises the shell's reload banner—fires only on a proven mismatch
+  (both SHAs known and different). See
   [`docs/specs/pattern-imports/pattern-updates.md`](../specs/pattern-imports/pattern-updates.md).
 - **Current default and planned end state.** The runner built-in default is off
   like every flag in this category; the shell build injects `true` unless the
@@ -237,8 +241,9 @@ propagate](#how-flags-propagate).
   background piece service) leave it off unless the env var is set. End state:
   graduate to always-on for system roots once golden-replay coverage has soaked
   and the home audit lands, then delete both auto-update flags.
-- **Status on 2026-07-14.** Implemented; on in the shell for non-home roots,
-  off elsewhere. Root reconciliation runs before bootstrap.
+- **Status on 2026-07-21.** Implemented; on in the shell for non-home roots,
+  off elsewhere. Root reconciliation and broken-root repair run before
+  bootstrap.
 - **Path to removal.** Graduate the home root (below), make the check
   unconditional, and remove both flags together.
 

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -220,18 +220,21 @@ propagate](#how-flags-propagate).
 - **Purpose.** At space open, rolls a space's **non-home** root system pattern
   (default-app) forward in place when its toolshed serves a newer content
   identity. Every tracked root uses the client/toolshed version gate and cached
-  `?identity` comparison before an in-place `patternIdentity` swap. The check
-  does not load the persisted identity, so an unloadable stale root can still
-  be replaced before bootstrap through that same path. Source-run toolsheds,
-  CLI, and daemon processes can receive the shared Labs revision through
-  `COMMIT_SHA`. Persisted roots are resolved without starting, and a verified
-  legacy root whose content-addressed source closure names the official entry
-  can have missing `patternSource` provenance back-filled. Custom sourceless
-  roots remain pinned. URL-based creation and recreation stamp provenance;
-  custom `RuntimeProgram` recreation does not. The check remains best-effort;
-  if identity lookup or replacement compilation is unavailable, the subsequent
-  root start retains its normal loud failure behavior. An unknown build SHA
-  skips silently; the `versionSkew` IPC
+  `?identity` comparison before an in-place `patternIdentity` swap. The
+  identity response, every fetched source/import, and the compiler-produced
+  entry must all agree with the same client build and identity. Equal identities
+  take the fast path only after the persisted artifact loads; an unloadable root
+  is rebuilt through that same identity-authorized source path before bootstrap.
+  Source-run toolsheds, CLI, and daemon processes can receive the shared Labs
+  revision through `COMMIT_SHA`. Persisted roots are resolved without starting.
+  A pre-provenance root may be back-filled only when its stored
+  `{ identity, symbol }` exactly equals the build-attested current official
+  entry; stale, custom, and repository-pinned sourceless roots remain pinned.
+  URL-based creation and recreation stamp provenance; custom `RuntimeProgram`
+  recreation does not. The check remains best-effort; if identity lookup or
+  replacement compilation is unavailable, the subsequent root start retains
+  its normal loud failure behavior. An unknown build SHA skips silently; the
+  `versionSkew` IPC
   signal—which raises the shell's reload banner—fires only on a proven mismatch
   (both SHAs known and different). See
   [`docs/specs/pattern-imports/pattern-updates.md`](../specs/pattern-imports/pattern-updates.md).

--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -19,6 +19,19 @@
 ./scripts/share-pattern-via-tailscale.sh --down                                 # Tear that down
 ```
 
+To exercise version-gated system-pattern updates with source-run processes,
+attest one Labs revision for the whole launch:
+
+```bash
+COMMIT_SHA="$(git rev-parse HEAD)" ./scripts/start-local-dev.sh --bg-updater
+```
+
+The script's children inherit the value: toolshed exposes it through
+`/api/meta`, shell bakes it into the browser runtime, and the optional
+background-piece-service forwards it to its workers. Pass the same value to
+standalone `cf` commands. Only use a revision that actually describes all
+launched Labs sources; a shared but false value defeats the safety gate.
+
 To let teammates interact with a locally-hosted pattern (e.g. "host latest-main
 `<pattern>` locally with `--inspect` and export it over Tailscale"), use
 `share-pattern-via-tailscale.sh`. It starts an isolated toolshed (with

--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -27,10 +27,13 @@ COMMIT_SHA="$(git rev-parse HEAD)" ./scripts/start-local-dev.sh --bg-updater
 ```
 
 The script's children inherit the value: toolshed exposes it through
-`/api/meta`, shell bakes it into the browser runtime, and the optional
-background-piece-service forwards it to its workers. Pass the same value to
-standalone `cf` commands. Only use a revision that actually describes all
-launched Labs sources; a shared but false value defeats the safety gate.
+`/api/meta` and pattern responses, shell bakes it into the browser runtime, and
+the optional background-piece-service forwards it to its workers. The
+source-run shell still loads its mutable worker graph from `/scripts`; the SHA
+attests the client build but does not redirect local development to the
+deployed `/builds/<sha>` namespace. Pass the same value to standalone `cf`
+commands. Only use a revision that actually describes all launched Labs
+sources; a shared but false value defeats the safety gate.
 
 To let teammates interact with a locally-hosted pattern (e.g. "host latest-main
 `<pattern>` locally with `--inspect` and export it over Tailscale"), use

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -12,9 +12,10 @@ Phase 1 shipped: the `systemPatternAutoUpdate` flag is on in the shell for
 non-home default-app roots (`systemPatternAutoUpdateHome` stays off pending the
 home.tsx stable-addressing audit). URL-based creation and recreation stamp
 update provenance; verified legacy system roots can recover missing provenance;
-and an unloadable tracked root is repaired by compiling its source directly
-when the client and toolshed attest the same build. The executed milestone map
-and the corrections found during implementation are archived at
+and an unloadable stale root is repaired before bootstrap through the same
+`?identity`-driven update path when the client and toolshed attest the same
+build. The executed milestone map and the corrections found during
+implementation are archived at
 [`docs/history/specs/pattern-imports/system-pattern-updates-implementation-plan.md`](../../history/specs/pattern-imports/system-pattern-updates-implementation-plan.md).
 Home root and published-pattern updates remain design (Phases 2–4).
 
@@ -114,8 +115,8 @@ Dispatched by the `cf:` prefix:
   updates); a bare slug **tracks**. Immutability is just a pinned ref.
 - **non-`cf:` toolshed source path** (system, e.g.
   `/api/patterns/system/default-app.tsx`) → after the build-version gate, use
-  `?identity` against the space's host for a loadable root; for an unloadable
-  root, fetch and compile the source directly under the matched runtime (below).
+  `?identity` against the space's host, then fetch and compile only when that
+  identity differs from the persisted one.
 
 **Born-from determinism.** The *string* is frozen at birth (which source); the
 *resolved identity* is live (which version). A non-home space's root
@@ -209,28 +210,21 @@ transaction, and only then start it:
    pinned. `host` = `mappedHostFor(space) ?? apiUrl`. Only same-origin toolshed
    sources participate in this v1 loop.
 2. **Version gate** (§ below). Compare the client build to this space's
-   toolshed build before loading the stored pattern, querying the current
-   identity, compiling a replacement, or mutating the root. Unknown or
-   mismatched builds leave it untouched; signal the shell only on a proven
-   mismatch (both SHAs known).
-3. Probe whether the stored `patternIdentity` can load in the current runtime
-   (for example, aged source may import a runtime API removed by the new build).
-4. **Broken-root repair.** If it cannot load (including a thrown cold-load
-   failure), fetch and compile `{host}{url}` directly. The compiler-produced
-   entry ref is authoritative: write it in place if it differs and back-fill
-   verified legacy provenance. This path skips `?identity`, but remains behind
-   the build gate. Fetch or compile failure performs no metadata write; the
-   subsequent root start retains its normal loud failure.
-5. For a loadable root, `currentId` = **cached**
-   `GET {host}{url}?identity` (cache keyed by
+   toolshed build before querying the current identity, compiling a
+   replacement, or mutating the root. Unknown or mismatched builds leave it
+   untouched; signal the shell only on a proven mismatch (both SHAs known).
+3. `currentId` = **cached** `GET {host}{url}?identity` (cache keyed by
    `(host, url)`; cleared on socket reset — the identity is fixed for the
    toolshed's lifetime, and a socket reset is the proxy for "maybe a restarted
    or different toolshed"). Steady state is an in-memory compare, no request.
-6. `currentId === running patternIdentity.identity` → done (after stamping
+   This step never loads the persisted pattern, so an obsolete identity that
+   cannot start does not block reconciliation. An identity failure performs no
+   metadata write; the subsequent root start retains its normal loud failure.
+4. `currentId === running patternIdentity.identity` → done (after stamping
    provenance if this is a verified legacy root).
-7. Else fetch `{host}{url}` source, `compilePattern(program, { space })`, and
+5. Else fetch `{host}{url}` source, `compilePattern(program, { space })`, and
    write the compiler-produced `{ identity, symbol }` entry ref.
-8. Start the reconciled root. A newly created root skips the check because it
+6. Start the reconciled root. A newly created root skips the check because it
    was compiled from the current source in the same ensure operation; a root
    discovered after a creation race is treated as persisted and reconciled.
 
@@ -238,10 +232,8 @@ transaction, and only then start it:
 
 The light `?identity` is only comparable to the worker's identity when
 **toolshed and worker are the same build** (then `computeModuleIdentities` is
-literally the same function). Directly compiling a replacement does not remove
-that safety requirement: source served by one build must not mutate durable
-state under a different build. The version check is therefore a precondition
-for every system-root update or repair:
+literally the same function). The version check is therefore a precondition for
+every system-root update or repair:
 
 - Compare the client's `gitSha` to the space's toolshed `gitSha` (`/api/meta`,
   cached per host).
@@ -296,9 +288,8 @@ so no build-dependence and no gate.
 - **Runtime worker**: an update-check step at space open, next to
   `handleGetSpaceRootPattern` / `ensureDefaultPattern`
   (`runtime-client/backends/runtime-processor.ts`, `pieces-controller.ts`):
-  per-space host resolution, verified legacy-provenance recovery, broken-root
-  direct compilation behind the version gate, `?identity` cache, and an
-  in-place `patternIdentity` swap.
+  per-space host resolution, verified legacy-provenance recovery, version gate,
+  `?identity` cache, and an in-place `patternIdentity` swap before bootstrap.
 - **Piece**: `patternSource` meta getter/setter; stamped by URL-based creation
   and recreation from the applicable source (system path, or a `cf:` ref derived
   from `defaultAppUrl`). Custom `RuntimeProgram` recreation remains unstamped;

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -232,6 +232,9 @@ transaction, and only then start it:
    carry the same build header. Compile with `compilePattern(program, { space })`.
    Apply only when the compiler supplies an entry ref whose identity exactly
    equals `currentId`; never synthesize a ref or fall back around `?identity`.
+   Provenance repair and identity replacement are transactional
+   compare-and-swap writes: the captured identity, source, and repository must
+   still match on every retry, so a concurrent custom-root replacement wins.
 7. Start the reconciled root. A newly created root skips the check because it
    was compiled from the current source in the same ensure operation; a root
    discovered after a creation race is treated as persisted and reconciled.

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -10,14 +10,17 @@ later phase) on demand for **published** patterns. Companion to `README.md`
 
 Phase 1 shipped: the `systemPatternAutoUpdate` flag is on in the shell for
 non-home default-app roots (`systemPatternAutoUpdateHome` stays off pending the
-home.tsx stable-addressing audit). The executed milestone map and the
+home.tsx stable-addressing audit). URL-based creation and recreation stamp
+update provenance; verified legacy system roots can recover missing provenance;
+and an unloadable tracked root is repaired by compiling its source directly,
+even when build metadata is unavailable. The executed milestone map and the
 corrections found during implementation are archived at
 [`docs/history/specs/pattern-imports/system-pattern-updates-implementation-plan.md`](../../history/specs/pattern-imports/system-pattern-updates-implementation-plan.md).
 Home root and published-pattern updates remain design (Phases 2–4).
 
 ## Last Updated
 
-2026-07-14
+2026-07-21
 
 ## Motivation
 
@@ -26,7 +29,8 @@ Home root and published-pattern updates remain design (Phases 2–4).
   roots are resolved without starting, reconciled against their tracked system
   source, and only then bootstrapped. The manual `recreateDefaultPattern`
   (shell Debugger button / CLI) remains a state-losing escape hatch: it mints a
-  new piece and relinks it.
+  new piece and relinks it. URL-based recreation stamps the new root's source so
+  the replacement remains eligible for future automatic repair.
 - **Two hazard cases to handle explicitly.** (1) We shipped a broken system
   pattern — once a fix ships, recovery must be automatic. (2) An
   schema-incompatible update slips through — the damage must be *bounded*
@@ -59,7 +63,7 @@ Home root and published-pattern updates remain design (Phases 2–4).
 | Pattern pointer `patternIdentity = {identity, symbol}` on the piece result cell | write `runner.ts:1012`, read `getPatternIdentityRef` `runner.ts:4441` | The thing an update rewrites |
 | **In-place re-run watcher** — `setupPatternWatcher` sinks the `patternIdentity` meta; on change it cancels the old pattern's nodes and re-instantiates the new pattern **onto the same result cell** | `runner.ts:1246` (enabled unless `doNotUpdateOnPatternChange`, `runner.ts:1341`) | Applies a metadata swap when the piece is already running; at space open, bootstrap reads the reconciled metadata directly |
 | Space root: `spaceCell.defaultPattern` link → root piece → `patternIdentity` | `packages/piece/src/manager.ts` (`linkDefaultPattern`/`getDefaultPattern`) | What a system update rewrites |
-| `ensureDefaultPattern` (resolve → reconcile → start) / `recreateDefaultPattern` (manual, **not** state-preserving) | `packages/piece/src/ops/pieces-controller.ts` | The automatic self-heal hook (ensure) and the state-losing escape hatch (recreate) |
+| `ensureDefaultPattern` (resolve → reconcile → start) / `recreateDefaultPattern` (manual, **not** state-preserving) | `packages/piece/src/ops/pieces-controller.ts` | The automatic self-heal hook (ensure) and the state-losing escape hatch (recreate); both URL-based creation paths stamp `patternSource` |
 | System patterns = **raw TSX served by path**, bundled via `deno compile --include`; **no name→identity manifest** | `packages/toolshed/routes/patterns/patterns-server.ts`, `patterns.routes.ts` | Where the current system source + its identity come from |
 | Per-space host resolution: `mappedHostFor(space)` / `registerSpaceHost` (3-tier: seed `spaceHostMap` → learned site-table → default) | `runtime.ts:1423` / `:1444`, `storage/v2-remote-session.ts` | Which toolshed a space's source is fetched from |
 | Build identity: `/api/meta` → `{ did, gitSha }` | `packages/toolshed/routes/meta/` | The version-skew signal |
@@ -89,6 +93,13 @@ Two decisions carry the whole design:
    running root, the existing watcher (`runner.ts:1246`) re-instantiates in
    place. No new apply machinery.
 
+A root created before provenance stamping may be admitted to this loop only
+when the verified, content-addressed source closure for its stored identity
+names the exact official system entry appropriate to the space (`home.tsx` for
+Home, `default-app.tsx` otherwise). The updater then back-fills
+`patternSource`. Space type alone is not provenance: an unverified or custom
+sourceless root stays pinned.
+
 System patterns run this loop automatically at space open (always-update);
 published patterns will run it behind an explicit user action (§ Phasing).
 
@@ -102,8 +113,9 @@ Dispatched by the `cf:` prefix:
   `cf:pattern:<hash>` ref is **frozen** (resolves to a constant → never
   updates); a bare slug **tracks**. Immutability is just a pinned ref.
 - **non-`cf:` toolshed source path** (system, e.g.
-  `/api/patterns/system/default-app.tsx`) → resolve via `?identity` against
-  the space's host (below).
+  `/api/patterns/system/default-app.tsx`) → for a loadable root, resolve via
+  `?identity` against the space's host; for an unloadable root, fetch and compile
+  the source directly under the current runtime (below).
 
 **Born-from determinism.** The *string* is frozen at birth (which source); the
 *resolved identity* is live (which version). A non-home space's root
@@ -190,28 +202,37 @@ and `home.tsx`:
 root with `runIt=false`, run this loop, re-resolve the cell after any metadata
 transaction, and only then start it:
 
-1. `url` = home space → `home.tsx`; else the root piece's `patternSource`.
-   `host` = `mappedHostFor(space) ?? apiUrl`. *(Change from today:
-   `ensureDefaultPattern` builds the URL from the global `apiUrl`,
-   `pieces-controller.ts:274` — it must resolve against the space's host, which
-   also fixes a latent cross-host bug where a foreign-homed space fetches the
-   wrong toolshed's default-app.)*
-2. **Version gate** (§ below). Not the same known build → skip; signal the
-   shell only on a proven mismatch (both shas known).
-3. `currentId` = **cached** `GET {host}{url}?identity` (cache keyed by
+1. `url` = the root piece's stored `patternSource`. If it is absent, recover it
+   only from a verified source closure whose exact entry path identifies the
+   official system root appropriate to this space; otherwise leave the root
+   pinned. `host` = `mappedHostFor(space) ?? apiUrl`. Only same-origin toolshed
+   sources participate in this v1 loop.
+2. Probe whether the stored `patternIdentity` can load in the current runtime
+   (for example, aged source may import a runtime API removed by the new build).
+3. **Broken-root repair.** If it cannot load (including a thrown cold-load
+   failure), fetch and compile `{host}{url}` directly. The compiler-produced
+   entry ref is authoritative: write it in place if it differs and back-fill
+   verified legacy provenance. This path deliberately uses neither the build
+   gate nor `?identity`. Fetch or compile failure performs no metadata write;
+   the subsequent root start retains its normal loud failure.
+4. **Healthy-root version gate** (§ below). Not the same known build → skip;
+   signal the shell only on a proven mismatch (both shas known).
+5. `currentId` = **cached** `GET {host}{url}?identity` (cache keyed by
    `(host, url)`; cleared on socket reset — the identity is fixed for the
    toolshed's lifetime, and a socket reset is the proxy for "maybe a restarted
    or different toolshed"). Steady state is an in-memory compare, no request.
-4. `currentId === running patternIdentity.identity` → done.
-5. else → fetch `{host}{url}` source, `compilePattern(program, { space })`,
-   write `patternIdentity = { identity: currentId, symbol }`.
-6. Start the reconciled root. A newly created root skips the check because it
+6. `currentId === running patternIdentity.identity` → done (after stamping
+   provenance if this is a verified legacy root).
+7. Else fetch `{host}{url}` source, `compilePattern(program, { space })`, and
+   write the compiler-produced `{ identity, symbol }` entry ref.
+8. Start the reconciled root. A newly created root skips the check because it
    was compiled from the current source in the same ensure operation; a root
    discovered after a creation race is treated as persisted and reconciled.
 
 ## Version-skew gate
 
-The light `?identity` is only comparable to the worker's identity when
+For a healthy, loadable root, the light `?identity` is only comparable to the
+worker's identity when
 **toolshed and worker are the same build** (then `computeModuleIdentities` is
 literally the same function). So gate on it:
 
@@ -225,16 +246,22 @@ literally the same function). So gate on it:
   visualizes it and may restart/reload the worker to pick up a matching client
   build (a page reload / cache-bust is what actually swaps the client bundle;
   the shell owns that UX).
-- **Unknown build on either side** (dev/source servers carry no sha) → touch
-  nothing and skip **silently** (`skipped-unknown-build`). Nothing is provably
-  newer, so there is nothing to tell the user — signalling here would raise
-  the reload banner on every space open in local dev, where no reload helps.
+- **Unknown build on either side** (dev/source servers carry no sha) → skip the
+  healthy-root update **silently** (`skipped-unknown-build`). Nothing is
+  provably newer, so there is nothing to tell the user — signalling here would
+  raise the reload banner on every space open in local dev, where no reload
+  helps.
 
-**The gate is exactly what makes the light `?identity` sound** — the only
-failure mode of the light computation is cross-build drift, and we now never
-compare across builds. Multi-toolshed makes the gate **per-space** (client vs
-*that* space's toolshed); rough edges accepted for v1, and a stale-client
-banner is useful hygiene beyond patterns.
+**The gate is exactly what makes the light `?identity` sound, not a precondition
+for repairing a broken root.** An unloadable root cannot continue as-is, so its
+already-proven source is compiled under the current runtime and that compiler's
+entry ref is installed. This works for CLI/daemon and source-run toolsheds that
+carry no build SHA, while preserving the no-cross-build-compare rule.
+
+For healthy roots, the only failure mode of the light computation is
+cross-build drift, and we now never compare across builds. Multi-toolshed makes
+the gate **per-space** (client vs *that* space's toolshed); rough edges accepted
+for v1, and a stale-client banner is useful hygiene beyond patterns.
 
 **The gate is a system-pattern concern only.** Published-pattern updates
 resolve by reading a slug's target `patternIdentity` (a cell read of a value
@@ -247,7 +274,8 @@ so no build-dependence and no gate.
   shipping — the primary defense (feasible precisely because the list is short
   and we own the source).
 - **Self-heal from a borked ship**: fix source → new identity → next space open
-  swaps it before bootstrap → recovered even when the old identity cannot load.
+  compiles and swaps it before bootstrap → recovered even when the old identity
+  cannot load and neither process exposes a build SHA.
 - **Rollback = redeploy**: ship the prior source → toolshed serves the prior
   identity → the same swap rolls back. No per-piece rollback state needed.
 - **Escape hatch**: manual `recreateDefaultPattern` remains (state-losing; last
@@ -264,10 +292,13 @@ so no build-dependence and no gate.
 - **Runtime worker**: an update-check step at space open, next to
   `handleGetSpaceRootPattern` / `ensureDefaultPattern`
   (`runtime-client/backends/runtime-processor.ts`, `pieces-controller.ts`):
-  per-space host resolution, version gate, `?identity` cache, in-place
-  `patternIdentity` swap.
-- **Piece**: `patternSource` meta getter/setter; stamped at creation from the
-  applicable source (system path, or a `cf:` ref derived from `defaultAppUrl`).
+  per-space host resolution, verified legacy-provenance recovery, broken-root
+  direct compilation, healthy-root version gate and `?identity` cache, and an
+  in-place `patternIdentity` swap.
+- **Piece**: `patternSource` meta getter/setter; stamped by URL-based creation
+  and recreation from the applicable source (system path, or a `cf:` ref derived
+  from `defaultAppUrl`). Custom `RuntimeProgram` recreation remains unstamped;
+  its optional repository locator is separate provenance.
 - **Space cell**: `defaultAppUrl` generalizes to a `cf:` ref (template). A
   per-space host-hint store is a later addition.
 - **IPC**: a worker→shell `versionSkew` message; shell banner + worker-restart

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -12,9 +12,9 @@ Phase 1 shipped: the `systemPatternAutoUpdate` flag is on in the shell for
 non-home default-app roots (`systemPatternAutoUpdateHome` stays off pending the
 home.tsx stable-addressing audit). URL-based creation and recreation stamp
 update provenance; verified legacy system roots can recover missing provenance;
-and an unloadable tracked root is repaired by compiling its source directly,
-even when build metadata is unavailable. The executed milestone map and the
-corrections found during implementation are archived at
+and an unloadable tracked root is repaired by compiling its source directly
+when the client and toolshed attest the same build. The executed milestone map
+and the corrections found during implementation are archived at
 [`docs/history/specs/pattern-imports/system-pattern-updates-implementation-plan.md`](../../history/specs/pattern-imports/system-pattern-updates-implementation-plan.md).
 Home root and published-pattern updates remain design (Phases 2–4).
 
@@ -113,9 +113,9 @@ Dispatched by the `cf:` prefix:
   `cf:pattern:<hash>` ref is **frozen** (resolves to a constant → never
   updates); a bare slug **tracks**. Immutability is just a pinned ref.
 - **non-`cf:` toolshed source path** (system, e.g.
-  `/api/patterns/system/default-app.tsx`) → for a loadable root, resolve via
-  `?identity` against the space's host; for an unloadable root, fetch and compile
-  the source directly under the current runtime (below).
+  `/api/patterns/system/default-app.tsx`) → after the build-version gate, use
+  `?identity` against the space's host for a loadable root; for an unloadable
+  root, fetch and compile the source directly under the matched runtime (below).
 
 **Born-from determinism.** The *string* is frozen at birth (which source); the
 *resolved identity* is live (which version). A non-home space's root
@@ -160,9 +160,10 @@ The apply is: ensure the new closure is loadable in the space
 (`compilePattern(program, { space })` writes source + compiled docs), then
 write `{ identity, symbol }` to the piece's `patternIdentity` meta. During space
 open, `ensureDefaultPattern` performs this write before calling `startPiece`,
-so an obsolete pattern that cannot load never blocks its replacement. If the
-piece is already running, the watcher cancels its old reactive nodes and
-re-instantiates the new pattern onto the **same result cell**.
+so an obsolete pattern that cannot load can be replaced before bootstrap once
+the client and toolshed builds match. If the piece is already running, the
+watcher cancels its old reactive nodes and re-instantiates the new pattern onto
+the **same result cell**.
 
 - **Survives**: the result cell's entity and inbound links; any state cells the
   new pattern still reads (addressed by stable key/cause).
@@ -207,17 +208,21 @@ transaction, and only then start it:
    official system root appropriate to this space; otherwise leave the root
    pinned. `host` = `mappedHostFor(space) ?? apiUrl`. Only same-origin toolshed
    sources participate in this v1 loop.
-2. Probe whether the stored `patternIdentity` can load in the current runtime
+2. **Version gate** (§ below). Compare the client build to this space's
+   toolshed build before loading the stored pattern, querying the current
+   identity, compiling a replacement, or mutating the root. Unknown or
+   mismatched builds leave it untouched; signal the shell only on a proven
+   mismatch (both SHAs known).
+3. Probe whether the stored `patternIdentity` can load in the current runtime
    (for example, aged source may import a runtime API removed by the new build).
-3. **Broken-root repair.** If it cannot load (including a thrown cold-load
+4. **Broken-root repair.** If it cannot load (including a thrown cold-load
    failure), fetch and compile `{host}{url}` directly. The compiler-produced
    entry ref is authoritative: write it in place if it differs and back-fill
-   verified legacy provenance. This path deliberately uses neither the build
-   gate nor `?identity`. Fetch or compile failure performs no metadata write;
-   the subsequent root start retains its normal loud failure.
-4. **Healthy-root version gate** (§ below). Not the same known build → skip;
-   signal the shell only on a proven mismatch (both shas known).
-5. `currentId` = **cached** `GET {host}{url}?identity` (cache keyed by
+   verified legacy provenance. This path skips `?identity`, but remains behind
+   the build gate. Fetch or compile failure performs no metadata write; the
+   subsequent root start retains its normal loud failure.
+5. For a loadable root, `currentId` = **cached**
+   `GET {host}{url}?identity` (cache keyed by
    `(host, url)`; cleared on socket reset — the identity is fixed for the
    toolshed's lifetime, and a socket reset is the proxy for "maybe a restarted
    or different toolshed"). Steady state is an in-memory compare, no request.
@@ -231,10 +236,12 @@ transaction, and only then start it:
 
 ## Version-skew gate
 
-For a healthy, loadable root, the light `?identity` is only comparable to the
-worker's identity when
+The light `?identity` is only comparable to the worker's identity when
 **toolshed and worker are the same build** (then `computeModuleIdentities` is
-literally the same function). So gate on it:
+literally the same function). Directly compiling a replacement does not remove
+that safety requirement: source served by one build must not mutate durable
+state under a different build. The version check is therefore a precondition
+for every system-root update or repair:
 
 - Compare the client's `gitSha` to the space's toolshed `gitSha` (`/api/meta`,
   cached per host).
@@ -246,22 +253,19 @@ literally the same function). So gate on it:
   visualizes it and may restart/reload the worker to pick up a matching client
   build (a page reload / cache-bust is what actually swaps the client bundle;
   the shell owns that UX).
-- **Unknown build on either side** (dev/source servers carry no sha) → skip the
-  healthy-root update **silently** (`skipped-unknown-build`). Nothing is
+- **Unknown build on either side** → skip the update or repair **silently**
+  (`skipped-unknown-build`). Nothing is
   provably newer, so there is nothing to tell the user — signalling here would
   raise the reload banner on every space open in local dev, where no reload
   helps.
 
-**The gate is exactly what makes the light `?identity` sound, not a precondition
-for repairing a broken root.** An unloadable root cannot continue as-is, so its
-already-proven source is compiled under the current runtime and that compiler's
-entry ref is installed. This works for CLI/daemon and source-run toolsheds that
-carry no build SHA, while preserving the no-cross-build-compare rule.
-
-For healthy roots, the only failure mode of the light computation is
-cross-build drift, and we now never compare across builds. Multi-toolshed makes
-the gate **per-space** (client vs *that* space's toolshed); rough edges accepted
-for v1, and a stale-client banner is useful hygiene beyond patterns.
+Source-run and headless processes can receive the same attested Labs revision
+through `COMMIT_SHA`: source-run toolshed exposes it from `/api/meta`, while the
+CLI and background-piece-service pass it as `Runtime.clientVersion` (including
+through the service's worker IPC). This makes the gate usable outside the
+browser without weakening it. Multi-toolshed makes the gate **per-space**
+(client vs *that* space's toolshed); rough edges accepted for v1, and a
+stale-client banner is useful hygiene beyond patterns.
 
 **The gate is a system-pattern concern only.** Published-pattern updates
 resolve by reading a slug's target `patternIdentity` (a cell read of a value
@@ -275,7 +279,7 @@ so no build-dependence and no gate.
   and we own the source).
 - **Self-heal from a borked ship**: fix source → new identity → next space open
   compiles and swaps it before bootstrap → recovered even when the old identity
-  cannot load and neither process exposes a build SHA.
+  cannot load, provided the client and toolshed attest the same build.
 - **Rollback = redeploy**: ship the prior source → toolshed serves the prior
   identity → the same swap rolls back. No per-piece rollback state needed.
 - **Escape hatch**: manual `recreateDefaultPattern` remains (state-losing; last
@@ -293,7 +297,7 @@ so no build-dependence and no gate.
   `handleGetSpaceRootPattern` / `ensureDefaultPattern`
   (`runtime-client/backends/runtime-processor.ts`, `pieces-controller.ts`):
   per-space host resolution, verified legacy-provenance recovery, broken-root
-  direct compilation, healthy-root version gate and `?identity` cache, and an
+  direct compilation behind the version gate, `?identity` cache, and an
   in-place `patternIdentity` swap.
 - **Piece**: `patternSource` meta getter/setter; stamped by URL-based creation
   and recreation from the applicable source (system path, or a `cf:` ref derived

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -11,11 +11,12 @@ later phase) on demand for **published** patterns. Companion to `README.md`
 Phase 1 shipped: the `systemPatternAutoUpdate` flag is on in the shell for
 non-home default-app roots (`systemPatternAutoUpdateHome` stays off pending the
 home.tsx stable-addressing audit). URL-based creation and recreation stamp
-update provenance; verified legacy system roots can recover missing provenance;
-and an unloadable stale root is repaired before bootstrap through the same
-`?identity`-driven update path when the client and toolshed attest the same
-build. The executed milestone map and the corrections found during
-implementation are archived at
+update provenance; a pre-provenance root can recover it only when its stored ref
+exactly equals the build-attested current official entry; and an unloadable
+tracked root is repaired before bootstrap through the same `?identity`-driven
+update path. Identity, source, imports, and the compiled entry must agree on one
+build and content identity. The executed milestone map and corrections found
+during implementation are archived at
 [`docs/history/specs/pattern-imports/system-pattern-updates-implementation-plan.md`](../../history/specs/pattern-imports/system-pattern-updates-implementation-plan.md).
 Home root and published-pattern updates remain design (Phases 2–4).
 
@@ -95,11 +96,11 @@ Two decisions carry the whole design:
    place. No new apply machinery.
 
 A root created before provenance stamping may be admitted to this loop only
-when the verified, content-addressed source closure for its stored identity
-names the exact official system entry appropriate to the space (`home.tsx` for
-Home, `default-app.tsx` otherwise). The updater then back-fills
-`patternSource`. Space type alone is not provenance: an unverified or custom
-sourceless root stays pinned.
+when its stored `{ identity, symbol }` exactly equals the build-attested current
+official entry appropriate to the space (`home.tsx` for Home,
+`default-app.tsx` otherwise). The updater then back-fills `patternSource`.
+Neither space type nor an author-controlled source filename is provenance: a
+stale, custom, or repository-pinned sourceless root stays pinned.
 
 System patterns run this loop automatically at space open (always-update);
 published patterns will run it behind an explicit user action (§ Phasing).
@@ -204,27 +205,34 @@ and `home.tsx`:
 root with `runIt=false`, run this loop, re-resolve the cell after any metadata
 transaction, and only then start it:
 
-1. `url` = the root piece's stored `patternSource`. If it is absent, recover it
-   only from a verified source closure whose exact entry path identifies the
-   official system root appropriate to this space; otherwise leave the root
-   pinned. `host` = `mappedHostFor(space) ?? apiUrl`. Only same-origin toolshed
-   sources participate in this v1 loop.
+1. `url` = the root piece's stored `patternSource`. If it is absent, derive the
+   official candidate URL for the space, but do not treat that path as
+   provenance. A root with explicit repository provenance remains pinned.
+   `host` = `mappedHostFor(space) ?? apiUrl`. Only same-origin toolshed sources
+   participate in this v1 loop.
 2. **Version gate** (§ below). Compare the client build to this space's
    toolshed build before querying the current identity, compiling a
    replacement, or mutating the root. Unknown or mismatched builds leave it
    untouched; signal the shell only on a proven mismatch (both SHAs known).
-3. `currentId` = **cached** `GET {host}{url}?identity` (cache keyed by
-   `(host, url)`; cleared on socket reset — the identity is fixed for the
-   toolshed's lifetime, and a socket reset is the proxy for "maybe a restarted
-   or different toolshed"). Steady state is an in-memory compare, no request.
-   This step never loads the persisted pattern, so an obsolete identity that
-   cannot start does not block reconciliation. An identity failure performs no
-   metadata write; the subsequent root start retains its normal loud failure.
-4. `currentId === running patternIdentity.identity` → done (after stamping
-   provenance if this is a verified legacy root).
-5. Else fetch `{host}{url}` source, `compilePattern(program, { space })`, and
-   write the compiler-produced `{ identity, symbol }` entry ref.
-6. Start the reconciled root. A newly created root skips the check because it
+3. `currentId` = **cached** `GET {host}{url}?identity`. The cache key is
+   `(host, url, clientBuild)`, entries expire, and failed lookups are evicted.
+   Accept the response only when its `X-Common-Fabric-Build` header exactly
+   equals `clientBuild`; this binds the identity to the build even if `/api/meta`
+   and the pattern request reach different processes during a rolling deploy.
+   An identity failure performs no metadata write; the subsequent root start
+   retains its normal loud failure.
+4. If `patternSource` is absent, admit the root only when its stored ref is
+   exactly `{ identity: currentId, symbol: "default" }`; otherwise leave it
+   pinned.
+5. If `currentId === running patternIdentity.identity`, probe that exact stored
+   artifact. A successful load is done (and may back-fill proven provenance).
+   A missing or unloadable artifact continues to repair rather than taking the
+   fast path.
+6. Fetch `{host}{url}` and its imports, requiring every successful response to
+   carry the same build header. Compile with `compilePattern(program, { space })`.
+   Apply only when the compiler supplies an entry ref whose identity exactly
+   equals `currentId`; never synthesize a ref or fall back around `?identity`.
+7. Start the reconciled root. A newly created root skips the check because it
    was compiled from the current source in the same ensure operation; a root
    discovered after a creation race is treated as persisted and reconciled.
 
@@ -237,8 +245,9 @@ every system-root update or repair:
 
 - Compare the client's `gitSha` to the space's toolshed `gitSha` (`/api/meta`,
   cached per host).
-- **Match** → direct compare against the running `patternIdentity` is valid;
-  **no sidecar id is stored.**
+- **Match** → proceed, but require the `?identity` and source responses to attest
+  that same SHA. Direct comparison against the running `patternIdentity` is
+  valid only after that request-level binding; **no sidecar id is stored.**
 - **Proven mismatch** (both shas known, different) → touch nothing; emit an
   IPC signal to the shell
   (`versionSkew: { space, clientVersion, toolshedVersion }`). The shell
@@ -252,12 +261,14 @@ every system-root update or repair:
   helps.
 
 Source-run and headless processes can receive the same attested Labs revision
-through `COMMIT_SHA`: source-run toolshed exposes it from `/api/meta`, while the
-CLI and background-piece-service pass it as `Runtime.clientVersion` (including
-through the service's worker IPC). This makes the gate usable outside the
-browser without weakening it. Multi-toolshed makes the gate **per-space**
-(client vs *that* space's toolshed); rough edges accepted for v1, and a
-stale-client banner is useful hygiene beyond patterns.
+through `COMMIT_SHA`: source-run toolshed exposes it from `/api/meta` and on
+pattern responses, while the CLI and background-piece-service pass it as
+`Runtime.clientVersion` (including through the service's worker IPC). The
+toolshed's own Runtime uses the same effective SHA precedence as `/api/meta`:
+`TOOLSHED_GIT_SHA`, then baked build metadata, then `COMMIT_SHA`. This makes the
+gate usable outside the browser without weakening it. Multi-toolshed makes the
+gate **per-space** (client vs *that* space's toolshed); rough edges accepted for
+v1, and a stale-client banner is useful hygiene beyond patterns.
 
 **The gate is a system-pattern concern only.** Published-pattern updates
 resolve by reading a slug's target `patternIdentity` (a cell read of a value
@@ -283,13 +294,15 @@ so no build-dependence and no gate.
 
 - **Toolshed**: `?identity` handler + boot-time `{ name → identity }` cache in
   the patterns route (`patterns.routes.ts` / `patterns.handlers.ts` /
-  `patterns-server.ts`); import `computeModuleIdentities` +
-  `transformInjectHelperModule` from the runner.
+  `patterns-server.ts`); source and identity responses expose a build
+  attestation; import `computeModuleIdentities` + `transformInjectHelperModule`
+  from the runner.
 - **Runtime worker**: an update-check step at space open, next to
   `handleGetSpaceRootPattern` / `ensureDefaultPattern`
   (`runtime-client/backends/runtime-processor.ts`, `pieces-controller.ts`):
-  per-space host resolution, verified legacy-provenance recovery, version gate,
-  `?identity` cache, and an in-place `patternIdentity` swap before bootstrap.
+  per-space host resolution, exact-identity legacy-provenance recovery,
+  build-bound `?identity` cache and source closure, and an in-place
+  `patternIdentity` swap before bootstrap.
 - **Piece**: `patternSource` meta getter/setter; stamped by URL-based creation
   and recreation from the applicable source (system path, or a `cf:` ref derived
   from `defaultAppUrl`). Custom `RuntimeProgram` recreation remains unstamped;

--- a/packages/background-piece-service/README.md
+++ b/packages/background-piece-service/README.md
@@ -91,7 +91,10 @@ This model enables:
 Start the service:
 
 ```sh
-API_URL=http://localhost:8000 OPERATOR_PASS=your-passphrase deno task start
+COMMIT_SHA=<labs-revision> \
+  API_URL=http://localhost:8000 \
+  OPERATOR_PASS=your-passphrase \
+  deno task start
 ```
 
 ### Environment Variables
@@ -100,6 +103,9 @@ API_URL=http://localhost:8000 OPERATOR_PASS=your-passphrase deno task start
 - `OPERATOR_PASS`: Passphrase for the operator identity (default:
   `implicit trust`)
 - `IDENTITY`: (Optional) Path to an identity keyfile
+- `COMMIT_SHA`: (Optional) Labs revision passed to worker runtimes for the
+  system-pattern update version gate. It must match the target toolshed's
+  reported revision.
 
 ### Monitoring
 

--- a/packages/background-piece-service/cast-admin.ts
+++ b/packages/background-piece-service/cast-admin.ts
@@ -1,6 +1,7 @@
 import { parseArgs } from "@std/cli/parse-args";
 import { PieceManager } from "@commonfabric/piece";
 import {
+  clientVersionFromEnv,
   compileAndSavePattern,
   experimentalOptionsFromEnv,
   Runtime,
@@ -64,6 +65,7 @@ export function createRuntime(
       memoryHost: new URL(toolshedUrl),
     }),
     experimental: experimentalOptionsFromEnv(envGet),
+    clientVersion: clientVersionFromEnv(envGet),
   }));
 }
 

--- a/packages/background-piece-service/src/main.ts
+++ b/packages/background-piece-service/src/main.ts
@@ -1,5 +1,6 @@
 import { parseArgs } from "@std/cli/parse-args";
 import {
+  clientVersionFromEnv,
   type EnvReader,
   experimentalOptionsFromEnv,
   Runtime,
@@ -63,6 +64,7 @@ export function createRuntime(
       memoryHost: new URL(env.API_URL),
     }),
     experimental: experimentalOptionsFromEnv(readEnv),
+    clientVersion: clientVersionFromEnv(readEnv),
   }));
 }
 

--- a/packages/background-piece-service/src/service.ts
+++ b/packages/background-piece-service/src/service.ts
@@ -115,6 +115,7 @@ export class BackgroundPieceService {
           identity: this.identity,
           timeoutMs: this.workerTimeoutMs,
           experimental: this.runtime.experimental,
+          clientVersion: this.runtime.clientVersion,
         });
         this.pieceSchedulers.set(did, scheduler);
         scheduler.start();

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -23,6 +23,7 @@ export interface WorkerOptions {
   did: string;
   toolshedUrl: string;
   identity: Identity;
+  clientVersion?: string;
   timeoutMs?: number;
   experimental?: {
     modernCellRep?: boolean;
@@ -54,6 +55,7 @@ export class WorkerController extends EventTarget {
   private toolshedUrl: string;
   private identity: Identity;
   private timeoutMs: number;
+  private clientVersion?: string;
   private experimental?: WorkerOptions["experimental"];
   private msgId: number = 0;
   private pending = new Map<
@@ -71,6 +73,7 @@ export class WorkerController extends EventTarget {
     this.identity = options.identity;
     this.toolshedUrl = options.toolshedUrl;
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TASK_TIMEOUT;
+    this.clientVersion = options.clientVersion;
     this.experimental = options.experimental;
 
     console.log(`${this.did}: Creating worker controller`);
@@ -97,6 +100,7 @@ export class WorkerController extends EventTarget {
         toolshedUrl: this.toolshedUrl,
         rawIdentity: this.identity.serialize(),
         experimental: this.experimental,
+        clientVersion: this.clientVersion,
       });
       this.state = WorkerState.Ready;
     } catch (e) {

--- a/packages/background-piece-service/src/worker-ipc.ts
+++ b/packages/background-piece-service/src/worker-ipc.ts
@@ -11,6 +11,7 @@ export type InitializationData = {
   did: string;
   toolshedUrl: string;
   rawIdentity: KeyPairRaw;
+  clientVersion?: string;
   experimental?: {
     modernCellRep?: boolean;
     persistentSchedulerState?: boolean;
@@ -23,6 +24,8 @@ export function isInitializationData(
   return !!(isRecord(value) &&
     typeof value.did === "string" &&
     typeof value.toolshedUrl === "string" &&
+    (value.clientVersion === undefined ||
+      typeof value.clientVersion === "string") &&
     isKeyPairRaw(value.rawIdentity));
 }
 

--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -153,7 +153,7 @@ export async function initialize(
     return;
   }
 
-  const { did, toolshedUrl, rawIdentity, experimental } = data;
+  const { did, toolshedUrl, rawIdentity, experimental, clientVersion } = data;
   const identity = await Identity.deserialize(rawIdentity);
   const apiUrl = new URL(toolshedUrl);
 
@@ -179,6 +179,7 @@ export async function initialize(
     // runtime's resolved flags; `{}` (constructor defaults) covers a bare
     // caller.
     experimental: experimental ?? {},
+    clientVersion,
     consoleHandler: consoleHandler,
     errorHandlers: [errorHandler],
   }));

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -181,6 +181,7 @@ function pieceEntry(
 
 function fakeRuntime(piecesCell: FakePiecesCell) {
   return {
+    clientVersion: "service-build",
     experimental: {
       modernCellRep: true,
       persistentSchedulerState: false,
@@ -464,7 +465,10 @@ describe("BackgroundPieceService", () => {
       runtime: runtime as never,
       workerTimeoutMs: 123,
       createSpaceManager: (options) => ({
-        start: () => started.push(options.did),
+        start: () => {
+          assertEquals(options.clientVersion, "service-build");
+          started.push(options.did);
+        },
         stop: () => {
           stopped.push(options.did);
           return Promise.resolve();
@@ -946,6 +950,7 @@ describe("WorkerController", () => {
         did: TEST_DID,
         toolshedUrl: "http://localhost:8000",
         identity: await Identity.generate({ implementation: "noble" }),
+        clientVersion: "worker-build",
       });
       await controller.initializeResolve;
       assertEquals(controller.isReady(), true);
@@ -954,6 +959,11 @@ describe("WorkerController", () => {
       await controller.runPiece(entry as never);
       await controller.shutdown();
       const worker = MockWorker.instances[0];
+      assertEquals(
+        (worker.messages[0] as { data: { clientVersion?: string } }).data
+          .clientVersion,
+        "worker-build",
+      );
       assertEquals(worker.terminated, true);
       assertEquals(
         worker.messages.map((message) =>
@@ -1143,9 +1153,15 @@ describe("background piece service entry point", () => {
       identity,
       // Experimental flags flow through the injectable reader and the
       // canonical runner mapping, not EnvVars (CT-1814).
-      (key) => key === "EXPERIMENTAL_MODERN_CELL_REP" ? "true" : undefined,
+      (key) =>
+        key === "EXPERIMENTAL_MODERN_CELL_REP"
+          ? "true"
+          : key === "COMMIT_SHA"
+          ? "main-runtime-sha"
+          : undefined,
     );
     assertEquals(runtime.experimental.modernCellRep, true);
+    assertEquals(runtime.clientVersion, "main-runtime-sha");
     await runtime.dispose();
   });
 
@@ -1460,10 +1476,11 @@ describe("cast admin entry point", () => {
       identity,
       (key) => {
         consulted.add(key);
-        return undefined;
+        return key === "COMMIT_SHA" ? "cast-runtime-sha" : undefined;
       },
     );
     try {
+      assertEquals(runtime.clientVersion, "cast-runtime-sha");
       // The canonical mapping consults the reader passed through the
       // CastAdminDependencies boundary — not process env — for every
       // env-wired EXPERIMENTAL_* flag.

--- a/packages/background-piece-service/test/worker-ipc.test.ts
+++ b/packages/background-piece-service/test/worker-ipc.test.ts
@@ -18,7 +18,14 @@ describe("isWorkerIPCRequest", () => {
       isWorkerIPCRequest({
         msgId: 1,
         type: "initialize",
-        data: { did, toolshedUrl, rawIdentity },
+        data: { did, toolshedUrl, rawIdentity, clientVersion: "build-sha" },
+      }),
+    );
+    assert(
+      !isWorkerIPCRequest({
+        msgId: 1,
+        type: "initialize",
+        data: { did, toolshedUrl, rawIdentity, clientVersion: 42 },
       }),
     );
     assert(!isWorkerIPCRequest({ msgId: 1, type: "initialize" }));

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,7 +27,8 @@ they need to ignore a stale inherited `INIT_CWD`.
 
 The child CLI process inherits the parent environment. The launcher only adds
 `CF_CLI_NAME=cf`, so caller-provided `CF_API_URL`, `CF_IDENTITY`, experimental
-flags, and CFC/sandbox-related environment variables continue to flow through.
+flags, `COMMIT_SHA` build attestation, and CFC/sandbox-related environment
+variables continue to flow through.
 
 From the Labs checkout:
 

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -2,6 +2,7 @@ import { createSession, isDID, Session } from "@commonfabric/identity";
 import { loadIdentity } from "./identity.ts";
 import {
   ACLManager,
+  clientVersionFromEnv,
   experimentalOptionsFromEnv,
   Runtime,
   runtimePresets,
@@ -50,6 +51,7 @@ export async function createRuntime(
       spaceIdentity: session.spaceIdentity,
     }),
     experimental: experimentalOptionsFromEnv(Deno.env.get),
+    clientVersion: clientVersionFromEnv(Deno.env.get),
   }));
 
   if (!(await runtime.healthCheck())) {

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -3,6 +3,7 @@ import { ensureDir } from "@std/fs";
 import { loadIdentity } from "./identity.ts";
 import {
   Cell,
+  clientVersionFromEnv,
   entityIdFrom,
   experimentalOptionsFromEnv,
   formatFabricRef,
@@ -222,6 +223,7 @@ export async function loadManager(config: SpaceConfig): Promise<PieceManager> {
           spaceIdentity: session.spaceIdentity,
         }),
         experimental: experimentalOptionsFromEnv(Deno.env.get),
+        clientVersion: clientVersionFromEnv(Deno.env.get),
         errorHandlers: [
           (error) => {
             runtimeErrors.push({

--- a/packages/cli/test/run-tests.ts
+++ b/packages/cli/test/run-tests.ts
@@ -41,6 +41,7 @@ const SERIAL_TESTS = [
   "test/inspect-remote.test.ts",
   "test/log-level.test.ts",
   "test/main-command.test.ts",
+  "test/runtime-client-version.test.ts",
   "test/test-runner-compile-byte-cache.test.ts",
   "test/test-runner-pattern-coverage.test.ts",
   "test/view-mod-gate.test.ts",

--- a/packages/cli/test/runtime-client-version.test.ts
+++ b/packages/cli/test/runtime-client-version.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { createRuntime as createAclRuntime } from "../lib/acl.ts";
+import { loadManager } from "../lib/piece.ts";
+import { withEnv } from "./utils.ts";
+
+const TEST_COMMIT_SHA = "cli-runtime-version-test-sha";
+
+describe("CLI runtime client version", () => {
+  it("passes COMMIT_SHA through the ACL runtime", async () => {
+    const identity = await Identity.fromPassphrase("acl runtime version test");
+    const session = await createSession({
+      identity,
+      spaceName: "acl-runtime-version",
+    });
+    const originalHealthCheck = Runtime.prototype.healthCheck;
+    let created: Runtime | undefined;
+    Runtime.prototype.healthCheck = function () {
+      created = this;
+      return Promise.resolve(false);
+    };
+
+    await withEnv("COMMIT_SHA", TEST_COMMIT_SHA, async () => {
+      try {
+        await expect(createAclRuntime({
+          apiUrl: new URL("https://toolshed.test"),
+          identityPath: "unused",
+          space: "unused",
+        }, session)).rejects.toThrow("Could not connect");
+        expect(created).toBeDefined();
+        expect(created!.clientVersion).toBe(TEST_COMMIT_SHA);
+      } finally {
+        Runtime.prototype.healthCheck = originalHealthCheck;
+        if (created) {
+          await (created.storageManager as unknown as {
+            closeNow(): Promise<void>;
+          }).closeNow();
+          await created.dispose();
+        }
+      }
+    });
+  });
+
+  it("passes COMMIT_SHA through the piece manager runtime", async () => {
+    const identity = await Identity.fromPassphrase(
+      "piece runtime version test",
+      { implementation: "noble" },
+    );
+    const keyPath = await Deno.makeTempFile();
+    await Deno.writeFile(keyPath, identity.toPkcs8());
+    const originalHealthCheck = Runtime.prototype.healthCheck;
+    let created: Runtime | undefined;
+    Runtime.prototype.healthCheck = function () {
+      created = this;
+      return Promise.resolve(false);
+    };
+
+    await withEnv("COMMIT_SHA", TEST_COMMIT_SHA, async () => {
+      try {
+        await expect(loadManager({
+          apiUrl: "https://toolshed.test",
+          identity: keyPath,
+          space: "piece-runtime-version",
+        })).rejects.toThrow("Could not connect");
+        expect(created).toBeDefined();
+        expect(created!.clientVersion).toBe(TEST_COMMIT_SHA);
+      } finally {
+        Runtime.prototype.healthCheck = originalHealthCheck;
+        await Deno.remove(keyPath);
+      }
+    });
+  });
+});

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -83,10 +83,15 @@ export class HttpProgramResolver implements ProgramResolver {
   #fetchImpl: typeof globalThis.fetch;
   constructor(
     main: string | URL,
-    fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+    fetchImpl?: typeof globalThis.fetch,
   ) {
     this.#mainUrl = !(main instanceof URL) ? new URL(main) : main;
-    this.#fetchImpl = fetchImpl;
+    // Keep the host receiver for browser fetch. Capturing a fetch function and
+    // later calling it as a resolver field makes WorkerGlobalScope reject the
+    // call with `Illegal invocation`.
+    this.#fetchImpl = fetchImpl
+      ? (input, init) => fetchImpl.call(globalThis, input, init)
+      : (input, init) => globalThis.fetch(input, init);
   }
 
   main(): Promise<Source> {

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -80,8 +80,13 @@ export class FileSystemProgramResolver implements ProgramResolver {
 export class HttpProgramResolver implements ProgramResolver {
   #mainUrl: URL;
   #main?: Promise<Source>;
-  constructor(main: string | URL) {
+  #fetchImpl: typeof globalThis.fetch;
+  constructor(
+    main: string | URL,
+    fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+  ) {
     this.#mainUrl = !(main instanceof URL) ? new URL(main) : main;
+    this.#fetchImpl = fetchImpl;
   }
 
   main(): Promise<Source> {
@@ -101,7 +106,7 @@ export class HttpProgramResolver implements ProgramResolver {
   }
 
   async #fetch(url: URL): Promise<Source> {
-    const res = await fetch(url);
+    const res = await this.#fetchImpl(url);
     if (!res.ok) {
       throw new Error(
         `Failed to fetch ${url}: ${res.status} ${res.statusText}`,

--- a/packages/js-compiler/test/program.test.ts
+++ b/packages/js-compiler/test/program.test.ts
@@ -1,0 +1,49 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { HttpProgramResolver } from "../program.ts";
+
+describe("HttpProgramResolver", () => {
+  it("invokes the default fetch with the host global as receiver", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = function (
+      this: typeof globalThis,
+      _input: RequestInfo | URL,
+      _init?: RequestInit,
+    ): Promise<Response> {
+      if (this !== globalThis) throw new TypeError("Illegal invocation");
+      return Promise.resolve(new Response("export default 42"));
+    } as typeof globalThis.fetch;
+
+    try {
+      const resolver = new HttpProgramResolver(
+        "https://patterns.example/main.ts",
+      );
+      expect(await resolver.main()).toEqual({
+        name: "/main.ts",
+        contents: "export default 42",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("invokes an injected fetch with the host global as receiver", async () => {
+    const fetchImpl = function (
+      this: typeof globalThis,
+      _input: RequestInfo | URL,
+      _init?: RequestInit,
+    ): Promise<Response> {
+      if (this !== globalThis) throw new TypeError("Illegal invocation");
+      return Promise.resolve(new Response("export default 42"));
+    } as typeof globalThis.fetch;
+
+    const resolver = new HttpProgramResolver(
+      "https://patterns.example/main.ts",
+      fetchImpl,
+    );
+    expect(await resolver.main()).toEqual({
+      name: "/main.ts",
+      contents: "export default 42",
+    });
+  });
+});

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -660,6 +660,15 @@ describe("RuntimeInternals", () => {
       expect(url.pathname).toBe("/scripts/worker-runtime.js");
       expect(url.searchParams.has("v")).toBe(false);
     });
+
+    it("keeps the local worker URL with an attested client version", async () => {
+      const url = await workerUrlFromCreate({
+        clientVersion: "source-checkout-sha",
+        getBuildHash: () => Promise.resolve("local-worker-hash"),
+      });
+      expect(url.pathname).toBe("/scripts/worker-runtime.js");
+      expect(url.searchParams.get("v")).toBe("local-worker-hash");
+    });
   });
 
   // CT-1623: starting a piece is expensive (pattern instantiation + eager

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -331,14 +331,14 @@ export class PiecesController<T = unknown> {
       if (isHomeSpace) {
         patternConfig = {
           name: "Home",
-          urlPath: "/api/patterns/system/home.tsx",
+          urlPath: HOME_PATTERN_URL,
           cause: `home-pattern-${Date.now()}`,
         };
       } else {
         const customUrl = await this.getDefaultAppUrlFromHome();
         patternConfig = {
           name: "DefaultPieceList",
-          urlPath: customUrl || "/api/patterns/system/default-app.tsx",
+          urlPath: customUrl || DEFAULT_APP_PATTERN_URL,
           cause: `space-root-${Date.now()}`,
         };
       }
@@ -372,6 +372,20 @@ export class PiecesController<T = unknown> {
 
       // Run pattern setup within same transaction
       this.#manager.runtime.run(tx, pattern, {}, pieceCell);
+
+      // Stamp the provenance the piece tracks for updates, mirroring
+      // ensureDefaultPattern (CT-1890). Without this, every recreated root
+      // is born unprovenanced and checkAndUpdateDefaultPattern skips
+      // sourceless non-home roots forever — the repair path would mint
+      // roots that can never auto-migrate. A custom program has no URL the
+      // auto-updater could re-fetch (stamping the "custom" placeholder
+      // would poison URL resolution — it would resolve relative to the
+      // host); its locator, when supplied, is recorded via
+      // setPatternRepository below, so a custom root without a repository
+      // intentionally stays unstamped.
+      if (options?.customProgram === undefined) {
+        setPatternSource(pieceCell, tx, patternConfig.urlPath);
+      }
 
       if (options?.repository !== undefined) {
         setPatternRepository(pieceCell, tx, options.repository);

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -35,18 +35,15 @@ const PIECE_TRACE_TIMINGS = typeof Deno !== "undefined" &&
 // System space-root patterns, served as raw TSX by the toolshed patterns route.
 export const HOME_PATTERN_URL = "/api/patterns/system/home.tsx";
 export const DEFAULT_APP_PATTERN_URL = "/api/patterns/system/default-app.tsx";
+const LOCAL_HOME_PATTERN_PATH = "/system/home.tsx";
+const LOCAL_DEFAULT_APP_PATTERN_PATH = "/system/default-app.tsx";
 
 /**
- * The system space-root pattern URL a space of this type is created with — the
- * home DID gets home.tsx, every other space the default app. Used to back-fill
- * `patternSource` for spaces created before provenance stamping.
- *
- * Known v1 limitation: an existing *custom-app* space (whose root was seeded
- * from home's `defaultAppUrl`) that carries no stored `patternSource` derives to
- * default-app.tsx here. The auto-update check must therefore only act when a
- * stored `patternSource` is present (or the running identity matches a known
- * system identity) — otherwise it would roll a custom app to the default. See
- * docs/specs/pattern-imports/pattern-updates.md risk list.
+ * The official system space-root pattern URL for a space type — the home DID
+ * gets home.tsx, every other space gets the default app. This derivation alone
+ * is not proof that an existing sourceless root is a system root: legacy
+ * recovery must first verify its stored source closure and exact entry path via
+ * {@link inferLegacySystemPatternSource}.
  */
 export function deriveSystemPatternUrl(
   space: MemorySpace,
@@ -55,6 +52,40 @@ export function deriveSystemPatternUrl(
   return space === runtime.userIdentityDID
     ? HOME_PATTERN_URL
     : DEFAULT_APP_PATTERN_URL;
+}
+
+/**
+ * Recover update provenance for a pre-`patternSource` root only when its
+ * content-addressed source closure verifies and names the official system entry
+ * appropriate to this space. The filename check is deliberately exact: a
+ * custom or mismatched root must remain pinned rather than being replaced with
+ * the default app.
+ */
+async function inferLegacySystemPatternSource(
+  root: Cell<unknown>,
+  runtime: Runtime,
+  space: MemorySpace,
+): Promise<string | undefined> {
+  const ref = getPatternIdentityRef(root);
+  if (ref === undefined) return undefined;
+  const program = await runtime.patternManager
+    .getPatternSourceProgramByIdentity(
+      ref.identity,
+      space,
+    );
+  const expected = deriveSystemPatternUrl(space, runtime);
+  switch (program?.main) {
+    case HOME_PATTERN_URL:
+    case LOCAL_HOME_PATTERN_PATH:
+      return expected === HOME_PATTERN_URL ? HOME_PATTERN_URL : undefined;
+    case DEFAULT_APP_PATTERN_URL:
+    case LOCAL_DEFAULT_APP_PATTERN_PATH:
+      return expected === DEFAULT_APP_PATTERN_URL
+        ? DEFAULT_APP_PATTERN_URL
+        : undefined;
+    default:
+      return undefined;
+  }
 }
 
 // Same logger as manager.ts's timePiecePhase: timing stats record even while
@@ -69,6 +100,7 @@ const pieceUpdateLogger = getLogger("piece.update", {
 /** The result of a system-pattern update check. */
 export type UpdateOutcome =
   | "updated"
+  | "repaired-provenance"
   | "current"
   | "skipped-skew"
   | "skipped-unknown-build"
@@ -621,19 +653,37 @@ export class PiecesController<T = unknown> {
       if (!root) return "current";
 
       // 3. Provenance + per-space host (NOT the global apiUrl — a foreign-homed
-      //    space must resolve against its own toolshed). A non-home root
-      //    created before provenance stamping has no patternSource; we must NOT
-      //    derive default-app.tsx for it — a custom-app space (seeded from
-      //    home's defaultAppUrl) would be silently rolled to the default app.
-      //    Deriving is only safe for the home root (definitionally home.tsx).
-      //    Legacy non-home roots stay pinned until re-created stamps them; a
-      //    known-system-identity match could relax this later (spec M2.3).
+      //    space must resolve against its own toolshed). A root created before
+      //    provenance stamping is eligible only when its content-addressed,
+      //    verified source closure names the official system entry appropriate
+      //    to this space. Blindly deriving by space type could replace a custom
+      //    home or a non-home root seeded from home's custom defaultAppUrl.
       const storedSource = getPatternSource(root);
-      if (storedSource === undefined && !isHomeSpace) {
+      const inferredSource = storedSource === undefined
+        ? await inferLegacySystemPatternSource(root, runtime, space)
+        : undefined;
+      if (storedSource === undefined && inferredSource === undefined) {
         return "current";
       }
-      const url = storedSource ?? deriveSystemPatternUrl(space, runtime);
+      const url = storedSource ?? inferredSource!;
       const host = runtime.mappedHostFor(space) ?? runtime.apiUrl.href;
+      const repairInferredProvenance = async (): Promise<UpdateOutcome> => {
+        const { error } = await runtime.editWithRetry((tx) => {
+          setPatternSource(root, tx, url);
+        });
+        if (error) {
+          pieceUpdateLogger.warn(
+            "provenance-repair-failed",
+            () => [
+              "checkAndUpdateDefaultPattern: provenance repair failed",
+              space,
+              error,
+            ],
+          );
+          return "current";
+        }
+        return "repaired-provenance";
+      };
 
       // The version gate (step 4) validates `host`'s build, and the light
       // ?identity is only trustworthy from that same build — so only act on a
@@ -645,36 +695,71 @@ export class PiecesController<T = unknown> {
         return "current";
       }
 
-      // 4. Version gate: the light ?identity is only comparable within a build.
-      const toolshedVersion = await runtime.toolshedGitSha(host);
-      if (!buildsMatch(runtime.clientVersion, toolshedVersion)) {
-        // An unknown sha on either side (dev/source servers carry none)
-        // proves nothing — skip silently. The skew signal raises the shell's
-        // "reload to update" banner, which must only claim what is proven:
-        // both builds known and different. Signalling on unknown would show
-        // the banner on every space open in local dev, where no reload helps.
-        if (
-          runtime.clientVersion === undefined || toolshedVersion === undefined
-        ) {
-          return "skipped-unknown-build";
+      const runningRef = getPatternIdentityRef(root);
+      let runningPatternIsLoadable = false;
+      if (runningRef !== undefined) {
+        try {
+          runningPatternIsLoadable =
+            await runtime.patternManager.loadPatternByIdentity(
+              runningRef.identity,
+              runningRef.symbol,
+              space,
+            ) !== undefined;
+        } catch (error) {
+          // A thrown cold-load failure is just as broken as an undefined result:
+          // continue into direct compilation so ensure() can repair before start.
+          pieceUpdateLogger.warn(
+            "stored-root-load-failed",
+            () => [
+              "checkAndUpdateDefaultPattern: stored root could not load",
+              space,
+              error,
+            ],
+          );
         }
-        runtime.reportVersionSkew({
-          space,
-          clientVersion: runtime.clientVersion,
-          toolshedVersion,
-        });
-        return "skipped-skew";
+      }
+      let currentId: string | undefined;
+
+      if (runningPatternIsLoadable) {
+        // 4. Healthy-root fast path. The light ?identity is only comparable
+        //    within a build, so retain the SHA gate for this cheap check.
+        const toolshedVersion = await runtime.toolshedGitSha(host);
+        if (!buildsMatch(runtime.clientVersion, toolshedVersion)) {
+          // An unknown sha on either side (dev/source servers carry none)
+          // proves nothing — skip silently. The skew signal raises the shell's
+          // "reload to update" banner, which must only claim what is proven:
+          // both builds known and different. Signalling on unknown would show
+          // the banner on every space open in local dev, where no reload helps.
+          if (
+            runtime.clientVersion === undefined || toolshedVersion === undefined
+          ) {
+            return "skipped-unknown-build";
+          }
+          runtime.reportVersionSkew({
+            space,
+            clientVersion: runtime.clientVersion,
+            toolshedVersion,
+          });
+          return "skipped-skew";
+        }
+
+        // 5. Current identity from the toolshed (cached).
+        currentId = await runtime.cachedPatternIdentity(host, url);
+        if (currentId === undefined) return "current"; // unresolved → skip
+
+        // 6. Compare to the running identity. A verified legacy root that is
+        //    already current needs only the missing provenance write.
+        if (currentId === runningRef?.identity) {
+          if (storedSource !== undefined) return "current";
+          return await repairInferredProvenance();
+        }
       }
 
-      // 5. Current identity from the toolshed (cached).
-      const currentId = await runtime.cachedPatternIdentity(host, url);
-      if (currentId === undefined) return "current"; // unresolved → skip
-
-      // 6. Compare to the running identity.
-      const running = getPatternIdentityRef(root)?.identity;
-      if (currentId === running) return "current";
-
-      // 7. Apply: compile the new source, then swap patternIdentity in place.
+      // 7. Apply/repair. A root that cannot load must not be blocked by the
+      //    version gate: fetch and compile its proven source directly, making
+      //    the compiler-produced entry ref authoritative instead of comparing
+      //    the cross-build light identity. Compilation failure is caught by the
+      //    outer best-effort boundary and leaves the stored root untouched.
       const program = await runtime.harness.resolve(
         new HttpProgramResolver(target.href),
       );
@@ -682,7 +767,21 @@ export class PiecesController<T = unknown> {
         space,
       });
       const entryRef = runtime.patternManager.getArtifactEntryRef(pattern) ??
-        { identity: currentId, symbol: "default" };
+        (currentId === undefined
+          ? undefined
+          : { identity: currentId, symbol: "default" });
+      if (entryRef === undefined) {
+        throw new Error("Compiled system pattern has no entry identity");
+      }
+      if (
+        entryRef.identity === runningRef?.identity &&
+        entryRef.symbol === runningRef.symbol
+      ) {
+        if (storedSource === undefined) {
+          return await repairInferredProvenance();
+        }
+        return "current";
+      }
       const { error } = await runtime.editWithRetry((tx) => {
         root.withTx(tx).setMetaRaw("patternIdentity", {
           identity: entryRef.identity,

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -687,19 +687,17 @@ export class PiecesController<T = unknown> {
         return "repaired-provenance";
       };
 
-      // The version gate (step 4) validates `host`'s build, and any replacement
-      // compiled from its source is only safe under that same build — so only
-      // act on a source served BY `host`. A cross-origin patternSource (a
-      // published / custom-app source on another host) would be gated against
-      // the wrong build; defer it to the cross-host published-pattern flow.
+      // The version gate (step 4) validates `host`'s build, and ?identity is
+      // only comparable within that build — so only act on a source served BY
+      // `host`. A cross-origin patternSource (a published / custom-app source
+      // on another host) would be gated against the wrong build; defer it to
+      // the cross-host published-pattern flow.
       const target = new URL(url, host);
       if (target.origin !== new URL(host).origin) {
         return "current";
       }
 
-      // 4. Version gate. This is a precondition for every mutation, including
-      // direct repair of an unloadable root. Falling back from ?identity to
-      // compilation does not make cross-build replacement safe.
+      // 4. Version gate. This is a precondition for every update.
       const toolshedVersion = await runtime.toolshedGitSha(host);
       if (!buildsMatch(runtime.clientVersion, toolshedVersion)) {
         // An unknown sha on either side proves nothing — skip silently. The
@@ -718,50 +716,23 @@ export class PiecesController<T = unknown> {
         return "skipped-skew";
       }
 
-      // 5. Determine whether the persisted root is loadable under the matched
-      // build. A failed load takes the direct compile-and-repair path below.
+      // 5. Current identity from the toolshed (cached). This does not load the
+      // persisted pattern, so a stale identity that cannot start can still be
+      // replaced before bootstrap.
       const runningRef = getPatternIdentityRef(root);
-      let runningPatternIsLoadable = false;
-      if (runningRef !== undefined) {
-        try {
-          runningPatternIsLoadable =
-            await runtime.patternManager.loadPatternByIdentity(
-              runningRef.identity,
-              runningRef.symbol,
-              space,
-            ) !== undefined;
-        } catch (error) {
-          // A thrown cold-load failure is just as broken as an undefined result:
-          // continue into direct compilation so ensure() can repair before start.
-          pieceUpdateLogger.warn(
-            "stored-root-load-failed",
-            () => [
-              "checkAndUpdateDefaultPattern: stored root could not load",
-              space,
-              error,
-            ],
-          );
-        }
-      }
-      let currentId: string | undefined;
+      const currentId = await runtime.cachedPatternIdentity(host, url);
+      if (currentId === undefined) return "current"; // unresolved → skip
 
-      if (runningPatternIsLoadable) {
-        // 6. Current identity from the toolshed (cached).
-        currentId = await runtime.cachedPatternIdentity(host, url);
-        if (currentId === undefined) return "current"; // unresolved → skip
-
-        // 7. Compare to the running identity. A verified legacy root that is
-        //    already current needs only the missing provenance write.
-        if (currentId === runningRef?.identity) {
-          if (storedSource !== undefined) return "current";
-          return await repairInferredProvenance();
-        }
+      // 6. Compare to the persisted identity. A verified legacy root that is
+      // already current needs only the missing provenance write.
+      if (currentId === runningRef?.identity) {
+        if (storedSource !== undefined) return "current";
+        return await repairInferredProvenance();
       }
 
-      // 8. Apply/repair. For an unloadable root, fetch and compile its proven
-      //    source directly under the already-matched build, making the
-      //    compiler-produced entry ref authoritative instead of depending on
-      //    ?identity. Compilation failure leaves the stored root untouched.
+      // 7. Apply. Fetch and compile only after ?identity proves that the
+      // toolshed serves a different pattern. Compilation failure leaves the
+      // persisted root untouched.
       const program = await runtime.harness.resolve(
         new HttpProgramResolver(target.href),
       );
@@ -769,12 +740,7 @@ export class PiecesController<T = unknown> {
         space,
       });
       const entryRef = runtime.patternManager.getArtifactEntryRef(pattern) ??
-        (currentId === undefined
-          ? undefined
-          : { identity: currentId, symbol: "default" });
-      if (entryRef === undefined) {
-        throw new Error("Compiled system pattern has no entry identity");
-      }
+        { identity: currentId, symbol: "default" };
       if (
         entryRef.identity === runningRef?.identity &&
         entryRef.symbol === runningRef.symbol

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -6,11 +6,13 @@ import {
   type EnvReader,
   experimentalOptionsFromEnv,
   getPatternIdentityRef,
+  getPatternRepository,
   getPatternSource,
   type JSONSchema,
   type MemorySpace,
   type ModuleByteCache,
   type PatternCoverageCollector,
+  patternResponseBuild,
   Runtime,
   runtimePresets,
   RuntimeProgram,
@@ -36,15 +38,13 @@ const PIECE_TRACE_TIMINGS = typeof Deno !== "undefined" &&
 // System space-root patterns, served as raw TSX by the toolshed patterns route.
 export const HOME_PATTERN_URL = "/api/patterns/system/home.tsx";
 export const DEFAULT_APP_PATTERN_URL = "/api/patterns/system/default-app.tsx";
-const LOCAL_HOME_PATTERN_PATH = "/system/home.tsx";
-const LOCAL_DEFAULT_APP_PATTERN_PATH = "/system/default-app.tsx";
 
 /**
  * The official system space-root pattern URL for a space type — the home DID
- * gets home.tsx, every other space gets the default app. This derivation alone
- * is not proof that an existing sourceless root is a system root: legacy
- * recovery must first verify its stored source closure and exact entry path via
- * {@link inferLegacySystemPatternSource}.
+ * gets home.tsx, every other space gets the default app. This derivation only
+ * selects the identity to check; it never proves that a sourceless root tracks
+ * that URL. Exact equality with the build-attested official identity supplies
+ * that proof below.
  */
 export function deriveSystemPatternUrl(
   space: MemorySpace,
@@ -53,40 +53,6 @@ export function deriveSystemPatternUrl(
   return space === runtime.userIdentityDID
     ? HOME_PATTERN_URL
     : DEFAULT_APP_PATTERN_URL;
-}
-
-/**
- * Recover update provenance for a pre-`patternSource` root only when its
- * content-addressed source closure verifies and names the official system entry
- * appropriate to this space. The filename check is deliberately exact: a
- * custom or mismatched root must remain pinned rather than being replaced with
- * the default app.
- */
-async function inferLegacySystemPatternSource(
-  root: Cell<unknown>,
-  runtime: Runtime,
-  space: MemorySpace,
-): Promise<string | undefined> {
-  const ref = getPatternIdentityRef(root);
-  if (ref === undefined) return undefined;
-  const program = await runtime.patternManager
-    .getPatternSourceProgramByIdentity(
-      ref.identity,
-      space,
-    );
-  const expected = deriveSystemPatternUrl(space, runtime);
-  switch (program?.main) {
-    case HOME_PATTERN_URL:
-    case LOCAL_HOME_PATTERN_PATH:
-      return expected === HOME_PATTERN_URL ? HOME_PATTERN_URL : undefined;
-    case DEFAULT_APP_PATTERN_URL:
-    case LOCAL_DEFAULT_APP_PATTERN_PATH:
-      return expected === DEFAULT_APP_PATTERN_URL
-        ? DEFAULT_APP_PATTERN_URL
-        : undefined;
-    default:
-      return undefined;
-  }
 }
 
 // Same logger as manager.ts's timePiecePhase: timing stats record even while
@@ -409,9 +375,10 @@ export class PiecesController<T = unknown> {
 
       // Stamp the provenance the piece tracks for updates, mirroring
       // ensureDefaultPattern (CT-1890). Without this, every recreated root
-      // is born unprovenanced and checkAndUpdateDefaultPattern skips
-      // sourceless non-home roots forever — the repair path would mint
-      // roots that can never auto-migrate. A custom program has no URL the
+      // is born unprovenanced and checkAndUpdateDefaultPattern can only admit
+      // it while its ref exactly equals the current official identity — the
+      // repair path would otherwise mint roots with no durable update source.
+      // A custom program has no URL the
       // auto-updater could re-fetch (stamping the "custom" placeholder
       // would poison URL resolution — it would resolve relative to the
       // host); its locator, when supplied, is recorded via
@@ -625,9 +592,9 @@ export class PiecesController<T = unknown> {
    * Roll the space's system root pattern forward in place if its toolshed
    * serves a newer content identity. Best-effort: every failure logs and
    * returns without throwing. During {@link ensureDefaultPattern}, this runs
-   * before the persisted root is started, so an unloadable obsolete identity
-   * can be replaced before bootstrap. If the root is already running, its
-   * watcher applies the same metadata swap in place.
+   * before the persisted root is started, so an eligible tracked root's
+   * unloadable obsolete identity can be replaced before bootstrap. If the root
+   * is already running, its watcher applies the same metadata swap in place.
    *
    * Never calls run()/stop()/recreateDefaultPattern.
    */
@@ -655,21 +622,21 @@ export class PiecesController<T = unknown> {
       if (!root) return "current";
 
       // 3. Provenance + per-space host (NOT the global apiUrl — a foreign-homed
-      //    space must resolve against its own toolshed). A root created before
-      //    provenance stamping is eligible only when its content-addressed,
-      //    verified source closure names the official system entry appropriate
-      //    to this space. Blindly deriving by space type could replace a custom
-      //    home or a non-home root seeded from home's custom defaultAppUrl.
+      //    space must resolve against its own toolshed). For a pre-provenance
+      //    root, derive only the official URL whose identity can be tested. The
+      //    URL or an author-controlled filename is not provenance: below, only
+      //    an exact match with the build-attested current identity admits it.
+      const runningRef = getPatternIdentityRef(root);
+      if (runningRef === undefined) return "current";
       const storedSource = getPatternSource(root);
-      const inferredSource = storedSource === undefined
-        ? await inferLegacySystemPatternSource(root, runtime, space)
-        : undefined;
-      if (storedSource === undefined && inferredSource === undefined) {
+      if (
+        storedSource === undefined && getPatternRepository(root) !== undefined
+      ) {
         return "current";
       }
-      const url = storedSource ?? inferredSource!;
+      const url = storedSource ?? deriveSystemPatternUrl(space, runtime);
       const host = runtime.mappedHostFor(space) ?? runtime.apiUrl.href;
-      const repairInferredProvenance = async (): Promise<UpdateOutcome> => {
+      const repairProvenance = async (): Promise<UpdateOutcome> => {
         const { error } = await runtime.editWithRetry((tx) => {
           setPatternSource(root, tx, url);
         });
@@ -715,38 +682,91 @@ export class PiecesController<T = unknown> {
         });
         return "skipped-skew";
       }
+      const expectedBuild = runtime.clientVersion;
+      if (expectedBuild === undefined) return "skipped-unknown-build";
 
-      // 5. Current identity from the toolshed (cached). This does not load the
-      // persisted pattern, so a stale identity that cannot start can still be
-      // replaced before bootstrap.
-      const runningRef = getPatternIdentityRef(root);
-      const currentId = await runtime.cachedPatternIdentity(host, url);
+      // 5. Current identity from the toolshed (cached per serving build). The
+      // response itself must attest `expectedBuild`, binding this request to the
+      // version gate even during a rolling deploy.
+      const currentId = await runtime.cachedPatternIdentity(
+        host,
+        url,
+        expectedBuild,
+      );
       if (currentId === undefined) return "current"; // unresolved → skip
 
-      // 6. Compare to the persisted identity. A verified legacy root that is
-      // already current needs only the missing provenance write.
-      if (currentId === runningRef?.identity) {
-        if (storedSource !== undefined) return "current";
-        return await repairInferredProvenance();
+      // A sourceless root is eligible only when its full content identity (which
+      // includes authored module paths) is exactly the official current entry.
+      // This admits a known system identity, never a lookalike filename. A stale
+      // sourceless root stays pinned until an explicit migration supplies its
+      // durable provenance.
+      if (
+        storedSource === undefined &&
+        (runningRef.identity !== currentId || runningRef.symbol !== "default")
+      ) {
+        return "current";
       }
 
-      // 7. Apply. Fetch and compile only after ?identity proves that the
-      // toolshed serves a different pattern. Compilation failure leaves the
-      // persisted root untouched.
+      // 6. Equal identity is not enough to declare the root healthy: persisted
+      // source/compiled closures or the stored symbol may still be unloadable.
+      // Probe the exact ref; only the successful load takes the fast path.
+      if (currentId === runningRef?.identity) {
+        let loadable = false;
+        try {
+          loadable = await runtime.patternManager.loadPatternByIdentity(
+            runningRef.identity,
+            runningRef.symbol,
+            space,
+          ) !== undefined;
+        } catch {
+          // Continue through the same identity-authorized source path below.
+        }
+        if (loadable) {
+          if (storedSource !== undefined) return "current";
+          return await repairProvenance();
+        }
+      }
+
+      // 7. Apply/repair. Every successful source response must attest the same
+      // build as ?identity; imports are checked too because HttpProgramResolver
+      // uses this fetch for the whole authored closure.
+      const attestedFetch: typeof globalThis.fetch = async (input, init) => {
+        const response = await runtime.fetch(input, init);
+        if (
+          response.ok && patternResponseBuild(response) !== expectedBuild
+        ) {
+          throw new Error(
+            `Pattern source response was not served by build ${expectedBuild}`,
+          );
+        }
+        return response;
+      };
       const program = await runtime.harness.resolve(
-        new HttpProgramResolver(target.href),
+        new HttpProgramResolver(target.href, attestedFetch),
       );
       const pattern = await runtime.patternManager.compilePattern(program, {
         space,
       });
-      const entryRef = runtime.patternManager.getArtifactEntryRef(pattern) ??
-        { identity: currentId, symbol: "default" };
+      const entryRef = runtime.patternManager.getArtifactEntryRef(pattern);
+      if (entryRef === undefined || entryRef.identity !== currentId) {
+        pieceUpdateLogger.warn(
+          "identity-attestation-mismatch",
+          () => [
+            "checkAndUpdateDefaultPattern: compiled source did not match " +
+            "the build-attested identity",
+            space,
+            currentId,
+            entryRef?.identity,
+          ],
+        );
+        return "current";
+      }
       if (
         entryRef.identity === runningRef?.identity &&
         entryRef.symbol === runningRef.symbol
       ) {
         if (storedSource === undefined) {
-          return await repairInferredProvenance();
+          return await repairProvenance();
         }
         return "current";
       }

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -629,29 +629,41 @@ export class PiecesController<T = unknown> {
       const runningRef = getPatternIdentityRef(root);
       if (runningRef === undefined) return "current";
       const storedSource = getPatternSource(root);
-      if (
-        storedSource === undefined && getPatternRepository(root) !== undefined
-      ) {
+      const storedRepository = getPatternRepository(root);
+      if (storedSource === undefined && storedRepository !== undefined) {
         return "current";
       }
       const url = storedSource ?? deriveSystemPatternUrl(space, runtime);
       const host = runtime.mappedHostFor(space) ?? runtime.apiUrl.href;
+      // Async identity/load/compile work must not authorize a later write to a
+      // root another client has replaced in the meantime. Reading all captured
+      // metadata inside each transaction makes both writes compare-and-swap;
+      // editWithRetry re-runs this predicate after every conflict.
+      const rootStillMatches = (candidate: Cell<NameSchema>): boolean => {
+        const candidateRef = getPatternIdentityRef(candidate);
+        return candidateRef?.identity === runningRef.identity &&
+          candidateRef.symbol === runningRef.symbol &&
+          getPatternSource(candidate) === storedSource &&
+          getPatternRepository(candidate) === storedRepository;
+      };
       const repairProvenance = async (): Promise<UpdateOutcome> => {
-        const { error } = await runtime.editWithRetry((tx) => {
+        const result = await runtime.editWithRetry((tx) => {
+          if (!rootStillMatches(root.withTx(tx))) return false;
           setPatternSource(root, tx, url);
+          return true;
         });
-        if (error) {
+        if (result.error) {
           pieceUpdateLogger.warn(
             "provenance-repair-failed",
             () => [
               "checkAndUpdateDefaultPattern: provenance repair failed",
               space,
-              error,
+              result.error,
             ],
           );
           return "current";
         }
-        return "repaired-provenance";
+        return result.ok ? "repaired-provenance" : "current";
       };
 
       // The version gate (step 4) validates `host`'s build, and ?identity is
@@ -770,21 +782,27 @@ export class PiecesController<T = unknown> {
         }
         return "current";
       }
-      const { error } = await runtime.editWithRetry((tx) => {
+      const result = await runtime.editWithRetry((tx) => {
+        if (!rootStillMatches(root.withTx(tx))) return false;
         root.withTx(tx).setMetaRaw("patternIdentity", {
           identity: entryRef.identity,
           symbol: entryRef.symbol,
         });
         setPatternSource(root, tx, url); // back-fill provenance
+        return true;
       });
-      if (error) {
+      if (result.error) {
         pieceUpdateLogger.warn(
           "swap-failed",
-          () => ["checkAndUpdateDefaultPattern: swap failed", space, error],
+          () => [
+            "checkAndUpdateDefaultPattern: swap failed",
+            space,
+            result.error,
+          ],
         );
         return "current";
       }
-      return "updated";
+      return result.ok ? "updated" : "current";
     } catch (error) {
       pieceUpdateLogger.warn(
         "check-failed",

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -1,6 +1,7 @@
 import {
   buildsMatch,
   type Cell,
+  clientVersionFromEnv,
   entityIdFrom,
   type EnvReader,
   experimentalOptionsFromEnv,
@@ -266,6 +267,7 @@ export class PiecesController<T = unknown> {
         spaceIdentity: session.spaceIdentity,
       }),
       experimental: experimentalOptionsFromEnv(readEnv),
+      clientVersion: clientVersionFromEnv(readEnv),
       moduleByteCache,
       patternCoverage,
       trustSnapshotProvider: () => ({
@@ -685,16 +687,39 @@ export class PiecesController<T = unknown> {
         return "repaired-provenance";
       };
 
-      // The version gate (step 4) validates `host`'s build, and the light
-      // ?identity is only trustworthy from that same build — so only act on a
-      // source served BY `host`. A cross-origin patternSource (a published /
-      // custom-app source on another host) would be gated against the wrong
-      // build; defer it to the cross-host published-pattern flow (Phase 4).
+      // The version gate (step 4) validates `host`'s build, and any replacement
+      // compiled from its source is only safe under that same build — so only
+      // act on a source served BY `host`. A cross-origin patternSource (a
+      // published / custom-app source on another host) would be gated against
+      // the wrong build; defer it to the cross-host published-pattern flow.
       const target = new URL(url, host);
       if (target.origin !== new URL(host).origin) {
         return "current";
       }
 
+      // 4. Version gate. This is a precondition for every mutation, including
+      // direct repair of an unloadable root. Falling back from ?identity to
+      // compilation does not make cross-build replacement safe.
+      const toolshedVersion = await runtime.toolshedGitSha(host);
+      if (!buildsMatch(runtime.clientVersion, toolshedVersion)) {
+        // An unknown sha on either side proves nothing — skip silently. The
+        // skew signal raises the shell's "reload to update" banner, which must
+        // only claim what is proven: both builds known and different.
+        if (
+          runtime.clientVersion === undefined || toolshedVersion === undefined
+        ) {
+          return "skipped-unknown-build";
+        }
+        runtime.reportVersionSkew({
+          space,
+          clientVersion: runtime.clientVersion,
+          toolshedVersion,
+        });
+        return "skipped-skew";
+      }
+
+      // 5. Determine whether the persisted root is loadable under the matched
+      // build. A failed load takes the direct compile-and-repair path below.
       const runningRef = getPatternIdentityRef(root);
       let runningPatternIsLoadable = false;
       if (runningRef !== undefined) {
@@ -721,33 +746,11 @@ export class PiecesController<T = unknown> {
       let currentId: string | undefined;
 
       if (runningPatternIsLoadable) {
-        // 4. Healthy-root fast path. The light ?identity is only comparable
-        //    within a build, so retain the SHA gate for this cheap check.
-        const toolshedVersion = await runtime.toolshedGitSha(host);
-        if (!buildsMatch(runtime.clientVersion, toolshedVersion)) {
-          // An unknown sha on either side (dev/source servers carry none)
-          // proves nothing — skip silently. The skew signal raises the shell's
-          // "reload to update" banner, which must only claim what is proven:
-          // both builds known and different. Signalling on unknown would show
-          // the banner on every space open in local dev, where no reload helps.
-          if (
-            runtime.clientVersion === undefined || toolshedVersion === undefined
-          ) {
-            return "skipped-unknown-build";
-          }
-          runtime.reportVersionSkew({
-            space,
-            clientVersion: runtime.clientVersion,
-            toolshedVersion,
-          });
-          return "skipped-skew";
-        }
-
-        // 5. Current identity from the toolshed (cached).
+        // 6. Current identity from the toolshed (cached).
         currentId = await runtime.cachedPatternIdentity(host, url);
         if (currentId === undefined) return "current"; // unresolved → skip
 
-        // 6. Compare to the running identity. A verified legacy root that is
+        // 7. Compare to the running identity. A verified legacy root that is
         //    already current needs only the missing provenance write.
         if (currentId === runningRef?.identity) {
           if (storedSource !== undefined) return "current";
@@ -755,11 +758,10 @@ export class PiecesController<T = unknown> {
         }
       }
 
-      // 7. Apply/repair. A root that cannot load must not be blocked by the
-      //    version gate: fetch and compile its proven source directly, making
-      //    the compiler-produced entry ref authoritative instead of comparing
-      //    the cross-build light identity. Compilation failure is caught by the
-      //    outer best-effort boundary and leaves the stored root untouched.
+      // 8. Apply/repair. For an unloadable root, fetch and compile its proven
+      //    source directly under the already-matched build, making the
+      //    compiler-produced entry ref authoritative instead of depending on
+      //    ?identity. Compilation failure leaves the stored root untouched.
       const program = await runtime.harness.resolve(
         new HttpProgramResolver(target.href),
       );

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import {
   getPatternIdentityRef,
   getPatternSource,
+  PATTERN_RESPONSE_BUILD_HEADER,
   resolveEntryIdentity,
   Runtime,
   type VersionSkewInfo,
@@ -29,32 +30,58 @@ const SOURCE_V1 = patternSource("v1");
 const SOURCE_V2 = patternSource("v2");
 
 const BUILD_SHA = "build-sha-1";
+const IMPORTED_MODULE_URL = "/api/patterns/system/update-marker.ts";
 
 /** Content identity a toolshed at this build would serve for `source`. */
-function identityForSource(source: string): Promise<string> {
+function identityForSource(
+  source: string,
+  imports: Record<string, string> = {},
+  entry = DEFAULT_APP_PATTERN_URL,
+): Promise<string> {
   return resolveEntryIdentity(
-    DEFAULT_APP_PATTERN_URL, // /api/patterns/system/default-app.tsx
-    (name) =>
-      name === DEFAULT_APP_PATTERN_URL
-        ? Promise.resolve(source)
-        : Promise.reject(new Error(`not found: ${name}`)),
+    entry,
+    (name) => {
+      if (name === entry) return Promise.resolve(source);
+      if (Object.hasOwn(imports, name)) return Promise.resolve(imports[name]);
+      return Promise.reject(new Error(`not found: ${name}`));
+    },
   );
 }
 
 interface StubControls {
   setSource(source: string): void;
+  setIdentitySource(source: string): void;
   setGitSha(sha: string | null): void;
+  setIdentityBuildSha(sha: string | null): void;
+  setSourceBuildSha(sha: string | null): void;
+  setImport(path: string, source: string): void;
+  setImportBuildSha(sha: string | null): void;
   failIdentity(fail: boolean): void;
   identityFetches(): number;
+  sourceFetches(): number;
   restore(): void;
 }
 
 function installFetchStub(): StubControls {
   const original = globalThis.fetch;
   let source = SOURCE_V1;
+  let identitySource: string | undefined;
   let gitSha: string | null = BUILD_SHA;
+  let identityBuildSha: string | null = BUILD_SHA;
+  let sourceBuildSha: string | null = BUILD_SHA;
+  let importBuildSha: string | null = BUILD_SHA;
+  const imports: Record<string, string> = {};
   let failIdentityFetch = false;
   let identityFetchCount = 0;
+  let sourceFetchCount = 0;
+
+  const patternHeaders = (
+    contentType: string,
+    buildSha: string | null,
+  ): HeadersInit => ({
+    "content-type": contentType,
+    ...(buildSha === null ? {} : { [PATTERN_RESPONSE_BUILD_HEADER]: buildSha }),
+  });
 
   globalThis.fetch = (async (input: string | URL | Request) => {
     const href = typeof input === "string"
@@ -77,12 +104,25 @@ function installFetchStub(): StubControls {
       if (url.searchParams.has("identity")) {
         identityFetchCount++;
         if (failIdentityFetch) throw new Error("identity fetch failed");
-        return new Response(await identityForSource(source), {
-          headers: { "content-type": "text/plain" },
-        });
+        return new Response(
+          await identityForSource(
+            identitySource ?? source,
+            imports,
+            url.pathname,
+          ),
+          { headers: patternHeaders("text/plain", identityBuildSha) },
+        );
       }
+      sourceFetchCount++;
       return new Response(source, {
-        headers: { "content-type": "text/typescript-jsx" },
+        headers: patternHeaders("text/typescript-jsx", sourceBuildSha),
+      });
+    }
+
+    if (Object.hasOwn(imports, url.pathname)) {
+      sourceFetchCount++;
+      return new Response(imports[url.pathname], {
+        headers: patternHeaders("text/typescript", importBuildSha),
       });
     }
 
@@ -91,9 +131,15 @@ function installFetchStub(): StubControls {
 
   return {
     setSource: (s) => (source = s),
+    setIdentitySource: (s) => (identitySource = s),
     setGitSha: (s) => (gitSha = s),
+    setIdentityBuildSha: (s) => (identityBuildSha = s),
+    setSourceBuildSha: (s) => (sourceBuildSha = s),
+    setImport: (path, s) => (imports[path] = s),
+    setImportBuildSha: (s) => (importBuildSha = s),
     failIdentity: (f) => (failIdentityFetch = f),
     identityFetches: () => identityFetchCount,
+    sourceFetches: () => sourceFetchCount,
     restore: () => (globalThis.fetch = original),
   };
 }
@@ -241,6 +287,44 @@ describe("checkAndUpdateDefaultPattern", () => {
     );
   });
 
+  it("repairs persisted artifacts when the served identity is unchanged", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const currentRef = getPatternIdentityRef(piece.getCell())!;
+    const sourceFetchesBefore = stub.sourceFetches();
+    const originalLoad = runtime.patternManager.loadPatternByIdentity;
+    let loadAttempts = 0;
+    runtime.patternManager.loadPatternByIdentity =
+      ((identity, symbol, space) => {
+        loadAttempts++;
+        if (loadAttempts === 1 && identity === currentRef.identity) {
+          return Promise.resolve(undefined);
+        }
+        return originalLoad.call(
+          runtime.patternManager,
+          identity,
+          symbol,
+          space,
+        );
+      }) as typeof runtime.patternManager.loadPatternByIdentity;
+
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+      expect(loadAttempts).toBe(1);
+      expect(stub.sourceFetches()).toBe(sourceFetchesBefore + 1);
+      await expect(
+        originalLoad.call(
+          runtime.patternManager,
+          currentRef.identity,
+          currentRef.symbol,
+          manager.getSpace(),
+        ),
+      ).resolves.toBeDefined();
+    } finally {
+      runtime.patternManager.loadPatternByIdentity = originalLoad;
+    }
+  });
+
   it("reconciles a persisted root discovered after a creation race", async () => {
     await setup({ systemPatternAutoUpdate: true });
     const existing = await controller.ensureDefaultPattern();
@@ -301,6 +385,75 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(versionSkews.length).toBe(1);
     expect(versionSkews[0].clientVersion).toBe(BUILD_SHA);
     expect(versionSkews[0].toolshedVersion).toBe("a-different-build");
+  });
+
+  it("rejects identity served by a different build than /api/meta", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const before = getPatternIdentityRef(piece.getCell());
+    const sourceFetchesBefore = stub.sourceFetches();
+
+    stub.setSource(SOURCE_V2);
+    stub.setIdentityBuildSha("rolling-deploy-build");
+
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    expect(getPatternIdentityRef(piece.getCell())).toEqual(before);
+    expect(stub.identityFetches()).toBe(1);
+    expect(stub.sourceFetches()).toBe(sourceFetchesBefore);
+  });
+
+  it("rejects source served by a different build than its identity", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const before = getPatternIdentityRef(piece.getCell());
+    const sourceFetchesBefore = stub.sourceFetches();
+
+    stub.setSource(SOURCE_V2);
+    stub.setSourceBuildSha("rolling-deploy-build");
+
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    expect(getPatternIdentityRef(piece.getCell())).toEqual(before);
+    expect(stub.identityFetches()).toBe(1);
+    expect(stub.sourceFetches()).toBe(sourceFetchesBefore + 1);
+  });
+
+  it("rejects an imported module served by a different build", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const before = getPatternIdentityRef(piece.getCell());
+    const sourceFetchesBefore = stub.sourceFetches();
+
+    stub.setImport(
+      IMPORTED_MODULE_URL,
+      'export const marker = "v2-from-import";\n',
+    );
+    stub.setSource([
+      "import { pattern } from 'commonfabric';",
+      "import { marker } from './update-marker.ts';",
+      "export default pattern<{ items: string[] }>(({ items }) => ({ items, marker }));",
+      "",
+    ].join("\n"));
+    stub.setImportBuildSha("rolling-deploy-build");
+
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    expect(getPatternIdentityRef(piece.getCell())).toEqual(before);
+    expect(stub.identityFetches()).toBe(1);
+    expect(stub.sourceFetches()).toBe(sourceFetchesBefore + 2);
+  });
+
+  it("rejects source whose compiled identity differs from ?identity", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const before = getPatternIdentityRef(piece.getCell());
+    const sourceFetchesBefore = stub.sourceFetches();
+
+    stub.setIdentitySource(SOURCE_V2);
+    stub.setSource(patternSource("different-source-response"));
+
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    expect(getPatternIdentityRef(piece.getCell())).toEqual(before);
+    expect(stub.identityFetches()).toBe(1);
+    expect(stub.sourceFetches()).toBe(sourceFetchesBefore + 1);
   });
 
   it("skips silently when both builds are unknown (dev servers)", async () => {
@@ -375,15 +528,15 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(getPatternIdentityRef(piece.getCell())?.identity).toBe(before);
   });
 
-  it("back-fills provenance on a verified legacy system root", async () => {
+  it("back-fills provenance when a legacy root is the current official identity", async () => {
     await setup({ systemPatternAutoUpdate: true });
-    const piece = await controller.recreateDefaultPattern({
-      customProgram: {
-        main: DEFAULT_APP_PATTERN_URL,
-        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
-      },
+    const piece = await controller.ensureDefaultPattern();
+    const { error } = await runtime.editWithRetry((tx) => {
+      piece.getCell().withTx(tx).setMetaRaw("patternSource", undefined);
     });
-    expect(getPatternSource(piece.getCell())).toBeUndefined();
+    expect(error).toBeUndefined();
+    const legacyRoot = (await manager.getDefaultPattern(false))!;
+    expect(getPatternSource(legacyRoot)).toBeUndefined();
 
     expect(await controller.checkAndUpdateDefaultPattern()).toBe(
       "repaired-provenance",
@@ -396,7 +549,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     );
   });
 
-  it("repairs an unloadable legacy system root when builds match", async () => {
+  it("does not infer provenance from an official-looking filename", async () => {
     await setup({ systemPatternAutoUpdate: true });
     const piece = await controller.recreateDefaultPattern({
       customProgram: {
@@ -404,57 +557,21 @@ describe("checkAndUpdateDefaultPattern", () => {
         files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
       },
     });
-    const rootLinkBefore = JSON.stringify(piece.getCell().getAsLink());
     const oldRef = getPatternIdentityRef(piece.getCell())!;
     expect(getPatternSource(piece.getCell())).toBeUndefined();
-    await manager.stopPiece(piece.getCell());
-
-    // Model the 2026-07-21 Loom incident: the verified authored source closure
-    // still identifies the official system root, but the current runtime can no
-    // longer load that old identity. The updater must resolve the new identity
-    // without loading the old one, then compile and install the newer source
-    // before ensure() starts the root.
-    const originalLoad = runtime.patternManager.loadPatternByIdentity;
-    runtime.patternManager.loadPatternByIdentity =
-      ((identity, symbol, space) =>
-        identity === oldRef.identity
-          ? Promise.reject(new Error("legacy identity cannot load"))
-          : originalLoad.call(
-            runtime.patternManager,
-            identity,
-            symbol,
-            space,
-          )) as typeof runtime.patternManager.loadPatternByIdentity;
     stub.setSource(SOURCE_V2);
 
-    try {
-      const repaired = await controller.ensureDefaultPattern();
-      await runtime.idle();
-
-      expect(JSON.stringify(repaired.getCell().getAsLink())).toBe(
-        rootLinkBefore,
-      );
-      expect(getPatternIdentityRef(repaired.getCell())?.identity).toBe(
-        await identityForSource(SOURCE_V2),
-      );
-      expect(getPatternSource(repaired.getCell())).toBe(
-        DEFAULT_APP_PATTERN_URL,
-      );
-      expect(stub.identityFetches()).toBe(1);
-      expect(versionSkews).toEqual([]);
-    } finally {
-      runtime.patternManager.loadPatternByIdentity = originalLoad;
-    }
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    const pinned = (await manager.getDefaultPattern(false))!;
+    expect(getPatternIdentityRef(pinned)).toEqual(oldRef);
+    expect(getPatternSource(pinned)).toBeUndefined();
+    expect(stub.identityFetches()).toBe(1);
+    expect(stub.sourceFetches()).toBe(0);
   });
 
   it("leaves a stale root untouched when replacement compilation fails", async () => {
     await setup({ systemPatternAutoUpdate: true });
-    const piece = await controller.recreateDefaultPattern({
-      customProgram: {
-        main: DEFAULT_APP_PATTERN_URL,
-        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
-      },
-    });
+    const piece = await controller.ensureDefaultPattern();
     const root = piece.getCell();
     const oldRef = getPatternIdentityRef(root)!;
     const originalCompile = runtime.patternManager.compilePattern;
@@ -469,7 +586,7 @@ describe("checkAndUpdateDefaultPattern", () => {
 
       const unchanged = (await manager.getDefaultPattern(false))!;
       expect(getPatternIdentityRef(unchanged)).toEqual(oldRef);
-      expect(getPatternSource(unchanged)).toBeUndefined();
+      expect(getPatternSource(unchanged)).toBe(DEFAULT_APP_PATTERN_URL);
       expect(stub.identityFetches()).toBe(1);
       expect(versionSkews).toEqual([]);
     } finally {
@@ -490,11 +607,12 @@ describe("checkAndUpdateDefaultPattern", () => {
     const before = getPatternIdentityRef(root)?.identity;
 
     // Even though the toolshed serves a (different) default-app identity, we must
-    // NOT roll this space to default-app: skip without touching it or fetching.
+    // NOT roll this space to default-app. The identity probe may establish that
+    // it is not a known official identity; source must never be fetched/applied.
     stub.setSource(SOURCE_V2);
     expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
     expect(getPatternIdentityRef(root)?.identity).toBe(before);
-    expect(stub.identityFetches()).toBe(0);
+    expect(stub.identityFetches()).toBe(1);
   });
 
   it("skips a custom home root with both update flags on", async () => {
@@ -516,7 +634,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
     expect(getPatternIdentityRef(root)).toEqual(before);
     expect(getPatternSource(root)).toBeUndefined();
-    expect(stub.identityFetches()).toBe(0);
+    expect(stub.identityFetches()).toBe(1);
   });
 
   it("holds the home root behind its own flag (M4.2)", async () => {

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -128,6 +128,29 @@ describe("checkAndUpdateDefaultPattern", () => {
     controller = new PiecesController(manager);
   }
 
+  async function setupHome(
+    experimental: Record<string, boolean>,
+    clientVersion: string | undefined = BUILD_SHA,
+  ) {
+    versionSkews = [];
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+      clientVersion,
+      experimental,
+      onVersionSkew: (info) => versionSkews.push(info),
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceDid: signer.did(),
+    });
+    expect(session.space).toBe(runtime.userIdentityDID);
+    manager = new PieceManager(session, runtime);
+    await manager.synced();
+    controller = new PiecesController(manager);
+  }
+
   beforeEach(() => {
     stub = installFetchStub();
     stub.setSource(SOURCE_V1);
@@ -352,16 +375,129 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(getPatternIdentityRef(piece.getCell())?.identity).toBe(before);
   });
 
-  it("skips a legacy non-home root with no patternSource (custom-app safety)", async () => {
+  it("back-fills provenance on a verified legacy system root", async () => {
     await setup({ systemPatternAutoUpdate: true });
-    // Model a legacy root created before provenance existed (which might be a
-    // custom app seeded from home's defaultAppUrl, NOT the default app).
-    // recreateDefaultPattern stamps patternSource since CT-1890, so erase the
-    // stamp to reproduce the sourceless legacy shape.
-    await controller.recreateDefaultPattern();
-    const stamped = (await manager.getDefaultPattern(false))!;
-    await runtime.editWithRetry((tx) => {
-      stamped.withTx(tx).setMetaRaw("patternSource", null);
+    const piece = await controller.recreateDefaultPattern({
+      customProgram: {
+        main: DEFAULT_APP_PATTERN_URL,
+        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
+      },
+    });
+    expect(getPatternSource(piece.getCell())).toBeUndefined();
+
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe(
+      "repaired-provenance",
+    );
+
+    const root = (await manager.getDefaultPattern(false))!;
+    expect(getPatternSource(root)).toBe(DEFAULT_APP_PATTERN_URL);
+    expect(getPatternIdentityRef(root)?.identity).toBe(
+      await identityForSource(SOURCE_V1),
+    );
+  });
+
+  it("repairs an unloadable legacy system root without build metadata", async () => {
+    await setup({ systemPatternAutoUpdate: true }, undefined);
+    stub.setGitSha(null);
+    const piece = await controller.recreateDefaultPattern({
+      customProgram: {
+        main: DEFAULT_APP_PATTERN_URL,
+        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
+      },
+    });
+    const rootLinkBefore = JSON.stringify(piece.getCell().getAsLink());
+    const oldRef = getPatternIdentityRef(piece.getCell())!;
+    expect(getPatternSource(piece.getCell())).toBeUndefined();
+    await manager.stopPiece(piece.getCell());
+
+    // Model the 2026-07-21 Loom incident: the verified authored source closure
+    // still identifies the official system root, but the current runtime can no
+    // longer load that old identity. Neither the daemon nor its source-run
+    // toolshed carries a build SHA, so the light ?identity comparison is
+    // unavailable. Repair must compile the tracked source directly instead.
+    const originalLoad = runtime.patternManager.loadPatternByIdentity;
+    runtime.patternManager.loadPatternByIdentity =
+      ((identity, symbol, space) =>
+        identity === oldRef.identity
+          ? Promise.reject(new Error("legacy identity cannot load"))
+          : originalLoad.call(
+            runtime.patternManager,
+            identity,
+            symbol,
+            space,
+          )) as typeof runtime.patternManager.loadPatternByIdentity;
+    stub.setSource(SOURCE_V2);
+
+    try {
+      const repaired = await controller.ensureDefaultPattern();
+      await runtime.idle();
+
+      expect(JSON.stringify(repaired.getCell().getAsLink())).toBe(
+        rootLinkBefore,
+      );
+      expect(getPatternIdentityRef(repaired.getCell())?.identity).toBe(
+        await identityForSource(SOURCE_V2),
+      );
+      expect(getPatternSource(repaired.getCell())).toBe(
+        DEFAULT_APP_PATTERN_URL,
+      );
+      expect(stub.identityFetches()).toBe(0);
+      expect(versionSkews).toEqual([]);
+    } finally {
+      runtime.patternManager.loadPatternByIdentity = originalLoad;
+    }
+  });
+
+  it("leaves an unloadable root untouched when repair compilation fails", async () => {
+    await setup({ systemPatternAutoUpdate: true }, undefined);
+    stub.setGitSha(null);
+    const piece = await controller.recreateDefaultPattern({
+      customProgram: {
+        main: DEFAULT_APP_PATTERN_URL,
+        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
+      },
+    });
+    const root = piece.getCell();
+    const oldRef = getPatternIdentityRef(root)!;
+    const originalLoad = runtime.patternManager.loadPatternByIdentity;
+    const originalCompile = runtime.patternManager.compilePattern;
+    runtime.patternManager.loadPatternByIdentity =
+      ((identity, symbol, space) =>
+        identity === oldRef.identity
+          ? Promise.resolve(undefined)
+          : originalLoad.call(
+            runtime.patternManager,
+            identity,
+            symbol,
+            space,
+          )) as typeof runtime.patternManager.loadPatternByIdentity;
+    runtime.patternManager.compilePattern = (() =>
+      Promise.reject(
+        new Error("repair compilation failed"),
+      )) as typeof runtime.patternManager.compilePattern;
+    stub.setSource(SOURCE_V2);
+
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+
+      const unchanged = (await manager.getDefaultPattern(false))!;
+      expect(getPatternIdentityRef(unchanged)).toEqual(oldRef);
+      expect(getPatternSource(unchanged)).toBeUndefined();
+      expect(stub.identityFetches()).toBe(0);
+      expect(versionSkews).toEqual([]);
+    } finally {
+      runtime.patternManager.loadPatternByIdentity = originalLoad;
+      runtime.patternManager.compilePattern = originalCompile;
+    }
+  });
+
+  it("skips a custom root with no patternSource", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-root.tsx",
+        files: [{ name: "/custom-root.tsx", contents: SOURCE_V1 }],
+      },
     });
     const root = (await manager.getDefaultPattern(false))!;
     expect(getPatternSource(root)).toBeUndefined();
@@ -375,26 +511,33 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(stub.identityFetches()).toBe(0);
   });
 
+  it("skips a custom home root with both update flags on", async () => {
+    await setupHome({
+      systemPatternAutoUpdate: true,
+      systemPatternAutoUpdateHome: true,
+    });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    const before = getPatternIdentityRef(root);
+    expect(getPatternSource(root)).toBeUndefined();
+
+    stub.setSource(SOURCE_V2);
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    expect(getPatternIdentityRef(root)).toEqual(before);
+    expect(getPatternSource(root)).toBeUndefined();
+    expect(stub.identityFetches()).toBe(0);
+  });
+
   it("holds the home root behind its own flag (M4.2)", async () => {
     // A home space (session space == the identity DID), with the base flag on
     // but the home flag off, must not auto-update — it short-circuits before
     // any fetch.
-    versionSkews = [];
-    storageManager = StorageManager.emulate({ as: signer });
-    runtime = new Runtime({
-      apiUrl: new URL("http://toolshed.test"),
-      storageManager,
-      clientVersion: BUILD_SHA,
-      experimental: { systemPatternAutoUpdate: true },
-    });
-    const homeSession = await createSession({
-      identity: signer,
-      spaceDid: signer.did(),
-    });
-    expect(homeSession.space).toBe(runtime.userIdentityDID);
-    manager = new PieceManager(homeSession, runtime);
-    await manager.synced();
-    controller = new PiecesController(manager);
+    await setupHome({ systemPatternAutoUpdate: true });
 
     expect(await controller.checkAndUpdateDefaultPattern()).toBe(
       "skipped-disabled",
@@ -422,20 +565,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     });
 
     it("stamps a recreated home root with home.tsx", async () => {
-      storageManager = StorageManager.emulate({ as: signer });
-      runtime = new Runtime({
-        apiUrl: new URL("http://toolshed.test"),
-        storageManager,
-        clientVersion: BUILD_SHA,
-      });
-      const homeSession = await createSession({
-        identity: signer,
-        spaceDid: signer.did(),
-      });
-      expect(homeSession.space).toBe(runtime.userIdentityDID);
-      manager = new PieceManager(homeSession, runtime);
-      await manager.synced();
-      controller = new PiecesController(manager);
+      await setupHome({});
 
       await controller.recreateDefaultPattern();
       const root = (await manager.getDefaultPattern(false))!;

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -411,8 +411,9 @@ describe("checkAndUpdateDefaultPattern", () => {
 
     // Model the 2026-07-21 Loom incident: the verified authored source closure
     // still identifies the official system root, but the current runtime can no
-    // longer load that old identity. Matching build attestations make it safe
-    // to compile the tracked source directly without relying on ?identity.
+    // longer load that old identity. The updater must resolve the new identity
+    // without loading the old one, then compile and install the newer source
+    // before ensure() starts the root.
     const originalLoad = runtime.patternManager.loadPatternByIdentity;
     runtime.patternManager.loadPatternByIdentity =
       ((identity, symbol, space) =>
@@ -439,14 +440,14 @@ describe("checkAndUpdateDefaultPattern", () => {
       expect(getPatternSource(repaired.getCell())).toBe(
         DEFAULT_APP_PATTERN_URL,
       );
-      expect(stub.identityFetches()).toBe(0);
+      expect(stub.identityFetches()).toBe(1);
       expect(versionSkews).toEqual([]);
     } finally {
       runtime.patternManager.loadPatternByIdentity = originalLoad;
     }
   });
 
-  it("does not inspect or repair an unloadable root when builds differ", async () => {
+  it("leaves a stale root untouched when replacement compilation fails", async () => {
     await setup({ systemPatternAutoUpdate: true });
     const piece = await controller.recreateDefaultPattern({
       customProgram: {
@@ -456,103 +457,10 @@ describe("checkAndUpdateDefaultPattern", () => {
     });
     const root = piece.getCell();
     const oldRef = getPatternIdentityRef(root)!;
-    const originalLoad = runtime.patternManager.loadPatternByIdentity;
     const originalCompile = runtime.patternManager.compilePattern;
-    let loads = 0;
-    let compiles = 0;
-    runtime.patternManager.loadPatternByIdentity = ((..._args: unknown[]) => {
-      loads++;
-      return Promise.reject(new Error("must not inspect mismatched build"));
-    }) as typeof runtime.patternManager.loadPatternByIdentity;
-    runtime.patternManager.compilePattern = ((..._args: unknown[]) => {
-      compiles++;
-      return Promise.reject(new Error("must not compile mismatched build"));
-    }) as typeof runtime.patternManager.compilePattern;
-    stub.setGitSha("a-different-build");
-    stub.setSource(SOURCE_V2);
-
-    try {
-      expect(await controller.checkAndUpdateDefaultPattern()).toBe(
-        "skipped-skew",
-      );
-      expect(getPatternIdentityRef(root)).toEqual(oldRef);
-      expect(getPatternSource(root)).toBeUndefined();
-      expect(loads).toBe(0);
-      expect(compiles).toBe(0);
-      expect(stub.identityFetches()).toBe(0);
-      expect(versionSkews.length).toBe(1);
-    } finally {
-      runtime.patternManager.loadPatternByIdentity = originalLoad;
-      runtime.patternManager.compilePattern = originalCompile;
-    }
-  });
-
-  it("does not inspect or repair an unloadable root when builds are unknown", async () => {
-    await setup({ systemPatternAutoUpdate: true }, undefined);
-    stub.setGitSha(null);
-    const piece = await controller.recreateDefaultPattern({
-      customProgram: {
-        main: DEFAULT_APP_PATTERN_URL,
-        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
-      },
-    });
-    const root = piece.getCell();
-    const oldRef = getPatternIdentityRef(root)!;
-    const originalLoad = runtime.patternManager.loadPatternByIdentity;
-    const originalCompile = runtime.patternManager.compilePattern;
-    let loads = 0;
-    let compiles = 0;
-    runtime.patternManager.loadPatternByIdentity = ((..._args: unknown[]) => {
-      loads++;
-      return Promise.reject(new Error("must not inspect unknown build"));
-    }) as typeof runtime.patternManager.loadPatternByIdentity;
-    runtime.patternManager.compilePattern = ((..._args: unknown[]) => {
-      compiles++;
-      return Promise.reject(new Error("must not compile unknown build"));
-    }) as typeof runtime.patternManager.compilePattern;
-    stub.setSource(SOURCE_V2);
-
-    try {
-      expect(await controller.checkAndUpdateDefaultPattern()).toBe(
-        "skipped-unknown-build",
-      );
-      expect(getPatternIdentityRef(root)).toEqual(oldRef);
-      expect(getPatternSource(root)).toBeUndefined();
-      expect(loads).toBe(0);
-      expect(compiles).toBe(0);
-      expect(stub.identityFetches()).toBe(0);
-      expect(versionSkews).toEqual([]);
-    } finally {
-      runtime.patternManager.loadPatternByIdentity = originalLoad;
-      runtime.patternManager.compilePattern = originalCompile;
-    }
-  });
-
-  it("leaves an unloadable root untouched when repair compilation fails", async () => {
-    await setup({ systemPatternAutoUpdate: true });
-    const piece = await controller.recreateDefaultPattern({
-      customProgram: {
-        main: DEFAULT_APP_PATTERN_URL,
-        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
-      },
-    });
-    const root = piece.getCell();
-    const oldRef = getPatternIdentityRef(root)!;
-    const originalLoad = runtime.patternManager.loadPatternByIdentity;
-    const originalCompile = runtime.patternManager.compilePattern;
-    runtime.patternManager.loadPatternByIdentity =
-      ((identity, symbol, space) =>
-        identity === oldRef.identity
-          ? Promise.resolve(undefined)
-          : originalLoad.call(
-            runtime.patternManager,
-            identity,
-            symbol,
-            space,
-          )) as typeof runtime.patternManager.loadPatternByIdentity;
     runtime.patternManager.compilePattern = (() =>
       Promise.reject(
-        new Error("repair compilation failed"),
+        new Error("replacement compilation failed"),
       )) as typeof runtime.patternManager.compilePattern;
     stub.setSource(SOURCE_V2);
 
@@ -562,10 +470,9 @@ describe("checkAndUpdateDefaultPattern", () => {
       const unchanged = (await manager.getDefaultPattern(false))!;
       expect(getPatternIdentityRef(unchanged)).toEqual(oldRef);
       expect(getPatternSource(unchanged)).toBeUndefined();
-      expect(stub.identityFetches()).toBe(0);
+      expect(stub.identityFetches()).toBe(1);
       expect(versionSkews).toEqual([]);
     } finally {
-      runtime.patternManager.loadPatternByIdentity = originalLoad;
       runtime.patternManager.compilePattern = originalCompile;
     }
   });

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -396,9 +396,8 @@ describe("checkAndUpdateDefaultPattern", () => {
     );
   });
 
-  it("repairs an unloadable legacy system root without build metadata", async () => {
-    await setup({ systemPatternAutoUpdate: true }, undefined);
-    stub.setGitSha(null);
+  it("repairs an unloadable legacy system root when builds match", async () => {
+    await setup({ systemPatternAutoUpdate: true });
     const piece = await controller.recreateDefaultPattern({
       customProgram: {
         main: DEFAULT_APP_PATTERN_URL,
@@ -412,9 +411,8 @@ describe("checkAndUpdateDefaultPattern", () => {
 
     // Model the 2026-07-21 Loom incident: the verified authored source closure
     // still identifies the official system root, but the current runtime can no
-    // longer load that old identity. Neither the daemon nor its source-run
-    // toolshed carries a build SHA, so the light ?identity comparison is
-    // unavailable. Repair must compile the tracked source directly instead.
+    // longer load that old identity. Matching build attestations make it safe
+    // to compile the tracked source directly without relying on ?identity.
     const originalLoad = runtime.patternManager.loadPatternByIdentity;
     runtime.patternManager.loadPatternByIdentity =
       ((identity, symbol, space) =>
@@ -448,9 +446,90 @@ describe("checkAndUpdateDefaultPattern", () => {
     }
   });
 
-  it("leaves an unloadable root untouched when repair compilation fails", async () => {
+  it("does not inspect or repair an unloadable root when builds differ", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.recreateDefaultPattern({
+      customProgram: {
+        main: DEFAULT_APP_PATTERN_URL,
+        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
+      },
+    });
+    const root = piece.getCell();
+    const oldRef = getPatternIdentityRef(root)!;
+    const originalLoad = runtime.patternManager.loadPatternByIdentity;
+    const originalCompile = runtime.patternManager.compilePattern;
+    let loads = 0;
+    let compiles = 0;
+    runtime.patternManager.loadPatternByIdentity = ((..._args: unknown[]) => {
+      loads++;
+      return Promise.reject(new Error("must not inspect mismatched build"));
+    }) as typeof runtime.patternManager.loadPatternByIdentity;
+    runtime.patternManager.compilePattern = ((..._args: unknown[]) => {
+      compiles++;
+      return Promise.reject(new Error("must not compile mismatched build"));
+    }) as typeof runtime.patternManager.compilePattern;
+    stub.setGitSha("a-different-build");
+    stub.setSource(SOURCE_V2);
+
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe(
+        "skipped-skew",
+      );
+      expect(getPatternIdentityRef(root)).toEqual(oldRef);
+      expect(getPatternSource(root)).toBeUndefined();
+      expect(loads).toBe(0);
+      expect(compiles).toBe(0);
+      expect(stub.identityFetches()).toBe(0);
+      expect(versionSkews.length).toBe(1);
+    } finally {
+      runtime.patternManager.loadPatternByIdentity = originalLoad;
+      runtime.patternManager.compilePattern = originalCompile;
+    }
+  });
+
+  it("does not inspect or repair an unloadable root when builds are unknown", async () => {
     await setup({ systemPatternAutoUpdate: true }, undefined);
     stub.setGitSha(null);
+    const piece = await controller.recreateDefaultPattern({
+      customProgram: {
+        main: DEFAULT_APP_PATTERN_URL,
+        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
+      },
+    });
+    const root = piece.getCell();
+    const oldRef = getPatternIdentityRef(root)!;
+    const originalLoad = runtime.patternManager.loadPatternByIdentity;
+    const originalCompile = runtime.patternManager.compilePattern;
+    let loads = 0;
+    let compiles = 0;
+    runtime.patternManager.loadPatternByIdentity = ((..._args: unknown[]) => {
+      loads++;
+      return Promise.reject(new Error("must not inspect unknown build"));
+    }) as typeof runtime.patternManager.loadPatternByIdentity;
+    runtime.patternManager.compilePattern = ((..._args: unknown[]) => {
+      compiles++;
+      return Promise.reject(new Error("must not compile unknown build"));
+    }) as typeof runtime.patternManager.compilePattern;
+    stub.setSource(SOURCE_V2);
+
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe(
+        "skipped-unknown-build",
+      );
+      expect(getPatternIdentityRef(root)).toEqual(oldRef);
+      expect(getPatternSource(root)).toBeUndefined();
+      expect(loads).toBe(0);
+      expect(compiles).toBe(0);
+      expect(stub.identityFetches()).toBe(0);
+      expect(versionSkews).toEqual([]);
+    } finally {
+      runtime.patternManager.loadPatternByIdentity = originalLoad;
+      runtime.patternManager.compilePattern = originalCompile;
+    }
+  });
+
+  it("leaves an unloadable root untouched when repair compilation fails", async () => {
+    await setup({ systemPatternAutoUpdate: true });
     const piece = await controller.recreateDefaultPattern({
       customProgram: {
         main: DEFAULT_APP_PATTERN_URL,

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   getPatternIdentityRef,
+  getPatternRepository,
   getPatternSource,
   PATTERN_RESPONSE_BUILD_HEADER,
   resolveEntryIdentity,
@@ -59,6 +60,7 @@ interface StubControls {
   failIdentity(fail: boolean): void;
   identityFetches(): number;
   sourceFetches(): number;
+  requestedHrefs(): string[];
   restore(): void;
 }
 
@@ -74,6 +76,7 @@ function installFetchStub(): StubControls {
   let failIdentityFetch = false;
   let identityFetchCount = 0;
   let sourceFetchCount = 0;
+  const requestedHrefs: string[] = [];
 
   const patternHeaders = (
     contentType: string,
@@ -90,6 +93,7 @@ function installFetchStub(): StubControls {
       ? input.href
       : input.url;
     const url = new URL(href);
+    requestedHrefs.push(url.href);
 
     if (url.pathname === "/api/meta") {
       return new Response(JSON.stringify({ did: "did:x", gitSha }), {
@@ -140,6 +144,7 @@ function installFetchStub(): StubControls {
     failIdentity: (f) => (failIdentityFetch = f),
     identityFetches: () => identityFetchCount,
     sourceFetches: () => sourceFetchCount,
+    requestedHrefs: () => [...requestedHrefs],
     restore: () => (globalThis.fetch = original),
   };
 }
@@ -228,6 +233,21 @@ describe("checkAndUpdateDefaultPattern", () => {
     const after = getPatternIdentityRef(piece.getCell())?.identity;
     expect(after).toBe(before);
     expect(after).toBe(await identityForSource(SOURCE_V1));
+  });
+
+  it("leaves a root without a pattern identity untouched", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const identityFetchesBefore = stub.identityFetches();
+    const { error } = await runtime.editWithRetry((tx) => {
+      piece.getCell().withTx(tx).setMetaRaw("patternIdentity", "missing");
+    });
+    expect(error).toBeUndefined();
+    const root = (await manager.getDefaultPattern(false))!;
+
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    expect(getPatternIdentityRef(root)).toBeUndefined();
+    expect(stub.identityFetches()).toBe(identityFetchesBefore);
   });
 
   it("rolls the root forward in place on a changed identity", async () => {
@@ -549,6 +569,211 @@ describe("checkAndUpdateDefaultPattern", () => {
     );
   });
 
+  it("keeps a legacy root unchanged when provenance repair cannot commit", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const { error } = await runtime.editWithRetry((tx) => {
+      piece.getCell().withTx(tx).setMetaRaw("patternSource", undefined);
+    });
+    expect(error).toBeUndefined();
+    const root = (await manager.getDefaultPattern(false))!;
+    const originalEditWithRetry = runtime.editWithRetry.bind(runtime);
+    runtime.editWithRetry = (() =>
+      Promise.resolve({
+        error: {
+          name: "StorageTransactionAborted" as const,
+          message: "provenance repair rejected",
+          reason: new Error("test rejection"),
+        },
+      })) as typeof runtime.editWithRetry;
+
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern(root)).toBe(
+        "current",
+      );
+      expect(getPatternSource(root)).toBeUndefined();
+    } finally {
+      runtime.editWithRetry = originalEditWithRetry;
+    }
+  });
+
+  it("repairs provenance through the source path when loading the current artifact throws", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const { error } = await runtime.editWithRetry((tx) => {
+      piece.getCell().withTx(tx).setMetaRaw("patternSource", undefined);
+    });
+    expect(error).toBeUndefined();
+
+    const originalLoad = runtime.patternManager.loadPatternByIdentity;
+    const sourceFetchesBefore = stub.sourceFetches();
+    let firstLoad = true;
+    runtime.patternManager.loadPatternByIdentity =
+      ((identity, symbol, space) => {
+        if (firstLoad) {
+          firstLoad = false;
+          throw new Error("persisted artifact is unreadable");
+        }
+        return originalLoad.call(
+          runtime.patternManager,
+          identity,
+          symbol,
+          space,
+        );
+      }) as typeof runtime.patternManager.loadPatternByIdentity;
+
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe(
+        "repaired-provenance",
+      );
+      expect(stub.sourceFetches()).toBe(sourceFetchesBefore + 1);
+      expect(getPatternSource(piece.getCell())).toBe(DEFAULT_APP_PATTERN_URL);
+    } finally {
+      runtime.patternManager.loadPatternByIdentity = originalLoad;
+    }
+  });
+
+  it("does not stamp provenance after a concurrent custom-root replacement", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const root = piece.getCell();
+    await manager.stopPiece(root);
+    const { error } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).setMetaRaw("patternSource", undefined);
+    });
+    expect(error).toBeUndefined();
+    const legacyRoot = (await manager.getDefaultPattern(false))!;
+
+    const loadStarted = Promise.withResolvers<void>();
+    const releaseLoad = Promise.withResolvers<void>();
+    const originalLoad = runtime.patternManager.loadPatternByIdentity;
+    runtime.patternManager.loadPatternByIdentity = (async () => {
+      loadStarted.resolve();
+      await releaseLoad.promise;
+      return undefined;
+    }) as typeof runtime.patternManager.loadPatternByIdentity;
+
+    try {
+      const update = controller.checkAndUpdateDefaultPattern(legacyRoot);
+      await loadStarted.promise;
+
+      const customRef = {
+        identity: await identityForSource(patternSource("concurrent-custom")),
+        symbol: "default",
+      };
+      const repository = "https://github.com/example/concurrent-pattern";
+      const replacement = await runtime.editWithRetry((tx) => {
+        const txRoot = legacyRoot.withTx(tx);
+        txRoot.setMetaRaw("patternIdentity", customRef);
+        txRoot.setMetaRaw("patternRepository", repository);
+      });
+      expect(replacement.error).toBeUndefined();
+
+      releaseLoad.resolve();
+      expect(await update).toBe("current");
+
+      const current = (await manager.getDefaultPattern(false))!;
+      expect(getPatternIdentityRef(current)).toEqual(customRef);
+      expect(getPatternRepository(current)).toBe(repository);
+      expect(getPatternSource(current)).toBeUndefined();
+    } finally {
+      releaseLoad.resolve();
+      runtime.patternManager.loadPatternByIdentity = originalLoad;
+    }
+  });
+
+  it("does not swap identity after a concurrent custom-root replacement", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const root = piece.getCell();
+    await manager.stopPiece(root);
+
+    const compileStarted = Promise.withResolvers<void>();
+    const releaseCompile = Promise.withResolvers<void>();
+    const originalCompile = runtime.patternManager.compilePattern;
+    runtime.patternManager.compilePattern = (async (input, cacheCtx) => {
+      compileStarted.resolve();
+      await releaseCompile.promise;
+      return await originalCompile.call(
+        runtime.patternManager,
+        input,
+        cacheCtx,
+      );
+    }) as typeof runtime.patternManager.compilePattern;
+    stub.setSource(SOURCE_V2);
+
+    try {
+      const update = controller.checkAndUpdateDefaultPattern(root);
+      await compileStarted.promise;
+
+      const customRef = {
+        identity: await identityForSource(patternSource("concurrent-custom")),
+        symbol: "default",
+      };
+      const repository = "https://github.com/example/concurrent-pattern";
+      const replacement = await runtime.editWithRetry((tx) => {
+        const txRoot = root.withTx(tx);
+        txRoot.setMetaRaw("patternIdentity", customRef);
+        txRoot.setMetaRaw("patternSource", undefined);
+        txRoot.setMetaRaw("patternRepository", repository);
+      });
+      expect(replacement.error).toBeUndefined();
+
+      releaseCompile.resolve();
+      expect(await update).toBe("current");
+
+      const current = (await manager.getDefaultPattern(false))!;
+      expect(getPatternIdentityRef(current)).toEqual(customRef);
+      expect(getPatternRepository(current)).toBe(repository);
+      expect(getPatternSource(current)).toBeUndefined();
+    } finally {
+      releaseCompile.resolve();
+      runtime.patternManager.compilePattern = originalCompile;
+    }
+  });
+
+  it("leaves a repository-pinned sourceless root untouched", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/repository-root.tsx",
+        files: [{ name: "/repository-root.tsx", contents: SOURCE_V1 }],
+      },
+      repository: "https://github.com/example/patterns",
+    });
+    const before = getPatternIdentityRef(piece.getCell());
+    const identityFetchesBefore = stub.identityFetches();
+    expect(getPatternSource(piece.getCell())).toBeUndefined();
+
+    stub.setSource(SOURCE_V2);
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    expect(getPatternIdentityRef(piece.getCell())).toEqual(before);
+    expect(stub.identityFetches()).toBe(identityFetchesBefore);
+  });
+
+  it("leaves a cross-origin tracked root untouched", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const before = getPatternIdentityRef(piece.getCell());
+    const identityFetchesBefore = stub.identityFetches();
+    const externalSource = "https://patterns.example/root.tsx";
+    const { error } = await runtime.editWithRetry((tx) => {
+      piece.getCell().withTx(tx).setMetaRaw("patternSource", externalSource);
+    });
+    expect(error).toBeUndefined();
+    const root = (await manager.getDefaultPattern(false))!;
+    expect(getPatternSource(root)).toBe(externalSource);
+
+    stub.setSource(SOURCE_V2);
+    expect(await controller.checkAndUpdateDefaultPattern(root)).toBe("current");
+    expect(getPatternIdentityRef(root)).toEqual(before);
+    expect(getPatternSource(root)).toBe(externalSource);
+    expect(stub.identityFetches()).toBe(identityFetchesBefore);
+    expect(
+      stub.requestedHrefs().some((href) => href.startsWith(externalSource)),
+    ).toBe(false);
+  });
+
   it("does not infer provenance from an official-looking filename", async () => {
     await setup({ systemPatternAutoUpdate: true });
     const piece = await controller.recreateDefaultPattern({
@@ -591,6 +816,27 @@ describe("checkAndUpdateDefaultPattern", () => {
       expect(versionSkews).toEqual([]);
     } finally {
       runtime.patternManager.compilePattern = originalCompile;
+    }
+  });
+
+  it("leaves the current root untouched when the identity swap cannot commit", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    await controller.ensureDefaultPattern();
+    const root = (await manager.getDefaultPattern(false))!;
+    const before = getPatternIdentityRef(root);
+    const originalWithTx = root.withTx;
+    root.withTx = (() => {
+      throw new Error("pattern identity swap rejected");
+    }) as typeof root.withTx;
+    stub.setSource(SOURCE_V2);
+
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern(root)).toBe(
+        "current",
+      );
+      expect(getPatternIdentityRef(root)).toEqual(before);
+    } finally {
+      root.withTx = originalWithTx;
     }
   });
 

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -12,6 +12,7 @@ import { createSession, Identity } from "@commonfabric/identity";
 import { PieceManager } from "../src/manager.ts";
 import {
   DEFAULT_APP_PATTERN_URL,
+  HOME_PATTERN_URL,
   PiecesController,
 } from "../src/ops/pieces-controller.ts";
 
@@ -69,7 +70,10 @@ function installFetchStub(): StubControls {
       });
     }
 
-    if (url.pathname === DEFAULT_APP_PATTERN_URL) {
+    if (
+      url.pathname === DEFAULT_APP_PATTERN_URL ||
+      url.pathname === HOME_PATTERN_URL
+    ) {
       if (url.searchParams.has("identity")) {
         identityFetchCount++;
         if (failIdentityFetch) throw new Error("identity fetch failed");
@@ -350,10 +354,15 @@ describe("checkAndUpdateDefaultPattern", () => {
 
   it("skips a legacy non-home root with no patternSource (custom-app safety)", async () => {
     await setup({ systemPatternAutoUpdate: true });
-    // recreateDefaultPattern does NOT stamp patternSource — it stands in for a
-    // legacy root created before provenance existed (which might be a custom app
-    // seeded from home's defaultAppUrl, NOT the default app).
+    // Model a legacy root created before provenance existed (which might be a
+    // custom app seeded from home's defaultAppUrl, NOT the default app).
+    // recreateDefaultPattern stamps patternSource since CT-1890, so erase the
+    // stamp to reproduce the sourceless legacy shape.
     await controller.recreateDefaultPattern();
+    const stamped = (await manager.getDefaultPattern(false))!;
+    await runtime.editWithRetry((tx) => {
+      stamped.withTx(tx).setMetaRaw("patternSource", null);
+    });
     const root = (await manager.getDefaultPattern(false))!;
     expect(getPatternSource(root)).toBeUndefined();
     const before = getPatternIdentityRef(root)?.identity;
@@ -391,5 +400,46 @@ describe("checkAndUpdateDefaultPattern", () => {
       "skipped-disabled",
     );
     expect(stub.identityFetches()).toBe(0);
+  });
+
+  describe("recreateDefaultPattern provenance (CT-1890)", () => {
+    it("stamps a recreated non-home root so it can auto-update", async () => {
+      await setup({ systemPatternAutoUpdate: true });
+      await controller.recreateDefaultPattern();
+      const root = (await manager.getDefaultPattern(false))!;
+      expect(getPatternSource(root)).toBe(DEFAULT_APP_PATTERN_URL);
+
+      // The stamp is the point: it makes the recreated root eligible for
+      // auto-update. A newer toolshed identity must roll it forward instead
+      // of being skipped forever at the sourceless-root gate.
+      stub.setSource(SOURCE_V2);
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
+      await runtime.idle();
+      const updated = (await manager.getDefaultPattern(false))!;
+      expect(getPatternIdentityRef(updated)?.identity).toBe(
+        await identityForSource(SOURCE_V2),
+      );
+    });
+
+    it("stamps a recreated home root with home.tsx", async () => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL("http://toolshed.test"),
+        storageManager,
+        clientVersion: BUILD_SHA,
+      });
+      const homeSession = await createSession({
+        identity: signer,
+        spaceDid: signer.did(),
+      });
+      expect(homeSession.space).toBe(runtime.userIdentityDID);
+      manager = new PieceManager(homeSession, runtime);
+      await manager.synced();
+      controller = new PiecesController(manager);
+
+      await controller.recreateDefaultPattern();
+      const root = (await manager.getDefaultPattern(false))!;
+      expect(getPatternSource(root)).toBe(HOME_PATTERN_URL);
+    });
   });
 });

--- a/packages/piece/test/default-app-golden-replay.test.ts
+++ b/packages/piece/test/default-app-golden-replay.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   getPatternIdentityRef,
+  PATTERN_RESPONSE_BUILD_HEADER,
   resolveEntryIdentity,
   Runtime,
 } from "@commonfabric/runner";
@@ -92,11 +93,17 @@ function installFetchStub(): StubControls {
     if (url.pathname === DEFAULT_APP_PATTERN_URL) {
       if (url.searchParams.has("identity")) {
         return new Response(await identityForSource(source), {
-          headers: { "content-type": "text/plain" },
+          headers: {
+            "content-type": "text/plain",
+            [PATTERN_RESPONSE_BUILD_HEADER]: BUILD_SHA,
+          },
         });
       }
       return new Response(source, {
-        headers: { "content-type": "text/typescript-jsx" },
+        headers: {
+          "content-type": "text/typescript-jsx",
+          [PATTERN_RESPONSE_BUILD_HEADER]: BUILD_SHA,
+        },
       });
     }
 

--- a/packages/piece/test/ensure-default-pattern.test.ts
+++ b/packages/piece/test/ensure-default-pattern.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { getPatternRepository, NAME, Runtime } from "@commonfabric/runner";
+import {
+  getPatternRepository,
+  getPatternSource,
+  NAME,
+  Runtime,
+} from "@commonfabric/runner";
 import type { RuntimeProgram } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createSession, Identity } from "@commonfabric/identity";
@@ -348,11 +353,26 @@ describe("PiecesController.recreateDefaultPattern", () => {
 
     expect(getPatternRepository(piece.getCell())).toBe(repository);
     expect((await piece.getPatternRef())?.source.repository).toBe(repository);
+    // The repository locator is the custom root's provenance; patternSource
+    // stays absent (there is no URL the auto-updater could re-fetch).
+    expect(getPatternSource(piece.getCell())).toBeUndefined();
   });
 
   it("rejects a repository locator without a custom root program", async () => {
     await expect(controller.recreateDefaultPattern({
       repository: "https://github.com/commontoolsinc/labs",
     })).rejects.toThrow(/only be supplied with a custom program/);
+  });
+
+  it("does not stamp patternSource for a custom root without a repository", async () => {
+    // A custom program has no URL the auto-updater could re-fetch, and there
+    // is no locator to record. Stamping the "custom" placeholder would poison
+    // the updater's URL resolution, so the root intentionally stays
+    // unstamped (CT-1890).
+    const piece = await controller.recreateDefaultPattern({
+      customProgram: defaultPatternProgram,
+    });
+
+    expect(getPatternSource(piece.getCell())).toBeUndefined();
   });
 });

--- a/packages/piece/test/home-golden-replay.test.ts
+++ b/packages/piece/test/home-golden-replay.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   getPatternIdentityRef,
+  PATTERN_RESPONSE_BUILD_HEADER,
   resolveEntryIdentity,
   Runtime,
 } from "@commonfabric/runner";
@@ -116,11 +117,17 @@ function installFetchStub(): StubControls {
     if (url.pathname === HOME_PATTERN_URL) {
       if (url.searchParams.has("identity")) {
         return new Response(await identityForSource(source), {
-          headers: { "content-type": "text/plain" },
+          headers: {
+            "content-type": "text/plain",
+            [PATTERN_RESPONSE_BUILD_HEADER]: BUILD_SHA,
+          },
         });
       }
       return new Response(source, {
-        headers: { "content-type": "text/typescript-jsx" },
+        headers: {
+          "content-type": "text/typescript-jsx",
+          [PATTERN_RESPONSE_BUILD_HEADER]: BUILD_SHA,
+        },
       });
     }
 

--- a/packages/runner/src/harness/index.ts
+++ b/packages/runner/src/harness/index.ts
@@ -11,4 +11,9 @@ export {
   computeEntryIdentity,
   resolveEntryIdentity,
 } from "./entry-identity.ts";
-export { buildsMatch, fetchToolshedGitSha } from "./version-gate.ts";
+export {
+  buildsMatch,
+  fetchToolshedGitSha,
+  PATTERN_RESPONSE_BUILD_HEADER,
+  patternResponseBuild,
+} from "./version-gate.ts";

--- a/packages/runner/src/harness/version-gate.ts
+++ b/packages/runner/src/harness/version-gate.ts
@@ -4,18 +4,32 @@
  * The toolshed answers `?identity` the *light* way (see
  * {@link ./entry-identity.ts}) — a computation that is only bit-for-bit
  * comparable to what the worker's runtime would produce when the two run the
- * **same build**. So before trusting a `?identity` value against a running
- * pattern's identity, the caller gates on build equality. The gate is exactly
- * what makes the light identity sound: we never compare identities across
- * builds.
+ * **same build**. Before trusting a `?identity` value against a running
+ * pattern's identity, the caller gates on build equality and then requires the
+ * identity/source responses themselves to attest that build. Together those
+ * checks make the light identity sound even across a rolling deployment: we
+ * never compare or compile responses from another build.
  *
  * Both build versions are the deploy's git sha — the client's is threaded in as
- * `Runtime.clientVersion` (from the shell's `COMMIT_SHA`), the toolshed's comes
- * from `GET /api/meta` (`gitSha`, itself derived from the same `COMMIT_SHA` at
- * build time).
+ * `Runtime.clientVersion`, and the toolshed's comes from `GET /api/meta`.
  */
 
 import type { RuntimeFetch } from "../runtime.ts";
+
+/**
+ * Response header that binds a served system-pattern identity/source to the
+ * toolshed process build that produced it. Browsers may read it because the
+ * patterns route exposes it through CORS.
+ */
+export const PATTERN_RESPONSE_BUILD_HEADER = "X-Common-Fabric-Build";
+
+/** The normalized build attestation on a system-pattern response, if any. */
+export function patternResponseBuild(
+  response: Pick<Response, "headers">,
+): string | undefined {
+  const value = response.headers.get(PATTERN_RESPONSE_BUILD_HEADER)?.trim();
+  return value || undefined;
+}
 
 /**
  * True only when both build versions are known AND equal. Any unknown

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -12,6 +12,8 @@ export type {
 } from "./runtime.ts";
 export {
   type BrowserWorkerPresetParams,
+  CLIENT_VERSION_ENV_VAR,
+  clientVersionFromEnv,
   type EnvReader,
   EXPERIMENTAL_ENV_VARS,
   experimentalOptionsFromEnv,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -76,6 +76,8 @@ export {
   ConsoleMethod,
   Engine,
   fetchToolshedGitSha,
+  PATTERN_RESPONSE_BUILD_HEADER,
+  patternResponseBuild,
   resolveEntryIdentity,
   type RuntimeProgram,
   type TypeScriptHarnessProcessOptions,

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -67,6 +67,9 @@
  * |                            | against the real deployment, not the builder's   |
  * |                            | localhost fallback); constructor default in the  |
  * |                            | local presets (patternTest/localDev/unitTest)    |
+ * | clientVersion              | delta (productionServer, remoteClient,           |
+ * |                            | browserWorker) — shared build attestation for    |
+ * |                            | the system-pattern update version gate           |
  * | fetch                      | real everywhere; patternTest delta (mock)        |
  * | errorHandlers              | delta (collectors/telemetry), per preset         |
  * | consoleHandler             | delta (productionServer, browserWorker)          |
@@ -167,6 +170,19 @@ const _unclassifiedOptions: never[] = [] as MissingOptionKeys[];
 
 /** Reads one environment variable; pass `Deno.env.get` in Deno contexts. */
 export type EnvReader = (name: string) => string | undefined;
+
+/** Shared build attestation consumed by shell and headless runtimes. */
+export const CLIENT_VERSION_ENV_VAR = "COMMIT_SHA";
+
+/**
+ * Read the current Labs build identity for a headless runtime. Empty values
+ * remain unknown so callers cannot accidentally satisfy a version gate with
+ * whitespace.
+ */
+export function clientVersionFromEnv(env: EnvReader): string | undefined {
+  const value = env(CLIENT_VERSION_ENV_VAR)?.trim();
+  return value || undefined;
+}
 
 /**
  * The one env mapping for {@link ExperimentalOptions}. `null` declares a flag
@@ -272,6 +288,8 @@ function coreOptions(params: CoreParams): RuntimeOptions {
 // ---------------------------------------------------------------------------
 
 export interface ProductionServerPresetParams extends CoreParams {
+  /** This process's Labs git SHA, for the system-pattern update version gate. */
+  clientVersion?: string;
   /**
    * Base URL patterns see (`patternEnvironment.apiUrl`) for relative fetches.
    * Defaults to `apiUrl`; toolshed passes its public API_URL here while
@@ -284,6 +302,8 @@ export interface ProductionServerPresetParams extends CoreParams {
 }
 
 export interface RemoteClientPresetParams extends CoreParams {
+  /** This client build's Labs git SHA, for the system-pattern update version gate. */
+  clientVersion?: string;
   errorHandlers?: ErrorHandler[];
   navigateCallback?: NavigateCallback;
   /** Shared compiled-module-byte cache (integration suites). */
@@ -347,6 +367,9 @@ export const runtimePresets = {
     return {
       ...coreOptions(params),
       patternEnvironment: { apiUrl: params.patternApiUrl ?? params.apiUrl },
+      ...(params.clientVersion !== undefined
+        ? { clientVersion: params.clientVersion }
+        : {}),
       ...(params.consoleHandler !== undefined
         ? { consoleHandler: params.consoleHandler }
         : {}),
@@ -368,6 +391,9 @@ export const runtimePresets = {
     return {
       ...coreOptions(params),
       patternEnvironment: { apiUrl: params.apiUrl },
+      ...(params.clientVersion !== undefined
+        ? { clientVersion: params.clientVersion }
+        : {}),
       ...(params.errorHandlers !== undefined
         ? { errorHandlers: params.errorHandlers }
         : {}),

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -60,7 +60,10 @@ import {
   resolveCommitBackpressure,
 } from "./scheduler/backpressure.ts";
 import { Engine } from "./harness/index.ts";
-import { fetchToolshedGitSha } from "./harness/version-gate.ts";
+import {
+  fetchToolshedGitSha,
+  patternResponseBuild,
+} from "./harness/version-gate.ts";
 import {
   CellLink,
   isCellLink,
@@ -186,8 +189,8 @@ export type PieceCreatedCallback = (piece: Cell<any>) => void;
 
 /**
  * TTL backstop for the system-pattern update caches (toolshed git sha and
- * ?identity). Bounds how long a stale value survives a toolshed redeploy
- * mid-session; the primary invalidation is clearPatternUpdateCaches().
+ * ?identity). Pattern identities are also keyed by and response-bound to their
+ * serving build, so a stale metadata entry cannot authorize another build.
  */
 const PATTERN_UPDATE_CACHE_TTL_MS = 5 * 60_000;
 
@@ -1948,11 +1951,10 @@ export class Runtime {
 
   // --- System-pattern update caches ---------------------------------------
   // A toolshed's build sha and each pattern's content identity are fixed for
-  // its process lifetime, so both are cached. Keyed by host / (host,url), with
-  // single-flight in-flight sharing. A failed (undefined) lookup is evicted so
-  // it retries. Cleared explicitly by clearPatternUpdateCaches() and, as a
-  // backstop against a toolshed redeploy mid-session (we have no
-  // storage-socket-reset event to hang invalidation on yet), after a TTL.
+  // its process lifetime, so both are cached. Identity entries include the
+  // expected serving build in their key and accept only a response attested by
+  // that build. A failed (undefined) lookup is evicted so it retries. Entries
+  // expire after a TTL and can also be cleared explicitly by tests/hosts.
   #toolshedGitShaCache = new Map<
     string,
     { at: number; value: Promise<string | undefined> }
@@ -1974,19 +1976,21 @@ export class Runtime {
 
   /**
    * A pattern file's content identity from its toolshed (cached), via
-   * `GET {host}{url}?identity`. Undefined on any failure. Equals the
-   * patternIdentity the worker would compile for the same source at the same
-   * build (see the toolshed parity test).
+   * `GET {host}{url}?identity`. The cache key includes `expectedBuild`, and the
+   * response must attest that build. Undefined on any failure. Equals the
+   * patternIdentity the worker would compile for the same source at that build
+   * (see the toolshed parity test).
    */
   cachedPatternIdentity(
     host: string | URL,
     url: string,
+    expectedBuild: string,
   ): Promise<string | undefined> {
-    const key = `${host.toString()} ${url}`;
+    const key = `${host.toString()} ${url} ${expectedBuild}`;
     return this.#cachedLookup(
       this.#patternIdentityCache,
       key,
-      () => this.#fetchPatternIdentity(host, url),
+      () => this.#fetchPatternIdentity(host, url, expectedBuild),
     );
   }
 
@@ -1999,12 +2003,14 @@ export class Runtime {
   async #fetchPatternIdentity(
     host: string | URL,
     url: string,
+    expectedBuild: string,
   ): Promise<string | undefined> {
     try {
       const u = new URL(url, host.toString());
       u.searchParams.set("identity", "");
       const res = await this.fetch(u);
       if (!res.ok) return undefined;
+      if (patternResponseBuild(res) !== expectedBuild) return undefined;
       const body = (await res.text()).trim();
       return body.length > 0 ? body : undefined;
     } catch {

--- a/packages/runner/test/pattern-update-cache.test.ts
+++ b/packages/runner/test/pattern-update-cache.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 
+import { PATTERN_RESPONSE_BUILD_HEADER } from "../src/harness/version-gate.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { VersionSkewInfo } from "../src/runtime.ts";
@@ -19,6 +20,7 @@ describe("Runtime system-pattern update helpers", () => {
   let calls: string[];
   let metaGitSha: string | null;
   let identityBody: string | { status: number };
+  let identityBuildSha: string | null;
 
   function makeRuntime(
     onVersionSkew?: (info: VersionSkewInfo) => void,
@@ -44,7 +46,13 @@ describe("Runtime system-pattern update helpers", () => {
             new Response("nope", { status: identityBody.status }),
           );
         }
-        return Promise.resolve(new Response(identityBody));
+        return Promise.resolve(
+          new Response(identityBody, {
+            headers: identityBuildSha === null
+              ? undefined
+              : { [PATTERN_RESPONSE_BUILD_HEADER]: identityBuildSha },
+          }),
+        );
       }
       return Promise.resolve(new Response("nf", { status: 404 }));
     }) as typeof globalThis.fetch;
@@ -62,6 +70,7 @@ describe("Runtime system-pattern update helpers", () => {
     calls = [];
     metaGitSha = "build-1";
     identityBody = "the-identity";
+    identityBuildSha = "build-1";
   });
 
   afterEach(async () => {
@@ -98,15 +107,21 @@ describe("Runtime system-pattern update helpers", () => {
     const host = "http://toolshed.test";
     const url = "/api/patterns/system/default-app.tsx";
     try {
-      expect(await rt.cachedPatternIdentity(host, url)).toBe("the-identity");
-      expect(await rt.cachedPatternIdentity(host, url)).toBe("the-identity");
+      expect(await rt.cachedPatternIdentity(host, url, "build-1")).toBe(
+        "the-identity",
+      );
+      expect(await rt.cachedPatternIdentity(host, url, "build-1")).toBe(
+        "the-identity",
+      );
       const idFetches = () =>
         calls.filter((c) => c.includes("identity")).length;
       expect(idFetches()).toBe(1);
 
       rt.clearPatternUpdateCaches();
       identityBody = "next-identity";
-      expect(await rt.cachedPatternIdentity(host, url)).toBe("next-identity");
+      expect(await rt.cachedPatternIdentity(host, url, "build-1")).toBe(
+        "next-identity",
+      );
       expect(idFetches()).toBe(2);
     } finally {
       await rt.dispose();
@@ -119,9 +134,38 @@ describe("Runtime system-pattern update helpers", () => {
     const host = "http://toolshed.test";
     const url = "/api/patterns/system/default-app.tsx";
     try {
-      expect(await rt.cachedPatternIdentity(host, url)).toBe(undefined);
-      expect(await rt.cachedPatternIdentity(host, url)).toBe(undefined);
+      expect(await rt.cachedPatternIdentity(host, url, "build-1")).toBe(
+        undefined,
+      );
+      expect(await rt.cachedPatternIdentity(host, url, "build-1")).toBe(
+        undefined,
+      );
       expect(calls.filter((c) => c.includes("identity")).length).toBe(2);
+    } finally {
+      await rt.dispose();
+    }
+  });
+
+  it("cachedPatternIdentity requires and keys by the serving build", async () => {
+    const rt = makeRuntime();
+    const host = "http://toolshed.test";
+    const url = "/api/patterns/system/default-app.tsx";
+    try {
+      expect(await rt.cachedPatternIdentity(host, url, "build-1")).toBe(
+        "the-identity",
+      );
+
+      identityBody = "next-identity";
+      identityBuildSha = "build-2";
+      expect(await rt.cachedPatternIdentity(host, url, "build-2")).toBe(
+        "next-identity",
+      );
+
+      identityBuildSha = "other-build";
+      expect(await rt.cachedPatternIdentity(host, url, "build-3")).toBe(
+        undefined,
+      );
+      expect(calls.filter((c) => c.includes("identity")).length).toBe(3);
     } finally {
       await rt.dispose();
     }

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  CLIENT_VERSION_ENV_VAR,
+  clientVersionFromEnv,
   EXPERIMENTAL_ENV_VARS,
   experimentalOptionsFromEnv,
   RUNTIME_OPTION_KEYS,
@@ -203,12 +205,14 @@ describe("runtimePresets conformance (CT-1814)", () => {
         consoleHandler,
         errorHandlers,
         telemetry,
+        clientVersion,
       })).toEqual({
         ...minimalOutputs.productionServer,
         patternEnvironment: { apiUrl: patternApiUrl },
         consoleHandler,
         errorHandlers,
         telemetry,
+        clientVersion,
       });
     });
 
@@ -220,6 +224,7 @@ describe("runtimePresets conformance (CT-1814)", () => {
         moduleByteCache,
         trustSnapshotProvider,
         patternCoverage,
+        clientVersion,
       })).toEqual({
         ...minimalOutputs.remoteClient,
         errorHandlers,
@@ -227,6 +232,7 @@ describe("runtimePresets conformance (CT-1814)", () => {
         moduleByteCache,
         trustSnapshotProvider,
         patternCoverage,
+        clientVersion,
       });
     });
 
@@ -349,6 +355,23 @@ describe("runtimePresets conformance (CT-1814)", () => {
       }
       expect(warnings.length).toBe(1);
       expect(String(warnings[0][0])).toContain("EXPERIMENTAL_MODERN_CELL_REP");
+    });
+  });
+
+  describe("clientVersionFromEnv", () => {
+    it("reads and trims the shared COMMIT_SHA", () => {
+      const consulted: string[] = [];
+      expect(clientVersionFromEnv((name) => {
+        consulted.push(name);
+        return "  build-sha-x  ";
+      })).toBe("build-sha-x");
+      expect(consulted).toEqual([CLIENT_VERSION_ENV_VAR]);
+      expect(CLIENT_VERSION_ENV_VAR).toBe("COMMIT_SHA");
+    });
+
+    it("treats unset and blank values as unknown", () => {
+      expect(clientVersionFromEnv(() => undefined)).toBeUndefined();
+      expect(clientVersionFromEnv(() => "   ")).toBeUndefined();
     });
   });
 

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -200,6 +200,12 @@ export class XRootView extends BaseView {
           // This client build's git sha, for the system-pattern auto-update
           // version-skew gate (compared to a space's toolshed /api/meta).
           clientVersion: COMMIT_SHA,
+          // A source-run shell serves its worker graph from /scripts even when
+          // COMMIT_SHA attests the checkout. Only deployed builds use the
+          // immutable /builds/<sha>/ namespace selected by RuntimeInternals.
+          workerUrl: ENVIRONMENT === "development"
+            ? new URL("/scripts/worker-runtime.js", globalThis.location.href)
+            : undefined,
           onError: (event) => this._handleRuntimeError(event, generation),
           onVersionSkew: this._handleVersionSkew,
           // Per-profile dogfood toggles: worker-console forwarding and the

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -180,9 +180,11 @@ describe("XRootView", () => {
     const { RuntimeInternals } = await import("@commonfabric/lib-shell");
     const originalCreate = RuntimeInternals.create;
     let capturedOnError: ((event: ErrorNotification) => void) | undefined;
+    let capturedWorkerUrl: URL | undefined;
     const fakeRuntime = {};
     RuntimeInternals.create = ((options) => {
       capturedOnError = options.onError;
+      capturedWorkerUrl = options.workerUrl;
       return Promise.resolve({
         runtime: () => fakeRuntime,
         dispose: () => Promise.resolve(),
@@ -208,6 +210,7 @@ describe("XRootView", () => {
       task.run([view.app]);
       await task.taskComplete;
       expect(capturedOnError).toBeDefined();
+      expect(capturedWorkerUrl?.pathname).toBe("/scripts/worker-runtime.js");
 
       const event: ErrorNotification = {
         type: NotificationType.ErrorReport,

--- a/packages/toolshed/.env.example
+++ b/packages/toolshed/.env.example
@@ -6,6 +6,14 @@ ENV=development
 PORT=8000
 LOG_LEVEL=debug
 
+## Build attestation
+# Shared Labs revision for source-run toolshed metadata and client runtimes.
+# Use the same value in shell, CLI, and background-piece-service processes.
+# COMMIT_SHA=
+# Explicit toolshed-only override; takes priority over compiled metadata and
+# COMMIT_SHA. Normally leave unset.
+# TOOLSHED_GIT_SHA=
+
 ## OpenTelemetry Configuration
 # Enable or disable OpenTelemetry tracing. When enabled, ALL spans (HTTP request
 # spans + LLM spans) are exported to OTEL_EXPORTER_OTLP_ENDPOINT. In deployed

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -264,6 +264,9 @@ export const EnvSchema = z.object({
   // Git SHA of the deployed commit. Set at deploy time; takes priority over
   // the build-baked SHA (see lib/build-info.ts).
   TOOLSHED_GIT_SHA: z.string().optional(),
+  // Shared Labs build attestation. This is the source-run fallback for
+  // /api/meta and is also consumed by headless Runtime clients.
+  COMMIT_SHA: z.string().optional(),
 
   // ===========================================================================
   // Sandbox Service

--- a/packages/toolshed/lib/build-info.test.ts
+++ b/packages/toolshed/lib/build-info.test.ts
@@ -29,21 +29,38 @@ Deno.test("normalize", async (t) => {
 
 Deno.test("resolveGitShaFrom", async (t) => {
   await t.step("env var wins over baked value", () => {
-    assertEquals(resolveGitShaFrom("env-sha", "baked-sha"), "env-sha");
+    assertEquals(
+      resolveGitShaFrom("env-sha", "baked-sha", "runtime-sha"),
+      "env-sha",
+    );
   });
   await t.step("trims env var before precedence check", () => {
-    assertEquals(resolveGitShaFrom("  env-sha  ", "baked-sha"), "env-sha");
+    assertEquals(
+      resolveGitShaFrom("  env-sha  ", "baked-sha", "runtime-sha"),
+      "env-sha",
+    );
   });
   await t.step("falls through to baked when env is unset/empty", () => {
-    assertEquals(resolveGitShaFrom(undefined, "baked-sha"), "baked-sha");
-    assertEquals(resolveGitShaFrom(null, "baked-sha"), "baked-sha");
-    assertEquals(resolveGitShaFrom("", "baked-sha"), "baked-sha");
-    assertEquals(resolveGitShaFrom("   ", "baked-sha"), "baked-sha");
+    for (const explicit of [undefined, null, "", "   "]) {
+      assertEquals(
+        resolveGitShaFrom(explicit, "baked-sha", "runtime-sha"),
+        "baked-sha",
+      );
+    }
   });
-  await t.step("returns null when both unset", () => {
-    assertEquals(resolveGitShaFrom(undefined, null), null);
-    assertEquals(resolveGitShaFrom("", null), null);
-    assertEquals(resolveGitShaFrom("   ", null), null);
+  await t.step(
+    "uses COMMIT_SHA when explicit and baked values are absent",
+    () => {
+      assertEquals(
+        resolveGitShaFrom(undefined, null, "  runtime-sha  "),
+        "runtime-sha",
+      );
+    },
+  );
+  await t.step("returns null when all values are unset", () => {
+    assertEquals(resolveGitShaFrom(undefined, null, undefined), null);
+    assertEquals(resolveGitShaFrom("", null, ""), null);
+    assertEquals(resolveGitShaFrom("   ", null, "   "), null);
   });
 });
 

--- a/packages/toolshed/lib/build-info.ts
+++ b/packages/toolshed/lib/build-info.ts
@@ -6,7 +6,8 @@
 //
 // In non-compiled runs (e.g. `deno task production` from a checkout) the
 // file does not exist and `commitSha` is null — `resolveGitSha()` then
-// returns the operator-set env var if any, otherwise null.
+// returns an operator-set attestation if any, then falls back to the shared
+// source-run COMMIT_SHA, otherwise null.
 
 import env from "@/env.ts";
 
@@ -55,8 +56,9 @@ export const buildInfo: BuildInfo = readBuildInfoFrom(COMPILED_PATH);
 export function resolveGitShaFrom(
   envValue: string | null | undefined,
   baked: string | null,
+  runtimeValue: string | null | undefined,
 ): string | null {
-  return normalize(envValue) ?? baked;
+  return normalize(envValue) ?? normalize(baked) ?? normalize(runtimeValue);
 }
 
 /**
@@ -68,10 +70,16 @@ export function resolveGitShaFrom(
  *      hot-patched binaries where you want to declare a different commit
  *      than what was compiled.
  *   2. SHA baked into the binary at build time (read above).
- *   3. `null` — `/api/meta` reports null.
+ *   3. Shared `COMMIT_SHA` env var — source-run attestation, used only when
+ *      there is no explicit toolshed override or compiled build metadata.
+ *   4. `null` — `/api/meta` reports null.
  *
  * Empty / whitespace-only values at any level are treated as unset.
  */
 export function resolveGitSha(): string | null {
-  return resolveGitShaFrom(env.TOOLSHED_GIT_SHA, buildInfo.commitSha);
+  return resolveGitShaFrom(
+    env.TOOLSHED_GIT_SHA,
+    buildInfo.commitSha,
+    env.COMMIT_SHA,
+  );
 }

--- a/packages/toolshed/routes/patterns/patterns.handlers.ts
+++ b/packages/toolshed/routes/patterns/patterns.handlers.ts
@@ -1,8 +1,26 @@
 import type { Context } from "@hono/hono";
+import { PATTERN_RESPONSE_BUILD_HEADER } from "@commonfabric/runner";
+import { resolveGitSha } from "@/lib/build-info.ts";
 import { PatternsServer } from "./patterns-server.ts";
 
 // Create a single server instance to be reused across requests
 const patternsServer = new PatternsServer();
+const PATTERN_BUILD = resolveGitSha();
+
+/** Headers shared by source and `?identity` responses from this process. */
+export function patternResponseHeaders(
+  contentType: string,
+  build: string | null = PATTERN_BUILD,
+): Record<string, string> {
+  return {
+    "Content-Type": contentType,
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Expose-Headers": PATTERN_RESPONSE_BUILD_HEADER,
+    ...(build === null ? {} : { [PATTERN_RESPONSE_BUILD_HEADER]: build }),
+  };
+}
 
 /**
  * Handler for serving pattern files from the patterns directory.
@@ -38,12 +56,7 @@ export const getPattern = async (
       const identity = await patternsServer.identity(filename);
       return new Response(identity, {
         status: 200,
-        headers: {
-          "Content-Type": "text/plain; charset=utf-8",
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "GET, OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type",
-        },
+        headers: patternResponseHeaders("text/plain; charset=utf-8"),
       });
     }
 
@@ -53,12 +66,9 @@ export const getPattern = async (
     // Return with proper headers for TSX files
     return new Response(content, {
       status: 200,
-      headers: {
-        "Content-Type": "text/typescript-jsx; charset=utf-8",
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "GET, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type",
-      },
+      headers: patternResponseHeaders(
+        "text/typescript-jsx; charset=utf-8",
+      ),
     });
   } catch (error) {
     const { status, body } = classifyPatternError(error);

--- a/packages/toolshed/routes/patterns/patterns.test.ts
+++ b/packages/toolshed/routes/patterns/patterns.test.ts
@@ -1,10 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import env from "@/env.ts";
+import { PATTERN_RESPONSE_BUILD_HEADER } from "@commonfabric/runner";
 import createApp from "@/lib/create-app.ts";
 import router from "@/routes/patterns/patterns.index.ts";
 import { PatternsServer } from "@/routes/patterns/patterns-server.ts";
-import { classifyPatternError } from "@/routes/patterns/patterns.handlers.ts";
+import {
+  classifyPatternError,
+  patternResponseHeaders,
+} from "@/routes/patterns/patterns.handlers.ts";
 
 const IDENTITY_RE = /^[A-Za-z0-9_-]{43}$/;
 
@@ -129,6 +133,17 @@ describe("Patterns API", () => {
       expect(response.headers.get("Content-Type")).toContain("text/plain");
       const identity = (await response.text()).trim();
       expect(identity).toMatch(IDENTITY_RE);
+    });
+
+    it("builds attested CORS response headers", () => {
+      const headers = new Headers(patternResponseHeaders(
+        "text/plain; charset=utf-8",
+        "test-build",
+      ));
+      expect(headers.get(PATTERN_RESPONSE_BUILD_HEADER)).toBe("test-build");
+      expect(headers.get("Access-Control-Expose-Headers")).toContain(
+        PATTERN_RESPONSE_BUILD_HEADER,
+      );
     });
 
     it("matches the shared resolveEntryIdentity over the real closure (HTTP-boundary drift guard)", async () => {

--- a/packages/toolshed/runtime-options.test.ts
+++ b/packages/toolshed/runtime-options.test.ts
@@ -28,6 +28,8 @@ Deno.test("toolshedRuntimeOptions splits MEMORY_URL/API_URL and honors the env r
     (name) =>
       name === "EXPERIMENTAL_MODERN_CELL_REP"
         ? "true"
+        : name === "TOOLSHED_GIT_SHA"
+        ? "toolshed-effective-sha"
         : name === "COMMIT_SHA"
         ? "toolshed-source-sha"
         : undefined,
@@ -42,7 +44,7 @@ Deno.test("toolshedRuntimeOptions splits MEMORY_URL/API_URL and honors the env r
   assertEquals(options.experimental?.modernCellRep, true);
   // Unset flags stay unset (tri-state fidelity), not coerced.
   assertEquals(options.experimental?.persistentSchedulerState, undefined);
-  assertEquals(options.clientVersion, "toolshed-source-sha");
+  assertEquals(options.clientVersion, "toolshed-effective-sha");
   assertEquals(options.cfcEnforcementMode, "enforce-explicit");
 });
 

--- a/packages/toolshed/runtime-options.test.ts
+++ b/packages/toolshed/runtime-options.test.ts
@@ -25,7 +25,12 @@ Deno.test("toolshedRuntimeOptions splits MEMORY_URL/API_URL and honors the env r
       API_URL: "http://api.test:9000/",
     },
     storageManager,
-    (name) => name === "EXPERIMENTAL_MODERN_CELL_REP" ? "true" : undefined,
+    (name) =>
+      name === "EXPERIMENTAL_MODERN_CELL_REP"
+        ? "true"
+        : name === "COMMIT_SHA"
+        ? "toolshed-source-sha"
+        : undefined,
   );
 
   assertEquals(options.apiUrl.href, "http://memory.test:8000/");
@@ -37,6 +42,7 @@ Deno.test("toolshedRuntimeOptions splits MEMORY_URL/API_URL and honors the env r
   assertEquals(options.experimental?.modernCellRep, true);
   // Unset flags stay unset (tri-state fidelity), not coerced.
   assertEquals(options.experimental?.persistentSchedulerState, undefined);
+  assertEquals(options.clientVersion, "toolshed-source-sha");
   assertEquals(options.cfcEnforcementMode, "enforce-explicit");
 });
 

--- a/packages/toolshed/runtime-options.ts
+++ b/packages/toolshed/runtime-options.ts
@@ -1,4 +1,5 @@
 import {
+  clientVersionFromEnv,
   type EnvReader,
   experimentalOptionsFromEnv,
   Runtime,
@@ -26,6 +27,7 @@ export function toolshedRuntimeOptions(
     patternApiUrl: new URL(config.API_URL),
     storageManager,
     experimental: experimentalOptionsFromEnv(envGet),
+    clientVersion: clientVersionFromEnv(envGet),
   });
 }
 

--- a/packages/toolshed/runtime-options.ts
+++ b/packages/toolshed/runtime-options.ts
@@ -1,5 +1,4 @@
 import {
-  clientVersionFromEnv,
   type EnvReader,
   experimentalOptionsFromEnv,
   Runtime,
@@ -7,6 +6,7 @@ import {
   runtimePresets,
 } from "@commonfabric/runner";
 import type { env as ToolshedEnv } from "@/env.ts";
+import { buildInfo, resolveGitShaFrom } from "@/lib/build-info.ts";
 
 /**
  * Assemble this toolshed's `RuntimeOptions` (CT-1814), extracted pure from
@@ -27,7 +27,11 @@ export function toolshedRuntimeOptions(
     patternApiUrl: new URL(config.API_URL),
     storageManager,
     experimental: experimentalOptionsFromEnv(envGet),
-    clientVersion: clientVersionFromEnv(envGet),
+    clientVersion: resolveGitShaFrom(
+      envGet("TOOLSHED_GIT_SHA"),
+      buildInfo.commitSha,
+      envGet("COMMIT_SHA"),
+    ) ?? undefined,
   });
 }
 


### PR DESCRIPTION
## Summary

- stamp `patternSource` on URL-based default-pattern recreation so recreated system roots remain eligible for automatic updates
- reconcile persisted roots before bootstrap and route every tracked system root through the matching-build gate plus cached `?identity`
- expose the existing `COMMIT_SHA` attestation to source-run toolshed metadata, CLI runtimes, and background-piece workers
- bind identity, source, and imported-module responses to one served build and require the compiled entry identity to match the attested identity
- make provenance repair and identity replacement compare-and-swap writes so concurrent custom-root changes always win

## Root cause

[commontoolsinc/loom#4197](https://github.com/commontoolsinc/loom/pull/4197) exposed three Labs gaps:

1. URL-based `recreateDefaultPattern()` did not persist update provenance.
2. Bootstrap could try to load an obsolete persisted identity before the updater had a chance to replace it.
3. Source-run toolshed and headless runtimes did not expose comparable build versions, so the safety gate could not prove that they matched.

## Behavior and safety

A Loom starter can pass its pinned Labs revision as `COMMIT_SHA` to toolshed, CLI, and background-service processes. Source-run toolshed reports that value from `/api/meta`; headless runtimes carry it as `clientVersion`, including across background-worker IPC.

Every tracked root now follows one update path:

1. require matching known client/toolshed versions
2. resolve `?identity` and require its response to attest the matched build
3. prove an equal persisted identity is still loadable; otherwise continue through the repair path
4. fetch the source and its HTTP import closure, requiring every response to attest the same build
5. compile and require the resulting entry identity to equal the `?identity` result
6. transactionally re-check the captured identity/source/repository before repairing provenance or swapping `patternIdentity`
7. reconcile before bootstrap

There is no compile-without-`?identity` fallback. Unknown, mismatched, mixed-deployment, or concurrently superseded responses never mutate the root. A sourceless pre-provenance root is admitted only when its full stored reference is already the current official default export; stale, custom, and repository-pinned roots remain pinned.

Toolshed SHA precedence is `TOOLSHED_GIT_SHA` → compiled metadata → `COMMIT_SHA`. In local shell development, `COMMIT_SHA` attests the client without redirecting the worker to a production-only `/builds/<sha>/...` URL.

## Validation

- `deno task check` — 400 paths
- `deno task check-docs` — 519 code blocks
- `deno task --cwd packages/piece test` — 20 test files, 237 steps
- `deno task --cwd packages/cli test` — 84 parallel files and 9 serial files
- `deno task --cwd packages/runner test` — 989 tests, 5,297 steps
- `deno task --cwd packages/toolshed test` — 78 tests, 226 steps
- `deno task --cwd packages/js-compiler test` — 9 tests, 68 steps
- `deno task --cwd packages/lib-shell test` — 5 tests, 36 steps
- `deno task integration patterns-reload` — 2 tests, 2 steps
- shell root-view regression — 1 test, 5 steps
- targeted coverage confirms every reachable new updater branch is exercised
- targeted lint, formatting, and diff checks
- independent adversarial re-review — no actionable findings

## Coverage ratchet

The runner-only delta is pre-existing timing-sensitive scheduler coverage: the changed runner paths are covered; this run has 7,194 uncovered lines, and an unrelated PR run had 7,197. The 7,175-line main sample happened to traverse 22 old non-settling scheduler lines.

NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7194 lines