### PR TITLE
refactor(runner): joinSchema keyword descent via forEachSubschema

### DIFF
--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -24,6 +24,7 @@ import {
   resolveCfcSchemaRefsOrThrow,
   selectReferencedCfcSchemaDefs,
 } from "./cfc/schema-refs.ts";
+import { forEachSubschema } from "./schema-walk.ts";
 export {
   CFC_ATOM_TYPE,
   CFC_CONCEPT_KIND,
@@ -288,74 +289,23 @@ export class ContextualFlowControl {
     if (schema.ifc) {
       ContextualFlowControl.addIfcAtoms(joined, schema.ifc.confidentiality);
     }
-    // A value validates against one (anyOf/oneOf) or all (allOf) branches, so the
-    // confidentiality LUB must union every branch's atoms; otherwise branch-local
-    // confidentiality is silently dropped (under-tainting fail-open, audit 1.6).
-    for (const key of ["anyOf", "oneOf", "allOf"] as const) {
-      const branches = (schema as Record<string, unknown>)[key];
-      if (Array.isArray(branches)) {
-        for (const branch of branches) {
-          if (branch !== undefined && typeof branch === "object") {
-            ContextualFlowControl.joinSchema(
-              joined,
-              branch as JSONSchema,
-              cfcSchemaChildRoot(
-                branch as JSONSchema,
-                schemaRoot,
-              ),
-              nextActive,
-            );
-          }
-        }
-      }
-    }
-    // Tuple element schemas carry their own confidentiality too.
-    if (Array.isArray((schema as Record<string, unknown>).prefixItems)) {
-      for (
-        const item of (schema as { prefixItems: JSONSchema[] }).prefixItems
-      ) {
-        if (item !== undefined && typeof item === "object") {
-          ContextualFlowControl.joinSchema(
-            joined,
-            item,
-            cfcSchemaChildRoot(item, schemaRoot),
-            nextActive,
-          );
-        }
-      }
-    }
-    if (schema.properties && typeof schema.properties === "object") {
-      for (const value of Object.values(schema.properties)) {
-        ContextualFlowControl.joinSchema(
-          joined,
-          value,
-          cfcSchemaChildRoot(value, schemaRoot),
-          nextActive,
-        );
-      }
-    }
-    if (
-      schema.additionalProperties &&
-      typeof schema.additionalProperties === "object"
-    ) {
+    // The LUB must union the atoms of every subschema a value could validate
+    // against — one (anyOf/oneOf) or all (allOf) branches, every property,
+    // every tuple slot, items and additionalProperties alike; a skipped
+    // keyword is branch-local confidentiality silently dropped
+    // (under-tainting fail-open, audit 1.6). `not` is unioned too: usually
+    // its atoms describe values the data must NOT contain — a conservative
+    // over-taint — but a nested `not` (not-of-not) re-selects values that DO
+    // match the inner subschema, so skipping `not` could under-taint.
+    forEachSubschema(schema, (child) => {
       ContextualFlowControl.joinSchema(
         joined,
-        schema.additionalProperties,
-        cfcSchemaChildRoot(
-          schema.additionalProperties,
-          schemaRoot,
-        ),
+        child,
+        cfcSchemaChildRoot(child, schemaRoot),
         nextActive,
       );
-    } else if (schema.items && typeof schema.items === "object") {
-      // TODO(@ubik2): need to handle prefixItems -- also probably not else if here
-      ContextualFlowControl.joinSchema(
-        joined,
-        schema.items,
-        cfcSchemaChildRoot(schema.items, schemaRoot),
-        nextActive,
-      );
-    } else if (schema.$ref) {
+    });
+    if (schema.$ref) {
       // Follow the references
       const resolvedSchema = ContextualFlowControl.resolveSchemaRefsOrThrow(
         schema,

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -292,11 +292,14 @@ export class ContextualFlowControl {
     // The LUB must union the atoms of every subschema a value could validate
     // against — one (anyOf/oneOf) or all (allOf) branches, every property,
     // every tuple slot, items and additionalProperties alike; a skipped
-    // keyword is branch-local confidentiality silently dropped
-    // (under-tainting fail-open, audit 1.6). `not` is unioned too: usually
-    // its atoms describe values the data must NOT contain — a conservative
-    // over-taint — but a nested `not` (not-of-not) re-selects values that DO
-    // match the inner subschema, so skipping `not` could under-taint.
+    // keyword is branch-local confidentiality silently dropped (under-tainting
+    // fail-open, audit 1.6). The default walk excludes the keywords we never
+    // emit (`if`/`then`/`else`, `patternProperties`, ...) — ifc flags in
+    // those unused schema fields are deliberately not collected. `not` is
+    // unioned too: usually its atoms describe values the data must NOT
+    // contain — a conservative over-taint — but a nested `not` (not-of-not)
+    // re-selects values that DO match the inner subschema, so skipping `not`
+    // could under-taint.
     forEachSubschema(schema, (child) => {
       ContextualFlowControl.joinSchema(
         joined,

--- a/packages/runner/test/cfc-joinschema-combinators.test.ts
+++ b/packages/runner/test/cfc-joinschema-combinators.test.ts
@@ -40,6 +40,47 @@ describe("ContextualFlowControl.lubSchema combinator descent", () => {
     } as JSONSchema)).toEqual(["t0", "t1"]);
   });
 
+  // joinSchema used to chain additionalProperties / items / $ref with
+  // `else if`, so a schema carrying more than one of them joined only the
+  // first — the same under-tainting class as the combinator gap above.
+  it("unions additionalProperties and items together", () => {
+    expect(atomsOf({
+      type: "object",
+      additionalProperties: {
+        type: "string",
+        ifc: { confidentiality: ["ap"] },
+      },
+      items: { type: "number", ifc: { confidentiality: ["it"] } },
+    } as JSONSchema)).toEqual(["ap", "it"]);
+  });
+
+  it("follows $ref alongside items", () => {
+    expect(atomsOf({
+      type: "array",
+      items: { type: "string", ifc: { confidentiality: ["el"] } },
+      $ref: "#/$defs/R",
+      $defs: {
+        R: { type: "array", ifc: { confidentiality: ["ref"] } },
+      },
+    } as JSONSchema)).toEqual(["el", "ref"]);
+  });
+
+  // A plain `not` over-taints conservatively, but a nested `not` (not-of-not)
+  // re-selects values that DO match the inner subschema — descending `not` is
+  // needed for soundness, not just conservatism.
+  it("unions confidentiality under not (conservative over-taint)", () => {
+    expect(atomsOf({
+      type: "string",
+      not: { ifc: { confidentiality: ["n"] } },
+    } as JSONSchema)).toEqual(["n"]);
+  });
+
+  it("reaches atoms under a double negation (not-of-not matches)", () => {
+    expect(atomsOf({
+      not: { not: { type: "string", ifc: { confidentiality: ["nn"] } } },
+    } as JSONSchema)).toEqual(["nn"]);
+  });
+
   it("does not mistake identical refs in different definition roots for a cycle", () => {
     const shared = { $ref: "#/$defs/V" } as const;
     expect(atomsOf({


### PR DESCRIPTION
## Summary

Replaces `joinSchema`'s hand-rolled subschema enumeration (~80 lines across `anyOf`/`oneOf`/`allOf`, `prefixItems`, `properties`, and the `additionalProperties`/`items`/`$ref` `else if` chain) with a single `forEachSubschema` callback from the shared schema-walk vocabulary (#4850), resolving the `TODO(@ubik2)` at the old chain. The bespoke rooted cycle tracker and per-child `cfcSchemaChildRoot` threading are unchanged — that's why this uses the shallow primitive rather than `walkSchema`.

Three behavior changes, all in the fail-closed direction (same under-tainting class as audit 1.6):

- `additionalProperties` and `items` both contribute atoms (previously first-wins via `else if`).
- `$ref` is followed even alongside `items`/`additionalProperties` (previously suppressed; an unresolvable ref there now throws instead of being skipped).
- `not` subschemas are unioned. Usually a conservative over-taint, but a nested `not` (not-of-not) re-selects values that DO match the inner subschema, so skipping `not` could under-taint.

Part of the prefixItems/schema-walk audit tracked in CT-1895.

## Test plan

- New regression tests in `cfc-joinschema-combinators.test.ts` pinning each behavior change: `additionalProperties`+`items` unioned, `$ref` alongside `items`, `not` descent, and double-negation reachability.
- Full runner suite: 989 passed / 0 failed. Only external `lubSchema` consumer (`packages/html`): 41 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `joinSchema` to use the shared `forEachSubschema` walker so all relevant subschemas are traversed, fixing prior under-tainting and adding focused regression tests. Documents that unused keywords are deliberately skipped, supporting CT-1895 by standardizing traversal.

- **Refactors**
  - Replaced hand-rolled traversal with `forEachSubschema`.
  - Kept the cycle tracker and `cfcSchemaChildRoot`; this remains a shallow walk, not `walkSchema`.
  - The walker excludes unused keywords (`if`/`then`/`else`, `patternProperties`, etc.); IFC in those fields is intentionally not collected.

- **Bug Fixes**
  - Union atoms from both `additionalProperties` and `items`.
  - Follow `$ref` even when `items`/`additionalProperties` are present; unresolved refs now throw.
  - Descend into `not` (including double negation) to avoid under-tainting; over-taints conservatively where applicable.

<sup>Written for commit 0383ed325c39139a76e643f81bddf641122fdd16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

