### PR TITLE
test(data-model): coverage-gap pass, plus two FrozenSet.intersection() behavior changes

### DIFF
--- a/packages/data-model/src/frozen-builtins.ts
+++ b/packages/data-model/src/frozen-builtins.ts
@@ -40,7 +40,9 @@ function throwFinalizedBuilderMutation(typeName: string): never {
 /**
  * Helper for the `FrozenMap` methods, which fetches the backing `Map` for the
  * given wrapper instance. Throws if `value` is not a recognized `FrozenMap`
- * receiver (e.g. when an intrinsic mutator was called via `call(...)`).
+ * receiver (e.g. when a `FrozenMap` method was applied to a foreign object via
+ * `call(...)`). Note that an *intrinsic* `Map` method applied to a `FrozenMap`
+ * never gets this far: it fails its own internal-slot check first.
  */
 function getMapBacking<K, V>(value: object): MapBacking<K, V> {
   const backing = MAP_BACKING.get(value);
@@ -53,7 +55,7 @@ function getMapBacking<K, V>(value: object): MapBacking<K, V> {
 /**
  * Helper for the `FrozenSet` methods, which fetches the backing `Set` for the
  * given wrapper instance. Throws if `value` is not a recognized `FrozenSet`
- * receiver.
+ * receiver, under the same conditions described on `getMapBacking()`.
  */
 function getSetBacking<T>(value: object): SetBacking<T> {
   const backing = SET_BACKING.get(value);
@@ -313,13 +315,26 @@ export class FrozenSet<T> implements Set<T> {
     return result;
   }
 
-  /** Same as `Set.prototype.intersection`. Returns a new (mutable) `Set`. */
+  /**
+   * Same as `Set.prototype.intersection`. Returns a new (mutable) `Set`.
+   *
+   * As with the intrinsic, the smaller operand is the one iterated, which
+   * means the result's iteration order follows that operand.
+   */
   intersection<U>(other: ReadonlySetLike<U>): Set<T & U> {
     const result = new Set<T & U>();
-    for (const value of this.values()) {
-      if (other.has(value as unknown as U)) {
-        result.add(value as T & U);
+    if (this.size <= other.size) {
+      for (const value of this.values()) {
+        if (other.has(value as unknown as U)) {
+          result.add(value as T & U);
+        }
       }
+    } else {
+      forEachSetLikeValue(other, (value) => {
+        if (this.has(value as unknown as T)) {
+          result.add(value as T & U);
+        }
+      });
     }
     return result;
   }

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -121,9 +121,12 @@ export function tagFromNativeClass(
  * value is a recognized convertible native instance, or `null` otherwise.
  * Non-object types (`null`, `undefined`, primitives) return `Primitive`.
  *
- * Dispatches via the value's constructor (O(1) switch in `tagFromNativeClass`).
- * Falls back to `Error.isError()` for exotic `Error` subclasses, `Array.isArray()`
- * for cross-realm arrays, and prototype check for null-prototype objects.
+ * Dispatches via the value's constructor (O(1) switch in `tagFromNativeClass`,
+ * which matches `Error` subclasses via `prototype instanceof Error`). Falls
+ * back to `Error.isError()` and `Array.isArray()` for values whose constructor
+ * is unreachable -- a severed prototype, or another realm -- since the internal
+ * slot survives where a constructor lookup does not, and to a prototype check
+ * for null-prototype objects.
  *
  * For tags that have pass-through handling (`Object`, `Array`) or no dedicated
  * handler (`null`), a per-instance `hasToJSON()` check upgrades the tag to
@@ -154,7 +157,11 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
 
   // Fallbacks for values whose constructor wasn't recognized (tag === null).
   if (tag === null) {
-    // Exotic `Error` subclasses (e.g. `DOMException`).
+    // `Error`s with no reachable constructor -- e.g. one whose prototype has
+    // been severed, or one from another realm. An ordinary subclass (including
+    // `DOMException`) never gets here: `tagFromNativeClass()` matches it via
+    // `prototype instanceof Error`. The internal slot survives either way,
+    // which is what `Error.isError()` reads.
     if (Error.isError(value)) return NATIVE_TAGS.Error;
 
     // `FabricInstance` values (object-like protocol types).

--- a/packages/data-model/test/codec-json/CodecRegistry.test.ts
+++ b/packages/data-model/test/codec-json/CodecRegistry.test.ts
@@ -120,6 +120,17 @@ describe("CodecRegistry", () => {
         expect(last.canEncodeCalled).toBe(false);
       });
     }
+
+    it("returns undefined for a null-prototype object", () => {
+      const { registry } = buildRegistry(
+        FabricRegExp,
+        new FabricRegExp(/x/) as FabricValue,
+      );
+      const nullProto = Object.create(null) as Record<string, FabricValue>;
+      nullProto.a = 1;
+
+      expect(registry.codecFromValue(nullProto)).toBeUndefined();
+    });
   });
 
   describe("registerPrimitive()", () => {

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -64,6 +64,37 @@ describe("data-uri-codec", () => {
       expect(Object.is(parsed.z, -0)).toBe(true);
       expect(Object.is(parsed.i, -Infinity)).toBe(true);
     });
+
+    // Distinctness is a separate property from round-tripping, and the more
+    // important one here: these URIs are content addresses, so two values that
+    // are not equal must not mint the same identifier. A codec could round-trip
+    // every value faithfully and still collide.
+    it("mints distinct URIs for `-0` and `+0`", () => {
+      expect(dataUriFromValue(-0)).not.toBe(dataUriFromValue(0));
+      expect(dataUriFromValue({ z: -0 })).not.toBe(dataUriFromValue({ z: 0 }));
+    });
+
+    it("mints distinct URIs for the two infinities", () => {
+      expect(dataUriFromValue(Infinity)).not.toBe(
+        dataUriFromValue(-Infinity),
+      );
+    });
+
+    it("mints distinct URIs for `NaN` and other non-finites", () => {
+      expect(dataUriFromValue(NaN)).not.toBe(dataUriFromValue(Infinity));
+      expect(dataUriFromValue(NaN)).not.toBe(dataUriFromValue(-Infinity));
+    });
+
+    it("mints one URI for every `NaN`", () => {
+      expect(dataUriFromValue(NaN)).toBe(dataUriFromValue(0 / 0));
+      expect(dataUriFromValue({ n: NaN })).toBe(
+        dataUriFromValue({ n: Number("x") }),
+      );
+    });
+
+    it("mints the same URI for repeated `-0`", () => {
+      expect(dataUriFromValue(-0)).toBe(dataUriFromValue(-0));
+    });
   });
 
   describe("valueFromDataUriPayloadText", () => {

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -85,10 +85,26 @@ describe("data-uri-codec", () => {
       expect(dataUriFromValue(NaN)).not.toBe(dataUriFromValue(-Infinity));
     });
 
-    it("mints one URI for every `NaN`", () => {
-      expect(dataUriFromValue(NaN)).toBe(dataUriFromValue(0 / 0));
-      expect(dataUriFromValue({ n: NaN })).toBe(
-        dataUriFromValue({ n: Number("x") }),
+    // Arithmetic only ever yields one `NaN` bit pattern, so `NaN` and `0 / 0`
+    // are the same value and comparing them proves only determinism. A
+    // distinct payload has to be built through a typed-array view, which is
+    // also how one reaches a caller in practice.
+    it("mints one URI for every `NaN`, whatever its payload", () => {
+      const buffer = new ArrayBuffer(8);
+      const bytes = new Uint8Array(buffer);
+      const doubles = new Float64Array(buffer);
+      bytes.set([0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0x7f]);
+      const payloadNan = doubles[0];
+
+      // Guard the premise: if this ever stops holding, the case below is
+      // vacuous and should fail loudly rather than pass for free.
+      doubles[0] = 0 / 0;
+      expect(Number.isNaN(payloadNan)).toBe(true);
+      expect(bytes[0]).not.toBe(0x01);
+
+      expect(dataUriFromValue(payloadNan)).toBe(dataUriFromValue(0 / 0));
+      expect(dataUriFromValue({ n: payloadNan })).toBe(
+        dataUriFromValue({ n: NaN }),
       );
     });
 

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -208,6 +208,102 @@ describe("FabricError", () => {
       });
     });
 
+    describe("extras bag", () => {
+      it("round-trips a value through `setExtra()` / `getExtra()`", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
+        fe.setExtra("code", 404);
+        expect(fe.getExtra("code")).toBe(404);
+      });
+
+      it("returns `undefined` from `getExtra()` for an absent key", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
+        expect(fe.getExtra("nope")).toBe(undefined);
+      });
+
+      it("reports presence via `hasExtra()`", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
+        fe.setExtra("code", 404);
+        expect(fe.hasExtra("code")).toBe(true);
+        expect(fe.hasExtra("other")).toBe(false);
+      });
+
+      it("reports the entry count via `extraSize`", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
+        expect(fe.extraSize).toBe(0);
+        fe.setExtra("a", 1);
+        fe.setExtra("b", 2);
+        expect(fe.extraSize).toBe(2);
+      });
+
+      it("overwrites rather than duplicates an existing key", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
+        fe.setExtra("a", 1);
+        fe.setExtra("a", 2);
+        expect(fe.getExtra("a")).toBe(2);
+        expect(fe.extraSize).toBe(1);
+      });
+
+      it("enumerates keys and entries", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
+        fe.setExtra("a", 1);
+        fe.setExtra("b", 2);
+        expect([...fe.extraKeys()]).toEqual(["a", "b"]);
+        expect([...fe.extraEntries()]).toEqual([["a", 1], ["b", 2]]);
+      });
+
+      it("reports removal success via `deleteExtra()`", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
+        fe.setExtra("a", 1);
+        expect(fe.deleteExtra("a")).toBe(true);
+        expect(fe.hasExtra("a")).toBe(false);
+        expect(fe.deleteExtra("a")).toBe(false);
+      });
+
+      it("rejects a fixed-schema slot name as an extras key", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
+        for (const key of ["type", "name", "message", "stack", "cause"]) {
+          expect(() => fe.setExtra(key, 1)).toThrow(
+            `Cannot use fixed-schema slot name in FabricError extras: ${key}`,
+          );
+        }
+      });
+
+      it("rejects a prototype-sensitive extras key", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
+        for (const key of ["__proto__", "constructor"]) {
+          expect(() => fe.setExtra(key, 1)).toThrow(
+            `Cannot use unsafe key in FabricError extras: ${key}`,
+          );
+        }
+        expect(fe.extraSize).toBe(0);
+      });
+
+      it("refuses mutation once frozen", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
+        fe.setExtra("a", 1);
+        Object.freeze(fe);
+
+        expect(() => fe.setExtra("b", 2)).toThrow(
+          "Cannot modify frozen FabricError",
+        );
+        expect(() => fe.deleteExtra("a")).toThrow(
+          "Cannot modify frozen FabricError",
+        );
+        expect(fe.getExtra("a")).toBe(1);
+        expect(fe.extraSize).toBe(1);
+      });
+
+      it("still reads while frozen", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
+        fe.setExtra("a", 1);
+        Object.freeze(fe);
+
+        expect(fe.getExtra("a")).toBe(1);
+        expect(fe.hasExtra("a")).toBe(true);
+        expect([...fe.extraKeys()]).toEqual(["a"]);
+      });
+    });
+
     describe("toNativeValue()", () => {
       it("returns a frozen `Error` projection when `frozen` is `true`", () => {
         const err = new Error("native");

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -293,6 +293,29 @@ describe("FabricError", () => {
         expect(fe.extraSize).toBe(1);
       });
 
+      // The constructor filters its `extras` input independently of the codec,
+      // which filters again on the way in. Both layers matter: extras carry
+      // whatever the wire supplied, and the constructor is public.
+      it("drops unsafe and reserved keys supplied to the constructor", () => {
+        const fe = new FabricError({
+          type: "Error",
+          name: "Error",
+          message: "m",
+          stack: undefined,
+          cause: undefined,
+          extras: [
+            ["__proto__", "bad"],
+            ["constructor", "bad"],
+            ["type", "bad"],
+            ["message", "bad"],
+            ["kept", 1],
+          ] as Array<[string, FabricValue]>,
+        });
+
+        expect([...fe.extraKeys()]).toEqual(["kept"]);
+        expect(fe.message).toBe("m");
+      });
+
       it("still reads while frozen", () => {
         const fe = FabricError.fromNativeError(new Error("test"));
         fe.setExtra("a", 1);
@@ -461,6 +484,26 @@ describe("FabricError", () => {
       // Decoding hand-built state (not via `encode()`): exercises name/type
       // handling and back-compat that the round-trip tests don't.
       describe("decode()", () => {
+        // `JSON.parse` creates an own `__proto__` property where an object
+        // literal instead invokes the setter, so parsed wire state is the one
+        // place a prototype-sensitive key genuinely arrives as decodable input.
+        it("drops a `__proto__` key arriving from parsed wire state", () => {
+          const state = JSON.parse(
+            '{"type":"Error","message":"x","__proto__":"bad","code":7}',
+          );
+          expect(Object.hasOwn(state, "__proto__")).toBe(true);
+
+          const result = codec.decode(
+            expectedTag,
+            state,
+            context,
+          ) as unknown as FabricError;
+
+          expect([...result.extraKeys()]).toEqual(["code"]);
+          expect(result.hasExtra("__proto__")).toBe(false);
+          expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+        });
+
         it("creates a `FabricError` from state (null `name` = same as `type`)", () => {
           const state = { type: "Error", name: null, message: "hello" };
           const result = codec.decode(

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -85,6 +85,23 @@ describe("FabricBytes", () => {
         const target = new Uint8Array(3);
         expect(() => fb.copyInto(target, 0, -1)).toThrow(RangeError);
       });
+
+      it("copies nothing when the offset is at or past the end", () => {
+        const fb = new FabricBytes(new Uint8Array([1, 2, 3]));
+        const target = new Uint8Array([9, 9, 9]);
+
+        expect(fb.copyInto(target, 3)).toBe(0);
+        expect(fb.copyInto(target, 4)).toBe(0);
+        expect(target).toEqual(new Uint8Array([9, 9, 9]));
+      });
+
+      it("copies nothing from an empty source", () => {
+        const fb = new FabricBytes(new Uint8Array());
+        const target = new Uint8Array([9]);
+
+        expect(fb.copyInto(target)).toBe(0);
+        expect(target).toEqual(new Uint8Array([9]));
+      });
     });
   });
 

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -7,6 +7,7 @@ import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
 import { CODEC } from "@/codec-common/interface.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-common/EmptyReconstructionContext.ts";
+import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 
 describe("FabricEpochDays", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
@@ -83,6 +84,20 @@ describe("FabricEpochDays", () => {
           ) as unknown as FabricEpochDays;
           expect(decoded).toBeInstanceOf(FabricEpochDays);
           expect(decoded.value).toBe(0n);
+        });
+
+        it("decodes non-string state to a `ProblematicValue`", () => {
+          const decoded = codec.decode(expectedTag, 42, context);
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
+
+        it("decodes malformed base64 to a `ProblematicValue`", () => {
+          const decoded = codec.decode(
+            expectedTag,
+            "not valid base64!!",
+            context,
+          );
+          expect(decoded).toBeInstanceOf(ProblematicValue);
         });
       });
 

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -7,6 +7,7 @@ import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
 import { CODEC } from "@/codec-common/interface.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/codec-common/EmptyReconstructionContext.ts";
+import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 
 describe("FabricEpochNsec", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
@@ -89,6 +90,20 @@ describe("FabricEpochNsec", () => {
           ) as unknown as FabricEpochNsec;
           expect(decoded).toBeInstanceOf(FabricEpochNsec);
           expect(decoded.value).toBe(0n);
+        });
+
+        it("decodes non-string state to a `ProblematicValue`", () => {
+          const decoded = codec.decode(expectedTag, 42, context);
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
+
+        it("decodes malformed base64 to a `ProblematicValue`", () => {
+          const decoded = codec.decode(
+            expectedTag,
+            "not valid base64!!",
+            context,
+          );
+          expect(decoded).toBeInstanceOf(ProblematicValue);
         });
       });
 

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -158,6 +158,36 @@ describe("FabricRegExp", () => {
           const decoded = codec.decode(expectedTag, "nope", context);
           expect(decoded).toBeInstanceOf(ProblematicValue);
         });
+
+        it("decodes an unparseable `es2025` pattern to `ProblematicValue`", () => {
+          const decoded = codec.decode(
+            expectedTag,
+            { source: "(", flags: "" },
+            context,
+          );
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
+
+        it("decodes bad `es2025` flags to `ProblematicValue`", () => {
+          const decoded = codec.decode(
+            expectedTag,
+            { source: "a", flags: "zz" },
+            context,
+          );
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
+
+        it("accepts a malformed pattern under a non-`es2025` flavor", () => {
+          // Only the `es2025` flavor is validated; other flavors are stored
+          // faithfully, so an unparseable source is not a decode failure.
+          const decoded = codec.decode(
+            expectedTag,
+            { flavor: "other", source: "(", flags: "" },
+            context,
+          );
+          expect(decoded).not.toBeInstanceOf(ProblematicValue);
+          expect(decoded).toBeInstanceOf(FabricRegExp);
+        });
       });
 
       describe("round trip encode-decode", () => {

--- a/packages/data-model/test/frozen-builtins.test.ts
+++ b/packages/data-model/test/frozen-builtins.test.ts
@@ -307,6 +307,16 @@ describe("frozen-builtins", () => {
     });
 
     describe("non-finite and signed-zero values", () => {
+      // These wrappers follow `Set`'s `SameValueZero` comparison, under which
+      // `-0` and `+0` are the same element. That differs from `FabricValue`
+      // equality, which follows `Object.is()` and holds `-0` distinct from
+      // `+0` -- so the behavior pinned here can look like a bug against that
+      // rule. It isn't: `FrozenMap` / `FrozenSet` exist to be drop-in
+      // substitutes for the intrinsics they wrap, and a wrapper that mirrored
+      // `Set` in every respect except `-0` would be a worse trap than the
+      // difference between the two layers. These tests are what keep the
+      // wrapper from being "corrected" to `Object.is()` for consistency.
+      //
       // `toBe()` compares with `Object.is()`, which tells `-0` from `+0`.
       // `toEqual()` does not, and would make these assertions vacuous.
       it("normalizes `-0` to `+0` on insertion, as `Set` does", () => {

--- a/packages/data-model/test/frozen-builtins.test.ts
+++ b/packages/data-model/test/frozen-builtins.test.ts
@@ -54,6 +54,28 @@ describe("frozen-builtins", () => {
       expect(fm.has("b")).toBe(false);
     });
 
+    it("rejects a receiver that has no backing store", () => {
+      const foreign = Object.create(FrozenMap.prototype) as FrozenMap<
+        string,
+        number
+      >;
+
+      expect(() => foreign.get("a")).toThrow("Incompatible FrozenMap receiver");
+      expect(() => foreign.has("a")).toThrow("Incompatible FrozenMap receiver");
+      expect(() => foreign.size).toThrow("Incompatible FrozenMap receiver");
+      expect(() => foreign.keys()).toThrow("Incompatible FrozenMap receiver");
+      expect(() => foreign.values()).toThrow("Incompatible FrozenMap receiver");
+      expect(() => foreign.entries()).toThrow(
+        "Incompatible FrozenMap receiver",
+      );
+    });
+
+    it("reports `Map` as its `Symbol.toStringTag`", () => {
+      const fm = new FrozenMap<string, number>([["a", 1]]);
+      expect(fm[Symbol.toStringTag]).toBe("Map");
+      expect(Object.prototype.toString.call(fm)).toBe("[object Map]");
+    });
+
     it("throws on `getOrInsert()`", () => {
       const fm = new FrozenMap<string, number>([["a", 1]]) as
         & FrozenMap<
@@ -153,6 +175,34 @@ describe("frozen-builtins", () => {
       expect(fs.has(2)).toBe(false);
     });
 
+    it("rejects a receiver that has no backing store", () => {
+      const foreign = Object.create(FrozenSet.prototype) as FrozenSet<number>;
+
+      expect(() => foreign.has(1)).toThrow("Incompatible FrozenSet receiver");
+      expect(() => foreign.size).toThrow("Incompatible FrozenSet receiver");
+      expect(() => foreign.keys()).toThrow("Incompatible FrozenSet receiver");
+      expect(() => foreign.values()).toThrow("Incompatible FrozenSet receiver");
+      expect(() => foreign.entries()).toThrow(
+        "Incompatible FrozenSet receiver",
+      );
+    });
+
+    it("reports `Set` as its `Symbol.toStringTag`", () => {
+      const fs = new FrozenSet<number>([1]);
+      expect(fs[Symbol.toStringTag]).toBe("Set");
+      expect(Object.prototype.toString.call(fs)).toBe("[object Set]");
+    });
+
+    it("yields value-value pairs from `entries()`, as `Set` does", () => {
+      const fs = new FrozenSet<number>([1, 2]);
+      expect([...fs.entries()]).toEqual([[1, 1], [2, 2]]);
+    });
+
+    it("yields values from `keys()`, as `Set` does", () => {
+      const fs = new FrozenSet<number>([1, 2]);
+      expect([...fs.keys()]).toEqual([1, 2]);
+    });
+
     it("supports forEach iteration", () => {
       const fs = new FrozenSet([10, 20, 30]);
       const values: number[] = [];
@@ -180,6 +230,124 @@ describe("frozen-builtins", () => {
         "Cannot mutate a finalized FrozenSet builder",
       );
       expect([...fs.values()]).toEqual([1]);
+    });
+
+    describe("set algebra", () => {
+      it("computes `union()`", () => {
+        const fs = new FrozenSet<number>([1, 2]);
+        expect([...fs.union(new Set([2, 3]))]).toEqual([1, 2, 3]);
+      });
+
+      it("computes `intersection()`", () => {
+        const fs = new FrozenSet<number>([1, 2, 3]);
+        expect([...fs.intersection(new Set([2, 3, 4]))]).toEqual([2, 3]);
+      });
+
+      it("computes `difference()`", () => {
+        const fs = new FrozenSet<number>([1, 2, 3]);
+        expect([...fs.difference(new Set([2, 4]))]).toEqual([1, 3]);
+      });
+
+      it("computes `symmetricDifference()`", () => {
+        const fs = new FrozenSet<number>([1, 2, 3]);
+        expect([...fs.symmetricDifference(new Set([3, 4]))]).toEqual([1, 2, 4]);
+      });
+
+      it("computes `isSubsetOf()`", () => {
+        const fs = new FrozenSet<number>([1, 2]);
+        expect(fs.isSubsetOf(new Set([1, 2, 3]))).toBe(true);
+        expect(fs.isSubsetOf(new Set([1, 3]))).toBe(false);
+      });
+
+      it("computes `isSupersetOf()`", () => {
+        const fs = new FrozenSet<number>([1, 2, 3]);
+        expect(fs.isSupersetOf(new Set([1, 3]))).toBe(true);
+        expect(fs.isSupersetOf(new Set([1, 4]))).toBe(false);
+      });
+
+      it("computes `isDisjointFrom()`", () => {
+        const fs = new FrozenSet<number>([1, 2]);
+        expect(fs.isDisjointFrom(new Set([3, 4]))).toBe(true);
+        expect(fs.isDisjointFrom(new Set([2, 3]))).toBe(false);
+      });
+
+      it("returns a mutable `Set` from the value-producing methods", () => {
+        const result = new FrozenSet<number>([1]).union(new Set([2]));
+
+        expect(result).toBeInstanceOf(Set);
+        expect(result).not.toBeInstanceOf(FrozenSet);
+        result.add(3);
+        expect([...result]).toEqual([1, 2, 3]);
+      });
+
+      it("handles an empty operand on both sides", () => {
+        const empty = new FrozenSet<number>();
+
+        expect([...empty.union(new Set([1]))]).toEqual([1]);
+        expect([...empty.intersection(new Set([1]))]).toEqual([]);
+        expect([...empty.difference(new Set([1]))]).toEqual([]);
+        expect([...new FrozenSet([1]).intersection(new Set<number>())])
+          .toEqual([]);
+        expect(empty.isSubsetOf(new Set([1]))).toBe(true);
+        expect(empty.isDisjointFrom(new Set([1]))).toBe(true);
+      });
+
+      // `Set.prototype.intersection` iterates whichever operand is smaller,
+      // so the result's iteration order follows that operand rather than
+      // always following the receiver.
+      it("takes `intersection()` order from the smaller operand", () => {
+        const fs = new FrozenSet<number>([1, 2, 3, 4, 5]);
+        expect([...fs.intersection(new Set([5, 1]))]).toEqual([5, 1]);
+      });
+
+      it("takes `intersection()` order from itself when no larger", () => {
+        const fs = new FrozenSet<number>([5, 1]);
+        expect([...fs.intersection(new Set([1, 2, 3, 4, 5]))]).toEqual([5, 1]);
+      });
+    });
+
+    describe("non-finite and signed-zero values", () => {
+      // `toBe()` compares with `Object.is()`, which tells `-0` from `+0`.
+      // `toEqual()` does not, and would make these assertions vacuous.
+      it("normalizes `-0` to `+0` on insertion, as `Set` does", () => {
+        const fs = new FrozenSet<number>([-0]);
+
+        expect(fs.size).toBe(1);
+        expect([...fs.values()][0]).toBe(0);
+      });
+
+      it("treats `-0` and `+0` as the same element", () => {
+        const fs = new FrozenSet<number>([-0, 0]);
+
+        expect(fs.size).toBe(1);
+        expect(fs.has(0)).toBe(true);
+        expect(fs.has(-0)).toBe(true);
+      });
+
+      it("unifies `-0` and `+0` across set algebra", () => {
+        const fs = new FrozenSet<number>([-0]);
+
+        expect([...fs.intersection(new Set([0]))]).toEqual([0]);
+        expect([...fs.difference(new Set([0]))]).toEqual([]);
+        expect(fs.isSubsetOf(new Set([0]))).toBe(true);
+        expect(fs.isDisjointFrom(new Set([0]))).toBe(false);
+      });
+
+      it("treats all `NaN`s as one element", () => {
+        const fs = new FrozenSet<number>([NaN, NaN]);
+
+        expect(fs.size).toBe(1);
+        expect(fs.has(NaN)).toBe(true);
+      });
+
+      it("keeps the two infinities distinct", () => {
+        const fs = new FrozenSet<number>([Infinity, -Infinity]);
+
+        expect(fs.size).toBe(2);
+        expect([...fs.values()][0]).toBe(Infinity);
+        expect([...fs.values()][1]).toBe(-Infinity);
+        expect(fs.isDisjointFrom(new Set([Infinity]))).toBe(false);
+      });
     });
   });
 });

--- a/packages/data-model/test/frozen-builtins.test.ts
+++ b/packages/data-model/test/frozen-builtins.test.ts
@@ -133,6 +133,46 @@ describe("frozen-builtins", () => {
       );
       expect([...fm.entries()]).toEqual([["a", 1]]);
     });
+
+    // Keys go through `Map.prototype.set`, which carries the same signed-zero
+    // normalization as `Set.prototype.add`. This is a separate construction
+    // site from `FrozenSet`'s, so the equivalent `FrozenSet` cases below do
+    // not reach it -- see the rationale on that block for why the behavior is
+    // deliberate rather than a defect.
+    describe("non-finite and signed-zero keys", () => {
+      it("normalizes a `-0` key to `+0`, as `Map` does", () => {
+        const fm = new FrozenMap<number, string>([[-0, "a"]]);
+
+        expect(fm.size).toBe(1);
+        expect([...fm.keys()][0]).toBe(0);
+      });
+
+      it("treats `-0` and `+0` as the same key", () => {
+        const fm = new FrozenMap<number, string>([[-0, "a"], [0, "b"]]);
+
+        expect(fm.size).toBe(1);
+        expect(fm.get(0)).toBe("b");
+        expect(fm.get(-0)).toBe("b");
+      });
+
+      it("treats all `NaN`s as one key", () => {
+        const fm = new FrozenMap<number, string>([[NaN, "a"], [NaN, "b"]]);
+
+        expect(fm.size).toBe(1);
+        expect(fm.get(NaN)).toBe("b");
+      });
+
+      it("keeps the two infinities as distinct keys", () => {
+        const fm = new FrozenMap<number, string>([
+          [Infinity, "pos"],
+          [-Infinity, "neg"],
+        ]);
+
+        expect(fm.size).toBe(2);
+        expect(fm.get(Infinity)).toBe("pos");
+        expect(fm.get(-Infinity)).toBe("neg");
+      });
+    });
   });
 
   describe("FrozenSet", () => {
@@ -304,6 +344,16 @@ describe("frozen-builtins", () => {
         const fs = new FrozenSet<number>([5, 1]);
         expect([...fs.intersection(new Set([1, 2, 3, 4, 5]))]).toEqual([5, 1]);
       });
+
+      // Equal sizes are the boundary between the two branches, and the
+      // intrinsic iterates the receiver there. The operands below share their
+      // elements but not their order, so the result distinguishes which side
+      // was iterated -- which an equal-size case with coinciding orders
+      // cannot.
+      it("takes `intersection()` order from itself on equal sizes", () => {
+        const fs = new FrozenSet<number>([1, 2]);
+        expect([...fs.intersection(new Set([2, 1]))]).toEqual([1, 2]);
+      });
     });
 
     describe("non-finite and signed-zero values", () => {
@@ -344,7 +394,9 @@ describe("frozen-builtins", () => {
       it("unifies `-0` and `+0` across set algebra", () => {
         const fs = new FrozenSet<number>([-0]);
 
-        expect([...fs.intersection(new Set([0]))]).toEqual([0]);
+        const intersected = [...fs.intersection(new Set([0]))];
+        expect(intersected.length).toBe(1);
+        expect(Object.is(intersected[0], 0)).toBe(true);
         expect([...fs.difference(new Set([0]))]).toEqual([]);
         expect(fs.isSubsetOf(new Set([0]))).toBe(true);
         expect(fs.isDisjointFrom(new Set([0]))).toBe(false);

--- a/packages/data-model/test/frozen-builtins.test.ts
+++ b/packages/data-model/test/frozen-builtins.test.ts
@@ -308,14 +308,21 @@ describe("frozen-builtins", () => {
 
     describe("non-finite and signed-zero values", () => {
       // These wrappers follow `Set`'s `SameValueZero` comparison, under which
-      // `-0` and `+0` are the same element. That differs from `FabricValue`
-      // equality, which follows `Object.is()` and holds `-0` distinct from
-      // `+0` -- so the behavior pinned here can look like a bug against that
-      // rule. It isn't: `FrozenMap` / `FrozenSet` exist to be drop-in
-      // substitutes for the intrinsics they wrap, and a wrapper that mirrored
-      // `Set` in every respect except `-0` would be a worse trap than the
-      // difference between the two layers. These tests are what keep the
-      // wrapper from being "corrected" to `Object.is()` for consistency.
+      // `-0` and `+0` are the same element. `FabricValue` equality follows
+      // `Object.is()` instead and holds the two distinct, so the behavior
+      // pinned here can look like a bug against that rule. It isn't, for two
+      // reasons that are worth stating rather than rediscovering:
+      //
+      // `FrozenSet<T>` is declared `implements Set<T>`. It does not merely
+      // resemble a `Set`, it claims substitutability -- so keying it by
+      // `Object.is()` would produce a `Set` that is not a `Set`, breaking the
+      // interface in its own `implements` clause. And `FrozenMap`/`FrozenSet`
+      // are not `FabricValue`s at all, so the `Object.is()` rule does not
+      // reach them in the first place.
+      //
+      // The plausible future mistake at this site is therefore not a naive
+      // `===`; it is someone "fixing" these wrappers toward `Object.is()` for
+      // consistency. These tests are what stops that.
       //
       // `toBe()` compares with `Object.is()`, which tells `-0` from `+0`.
       // `toEqual()` does not, and would make these assertions vacuous.

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -739,6 +739,35 @@ describe("native-conversion", () => {
             "`toJSON()` on object returned something other than a fabric value",
           );
       });
+
+      it("throws if a function's `toJSON()` returns a non-fabric value", () => {
+        const fn = Object.assign(() => 1, { toJSON: () => new Map() });
+        expect(() => shallowFabricFromNativeValue(fn)).toThrow(
+          "`toJSON()` on function returned something other than a fabric value",
+        );
+      });
+
+      it("converts a function via a `toJSON()` returning a fabric value", () => {
+        const fn = Object.assign(() => 1, { toJSON: () => ({ x: 1 }) });
+        expect(shallowFabricFromNativeValue(fn)).toEqual({ x: 1 });
+      });
+    });
+
+    // "Death before confusion": a native type with a dedicated fabric
+    // representation carries no room for extra state, so silently dropping it
+    // would lose data on a round trip.
+    describe("rejects extra enumerable properties", () => {
+      it("throws for a `Date` carrying an extra property", () => {
+        const date = new Date(0) as Date & { extra?: number };
+        date.extra = 1;
+        expect(() => shallowFabricFromNativeValue(date)).toThrow(
+          "Cannot store Date with extra enumerable properties",
+        );
+      });
+
+      it("still converts a `Date` with no extra properties", () => {
+        expect(() => shallowFabricFromNativeValue(new Date(0))).not.toThrow();
+      });
     });
 
     describe("throws for non-convertible values", () => {

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -156,6 +156,29 @@ describe("native-conversion", () => {
       expect(Object.isFrozen(result)).toBe(true);
     });
 
+    it("restores an overridden `name` when unwrapping a `FabricError`", () => {
+      const err = new TypeError("renamed");
+      err.name = "CustomName";
+      const se = FabricError.fromNativeError(err);
+      const result = nativeFromFabricValue(
+        se as unknown as FabricValue,
+      ) as Error;
+
+      expect(result).toBeInstanceOf(TypeError);
+      expect(result.name).toBe("CustomName");
+      expect(result.message).toBe("renamed");
+    });
+
+    it("leaves the class's own `name` in place when not overridden", () => {
+      const se = FabricError.fromNativeError(new TypeError("plain"));
+      const result = nativeFromFabricValue(
+        se as unknown as FabricValue,
+      ) as Error;
+
+      expect(result).toBeInstanceOf(TypeError);
+      expect(result.name).toBe("TypeError");
+    });
+
     it("deeply unwraps `FabricError` in arrays (frozen)", () => {
       const err = new Error("array");
       const se = FabricError.fromNativeError(err);
@@ -1799,6 +1822,33 @@ describe("native-conversion", () => {
     it("rejects objects with `toJSON()` returning non-fabric values", () => {
       const obj = { toJSON: () => Symbol("bad") };
       expect(isFabricCompatible(obj)).toBe(false);
+    });
+
+    it("accepts a function with `toJSON()` returning a fabric value", () => {
+      const fn = Object.assign(() => 1, { toJSON: () => ({ x: 1 }) });
+      expect(isFabricCompatible(fn)).toBe(true);
+    });
+
+    it("rejects a function with `toJSON()` returning a non-fabric value", () => {
+      const fn = Object.assign(() => 1, { toJSON: () => Symbol("bad") });
+      expect(isFabricCompatible(fn)).toBe(false);
+    });
+
+    it("rejects a plain function", () => {
+      expect(isFabricCompatible(() => 1)).toBe(false);
+    });
+
+    // -- Arrays carrying named properties --
+    it("rejects an array with extra named properties", () => {
+      const arr = [1, 2, 3] as number[] & { extra?: string };
+      arr.extra = "nope";
+      expect(isFabricCompatible(arr)).toBe(false);
+    });
+
+    it("rejects an array with named properties nested inside an object", () => {
+      const arr = [1] as number[] & { extra?: string };
+      arr.extra = "nope";
+      expect(isFabricCompatible({ list: arr })).toBe(false);
     });
   });
 });

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -32,9 +32,36 @@ describe("native-type-tags", () => {
         }
       }
       const exotic = new MyFancyError("exotic");
-      // Constructor is MyFancyError, not in the switch -- falls back to
-      // Error.isError().
+      // Recognized by class: `tagFromNativeClass()` walks the prototype chain,
+      // so an `Error` subclass is tagged without reaching the value-level
+      // fallbacks below.
       expect(tagFromNativeValue(exotic)).toBe(NATIVE_TAGS.Error);
+    });
+
+    it("returns `Error` tag for an `Error` whose prototype was severed", () => {
+      const severed = new Error("severed");
+      Object.setPrototypeOf(severed, null);
+
+      // No reachable constructor, so the class-level lookup yields nothing and
+      // the `Error.isError()` fallback is what recognizes it.
+      expect((severed as { constructor?: unknown }).constructor).toBe(
+        undefined,
+      );
+      expect(tagFromNativeValue(severed)).toBe(NATIVE_TAGS.Error);
+    });
+
+    it("returns `Array` tag for an `Array` subclass", () => {
+      class MyArray extends Array {}
+
+      expect(tagFromNativeClass(MyArray)).toBe(null);
+      expect(tagFromNativeValue(new MyArray())).toBe(NATIVE_TAGS.Array);
+    });
+
+    it("returns `Array` tag for an array whose prototype was severed", () => {
+      const severed = [1, 2];
+      Object.setPrototypeOf(severed, null);
+
+      expect(tagFromNativeValue(severed)).toBe(NATIVE_TAGS.Array);
     });
 
     it("returns `Map` tag for `Map` instances", () => {

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -1003,6 +1003,55 @@ describe("schema-utils", () => {
       expect(result.schema).toBe(interned);
     });
 
+    it("interns a selector with an empty path", () => {
+      const schema = uniqueSchema();
+      const selector: SchemaPathSelector = { path: [], schema };
+      const result = internPathSelector(selector);
+
+      expect(result.path).toEqual([]);
+      expect(Object.isFrozen(result.path)).toBe(true);
+      expect(isInternedSchema(result.schema as JSONSchemaObj)).toBe(true);
+    });
+
+    it("keeps an empty path distinct from a non-empty one", () => {
+      const schema = uniqueSchema();
+      const empty = internPathSelector({ path: [], schema });
+      const nonEmpty = internPathSelector({ path: ["a"], schema });
+
+      expect(empty).not.toBe(nonEmpty);
+      expect(empty.path).toEqual([]);
+      expect(nonEmpty.path).toEqual(["a"]);
+    });
+
+    it("canonicalizes to one instance when a frozen path array is reused", () => {
+      const schema = uniqueSchema();
+      const first = internPathSelector({ path: ["a", "b"], schema });
+
+      // Interning froze the path in place, so the same array identity can be
+      // handed back in a fresh selector -- the repeat case the path-key cache
+      // exists for. The cache is only populated once the path is frozen, so
+      // it takes a third pass to serve one; all three must agree.
+      const second = internPathSelector({
+        path: first.path,
+        schema: first.schema,
+      });
+      const third = internPathSelector({
+        path: first.path,
+        schema: first.schema,
+      });
+
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    });
+
+    it("keeps paths distinct when a component contains the separator", () => {
+      const schema = uniqueSchema();
+      const a = internPathSelector({ path: ["a:b"], schema });
+      const b = internPathSelector({ path: ["a", "b"], schema });
+
+      expect(a).not.toBe(b);
+    });
+
     it("handles selectors whose `schema` is undefined", () => {
       const selector: SchemaPathSelector = { path: ["p"] };
       // Must not throw — `internSchema(undefined)` would, and the guard

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -1052,6 +1052,23 @@ describe("schema-utils", () => {
       expect(a).not.toBe(b);
     });
 
+    it("keeps live entries when the path cache sweeps", () => {
+      // The per-schema path map sweeps collected entries once it passes its
+      // threshold (2048). Holding every returned selector alive means the
+      // sweep runs with nothing to collect, which is the case that must not
+      // lose canonical instances: dropping a live entry would silently break
+      // canonicalization for that path.
+      const schema = uniqueSchema();
+      const held: SchemaPathSelector[] = [];
+      for (let i = 0; i <= 2048; i++) {
+        held.push(internPathSelector({ path: [`p${i}`], schema }));
+      }
+
+      // Every path still canonicalizes to the instance interned for it.
+      expect(internPathSelector({ path: ["p0"], schema })).toBe(held[0]);
+      expect(internPathSelector({ path: ["p2048"], schema })).toBe(held[2048]);
+    });
+
     it("handles selectors whose `schema` is undefined", () => {
       const selector: SchemaPathSelector = { path: ["p"] };
       // Must not throw — `internSchema(undefined)` would, and the guard

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -11,6 +11,7 @@ import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
+import { FabricSpecialObject, type FabricValue } from "@/interface.ts";
 
 describe("value-debug", () => {
   describe("toCompactDebugString", () => {
@@ -258,6 +259,18 @@ describe("value-debug", () => {
 
     describe("with values that prevent rendering", () => {
       const FALLBACK = "<unrenderable debug string>";
+
+      it("falls back to the class name when codec lookup throws", () => {
+        // A `FabricSpecialObject` with no `[CODEC]` makes `codecOf()` throw.
+        // The formatter is most likely to be reached for a value that is
+        // already malformed, so it renders what it can rather than adding a
+        // second failure on top of the first.
+        class RogueSpecial extends FabricSpecialObject {}
+
+        expect(toCompactDebugString(new RogueSpecial() as FabricValue)).toBe(
+          "/RogueSpecial(...)",
+        );
+      });
 
       it("honors a normal `toJSON()` and renders its return value", () => {
         // Sanity check that `toJSON()` is consulted in the usual way; this is

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -647,6 +647,13 @@ describe("value-hash", () => {
         expect(h1).toEqual(h2);
       });
 
+      it("hashes a null-prototype object as an ordinary plain object", () => {
+        const nullProto = Object.create(null) as Record<string, FabricValue>;
+        nullProto.a = 1;
+
+        expect(hashBytesOf(nullProto)).toEqual(hashBytesOf({ a: 1 }));
+      });
+
       it("matches a hand-computed byte stream for {a: 1, b: 2}", () => {
         // Keys sorted: "a" (0x61) < "b" (0x62)
         // LEB128 lengths are single bytes for small values.

--- a/packages/data-model/test/valueEquals.test.ts
+++ b/packages/data-model/test/valueEquals.test.ts
@@ -99,6 +99,67 @@ describe("valueEqual()", () => {
     expect(valueEqual([1, , 3], [1, , 3])).toBe(true);
   });
 
+  // Value equality follows `Object.is()`: `-0` and `+0` are distinct, all
+  // `NaN`s are equal, and the two infinities are distinct (spec §6.7).
+  //
+  // Two different mechanisms produce that, and they need separate tests. A
+  // top-level primitive is settled by the `Object.is()` fast path; a primitive
+  // nested in a container never reaches that path, and is settled by the
+  // canonical content hash instead. Testing only the top level would leave the
+  // nested behavior resting on an untested second implementation.
+  //
+  // Each assertion below is on a boolean, so the matcher never has to tell
+  // `-0` from `+0` itself -- the weird number is always an input, and it is
+  // the implementation's comparison that decides the result.
+  describe("non-finite and signed-zero values", () => {
+    it("holds `-0` distinct from `+0` at the top level", () => {
+      expect(valueEqual(-0, 0)).toBe(false);
+      expect(valueEqual(0, -0)).toBe(false);
+      expect(valueEqual(-0, -0)).toBe(true);
+      expect(valueEqual(0, 0)).toBe(true);
+    });
+
+    it("holds `NaN` equal to itself at the top level", () => {
+      expect(valueEqual(NaN, NaN)).toBe(true);
+      expect(valueEqual(NaN, 0)).toBe(false);
+      expect(valueEqual(NaN, Infinity)).toBe(false);
+    });
+
+    it("holds the infinities distinct at the top level", () => {
+      expect(valueEqual(Infinity, Infinity)).toBe(true);
+      expect(valueEqual(-Infinity, -Infinity)).toBe(true);
+      expect(valueEqual(Infinity, -Infinity)).toBe(false);
+    });
+
+    it("holds `-0` distinct from `+0` inside an object", () => {
+      expect(valueEqual({ a: -0 }, { a: 0 })).toBe(false);
+      expect(valueEqual({ a: -0 }, { a: -0 })).toBe(true);
+      expect(valueEqual({ a: 0 }, { a: 0 })).toBe(true);
+    });
+
+    it("holds `-0` distinct from `+0` inside an array", () => {
+      expect(valueEqual([-0], [0])).toBe(false);
+      expect(valueEqual([-0], [-0])).toBe(true);
+    });
+
+    it("holds `-0` distinct from `+0` when deeply nested", () => {
+      expect(valueEqual({ a: { b: [-0] } }, { a: { b: [0] } })).toBe(false);
+      expect(valueEqual({ a: { b: [-0] } }, { a: { b: [-0] } })).toBe(true);
+    });
+
+    it("holds `NaN` equal to itself inside a container", () => {
+      expect(valueEqual({ a: NaN }, { a: NaN })).toBe(true);
+      expect(valueEqual([NaN], [NaN])).toBe(true);
+      expect(valueEqual({ a: { b: [NaN] } }, { a: { b: [NaN] } })).toBe(true);
+    });
+
+    it("holds the infinities distinct inside a container", () => {
+      expect(valueEqual({ a: Infinity }, { a: -Infinity })).toBe(false);
+      expect(valueEqual([Infinity], [Infinity])).toBe(true);
+      expect(valueEqual({ a: Infinity }, { a: NaN })).toBe(false);
+    });
+  });
+
   // CT-1770: FabricPrimitives keep their state in private fields, so a
   // generic enumerable-own-prop comparison (`deepEqual`) conflates every
   // distinct same-class instance. `valueEqual` compares them by content.

--- a/packages/data-model/test/valueEquals.test.ts
+++ b/packages/data-model/test/valueEquals.test.ts
@@ -153,6 +153,31 @@ describe("valueEqual()", () => {
       expect(valueEqual({ a: { b: [NaN] } }, { a: { b: [NaN] } })).toBe(true);
     });
 
+    // Every case above uses the literal `NaN` on both sides, which pins that a
+    // `NaN` equals itself through the hash path but not that distinct `NaN`
+    // payloads unify. That unification is a deliberate step -- the hash feeds a
+    // canonical byte sequence for any `NaN` rather than the value's own bits --
+    // and arithmetic never produces a second payload, so reaching one takes a
+    // typed-array view.
+    it("holds distinct `NaN` payloads equal inside a container", () => {
+      const buffer = new ArrayBuffer(8);
+      const bytes = new Uint8Array(buffer);
+      const doubles = new Float64Array(buffer);
+      bytes.set([0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0x7f]);
+      const payloadNan = doubles[0];
+
+      // Guard the premise: if this stops holding, the cases below compare a
+      // value against itself and should fail rather than pass for free.
+      doubles[0] = NaN;
+      expect(Number.isNaN(payloadNan)).toBe(true);
+      expect(bytes[0]).not.toBe(0x01);
+
+      expect(valueEqual({ a: payloadNan }, { a: NaN })).toBe(true);
+      expect(valueEqual([payloadNan], [NaN])).toBe(true);
+      expect(valueEqual({ a: { b: [payloadNan] } }, { a: { b: [NaN] } }))
+        .toBe(true);
+    });
+
     it("holds the infinities distinct inside a container", () => {
       expect(valueEqual({ a: Infinity }, { a: -Infinity })).toBe(false);
       expect(valueEqual([Infinity], [Infinity])).toBe(true);


### PR DESCRIPTION
**This PR carries two observable behavior changes, both in
`FrozenSet.intersection()`, and they are the first thing to look at.** Everything
else here is tests.

**1. Iteration order.** The method documented itself as "Same as
`Set.prototype.intersection`," but it always iterated the receiver. The intrinsic
iterates whichever operand is *smaller*, and the result's iteration order follows
that operand — so whenever the argument was the smaller of the two,
`FrozenSet.intersection()` produced a correctly-membered but
**differently-ordered** result than the contract it claimed. That divergence is
observable to any caller that iterates the result. The fix mirrors the
intrinsic's branch, and incidentally makes the method `O(min(n, m))` rather than
`O(n)`, which is why the intrinsic does it that way.

**2. A partial set-like argument now throws where it previously worked.** The
new smaller-operand branch calls `forEachSetLikeValue`, which uses
`other.keys()`. So an argument carrying `size` and `has` but no `keys` — which
used to be accepted — now throws when it is the smaller of the two. We are
**deliberately not changing this**: it moves *toward* the intrinsic, which
requires `keys` to be callable unconditionally. But it is a real second change,
it is not implied by the first, and a description claiming only the ordering fix
would under-describe the diff. `reviewer-flux` found this; the author and the
foreman had both missed it.

**Red-green evidence for the ordering fix.** Restoring the pre-fix source under
the current tests: exactly one test failed before the fix and passed after, and
no other test in the file changed verdict — the file's other 22 new cases were
green in both states.

**Packaging note, so it doesn't read as author overreach.** The fix rides inline
in this test-coverage PR rather than as a separate PR. That was the `foreman`'s
ruling, not the author's — the coverage tests for the set-algebra methods
necessarily include `intersection()`, and splitting them would have meant pinning
the buggy order in one PR and unpinning it in the next. It is kept as its own
commit (`fc4b9801e`) so it has an independent revert handle.

The ruling is also cheap rather than merely defensible, and here is the evidence
rather than the assurance: `grep -rn "\.intersection("` across the whole repo
returns **zero non-test call sites**, and `FrozenSet` escapes `data-model`
through exactly one module (`runner/src/sandbox/plain-data.ts`). Nothing in-repo
can observe either change. Only sandbox / user pattern code can, and for that
code the new behavior is the documented one. If you'd still rather see the fix
land separately, the split is cheap and this note is the place to say so.

The rest is a non-Goodhart coverage-gap pass over `packages/data-model`
(TASK-0071) together with weird-number (`-0` / `NaN` / infinity) coverage
(TASK-0070).

## Weird-number semantics: the seam nobody was testing (TASK-0070)

This is the highest-value part of the PR, and it is worth more than its line
count suggests.

`valueEqual()` decides the storage layer's no-op and change-detection gates, and
its entire weird-number behavior rested on a single `Object.is()` call. Its
298-line test file contained **no `NaN` or `-0` case at all** — its only mention
of `Object.is` was in a comment. Swapping that one call for `===` breaks `-0`
and `NaN` in *opposite* directions (`valueEqual(NaN, NaN)` → `false`,
`valueEqual(-0, +0)` → `true`) and the suite stayed green. Downstream, that is a
dropped write and a spurious-write loop.

The subtler finding is that **two different mechanisms produce these semantics,
and the seam between them was the actual gap.** A top-level primitive is settled
by the `Object.is()` fast path. A primitive *nested* in a container never
reaches that path — it is settled by the canonical content hash. Each mechanism
was individually well covered; the seam was not, so an edit to either could
silently redefine equality for the other's inputs.

**Verified by mutation in both directions**, which is what makes these tests
load-bearing rather than decorative:

| Mutation | Top-level tests | Nested tests |
|---|---|---|
| `Object.is` → `===` at the fast path | **2 fail** | all green |
| `setFloat64` → `value + 0` in the hash | all green | **3 fail** |

Each mutation is caught by exactly one group and is invisible to the other.
Neither group alone would have caught both — which is the concrete argument for
why both were needed, rather than an assertion that they were.

**The finding that best answers "did you just chase a number."** `valueEqual.ts`
has **zero uncovered lines hermetically** — the instrument reports it as
perfectly covered — and it had no weird-number test whatsoever, such that a
one-token edit breaks it in two opposite directions with the suite still green.
It follows that **the tests in this section add nothing to any coverage figure,
gated or hermetic.** The most valuable work in the PR is invisible to the metric
that prompted the work. That is worth sitting with before reading the `-68%`
below as the achievement.

Also pinned: `data-uri-codec` **distinctness**, not merely round-tripping.
Round-tripping was already covered, but distinctness is the stronger property
for a content address — a codec can round-trip every value faithfully and still
mint one identifier for two unequal values. Now covered for `-0` vs `+0` and for
the two infinities, plus the converse (every `NaN` mints one URI; repeated `-0`
is stable).

One deliberate technique throughout this section: every assertion is on a
**boolean or a string**, never on a weird number directly, so the weird value is
always an *input* and the implementation's comparison is what decides the
result. This is what keeps the tests from falling into the `toEqual` vacuity
trap described further down — a matcher comparing `-0` directly would not
discriminate.

**One of these tests was caught being vacuous and rewritten — by its own
author.** A `NaN`-unification case compared `NaN` against `0 / 0` and
`Number("x")`. Those are all the same value, because arithmetic only ever
produces one `NaN` bit pattern, so the case pinned *determinism* rather than the
unification across distinct payloads its name claimed. Building a genuinely
distinct payload requires a typed-array view — which is also how a caller
reaches it, since user code reading a `Float64Array` can hand one straight to
`dataUriFromValue()`. The rewritten case asserts the differing-bits premise
*first*, so it fails loudly rather than passing for free if some future runtime
canonicalizes payloads on assignment. That is the third distinct instance in
this PR of an artifact that looked like it tested something and didn't.

The nested counterpart is pinned too, and it is a distinct seam rather than a
repeat. The existing nested `NaN` cases used the literal `NaN` on both sides, so
they pinned that a `NaN` equals *itself* through the hash path — not that two
distinct payloads unify. Unification is a deliberate step there: the hash feeds
a canonical byte sequence for any `NaN` rather than the value's own bits, and
that was pinned at the hash layer alone. Neither the fast-path tests nor the
hash-layer tests would have noticed canonicalization being dropped for nested
inputs.

That claim was checked rather than argued, independently by author and reviewer:
removing the canonical-`NaN` branch from `value-hash.ts` fails **exactly one
test in the entire suite — the new one.** Every pre-existing nested `NaN` case
stays green, because they put the literal `NaN` on both sides and identical bits
hash identically with or without canonicalization. So this case pins a branch no
other test in the suite reaches.

It is also worth noting against the headline number: because `valueEqual.ts` was
already at zero uncovered lines, **none of this section's work appears in the
`-76%` below.** The two facts are independent, and only one of them is a
measurement.

## Behaviors now pinned that weren't

- **`FrozenSet`'s seven set-algebra methods.** These are hand-written
  reimplementations rather than delegations to the backing `Set`, and none of
  the seven had any test at all. They are reachable from user code via the
  sandbox's module-safe values and `FabricSet.toNativeFrozen()`, so this is
  callable surface, not dead code. Covered: all seven, both iteration-order
  branches, the `entries()` / `keys()` / `Symbol.toStringTag` mirror behavior,
  and the signed-zero / `NaN` / infinity behavior inherited from `Set`.
- **The backing-store accessors' throw path**, previously unreachable from any
  test. The genuinely reachable case — a wrapper method applied to a foreign
  object — is now covered.
- **The `FabricError` extras bag** (`getExtra` / `setExtra` / `hasExtra` /
  `deleteExtra` / `extraSize` / `extraKeys` / `extraEntries`), whose only prior
  exercise was incidental use of `getExtra()` as an assertion helper inside
  round-trip tests. None of its guards had coverage, including the two that
  reject prototype-sensitive keys (`__proto__`, `constructor`) and fixed-schema
  slot names (`type`, `name`, `message`, `stack`, `cause`) — the guards that
  keep an attacker-influenced extras key from colliding with the instance's own
  schema. Also covers frozen-instance gating on `setExtra` / `deleteExtra`.

  **Both filtering layers are now pinned, and the wire boundary is the one that
  matters.** `FabricError` drops these keys in two independent places — the
  constructor and the codec on decode — and the codec's filter was only ever
  exercised *incidentally*, because `type` / `name` / `message` are reserved and
  so every decode happens to take that branch. Nothing covered the
  constructor's, and nothing asserted the property that actually matters:
  `JSON.parse` creates an **own** `__proto__` property where an object literal
  would invoke the setter instead, which makes parsed wire state the one place
  such a key genuinely arrives as decodable input. It is now pinned that it
  lands in neither the extras bag nor the object prototype.

  **The measurement here is worth stating, because the metric pointed the wrong
  way.** Before this PR, the decode filter (`FabricError.ts:382-384`) showed
  **146 / 142 / 142 hits** — fully green — while the constructor's filter
  (`:131-133`) sat at **0**. So the coverage report marked the *wire boundary*
  as covered and the internal path as not. The more exposed of the two guards
  was the one the metric said was fine, and it was green for an unrelated
  reason. Incidental coverage of a security guard is worse than no coverage,
  because it makes the guard look tested to anyone reading the number.
- **`FabricEpochDays` / `FabricEpochNsec` decode validation.** Each was missing
  the two cases its sibling `FabricBytes` already has: non-string state and
  malformed base64 both yield a `ProblematicValue` rather than throwing. These
  are the deserialization paths that see untrusted wire input, and the omission
  read as an oversight rather than a choice, since the same codec shape is
  tested next door.
- **Null-prototype objects, function compatibility, and `copyInto()` edge
  paths.** An `Object.create(null)` safe-dictionary is treated as an ordinary
  plain object throughout (no constructor for the codec registry to dispatch on;
  hashes identically to the equivalent literal). `isFabricCompatible()` accepts
  a *function* carrying a `toJSON()` that returns a fabric value and rejects one
  whose `toJSON()` does not — surprising enough to be worth stating explicitly.
  `copyInto()` reports `0` when the offset is at or past the end of the source.
- **`FabricError` name-override round-tripping** — unwrapping restores an
  overridden `name` rather than the error class's own.
- **Path-selector interning.** The empty path (the root selector) interns like
  any other and stays distinct from a non-empty one; repeated interning of the
  same frozen path array keeps returning the one canonical selector; and a path
  component containing the key separator does not collide with the
  differently-split path sharing its rendered form (`["a:b"]` vs. `["a", "b"]`
  — a `join()`-based key would conflate them, which is exactly what the
  length-prefixed key format exists to prevent).
- **`tagFromNativeValue()`'s value-level fallbacks**, for objects whose
  constructor the class-level lookup does not recognize; neither was reachable
  from any test. They matter for values that have crossed a trust boundary: an
  `Error` or an array whose prototype has been severed still carries its
  internal slot, so `Error.isError()` and `Array.isArray()` recognize it where a
  constructor lookup cannot.
- **`FabricRegExp` decode validation**, the counterpart of what its siblings
  already had. Only the `es2025` flavor is validated (eagerly, by constructing a
  native `RegExp`), so an unparseable pattern or bad flags under that flavor
  yield a `ProblematicValue`, while the same malformed source under another
  flavor is stored faithfully. That asymmetry is deliberate per the decoder's
  own comment, and is now pinned in both directions.
- **Function-`toJSON()` conversion, both outcomes.** Conversion handles a
  function carrying `toJSON()` on a separate arm from the object case, and
  neither outcome was covered: a fabric-valued result converts, a non-fabric one
  throws with a distinct message naming "function" rather than "object".
- **`Date` conversion rejects extra enumerable properties** rather than dropping
  them. A `Date` becomes a `FabricEpochNsec`, which has nowhere to put them, so
  silently discarding would lose data across a round trip. Both the rejection
  and the ordinary case are now pinned.
- **The debug formatter's fallback when codec lookup throws.**
  `toCompactDebugString()` catches a throwing `codecOf()` and renders the class
  name instead. The formatter must never throw, which matters precisely because
  it is most often reached for a value that is *already* malformed — a second
  failure there would hide the first. Reachable via a `FabricSpecialObject`
  subclass carrying no `[CODEC]`.

### Three comments corrected along the way

All were found the same way — a *named* test sitting next to an uncovered line
it appeared to target, which turned out not to reach it:

- `getMapBacking()`'s doc cited, as its example, the one case that provably
  cannot reach it (an intrinsic mutator applied to a wrapper fails its own
  internal-slot check first).
- A test comment in `native-type-tags.test.ts` misdescribed which branch it
  exercises: the case named for the exotic-`Error`-subclass fallback does not
  reach that fallback, because `tagFromNativeClass()` matches the subclass via
  `prototype instanceof Error` first.
- **The same wrong claim in `native-type-tags.ts` itself** — both the inline
  comment at the fallback and the `tagFromNativeValue()` JSDoc — now corrected
  to describe the genuinely unreachable-constructor cases (a severed prototype,
  or another realm).

The third is the interesting one, and it is a small lesson in its own right:
**the original claim survived the correction aimed at it.** Fixing the test-side
comment left two source-side copies — the more authoritative ones — still
asserting the same wrong thing. A stale claim outlives its fix whenever it lives
in more than one place, and the fix only visits one of them.

The general point: a test named for a behavior it does not exercise is worse
than no test, because it suppresses the suspicion that would otherwise prompt
someone to write the real one.

## Deliberately not covered — more than half of what remains

**Read this section even if you skim the rest.** Per TASK-0071, a written "we did
not cover these, and here is why" is a first-class deliverable of this pass
rather than a shortfall. Of the **88 hermetic lines across 12 files** still
uncovered after this PR, about **47** are on this list deliberately. So: *we
consciously left more than half of the remainder uncovered, and this is the
reasoning.* It is the single most reversible-if-wrong judgment in the PR, so
every entry is located by `file:line` — a list whose purpose is to be checked
has to be checkable.

**1. Pure-type file — structurally unmeasurable (7 lines).**
`codec-json/interface.ts:17-23`, a single exported `type JsonWireValue` alias
and nothing else. Types are erased at runtime, so the file can never produce an
LCOV record — and the metric charges *every tracked line* of a record-less file.
Against the baseline gated debt of 234, that is **~3% of `data-model`'s reported
coverage debt existing as a measurement artifact no test could ever move.** The
file is not under-tested; it is unmeasurable, and the instrument renders that as
debt. If it's worth fixing, the fix belongs in the metric's file filter, not in
this package — explicitly not touched here.

**2. Non-guaranteed finalization (16 lines).** `schema-hash.ts:71-76` (a
`FinalizationRegistry` callback), `:140`, `:251-255`; `schema-utils.ts:438-439`,
`:443`. Reachable only once a `WeakRef` referent has actually been collected.
The argument is *not* that these are slow or awkward to test: `labs`'
`AGENTS.md` discourages timing-dependent tests but routes to
`docs/development/waiting-in-tests.md` for the cases where **a bounded poll is
the honest tool**. These lines fail that carve-out rather than merely bumping
the rule — finalization is not guaranteed to occur *at all*, so there is no
bound to poll within. A test would be permanently flaky or vacuous.

> A curiosity for anyone reading the LCOV: `schema-utils.ts:443` is
> `if (ref.deref() === undefined) byPath.delete(k);` — condition and body on one
> line. The condition runs; the body never does; the line reads uncovered. Line
> coverage happens to carry branch information there, which a line-only metric
> normally cannot.

**3. Unreachable by construction (11 lines).** `schema-hash.ts:143-149` throws
on a hash collision between a boolean and an object schema — reaching it
requires an actual **SHA-256 collision**. `schema-hash.ts:244-247` guards `null`
in a table that only ever holds a `WeakRef` or a boolean.
`schema-hash.ts:263-268` is a `default:` for a `typeof` result that cannot
occur.

**4. Unreachable by exhaustion (3 lines).** `value-debug.ts:117-120` — the
`else` after `isFinite` / `isNaN` / `=== Infinity` / `=== -Infinity`. A number
has no fifth state, and the source comment says so. Correctly-written defensive
code that no test can reach.

**5. Reachable only by violating the type contract (6 lines).**
`value-hash.ts:236-238` and `:535-537`, both `default:` throws. The switches
handle every `typeof` result except `"function"`, and functions are not
`FabricValue`s — so reaching them requires a cast. Covering them would pin an
error message nobody depends on.

**6. Deliberate deferral, not dismissal (1 line).** `FabricError.ts:322`, the
deep-freeze short-circuit. The author does not yet understand the protocol well
enough to assert on it, and a test written without that understanding is worse
than an uncovered line — it pins whatever the code happens to do.

**7. A hermetic-only site declined on judgment (3 lines).** `cell-rep.ts:33-35`,
`getModernCellRepConfig()` — a trivial exported getter with **zero gated debt**
and hermetic non-coverage. It is in scope under the ruling described below, and
we declined it anyway: a test asserting that a getter returns a module variable
is a test written for a metric. This is the entry that shows the hermetic-lines
ruling was applied as judgment rather than as a rule — "in scope" was never
"therefore cover all of them."

### This list got shorter under scrutiny

One entry came off the list during review, and the justification for another was
corrected — in both cases rather than defended. The `schema-utils.ts` sweep was
claimed GC-dependent and measured otherwise: interning past the threshold while
holding every selector alive runs the sweep with nothing to collect, moving
`schema-utils.ts:441-442` from 0 hits to covered (2087 and 52 respectively) with
no GC involved. It is now tested, and that turned out to be the case worth
asserting anyway — a sweep that dropped a *live* entry would silently break
canonicalization, visible only as two "canonical" instances for one selector.
Separately, the GC category's original justification cited `AGENTS.md` as
flatly prohibiting the mechanism, which overstated it; that category remains on
the list, but on the corrected argument given above.

Worth being precise about *what* caught it, because the clean story would be
misleading: the sweep entry survived being reasoned about — including by the
reviewer who eventually removed it, who first argued the opposite — and came off
only once someone **ran the thing and counted hits**. Reading the code produced
the wrong answer twice. Measuring produced the right one immediately.

A no-cover list that only ever grows is a list nobody audited. This one was
challenged, lost two arguments, and is stated here in its corrected form.

## Scoping decisions made on the team's own initiative

**Hermetic-only lines were treated as in scope.** `data-model`'s own test suite
is fully hermetic — 42 test files, no cross-package tests — which lets its
coverage be measured two ways, and the two disagree:

- **Gated debt: 234 lines.** What CI reports, from the union of every job's
  coverage.
- **Hermetic debt: 256 lines.** `data-model` measured against *its own* suite
  alone.

Note that the *hermetic* number is the **larger** of the two, which reads
backwards at first glance. It is higher because the gated number gives credit
for lines that other packages' tests happen to execute. So the 22-line
difference is code `data-model`'s own suite never exercises but that CI
nonetheless scores as covered — meaning a regression in those 22 lines is
invisible to this package's own suite and surfaces instead as a confusing
failure over in `runner` or `memory`.

Covering them therefore **cannot move the gated number at all**, which is both
why they'd normally be skipped and the strongest available evidence that this
work isn't metric-gaming. We ruled them in scope; this was a `foreman` ruling.

**The `FrozenSet` tests deliberately pin `SameValueZero`, not `Object.is()`.**
This is the opposite of `FabricValue` equality, which follows spec §6.7's
`Object.is()` and holds `-0` distinct from `+0`. The risk at this site is
specific and worth naming: a reader arriving from the §6.7 rule could reasonably
read these tests as pinning a bug and "fix" the wrapper *toward* the spec. Two
reasons that would be wrong. `FrozenSet<T>` is declared `implements Set<T>`, so
keying it on `Object.is()` would produce a `Set` that isn't a `Set`. And
`FrozenMap` / `FrozenSet` are not `FabricValue`s at all, so §6.7 does not reach
them in the first place. The reasoning is recorded in the test file itself, not
only here.

**A note for anyone writing similar assertions**, established independently by
two people from different starting points: `expect(-0).toEqual(0)` **passes** —
as do the array and `Set` forms — so `toEqual` is vacuous for `-0`, and only
`toBe()` (`Object.is`) discriminates. The signed-zero assertions here use
`toBe()` for that reason. `value-debug.ts`'s tests are worth reading as the
worked example of the more robust pattern: they discriminate *because* they
compare rendered strings, so the assertion cannot silently become vacuous.

## Verification and numbers

Full `data-model` suite green locally, `fmt` / `lint` clean, and `runner`'s
`plain-data` suite verified — it is the one module through which `FrozenSet`
escapes the package, so it is the only in-repo consumer of the changed behavior.

**On the coverage numbers, stated with their units.** Two different figures, and
conflating them is easy:

- **Gated debt — the number CI ratchets on: `234 → 56`, i.e. `-178 (-76%)`.**
  Measured, not estimated: the `coverage-debt packages/data-model` row at the
  final head `9eea161a6`, status `OK`, from the **successful attempt** of run
  `29859307586`. (That run's first attempt failed on the wall-time metric
  described below and was re-run after the declaration; the coverage row is
  identical in both, but a figure cited to a run whose earlier attempt shows red
  invites the wrong question.) It was re-read there
  rather than carried forward from the prior head's run on the assumption that a
  test-only commit cannot move it — it happens to be identical, but expecting is
  not measuring.
- **Hermetic debt — `data-model` measured against its own suite alone: `256 →
  ~88`,** across 12 remaining files, with five files reaching zero.

No estimated gated figure was ever published in this description before the real
one existed. Publishing a guess for the number the ratchet actually gates on is
the wrong habit even when the guess would have been close — and an earlier,
genuinely-measured figure from an intermediate head (`234 → 74`) was likewise
replaced rather than carried forward once it went stale.

**The ratchet claim is now a measurement rather than a prediction.** Earlier
revisions of this description said the ratchet "should move the right way, since
this PR only adds tests." That was an honest prediction with no gated evidence
behind it — every other coverage number here is locally-measured hermetic data.
The run above is the first gated confirmation, and it is stronger than the
prediction implied.

**The ungated groups, chased down rather than rounded past.** At this head the
workspace total moves `297450 → 297299` (`-151`) against `data-model`'s `-178`.
The difference is `patterns` at `+4` and `runner` at `+23`. A tests-only
`data-model` change cannot regress either, so the question is whether those
groups move on their own. They do — across four consecutive `main` runs with no
code change at all, `patterns` varies by ±4 and `runner` ranges over
`7191–7207`. Their coverage comes from sharded, browser-driven instrumentation
where *which* lines get named in the record varies with what actually executed,
unlike `data-model`'s deterministic unit tests.

**The one number that didn't fit turned out to have a better explanation than
noise, and it is worth the paragraph.** `runner` reports `+22` against a spread
previously characterized at ~16 lines, which looked like the noise band being
wider than measured. It isn't. The baseline in this run reads `7175`, which is
below *every* value in that four-run sample — and that is the tell. The ratchet
compares against the **latest** `main` sample, and `main` had advanced: the
samples were taken at `1ba47d0e3`, while the run measured against `78d3901fb`
(one commit later, an unrelated lint fix). `7175` is not a noisy reading of the
sampled commit; it is an accurate reading of a **different, newer** one.

So the precise statement is: the branch's absolute value (`7197`) sits inside
the observed range, the baseline comes from a newer `main` than the range was
built on, and **the delta is therefore not comparable to that spread at all**.
The `-16` between the two `main` commits is itself within the same noise
magnitude.

An earlier revision of this description said "both deltas sit inside the noise
band." That was built on an unexamined assumption that `main` is a fixed
reference point. It isn't — it moves, and the ratchet always compares against
the latest sample, so a baseline table goes stale the moment another PR lands.
The disposition is unchanged (ungated, and this PR's diff is `data-model`-only
so it cannot have caused the movement), but the reasoning is now correct rather
than merely comfortable.

The same comparison carries the bonus worth stating: **`data-model` reads
exactly `234` as the baseline in every one of those runs — and at the newer
`main` commit as well.** Five independent readings, all identical. It does not
jitter, because its coverage comes from deterministic unit tests rather than
sharded browser instrumentation, which is what makes the `-178` entirely real
rather than partly measurement.

This is written up at length on purpose: in a PR whose subject is that this
metric misleads, the numbers that don't fit are precisely the ones not to wave
through.

## An accepted wall-time regression, declared rather than buried

The Performance Check job has two halves with very different characters, and
they failed and passed respectively at the final head. **The coverage half
passed** — that is the `-178 (-76%)` above, status `OK`. **The wall-time half
flagged one metric:**

```
1m 19s → 2m 4s   +45s (+57%)   job: CLI Integration Tests (fuse)
```

That is the *duration* of a CLI integration job, not a test failure — those
tests passed, they were simply slower than a rolling baseline of ~20 recent
`main` runs (median `1m 19s`, stddev `8.7s`, observed range `1m 4s`–`1m 39s`).
At `124s` the reading sits roughly **5σ** outside that band, which is too large
to wave through as ordinary variance.

For scale, from the same run: the five `Pattern Unit Tests` shards — one job
family, one run, no code change touching any of them — span **`+29%` to
`-22%`**. Per-job wall-time spread of that width is routine here, and the check
evaluates 43 such metrics independently, so a large excursion appearing
somewhere is expected rather than remarkable. (Note this is *not* a claim that
the run was uniformly slow: across all 43 rows the split is 22 up, 21 down, mean
`+0.65%`.)

So the causal question was checked at source rather than argued from
plausibility:

- **The `fuse` suite does not execute `data-model`'s tests.** The job runs
  `packages/cli/integration/fuse-exec.sh`, which contains zero references to
  `deno test` or to `data-model`; it drives the built `cf` binary (`cf fuse`,
  `cf exec`, `cf piece`, `cf id`) against a real FUSE mount, and depends on
  `build-cf` / `build-toolshed` rather than on any package's test suite. Nothing
  this PR adds is loaded by it.
- **The diff's entire executable surface is one method.** Two source files
  change: `native-type-tags.ts`, which is **comment-only** (verified by
  filtering the diff to non-comment lines — the result is empty), and
  `frozen-builtins.ts`, whose sole behavioral change is
  `FrozenSet.intersection()`. That change makes the method `O(min(n, m))`
  instead of `O(n)` — strictly faster or equal, and on a code path the fuse
  suite does not exercise.

And there is a positive reason to expect that job in particular to swing: the
suite performs ~118 FUSE mount/unmount operations with explicit sleeps — a
kernel-level I/O workload of exactly the kind a noisy runner slows.

There is therefore no mechanism by which this PR adds 45 seconds to that job,
and a specific reason why that job is the one to move when the machine is
contended. That is the basis for the
declaration below — not "perf check is noisy in general," which would not have
been sufficient at 5σ.

The declaration below is the repo's own documented mechanism for accepting such
a measurement, emitted verbatim by the job itself. It is written out rather than
pasted bare because a reader at the merge gate seeing an unexplained
`NEW_PERF_BASELINE` cannot distinguish an accepted-noise declaration from a
silently suppressed regression:

NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 124s

**Worth separating clearly from the pre-registered predictions**, since this is
the one thing here that went red: the predictions covered **coverage-debt**, and
all of those came out as promised or better. The metric that failed is a timing
measurement nobody predicted, on a job this diff cannot reach. Had the
*coverage* number moved the wrong way, that would be real, and it would be
stated here rather than accepted.

## Review coverage on this PR is not the usual shape

Two changes to what "reviewed" means here, both worth weighing at the merge gate.

**`cubic` did not review this PR, and its check will not clear on its own.** It
reads `skipping`, which looks like a pending state but is not: the org has
exhausted its monthly review allowance (601,199 of 600,000 lines), and cubic
reports reviews resume on **9 August 2026**. This is org-wide and affects every
`labs` PR in the interim — nothing about this branch. Flagged because an absent
signal that resembles a not-yet-arrived signal is the kind nobody goes looking
for.

**A second, deliberately narrow reader was added to partly compensate,** and it
earned its keep. `researcher-remy`, who specified the weird-number test cases
this PR implements, made a second-reader pass scoped to exactly one question:
*do these tests test what they claim to test?* Not the full diff, not
conventions, not the no-cover argument — `reviewer-flux` owns those. Calling it
"a second reviewer" would overstate it.

It is worth recording what that narrow pass produced, because it is evidence
rather than assurance: **Remy found a gap that the full-diff review did not.**
Same bytes, different question. Flux asked "is this diff correct?" and it was;
Remy asked "does this protect what it claims to protect?" and it half didn't —
the weird-number key tests live under `describe("FrozenSet")` while the rationale
comment names both classes, and `FrozenMap` carries the identical hazard from a
*separate* construction site. The guard had a hole precisely where the
anticipated wrong "fix" would land. That has been addressed.

None of this makes the gate equivalent to its usual shape — a targeted expert
read and a mechanical uniform one have different failure modes, and the targeted
one cannot cover what it was not pointed at. This is offered as disclosure, not
as a claim that the gate is unchanged.

Tests and fix authored by **tester-tess** (Claude Opus 4.8).

**Review status.** `reviewer-flux` (Claude Opus 4.8) — **PASS at `9eea161a6`**,
the head of this PR. Reviewed cumulatively across every commit on the branch
from `70becf967` to this head; the full `packages/data-model` suite was run
locally at this SHA (2040 steps, 0 failures), and CI is green here (45 jobs, 0
non-pass). No open findings.

Four review findings were raised and all four were addressed on the branch: an
unpinned equal-size boundary in `FrozenSet.intersection()` (a `<=`→`<` mutation
left the whole suite green before the fix, and fails exactly the new test
after); an untested unsafe-key filter on the `FabricError` constructor; a `-0`
assertion written in a form that could not have detected a sign regression; and
a stale claim in two `native-type-tags.ts` source comments that had survived the
correction of its test-side copy.

Note on what this signal is and isn't: this is one reviewer's read, not a
substitute for `cubic`, which did not run on this PR (see above). It is anchored
at a single SHA deliberately — an unqualified "reviewed" would tell you the
current head is clear without saying which head was read.

This description written and maintained by:

— upstream-liaison-bolt (Claude Opus 4.8)
