### PR TITLE
feat(cli): safely save and amend Git commit views

### DIFF
--- a/packages/cli/lib/view/commitmsg.ts
+++ b/packages/cli/lib/view/commitmsg.ts
@@ -4,13 +4,41 @@
  * the `commit`/`Author`/`Date` header and before the diff. `cf view` lets the
  * message of the HEAD commit be edited in place; saving amends that commit.
  */
+import { basename, dirname, isAbsolute, join, relative } from "@std/path";
 
 /** The indent git puts before every commit-message line. */
 export const MESSAGE_INDENT = "    ";
 
 // An object id is 40 hex characters in a SHA-1 repository and 64 in a SHA-256
-// one; git also prints abbreviated ids, of at least seven characters.
-const COMMIT_RE = /^commit ([0-9a-f]{7,64})\b/;
+// one; Git accepts abbreviated ids with a minimum length of four characters.
+const OBJECT_ID = "[0-9a-f]{4,64}";
+const COMMIT_RE = new RegExp(`^commit (${OBJECT_ID})\\b`);
+const ONELINE_COMMIT_RE = new RegExp(`^(${OBJECT_ID})\\s+\\S`);
+const EMAIL_COMMIT_RE = new RegExp(
+  `^From (${OBJECT_ID}) Mon Sep 17 00:00:00 2001$`,
+);
+
+const withoutTransportCR = (line: string): string =>
+  line.endsWith("\r") ? line.slice(0, -1) : line;
+
+const emailCommitAt = (
+  lines: readonly string[],
+  index: number,
+): RegExpExecArray | null => {
+  const match = EMAIL_COMMIT_RE.exec(withoutTransportCR(lines[index] ?? ""));
+  if (!match) return null;
+  const headers: string[] = [];
+  for (let next = index + 1; next < lines.length; next++) {
+    const line = withoutTransportCR(lines[next]);
+    if (line === "") break;
+    headers.push(line);
+  }
+  return headers.some((line) => /^From: .+<[^<>]*>$/.test(line)) &&
+      headers.some((line) => /^Date: .+/.test(line)) &&
+      headers.some((line) => /^Subject: .+/.test(line))
+    ? match
+    : null;
+};
 
 export interface CommitMessage {
   /** The commit hash, as printed after `commit `. */
@@ -18,6 +46,75 @@ export interface CommitMessage {
   /** First and last (inclusive) 0-based line indices of the indented message. */
   readonly start: number;
   readonly end: number;
+}
+
+export interface CommitHeader {
+  /** The commit hash, as printed after `commit `. */
+  readonly sha: string;
+  /** The 0-based line index of the `commit` header. */
+  readonly line: number;
+}
+
+/** Locate commit headers independently of whether they have a message body. */
+export function findCommitHeaders(lines: readonly string[]): CommitHeader[] {
+  const headers: CommitHeader[] = [];
+  let sawContent = false;
+  let sawEmailPatch = false;
+  let format: "standard" | "compact" | "email" | null = null;
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    const text = withoutTransportCR(line);
+    let match: RegExpExecArray | null = null;
+    if (format === "standard") match = COMMIT_RE.exec(text);
+    else if (format === "compact") match = ONELINE_COMMIT_RE.exec(text);
+    else if (format === "email" && sawEmailPatch) {
+      match = emailCommitAt(lines, index);
+    } else if (!sawContent) {
+      match = COMMIT_RE.exec(text);
+      if (match) format = "standard";
+      else {
+        match = emailCommitAt(lines, index);
+        if (match) format = "email";
+        else {
+          match = ONELINE_COMMIT_RE.exec(text);
+          if (match) format = "compact";
+        }
+      }
+    }
+    if (match) {
+      headers.push({ sha: match[1], line: index });
+      sawContent = true;
+      sawEmailPatch = false;
+      continue;
+    }
+    if (format === "email" && text.startsWith("diff --git ")) {
+      sawEmailPatch = true;
+    }
+    if (text.trim().length > 0) sawContent = true;
+  }
+  return headers;
+}
+
+/** Locate syntactically possible email headers for assigning file diffs to
+ * commits. Email message text can contain a complete envelope, so callers
+ * validate these candidates against the blobs named by each diff. An empty
+ * result means the input is not email-formatted commit output. */
+export function findCommitHeaderCandidates(
+  lines: readonly string[],
+): CommitHeader[] {
+  const headers = findCommitHeaders(lines);
+  if (
+    headers.length === 0 ||
+    !EMAIL_COMMIT_RE.test(withoutTransportCR(lines[headers[0].line] ?? ""))
+  ) {
+    return [];
+  }
+  const candidates: CommitHeader[] = [];
+  for (let index = 0; index < lines.length; index++) {
+    const match = emailCommitAt(lines, index);
+    if (match) candidates.push({ sha: match[1], line: index });
+  }
+  return candidates;
 }
 
 /**
@@ -29,19 +126,22 @@ export interface CommitMessage {
 export function findCommitMessages(lines: readonly string[]): CommitMessage[] {
   const out: CommitMessage[] = [];
   for (let i = 0; i < lines.length; i++) {
-    const m = COMMIT_RE.exec(lines[i]);
+    const m = COMMIT_RE.exec(withoutTransportCR(lines[i]));
     if (!m) continue;
     // Skip the header lines (Author, Date, Merge, …) to the blank separator.
     let j = i + 1;
     while (
-      j < lines.length && lines[j] !== "" &&
-      !lines[j].startsWith(MESSAGE_INDENT)
+      j < lines.length && withoutTransportCR(lines[j]) !== "" &&
+      !withoutTransportCR(lines[j]).startsWith(MESSAGE_INDENT)
     ) {
       j++;
     }
-    if (lines[j] === "") j++; // the blank line before the message
+    if (j < lines.length && withoutTransportCR(lines[j]) === "") j++;
     const start = j;
-    while (j < lines.length && lines[j].startsWith(MESSAGE_INDENT)) j++;
+    while (
+      j < lines.length &&
+      withoutTransportCR(lines[j]).startsWith(MESSAGE_INDENT)
+    ) j++;
     if (j > start) out.push({ sha: m[1], start, end: j - 1 });
   }
   return out;
@@ -66,7 +166,7 @@ export function extractMessage(
 ): string {
   const body: string[] = [];
   for (let i = msg.start; i <= msg.end; i++) {
-    const line = lines[i] ?? "";
+    const line = withoutTransportCR(lines[i] ?? "");
     body.push(
       line.startsWith(MESSAGE_INDENT) ? line.slice(4) : line.trimStart(),
     );
@@ -77,7 +177,7 @@ export function extractMessage(
 /** Whether `sha` names the same commit as `head` (either may be abbreviated). */
 export function sameCommit(sha: string, head: string): boolean {
   const n = Math.min(sha.length, head.length);
-  return n >= 7 && sha.slice(0, n) === head.slice(0, n);
+  return n >= 4 && sha.slice(0, n) === head.slice(0, n);
 }
 
 /**
@@ -87,43 +187,1479 @@ export function sameCommit(sha: string, head: string): boolean {
 export interface GitRunner {
   /** The current commit's full hash, or null (not a repo, or git failed). */
   headSha(): string | null;
-  /** Replace the HEAD commit's message with `message`, keeping its tree and the
-   * index untouched. Returns a status line; throws on failure. */
-  amendMessage(message: string): string;
+  /** The symbolic ref checked out at HEAD, or `HEAD` when detached. */
+  headRef?(): string | null;
+  /** Resolve an abbreviated commit name to its full object id. */
+  resolveCommit?(sha: string): string | null;
+  /** Whether the old and new blob names in one file diff belong to a commit
+   * and its first parent. Paths use Git's repository-relative form. */
+  commitMatchesDiff?(
+    commit: string,
+    oldPath: string | undefined,
+    newPath: string | undefined,
+    oldObject: string,
+    newObject: string,
+  ): boolean;
+  /** Read a file's blob from `commit`, addressed by its absolute workspace
+   * path. A path absent from the commit returns null. */
+  fileAtCommit(commit: string, path: string): string | null;
+  /** Apply only the change from `before` to `after` to `committed`. */
+  applyFileChanges(
+    committed: string,
+    before: string,
+    after: string,
+    path: string,
+  ): string;
+  /** Amend HEAD with each file's exact contents. A null message preserves the
+   * existing commit message byte for byte. Merge the change from the current
+   * HEAD into the real index, preserving staged changes that do not conflict.
+   * Other staged paths stay in the real index. An empty map changes no files.
+   * When provided, `expectedWorkspace` contains the working files that
+   * must remain unchanged while commit hooks run. Returns the status and amended
+   * object; throws on failure. */
+  amendCommit(
+    message: string | null,
+    files: ReadonlyMap<string, string>,
+    expectedHead: string,
+    expectedRef?: string | null,
+    expectedWorkspace?: ReadonlyMap<string, string>,
+  ): { status: string; head: string };
 }
 
 export function realGit(cwd: string): GitRunner {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const runBytes = (
+    args: readonly string[],
+    env?: Readonly<Record<string, string>>,
+    commandCwd = cwd,
+  ): Uint8Array => {
+    const r = new Deno.Command("git", {
+      args: [...args],
+      cwd: commandCwd,
+      env,
+      stdout: "piped",
+      stderr: "piped",
+    }).outputSync();
+    if (!r.success) {
+      const err = decoder.decode(r.stderr).trim();
+      throw new Error(err || `git ${args[0] ?? "command"} failed`);
+    }
+    return r.stdout;
+  };
+  const run = (
+    args: readonly string[],
+    env?: Readonly<Record<string, string>>,
+    commandCwd = cwd,
+  ): string => decoder.decode(runBytes(args, env, commandCwd));
+
+  let cachedRoot: string | null = null;
+  const repoRoot = (): string => {
+    if (cachedRoot !== null) return cachedRoot;
+    const root = run(["rev-parse", "--show-toplevel"]).trim();
+    if (!root) throw new Error("git repository root is unavailable");
+    try {
+      cachedRoot = Deno.realPathSync(root);
+    } catch {
+      cachedRoot = root;
+    }
+    return cachedRoot;
+  };
+  const repoPath = (path: string): string => {
+    if (!isAbsolute(path)) {
+      throw new Error(`git amend path is not absolute: ${path}`);
+    }
+    const root = repoRoot();
+    let lexicalRoot: string | null = null;
+    let ancestor = dirname(path);
+    for (;;) {
+      try {
+        if (Deno.realPathSync(ancestor) === root) {
+          lexicalRoot = ancestor;
+        }
+      } catch {
+        // Keep looking for the repository ancestor.
+      }
+      const parent = dirname(ancestor);
+      if (parent === ancestor) break;
+      ancestor = parent;
+    }
+    if (lexicalRoot === null) {
+      throw new Error(`git amend path is outside the repository: ${path}`);
+    }
+    const rel = relative(lexicalRoot, path);
+    if (
+      rel === "" || rel === ".." || rel.startsWith("../") ||
+      rel.startsWith("..\\") || isAbsolute(rel)
+    ) {
+      throw new Error(`git amend path is outside the repository: ${path}`);
+    }
+    let canonicalPath: string;
+    try {
+      canonicalPath = Deno.realPathSync(path);
+    } catch {
+      canonicalPath = join(Deno.realPathSync(dirname(path)), basename(path));
+    }
+    const canonicalRel = relative(root, canonicalPath);
+    if (
+      canonicalRel === "" || canonicalRel === ".." ||
+      canonicalRel.startsWith("../") || canonicalRel.startsWith("..\\") ||
+      isAbsolute(canonicalRel)
+    ) {
+      throw new Error(`git amend path is outside the repository: ${path}`);
+    }
+    return Deno.build.os === "windows" ? rel.replaceAll("\\", "/") : rel;
+  };
+
+  interface ObjectEntry {
+    mode: string;
+    object: string;
+  }
+  interface IndexEntry extends ObjectEntry {
+    assumeUnchanged: boolean;
+    skipWorktree: boolean;
+  }
+  const indexEntry = (
+    path: string,
+    env?: Readonly<Record<string, string>>,
+  ): IndexEntry | null => {
+    const raw = run(
+      ["--literal-pathspecs", "ls-files", "--stage", "-z", "--", path],
+      env,
+      repoRoot(),
+    );
+    const entries = raw.split("\0").filter((entry) => entry.length > 0);
+    if (entries.length === 0) return null;
+    if (entries.length !== 1) {
+      throw new Error(`git index has unmerged entries for ${path}`);
+    }
+    const match = entries[0].match(/^([0-7]{6}) ([0-9a-f]+) ([0-3])\t/);
+    if (!match || match[3] !== "0") {
+      throw new Error(`git index has an unmerged entry for ${path}`);
+    }
+    const verboseTag = run(
+      ["--literal-pathspecs", "ls-files", "-v", "-z", "--", path],
+      env,
+      repoRoot(),
+    )[0] ?? "";
+    const statusTag = run(
+      ["--literal-pathspecs", "ls-files", "-t", "-z", "--", path],
+      env,
+      repoRoot(),
+    )[0] ?? "";
+    return {
+      mode: match[1],
+      object: match[2],
+      assumeUnchanged: verboseTag !== verboseTag.toUpperCase(),
+      skipWorktree: statusTag === "S",
+    };
+  };
+  const treeEntry = (commit: string, path: string): ObjectEntry | null => {
+    const raw = run(
+      ["--literal-pathspecs", "ls-tree", "-z", commit, "--", path],
+      undefined,
+      repoRoot(),
+    );
+    const entries = raw.split("\0").filter((entry) => entry.length > 0);
+    if (entries.length === 0) return null;
+    if (entries.length !== 1) {
+      throw new Error(`git tree has more than one entry for ${path}`);
+    }
+    const match = entries[0].match(/^([0-7]{6}) (?:blob|commit) ([0-9a-f]+)\t/);
+    if (!match) throw new Error(`git tree entry is invalid for ${path}`);
+    return { mode: match[1], object: match[2] };
+  };
+  const readFilteredBlob = (object: string, path: string): string =>
+    run(
+      ["cat-file", "--filters", `--path=${path}`, object],
+      undefined,
+      repoRoot(),
+    );
+  const setIndexEntry = (
+    path: string,
+    entry: IndexEntry | null,
+    env?: Readonly<Record<string, string>>,
+  ): void => {
+    if (entry === null) {
+      run(
+        [
+          "--literal-pathspecs",
+          "update-index",
+          "--force-remove",
+          "--",
+          path,
+        ],
+        env,
+        repoRoot(),
+      );
+      return;
+    }
+    run(
+      [
+        "--literal-pathspecs",
+        "update-index",
+        "--no-assume-unchanged",
+        "--no-skip-worktree",
+        "--",
+        path,
+      ],
+      env,
+      repoRoot(),
+    );
+    run(
+      [
+        "update-index",
+        "--add",
+        "--cacheinfo",
+        `${entry.mode},${entry.object},${path}`,
+      ],
+      env,
+      repoRoot(),
+    );
+    const flags = [
+      ...(entry.assumeUnchanged ? ["--assume-unchanged"] : []),
+      ...(entry.skipWorktree ? ["--skip-worktree"] : []),
+    ];
+    if (flags.length > 0) {
+      run(
+        ["--literal-pathspecs", "update-index", ...flags, "--", path],
+        env,
+        repoRoot(),
+      );
+    }
+  };
+  const applyFileChanges = (
+    committed: string,
+    before: string,
+    after: string,
+    path: string,
+  ): string => {
+    if (before === after) return committed;
+    if (committed === before) return after;
+    const tempDir = Deno.makeTempDirSync({ prefix: "cf-view-merge-" });
+    const committedPath = join(tempDir, "committed");
+    const beforePath = join(tempDir, "before");
+    const afterPath = join(tempDir, "after");
+    try {
+      Deno.writeTextFileSync(committedPath, committed);
+      Deno.writeTextFileSync(beforePath, before);
+      Deno.writeTextFileSync(afterPath, after);
+      interface TextChange {
+        oldStart: number;
+        oldCount: number;
+        newStart: number;
+        newCount: number;
+        oldLines: string[];
+        newLines: string[];
+      }
+      const changesBetween = (from: string, to: string): TextChange[] => {
+        const diff = new Deno.Command("git", {
+          args: [
+            "diff",
+            "--no-index",
+            "--text",
+            "--no-color",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--unified=0",
+            "--",
+            from,
+            to,
+          ],
+          cwd: repoRoot(),
+          stdout: "piped",
+          stderr: "piped",
+        }).outputSync();
+        if (diff.code === 0) return [];
+        if (diff.code !== 1) {
+          const error = decoder.decode(diff.stderr).trim();
+          throw new Error(error || `Could not compare pager edits for ${path}`);
+        }
+        const changes: TextChange[] = [];
+        let current: TextChange | null = null;
+        for (const line of decoder.decode(diff.stdout).split("\n")) {
+          const header = line.match(
+            /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/,
+          );
+          if (header) {
+            const oldCount = header[2] === undefined ? 1 : Number(header[2]);
+            const newCount = header[4] === undefined ? 1 : Number(header[4]);
+            current = {
+              oldStart: oldCount === 0
+                ? Number(header[1])
+                : Number(header[1]) - 1,
+              oldCount,
+              newStart: newCount === 0
+                ? Number(header[3])
+                : Number(header[3]) - 1,
+              newCount,
+              oldLines: [],
+              newLines: [],
+            };
+            changes.push(current);
+            continue;
+          }
+          if (current && line.startsWith("-")) {
+            current.oldLines.push(line.slice(1));
+          } else if (current && line.startsWith("+")) {
+            current.newLines.push(line.slice(1));
+          }
+        }
+        if (
+          changes.some((change) =>
+            change.oldLines.length !== change.oldCount ||
+            change.newLines.length !== change.newCount
+          )
+        ) {
+          throw new Error(`Could not parse pager edits for ${path}`);
+        }
+        return changes;
+      };
+      const mergeNonOverlappingChanges = (): string => {
+        const workspaceChanges = changesBetween(committedPath, beforePath);
+        const pagerChanges = changesBetween(beforePath, afterPath);
+        const conflicts = (pager: TextChange, workspace: TextChange) => {
+          const pagerEnd = pager.oldStart + pager.oldCount;
+          const workspaceEnd = workspace.newStart + workspace.newCount;
+          if (pager.oldCount === 0) {
+            if (
+              workspace.oldCount > 0 && workspace.newCount === 0 &&
+              pager.oldStart === workspace.newStart
+            ) {
+              return true;
+            }
+            return workspace.newCount > 0 &&
+              pager.oldStart > workspace.newStart &&
+              pager.oldStart < workspaceEnd;
+          }
+          if (workspace.newCount === 0) {
+            return workspace.newStart > pager.oldStart &&
+              workspace.newStart < pagerEnd;
+          }
+          return pager.oldStart < workspaceEnd &&
+            workspace.newStart < pagerEnd;
+        };
+        const mapBoundary = (
+          position: number,
+          side: "start" | "end",
+        ): number => {
+          let delta = 0;
+          for (const change of workspaceChanges) {
+            const newEnd = change.newStart + change.newCount;
+            const oldEnd = change.oldStart + change.oldCount;
+            if (position < change.newStart) return position - delta;
+            if (position === change.newStart) {
+              return change.newCount === 0 && side === "start"
+                ? oldEnd
+                : change.oldStart;
+            }
+            if (position < newEnd) {
+              throw new Error(
+                `Pager edits overlap workspace changes in ${path}; no commit was amended.`,
+              );
+            }
+            if (position === newEnd) return oldEnd;
+            delta += change.newCount - change.oldCount;
+          }
+          return position - delta;
+        };
+        const mapped = pagerChanges.map((change, originalIndex) => {
+          if (
+            workspaceChanges.some((workspace) => conflicts(change, workspace))
+          ) {
+            throw new Error(
+              `Pager edits overlap workspace changes in ${path}; no commit was amended.`,
+            );
+          }
+          return {
+            ...change,
+            originalIndex,
+            mappedStart: mapBoundary(change.oldStart, "start"),
+            mappedEnd: mapBoundary(
+              change.oldStart + change.oldCount,
+              "end",
+            ),
+          };
+        });
+        const splitLines = (text: string): string[] => {
+          if (text === "") return [];
+          const body = text.endsWith("\n") ? text.slice(0, -1) : text;
+          return body === "" ? [""] : body.split("\n");
+        };
+        const lines = splitLines(committed);
+        for (
+          const change of [...mapped].sort((a, b) =>
+            b.mappedStart - a.mappedStart ||
+            b.originalIndex - a.originalIndex
+          )
+        ) {
+          const found = lines.slice(change.mappedStart, change.mappedEnd);
+          if (
+            found.length !== change.oldLines.length ||
+            found.some((line, index) => line !== change.oldLines[index])
+          ) {
+            throw new Error(
+              `Pager edits overlap committed changes in ${path}; no commit was amended.`,
+            );
+          }
+          lines.splice(
+            change.mappedStart,
+            change.mappedEnd - change.mappedStart,
+            ...change.newLines,
+          );
+        }
+        const finalNewline = before.endsWith("\n") === after.endsWith("\n")
+          ? committed.endsWith("\n")
+          : after.endsWith("\n");
+        return lines.join("\n") + (finalNewline ? "\n" : "");
+      };
+      const result = new Deno.Command("git", {
+        args: [
+          "merge-file",
+          "-p",
+          "-L",
+          "committed version",
+          "-L",
+          "pager baseline",
+          "-L",
+          "pager version",
+          committedPath,
+          beforePath,
+          afterPath,
+        ],
+        cwd: repoRoot(),
+        stdout: "piped",
+        stderr: "piped",
+      }).outputSync();
+      if (result.code > 0 && result.code < 128) {
+        return mergeNonOverlappingChanges();
+      }
+      if (!result.success) {
+        const error = decoder.decode(result.stderr).trim();
+        throw new Error(error || `Could not apply pager edits to ${path}`);
+      }
+      return decoder.decode(result.stdout);
+    } finally {
+      try {
+        Deno.removeSync(tempDir, { recursive: true });
+      } catch {
+        // Temporary merge files are removed when possible.
+      }
+    }
+  };
+
   return {
     headSha() {
       try {
-        const r = new Deno.Command("git", {
-          args: ["rev-parse", "HEAD"],
-          cwd,
-          stdout: "piped",
-          stderr: "null",
-        }).outputSync();
-        if (!r.success) return null;
-        return new TextDecoder().decode(r.stdout).trim() || null;
+        return run(["rev-parse", "HEAD"]).trim() || null;
       } catch {
         return null;
       }
     },
-    amendMessage(message) {
-      // `--only` with no pathspec rewords the message and does not fold in
-      // staged changes. The message (its newlines intact) is passed as a single
-      // `-m` argument, keeping the call synchronous — no stdin pipe or temp
-      // file — to match the synchronous save path.
-      const r = new Deno.Command("git", {
-        args: ["commit", "--amend", "--only", "-m", message],
-        cwd,
-        stdout: "piped",
-        stderr: "piped",
-      }).outputSync();
-      if (!r.success) {
-        const err = new TextDecoder().decode(r.stderr).trim();
-        throw new Error(err || "git commit --amend failed");
+    headRef() {
+      try {
+        return run(["rev-parse", "--symbolic-full-name", "HEAD"]).trim() ||
+          null;
+      } catch {
+        return null;
       }
-      return "Amended the commit message";
+    },
+    resolveCommit(sha) {
+      if (!new RegExp(`^${OBJECT_ID}$`).test(sha)) return null;
+      try {
+        return run(["rev-parse", "--verify", `${sha}^{commit}`]).trim() || null;
+      } catch {
+        return null;
+      }
+    },
+    commitMatchesDiff(commit, oldPath, newPath, oldObject, newObject) {
+      const objectName = new RegExp(`^${OBJECT_ID}$`);
+      if (!objectName.test(oldObject) || !objectName.test(newObject)) {
+        return false;
+      }
+      try {
+        const resolved = run([
+          "rev-parse",
+          "--verify",
+          `${commit}^{commit}`,
+        ]).trim();
+        const [, parent] = run([
+          "rev-list",
+          "--parents",
+          "-n",
+          "1",
+          resolved,
+        ]).trim().split(" ");
+        const oldEntry = parent && oldPath ? treeEntry(parent, oldPath) : null;
+        const newEntry = newPath ? treeEntry(resolved, newPath) : null;
+        const matches = (
+          printed: string,
+          entry: ObjectEntry | null,
+        ): boolean =>
+          /^0+$/.test(printed)
+            ? entry === null
+            : entry !== null && sameCommit(printed, entry.object);
+        return matches(oldObject, oldEntry) && matches(newObject, newEntry);
+      } catch {
+        return false;
+      }
+    },
+    fileAtCommit(commit, path) {
+      const rel = repoPath(path);
+      const entry = treeEntry(commit, rel);
+      return entry ? readFilteredBlob(entry.object, rel) : null;
+    },
+    applyFileChanges,
+    amendCommit(
+      message,
+      files,
+      expectedHead,
+      expectedRef,
+      expectedWorkspace,
+    ) {
+      const root = repoRoot();
+      let referenceStorage = "files";
+      try {
+        referenceStorage = run(
+          ["config", "--get", "extensions.refStorage"],
+          undefined,
+          root,
+        ).trim().toLowerCase() || "files";
+      } catch {
+        // Repositories using loose and packed refs omit this extension.
+      }
+      if (referenceStorage !== "files" && referenceStorage !== "reftable") {
+        throw new Error(
+          `Git reference storage '${referenceStorage}' cannot be amended safely; no commit was amended.`,
+        );
+      }
+      const fileBackedRefs = referenceStorage === "files";
+      const oldHead = run(["rev-parse", "HEAD"], undefined, root).trim();
+      if (!sameCommit(expectedHead, oldHead)) {
+        throw new Error(
+          "HEAD moved before the amend began; no commit was amended.",
+        );
+      }
+      const targetRef = run(
+        ["rev-parse", "--symbolic-full-name", "HEAD"],
+        undefined,
+        root,
+      ).trim();
+      if (expectedRef && targetRef !== expectedRef) {
+        throw new Error(
+          "HEAD now names a different branch; no commit was amended.",
+        );
+      }
+      const tempDir = Deno.makeTempDirSync({ prefix: "cf-view-amend-" });
+      const tempIndex = join(tempDir, "index");
+      const tempEnv = { GIT_INDEX_FILE: tempIndex };
+      const referenceJournal = join(tempDir, "reference-transactions");
+      const hookProxyMarker = crypto.randomUUID();
+      const installHookProxy = (): string => {
+        let configuredHooksPath: string | null = null;
+        try {
+          const value = run(
+            ["config", "--null", "--path", "--get", "core.hooksPath"],
+            undefined,
+            root,
+          );
+          configuredHooksPath = value.endsWith("\0")
+            ? value.slice(0, -1)
+            : value;
+        } catch {
+          // No configured hooks path uses the repository's hooks directory.
+        }
+        let hooksPath: string | null;
+        if (configuredHooksPath === null) {
+          hooksPath = run(
+            [
+              "rev-parse",
+              "--path-format=absolute",
+              "--git-path",
+              "hooks",
+            ],
+            undefined,
+            root,
+          ).trim();
+        } else if (configuredHooksPath === "") {
+          hooksPath = null;
+        } else {
+          hooksPath = isAbsolute(configuredHooksPath)
+            ? configuredHooksPath
+            : join(root, configuredHooksPath);
+        }
+
+        const shellQuote = (value: string): string => {
+          const shellPath = Deno.build.os === "windows"
+            ? value.replaceAll("\\", "/")
+            : value;
+          return `'${shellPath.replaceAll("'", `'"'"'`)}'`;
+        };
+        const proxyStart = `'cfview.hookProxyStart'='${hookProxyMarker}'`;
+        const proxyEnd = `'cfview.hookProxyEnd'='${hookProxyMarker}'`;
+        const stripProxyConfig = `cf_view_proxy_start=${shellQuote(proxyStart)}
+cf_view_proxy_end=${shellQuote(proxyEnd)}
+case "\${GIT_CONFIG_PARAMETERS-}" in
+  *"$cf_view_proxy_start"*"$cf_view_proxy_end"*) ;;
+  *) exit 1 ;;
+esac
+cf_view_config_prefix=\${GIT_CONFIG_PARAMETERS%%"$cf_view_proxy_start"*}
+cf_view_config_after_start=\${GIT_CONFIG_PARAMETERS#*"$cf_view_proxy_start"}
+cf_view_config_suffix=\${cf_view_config_after_start#*"$cf_view_proxy_end"}
+GIT_CONFIG_PARAMETERS=$cf_view_config_prefix$cf_view_config_suffix
+export GIT_CONFIG_PARAMETERS
+`;
+        const sourceGitDir = run(
+          [
+            "rev-parse",
+            "--path-format=absolute",
+            "--absolute-git-dir",
+          ],
+          undefined,
+          root,
+        ).replace(/\r?\n$/, "");
+        const normalizeForeignHooksPath = Deno.build.os === "windows"
+          ? `hooks_path=$(printf '%s\\n' "$hooks_path" | sed 's|\\\\|/|g')
+`
+          : "";
+        const foreignHookRoute = (name: string): string =>
+          `current_git_dir=$(git rev-parse --path-format=absolute --absolute-git-dir 2>/dev/null) || exit 1
+if test "$current_git_dir" != ${shellQuote(sourceGitDir)}; then
+  ${stripProxyConfig}
+  hooks_path=$(git config --path --get core.hooksPath)
+  config_status=$?
+  if test "$config_status" -eq 1; then
+    hooks_path=$(git rev-parse --path-format=absolute --git-path hooks) || exit 1
+  elif test "$config_status" -ne 0; then
+    exit "$config_status"
+  elif test -z "$hooks_path"; then
+    exit 0
+  fi
+  ${normalizeForeignHooksPath}case "$hooks_path" in
+    /*|[A-Za-z]:/*) ;;
+    *)
+      hook_root=$(git rev-parse --show-toplevel 2>/dev/null) ||
+        hook_root=$(git rev-parse --absolute-git-dir) || exit 1
+      hooks_path="$hook_root/$hooks_path"
+      ;;
+  esac
+  foreign_hook="$hooks_path/${name}"
+  if test -x "$foreign_hook"; then
+    exec "$foreign_hook" "$@"
+  fi
+  exit 0
+fi
+`;
+        const hookNames = [
+          "applypatch-msg",
+          "pre-applypatch",
+          "post-applypatch",
+          "pre-commit",
+          "pre-merge-commit",
+          "prepare-commit-msg",
+          "commit-msg",
+          "post-commit",
+          "pre-rebase",
+          "post-checkout",
+          "post-merge",
+          "pre-push",
+          "pre-receive",
+          "update",
+          "proc-receive",
+          "post-receive",
+          "post-update",
+          "push-to-checkout",
+          "pre-auto-gc",
+          "post-rewrite",
+          "sendemail-validate",
+          "fsmonitor-watchman",
+          "p4-changelist",
+          "p4-prepare-changelist",
+          "p4-post-changelist",
+          "p4-pre-submit",
+          "post-index-change",
+        ];
+        const missingRefObject = "0".repeat(oldHead.length);
+        const captureTarget = (variable: string): string =>
+          `${variable}=$(git rev-parse --verify ${
+            shellQuote(targetRef)
+          } 2>/dev/null) || ${variable}=${missingRefObject}\n`;
+        const recordTargetTransition =
+          `if test "$cf_view_target_before" != "$cf_view_target_after"; then\n` +
+          `  printf '%s %s %s\\n' "$cf_view_target_before" "$cf_view_target_after" ${
+            shellQuote(targetRef)
+          } >> ${shellQuote(referenceJournal)} || exit 1\n` +
+          `fi\n`;
+        const proxyPath = join(tempDir, "hooks");
+        Deno.mkdirSync(proxyPath);
+        for (const name of hookNames) {
+          const original = hooksPath === null ? null : join(hooksPath, name);
+          const runOriginal = original === null
+            ? ""
+            : `if test -x ${shellQuote(original)}; then
+  ${shellQuote(original)} "$@"
+  status=$?
+fi
+`;
+          const wrapper = join(proxyPath, name);
+          Deno.writeTextFileSync(
+            wrapper,
+            `#!/bin/sh
+${foreignHookRoute(name)}${
+              captureTarget("cf_view_target_before")
+            }${stripProxyConfig}status=0
+${runOriginal}${
+              captureTarget("cf_view_target_after")
+            }${recordTargetTransition}exit "$status"
+`,
+          );
+          Deno.chmodSync(wrapper, 0o755);
+        }
+
+        const original = hooksPath === null
+          ? null
+          : join(hooksPath, "reference-transaction");
+        const wrapper = join(proxyPath, "reference-transaction");
+        const payloadPrefix = `${referenceJournal}.payload`;
+        const runOriginal = original === null
+          ? ""
+          : `if test -x ${shellQuote(original)}; then
+  ${shellQuote(original)} "$@" < "$payload"
+status=$?
+fi
+`;
+        Deno.writeTextFileSync(
+          wrapper,
+          `#!/bin/sh
+${foreignHookRoute("reference-transaction")}payload=${
+            shellQuote(payloadPrefix)
+          }.$$
+cat > "$payload" || exit 1
+status=0
+if test "\${1-}" = committed; then
+  cat "$payload" >> ${shellQuote(referenceJournal)} || exit 1
+fi
+${captureTarget("cf_view_target_before")}${stripProxyConfig}${runOriginal}${
+            captureTarget("cf_view_target_after")
+          }${recordTargetTransition}rm -f "$payload"
+exit "$status"
+`,
+        );
+        Deno.chmodSync(wrapper, 0o755);
+        return proxyPath;
+      };
+      let hookProxy: string;
+      try {
+        hookProxy = installHookProxy();
+      } catch (error) {
+        try {
+          Deno.removeSync(tempDir, { recursive: true });
+        } catch {
+          // Temporary content cleanup is best effort.
+        }
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Could not prepare Git hooks for the amend; no commit was amended: ${detail}`,
+        );
+      }
+      const prepared: Array<{
+        path: string;
+        commit: ObjectEntry;
+        before: IndexEntry | null;
+        after: IndexEntry | null;
+      }> = [];
+      let contentNumber = 0;
+      const tempFile = (contents: string): string => {
+        const path = join(tempDir, `content-${contentNumber++}`);
+        Deno.writeTextFileSync(path, contents);
+        return path;
+      };
+      const hash = (contents: string, repoPath: string): string => {
+        const contentPath = tempFile(contents);
+        return run(
+          ["hash-object", "-w", `--path=${repoPath}`, contentPath],
+          undefined,
+          root,
+        ).trim();
+      };
+      const mergeIndex = (
+        path: string,
+        indexed: string,
+        original: string,
+        amended: string,
+      ): string => {
+        if (indexed === original) return amended;
+        if (indexed === amended || amended === original) return indexed;
+        const result = new Deno.Command("git", {
+          args: [
+            "merge-file",
+            "-p",
+            "-L",
+            "staged version",
+            "-L",
+            "current HEAD",
+            "-L",
+            "pager version",
+            tempFile(indexed),
+            tempFile(original),
+            tempFile(amended),
+          ],
+          cwd: root,
+          stdout: "piped",
+          stderr: "piped",
+        }).outputSync();
+        if (result.code > 0 && result.code < 128) {
+          throw new Error(
+            `Pager edits conflict with staged changes in ${path}; no commit was amended.`,
+          );
+        }
+        if (!result.success) {
+          const error = decoder.decode(result.stderr).trim();
+          throw new Error(error || `Could not merge staged changes in ${path}`);
+        }
+        return decoder.decode(result.stdout);
+      };
+      let committedHead: string | null = null;
+      let publishedRef: string | null = null;
+      let publishedLogRef: string | null = null;
+      let rollbackHead: string | null = null;
+      let refUpdated = false;
+      let indexLock: string | null = null;
+      let ownsIndexLock = false;
+      let preparedIndex: string | null = null;
+      const referenceLocks: string[] = [];
+      const releaseReferenceLocks = (): string[] => {
+        const errors: string[] = [];
+        for (let index = referenceLocks.length - 1; index >= 0; index--) {
+          try {
+            Deno.removeSync(referenceLocks[index]);
+            referenceLocks.splice(index, 1);
+          } catch (error) {
+            const lock = referenceLocks[index];
+            const quarantine = join(
+              dirname(lock),
+              `.cf-view-lock-${crypto.randomUUID()}`,
+            );
+            try {
+              Deno.renameSync(lock, quarantine);
+              referenceLocks.splice(index, 1);
+              errors.push(`${error}; moved the lock to ${quarantine}`);
+            } catch (renameError) {
+              errors.push(`${error}; could not move the lock: ${renameError}`);
+            }
+          }
+        }
+        return errors;
+      };
+      const sameIndexEntry = (
+        a: IndexEntry | null,
+        b: IndexEntry | null,
+      ): boolean =>
+        a === null || b === null
+          ? a === b
+          : a.mode === b.mode && a.object === b.object &&
+            a.assumeUnchanged === b.assumeUnchanged &&
+            a.skipWorktree === b.skipWorktree;
+      try {
+        for (const [absolute, contents] of files) {
+          const path = repoPath(absolute);
+          const headEntry = treeEntry(oldHead, path);
+          if (!headEntry) {
+            throw new Error(`git commit does not contain ${path}`);
+          }
+          const before = indexEntry(path);
+          if (
+            before !== null &&
+            (Number.parseInt(before.mode, 8) & 0o170000) !==
+              (Number.parseInt(headEntry.mode, 8) & 0o170000)
+          ) {
+            throw new Error(
+              `Pager edits conflict with a staged file type change in ${path}; no commit was amended.`,
+            );
+          }
+          const after = before === null ? null : {
+            mode: before.mode,
+            object: hash(
+              mergeIndex(
+                path,
+                readFilteredBlob(before.object, path),
+                readFilteredBlob(headEntry.object, path),
+                contents,
+              ),
+              path,
+            ),
+            assumeUnchanged: before.assumeUnchanged,
+            skipWorktree: before.skipWorktree,
+          };
+          prepared.push({
+            path,
+            commit: {
+              mode: headEntry.mode,
+              object: hash(contents, path),
+            },
+            before,
+            after,
+          });
+        }
+
+        run(["read-tree", oldHead], tempEnv, root);
+        for (const file of prepared) {
+          run(
+            [
+              "update-index",
+              "--add",
+              "--cacheinfo",
+              `${file.commit.mode},${file.commit.object},${file.path}`,
+            ],
+            tempEnv,
+            root,
+          );
+        }
+        const expectedTree = run(["write-tree"], tempEnv, root).trim();
+        const commitMessageBytes = (raw: Uint8Array): Uint8Array => {
+          for (let index = 0; index + 1 < raw.length; index++) {
+            if (raw[index] === 10 && raw[index + 1] === 10) {
+              return raw.slice(index + 2);
+            }
+          }
+          return new Uint8Array();
+        };
+        const sameBytes = (a: Uint8Array, b: Uint8Array): boolean =>
+          a.length === b.length && a.every((byte, index) => byte === b[index]);
+        const oldCommitBytes = runBytes(
+          ["cat-file", "commit", oldHead],
+          undefined,
+          root,
+        );
+        const oldCommit = decoder.decode(oldCommitBytes);
+        const commitLineage = (raw: string) => {
+          const separator = raw.indexOf("\n\n");
+          const header = separator < 0 ? raw : raw.slice(0, separator);
+          const lines = header.split("\n");
+          return {
+            author: lines.find((line) => line.startsWith("author ")) ?? "",
+            encoding: lines.find((line) =>
+              line.startsWith("encoding ")
+            )?.slice(9) ??
+              "UTF-8",
+            parents: lines.filter((line) => line.startsWith("parent ")),
+          };
+        };
+        const oldLineage = commitLineage(oldCommit);
+        const oldMessage = commitMessageBytes(oldCommitBytes);
+        const hasOriginalLineage = (object: string): boolean => {
+          try {
+            const lineage = commitLineage(
+              run(["cat-file", "commit", object], undefined, root),
+            );
+            return lineage.author === oldLineage.author &&
+              lineage.parents.length === oldLineage.parents.length &&
+              lineage.parents.every((parent, index) =>
+                parent === oldLineage.parents[index]
+              );
+          } catch {
+            return false;
+          }
+        };
+        const replacementMessage = message === null
+          ? null
+          : message.length === 0
+          ? ""
+          : message.endsWith("\n")
+          ? message
+          : `${message}\n`;
+        const expectedMessage = replacementMessage === null
+          ? oldMessage
+          : encoder.encode(replacementMessage);
+        const commitEncoding = replacementMessage === null
+          ? oldLineage.encoding
+          : "UTF-8";
+        const messageFile = join(tempDir, `content-${contentNumber++}`);
+        Deno.writeFileSync(messageFile, expectedMessage);
+        const reflogAction = `cf-view-amend-${crypto.randomUUID()}`;
+        const commitOutput = run(
+          [
+            "-c",
+            "core.logAllRefUpdates=always",
+            "-c",
+            `core.abbrev=${oldHead.length}`,
+            "-c",
+            "color.ui=false",
+            "-c",
+            "color.status=false",
+            "-c",
+            `i18n.commitEncoding=${commitEncoding}`,
+            "-c",
+            `cfview.hookProxyStart=${hookProxyMarker}`,
+            "-c",
+            `core.hooksPath=${hookProxy}`,
+            "-c",
+            `cfview.hookProxyEnd=${hookProxyMarker}`,
+            "commit",
+            "--amend",
+            "--no-quiet",
+            "--allow-empty",
+            "--allow-empty-message",
+            "--cleanup=verbatim",
+            "-F",
+            messageFile,
+          ],
+          { ...tempEnv, GIT_REFLOG_ACTION: reflogAction },
+          root,
+        );
+        const markedRefs = new Set(
+          run(
+            ["reflog", "show", "--all", "--format=%H%x00%gD%x00%gs"],
+            undefined,
+            root,
+          ).split("\n").flatMap((line) => {
+            const [, selector, subject] = line.split("\0");
+            const suffix = selector?.lastIndexOf("@{") ?? -1;
+            return suffix > 0 && subject?.startsWith(`${reflogAction}:`)
+              ? [selector.slice(0, suffix)]
+              : [];
+          }),
+        );
+        markedRefs.add(targetRef);
+        markedRefs.add("HEAD");
+        interface ReflogTransition {
+          ref: string;
+          old: string;
+          object: string;
+          marked: boolean;
+          sequence: number;
+        }
+        const readFileReflogTransitions = (
+          ref: string,
+        ): ReflogTransition[] => {
+          try {
+            const logPath = run(
+              [
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-path",
+                `logs/${ref}`,
+              ],
+              undefined,
+              root,
+            ).trim();
+            return Deno.readTextFileSync(logPath).split("\n").flatMap(
+              (line, sequence): ReflogTransition[] => {
+                const tab = line.indexOf("\t");
+                if (tab < 0) return [];
+                const [old, object] = line.slice(0, tab).split(" ");
+                if (!old || !object) return [];
+                return [{
+                  ref,
+                  old,
+                  object,
+                  marked: line.slice(tab + 1).startsWith(`${reflogAction}:`),
+                  sequence,
+                }];
+              },
+            );
+          } catch {
+            return [];
+          }
+        };
+        const readPublicReflogTransitions = (
+          ref: string,
+        ): ReflogTransition[] => {
+          try {
+            const newestFirst = run(
+              ["reflog", "show", ref, "--format=%H%x00%gD%x00%gs"],
+              undefined,
+              root,
+            ).split("\n").flatMap((line) => {
+              const [object, selector, subject] = line.split("\0");
+              const suffix = selector?.lastIndexOf("@{") ?? -1;
+              const ordinal = suffix > 0 && selector.endsWith("}")
+                ? Number(selector.slice(suffix + 2, -1))
+                : Number.NaN;
+              return object && Number.isSafeInteger(ordinal)
+                ? [{ object, subject: subject ?? "", ordinal }]
+                : [];
+            }).sort((a, b) => a.ordinal - b.ordinal);
+            return newestFirst.map((entry, index) => ({
+              ref,
+              old: newestFirst[index + 1]?.object ?? oldHead,
+              object: entry.object,
+              marked: entry.subject.startsWith(`${reflogAction}:`),
+              sequence: newestFirst.length - index - 1,
+            })).reverse();
+          } catch {
+            return [];
+          }
+        };
+        const readReflogTransitions = fileBackedRefs
+          ? readFileReflogTransitions
+          : readPublicReflogTransitions;
+        const transactionTransitions = (() => {
+          try {
+            return Deno.readTextFileSync(referenceJournal).split("\n").flatMap(
+              (line, sequence): ReflogTransition[] => {
+                const first = line.indexOf(" ");
+                const second = line.indexOf(" ", first + 1);
+                if (first < 0 || second < 0) return [];
+                const old = line.slice(0, first);
+                const object = line.slice(first + 1, second);
+                const ref = line.slice(second + 1);
+                return old && object && ref
+                  ? [{ ref, old, object, marked: true, sequence }]
+                  : [];
+              },
+            );
+          } catch {
+            return [];
+          }
+        })();
+        const markerTip = (
+          refTransitions: readonly ReflogTransition[],
+          anchor: ReflogTransition,
+        ): string => {
+          let tip = anchor.object;
+          const start = refTransitions.findIndex((entry) =>
+            entry.sequence === anchor.sequence
+          );
+          for (let index = start + 1; index < refTransitions.length; index++) {
+            const next = refTransitions[index];
+            if (!next?.marked) break;
+            if (
+              next.old !== tip &&
+              !(next.old === next.object && /^0+$/.test(next.object))
+            ) break;
+            tip = next.object;
+          }
+          return tip;
+        };
+        const transitions = transactionTransitions.length > 0
+          ? transactionTransitions
+          : [...markedRefs].flatMap(readReflogTransitions);
+        const missingObject = "0".repeat(oldHead.length);
+        const refObject = (ref: string): string => {
+          try {
+            return run(["rev-parse", ref], undefined, root).trim();
+          } catch {
+            return missingObject;
+          }
+        };
+        const symbolicHead = (): string | null => {
+          try {
+            return run(
+              ["rev-parse", "--symbolic-full-name", "HEAD"],
+              undefined,
+              root,
+            ).trim();
+          } catch {
+            return null;
+          }
+        };
+        const currentRef = symbolicHead();
+        const currentHead = refObject("HEAD");
+        const anchored = transitions.filter((entry) =>
+          entry.marked && entry.old === oldHead &&
+          hasOriginalLineage(entry.object)
+        );
+        const targetEntries = anchored.filter((entry) =>
+          entry.ref === targetRef
+        );
+        const namedEntries = anchored.filter((entry) => entry.ref !== "HEAD");
+        const candidates = targetEntries.length > 0
+          ? targetEntries
+          : namedEntries.length > 0
+          ? namedEntries
+          : anchored.filter((entry) =>
+            entry.ref === "HEAD" &&
+            (currentRef === "HEAD" ||
+              (currentRef === targetRef && entry.object === oldHead))
+          );
+        const uniqueCandidates = [...new Map(
+          candidates.map((entry) => [
+            `${entry.ref}\0${entry.object}\0${entry.sequence}`,
+            entry,
+          ]),
+        ).values()];
+        const published = uniqueCandidates.length === 1
+          ? uniqueCandidates[0]
+          : null;
+        publishedLogRef = published?.ref ?? null;
+        publishedRef = published?.ref === "HEAD" && currentRef !== "HEAD"
+          ? targetRef
+          : published?.ref ?? null;
+        committedHead = published?.object ?? null;
+        if (published) {
+          const refTransitions = transitions.filter((entry) =>
+            entry.ref === publishedLogRef
+          );
+          rollbackHead = markerTip(refTransitions, published);
+        }
+        if (!published && uniqueCandidates.length === 0) {
+          const resolvedTarget = refObject(targetRef);
+          const targetHead = resolvedTarget === missingObject
+            ? null
+            : resolvedTarget;
+          const summaryObjects = new Set(
+            [...commitOutput.matchAll(/ ([0-9a-f]{40}|[0-9a-f]{64})\]/g)]
+              .map((match) => match[1]),
+          );
+          if (
+            targetHead !== null && summaryObjects.has(targetHead) &&
+            hasOriginalLineage(targetHead) &&
+            (targetRef !== "HEAD" || currentRef === "HEAD")
+          ) {
+            publishedLogRef = targetRef;
+            publishedRef = targetRef;
+            committedHead = targetHead;
+            rollbackHead = targetHead;
+          }
+        }
+        refUpdated = publishedRef !== null && committedHead !== null;
+        if (!refUpdated) {
+          throw new Error(
+            uniqueCandidates.length > 1
+              ? "Git published more than one possible amended commit."
+              : "Git did not publish the amended commit.",
+          );
+        }
+        if (committedHead === null || publishedRef === null) {
+          throw new Error("Git did not publish the amended commit.");
+        }
+        if (!hasOriginalLineage(committedHead)) {
+          throw new Error(
+            "HEAD changed before Git created the amended commit; no commit was amended.",
+          );
+        }
+        const referenceLockPaths = fileBackedRefs
+          ? [
+            `${
+              run(
+                [
+                  "rev-parse",
+                  "--path-format=absolute",
+                  "--git-path",
+                  publishedRef,
+                ],
+                undefined,
+                root,
+              ).trim()
+            }.lock`,
+            `${
+              run(
+                [
+                  "rev-parse",
+                  "--path-format=absolute",
+                  "--git-path",
+                  "HEAD",
+                ],
+                undefined,
+                root,
+              ).trim()
+            }.lock`,
+          ]
+          : [
+            join(
+              run(
+                [
+                  "rev-parse",
+                  "--path-format=absolute",
+                  "--git-common-dir",
+                ],
+                undefined,
+                root,
+              ).trim(),
+              "reftable",
+              "tables.list.lock",
+            ),
+            join(
+              run(["rev-parse", "--absolute-git-dir"], undefined, root).trim(),
+              "reftable",
+              "tables.list.lock",
+            ),
+          ];
+        for (const lock of [...new Set(referenceLockPaths)].sort()) {
+          try {
+            Deno.mkdirSync(dirname(lock), { recursive: true });
+            Deno.openSync(lock, { write: true, createNew: true }).close();
+            referenceLocks.push(lock);
+          } catch {
+            throw new Error(
+              "The checked-out Git reference is locked; no commit was amended.",
+            );
+          }
+        }
+        const lockedRef = symbolicHead();
+        const lockedHead = refObject("HEAD");
+        const lockedPublished = refObject(publishedRef);
+        if (lockedPublished !== rollbackHead) {
+          const lockedTransitions = readReflogTransitions(
+            publishedLogRef ?? publishedRef,
+          );
+          const anchor = lockedTransitions.find((entry) =>
+            entry.marked && entry.old === oldHead &&
+            entry.object === committedHead
+          );
+          if (anchor) {
+            const lockedTip = markerTip(lockedTransitions, anchor);
+            if (lockedTip === lockedPublished) rollbackHead = lockedTip;
+          }
+          if (lockedPublished === committedHead) {
+            rollbackHead = committedHead;
+          }
+        }
+        if (
+          currentRef !== targetRef || currentHead !== committedHead ||
+          lockedRef !== targetRef || lockedHead !== committedHead ||
+          lockedPublished !== committedHead
+        ) {
+          throw new Error(
+            "HEAD changed during the amend; no commit was amended.",
+          );
+        }
+        const committedTree = run(
+          ["rev-parse", `${committedHead}^{tree}`],
+          undefined,
+          root,
+        ).trim();
+        if (committedTree !== expectedTree) {
+          throw new Error(
+            "A commit hook changed the amended tree; no commit was amended.",
+          );
+        }
+        const rawCommit = runBytes(
+          ["cat-file", "commit", committedHead],
+          undefined,
+          root,
+        );
+        const committedMessage = commitMessageBytes(rawCommit);
+        if (!sameBytes(committedMessage, expectedMessage)) {
+          throw new Error(
+            "A commit hook changed the amended message; no commit was amended.",
+          );
+        }
+        const finalRef = run(
+          ["rev-parse", "--symbolic-full-name", "HEAD"],
+          undefined,
+          root,
+        ).trim();
+        const finalHead = run(["rev-parse", "HEAD"], undefined, root).trim();
+        if (finalRef !== targetRef || finalHead !== committedHead) {
+          throw new Error(
+            "HEAD changed before the amend completed; no commit was amended.",
+          );
+        }
+        for (const [path, expected] of expectedWorkspace ?? []) {
+          let actual: string;
+          try {
+            actual = Deno.readTextFileSync(path);
+          } catch {
+            throw new Error(
+              `${path} could not be read after commit hooks ran; no commit was amended.`,
+            );
+          }
+          if (actual !== expected) {
+            throw new Error(
+              `${path} changed while commit hooks ran; no commit was amended.`,
+            );
+          }
+        }
+
+        if (prepared.length > 0) {
+          const realIndex = run(
+            ["rev-parse", "--path-format=absolute", "--git-path", "index"],
+            undefined,
+            root,
+          ).trim();
+          indexLock = `${realIndex}.lock`;
+          try {
+            Deno.openSync(indexLock, {
+              write: true,
+              createNew: true,
+            }).close();
+            ownsIndexLock = true;
+          } catch {
+            throw new Error(
+              "The Git index is locked; no commit was amended.",
+            );
+          }
+          preparedIndex = Deno.makeTempFileSync({
+            dir: dirname(realIndex),
+            prefix: "cf-view-index-",
+          });
+          Deno.copyFileSync(realIndex, preparedIndex);
+          const realIndexEnv = { GIT_INDEX_FILE: preparedIndex };
+          for (const file of prepared) {
+            if (
+              !sameIndexEntry(indexEntry(file.path, realIndexEnv), file.before)
+            ) {
+              throw new Error(
+                `The Git index changed for ${file.path} during the amend; no staged changes were overwritten.`,
+              );
+            }
+            setIndexEntry(file.path, file.after, realIndexEnv);
+          }
+          Deno.copyFileSync(preparedIndex, indexLock);
+          Deno.renameSync(indexLock, realIndex);
+          ownsIndexLock = false;
+        }
+        const releaseErrors = releaseReferenceLocks();
+        return {
+          status: releaseErrors.length === 0
+            ? "Amended the commit"
+            : `Amended the commit; could not release Git reference locks: ${
+              releaseErrors.join("; ")
+            }`,
+          head: committedHead,
+        };
+      } catch (error) {
+        const rollbackErrors = releaseReferenceLocks();
+        if (
+          refUpdated && committedHead !== null && publishedRef !== null &&
+          rollbackHead !== null
+        ) {
+          try {
+            run(
+              [
+                "update-ref",
+                "-m",
+                "cf view: restore HEAD after failed amend",
+                publishedRef,
+                oldHead,
+                rollbackHead,
+              ],
+              undefined,
+              root,
+            );
+          } catch (rollbackError) {
+            rollbackErrors.push(String(rollbackError));
+          }
+        }
+        if (ownsIndexLock && indexLock !== null) {
+          try {
+            Deno.removeSync(indexLock);
+            ownsIndexLock = false;
+          } catch (rollbackError) {
+            rollbackErrors.push(String(rollbackError));
+          }
+        }
+        const suffix = rollbackErrors.length > 0
+          ? `; rollback failed: ${rollbackErrors.join("; ")}`
+          : "";
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(`${detail}${suffix}`);
+      } finally {
+        if (preparedIndex !== null) {
+          try {
+            Deno.removeSync(preparedIndex);
+          } catch {
+            // Temporary index cleanup is best effort.
+          }
+        }
+        try {
+          Deno.removeSync(tempDir, { recursive: true });
+        } catch {
+          // Temporary content cleanup is best effort.
+        }
+      }
     },
   };
 }

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -114,6 +114,10 @@ function findRepoRoot(cwd: string): string | null {
  * structure are not present.
  */
 export interface DiffEdit {
+  /** The diff text used to build this edit map. Commit-only views have no file
+   * mappings, so the source text is also what makes their HEAD message
+   * editable. */
+  readonly sourceText?: string;
   /** Diff line → the file line it edits, with its marker width (1, or 0 for a
    * trimmed empty context line). */
   readonly lines: ReadonlyMap<
@@ -296,7 +300,7 @@ export function buildDiffDocument(
   return {
     doc,
     maps: buildMaps(diffLineStarts, rawLines, mappings),
-    edit: buildEdit(rawLines, mappings, hunks),
+    edit: buildEdit(text, rawLines, mappings, hunks),
   };
 }
 
@@ -304,6 +308,7 @@ export function buildDiffDocument(
  * diff line, plus that file's captured content for save-time splicing and the
  * verified hunks that save rewrites. */
 function buildEdit(
+  sourceText: string,
   rawLines: string[],
   mappings: Map<string, FileMapping>,
   hunks: DiffHunkInfo[],
@@ -320,7 +325,7 @@ function buildEdit(
       lines.set(diffLine, { absPath: m.absPath, newLine, markerLen });
     }
   }
-  return { lines, fileText, hunks };
+  return { sourceText, lines, fileText, hunks };
 }
 
 // --- hunk rendering + structure ------------------------------------------------

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -19,8 +19,11 @@ import {
 } from "./diffdoc.ts";
 import { type DiffHunk, type DiffModel, parseDiff } from "./diff.ts";
 import {
+  type CommitHeader,
   type CommitMessage,
   extractMessage,
+  findCommitHeaderCandidates,
+  findCommitHeaders,
   findCommitMessages,
   type GitRunner,
   MESSAGE_INDENT,
@@ -45,25 +48,38 @@ export function diffSource(
   git?: GitRunner,
 ): EditableSource {
   const files = [...edit.fileText.keys()];
-  // The HEAD commit's hash, computed once — the message of that commit (and only
-  // it) is editable. Absent when there is no git runner or no repository.
-  let headResolved = false;
-  let head: string | null = null;
-  const headSha = (): string | null => {
-    if (!headResolved) {
-      headResolved = true;
-      head = git?.headSha() ?? null;
+  const expectedFiles = new Map(edit.fileText);
+  // The HEAD commit at open is the commit represented by the `git show` output.
+  // After this pager amends it, `expectedHead` follows the new commit while the
+  // displayed header continues to name the original object.
+  const shownHead = git?.headSha() ?? null;
+  const shownRef = git?.headRef?.() ?? null;
+  let expectedHead = shownHead;
+  const resolvedCommits = new Map<string, string | null>();
+  const matchesShownHead = (sha: string): boolean => {
+    if (!shownHead) return false;
+    if (!git?.resolveCommit) return sameCommit(sha, shownHead);
+    if (!resolvedCommits.has(sha)) {
+      resolvedCommits.set(sha, git.resolveCommit(sha));
     }
-    return head;
+    return resolvedCommits.get(sha) === shownHead;
   };
 
   // The HEAD commit's message region in the given lines, or null. The regions
   // shift as the diff is edited, so they are re-derived from the current text.
   const editableMessage = (lines: readonly string[]): CommitMessage | null => {
-    const h = headSha();
-    if (!h) return null;
+    if (!shownHead) return null;
     for (const m of findCommitMessages(lines)) {
-      if (sameCommit(m.sha, h)) return m;
+      if (matchesShownHead(m.sha)) return m;
+    }
+    return null;
+  };
+  const representedCommit = (
+    lines: readonly string[],
+  ): { sha: string } | null => {
+    if (!shownHead) return null;
+    for (const commit of findCommitHeaders(lines)) {
+      if (matchesShownHead(commit.sha)) return { sha: commit.sha };
     }
     return null;
   };
@@ -72,13 +88,17 @@ export function diffSource(
   // grows, so keep a mutable copy that expand and save share. A hunk is writable
   // only when its new side identifies one current workspace range. Historical
   // hunks in `git log -p` can repeat that range and must not write it again.
-  const saveHunks = mutableHunks(edit);
+  const saveHunks = mutableHunks(
+    edit,
+    hunkCommitOwners(edit.sourceText ?? "", git),
+  );
 
   // No file on disk backs this diff (nothing resolved or verified): read-only.
   // A deletion of an entire file has no new-side lines, but its empty workspace
   // file still fixes the removed lines' insertion point exactly.
   if (
-    edit.lines.size === 0 && !saveHunks.some((h) => canResurrect(h))
+    edit.lines.size === 0 && !saveHunks.some((h) => canResurrect(h)) &&
+    !editableMessage((edit.sourceText ?? "").split("\n"))
   ) {
     return {
       label: null,
@@ -97,17 +117,39 @@ export function diffSource(
   // keystroke reuse them.
   let memoText: string | null = null;
   let memoModel: DiffModel | null = null;
+  let memoCommits: readonly CommitHeader[] = [];
   let memoMessages: readonly CommitMessage[] = [];
   const classify = (
     lines: readonly string[],
-  ): { model: DiffModel | null; messages: readonly CommitMessage[] } => {
+  ): {
+    model: DiffModel | null;
+    commits: readonly CommitHeader[];
+    messages: readonly CommitMessage[];
+  } => {
     const text = lines.join("\n");
     if (text !== memoText) {
       memoText = text;
       memoModel = parseDiff(text);
+      memoCommits = findCommitHeaders(lines);
       memoMessages = findCommitMessages(lines);
     }
-    return { model: memoModel, messages: memoMessages };
+    return {
+      model: memoModel,
+      commits: memoCommits,
+      messages: memoMessages,
+    };
+  };
+
+  const commitAt = (
+    commits: readonly CommitHeader[],
+    row: number,
+  ): CommitHeader | null => {
+    let owner: CommitHeader | null = null;
+    for (const commit of commits) {
+      if (commit.line > row) break;
+      owner = commit;
+    }
+    return owner;
   };
 
   const kindOf = (
@@ -122,10 +164,9 @@ export function diffSource(
       row,
     );
     if (diffKind) return diffKind;
-    const h = headSha();
-    if (h) {
+    if (shownHead) {
       const m = messageAt(messages, row);
-      if (m && sameCommit(m.sha, h)) return "message";
+      if (m && matchesShownHead(m.sha)) return "message";
     }
     return null;
   };
@@ -144,13 +185,24 @@ export function diffSource(
       // A message line is editable past its four-space indent.
       return kind === "message" ? MESSAGE_INDENT.length : null;
     },
+    notEditableMessage: (lines, row) => {
+      if (!shownHead) return null;
+      const commit = commitAt(classify(lines).commits, row);
+      return commit && !matchesShownHead(commit.sha)
+        ? "This line belongs to a commit other than HEAD and cannot be edited."
+        : null;
+    },
     regionKind: kindOf,
     insertPrefix: "+",
     messageIndent: MESSAGE_INDENT,
   };
 
   return {
-    label: files.length === 1 ? shortName(files[0]) : `${files.length} files`,
+    label: files.length === 0
+      ? null
+      : files.length === 1
+      ? shortName(files[0])
+      : `${files.length} files`,
     isDiff: true,
     editable: true,
     policy,
@@ -161,68 +213,301 @@ export function diffSource(
     // not the whole diff, and the unchanged headers never flicker colour. The
     // full parse on pause restores workspace-verified spans across the edit.
     createHighlighter: (text, seed) => createDiffHighlighter(text, seed),
-    dirtyLabels: (original, current) => dirtyLabels(original, current),
+    dirtyLabels: (original, current) =>
+      [
+        ...collectFileOutputs(
+          current,
+          expectedFiles,
+          saveHunks,
+          changedHunkIndices(original, current),
+        ).keys(),
+      ].map(shortName),
     revert: (original, current, cursorLine, scope) =>
       revert(original, current, cursorLine, scope),
     expandContext: (current, baseline, cursorLine, up) =>
       expandContext(ws, cache, saveHunks, current, baseline, cursorLine, up),
     expandRoom: (current) => expandRoom(ws, cache, saveHunks, current),
-    save: (text) => save(text, edit.fileText, saveHunks),
+    save: (text, baseline, options) => {
+      const changedHunks = baseline === undefined
+        ? undefined
+        : changedHunkIndices(baseline, text);
+      const amendedHunks = new Set(
+        [...changedHunks ?? []].filter((index) => {
+          const sha = saveHunks[index]?.commitSha;
+          return sha !== null && sha !== undefined && matchesShownHead(sha);
+        }),
+      );
+      const changes = collectFileOutputs(
+        text,
+        expectedFiles,
+        saveHunks,
+        changedHunks,
+      );
+      const advancedHunks = changes.size === 0
+        ? []
+        : planSavedHunkRanges(text, saveHunks, changedHunks);
+      const pending = options?.amendCommit === false || baseline === undefined
+        ? null
+        : pendingAmend(
+          editableMessage,
+          representedCommit,
+          amendedHunks.size > 0,
+          baseline,
+          text,
+        );
+      let replacementMessage: string | null = null;
+      if (pending && baseline !== undefined) {
+        const currentLines = text.split("\n");
+        const baselineLines = baseline.split("\n");
+        const message = editableMessage(currentLines);
+        const baselineMessage = editableMessage(baselineLines);
+        const messageChanged = message === null || baselineMessage === null
+          ? message !== baselineMessage
+          : extractMessage(currentLines, message) !==
+            extractMessage(baselineLines, baselineMessage);
+        if (messageChanged) {
+          replacementMessage = message === null
+            ? ""
+            : extractMessage(currentLines, message);
+        }
+      }
+      const commit = pending ? representedCommit(text.split("\n")) : null;
+      const commitFiles = new Map<string, string>();
+      if (pending) {
+        if (
+          !git || !commit || !expectedHead || !shownHead ||
+          baseline === undefined
+        ) {
+          throw new Error("No commit to amend.");
+        }
+        const live = git.headSha();
+        if (!live || !sameCommit(expectedHead, live)) {
+          throw new Error(
+            "HEAD has moved since this diff was shown; the commit was not amended.",
+          );
+        }
+        const liveRef = git.headRef?.() ?? null;
+        if (shownRef !== null && liveRef !== shownRef) {
+          throw new Error(
+            "HEAD now names a different branch; the commit was not amended.",
+          );
+        }
+        const commitBase = new Map<string, string>();
+        const amendedPaths = new Set(
+          [...amendedHunks].flatMap((index) => {
+            const path = saveHunks[index]?.absPath;
+            return path === null || path === undefined ? [] : [path];
+          }),
+        );
+        for (const path of amendedPaths) {
+          const committed = git.fileAtCommit(expectedHead, path);
+          if (committed === null) {
+            throw new Error(`The shown commit does not contain ${path}.`);
+          }
+          commitBase.set(path, committed);
+        }
+        const pagerFiles = collectFileOutputs(
+          text,
+          expectedFiles,
+          saveHunks,
+          amendedHunks,
+        );
+        for (const path of amendedPaths) {
+          const committed = commitBase.get(path);
+          const before = expectedFiles.get(path);
+          const after = pagerFiles.get(path);
+          if (
+            committed === undefined || before === undefined ||
+            after === undefined
+          ) {
+            throw new Error(
+              `Could not rebuild ${path} for the amended commit.`,
+            );
+          }
+          commitFiles.set(
+            path,
+            git.applyFileChanges(committed, before, after, path),
+          );
+        }
+      }
+
+      const writes = [...changes].flatMap(([path, contents]) => {
+        const before = ws.read(path);
+        if (before === null) {
+          throw new Error(`Could not read ${path}; no files were saved.`);
+        }
+        const expected = expectedFiles.get(path);
+        if (expected === undefined) {
+          throw new Error(`No saved baseline exists for ${path}.`);
+        }
+        if (before !== expected && before !== contents) {
+          throw new Error(
+            `${path} changed after this view opened; no files were saved.`,
+          );
+        }
+        return before === contents ? [] : [{ path, before, contents }];
+      });
+      const attempted: typeof writes = [];
+      try {
+        for (const write of writes) {
+          attempted.push(write);
+          Deno.writeTextFileSync(write.path, write.contents);
+        }
+
+        let amended: string | null = null;
+        if (pending && git && expectedHead) {
+          const result = git.amendCommit(
+            replacementMessage,
+            commitFiles,
+            expectedHead,
+            shownRef,
+            changes,
+          );
+          amended = result.status;
+          expectedHead = result.head;
+        }
+        for (const [path, contents] of changes) {
+          expectedFiles.set(path, contents);
+          cache?.delete(path);
+        }
+        for (const { hunk, newStart, newCount } of advancedHunks) {
+          hunk.newStart = newStart;
+          hunk.newCount = newCount;
+        }
+        return saveStatus(writes.length, amended);
+      } catch (error) {
+        const rollbackErrors: string[] = [];
+        for (const write of attempted.reverse()) {
+          try {
+            const live = ws.read(write.path);
+            if (live === write.before) continue;
+            if (live !== write.contents) {
+              rollbackErrors.push(
+                `${write.path} changed again and was not restored`,
+              );
+              continue;
+            }
+            Deno.writeTextFileSync(write.path, write.before);
+          } catch (rollbackError) {
+            rollbackErrors.push(String(rollbackError));
+          }
+        }
+        const detail = error instanceof Error ? error.message : String(error);
+        const suffix = rollbackErrors.length > 0
+          ? `; restoring files failed: ${rollbackErrors.join("; ")}`
+          : "";
+        throw new Error(`${detail}${suffix}`);
+      }
+    },
     pendingAmend: (baseline, current) =>
-      pendingAmend(editableMessage, baseline, current),
-    amendCommit: (baseline, current) =>
-      amendCommit(git, editableMessage, baseline, current),
+      pendingAmend(
+        editableMessage,
+        representedCommit,
+        [...changedHunkIndices(baseline, current)].some((index) => {
+          const sha = saveHunks[index]?.commitSha;
+          return sha !== null && sha !== undefined && matchesShownHead(sha);
+        }),
+        baseline,
+        current,
+      ),
+    baselineAfterSave: (baseline, current, options) =>
+      options?.amendCommit === false
+        ? baselineWithCurrentHunks(baseline, current)
+        : current,
   };
 }
 
-/** The commit whose message a save would amend: the HEAD message region differs
- * from the baseline, or has been deleted outright. Null otherwise. */
+/** The commit a save would amend when changed text represents HEAD. */
 function pendingAmend(
   editableMessage: (lines: readonly string[]) => CommitMessage | null,
+  representedCommit: (lines: readonly string[]) => { sha: string } | null,
+  commitContentsChanged: boolean,
   baseline: string,
   current: string,
 ): { sha: string; subject: string } | null {
+  if (baseline === current) return null;
   const curLines = current.split("\n");
   const baseLines = baseline.split("\n");
   const msg = editableMessage(curLines);
   const baseMsg = editableMessage(baseLines);
+  const messageChanged = msg === null || baseMsg === null
+    ? msg !== baseMsg
+    : extractMessage(curLines, msg) !== extractMessage(baseLines, baseMsg);
+  if (!messageChanged && !commitContentsChanged) return null;
   if (!msg) {
     // Every line of the region was deleted, so there is no region left to read
     // the new message from. The message the save would write is empty, and the
     // caller refuses an empty subject.
-    return baseMsg ? { sha: baseMsg.sha, subject: "" } : null;
+    if (baseMsg) return { sha: baseMsg.sha, subject: "" };
+    const commit = representedCommit(curLines);
+    return commit && representedCommit(baseLines)
+      ? { sha: commit.sha, subject: "(empty commit message)" }
+      : null;
   }
   const newText = extractMessage(curLines, msg);
-  if (baseMsg && extractMessage(baseLines, baseMsg) === newText) {
-    return null; // the message is unchanged
-  }
   // The subject is the first non-blank line — git strips leading blanks — so an
   // all-blank message reports an empty subject, which the caller refuses.
   const subject = newText.split("\n").find((l) => l.trim() !== "") ?? "";
   return { sha: msg.sha, subject };
 }
 
-/** Amend the HEAD commit's message from the edited text. Re-reads HEAD to guard
- * against it having moved (an external commit) since the diff was shown — the
- * amend rewrites whatever is HEAD, so it must still be the commit the message
- * belongs to. Throws when there is no git runner or no editable message (the
- * caller checks {@link pendingAmend} first, so those are defensive). */
-function amendCommit(
-  git: GitRunner | undefined,
-  editableMessage: (lines: readonly string[]) => CommitMessage | null,
-  _baseline: string,
-  current: string,
-): string {
-  const curLines = current.split("\n");
-  const msg = editableMessage(curLines);
-  if (!git || !msg) throw new Error("No commit message to amend.");
-  const live = git.headSha();
-  if (!live || !sameCommit(msg.sha, live)) {
-    throw new Error(
-      "HEAD has moved since this diff was shown; the commit was not amended.",
+/** The hunks whose rendered text changed between the last save and now. */
+function changedHunkIndices(original: string, current: string): Set<number> {
+  if (original === current) return new Set();
+  const before = parseDiff(original);
+  const after = parseDiff(current);
+  if (!before || !after) return new Set();
+  const bodies = (model: DiffModel, text: string): string[] => {
+    const raw = text.split("\n");
+    return model.files.flatMap((file) =>
+      file.hunks.map((hunk) =>
+        raw.slice(hunk.headerLine, hunk.endLine + 1).join("\n")
+      )
+    );
+  };
+  const beforeBodies = bodies(before, original);
+  const afterBodies = bodies(after, current);
+  return new Set(
+    afterBodies.flatMap((body, index) =>
+      beforeBodies[index] === body ? [] : [index]
+    ),
+  );
+}
+
+/** Build the clean baseline after saving only workspace-backed hunk edits.
+ * Commit-message text stays as it was before the save, so an edited message
+ * remains dirty and can still be amended or cancelled separately. */
+function baselineWithCurrentHunks(original: string, current: string): string {
+  const before = parseDiff(original);
+  const after = parseDiff(current);
+  if (!before || !after) return original;
+  const hunks = (model: DiffModel) =>
+    model.files.flatMap((file) =>
+      file.hunks.map((hunk) => ({
+        path: file.newPath ?? file.oldPath,
+        hunk,
+      }))
+    );
+  const beforeHunks = hunks(before);
+  const afterHunks = hunks(after);
+  if (
+    beforeHunks.length !== afterHunks.length ||
+    beforeHunks.some((entry, index) => entry.path !== afterHunks[index]?.path)
+  ) {
+    return original;
+  }
+  const baselineLines = original.split("\n");
+  const currentLines = current.split("\n");
+  for (let index = beforeHunks.length - 1; index >= 0; index--) {
+    const beforeHunk = beforeHunks[index].hunk;
+    const afterHunk = afterHunks[index].hunk;
+    baselineLines.splice(
+      beforeHunk.headerLine,
+      beforeHunk.endLine - beforeHunk.headerLine + 1,
+      ...currentLines.slice(afterHunk.headerLine, afterHunk.endLine + 1),
     );
   }
-  return git.amendMessage(extractMessage(curLines, msg));
+  return baselineLines.join("\n");
 }
 
 /**
@@ -360,7 +645,7 @@ function hunkFooting(
   // an insert grows past the file range). Insertion positions and the global
   // index come from the parse. Clamp how far context may grow by the
   // neighbouring hunks of the SAME file, so an expansion never overlaps another
-  // hunk's file range — that would make save() splice the two ranges into each
+  // hunk's file range — that would splice the two ranges into each
   // other (silently dropping edits or duplicating lines) and malform the diff.
   const range = hunks[index];
   if (!range) return null;
@@ -606,12 +891,13 @@ function joinAdjacent(
   const a = hunks[first];
   const b = hunks[first + 1];
   if (!a || !b || a.absPath === null || a.absPath !== b.absPath) return null;
+  if ((a.commitSha ?? null) !== (b.commitSha ?? null)) return null;
   if (a.newStart + a.newCount !== b.newStart) return null; // a gap remains
   if (!isWritable(a) || !isWritable(b)) return null;
   const joined = dropHeaderBetween(text, first);
   const joinedBase = dropHeaderBetween(baseline, first);
   if (!joined || !joinedBase) return null;
-  // save() pairs the text's hunks with this map by position, so it loses an
+  // Saving pairs the text's hunks with this map by position, so it loses an
   // entry exactly as the text loses a header.
   a.newCount += b.newCount;
   a.oldNoTrailingNewline ||= b.oldNoTrailingNewline;
@@ -681,38 +967,6 @@ function applyExpansion(
 }
 
 /**
- * The filenames whose lines differ between the original diff and the edited one.
- * Each file's slice of the diff text (its header through its last hunk line) is
- * compared, matched by path so a line shift in an earlier file does not
- * misattribute a later one. Repeated paths (`git log -p`) are concatenated. A
- * change that touches no file's slice — an edited commit message — names no
- * file, so a save (and the quit prompt) reflects that it writes no files.
- */
-function dirtyLabels(original: string, current: string): string[] {
-  if (original === current) return [];
-  const o = parseDiff(original);
-  const c = parseDiff(current);
-  if (!o || !c) return [];
-  const bodies = (model: DiffModel, text: string): Map<string, string> => {
-    const raw = text.split("\n");
-    const m = new Map<string, string>();
-    for (const f of model.files) {
-      const path = f.newPath ?? f.oldPath ?? "(unknown)";
-      const body = raw.slice(f.headerLine, f.endLine + 1).join("\n");
-      m.set(path, (m.get(path) ?? "") + "\n" + body);
-    }
-    return m;
-  };
-  const ob = bodies(o, original);
-  const cb = bodies(c, current);
-  const out: string[] = [];
-  for (const [path, body] of cb) {
-    if (body !== ob.get(path)) out.push(shortName(path));
-  }
-  return out;
-}
-
-/**
  * An incremental highlighter for a diff. It recolours only the lines an edit
  * changes (found by a common prefix/suffix of the line arrays) and keeps `seed`
  * — the colours {@link buildDiffDocument} produced for the unedited text — for
@@ -764,7 +1018,7 @@ export function createDiffHighlighter(
  * that can be resurrected. A line belongs only when the hunk's new side matched
  * a file on disk. Structural lines, empty lines, unverified hunks, and text
  * outside a hunk are refused. Hunks are matched to the save map by document
- * order, as {@link save} does, so a repeated file in `git log -p` and a context
+ * order, as saving does, so a repeated file in `git log -p` and a context
  * expansion both stay in step.
  */
 function editableHunkRegion(
@@ -853,7 +1107,6 @@ function isMarkdownDiffLine(rawLines: string[], lineIdx: number): boolean {
 export const _internal = {
   editableStart,
   pendingAmend,
-  amendCommit,
   dropHeaderBetween,
   joinAdjacent,
 };
@@ -890,6 +1143,8 @@ interface MutableHunk {
   verified: boolean;
   oldNoTrailingNewline?: boolean;
   newNoTrailingNewline?: boolean;
+  /** The nearest preceding commit header in the source text. */
+  commitSha?: string | null;
   /** This is the first verified hunk that names its workspace range. */
   writable?: boolean;
   /** Removed lines have a workspace-verified insertion point. */
@@ -925,10 +1180,16 @@ function rangesOverlap(a: MutableHunk, b: MutableHunk): boolean {
  * can repeat a file across historical commits. The first verified occurrence
  * represents the current workspace, while a later overlapping occurrence must
  * not overwrite edits made through the first. */
-function mutableHunks(edit: DiffEdit): MutableHunk[] {
+function mutableHunks(
+  edit: DiffEdit,
+  commitOwners: readonly (string | null)[] = [],
+): MutableHunk[] {
   const claimed = new Map<string, MutableHunk[]>();
-  return edit.hunks.map((hunk) => {
-    const out: MutableHunk = { ...hunk };
+  return edit.hunks.map((hunk, index) => {
+    const out: MutableHunk = {
+      ...hunk,
+      commitSha: commitOwners[index] ?? null,
+    };
     const file = hunk.absPath === null
       ? undefined
       : edit.fileText.get(hunk.absPath);
@@ -947,12 +1208,61 @@ function mutableHunks(edit: DiffEdit): MutableHunk[] {
   });
 }
 
+/** The commit header that owns each parsed hunk, in document order. */
+function hunkCommitOwners(
+  text: string,
+  git?: GitRunner,
+): (string | null)[] {
+  const model = parseDiff(text);
+  if (!model) return [];
+  const lines = text.split("\n");
+  const headers = findCommitHeaders(lines);
+  const candidates = findCommitHeaderCandidates(lines);
+  return model.files.flatMap((file) => {
+    let owner: string | null = null;
+    if (candidates.length > 0 && git?.commitMatchesDiff) {
+      const firstHunk = file.hunks[0]?.headerLine ?? file.endLine + 1;
+      const objects = lines.slice(file.headerLine, firstHunk).map((line) =>
+        line.replace(/\r$/, "")
+      ).map((line) =>
+        /^index ([0-9a-f]{4,64})\.\.([0-9a-f]{4,64})(?:\s|$)/.exec(
+          line,
+        )
+      ).find((match) => match !== null);
+      if (objects) {
+        for (let index = candidates.length - 1; index >= 0; index--) {
+          const candidate = candidates[index];
+          if (!candidate || candidate.line >= file.headerLine) continue;
+          if (
+            git.commitMatchesDiff(
+              candidate.sha,
+              file.oldPath,
+              file.newPath,
+              objects[1],
+              objects[2],
+            )
+          ) {
+            owner = candidate.sha;
+            break;
+          }
+        }
+      }
+    } else {
+      for (const header of headers) {
+        if (header.line >= file.headerLine) break;
+        owner = header.sha;
+      }
+    }
+    return file.hunks.map(() => owner);
+  });
+}
+
 /**
- * Rebuild each touched file from the edited diff. The edited diff's hunks are
+ * Rebuild each changed file from the edited diff. The edited diff's hunks are
  * matched to the hunks recorded at open, in document order — robust to `git log
  * -p` repeating a file and its ranges across commits — and only the verified
- * ones are written (their captured content is known to be the hunk's new side,
- * so an unverified hunk is never miswritten). For each, the current new side
+ * ones are considered. Their captured content is known to be the hunk's new
+ * side, so an unverified hunk is never used. For each, the current new side
  * (its context and added lines, markers stripped) replaces the file lines that
  * hunk covered, taken from the recorded `newStart`/`newCount`. Hunks apply high
  * line number first so earlier ranges do not shift.
@@ -966,11 +1276,12 @@ function mutableHunks(edit: DiffEdit): MutableHunk[] {
  * Inter-hunk text (`git log -p` commit metadata, a trailing separator) falls
  * outside the parsed body, so it is never absorbed.
  */
-function save(
+function collectFileOutputs(
   text: string,
   fileText: ReadonlyMap<string, string>,
   hunks: readonly MutableHunk[],
-): string {
+  changedHunks?: ReadonlySet<number>,
+): Map<string, string> {
   const model = parseDiff(text);
   const rawLines = text.split("\n");
   const byFile = new Map<string, FileSplice[]>();
@@ -982,8 +1293,10 @@ function save(
       if (kind === "ctx" || kind === "add") finalNewSideLine = i;
     }
     for (const hunk of file.hunks) {
-      const info = hunks[hunkIndex++];
-      if (!info || !isWritable(info) || !info.absPath) continue;
+      const index = hunkIndex++;
+      const info = hunks[index];
+      const include = changedHunks === undefined || changedHunks.has(index);
+      if (!include || !info || !isWritable(info) || !info.absPath) continue;
       const newSide: string[] = [];
       let noTrailingNewline = false;
       for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
@@ -1016,7 +1329,7 @@ function save(
     }
   }
 
-  const out = new Map<string, string[]>();
+  const out = new Map<string, string>();
   for (const [path, splices] of byFile) {
     const base = fileText.get(path);
     if (base === undefined) continue;
@@ -1039,16 +1352,60 @@ function save(
         fileLines[last] = fileLines[last].slice(0, -1);
       }
     }
-    out.set(path, fileLines);
+    out.set(path, fileLines.join("\n"));
   }
+  return out;
+}
 
-  let written = 0;
-  for (const [path, fileLines] of out) {
-    Deno.writeTextFileSync(path, fileLines.join("\n"));
-    written++;
+/**
+ * Advance each writable hunk's workspace range to the file produced by this
+ * save. A line insertion or deletion changes the edited hunk's size and shifts
+ * every later hunk in the same file. The plan is built before any file or Git
+ * change, then applied only after the whole save succeeds.
+ */
+function planSavedHunkRanges(
+  text: string,
+  hunks: readonly MutableHunk[],
+  changedHunks?: ReadonlySet<number>,
+): Array<{ hunk: MutableHunk; newStart: number; newCount: number }> {
+  const parsed = parseDiff(text)?.files.flatMap((file) => file.hunks) ?? [];
+  if (parsed.length !== hunks.length) {
+    throw new Error("The edited diff no longer matches its saved hunk map.");
   }
-  if (written === 0) return "No editable changes to save.";
-  return written === 1
-    ? `Saved ${shortName([...out.keys()][0])}`
-    : `Saved ${written} files`;
+  const saved = hunks.flatMap((hunk, index) => {
+    const include = changedHunks === undefined || changedHunks.has(index);
+    return include && isWritable(hunk) && hunk.absPath
+      ? [{
+        index,
+        path: hunk.absPath,
+        start: spliceStart(hunk),
+        oldCount: hunk.newCount,
+        newCount: parsed[index].newCount,
+      }]
+      : [];
+  });
+
+  return hunks.flatMap((hunk, index) => {
+    if (!isWritable(hunk) || !hunk.absPath) return [];
+    const own = saved.find((change) => change.index === index);
+    const shift = saved.reduce(
+      (total, change) =>
+        change.path === hunk.absPath && change.start < spliceStart(hunk)
+          ? total + change.newCount - change.oldCount
+          : total,
+      0,
+    );
+    const start = spliceStart(hunk) + shift;
+    const newCount = own?.newCount ?? hunk.newCount;
+    return [{
+      hunk,
+      newStart: newCount === 0 ? start : start + 1,
+      newCount,
+    }];
+  });
+}
+
+function saveStatus(changed: number, amended: string | null): string {
+  const saved = `Saved ${changed} ${changed === 1 ? "file" : "files"}`;
+  return amended ? `${saved}; ${amended}` : saved;
 }

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -60,6 +60,13 @@ export interface HunkRoom {
   atFileBottom: boolean;
 }
 
+/** Which parts of an edited view a save should persist. Commit-aware sources
+ * amend by default. The file-only choice writes changes backed by workspace
+ * files without rewriting Git history. */
+export interface SaveOptions {
+  readonly amendCommit?: boolean;
+}
+
 export interface EditableSource {
   /** A short label for the editable target (the filename), or null. */
   readonly label: string | null;
@@ -89,8 +96,18 @@ export interface EditableSource {
     text: string,
     seedLines?: readonly Line[],
   ): Highlighter;
-  /** Persist the edited text. Returns a status message. Throws on I/O failure. */
-  save(text: string): string;
+  /** Persist the edited text. `baseline` is the text at the last successful
+   * save. Returns a status message. Throws on failure. */
+  save(text: string, baseline?: string, options?: SaveOptions): string;
+  /** The clean baseline after a successful save. Most sources persist the
+   * whole buffer and omit this method. A commit view that saves files without
+   * amending keeps commit-message edits outside the returned baseline, so they
+   * remain visibly unsaved. */
+  baselineAfterSave?(
+    baseline: string,
+    current: string,
+    options?: SaveOptions,
+  ): string;
   /** The labels (filenames) of the targets that differ between `original` and
    * `current` — what a save would actually write. A plain file is its one label
    * when changed; a diff reports just the files whose lines an edit touched, so
@@ -128,17 +145,13 @@ export interface EditableSource {
    * map to fixed file lines: edits stay within a line, past the diff marker. A
    * plain file has no policy and is edited freely. */
   readonly policy?: EditPolicy;
-  /** When an edited commit message (in `git show` output) differs from its
-   * original and belongs to the HEAD commit, the commit whose message a save
+  /** When changed `git show` output contains the HEAD commit, the commit a save
    * would amend — for the confirmation prompt. Null when no such change is
-   * pending. Absent on sources that never edit a commit message. */
+   * pending. Absent on sources that never edit a commit. */
   pendingAmend?(
     baseline: string,
     current: string,
   ): { sha: string; subject: string } | null;
-  /** Amend the HEAD commit's message from the edited text, returning a status
-   * line. Called only after the save has been confirmed. */
-  amendCommit?(baseline: string, current: string): string;
   /** The path of the backing file, when there is a single one. The file picker
    * opens in its directory. */
   readonly path?: string;
@@ -160,6 +173,12 @@ export interface EditPolicy {
    * Takes the whole set of lines because editability depends on the row's
    * region. */
   editStart(lines: readonly string[], row: number): number | null;
+  /** A source-specific explanation for refusing an edit at `row`, or null to
+   * use the editor's general explanation. */
+  notEditableMessage?(
+    lines: readonly string[],
+    row: number,
+  ): string | null;
   /** What the row at `row` belongs to: a diff hunk's new side (edited as a
    * removed/added pair), a removed line that can be resurrected, an editable
    * commit message (edited as plain indented text), or neither. Drives how the
@@ -198,7 +217,7 @@ export function fileSource(path: string): EditableSource {
       },
     save: (text) => {
       Deno.writeTextFileSync(path, text);
-      return `Saved ${shortName(path)}`;
+      return "Saved 1 file";
     },
   };
 }

--- a/packages/cli/lib/view/mod.ts
+++ b/packages/cli/lib/view/mod.ts
@@ -27,7 +27,7 @@ import {
   readonlySource,
 } from "./editsource.ts";
 import { diffSource } from "./diffedit.ts";
-import { realGit } from "./commitmsg.ts";
+import { findCommitHeaders, realGit } from "./commitmsg.ts";
 
 export { ViewError };
 
@@ -101,9 +101,17 @@ export function buildView(
   semantics: () => Semantics | undefined;
   editSource: EditableSource;
 } {
-  const tryDiff = forceDiff ?? looksLikeDiff(text);
-  const model = tryDiff ? parseDiff(text) : null;
-  if (model && (forceDiff || mostlyDiff(model, text))) {
+  const commitOutput = looksLikeCommitOutput(text);
+  const tryDiff = forceDiff ?? (looksLikeDiff(text) || commitOutput);
+  const parsedDiff = tryDiff ? parseDiff(text) : null;
+  const model: DiffModel | null = parsedDiff ??
+    (tryDiff && commitOutput
+      ? {
+        files: [],
+        lines: text.split("\n").map(() => ({ kind: "other" as const })),
+      }
+      : null);
+  if (model && (forceDiff || commitOutput || mostlyDiff(model, text))) {
     const ws = realWorkspace(safeCwd());
     // One workspace cache shared by the initial build and every deferred
     // re-parse, so the named files are read and parsed once per session.
@@ -113,8 +121,8 @@ export function buildView(
       doc,
       semantics: () =>
         createDiffSemantics(text, maps, { cwd: safeCwd() }) ?? undefined,
-      // A diff edits the new side of the files it touches, in place; a
-      // `git show`'s HEAD commit message is editable and amended on save.
+      // A diff edits the new side of the files it touches, in place. Saving
+      // edited `git show` output amends HEAD with those file and message edits.
       editSource: diffSource(ws, edit, cache, realGit(safeCwd())),
     };
   }
@@ -128,6 +136,39 @@ export function buildView(
       "This view is of a pipe — there is no underlying file to edit.",
     ),
   };
+}
+
+/** A standard `git show` or `git log` header. Unlike a diff heuristic, this also
+ * recognizes commits with no message or textual file hunks. */
+function looksLikeCommitOutput(text: string): boolean {
+  const lines = text.split("\n").map((line) =>
+    line.endsWith("\r") ? line.slice(0, -1) : line
+  );
+  const first = lines.findIndex((line) => line.trim().length > 0);
+  if (first < 0) return false;
+  const commits = findCommitHeaders(lines);
+  const commit = commits.find((candidate) => candidate.line === first);
+  if (!commit) return false;
+  if (lines[first].startsWith(`From ${commit.sha} `)) {
+    const separator = lines.indexOf("", first + 1);
+    if (separator < 0) return false;
+    const headers = lines.slice(first + 1, separator);
+    return headers.some((line) => /^From: .+<[^<>]*>$/.test(line)) &&
+      headers.some((line) => /^Date: .+/.test(line)) &&
+      headers.some((line) => /^Subject: .+/.test(line));
+  }
+  if (!lines[first].startsWith(`commit ${commit.sha}`)) {
+    return lines.slice(first + 1).some((line) =>
+      line.startsWith("diff --git ")
+    );
+  }
+  const separator = lines.indexOf("", first + 1);
+  if (separator < 0) return false;
+  const headers = lines.slice(first + 1, separator);
+  return headers.some((line) =>
+    /^Author:\s+.*<[^<>]*>$/.test(line) ||
+    /^author .*<[^<>]*> -?\d+ [+-]\d{4}$/.test(line)
+  );
 }
 
 /** At least a quarter of the non-empty lines parse as diff content. Headers in

--- a/packages/cli/lib/view/pager.ts
+++ b/packages/cli/lib/view/pager.ts
@@ -182,8 +182,9 @@ export async function runPager(
   };
 
   // A prompt button press shows the button pushed for a moment before its result
-  // lands. The captured pushed frame is painted now; a timer then draws the real
-  // state (the dialog closed, or the next prompt up). Any key drops the wait.
+  // lands. The captured pushed frame is painted before the button's synchronous
+  // action starts. A timer then draws the real state (the dialog closed, or the
+  // next prompt up). Any key drops the wait.
   let cancelPush: (() => void) | undefined;
   const stopPush = () => {
     if (cancelPush) {
@@ -311,31 +312,40 @@ export async function runPager(
       const chunk = concat(leftover, buf.subarray(0, n));
       const { keys, rest } = decodeKeys(chunk);
       leftover = rest;
+      // A partial key sequence has not changed the session. Keep any active
+      // animation on screen while its remaining bytes arrive.
+      if (keys.length === 0) continue;
+      let pushStarted = false;
       for (const key of keys) {
-        session.handleKey(key);
+        // A new key ends animations and short-lived messages left by the
+        // previous key, including an earlier key decoded from this same read.
+        stopReveal();
+        stopExpiry();
+        stopPush();
+        pushStarted = false;
+        session.handleKey(key, () => {
+          // activateButton calls this after capturing the pushed frame and
+          // before running the action, so a slow synchronous save leaves the
+          // button visibly depressed for the duration of the work.
+          pushStarted = startPush();
+        });
         if (session.quit) break;
       }
       if (session.quit) {
         stopReveal();
         stopExpiry();
-        stopPush();
-        // A committing button (Save / Discard, and amend-Yes) sets quit as its
-        // action. Hold its pressed frame on screen for the press moment before
-        // the screen is torn down, so it depresses like any other button rather
-        // than vanishing. A bare `q` has nothing pushed and exits at once.
-        const push = session.pendingPush;
-        if (push) {
-          paint(push.doc, push.view);
+        // A committing button can set quit as its action. Its pressed frame is
+        // already on screen. Hold it for the rest of the press moment before
+        // tearing the screen down. A bare `q` exits at once.
+        if (pushStarted) {
+          stopPush();
           await deps.delay(PUSH_FRAME_MS);
         }
         break;
       }
-      stopReveal();
-      stopExpiry();
-      stopPush();
       // A reveal or a button press draws its own frames, ending on the finished
       // one; otherwise draw the new state now.
-      if (!startReveal() && !startPush()) {
+      if (!startReveal() && !pushStarted) {
         draw();
         startExpiry(); // starts the clock on the message the draw put up
       }

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -57,6 +57,7 @@ import type {
   ExpandResult,
   HunkRoom,
   RevertScope,
+  SaveOptions,
 } from "./editsource.ts";
 import type { Highlighter } from "./parse.ts";
 import type { DirEntry, FileGateway } from "./filegateway.ts";
@@ -230,9 +231,6 @@ export class Session {
   private dialogFocus = 0;
   /** What the active save prompt does on confirm. */
   private savePromptThen: "quit" | null = null;
-  /** Set once the user confirms amending the commit message, so the save that
-   * follows goes ahead instead of prompting again. */
-  private amendConfirmed = false;
   /** Filenames a save would write, computed when the quit prompt opens and
    * listed above it. */
   private editedFiles: string[] = [];
@@ -705,10 +703,11 @@ export class Session {
     const subject = full.length > 46 ? `${full.slice(0, 45)}…` : full;
     return {
       title: "Amend Commit",
-      body: [`Amend commit ${sha}?`, `“${subject}”`],
+      body: [`Amend commit ${sha}, or save files only?`, `“${subject}”`],
       buttons: [
-        { label: "Yes", hotkey: "y", kind: "default" },
-        { label: "No", hotkey: "n", kind: "cancel" },
+        { label: "Amend commit", hotkey: "a", kind: "default" },
+        { label: "Save files only", hotkey: "s" },
+        { label: "Cancel", hotkey: "c", kind: "cancel" },
       ],
     };
   }
@@ -737,7 +736,7 @@ export class Session {
     return { title: "Revert", body: ["Revert which changes?"], buttons };
   }
 
-  handleKey(key: Key): void {
+  handleKey(key: Key, beforeButtonAction?: () => void): void {
     // A reveal is animated by the driver over the frames after the key that
     // caused it, so the next key ends it whatever it was. A message that takes
     // itself away goes now rather than waiting out its moment, before this key
@@ -749,7 +748,7 @@ export class Session {
       this.mode === "savePrompt" || this.mode === "amendPrompt" ||
       this.mode === "revertPrompt"
     ) {
-      this.handleDialogKey(key);
+      this.handleDialogKey(key, beforeButtonAction);
       return;
     }
     if (this.mode === "filePicker") {
@@ -2274,9 +2273,13 @@ export class Session {
   }
 
   private notEditableMessage(): string {
-    return this.canResurrectRemovedLine()
-      ? "This removed line isn't editable; press R to resurrect it."
-      : NOT_EDITABLE_MSG;
+    if (this.canResurrectRemovedLine()) {
+      return "This removed line isn't editable; press R to resurrect it.";
+    }
+    const b = this.buffer;
+    const policy = this.source?.policy;
+    return (b ? policy?.notEditableMessage?.(b.lines, b.row) : null) ??
+      NOT_EDITABLE_MSG;
   }
 
   private afterMove(): void {
@@ -2461,7 +2464,7 @@ export class Session {
     else this.message = `C-x ${key.name}: unbound`;
   }
 
-  private requestSave(): boolean {
+  private requestSave(target?: "amend" | "workspace"): boolean {
     if (!this.source || !this.buffer) {
       this.message = "Nothing to save.";
       return false;
@@ -2472,53 +2475,61 @@ export class Session {
     }
     const baseline = this.buffer.baseline();
     const current = this.buffer.text();
-    // A changed commit message rewrites git history, so confirm before saving.
+    if (!this.buffer.dirty()) {
+      this.message = "Saved 0 files";
+      return true;
+    }
+    // Saving changed commit output rewrites git history, so confirm first.
     const amend = this.source.pendingAmend?.(baseline, current) ?? null;
-    if (amend && !this.amendConfirmed) {
-      if (amend.subject.trim() === "") {
-        this.message = "Refusing to amend: the commit message would be empty.";
-        return false;
-      }
+    if (amend && target === undefined) {
       this.mode = "amendPrompt";
       this.focusDefaultButton();
       this.message = "";
       return false;
     }
+    if (amend && target === "amend" && amend.subject.trim() === "") {
+      this.message = "Refusing to amend: the commit message would be empty.";
+      return false;
+    }
+    const options: SaveOptions | undefined = target === "workspace"
+      ? { amendCommit: false }
+      : undefined;
     try {
-      // Amend the commit before writing files: if the amend fails (an empty
-      // message, a rejecting hook, HEAD moved) nothing is written to disk, so a
-      // failed save never leaves the files half-written.
-      const amended = amend
-        ? this.source.amendCommit!(baseline, current)
-        : null;
-      const saved = this.source.save(current);
-      this.message = amended
-        ? (/^No(thing)?\b/.test(saved) ? amended : `${saved}; ${amended}`)
-        : saved;
-      this.buffer.commitSaved();
+      this.message = this.source.save(current, baseline, options);
+      const savedBaseline = this.source.baselineAfterSave?.(
+        baseline,
+        current,
+        options,
+      ) ?? current;
+      this.buffer.setBaseline(savedBaseline);
+      if (target === "workspace" && this.buffer.dirty()) {
+        this.message += "; commit message remains unsaved";
+      }
       return true;
     } catch (e) {
       this.message = `Save failed: ${e instanceof Error ? e.message : e}`;
       return false;
-    } finally {
-      this.amendConfirmed = false;
     }
   }
 
   private applyAmendButton(button: DialogButton): void {
-    if (button.hotkey === "y") {
-      this.amendConfirmed = true;
-      const ok = this.requestSave();
+    if (button.hotkey === "a" || button.hotkey === "s") {
+      const ok = this.requestSave(
+        button.hotkey === "a" ? "amend" : "workspace",
+      );
       this.mode = "normal";
       this.editedFiles = [];
-      if (ok && this.savePromptThen === "quit") this.quit = true;
+      if (
+        ok && this.savePromptThen === "quit" && !this.buffer?.dirty()
+      ) {
+        this.quit = true;
+      }
       this.savePromptThen = null;
     } else if (button.kind === "cancel") {
       this.mode = "normal";
-      this.amendConfirmed = false;
       this.savePromptThen = null;
       this.editedFiles = [];
-      this.message = "Save cancelled — the commit was not amended.";
+      this.message = "Save cancelled.";
     }
   }
 
@@ -2570,7 +2581,10 @@ export class Session {
    * move the focus ring between buttons, wrapping around; Space and Enter
    * activate the focused button; Esc activates the cancel button; a button's
    * shortcut letter activates it directly. Any other key leaves the prompt up. */
-  private handleDialogKey(key: Key): void {
+  private handleDialogKey(
+    key: Key,
+    beforeButtonAction?: () => void,
+  ): void {
     // Reached only from the prompt modes, each of which builds a dialog with at
     // least two buttons, so the dialog is present and its row is non-empty.
     const dialog = this.promptDialog()!;
@@ -2602,14 +2616,18 @@ export class Session {
       index = buttons.findIndex((b) => b.hotkey.toLowerCase() === k);
     }
     if (index < 0 || index >= n) return; // an unbound key leaves the prompt up
-    this.activateButton(dialog, index);
+    this.activateButton(dialog, index, beforeButtonAction);
   }
 
-  /** Run a prompt button's action, first capturing the frame that shows it
-   * pushed so the driver can play the press before the result appears. The
-   * pressed button is drawn focused as well, so a shortcut-key press shows it
-   * highlighted rather than leaving the highlight on whatever Tab last chose. */
-  private activateButton(dialog: DialogState, index: number): void {
+  /** Capture a prompt button's pushed frame, let the driver paint it, then run
+   * the button's action. The pressed button is drawn focused as well, so a
+   * shortcut-key press shows it highlighted rather than leaving the highlight
+   * on whatever Tab last chose. */
+  private activateButton(
+    dialog: DialogState,
+    index: number,
+    beforeButtonAction?: () => void,
+  ): void {
     this.dialogFocus = index;
     this.pendingPush = {
       doc: this.displayDoc(),
@@ -2618,6 +2636,7 @@ export class Session {
         dialog: { ...dialog, focus: index, pushed: index },
       },
     };
+    beforeButtonAction?.();
     const button = dialog.buttons[index];
     if (this.mode === "savePrompt") this.applySaveButton(button);
     else if (this.mode === "amendPrompt") this.applyAmendButton(button);

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -5,10 +5,12 @@ import type { JSONSchema } from "@commonfabric/api";
 import { PiecesController } from "@commonfabric/piece/ops";
 import {
   type ExecCommandSpec,
+  normalizeCallableInputForExecution,
   parseExecArgs,
   renderExecHelp,
   renderExecHelpJson,
   renderPieceCallHelp,
+  resolveExecInvocation,
   resolveParsedExecInput,
 } from "../lib/exec-schema.ts";
 import {
@@ -390,6 +392,186 @@ describe("parseExecArgs", () => {
   });
 });
 
+describe("parseExecArgs edge cases", () => {
+  it("validates every generated flag value by its schema type", () => {
+    const spec = makeSpec("tool", {
+      type: "object",
+      properties: {
+        enabled: { type: "boolean" },
+        count: { type: "number" },
+        whole: { type: "integer" },
+        items: { type: "array" },
+        config: { type: "object" },
+        nothing: { type: "null" },
+      },
+    });
+
+    expect(() => parseExecArgs(spec, ["--enabled=maybe"])).toThrow(
+      /expected true or false/,
+    );
+    expect(() => parseExecArgs(spec, ["--count", "NaN"])).toThrow(
+      /expected number/,
+    );
+    expect(() => parseExecArgs(spec, ["--whole", "1.5"])).toThrow(
+      /expected integer/,
+    );
+    expect(() => parseExecArgs(spec, ["--items", "{"])).toThrow(
+      /Invalid JSON/,
+    );
+    expect(() => parseExecArgs(spec, ["--items", "{}"])).toThrow(
+      /expected array JSON/,
+    );
+    expect(() => parseExecArgs(spec, ["--config", "[]"])).toThrow(
+      /expected object JSON/,
+    );
+    expect(() => parseExecArgs(spec, ["--nothing", "false"])).toThrow(
+      /expected null/,
+    );
+    expect(parseExecArgs(spec, ["--nothing", "null"]).input).toEqual({
+      nothing: null,
+    });
+  });
+
+  it("rejects conflicting object-input modes at the point they conflict", () => {
+    const spec = makeSpec("tool", {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        enabled: { type: "boolean" },
+      },
+    });
+
+    expect(() => parseExecArgs(spec, ["value"])).toThrow(
+      /Unexpected argument value/,
+    );
+    expect(() => parseExecArgs(spec, ["--json", "--query", "tea"])).toThrow(
+      /cannot be combined/,
+    );
+    expect(() => parseExecArgs(spec, ["--query", "tea", "--json", "{}"]))
+      .toThrow(/cannot be combined/);
+    expect(() => parseExecArgs(spec, ["--json", "{}", "--json", "{}"]))
+      .toThrow(/only be provided once/);
+    expect(() =>
+      parseExecArgs(spec, ["--query", "tea", "--json-file", "input.json"])
+    ).toThrow(/json-file cannot be combined/);
+    expect(() =>
+      parseExecArgs(spec, ["--json", "{}", "--json-file", "input.json"])
+    ).toThrow(/only be provided once/);
+    expect(() => parseExecArgs(spec, ["--json-file"])).toThrow(
+      /Missing value/,
+    );
+    expect(parseExecArgs(spec, ["--json-file", "-"])).toMatchObject({
+      readJsonFromStdin: true,
+      usedJsonInput: true,
+    });
+    expect(parseExecArgs(spec, ["--no-enabled"]).input).toEqual({
+      enabled: false,
+    });
+    expect(() => parseExecArgs(spec, ["--no-query"])).toThrow(
+      /Unknown flag/,
+    );
+    expect(() => parseExecArgs(spec, ["--query"])).toThrow(/Missing value/);
+  });
+
+  it("handles each non-object input mode and its errors", () => {
+    const booleanSpec = makeSpec("tool", { type: "boolean" });
+    const stringSpec = makeSpec("tool", { type: "string" });
+
+    expect(parseExecArgs(booleanSpec, ["--value", "true"]).input).toBe(true);
+    expect(() => parseExecArgs(stringSpec, ["--value", "one", "extra"]))
+      .toThrow(/Unexpected argument extra/);
+    expect(() => parseExecArgs(stringSpec, ["--other", "value"])).toThrow(
+      /Unknown flag/,
+    );
+    expect(() => parseExecArgs(stringSpec, ["--json", "--other"])).toThrow(
+      /cannot be combined/,
+    );
+    expect(parseExecArgs(stringSpec, ["--json", '"value"']).input).toBe(
+      "value",
+    );
+    expect(parseExecArgs(stringSpec, ["--json-file", "-"])).toMatchObject({
+      readJsonFromStdin: true,
+      usedJsonInput: true,
+    });
+    expect(parseExecArgs(stringSpec, ["--json-file", "input.json"]).inputFile)
+      .toEqual({ format: "json", path: "input.json" });
+  });
+
+  it("validates explicit verbs and explicit-verb help", () => {
+    const spec = makeSpec("tool", { type: "object", properties: {} });
+
+    expect(() => parseExecArgs(spec, ["invoke"])).toThrow(/Invalid verb/);
+    expect(() => parseExecArgs(spec, ["--help", "extra"])).toThrow(
+      /Unknown flag --help/,
+    );
+    expect(parseExecArgs(spec, ["run", "--help"])).toMatchObject({
+      verb: "run",
+      showHelp: true,
+      showHelpJson: false,
+    });
+    expect(parseExecArgs(spec, ["run", "--help", "--json"]))
+      .toMatchObject({ showHelp: true, showHelpJson: true });
+    expect(() => parseExecArgs(spec, ["run", "--help", "extra"])).toThrow(
+      /Unknown flag --help/,
+    );
+  });
+});
+
+describe("resolveParsedExecInput edge cases", () => {
+  it("reports empty and malformed JSON read from stdin", async () => {
+    const spec = makeSpec("tool", { type: "object", properties: {} });
+    const parsed = parseExecArgs(spec, ["--json"]);
+
+    await expect(resolveParsedExecInput(spec, parsed, {
+      readTextInput: () => Promise.resolve("  \n"),
+    })).rejects.toThrow(/Expected JSON/);
+    await expect(resolveParsedExecInput(spec, parsed, {
+      readTextInput: () => Promise.resolve("not json"),
+    })).rejects.toThrow(/Invalid JSON/);
+  });
+
+  it("parses primitive stdin and handles terminal or empty implicit input", async () => {
+    const primitive = makeSpec("handler", { type: "boolean" });
+    const parsed = parseExecArgs(primitive, ["--value-file", "-"]);
+    expect(
+      await resolveParsedExecInput(primitive, parsed, {
+        readTextInput: () => Promise.resolve("false"),
+      }),
+    ).toBe(false);
+
+    const optional = makeSpec("handler", {
+      type: "object",
+      properties: {},
+    });
+    expect(
+      (await resolveExecInvocation(optional, [], {
+        isStdinTerminal: () => true,
+      })).input,
+    ).toEqual({});
+    expect(
+      (await resolveExecInvocation(optional, [], {
+        isStdinTerminal: () => false,
+        readTextInput: () => Promise.resolve(""),
+      })).input,
+    ).toEqual({});
+  });
+
+  it("normalizes only object inputs for tools with a string help field", () => {
+    const spec = makeSpec("tool", {
+      type: "object",
+      properties: { help: { type: "string" } },
+    });
+
+    expect(normalizeCallableInputForExecution(spec, null)).toBe(null);
+    expect(normalizeCallableInputForExecution(spec, ["value"])).toEqual([
+      "value",
+    ]);
+    expect(normalizeCallableInputForExecution(spec, { query: "tea" })).toEqual(
+      { query: "tea", help: "" },
+    );
+  });
+});
+
 describe("resolveParsedExecInput", () => {
   it("reads text payloads from files for primitive inputs", async () => {
     const spec = makeSpec("handler", { type: "string" });
@@ -624,6 +806,64 @@ describe("renderExecHelp", () => {
 
     expect(help).toContain("--help=<boolean> | --no-help");
     expect(help).toContain("Boolean. Use --help=true or --no-help.");
+  });
+
+  it("renders typed flags, schema details, deep shapes, and empty output objects", () => {
+    const help = renderExecHelp(
+      "/tmp/complex.tool",
+      makeSpec(
+        "tool",
+        {
+          type: "object",
+          properties: {
+            enabled: {
+              type: "boolean",
+              default: true,
+              description: "Enables the operation.",
+            },
+            count: { type: "integer" },
+            settings: { type: "object", properties: {} },
+            items: { type: "array", items: { type: "string" } },
+            nothing: { type: "null" },
+            mode: { enum: ["fast", "safe"] },
+            choice: { anyOf: [{ type: "string" }, { type: "number" }] },
+            deep: {
+              type: "object",
+              properties: {
+                one: {
+                  type: "object",
+                  properties: {
+                    two: {
+                      type: "object",
+                      properties: {
+                        three: {
+                          type: "object",
+                          properties: { four: { type: "string" } },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          required: ["enabled", "count", "settings", "items", "nothing"],
+        },
+        { type: "object", properties: {} },
+      ),
+    );
+
+    expect(help).toContain("--enabled | --no-enabled");
+    expect(help).toContain("--count <integer>");
+    expect(help).toContain("--settings <json-object>");
+    expect(help).toContain("--items <json-array>");
+    expect(help).toContain("--nothing <null>");
+    expect(help).toContain('Allowed: "fast" | "safe".');
+    expect(help).toContain("Default: true.");
+    expect(help).toContain("Enables the operation.");
+    expect(help).toContain("choice?: string | number");
+    expect(help).toContain("{...}");
+    expect(help).toContain("JSON on success.");
   });
 });
 

--- a/packages/cli/test/run-tests.ts
+++ b/packages/cli/test/run-tests.ts
@@ -43,6 +43,7 @@ const SERIAL_TESTS = [
   "test/main-command.test.ts",
   "test/test-runner-compile-byte-cache.test.ts",
   "test/test-runner-pattern-coverage.test.ts",
+  "test/view-commitmsg.test.ts",
   "test/view-mod-gate.test.ts",
   "test/view-pager-pty.test.ts",
 ];

--- a/packages/cli/test/view-commitmsg.test.ts
+++ b/packages/cli/test/view-commitmsg.test.ts
@@ -1,6 +1,7 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import {
   extractMessage,
+  findCommitHeaders,
   findCommitMessages,
   messageAt,
   realGit,
@@ -78,9 +79,56 @@ Deno.test("findCommitMessages: several commits (git log -p) each get a region", 
   assertEquals(msgs.map((m) => [m.start, m.end]), [[3, 3], [8, 8]]);
 });
 
+Deno.test("findCommitHeaders: compact, reference, and email formats", () => {
+  const full = "0123456789abcdef0123456789abcdef01234567";
+  assertEquals(findCommitHeaders([`${full} Subject`]), [
+    { sha: full, line: 0 },
+  ]);
+  assertEquals(
+    findCommitHeaders(["89abcdef (Reference subject, 2026-07-20)"]),
+    [{ sha: "89abcdef", line: 0 }],
+  );
+  assertEquals(
+    findCommitHeaders([
+      `From ${full} Mon Sep 17 00:00:00 2001`,
+      "From: A B <a@b.example>",
+      "Date: Wed, 1 Jul 2026 12:00:00 -0700",
+      "Subject: [PATCH] Subject",
+      "",
+    ]),
+    [{ sha: full, line: 0 }],
+  );
+  assertEquals(
+    findCommitHeaders([`${full} Empty HEAD`, "89abcdef Parent with a patch"]),
+    [{ sha: full, line: 0 }, { sha: "89abcdef", line: 1 }],
+  );
+});
+
+Deno.test("findCommitHeaders: email message text is not a compact header", () => {
+  const full = "0123456789abcdef0123456789abcdef01234567";
+  const lines = [
+    `From ${full} Mon Sep 17 00:00:00 2001`,
+    "From: A B <a@b.example>",
+    "Date: Wed, 1 Jul 2026 12:00:00 -0700",
+    "Subject: [PATCH] Subject",
+    "",
+    "ffff ordinary body line",
+    "commit deadbeef",
+    `From ${"f".repeat(40)} Mon Sep 17 00:00:00 2001`,
+    "From: Fake Author <fake@example.test>",
+    "Date: Wed, 1 Jul 2026 12:00:00 -0700",
+    "Subject: [PATCH] Embedded envelope",
+    "",
+    "diff --git a/f b/f",
+  ];
+
+  assertEquals(findCommitHeaders(lines), [{ sha: full, line: 0 }]);
+});
+
 Deno.test("findCommitMessages: a commit with no message body yields no region", () => {
   const lines = ["commit deadbeef", "Author: A", "", "diff --git a/f b/f"];
   assertEquals(findCommitMessages(lines).length, 0);
+  assertEquals(findCommitHeaders(lines), [{ sha: "deadbeef", line: 0 }]);
 });
 
 Deno.test("messageAt: maps a row to its region or null", () => {
@@ -99,11 +147,32 @@ Deno.test("extractMessage: strips the four-space indent and joins", () => {
   );
 });
 
-Deno.test("sameCommit: matches on the shorter (abbreviated) prefix, refuses too-short", () => {
+Deno.test("commit messages ignore CRLF transport carriage returns", () => {
+  const lines = [
+    "commit 0123456789abcdef0123456789abcdef01234567",
+    "Author: A B <a@b.example>",
+    "Date:   Wed Jul 1 12:00:00 2026 -0700",
+    "",
+    "    Subject line",
+    "    ",
+    "    Body paragraph.",
+    "",
+  ].join("\r\n").split("\n");
+  const messages = findCommitMessages(lines);
+
+  assertEquals(messages.length, 1);
+  assertEquals(
+    extractMessage(lines, messages[0]),
+    "Subject line\n\nBody paragraph.",
+  );
+});
+
+Deno.test("sameCommit: matches Git's four-character minimum abbreviation", () => {
   assert(sameCommit("0123456", "0123456789abcdef"), "7-char abbrev matches");
+  assert(sameCommit("0123", "0123456789abcdef"), "4-char abbrev matches");
   assert(sameCommit("0123456789abcdef", "0123456"), "either side may be short");
   assert(!sameCommit("0123456", "0123999"), "different prefix");
-  assert(!sameCommit("012", "0123456"), "under seven chars never matches");
+  assert(!sameCommit("012", "0123456"), "under four chars never matches");
 });
 
 // --- realGit against a throwaway repository -----------------------------------
@@ -112,10 +181,12 @@ async function git(
   root: string,
   args: string[],
   stdin?: string,
+  env?: Record<string, string>,
 ): Promise<string> {
   const cmd = new Deno.Command("git", {
     args,
     cwd: root,
+    env,
     stdin: stdin !== undefined ? "piped" : "null",
     stdout: "piped",
     stderr: "piped",
@@ -128,6 +199,58 @@ async function git(
   }
   const o = await p.output();
   return new TextDecoder().decode(o.stdout);
+}
+
+async function installHook(root: string, name: string, script: string) {
+  const path = `${root}/.git/hooks/${name}`;
+  await Deno.writeTextFile(path, `#!/bin/sh\n${script}\n`);
+  await Deno.chmod(path, 0o755);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+async function initReftable(root: string): Promise<boolean> {
+  const initialized = await new Deno.Command("git", {
+    args: ["init", "-q", "--ref-format=reftable"],
+    cwd: root,
+    stdout: "null",
+    stderr: "null",
+  }).output();
+  return initialized.success;
+}
+
+async function withGitShim<T>(
+  body: string,
+  callback: () => T | Promise<T>,
+): Promise<T> {
+  const lookup = await new Deno.Command("which", {
+    args: ["git"],
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  assert(lookup.success, "the real Git executable is available");
+  const realGitPath = new TextDecoder().decode(lookup.stdout).trim();
+  const shimDir = await Deno.makeTempDir();
+  const shim = `${shimDir}/git`;
+  await Deno.writeTextFile(
+    shim,
+    `#!/bin/sh
+${body}
+exec ${shellQuote(realGitPath)} "$@"
+`,
+  );
+  await Deno.chmod(shim, 0o755);
+  const originalPath = Deno.env.get("PATH");
+  Deno.env.set("PATH", `${shimDir}:${originalPath ?? ""}`);
+  try {
+    return await callback();
+  } finally {
+    if (originalPath === undefined) Deno.env.delete("PATH");
+    else Deno.env.set("PATH", originalPath);
+    await Deno.remove(shimDir, { recursive: true });
+  }
 }
 
 Deno.test("realGit: reads HEAD and amends the message, keeping the tree", async () => {
@@ -148,8 +271,12 @@ Deno.test("realGit: reads HEAD and amends the message, keeping the tree", async 
     await Deno.writeTextFile(`${root}/f.txt`, "a\nb\nc\n");
     await git(root, ["add", "f.txt"]);
 
-    const status = g.amendMessage("new subject\n\nnew body");
-    assert(status.includes("Amended"), status);
+    const status = g.amendCommit(
+      "new subject\n\nnew body",
+      new Map(),
+      head,
+    );
+    assert(status.status.includes("Amended"), status.status);
     assertEquals(
       (await git(root, ["log", "-1", "--format=%B"])).trim(),
       "new subject\n\nnew body",
@@ -157,6 +284,1855 @@ Deno.test("realGit: reads HEAD and amends the message, keeping the tree", async 
     assert(g.headSha() !== head, "amending produced a new commit");
     // The committed tree still has two lines; the staged `c` was not included.
     assertEquals(await git(root, ["show", "HEAD:f.txt"]), "a\nb\n");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test({
+  name: "realGit: preserves a configured reference-transaction hook",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      const journal = `${root}/hook-journal`;
+      await installHook(
+        root,
+        "reference-transaction",
+        `printf '%s\\n' "$1" >> ${shellQuote(journal)}
+cat >> ${shellQuote(journal)}`,
+      );
+      const runner = realGit(root);
+      const original = runner.headSha();
+      assert(original, "repository has a HEAD commit");
+
+      runner.amendCommit("amended", new Map(), original);
+
+      const hookOutput = await Deno.readTextFile(journal);
+      assert(hookOutput.includes("prepared\n"), hookOutput);
+      assert(hookOutput.includes("committed\n"), hookOutput);
+      assert(hookOutput.includes(" refs/heads/"), hookOutput);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: preserves hook paths and hooks installed during the amend",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      const helperMarker = `${root}/helper-ran`;
+      const helper = `${root}/.git/check`;
+      await Deno.writeTextFile(
+        helper,
+        `#!/bin/sh\nprintf ran > ${shellQuote(helperMarker)}\n`,
+      );
+      await Deno.chmod(helper, 0o755);
+      const commitMessageHook = `${root}/.git/hooks/commit-msg`;
+      await installHook(
+        root,
+        "pre-commit",
+        `"$(dirname "$0")/../check"
+printf '#!/bin/sh\\nexit 1\\n' > ${shellQuote(commitMessageHook)}
+chmod +x ${shellQuote(commitMessageHook)}`,
+      );
+      const runner = realGit(root);
+      const original = runner.headSha();
+      assert(original, "repository has a HEAD commit");
+
+      assertThrows(
+        () => runner.amendCommit("amended", new Map(), original),
+        Error,
+      );
+
+      assertEquals(await Deno.readTextFile(helperMarker), "ran");
+      assertEquals(runner.headSha(), original);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: preserves whitespace in a relative core.hooksPath",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      const hooksName = " custom-hooks ";
+      await git(root, ["config", "core.hooksPath", hooksName]);
+      const hooks = `${root}/${hooksName}`;
+      await Deno.mkdir(hooks);
+      const marker = `${root}/post-commit-ran`;
+      const hook = `${hooks}/post-commit`;
+      await Deno.writeTextFile(
+        hook,
+        `#!/bin/sh\nprintf ran > ${shellQuote(marker)}\n`,
+      );
+      await Deno.chmod(hook, 0o755);
+      const runner = realGit(root);
+      const original = runner.headSha();
+      assert(original, "repository has a HEAD commit");
+
+      runner.amendCommit("amended", new Map(), original);
+
+      assertEquals(await Deno.readTextFile(marker), "ran");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: source hooks observe their configured hooks path",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      const hooksName = "custom hooks";
+      await git(root, ["config", "core.hooksPath", hooksName]);
+      const hooks = `${root}/${hooksName}`;
+      await Deno.mkdir(hooks);
+      const marker = `${root}/pre-commit-ran`;
+      const hook = `${hooks}/pre-commit`;
+      await Deno.writeTextFile(
+        hook,
+        `#!/bin/sh
+test "$(git config --get core.hooksPath)" = ${shellQuote(hooksName)} || exit 41
+printf ran > ${shellQuote(marker)}
+`,
+      );
+      await Deno.chmod(hook, 0o755);
+      const runner = realGit(root);
+      const original = runner.headSha();
+      assert(original, "repository has a HEAD commit");
+
+      runner.amendCommit("amended", new Map(), original);
+
+      assertEquals(await Deno.readTextFile(marker), "ran");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: preserves an explicitly empty core.hooksPath",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      const marker = `${root}/post-commit-ran`;
+      await installHook(
+        root,
+        "post-commit",
+        `printf ran > ${shellQuote(marker)}`,
+      );
+      await git(root, ["config", "core.hooksPath", ""]);
+      const runner = realGit(root);
+      const original = runner.headSha();
+      assert(original, "repository has a HEAD commit");
+
+      runner.amendCommit("amended", new Map(), original);
+
+      let hookRan = true;
+      try {
+        await Deno.stat(marker);
+      } catch (error) {
+        if (error instanceof Deno.errors.NotFound) hookRan = false;
+        else throw error;
+      }
+      assert(!hookRan, "the disabled hook did not run");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: hook-spawned Git uses the other repository's hooks",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    const other = await Deno.makeTempDir();
+    try {
+      for (const repository of [root, other]) {
+        await git(repository, ["init", "-q"]);
+        await git(repository, ["config", "user.email", "t@t.test"]);
+        await git(repository, ["config", "user.name", "Test"]);
+        await git(repository, [
+          "commit",
+          "-q",
+          "--allow-empty",
+          "-m",
+          "original",
+        ]);
+      }
+      await installHook(other, "pre-commit", "exit 1");
+      await installHook(
+        root,
+        "post-commit",
+        `unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
+git -C ${shellQuote(other)} commit --allow-empty -q -m nested`,
+      );
+      const runner = realGit(root);
+      const original = runner.headSha();
+      const otherOriginal = (await git(other, ["rev-parse", "HEAD"])).trim();
+      assert(original && otherOriginal, "both repositories have HEAD commits");
+
+      const result = runner.amendCommit("amended", new Map(), original);
+
+      assert(result.head !== original, "the source commit was amended");
+      assertEquals(
+        (await git(other, ["rev-parse", "HEAD"])).trim(),
+        otherOriginal,
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+      await Deno.remove(other, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: preserves nested Git configuration for another repository",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    const other = await Deno.makeTempDir();
+    try {
+      for (const repository of [root, other]) {
+        await git(repository, ["init", "-q"]);
+        await git(repository, ["config", "user.email", "t@t.test"]);
+        await git(repository, ["config", "user.name", "Test"]);
+        await git(repository, [
+          "commit",
+          "-q",
+          "--allow-empty",
+          "-m",
+          "original",
+        ]);
+      }
+      const marker = `${other}/pre-commit-ran`;
+      await installHook(
+        other,
+        "pre-commit",
+        `test "$(git config --get nested.flag)" = yes || exit 43
+printf ran > ${shellQuote(marker)}`,
+      );
+      await installHook(
+        root,
+        "post-commit",
+        `unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
+git -C ${
+          shellQuote(other)
+        } -c nested.flag=yes commit --allow-empty -q -m nested`,
+      );
+      const runner = realGit(root);
+      const original = runner.headSha();
+      assert(original, "source repository has a HEAD commit");
+
+      runner.amendCommit("amended", new Map(), original);
+
+      assertEquals(await Deno.readTextFile(marker), "ran");
+      assertEquals(
+        (await git(other, ["rev-list", "--count", "HEAD"])).trim(),
+        "2",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+      await Deno.remove(other, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: hook-spawned Git uses a linked worktree's hooks",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const parent = await Deno.makeTempDir();
+    const root = `${parent}/root`;
+    const linked = `${parent}/linked`;
+    try {
+      await Deno.mkdir(root);
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      await git(root, ["worktree", "add", "-q", "-b", "linked", linked]);
+      await git(root, ["config", "extensions.worktreeConfig", "true"]);
+      await git(root, [
+        "config",
+        "--worktree",
+        "core.hooksPath",
+        ".root-hooks",
+      ]);
+      await git(linked, [
+        "config",
+        "--worktree",
+        "core.hooksPath",
+        ".linked-hooks",
+      ]);
+      await Deno.mkdir(`${root}/.root-hooks`);
+      await Deno.mkdir(`${linked}/.linked-hooks`);
+      const rootMarker = `${root}/pre-commit-ran`;
+      const linkedMarker = `${linked}/pre-commit-ran`;
+      await Deno.writeTextFile(
+        `${root}/.root-hooks/pre-commit`,
+        `#!/bin/sh
+test ! -e ${shellQuote(rootMarker)} || exit 44
+printf ran > ${shellQuote(rootMarker)}
+`,
+      );
+      await Deno.chmod(`${root}/.root-hooks/pre-commit`, 0o755);
+      await Deno.writeTextFile(
+        `${linked}/.linked-hooks/pre-commit`,
+        `#!/bin/sh
+printf ran > ${shellQuote(linkedMarker)}
+`,
+      );
+      await Deno.chmod(`${linked}/.linked-hooks/pre-commit`, 0o755);
+      await Deno.writeTextFile(
+        `${root}/.root-hooks/post-commit`,
+        `#!/bin/sh
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
+git -C ${shellQuote(linked)} commit --allow-empty -q -m nested
+`,
+      );
+      await Deno.chmod(`${root}/.root-hooks/post-commit`, 0o755);
+      const runner = realGit(root);
+      const original = runner.headSha();
+      assert(original, "source repository has a HEAD commit");
+
+      runner.amendCommit("amended", new Map(), original);
+
+      assertEquals(await Deno.readTextFile(rootMarker), "ran");
+      assertEquals(await Deno.readTextFile(linkedMarker), "ran");
+      assertEquals(
+        (await git(linked, ["rev-list", "--count", "HEAD"])).trim(),
+        "2",
+      );
+    } finally {
+      await Deno.remove(parent, { recursive: true });
+    }
+  },
+});
+
+Deno.test("realGit: accepts an amend that reproduces the same commit object", async () => {
+  const root = await Deno.makeTempDir();
+  const authorDate = Deno.env.get("GIT_AUTHOR_DATE");
+  const committerDate = Deno.env.get("GIT_COMMITTER_DATE");
+  try {
+    const fixedDate = "2001-01-01T00:00:00+00:00";
+    Deno.env.set("GIT_AUTHOR_DATE", fixedDate);
+    Deno.env.set("GIT_COMMITTER_DATE", fixedDate);
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await Deno.writeTextFile(`${root}/f.txt`, "same\n");
+    await git(root, ["add", "f.txt"]);
+    await git(root, ["commit", "-q", "-m", "same"]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    const result = runner.amendCommit("same", new Map(), head);
+
+    assertEquals(result.head, head);
+    assertEquals(runner.headSha(), head);
+    assert(result.status.includes("Amended"), result.status);
+  } finally {
+    if (authorDate === undefined) Deno.env.delete("GIT_AUTHOR_DATE");
+    else Deno.env.set("GIT_AUTHOR_DATE", authorDate);
+    if (committerDate === undefined) Deno.env.delete("GIT_COMMITTER_DATE");
+    else Deno.env.set("GIT_COMMITTER_DATE", committerDate);
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: preserves non-UTF-8 commit message bytes", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await git(root, ["config", "i18n.commitEncoding", "ISO-8859-1"]);
+    const file = `${root}/f.txt`;
+    await Deno.writeTextFile(file, "before\n");
+    await git(root, ["add", "f.txt"]);
+    const messagePath = `${root}/message`;
+    await Deno.writeFile(messagePath, new Uint8Array([0xff, 0x0a]));
+    await git(root, [
+      "commit",
+      "-q",
+      "--allow-empty",
+      "--cleanup=verbatim",
+      "-F",
+      messagePath,
+    ]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+    await git(root, ["config", "--unset", "i18n.commitEncoding"]);
+    await Deno.writeTextFile(file, "after\n");
+
+    runner.amendCommit(null, new Map([[file, "after\n"]]), head);
+
+    const output = await new Deno.Command("git", {
+      args: ["cat-file", "commit", "HEAD"],
+      cwd: root,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    assert(output.success, "the amended commit can be read");
+    let separator = -1;
+    for (let index = 0; index + 1 < output.stdout.length; index++) {
+      if (output.stdout[index] === 10 && output.stdout[index + 1] === 10) {
+        separator = index;
+        break;
+      }
+    }
+    assert(separator >= 0, "the commit has a message separator");
+    assertEquals(
+      output.stdout.slice(separator + 2),
+      new Uint8Array([0xff, 0x0a]),
+    );
+    assertEquals(await git(root, ["show", "HEAD:f.txt"]), "after\n");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: labels edited commit messages as UTF-8", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await git(root, ["config", "i18n.commitEncoding", "ISO-8859-1"]);
+    await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    runner.amendCommit("é edited", new Map(), head);
+
+    const raw = await git(root, ["cat-file", "commit", "HEAD"]);
+    assert(!raw.includes("encoding ISO-8859-1\n"), raw);
+    assertEquals(
+      await git(root, [
+        "-c",
+        "i18n.logOutputEncoding=UTF-8",
+        "log",
+        "-1",
+        "--format=%B",
+      ]),
+      "é edited\n\n",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: amends a valid empty commit", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    const result = runner.amendCommit("amended", new Map(), head);
+
+    assert(result.head !== head, "the empty commit was replaced");
+    assertEquals(
+      (await git(root, ["log", "-1", "--format=%s"])).trim(),
+      "amended",
+    );
+    assertEquals((await git(root, ["show", "--format=", "--stat"])).trim(), "");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: amends reftable commits and preserves staged state", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    if (!await initReftable(root)) return;
+
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await Deno.writeTextFile(`${root}/selected.txt`, "original selected\n");
+    await Deno.writeTextFile(`${root}/unrelated.txt`, "original unrelated\n");
+    await git(root, ["add", "selected.txt", "unrelated.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    const marker = `${root}/hook-ran`;
+    await installHook(root, "pre-commit", `touch ${shellQuote(marker)}`);
+    await Deno.writeTextFile(`${root}/selected.txt`, "amended selected\n");
+    await Deno.writeTextFile(`${root}/unrelated.txt`, "staged unrelated\n");
+    await git(root, ["add", "unrelated.txt"]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    const result = runner.amendCommit(
+      "amended",
+      new Map([[`${root}/selected.txt`, "amended selected\n"]]),
+      head,
+    );
+
+    assert(result.head !== head, "the reftable commit was replaced");
+    assertEquals(runner.headSha(), result.head);
+    assertEquals(
+      (await git(root, ["log", "-1", "--format=%s"])).trim(),
+      "amended",
+    );
+    assertEquals(
+      await git(root, ["show", "HEAD:selected.txt"]),
+      "amended selected\n",
+    );
+    assertEquals(
+      await git(root, ["show", "HEAD:unrelated.txt"]),
+      "original unrelated\n",
+    );
+    assertEquals(
+      await git(root, ["show", ":unrelated.txt"]),
+      "staged unrelated\n",
+    );
+    await Deno.stat(marker);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: amends a detached reftable HEAD", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    if (!await initReftable(root)) return;
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await Deno.writeTextFile(`${root}/f.txt`, "original\n");
+    await git(root, ["add", "f.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    const branch = (await git(root, ["symbolic-ref", "HEAD"])).trim();
+    const original = (await git(root, ["rev-parse", "HEAD"])).trim();
+    await git(root, ["checkout", "-q", "--detach"]);
+    const runner = realGit(root);
+
+    const result = runner.amendCommit(
+      "detached amend",
+      new Map([[`${root}/f.txt`, "amended\n"]]),
+      original,
+      "HEAD",
+    );
+
+    assert(result.head !== original, "the detached commit was replaced");
+    assertEquals(runner.headRef!(), "HEAD");
+    assertEquals(runner.headSha(), result.head);
+    assertEquals((await git(root, ["rev-parse", branch])).trim(), original);
+    assertEquals(await git(root, ["show", "HEAD:f.txt"]), "amended\n");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: amends reftable commits in a linked worktree", async () => {
+  const parent = await Deno.makeTempDir();
+  const root = `${parent}/repository`;
+  const linked = `${parent}/linked`;
+  try {
+    await Deno.mkdir(root);
+    if (!await initReftable(root)) return;
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await Deno.writeTextFile(`${root}/f.txt`, "original\n");
+    await git(root, ["add", "f.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    await git(root, ["worktree", "add", "-q", "-b", "topic", linked]);
+    const runner = realGit(linked);
+    const original = runner.headSha();
+    const branch = runner.headRef!();
+    assert(original && branch, "the linked worktree has a branch and commit");
+
+    const result = runner.amendCommit(
+      "linked amend",
+      new Map([[`${linked}/f.txt`, "linked\n"]]),
+      original,
+      branch,
+    );
+
+    assert(result.head !== original, "the linked-worktree commit was replaced");
+    assertEquals(runner.headSha(), result.head);
+    assertEquals(await git(linked, ["show", "HEAD:f.txt"]), "linked\n");
+    assertEquals((await git(root, ["rev-parse", branch])).trim(), result.head);
+  } finally {
+    await Deno.remove(parent, { recursive: true });
+  }
+});
+
+Deno.test({
+  name: "realGit: rolls back a reftable amend rewritten by a hook",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      if (!await initReftable(root)) return;
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await Deno.writeTextFile(`${root}/f.txt`, "original\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      const runner = realGit(root);
+      const original = runner.headSha();
+      assert(original, "repository has a HEAD commit");
+      await installHook(
+        root,
+        "commit-msg",
+        `printf '\\nHook-Trailer: added\\n' >> "$1"`,
+      );
+
+      assertThrows(
+        () => runner.amendCommit("amended", new Map(), original),
+        Error,
+        "hook changed",
+      );
+
+      assertEquals(runner.headSha(), original);
+      assertEquals(
+        (await git(root, ["log", "-1", "--format=%s"])).trim(),
+        "original",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: rolls back nested reftable commits made by a hook",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      if (!await initReftable(root)) return;
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await Deno.writeTextFile(`${root}/f.txt`, "original\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      const runner = realGit(root);
+      const original = runner.headSha();
+      assert(original, "repository has a HEAD commit");
+      const marker = `${root}/.git/nested-reftable-hook-ran`;
+      await installHook(
+        root,
+        "post-commit",
+        `if test ! -e ${shellQuote(marker)}; then
+  touch ${shellQuote(marker)}
+  git commit --allow-empty -q -m nested
+fi`,
+      );
+
+      assertThrows(
+        () => runner.amendCommit("amended", new Map(), original),
+        Error,
+        "HEAD changed",
+      );
+
+      assertEquals(runner.headSha(), original);
+      assertEquals(
+        (await git(root, ["rev-list", "--count", "HEAD"])).trim(),
+        "1",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: accepts an amend after a hook expires its reflog entry",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    for (const storage of ["files", "reftable"] as const) {
+      const root = await Deno.makeTempDir();
+      try {
+        if (storage === "reftable") {
+          if (!await initReftable(root)) continue;
+        } else {
+          await git(root, ["init", "-q"]);
+        }
+        await git(root, ["config", "user.email", "t@t.test"]);
+        await git(root, ["config", "user.name", "Test"]);
+        await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+        await installHook(
+          root,
+          "post-commit",
+          "git reflog expire --expire=now --all",
+        );
+        const runner = realGit(root);
+        const original = runner.headSha();
+        assert(original, "repository has a HEAD commit");
+
+        const result = runner.amendCommit("amended", new Map(), original);
+
+        assert(result.head !== original, `${storage} replaced the commit`);
+        assertEquals(runner.headSha(), result.head);
+        assertEquals(
+          (await git(root, ["log", "-1", "--format=%s"])).trim(),
+          "amended",
+        );
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: rolls back without a reflog when hook validation fails",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    for (const storage of ["files", "reftable"] as const) {
+      const root = await Deno.makeTempDir();
+      try {
+        if (storage === "reftable") {
+          if (!await initReftable(root)) continue;
+        } else {
+          await git(root, ["init", "-q"]);
+        }
+        await git(root, ["config", "user.email", "t@t.test"]);
+        await git(root, ["config", "user.name", "Test"]);
+        const path = `${root}/f.txt`;
+        await Deno.writeTextFile(path, "original\n");
+        await git(root, ["add", "f.txt"]);
+        await git(root, ["commit", "-q", "-m", "original"]);
+        await installHook(
+          root,
+          "post-commit",
+          `git reflog expire --expire=now --all\nprintf 'hook change\\n' > ${
+            shellQuote(path)
+          }`,
+        );
+        const runner = realGit(root);
+        const original = runner.headSha();
+        assert(original, "repository has a HEAD commit");
+
+        assertThrows(
+          () =>
+            runner.amendCommit(
+              "amended",
+              new Map(),
+              original,
+              undefined,
+              new Map([[path, "original\n"]]),
+            ),
+          Error,
+          "changed while commit hooks ran",
+        );
+
+        assertEquals(runner.headSha(), original);
+        assertEquals(await Deno.readTextFile(path), "hook change\n");
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: rolls back nested commits after hooks expire reflogs",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    for (const storage of ["files", "reftable"] as const) {
+      const root = await Deno.makeTempDir();
+      try {
+        if (storage === "reftable") {
+          if (!await initReftable(root)) continue;
+        } else {
+          await git(root, ["init", "-q"]);
+        }
+        await git(root, ["config", "user.email", "t@t.test"]);
+        await git(root, ["config", "user.name", "Test"]);
+        await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+        const marker = `${root}/.git/nested-expiry-hook-ran`;
+        await installHook(
+          root,
+          "post-commit",
+          `if test ! -e ${shellQuote(marker)}; then
+  touch ${shellQuote(marker)}
+  git commit --allow-empty -q -m nested
+  git reflog expire --expire=now --all
+fi`,
+        );
+        const runner = realGit(root);
+        const original = runner.headSha();
+        assert(original, "repository has a HEAD commit");
+
+        const error = assertThrows(
+          () => runner.amendCommit("amended", new Map(), original),
+          Error,
+          "HEAD changed",
+        );
+        assert(!error.message.includes("rollback failed"), error.message);
+
+        assertEquals(runner.headSha(), original, storage);
+        assertEquals(
+          (await git(root, ["rev-list", "--count", "HEAD"])).trim(),
+          "1",
+          storage,
+        );
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: journals nested commits from a reference-transaction hook",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    for (const storage of ["files", "reftable"] as const) {
+      const root = await Deno.makeTempDir();
+      try {
+        if (storage === "reftable") {
+          if (!await initReftable(root)) continue;
+        } else {
+          await git(root, ["init", "-q"]);
+        }
+        await git(root, ["config", "user.email", "t@t.test"]);
+        await git(root, ["config", "user.name", "Test"]);
+        await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+        const marker = `${root}/.git/reference-hook-ran`;
+        await installHook(
+          root,
+          "reference-transaction",
+          `if test "$1" = committed && test ! -e ${shellQuote(marker)}; then
+  touch ${shellQuote(marker)}
+  git commit --allow-empty -q -m nested
+  git reflog expire --expire=now --all
+fi`,
+        );
+        const runner = realGit(root);
+        const original = runner.headSha();
+        assert(original, "repository has a HEAD commit");
+
+        const error = assertThrows(
+          () => runner.amendCommit("amended", new Map(), original),
+          Error,
+          "HEAD changed",
+        );
+        assert(!error.message.includes("rollback failed"), error.message);
+
+        assertEquals(runner.headSha(), original, storage);
+        assertEquals(
+          (await git(root, ["rev-list", "--count", "HEAD"])).trim(),
+          "1",
+          storage,
+        );
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: restores a checked-out ref deleted by a hook",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    for (const storage of ["files", "reftable"] as const) {
+      const root = await Deno.makeTempDir();
+      try {
+        if (storage === "reftable") {
+          if (!await initReftable(root)) continue;
+        } else {
+          await git(root, ["init", "-q"]);
+        }
+        await git(root, ["config", "user.email", "t@t.test"]);
+        await git(root, ["config", "user.name", "Test"]);
+        await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+        const runner = realGit(root);
+        const original = runner.headSha();
+        const branch = runner.headRef!();
+        assert(original && branch, "repository has a branch and HEAD commit");
+        await installHook(
+          root,
+          "post-commit",
+          `git update-ref -d ${shellQuote(branch)}
+git reflog expire --expire=now --all`,
+        );
+
+        const error = assertThrows(
+          () => runner.amendCommit("amended", new Map(), original),
+          Error,
+          "HEAD changed",
+        );
+        assert(!error.message.includes("rollback failed"), error.message);
+
+        assertEquals(runner.headSha(), original, storage);
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    }
+  },
+});
+
+Deno.test("realGit: preserves pager insertion order around a workspace insertion", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    const runner = realGit(root);
+    assert(runner.applyFileChanges, "the real Git runner applies file changes");
+    assertEquals(
+      runner.applyFileChanges(
+        "A\nB\n",
+        "A\nX\nB\n",
+        "A\nP\nX\nQ\nB\n",
+        `${root}/f.txt`,
+      ),
+      "A\nP\nQ\nB\n",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: rejects an insertion at a hidden deletion boundary", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    const runner = realGit(root);
+
+    assertThrows(
+      () =>
+        runner.applyFileChanges(
+          "A\nX\nB\n",
+          "A\nB\n",
+          "A\nP\nB\n",
+          `${root}/f.txt`,
+        ),
+      Error,
+      "overlap workspace changes",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: amends selected files and preserves unrelated staged changes", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await Deno.writeTextFile(`${root}/selected.txt`, "old selected\n");
+    await Deno.writeTextFile(`${root}/unrelated.txt`, "old unrelated\n");
+    await git(root, ["add", "selected.txt", "unrelated.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+
+    await Deno.writeTextFile(`${root}/selected.txt`, "new selected\n");
+    await Deno.writeTextFile(`${root}/unrelated.txt`, "staged unrelated\n");
+    await git(root, ["add", "unrelated.txt"]);
+
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+    const status = runner.amendCommit(
+      "amended",
+      new Map([[`${root}/selected.txt`, "new selected\n"]]),
+      head,
+    );
+    assert(status.status.includes("Amended"), status.status);
+    assertEquals(
+      await git(root, ["show", "HEAD:selected.txt"]),
+      "new selected\n",
+    );
+    assertEquals(
+      await git(root, ["show", "HEAD:unrelated.txt"]),
+      "old unrelated\n",
+    );
+    assertEquals(
+      await git(root, ["show", ":unrelated.txt"]),
+      "staged unrelated\n",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: commits exact pager contents while preserving staged and unstaged edits in the same file", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    const path = `${root}/selected.txt`;
+    await Deno.writeTextFile(path, "one\ntwo\nthree\nfour\nfive\n");
+    await git(root, ["add", "selected.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+
+    // Line one is staged. Line five is only in the working tree. The pager
+    // edit to line four belongs in HEAD, the index, and the working tree.
+    await Deno.writeTextFile(path, "ONE\ntwo\nthree\nfour\nfive\n");
+    await git(root, ["add", "selected.txt"]);
+    await Deno.writeTextFile(path, "ONE\ntwo\nthree\nFOUR\nFIVE\n");
+
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+    const status = runner.amendCommit(
+      "amended",
+      new Map([[path, "one\ntwo\nthree\nFOUR\nfive\n"]]),
+      head,
+    );
+    assert(status.status.includes("Amended"), status.status);
+    assertEquals(
+      await git(root, ["show", "HEAD:selected.txt"]),
+      "one\ntwo\nthree\nFOUR\nfive\n",
+    );
+    assertEquals(
+      await git(root, ["show", ":selected.txt"]),
+      "ONE\ntwo\nthree\nFOUR\nfive\n",
+    );
+    assertEquals(
+      await Deno.readTextFile(path),
+      "ONE\ntwo\nthree\nFOUR\nFIVE\n",
+    );
+    assertEquals(
+      await git(root, ["status", "--porcelain"]),
+      "MM selected.txt\n",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: refuses a pager edit that conflicts with a staged edit", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    const path = `${root}/selected.txt`;
+    await Deno.writeTextFile(path, "one\ntwo\nthree\n");
+    await git(root, ["add", "selected.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    await Deno.writeTextFile(path, "one\nSTAGED\nthree\n");
+    await git(root, ["add", "selected.txt"]);
+
+    let error = "";
+    try {
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+      runner.amendCommit(
+        "amended",
+        new Map([[path, "one\nPAGER\nthree\n"]]),
+        head,
+      );
+    } catch (caught) {
+      error = caught instanceof Error ? caught.message : String(caught);
+    }
+    assert(error.includes("conflict"), error || "the amend did not fail");
+    assertEquals(
+      await git(root, ["show", "HEAD:selected.txt"]),
+      "one\ntwo\nthree\n",
+    );
+    assertEquals(
+      await git(root, ["show", ":selected.txt"]),
+      "one\nSTAGED\nthree\n",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: refuses to merge content into a staged file type change", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    const path = `${root}/selected.txt`;
+    await Deno.writeTextFile(path, "target");
+    await git(root, ["add", "selected.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    const linkObject =
+      (await git(root, ["hash-object", "-w", "--stdin"], "target"))
+        .trim();
+    await git(root, [
+      "update-index",
+      "--cacheinfo",
+      `120000,${linkObject},selected.txt`,
+    ]);
+    const stagedBefore = await git(root, [
+      "ls-files",
+      "--stage",
+      "selected.txt",
+    ]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    assertThrows(
+      () =>
+        runner.amendCommit(
+          "amended",
+          new Map([[path, "TARGET"]]),
+          head,
+        ),
+      Error,
+      "staged file type change",
+    );
+
+    assertEquals(runner.headSha(), head);
+    assertEquals(await git(root, ["show", "HEAD:selected.txt"]), "target");
+    assertEquals(
+      await git(root, ["ls-files", "--stage", "selected.txt"]),
+      stagedBefore,
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: merges content through a staged executable mode change", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    const path = `${root}/selected.txt`;
+    await Deno.writeTextFile(path, "original\n");
+    await git(root, ["add", "selected.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    await git(root, ["update-index", "--chmod=+x", "selected.txt"]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    runner.amendCommit(
+      "amended",
+      new Map([[path, "pager\n"]]),
+      head,
+    );
+
+    assertEquals(await git(root, ["show", "HEAD:selected.txt"]), "pager\n");
+    assert(
+      (await git(root, ["ls-files", "--stage", "selected.txt"])).startsWith(
+        "100755 ",
+      ),
+    );
+    assertEquals(await git(root, ["show", ":selected.txt"]), "pager\n");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test({
+  name: "realGit: amends a POSIX path containing a literal backslash",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      const path = `${root}/back\\slash.txt`;
+      await Deno.writeTextFile(path, "old\n");
+      await git(root, ["add", "--", "back\\slash.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+
+      runner.amendCommit("amended", new Map([[path, "pager\n"]]), head);
+      assertEquals(
+        await git(root, ["show", "HEAD:back\\slash.txt"]),
+        "pager\n",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: keeps an in-repository symlink's lexical Git path",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      const link = `${root}/link.txt`;
+      const target = `${root}/target.txt`;
+      Deno.writeTextFileSync(link, "link head\n");
+      Deno.writeTextFileSync(target, "target head\n");
+      await git(root, ["add", "link.txt", "target.txt"]);
+      await git(root, ["commit", "-q", "-m", "head"]);
+      const head = (await git(root, ["rev-parse", "HEAD"])).trim();
+      Deno.removeSync(link);
+      Deno.symlinkSync("target.txt", link);
+
+      realGit(root).amendCommit(
+        "head",
+        new Map([[link, "pager\n"]]),
+        head,
+      );
+
+      assertEquals(await git(root, ["show", "HEAD:link.txt"]), "pager\n");
+      assertEquals(
+        await git(root, ["show", "HEAD:target.txt"]),
+        "target head\n",
+      );
+    } finally {
+      Deno.removeSync(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: keeps a symlinked directory's lexical Git path",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await Deno.mkdir(`${root}/subalias`);
+      await Deno.writeTextFile(`${root}/f.txt`, "root head\n");
+      await Deno.writeTextFile(`${root}/subalias/f.txt`, "alias head\n");
+      await git(root, ["add", "f.txt", "subalias/f.txt"]);
+      await git(root, ["commit", "-q", "-m", "head"]);
+      const head = (await git(root, ["rev-parse", "HEAD"])).trim();
+      await Deno.remove(`${root}/subalias`, { recursive: true });
+      await Deno.symlink(".", `${root}/subalias`);
+
+      realGit(root).amendCommit(
+        "head",
+        new Map([[`${root}/subalias/f.txt`, "pager\n"]]),
+        head,
+      );
+
+      assertEquals(await git(root, ["show", "HEAD:subalias/f.txt"]), "pager\n");
+      assertEquals(await git(root, ["show", "HEAD:f.txt"]), "root head\n");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test("realGit: reads and writes selected files through clean filters", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await git(root, ["config", "filter.caps.clean", "tr a-z A-Z"]);
+    await git(root, ["config", "filter.caps.smudge", "tr A-Z a-z"]);
+    await Deno.writeTextFile(`${root}/.gitattributes`, "*.dat filter=caps\n");
+    const path = `${root}/f.dat`;
+    await Deno.writeTextFile(path, "original\n");
+    await git(root, ["add", ".gitattributes", "f.dat"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    assertEquals(runner.fileAtCommit(head, path), "original\n");
+    runner.amendCommit("amended", new Map([[path, "pager\n"]]), head);
+
+    assertEquals(await git(root, ["show", "HEAD:f.dat"]), "PAGER\n");
+    assertEquals(await git(root, ["show", ":f.dat"]), "PAGER\n");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: handles an index path beginning with a stage prefix", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    const path = `${root}/1:f.txt`;
+    await Deno.writeTextFile(path, "original\n");
+    await git(root, ["add", "--", "1:f.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    runner.amendCommit("amended", new Map([[path, "pager\n"]]), head);
+    assertEquals(await git(root, ["show", "HEAD:1:f.txt"]), "pager\n");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: preserves assume-unchanged and skip-worktree index flags", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await Deno.writeTextFile(`${root}/assume.txt`, "old assume\n");
+    await Deno.writeTextFile(`${root}/skip.txt`, "old skip\n");
+    await git(root, ["add", "assume.txt", "skip.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    await git(root, ["update-index", "--assume-unchanged", "assume.txt"]);
+    await git(root, ["update-index", "--skip-worktree", "skip.txt"]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    runner.amendCommit(
+      "amended",
+      new Map([
+        [`${root}/assume.txt`, "pager assume\n"],
+        [`${root}/skip.txt`, "pager skip\n"],
+      ]),
+      head,
+    );
+    assert(
+      (await git(root, ["ls-files", "-v", "assume.txt"])).startsWith("h "),
+    );
+    assert((await git(root, ["ls-files", "-t", "skip.txt"])).startsWith("S "));
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test({
+  name: "realGit: rejects a commit tree changed by a hook",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      const path = `${root}/f.txt`;
+      await Deno.writeTextFile(path, "original\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      await installHook(
+        root,
+        "pre-commit",
+        `printf 'hook\\n' > "$GIT_WORK_TREE/f.txt"\ngit add -- f.txt`,
+      );
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+
+      let error = "";
+      try {
+        runner.amendCommit("amended", new Map([[path, "pager\n"]]), head);
+      } catch (caught) {
+        error = caught instanceof Error ? caught.message : String(caught);
+      }
+      assert(error.includes("hook changed"), error || "the amend did not fail");
+      assertEquals(runner.headSha(), head);
+      assertEquals(await git(root, ["show", "HEAD:f.txt"]), "original\n");
+      assertEquals(await git(root, ["show", ":f.txt"]), "original\n");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: rejects a selected working file changed by a hook",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      const path = `${root}/f.txt`;
+      await Deno.writeTextFile(path, "original\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      await installHook(root, "pre-commit", "printf 'hook\\n' > f.txt");
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+
+      assertThrows(
+        () =>
+          runner.amendCommit(
+            "amended",
+            new Map([[path, "pager\n"]]),
+            head,
+            undefined,
+            new Map([[path, "pager\n"]]),
+          ),
+        Error,
+        "changed while commit hooks ran",
+      );
+
+      assertEquals(runner.headSha(), head);
+      assertEquals(await git(root, ["show", "HEAD:f.txt"]), "original\n");
+      assertEquals(await git(root, ["show", ":f.txt"]), "original\n");
+      assertEquals(await Deno.readTextFile(path), "hook\n");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: a concurrent branch update wins the compare-and-swap",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      const path = `${root}/f.txt`;
+      await Deno.writeTextFile(path, "original\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+      const tree = (await git(root, ["rev-parse", `${head}^{tree}`])).trim();
+      const concurrent = (await git(
+        root,
+        ["commit-tree", tree, "-p", head],
+        "concurrent\n",
+      )).trim();
+      assert(concurrent, "created the concurrent commit");
+      const branch = (await git(root, ["symbolic-ref", "HEAD"])).trim();
+      await installHook(
+        root,
+        "pre-commit",
+        `git --git-dir=${shellQuote(`${root}/.git`)} update-ref ${
+          shellQuote(branch)
+        } ${shellQuote(concurrent)} ${shellQuote(head)}`,
+      );
+
+      let error = "";
+      try {
+        runner.amendCommit("amended", new Map([[path, "pager\n"]]), head);
+      } catch (caught) {
+        error = caught instanceof Error ? caught.message : String(caught);
+      }
+      assert(error.length > 0, "the raced amend failed");
+      assertEquals(runner.headSha(), concurrent);
+      assertEquals(await git(root, ["show", "HEAD:f.txt"]), "original\n");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: refuses to overwrite a selected path staged during hooks",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      const path = `${root}/f.txt`;
+      await Deno.writeTextFile(path, "original\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+      await installHook(
+        root,
+        "pre-commit",
+        `printf 'concurrent staged\\n' > f.txt\nGIT_INDEX_FILE=${
+          shellQuote(`${root}/.git/index`)
+        } git add -- f.txt`,
+      );
+
+      let error = "";
+      try {
+        runner.amendCommit("amended", new Map([[path, "pager\n"]]), head);
+      } catch (caught) {
+        error = caught instanceof Error ? caught.message : String(caught);
+      }
+      assert(
+        error.includes("index changed"),
+        error || "the amend did not fail",
+      );
+      assertEquals(runner.headSha(), head);
+      assertEquals(await git(root, ["show", ":f.txt"]), "concurrent staged\n");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: branch-aware hooks see the branch being amended",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await Deno.writeTextFile(`${root}/f.txt`, "original\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      const runner = realGit(root);
+      const branch = runner.headRef!();
+      const head = runner.headSha();
+      assert(branch && head, "repository has a branch and HEAD commit");
+      await installHook(
+        root,
+        "pre-commit",
+        `test "$(git branch --show-current)" = ${shellQuote(branch.slice(11))}`,
+      );
+
+      runner.amendCommit("amended", new Map(), head, branch);
+      assert(runner.headSha() !== head, "the branch-aware hook allowed amend");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test("realGit: refuses a different branch at the same commit", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await Deno.writeTextFile(`${root}/f.txt`, "original\n");
+    await git(root, ["add", "f.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    const runner = realGit(root);
+    const branch = runner.headRef!();
+    const head = runner.headSha();
+    assert(branch && head, "repository has a branch and HEAD commit");
+    await git(root, ["checkout", "-q", "-b", "topic"]);
+
+    assertThrows(
+      () => runner.amendCommit("amended", new Map(), head, branch),
+      Error,
+      "different branch",
+    );
+    assertEquals(await git(root, ["rev-parse", branch]), `${head}\n`);
+    assertEquals(
+      await git(root, ["rev-parse", "refs/heads/topic"]),
+      `${head}\n`,
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test({
+  name: "realGit: a branch switch during hooks leaves both branches unamended",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await Deno.writeTextFile(`${root}/f.txt`, "original\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      await git(root, ["branch", "topic"]);
+      const runner = realGit(root);
+      const branch = runner.headRef!();
+      const head = runner.headSha();
+      assert(branch && head, "repository has a branch and HEAD commit");
+      await installHook(root, "pre-commit", "git checkout -q topic");
+
+      let error = "";
+      try {
+        runner.amendCommit("amended", new Map(), head, branch);
+      } catch (caught) {
+        error = caught instanceof Error ? caught.message : String(caught);
+      }
+      assert(error.length > 0, "the branch-switching amend failed");
+      assertEquals(runner.headRef!(), "refs/heads/topic");
+      assertEquals(await git(root, ["rev-parse", branch]), `${head}\n`);
+      assertEquals(
+        await git(root, ["rev-parse", "refs/heads/topic"]),
+        `${head}\n`,
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: rolls back a nested commit made by a post-commit hook",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await Deno.writeTextFile(`${root}/f.txt`, "original\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+      const marker = `${root}/.git/nested-hook-ran`;
+      await installHook(
+        root,
+        "post-commit",
+        `if test ! -e ${shellQuote(marker)}; then
+  touch ${shellQuote(marker)}
+  git commit --allow-empty -q -m nested
+fi`,
+      );
+
+      let error = "";
+      try {
+        runner.amendCommit("amended", new Map(), head);
+      } catch (caught) {
+        error = caught instanceof Error ? caught.message : String(caught);
+      }
+      assert(error.includes("HEAD changed"), error || "the amend did not fail");
+      assertEquals(runner.headSha(), head);
+      assertEquals(
+        (await git(root, ["rev-list", "--count", "HEAD"])).trim(),
+        "1",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "realGit: rollback preserves a concurrent update to the original branch",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await Deno.writeTextFile(`${root}/f.txt`, "original\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      await git(root, ["branch", "topic"]);
+      const runner = realGit(root);
+      const branch = runner.headRef!();
+      const head = runner.headSha();
+      assert(branch && head, "repository has a branch and HEAD commit");
+      const tree = (await git(root, ["rev-parse", `${head}^{tree}`])).trim();
+      const concurrent = (await git(
+        root,
+        ["commit-tree", tree, "-p", head],
+        "concurrent\n",
+      )).trim();
+      await installHook(
+        root,
+        "pre-commit",
+        `git --git-dir=${shellQuote(`${root}/.git`)} update-ref ${
+          shellQuote(branch)
+        } ${shellQuote(concurrent)} ${shellQuote(head)}\ngit checkout -q topic`,
+      );
+
+      let error = "";
+      try {
+        runner.amendCommit("amended", new Map(), head, branch);
+      } catch (caught) {
+        error = caught instanceof Error ? caught.message : String(caught);
+      }
+      assert(error.length > 0, "the raced amend failed");
+      assertEquals(await git(root, ["rev-parse", branch]), `${concurrent}\n`);
+      assertEquals(
+        await git(root, ["rev-parse", "refs/heads/topic"]),
+        `${head}\n`,
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: reflog ownership distinguishes a hook's replacement commit",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await Deno.writeTextFile(`${root}/f.txt`, "base\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "base"]);
+      await Deno.writeTextFile(`${root}/f.txt`, "original\n");
+      await git(root, ["commit", "-qam", "original"]);
+      await git(root, ["branch", "topic"]);
+
+      const runner = realGit(root);
+      const branch = runner.headRef!();
+      const head = runner.headSha();
+      assert(branch && head, "repository has a branch and HEAD commit");
+      const parent = (await git(root, ["rev-parse", `${head}^`])).trim();
+      const tree = (await git(root, ["rev-parse", `${head}^{tree}`])).trim();
+      const authorName = (await git(root, [
+        "show",
+        "-s",
+        "--format=%an",
+        head,
+      ])).trim();
+      const authorEmail = (await git(root, [
+        "show",
+        "-s",
+        "--format=%ae",
+        head,
+      ])).trim();
+      const authorDate = (await git(root, [
+        "show",
+        "-s",
+        "--format=%aI",
+        head,
+      ])).trim();
+      const replacement = (await git(
+        root,
+        ["commit-tree", tree, "-p", parent],
+        "amended\n",
+        {
+          GIT_AUTHOR_NAME: authorName,
+          GIT_AUTHOR_EMAIL: authorEmail,
+          GIT_AUTHOR_DATE: authorDate,
+          GIT_COMMITTER_DATE: "2001-01-01T00:00:00+00:00",
+        },
+      )).trim();
+      assert(replacement !== head, "the hook replacement is a new commit");
+      await installHook(
+        root,
+        "post-commit",
+        `git update-ref refs/heads/topic ${shellQuote(replacement)} ${
+          shellQuote(head)
+        }\ngit checkout -q topic`,
+      );
+
+      let error = "";
+      try {
+        runner.amendCommit("amended", new Map(), head, branch);
+      } catch (caught) {
+        error = caught instanceof Error ? caught.message : String(caught);
+      }
+      assert(error.length > 0, "the branch-switching amend failed");
+      assertEquals(await git(root, ["rev-parse", branch]), `${head}\n`);
+      assertEquals(
+        await git(root, ["rev-parse", "refs/heads/topic"]),
+        `${replacement}\n`,
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: rejects a commit message rewritten by a hook",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await Deno.writeTextFile(`${root}/f.txt`, "original\n");
+      await git(root, ["add", "f.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+      await installHook(
+        root,
+        "commit-msg",
+        `printf '\\nHook-Trailer: added\\n' >> "$1"`,
+      );
+
+      let error = "";
+      try {
+        runner.amendCommit("amended", new Map(), head);
+      } catch (caught) {
+        error = caught instanceof Error ? caught.message : String(caught);
+      }
+      assert(error.includes("hook changed"), error || "the amend did not fail");
+      assertEquals(runner.headSha(), head);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test("realGit: Git refuses amend while resolving a conflicted merge", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await Deno.writeTextFile(`${root}/f.txt`, "base\n");
+    await git(root, ["add", "f.txt"]);
+    await git(root, ["commit", "-q", "-m", "base"]);
+    await git(root, ["checkout", "-q", "-b", "side"]);
+    await Deno.writeTextFile(`${root}/f.txt`, "side\n");
+    await git(root, ["commit", "-qam", "side"]);
+    await git(root, ["checkout", "-q", "-"]);
+    await Deno.writeTextFile(`${root}/f.txt`, "main\n");
+    await git(root, ["commit", "-qam", "main"]);
+    await git(root, ["merge", "side"]);
+    await Deno.stat(`${root}/.git/MERGE_HEAD`);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    assertThrows(
+      () => runner.amendCommit("amended", new Map(), head),
+      Error,
+      "middle of a merge",
+    );
+    assertEquals(runner.headSha(), head);
   } finally {
     await Deno.remove(root, { recursive: true });
   }
@@ -171,12 +2147,12 @@ Deno.test("realGit: headSha is null outside a repository", () => {
   }
 });
 
-Deno.test("realGit: amendMessage throws when git fails (not a repository)", () => {
+Deno.test("realGit: amendCommit throws when git fails (not a repository)", () => {
   const root = Deno.makeTempDirSync();
   try {
     let threw = false;
     try {
-      realGit(root).amendMessage("x");
+      realGit(root).amendCommit("x", new Map(), "0000000");
     } catch {
       threw = true;
     }
@@ -190,4 +2166,896 @@ Deno.test("realGit: headSha is null when git cannot run (bad cwd)", () => {
   // A cwd that does not exist makes the git subprocess fail to launch; the
   // runner catches it and reports no HEAD rather than throwing.
   assertEquals(realGit("/no/such/directory/really").headSha(), null);
+});
+
+Deno.test("realGit: validates selected paths before reading commit contents", async () => {
+  const root = await Deno.makeTempDir();
+  const outside = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await Deno.writeTextFile(`${root}/tracked.txt`, "tracked\n");
+    await git(root, ["add", "tracked.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    await Deno.writeTextFile(`${outside}/outside.txt`, "outside\n");
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    assertThrows(
+      () => runner.fileAtCommit(head, "tracked.txt"),
+      Error,
+      "not absolute",
+    );
+    assertThrows(
+      () => runner.fileAtCommit(head, `${outside}/outside.txt`),
+      Error,
+      "outside the repository",
+    );
+    assertEquals(runner.fileAtCommit(head, `${root}/missing.txt`), null);
+
+    if (Deno.build.os !== "windows") {
+      await Deno.symlink(outside, `${root}/escape`);
+      assertThrows(
+        () => runner.fileAtCommit(head, `${root}/escape/outside.txt`),
+        Error,
+        "outside the repository",
+      );
+    }
+  } finally {
+    await Deno.remove(root, { recursive: true });
+    await Deno.remove(outside, { recursive: true });
+  }
+});
+
+Deno.test("realGit: reports unavailable optional Git queries", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const runner = realGit(root);
+
+    assertEquals(runner.headRef!(), null);
+    assertEquals(runner.resolveCommit!("not-an-object"), null);
+    assertEquals(runner.resolveCommit!("abcd"), null);
+    assertEquals(
+      runner.commitMatchesDiff!("abcd", "old", "new", "bad", "cafe"),
+      false,
+    );
+    assertEquals(
+      runner.commitMatchesDiff!("abcd", "old", "new", "beef", "cafe"),
+      false,
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: rejects a stale expected HEAD", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    assertThrows(
+      () => runner.amendCommit("amended", new Map(), "0".repeat(head.length)),
+      Error,
+      "HEAD moved before",
+    );
+    assertEquals(runner.headSha(), head);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: preserves a selected path staged for deletion", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    const path = `${root}/selected.txt`;
+    await Deno.writeTextFile(path, "original\n");
+    await git(root, ["add", "selected.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    await git(root, ["rm", "-q", "--cached", "selected.txt"]);
+    await Deno.writeTextFile(path, "workspace\n");
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    runner.amendCommit(
+      "amended",
+      new Map([[path, "committed by pager\n"]]),
+      head,
+    );
+
+    assertEquals(
+      await git(root, ["show", "HEAD:selected.txt"]),
+      "committed by pager\n",
+    );
+    assertEquals(
+      await git(root, ["ls-files", "--stage", "--", "selected.txt"]),
+      "",
+    );
+    assertEquals(await Deno.readTextFile(path), "workspace\n");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: rejects both multi-stage and lone unmerged index entries", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    const path = `${root}/selected.txt`;
+    await Deno.writeTextFile(path, "original\n");
+    await git(root, ["add", "selected.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    const object = (await git(root, ["rev-parse", "HEAD:selected.txt"])).trim();
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head && object, "repository has a committed file");
+
+    await git(root, ["update-index", "--force-remove", "selected.txt"]);
+    await git(
+      root,
+      ["update-index", "--index-info"],
+      `100644 ${object} 1\tselected.txt\n100644 ${object} 2\tselected.txt\n`,
+    );
+    assertThrows(
+      () =>
+        runner.amendCommit(
+          "amended",
+          new Map([[path, "pager\n"]]),
+          head,
+        ),
+      Error,
+      "unmerged entries",
+    );
+
+    await git(root, ["update-index", "--force-remove", "selected.txt"]);
+    await git(
+      root,
+      ["update-index", "--index-info"],
+      `100644 ${object} 1\tselected.txt\n`,
+    );
+    assertThrows(
+      () =>
+        runner.amendCommit(
+          "amended",
+          new Map([[path, "pager\n"]]),
+          head,
+        ),
+      Error,
+      "unmerged entry",
+    );
+    assertEquals(runner.headSha(), head);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: rejects a selected path that HEAD does not contain", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+    const path = `${root}/new.txt`;
+    await Deno.writeTextFile(path, "workspace\n");
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    assertThrows(
+      () =>
+        runner.amendCommit(
+          "amended",
+          new Map([[path, "pager\n"]]),
+          head,
+        ),
+      Error,
+      "does not contain new.txt",
+    );
+    assertEquals(runner.headSha(), head);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: a no-op pager change keeps the committed contents", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    const runner = realGit(root);
+
+    assertEquals(
+      runner.applyFileChanges(
+        "committed\n",
+        "workspace\n",
+        "workspace\n",
+        `${root}/f.txt`,
+      ),
+      "committed\n",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: fallback merge handles insertions around added and empty content", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    const runner = realGit(root);
+    const path = `${root}/selected.txt`;
+
+    assertEquals(
+      runner.applyFileChanges(
+        "A\nB\nC\n",
+        "A\nX\nB\nC\n",
+        "P\nA\nQ\nX\nR\nB\nC\n",
+        path,
+      ),
+      "P\nA\nQ\nR\nB\nC\n",
+    );
+    assertEquals(
+      runner.applyFileChanges("", "X\n", "P\nX\nQ\n", path),
+      "P\nQ",
+    );
+    assertEquals(
+      runner.applyFileChanges("\n", "\nX\n", "P\n\nX\nQ\n", path),
+      "P\n\nQ\n",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: fallback merge rejects a deletion inside a pager replacement", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+
+    assertThrows(
+      () =>
+        realGit(root).applyFileChanges(
+          "A\nB\nC\nD\n",
+          "A\nD\n",
+          "P\n",
+          `${root}/selected.txt`,
+        ),
+      Error,
+      "overlap workspace changes",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("realGit: preserves a staged version that already matches the pager", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await git(root, ["init", "-q"]);
+    await git(root, ["config", "user.email", "t@t.test"]);
+    await git(root, ["config", "user.name", "Test"]);
+    const path = `${root}/selected.txt`;
+    await Deno.writeTextFile(path, "original\n");
+    await git(root, ["add", "selected.txt"]);
+    await git(root, ["commit", "-q", "-m", "original"]);
+    await Deno.writeTextFile(path, "pager\n");
+    await git(root, ["add", "selected.txt"]);
+    const runner = realGit(root);
+    const head = runner.headSha();
+    assert(head, "repository has a HEAD commit");
+
+    runner.amendCommit(
+      "amended",
+      new Map([[path, "pager\n"]]),
+      head,
+    );
+
+    assertEquals(await git(root, ["show", "HEAD:selected.txt"]), "pager\n");
+    assertEquals(await git(root, ["show", ":selected.txt"]), "pager\n");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test({
+  name: "realGit: recovers amend ownership from file and reftable reflogs",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    for (const storage of ["files", "reftable"] as const) {
+      const root = await Deno.makeTempDir();
+      try {
+        if (storage === "reftable") {
+          if (!await initReftable(root)) continue;
+        } else {
+          await git(root, ["init", "-q"]);
+        }
+        await git(root, ["config", "user.email", "t@t.test"]);
+        await git(root, ["config", "user.name", "Test"]);
+        await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+        const marker = `${root}/fallback-hook-ran`;
+        await installHook(
+          root,
+          "reference-transaction",
+          `if test "\${1-}" = committed; then
+  journal="$(dirname "$GIT_INDEX_FILE")/reference-transactions"
+  rm -f "$journal" || exit 1
+  test ! -e "$journal" || exit 1
+  printf ran > ${shellQuote(marker)}
+fi`,
+        );
+        const runner = realGit(root);
+        const head = runner.headSha();
+        assert(head, `${storage} repository has a HEAD commit`);
+
+        const result = runner.amendCommit("amended", new Map(), head);
+
+        assert(result.head !== head, `${storage} HEAD was amended`);
+        assertEquals(await Deno.readTextFile(marker), "ran");
+        assertEquals(
+          (await git(root, ["log", "-1", "--format=%s"])).trim(),
+          "amended",
+        );
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: ignores a journal transition to a missing commit",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      await installHook(
+        root,
+        "reference-transaction",
+        `if test "\${1-}" = committed; then
+  read old object ref
+  if test "$old" != 0000000000000000000000000000000000000000 && test "$object" != 0000000000000000000000000000000000000000; then
+    printf '%s %s %s\n' "$old" ffffffffffffffffffffffffffffffffffffffff "$ref" > "$(dirname "$GIT_INDEX_FILE")/reference-transactions"
+  fi
+fi`,
+      );
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+
+      const result = runner.amendCommit("amended", new Map(), head);
+
+      assert(result.head !== head, "the commit summary recovered ownership");
+      assertEquals(runner.headSha(), result.head);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: rejects two journal claims for the amended commit",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      await installHook(
+        root,
+        "reference-transaction",
+        `if test "\${1-}" = committed; then
+  read old object ref
+  if test "$old" != 0000000000000000000000000000000000000000 && test "$object" != 0000000000000000000000000000000000000000; then
+    printf '%s %s %s\n%s %s %s\n' "$old" "$object" refs/heads/claim-a "$old" "$object" refs/heads/claim-b > "$(dirname "$GIT_INDEX_FILE")/reference-transactions"
+  fi
+fi`,
+      );
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+
+      assertThrows(
+        () => runner.amendCommit("amended", new Map(), head),
+        Error,
+        "more than one possible amended commit",
+      );
+      assert(
+        runner.headSha() !== head,
+        "ambiguous ownership leaves the new ref untouched",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "realGit: reports when a hook restores the old ref before ownership is established",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      const runner = realGit(root);
+      const branch = runner.headRef!();
+      const head = runner.headSha();
+      assert(branch && head, "repository has a branch and HEAD commit");
+      await installHook(
+        root,
+        "reference-transaction",
+        `if test "\${1-}" = committed; then
+  rm -f "$(dirname "$GIT_INDEX_FILE")/reference-transactions"
+fi`,
+      );
+      await installHook(
+        root,
+        "post-commit",
+        `git update-ref ${shellQuote(branch)} ${shellQuote(head)}`,
+      );
+
+      assertThrows(
+        () => runner.amendCommit("amended", new Map(), head),
+        Error,
+        "did not publish the amended commit",
+      );
+      assertEquals(runner.headSha(), head);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "realGit: follows a marked journal chain when rolling back nested commits",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      const runner = realGit(root);
+      const branch = runner.headRef!();
+      const head = runner.headSha();
+      assert(branch && head, "repository has a branch and HEAD commit");
+      const marker = `${root}/nested-hook-ran`;
+      await installHook(
+        root,
+        "post-commit",
+        `if test ! -e ${shellQuote(marker)}; then
+  : > ${shellQuote(marker)}
+  amended=$(git rev-parse HEAD)
+  git commit --allow-empty -q -m nested
+  printf '%s %s %s\n' ${shellQuote(head)} "$amended" ${
+          shellQuote(branch)
+        } > "$(dirname "$GIT_INDEX_FILE")/reference-transactions"
+fi`,
+      );
+
+      const error = assertThrows(
+        () => runner.amendCommit("amended", new Map(), head),
+        Error,
+        "HEAD changed during the amend",
+      );
+      assert(!error.message.includes("rollback failed"), error.message);
+      assertEquals(runner.headSha(), head);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "realGit: uses the commit summary when hook journals and reflogs are gone",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      const journalMarker = `${root}/journal-removed`;
+      const reflogMarker = `${root}/reflogs-removed`;
+      await installHook(
+        root,
+        "reference-transaction",
+        `if test "\${1-}" = committed; then
+  journal="$(dirname "$GIT_INDEX_FILE")/reference-transactions"
+  rm -f "$journal" || exit 1
+  test ! -e "$journal" || exit 1
+  printf ran > ${shellQuote(journalMarker)}
+fi`,
+      );
+      await installHook(
+        root,
+        "post-commit",
+        `git reflog expire --expire=now --all || exit 1
+test -z "$(git reflog show --all)" || exit 1
+printf ran > ${shellQuote(reflogMarker)}`,
+      );
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+
+      const result = runner.amendCommit("amended", new Map(), head);
+
+      assert(result.head !== head, "the summary identified the amended commit");
+      assertEquals(await Deno.readTextFile(journalMarker), "ran");
+      assertEquals(await Deno.readTextFile(reflogMarker), "ran");
+      assertEquals((await git(root, ["reflog", "show", "--all"])).trim(), "");
+      assertEquals(runner.headSha(), result.head);
+      assertEquals(
+        (await git(root, ["log", "-1", "--format=%s"])).trim(),
+        "amended",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "realGit: rolls back when a selected workspace file disappears in a hook",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      const path = `${root}/selected.txt`;
+      await Deno.writeTextFile(path, "original\n");
+      await git(root, ["add", "selected.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      await Deno.writeTextFile(path, "pager\n");
+      await installHook(root, "post-commit", `rm -f ${shellQuote(path)}`);
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+
+      assertThrows(
+        () =>
+          runner.amendCommit(
+            "amended",
+            new Map([[path, "pager\n"]]),
+            head,
+            undefined,
+            new Map([[path, "pager\n"]]),
+          ),
+        Error,
+        "could not be read after commit hooks ran",
+      );
+      assertEquals(runner.headSha(), head);
+      assertEquals(
+        await git(root, ["show", "HEAD:selected.txt"]),
+        "original\n",
+      );
+      assertEquals(await git(root, ["show", ":selected.txt"]), "original\n");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "realGit: reports a reference lock created after Git publishes the amend",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
+      const runner = realGit(root);
+      const branch = runner.headRef!();
+      const head = runner.headSha();
+      assert(branch && head, "repository has a branch and HEAD commit");
+      const refPath = (await git(root, [
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-path",
+        branch,
+      ])).trim();
+      const lock = `${refPath}.lock`;
+      await installHook(root, "post-commit", `: > ${shellQuote(lock)}`);
+
+      const error = assertThrows(
+        () => runner.amendCommit("amended", new Map(), head),
+        Error,
+        "reference is locked",
+      );
+      assert(error.message.includes("rollback failed"), error.message);
+      assert(runner.headSha() !== head, "the lock also prevented rollback");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: rolls back when the real index is locked after hooks",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      const path = `${root}/selected.txt`;
+      await Deno.writeTextFile(path, "original\n");
+      await git(root, ["add", "selected.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      const lock = `${root}/.git/index.lock`;
+      await installHook(root, "post-commit", `: > ${shellQuote(lock)}`);
+      const runner = realGit(root);
+      const head = runner.headSha();
+      assert(head, "repository has a HEAD commit");
+
+      assertThrows(
+        () =>
+          runner.amendCommit(
+            "amended",
+            new Map([[path, "pager\n"]]),
+            head,
+          ),
+        Error,
+        "index is locked",
+      );
+      assertEquals(runner.headSha(), head);
+      assertEquals(
+        await git(root, ["show", "HEAD:selected.txt"]),
+        "original\n",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: surfaces malformed repository and tree responses from Git",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      const path = `${root}/tracked.txt`;
+      await Deno.writeTextFile(path, "tracked\n");
+      await git(root, ["add", "tracked.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      const head = (await git(root, ["rev-parse", "HEAD"])).trim();
+
+      await withGitShim(
+        `if test "$1" = rev-parse && test "$2" = --show-toplevel; then
+  exit 0
+fi`,
+        () =>
+          assertThrows(
+            () => realGit(root).fileAtCommit(head, path),
+            Error,
+            "repository root is unavailable",
+          ),
+      );
+      await withGitShim(
+        `if test "$1" = rev-parse && test "$2" = --show-toplevel; then
+  printf '%s\\n' /definitely/missing/cf-view-root
+  exit 0
+fi`,
+        () =>
+          assertThrows(
+            () => realGit(root).fileAtCommit(head, path),
+            Error,
+            "outside the repository",
+          ),
+      );
+      assertThrows(
+        () => realGit(root).fileAtCommit(head, `${root}/missing/child.txt`),
+        Error,
+      );
+      await withGitShim(
+        `if test "$1" = --literal-pathspecs && test "$2" = ls-tree; then
+  printf '100644 blob aaaa\\ttracked.txt\\000100644 blob bbbb\\ttracked.txt\\000'
+  exit 0
+fi`,
+        () =>
+          assertThrows(
+            () => realGit(root).fileAtCommit(head, path),
+            Error,
+            "more than one entry",
+          ),
+      );
+      await withGitShim(
+        `if test "$1" = --literal-pathspecs && test "$2" = ls-tree; then
+  printf 'malformed\\000'
+  exit 0
+fi`,
+        () =>
+          assertThrows(
+            () => realGit(root).fileAtCommit(head, path),
+            Error,
+            "tree entry is invalid",
+          ),
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "realGit: reports failures and malformed output from merge helpers",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      const path = `${root}/selected.txt`;
+      await withGitShim(
+        `if test "$1" = merge-file; then
+  printf '%s\\n' 'forced merge failure' >&2
+  exit 128
+fi`,
+        () =>
+          assertThrows(
+            () => realGit(root).applyFileChanges("A\n", "B\n", "C\n", path),
+            Error,
+            "forced merge failure",
+          ),
+      );
+      await withGitShim(
+        `if test "$1" = diff; then
+  printf '%s\\n' 'forced diff failure' >&2
+  exit 2
+fi`,
+        () =>
+          assertThrows(
+            () =>
+              realGit(root).applyFileChanges(
+                "A\nB\nC\nD\n",
+                "A\nD\n",
+                "P\n",
+                path,
+              ),
+            Error,
+            "forced diff failure",
+          ),
+      );
+      await withGitShim(
+        `if test "$1" = diff; then
+  printf '@@ -1,2 +1,2 @@\\n-old\\n+new\\n'
+  exit 1
+fi`,
+        () =>
+          assertThrows(
+            () =>
+              realGit(root).applyFileChanges(
+                "A\nB\nC\nD\n",
+                "A\nD\n",
+                "P\n",
+                path,
+              ),
+            Error,
+            "Could not parse pager edits",
+          ),
+      );
+      const calls = `${root}/diff-calls`;
+      await withGitShim(
+        `if test "$1" = diff; then
+  if test ! -e ${shellQuote(calls)}; then
+    : > ${shellQuote(calls)}
+    exit 0
+  fi
+  printf '@@ -1 +1 @@\\n-A\\n+P\\n'
+  exit 1
+fi`,
+        () =>
+          assertThrows(
+            () => realGit(root).applyFileChanges("X\n", "A\n", "P\n", path),
+            Error,
+            "overlap committed changes",
+          ),
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "realGit: reports injected ref-storage, hook setup, and staged merge failures",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const root = await Deno.makeTempDir();
+    try {
+      await git(root, ["init", "-q"]);
+      await git(root, ["config", "user.email", "t@t.test"]);
+      await git(root, ["config", "user.name", "Test"]);
+      const path = `${root}/selected.txt`;
+      await Deno.writeTextFile(path, "original\n");
+      await git(root, ["add", "selected.txt"]);
+      await git(root, ["commit", "-q", "-m", "original"]);
+      const head = (await git(root, ["rev-parse", "HEAD"])).trim();
+
+      await withGitShim(
+        `if test "$1" = config && test "$2" = --get && test "$3" = extensions.refStorage; then
+  printf '%s\\n' future-format
+  exit 0
+fi`,
+        () =>
+          assertThrows(
+            () => realGit(root).amendCommit("amended", new Map(), head),
+            Error,
+            "cannot be amended safely",
+          ),
+      );
+      await withGitShim(
+        `if test "$1" = rev-parse && test "$2" = --path-format=absolute && test "$3" = --absolute-git-dir; then
+  printf '%s\\n' 'forced hook setup failure' >&2
+  exit 1
+fi`,
+        () =>
+          assertThrows(
+            () => realGit(root).amendCommit("amended", new Map(), head),
+            Error,
+            "Could not prepare Git hooks",
+          ),
+      );
+
+      await Deno.writeTextFile(path, "staged\n");
+      await git(root, ["add", "selected.txt"]);
+      await withGitShim(
+        `if test "$1" = merge-file; then
+  printf '%s\\n' 'forced staged merge failure' >&2
+  exit 128
+fi`,
+        () =>
+          assertThrows(
+            () =>
+              realGit(root).amendCommit(
+                "amended",
+                new Map([[path, "pager\n"]]),
+                head,
+              ),
+            Error,
+            "forced staged merge failure",
+          ),
+      );
+      assertEquals((await git(root, ["rev-parse", "HEAD"])).trim(), head);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
 });

--- a/packages/cli/test/view-diffedit-cov.test.ts
+++ b/packages/cli/test/view-diffedit-cov.test.ts
@@ -8,7 +8,7 @@
  * original diff, a missing workspace file, a hunk with no room to expand, the
  * read-only (no-disk) source, and the defensive guards in `save`.
  */
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
 import { parseDiff } from "../lib/view/diff.ts";
 import {
@@ -625,7 +625,7 @@ Deno.test("diffedit cov: save skips a verified hunk whose file was not captured 
   const text = "@@ -1,1 +1,1 @@\n+only line\n";
   assertEquals(
     src.save(text),
-    "No editable changes to save.",
+    "Saved 0 files",
     "an uncaptured file is skipped, leaving nothing written",
   );
 });
@@ -693,27 +693,115 @@ Deno.test("editableStart: editable only inside a verified hunk", () => {
   );
 });
 
-// --- commit-message amend helpers -------------------------------------------
-
-Deno.test("amendCommit: throws with no git runner (defensive; caller checks first)", () => {
-  let threw = false;
-  try {
-    _de.amendCommit(undefined, () => null, "", "");
-  } catch {
-    threw = true;
-  }
-  assert(threw, "no git runner means nothing to amend");
-});
+// --- commit amend helpers ----------------------------------------------------
 
 Deno.test("pendingAmend: null when there is no editable message", () => {
-  assertEquals(_de.pendingAmend(() => null, "a", "b"), null);
+  assertEquals(
+    _de.pendingAmend(() => null, () => null, false, "a", "b"),
+    null,
+  );
 });
 
-Deno.test("pendingAmend: null when the message is unchanged", () => {
+Deno.test("pendingAmend: null when the full buffer is unchanged", () => {
   const msg = { sha: "abcdef1", start: 0, end: 0 };
-  // The same one-line message in both baseline and current: no change.
   const both = () => msg;
-  assertEquals(_de.pendingAmend(both, "    hi", "    hi"), null);
+  assertEquals(_de.pendingAmend(both, both, false, "    hi", "    hi"), null);
+});
+
+Deno.test("pendingAmend: an unchanged message still amends changed commit contents", () => {
+  const msg = { sha: "abcdef1", start: 0, end: 0 };
+  const both = () => msg;
+  assertEquals(
+    _de.pendingAmend(both, both, true, "    hi\n-old", "    hi\n+new"),
+    { sha: "abcdef1", subject: "hi" },
+  );
+});
+
+Deno.test("baselineAfterSave: keeps the baseline for a changed hunk layout", () => {
+  const { ws, done } = tempWs({ "m.ts": FILE_TEXT });
+  try {
+    const { src } = sourceFor(DIFF, ws);
+    const moved = DIFF.replace("b/m.ts", "b/other.ts");
+    assertEquals(
+      src.baselineAfterSave!(DIFF, moved, { amendCommit: false }),
+      DIFF,
+    );
+
+    const extra = `${DIFF}@@ -5,0 +6,1 @@\n+extra\n`;
+    assertEquals(
+      src.baselineAfterSave!(DIFF, extra, { amendCommit: false }),
+      DIFF,
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffSource: ignores commit-shaped text inside a file diff", () => {
+  const head = "1".repeat(40);
+  const embedded = "2".repeat(40);
+  const text = [
+    `From ${head} Mon Sep 17 00:00:00 2001`,
+    "From: A B <a@b.example>",
+    "Date: Wed, 1 Jul 2026 12:00:00 -0700",
+    "Subject: [PATCH] Subject",
+    "",
+    "diff --git a/m.ts b/m.ts",
+    "index 1111..2222 100644",
+    "--- a/m.ts",
+    "+++ b/m.ts",
+    "@@ -1,1 +1,1 @@",
+    "-old",
+    "+new",
+    `From ${embedded} Mon Sep 17 00:00:00 2001`,
+    "From: C D <c@d.example>",
+    "Date: Thu, 2 Jul 2026 12:00:00 -0700",
+    "Subject: embedded text",
+    "",
+  ].join("\n");
+  const { ws, done } = tempWs({ "m.ts": "new\n" });
+  const matched: string[] = [];
+  try {
+    const model = parseDiff(text)!;
+    const { edit } = buildDiffDocument(text, model, ws);
+    const src = diffSource(ws, edit, undefined, {
+      headSha: () => head,
+      fileAtCommit: () => null,
+      applyFileChanges: (committed) => committed,
+      amendCommit: () => ({ status: "unused", head }),
+      commitMatchesDiff: (commit) => {
+        matched.push(commit);
+        return commit === head;
+      },
+    });
+    const edited = text.replace("+new", "+newer");
+
+    assertEquals(src.pendingAmend!(text, edited), {
+      sha: head,
+      subject: "(empty commit message)",
+    });
+    assertEquals(matched, [head]);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("save: rejects a diff with a different hunk count", () => {
+  const { root, ws, done } = tempWs({ "m.ts": FILE_TEXT });
+  try {
+    const { src } = sourceFor(DIFF, ws);
+    const edited = `${DIFF.replace("+const y = 2;", "+const y = 20;")}` +
+      `@@ -3,0 +4,1 @@\n+const added = true;\n`;
+
+    assertThrows(
+      () => src.save(edited, DIFF, { amendCommit: false }),
+      Error,
+      "The edited diff no longer matches its saved hunk map.",
+    );
+    assertEquals(Deno.readTextFileSync(join(root, "m.ts")), FILE_TEXT);
+  } finally {
+    done();
+  }
 });
 
 // --- message-scope revert ----------------------------------------------------
@@ -883,4 +971,38 @@ Deno.test("diffedit cov: joinAdjacent declines when the text will not drop a hea
     { absPath: "/x", newStart: 2, newCount: 1, verified: true },
   ];
   assertEquals(_de.joinAdjacent(oneHunk, oneHunk, hunks, 0), null);
+});
+
+Deno.test("diffedit cov: joinAdjacent keeps hunks from different commits separate", () => {
+  const twoHunks = `diff --git a/m.ts b/m.ts
+--- a/m.ts
++++ b/m.ts
+@@ -1,1 +1,1 @@
+-a
++A
+@@ -2,1 +2,1 @@
+-b
++B
+`;
+  const hunks = [
+    {
+      absPath: "/x",
+      newStart: 1,
+      newCount: 1,
+      verified: true,
+      writable: true,
+      commitSha: "1111",
+    },
+    {
+      absPath: "/x",
+      newStart: 2,
+      newCount: 1,
+      verified: true,
+      writable: true,
+      commitSha: "2222",
+    },
+  ];
+
+  assertEquals(_de.joinAdjacent(twoHunks, twoHunks, hunks, 0), null);
+  assertEquals(hunks.length, 2);
 });

--- a/packages/cli/test/view-diffedit-gate.test.ts
+++ b/packages/cli/test/view-diffedit-gate.test.ts
@@ -45,7 +45,7 @@ Deno.test("diffedit gate: save skips a verified hunk whose path parsed but has n
   );
   assertEquals(
     src.save(text),
-    "No editable changes to save.",
+    "Saved 0 files",
     "a path with no captured base content is skipped, leaving nothing written",
   );
 });

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -4,12 +4,12 @@
  * resurrected, and saving splices the edited lines back into the underlying
  * files. A diff matching no file on disk is read-only.
  */
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
 import { parseDiff } from "../lib/view/diff.ts";
 import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { createDiffHighlighter, diffSource } from "../lib/view/diffedit.ts";
-import type { GitRunner } from "../lib/view/commitmsg.ts";
+import { type GitRunner, realGit } from "../lib/view/commitmsg.ts";
 import { Session } from "../lib/view/session.ts";
 import { promptText } from "./view-helpers.ts";
 
@@ -25,12 +25,15 @@ function type(s: Session, text: string): void {
   for (const ch of text) s.handleKey({ name: ch, char: ch });
 }
 
-/** Enter edit mode if needed and move the cursor down to the given diff line. */
+/** Enter edit mode if needed and move the cursor to the given diff line. */
 function toLine(s: Session, line: number): void {
   if (!s.view().cursor) press(s, "e"); // enter edit mode at the top
   let guard = 0;
   while ((s.view().cursor?.line ?? -1) < line && guard++ < 1000) {
     press(s, "down");
+  }
+  while ((s.view().cursor?.line ?? -1) > line && guard++ < 1000) {
+    press(s, "up");
   }
 }
 
@@ -127,21 +130,27 @@ const GIT_SHOW = [
 // Line indices: 4 = subject, 5 = blank message line, 6 = body; 13 = a hunk
 // context line (editable); 16 = removed; 17,18 = additions.
 
-/** A fake git runner recording the message an amend would write. */
+/** A fake git runner recording the replacement message, or null when preserved. */
 function fakeGit(head: string | null): {
   git: GitRunner;
   amended: () => string | null;
+  amendedPaths: () => readonly string[] | null;
 } {
   let amended: string | null = null;
+  let amendedPaths: readonly string[] | null = null;
   return {
     git: {
       headSha: () => head,
-      amendMessage: (m) => {
+      fileAtCommit: (_commit, path) => Deno.readTextFileSync(path),
+      applyFileChanges: (_committed, _before, after) => after,
+      amendCommit: (m, files, expectedHead) => {
         amended = m;
-        return "Amended the commit message";
+        amendedPaths = [...files.keys()];
+        return { status: "Amended the commit", head: expectedHead };
       },
     },
     amended: () => amended,
+    amendedPaths: () => amendedPaths,
   };
 }
 
@@ -151,19 +160,37 @@ function fakeGit(head: string | null): {
 function movingGit(first: string, later: string): {
   git: GitRunner;
   amended: () => string | null;
+  amendedPaths: () => readonly string[] | null;
 } {
   let calls = 0;
   let amended: string | null = null;
+  let amendedPaths: readonly string[] | null = null;
   return {
     git: {
       headSha: () => (++calls === 1 ? first : later),
-      amendMessage: (m) => {
+      fileAtCommit: (_commit, path) => Deno.readTextFileSync(path),
+      applyFileChanges: (_committed, _before, after) => after,
+      amendCommit: (m, files, expectedHead) => {
         amended = m;
-        return "Amended the commit message";
+        amendedPaths = [...files.keys()];
+        return { status: "Amended the commit", head: expectedHead };
       },
     },
     amended: () => amended,
+    amendedPaths: () => amendedPaths,
   };
+}
+
+function runGit(root: string, args: string[]): string {
+  const output = new Deno.Command("git", {
+    args,
+    cwd: root,
+    stdout: "piped",
+    stderr: "piped",
+  }).outputSync();
+  const stderr = new TextDecoder().decode(output.stderr).trim();
+  assert(output.success, stderr || `git ${args[0]} failed`);
+  return new TextDecoder().decode(output.stdout);
 }
 
 Deno.test("diffedit: edits an added line in place and saves it to the file", () => {
@@ -626,11 +653,16 @@ index 0000000..1111111 100644
 +const w = 3;
 `;
 
-Deno.test("diffedit: a save reports only the files an edit actually touched", () => {
+Deno.test("diffedit: a save writes and reports only files whose contents changed", () => {
   const root = Deno.makeTempDirSync();
   try {
-    Deno.writeTextFileSync(join(root, "x.ts"), "const x = 1;\nconst y = 3;\n");
-    Deno.writeTextFileSync(join(root, "z.ts"), "const z = 1;\nconst w = 3;\n");
+    const xPath = join(root, "x.ts");
+    const zPath = join(root, "z.ts");
+    Deno.writeTextFileSync(xPath, "const x = 1;\nconst y = 3;\n");
+    Deno.writeTextFileSync(zPath, "const z = 1;\nconst w = 3;\n");
+    const oldTime = new Date("2000-01-01T00:00:00.000Z");
+    Deno.utimeSync(zPath, oldTime, oldTime);
+    const zMtime = Deno.statSync(zPath).mtime?.getTime();
     const ws: DiffWorkspace = {
       resolve: (p) => join(root, p),
       read: (a) => {
@@ -648,8 +680,139 @@ Deno.test("diffedit: a save reports only the files an edit actually touched", ()
     const edited = TWO_FILE_DIFF.replace("+const y = 3;", "+const y = 30;");
     assertEquals(src.dirtyLabels!(TWO_FILE_DIFF, edited), ["x.ts"]);
     assertEquals(src.dirtyLabels!(TWO_FILE_DIFF, TWO_FILE_DIFF), []);
+    assertEquals(src.save(edited), "Saved 1 file");
+    assertEquals(Deno.readTextFileSync(xPath), "const x = 1;\nconst y = 30;\n");
+    assertEquals(Deno.readTextFileSync(zPath), "const z = 1;\nconst w = 3;\n");
+    assertEquals(
+      Deno.statSync(zPath).mtime?.getTime(),
+      zMtime,
+      "the untouched file was not opened for writing",
+    );
   } finally {
     Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: save reports exact zero- and two-file counts", () => {
+  const { ws, done } = twoFileWs();
+  try {
+    const model = parseDiff(TWO_FILE_DIFF)!;
+    const { edit } = buildDiffDocument(TWO_FILE_DIFF, model, ws);
+    const src = diffSource(ws, edit);
+    assertEquals(src.save(TWO_FILE_DIFF), "Saved 0 files");
+    const edited = TWO_FILE_DIFF
+      .replace("+const y = 3;", "+const y = 30;")
+      .replace("+const w = 3;", "+const w = 30;");
+    assertEquals(src.save(edited), "Saved 2 files");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: save reports zero when the edited contents are already on disk", () => {
+  const { ws, done } = twoFileWs();
+  try {
+    const model = parseDiff(TWO_FILE_DIFF)!;
+    const { edit } = buildDiffDocument(TWO_FILE_DIFF, model, ws);
+    const src = diffSource(ws, edit);
+    const edited = TWO_FILE_DIFF.replace(
+      "+const y = 3;",
+      "+const y = 30;",
+    );
+    const xPath = [...edit.fileText.keys()].find((path) =>
+      path.endsWith("x.ts")
+    )!;
+    Deno.writeTextFileSync(xPath, "const x = 1;\nconst y = 30;\n");
+    const oldTime = new Date("2000-01-01T00:00:00.000Z");
+    Deno.utimeSync(xPath, oldTime, oldTime);
+    const mtime = Deno.statSync(xPath).mtime?.getTime();
+
+    assertEquals(src.save(edited, TWO_FILE_DIFF), "Saved 0 files");
+    assertEquals(
+      Deno.statSync(xPath).mtime?.getTime(),
+      mtime,
+      "a file already holding the saved contents was not rewritten",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: a later save can restore the contents captured at open", () => {
+  const { ws, done } = twoFileWs();
+  try {
+    const model = parseDiff(TWO_FILE_DIFF)!;
+    const { edit } = buildDiffDocument(TWO_FILE_DIFF, model, ws);
+    const src = diffSource(ws, edit);
+    const first = TWO_FILE_DIFF.replace(
+      "+const y = 3;",
+      "+const y = 30;",
+    );
+    assertEquals(src.save(first, TWO_FILE_DIFF), "Saved 1 file");
+    assertEquals(src.save(TWO_FILE_DIFF, first), "Saved 1 file");
+    assertEquals(
+      ws.read([...edit.fileText.keys()][0]),
+      "const x = 1;\nconst y = 3;\n",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: a later save uses the hunk size produced by an insertion", () => {
+  const { root, ws, done } = tempWorkspace();
+  try {
+    const s = diffSession(ws);
+    toLine(s, 9); // the added answer line
+    press(s, "end", "enter");
+    type(s, "// inserted");
+    press(s, "f3");
+
+    press(s, "up", "end");
+    type(s, " // second save");
+    press(s, "f3");
+
+    assertEquals(
+      Deno.readTextFileSync(join(root, "m.ts")),
+      FILE_TEXT.replace(
+        "export const answer = double(21);\n",
+        "export const answer = double(21); // second save\n// inserted\n",
+      ),
+      "the second save does not duplicate the hunk's final line",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: save refuses to overwrite a file changed after opening", () => {
+  const { ws, done } = twoFileWs();
+  try {
+    const model = parseDiff(TWO_FILE_DIFF)!;
+    const { edit } = buildDiffDocument(TWO_FILE_DIFF, model, ws);
+    const src = diffSource(ws, edit);
+    const edited = TWO_FILE_DIFF.replace(
+      "+const y = 3;",
+      "+const y = 30;",
+    );
+    const xPath = [...edit.fileText.keys()].find((path) =>
+      path.endsWith("x.ts")
+    )!;
+    const external = "const x = 1;\nconst y = 300; // external\n";
+    Deno.writeTextFileSync(xPath, external);
+
+    assertThrows(
+      () => src.save(edited, TWO_FILE_DIFF),
+      Error,
+      "changed after this view opened",
+    );
+    assertEquals(
+      Deno.readTextFileSync(xPath),
+      external,
+      "the external edit remains untouched",
+    );
+  } finally {
+    done();
   }
 });
 
@@ -779,13 +942,14 @@ function expandSession(): { root: string; s: Session; done: () => void } {
     },
   };
   const model = parseDiff(EXPAND_DIFF)!;
-  const { doc, edit } = buildDiffDocument(EXPAND_DIFF, model, ws);
+  const cache = new Map();
+  const { doc, edit } = buildDiffDocument(EXPAND_DIFF, model, ws, cache);
   const s = new Session(
     doc,
     { color: false, showLineNumbers: false },
     { width: 80, height: 30 },
     undefined,
-    diffSource(ws, edit),
+    diffSource(ws, edit, cache),
   );
   return { root, s, done: () => Deno.removeSync(root, { recursive: true }) };
 }
@@ -1514,6 +1678,26 @@ Deno.test("diffedit: expanding after an insert reveals the right file lines", ()
   }
 });
 
+Deno.test("diffedit: expanding after saving an insert reads the saved file", () => {
+  const { s, done } = expandSession();
+  try {
+    toLine(s, 7); // "+delta"
+    press(s, "end", "enter");
+    type(s, "INS");
+    press(s, "f3");
+
+    const epsilon = s.doc.text.split("\n").indexOf(" epsilon");
+    toLine(s, epsilon);
+    s.handleKey({ name: "ctrl-l" });
+    assert(
+      s.doc.text.includes(" epsilon\n zeta\n eta\n theta"),
+      s.doc.text,
+    );
+  } finally {
+    done();
+  }
+});
+
 Deno.test("diffedit: insert + expand + edit then save writes the file correctly", () => {
   const { root, s, done } = expandSession();
   try {
@@ -1554,7 +1738,11 @@ function stubWs(root: string): DiffWorkspace {
   };
 }
 
-function sessionFor(diff: string, ws: DiffWorkspace): Session {
+function sessionFor(
+  diff: string,
+  ws: DiffWorkspace,
+  git?: GitRunner,
+): Session {
   const model = parseDiff(diff)!;
   const { doc, edit } = buildDiffDocument(diff, model, ws);
   return new Session(
@@ -1562,7 +1750,7 @@ function sessionFor(diff: string, ws: DiffWorkspace): Session {
     { color: false, showLineNumbers: false },
     { width: 80, height: 40 },
     undefined,
-    diffSource(ws, edit),
+    diffSource(ws, edit, undefined, git),
   );
 }
 
@@ -1602,7 +1790,11 @@ Deno.test("diffedit: saving a git log -p diff does not absorb commit text or wri
       "+realLine0",
       "",
     ].join("\n");
-    const s = sessionFor(log, stubWs(root));
+    const s = sessionFor(
+      log,
+      stubWs(root),
+      fakeGit("bbbbbbbbbbbbbbbb").git,
+    );
     const before = s.doc.text;
     toLine(s, 24); // the stale hunk's "-original" line
     assert(
@@ -1611,7 +1803,10 @@ Deno.test("diffedit: saving a git log -p diff does not absorb commit text or wri
     );
     press(s, "R");
     assertEquals(s.doc.text, before, "the stale removed line stayed protected");
-    assert(s.view().message.includes("isn't editable"), s.view().message);
+    assertEquals(
+      s.view().message,
+      "This line belongs to a commit other than HEAD and cannot be edited.",
+    );
     press(s, "f3"); // save with no edits at all
     assertEquals(
       Deno.readTextFileSync(join(root, "x.ts")),
@@ -2302,9 +2497,13 @@ Deno.test("diffedit: an edit-mode search skips the preamble to a savable line", 
 // --- editing the HEAD commit's message (git show) ----------------------------
 
 Deno.test("diffedit: the HEAD commit's message is editable; save prompts then amends", () => {
-  const { ws, done } = tempWorkspace();
+  const { root, ws, done } = tempWorkspace();
   const fg = fakeGit(SHOW_SHA); // the shown commit IS HEAD
   try {
+    const path = join(root, "m.ts");
+    const oldTime = new Date("2000-01-01T00:00:00.000Z");
+    Deno.utimeSync(path, oldTime, oldTime);
+    const mtime = Deno.statSync(path).mtime?.getTime();
     const s = diffSessionFrom(ws, GIT_SHOW, 20, fg.git);
     toLine(s, 4); // the subject line — an editable message line
     press(s, "end");
@@ -2323,29 +2522,337 @@ Deno.test("diffedit: the HEAD commit's message is editable; save prompts then am
     );
     assertEquals(fg.amended(), null, "nothing amended before confirming");
     // Confirm: the amend runs with the edited message (indent stripped).
-    press(s, "y");
+    press(s, "a");
     assertEquals(
       fg.amended(),
       "Subject line of the commit EDIT\n\nA body paragraph of the message.",
     );
-    assert(s.view().message.includes("Amended"), s.view().message);
+    assertEquals(fg.amendedPaths(), []);
+    assertEquals(s.view().message, "Saved 0 files; Amended the commit");
+    assertEquals(
+      Deno.statSync(path).mtime?.getTime(),
+      mtime,
+      "a message-only amend did not write the unchanged file",
+    );
   } finally {
     done();
   }
 });
 
-Deno.test("diffedit: declining the amend prompt writes nothing", () => {
-  const { ws, done } = tempWorkspace();
+Deno.test("diffedit: a commit with no file diff can amend its message", () => {
+  const commitOnly = [
+    `commit ${SHOW_SHA}`,
+    "Author: A B <a@b.example>",
+    "Date:   Wed Jul 1 12:00:00 2026 -0700",
+    "",
+    "    Empty commit subject",
+    "",
+  ].join("\n");
+  const ws: DiffWorkspace = { resolve: () => null, read: () => null };
+  const model = {
+    files: [],
+    lines: commitOnly.split("\n").map(() => ({ kind: "other" as const })),
+  };
+  const { doc, edit } = buildDiffDocument(commitOnly, model, ws);
+  const fg = fakeGit(SHOW_SHA);
+  const src = diffSource(ws, edit, undefined, fg.git);
+  assertEquals(src.editable, true);
+  assertEquals(src.label, null);
+  const s = new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 80, height: 12 },
+    undefined,
+    src,
+  );
+
+  toLine(s, 4);
+  press(s, "end");
+  type(s, " EDIT");
+  press(s, "f3");
+  assert(promptText(s.view()).includes("Amend commit"), promptText(s.view()));
+  press(s, "s");
+  assertEquals(fg.amended(), null);
+  assertEquals(
+    s.view().message,
+    "Saved 0 files; commit message remains unsaved",
+  );
+  press(s, "f3");
+  press(s, "a");
+  assertEquals(fg.amended(), "Empty commit subject EDIT");
+  assertEquals(fg.amendedPaths(), []);
+  assertEquals(s.view().message, "Saved 0 files; Amended the commit");
+});
+
+Deno.test("diffedit: the amend prompt offers explicit save actions", () => {
+  const { root, ws, done } = tempWorkspace();
   const fg = fakeGit(SHOW_SHA);
   try {
+    const path = join(root, "m.ts");
+    const before = Deno.readTextFileSync(path);
     const s = diffSessionFrom(ws, GIT_SHOW, 20, fg.git);
     toLine(s, 6); // the body line
     press(s, "end");
     type(s, " more");
+    toLine(s, 17);
+    press(s, "end");
+    type(s, " // pending");
     press(s, "f3");
-    press(s, "n"); // decline
+    assertEquals(
+      s.view().dialog?.buttons.map(({ label, hotkey }) => ({ label, hotkey })),
+      [
+        { label: "Amend commit", hotkey: "a" },
+        { label: "Save files only", hotkey: "s" },
+        { label: "Cancel", hotkey: "c" },
+      ],
+    );
+    press(s, "y", "n");
+    assert(s.view().dialog, "the former yes/no keys do nothing");
+    press(s, "c");
     assertEquals(fg.amended(), null, "the commit was not amended");
-    assert(s.view().message.toLowerCase().includes("cancel"), s.view().message);
+    assertEquals(Deno.readTextFileSync(path), before, "no file was saved");
+    assertEquals(s.view().message, "Save cancelled.");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: saving files only leaves a message edit unsaved", () => {
+  const { root, ws, done } = tempWorkspace();
+  const fg = fakeGit(SHOW_SHA);
+  try {
+    const s = diffSessionFrom(ws, GIT_SHOW, 20, fg.git);
+    toLine(s, 4);
+    press(s, "end");
+    type(s, " EDIT");
+    toLine(s, 17);
+    press(s, "end");
+    type(s, " // workspace");
+
+    press(s, "f3");
+    press(s, "s");
+
+    assertEquals(fg.amended(), null, "files-only save did not amend HEAD");
+    assert(
+      Deno.readTextFileSync(join(root, "m.ts")).includes("// workspace"),
+      "the hunk edit was written to its workspace file",
+    );
+    assertEquals(
+      s.view().message,
+      "Saved 1 file; commit message remains unsaved",
+    );
+
+    // Only the message remains dirty. Saving again offers the same explicit
+    // choice, and amending now does not absorb the earlier workspace-only edit.
+    press(s, "f3");
+    assert(s.view().dialog, "the unsaved message prompts again");
+    press(s, "a");
+    assertEquals(
+      fg.amended(),
+      "Subject line of the commit EDIT\n\nA body paragraph of the message.",
+    );
+    assertEquals(fg.amendedPaths(), []);
+    assertEquals(s.view().message, "Saved 0 files; Amended the commit");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: saving files only can complete a pending quit", () => {
+  const { root, ws, done } = tempWorkspace();
+  const fg = fakeGit(SHOW_SHA);
+  try {
+    const s = diffSessionFrom(ws, GIT_SHOW, 20, fg.git);
+    toLine(s, 17);
+    press(s, "end");
+    type(s, " // workspace");
+    press(s, "escape", "q");
+    press(s, "s"); // Save in the ordinary quit prompt.
+    assert(!s.quit, "the commit choice is still pending");
+    press(s, "s"); // Save files only in the commit prompt.
+
+    assert(s.quit, "the clean buffer can quit after its files are saved");
+    assertEquals(fg.amended(), null);
+    assert(
+      Deno.readTextFileSync(join(root, "m.ts")).includes("// workspace"),
+      "the workspace file contains the edit",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: a failed amend restores files written by the save", () => {
+  const { root, ws, done } = tempWorkspace();
+  try {
+    const path = join(root, "m.ts");
+    const git: GitRunner = {
+      headSha: () => SHOW_SHA,
+      fileAtCommit: (_commit, file) => Deno.readTextFileSync(file),
+      applyFileChanges: (_committed, _before, after) => after,
+      amendCommit: () => {
+        throw new Error("commit hook rejected the amend");
+      },
+    };
+    const model = parseDiff(GIT_SHOW)!;
+    const { edit } = buildDiffDocument(GIT_SHOW, model, ws);
+    const src = diffSource(ws, edit, undefined, git);
+    const edited = GIT_SHOW.replace(
+      "+export const answer = double(21);",
+      "+export const answer = double(21); // pager edit",
+    );
+    let error = "";
+    try {
+      src.save(edited, GIT_SHOW);
+    } catch (caught) {
+      error = caught instanceof Error ? caught.message : String(caught);
+    }
+    assert(
+      error.includes("commit hook rejected"),
+      error || "save did not fail",
+    );
+    assertEquals(
+      Deno.readTextFileSync(path),
+      FILE_TEXT,
+      "the failed amend left the workspace file as it was before save",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: save refuses a selected workspace file that disappeared", () => {
+  const { root, ws, done } = tempWorkspace();
+  try {
+    const model = parseDiff(DIFF)!;
+    const { edit } = buildDiffDocument(DIFF, model, ws);
+    const source = diffSource(ws, edit);
+    Deno.removeSync(join(root, "m.ts"));
+    const edited = DIFF.replace(
+      "+export const answer = double(21);",
+      "+export const answer = double(21); // pager",
+    );
+
+    assertThrows(
+      () => source.save(edited, DIFF),
+      Error,
+      "Could not read",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: failed amend accepts a file already restored by the Git runner", () => {
+  const { root, ws, done } = tempWorkspace();
+  try {
+    const path = join(root, "m.ts");
+    const git: GitRunner = {
+      headSha: () => SHOW_SHA,
+      fileAtCommit: (_commit, file) => Deno.readTextFileSync(file),
+      applyFileChanges: (_committed, _before, after) => after,
+      amendCommit: () => {
+        Deno.writeTextFileSync(path, FILE_TEXT);
+        throw new Error("commit hook rejected the amend");
+      },
+    };
+    const model = parseDiff(GIT_SHOW)!;
+    const { edit } = buildDiffDocument(GIT_SHOW, model, ws);
+    const source = diffSource(ws, edit, undefined, git);
+    const edited = GIT_SHOW.replace(
+      "+export const answer = double(21);",
+      "+export const answer = double(21); // pager",
+    );
+
+    const error = assertThrows(
+      () => source.save(edited, GIT_SHOW),
+      Error,
+      "commit hook rejected",
+    );
+    assert(!error.message.includes("restoring files failed"), error.message);
+    assertEquals(Deno.readTextFileSync(path), FILE_TEXT);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: reports an error while reading a file for rollback", () => {
+  const root = Deno.makeTempDirSync();
+  const path = join(root, "m.ts");
+  Deno.writeTextFileSync(path, FILE_TEXT);
+  let rollback = false;
+  const ws: DiffWorkspace = {
+    resolve: (relative) => join(root, relative),
+    read: (absolute) => {
+      if (rollback) throw new Error("rollback read failed");
+      return Deno.readTextFileSync(absolute);
+    },
+  };
+  const git: GitRunner = {
+    headSha: () => SHOW_SHA,
+    fileAtCommit: (_commit, file) => Deno.readTextFileSync(file),
+    applyFileChanges: (_committed, _before, after) => after,
+    amendCommit: () => {
+      rollback = true;
+      throw new Error("commit hook rejected the amend");
+    },
+  };
+  try {
+    const model = parseDiff(GIT_SHOW)!;
+    const { edit } = buildDiffDocument(GIT_SHOW, model, ws);
+    const source = diffSource(ws, edit, undefined, git);
+    const edited = GIT_SHOW.replace(
+      "+export const answer = double(21);",
+      "+export const answer = double(21); // pager",
+    );
+
+    const error = assertThrows(
+      () => source.save(edited, GIT_SHOW),
+      Error,
+      "restoring files failed",
+    );
+    assert(error.message.includes("rollback read failed"), error.message);
+    assert(Deno.readTextFileSync(path).includes("// pager"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: a failed amend preserves a file changed during the amend", () => {
+  const { root, ws, done } = tempWorkspace();
+  try {
+    const path = join(root, "m.ts");
+    const git: GitRunner = {
+      headSha: () => SHOW_SHA,
+      fileAtCommit: (_commit, file) => Deno.readTextFileSync(file),
+      applyFileChanges: (_committed, _before, after) => after,
+      amendCommit: (_message, _files, _head, _ref, expectedWorkspace) => {
+        assert(
+          expectedWorkspace?.get(path)?.includes("// pager edit"),
+          "the amend validates the workspace contents written by the save",
+        );
+        Deno.writeTextFileSync(path, "changed during amend\n");
+        throw new Error("commit hook rejected the amend");
+      },
+    };
+    const model = parseDiff(GIT_SHOW)!;
+    const { edit } = buildDiffDocument(GIT_SHOW, model, ws);
+    const src = diffSource(ws, edit, undefined, git);
+    const edited = GIT_SHOW.replace(
+      "+export const answer = double(21);",
+      "+export const answer = double(21); // pager edit",
+    );
+
+    assertThrows(
+      () => src.save(edited, GIT_SHOW),
+      Error,
+      "changed again and was not restored",
+    );
+    assertEquals(
+      Deno.readTextFileSync(path),
+      "changed during amend\n",
+      "the later file contents remain untouched",
+    );
   } finally {
     done();
   }
@@ -2363,7 +2870,7 @@ Deno.test("diffedit: Enter in a message adds another indented line", () => {
     // The new line carries git's four-space indent and stays a message line.
     assertEquals(s.doc.lines[5].text, "    second subject line");
     press(s, "f3");
-    press(s, "y");
+    press(s, "a");
     assertEquals(
       fg.amended(),
       "Subject line of the commit\nsecond subject line\n\n" +
@@ -2383,6 +2890,10 @@ Deno.test("diffedit: a non-HEAD commit's message is not editable", () => {
     const before = s.doc.text;
     type(s, "X");
     assertEquals(s.doc.text, before, "a non-HEAD message is read-only");
+    assertEquals(
+      s.view().message,
+      "This line belongs to a commit other than HEAD and cannot be edited.",
+    );
     // Saving does not offer to amend a commit that is not HEAD.
     press(s, "f3");
     assertEquals(fg.amended(), null, "a non-HEAD commit is never amended");
@@ -2391,7 +2902,112 @@ Deno.test("diffedit: a non-HEAD commit's message is not editable", () => {
   }
 });
 
-Deno.test("diffedit: editing only a hunk (not the message) saves with no amend prompt", () => {
+Deno.test("diffedit: a blank line before the first commit has no commit owner", () => {
+  const { ws, done } = tempWorkspace();
+  const fg = fakeGit(SHOW_SHA);
+  try {
+    const text = `\n${GIT_SHOW}`;
+    const model = parseDiff(text)!;
+    const { edit } = buildDiffDocument(text, model, ws);
+    const source = diffSource(ws, edit, undefined, fg.git);
+
+    assertEquals(
+      source.policy?.notEditableMessage?.(text.split("\n"), 0),
+      null,
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: refuses to amend after the represented commit header is removed", () => {
+  const { root, ws, done } = tempWorkspace();
+  const fg = fakeGit(SHOW_SHA);
+  try {
+    const model = parseDiff(GIT_SHOW)!;
+    const { edit } = buildDiffDocument(GIT_SHOW, model, ws);
+    const source = diffSource(ws, edit, undefined, fg.git);
+    const edited = GIT_SHOW.replace(`commit ${SHOW_SHA}\n`, "").replace(
+      "+export const answer = double(21);",
+      "+export const answer = double(21); // pager",
+    );
+
+    assertThrows(
+      () => source.save(edited, GIT_SHOW),
+      Error,
+      "No commit to amend",
+    );
+    assertEquals(fg.amended(), null);
+    assertEquals(Deno.readTextFileSync(join(root, "m.ts")), FILE_TEXT);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: refuses to amend after HEAD switches branches", () => {
+  const { root, ws, done } = tempWorkspace();
+  let currentRef = "refs/heads/main";
+  const git: GitRunner = {
+    headSha: () => SHOW_SHA,
+    headRef: () => currentRef,
+    fileAtCommit: (_commit, path) => Deno.readTextFileSync(path),
+    applyFileChanges: (_committed, _before, after) => after,
+    amendCommit: () => {
+      throw new Error("amend must not run");
+    },
+  };
+  try {
+    const model = parseDiff(GIT_SHOW)!;
+    const { edit } = buildDiffDocument(GIT_SHOW, model, ws);
+    const source = diffSource(ws, edit, undefined, git);
+    const edited = GIT_SHOW.replace(
+      "+export const answer = double(21);",
+      "+export const answer = double(21); // pager",
+    );
+    currentRef = "refs/heads/topic";
+
+    assertThrows(
+      () => source.save(edited, GIT_SHOW),
+      Error,
+      "different branch",
+    );
+    assertEquals(Deno.readTextFileSync(join(root, "m.ts")), FILE_TEXT);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: refuses to amend a selected path missing from the shown commit", () => {
+  const { root, ws, done } = tempWorkspace();
+  const git: GitRunner = {
+    headSha: () => SHOW_SHA,
+    fileAtCommit: () => null,
+    applyFileChanges: (_committed, _before, after) => after,
+    amendCommit: () => {
+      throw new Error("amend must not run");
+    },
+  };
+  try {
+    const model = parseDiff(GIT_SHOW)!;
+    const { edit } = buildDiffDocument(GIT_SHOW, model, ws);
+    const source = diffSource(ws, edit, undefined, git);
+    const edited = GIT_SHOW.replace(
+      "+export const answer = double(21);",
+      "+export const answer = double(21); // pager",
+    );
+
+    assertThrows(
+      () => source.save(edited, GIT_SHOW),
+      Error,
+      "shown commit does not contain",
+    );
+    assertEquals(Deno.readTextFileSync(join(root, "m.ts")), FILE_TEXT);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: editing only a hunk prompts and amends the file into the commit", () => {
   const { root, ws, done } = tempWorkspace();
   const fg = fakeGit(SHOW_SHA);
   try {
@@ -2400,15 +3016,896 @@ Deno.test("diffedit: editing only a hunk (not the message) saves with no amend p
     press(s, "end");
     type(s, " // x");
     press(s, "f3");
-    // The message is unchanged, so no amend prompt and no amend.
-    assert(s.view().message.startsWith("Saved"), s.view().message);
-    assertEquals(fg.amended(), null, "an unchanged message is not amended");
+    assert(promptText(s.view()).includes("Amend commit"), promptText(s.view()));
+    assertEquals(fg.amended(), null, "nothing amended before confirmation");
+    press(s, "a");
+    assertEquals(fg.amended(), null, "the unchanged message is preserved");
+    assertEquals(fg.amendedPaths(), [join(root, "m.ts")]);
+    assertEquals(s.view().message, "Saved 1 file; Amended the commit");
     assert(
       Deno.readTextFileSync(join(root, "m.ts")).includes("// x"),
-      "the hunk edit was written",
+      "the hunk edit was written before the commit was amended",
     );
   } finally {
     done();
+  }
+});
+
+Deno.test("diffedit: saving edited git show output amends the real HEAD tree", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "m.ts");
+    Deno.writeTextFileSync(
+      path,
+      FILE_TEXT.replace(
+        "export const answer = double(21);\nconst extra = answer + 1;",
+        "export const answer = 42;",
+      ),
+    );
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "parent"]);
+    Deno.writeTextFileSync(path, FILE_TEXT);
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "Subject line of the commit"]);
+
+    const shown = runGit(root, ["show", "--no-ext-diff", "--no-color", "HEAD"]);
+    const ws: DiffWorkspace = {
+      resolve: (relative) => join(root, relative),
+      read: (absolute) => {
+        try {
+          return Deno.readTextFileSync(absolute);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const model = parseDiff(shown)!;
+    const { doc, edit } = buildDiffDocument(shown, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 30 },
+      undefined,
+      diffSource(ws, edit, undefined, realGit(root)),
+    );
+    const line = s.doc.lines.findIndex((entry) =>
+      entry.text === "+export const answer = double(21);"
+    );
+    assert(line >= 0, "git show contains the added line");
+    toLine(s, line);
+    press(s, "end");
+    type(s, " // amended");
+    press(s, "f3");
+    assert(promptText(s.view()).includes("Amend commit"), promptText(s.view()));
+    press(s, "a");
+
+    assertEquals(s.view().message, "Saved 1 file; Amended the commit");
+    assert(
+      runGit(root, ["show", "HEAD:m.ts"]).includes("double(21); // amended"),
+      "the amended commit contains the pager edit",
+    );
+    assertEquals(runGit(root, ["status", "--porcelain"]), "");
+
+    press(s, "end");
+    type(s, " twice");
+    press(s, "f3");
+    press(s, "a");
+    assertEquals(s.view().message, "Saved 1 file; Amended the commit");
+    assert(
+      runGit(root, ["show", "HEAD:m.ts"]).includes(
+        "double(21); // amended twice",
+      ),
+      "a later save amends the commit from the previous pager result",
+    );
+    assertEquals(runGit(root, ["status", "--porcelain"]), "");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: a hunk-only amend preserves the raw commit message", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "f.txt");
+    Deno.writeTextFileSync(path, "before\n");
+    runGit(root, ["add", "f.txt"]);
+    runGit(root, ["commit", "-q", "-m", "parent"]);
+    Deno.writeTextFileSync(path, "after\n");
+    runGit(root, ["add", "f.txt"]);
+    runGit(root, [
+      "commit",
+      "-q",
+      "--cleanup=verbatim",
+      "-m",
+      "\nsubject\n\n\n",
+    ]);
+    const rawBefore = runGit(root, ["cat-file", "commit", "HEAD"]);
+    const messageBefore = rawBefore.slice(rawBefore.indexOf("\n\n") + 2);
+    const shown = runGit(root, [
+      "show",
+      "--no-ext-diff",
+      "--no-color",
+      "HEAD",
+    ]);
+    const ws = stubWs(root);
+    const model = parseDiff(shown)!;
+    const { edit } = buildDiffDocument(shown, model, ws);
+    const source = diffSource(ws, edit, undefined, realGit(root));
+    const edited = shown.replace("+after\n", "+after edited\n");
+
+    assertEquals(
+      source.save(edited, shown),
+      "Saved 1 file; Amended the commit",
+    );
+
+    const rawAfter = runGit(root, ["cat-file", "commit", "HEAD"]);
+    assertEquals(
+      rawAfter.slice(rawAfter.indexOf("\n\n") + 2),
+      messageBefore,
+    );
+    assertEquals(runGit(root, ["show", "HEAD:f.txt"]), "after edited\n");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: abbreviated, compact, and email formats amend hunk edits", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "f.txt");
+    Deno.writeTextFileSync(path, "before\n");
+    runGit(root, ["add", "f.txt"]);
+    runGit(root, ["commit", "-q", "-m", "parent"]);
+    Deno.writeTextFileSync(path, "value 0\n");
+    runGit(root, [
+      "commit",
+      "-qa",
+      "-m",
+      "subject",
+      "-m",
+      `ffff ordinary body line
+commit deadbeef
+From ${"f".repeat(40)} Mon Sep 17 00:00:00 2001
+From: Fake Author <fake@example.test>
+Date: Wed, 1 Jul 2026 12:00:00 -0700
+Subject: [PATCH] Embedded envelope`,
+    ]);
+    const message = runGit(root, ["cat-file", "commit", "HEAD"]).split(
+      "\n\n",
+    ).slice(1).join("\n\n");
+
+    const formats: Array<{ name: string; args: string[] }> = [
+      {
+        name: "four-character medium",
+        args: ["--pretty=medium", "--abbrev-commit", "--abbrev=4"],
+      },
+      { name: "oneline", args: ["--pretty=oneline"] },
+      { name: "reference", args: ["--pretty=reference"] },
+      { name: "email", args: ["--pretty=email"] },
+    ];
+    for (const [index, format] of formats.entries()) {
+      const shown = runGit(root, [
+        "show",
+        ...format.args,
+        "--no-ext-diff",
+        "--no-color",
+        "HEAD",
+      ]);
+      const current = `value ${index}`;
+      const next = `value ${index + 1}`;
+      assert(
+        shown.includes(`+${current}\n`),
+        `${format.name} output has the hunk`,
+      );
+      if (format.name === "four-character medium") {
+        assert(/^commit [0-9a-f]{4}\n/.test(shown), shown.split("\n")[0]);
+      }
+      const ws = stubWs(root);
+      const model = parseDiff(shown)!;
+      const { edit } = buildDiffDocument(shown, model, ws);
+      const source = diffSource(ws, edit, undefined, realGit(root));
+      const edited = shown.replace(`+${current}\n`, `+${next}\n`);
+
+      assertEquals(
+        source.save(edited, shown),
+        "Saved 1 file; Amended the commit",
+        format.name,
+      );
+      assertEquals(runGit(root, ["show", "HEAD:f.txt"]), `${next}\n`);
+      const raw = runGit(root, ["cat-file", "commit", "HEAD"]);
+      assertEquals(raw.split("\n\n").slice(1).join("\n\n"), message);
+    }
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: standard and compact views skip email ownership checks", () => {
+  const { ws, done } = tempWorkspace();
+  try {
+    let ownershipChecks = 0;
+    const git: GitRunner = {
+      ...fakeGit(SHOW_SHA).git,
+      commitMatchesDiff: () => {
+        ownershipChecks++;
+        return true;
+      },
+    };
+    const diff = GIT_SHOW.slice(GIT_SHOW.indexOf("diff --git "));
+    const views = [
+      GIT_SHOW,
+      `${SHOW_SHA} Subject\n${diff}`,
+      `${SHOW_SHA.slice(0, 8)} (Subject, 2026-07-20)\n${diff}`,
+    ];
+
+    for (const shown of views) {
+      const model = parseDiff(shown)!;
+      const { edit } = buildDiffDocument(shown, model, ws);
+      diffSource(ws, edit, undefined, git);
+    }
+
+    assertEquals(ownershipChecks, 0);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: consecutive compact commits keep historical hunk ownership", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "f.txt");
+    Deno.writeTextFileSync(path, "before\n");
+    runGit(root, ["add", "f.txt"]);
+    runGit(root, ["commit", "-q", "-m", "base"]);
+    Deno.writeTextFileSync(path, "after\n");
+    runGit(root, ["commit", "-qam", "parent with patch"]);
+    runGit(root, ["commit", "-q", "--allow-empty", "-m", "empty HEAD"]);
+    const head = runGit(root, ["rev-parse", "HEAD"]);
+    const shown = runGit(root, [
+      "log",
+      "-2",
+      "--pretty=oneline",
+      "-p",
+      "--no-ext-diff",
+      "--no-color",
+    ]);
+    const ws = stubWs(root);
+    const model = parseDiff(shown)!;
+    const { edit } = buildDiffDocument(shown, model, ws);
+    const source = diffSource(ws, edit, undefined, realGit(root));
+
+    assertEquals(
+      source.save(shown.replace("+after\n", "+workspace edit\n"), shown),
+      "Saved 1 file",
+    );
+    assertEquals(runGit(root, ["rev-parse", "HEAD"]), head);
+    assertEquals(Deno.readTextFileSync(path), "workspace edit\n");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: consecutive email commits keep historical hunk ownership", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "f.txt");
+    Deno.writeTextFileSync(path, "before\n");
+    runGit(root, ["add", "f.txt"]);
+    runGit(root, ["commit", "-q", "-m", "base"]);
+    Deno.writeTextFileSync(path, "after\n");
+    runGit(root, ["commit", "-qam", "parent with patch"]);
+    runGit(root, ["commit", "-q", "--allow-empty", "-m", "empty HEAD"]);
+    const head = runGit(root, ["rev-parse", "HEAD"]);
+    const shown = runGit(root, [
+      "log",
+      "-2",
+      "--pretty=email",
+      "-p",
+      "--no-ext-diff",
+      "--no-color",
+    ]);
+    const ws = stubWs(root);
+    const model = parseDiff(shown)!;
+    const { edit } = buildDiffDocument(shown, model, ws);
+    const source = diffSource(ws, edit, undefined, realGit(root));
+
+    assertEquals(
+      source.save(shown.replace("+after\n", "+workspace edit\n"), shown),
+      "Saved 1 file",
+    );
+    assertEquals(runGit(root, ["rev-parse", "HEAD"]), head);
+    assertEquals(Deno.readTextFileSync(path), "workspace edit\n");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: a CRLF commit preamble keeps an LF-normalized message", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "f.txt");
+    Deno.writeTextFileSync(path, "before\n");
+    runGit(root, ["add", "f.txt"]);
+    runGit(root, ["commit", "-q", "-m", "parent"]);
+    Deno.writeTextFileSync(path, "after\n");
+    runGit(root, ["commit", "-qam", "subject", "-m", "body"]);
+
+    const shownLf = runGit(root, [
+      "show",
+      "--no-ext-diff",
+      "--no-color",
+      "HEAD",
+    ]);
+    const diffStart = shownLf.indexOf("diff --git ");
+    assert(diffStart >= 0, "git show contains a file diff");
+    const shown = shownLf.slice(0, diffStart).replaceAll("\n", "\r\n") +
+      shownLf.slice(diffStart);
+    const ws = stubWs(root);
+    const model = parseDiff(shown)!;
+    const { edit } = buildDiffDocument(shown, model, ws);
+    const source = diffSource(ws, edit, undefined, realGit(root));
+    const edited = shown.replace("+after\n", "+after edited\n");
+
+    assertEquals(
+      source.save(edited, shown),
+      "Saved 1 file; Amended the commit",
+    );
+    const rawCommit = runGit(root, ["cat-file", "commit", "HEAD"]);
+    assertEquals(
+      rawCommit.slice(rawCommit.indexOf("\n\n") + 2),
+      "subject\n\nbody\n",
+    );
+    assertEquals(Deno.readTextFileSync(path), "after edited\n");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test({
+  name: "diffedit: a commit view saves through clean and textconv filters",
+  ignore: Deno.build.os === "windows",
+  fn() {
+    const root = Deno.makeTempDirSync();
+    try {
+      runGit(root, ["init", "-q"]);
+      runGit(root, ["config", "user.email", "t@t.test"]);
+      runGit(root, ["config", "user.name", "Test"]);
+      runGit(root, [
+        "config",
+        "filter.caps.clean",
+        "tr '[:lower:]' '[:upper:]'",
+      ]);
+      runGit(root, [
+        "config",
+        "filter.caps.smudge",
+        "tr '[:upper:]' '[:lower:]'",
+      ]);
+      const textconv = join(root, ".git", "lower-textconv.sh");
+      Deno.writeTextFileSync(
+        textconv,
+        "#!/bin/sh\ntr '[:upper:]' '[:lower:]' < \"$1\"\n",
+      );
+      Deno.chmodSync(textconv, 0o755);
+      runGit(root, ["config", "diff.lower.textconv", textconv]);
+      Deno.writeTextFileSync(
+        join(root, ".gitattributes"),
+        "*.dat filter=caps diff=lower\n",
+      );
+      const path = join(root, "f.dat");
+      Deno.writeTextFileSync(path, "old\n");
+      runGit(root, ["add", ".gitattributes", "f.dat"]);
+      runGit(root, ["commit", "-q", "-m", "parent"]);
+      Deno.writeTextFileSync(path, "new\n");
+      runGit(root, ["commit", "-qam", "head"]);
+
+      const shown = runGit(root, [
+        "show",
+        "--no-ext-diff",
+        "--no-color",
+        "HEAD",
+      ]);
+      const ws = stubWs(root);
+      const model = parseDiff(shown)!;
+      const { doc, edit } = buildDiffDocument(shown, model, ws);
+      const s = new Session(
+        doc,
+        { color: false, showLineNumbers: false },
+        { width: 80, height: 20 },
+        undefined,
+        diffSource(ws, edit, undefined, realGit(root)),
+      );
+      const line = s.doc.lines.findIndex((entry) => entry.text === "+new");
+      assert(line >= 0, "textconv exposes the filtered added line");
+      toLine(s, line);
+      press(s, "end");
+      press(s, "backspace", "backspace", "backspace");
+      type(s, "pager");
+      press(s, "f3");
+      press(s, "a");
+
+      assertEquals(s.view().message, "Saved 1 file; Amended the commit");
+      assertEquals(runGit(root, ["show", "HEAD:f.dat"]), "PAGER\n");
+      assertEquals(runGit(root, ["show", ":f.dat"]), "PAGER\n");
+      assertEquals(Deno.readTextFileSync(path), "pager\n");
+      assertEquals(runGit(root, ["status", "--porcelain"]), "");
+    } finally {
+      Deno.removeSync(root, { recursive: true });
+    }
+  },
+});
+
+Deno.test("diffedit: an empty-message commit amends when its hunk changes", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "m.ts");
+    Deno.writeTextFileSync(path, "before\n");
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "parent"]);
+    Deno.writeTextFileSync(path, "after\n");
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "--allow-empty-message", "-m", ""]);
+
+    const shown = runGit(root, ["show", "--no-ext-diff", "--no-color", "HEAD"]);
+    const ws = stubWs(root);
+    const model = parseDiff(shown)!;
+    const { doc, edit } = buildDiffDocument(shown, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 20 },
+      undefined,
+      diffSource(ws, edit, undefined, realGit(root)),
+    );
+    const line = s.doc.lines.findIndex((entry) => entry.text === "+after");
+    assert(line >= 0, "git show contains the added line");
+    toLine(s, line);
+    press(s, "end");
+    type(s, " amended");
+    press(s, "f3");
+    assert(promptText(s.view()).includes("Amend commit"), promptText(s.view()));
+    press(s, "a");
+
+    assertEquals(s.view().message, "Saved 1 file; Amended the commit");
+    assertEquals(runGit(root, ["show", "HEAD:m.ts"]), "after amended\n");
+    assertEquals(runGit(root, ["log", "-1", "--format=%B"]), "\n");
+    assertEquals(runGit(root, ["status", "--porcelain"]), "");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: later hunk saves retain earlier amendments in the same file", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "m.ts");
+    const parent = Array.from(
+      { length: 16 },
+      (_, index) => `line ${index + 1}`,
+    );
+    Deno.writeTextFileSync(path, `${parent.join("\n")}\n`);
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "parent"]);
+    const head = [...parent];
+    head[1] = "line 2 committed";
+    head[14] = "line 15 committed";
+    Deno.writeTextFileSync(path, `${head.join("\n")}\n`);
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "two hunks"]);
+
+    const shown = runGit(root, ["show", "--no-ext-diff", "--no-color", "HEAD"]);
+    const ws = stubWs(root);
+    const model = parseDiff(shown)!;
+    assertEquals(model.files[0].hunks.length, 2, "git show has two hunks");
+    const { doc, edit } = buildDiffDocument(shown, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 30 },
+      undefined,
+      diffSource(ws, edit, undefined, realGit(root)),
+    );
+    const first = s.doc.lines.findIndex((entry) =>
+      entry.text === "+line 2 committed"
+    );
+    assert(first >= 0, "git show contains the first hunk");
+    toLine(s, first);
+    press(s, "end", "enter");
+    type(s, "inserted after first hunk line");
+    press(s, "f3");
+    press(s, "a");
+
+    const second = s.doc.lines.findIndex((entry) =>
+      entry.text === "+line 15 committed"
+    );
+    assert(second >= 0, "git show contains the second hunk");
+    toLine(s, second);
+    press(s, "end");
+    type(s, " second save");
+    press(s, "f3");
+    press(s, "a");
+
+    const committed = runGit(root, ["show", "HEAD:m.ts"]);
+    assert(
+      committed.includes(
+        "line 2 committed\ninserted after first hunk line\nline 3\n",
+      ),
+      committed,
+    );
+    assert(committed.includes("line 15 committed second save\n"), committed);
+    assertEquals(runGit(root, ["status", "--porcelain"]), "");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: editing a HEAD hunk does not amend a matching historical hunk", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "m.ts");
+    const parent = Array.from(
+      { length: 12 },
+      (_, index) => `line ${index + 1}`,
+    );
+    Deno.writeTextFileSync(path, `${parent.join("\n")}\n`);
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "parent"]);
+
+    const historical = [...parent];
+    historical[9] = "line 10 historical";
+    Deno.writeTextFileSync(path, `${historical.join("\n")}\n`);
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "historical line"]);
+
+    const current = [...historical];
+    current[9] = "line 10 current";
+    Deno.writeTextFileSync(path, `${current.join("\n")}\n`);
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "current line"]);
+
+    const head = [...current];
+    head[2] = "line 3 head";
+    Deno.writeTextFileSync(path, `${head.join("\n")}\n`);
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "head line"]);
+    const shown = runGit(root, [
+      "log",
+      "-p",
+      "-3",
+      "--no-ext-diff",
+      "--no-color",
+    ]);
+
+    const workspace = [...head];
+    workspace[9] = "line 10 historical";
+    Deno.writeTextFileSync(path, `${workspace.join("\n")}\n`);
+    const ws = stubWs(root);
+    const model = parseDiff(shown)!;
+    const { doc, edit } = buildDiffDocument(shown, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 40 },
+      undefined,
+      diffSource(ws, edit, undefined, realGit(root)),
+    );
+    const line = s.doc.lines.findIndex((entry) =>
+      entry.text === "+line 3 head"
+    );
+    assert(line >= 0, "git log contains the HEAD hunk");
+    toLine(s, line);
+    press(s, "end");
+    type(s, " amended");
+    press(s, "f3");
+    assert(promptText(s.view()).includes("Amend commit"), promptText(s.view()));
+    press(s, "a");
+    assertEquals(s.view().message, "Saved 1 file; Amended the commit");
+
+    const amendedHead = [...head];
+    amendedHead[2] = "line 3 head amended";
+    const amendedWorkspace = [...workspace];
+    amendedWorkspace[2] = "line 3 head amended";
+    assertEquals(
+      runGit(root, ["show", "HEAD:m.ts"]),
+      `${amendedHead.join("\n")}\n`,
+      "the amended commit keeps the current version of the historical line",
+    );
+    assertEquals(
+      Deno.readTextFileSync(path),
+      `${amendedWorkspace.join("\n")}\n`,
+      "the unrelated worktree version of the historical line remains",
+    );
+    assertEquals(runGit(root, ["status", "--porcelain"]), " M m.ts\n");
+
+    const amendedSha = runGit(root, ["rev-parse", "HEAD"]);
+    const historicalLine = s.doc.lines.findIndex((entry) =>
+      entry.text === "+line 10 historical"
+    );
+    assert(historicalLine > line, "git log contains the older writable hunk");
+    toLine(s, historicalLine);
+    press(s, "end");
+    type(s, " workspace edit");
+    press(s, "f3");
+
+    amendedWorkspace[9] = "line 10 historical workspace edit";
+    assertEquals(
+      s.view().dialog,
+      null,
+      "an older commit does not prompt amend",
+    );
+    assertEquals(s.view().message, "Saved 1 file");
+    assertEquals(
+      runGit(root, ["rev-parse", "HEAD"]),
+      amendedSha,
+      "editing an older commit's hunk does not move HEAD",
+    );
+    assertEquals(
+      Deno.readTextFileSync(path),
+      `${amendedWorkspace.join("\n")}\n`,
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: a historical insertion does not shift a later HEAD amend", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "m.ts");
+    const base = Array.from({ length: 14 }, (_, index) => `line ${index + 1}`);
+    Deno.writeTextFileSync(path, `${base.join("\n")}\n`);
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "base"]);
+
+    const historical = [...base];
+    historical[1] = "line 2 historical";
+    Deno.writeTextFileSync(path, `${historical.join("\n")}\n`);
+    runGit(root, ["commit", "-qam", "historical"]);
+
+    const head = [...historical];
+    head[11] = "line 12 head";
+    Deno.writeTextFileSync(path, `${head.join("\n")}\n`);
+    runGit(root, ["commit", "-qam", "head"]);
+    const shown = runGit(root, [
+      "log",
+      "-p",
+      "-2",
+      "-U0",
+      "--no-ext-diff",
+      "--no-color",
+    ]);
+    const ws = stubWs(root);
+    const model = parseDiff(shown)!;
+    const { doc, edit } = buildDiffDocument(shown, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 30 },
+      undefined,
+      diffSource(ws, edit, undefined, realGit(root)),
+    );
+
+    const older = s.doc.lines.findIndex((entry) =>
+      entry.text === "+line 2 historical"
+    );
+    assert(older >= 0, "git log contains the historical hunk");
+    toLine(s, older);
+    press(s, "end", "enter");
+    type(s, "historical workspace insertion");
+    press(s, "f3");
+    assertEquals(s.view().dialog, null, "the historical edit does not amend");
+    assertEquals(s.view().message, "Saved 1 file");
+
+    const headLine = s.doc.lines.findIndex((entry) =>
+      entry.text === "+line 12 head"
+    );
+    assert(headLine >= 0, "git log contains the HEAD hunk");
+    toLine(s, headLine);
+    press(s, "end");
+    type(s, " amended");
+    press(s, "f3");
+    assert(promptText(s.view()).includes("Amend commit"), promptText(s.view()));
+    press(s, "a");
+    assertEquals(s.view().message, "Saved 1 file; Amended the commit");
+
+    const amendedHead = [...head];
+    amendedHead[11] = "line 12 head amended";
+    assertEquals(
+      runGit(root, ["show", "HEAD:m.ts"]),
+      `${amendedHead.join("\n")}\n`,
+    );
+    const workspace = [...amendedHead];
+    workspace.splice(2, 0, "historical workspace insertion");
+    assertEquals(Deno.readTextFileSync(path), `${workspace.join("\n")}\n`);
+    assertEquals(runGit(root, ["status", "--porcelain"]), " M m.ts\n");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: expanded workspace context stays outside the amended commit", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "m.ts");
+    const base = Array.from({ length: 12 }, (_, index) => `line ${index + 1}`);
+    Deno.writeTextFileSync(path, `${base.join("\n")}\n`);
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "base"]);
+
+    const head = [...base];
+    head[9] = "line 10 head";
+    Deno.writeTextFileSync(path, `${head.join("\n")}\n`);
+    runGit(root, ["commit", "-qam", "head"]);
+    const shown = runGit(root, [
+      "show",
+      "-U0",
+      "--no-ext-diff",
+      "--no-color",
+      "HEAD",
+    ]);
+
+    const workspace = [...head];
+    workspace[8] = "line 9 unstaged";
+    Deno.writeTextFileSync(path, `${workspace.join("\n")}\n`);
+    const ws = stubWs(root);
+    const model = parseDiff(shown)!;
+    const { doc, edit } = buildDiffDocument(shown, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 30 },
+      undefined,
+      diffSource(ws, edit, undefined, realGit(root)),
+    );
+    const line = s.doc.lines.findIndex((entry) =>
+      entry.text === "+line 10 head"
+    );
+    assert(line >= 0, "git show contains the HEAD hunk");
+    const header = s.doc.lines.findLastIndex((entry, index) =>
+      index < line && entry.text.startsWith("@@ ")
+    );
+    assert(header >= 0, "git show contains the HEAD hunk header");
+    toLine(s, header);
+    press(s, "ctrl-l");
+    assert(
+      s.doc.lines.some((entry) => entry.text === " line 9 unstaged"),
+      `expansion reveals the unstaged workspace line:\n${s.doc.text}`,
+    );
+    const expandedLine = s.doc.lines.findIndex((entry) =>
+      entry.text === "+line 10 head"
+    );
+    toLine(s, expandedLine);
+    press(s, "end");
+    type(s, " amended");
+    assert(s.doc.text.includes("+line 10 head amended"), s.doc.text);
+    press(s, "f3");
+    assert(promptText(s.view()).includes("Amend commit"), promptText(s.view()));
+    press(s, "a");
+    assertEquals(s.view().message, "Saved 1 file; Amended the commit");
+
+    const amendedHead = [...head];
+    amendedHead[9] = "line 10 head amended";
+    assertEquals(
+      runGit(root, ["show", "HEAD:m.ts"]),
+      `${amendedHead.join("\n")}\n`,
+      "the expanded unstaged line is absent from the commit",
+    );
+    workspace[9] = "line 10 head amended";
+    assertEquals(Deno.readTextFileSync(path), `${workspace.join("\n")}\n`);
+    assertEquals(runGit(root, ["status", "--porcelain"]), " M m.ts\n");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: an amend excludes unrelated same-file edits and preserves their staged state", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    runGit(root, ["config", "user.email", "t@t.test"]);
+    runGit(root, ["config", "user.name", "Test"]);
+    const path = join(root, "m.ts");
+    const parentLines = Array.from({ length: 12 }, (_, i) => `line ${i + 1}`);
+    const commitLines = [...parentLines];
+    commitLines[5] = "line 6 committed";
+    Deno.writeTextFileSync(path, `${parentLines.join("\n")}\n`);
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "parent"]);
+    Deno.writeTextFileSync(path, `${commitLines.join("\n")}\n`);
+    runGit(root, ["add", "m.ts"]);
+    runGit(root, ["commit", "-q", "-m", "commit view"]);
+    const shown = runGit(root, ["show", "--no-ext-diff", "--no-color", "HEAD"]);
+
+    const indexLines = [...commitLines];
+    indexLines[3] = "line 4 staged";
+    Deno.writeTextFileSync(path, `${indexLines.join("\n")}\n`);
+    runGit(root, ["add", "m.ts"]);
+    const workspaceLines = [...commitLines];
+    workspaceLines[11] = "line 12 unstaged";
+    Deno.writeTextFileSync(path, `${workspaceLines.join("\n")}\n`);
+
+    const ws: DiffWorkspace = {
+      resolve: (relative) => join(root, relative),
+      read: (absolute) => {
+        try {
+          return Deno.readTextFileSync(absolute);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const model = parseDiff(shown)!;
+    const { doc, edit } = buildDiffDocument(shown, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 30 },
+      undefined,
+      diffSource(ws, edit, undefined, realGit(root)),
+    );
+    const line = s.doc.lines.findIndex((entry) =>
+      entry.text === "+line 6 committed"
+    );
+    assert(line >= 0, "git show contains the committed line");
+    toLine(s, line);
+    press(s, "end");
+    type(s, " EDIT");
+    press(s, "f3");
+    press(s, "a");
+
+    const amendedCommit = [...commitLines];
+    amendedCommit[5] = "line 6 committed EDIT";
+    const amendedIndex = [...indexLines];
+    amendedIndex[5] = "line 6 committed EDIT";
+    const amendedWorkspace = [...workspaceLines];
+    amendedWorkspace[5] = "line 6 committed EDIT";
+    assertEquals(
+      runGit(root, ["show", "HEAD:m.ts"]),
+      `${amendedCommit.join("\n")}\n`,
+    );
+    assertEquals(
+      runGit(root, ["show", ":m.ts"]),
+      `${amendedIndex.join("\n")}\n`,
+    );
+    assertEquals(
+      Deno.readTextFileSync(path),
+      `${amendedWorkspace.join("\n")}\n`,
+    );
+    assertEquals(runGit(root, ["status", "--porcelain"]), "MM m.ts\n");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
   }
 });
 
@@ -2432,7 +3929,7 @@ Deno.test("diffedit: quitting with an edited message confirms the save then the 
       promptText(s.view()),
     );
     assert(!s.quit, "not quit until the amend is confirmed");
-    press(s, "y"); // confirm the amend → save, amend, and quit
+    press(s, "a"); // confirm the amend → save, amend, and quit
     assert(s.quit, "quits after the amend");
     assert(
       fg.amended()?.startsWith("Subject line of the commit Q"),
@@ -2458,7 +3955,7 @@ Deno.test("diffedit: with no git runner the message is not editable", () => {
 
 // --- amend safety (review follow-ups) ----------------------------------------
 
-Deno.test("diffedit: refuses to save an all-blank commit message", () => {
+Deno.test("diffedit: refuses to amend an all-blank commit message", () => {
   const { ws, done } = tempWorkspace();
   const fg = fakeGit(SHOW_SHA);
   try {
@@ -2470,16 +3967,17 @@ Deno.test("diffedit: refuses to save an all-blank commit message", () => {
       press(s, "ctrl-k"); // kill to end (nudged past the indent)
     }
     press(s, "f3");
+    assert(s.view().dialog, "the files-only alternative remains available");
+    press(s, "a");
     assert(s.view().message.includes("would be empty"), s.view().message);
     assertEquals(fg.amended(), null, "an empty message is never amended");
-    // No amend prompt was raised, so no file was written either.
     assert(s.view().dialog == null, "no prompt is left open");
   } finally {
     done();
   }
 });
 
-Deno.test("diffedit: refuses to save when every commit-message line is deleted", () => {
+Deno.test("diffedit: refuses to amend when every commit-message line is deleted", () => {
   const { root, ws, done } = tempWorkspace();
   const before = Deno.readTextFileSync(join(root, "m.ts"));
   const fg = fakeGit(SHOW_SHA);
@@ -2496,6 +3994,8 @@ Deno.test("diffedit: refuses to save when every commit-message line is deleted",
     }
     assertEquals(s.doc.lines[4].text, "", "no message lines are left");
     press(s, "f3");
+    assert(s.view().dialog, "the files-only alternative remains available");
+    press(s, "a");
     assert(s.view().message.includes("would be empty"), s.view().message);
     assertEquals(fg.amended(), null, "the commit was not amended");
     assertEquals(s.view().dialog, null, "no prompt is left open");
@@ -2526,7 +4026,7 @@ Deno.test("diffedit: a SHA-256 repository's commit message is editable and amend
     assertEquals(s.doc.lines[4].text, "    Subject line of the commit EDIT");
     press(s, "f3");
     assert(promptText(s.view()).includes("Amend commit"), promptText(s.view()));
-    press(s, "y");
+    press(s, "a");
     assertEquals(
       fg.amended(),
       "Subject line of the commit EDIT\n\nA body paragraph of the message.",
@@ -2546,7 +4046,7 @@ Deno.test("diffedit: does not amend (or write files) when HEAD moved since the d
     press(s, "end");
     type(s, " X");
     press(s, "f3"); // editability used the cached (original) HEAD
-    press(s, "y"); // the amend re-reads HEAD, sees it moved, and refuses
+    press(s, "a"); // the amend re-reads HEAD, sees it moved, and refuses
     assertEquals(fg.amended(), null, "no amend when HEAD moved");
     assert(s.view().message.includes("HEAD has moved"), s.view().message);
     // The amend runs before the file write, so a refusal leaves files untouched.

--- a/packages/cli/test/view-editor.test.ts
+++ b/packages/cli/test/view-editor.test.ts
@@ -197,6 +197,26 @@ Deno.test("editor: F3 saves the edited text to disk", async () => {
   }
 });
 
+Deno.test("editor: F3 on an unchanged file reports zero and does not write", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".ts" });
+  try {
+    await Deno.writeTextFile(path, "hello\n");
+    const oldTime = new Date("2000-01-01T00:00:00.000Z");
+    await Deno.utime(path, oldTime, oldTime);
+    const mtime = (await Deno.stat(path)).mtime?.getTime();
+    const s = editSession("hello\n", fileSource(path));
+    press(s, "f3");
+    assertEquals(s.view().message, "Saved 0 files");
+    assertEquals(
+      (await Deno.stat(path)).mtime?.getTime(),
+      mtime,
+      "the unchanged file was not opened for writing",
+    );
+  } finally {
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("editor: C-x C-s saves to disk", async () => {
   const path = await Deno.makeTempFile({ suffix: ".ts" });
   try {

--- a/packages/cli/test/view-mod-cov.test.ts
+++ b/packages/cli/test/view-mod-cov.test.ts
@@ -31,6 +31,13 @@ Deno.test("buildView: a pipe with no file is a read-only source", () => {
   assertEquals(r.editSource.editable, false);
 });
 
+Deno.test("buildView: blank input remains a read-only source", () => {
+  const r = buildView(" \n\t\n");
+
+  assertEquals(r.editSource.isDiff, undefined);
+  assertEquals(r.editSource.editable, false);
+});
+
 Deno.test("buildView: a diff takes the diff branch and a diff-semantics closure", () => {
   const r = buildView(DIFF);
   r.semantics(); // runs createDiffSemantics (the diff closure body)
@@ -38,6 +45,150 @@ Deno.test("buildView: a diff takes the diff branch and a diff-semantics closure"
     r.doc.lines.some((l) => l.text.startsWith("@@")),
     "rendered as a diff",
   );
+});
+
+Deno.test("buildView: commit output with no file diff takes the commit-editing branch", () => {
+  const commit = [
+    "commit 0123456789abcdef0123456789abcdef01234567",
+    "Author: A B <a@b.example>",
+    "Date:   Wed Jul 1 12:00:00 2026 -0700",
+    "",
+    "    Empty commit subject",
+    "",
+  ].join("\n");
+  const r = buildView(commit);
+  assertEquals(r.editSource.isDiff, true);
+  assertEquals(r.editSource.label, null);
+});
+
+Deno.test("buildView: a commit with no message takes the commit branch", () => {
+  const commit = [
+    "commit 0123456789abcdef0123456789abcdef01234567",
+    "Author: A B <a@b.example>",
+    "Date:   Wed Jul 1 12:00:00 2026 -0700",
+    "",
+  ].join("\n");
+  const r = buildView(commit);
+  assertEquals(r.editSource.isDiff, true);
+  assertEquals(r.editSource.label, null);
+});
+
+Deno.test("buildView: commit-looking prose without Git metadata stays a source file", () => {
+  const text = [
+    "commit 0123456789abcdef0123456789abcdef01234567",
+    "",
+    "    Ordinary prose",
+    "",
+  ].join("\n");
+  const named = buildView(text, "notes.txt");
+  const piped = buildView(text);
+
+  assertEquals(named.editSource.isDiff, undefined);
+  assertEquals(named.editSource.editable, true);
+  assertEquals(piped.editSource.isDiff, undefined);
+  assertEquals(piped.editSource.editable, false);
+});
+
+Deno.test("buildView: a commit token followed by ordinary text stays a source file", () => {
+  const r = buildView("commit deadbee\nordinary text\n", "notes.txt");
+
+  assertEquals(r.editSource.isDiff, undefined);
+  assertEquals(r.editSource.editable, true);
+});
+
+Deno.test("buildView: a standard commit header without its separator stays source", () => {
+  const text = [
+    "commit 0123456789abcdef0123456789abcdef01234567",
+    "Author: A B <a@b.example>",
+    "Date:   Wed Jul 1 12:00:00 2026 -0700",
+  ].join("\n");
+  const r = buildView(text, "notes.txt");
+
+  assertEquals(r.editSource.isDiff, undefined);
+  assertEquals(r.editSource.editable, true);
+});
+
+Deno.test("buildView: an email commit header without its separator stays source", () => {
+  const sha = "0123456789abcdef0123456789abcdef01234567";
+  const text = [
+    `From ${sha} Mon Sep 17 00:00:00 2001`,
+    "From: A B <a@b.example>",
+    "Date: Wed, 1 Jul 2026 12:00:00 -0700",
+    "Subject: [PATCH] Subject",
+  ].join("\n");
+  const r = buildView(text, "notes.txt");
+
+  assertEquals(r.editSource.isDiff, undefined);
+  assertEquals(r.editSource.editable, true);
+});
+
+Deno.test("buildView: Git's built-in commit header formats take the commit branch", () => {
+  const sha = "0123456789abcdef0123456789abcdef01234567";
+  const formats = [
+    ["short", "Author: A B <a@b.example>"],
+    ["full", "Author: A B <a@b.example>\nCommit: C D <c@d.example>"],
+    [
+      "fuller",
+      "Author: A B <a@b.example>\nAuthorDate: Wed Jul 1 12:00:00 2026 -0700\n" +
+      "Commit: C D <c@d.example>\nCommitDate: Wed Jul 1 12:00:00 2026 -0700",
+    ],
+    [
+      "raw",
+      `tree ${"a".repeat(40)}\nauthor A B <a@b.example> 1782932400 -0700\n` +
+      "committer C D <c@d.example> 1782932400 -0700",
+    ],
+  ];
+
+  for (const [format, headers] of formats) {
+    const text = `commit ${sha}\n${headers}\n\n    Subject\n`;
+    assertEquals(
+      buildView(text).editSource.isDiff,
+      true,
+      `${format} output is a commit view`,
+    );
+  }
+});
+
+Deno.test("buildView: compact and email commit formats retain diff ownership", () => {
+  const sha = "0123456789abcdef0123456789abcdef01234567";
+  const formats = [
+    ["oneline", `${sha} Subject\n${DIFF}`],
+    ["reference", `0123 (Subject, 2026-07-20)\n${DIFF}`],
+    [
+      "email",
+      [
+        `From ${sha} Mon Sep 17 00:00:00 2001`,
+        "From: A B <a@b.example>",
+        "Date: Wed, 1 Jul 2026 12:00:00 -0700",
+        "Subject: [PATCH] Subject",
+        "",
+        "Body",
+        "",
+        DIFF,
+      ].join("\n"),
+    ],
+  ];
+
+  for (const [format, text] of formats) {
+    assertEquals(
+      buildView(text).editSource.isDiff,
+      true,
+      `${format} output retains commit-aware diff handling`,
+    );
+  }
+});
+
+Deno.test("buildView: CRLF commit-only output takes the commit branch", () => {
+  const text = [
+    "commit 0123456789abcdef0123456789abcdef01234567",
+    "Author: A B <a@b.example>",
+    "Date:   Wed Jul 1 12:00:00 2026 -0700",
+    "",
+    "    Subject",
+    "",
+  ].join("\r\n");
+
+  assertEquals(buildView(text).editSource.isDiff, true);
 });
 
 Deno.test("buildView: forceDiff pins diff mode even on non-diff text", () => {

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -596,11 +596,72 @@ Deno.test("pager: a prompt button's result waits for the press animation to fini
     "the result waited for the press timer, so it never drew",
   );
 
+  const partial = await run([
+    ...openRevert,
+    { bytes: new Uint8Array([0xce]) }, // first byte of a split UTF-8 key
+    { eof: true },
+  ]);
+  assert(
+    !partial.some((w) => w.includes("Cancelled")),
+    "an incomplete next key kept the pressed frame on screen",
+  );
+
   const fired = await run([...openRevert, { fireTimers: true }, { eof: true }]);
   assert(
     fired.some((w) => w.includes("Cancelled")),
     "the press timer drew the result",
   );
+});
+
+Deno.test("pager: paints a pressed button before its synchronous action starts", async () => {
+  const { doc, source: base, dir } = editableDoc();
+  try {
+    const { deps, writes } = makeFake({
+      steps: [
+        { bytes: enc("e") },
+        { bytes: enc("X") },
+        { bytes: enc("\x18") }, // Ctrl-X
+        { bytes: enc("\x13") }, // Ctrl-S: open the amend prompt
+        { bytes: enc("a") }, // Amend commit
+        { eof: true },
+      ],
+    });
+    let promptFramesWhenSaveStarted = -1;
+    let pressedFrameWasDistinct = false;
+    const source = {
+      ...base,
+      pendingAmend: () => ({
+        sha: "0123456789abcdef0123456789abcdef01234567",
+        subject: "A commit subject",
+      }),
+      save: (
+        text: string,
+        baseline?: string,
+        options?: Parameters<typeof base.save>[2],
+      ) => {
+        const promptFrames = writes.filter((write) =>
+          write.includes("Amend commit 012345678")
+        );
+        promptFramesWhenSaveStarted = promptFrames.length;
+        pressedFrameWasDistinct = promptFrames[0] !== promptFrames[1];
+        return base.save(text, baseline, options);
+      },
+    };
+
+    await runPager(doc, OPTS, undefined, source, deps);
+
+    assertEquals(
+      promptFramesWhenSaveStarted,
+      2,
+      "the ordinary prompt frame and its pressed frame were written before save",
+    );
+    assert(
+      pressedFrameWasDistinct,
+      "the second frame visibly pressed the button",
+    );
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
+  }
 });
 
 Deno.test("pager: a committing button plays its press before the pager quits", async () => {


### PR DESCRIPTION
Diff saves previously reconstructed every verified file, including files the user had not edited. Commit views could amend a changed message without placing edited file contents into the commit, and they offered no safe way to save those files without rewriting history.

Track edits by hunk and write only backing files whose contents changed. Report the exact file count, offer Amend commit, Save files only, and Cancel as distinct actions, and keep an unsaved message visibly dirty after a files-only save.

Recognize supported Git commit output only when its structured metadata is present. Resolve ambiguous email-formatted patch ownership from commit and blob objects so historical hunks and commit-like message text cannot be assigned to HEAD.

Build amendments from the displayed commit through an isolated index, then merge the selected results back into the real index. Preserve unrelated staged and unstaged edits, same-file changes, index flags, file modes, filters, lexical paths, original message bytes, and commit encoding. Reject conflicts, stale files, incompatible type changes, moved references, and ambiguous insertions before publishing the result.

Run configured hooks in the active worktree while journaling owned reference transactions. Protect file-backed and reftable repositories, detached heads, linked worktrees, hook-spawned commits, and nested repository commands. Validate hook changes and roll back only owned state so concurrent workspace, index, and reference updates survive a failed amend.

Paint pressed buttons before synchronous file or Git work starts and preserve animations across partial terminal key reads. Give refused edits a commit-specific status when the line belongs to a commit other than HEAD, while retaining the existing guidance for diff structure and resurrectable removed lines. Add coverage for selective saves, output formats, races, hooks, rollback, repository layouts, repeated saves, explicit actions, historical commit refusals, and terminal animation ordering.

Remove a stray test marker from the commit-message module.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add safe, selective save and amend for commit views in the CLI. Only changed files are written, commit-only views can edit the message, and users can choose Amend commit or Save files only without rewriting history.

- **New Features**
  - Save only what changed: track edits by hunk and write only modified backing files; report “Saved N files” (including “Saved 0 files”).
  - Save prompt offers three actions: Amend commit, Save files only, Cancel; the commit message stays dirty after a files‑only save.
  - Commit-aware editing: detect valid commit output (compact, oneline, and email formats) and allow editing only the displayed commit’s message, including commit-only views with no file diffs.
  - Safe amend flow: build in an isolated index and merge back; preserve unrelated staged/unstaged changes, index flags, modes, filters, paths, and message bytes/encoding; reject conflicts, stale files, incompatible type changes, moved refs, and ambiguous insertions; run hooks in the active worktree; journal ref updates and roll back only owned state; protect reftable/file‑backed repos, detached HEADs, linked worktrees, and hook‑spawned commits.

- **Bug Fixes**
  - Prevent saving files the user did not edit.
  - Paint pressed buttons before work starts; keep animations across partial key reads and split UTF‑8 keys.
  - Clear status for refused edits when the displayed commit is not `HEAD`; preserve existing diff guidance.
  - Added coverage for selective saves, commit formats, races, hooks, rollback, repository layouts, repeated saves, explicit actions, and animation ordering.

<sup>Written for commit 6493efc77fa4617f05f6b962c4213bc5f0853581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

