### PR TITLE
docs: define the piece source lifecycle

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -256,6 +256,17 @@ propagate](#how-flags-propagate).
   identity/source/import revisions fails closed at the compiled-identity
   comparison. See
   [`docs/specs/pattern-imports/pattern-updates.md`](../specs/pattern-imports/pattern-updates.md).
+
+  **Current behavior.** Before a release, the existing golden replay tests load
+  representative state written by the previous pattern version. They verify
+  that the new version preserves the state's intended meaning and behavior. The
+  updater itself does not infer stable-key, stable-cause, migration, or
+  behavioral compatibility during deployment.
+
+  **Planned behavior.** The general piece-source lifecycle will reject known
+  structural schema incompatibilities before applying an unattended source
+  transition. Semantic compatibility will continue to be checked before release
+  rather than inferred by the runtime.
 - **Current default and planned end state.** The runner built-in default is off
   like every flag in this category; the shell build injects `true` unless the
   define is set to `"false"`, so the deployed product (and local shell dev

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -283,23 +283,40 @@ runtime-neutral digest:
 const hashes = computeModuleHashes(authoredProgram, {
   runtimeFingerprint: "",
 });
+const normalizedExports = Object.entries(publicSubpaths)
+  .sort(([a], [b]) => utf8Compare(a, b))
+  .map(([subpath, filename]) => [subpath, filename]);
 const runtimeNeutralProgramDigest = hashStringOf({
   v: "cf/runtime-neutral-program-digest/v1",
   main: authoredProgram.main,
   modules: [...hashes]
     .sort(([a], [b]) => utf8Compare(a, b))
     .map(([filename, identity]) => [filename, identity]),
+  exports: normalizedExports,
 });
 ```
 
 The input is the explicitly enumerated canonical authored program before adding
 fabric-mounted files or synthetic retention links. It includes every enumerated
 authored file, including an unreachable sibling and an authored declaration
-file. Each per-module identity includes the canonical filename, normalized
-source, internal import graph, and external specifier text, including fabric
-pins. The digest excludes the selected export, which revision comparison checks
-separately. It is comparison metadata rather than a fabric URL, executable
-identity, or revert target.
+file. It also includes the normalized exact public-subpath map from the
+immutable authored-program manifest. A program with no explicit subpaths uses
+an empty map; its entry remains implicitly public through `main`. Each
+per-module identity includes the canonical filename, normalized source,
+internal import graph, and external specifier text, including fabric pins. The
+digest excludes the selected executable export, which revision comparison
+checks separately. It is comparison metadata rather than a fabric URL,
+executable identity, or revert target.
+
+`publicSubpaths` is required lifecycle input alongside the repository's current
+`Program` shape. The existing `Program` interface has only `main` and `files`.
+Adding the map to source ingestion and retained manifests is required work; the
+digest code above describes the target algorithm rather than current behavior.
+
+Changing only the public-subpath map changes the manifest identity and this
+digest. It does not change any per-module identity or the executable entry
+identity. Piece lifecycle history therefore records a source-only revision and
+propagates it to followers without rebuilding unchanged modules.
 
 The lifecycle source service must materialize that complete `Program` before
 import-closure resolution. The current `ProgramResolver` interface cannot
@@ -538,7 +555,8 @@ identity over a shared set of module documents.
 Piece revision history separately uses the immutable
 `cf/authored-program-manifest/v1` value from
 [piece-source-lifecycle.md](piece-source-lifecycle.md) to bind the canonical main
-and every authored file, including files outside that executable graph.
+and every authored file, including files outside that executable graph. The
+same manifest binds the exact public-subpath map.
 
 This replaces the whole-program `PatternMeta` store after the flag flip (the two
 coexist behind the flag until then). The compiler-version and `sesValidated`

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -16,7 +16,8 @@ transitive import graph, and (2) ES-module loading into SES compartments. The
 motivating consumer is [persistent scheduler state](persistent-scheduler-state.md),
 whose action implementation fingerprint is currently unstable across reloads.
 
-All phases are complete. Identity decoupling (Phase 1, formerly behind
+All phases of the original loader rollout are complete. Identity decoupling
+(Phase 1, formerly behind
 `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`) is merged. The module-loading
 mechanism (Phases 2–4) is the production path: a synchronous SES
 virtual-module-record loader, a TS→record adapter that runs the full CF
@@ -29,9 +30,15 @@ path, and a structural graph verifier. Security hardening landed alongside
 done: the flag was flipped, then the flag, the AMD bundle pipeline, and the AMD
 compilation cache were deleted.
 
+The module hash accepts an optional runtime fingerprint, and unit tests cover
+its effect on external-dependency leaves. Production pattern compilation,
+entry-identity calculation, source verification, and replication currently use
+the empty default. The fingerprint-aware executable-identity and lifecycle
+rules below are settled target behavior that still requires integration.
+
 ## Last Updated
 
-2026-07-21
+2026-07-22
 
 ## Summary
 
@@ -52,11 +59,11 @@ TypeScript source** and the hashes of every module it imports. That hash is:
 
 - **stable** across entry points and unrelated sibling files, because it depends
   only on the module's own reachable import closure;
-- **stable across TCB evolution**, because it hashes the author's source, not the
-  compiled output. A transformer or compiler improvement must not retroactively
-  change the identity of code the author never edited — code references can
-  point at long-known-good versions, and the trusted computing base (the
-  transformer/compiler) evolves independently of them;
+- **stable as authored source across TCB evolution**, because a runtime-neutral
+  module identity hashes the author's source and pinned specifiers rather than
+  compiled output. The executable module identity separately folds the runtime
+  fingerprint into external-dependency leaves. An affected importer therefore
+  receives a new executable identity after a runtime upgrade;
 - **transitively sensitive**, because changing any module in that closure changes
   the importing module's hash too — behavior can change when an imported function
   *or an imported type* changes, and the fingerprint must reflect that.
@@ -85,10 +92,10 @@ this work and is out of scope.
 - Make that identity sensitive to transitive changes: editing an imported
   function or type invalidates the fingerprint of everything that transitively
   imports it.
-- Keep code identity stable across TCB evolution: a transformer/compiler change
-  must not invalidate references to unchanged authored source. Compilation-
-  semantics changes are captured separately by the scheduler's
-  `runtimeFingerprint`, not by the per-module content hash.
+- Keep a runtime-neutral identity for unchanged authored source across TCB
+  evolution. Fold the runtime fingerprint into executable identities whose
+  reachable graphs contain external dependencies. Revision history can then
+  distinguish a runtime rebuild from an authored-source edit.
 - Track type imports as well as value imports, because the transformer lowers
   types into emitted output (schema generation), so types affect runtime
   behavior.
@@ -206,15 +213,13 @@ For each authored module `M`:
   the CF transformer pipeline and before TypeScript emit. Normalization is
   limited to line-ending canonicalization; type annotations and comments are
   retained. Hashing the author's source rather than compiled JS is deliberate:
-  - It keeps code identity **stable across TCB evolution.** The transformer and
-    compiler are the trusted computing base; they improve over time. Hashing
-    emitted output would give the same authored code a new identity on every
-    transformer release, so a reference could never denote a long-known-good
-    version of code. Hashing source ties identity to author intent. Compilation-
-    semantics changes are handled on a separate axis by the scheduler's
-    `runtimeFingerprint` (which already encodes the runtime/scheduler version),
-    so the scheduler still invalidates correctly when the TCB changes — without
-    destroying the durable code identity.
+  - It keeps the runtime-neutral module identity **stable across TCB
+    evolution.** The transformer and compiler are the trusted computing base;
+    they improve over time. Hashing emitted output would make it impossible to
+    tell a runtime rebuild from an authored-source change. The executable module
+    identity separately includes `runtimeFingerprint` on external-dependency
+    leaves. A runtime upgrade therefore changes affected executable identities
+    without changing the runtime-neutral module identity.
   - It naturally **includes types**, which are load-bearing (the transformer
     lowers types into emitted schemas). We therefore do *not* strip types, and
     do *not* need to distinguish type-only from value imports.
@@ -244,6 +249,80 @@ leafOrHash(target) =
 upgrade invalidates everything that imports them, consistent with the existing
 `runtimeFingerprint` invariant.
 
+The executable runtime fingerprint comes from one authoritative provider,
+`getExecutableRuntimeFingerprint()`. Its version-1 value is a domain-separated
+hash with the tag `cf/executable-runtime-fingerprint/v1`. The hash includes:
+
+- the value returned by `getCompileCacheRuntimeVersion()`;
+- `schedulerRuntimeFingerprint()`;
+- an automatically generated catalog hash of the implementations and export
+  surfaces of every pattern-facing runtime module; and
+- an automatically generated catalog hash of the sandbox and execution-policy
+  inputs that can change pattern behavior.
+
+The existing compile-cache runtime version intentionally hashes a broad set of
+compiler, transformer, schema, harness, sandbox, API, compiler-option, and
+dependency inputs. Version 1 uses that value as a mandatory input even though it
+can over-invalidate executable identities. A later design may split
+representation-only cache inputs from executable semantics. Such a split may
+roll `runtimeVersion` alone only for an input proven unable to affect compiled
+behavior. A compiler, transformer, generated-schema, runtime-module, sandbox,
+execution-policy, or scheduler-semantics change must roll the executable runtime
+fingerprint.
+
+The provider and its input catalogs are required production work. Once the
+provider is enabled, inability to calculate its value fails closed. The empty
+fingerprint remains only the canonical interpretation of source documents
+published before this integration. It is not a valid fingerprint for newly
+published source whose identity depends on an external module.
+
+Piece history compares complete authored programs with a versioned,
+runtime-neutral digest:
+
+```text
+const hashes = computeModuleHashes(authoredProgram, {
+  runtimeFingerprint: "",
+});
+const runtimeNeutralProgramDigest = hashStringOf({
+  v: "cf/runtime-neutral-program-digest/v1",
+  main: authoredProgram.main,
+  modules: [...hashes]
+    .sort(([a], [b]) => utf8Compare(a, b))
+    .map(([filename, identity]) => [filename, identity]),
+});
+```
+
+The input is the explicitly enumerated canonical authored program before adding
+fabric-mounted files or synthetic retention links. It includes every enumerated
+authored file, including an unreachable sibling and an authored declaration
+file. Each per-module identity includes the canonical filename, normalized
+source, internal import graph, and external specifier text, including fabric
+pins. The digest excludes the selected export, which revision comparison checks
+separately. It is comparison metadata rather than a fabric URL, executable
+identity, or revert target.
+
+The lifecycle source service must materialize that complete `Program` before
+import-closure resolution. The current `ProgramResolver` interface cannot
+enumerate unreachable files, so existing resolver-only flows define their input
+as the reachable closure until they adopt an explicit program manifest.
+
+Authored and verified mounted `.d.ts` files are source-only identity nodes. A
+value or type import of one of these declarations contributes the declaration's
+module identity to every transitive importer. The declaration is stored in
+source history but does not produce a JavaScript module record.
+
+Declaration stubs supplied by the runtime for modules such as `commonfabric`
+remain type-check inputs rather than authored identity nodes. The authored bare
+specifier stays an external leaf that contains the runtime fingerprint. Record
+assembly, compiled-cache membership, and compiled links include only emitted
+modules.
+
+Production `Engine` paths currently filter every `.d.ts` file before
+`computeFabricModuleIdentities`, `CacheableModule` construction, and
+`writeSourceDocs`. Replacing that blanket filter with provenance-aware
+type-check, identity and source-history, and emitted sets is required integration
+work.
+
 **Cycles.** ES modules permit import cycles, so the import graph is not strictly
 a DAG. Compute over the condensation: find strongly-connected components, hash
 each SCC as a unit (members sorted by stable path, concatenating their
@@ -259,11 +338,13 @@ reduce to the formula above.
   `M`'s closure, file ordering, or any whole-program prefix. Therefore the same
   module with the same reachable imports hashes identically no matter which
   entry point pulled it into a compilation.
-- **TCB independence.** `moduleHash(M)` is a function of authored source, not of
-  the transformer/compiler version, so a TCB upgrade leaves it unchanged. The
-  scheduler's `runtimeFingerprint` covers the "did the compilation semantics
-  change" question separately, so trusting a persisted observation still
-  requires both a matching `moduleHash` *and* a matching `runtimeFingerprint`.
+- **Runtime sensitivity with source continuity.** `moduleHash(M)` changes with
+  `runtimeFingerprint` when `M` or its reachable dependencies import an external
+  module. A module with no reachable external dependency remains unchanged. A
+  separate runtime-neutral module identity over authored source and pinned
+  specifiers identifies the module across runtime rebuilds. Trusting a persisted
+  observation still requires both a matching `moduleHash` and a matching
+  `runtimeFingerprint`.
 - **Transitive sensitivity.** If any module `N` in `M`'s closure changes,
   `moduleHash(N)` changes; since `moduleHash(N)` is an input to every module that
   transitively imports `N`, all of their hashes change. Changes propagate to
@@ -358,46 +439,90 @@ The cache key moves from whole-program `computeId` to per-module
 ### Storage model: two content-addressed document sets, per space
 
 The persistent cache is **content-addressed cells**, not an in-process map. Each
-module is stored as two regular cells, in the **target space** (per-space — there
-is no global cache), and the storage layer's existing **sigil-link following**
-under a schema loads the whole import closure transitively from a single request
-(cycles handled by per-document dedup, as for any linked data):
+emitted module is stored as two regular cells in the **target space**. Authored
+and mounted declarations have only a source document because they emit no
+JavaScript record. There is no global cache. The storage layer's existing
+**sigil-link following** under a schema loads the whole import closure
+transitively from a single request. Per-document dedup handles cycles, as for any
+linked data:
 
-1. **Source set — `pattern:<identity>`.** Authored TypeScript, keyed by the
-   per-module Merkle `moduleHash` (`cf:module/<hash>`). It is runtime-version
-   independent (written essentially once ever) and **self-verifying**: a reader
-   checks `hash(content) === <identity>`, so content-addressing *is* the
-   integrity — no separate label needed.
-2. **Compiled set — `compileCache:<runtimeVersion>/<identity>`.** Compiled +
-   verified JS, keyed by `(runtimeVersion, identity)`. A runtime/transformer
-   upgrade rolls `runtimeVersion`, recompiling this set while the source set
-   persists.
+1. **Source set — `pattern:<identity>`.** Authored TypeScript implementation and
+   declaration source, keyed by the per-module Merkle `moduleHash`
+   (`cf:module/<hash>`). It is independent of the compiled-cache
+   `runtimeVersion`. An affected module receives another source set when
+   `runtimeFingerprint` changes. It is **self-verifying**: a reader recomputes
+   the identity from the source, import graph, and recorded identity
+   fingerprint. Content addressing is the integrity check, so no separate label
+   is needed.
+2. **Compiled set — `compileCache:<runtimeVersion>/<identity>`.** Compiled and
+   verified JS, keyed by `(runtimeVersion, identity)`. Under the version-1
+   executable-fingerprint rule, the existing broad compiler-input fingerprint
+   rolls both `runtimeVersion` and `runtimeFingerprint`. That creates a new
+   executable identity for an affected module and writes a new source set. A
+   future representation-only cache change may roll `runtimeVersion` alone only
+   after the fingerprint inputs distinguish it from executable semantics.
 
-Each document holds
-`{ code, filename, imports: [{ specifier, link }], delegatedModuleIdentities? }`,
-where `link` is a sigil link to the dependency's document in the same set.
+Each new source document whose reachable graph contains an external dependency
+also records the runtime fingerprint used for its identity. A source document
+without such a dependency uses the canonical empty fingerprint, and writers
+omit the field for that value. The same identity therefore never has two
+effective fingerprint representations. Other non-normative fields, including
+annotations and synthetic retention links, may differ without changing module
+identity. An absent fingerprint field always means the empty value for legacy
+compatibility. Verification recomputes that document under the effective value.
+Removing the non-empty field from a newer document therefore produces an
+identity mismatch without a separate missing-field rule. A verifier rejects a
+non-empty value on a document whose identity does not depend on it because that
+fingerprint representation is not canonical.
+As in the existing per-view verifier, each source document becomes the root of
+its authored-import view and supplies that view's effective fingerprint.
+Synthetic retention links are excluded. This lets one retained source set hold
+unrelated legacy and current roots without applying one entry fingerprint to
+every document.
+
+Source and compiled documents share the base shape
+`{ code, filename, imports: [{ specifier, link }], delegatedModuleIdentities? }`.
+A source document may additionally carry the runtime fingerprint used for its
+identity. Their link sets are different. A source document stores internal
+authored-import links, including links to authored declarations. It omits fabric
+edges so one program's source closure does not absorb another program.
+Synthetic retention links may keep other source roots alive, but they are
+excluded from the identity hash and executable graph traversal. A compiled
+document stores runtime edges only between emitted modules. It includes fabric
+edges needed by the self-contained compiled closure. The entry compiled
+document also uses synthetic `cf:cache-root/` links to load emitted modules that
+no runtime edge reaches. Compiled runtime and synthetic links only target
+emitted modules. They never target a declaration document.
+
 `delegatedModuleIdentities` is mutable metadata, excluded from the Merkle
 identity, that records predecessor module hashes whose writer authority the
-current module may exercise. Since content-addressing does not authenticate
+current module may exercise. Since content addressing does not authenticate
 that mutable field, source documents carry the compiler integrity stamp on the
-delegation field alone; compiled documents authenticate it with their existing
+delegation field alone. Compiled documents authenticate it with their existing
 root compiler stamp. Loaders discard delegation metadata without the applicable
-stamp. The general source/compiled save path computes one union of newly derived
-entries and authenticated entries already stored in either document set under
-`editWithRetry`, writes that same union to both sets, and registers the union
-from the successful commit under the attesting space in the active runtime. It
-never replaces entries, because one content-addressed successor can be shared by
-patterns updated from different predecessors. Because
-`identity` is a one-way Merkle hash, the `imports` links are load-bearing (stored
-explicitly), but the parent hash commits to its children's identities, so the
-graph wiring is verifiable on load by recomputing identities and checking each
-against its document key — the content-addressed analog of the structural graph
-verifier. A module shared by N programs is stored once per `(space, identity)`;
-a "program" is just an entry identity over a shared set of module documents.
+stamp. The general source and compiled save path computes one union of newly
+derived entries and authenticated entries already stored in either document set
+under `editWithRetry`. It writes that same union to both sets and registers the
+union from the successful commit under the attesting space in the active
+runtime. It never replaces entries, because one content-addressed successor can
+be shared by patterns updated from different predecessors.
+
+Because `identity` is a one-way Merkle hash, internal source links are
+load-bearing and stored explicitly. The parent hash commits to those children's
+identities. The authored graph wiring is verifiable on load by recomputing
+identities and checking each against its document key. This is the
+content-addressed analog of the structural graph verifier. A module shared by N
+programs is stored once per `(space, identity)`. An executable graph is an entry
+identity over a shared set of module documents.
+Piece revision history separately uses the immutable
+`cf/authored-program-manifest/v1` value from
+[piece-source-lifecycle.md](piece-source-lifecycle.md) to bind the canonical main
+and every authored file, including files outside that executable graph.
 
 This replaces the whole-program `PatternMeta` store after the flag flip (the two
-coexist behind the flag until then). The compiler-version `fingerprint` and
-`sesValidated` gating carry over: `runtimeVersion` is the fingerprint, and the
+coexist behind the flag until then). The compiler-version and `sesValidated`
+gating carry over. `runtimeVersion` selects a compiled-cache variant. It is
+separate from the `runtimeFingerprint` input to executable module identity. The
 compiled set is only ever written from verified output (see the threat model).
 
 ### Module update delegation (`piece setsrc`)
@@ -454,13 +579,14 @@ versus the in-process cache, because the runtime `eval`s the cell's contents.
 The cache is designed around this:
 
 - **Source set integrity is free.** `pattern:<identity>` is keyed by a hash of
-  its own contents, so a reader self-checks `hash(content) === <identity>`. A
-  tampered source document fails the check; a poisoned-but-different source would
-  not hash to the requested identity. Recompiling a source document also re-runs
-  the SES verifier, so a malformed source is rejected on the compile path. The
-  one exception is mutable delegation metadata, which is deliberately outside
-  that hash and therefore requires its own field-level compiler integrity stamp
-  before a loader can use it as authority.
+  its own contents, import graph, and recorded identity fingerprint, so a reader
+  recomputes and checks the requested identity. A tampered source document or
+  fingerprint fails the check. The verifier also rejects a non-empty fingerprint
+  on a module whose identity does not depend on one. Recompiling a source
+  document also re-runs the SES verifier, so a malformed source is rejected on
+  the compile path. Mutable delegation metadata is deliberately outside that
+  hash and requires its own field-level compiler integrity stamp before a loader
+  can use it as authority.
 - **Compiled set integrity is a CFC label.** `compileCache:<runtimeVersion>/<identity>`
   is keyed by the *source* identity, which does not bind the *JS* bytes.
   The compiled document therefore carries a **CFC integrity label**, written with
@@ -528,10 +654,10 @@ not currently have. Concretely:
 
 - `SchedulerActionObservationV1.implementationFingerprint` becomes
   `moduleHash(M)#symbol` instead of `src:/<id>/path:line:col`. It is stable
-  across reloads, entry points, and TCB upgrades, and it changes when any
-  transitive import (value or type) changes — exactly the validity condition the
-  scheduler needs to decide whether a persisted observation may be trusted, in
-  combination with the separately-checked `runtimeFingerprint`.
+  across reloads and entry points. It changes when any transitive import (value
+  or type) changes. It also changes when the runtime fingerprint changes and the
+  reachable graph contains an external dependency. The scheduler continues to
+  check `runtimeFingerprint` separately before trusting a persisted observation.
 - The version-1 "implementation fingerprint is a placeholder" limitation in that
   spec is resolved: the fingerprint is now content-derived, so a clean
   observation can no longer be trusted against changed code.
@@ -594,9 +720,16 @@ Sequence identity first to retire the rehydration bug quickly, then the loader.
   `moduleHash` and the same action implementation fingerprint.
 - Changing a transitively-imported value function changes the importer's
   `moduleHash`; changing a transitively-imported **type** also changes it.
-- Recompiling unchanged source under a changed transformer/compiler version
-  leaves `moduleHash` unchanged (TCB independence); the scheduler still
-  invalidates via `runtimeFingerprint`.
+- Changing an authored `.d.ts` declaration changes every importer identity that
+  reaches it, invalidates the compiled-cache entry, and persists the declaration
+  as source-only history without emitting a JavaScript record. A later warm load
+  does not request a compiled declaration document. Runtime-provided declaration
+  stubs remain external fingerprinted dependencies.
+- Recompiling unchanged source under a changed runtime fingerprint changes the
+  `moduleHash` of every module whose reachable graph contains an external
+  dependency. Its runtime-neutral module identity and the complete program's
+  runtime-neutral digest remain unchanged. A module with no reachable external
+  dependency keeps its `moduleHash`.
 - An unrelated sibling file added to or removed from the compilation does not
   change an untouched module's hash.
 - Import cycles produce deterministic, stable hashes across reloads.
@@ -622,8 +755,14 @@ Sequence identity first to retire the rehydration bug quickly, then the loader.
   integrity label is treated as a miss and recompiled from the self-verifying
   source document; only integrity-valid documents are reused without
   re-verification.
-- Runtime-version bump misses the compiled set (recompile) while the source set
-  (`pattern:<identity>`) persists.
+- A future representation-only compile-cache `runtimeVersion` bump with an
+  unchanged runtime fingerprint misses the compiled set and recompiles while
+  the source set (`pattern:<identity>`) persists. Version 1 treats the current
+  broad compiler-input version as executable and therefore rolls both values.
+- A `runtimeFingerprint` bump gives an affected entry module a new executable
+  identity and writes a new source set. The prior source set remains retained
+  for history. Tests compare the runtime-neutral digest to classify this as a
+  runtime rebuild rather than an authored-source change.
 
 ## Appendix: Current Pipeline Reference
 

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -390,6 +390,27 @@ There is no value/type filtering and no dependence on emit elision. The earlier
 behavior-changing type edit as a no-op, which is exactly the under-counting we
 must avoid.
 
+A static fabric type edge in the supported ESM-style syntax also follows the
+ordinary pin-in-source rule. An `import type`, type-only named import or export,
+or inline `import("cf:…").Type` reference cannot remain mutable in deployed
+source. If it could, a later type change could alter generated schemas and
+executable behavior without changing the importing pattern's stored source. The
+current `rewriteFabricPins` visitor already rewrites import declarations, export
+declarations, and inline import-type nodes. `collectImportSpecifiers` already
+includes these edges in module identity. Automatic piece deployment still
+uses an ordinary local resolver before invoking the rewriter. It therefore
+rejects every fabric import or export declaration at that stage, including an
+already-pinned reference. Correct pin-on-deploy ordering remains required
+integration work.
+
+The CommonJS-style TypeScript form
+`import type Alias = require("cf:…")` is unsupported. The current visitors do
+not recognize its `ImportEqualsDeclaration`, so graph discovery, rewriting, and
+identity calculation must reject it explicitly rather than allow it to bypass
+the pin. Production resolution and persistence of all authored declaration
+inputs also require the integration described in
+[pattern-imports/implementation-plan.md](pattern-imports/implementation-plan.md).
+
 ### Loader: ES modules in SES compartments
 
 Move from one flattened AMD bundle to ES modules loaded through the SES module

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -145,10 +145,14 @@ separate fields:
   For a local deployment, passing the repository root as `--root` therefore
   preserves a path inside that repository rather than only a basename.
   Absolute paths from the author's machine are never persisted.
-- `source.origin` is the optional `patternSource` update provenance carried by
-  the piece. Today only toolshed system-pattern paths drive an implemented
-  update check. General source URLs include external `https://` URLs and
-  fabric-internal `cf:` URLs, including the host-qualified `cf://...` form. A
+- `source.origin` is the optional update provenance carried by the piece. Today
+  it is backed by a raw `patternSource` string. The specialized updater can
+  reconcile same-toolshed system-pattern paths. The raw field alone is not
+  durable per-piece consent to future updates. The general lifecycle replaces
+  that legacy representation with structured origin and revision state for
+  every piece, including a space root. General source URLs include external
+  `https://` URLs and fabric-internal `cf:` URLs, including the host-qualified
+  `cf://...` form. A
   fabric URL that is unpinned and resolves to a piece or another mutable
   `patternIdentity`-bearing entity follows that entity's current pattern. A
   fabric URL that resolves to `pattern:<identity>` names content-addressed

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -10,13 +10,15 @@ import { TodoItem } from "cf:pattern:AvcnyZ…rC1c";               // a content-
 
 A reference names a **starting cell** — by slug or by cell URI, optionally
 qualified by space and toolshed host — and resolution **follows the pointer
-chain until it reaches a content-addressed pattern source**. A slug may point
-at a deployed piece (then we mean "the pattern that piece currently runs" —
-one more hop, reading the piece's `patternIdentity`) or directly at a pattern
-(a named, updatable publication). Either way the chain terminates at an
-entry-module identity in the same namespace as the compile cache and
-`cf:module/<hash>` (`packages/runner/src/harness/module-identity.ts`), and that
-terminal hash is what deployed importers pin.
+chain until it reaches content-addressed pattern source**. A slug may point at
+a deployed piece (then we mean "the pattern that piece currently runs" — one
+more hop, reading the piece's `patternIdentity`) or at a publication. A
+reference without a subpath selects the pattern's entry module. A reference
+with a subpath selects a module through the current immutable authored-program
+manifest's explicit exports map. The selected module identity is in the same
+namespace as the compile cache and `cf:module/<hash>`
+(`packages/runner/src/harness/module-identity.ts`), and that selected identity
+is what deployed importers pin.
 
 There is deliberately **no type tag in the specifier** (`cf:piece/…` vs
 `cf:pattern/…` was considered and dropped, § Alternatives): slug cells are
@@ -34,8 +36,11 @@ so any fabric import or export declaration fails initial local resolution. This
 includes an already-pinned reference. An unpinned declaration therefore never
 reaches the rewriter. Dynamic per-space route registration and home-site-table
 hydration are implemented as foundations. Applying a host supplied by a
-`cf://` import remains planned, as do `cf publish` and source subpaths. This
-remains the design of record; for the as-built pointer model note that the
+`cf://` import remains planned, as do `cf publish`, authored-program exports
+maps, and source-subpath resolution. Compile and pin/update resolution now
+reject every subpath before attempting entry resolution, so current tooling
+cannot create a misleading entry pin for an unsupported subpath. This remains
+the design of record; for the as-built pointer model note that the
 patternId + pattern **meta cell** this document originally leaned on were
 **retired** in `#4156`
 (`docs/specs/pattern-id-retirement.md`) — a piece now carries only
@@ -91,7 +96,7 @@ general piece origin model is described in `../piece-source-lifecycle.md`.
 | `ProgramResolver` seam (`main()` / `resolveSource(specifier)`, async) | `packages/js-compiler/program.ts`, `typescript/resolver.ts` | The hook where fabric imports plug in; it discovers only the reachable closure and cannot enumerate unreachable authored files |
 | Authored-import policy | `packages/runner/src/sandbox/runtime-module-policy.ts` | Single dispatch point for `cf:` specifiers |
 | Per-module Merkle identity (source + deps; external deps fold the full specifier string into the leaf: `runtime:${specifier}@${fingerprint}`) | `computeModuleHashes` in `packages/runner/src/harness/module-identity.ts` | Makes pinned specifiers content-derived with **no hashing changes** (§ Snapshot semantics); the primitive includes type edges, but production engine paths currently remove authored `.d.ts` files before identity and persistence |
-| Piece → pattern pointer: `meta("patternIdentity")` = `{ identity, symbol }` (entry-module identity), the sole pointer post-`#4156` (a separate `meta("pattern")` survives only as a builtin parent-backlink) | write `applySetupState`, read `getPatternIdentityRef` in `packages/runner/src/runner.ts` | The terminal hop of the resolution chain |
+| Piece → pattern pointer: `meta("patternIdentity")` = `{ identity, symbol }` (entry-module identity), the sole pointer post-`#4156` (a separate `meta("pattern")` survives only as a builtin parent-backlink) | write `applySetupState`, read `getPatternIdentityRef` in `packages/runner/src/runner.ts` | The terminal pointer hop for an entry import and the route to the retained manifest for a future subpath import |
 | Pattern source-of-truth: the `pattern:<identity>` source-doc closure (there is no longer a meta cell; the retired one's `program` was pure duplication of these docs) | `packages/runner/src/compilation-cache/cell-cache.ts` | Recovered via `getPatternSourceProgramByIdentity` / `loadVerifiedSourceClosure` |
 | Compile cache: source docs at cell key **`pattern:<identity>`**, compiled docs at `compileCache:<rtVersion>/<identity>` | `packages/runner/src/compilation-cache/cell-cache.ts` (`sourceDocKey`/`compiledDocKey`) | **The URI a pattern is saved under by hash.** Content-addressed per-module source + compiled storage; imports resolve from and dedupe into it |
 | Slug cells: generic **redirect link to any cell** (`setSlugLink` is target-agnostic; only `resolvePieceAddress` layers a "must be a piece" check) | `packages/piece/src/slugs.ts` | Slugs can name pieces *or* patterns today, mechanically |
@@ -110,13 +115,14 @@ Because both come up, and only one is the pin:
   a reference *starting point* (the chase reads its `patternIdentity`); never
   the pin.
 - **`pattern:<identity>`** — the per-module **source-set document key**
-  (`cell-cache.ts:sourceDocKey`), where `<identity>` is the prefix-free
-  entry-module Merkle hash (authored source + authored path + dep hashes;
-  `computeModuleHashes`). Verifiable by re-hashing, entry-point independent,
-  and the namespace all existing by-identity machinery keys on
-  (`cf:module/<hash>`, compile cache, `$patternRef`,
-  `meta("patternIdentity")`). **This is the pin**, and `cf:pattern:<identity>`
-  is its reference spelling.
+  (`cell-cache.ts:sourceDocKey`), where `<identity>` is a prefix-free module
+  Merkle hash (authored source + authored path + dependency hashes;
+  `computeModuleHashes`). A piece's `patternIdentity` uses the entry module's
+  identity. A subpath pin uses the selected module's identity. Both are
+  verifiable by re-hashing and use the namespace that the existing by-identity
+  machinery keys on (`cf:module/<hash>`, compile cache, `$patternRef`, and
+  `meta("patternIdentity")`). **This is the kind of identity used by a pin**,
+  and `cf:pattern:<identity>` addresses one exact module directly.
 
 ### Tooling reference for a running piece
 
@@ -193,10 +199,10 @@ cf://<host>/<space>/<ref>[/<subpath>][@<pin>]      ; explicit toolshed
 
 ref     = slug                ; no ":" — isSlugAddress convention
         | "of:fid1:" hash     ; cell URI (a piece / a cell carrying patternIdentity)
-        | "pattern:" hash     ; entry-module identity (content-addressed source)
+        | "pattern:" hash     ; exact module identity (content-addressed source)
 space   = space-name | space-did ; parser shape; resolution currently requires a DID
 host    = domain[":"port]     ; a toolshed
-pin     = "@" hash            ; entry-module identity
+pin     = "@" hash            ; selected module identity
 hash    = 43 base64url chars  ; hashStringOf/hashOf output (value-hash.ts):
                               ; [A-Za-z0-9_-], case-SENSITIVE, no padding —
                               ; e.g. Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c
@@ -213,7 +219,7 @@ Examples:
 ```tsx
 // Shown for illustration only.
 import { TodoItem } from "cf:todo-list";                            // slug, current space
-import { todoSchema } from "cf:todo-list/schemas";                  // subpath (phase 2)
+import { todoSchema } from "cf:todo-list/schemas";                  // explicitly exported subpath (phase 4)
 import { TodoItem } from "cf:/kitchen/todo-list";                   // name-shaped space parses, but resolution rejects it
 import { TodoItem } from "cf:/did:key:z6Mk…/todo-list";             // space by DID
 import { TodoItem } from "cf://toolshed.common.tools/did:key:z6Mk…/todo-list";  // explicit toolshed
@@ -222,6 +228,7 @@ import { TodoItem } from "cf:/did:key:z6Mk…/of:fid1:ZwjMI…A2Os";    // a pie
 
 // What a deployed importer actually stores (§ Snapshot semantics):
 import { TodoItem } from "cf:/did:key:z6Mk…/todo-list@AvcnyZ…rC1c";
+import { todoSchema } from "cf:todo-list/schemas@Us7JkQ…a91D";
 ```
 
 Parsing rules (each form is disjoint by prefix; no segment counting needed):
@@ -238,25 +245,71 @@ Parsing rules (each form is disjoint by prefix; no segment counting needed):
   validate as a slug. `pattern:` refs are space-free-capable (content
   addressed; the space, if given, is only a resolution hint). Slug refs are
   always space-scoped (slug ids are `slugIdForSpace(space, slug)`), with the
-  current space as default.
+  current space as default. A parsed `pattern:` ref with a subpath is rejected
+  during resolution because one module identity does not bind an exports map.
 - The emitted-namespace specifiers `cf:module/<hash>` and `cf:cache-root/`
   remain compiler-internal and are **rejected in authored source**.
 
-### Resolution rule (uniform, type-free)
+### Resolution and target selection
 
-Starting from the named cell, follow pointers until a pattern source is
-reached:
+A trailing pin already names the exact selected module. Frozen compilation
+loads that content-addressed module directly and does not read the preceding
+slug, piece, publication, or exports map. The preceding text remains in the
+specifier so an explicit dependency update can resolve the same public name
+again.
+
+An unpinned reference first follows pointers until it reaches pattern source:
 
 1. slug → slug cell's redirect target (`resolveSlugTargetCell`);
-2. a cell carrying a `patternIdentity` meta (a **piece**) → its `.identity` is
-   the terminal identity (`getPatternIdentityRef`, `runner.ts:4441`);
-3. a `pattern:<identity>` ref → already terminal.
+2. a cell carrying `patternIdentity` (a **piece**, or a future publication
+   pointer) → its current pattern and retained authored-program manifest;
+3. a `pattern:<identity>` ref → that exact content-addressed module.
 
-Anything that doesn't chase to a pattern is a compile error ("does not resolve
-to a pattern", naming the chain followed). The chain is short (≤2 hops) and
-each hop is an ordinary cell read under ordinary space authz. (This matches the
-as-built chase in `packages/runner/src/fabric-ref-resolution.ts`; the retired
-meta cell added no hop.)
+Without a subpath, a piece or publication selects its entry-module identity. A
+direct `pattern:<identity>` also selects that exact module. With a subpath, the
+piece or publication's current immutable manifest must map the public subpath
+to an authored filename. Resolution selects that file's source-document
+identity. A direct `pattern:<identity>` never accepts a subpath. A caller that
+already knows the target module identity uses
+`cf:pattern:<target-module-identity>`.
+
+Anything that does not chase to pattern source is a compile error ("does not
+resolve to a pattern", naming the chain followed). An unpinned subpath also
+fails when the target has no retained manifest or does not explicitly export
+that name. Each pointer hop is an ordinary cell read under the space's ordinary
+authorization. The entry-only chase matches the as-built resolver in
+`packages/runner/src/fabric-ref-resolution.ts`. Manifest-backed subpath
+selection remains required work.
+
+### Explicit public subpaths
+
+The immutable `cf/authored-program-manifest/v1` value contains an `exports`
+map from public subpaths to canonical authored filenames in that manifest. The
+empty subpath implicitly selects `main`; the map cannot replace it. Version 1
+supports exact keys only. It has no wildcard or conditional entries. A key has
+no leading or trailing slash, empty segment, `.` segment, `..` segment, or `@`
+character. The `@` character remains the pin delimiter in the specifier
+grammar. Lookup compares the parsed subpath exactly. It does not percent-decode
+or fold case. A target must be one of the manifest's authored files.
+
+An export may target an authored `.d.ts` file. A type-only import uses that
+declaration identity normally. A value import from a declaration-only target
+fails because there is no emitted runtime module. The exports map defines the
+supported import surface. It is not an access-control boundary: the pattern,
+manifest, and all retained source files still have the same visibility within
+their space.
+
+Entry-module re-exports do not create public subpaths. Tooling may offer to add
+a manifest entry when an author publishes a subpath, but the immutable map is
+the authority. This separates a stable public name from internal file layout
+and rejects arbitrary-file access.
+
+The manifest's content identity and the runtime-neutral program digest include
+the normalized exports map. Changing only that map creates a source-only piece
+revision even when every file identity and the executable entry identity remain
+unchanged. Followers therefore observe the new public surface through revision
+propagation. Existing static importers stay on their selected module pins until
+an explicit dependency update.
 
 Why this shape:
 
@@ -311,12 +364,20 @@ Mechanics:
 
 1. When a pattern containing an unpinned mutable reference is **deployed** (or
    a dev/iterate flow explicitly resolves dependencies), the toolchain runs
-   the resolution rule to the terminal entry-module identity and **rewrites
-   the specifier in the stored source** to the pinned form:
+   the resolution rule to the selected module identity and **rewrites the
+   specifier in the stored source** to the pinned form:
 
    ```tsx
    import { TodoItem } from "cf:/did:key:z6Mk…/todo-list@AvcnyZ…rC1c";
+   import { todoSchema } from "cf:todo-list/schemas@Us7JkQ…a91D";
    ```
+
+   A reference without a subpath selects the entry module, so its pin equals
+   the target piece's current `patternIdentity.identity`. For a subpath, pin
+   time reads the target's immutable manifest, resolves the exports-map entry,
+   and pins that file's module identity. `cf deps update` repeats this lookup
+   against the target's current manifest. It rewrites the pin when either the
+   public name points to another file or the selected file's identity changes.
 
    Pinning applies to every supported static, ESM-style fabric reference in
    TypeScript module and type syntax. This includes `import type`, type-only
@@ -388,8 +449,8 @@ Mechanics:
 
 4. **Updating is an explicit authoring action.** `cf deps update
    [<specifier>]` (and an equivalent affordance in the shell's iterate flow)
-   re-runs resolution and rewrites the pin — an ordinary source edit. The
-   unpinned form never reaches
+   re-runs pointer and exports-map resolution and rewrites the pin — an
+   ordinary source edit. The unpinned form never reaches
    deployed storage: deploying with an unpinned mutable reference pins it; a
    stored program containing one is a compile error. `cf dev`/`cf check`
    resolve unpinned references live against the connected toolshed and print
@@ -412,10 +473,13 @@ so tooling knows what to re-resolve). This deliberately borrows the
 `npm:pkg@version` shape — the pin step is "lockfile semantics, written back
 into the import statement."
 
-### Why the pin is the entry-module identity
+### Why the pin is the selected module identity
 
-The pin records what `meta("patternIdentity")` already carries. The
-alternatives fail:
+For an entry import, the pin records what `meta("patternIdentity")` already
+carries. For a public subpath, the immutable manifest selects another authored
+module and the pin records that module's identity. In both cases the pin names
+the exact source-document closure that compilation mounts. The alternatives
+fail:
 
 - *a piece's `of:` entity URI* (a causal/cell ref): its derivation is not
   purely source-content, so a fetched program can't be verified against it by
@@ -424,10 +488,19 @@ alternatives fail:
   ref, could not have been the pin.)
 - *whole-program id* (`computeId`): entry-point and sibling-file sensitive,
   and not the namespace existing load machinery keys on.
+- *authored-program manifest identity*: it would bind the exports map, but the
+  frozen resolver would still need a second lookup to discover and mount the
+  selected module. Pinning the selected module makes that lookup unnecessary.
 
-Because the identity is a Merkle root, the program's transitive internal source
+Because the selected identity is a Merkle root, its transitive internal source
 closure is discoverable and verifiable from it. Source documents at
 `pattern:<identity>` store per-module source and internal authored-import links.
+The original locator and subpath remain before the pin, so dependency tooling
+can resolve a later manifest without making the frozen compile depend on it. A
+direct `cf:pattern:<identity>` names only one module closure. It cannot use a
+subpath because the same module may appear in more than one immutable manifest
+with different public maps.
+
 Pinned fabric dependencies remain external to that closure and are retained by
 parsing their content identities from source. Pinned chains cannot cycle because
 a hash cannot reference itself. Unpinned mutable references can form cycles only
@@ -444,8 +517,8 @@ declaration source. Runtime-supplied declaration stubs can describe runtime
 modules for TypeScript, but they are not authored identity nodes. The
 corresponding bare runtime specifier remains an external fingerprinted leaf.
 The entry module is the program's `main`. Subpaths such as `/schemas` address
-other files in the same program and are a phase-2 extension. They use the same
-resolution with an extra path join inside the mounted program.
+only exact public names in the immutable authored-program manifest. They do not
+expose arbitrary filenames or infer names from entry-module re-exports.
 
 ## Coexistence with esm.sh / npm / jsr (later)
 
@@ -455,7 +528,7 @@ resolution with an extra path join inside the mounted program.
 |---|---|---|
 | `./ ../ /` | program-relative files | today |
 | bare (`commonfabric`, `turndown`, …) | **reserved for runtime modules only**, allowlist | today; never used for packages |
-| `cf:` (authored reference grammar above) | this spec | today for content-addressed and same-toolshed references; host-qualified routing and subpaths planned |
+| `cf:` (authored reference grammar above) | this spec | today for content-addressed and same-toolshed entry references; host-qualified routing, explicit exports maps, and subpaths planned |
 | `cf:module/`, `cf:cache-root/` | compiled output / cache internals; rejected in authored source | today |
 | `npm: jsr: https:` | future external packages | reserved now |
 
@@ -509,27 +582,37 @@ with storage and network access, and `ProgramResolver.resolveSource` is async)
 
 Engine wraps the authored resolver; on a `cf:` specifier:
 
-1. **Reference → identity**: pinned (or `pattern:` ref) → use the hash, never
-   touch the mutable pointer. Unpinned (authoring/dev only) → run the uniform
-   chase **as ordinary cell reads through the compiling runtime's storage**
-   (slug cell redirect → the piece's `patternIdentity`) —
-   `cf check`/`cf dev` already construct a runtime (`packages/cli/lib/dev.ts`),
-   and every production compile happens inside one, so space authz is exactly
-   memory-read authz. Host-qualified refs are the same reads with the space
-   routed to its host via `spaceHostMap` (§ Cross-host references).
-2. **Identity → source set**, first hit wins, every hop hash-verified:
+1. **Reference and public subpath → selected identity**:
+   - Before M4, both compile resolution and the shared pin/update chase reject
+     every subpath with `"subpaths not yet supported (M4)"`. They do this before
+     resolving an entry identity.
+   - A pinned reference uses the selected module hash and never touches the
+     mutable pointer. A direct `pattern:` reference uses its exact module hash
+     and rejects a subpath.
+   - An unpinned entry reference runs the uniform chase **as ordinary cell
+     reads through the compiling runtime's storage** (slug cell redirect → the
+     piece's `patternIdentity`). `cf check` and `cf dev` already construct a
+     runtime (`packages/cli/lib/dev.ts`), and every production compile happens
+     inside one, so space authorization is exactly memory-read authorization.
+   - In M4, an unpinned subpath continues from the mutable target to its current
+     source revision and immutable manifest. It performs an exact exports-map
+     lookup and selects the mapped file's source-document identity.
+
+   Host-qualified refs use the same reads with the space routed to its host via
+   `spaceHostMap` (§ Cross-host references).
+2. **Selected identity → source set**, first hit wins, every hop hash-verified:
    1. local/space compile-cache source docs (`pattern:<identity>`, walking
       import links);
    2. the space named in the reference, routed to its host if the ref is
       host-qualified.
 3. **Verify**: recompute `computeModuleHashes` over the fetched program (its
-   own namespace, its own authored paths) and require the entry hash to equal
-   the requested identity. Mismatch = compile error. This is what makes every
-   mirror trust-free.
+   own namespace, its own authored paths) and require the selected module hash
+   to equal the requested identity. Mismatch = compile error. This is what
+   makes every mirror trust-free.
 4. **Mount for type-checking and emission**: splice the fetched files into the
    TS program under a reserved prefix such as
    `/~cf/<identity>/<original-path>`. Thread a
-   specifier-to-mounted-entry alias map into the compiler so
+   specifier-to-mounted-module alias map into the compiler so
    `resolveModuleNameLiterals` (`compiler.ts:176`) maps the `cf:` specifier to
    the mounted file. Relative imports inside the subtree resolve as ordinary
    path joins.
@@ -621,14 +704,18 @@ unchanged.
 
 - `cf deps update <file> [--import <specifier>]`: pins unpinned mutable refs by
   rewriting the stored source, which re-derives the pinned identity and its
-  `pattern:<identity>` source documents.
+  `pattern:<identity>` source documents. Before M4, it rejects a public subpath
+  without rewriting it. In M4, it re-resolves the pointer and public subpath,
+  then rewrites the selected module pin.
 - Automatic pinning during piece deployment remains required work. The CLI
   intentionally has no `cf deploy` command.
 - `cf publish <pattern> [--slug name] [--space …]` *(not yet built)*: after
   source-read authorization, destination-write authorization, and CFC
   approval, copy the verified source closure and create a lightweight
   patternIdentity-bearing publication cell in the target space, then
-  optionally assign the slug. Do not copy the source piece or its state.
+  optionally assign the slug. Do not copy the source piece or its state. The
+  subpath phase also copies the immutable authored-program manifest and makes
+  the publication expose its current source revision.
 - `cf dev` / `cf check`: live-resolve unpinned refs against the connected
   toolshed; `--frozen` to forbid (CI). `--show-transformed` shows mounted
   files like any other program file.
@@ -646,7 +733,8 @@ unchanged.
 3. **`cf publish` + host-qualified refs** — cross-host reads via
    ordinary per-space routing, including registration of the supplied host
    before the referenced space opens.
-4. **Subpaths; `npm:`/esm.sh vendoring** on the same rails.
+4. **Explicit exports maps and subpaths; `npm:`/esm.sh vendoring** on the same
+   rails.
 
 ## Security considerations
 
@@ -693,6 +781,9 @@ unchanged.
 | Slug/space not found, or no read access | "cannot resolve cf:… (space/slug/permission)" naming the failing hop |
 | Chain does not terminate at a pattern (slug → data cell, piece without pattern, …) | "cf:… does not resolve to a pattern" + the chain followed |
 | Unpinned mutable ref in deployed/`--frozen` compile | "unpinned fabric import; run `cf deps update` / deploy to pin" |
+| Any subpath before M4 | "subpaths not yet supported (M4)" before entry resolution or pin rewrite |
+| Unpinned subpath is absent from the target manifest | "cf:… does not export subpath '<name>'" |
+| Direct `cf:pattern:<identity>` carries a subpath | "content-addressed module refs do not accept subpaths; use the target module identity" |
 | Source set unavailable at every resolution hop | "source for pattern:<hash> not found (tried: local cache, space … on host …)" |
 | Hash mismatch on fetched source | "integrity failure for <hash> from <source>" (and the hop is skipped, next source tried) |
 | Cycle during live (unpinned) resolution | "cyclic imports: A → B → A" |
@@ -707,6 +798,24 @@ unchanged.
 - **Resolution chase**: slug→piece→pattern, slug→pattern (direct
   publication), `of:<patternId>` start, `pattern:<hash>` terminal; "not a
   pattern" failures per chain shape.
+- **Explicit public subpaths**: exact exports-map lookup selects and pins the
+  target module; undeclared filenames, malformed keys, missing targets,
+  wildcard entries, and `cf:pattern:<identity>/<subpath>` fail. Entry imports
+  remain implicitly public. Re-exporting a file from the entry does not publish
+  a subpath.
+- **Pre-M4 fail-closed behavior**: compile resolution and `cf deps update`
+  reject `cf:dep/schemas` before chasing `dep`; neither path writes an entry
+  identity into a subpath pin.
+- **Subpath updates**: changing a public name's target or changing the target
+  file causes `cf deps update` to rewrite the selected module pin. A pinned
+  importer remains byte-identical until that explicit update.
+- **Declaration subpaths**: a type-only import from an exported `.d.ts` target
+  affects importer identity and persists source. A value import from that
+  declaration-only target fails before runtime.
+- **Exports-map history**: changing only the map changes the manifest identity,
+  runtime-neutral program digest, and source revision. It preserves every
+  module identity and propagates the source-only revision to followers. Revert
+  restores the prior map.
 - **Identity folding** (red-green): two importers identical except for the pin
   hash get different module identities; pin rewrite changes `computeId`.
 - **Runtime rebuild identity**: identical authored files and pins compiled with
@@ -791,11 +900,12 @@ unchanged.
    selecting an earlier retained program.
 
    Each revision retains the complete authored program through an immutable
-   version-1 manifest of its canonical main and exact filename-to-source-identity
-   set. It also retains the complete transitive graph of pinned fabric
-   dependencies, with repeated identities stored once. The manifest, rather than
-   mutable synthetic root links on an entry source document, makes source-only
-   revisions and later revert reliable.
+   version-1 manifest of its canonical main, exact
+   filename-to-source-identity set, and public-subpath map. It also retains the
+   complete transitive graph of pinned fabric dependencies, with repeated
+   identities stored once. The manifest, rather than mutable synthetic root
+   links on an entry source document, makes source-only revisions and later
+   revert reliable.
 
    Source ingestion must enumerate the intended authored file set before
    import-closure resolution. Current `ProgramResolver` flows expose only the
@@ -818,6 +928,25 @@ unchanged.
    use the empty default. Threading a non-empty fingerprint through compilation,
    source retention and per-document mount verification, piece revisions, the
    authoritative provider, and rebuild propagation remains required work.
+4. **Explicit public subpaths and selected-module pins.** A subpath resolves
+   only through an exact entry in the immutable authored-program manifest's
+   exports map. The entry module remains public by default. Version 1 has no
+   wildcard or conditional mappings, and arbitrary authored filenames are not
+   importable. Entry-module re-exports do not define the map. The map is a
+   public API boundary, not an access-control boundary.
+
+   Pin time resolves the public name and writes the selected file's module
+   identity as the trailing pin. A reference without a subpath continues to
+   pin the entry-module identity. Frozen compilation uses the pin without
+   reading the mutable target or manifest. `cf deps update` re-resolves the
+   preserved locator and public name against the current manifest.
+
+   A direct `cf:pattern:<identity>` names one exact module and does not accept a
+   subpath because that identity does not bind one authoritative exports map.
+   The manifest identity and runtime-neutral program digest include the map, so
+   a map-only edit creates a source-only revision and propagates to followers.
+   Authored-program manifests, subpath resolution, and selected-module pinning
+   are required work.
 
 ## Open questions
 
@@ -843,11 +972,7 @@ unchanged.
    `patternIdentity` meta present ⇒ a pattern-bearing cell). Good enough, or
    should slug assignment stamp an explicit kind on the slug cell for better
    errors and tooling?
-3. **Subpath surface.** Whether subpaths may address any file in the program
-   or only files the entry re-exports (an "exports map" discipline, like npm's
-   `exports`). Start permissive, tighten if published-internal-file coupling
-   becomes a problem.
-4. **Public distribution surface.** Should the product standardize a dedicated
+3. **Public distribution surface.** Should the product standardize a dedicated
    distribution space whose space-wide ACL grants `READ` to `*`, making every
    pattern in that space readable by any authenticated identity? Should it also
    offer an anonymous, CDN-cacheable HTTP endpoint? An anonymous endpoint would
@@ -855,7 +980,7 @@ unchanged.
    source. It could serve only patterns copied under that policy after CFC
    allows unrestricted disclosure. A URL or content identity alone must never
    qualify a pattern for either form of distribution.
-5. **Host-route reliability and relocation.** The known-hint registration rule
+4. **Host-route reliability and relocation.** The known-hint registration rule
    does not say what to do when a recorded host is unavailable, a space moves,
    or more than one host can serve the same space. Revisit how route changes
    are authenticated, how stale site-table entries are replaced, whether

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -83,9 +83,9 @@ general piece origin model is described in `../piece-source-lifecycle.md`.
 
 | Piece of machinery | Where | Role here |
 |---|---|---|
-| `ProgramResolver` seam (`main()` / `resolveSource(specifier)`, async) | `packages/js-compiler/program.ts`, `typescript/resolver.ts` | The hook where fabric imports plug in; compilation already runs inside a runtime with storage + network access |
+| `ProgramResolver` seam (`main()` / `resolveSource(specifier)`, async) | `packages/js-compiler/program.ts`, `typescript/resolver.ts` | The hook where fabric imports plug in; it discovers only the reachable closure and cannot enumerate unreachable authored files |
 | Authored-import policy | `packages/runner/src/sandbox/runtime-module-policy.ts` | Single dispatch point for `cf:` specifiers |
-| Per-module Merkle identity (source + deps; external deps fold the full specifier string into the leaf: `runtime:${specifier}@${fingerprint}`) | `computeModuleHashes` in `packages/runner/src/harness/module-identity.ts` | Makes pinned specifiers content-derived with **no hashing changes** (§ Snapshot semantics) |
+| Per-module Merkle identity (source + deps; external deps fold the full specifier string into the leaf: `runtime:${specifier}@${fingerprint}`) | `computeModuleHashes` in `packages/runner/src/harness/module-identity.ts` | Makes pinned specifiers content-derived with **no hashing changes** (§ Snapshot semantics); the primitive includes type edges, but production engine paths currently remove authored `.d.ts` files before identity and persistence |
 | Piece → pattern pointer: `meta("patternIdentity")` = `{ identity, symbol }` (entry-module identity), the sole pointer post-`#4156` (a separate `meta("pattern")` survives only as a builtin parent-backlink) | write `applySetupState`, read `getPatternIdentityRef` in `packages/runner/src/runner.ts` | The terminal hop of the resolution chain |
 | Pattern source-of-truth: the `pattern:<identity>` source-doc closure (there is no longer a meta cell; the retired one's `program` was pure duplication of these docs) | `packages/runner/src/compilation-cache/cell-cache.ts` | Recovered via `getPatternSourceProgramByIdentity` / `loadVerifiedSourceClosure` |
 | Compile cache: source docs at cell key **`pattern:<identity>`**, compiled docs at `compileCache:<rtVersion>/<identity>` | `packages/runner/src/compilation-cache/cell-cache.ts` (`sourceDocKey`/`compiledDocKey`) | **The URI a pattern is saved under by hash.** Content-addressed per-module source + compiled storage; imports resolve from and dedupe into it |
@@ -323,6 +323,24 @@ Mechanics:
    transitively different program ids (`engine.ts:computeId` hashes the source
    files, which contain the specifier). No changes to any hashing code.
 
+   The runtime fingerprint is part of the same external-dependency leaf. An
+   importer therefore receives a new executable identity when that fingerprint
+   changes, even when its authored files and pinned specifiers do not. This is a
+   runtime rebuild, not an authored-source edit.
+
+   Each source document in a pinned imported subtree retains the effective
+   identity fingerprint under which that document was published. Pure modules
+   use the canonical empty fingerprint, while newly published importers of
+   external modules use the published non-empty value. For every document whose
+   reachable graph contains an external dependency, the current runtime must be
+   compatible with the recorded effective fingerprint. This check includes an
+   affected legacy document whose absent field has the canonical empty value.
+   Pure modules need no compatibility check because their identities do not
+   depend on the fingerprint. If the check fails, compilation requires a newly
+   published dependency and pin. The compiler never re-identifies the old
+   pinned source in place or hashes the whole mount under the entry document's
+   fingerprint.
+
 3. **No re-resolution on recompile.** Cold compiles (cache-version bumps,
    eviction) recompile from the stored, pinned source. This is the reason the
    pin lives *in the source* rather than being an emergent property of "first
@@ -370,21 +388,27 @@ alternatives fail:
 - *whole-program id* (`computeId`): entry-point and sibling-file sensitive,
   and not the namespace existing load machinery keys on.
 
-Because the identity is a Merkle root, the transitive source closure is
-discoverable and verifiable from it (source docs at `pattern:<identity>` store
-per-module source + resolved import links), and pinned chains cannot cycle — a
-hash cannot reference itself. (Unpinned mutable references can form cycles —
-A imports slug B whose pattern imports slug A — only during live dev
-resolution, where the resolver needs an ordinary cycle guard.)
+Because the identity is a Merkle root, the program's transitive internal source
+closure is discoverable and verifiable from it. Source documents at
+`pattern:<identity>` store per-module source and internal authored-import links.
+Pinned fabric dependencies remain external to that closure and are retained by
+parsing their content identities from source. Pinned chains cannot cycle because
+a hash cannot reference itself. Unpinned mutable references can form cycles only
+during live development resolution. For example, pattern A can import a slug for
+pattern B while B imports a slug for A. The resolver needs an ordinary cycle
+guard for that case.
 
 ## What an import gives you
 
-The imported module's **exports**: patterns, schemas (`schemas.tsx` sharing is
-a first-class use case), types, lifts/handlers, plain helpers. Imports are
-type-checked against the real fetched source, not declarations. The entry
-module is the program's `main`; subpaths (`/schemas` etc.) address other files
-in the same program and are a phase-2 extension (same resolution, an extra path
-join inside the mounted program).
+The imported module's **exports** include patterns, schemas (`schemas.tsx`
+sharing is a first-class use case), types, lifts and handlers, and plain
+helpers. Imports are type-checked against fetched authored implementation and
+declaration source. Runtime-supplied declaration stubs can describe runtime
+modules for TypeScript, but they are not authored identity nodes. The
+corresponding bare runtime specifier remains an external fingerprinted leaf.
+The entry module is the program's `main`. Subpaths such as `/schemas` address
+other files in the same program and are a phase-2 extension. They use the same
+resolution with an extra path join inside the mounted program.
 
 ## Coexistence with esm.sh / npm / jsr (later)
 
@@ -465,9 +489,10 @@ Engine wraps the authored resolver; on a `cf:` specifier:
    own namespace, its own authored paths) and require the entry hash to equal
    the requested identity. Mismatch = compile error. This is what makes every
    mirror trust-free.
-4. **Mount for type-checking**: splice the fetched files into the TS program
-   under a reserved prefix (e.g. `/~cf/<identity>/<original-path>`), and
-   thread a specifier→mounted-entry alias map into the compiler so
+4. **Mount for type-checking and emission**: splice the fetched files into the
+   TS program under a reserved prefix such as
+   `/~cf/<identity>/<original-path>`. Thread a
+   specifier-to-mounted-entry alias map into the compiler so
    `resolveModuleNameLiterals` (`compiler.ts:176`) maps the `cf:` specifier to
    the mounted file. Relative imports inside the subtree resolve as ordinary
    path joins.
@@ -482,28 +507,31 @@ anything. Therefore:
 - The importer's modules treat the `cf:` specifier as an **external dep** for
   identity purposes (status quo hashing; the pin in the specifier carries the
   content into the hash — § Snapshot semantics).
-- The imported subtree is **not re-emitted** as part of the importer's
-  compilation. Mounted files participate in type-checking only; the importer's
-  emitted module records reference `cf:module/<published-identity>` edges
-  (`module-record-compiler.ts` already emits cross-module edges in exactly
-  this form).
-- If the compiled set for the imported identity is missing (runtime-version
-  bump, never compiled here), compile the imported program **as its own
-  compilation** (existing `loadPatternByIdentity`-shaped path) and let the
-  compile cache absorb it; then the importer's edges resolve normally.
+- Mounted implementation modules are compiled and emitted in the importer's
+  self-contained record graph. Their records keep the published identities
+  computed in the imported program's namespace. Mounted declarations
+  participate in type checking and source history but do not emit records.
+- The importer's emitted records reference imported implementation modules
+  through `cf:module/<published-identity>` edges. A cache hit can reuse compiled
+  bytes already stored under that identity. On a miss, the same importer
+  compilation emits the mounted implementation module and writes it under its
+  published identity.
 
 Payoff: at runtime, an importer and a running piece of the imported pattern
 share compiled artifacts and live module namespaces
-(`modulesByIdentity`, `addressableByIdentity` in `pattern-manager.ts`) — the
-import costs nothing the deployed pattern hasn't already paid.
+(`modulesByIdentity`, `addressableByIdentity` in `pattern-manager.ts`). The
+importer's record graph remains self-contained, while content identities let it
+reuse work the deployed pattern has already paid for.
 
 **Availability is a compile-time concern only.** The compile's write-back
-copies the imported modules' source + compiled docs into the **compiling
-space** (content-addressed keys, idempotent), so both rehydration paths —
-warm (compiled-doc links) and cold (source docs re-fetched by hash) — read
-locally. The referenced space/host must be reachable when a ref is pinned or
-first compiled, never to reload a deployed importer. (This copy is exactly
-the provenance-relevant flow flagged under § Security.)
+copies the imported implementation modules' source and compiled documents into
+the **compiling space**. It copies imported declaration source without creating
+compiled declaration documents. The keys are content-addressed and writes are
+idempotent, so both rehydration paths read locally. The warm path follows
+compiled-document links. The cold path fetches source documents by hash. The
+referenced space or host must be reachable when a reference is pinned or first
+compiled, but not when a deployed importer reloads. This copy is the
+provenance-relevant flow flagged under § Security.
 
 ### 4. Cross-host references: no service surface at all
 
@@ -644,6 +672,14 @@ unchanged.
   pattern" failures per chain shape.
 - **Identity folding** (red-green): two importers identical except for the pin
   hash get different module identities; pin rewrite changes `computeId`.
+- **Runtime rebuild identity**: identical authored files and pins compiled with
+  two runtime fingerprints produce different importer identities while their
+  runtime-neutral program digest remains equal.
+- **Authored declarations**: changing an imported authored `.d.ts` file changes
+  the importer identity, misses prior compiled bytes, persists both declaration
+  revisions, and propagates the new source revision to a follower. A warm load
+  requests no compiled declaration document, while runtime type stubs stay
+  external fingerprinted dependencies.
 - **Snapshot semantics**: deploy piece A; deploy importer B (pin captured);
   move A's piece (and separately: re-point the slug) to a new pattern; B's
   compile, identity, and behavior are byte-identical until `cf deps update`,
@@ -665,14 +701,14 @@ unchanged.
 ## Resolved questions
 
 1. **Publish granularity and source visibility.** Within a space, a pattern and
-   its verified source closure have the same ACL and visibility: that space's.
-   A caller that can resolve the pattern there may read its source. A caller
-   that cannot resolve it gains nothing from knowing its URL or content
-   identity. Assigning a slug to a pattern already present in the space is only
-   naming and discovery; it creates no separate source grant. Publishing into
-   another space is different: it creates an ACL-scoped replica under the
-   destination space's visibility and requires destination write authorization
-   plus a permitted CFC flow.
+   its source documents, authored-program manifests, and source revision history
+   have the same ACL and visibility: that space's. A caller that can resolve the
+   pattern there may read its source. A caller that cannot resolve it gains
+   nothing from knowing its URL or content identity. Assigning a slug to a
+   pattern already present in the space is only naming and discovery; it creates
+   no separate source grant. Publishing into another space is different: it
+   creates an ACL-scoped replica under the destination space's visibility and
+   requires destination write authorization plus a permitted CFC flow.
 2. **Registration of a known space-to-host hint, within the current routing
    model.** Use the ordinary per-space storage session rather than a short-lived
    secondary session. A host-qualified operation registers its accepted hint
@@ -686,6 +722,65 @@ unchanged.
    still needs the pre-open conflict guard. This settles how a known hint enters
    the current session. It does not settle host discovery, availability,
    failover, or space relocation.
+3. **Runtime-fingerprint interaction.** A runtime fingerprint change creates a
+   new executable identity for an importer whose reachable graph contains an
+   external dependency, even when its authored source and fabric pins are
+   unchanged. A detached piece's owner, or a deployment migration service with
+   that space's write authority, may publish the runtime rebuild through the
+   ordinary guarded source transition. A web-origin piece publishes only a
+   rebuild of its resolved web source. A mutable fabric follower publishes only
+   a revision it adopted from its upstream origin. An immutable fabric-origin
+   piece does not move while keeping that origin.
+
+   Followers do not rebuild upstream retained source locally. They adopt the new
+   identity after the upstream piece advertises it. A middle piece in a follow
+   chain adopts the revision before advertising its accepted local revision to
+   downstream followers. A follower that cannot execute the published
+   fingerprint remains on its last accepted revision and reports an
+   incompatibility.
+
+   Piece revisions record the accepted runtime fingerprint and the version-1
+   runtime-neutral program digest defined in
+   [module-loading.md](../module-loading.md). An ordinary transition has the
+   runtime-rebuild cause only when the executable identity and accepted
+   fingerprint changed while the digest, selected export, and active origin
+   remained equal. Revert compares source and fingerprint with its selected
+   historical revision because it intentionally detaches. An immutable fabric
+   origin does not move to a new identity. Loading that exact identity fails if
+   the current runtime cannot execute its recorded fingerprint. A user may
+   detach and rebuild the current retained authored program under the new
+   runtime. This is a direct edit rather than a revert, so it works even when
+   the piece has only its creation revision. Revert remains the operation for
+   selecting an earlier retained program.
+
+   Each revision retains the complete authored program through an immutable
+   version-1 manifest of its canonical main and exact filename-to-source-identity
+   set. It also retains the complete transitive graph of pinned fabric
+   dependencies, with repeated identities stored once. The manifest, rather than
+   mutable synthetic root links on an entry source document, makes source-only
+   revisions and later revert reliable.
+
+   Source ingestion must enumerate the intended authored file set before
+   import-closure resolution. Current `ProgramResolver` flows expose only the
+   reachable closure. An unindexed web entry therefore has no unreachable files
+   in its lifecycle source until a web program manifest supplies that list.
+
+   Runtime compatibility is explicit. An equal fingerprint is compatible by
+   default. A runtime may support another recorded fingerprint only through a
+   versioned compatibility declaration. It must not infer compatibility from
+   similar strings or successful compilation.
+
+   [module-loading.md](../module-loading.md) defines the target authoritative
+   `getExecutableRuntimeFingerprint()` provider and its versioned input policy.
+   The existing broad compile-cache runtime version is a mandatory input in
+   version 1. A later representation-only cache version may move independently
+   only after its inputs are separated from executable semantics.
+
+   The optional `runtimeFingerprint` input and its module-identity test are
+   implemented. Production pattern compilation and source verification still
+   use the empty default. Threading a non-empty fingerprint through compilation,
+   source retention and per-document mount verification, piece revisions, the
+   authoritative provider, and rebuild propagation remains required work.
 
 ## Open questions
 
@@ -720,11 +815,6 @@ unchanged.
    or only files the entry re-exports (an "exports map" discipline, like npm's
    `exports`). Start permissive, tighten if published-internal-file coupling
    becomes a problem.
-5. **Runtime-fingerprint interaction.** External-dep leaves include
-   `runtimeFingerprint`; a runtime upgrade thus shifts importer identities even
-   with identical pins (status quo for runtime modules, now also for fabric
-   refs). Acceptable, but worth stating in the compile-cache invalidation
-   docs.
 6. **Public distribution surface.** Should the product standardize a dedicated
    distribution space whose space-wide ACL grants `READ` to `*`, making every
    pattern in that space readable by any authenticated identity? Should it also

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -26,18 +26,21 @@ distinction evaporates at pin time — both freeze to the same kind of hash.
 
 ## Status
 
-**Implemented** (`#4081`; grammar/resolver/pinning/mounting as described). This
-remains the design of record; for the as-built pointer model note that the
-patternId + pattern **meta cell** this document originally leaned on were
-**retired** in `#4156` (`docs/specs/pattern-id-retirement.md`) — a piece now
-carries only `patternIdentity = { identity, symbol }`, and a pattern's source
-lives in the `pattern:<identity>` source-doc closure. References below are
-updated to match. Update propagation (rolling a running piece to a new version)
-is a companion: `pattern-updates.md`.
+**Implemented for content-addressed and same-toolshed references** (`#4081`):
+parsing, slug and piece resolution, deploy-time pinning, and mounting. Dynamic
+host-qualified routing, `cf publish`, and source subpaths remain planned as
+listed under Phasing. This remains the design of record; for the as-built
+pointer model note that the patternId + pattern **meta cell** this document
+originally leaned on were **retired** in `#4156`
+(`docs/specs/pattern-id-retirement.md`) — a piece now carries only
+`patternIdentity = { identity, symbol }`, and a pattern's source lives in the
+`pattern:<identity>` source-doc closure. References below are updated to match.
+System-root update propagation is described in `pattern-updates.md`; the
+general piece origin model is described in `../piece-source-lifecycle.md`.
 
 ## Last Updated
 
-2026-07-17
+2026-07-21
 
 ## Motivation
 
@@ -78,15 +81,15 @@ is a companion: `pattern-updates.md`.
 | Piece of machinery | Where | Role here |
 |---|---|---|
 | `ProgramResolver` seam (`main()` / `resolveSource(specifier)`, async) | `packages/js-compiler/program.ts`, `typescript/resolver.ts` | The hook where fabric imports plug in; compilation already runs inside a runtime with storage + network access |
-| Authored-import policy | `packages/runner/src/sandbox/runtime-module-policy.ts:25` | Single dispatch point to extend for `cf:` specifiers |
-| Per-module Merkle identity (source + deps; external deps fold the full specifier string into the leaf: `runtime:${specifier}@${fingerprint}`) | `packages/runner/src/harness/module-identity.ts:145-149` | Makes pinned specifiers content-derived with **no hashing changes** (§ Snapshot semantics) |
-| Piece → pattern pointer: `meta("patternIdentity")` = `{ identity, symbol }` (entry-module identity), the sole pointer post-`#4156` (a separate `meta("pattern")` survives only as a builtin parent-backlink) | write `runner.ts:1012`, read `getPatternIdentityRef` `runner.ts:4441` | The terminal hop of the resolution chain |
+| Authored-import policy | `packages/runner/src/sandbox/runtime-module-policy.ts` | Single dispatch point for `cf:` specifiers |
+| Per-module Merkle identity (source + deps; external deps fold the full specifier string into the leaf: `runtime:${specifier}@${fingerprint}`) | `computeModuleHashes` in `packages/runner/src/harness/module-identity.ts` | Makes pinned specifiers content-derived with **no hashing changes** (§ Snapshot semantics) |
+| Piece → pattern pointer: `meta("patternIdentity")` = `{ identity, symbol }` (entry-module identity), the sole pointer post-`#4156` (a separate `meta("pattern")` survives only as a builtin parent-backlink) | write `applySetupState`, read `getPatternIdentityRef` in `packages/runner/src/runner.ts` | The terminal hop of the resolution chain |
 | Pattern source-of-truth: the `pattern:<identity>` source-doc closure (there is no longer a meta cell; the retired one's `program` was pure duplication of these docs) | `packages/runner/src/compilation-cache/cell-cache.ts` | Recovered via `getPatternSourceProgramByIdentity` / `loadVerifiedSourceClosure` |
 | Compile cache: source docs at cell key **`pattern:<identity>`**, compiled docs at `compileCache:<rtVersion>/<identity>` | `packages/runner/src/compilation-cache/cell-cache.ts` (`sourceDocKey`/`compiledDocKey`) | **The URI a pattern is saved under by hash.** Content-addressed per-module source + compiled storage; imports resolve from and dedupe into it |
-| Slug cells: generic **redirect link to any cell** (`setSlugLink` is target-agnostic; only `resolvePieceAddress` layers a "must be a piece" check) | `packages/piece/src/slugs.ts:34-80` | Slugs can name pieces *or* patterns today, mechanically |
+| Slug cells: generic **redirect link to any cell** (`setSlugLink` is target-agnostic; only `resolvePieceAddress` layers a "must be a piece" check) | `packages/piece/src/slugs.ts` | Slugs can name pieces *or* patterns today, mechanically |
 | Slug ids: `hashOf({causal:{space, slug}})`; slug grammar `[a-z0-9]+(-[a-z0-9]+)*`, ≤80 chars; **`isSlugAddress(t) = !t.includes(":")`** | `packages/runner/src/slugs.ts` | The existing slug-vs-URI discriminator the grammar reuses |
-| `loadPatternByIdentity(entryIdentity, symbol, space)` | `packages/runner/src/pattern-manager.ts:839` | Existing by-identity load path the resolver builds on |
-| Per-space host routing: `spaceHostMap` resolves each space to its memory host; foreign-host sessions are ordinary authenticated memory sessions (#3947) | `packages/runner/src/storage/v2-remote-session.ts:47` | Cross-toolshed refs are just cell reads in a space routed to another host — no HTTP endpoints needed |
+| `loadPatternByIdentity(entryIdentity, symbol, space)` | `packages/runner/src/pattern-manager.ts` | Existing by-identity load path the resolver builds on |
+| Per-space host routing: `spaceHostMap` resolves each space to its memory host; foreign-host sessions are ordinary authenticated memory sessions (#3947) | `packages/runner/src/storage/v2-remote-session.ts` | Reads work for a foreign space whose route is already known; applying a host from an explicit `cf://` reference remains planned |
 
 ### The two "pattern by hash" handles, explicitly
 
@@ -141,9 +144,19 @@ separate fields:
   preserves a path inside that repository rather than only a basename.
   Absolute paths from the author's machine are never persisted.
 - `source.origin` is the optional `patternSource` update provenance carried by
-  the piece (a `cf:` publication ref or a toolshed system-pattern path). It
-  answers "where should updates be checked?", not "which exact bytes are
-  running?"; `source.ref` answers the latter.
+  the piece. Today only toolshed system-pattern paths drive an implemented
+  update check. General source URLs include external `https://` URLs and
+  fabric-internal `cf:` URLs, including the host-qualified `cf://...` form. A
+  fabric URL that is unpinned and resolves to a piece or another mutable
+  `patternIdentity`-bearing entity follows that entity's current pattern. A
+  fabric URL that resolves to `pattern:<identity>` names content-addressed
+  source and cannot update. A trailing `@<identity>` pin makes any fabric URL
+  immutable, even when its unpinned form names a piece. These piece-origin
+  semantics are specified in
+  [`../piece-source-lifecycle.md`](../piece-source-lifecycle.md) and require
+  work. An origin answers "where did this source come from, and should that
+  place be checked again?"; `source.ref` answers "which exact bytes are
+  running?"
 
 `cf piece new`, `cf piece setsrc`, and custom `cf piece set-home` accept
 `--repository <locator>` alongside `--root`. `new` and custom `set-home` stamp
@@ -368,7 +381,7 @@ join inside the mounted program).
 |---|---|---|
 | `./ ../ /` | program-relative files | today |
 | bare (`commonfabric`, `turndown`, …) | **reserved for runtime modules only**, allowlist | today; never used for packages |
-| `cf:` (authored reference grammar above) | this spec | new |
+| `cf:` (authored reference grammar above) | this spec | today for content-addressed and same-toolshed references; host-qualified routing and subpaths planned |
 | `cf:module/`, `cf:cache-root/` | compiled output / cache internals; rejected in authored source | today |
 | `npm: jsr: https:` | future external packages | reserved now |
 
@@ -517,12 +530,14 @@ unchanged.
 
 ### 5. CLI / shell
 
-- `cf deploy`: pins unpinned mutable refs (rewrites the stored source, which
-  re-derives the pinned identity and its `pattern:<identity>` source docs).
+- `cf deps update <file> [--import <specifier>]`: pins unpinned mutable refs by
+  rewriting the stored source, which re-derives the pinned identity and its
+  `pattern:<identity>` source documents.
+- Automatic pinning during piece deployment remains required work. The CLI
+  intentionally has no `cf deploy` command.
 - `cf publish <pattern> [--slug name] [--space …]` *(not yet built)*: ensure the
   source docs exist in the target space + assign the slug to a
   patternIdentity-bearing cell.
-- `cf deps update [specifier]`: re-resolve + rewrite pins.
 - `cf dev` / `cf check`: live-resolve unpinned refs against the connected
   toolshed; `--frozen` to forbid (CI). `--show-transformed` shows mounted
   files like any other program file.

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -4,7 +4,7 @@ Letting authored patterns import other patterns published in the fabric:
 
 ```tsx
 // Shown for illustration only.
-import { TodoItem, todoSchema } from "cf:/kitchen/todo-list";  // a slug — names a piece OR a published pattern
+import { TodoItem, todoSchema } from "cf:/did:key:z6Mk…/todo-list";  // a slug in an identified space
 import { TodoItem } from "cf:pattern:AvcnyZ…rC1c";               // a content-addressed source, directly
 ```
 
@@ -157,9 +157,11 @@ separate fields:
   fabric URL that is unpinned and resolves to a piece or another mutable
   `patternIdentity`-bearing entity follows that entity's current pattern. A
   fabric URL that resolves to `pattern:<identity>` names content-addressed
-  source and cannot update. A trailing `@<identity>` pin makes any fabric URL
-  immutable, even when its unpinned form names a piece. These piece-origin
-  semantics are specified in
+  source and cannot update. A trailing `@<identity>` pin on an entity-FID URL
+  makes that URL immutable, even though its unpinned form names a piece. The
+  tentative piece-origin policy rejects slug-shaped URLs even when they carry a
+  pin. Authored static imports remain a separate case and may use pinned slugs.
+  These piece-origin semantics are specified in
   [`../piece-source-lifecycle.md`](../piece-source-lifecycle.md) and require
   work. An origin answers "where did this source come from, and should that
   place be checked again?"; `source.ref` answers "which exact bytes are
@@ -187,7 +189,7 @@ cf://<host>/<space>/<ref>[/<subpath>][@<pin>]      ; explicit toolshed
 ref     = slug                ; no ":" — isSlugAddress convention
         | "of:fid1:" hash     ; cell URI (a piece / a cell carrying patternIdentity)
         | "pattern:" hash     ; entry-module identity (content-addressed source)
-space   = space-name | space-did
+space   = space-name | space-did ; parser shape; resolution currently requires a DID
 host    = domain[":"port]     ; a toolshed
 pin     = "@" hash            ; entry-module identity
 hash    = 43 base64url chars  ; hashStringOf/hashOf output (value-hash.ts):
@@ -207,14 +209,14 @@ Examples:
 // Shown for illustration only.
 import { TodoItem } from "cf:todo-list";                            // slug, current space
 import { todoSchema } from "cf:todo-list/schemas";                  // subpath (phase 2)
-import { TodoItem } from "cf:/kitchen/todo-list";                   // space by name
+import { TodoItem } from "cf:/kitchen/todo-list";                   // name-shaped space parses, but resolution rejects it
 import { TodoItem } from "cf:/did:key:z6Mk…/todo-list";             // space by DID
-import { TodoItem } from "cf://toolshed.common.tools/kitchen/todo-list";  // explicit toolshed
+import { TodoItem } from "cf://toolshed.common.tools/did:key:z6Mk…/todo-list";  // explicit toolshed
 import { TodoItem } from "cf:pattern:AvcnyZ…rC1c";                    // content-addressed, space-free
-import { TodoItem } from "cf:/kitchen/of:fid1:ZwjMI…A2Os";          // a piece (patternIdentity-bearing cell) by URI
+import { TodoItem } from "cf:/did:key:z6Mk…/of:fid1:ZwjMI…A2Os";    // a piece (patternIdentity-bearing cell) by URI
 
 // What a deployed importer actually stores (§ Snapshot semantics):
-import { TodoItem } from "cf:/kitchen/todo-list@AvcnyZ…rC1c";
+import { TodoItem } from "cf:/did:key:z6Mk…/todo-list@AvcnyZ…rC1c";
 ```
 
 Parsing rules (each form is disjoint by prefix; no segment counting needed):
@@ -263,8 +265,12 @@ Why this shape:
   is entirely ours via the `ProgramResolver`/compiler-host seam, and TypeScript
   is satisfied through the same mechanism that resolves `commonfabric` today
   (`packages/js-compiler/typescript/compiler.ts:176-207`).
-- **It is the shell's URL shape with a scheme on it** —
-  `/{spaceNameOrDid}/{pieceIdOrSlug}` — so users learn one addressing model.
+- **Its durable identifier forms follow the shell's URL shapes.** A mutable
+  piece uses `cf:/<space-did>/of:fid1:<piece-id>`. An immutable pattern uses the
+  space-free `cf:pattern:<identity>` form. Authored static imports may still use
+  a slug because deployment pins its terminal content identity. A piece origin
+  does not accept that slug-shaped form under the tentative direction in Open
+  question 1. Human-readable URL aliases belong in a separate shortlink layer.
 - **Publication = naming.** `slug → a cell carrying patternIdentity` (a piece,
   or a published-pointer cell) in a readable space is the whole publish story;
   updating the slug is publishing a new version (dist-tag semantics). Pieces and
@@ -304,7 +310,7 @@ Mechanics:
    the specifier in the stored source** to the pinned form:
 
    ```tsx
-   import { TodoItem } from "cf:/kitchen/todo-list@AvcnyZ…rC1c";
+   import { TodoItem } from "cf:/did:key:z6Mk…/todo-list@AvcnyZ…rC1c";
    ```
 
    The stored program is then fully deterministic: compilation, identity, and
@@ -683,10 +689,24 @@ unchanged.
 
 ## Open questions
 
-1. **Space-name resolution.** Refs with space *names* (not DIDs) need a
-   name→DID mapping per host; the shell resolves names client-side today and
-   there is no service surface here to hang it on. Name squatting/renaming
-   semantics need a decision before phase 2 (DID-form refs sidestep it).
+1. **Identifier-only durable URLs and future shortlinks, tentative.** The
+   current resolver rejects a name in the space position. The tentative
+   direction is to preserve that boundary rather than add name-to-DID
+   resolution to the fabric URL grammar. A durable piece-origin URL uses the
+   repository's stable identifier forms: a DID for the space, an entity FID
+   for a mutable piece or publication pointer, or a content identity for an
+   immutable pattern. Current-space shorthand for an unpinned mutable entity
+   normalizes to the explicit space DID and entity FID before it becomes origin
+   state. A direct pattern identity or a pin on an entity-FID URL normalizes to
+   the space-free content identity. The piece-origin validator rejects a
+   slug-shaped or root-only fabric reference, including a pinned slug. Existing
+   authored import aliases remain a separate case because deployment pins their
+   terminal content identity into source. A UI or future shortlink service may
+   map a custom string to a canonical identifier URL before the lifecycle sees
+   it. The shortlink is not itself the durable origin or a repoint target.
+   Further study must settle whether spaces should eventually have FIDs rather
+   than DIDs, shortlink ownership and reassignment, and whether supplied aliases
+   receive separate optional provenance metadata.
 2. **Slug-cell typing.** The uniform chase duck-types its hops (a
    `patternIdentity` meta present ⇒ a pattern-bearing cell). Good enough, or
    should slug assignment stamp an explicit kind on the slug cell for better

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -52,10 +52,12 @@ general piece origin model is described in `../piece-source-lifecycle.md`.
   (`packages/runner/src/builtins/fetch-program.ts`) fetches and compiles remote
   programs at *runtime*, untyped at the call site. An import is compile-time:
   TypeScript checks the binding names and types against the real source.
-- **A publishing story that is just naming.** Pointing a slug at a cell that
-  carries a `patternIdentity` (a piece, or a lightweight published-pointer
-  cell) in a readable space *is* publication: a human-readable, updatable name
-  (a dist-tag) for a content-addressed artifact. No registry product required.
+- **A publishing story built from naming and placement.** Pointing a slug at a
+  cell that carries a `patternIdentity` (a piece, or a lightweight
+  published-pointer cell) gives a pattern a human-readable, updatable name (a
+  dist-tag) within that space. It does not change the space's ACL. Publishing
+  into another space creates a replica under that destination space's ACL.
+  No registry product required.
 - **Foundation for external packages.** The same resolution seam, pinning
   model, and collision rules are designed so that `npm:`/esm.sh support can be
   added later without revisiting this design (§ External packages).
@@ -510,10 +512,15 @@ depended on the transport).
 
 Consequences:
 
-- **Publication is purely a data/authz act**: make the slug cell, the
-  patternIdentity-bearing cell it points at, and the `pattern:<identity>` source
-  docs readable in a space (`cf publish` is sugar for writing them to such a
-  space and assigning the slug). Whoever can read the space can import; nobody
+- **Publication separates naming from placement.** Assigning a slug to a
+  pattern already present in a space only gives it another name; it does not
+  change that space's ACL. `cf publish --space` creates a lightweight
+  patternIdentity-bearing publication cell in the target space, copies the
+  verified source closure, then optionally assigns a slug. It does not copy the
+  source piece or any of that piece's state. The replica has the target space's
+  ACL and may therefore have a different audience. The operation requires
+  source-read authorization, destination-write authorization, and a permitted
+  CFC flow. Whoever can read the target space can import its replica; nobody
   else can.
 - **The host segment maps to a `spaceHostMap` entry.** One mechanical work
   item: the map is fixed at storage construction today
@@ -521,9 +528,10 @@ Consequences:
   the resolver needs either dynamic registration of a space→host route on the
   live session or a short-lived secondary session for the foreign space.
 - A cacheable, anonymous HTTP mirror for published patterns (CDN-style
-  distribution to readers with no fabric identity) remains *possible* later —
-  it would be trust-free thanks to hash verification — but it is an
-  optimization, not part of this design (§ Open questions).
+  distribution to readers with no fabric identity) remains *possible* later.
+  It would need an explicit anonymous visibility policy that covers the whole
+  pattern, including its source, and hash verification would still protect
+  integrity. It is not part of this design (§ Open questions).
 
 The existing `/api/patterns/:filename` (repo-file serving) is unrelated and
 unchanged.
@@ -535,9 +543,11 @@ unchanged.
   `pattern:<identity>` source documents.
 - Automatic pinning during piece deployment remains required work. The CLI
   intentionally has no `cf deploy` command.
-- `cf publish <pattern> [--slug name] [--space …]` *(not yet built)*: ensure the
-  source docs exist in the target space + assign the slug to a
-  patternIdentity-bearing cell.
+- `cf publish <pattern> [--slug name] [--space …]` *(not yet built)*: after
+  source-read authorization, destination-write authorization, and CFC
+  approval, copy the verified source closure and create a lightweight
+  patternIdentity-bearing publication cell in the target space, then
+  optionally assign the slug. Do not copy the source piece or its state.
 - `cf dev` / `cf check`: live-resolve unpinned refs against the connected
   toolshed; `--frozen` to forbid (CI). `--show-transformed` shows mounted
   files like any other program file.
@@ -573,10 +583,16 @@ unchanged.
   CFC verified-identity resolution uses
   (`docs/specs/content-addressed-action-identity.md`); imported modules verify
   and register exactly like authored ones. No new identity kind is introduced.
-- **No new authorization surface.** Resolution and content fetch are memory
-  reads under existing space authz — including cross-host (`spaceHostMap`
-  sessions authenticate like any other). Nothing exposes data a space-read
-  doesn't already grant.
+- **Source shares the containing space's ACL.** Within a space, every cell and
+  document that makes a pattern resolvable, including its verified source
+  closure, has that space's visibility. Anyone authorized to resolve the
+  pattern in that space may read its source; there is no separate
+  source-publication permission. Assigning a slug names the pattern but does
+  not grant access. Knowing a content identity or fabric URL is also not
+  authorization. The same content identity can be replicated into spaces with
+  different ACLs, and each replica follows its containing space's ACL.
+  Resolution and content fetch remain memory reads under existing space authz,
+  including cross-host reads through authenticated `spaceHostMap` sessions.
 - **Pattern source is data with provenance.** Patterns can contain private
   information (literals, prompts, embedded knowledge), so source docs are not
   exempt from CFC: fetching an imported pattern's source is a labeled read,
@@ -622,46 +638,58 @@ unchanged.
   error; fallback hop succeeds.
 - **Multi-runtime** (`multiUserTest` harness): user 1 deploys + publishes;
   user 2 imports across spaces; CFC verified identity intact.
+- **Authorization**: within one space, pattern and source visibility match; a
+  slug, URL, or content identity grants no access; a cross-space publish adopts
+  the target space's ACL only after authorization and CFC checks; revoking
+  origin access blocks future resolution without deleting source already
+  accepted into another space.
 - **Failure modes**: one test per row of the table.
+
+## Resolved questions
+
+1. **Publish granularity and source visibility.** Within a space, a pattern and
+   its verified source closure have the same ACL and visibility: that space's.
+   A caller that can resolve the pattern there may read its source. A caller
+   that cannot resolve it gains nothing from knowing its URL or content
+   identity. Assigning a slug to a pattern already present in the space is only
+   naming and discovery; it creates no separate source grant. Publishing into
+   another space is different: it creates an ACL-scoped replica under the
+   destination space's visibility and requires destination write authorization
+   plus a permitted CFC flow.
 
 ## Open questions
 
-1. **Publish granularity.** Is "publish" a distinct user action (`cf publish`
-   / slug assignment) or implicit for any pattern readable by the reference
-   resolver? Implicit is ergonomic but turns space-read into
-   source-disclosure; explicit publish is the conservative default proposed
-   here.
-2. **Space-name resolution.** Refs with space *names* (not DIDs) need a
+1. **Space-name resolution.** Refs with space *names* (not DIDs) need a
    name→DID mapping per host; the shell resolves names client-side today and
    there is no service surface here to hang it on. Name squatting/renaming
    semantics need a decision before phase 2 (DID-form refs sidestep it).
-3. **Slug-cell typing.** The uniform chase duck-types its hops (a
+2. **Slug-cell typing.** The uniform chase duck-types its hops (a
    `patternIdentity` meta present ⇒ a pattern-bearing cell). Good enough, or
    should slug assignment stamp an explicit kind on the slug cell for better
    errors and tooling?
-4. **Type-only imports.** Should `import type { … }` from a fabric ref skip
+3. **Type-only imports.** Should `import type { … }` from a fabric ref skip
    the pin requirement (types don't affect runtime identity)? Tempting, but
    the transformer lowers types into schemas — so types DO affect emitted
    behavior, and the conservative answer is no special-casing. Revisit with
    evidence.
-5. **Subpath surface.** Whether subpaths may address any file in the program
+4. **Subpath surface.** Whether subpaths may address any file in the program
    or only files the entry re-exports (an "exports map" discipline, like npm's
    `exports`). Start permissive, tighten if published-internal-file coupling
    becomes a problem.
-6. **Runtime-fingerprint interaction.** External-dep leaves include
+5. **Runtime-fingerprint interaction.** External-dep leaves include
    `runtimeFingerprint`; a runtime upgrade thus shifts importer identities even
    with identical pins (status quo for runtime modules, now also for fabric
    refs). Acceptable, but worth stating in the compile-cache invalidation
    docs.
-7. **What "publicly readable" means — and a possible public endpoint.**
-   Memory sessions are authenticated; importing requires *some* identity the
-   publishing space grants read to. Does publication mean "readable by any
-   authenticated identity" (a broad grant)? An anonymous, CDN-cacheable HTTP
-   endpoint serving **public** patterns by identity may still be useful on
-   top (trust-free via hash verification) — deliberately left open rather
-   than rejected; it only makes sense for content whose labels permit
-   unrestricted disclosure (see the provenance note in § Security).
-8. **Dynamic space→host routes.** `spaceHostMap` is fixed at storage
+6. **Public distribution surface.** Should the product standardize a dedicated
+   distribution space whose space-wide ACL grants `READ` to `*`, making every
+   pattern in that space readable by any authenticated identity? Should it also
+   offer an anonymous, CDN-cacheable HTTP endpoint? An anonymous endpoint would
+   need an explicit visibility policy applied equally to a pattern and its
+   source. It could serve only patterns copied under that policy after CFC
+   allows unrestricted disclosure. A URL or content identity alone must never
+   qualify a pattern for either form of distribution.
+7. **Dynamic space→host routes.** `spaceHostMap` is fixed at storage
    construction; host-qualified refs discovered mid-compile need dynamic
    route registration (or a short-lived secondary session). Small, but it
    touches session lifecycle — design alongside phase 3.

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -28,10 +28,11 @@ distinction evaporates at pin time — both freeze to the same kind of hash.
 
 **Implemented for content-addressed and same-toolshed references** (`#4081`):
 parsing, slug and piece resolution, deploy-time pinning, and mounting. Dynamic
-host-qualified routing, `cf publish`, and source subpaths remain planned as
-listed under Phasing. This remains the design of record; for the as-built
-pointer model note that the patternId + pattern **meta cell** this document
-originally leaned on were **retired** in `#4156`
+per-space route registration and home-site-table hydration are implemented as
+foundations. Applying a host supplied by a `cf://` import remains planned, as
+do `cf publish` and source subpaths. This remains the design of record; for the
+as-built pointer model note that the patternId + pattern **meta cell** this
+document originally leaned on were **retired** in `#4156`
 (`docs/specs/pattern-id-retirement.md`) — a piece now carries only
 `patternIdentity = { identity, symbol }`, and a pattern's source lives in the
 `pattern:<identity>` source-doc closure. References below are updated to match.
@@ -40,7 +41,7 @@ general piece origin model is described in `../piece-source-lifecycle.md`.
 
 ## Last Updated
 
-2026-07-21
+2026-07-22
 
 ## Motivation
 
@@ -91,7 +92,7 @@ general piece origin model is described in `../piece-source-lifecycle.md`.
 | Slug cells: generic **redirect link to any cell** (`setSlugLink` is target-agnostic; only `resolvePieceAddress` layers a "must be a piece" check) | `packages/piece/src/slugs.ts` | Slugs can name pieces *or* patterns today, mechanically |
 | Slug ids: `hashOf({causal:{space, slug}})`; slug grammar `[a-z0-9]+(-[a-z0-9]+)*`, ≤80 chars; **`isSlugAddress(t) = !t.includes(":")`** | `packages/runner/src/slugs.ts` | The existing slug-vs-URI discriminator the grammar reuses |
 | `loadPatternByIdentity(entryIdentity, symbol, space)` | `packages/runner/src/pattern-manager.ts` | Existing by-identity load path the resolver builds on |
-| Per-space host routing: `spaceHostMap` resolves each space to its memory host; foreign-host sessions are ordinary authenticated memory sessions (#3947) | `packages/runner/src/storage/v2-remote-session.ts` | Reads work for a foreign space whose route is already known; applying a host from an explicit `cf://` reference remains planned |
+| Per-space host routing: `spaceHostMap` seeds routes, `registerSpaceHost` adds a route before a space opens, and the home-space site table hydrates durable hints; foreign-host sessions are ordinary authenticated memory sessions | `packages/runner/src/storage/v2-remote-session.ts`, `packages/runner/src/storage/v2.ts`, and `packages/runtime-client/backends/runtime-processor.ts` | Reads work for a foreign space whose route is already known. A seeded route can only be confirmed. A later hint currently replaces an earlier late hint while the space remains unopened. After the space opens, only its previously registered matching hint can be confirmed. Applying a host from an explicit `cf://` reference remains planned |
 
 ### The two "pattern by hash" handles, explicitly
 
@@ -500,19 +501,20 @@ the provenance-relevant flow flagged under § Security.)
 
 ### 4. Cross-host references: no service surface at all
 
-A runtime is no longer bound to one memory host: `spaceHostMap`
-(`storage/v2-remote-session.ts:createStorageAddressResolver`, PR #3947)
-routes each space to its host, and a foreign-host session is an ordinary
-authenticated memory session. (`spaceHostMap` itself is an **interim
-mechanism** — per-space host resolution will evolve; this design depends only
-on the property "a space's cells are readable wherever the space lives", not
-on the map's current shape.) So a `cf://host/space/ref` reference resolves
-exactly like a local one — slug chase, piece/meta hops, and `pattern:<identity>`
-source-doc reads are all cell reads in a space that happens to live on
-another host, under that host's normal authz. No resolve endpoint, no
-content endpoint; nothing re-implements space authorization in an HTTP
-route, and hash verification of fetched sources is unchanged (it never
-depended on the transport).
+A runtime is no longer bound to one memory host. `spaceHostMap` seeds known
+routes when storage is constructed. `registerSpaceHost` can register a later
+hint before that space opens, and the home-space site table hydrates durable
+hints into a new runtime. A foreign-host connection is an ordinary
+authenticated memory session. These mechanisms remain interim. This design
+depends only on the property that a space's cells are readable wherever the
+space lives, not on the current map or site-table shape.
+
+Once a route is in effect, a `cf://host/space/ref` reference resolves exactly
+like a local one. Slug chase, piece metadata, and `pattern:<identity>` source
+reads are ordinary cell reads in a space that happens to live on another host.
+The runtime does not use a separate resolver endpoint, content endpoint, or
+short-lived secondary session. The destination host applies its ordinary
+authorization, and source hash verification remains independent of transport.
 
 Consequences:
 
@@ -526,11 +528,15 @@ Consequences:
   source-read authorization, destination-write authorization, and a permitted
   CFC flow. Whoever can read the target space can import its replica; nobody
   else can.
-- **The host segment maps to a `spaceHostMap` entry.** One mechanical work
-  item: the map is fixed at storage construction today
-  (`v2.ts` options), while a host-qualified ref is discovered mid-compile —
-  the resolver needs either dynamic registration of a space→host route on the
-  live session or a short-lived secondary session for the foreign space.
+- **The host segment supplies a late-bound route hint.** The resolver must
+  register that hint on the ordinary storage manager before it opens the
+  referenced space. A seeded route wins for the current session. An accepted
+  late hint must also remain stable before the first open; a different hint is
+  a conflict. After the space opens, registration can only confirm the hint
+  that was already in effect. Any other registration attempt fails rather than
+  opening a second connection for the same space. The current registry still
+  replaces a different late hint before the first open. Host-qualified import
+  resolution must add this conflict guard when it adopts the registration path.
 - A cacheable, anonymous HTTP mirror for published patterns (CDN-style
   distribution to readers with no fabric identity) remains *possible* later.
   It would need an explicit anonymous visibility policy that covers the whole
@@ -567,7 +573,8 @@ unchanged.
    `cf deps update`. (Resolution = the compiling runtime's storage reads
    throughout — no phase adds a service endpoint.)
 3. **`cf publish` + host-qualified refs** — cross-host reads via
-   `spaceHostMap` routing, incl. the dynamic-route work item above.
+   ordinary per-space routing, including registration of the supplied host
+   before the referenced space opens.
 4. **Subpaths; `npm:`/esm.sh vendoring** on the same rails.
 
 ## Security considerations
@@ -660,6 +667,19 @@ unchanged.
    another space is different: it creates an ACL-scoped replica under the
    destination space's visibility and requires destination write authorization
    plus a permitted CFC flow.
+2. **Registration of a known space-to-host hint, within the current routing
+   model.** Use the ordinary per-space storage session rather than a short-lived
+   secondary session. A host-qualified operation registers its accepted hint
+   before opening the space. An operation that removes the host from its
+   canonical reference must persist the route in the home-space site table
+   after live registration accepts it and before committing the hostless
+   reference. A seeded route can only be confirmed. Once a late hint is
+   accepted, a different hint is a conflict even before the space opens. After
+   the space opens, only the hint already in effect can be confirmed. Any other
+   attempt fails rather than silently changing the route. The current registry
+   still needs the pre-open conflict guard. This settles how a known hint enters
+   the current session. It does not settle host discovery, availability,
+   failover, or space relocation.
 
 ## Open questions
 
@@ -693,7 +713,10 @@ unchanged.
    source. It could serve only patterns copied under that policy after CFC
    allows unrestricted disclosure. A URL or content identity alone must never
    qualify a pattern for either form of distribution.
-7. **Dynamic space→host routes.** `spaceHostMap` is fixed at storage
-   construction; host-qualified refs discovered mid-compile need dynamic
-   route registration (or a short-lived secondary session). Small, but it
-   touches session lifecycle — design alongside phase 3.
+7. **Host-route reliability and relocation.** The known-hint registration rule
+   does not say what to do when a recorded host is unavailable, a space moves,
+   or more than one host can serve the same space. Revisit how route changes
+   are authenticated, how stale site-table entries are replaced, whether
+   failover is allowed, and how an open session closes and reconnects without
+   losing or duplicating work. The site-table watcher currently races the first
+   space open, so reliable bootstrap ordering also remains part of this topic.

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -27,12 +27,17 @@ distinction evaporates at pin time — both freeze to the same kind of hash.
 ## Status
 
 **Implemented for content-addressed and same-toolshed references** (`#4081`):
-parsing, slug and piece resolution, deploy-time pinning, and mounting. Dynamic
-per-space route registration and home-site-table hydration are implemented as
-foundations. Applying a host supplied by a `cf://` import remains planned, as
-do `cf publish` and source subpaths. This remains the design of record; for the
-as-built pointer model note that the patternId + pattern **meta cell** this
-document originally leaned on were **retired** in `#4156`
+parsing, slug and piece resolution, mounting, the pin-rewrite primitive, and
+`cf deps update`. Automatic pin-on-deploy is incomplete. The current piece
+deployment path resolves the local program before it invokes the pin rewriter,
+so any fabric import or export declaration fails initial local resolution. This
+includes an already-pinned reference. An unpinned declaration therefore never
+reaches the rewriter. Dynamic per-space route registration and home-site-table
+hydration are implemented as foundations. Applying a host supplied by a
+`cf://` import remains planned, as do `cf publish` and source subpaths. This
+remains the design of record; for the as-built pointer model note that the
+patternId + pattern **meta cell** this document originally leaned on were
+**retired** in `#4156`
 (`docs/specs/pattern-id-retirement.md`) — a piece now carries only
 `patternIdentity = { identity, symbol }`, and a pattern's source lives in the
 `pattern:<identity>` source-doc closure. References below are updated to match.
@@ -312,6 +317,38 @@ Mechanics:
    ```tsx
    import { TodoItem } from "cf:/did:key:z6Mk…/todo-list@AvcnyZ…rC1c";
    ```
+
+   Pinning applies to every supported static, ESM-style fabric reference in
+   TypeScript module and type syntax. This includes `import type`, type-only
+   named imports and exports, and inline references such as
+   `import("cf:/did:key:z6Mk…/todo-list").TodoItem`. There is no type-only
+   exception. Common Fabric lowers imported types into schemas that affect
+   validation, reactivity, and emitted behavior. Leaving such a reference
+   mutable would let a dependency change a deployed pattern without changing
+   the pattern's stored source. The pin remains in authored source even when
+   TypeScript erases the corresponding JavaScript import.
+
+   TypeScript's CommonJS-style
+   `import type Alias = require("cf:…")` form is not part of the supported ESM
+   import surface. It must be rejected explicitly rather than ignored by
+   pinning or identity collection. That rejection and its regression test are
+   required work.
+
+   **Implemented:** `rewriteFabricPins` visits import declarations, export
+   declarations, and inline import-type nodes. Its tests cover both
+   `import type` and `import("cf:…").Type`. Module identity collection also
+   includes those type edges. `cf deps update` collects the local program with
+   fabric references allowed before running the rewriter.
+
+   **Deploy integration required:** `getPinnedProgramFromFile()` currently
+   calls the ordinary harness resolver before `pinProgramFabricImports()`.
+   That resolver has no fabric-aware layer, so any fabric import or export
+   declaration fails, including one that is already pinned. An unpinned
+   declaration therefore cannot reach the rewriter. Deployment must collect the
+   local program while allowing fabric references, rewrite every file, and then
+   perform the frozen compile. Complete production resolution, identity, and
+   persistence of authored `.d.ts` inputs also remains required work. Neither
+   gap creates a type-only exception to the target pinning rule.
 
    The stored program is then fully deterministic: compilation, identity, and
    execution never read the slug or piece again.
@@ -806,16 +843,11 @@ unchanged.
    `patternIdentity` meta present ⇒ a pattern-bearing cell). Good enough, or
    should slug assignment stamp an explicit kind on the slug cell for better
    errors and tooling?
-3. **Type-only imports.** Should `import type { … }` from a fabric ref skip
-   the pin requirement (types don't affect runtime identity)? Tempting, but
-   the transformer lowers types into schemas — so types DO affect emitted
-   behavior, and the conservative answer is no special-casing. Revisit with
-   evidence.
-4. **Subpath surface.** Whether subpaths may address any file in the program
+3. **Subpath surface.** Whether subpaths may address any file in the program
    or only files the entry re-exports (an "exports map" discipline, like npm's
    `exports`). Start permissive, tighten if published-internal-file coupling
    becomes a problem.
-6. **Public distribution surface.** Should the product standardize a dedicated
+4. **Public distribution surface.** Should the product standardize a dedicated
    distribution space whose space-wide ACL grants `READ` to `*`, making every
    pattern in that space readable by any authenticated identity? Should it also
    offer an anonymous, CDN-cacheable HTTP endpoint? An anonymous endpoint would
@@ -823,7 +855,7 @@ unchanged.
    source. It could serve only patterns copied under that policy after CFC
    allows unrestricted disclosure. A URL or content identity alone must never
    qualify a pattern for either form of distribution.
-7. **Host-route reliability and relocation.** The known-hint registration rule
+5. **Host-route reliability and relocation.** The known-hint registration rule
    does not say what to do when a recorded host is unavailable, a space moves,
    or more than one host can serve the same space. Revisit how route changes
    are authenticated, how stale site-table entries are replaced, whether

--- a/docs/specs/pattern-imports/implementation-plan.md
+++ b/docs/specs/pattern-imports/implementation-plan.md
@@ -921,10 +921,17 @@ One integration test (runner-level, in-process, two "deploys"):
   source closure, creates a lightweight patternIdentity-bearing publication
   cell, and optionally assigns a slug in the target space. It does not copy the
   source piece or its state. The resulting replica uses the destination space's
-  ACL. Host-qualified refs need dynamic space→host routes (`spaceHostMap` is
-  interim) and CFC label propagation for fetched source (spec § Security). A
-  possible public-pattern HTTP endpoint remains open under the public
-  distribution question in the spec.
+  ACL. Host-qualified refs register their accepted hint through the ordinary
+  per-space storage manager before opening the target space. Do not use a
+  secondary session. A seeded route can only be confirmed. Once a late hint is
+  accepted, a different hint is a conflict even before the space opens. After
+  the space opens, only the hint already in effect can be confirmed. The
+  current registry still needs the pre-open conflict guard. Dynamic
+  registration and site-table hydration exist as foundations, but
+  import-resolver integration, host failure, and space relocation remain work.
+  Cross-host publication also needs CFC label propagation for fetched source
+  (spec § Security). A possible public-pattern HTTP endpoint remains open under
+  the public distribution question in the spec.
 - **M4 subpaths + npm vendoring**: subpath = alias to a non-entry mounted
   file (grammar already parses it); `npm:` = fetch via esm.sh → vendor as a
   content-addressed source set → same rails.

--- a/docs/specs/pattern-imports/implementation-plan.md
+++ b/docs/specs/pattern-imports/implementation-plan.md
@@ -93,7 +93,8 @@ Reload paths:
 ## Glossary (use these exact terms in code comments)
 
 - **fabric ref / fabric specifier** — an authored import specifier under the
-  `cf:` grammar (`cf:pattern:<hash>`, `cf:/kitchen/todo-list@<hash>`, …).
+  `cf:` grammar
+  (`cf:pattern:<hash>`, `cf:/did:key:z6Mk…/todo-list@<hash>`, …).
 - **pin** — the trailing `@<hash>` entry-module identity on a mutable ref.
 - **hash** — 43 base64url chars (`[A-Za-z0-9_-]`, case-SENSITIVE, no
   padding), the unprefixed output of `hashStringOf`/`hashOf`
@@ -769,9 +770,11 @@ export async function resolveFabricRefToIdentity(
 Algorithm (spec § Resolution rule — implement hops exactly):
 
 1. Space: `ref.space` undefined → `compilingSpace`; a DID → use as-is; a name
-   → M2 throws `"space names require name→DID resolution; use a DID"` (names
-   are NOT in M2 scope — the space-name resolution question remains open in
-   the spec).
+   → M2 throws
+   `"space names are currently unsupported; resolve the name to a DID first"`.
+   The tentative identifier-only policy keeps name resolution outside the
+   fabric resolver. README Open question 1 retains that policy for further
+   study and places human-readable aliases in a future shortlink service.
 2. Start cell:
    - slug → M2.1 resolver (wrap `SlugResolutionError` with the chain so far).
    - `of:` URI → reconstruct the entity id from the parsed hash via the
@@ -876,7 +879,7 @@ file layout, e.g. how `dev.ts` registers).
   `pattern-deploy`; the CLI command that writes a pattern's program to the
   pattern meta). Before writing the program: run `rewriteFabricPins` over
   every file, with `resolvePin` = M2.2 chase via the connected runtime; if
-  any rewrite happened, print each (`pinned cf:/kitchen/todo-list →
+  any rewrite happened, print each (`pinned cf:/did:key:z6Mk…/todo-list →
   @AvcnyZ…`). The STORED program is the pinned one. Deploying with an
   unresolvable ref fails the deploy with the chase's error.
 - **`cf deps update [file] [--import <specifier>]`**: new command; operates

--- a/docs/specs/pattern-imports/implementation-plan.md
+++ b/docs/specs/pattern-imports/implementation-plan.md
@@ -29,27 +29,35 @@ These were settled in the spec + design review. Implement as stated:
    to an entry-module identity.
 2. **Pin-in-source** (rewrite the import specifier at pin time). No lockfile
    side-table. No pin resolution at compile time for stored programs.
-3. **Imported subtrees keep their published identities.** Mounted files hash
+3. **Type-only fabric references are pinned.** Supported ESM-style
+   `import type`, type-only named imports and exports, and inline
+   `import("cf:…").Type` references follow the same deploy-time rewrite and
+   frozen-compile rules as value imports. The transformer uses imported types
+   to generate runtime schemas, so an unpinned type could change executable
+   behavior under unchanged stored source. Reject the unsupported CommonJS-style
+   `import type Alias = require("cf:…")` form before resolution or identity
+   calculation.
+4. **Imported subtrees keep their published identities.** Mounted files hash
    with their original authored paths and each source document's effective
    identity fingerprint. Identities, cache docs, and live modules therefore
    dedupe with the already-deployed pattern. This is Strategy A; the "fresh
    identities per importer" variant (A′) was considered and rejected (no
    dedupe, divergent CFC provenance).
-4. **Self-contained bundles**: imported modules ARE compiled and emitted as
+5. **Self-contained bundles**: imported modules ARE compiled and emitted as
    part of the importer's record graph (no lazy cross-bundle loading at
    evaluation time). Dedup happens via identity (cache hits, idempotent
    write-back, `modulesByIdentity`), not via emission-skipping.
-5. **Source set stays per-program**: an importer's source docs do NOT link to
+6. **Source set stays per-program**: an importer's source docs do NOT link to
    the imported subtree's source docs (the `cf:` specifier itself carries the
    target identity; loaders parse it). The **compiled** set DOES link across
    the boundary (it has no Merkle-union verification, and the link gives the
    warm loader the full closure for free).
-6. **No service endpoints.** All resolution and fetch are cell reads through
+7. **No service endpoints.** All resolution and fetch are cell reads through
    the compiling runtime's storage session.
-7. **v1 limitation**: an imported subtree whose modules use root-absolute
+8. **v1 limitation**: an imported subtree whose modules use root-absolute
    internal imports (`import … from "/utils.ts"`) is rejected at fetch time
    with a clear error. Relative (`./`, `../`) imports only inside subtrees.
-8. **CFC provenance of fetched source is follow-up work** (spec § Security).
+9. **CFC provenance of fetched source is follow-up work** (spec § Security).
    Do not build label propagation now; do not silently strip it either —
    the write-back path reuses existing write machinery so labels flow (or
    fail) exactly as any cell write does today.
@@ -629,7 +637,7 @@ export class FabricAwareResolver implements ProgramResolver {
       `ROOT_LINK_SPECIFIER` retention links. Mount only that entry view. This
       prevents unreachable documents and sibling retained generations from
       becoming executable mount files.
-   f. **Root-absolute import check** (decision 7): for every document in that
+   f. **Root-absolute import check** (decision 8): for every document in that
       entry view, run `collectImportSpecifiers` (from
       `@commonfabric/js-compiler`). Any specifier starting with `"/"` throws
       `"imported pattern <hash> uses root-absolute imports; not supported"`.
@@ -846,7 +854,7 @@ File: `packages/runner/src/compilation-cache/cell-cache.ts`.
    `unreachedRoots` (line 96) stays UNTOUCHED — it must keep seeing fabric
    edges as reachability (otherwise every mounted module gets a synthetic
    root link from the importer's entry, dragging subtrees back into the
-   importer's source closure — the exact thing decision 5 forbids).
+   importer's source closure — the exact thing decision 6 forbids).
 2. **Compiled side**: `writeCompiledDocs`, compiled synthetic roots, and
    compiled import links consume only the emitted set. Direct compiled links
    come only from runtime imports extracted from emitted JavaScript. A
@@ -1055,11 +1063,19 @@ on the original string. Skip non-fabric specifiers; skip refs where
 `import()` expression? — dynamic imports are unsupported by the compiler
 (resolver.ts comment) so they cannot occur in valid programs; ignore.
 
+Detect an `ImportEqualsDeclaration` whose external module reference is a
+`cf:` string and reject it with
+`"fabric import-equals syntax is unsupported; use an ESM import type"`.
+Apply the same validation in graph discovery and identity collection so this
+syntax cannot bypass the pin or become an unhashed runtime dependency.
+
 Tests: fixtures with weird-but-valid formatting (multiline imports, comments
 between clause and specifier, `export * from`, `import type`, single vs
 double quotes — PRESERVE the original quote character: detect from the
 literal's raw text). Assert byte-identity outside the replaced spans
-(compare prefix/suffix slices, not just "compiles").
+(compare prefix/suffix slices, not just "compiles"). Add a rejection test for
+`import type Alias = require("cf:dep")` in rewriting, graph discovery, and
+identity calculation.
 
 ### M2.4 Engine: unpinned refs in dev mode
 
@@ -1074,7 +1090,7 @@ literal's raw text). Assert byte-identity outside the replaced spans
     `resolvedPins()` accessor.
   - cross-space (`ref.space` a DID ≠ compiling space): fetch via
     `loadVerifiedSourceClosure(runtime, refSpace, …)` — the storage session
-    routes; CFC caveat is documented follow-up (decision 8). The write-back
+    routes; CFC caveat is documented follow-up (decision 9). The write-back
     then copies the docs into the compiling space (this is `replicateClosures`
     semantics through the normal compile path — no extra code, but ADD a test
     asserting it happens, and a `logger.info` naming source space → dest
@@ -1091,13 +1107,17 @@ the slug cell after pinning, recompile → still works).
 Read `packages/cli/` command structure first (mirror an existing command's
 file layout, e.g. how `dev.ts` registers).
 
-- **Deploy pinning**: find the deploy path (`cf` skill docs:
-  `pattern-deploy`; the CLI command that writes a pattern's program to the
-  pattern meta). Before writing the program: run `rewriteFabricPins` over
-  every file, with `resolvePin` = M2.2 chase via the connected runtime; if
-  any rewrite happened, print each (`pinned cf:/did:key:z6Mk…/todo-list →
-  @AvcnyZ…`). The STORED program is the pinned one. Deploying with an
-  unresolvable ref fails the deploy with the chase's error.
+- **Deploy pinning**: `getPinnedProgramFromFile()` currently calls
+  `getProgramFromFile()`. Its ordinary harness resolver has no fabric-aware
+  layer, so it rejects every fabric import or export declaration before
+  `pinProgramFabricImports()` runs. An already-pinned declaration fails too,
+  and an unpinned declaration never reaches the rewriter. Replace that ordering
+  with the `cf deps update` pattern: call `collectLocalProgram()` with fabric
+  imports allowed, run `pinProgramFabricImports()` over every collected file,
+  then pass the pinned program through the frozen compile path. If any rewrite
+  happened, print each (`pinned cf:/did:key:z6Mk…/todo-list → @AvcnyZ…`). The
+  stored program is the pinned one. Deploying with an unresolvable reference
+  fails with the chase's error.
 - **`cf deps update [file] [--import <specifier>]`**: new command; operates
   on the local working files (filesystem), not deployed state: parse, chase
   every mutable fabric ref (or just `--import`), rewrite pins in place,
@@ -1109,7 +1129,12 @@ file layout, e.g. how `dev.ts` registers).
 
 Tests: CLI-level tests follow whatever harness existing cli tests use (look
 in `packages/cli` for test conventions; if commands are thin over lib
-functions, test the lib functions and add one smoke test per command).
+functions, test the lib functions and add one smoke test per command). Add
+pin-on-deploy regressions for an unpinned value import, `import type`, a
+type-only export, and an inline import type. Each unpinned reference must reach
+the rewriter before the frozen compile. Add an already-pinned import regression
+that reaches the frozen compile without local-resolution failure. Keep the
+existing `cf deps update` coverage.
 
 ### M2.6 End-to-end snapshot-semantics test (the spec's core scenario)
 
@@ -1207,6 +1232,6 @@ One integration test (runner-level, in-process, two "deploys"):
   applies the ordinary compile-time helper transform exactly once. Preserve the
   existing tolerance for source stored in the legacy envelope.
 - Do NOT thread a space through globals/singletons — it rides options.
-- Do NOT touch CFC label code paths in this work (decision 8); if a test
+- Do NOT touch CFC label code paths in this work (decision 9); if a test
   fails on labels, stop and escalate rather than loosening a check.
 - Do NOT introduce new CLI flags beyond `cf deps update`'s listed ones.

--- a/docs/specs/pattern-imports/implementation-plan.md
+++ b/docs/specs/pattern-imports/implementation-plan.md
@@ -30,10 +30,11 @@ These were settled in the spec + design review. Implement as stated:
 2. **Pin-in-source** (rewrite the import specifier at pin time). No lockfile
    side-table. No pin resolution at compile time for stored programs.
 3. **Imported subtrees keep their published identities.** Mounted files hash
-   with their original authored paths (per-subtree prefix strip), so
-   identities, cache docs, and live modules dedupe with the already-deployed
-   pattern. This is Strategy A; the "fresh identities per importer" variant
-   (A′) was considered and rejected (no dedupe, divergent CFC provenance).
+   with their original authored paths and each source document's effective
+   identity fingerprint. Identities, cache docs, and live modules therefore
+   dedupe with the already-deployed pattern. This is Strategy A; the "fresh
+   identities per importer" variant (A′) was considered and rejected (no
+   dedupe, divergent CFC provenance).
 4. **Self-contained bundles**: imported modules ARE compiled and emitted as
    part of the importer's record graph (no lazy cross-bundle loading at
    evaluation time). Dedup happens via identity (cache hits, idempotent
@@ -67,7 +68,8 @@ engine.resolve(resolver)  ◄── FabricAwareResolver wraps EngineProgramResol
 resolved program (authored ∪ mounted files)
       │
       ├─ computeFabricModuleIdentities: authored set stripped /<id>,            [M1.3]
-      │  each subtree stripped /~cf/<hash> → PUBLISHED identities, merged map
+      │  each subtree stripped /~cf/<hash>; each document verifies under
+      │  its PUBLISHED identity fingerprint; verified identities form merged map
       │
       ├─ compiler.compileToModules(..., { specifierAliases })                   [M1.1]
       │     TypeScriptHost maps "cf:…" → mounted entry path (type-check)
@@ -75,17 +77,18 @@ resolved program (authored ∪ mounted files)
       ├─ compileSourcesToRecords(..., { specifierAliases, identityByPath })     [M1.2]
       │     record resolutions: "cf:…" → "cf:module/<published-identity>"
       │
-      └─ CacheableModule[]: mounted modules carry original filenames;           [M1.5]
-         importer modules gain fabric edges {specifier, targetIdentity}
-              │
-              ├─ writeSourceDocs: fabric edges NOT stored as links              [M1.6]
-              └─ writeCompiledDocs: fabric edges stored as links (warm walk)
+      ├─ source-persistence descriptors: all authored/mounted identity nodes,   [M1.5]
+      │  including declarations; fabric edges are not stored as source links    [M1.6]
+      │
+      └─ emitted CacheableModule[]: mounted implementation modules keep their   [M1.5]
+         original filenames; emitted runtime fabric edges become compiled links [M1.6]
 ```
 
 Reload paths:
-- **Warm** (compiled docs): `loadCompiledClosure` follows the fabric link →
-  full closure → `evaluateCachedModules`. Verify this works; small fixes only.
-  [M1.7]
+- **Warm** (compiled docs): for a value import, `loadCompiledClosure` follows
+  the fabric link to the full runtime closure and then calls
+  `evaluateCachedModules`. A type-only edge is absent from compiled runtime
+  links. Verify both cases. [M1.7]
 - **Cold** (source docs): importer closure excludes subtrees by design; the
   same `FabricAwareResolver` wrapped around `compileResolvedToRecordGraph`'s
   resolver re-fetches each subtree by the hash in the specifier. [M1.7]
@@ -383,21 +386,31 @@ File: `packages/runner/src/sandbox/module-record-compiler.ts` (next to
 // Shown for illustration only.
 export const FABRIC_MOUNT_ROOT = "/~cf/";
 
+export interface PublishedFabricModule {
+  /** Published identity that the verified source document was stored under. */
+  identity: string;
+  /** Effective fingerprint used to verify this document's identity. */
+  identityRuntimeFingerprint: string;
+}
+
 export interface FabricMount {
   /** Terminal identity the subtree was fetched by (and must hash back to). */
   entryIdentity: string;
   /** Mounted path of the subtree's entry file. */
   entryPath: string;          // `${FABRIC_MOUNT_ROOT}${entryIdentity}${storedEntryFilename}`
+  /** Verified published identity and effective fingerprint for each mounted path. */
+  publishedModules: ReadonlyMap<string, PublishedFabricModule>;
   /** The fabric specifiers that resolve to this mount (≥1). */
   specifiers: string[];
 }
 
 /**
  * Identity map for a program containing fabric mounts. Authored files hash
- * with `idPrefix` stripped (status quo); each mount's files hash as their own
- * standalone program with `/~cf/<entryIdentity>` stripped, so they reproduce
- * their PUBLISHED identities. Throws if a mount's entry does not hash back to
- * `entryIdentity` (integrity failure — wrong bytes mounted).
+ * with `idPrefix` stripped (status quo). Each mounted source document verifies
+ * under its published effective fingerprint with `/~cf/<entryIdentity>`
+ * stripped, so mixed legacy and current documents preserve their published
+ * identities. Throws if any mounted source does not hash back to its recorded
+ * identity or the entry does not match `entryIdentity`.
  */
 export function computeFabricModuleIdentities(
   sources: Source[],
@@ -415,16 +428,24 @@ Implementation:
    (The fabric edges inside authored sources resolve as EXTERNAL deps because
    the mounted file names never match the specifier — this is what folds the
    pin into the importer's hash. Do not "fix" that.)
-3. Each mount → `computeModuleIdentities(mountFiles,
-   { idPrefix: `/~cf/${m.entryIdentity}`, runtimeFingerprint })`.
+3. For each mount, require the mounted path set to equal the keys of
+   `m.publishedModules`. Group those entries by effective fingerprint. For each
+   distinct value, run `computeModuleIdentities` over the mounted view with
+   `idPrefix` set to `/~cf/${m.entryIdentity}` and that fingerprint. Compare the
+   recomputed identity for every entry in the group with its recorded identity.
+   Merge the recorded identities only after all comparisons succeed. This
+   preserves the identity of every published document instead of applying the
+   entry document's fingerprint to the entire closure. The authored importer
+   uses the current fingerprint through `options`, so its own identity changes
+   after a runtime upgrade without changing the pin.
    **Note**: subtree files may themselves contain fabric specifiers
    (transitive imports) — those are external deps within the subtree
    computation, exactly as they were when the subtree was published. Files of
    a TRANSITIVE mount are NOT part of this mount's partition (they live under
    their own `/~cf/<h2>/` prefix).
-4. Verify `result.get(m.entryPath) === m.entryIdentity`; throw with both
-   values on mismatch.
-5. Merge all maps (key sets are disjoint by construction) and return.
+4. Verify that `m.publishedModules.get(m.entryPath)?.identity` equals
+   `m.entryIdentity`; throw with both values on mismatch.
+5. Merge all maps. The key sets are disjoint by construction.
 
 Tests (new file `packages/runner/test/fabric-module-identity.test.ts`):
 - Two-file subtree published standalone (compute identities with no prefix),
@@ -434,6 +455,128 @@ Tests (new file `packages/runner/test/fabric-module-identity.test.ts`):
 - Mount entry mismatch (tampered byte) → throws.
 - File under `/~cf/` with no matching mount → throws.
 - Two mounts whose subtrees both contain `/main.tsx` → no interference.
+- A mount with an affected entry and a pure internal module verifies the
+  entry under its non-empty fingerprint and the pure module under the canonical
+  empty value.
+- Synthetic root links and documents outside the entry's authored-import view
+  do not become mounted modules. Two retained generations with the same
+  filename therefore cannot overwrite one another in a mount.
+
+#### Authored declaration-file integration
+
+Authored `.d.ts` files participate in module identity and source history even
+though they do not emit JavaScript records. Production `Engine` paths currently
+remove declarations before `computeFabricModuleIdentities`, build
+`CacheableModule` values only for emitted modules, and therefore omit
+declarations from `writeSourceDocs`.
+
+Required changes:
+
+1. Preserve source provenance before resolver output is merged. Distinguish
+   explicitly enumerated authored files, verified mounted files, and declaration
+   stubs supplied by `EngineProgramResolver` for runtime modules. A filename or
+   `.d.ts` suffix alone does not establish provenance.
+2. Extend production graph discovery to follow string-literal inline import-type
+   references such as `import("./types.d.ts").Foo`. `collectImportSpecifiers`
+   already includes these edges for identity, while `resolveProgram()`
+   deliberately does not fetch their targets. Load relative, authored, mounted,
+   and fabric inline type targets before identity calculation and type checking.
+   Apply the ordinary fabric pin and alias rules to a fabric target. When an
+   allowed bare runtime target is unresolved, preserve the existing
+   `resolveProgram()` fallback that asks the resolver for
+   `${identifier}.d.ts`. Apply that fallback to an inline-only reference too.
+   The returned runtime stub belongs only to the type-check set. Continue to
+   reject or ignore dynamic import expressions according to the existing
+   policy; they are not type-only edges.
+3. Build three sets. The type-check set contains all resolved inputs, including
+   runtime declaration stubs. The identity and source-history set contains the
+   implementation sources already identified today plus authored and mounted
+   declarations. The emitted and compiled-cache set contains only modules that
+   produce JavaScript records.
+4. Exclude runtime-provided declaration stubs from the identity set. An authored
+   import of `commonfabric` must remain an external leaf containing the runtime
+   fingerprint even though TypeScript reads a supplied `commonfabric.d.ts`.
+5. Keep authored and mounted declarations in the identity set. A type-import
+   edge contributes the declaration identity to its importer like any other
+   internal edge. Persist and verify those declarations through `SourceDoc` and
+   include them in immutable authored-program manifests.
+6. Restrict record assembly, compiled-cache lookup, compiled-document writes,
+   compiled synthetic roots, and compiled import links to the emitted set. No
+   compiled document or runtime record exists for a declaration. Derive direct
+   compiled links only from import specifiers present in emitted JavaScript.
+   Keep the broader value-and-type graph for source identity and source links.
+7. Add a production-engine regression in which an entry uses
+   `import("./types.d.ts").Foo`. Prove that resolution fetches the declaration,
+   changing it changes the entry identity and compiled bytes, and both revisions
+   remain restorable from source history. Run the corresponding case through a
+   pinned fabric inline type reference as well. Also prove follower propagation,
+   that `commonfabric` remains an external fingerprinted leaf, and that a cold
+   write followed by a warm load succeeds without requesting a compiled
+   declaration document. Add a separate inline-only
+   `import("commonfabric/schema").Schema` regression. It must find the existing
+   runtime declaration through the `${identifier}.d.ts` fallback without
+   turning the bare runtime module into an authored identity node or broadening
+   the sandbox import allowlist. This is distinct from the helper-injected
+   `commonfabric` import.
+
+#### Runtime-fingerprint integration
+
+A current runtime fingerprint is part of the executable identity of an authored
+importer because a fabric specifier is an external-dependency leaf. A fingerprint
+change therefore creates a new importer identity even when its source and pins
+are unchanged. Every document in a pinned mount keeps the identity and effective
+fingerprint under which it was published. It is not re-identified under the
+importing runtime. The current runtime must reject the import with an actionable
+republish-and-repin error when it cannot execute a recorded fingerprint.
+
+The hash primitive already accepts an optional `runtimeFingerprint`, and
+`module-identity.test.ts` proves that changing it changes a module that imports
+an external dependency. The production engine, entry-identity helper, source
+verification, and replication paths currently use the empty default. Source
+documents do not record which non-empty fingerprint created an identity. The
+piece lifecycle has no revision metadata or separate operation and cause for a
+runtime rebuild.
+
+Before enabling a non-empty production fingerprint:
+
+1. Implement the authoritative `getExecutableRuntimeFingerprint()` provider
+   defined in [module-loading.md](../module-loading.md). Version 1 hashes the
+   existing broad compile-cache runtime version, the scheduler fingerprint, and
+   automatic catalogs of pattern-facing runtime modules and execution-policy
+   inputs. Inability to calculate the value fails closed. The empty value is
+   reserved for legacy source verification.
+2. Thread the provider's current value through authored identity calculation,
+   source-document construction, compilation, and cache lookup.
+3. Add optional normative `identityRuntimeFingerprint` fields to `SourceDoc`
+   and `StoredSourceDoc`. Use the effective value when verifying a retained or
+   mounted closure. An absent legacy field has the canonical empty value. A
+   newly published module whose reachable graph contains an external dependency
+   stores the non-empty provider value.
+   Verification recomputes under the effective value, so removing or changing a
+   required value creates an ordinary identity mismatch. Reject a non-empty
+   value for an unaffected module because that representation is not canonical.
+4. Carry each source document's recorded fingerprint separately from the
+   current fingerprint used for the importer. Treat equality as compatible by
+   default. Permit another fingerprint only through a versioned runtime
+   compatibility declaration.
+5. Compute `cf/runtime-neutral-program-digest/v1` exactly as defined in
+   [module-loading.md](../module-loading.md): hash the canonical main filename
+   and the UTF-8 filename-sorted runtime-neutral identities of every authored
+   file. Do not include mounted files or synthetic retention links. Piece
+   history uses this comparison value with the selected export and active
+   origin to distinguish a runtime rebuild from a source edit.
+6. Record the accepted runtime fingerprint and a separate revision cause. A
+   detached piece or resolved web origin may publish an authorized runtime
+   rebuild. A mutable fabric follower only adopts the revision advertised by
+   its upstream origin. An immutable fabric-origin piece does not move while
+   retaining that origin. Every accepted revision can then propagate to that
+   piece's own downstream followers through the ordinary guarded update.
+7. Test source verification across mixed fingerprints, unchanged-pin importer
+   invalidation, compatible and incompatible old-fingerprint pins, legacy
+   documents, cache misses, lifecycle history, authorized upstream rebuild
+   propagation through a multi-piece follow chain, detach-and-rebuild recovery
+   for a first immutable-origin revision, and revert that rebuilds an earlier
+   retained authored program under the current runtime.
 
 ### M1.4 The resolver wrapper: `FabricAwareResolver`
 
@@ -482,21 +625,29 @@ export class FabricAwareResolver implements ProgramResolver {
       ctx.space, hash, tx)`. `undefined` → throw
       `"source for pattern:<hash> not found in space <space> (or failed
       integrity verification)"`.
-   e. **Root-absolute import check** (decision 7): for every doc, run
-      `collectImportSpecifiers` (from `@commonfabric/js-compiler`); any
-      specifier starting with `"/"` → throw `"imported pattern <hash> uses
-      root-absolute imports; not supported"`. (Relative and fabric and
-      runtime-module specifiers pass.)
-   f. Mount: for each doc, `mountedFiles.set("/~cf/" + hash + doc.filename,
+   e. Starting at the entry document, walk authored import links and exclude
+      `ROOT_LINK_SPECIFIER` retention links. Mount only that entry view. This
+      prevents unreachable documents and sibling retained generations from
+      becoming executable mount files.
+   f. **Root-absolute import check** (decision 7): for every document in that
+      entry view, run `collectImportSpecifiers` (from
+      `@commonfabric/js-compiler`). Any specifier starting with `"/"` throws
+      `"imported pattern <hash> uses root-absolute imports; not supported"`.
+      Relative, fabric, and runtime-module specifiers pass. Do not inspect an
+      excluded synthetic root because it cannot execute through this mount.
+   g. For each document in the entry view,
+      `mountedFiles.set("/~cf/" + hash + doc.filename,
       { name: …, contents: doc.code })`. Entry path =
       `/~cf/<hash><entryFilename>` where `entryFilename` comes from
       `verifySourceDocs`'s `entryFilename` (already returned inside
       `loadVerifiedSourceClosure` — if not surfaced, extend
-      `loadVerifiedSourceClosure` to return `{ docs, entryFilename }`; check
-      its callers: `replicateClosures` and the pattern-manager cold path —
-      adjust both destructurings).
-   g. Record `FabricMount` + alias (`identifier → entryPath`); return the
-      entry Source.
+      `loadVerifiedSourceClosure` to return `{ docs, entryFilename }`; check its
+      callers: `replicateClosures` and the pattern-manager cold path — adjust
+      both destructurings). For each mounted path, record the source document's
+      verified identity and effective identity fingerprint in
+      `publishedModules`. An absent legacy field contributes the empty value.
+   h. Record `FabricMount`, including `publishedModules`, plus the alias
+      (`identifier → entryPath`); return the entry Source.
 
 Pitfalls to encode as comments + tests:
 - The walk calls `resolveSource` with the verbatim specifier text (bare
@@ -506,9 +657,9 @@ Pitfalls to encode as comments + tests:
   texts pinning the same hash (e.g. `cf:pattern:<h>` and a pinned slug form
   in M2) → step (b) returns the same Source object, and `resolveProgram`
   stores it under BOTH identifiers → **duplicate entries in
-  `program.files`**. Therefore M1.5 must dedupe `moduleFiles` by name (see
-  there). Write the test now (two import lines, same hash) and let it go
-  green in M1.5.
+  `program.files`**. Therefore M1.5 must dedupe the identity and source-history
+  set by name (see there). Write the test now with two import lines and the same
+  hash. Let it go green in M1.5.
 - Authored programs must not collide with the mount root: in
   `compileToRecordGraph` authored names carry the `/<id>/` prefix so they
   can't start with `/~cf/`; in `compileResolvedToRecordGraph` they are
@@ -521,8 +672,9 @@ in-process runtime (mirror the setup of existing cell-cache tests — find
 bootstrap). Seed source docs by running `writeSourceDocs` with a small
 hand-built module set. Cover: fetch+mount happy path; missing hash; tampered
 doc (flip a byte in a stored cell → verification failure surfaces as
-not-found error); root-absolute rejection; dedupe-by-identity; M2/M3/M4
-scope errors.
+not-found error); root-absolute rejection in the entry view; acceptance of a
+root-absolute import in an excluded synthetic root; dedupe-by-identity;
+M2/M3/M4 scope errors.
 
 ### M1.5 Engine integration
 
@@ -558,55 +710,97 @@ File: `packages/runner/src/harness/engine.ts`.
    - After `this.resolve(resolver)`: collect
      `const mounts = options.fabricImports ? resolver.mounts() : []` and
      `const aliases = …specifierAliases()`.
-   - **Dedupe `moduleFiles` by `name`** after the `.d.ts` filter, asserting
-     equal contents on duplicates (see M1.4 pitfall):
+   - Preserve provenance while assembling the resolved program. Files from the
+     explicit authored `Program` are authored. Files created from verified
+     `SourceDoc` values are mounted. Declaration stubs returned only by
+     `EngineProgramResolver` are runtime type inputs. Carry this classification
+     separately from each `Source.name`.
+   - Build the three sets from the declaration-file integration section. Pass
+     the full type-check set to TypeScript. Pass the identity and source-history
+     set to `computeFabricModuleIdentities`. Pass only the emitted set to record
+     assembly and compiled-cache operations.
+   - **Dedupe the identity and source-history set by `name`**, asserting equal
+     contents and equal provenance on duplicates (see M1.4 pitfall). Reject a
+     provenance mismatch before projecting the wrapper back to `Source`:
      ```ts
      // Shown for illustration only.
-     const byName = new Map<string, Source>();
-     for (const f of moduleFiles) {
-       const prev = byName.get(f.name);
-       if (prev !== undefined && prev.contents !== f.contents) throw new Error(…);
-       byName.set(f.name, f);
+     type IdentitySourceInput = {
+       source: Source;
+       provenance: "authored" | "mounted";
+     };
+     const byName = new Map<string, IdentitySourceInput>();
+     for (const input of identitySourceInputs) {
+       const prev = byName.get(input.source.name);
+       if (
+         prev !== undefined &&
+         (prev.source.contents !== input.source.contents ||
+           prev.provenance !== input.provenance)
+       ) throw new Error(…);
+       byName.set(input.source.name, input);
      }
-     const uniqueModuleFiles = [...byName.values()];
+     const uniqueIdentitySourceFiles = [...byName.values()]
+       .map(({ source }) => source);
      ```
    - Guard: any file of the ORIGINAL `program.files` (pre-pretransform input)
      named under `/~cf/` → throw `"/~cf/ is a reserved namespace"`.
    - Identity computation (line 242): replace `computeModuleIdentities(…)`
-     with `computeFabricModuleIdentities(uniqueModuleFiles, mounts,
+     with `computeFabricModuleIdentities(uniqueIdentitySourceFiles, mounts,
      { idPrefix: \`/${id}\` })`. (With zero mounts it must behave byte-for-byte
      like today — M1.3 guarantees it; add a regression assertion to an
      existing engine test rather than trusting it.)
-   - Pass `specifierAliases: aliases` into BOTH `compiler.compileToModules`
-     (line 282) and `compileSourcesToRecords` (line 324).
-   - Fabric edges into write-back descriptors (line 407): `importEdges` comes
-     from `resolveModuleImports` whose `externalDeps` include fabric
-     specifiers. Extend the `modules` mapping:
+   - Pass `specifierAliases: aliases` into `compiler.compileToModules` over the
+     type-check set and into `compileSourcesToRecords` over the emitted set.
+     Derive `emittedIdentityByPath` by restricting `identityByPath` to emitted
+     modules. Give record assembly only that restricted map.
+   - Restrict `precompiledModulesFor` requests and module-byte-cache completeness
+     checks to emitted identities. An authored declaration has a source identity
+     but never has a compiled body.
+   - Split source and compiled edges in write-back descriptors.
+     `resolveModuleImports` includes type-only edges and therefore supplies the
+     source identity and source-history descriptors. It must not directly
+     supply compiled links. Derive compiled import specifiers from the emitted
+     JavaScript, using the same `importSpecs` extraction persisted on compiled
+     documents. Resolve only those runtime specifiers through internal paths or
+     `specifierAliases`, and map their targets through
+     `emittedIdentityByPath`:
      ```ts
      // Shown for illustration only.
-     const fabricEdges = (importEdges.get(file.name)?.externalDeps ?? [])
-       .filter((s) => isFabricImportSpecifier(s))
-       .map((s) => {
-         const target = aliases.get(s);
-         if (target === undefined) throw new Error(`unresolved fabric specifier '${s}' survived compile`);
-         return { specifier: s, targetIdentity: identityByPath.get(target)! };
-       });
-     // imports: [...internalDeps-mapped, ...fabricEdges]
+     const runtimeSpecifiers = deriveModuleRecordFields(compiledJs).importSpecs;
+     const compiledImports = runtimeSpecifiers.flatMap((specifier) => {
+       const target = resolveInternalOrAliasTarget(file, specifier, aliases);
+       if (target === undefined) return []; // A runtime-provided module.
+       const targetIdentity = emittedIdentityByPath.get(target);
+       if (targetIdentity === undefined) {
+         throw new Error(
+           `emitted module '${file.name}' imports declaration-only target '${specifier}'`,
+         );
+       }
+       return [{
+         specifier,
+         targetIdentity,
+       }];
+     });
      ```
+     Build source-persistence descriptors from the identity and source-history
+     set with the complete value-and-type edge graph. Build compiled descriptors
+     from emitted records and `compiledImports` only. A source descriptor may
+     represent a declaration and have no compiled counterpart. A type-only edge
+     between two emitted `.ts` modules remains a source link but is not a direct
+     compiled link. Fail clearly if emitted JavaScript names a declaration-only
+     target instead of manufacturing a compiled link for it.
    - `filename` for mounted files (line 422): `stripModuleIdPrefix(file.name,
      id)` only strips `/<id>`; mounted names need the mount prefix stripped
      instead. Write a small helper
      `storedFilenameFor(name, id, mounts)` → authored: status quo; mounted:
      `name.slice(("/~cf/" + m.entryIdentity).length)`.
-3. `compileResolvedToRecordGraph` (engine.ts:454): same wrapper + same merged
-   identity computation + same aliases into `compileToModules` + same fabric
-   edges, with `idPrefix` ABSENT for the authored set (stored names are
-   prefix-free) and `space` from a new optional parameter
-   `options?: { fabricImports?: { space: MemorySpace } }`. The caller
-   (pattern-manager, M1.7) threads the space it already has. NOTE: this path
-   builds no record graph itself — it returns `CacheableModule[]`; the
-   emitted set now contains mounted modules too, which is exactly what the
-   cached-module evaluator needs (self-contained closure).
+3. `compileResolvedToRecordGraph` (engine.ts:454): use the same provenance
+   classification, three sets, merged identity computation, aliases, and fabric
+   edges, with `idPrefix` absent for the authored set because stored names are
+   prefix-free. Add `options?: { fabricImports?: { space: MemorySpace } }`; the
+   pattern-manager caller in M1.7 threads the space it already has. Return
+   separate source-persistence descriptors and emitted `CacheableModule`
+   values. The emitted set contains mounted implementation modules for the
+   self-contained cached-module evaluator. It excludes all declarations.
 
 Tests (`packages/runner/test/fabric-imports-engine.test.ts`, in-process
 runtime):
@@ -639,7 +833,9 @@ runtime):
 
 File: `packages/runner/src/compilation-cache/cell-cache.ts`.
 
-1. `storedImportRefs` (line 119): skip fabric edges when building SOURCE
+1. Source-document construction consumes the identity and source-history set,
+   including authored and mounted declarations. `storedImportRefs` (line 119)
+   keeps internal declaration edges but skips fabric edges when building source
    links:
    ```ts
    // Shown for illustration only.
@@ -651,27 +847,47 @@ File: `packages/runner/src/compilation-cache/cell-cache.ts`.
    edges as reachability (otherwise every mounted module gets a synthetic
    root link from the importer's entry, dragging subtrees back into the
    importer's source closure — the exact thing decision 5 forbids).
-2. **Compiled side**: find `writeCompiledDocs` / the compiled-doc builder in
-   this file (below the source-set section). Confirm which import list it
-   stores. Required end state: compiled docs DO carry fabric edges as links
+2. **Compiled side**: `writeCompiledDocs`, compiled synthetic roots, and
+   compiled import links consume only the emitted set. Direct compiled links
+   come only from runtime imports extracted from emitted JavaScript. A
+   declaration identity is never a compiled-cache member or link target. A
+   value fabric import between emitted modules becomes a link
    (`{specifier: "cf:pattern:…", link → compiledDocKey(rtv, <identity>)}`).
-   If it shares `storedImportRefs`, give that function an
-   `{ includeFabricEdges: boolean }` parameter rather than duplicating it.
-3. `verifySourceDocs` needs NO change (importer closures no longer contain
-   subtree docs). Add a regression test proving it: write back an importer's
-   modules, `loadVerifiedSourceClosure(importerEntry)` → returns ONLY the
-   importer's own docs, verification ok, and the importer doc's stored
-   imports contain no fabric specifier.
+   An erased type-only import does not. Use separate source and compiled
+   descriptor fields rather than assuming both stores have the same membership
+   or edge graph. The compiled synthetic-root pass may still link an otherwise
+   unreachable emitted module under `cf:cache-root/`; that is not the erased
+   type-only specifier.
+3. `verifySourceDocs` still verifies only the importer's closure because that
+   closure no longer contains subtree docs. It must also read the normative
+   identity fingerprint from each source document and use it when recomputing
+   the identity. Add a regression test proving both properties: write back an
+   importer's modules, `loadVerifiedSourceClosure(importerEntry)` returns only
+   the importer's own docs, verification succeeds under the recorded
+   fingerprint, and the importer doc's stored imports contain no fabric
+   specifier.
 
-Tests (extend the existing cell-cache test file): the regression above; plus
-compiled-closure walk: `loadCompiledClosure(importerEntry)` returns importer
-AND subtree compiled docs (fabric link followed); plus `replicateClosures`
-of an importer — **expected to fail or lose the subtree** (source closure
-excludes it). Fix inside `replicateClosures`: after replicating the
-importer's closure, parse each replicated source doc's external specifiers
-(`collectImportSpecifiers` + `isFabricImportSpecifier` + `pinnedIdentity`)
-and recurse per subtree identity (visited-set on identities). Test: replicate
-importer to a second space → importer loads cold in that space.
+Tests (extend the existing cell-cache and module-byte-cache test files): the
+regression above; a program with an authored declaration writes declaration
+source but no declaration compiled document, then obtains a warm compiled-cache
+hit without requesting one; a runtime declaration stub does not appear in the
+source set and its module remains an external fingerprinted leaf; a compiled
+closure walk returns importer and subtree emitted docs but no declaration docs;
+and a type-only relative edge between two emitted `.ts` modules appears under
+its authored specifier in the source links but not the compiled runtime links.
+The emitted target may still be retained by a synthetic compiled root. Also
+show that `replicateClosures` of an importer initially fails or loses the
+subtree because the source closure excludes it. Fix `replicateClosures` by
+parsing each replicated source doc's external specifiers with
+`collectImportSpecifiers`, `isFabricImportSpecifier`, and `pinnedIdentity`, then
+recurse per subtree identity with a visited set. Test that an importer replicated
+to a second space loads cold in that space.
+
+The piece-lifecycle manifest writer reuses this recursive pinned-dependency walk
+as a retention walk. It records each dependency identity once and retains the
+complete transitive graph. A regression removes every incidental source root
+after retaining an importer whose pinned dependency has another pinned
+dependency, then restores and compiles the importer from its revision manifest.
 
 ### M1.7 Reload paths (warm + cold)
 
@@ -941,19 +1157,26 @@ One integration test (runner-level, in-process, two "deploys"):
 
 ## Invariants checklist (the reviewer will check every one)
 
-1. A compile with zero fabric imports is byte-for-byte unchanged (identities,
-   records, cache docs, behavior). Guard: run the existing engine + cache
-   test suites untouched; they must pass without edits (any needed edit =
-   design smell, stop and flag).
+1. Fabric resolution does not otherwise change a compile with zero fabric
+   imports. The declaration-identity and runtime-fingerprint integrations in
+   this plan intentionally change identities and source persistence when their
+   inputs require it. Outside those migrations, identities, records, cache
+   documents, and behavior remain byte-for-byte unchanged. Guard this boundary
+   with the existing engine and cache suites plus the migration tests specified
+   above.
 2. A mounted module's computed identity ALWAYS equals the identity it was
    fetched by (M1.3 throws otherwise) — never trust, always recompute.
-3. The importer's module identity changes iff its own bytes change — and the
-   pin is part of its bytes. No identity input lives outside `program.files`.
+3. The importer's module identity changes when its own source, a transitive
+   authored dependency, a fabric pin, or its effective runtime fingerprint
+   changes. Runtime-provided declaration stubs remain external fingerprinted
+   dependencies rather than internal authored files.
 4. Source closures never span programs; compiled closures may (links).
 5. Fabric specifiers never appear in: emitted record KEYS (only
    `cf:module/<hash>`), source-doc links, slug cells. They appear verbatim
-   in: authored source, record `resolutions` keys, compiled require() calls,
-   CacheableModule/compiled-doc import edges.
+   in authored source and identity inputs. A value import also appears in record
+   `resolutions`, compiled `require()` calls, and emitted-module compiled edges.
+   A type-only import may be erased from JavaScript but still affects identity
+   and retains its pinned source dependency.
 6. Every error message names the failing specifier and (where applicable) the
    chain of hops — copy the exact strings from this plan.
 7. No new HTTP surface, no new authz checks — reads go through normal cell
@@ -964,8 +1187,8 @@ One integration test (runner-level, in-process, two "deploys"):
 
 | Risk | Check | Fallback |
 |---|---|---|
-| Injected helper module (`transformInjectHelperModule` → `transformCfDirective`) references a path that breaks under mount prefixing | FIRST test in M1.4: mount a closure produced by a real `compileToRecordGraph` write-back (which contains whatever the helper injects), not a hand-built one | If the helper import is non-relative and path-ambiguous: serve it from the wrapper by suffix-matching within the requesting subtree — but ESCALATE first; this needs a design look |
-| `loadCompiledClosure` verifies link/edge consistency in a way fabric links violate | M1.6 compiled-walk test before any M1.7 work | Teach its check the fabric branch (same shape as verifySourceDocs partition — but escalate; the compiled set's integrity model is CFC labels, changes there are security-sensitive |
+| Injected helper module (`transformInjectHelperModule` → `transformCfDirective`) references a path that breaks under mount prefixing | FIRST test in M1.4: mount pristine source produced by a real `compileToRecordGraph` write-back and assert that the ordinary compile-time helper transform runs exactly once. Cover the tolerated legacy envelope in a separate fixture. | If the helper import is non-relative and path-ambiguous: serve it from the wrapper by suffix-matching within the requesting subtree — but ESCALATE first; this needs a design look |
+| `loadCompiledClosure` verifies link/edge consistency in a way fabric links violate | M1.6 compiled-walk test before any M1.7 work | Teach its check the fabric branch. Use the same shape as the `verifySourceDocs` partition, but escalate first because the compiled set's integrity model uses CFC labels and is security-sensitive. |
 | `evaluateCachedModules` record building can't map fabric edges | M1.7 step 2 test-first | Small resolution branch keyed on `isFabricImportSpecifier` |
 | Engine cache-hit (`fullHit`) misbehaves with mounted identities | M1.5 test: SECOND compile of the importer is a full hit (no TS compile — assert via the `compile-cache-hit` log or `esmCacheStats`) | — |
 | TS extension inference for mounted entry (`.tsx` vs `.ts`) | M1.1 alias test uses a `.tsx` target | use stored filename's real extension (already in plan) |
@@ -979,8 +1202,10 @@ One integration test (runner-level, in-process, two "deploys"):
   the explicit pin-rewrite tool (M2.3) invoked by deploy/`deps update`.
 - Do NOT add fabric links to SOURCE docs or "fix" `verifySourceDocs` to
   union across programs.
-- Do NOT re-pretransform mounted sources (they are stored post-pretransform;
-  they enter via the resolver, which naturally skips pretransform).
+- Do NOT pretransform mounted source before storing or mounting it. Source
+  documents retain pristine authored bytes. After resolution, the engine
+  applies the ordinary compile-time helper transform exactly once. Preserve the
+  existing tolerance for source stored in the legacy envelope.
 - Do NOT thread a space through globals/singletons — it rides options.
 - Do NOT touch CFC label code paths in this work (decision 8); if a test
   fails on labels, stop and escalate rather than loosening a check.

--- a/docs/specs/pattern-imports/implementation-plan.md
+++ b/docs/specs/pattern-imports/implementation-plan.md
@@ -26,7 +26,7 @@ These were settled in the spec + design review. Implement as stated:
 
 1. **One grammar, no type tag**: `cf:<ref>`, `cf:/<space>/<ref>`,
    `cf://<host>/<space>/<ref>`, trailing `@<pin>`. Resolution chases pointers
-   to an entry-module identity.
+   and selects a module identity.
 2. **Pin-in-source** (rewrite the import specifier at pin time). No lockfile
    side-table. No pin resolution at compile time for stored programs.
 3. **Type-only fabric references are pinned.** Supported ESM-style
@@ -61,6 +61,14 @@ These were settled in the spec + design review. Implement as stated:
    Do not build label propagation now; do not silently strip it either —
    the write-back path reuses existing write machinery so labels flow (or
    fail) exactly as any cell write does today.
+10. **Subpaths use explicit public exports.** The immutable
+    `cf/authored-program-manifest/v1` value maps exact public subpaths to
+    authored filenames. The entry is public without a map entry. There are no
+    wildcard or conditional entries in version 1, and arbitrary files are not
+    addressable. Pin time writes the selected file's module identity. Frozen
+    compilation does not consult the map. A direct `cf:pattern:<identity>`
+    names one exact module and never accepts a subpath. The manifest identity
+    and runtime-neutral program digest include the map.
 
 ## Architecture recap (what plugs in where)
 
@@ -106,13 +114,14 @@ Reload paths:
 - **fabric ref / fabric specifier** — an authored import specifier under the
   `cf:` grammar
   (`cf:pattern:<hash>`, `cf:/did:key:z6Mk…/todo-list@<hash>`, …).
-- **pin** — the trailing `@<hash>` entry-module identity on a mutable ref.
+- **pin** — the trailing `@<hash>` selected-module identity on a mutable ref.
 - **hash** — 43 base64url chars (`[A-Za-z0-9_-]`, case-SENSITIVE, no
   padding), the unprefixed output of `hashStringOf`/`hashOf`
   (`packages/data-model/src/value-hash.ts:553`). NOT hex — e.g.
   `Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c`. Never lowercase or
   otherwise normalize a hash.
-- **terminal identity** — the entry-module identity a ref resolves to.
+- **terminal identity** — the selected-module identity after pointer and
+  subpath resolution. It is the entry-module identity when no subpath exists.
 - **subtree** — the source closure of one imported pattern (its own program).
 - **mount** — a subtree's files spliced into a compilation under
   `/~cf/<terminalIdentity>/<storedFilename>`.
@@ -136,12 +145,12 @@ export interface FabricRef {
   ref:
     | { kind: "slug"; slug: string }
     // "of" = entity URI (stored/spelled "of:fid1:<hash>"); "pattern" =
-    // entry-module identity ("pattern:<hash>"). hash is the bare base64url
+    // exact module identity ("pattern:<hash>"). hash is the bare base64url
     // part (no "fid1:" tag) in both cases.
     | { kind: "uri"; scheme: "of" | "pattern"; hash: string };
-  /** Path inside the target program (phase 4; parsed, rejected downstream). */
+  /** Exact public name in the target manifest (phase 4; currently rejected). */
   subpath?: string;
-  /** Trailing @<hash> pin (base64url — see glossary; never normalized). */
+  /** Trailing selected-module @<hash> pin; never normalized. */
   pin?: string;
 }
 
@@ -570,9 +579,10 @@ Before enabling a non-empty production fingerprint:
 5. Compute `cf/runtime-neutral-program-digest/v1` exactly as defined in
    [module-loading.md](../module-loading.md): hash the canonical main filename
    and the UTF-8 filename-sorted runtime-neutral identities of every authored
-   file. Do not include mounted files or synthetic retention links. Piece
-   history uses this comparison value with the selected export and active
-   origin to distinguish a runtime rebuild from a source edit.
+   file. Also hash the UTF-8 key-sorted public exports map. Do not include
+   mounted files or synthetic retention links. Piece history uses this
+   comparison value with the selected export and active origin to distinguish
+   a runtime rebuild from a source edit.
 6. Record the accepted runtime fingerprint and a separate revision cause. A
    detached piece or resolved web origin may publish an authorized runtime
    rebuild. A mutable fabric follower only adopts the revision advertised by
@@ -993,13 +1003,20 @@ export async function resolveFabricRefToIdentity(
 
 Algorithm (spec § Resolution rule — implement hops exactly):
 
-1. Space: `ref.space` undefined → `compilingSpace`; a DID → use as-is; a name
+1. Scope guard: when `ref.subpath` is present, throw
+   `"subpaths not yet supported (M4): <specifier>"` before resolving the space,
+   slug, piece, or entry identity. This guard is shared by deployment pinning
+   and `cf deps update`; otherwise those paths can silently write the entry
+   identity as the pin for an unsupported subpath. M4 replaces this guard with
+   manifest lookup. Keep the independent `FabricAwareResolver` guard until M4
+   also teaches frozen compilation to mount a selected subpath module.
+2. Space: `ref.space` undefined → `compilingSpace`; a DID → use as-is; a name
    → M2 throws
    `"space names are currently unsupported; resolve the name to a DID first"`.
    The tentative identifier-only policy keeps name resolution outside the
    fabric resolver. README Open question 1 retains that policy for further
    study and places human-readable aliases in a future shortlink service.
-2. Start cell:
+3. Start cell:
    - slug → M2.1 resolver (wrap `SlugResolutionError` with the chain so far).
    - `of:` URI → reconstruct the entity id from the parsed hash via the
      `uri-utils.ts` helpers (`fromURI("of:fid1:" + hash)` / the `{"/": id}`
@@ -1007,17 +1024,17 @@ Algorithm (spec § Resolution rule — implement hops exactly):
      hand-building the string), then `sync()`.
    - `pattern:` → already terminal (return immediately; callers normally
      short-circuit via `pinnedIdentity` and never get here).
-3. Piece hop: if the cell has pattern metadata — use the SAME accessors the
+4. Piece hop: if the cell has pattern metadata — use the SAME accessors the
    runner uses (`getPatternIdentityRef` / `getPatternId` around
    `packages/runner/src/runner.ts:4137`; export them if module-private):
    - `patternIdentity` present → its `.identity` IS the terminal identity;
      append hops; done.
    - else `patternId` present → load the pattern meta cell by that URI
      (mirror how `PatternManager` reads meta cells — `patternMetaSchema`),
-     continue at 4.
+     continue at 5.
    - neither, and the cell itself is not a pattern meta cell → throw
      `"cf:… does not resolve to a pattern (chain: …)"`.
-4. Pattern-meta hop: `entryIdentity` field present → done. Absent → throw
+5. Pattern-meta hop: `entryIdentity` field present → done. Absent → throw
    `"pattern meta for cf:… has no entryIdentity (legacy pattern; re-deploy
    it)"`. (Computing it from `program` requires a full pretransform+hash
    pass — deliberately out of scope; the error names the remedy.)
@@ -1031,7 +1048,10 @@ setters from runner.ts — find `setMetaRaw("pattern", …)` usage at
 runner.ts:901 and mirror it); slug → piece; slug → pattern meta directly;
 slug → plain data cell (error + chain); missing slug; `of:` directly to meta
 cell; piece with only legacy `patternId`; meta without `entryIdentity`
-(error message).
+(error message). Add a direct `pattern:` subpath test that proves the scope
+guard runs before the otherwise-terminal identity is returned. Add a CLI
+pin/update regression that resolves a valid slug but rejects its subpath rather
+than writing the slug target's entry identity.
 
 ### M2.3 Pin rewriting (byte-precise source surgery)
 
@@ -1176,9 +1196,55 @@ One integration test (runner-level, in-process, two "deploys"):
   Cross-host publication also needs CFC label propagation for fetched source
   (spec § Security). A possible public-pattern HTTP endpoint remains open under
   the public distribution question in the spec.
-- **M4 subpaths + npm vendoring**: subpath = alias to a non-entry mounted
-  file (grammar already parses it); `npm:` = fetch via esm.sh → vendor as a
-  content-addressed source set → same rails.
+- **M4 explicit subpaths**: extend lifecycle source ingestion and retained
+  publications with the following behavior.
+
+  1. Add an `exports` map to `cf/authored-program-manifest/v1`. The empty
+     subpath implicitly selects `main` and cannot appear in the map. Require
+     each key to be a canonical slash-separated public name with no leading or
+     trailing slash, empty segment, `.` segment, `..` segment, or `@`
+     character. Reject noncanonical keys, duplicate keys, wildcards,
+     conditions, and targets that are not canonical authored filenames in the
+     manifest. Compare the parsed subpath exactly. Do not percent-decode or
+     fold case.
+  2. Include the UTF-8 key-sorted map in the manifest identity and
+     `cf/runtime-neutral-program-digest/v1`. A map-only edit creates a new
+     source revision even when all module identities and the executable entry
+     identity stay equal. Revert restores the previous map. Followers observe
+     the new revision.
+  3. Make each mutable import target expose its current immutable manifest
+     through the source revision. This applies to pieces and future lightweight
+     publication pointers. A target that exposes only `patternIdentity` cannot
+     resolve an unpinned subpath.
+  4. At pin time, chase the mutable locator to its current source revision.
+     Look up the exact public subpath, load the mapped file's verified
+     source-document identity, and write that selected module identity as the
+     trailing pin. Preserve the locator and subpath before the pin. `cf deps
+     update` repeats the lookup against the current manifest. Replace the M2
+     subpath guard in `resolveFabricRefToIdentity()` with this branch. Extend
+     `FabricChaseResult` with `selectedIdentity`; keep `entryIdentity` as the
+     identity reached by the pointer chase. The two values are equal without a
+     subpath. Pin rewriting must use `selectedIdentity`.
+  5. During frozen compilation, let the existing `pinnedIdentity()` fast path
+     mount the selected module closure directly. Do not read the mutable target
+     or manifest. An entry import continues to pin
+     `patternIdentity.identity`, so M1 and M2 behavior stays unchanged.
+  6. Reject any subpath on a direct `cf:pattern:<identity>` reference. One
+     module source identity does not bind an authoritative manifest. A caller
+     that knows the target module identity uses it directly. Do not infer
+     public names from entry-module re-exports or expose a file merely because
+     its source document is readable.
+  7. Permit an exports-map target to be an authored `.d.ts` file. Type-only
+     imports retain and hash that declaration normally. Reject a value import
+     from a declaration-only target because it has no emitted runtime module.
+  8. Test exact selection, selected-module pin rewrite, frozen resolution after
+     the mutable target disappears, explicit dependency updates, invalid map
+     entries, arbitrary-file rejection, direct-pattern subpath rejection,
+     declaration targets, map-only revision propagation, and revert.
+- **Later npm vendoring**: `npm:` fetches through the selected package source,
+  vendors a content-addressed source set, and then uses the same identity and
+  mounting machinery. Its design remains separate from explicit fabric
+  subpaths.
 
 ## Invariants checklist (the reviewer will check every one)
 

--- a/docs/specs/pattern-imports/implementation-plan.md
+++ b/docs/specs/pattern-imports/implementation-plan.md
@@ -769,8 +769,9 @@ export async function resolveFabricRefToIdentity(
 Algorithm (spec § Resolution rule — implement hops exactly):
 
 1. Space: `ref.space` undefined → `compilingSpace`; a DID → use as-is; a name
-   → M2 throws `"space names require name→DID resolution (open question 2);
-   use a DID"` (names are NOT in M2 scope — spec open question).
+   → M2 throws `"space names require name→DID resolution; use a DID"` (names
+   are NOT in M2 scope — the space-name resolution question remains open in
+   the spec).
 2. Start cell:
    - slug → M2.1 resolver (wrap `SlugResolutionError` with the chain so far).
    - `of:` URI → reconstruct the entity id from the parsed hash via the
@@ -915,11 +916,15 @@ One integration test (runner-level, in-process, two "deploys"):
 
 ## M3 / M4 — sketches only (do NOT implement)
 
-- **M3 cross-host + publish**: `cf publish` (write source docs + meta + slug
-  to a target space), host-qualified refs (needs dynamic space→host routes —
-  spec open question 8; `spaceHostMap` is interim), CFC label propagation for
-  fetched source (spec § Security), possible public-pattern HTTP endpoint
-  (spec open question 7 — left open).
+- **M3 cross-host + publish**: `cf publish` verifies source-read authorization,
+  destination-write authorization, and the CFC flow. It copies the verified
+  source closure, creates a lightweight patternIdentity-bearing publication
+  cell, and optionally assigns a slug in the target space. It does not copy the
+  source piece or its state. The resulting replica uses the destination space's
+  ACL. Host-qualified refs need dynamic space→host routes (`spaceHostMap` is
+  interim) and CFC label propagation for fetched source (spec § Security). A
+  possible public-pattern HTTP endpoint remains open under the public
+  distribution question in the spec.
 - **M4 subpaths + npm vendoring**: subpath = alias to a non-entry mounted
   file (grammar already parses it); `npm:` = fetch via esm.sh → vendor as a
   content-addressed source set → same rails.

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -54,7 +54,7 @@ into the same active-origin and revision model.
   background and lets the existing pattern watcher apply a verified move. The
   current instantiation never waits for network or compilation.
 - **Two hazard cases to handle explicitly.** (1) We shipped a broken system
-  pattern — once a fix ships, recovery must be automatic. (2) An
+  pattern — once a fix ships, recovery must be automatic. (2) A
   schema-incompatible update slips through — the damage must be *bounded*
   (fast rollback), because the schema-valid-but-semantically-wrong case is not
   reliably detectable.
@@ -257,13 +257,23 @@ the piece is already running, the
 watcher cancels its old reactive nodes and re-instantiates the new pattern onto
 the **same result cell**.
 
-- **Survives**: the result cell's entity and inbound links; any state cells the
-  new pattern still reads (addressed by stable key/cause).
-- **Does not survive**: data under keys the new pattern drops or renames — the
-  **schema-compat crux**, and the boundary between the two hazard cases
-  ("missing data" vs "stuck/wrong"). The mitigating discipline is an authoring
-  one: durable state addressed by stable key/cause, not positionally. We do
-  **not** gate on a pre-apply schema dry-run in v1.
+- **Survives**: the result cell's entity and inbound links. State remains
+  reachable when the new pattern reads it through the same stable keys and
+  causes.
+- **Can become unreachable**: data under keys the new pattern drops or
+  renames. This continuity is a semantic contract. CI and golden replay tests
+  must exercise representative prior state and verify that the proposed source
+  still reads and preserves it. The deployment runtime does not try to infer
+  stable-key or stable-cause compatibility.
+
+The specialized system-source updater does not perform the complete pre-apply
+structural comparison specified for the general piece lifecycle. Automatic
+origin updates in that lifecycle reject known argument, result, or
+retained-input incompatibilities and keep the last accepted source. A manual
+source replacement reports a known incompatibility as a warning and can proceed
+only after explicit acceptance. Neither structural check proves semantic state
+continuity. The root-interface contract remains mandatory in both cases. See
+the [`Compatibility policy`](../piece-source-lifecycle.md#compatibility-policy).
 
 ## System-source patterns — the loop
 
@@ -387,7 +397,10 @@ binary populates from baked build metadata; the updater does not consult it.
 
 - **CI golden replay** against the short, controlled system list before
   shipping — the primary defense (feasible precisely because the list is short
-  and we own the source).
+  and we own the source). Synthetic home-shaped and default-app-shaped replays
+  prove that the update mechanism preserves representative stable-key state.
+  Broader release coverage still needs fixtures for each supported
+  version-to-version transition.
 - **Self-heal from a borked ship**: fix source → new identity → a root's next
   space open compiles and swaps it before bootstrap; an ordinary pattern's next
   instantiation starts its current graph and then rolls it forward in place.
@@ -426,8 +439,10 @@ binary populates from baked build metadata; the updater does not consult it.
 1. **Default (non-home) space root, always-update.** Least risky —
    `default-app.tsx` carries little durable state. `patternSource` field +
    in-place swap + toolshed `?identity` + local compiled-identity check.
-2. **Home root.** Carries real user data (favorites/journal/spaces) → depends
-   on the stable-addressing discipline and golden coverage of `home.tsx`.
+2. **Home root.** Carries real user data (favorites/journal/spaces). A
+   representative golden replay enabled its rollout with the other system
+   roots. Broader version-to-version CI coverage remains release discipline,
+   not a deployment-time semantic check.
 3. **Other system-source patterns.** Recover a non-root's verified authored
    entry path at instantiation, recognize a system source by its same-toolshed
    `?identity` route, and check it without delaying the current graph.
@@ -461,12 +476,17 @@ binary populates from baked build metadata; the updater does not consult it.
    migration, update, detach, follow, fork, revert, and repoint use the ordinary
    piece rules. Assigning the root role separately requires root-interface
    compatibility.
-
-## Open questions
-
-3. **Home-data stable addressing** — verify `home.tsx` addresses its durable
-   state by stable key/cause before enabling always-update on the home root
-   (Phase 2 gate). Resolved 2026-07-21: `home-golden-replay.test.ts` pins state
-   survival across an in-place N→N+1 roll over representative favorites /
-   journal / spaces data, and the home-specific flag was removed on its
-   strength (with the estuary home-brick incident as the forcing event).
+3. **Home-data stable addressing.** `home-golden-replay.test.ts` pins
+   representative favorites, journal, and spaces state across an in-place
+   update. That evidence allowed the home root to use the same updater as other
+   system roots. Future supported source transitions need CI fixtures using
+   representative prior state.
+4. **Compatibility checks and deployment boundary.** Publishing or uploading
+   pattern source does not compare it with an existing piece. A manual
+   replacement compares argument, result, and retained-input schemas, warns on
+   a known incompatibility, and requires explicit acceptance to continue. An
+   automatic origin update blocks the same known structural incompatibility
+   because no user is present to accept it. The root-interface contract remains
+   mandatory. Stable keys, stable causes, intended migration, and behavior are
+   verified by CI audits and golden replays. The runtime does not try to infer
+   those semantic contracts during deployment.

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -183,10 +183,15 @@ prefix:
   `/api/patterns/system/default-app.tsx`) → use `?identity` against the space's
   host, then fetch and compile whenever the persisted artifact needs an update
   or repair.
-
-General source URL origins use the discriminated active-origin and revision
-schemas defined by the piece source lifecycle spec. They do not permanently
-overload this raw string with origin-kind-specific behavior.
+- **General source URL origins** use the discriminated active-origin and
+  revision schemas defined by the piece source lifecycle spec. They must not
+  overload the raw string with origin-kind-specific behavior. A fabric
+  `cf://` URL that is unpinned and resolves to a mutable
+  `patternIdentity`-bearing entity stores the stable entity rather than a slug
+  and follows its current pattern. A fabric URL that resolves to
+  `pattern:<hash>` or carries a trailing pin on an entity FID stores exact,
+  immutable source and cannot update. The tentative piece-origin policy rejects
+  slug-shaped URLs even when pinned. Static imports may still use pinned slugs.
 
 Baseline migration preserves the current pattern independently from update
 authority. It creates an active origin only when a durable tracking choice can
@@ -207,11 +212,16 @@ supplies and authorizes an origin.
 
 **Born-from determinism.** The system chooses a root's initial source when it
 creates the space. In the target model, it passes that source through the same
-creation transition used for any other piece. The current implementation
-instead seeds a non-home root's raw `patternSource` from the home root's
-`defaultAppUrl`. Editing that template later does not change an existing root.
-Changing that root's source is an ordinary repoint, edit, revert, or other
-lifecycle operation.
+creation transition used for any other piece. That transition writes the first
+revision. It writes a normalized active origin only when creation also makes
+the ordinary explicit choice to accept future updates from a mutable default.
+The current implementation instead seeds a non-home root's raw `patternSource`
+from the home root's `defaultAppUrl`. Editing that template later does **not**
+change an existing root. Changing that root's source is an ordinary repoint,
+edit, revert, or other lifecycle operation. Under the tentative identifier-only
+URL policy, a template stores a canonical space DID with a stable entity FID,
+or it stores a space-free content identity. A future shortlink service resolves
+a custom string before the template reaches the lifecycle operation.
 
 Today `defaultAppUrl` is output state on the home root. That is not a durable
 home for creation configuration once the home root can be repointed or
@@ -228,6 +238,14 @@ new per-ref storage:
 cf:[[//toolshed.url]/space/][slug]
 ```
 
+These are fabric-internal source URLs as well as import specifiers. When used
+as a piece origin, an unpinned URL that resolves to a piece or another mutable
+pattern-bearing entity follows its current `patternIdentity`. A URL that
+resolves directly to a content-addressed pattern is immutable. A trailing pin
+on an entity-FID URL makes that URL immutable, including when its unpinned ref
+names a piece. The piece-origin validator rejects a slug-shaped form even when
+it has a pin.
+
 - The `//toolshed.url` host means *"this space lived at this URL at least at
   some point"* — a bootstrap hint for when the runtime does not already know
   where a space is hosted (we have not built host-discovery-without-hints yet;
@@ -238,20 +256,24 @@ cf:[[//toolshed.url]/space/][slug]
   route into the home-space site table before it commits a canonical host-less
   target. A template may then keep the form `cf:/<space-did>/<ref>`. The
   revision also retains the supplied `cf://` URL. A lifecycle follow resolves
-  an unpinned slug once and stores the stable entity. A pinned ref normalizes to
-  exact pattern source. The host is routing, not identity; it is not copied
-  into every canonical target.
+  and stores the piece named by a stable entity FID. Under the tentative
+  identifier-only policy, a human-readable shortlink resolves before this
+  operation. A pin on an entity-FID ref normalizes to exact pattern source. The
+  host is routing, not identity; it is not copied into every canonical target.
 - Host **hints belong to the space**, not to each cross-space link — a
   home-space site table is the current durable store and the seed of later host
   discovery. The runtime processor hydrates its entries on startup. Writing it
   from a host-qualified lifecycle operation remains required work.
 - **Optional ref**: `cf://toolshed/space/` with no ref resolves that space's
   current root pattern through the space cell's `defaultPattern` and then its
-  `patternIdentity`. Static resolution pins that result. A lifecycle operation
-  that starts from this form stores the resolved root piece as its stable
-  origin; later relinking of the space root does not redirect the follower.
-- Space is a **DID** (names still require name→DID resolution — README open
-  question).
+  `patternIdentity`. Static resolution pins that result. Under the tentative
+  identifier-only piece-origin policy, the lifecycle resolver rejects this
+  root shorthand. An outer authoring layer may resolve it to the current root
+  piece FID before invoking the lifecycle. Later relinking of the space root
+  then does not redirect the follower.
+- Space is a **DID**. The tentative policy rejects names in fabric URLs and
+  leaves human-readable aliases to a future shortlink service. README Open
+  question 1 retains this decision for further study.
 
 ## In-place apply
 

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -405,12 +405,16 @@ binary populates from baked build metadata; the updater does not consult it.
 5. **Cross-host origins.** Persist accepted space-to-host hints and enforce CFC
    provenance labels on fetched source.
 
+## Resolved questions
+
+1. **System-pattern identity query.** Keep the implemented `GET …?identity`
+   application protocol. It returns the identity of the complete authored
+   pattern closure, so neither a raw source-file `ETag` nor a `HEAD` request can
+   replace it. Strong `ETag`s and conditional revalidation apply independently
+   to each HTTP representation and complement the closure identity.
+
 ## Open questions
 
-1. **`?identity` vs ETag/HEAD.** Resolved 2026-07-22: they are complementary.
-   `?identity` remains the explicit closure-identity value used for update
-   authorization; checksum `ETag`s plus mandatory conditional revalidation keep
-   its body and every source module cacheable without allowing stale replay.
 2. **Where the root's `patternSource` lives** — the root piece meta (general;
    recommended) vs the space cell (co-located with `defaultPattern`). Recommend
    the piece; the space cell holds only the `defaultAppUrl` template.

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -7,6 +7,8 @@ patterns. The general lifecycle for ordinary pieces, including external
 `https://` origins, fabric `cf://` origins, following another piece, source
 history, revert, and repoint, is specified in
 [`../piece-source-lifecycle.md`](../piece-source-lifecycle.md).
+The specialized root path is transitional. In the target model, a space root
+uses the same source lifecycle as every other piece.
 
 This document is also a companion to `README.md`, which covers static `cf:`
 imports and publication through naming and placement. Static imports remain
@@ -29,7 +31,9 @@ and an unloadable tracked root is repaired before bootstrap through the same
 found during implementation are archived at
 [`docs/history/specs/pattern-imports/system-pattern-updates-implementation-plan.md`](../../history/specs/pattern-imports/system-pattern-updates-implementation-plan.md).
 The home root rides the shipped root machinery since the second flag's removal;
-general piece origins and source history remain design.
+general piece origins and source history remain design. When that work lands,
+new roots use the ordinary piece creation transition and existing roots migrate
+into the same active-origin and revision model.
 
 ## Last Updated
 
@@ -56,14 +60,15 @@ general piece origins and source history remain design.
   reliably detectable.
 - **A reusable mechanism.** The existing "resolve a source pointer to a current
   identity, then swap in place" loop is a foundation for general piece origins.
-  Ordinary pieces need history, detach, compatibility, authorization, and
-  concurrency guarantees before they can use that lifecycle.
+  Roots and other pieces need the same history, detach, compatibility,
+  authorization, and concurrency guarantees before they can share one path.
 
 ## Non-goals (this doc / v1)
 
-- **General piece origins and source history.** Web URL origins, fabric URLs
-  that name pieces or content-addressed patterns, detach, fork, revert, and
-  repoint are specified in
+- **General piece origins and source history.** This specialized updater does
+  not provide the ordinary lifecycle that roots will eventually use. Web URL
+  origins, fabric URLs that name pieces or content-addressed patterns, detach,
+  fork, revert, and repoint are specified in
   [`../piece-source-lifecycle.md`](../piece-source-lifecycle.md).
 - **Lineage / fork detection.** No substrate exists today — `parents` was
   deleted with the pattern-id retirement, and `pieceLineageSchema`
@@ -103,7 +108,7 @@ piece, its verified source-doc closure supplies the authored entry path; the
 runtime persists that path on the piece only after the matching same-toolshed
 `?identity` route succeeds.
 
-## The model
+## The implemented specialized model
 
 Two decisions carry the whole design:
 
@@ -159,10 +164,16 @@ after successful instantiation, without delaying that instantiation. The
 general lifecycle replaces this specialized path after its source-state and
 history requirements are implemented.
 
-### `patternSource`: current value and planned migration
+This specialized implementation does not define different target semantics for
+roots. Under the general lifecycle, every piece with an active origin,
+including a space root, reconciles through the ordinary piece path.
 
-A string meta on the piece result cell (space root: on the root piece).
-Dispatched by the `cf:` prefix:
+### Legacy `patternSource` and planned migration
+
+`patternSource` is currently a string meta on the piece result cell. For a space
+root it is stored on the root piece. Once ordinary lifecycle storage is
+available, this string is migration input only. It is dispatched by the `cf:`
+prefix:
 
 - **`cf:` fabric ref** (published) → resolve via the fabric chase
   (`fabric-ref-resolution.ts`: slug → piece → `patternIdentity`). A
@@ -177,15 +188,36 @@ General source URL origins use the discriminated active-origin and revision
 schemas defined by the piece source lifecycle spec. They do not permanently
 overload this raw string with origin-kind-specific behavior.
 
-**Born-from determinism.** Once recorded, the *string* is frozen (which source);
-the *resolved identity* is live (which version). A non-home space's root
-`patternSource` is seeded at creation from home's `defaultAppUrl`, then frozen —
-so editing `defaultAppUrl` later does **not** silently migrate existing spaces
-(pushing a new default app to them is an explicit re-point).
+Baseline migration preserves the current pattern independently from update
+authority. It creates an active origin only when a durable tracking choice can
+be established under the ordinary consent rule. Otherwise it keeps the legacy
+locator only as inactive historical provenance and migrates the piece as
+detached. Rollout flags are not durable per-piece consent.
 
-`defaultAppUrl` (on the space cell) is thus the **template** that seeds new
-spaces' root `patternSource`; it is distinct from the per-piece frozen
-`patternSource`, and it itself migrates to a `cf:` ref under the grammar below.
+Migration resolves a relative system path against the currently accepted
+toolshed route for the space and stores the resulting absolute web URL. If no
+accepted host can be established, migration does not invent an active origin.
+A later host remapping does not rewrite the stored URL; that requires an
+ordinary repoint.
+
+A source-less legacy root does not gain an origin merely because it is a root.
+The specialized updater can derive an official candidate path, but ordinary
+migration keeps the root detached unless a durable tracking choice explicitly
+supplies and authorizes an origin.
+
+**Born-from determinism.** The system chooses a root's initial source when it
+creates the space. In the target model, it passes that source through the same
+creation transition used for any other piece. The current implementation
+instead seeds a non-home root's raw `patternSource` from the home root's
+`defaultAppUrl`. Editing that template later does not change an existing root.
+Changing that root's source is an ordinary repoint, edit, revert, or other
+lifecycle operation.
+
+Today `defaultAppUrl` is output state on the home root. That is not a durable
+home for creation configuration once the home root can be repointed or
+relinked like any other piece. Root lifecycle unification moves the value into
+space-creation configuration outside any root piece. It is never origin state
+for an existing root.
 
 ### Grammar extension: host as a hint
 
@@ -382,8 +414,10 @@ binary populates from baked build metadata; the updater does not consult it.
   and recreation from the applicable source (system path, or a `cf:` ref derived
   from `defaultAppUrl`). Custom `RuntimeProgram` recreation remains unstamped;
   its optional repository locator is separate provenance.
-- **Space cell**: `defaultAppUrl` generalizes to a `cf:` ref (template). A
-  per-space host-hint store is a later addition.
+- **Home root and creation configuration**: `defaultAppUrl` currently lives on
+  the home root. Root lifecycle unification moves it into durable
+  space-creation configuration outside any root piece. A per-space host-hint
+  store is a later addition.
 - **Grammar/resolver**: implement `cf://host/...` (register-on-ingest; today
   it throws "M3 not yet supported"); slug-optional = space root.
 
@@ -397,11 +431,17 @@ binary populates from baked build metadata; the updater does not consult it.
 3. **Other system-source patterns.** Recover a non-root's verified authored
    entry path at instantiation, recognize a system source by its same-toolshed
    `?identity` route, and check it without delaying the current graph.
-4. **General piece source lifecycle.** Reconcile external web URLs and fabric
-   URLs before ordinary piece start. Subscribe while running only when an
-   unpinned fabric URL resolves to a mutable pattern-bearing entity. Add atomic
-   revision history, detach, fork, revert, and repoint semantics as specified
-   in [`../piece-source-lifecycle.md`](../piece-source-lifecycle.md).
+4. **General piece source lifecycle.** Create every new space root through the
+   ordinary piece source transition using the system-selected default. Move the
+   home root's `defaultAppUrl` into creation configuration outside any root.
+   Migrate existing roots into baseline revisions without treating
+   `patternSource`, rollout flags, or the root role as consent to future
+   updates. Reconcile external web URLs and fabric URLs before the ordinary
+   start of any piece, including a root. Add atomic revision history, detach,
+   fork, revert, and repoint semantics as specified in
+   [`../piece-source-lifecycle.md`](../piece-source-lifecycle.md). Retire the
+   specialized root lifecycle path after migration. Validate the root-interface
+   contract whenever `defaultPattern` is created or relinked.
 5. **Cross-host origins.** Persist accepted space-to-host hints and enforce CFC
    provenance labels on fetched source.
 
@@ -412,12 +452,18 @@ binary populates from baked build metadata; the updater does not consult it.
    pattern closure, so neither a raw source-file `ETag` nor a `HEAD` request can
    replace it. Strong `ETag`s and conditional revalidation apply independently
    to each HTTP representation and complement the closure identity.
+2. **Space-root lifecycle and migration.** A space root is an ordinary piece.
+   The system chooses its initial source when creating the space and uses the
+   same source-creation transition as every other piece. The configured default
+   affects only future roots. Existing roots migrate into the ordinary revision
+   and active-origin model. Migration does not infer tracking consent from a raw
+   `patternSource`, a rollout flag, or the root role. After creation or
+   migration, update, detach, follow, fork, revert, and repoint use the ordinary
+   piece rules. Assigning the root role separately requires root-interface
+   compatibility.
 
 ## Open questions
 
-2. **Where the root's `patternSource` lives** — the root piece meta (general;
-   recommended) vs the space cell (co-located with `defaultPattern`). Recommend
-   the piece; the space cell holds only the `defaultAppUrl` template.
 3. **Home-data stable addressing** — verify `home.tsx` addresses its durable
    state by stable key/cause before enabling always-update on the home root
    (Phase 2 gate). Resolved 2026-07-21: `home-golden-replay.test.ts` pins state

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -232,17 +232,24 @@ cf:[[//toolshed.url]/space/][slug]
   some point"* — a bootstrap hint for when the runtime does not already know
   where a space is hosted (we have not built host-discovery-without-hints yet;
   this is a first step toward it).
-- **On ingest**, a host-bearing ref is normalized: extract the host →
-  `runtime.registerSpaceHost(space, host)` (feeds the learned site-table) →
-  store the **canonical host-less form** `cf:/<space-did>/<slug>`. The host is
-  routing, not identity; it is never smeared across every provenance ref.
+- **On ingest**, a host-bearing resolver input registers the host with
+  `runtime.registerSpaceHost(space, host)`, which changes only the live runtime.
+  The lifecycle operation separately writes the accepted space DID to host
+  route into the home-space site table before it commits a canonical host-less
+  target. A template may then keep the form `cf:/<space-did>/<ref>`. The
+  revision also retains the supplied `cf://` URL. A lifecycle follow resolves
+  an unpinned slug once and stores the stable entity. A pinned ref normalizes to
+  exact pattern source. The host is routing, not identity; it is not copied
+  into every canonical target.
 - Host **hints belong to the space**, not to each cross-space link — a
-  per-space host-hint store is the right long-term home (and the seed of
-  host-discovery). Deferred; v1 needs none.
-- **Optional slug**: `cf://toolshed/space/` (no slug) = *that space's root
-  pattern* (resolve via the space cell's `defaultPattern` → its
-  `patternIdentity`). This is how a template like `defaultAppUrl` says "point
-  at another space and track whatever it runs as its root."
+  home-space site table is the current durable store and the seed of later host
+  discovery. The runtime processor hydrates its entries on startup. Writing it
+  from a host-qualified lifecycle operation remains required work.
+- **Optional ref**: `cf://toolshed/space/` with no ref resolves that space's
+  current root pattern through the space cell's `defaultPattern` and then its
+  `patternIdentity`. Static resolution pins that result. A lifecycle operation
+  that starts from this form stores the resolved root piece as its stable
+  origin; later relinking of the space root does not redirect the follower.
 - Space is a **DID** (names still require name→DID resolution — README open
   question).
 
@@ -457,8 +464,17 @@ binary populates from baked build metadata; the updater does not consult it.
    [`../piece-source-lifecycle.md`](../piece-source-lifecycle.md). Retire the
    specialized root lifecycle path after migration. Validate the root-interface
    contract whenever `defaultPattern` is created or relinked.
-5. **Cross-host origins.** Persist accepted space-to-host hints and enforce CFC
-   provenance labels on fetched source.
+5. **Cross-host origins.** Validate and register the supplied space-to-host hint
+   through the ordinary per-space storage manager before opening the origin
+   space. After registration accepts it, persist it before committing a
+   hostless canonical origin, and hydrate it before later resolution. Do not
+   create a secondary session. A seeded route can only be confirmed. Once a
+   late hint is accepted, a different hint is a conflict even before the space
+   opens. After the space opens, only the hint already in effect can be
+   confirmed. Any other route attempt fails the transition. Add ordinary
+   authorization checks. Cross-host routing uses the same provenance checks as
+   a source flow between spaces on one toolshed. Reliable recovery from an
+   unavailable host or a moved space remains open design work.
 
 ## Resolved questions
 

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -1,11 +1,16 @@
-# Pattern Updates — rolling a running piece forward
+# System-source pattern updates — rolling running pieces forward
 
-How a running piece moves from the pattern version it was created with to a
-newer one — automatically for patterns backed by a same-toolshed **system
-source** (including home and default-app), and (a later phase) on demand for
-**published** patterns. Companion to `README.md`
-(which covers `cf:` imports and publishing-as-naming); this doc covers the
-*update propagation* side.
+How the currently implemented, specialized updater moves pieces backed by a
+same-toolshed **system source** from one pattern version to another. This
+includes home, default-app, and other successfully instantiated system-source
+patterns. The general lifecycle for ordinary pieces, including external
+`https://` origins, fabric `cf://` origins, following another piece, source
+history, revert, and repoint, is specified in
+[`../piece-source-lifecycle.md`](../piece-source-lifecycle.md).
+
+This document is also a companion to `README.md`, which covers static `cf:`
+imports and publication through naming and placement. Static imports remain
+pinned and do not adopt the live update behavior specified for piece origins.
 
 ## Status
 
@@ -24,7 +29,7 @@ and an unloadable tracked root is repaired before bootstrap through the same
 found during implementation are archived at
 [`docs/history/specs/pattern-imports/system-pattern-updates-implementation-plan.md`](../../history/specs/pattern-imports/system-pattern-updates-implementation-plan.md).
 The home root rides the shipped root machinery since the second flag's removal;
-published-pattern updates remain design.
+general piece origins and source history remain design.
 
 ## Last Updated
 
@@ -49,14 +54,17 @@ published-pattern updates remain design.
   schema-incompatible update slips through — the damage must be *bounded*
   (fast rollback), because the schema-valid-but-semantically-wrong case is not
   reliably detectable.
-- **One mechanism, two audiences.** The same "resolve a source pointer to a
-  current identity, swap in place" loop serves system patterns (auto) now and
-  published patterns (on click) later; they differ only in the resolver.
+- **A reusable mechanism.** The existing "resolve a source pointer to a current
+  identity, then swap in place" loop is a foundation for general piece origins.
+  Ordinary pieces need history, detach, compatibility, authorization, and
+  concurrency guarantees before they can use that lifecycle.
 
 ## Non-goals (this doc / v1)
 
-- **Published-pattern update UX** (a shell "update available" affordance) —
-  designed-*for* here, implemented later (§ Phasing).
+- **General piece origins and source history.** Web URL origins, fabric URLs
+  that name pieces or content-addressed patterns, detach, fork, revert, and
+  repoint are specified in
+  [`../piece-source-lifecycle.md`](../piece-source-lifecycle.md).
 - **Lineage / fork detection.** No substrate exists today — `parents` was
   deleted with the pattern-id retirement, and `pieceLineageSchema`
   (`packages/runner/src/schemas.ts`) is dead code, referenced nowhere.
@@ -147,10 +155,11 @@ The exception's semantics are deliberately narrow:
   space — not (yet) an automated restoration mechanism.
 
 Default system roots run this loop before bootstrap. Every other pattern runs it
-after successful instantiation, without delaying that instantiation. Published
-patterns will use a separate explicit action (§ Phasing).
+after successful instantiation, without delaying that instantiation. The
+general lifecycle replaces this specialized path after its source-state and
+history requirements are implemented.
 
-### `patternSource`: one field, two variants
+### `patternSource`: current value and planned migration
 
 A string meta on the piece result cell (space root: on the root piece).
 Dispatched by the `cf:` prefix:
@@ -163,6 +172,10 @@ Dispatched by the `cf:` prefix:
   `/api/patterns/system/default-app.tsx`) → use `?identity` against the space's
   host, then fetch and compile whenever the persisted artifact needs an update
   or repair.
+
+General source URL origins use the discriminated active-origin and revision
+schemas defined by the piece source lifecycle spec. They do not permanently
+overload this raw string with origin-kind-specific behavior.
 
 **Born-from determinism.** Once recorded, the *string* is frozen (which source);
 the *resolved identity* is live (which version). A non-home space's root
@@ -384,11 +397,13 @@ binary populates from baked build metadata; the updater does not consult it.
 3. **Other system-source patterns.** Recover a non-root's verified authored
    entry path at instantiation, recognize a system source by its same-toolshed
    `?identity` route, and check it without delaying the current graph.
-4. **Published-pattern updates.** `patternSource` = `cf:` ref; lazy check +
-   shell "update available" + click-to-apply; fork/lineage handling
-   (needs the deferred lineage substrate).
-5. **Cross-host published** + persisted space→host hints + CFC provenance
-   labels on fetched source.
+4. **General piece source lifecycle.** Reconcile external web URLs and fabric
+   URLs before ordinary piece start. Subscribe while running only when an
+   unpinned fabric URL resolves to a mutable pattern-bearing entity. Add atomic
+   revision history, detach, fork, revert, and repoint semantics as specified
+   in [`../piece-source-lifecycle.md`](../piece-source-lifecycle.md).
+5. **Cross-host origins.** Persist accepted space-to-host hints and enforce CFC
+   provenance labels on fetched source.
 
 ## Open questions
 

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -1,0 +1,519 @@
+# Piece source lifecycle
+
+How code enters the fabric, how a piece remembers where that code came from,
+how tracked code changes reach a piece, and how a user can detach, revert, or
+resume tracking.
+
+This is the design of record for source origins and source history on pieces.
+[`pattern-imports/README.md`](pattern-imports/README.md) remains the design of
+record for static imports inside pattern source.
+[`pattern-imports/pattern-updates.md`](pattern-imports/pattern-updates.md)
+describes the narrower system-root update mechanism that exists today.
+
+## Status
+
+The content-addressed source and in-place pattern replacement foundations are
+implemented. Local command-line creation is implemented end to end. Automatic
+updates exist only for system space roots. The general origin, history,
+forking, following, reverting, and repointing model in this document requires
+work unless the implementation table says otherwise.
+
+Status labels in this document have exact meanings:
+
+- **Implemented** means the interaction works end to end now.
+- **Partial** means a recognizable path performs the interaction in a limited
+  form, but one or more required guarantees are missing.
+- A status ending in **required** names the missing capability. Lower-level
+  building blocks may exist, but no user-facing operation performs the
+  interaction.
+
+The status table evaluates each requested interaction separately. The revision
+log is a cross-cutting requirement in its own row; its absence does not turn an
+otherwise complete first-time creation command into an unimplemented command.
+
+## Last updated
+
+2026-07-21
+
+## Terms
+
+A **pattern source** is an authored program. The fabric stores its verified
+module closure under a content-derived identity.
+
+A **piece** is a stateful instance that runs one exported pattern. Its
+`patternIdentity` metadata contains the identity and export symbol of the exact
+pattern it currently runs.
+
+An **origin** is an optional source URL that a piece remembers durably. URL in
+this document includes both web URLs and fabric-internal URLs:
+
+- An `https://` URL identifies an external program endpoint that can return new
+  source later. Its origin record also stores the entry export name that should
+  run.
+- A fabric `cf:` URL, including the host-qualified `cf://...` form, resolves
+  inside the fabric. An unpinned URL that resolves to a stable piece follows
+  that piece's current pattern identity and export symbol. The same live rule
+  applies to another stable, mutable cell that carries `patternIdentity`, such
+  as the planned lightweight publication pointer. A URL that directly names a
+  content-addressed pattern is immutable and stores the selected export symbol.
+  A trailing `@<identity>` pin also makes any fabric URL immutable, even when
+  the unpinned text names a piece or publication pointer.
+
+For example, a host-qualified fabric URL can resolve through
+`cf://toolshed.example/<space>/of:fid1:<piece-id>` to a piece, or through
+`cf://toolshed.example/<space>/pattern:<identity>` to exact pattern source.
+The shorter `cf:<ref>` and `cf:/<space>/<ref>` forms use the same fabric URL
+grammar. A user can supply a slug or host routing hint, but durable metadata
+normalizes it to the stable piece entity or content-addressed pattern it
+resolved to.
+
+Classification happens before the origin is stored. An explicit pin wins over
+the target's mutable shape and normalizes to `cf:pattern:<identity>` plus the
+selected export symbol. An unpinned URL that resolves to a mutable
+`patternIdentity`-bearing entity normalizes to that stable entity rather than
+its slug.
+
+A host in `cf://...` is a routing hint, not target identity. The transition
+retains the supplied URL in history and must persist the space DID to host route
+before it commits a hostless canonical target. If the route cannot be persisted,
+the origin transition fails without changing the piece. A later load hydrates
+that durable route before resolving the canonical fabric target.
+
+An origin is not proof of the bytes currently running. The content-addressed
+`patternIdentity` is that proof. A fabric URL that names a content-addressed
+pattern repeats the exact identity, so resolving it cannot discover an update.
+It remains useful as durable provenance and as a repoint target. An origin is
+also not the descriptive `patternRepository` value exposed by tooling. A
+repository locator can help a person find a project, but the runtime does not
+fetch it or track it for updates.
+
+A piece with no active origin is **detached**. Manually authored code and
+LLM-generated code start detached. Forking, directly editing, and reverting
+also detach a piece.
+
+In this document, **wishing code into being** means a product authoring
+affordance that asks an LLM to write pattern source. It is distinct from the
+runtime `wish()` builtin. The builtin discovers and connects to existing
+pieces; it does not generate pattern source.
+
+## Core invariants
+
+1. `patternIdentity` and its export symbol identify the exact source a piece
+   runs. Loading code never depends on an origin still being reachable.
+2. At most one source URL is active at a time. It resolves as an external web
+   endpoint, a mutable fabric `patternIdentity`-bearing entity, or an immutable
+   fabric pattern.
+3. Every successful transition records the new exact source, the active origin
+   after the transition, and the reason for the transition in an append-only
+   revision log. Each revision is a storage-retention root for its verified
+   source closure in the piece's space. Revert never depends on an origin or an
+   incidental compile-cache entry still existing.
+4. Every accepted state gets a fresh, stable revision identifier. Updating the
+   current source, the active origin, and the revision log is one atomic
+   operation. The transaction compares the expected revision head, current
+   pattern, and active origin before it commits. A concurrent detach, repoint,
+   or edit cannot be overwritten by a late origin check, including when both
+   states happen to use the same pattern identity.
+5. A direct source replacement detaches the piece unless the operation is an
+   automatic refresh from its active origin or an explicit repoint.
+6. Reverting selects exact historical code and detaches. Repointing selects a
+   historical origin and resolves its current code. These are separate user
+   actions.
+7. A failed fetch, unreadable followed piece, invalid program, integrity
+   failure, or incompatible schema leaves the current source and history
+   unchanged. A piece that already has valid source can continue to run its
+   last accepted source.
+8. Static `cf:` imports keep their existing snapshot semantics. Following a
+   piece does not make imports in that piece or in another pattern live.
+9. Creation and every later transition use ordinary authorization for the
+   target piece's space. Following grants no write access to the origin piece.
+10. Moving source between spaces is an information flow, not just a read. The
+    operation propagates CFC provenance labels and fails closed before copying
+    source when those labels do not permit the destination flow.
+11. A content-addressed or explicitly pinned fabric URL never reports an
+    update. Reconciliation verifies and loads the named source, but the URL
+    cannot resolve to a different pattern identity later.
+
+## Logical state
+
+The names below describe the logical model. They do not require the eventual
+storage schema to use these exact TypeScript field names.
+
+| State | Meaning | Repository status |
+|---|---|---|
+| Current pattern | `{ identity, symbol }` for the exact executable export | Implemented as `patternIdentity` metadata on the piece result cell |
+| Verified source closure | The authored files addressed by the current identity | Implemented as `pattern:<identity>` source documents |
+| Active origin | No origin, an external `https://` URL with an entry export, a stable mutable fabric-entity URL, or a content-addressed fabric pattern URL with an export symbol | Partial: `patternSource` stores a string for system roots, but general web and fabric URL origins are not supported end to end |
+| Revision head | The stable identifier of the latest accepted source and origin state | Revision head required |
+| Source revision log | Ordered records of every accepted source and origin state, with a durable reference to each verified source closure | Revision log required |
+| Descriptive repository | Optional locator shown by tooling; never followed | Implemented as `patternRepository` metadata |
+
+A revision record contains at least:
+
+- a stable revision identifier and the preceding revision identifier, if any;
+- the pattern identity and export symbol accepted by the piece;
+- a durable retention reference for the verified source closure;
+- the compatibility descriptors needed to validate a later replacement;
+- the active origin after that transition, if any;
+- the user-supplied source URL and routing hint when normalization changed it;
+- the transition kind, such as local create, web URL create, fabric pattern
+  create, follow, automatic update, direct edit, fork, revert, or repoint; and
+- the selected revision for a revert or repoint, or the stable source-piece
+  reference for a fork, when applicable.
+
+The initial creation is the first revision. Keeping creation in the same log
+lets a fork record `forkedFrom` without making the original piece an active
+origin. A fork does not copy the other piece's revision log. That history
+belongs to the other piece and may contain references the new owner cannot
+read. `forkedFrom` records derivation only. It is not offered as a repoint
+target unless this piece also followed that origin in another revision.
+
+The current pattern and active origin remain directly readable metadata. The
+revision head names a latest revision that mirrors them. They are written
+together so the log cannot claim a transition that the piece did not adopt.
+
+When lifecycle history is introduced, the first lifecycle-aware load or
+mutation of an existing piece creates a baseline revision from its current
+pattern and recognized origin metadata. The runtime first verifies and retains
+the current source closure. If it cannot do so, it leaves the piece in its
+legacy state and reports that history migration is blocked. It does not invent
+a revision whose source cannot be restored.
+
+## Source transitions
+
+| Interaction | Exact source after the interaction | Active origin after the interaction | History effect |
+|---|---|---|---|
+| Create from local code with the command line | The pushed local program | None | Append a local-create revision |
+| Create from LLM-generated code | The generated program | None | Append a generated-create revision |
+| Create from a source URL with the command line | The program resolved from the `https://` or fabric `cf:` URL, including `cf://` | The normalized URL and any required export selector | Append a web URL create, follow, or fabric pattern create revision according to what the URL resolves to |
+| Create from a known source URL in the UI | The program resolved from the `https://` or fabric `cf:` URL, including `cf://` | The normalized URL and any required export selector | Append a web URL create, follow, or fabric pattern create revision according to what the URL resolves to |
+| Refresh from an external web URL | The newly fetched program, if its identity or export symbol changed and it passed validation | The same `https://` URL and entry export | Append an automatic-update revision only when the identity or export symbol changes |
+| Load from a content-addressed or explicitly pinned fabric URL | The exact program named by the identity or trailing pin | The normalized fabric pattern URL and export symbol | Do not append an automatic-update revision because the resolved identity cannot change |
+| Fork a piece | The source currently used by the selected piece | None | Append a fork revision with `forkedFrom`; do not copy the source piece's log |
+| Follow a piece through an unpinned fabric URL | The source currently used by the selected piece | A normalized fabric URL containing a stable reference to that piece | Append a follow revision |
+| Refresh from a mutable fabric entity | The entity's current source, if its identity or export symbol changed and it passed validation | The same stable fabric entity URL | Append an automatic-update revision only when the identity or export symbol changes |
+| Directly edit or wish an existing piece to change | The newly authored or generated program | None | Append a direct-edit revision; the prior revision retains the former origin |
+| Revert | The exact source named by a selected earlier revision | None | Append a revert revision that names the selected revision |
+| Repoint | The current source resolved from a selected earlier origin | The selected web or fabric URL | Append a repoint revision |
+
+Direct command-line source updates follow the same detach rule as LLM edits.
+Otherwise a later load could silently replace a user's edit with a refresh
+from an origin they no longer intended to follow.
+
+For an unpinned fabric URL that resolves to a mutable entity, the stored
+reference names the stable entity, not a slug. A piece is the product case in
+this lifecycle. A lightweight publication pointer uses the same resolution and
+subscription rule if that feature is added. If a user begins with a slug, the
+operation resolves it once and stores a fully qualified reference containing
+the space DID and stable entity. Reassigning the slug must not redirect
+existing followers to a different entity. Self-following is rejected. Follow
+creation walks the active-origin chain and rejects a cycle. If an origin in
+that chain cannot be read, creation fails closed rather than accepting a
+relationship whose cycle status is unknown.
+
+For a fabric URL that directly names content-addressed pattern source, or that
+contains a trailing pin, the stored reference names that exact pattern
+identity. Slug reassignment, piece updates, and publication changes cannot move
+it. The selected export symbol is stored beside the URL because one pattern
+source can expose more than one export. A pin fixes the pattern identity, not
+the export symbol. The operation therefore stores an explicit selector or
+loads the pinned source and chooses its normal entry export. It does not copy a
+symbol from a mutable target unless that export exists in the pinned source.
+
+An external web URL is an absolute, canonical fetch location. Its origin record
+also stores the resolved entry export name. An omitted export uses the
+compiler's normal entry export at creation, and the chosen name is then
+persisted. Persistent origin metadata must not contain credentials. An
+authenticated fetch uses a separate credential or capability reference. Every
+source URL stays under the target piece's ordinary access controls because it
+can disclose where private code came from.
+
+## Source URL policy
+
+A source URL is both a source locator and a code trust decision. Mutable URLs
+also grant an endpoint or piece permission to change the code later. The
+general origin implementation must enforce these rules before it is enabled:
+
+- External web origins use HTTPS in production. A deployment may explicitly
+  allow HTTP for local development origins. Other web schemes are rejected.
+- User information and secret-bearing query parameters are not stored in the
+  URL. Credentials are supplied through a separately protected capability.
+- Redirects are checked as new destinations. Same-origin redirects may be
+  followed. A cross-origin redirect requires the user to repoint and confirm
+  the new origin. A redirect may not weaken HTTPS to HTTP.
+- The fetch service applies the deployment's outbound-network policy after
+  DNS resolution. Private, loopback, and link-local destinations are denied
+  unless the deployment explicitly allows them. The checks also apply after
+  every redirect.
+- Configured limits cover each response, the number of modules, and the total
+  source closure. Exceeding a limit fails the transition before source is
+  retained or run.
+- One runtime source service handles both command-line and UI callers. It sends
+  `https://` URLs through the checked network fetch path and `cf:` URLs through
+  authenticated fabric resolution. UI code does not bypass either path.
+- A host component in `cf://...` is a routing hint. Fabric authorization and
+  content verification still apply at the destination. The URL does not become
+  an ordinary unauthenticated HTTP fetch. A hostless canonical origin is not
+  committed until the routing hint is in the durable site table.
+- Creating or repointing an `https://` origin or a mutable fabric-entity origin
+  requires explicit consent to future automatic code changes from that
+  endpoint or entity. HTTPS authenticates a web endpoint in transit, while the
+  accepted content identity records the exact bytes. If an origin names an
+  expected publisher identity, each update must also carry a valid signature
+  from that publisher.
+- A content-addressed or explicitly pinned fabric origin is a one-time trust
+  decision about exact bytes. It does not grant any publisher, piece, slug, or
+  host permission to replace those bytes later.
+
+Without a publisher signature, a web URL update is trusted because the user
+granted the HTTPS endpoint permission to change the piece's code. Content
+addressing detects substitution after acceptance; it does not turn a new
+response from that endpoint into publisher-signed code.
+
+## Reconciliation when a piece loads
+
+Loading a piece with an active origin performs these steps before starting its
+pattern:
+
+1. Read the current `patternIdentity`, active source URL, and stable revision
+   head.
+2. Resolve the origin.
+   - For an external web URL, apply the network URL policy, fetch the complete
+     authored module closure, compute its content identity, and select the
+     stored entry export.
+   - For an unpinned fabric URL that names a mutable entity, read that entity's
+     current `patternIdentity` and make its verified source closure available
+     in the following piece's space.
+   - For a fabric URL that names a content-addressed pattern or contains an
+     explicit pin, load and verify that exact source closure and select the
+     stored export symbol.
+   - Before any cross-space copy, enforce the source's CFC provenance labels
+     for the destination and fail closed when the flow is not permitted.
+3. If the resolved identity and symbol equal the current values, start the
+   current pattern without writing a revision.
+4. Compile and verify a changed candidate. Apply the same backward-compatible
+   pattern and retained-input checks used by ordinary piece source updates.
+5. Write the verified candidate closure as a durable retention root in the
+   target space and wait for that write to succeed. A failed write fails the
+   transition. It is not converted into a background warning.
+6. In one transaction, compare the expected revision head, current pattern,
+   and active origin. If all remain current, append the revision, retain the
+   active origin, replace `patternIdentity`, and advance the revision head.
+7. Start the accepted pattern on the existing piece result cell.
+
+If reconciliation fails and the current source remains loadable, the runtime
+starts that source and reports the origin check failure to the UI. An
+incompatible candidate is blocked rather than applied automatically. A user
+may explicitly fork or force a detached update when preserving the existing
+piece state is not possible.
+
+Compatibility descriptors needed for this check are retained with the source
+state. This lets the runtime check a candidate without executing the prior
+implementation. A legacy piece that has neither a loadable prior source nor
+persisted compatibility descriptors cannot update automatically. The user
+must explicitly choose a detached force update or fork instead.
+
+This order generalizes the system-root repair path that already reconciles a
+persisted root before bootstrap. The system-root updater has a narrower repair
+contract and can replace an obsolete root before loading it. The general path
+does not silently skip state-compatibility checks when prior source is
+unavailable.
+
+## Following while a piece is running
+
+Load-time reconciliation recovers updates missed while a following piece was
+stopped. While it is running, the runtime also subscribes when its unpinned
+fabric URL resolves to a stable mutable entity. It observes that entity's
+current `patternIdentity`. A content-addressed or explicitly pinned fabric URL
+has no subscription because its target cannot change. Each notification enters
+the same guarded transition described above. There is no separate unguarded
+update path.
+
+The subscription ends when the following piece stops, detaches, or repoints.
+Authorization loss, a prohibited cross-space information flow, unavailable
+source, and validation failure leave the last accepted source running and
+surface an origin error. A concurrent local edit or repoint advances the
+revision head, so an in-flight notification from the former origin cannot
+commit. Restoring authorization does not require polling: a new subscription
+or the next load performs reconciliation from the origin's current state.
+
+## Revert and repoint semantics
+
+Revert and repoint answer different questions:
+
+- **Revert** asks, "Run these exact bytes again." It uses an immutable pattern
+  identity from the revision log. It does not contact the revision's former
+  origin and does not resume updates.
+- **Repoint** asks, "Follow this place again." It selects a source URL from
+  history, restores its normalized web or fabric form, resolves that origin
+  now, and adopts its current source.
+
+Repointing a content-addressed or explicitly pinned fabric URL adopts the same
+exact source again because that URL is immutable. Repointing an unpinned
+mutable fabric entity URL resumes following that entity's current pattern.
+Repointing an external web URL fetches its current response.
+
+This distinction avoids a surprising state in which a user reverts to repair a
+regression and the next load immediately reapplies the origin's broken source.
+
+History is append-only. Reverting or repointing does not remove the selected
+record or truncate later records. Repeated transitions may therefore name the
+same pattern identity more than once, with different reasons or origin states.
+
+## Trust model
+
+Choosing a mutable active origin is an ongoing trust decision. A later program
+from that web endpoint or mutable fabric entity runs with the following piece's
+authority after it passes verification and compatibility checks. A
+content-addressed or explicitly pinned fabric origin cannot change. The content
+identity proves which bytes were accepted and detects corrupted transfer. It
+does not prove that a publisher, piece owner, or URL owner made a safe change.
+
+Forking or following across spaces also moves authored source into the target
+space. Read authorization alone does not authorize that information flow. CFC
+provenance checks run before replication on the same toolshed as well as
+across toolsheds.
+
+The UI must distinguish detached pieces, immutable fabric-origin pieces, and
+pieces that update automatically. It shows the active source URL and whether
+that URL resolved to a web endpoint, mutable fabric entity, or exact fabric
+pattern. It also shows when a trailing pin made a piece-looking URL immutable.
+It offers detach and revert actions near mutable-origin controls. The revision
+log provides an exact rollback target after a bad but valid update.
+
+## Current implementation
+
+| Requested interaction | Status | Evidence and remaining work |
+|---|---|---|
+| Manually push local code with an identity key and create a piece | **Implemented** | `cf piece new` resolves a local file program, writes its content-addressed source closure in the target space, creates a piece, and authenticates through the supplied identity. `cf piece setsrc` updates the same piece. |
+| Wish a new pattern into being with an LLM-backed UI | **Partial** | The `write-and-run` example asks an LLM for pattern code and passes it to `compileAndRun`, whose callback lets the browser worker register the new piece in a space. It is not a general product affordance and does not record a source revision. The runtime `wish()` builtin is discovery, not code generation. |
+| Manually push code from a source URL and create a piece that remembers it | **CLI URL flow required** | The command-line `new` and `setsrc` commands accept local filesystem entries. `RuntimeClient.createPage(URL)` and `HttpProgramResolver` can fetch `http:` and `https:` source. Fabric resolution can resolve content-addressed patterns and same-toolshed piece references to a source identity, but its result does not carry the export symbol as origin state. Neither path gives the command line a general `https://` or `cf://` source-origin operation. `--repository` is descriptive metadata and is not an origin. |
+| Use a UI affordance to push a known source URL into an owned space | **Partial** | `fetchProgram` with `compileAndRun`, the omnibox's `fetchAndRunPattern`, and `RuntimeClient.createPage(URL)` can fetch and run indexed web programs. The resulting piece does not receive a general active source URL or a source revision. There is no corresponding fabric URL affordance. |
+| Load or create from an immutable fabric URL | **Immutable URL flow required** | The source cache and fabric resolver can load verified `cf:pattern:<identity>` source and honor a trailing pin, but no product operation normalizes that URL and export symbol into immutable piece origin metadata or appends the required revision. |
+| Automatically refresh a mutable URL-origin piece when loaded | **Partial** | The shell enables pre-start URL reconciliation for non-home system roots. Home-root updates remain behind `systemPatternAutoUpdateHome`. Ordinary pieces, external web URLs, and mutable fabric entity URLs do not use this path. A content-addressed or explicitly pinned fabric URL intentionally has nothing to refresh. |
+| Fork an existing piece and detach it | **Fork operation required** | Tooling can recover a piece's verified source closure, and the runtime can create another piece from a program. There is no fork operation or UI, no `forkedFrom` history, and no atomic detach contract. |
+| Follow another piece and receive its source updates | **Follow operation required** | `cf:` resolution can read another piece's current `patternIdentity`, content-addressed source can be replicated, and a running piece watches its own `patternIdentity` for in-place swaps. No operation stores an unpinned, normalized fabric entity URL as the active origin, reconciles it on load, subscribes to the origin while running, or exposes follow and unfollow UI. Cross-host routing also remains incomplete. |
+| Wish an existing piece to change and detach it | **LLM edit UI required** | `PieceController.setPattern` and `cf piece setsrc` replace a pattern in place with schema checks. There is no LLM-backed edit affordance or revision log. Existing setup writes also preserve `patternSource` and `patternRepository` when replacements omit them, so the required detach behavior is not implemented. |
+| Revert to source previously used by the same piece | **Revert operation required** | Old immutable source documents may still exist by content identity, but the piece has no index of identities it previously used and no revert operation or UI. Cache retention is not a history contract. |
+| Repoint to a web URL, mutable fabric entity URL, or immutable fabric URL previously used | **Repoint operation required** | There is no origin history, general origin resolver at piece load, repoint operation, or UI. |
+| Record every previous source and origin | **History storage required** | `pieceLineageSchema` and `pieceSourceCellSchema` are declarations with no readers or writers. Current pieces retain only the current `patternIdentity`, optional `patternSource`, and optional `patternRepository`. |
+
+The implementation evidence for this table is concentrated in:
+
+- [`packages/runner/src/runner.ts`](../../packages/runner/src/runner.ts) for
+  current pattern, origin, and repository metadata and the in-place watcher;
+- [`packages/runner/src/compilation-cache/cell-cache.ts`](../../packages/runner/src/compilation-cache/cell-cache.ts)
+  and
+  [`packages/runner/src/pattern-manager.ts`](../../packages/runner/src/pattern-manager.ts)
+  for verified source closures and cross-space closure replication;
+- [`packages/cli/commands/piece.ts`](../../packages/cli/commands/piece.ts) and
+  [`packages/cli/lib/piece.ts`](../../packages/cli/lib/piece.ts) for local-file
+  creation and source replacement;
+- [`packages/runtime-client/runtime-client.ts`](../../packages/runtime-client/runtime-client.ts)
+  and
+  [`packages/runtime-client/backends/runtime-processor.ts`](../../packages/runtime-client/backends/runtime-processor.ts)
+  for URL-backed page creation without origin stamping;
+- [`packages/piece/src/ops/pieces-controller.ts`](../../packages/piece/src/ops/pieces-controller.ts)
+  for system-root origin stamping and pre-start reconciliation;
+- [`packages/patterns/system/common-fabric.tsx`](../../packages/patterns/system/common-fabric.tsx),
+  [`packages/patterns/system/omnibox-fab.tsx`](../../packages/patterns/system/omnibox-fab.tsx),
+  and
+  [`packages/patterns/system/suggestion.tsx`](../../packages/patterns/system/suggestion.tsx)
+  for the current indexed-URL UI flow;
+- [`packages/patterns/examples/write-and-run.tsx`](../../packages/patterns/examples/write-and-run.tsx)
+  and
+  [`packages/runner/src/builtins/compile-and-run.ts`](../../packages/runner/src/builtins/compile-and-run.ts)
+  for the example LLM-backed creation machinery; and
+- [`packages/runner/src/schemas.ts`](../../packages/runner/src/schemas.ts) for
+  the unused lineage declarations.
+
+## Implemented foundations to preserve
+
+- A compiled pattern has a content-derived entry identity. The source-doc
+  closure under `pattern:<identity>` can recover the authored files.
+- A piece stores only `{ identity, symbol }` as its executable pattern pointer.
+- Changing `patternIdentity` can re-instantiate a running piece in place on the
+  same result cell.
+- `PieceController.setPattern` uses the previous identity as a concurrency
+  guard and validates backward-compatible pattern and retained-input schemas.
+  The identity-only guard is a foundation, but it cannot protect an
+  origin-only transition whose source identity stays unchanged.
+- Fabric reference parsing and resolution support content-addressed pattern
+  references, explicit pins, and same-toolshed mutable references by stable
+  entity or slug. Static imports pin mutable references into source.
+- System space roots carry a `patternSource` URL path when created through
+  `ensureDefaultPattern`. Non-home roots can check that source and replace
+  `patternIdentity` before starting.
+- Tooling exposes the immutable source ref, optional repository locator,
+  authored entry path, and optional current `patternSource` origin separately.
+
+## Work required
+
+1. Define a discriminated origin schema for external web URLs, stable mutable
+   fabric-entity URLs, and immutable fabric URLs created by a direct pattern
+   identity or trailing pin. Add a source-state schema with a stable revision
+   head. Define immutable revision records, including durable source retention
+   and the compatibility descriptors needed without executing an old pattern.
+   Replace the unused lineage declarations or remove them rather than treating
+   dead declarations as a shipped feature.
+2. Provide one atomic source-transition API used by every caller. It must wait
+   for failure-propagating closure persistence and compare the expected
+   revision head, current pattern, and active origin. Add baseline revision
+   migration for existing pieces.
+3. Make local edits explicitly clear active origin metadata. Make source URL
+   creation accept and normalize both `https://` and fabric `cf:` inputs,
+   including `cf://`. Resolve an unpinned fabric slug once, then store either a
+   stable, fully qualified mutable entity or the exact content-addressed pattern
+   reference. Make a trailing pin override the mutable target. Persist an
+   accepted space-to-host route before removing the host from the canonical
+   target. Keep the supplied URL in history. Keep `patternRepository` separate
+   and clear it when newly generated or directly edited code no longer belongs
+   to that repository.
+4. Add origin reconciliation to the ordinary piece start path. Add an
+   event-driven subscription while an unpinned mutable fabric origin is
+   running. Do not subscribe for a content-addressed or explicitly pinned
+   fabric origin. Reuse content verification, schema compatibility, guarded
+   source transitions, and the existing in-place pattern watcher.
+5. Build the central source URL service. Apply the network policy and explicit
+   ongoing-code consent to mutable web origins. Apply fabric authorization,
+   content verification, pin handling, durable routing, and provenance checks
+   to fabric origins. Store the required export selector and keep credentials
+   in separately protected capabilities.
+6. Add command-line URL creation and explicit detach, follow, revert, and
+   repoint operations. Add matching UI affordances, including the LLM-backed
+   create and edit flows.
+7. Expose revision history and origin-check failures through runtime-client
+   protocol types and shell views. Do not infer history from source-cache
+   contents.
+8. Enforce CFC provenance on every cross-space source flow, including spaces
+   on the same toolshed. Preserve ordinary read authorization and verify every
+   replicated source closure by content identity. Complete dynamic
+   space-to-host routing for origins in other toolsheds.
+9. Test each transition, concurrent source and origin races, failed and
+   incompatible updates, baseline migration, self-follow and follow cycles,
+   subscription cancellation, authorization loss, source unavailability,
+   cross-space authorization and provenance, web and fabric URL policy,
+   mutable versus content-addressed fabric targets, explicit pins, durable host
+   routing after reload, and reload behavior.
+   Tests must prove the current source, active origin, revision head, retained
+   closure, and revision log after each operation.
+
+## Relationship to pattern imports
+
+Pattern imports and piece origins intentionally have different update rules.
+An unpinned mutable `cf:` import is resolved and written back with an immutable
+pin when source is deployed. The deployed importer does not track later
+changes. The same fabric URL used as piece-origin metadata stays live when it
+is unpinned and resolves to a mutable `patternIdentity`-bearing entity. The
+piece can then follow that entity's current pattern. A fabric origin that
+resolves to `pattern:<identity>` or carries a trailing pin is immutable and has
+no later update to discover.
+
+Piece-origin metadata remains outside authored source. Mutable web and fabric
+entity origins are checked when that piece loads. A content-addressed or pinned
+fabric origin is verified when loaded but always resolves to the same exact
+source.
+
+This separation keeps a pattern's module identity deterministic while allowing
+a stateful piece to adopt a new, separately content-addressed pattern through
+an explicit tracking relationship.

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -92,8 +92,13 @@ its slug.
 A host in `cf://...` is a routing hint, not target identity. The transition
 retains the supplied URL in history and must persist the space DID to host route
 before it commits a hostless canonical target. If the route cannot be persisted,
-the origin transition fails without changing the piece. A later load hydrates
-that durable route before resolving the canonical fabric target.
+the origin transition fails without changing the piece. The transition also
+registers the accepted hint on the ordinary storage manager before opening the
+origin space. It does not create a secondary session. A conflicting seeded
+route or previously accepted late hint fails the transition. After the origin
+space opens, only the hint that was already registered can be confirmed. Any
+other route attempt fails the transition. A later load hydrates the durable
+route before resolving the canonical fabric target.
 
 An origin is not proof of the bytes currently running. The content-addressed
 `patternIdentity` is that proof. A fabric URL that names a content-addressed
@@ -373,6 +378,42 @@ granted the HTTPS endpoint permission to change the piece's code. Content
 addressing detects substitution after acceptance; it does not turn a new
 response from that endpoint into publisher-signed code.
 
+## Fabric route registration
+
+A host-qualified fabric URL supplies a route hint for a space DID. A lifecycle
+operation first validates the hint and registers it with the runtime's ordinary
+per-space storage manager. After registration accepts the route, the operation
+durably records it in the home-space site table. It then opens and resolves the
+origin space. The operation may commit a hostless canonical origin only after
+registration and persistence succeed.
+
+If persistence fails after registration, the transition leaves the piece
+unchanged. The accepted hint may remain available in that runtime until it
+stops. A retry can confirm the same hint and attempt the durable write again.
+The operation never persists a hint that the live registry has already
+rejected.
+
+The runtime does not open a short-lived secondary session for origin
+resolution. A configured route and an existing live connection remain stable
+for the current session. A seeded route can only be confirmed. Once a late hint
+is accepted, a different hint is a conflict even before the space opens. After
+the space opens, only the hint already in effect can be confirmed. Any other
+attempt fails without changing the piece. It does not silently reconnect or
+allow two live connections to disagree about where the same space resides.
+
+This policy settles ingestion of a known host hint. It does not yet make route
+discovery reliable. Host unavailability, replicated hosts, failover, stale
+site-table entries, authenticated space relocation, and closing and reopening
+an affected live session remain open design work.
+
+| Capability | Repository status | Remaining work |
+|---|---|---|
+| Register a late host hint before a space opens | **Implemented** | `StorageManager.registerSpaceHost` adds the route. A seed can only be confirmed, and an opened space accepts only its previously registered matching hint |
+| Keep an accepted late hint stable before opening | **Conflict guard required** | `StorageManager.registerSpaceHost` currently replaces a different late hint while the space remains unopened |
+| Hydrate durable hints in a new runtime | **Implemented** | The runtime processor watches the home-space site table and registers its entries. Callers that need ordering must also register through IPC before the first open |
+| Accept a host-qualified piece origin | **Origin integration required** | No source lifecycle operation persists and registers a `cf://` hint before resolving and committing the origin |
+| Recover from host failure or space movement | **Reliability design required** | There is no authoritative route-change, failover, or live close-and-reopen protocol |
+
 ## Reconciliation when a piece loads
 
 Loading a piece with an active origin performs these steps before starting its
@@ -568,6 +609,12 @@ The implementation evidence for this table is concentrated in:
   same-toolshed system-source patterns are checked in the background. This is a
   transitional implementation and migration input, not a target lifecycle
   exception.
+- Storage supports late registration of a space-to-host hint before that space
+  opens. The runtime processor hydrates durable hints from the home-space site
+  table. A seeded route can only be confirmed. An opened space accepts only its
+  previously registered matching hint. Before a space opens, however, a new
+  late hint currently replaces the previous one. Piece-origin operations do
+  not yet use this machinery.
 - Tooling exposes the immutable source ref, optional repository locator,
   authored entry path, and optional current `patternSource` origin separately.
 
@@ -596,9 +643,13 @@ The implementation evidence for this table is concentrated in:
    stable, fully qualified mutable entity or the exact content-addressed pattern
    reference. Make a trailing pin override the mutable target. Persist an
    accepted space-to-host route before removing the host from the canonical
-   target. Keep the supplied URL in history. Keep `patternRepository` separate
-   and clear it when newly generated or directly edited code no longer belongs
-   to that repository.
+   target. Validate and register the route before writing it to the site table,
+   then open the origin space. Fail a conflicting seeded route or previously
+   accepted late hint, including before the first open. Once the space opens,
+   fail any hint that was not already registered and matching. Do not create a
+   secondary session. Keep the supplied URL in history. Keep
+   `patternRepository` separate and clear it when newly generated or directly
+   edited code no longer belongs to that repository.
 4. Add origin reconciliation to the ordinary piece start path. Add an
    event-driven subscription while an unpinned mutable fabric origin is
    running. Do not subscribe for a content-addressed or explicitly pinned
@@ -628,8 +679,11 @@ The implementation evidence for this table is concentrated in:
    contents.
 8. Enforce CFC provenance on every cross-space source flow, including spaces
    on the same toolshed. Preserve ordinary read authorization and verify every
-   replicated source closure by content identity. Complete dynamic
-   space-to-host routing for origins in other toolsheds.
+   replicated source closure by content identity. Connect host-qualified origin
+   ingestion to the implemented late-bound route registry and durable site
+   table. Design reliable discovery, authenticated route replacement, host
+   failover, and explicit close-and-reopen behavior for unavailable or moved
+   spaces.
 9. Add CI golden replays that carry representative durable state from each
    supported prior source to its proposed replacement. These tests cover
    stable keys and causes, intended migration, and behavior that schemas cannot
@@ -640,10 +694,11 @@ The implementation evidence for this table is concentrated in:
    subscription cancellation, authorization loss, source unavailability,
    cross-space authorization and provenance, web and fabric URL policy,
    mutable versus content-addressed fabric targets, explicit pins, durable host
-   routing after reload, space-root creation from a default, changes to a
-   default after root creation, tracked and detached root baseline migration,
-   source-less legacy roots, relative-path normalization, root-interface
-   rejection, and reload behavior.
+   routing after reload, conflicts between late hints before a target opens,
+   route conflicts after a target opens, space-root creation from a default,
+   changes to a default after root creation, tracked and detached root baseline
+   migration, source-less legacy roots, relative-path normalization,
+   root-interface rejection, and reload behavior.
    Tests must prove the current source, active origin, revision head, retained
    closure, and revision log after each operation.
 

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -37,7 +37,7 @@ otherwise complete first-time creation command into an unimplemented command.
 
 ## Last updated
 
-2026-07-21
+2026-07-22
 
 ## Terms
 
@@ -135,10 +135,14 @@ pieces; it does not generate pattern source.
 6. Reverting selects exact historical code and detaches. Repointing selects a
    historical origin and resolves its current code. These are separate user
    actions.
-7. A failed fetch, unreadable followed piece, invalid program, integrity
-   failure, or incompatible schema leaves the current source and history
-   unchanged. A piece that already has valid source can continue to run its
-   last accepted source.
+7. An unattended origin update that encounters a failed fetch, unreadable
+   followed piece, invalid program, integrity failure, or structurally
+   incompatible candidate leaves the current source and history unchanged. A
+   piece that already has valid source can continue to run its last accepted
+   source. A manual replacement still rejects invalid or unverifiable source,
+   but it may apply a structural incompatibility after the user explicitly
+   accepts the warning. Semantic compatibility is established by tests rather
+   than inferred by the runtime.
 8. Static `cf:` imports keep their existing snapshot semantics. Following a
    piece does not make imports in that piece or in another pattern live.
 9. Creation and every later transition use ordinary authorization for the
@@ -245,7 +249,7 @@ and link that new piece as the space root.
 | Fork a piece | The source currently used by the selected piece | None | Append a fork revision with `forkedFrom`; do not copy the source piece's log |
 | Follow a piece through an unpinned fabric URL | The source currently used by the selected piece | A normalized fabric URL containing a stable reference to that piece | Append a follow revision |
 | Refresh from a mutable fabric entity | The entity's current source, if its identity or export symbol changed and it passed validation | The same stable fabric entity URL | Append an automatic-update revision only when the identity or export symbol changes |
-| Directly edit or wish an existing piece to change | The newly authored or generated program | None | Append a direct-edit revision; the prior revision retains the former origin |
+| Directly edit or wish an existing piece to change | The newly authored or generated program, after the user explicitly accepts any structural compatibility warning | None | Append a direct-edit revision; the prior revision retains the former origin |
 | Revert | The exact source named by a selected earlier revision | None | Append a revert revision that names the selected revision |
 | Repoint | The current source resolved from a selected earlier origin | The selected web or fabric URL | Append a repoint revision |
 
@@ -258,6 +262,46 @@ repoint through the same operations as any other piece. Changing the system's
 default source affects only roots created afterward. Changing an existing
 space's root is an explicit piece lifecycle operation or an explicit relink to
 another ordinary piece that passes the root-interface compatibility check.
+
+## Compatibility policy
+
+Uploading, compiling, or publishing content-addressed pattern source does not
+change an existing piece. These operations have no prior piece contract to
+compare, so piece compatibility does not gate them. Compatibility is evaluated
+when a candidate pattern is applied to an existing piece.
+
+The runtime can compare the previous and candidate argument schemas, result
+schemas, and retained input links. Before a manual source replacement, the
+caller compiles and verifies the candidate and runs these structural
+comparisons. A reported backward incompatibility becomes an actionable warning.
+The UI requires explicit confirmation, and command-line tooling requires an
+explicit flag, before applying it. An accepted manual replacement is a direct
+edit, so it detaches the piece and appends a revision.
+
+An automatic origin update has no user present to accept a warning. A known
+structural incompatibility therefore blocks the transition. The piece keeps its
+last accepted source, active origin, revision head, and history, and the UI
+reports the rejected candidate.
+
+Stable keys and causes, intended data migration, and behavior are semantic
+contracts. The runtime cannot reliably infer them from schemas. CI tests and
+golden replays must load representative state created by the previous source,
+apply the proposed source, and verify that the new code reads and preserves the
+intended state. Deployment does not repeat those tests or use runtime guesses
+to enforce semantic compatibility.
+
+The root role adds one independent structural requirement. Creating or
+relinking a root, and every later source transition on that root, must leave it
+with the operations and state the space runtime requires. Explicit acceptance
+of a schema warning does not waive this root-interface contract.
+
+| Concern | Target policy | Repository status |
+|---|---|---|
+| Structural schema comparison | Compare argument and result schemas and validate retained inputs when replacing an existing piece's source | **Implemented** for `PieceController.setPattern` |
+| Manual incompatible replacement | Warn with details and require explicit confirmation or a command-line flag; an accepted replacement detaches | **Warning flow required**: `setPattern` currently rejects unless `dangerouslyAllowIncompatibleSchema` is supplied, and the command line exposes that flag without a first-class warning and confirmation flow |
+| Automatic incompatible update | Reject a known structural incompatibility and keep the last accepted lifecycle state | **Automatic guard required**: the specialized system-source updater changes `patternIdentity` without the complete pre-apply comparison, and general origin reconciliation is not implemented |
+| Semantic state continuity | Verify intended stable-key, stable-cause, migration, and behavior contracts in CI | **Broader CI coverage required**: synthetic home-shaped and default-app-shaped golden replays exist, but general version-to-version fixtures remain |
+| Root-interface contract | Enforce the root role after every creation, relink, and source transition | **Root validation required**: root linking and source replacement do not validate that contract |
 
 For an unpinned fabric URL that resolves to a mutable entity, the stored
 reference names the stable entity, not a slug. A piece is the product case in
@@ -350,8 +394,9 @@ pattern:
      for the destination and fail closed when the flow is not permitted.
 3. If the resolved identity and symbol equal the current values, start the
    current pattern without writing a revision.
-4. Compile and verify a changed candidate. Apply the same backward-compatible
-   pattern and retained-input checks used by ordinary piece source updates.
+4. Compile and verify a changed candidate. Compare its argument and result
+   schemas and retained inputs with the accepted source. Automatic
+   reconciliation accepts only a backward-compatible candidate.
 5. Write the verified candidate closure as a durable retention root in the
    target space and wait for that write to succeed. A failed write fails the
    transition. It is not converted into a background warning.
@@ -363,8 +408,8 @@ pattern:
 If reconciliation fails and the current source remains loadable, the runtime
 starts that source and reports the origin check failure to the UI. An
 incompatible candidate is blocked rather than applied automatically. A user
-may explicitly fork or force a detached update when preserving the existing
-piece state is not possible.
+may explicitly fork or perform a detached manual replacement after accepting
+the compatibility warning.
 
 Compatibility descriptors needed for this check are retained with the source
 state. This lets the runtime check a candidate without executing the prior
@@ -463,11 +508,11 @@ log provides an exact rollback target after a bad but valid update.
 | Manually push code from a source URL and create a piece that remembers it | **CLI URL flow required** | The command-line `new` and `setsrc` commands accept local filesystem entries. `RuntimeClient.createPage(URL)` and `HttpProgramResolver` can fetch `http:` and `https:` source. Fabric resolution can resolve content-addressed patterns and same-toolshed piece references to a source identity, but its result does not carry the export symbol as origin state. Neither path gives the command line a general `https://` or `cf://` source-origin operation. `--repository` is descriptive metadata and is not an origin. |
 | Use a UI affordance to push a known source URL into an owned space | **Partial** | `fetchProgram` with `compileAndRun`, the omnibox's `fetchAndRunPattern`, and `RuntimeClient.createPage(URL)` can fetch and run indexed web programs. The resulting piece does not receive a general active source URL or a source revision. There is no corresponding fabric URL affordance. |
 | Load or create from an immutable fabric URL | **Immutable URL flow required** | The source cache and fabric resolver can load verified `cf:pattern:<identity>` source and honor a trailing pin, but no product operation normalizes that URL and export symbol into immutable piece origin metadata or appends the required revision. |
-| Automatically refresh a mutable URL-origin piece when loaded | **Partial** | The shell reconciles system roots before bootstrap and checks other successfully instantiated same-toolshed system-source patterns in the background. External web URLs and mutable fabric entity URLs do not use this path. A content-addressed or explicitly pinned fabric URL intentionally has nothing to refresh. |
+| Automatically refresh a mutable URL-origin piece when loaded | **Partial** | The shell reconciles system roots before bootstrap and checks other successfully instantiated same-toolshed system-source patterns in the background. The specialized updater changes `patternIdentity` without the complete pre-apply structural comparison. A running pattern's setup can refuse an incompatible argument shape and keep the old graph, but the metadata pointer has already changed. External web URLs and mutable fabric entity URLs do not use this path. A content-addressed or explicitly pinned fabric URL intentionally has nothing to refresh. |
 | Manage a space root through the ordinary piece lifecycle | **Lifecycle unification required** | A root is already a piece and the specialized updater can replace its pattern in place. Creation still stamps a raw `patternSource`, reconciliation bypasses revision history, and update authority is not durable per piece. Root updates still use a separate controller path. The creation template currently lives on the mutable home root, relative source paths are not ordinary origins, and root linking does not validate a root interface. New-root creation, legacy-root migration, and later transitions do not yet use the ordinary lifecycle path. |
 | Fork an existing piece and detach it | **Fork operation required** | Tooling can recover a piece's verified source closure, and the runtime can create another piece from a program. There is no fork operation or UI, no `forkedFrom` history, and no atomic detach contract. |
 | Follow another piece and receive its source updates | **Follow operation required** | `cf:` resolution can read another piece's current `patternIdentity`, content-addressed source can be replicated, and a running piece watches its own `patternIdentity` for in-place swaps. No operation stores an unpinned, normalized fabric entity URL as the active origin, reconciles it on load, subscribes to the origin while running, or exposes follow and unfollow UI. Cross-host routing also remains incomplete. |
-| Wish an existing piece to change and detach it | **LLM edit UI required** | `PieceController.setPattern` and `cf piece setsrc` replace a pattern in place with schema checks. There is no LLM-backed edit affordance or revision log. Existing setup writes also preserve `patternSource` and `patternRepository` when replacements omit them, so the required detach behavior is not implemented. |
+| Wish an existing piece to change and detach it | **LLM edit UI required** | `PieceController.setPattern` and `cf piece setsrc` reject incompatible pattern or retained-input schemas unless `dangerouslyAllowIncompatibleSchema` is supplied. The command line exposes that override, but it does not first present the target warning and confirmation flow. There is no LLM-backed edit affordance or revision log. Existing setup writes also preserve `patternSource` and `patternRepository` when replacements omit them, so the required detach behavior is not implemented. |
 | Revert to source previously used by the same piece | **Revert operation required** | Old immutable source documents may still exist by content identity, but the piece has no index of identities it previously used and no revert operation or UI. Cache retention is not a history contract. |
 | Repoint to a web URL, mutable fabric entity URL, or immutable fabric URL previously used | **Repoint operation required** | There is no origin history, general origin resolver at piece load, repoint operation, or UI. |
 | Record every previous source and origin | **History storage required** | `pieceLineageSchema` and `pieceSourceCellSchema` are declarations with no readers or writers. Current pieces retain only the current `patternIdentity`, optional `patternSource`, and optional `patternRepository`. |
@@ -510,8 +555,10 @@ The implementation evidence for this table is concentrated in:
   same result cell.
 - `PieceController.setPattern` uses the previous identity as a concurrency
   guard and validates backward-compatible pattern and retained-input schemas.
-  The identity-only guard is a foundation, but it cannot protect an
-  origin-only transition whose source identity stays unchanged.
+  It can bypass both checks through `dangerouslyAllowIncompatibleSchema`.
+  Presenting the mismatch as a warning before an explicit manual override is
+  still required. The identity-only guard is a foundation, but it cannot
+  protect an origin-only transition whose source identity stays unchanged.
 - Fabric reference parsing and resolution support content-addressed pattern
   references, explicit pins, and same-toolshed mutable references by stable
   entity or slug. Static imports pin mutable references into source.
@@ -556,10 +603,12 @@ The implementation evidence for this table is concentrated in:
    event-driven subscription while an unpinned mutable fabric origin is
    running. Do not subscribe for a content-addressed or explicitly pinned
    fabric origin. Reuse content verification, schema compatibility, guarded
-   source transitions, and the existing in-place pattern watcher. Use this same
-   path for space roots and retire the specialized root reconciler after
-   migration. Move the current home-root `defaultAppUrl` into durable
-   space-creation configuration outside any root piece. Space creation must
+   source transitions, and the existing in-place pattern watcher. Automatic
+   transitions must reject a known structural incompatibility and preserve the
+   last accepted lifecycle state. Use this same path for space roots and retire
+   the specialized root reconciler after migration. Move the current home-root
+   `defaultAppUrl` into durable space-creation configuration outside any root
+   piece. Space creation must
    resolve that configured default through the ordinary create transition and
    then link the resulting piece as the root. Creating or relinking that link
    must validate the runtime's root-interface contract.
@@ -570,7 +619,10 @@ The implementation evidence for this table is concentrated in:
    in separately protected capabilities.
 6. Add command-line URL creation and explicit detach, follow, revert, and
    repoint operations. Add matching UI affordances, including the LLM-backed
-   create and edit flows.
+   create and edit flows. Before a manual source replacement, show structural
+   compatibility findings and require explicit confirmation or a command-line
+   flag to continue. An accepted incompatible replacement must detach. Root
+   role validation remains mandatory after an override.
 7. Expose revision history and origin-check failures through runtime-client
    protocol types and shell views. Do not infer history from source-cache
    contents.
@@ -578,8 +630,13 @@ The implementation evidence for this table is concentrated in:
    on the same toolshed. Preserve ordinary read authorization and verify every
    replicated source closure by content identity. Complete dynamic
    space-to-host routing for origins in other toolsheds.
-9. Test each transition, concurrent source and origin races, failed and
-   incompatible updates, baseline migration, self-follow and follow cycles,
+9. Add CI golden replays that carry representative durable state from each
+   supported prior source to its proposed replacement. These tests cover
+   stable keys and causes, intended migration, and behavior that schemas cannot
+   prove. Extend the current synthetic system-root replays with general
+   version-to-version fixtures. Test each transition, concurrent source and
+   origin races, failed and incompatible updates, baseline migration,
+   self-follow and follow cycles,
    subscription cancellation, authorization loss, source unavailability,
    cross-space authorization and provenance, web and fabric URL policy,
    mutable versus content-addressed fabric targets, explicit pins, durable host

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -147,8 +147,9 @@ pieces; it does not generate pattern source.
 
 1. `patternIdentity` and its export symbol identify the exact executable export
    a piece runs. The current revision retains the complete authored program,
-   including files outside that export's reachable import graph. Loading code
-   never depends on an origin still being reachable.
+   including files outside that export's reachable import graph and the exact
+   public-subpath map. Loading code never depends on an origin still being
+   reachable.
 2. At most one source URL is active at a time. It resolves as an external web
    endpoint, a mutable fabric `patternIdentity`-bearing entity, or an immutable
    fabric pattern.
@@ -213,9 +214,9 @@ storage schema to use these exact TypeScript field names.
 |---|---|---|
 | Current pattern | `{ identity, symbol }` for the exact executable export | Implemented as `patternIdentity` metadata on the piece result cell |
 | Verified identity closure | The authored implementation and declaration files that determine the current executable identity | **Implementation files stored**: `pattern:<identity>` source documents exist, but production filters authored `.d.ts` files before identity and persistence |
-| Retained authored program | An immutable version-1 manifest for the complete authored program accepted by the current revision, including unreachable files | **Program manifest required**: source documents can retain extra roots, but no piece revision binds the exact accepted file set |
+| Retained authored program | An immutable version-1 manifest for the complete authored program accepted by the current revision, including unreachable files and its exact public-subpath map | **Manifest and exports required**: source documents can retain extra roots, but no piece revision binds the exact accepted file set or public map |
 | Runtime fingerprint | The trusted runtime identity used to calculate the accepted executable pattern identity | **Authoritative provider required**: the optional module-hash input exists, but production compilation and source verification still use the empty default |
-| Runtime-neutral program digest | The version-1 digest of the canonical main filename and every authored file's runtime-neutral module identity | **Lifecycle comparison required**: the module hash can run with the empty fingerprint, but the complete program digest is not recorded |
+| Runtime-neutral program digest | The version-1 digest of the canonical main filename, every authored file's runtime-neutral module identity, and the public-subpath map | **Digest and lifecycle required**: the module hash can run with the empty fingerprint, but the complete program digest is not recorded |
 | Active origin | No origin, an external `https://` URL with an entry export, a stable mutable fabric-entity URL, or a content-addressed fabric pattern URL with an export symbol | Partial: `patternSource` stores a string for system roots, but general web and fabric URL origins are not supported end to end |
 | Revision head | The stable identifier of the latest accepted source and origin state | Revision head required |
 | Source revision log | Ordered records of every accepted source and origin state, with a durable reference to each immutable authored-program manifest | Revision log required |
@@ -224,21 +225,33 @@ storage schema to use these exact TypeScript field names.
 The runtime-neutral program digest is
 `cf/runtime-neutral-program-digest/v1` from
 [module-loading.md](module-loading.md). It covers the canonical main filename
-and every authored file, including unreachable siblings. It excludes mounted
-files, synthetic retention links, and the selected export. The digest is
-comparison metadata. It is not a fabric URL target, an executable pattern
-identity, or a revert target.
+and every authored file, including unreachable siblings. It also covers the
+normalized exact map from public subpaths to authored filenames. It excludes
+mounted files, synthetic retention links, and the selected executable export.
+The digest is comparison metadata. It is not a fabric URL target, an executable
+pattern identity, or a revert target.
 
-Lifecycle ingestion first materializes a complete `Program` with a canonical
-`main` and an explicit `files` list. That list defines the authored program for
-history. Command-line directory input, LLM output, and a web program manifest
-must enumerate every intended file before import-closure resolution. A retained
-authored-program manifest provides the list for fork, follow, revert, and
-rebuild. A raw web entry point or another `ProgramResolver` that cannot enumerate
-files defines its authored program as only the reachable closure it returns. It
-cannot later report an unenumerated sibling as a source update. Duplicate
-canonical filenames are rejected. Declaration stubs injected by the runtime for
-type checking are not authored files and do not enter this list.
+Lifecycle ingestion first materializes the repository's current `Program`
+shape, with a canonical `main` and an explicit `files` list. It pairs that value
+with a normalized public-subpath map. Together they define the authored program
+for history. Command-line directory input, LLM output, and a web program
+manifest must enumerate every intended file before import-closure resolution.
+They must also supply the public map, or the canonical empty map when only the
+implicit entry is public. A retained authored-program manifest provides both
+for fork, follow, revert, and rebuild. A raw web entry point or another
+`ProgramResolver` that cannot enumerate files defines its authored program as
+only the reachable closure it returns. It cannot later report an unenumerated
+sibling as a source update. Duplicate canonical filenames are rejected.
+Invalid public names and targets outside the authored file set are also
+rejected. Declaration stubs injected by the runtime for type checking are not
+authored files and do not enter this list.
+
+A direct `cf:pattern:<identity>` URL is one of these resolver-only inputs. The
+module identity binds its reachable source closure, but it does not bind one
+complete authored-program manifest. Creating a piece from that URL therefore
+retains the reachable closure with an empty public-subpath map. A mutable piece
+or publication origin can preserve and propagate its complete retained
+manifest, including unreachable files and explicit public subpaths.
 
 The current `ProgramResolver` interface exposes only `main()` and
 `resolveSource()`, and `resolveProgram()` returns only the reachable import
@@ -248,14 +261,17 @@ and retained-manifest sources is required integration work.
 Each revision's source-retention reference names an immutable
 `cf/authored-program-manifest/v1` value. The manifest contains the canonical
 main filename and a UTF-8 filename-sorted list of every authored file with its
-verified source-document identity. It directly retains those source documents
-and the complete transitive graph of content-addressed fabric dependencies
-pinned by the program. Recursive retention deduplicates dependency identities
-and parses pinned fabric specifiers because source documents intentionally omit
-fabric links. Its file list must reproduce the revision's runtime-neutral
-program digest. It does not rely on the entry source document's synthetic root
-links. Those links are non-normative and can be rewritten when another program
-uses the same entry identity.
+verified source-document identity. It also contains a UTF-8 key-sorted exact
+map from public subpaths to canonical authored filenames. The empty subpath
+implicitly selects the canonical main and does not appear in the map. The
+manifest directly retains its source documents and the complete transitive
+graph of content-addressed fabric dependencies pinned by the program. Recursive
+retention deduplicates dependency identities and parses pinned fabric
+specifiers because source documents intentionally omit fabric links. Its file
+list and public map must reproduce the revision's runtime-neutral program
+digest. It does not rely on the entry source document's synthetic root links.
+Those links are non-normative and can be rewritten when another program uses
+the same entry identity.
 
 The revision embeds this value or points to a content-addressed copy. It never
 points through a mutable piece, slug, origin, or entry-document retention list.
@@ -295,6 +311,13 @@ The current pattern, retained-program reference and digest, accepted origin
 revision, and active origin remain directly readable metadata. The revision head
 names a latest revision that mirrors them. They are written together so the log
 cannot claim a transition that the piece did not adopt.
+
+Changing only the manifest's public-subpath map is an accepted source revision.
+It changes the retained manifest and runtime-neutral program digest while
+preserving every module identity and the executable `patternIdentity`. A piece
+advertises that revision to downstream followers like any other source-only
+revision. Existing pinned static imports do not move until their owners perform
+an explicit dependency update.
 
 A runtime fingerprint change that produces a new executable pattern identity is
 an accepted source revision even when the authored source is unchanged. For an
@@ -736,6 +759,7 @@ mislabeling the current creation revision as a revert target.
 | Load or create from an immutable fabric URL | **Immutable URL flow required** | The source cache and fabric resolver can load verified `cf:pattern:<identity>` source and honor a trailing pin on an entity-FID reference. No product operation normalizes that URL and export symbol into immutable piece origin metadata or appends the required revision. |
 | Automatically refresh a mutable URL-origin piece when loaded | **Partial** | The shell reconciles system roots before bootstrap and checks other successfully instantiated same-toolshed system-source patterns in the background. The specialized updater changes `patternIdentity` without the complete pre-apply structural comparison. A running pattern's setup can refuse an incompatible argument shape and keep the old graph, but the metadata pointer has already changed. External web URLs and mutable fabric entity URLs do not use this path. A content-addressed or explicitly pinned fabric URL intentionally has nothing to refresh. |
 | Retain authored declaration files | **Declaration identity work required** | `computeModuleHashes` follows type-import edges, but production engine paths remove authored `.d.ts` files before module identity calculation, source-document construction, and cache persistence. Declaration-only changes can therefore reuse stale executable identities and compiled bytes. |
+| Publish explicit source subpaths | **Exports-map support required** | The `cf:` grammar parses a subpath. Compile resolution and the shared pin/update chase reject it before entry resolution, so current tooling cannot create a misleading subpath pin. There is no immutable authored-program manifest or exact public exports map. Entry imports continue to pin the entry identity. |
 | Record and propagate a runtime rebuild | **Provider and lifecycle required** | `computeModuleHashes` accepts `runtimeFingerprint`, and its unit test proves that changing the fingerprint changes a module with an external dependency. Production pattern compilation and source verification use the empty default. There is no authoritative executable-fingerprint provider. Source documents do not retain a non-empty identity fingerprint, and pieces have no revision log, runtime-neutral program digest, runtime-rebuild cause, owner-published propagation contract, or cross-runtime revert handling. |
 | Manage a space root through the ordinary piece lifecycle | **Lifecycle unification required** | A root is already a piece and the specialized updater can replace its pattern in place. Creation still stamps a raw `patternSource`, reconciliation bypasses revision history, and update authority is not durable per piece. Root updates still use a separate controller path. The creation template currently lives on the mutable home root, relative source paths are not ordinary origins, and root linking does not validate a root interface. New-root creation, legacy-root migration, and later transitions do not yet use the ordinary lifecycle path. |
 | Fork an existing piece and detach it | **Fork operation required** | Tooling can recover a piece's verified source closure, and the runtime can create another piece from a program. There is no fork operation or UI, no `forkedFrom` history, and no atomic detach contract. |
@@ -813,16 +837,19 @@ The implementation evidence for this table is concentrated in:
    revision head. Define immutable revision records and
    `cf/authored-program-manifest/v1`. Each manifest binds the canonical main and
    exact filename-to-source-identity set, including authored `.d.ts` files. It
-   retains every transitive pinned fabric dependency once. Add a complete
-   program enumeration path before import-closure resolution. Revisions also
-   record the accepted runtime fingerprint,
-   runtime-neutral program digest, separate operation and cause fields, and the
-   compatibility descriptors needed without executing an old pattern. Replace
-   the unused lineage declarations or remove them rather than treating dead
-   declarations as a shipped feature. Implement the authoritative version-1
-   executable runtime fingerprint and runtime-neutral program digest defined in
-   [module-loading.md](module-loading.md). Treat an unavailable production
-   fingerprint as an error rather than publishing under the legacy empty value.
+   also binds the normalized exact public-subpath map. Add validation that
+   accepts only authored-file targets and includes the map in the manifest
+   identity and runtime-neutral program digest. It retains every transitive
+   pinned fabric dependency once. Add a complete program enumeration path
+   before import-closure resolution. Revisions also record the accepted runtime
+   fingerprint, runtime-neutral program digest, separate operation and cause
+   fields, and the compatibility descriptors needed without executing an old
+   pattern. Replace the unused lineage declarations or remove them rather than
+   treating dead declarations as a shipped feature. Implement the authoritative
+   version-1 executable runtime fingerprint and runtime-neutral program digest
+   defined in [module-loading.md](module-loading.md). Treat an unavailable
+   production fingerprint as an error rather than publishing under the legacy
+   empty value.
 2. Provide one atomic source-transition API used by every caller. It must wait
    for failure-propagating closure persistence and compare the expected
    revision head, current pattern, and active origin. Mutable-origin activation
@@ -918,19 +945,24 @@ The implementation evidence for this table is concentrated in:
    immutable-origin repoint, cross-runtime revert under a new executable
    identity, detach-and-rebuild recovery from an incompatible first
    immutable-origin revision, two source-only revisions that share an entry
-   identity but restore different unreachable files, and a nested pinned fabric
-   dependency restored after incidental source roots disappear. Tests must prove
-   the current source, active origin, revision head, authored-program manifest,
-   recursively retained dependency graph, and revision log after each operation.
+   identity but restore different unreachable files, a public-subpath-map-only
+   revision that propagates through a follower and can be reverted, and a
+   nested pinned fabric dependency restored after incidental source roots
+   disappear. Tests must prove the current source, active origin, revision
+   head, authored-program manifest, recursively retained dependency graph, and
+   revision log after each operation.
 
 ## Relationship to pattern imports
 
 Pattern imports and piece origins intentionally have different update rules.
 An unpinned mutable `cf:` import is resolved and written back with an immutable
-pin when source is deployed. This includes type-only imports because Common
-Fabric uses imported types to generate runtime schemas. Supported ESM-style
-type imports follow this rule. Unsupported import-equals syntax is rejected
-rather than left mutable. The deployed importer does not track later changes.
+pin when source is deployed. An entry import pins the target piece's entry
+module identity. An explicitly published subpath resolves through the current
+authored-program manifest and pins the selected module identity. This includes
+type-only imports because Common Fabric uses imported types to generate runtime
+schemas. Supported ESM-style type imports follow this rule. Unsupported
+import-equals syntax is rejected rather than left mutable. The deployed
+importer does not track later changes to the piece or its public-subpath map.
 The same fabric URL used as piece-origin metadata stays live when it is unpinned
 and resolves to a mutable
 `patternIdentity`-bearing entity. The piece can then follow that entity's

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -145,16 +145,19 @@ pieces; it does not generate pattern source.
 
 ## Core invariants
 
-1. `patternIdentity` and its export symbol identify the exact source a piece
-   runs. Loading code never depends on an origin still being reachable.
+1. `patternIdentity` and its export symbol identify the exact executable export
+   a piece runs. The current revision retains the complete authored program,
+   including files outside that export's reachable import graph. Loading code
+   never depends on an origin still being reachable.
 2. At most one source URL is active at a time. It resolves as an external web
    endpoint, a mutable fabric `patternIdentity`-bearing entity, or an immutable
    fabric pattern.
-3. Every successful transition records the new exact source, the active origin
-   after the transition, and the reason for the transition in an append-only
-   revision log. Each revision is a storage-retention root for its verified
-   source closure in the piece's space. Revert never depends on an origin or an
-   incidental compile-cache entry still existing.
+3. Every successful transition records the new exact authored program, the
+   active origin after the transition, and the reason for the transition in an
+   append-only revision log. Each revision is a storage-retention root for its
+   immutable authored-program manifest, verified source documents, and pinned
+   fabric dependency closures in the piece's space. Revert never depends on an
+   origin or an incidental compile-cache entry still existing.
 4. Every accepted state gets a fresh, stable revision identifier. Updating the
    current source, the active origin, and the revision log is one atomic
    operation. The transaction compares the expected revision head, current
@@ -163,9 +166,9 @@ pieces; it does not generate pattern source.
    states happen to use the same pattern identity.
 5. A direct source replacement detaches the piece unless the operation is an
    automatic refresh from its active origin or an explicit repoint.
-6. Reverting selects exact historical code and detaches. Repointing selects a
-   historical origin and resolves its current code. These are separate user
-   actions.
+6. Reverting selects an exact retained historical authored program and detaches.
+   Repointing selects a historical origin and resolves its current program.
+   These are separate user actions.
 7. An unattended origin update that encounters a failed fetch, unreadable
    followed piece, invalid program, integrity failure, or structurally
    incompatible candidate leaves the current source and history unchanged. A
@@ -188,11 +191,12 @@ pieces; it does not generate pattern source.
     exposes the operations and state the space runtime requires. An arbitrary
     piece cannot become a root merely because it is a piece.
 12. Within a space, every cell and document that makes a pattern resolvable,
-    including its verified source closure, uses that space's ACL. The source
-    therefore has the same visibility as the pattern in that space. Anyone
-    authorized to resolve the pattern there may read its source. A fabric URL,
-    slug, or content identity does not grant access by itself. The same content
-    identity can have replicas in spaces with different ACLs.
+    including its authored-program manifests, revision history, and verified
+    source documents, uses that space's ACL. The source therefore has the same
+    visibility as the pattern in that space. Anyone authorized to resolve the
+    pattern there may read its source. A fabric URL, slug, or content identity
+    does not grant access by itself. The same content identity can have replicas
+    in spaces with different ACLs.
 13. Moving source between spaces is an information flow, not just a read. The
     operation propagates CFC provenance labels and fails closed before copying
     source when those labels do not permit the destination flow.
@@ -208,24 +212,73 @@ storage schema to use these exact TypeScript field names.
 | State | Meaning | Repository status |
 |---|---|---|
 | Current pattern | `{ identity, symbol }` for the exact executable export | Implemented as `patternIdentity` metadata on the piece result cell |
-| Verified source closure | The authored files addressed by the current identity | Implemented as `pattern:<identity>` source documents |
+| Verified identity closure | The authored implementation and declaration files that determine the current executable identity | **Implementation files stored**: `pattern:<identity>` source documents exist, but production filters authored `.d.ts` files before identity and persistence |
+| Retained authored program | An immutable version-1 manifest for the complete authored program accepted by the current revision, including unreachable files | **Program manifest required**: source documents can retain extra roots, but no piece revision binds the exact accepted file set |
+| Runtime fingerprint | The trusted runtime identity used to calculate the accepted executable pattern identity | **Authoritative provider required**: the optional module-hash input exists, but production compilation and source verification still use the empty default |
+| Runtime-neutral program digest | The version-1 digest of the canonical main filename and every authored file's runtime-neutral module identity | **Lifecycle comparison required**: the module hash can run with the empty fingerprint, but the complete program digest is not recorded |
 | Active origin | No origin, an external `https://` URL with an entry export, a stable mutable fabric-entity URL, or a content-addressed fabric pattern URL with an export symbol | Partial: `patternSource` stores a string for system roots, but general web and fabric URL origins are not supported end to end |
 | Revision head | The stable identifier of the latest accepted source and origin state | Revision head required |
-| Source revision log | Ordered records of every accepted source and origin state, with a durable reference to each verified source closure | Revision log required |
+| Source revision log | Ordered records of every accepted source and origin state, with a durable reference to each immutable authored-program manifest | Revision log required |
 | Descriptive repository | Optional locator shown by tooling; never followed | Implemented as `patternRepository` metadata |
+
+The runtime-neutral program digest is
+`cf/runtime-neutral-program-digest/v1` from
+[module-loading.md](module-loading.md). It covers the canonical main filename
+and every authored file, including unreachable siblings. It excludes mounted
+files, synthetic retention links, and the selected export. The digest is
+comparison metadata. It is not a fabric URL target, an executable pattern
+identity, or a revert target.
+
+Lifecycle ingestion first materializes a complete `Program` with a canonical
+`main` and an explicit `files` list. That list defines the authored program for
+history. Command-line directory input, LLM output, and a web program manifest
+must enumerate every intended file before import-closure resolution. A retained
+authored-program manifest provides the list for fork, follow, revert, and
+rebuild. A raw web entry point or another `ProgramResolver` that cannot enumerate
+files defines its authored program as only the reachable closure it returns. It
+cannot later report an unenumerated sibling as a source update. Duplicate
+canonical filenames are rejected. Declaration stubs injected by the runtime for
+type checking are not authored files and do not enter this list.
+
+The current `ProgramResolver` interface exposes only `main()` and
+`resolveSource()`, and `resolveProgram()` returns only the reachable import
+closure. Complete-program enumeration for directory, generated, indexed web,
+and retained-manifest sources is required integration work.
+
+Each revision's source-retention reference names an immutable
+`cf/authored-program-manifest/v1` value. The manifest contains the canonical
+main filename and a UTF-8 filename-sorted list of every authored file with its
+verified source-document identity. It directly retains those source documents
+and the complete transitive graph of content-addressed fabric dependencies
+pinned by the program. Recursive retention deduplicates dependency identities
+and parses pinned fabric specifiers because source documents intentionally omit
+fabric links. Its file list must reproduce the revision's runtime-neutral
+program digest. It does not rely on the entry source document's synthetic root
+links. Those links are non-normative and can be rewritten when another program
+uses the same entry identity.
+
+The revision embeds this value or points to a content-addressed copy. It never
+points through a mutable piece, slug, origin, or entry-document retention list.
 
 A revision record contains at least:
 
 - a stable revision identifier and the preceding revision identifier, if any;
 - the pattern identity and export symbol accepted by the piece;
-- a durable retention reference for the verified source closure;
+- the runtime fingerprint used for that identity and the runtime-neutral program
+  digest;
+- a durable reference to the immutable authored-program manifest;
 - the compatibility descriptors needed to validate a later replacement;
 - the active origin after that transition, if any;
+- the origin revision accepted from a followed piece, when applicable;
 - the user-supplied source URL and routing hint when normalization changed it;
-- the transition kind, such as local create, web URL create, fabric pattern
-  create, follow, automatic update, direct edit, fork, revert, or repoint; and
+- the operation, such as local create, web URL create, fabric pattern create,
+  follow, automatic update, direct edit, fork, revert, or repoint;
+- the cause, such as baseline, authored-source change, origin update, origin
+  runtime rebuild, runtime rebuild, historical-source restore, or origin-only
+  change; and
 - the selected revision for a revert or repoint, or the stable source-piece
-  reference for a fork, when applicable.
+  reference for a fork, or the preceding revision selected by detach and
+  rebuild, when applicable.
 
 The initial creation is the first revision. Keeping creation in the same log
 lets a fork record `forkedFrom` without making the original piece an active
@@ -234,9 +287,53 @@ belongs to the other piece and may contain references the new owner cannot
 read. `forkedFrom` records derivation only. It is not offered as a repoint
 target unless this piece also followed that origin in another revision.
 
-The current pattern and active origin remain directly readable metadata. The
-revision head names a latest revision that mirrors them. They are written
-together so the log cannot claim a transition that the piece did not adopt.
+Fork, follow, revert, and source replication read the selected revision's
+immutable authored-program manifest. They do not reconstruct a program by
+walking the entry source document's current synthetic retention links.
+
+The current pattern, retained-program reference and digest, accepted origin
+revision, and active origin remain directly readable metadata. The revision head
+names a latest revision that mirrors them. They are written together so the log
+cannot claim a transition that the piece did not adopt.
+
+A runtime fingerprint change that produces a new executable pattern identity is
+an accepted source revision even when the authored source is unchanged. For an
+ordinary transition, the cause is a runtime rebuild only when all of these
+comparisons with the preceding revision hold: the executable identity changed,
+the accepted runtime fingerprint changed, and the runtime-neutral program
+digest, selected export, and active origin remained equal. A revert performs the
+same source and fingerprint comparisons against its selected historical
+revision. It intentionally clears that revision's former origin. The operation
+records how the transition was requested, while the cause records why the
+executable identity differs from its comparison revision. A manual detached
+rebuild performs the same comparison against the preceding revision and
+intentionally clears its origin. A runtime rebuild does not otherwise detach or
+repoint the piece.
+
+A piece may have downstream followers regardless of its own origin state. A
+detached piece may publish a runtime rebuild through its owner or a deployment
+migration service with write authority for its space. A web-origin piece may
+publish only the result of resolving and compiling its active web origin. A
+mutable fabric follower may publish only a revision it adopted from its upstream
+origin. An immutable fabric-origin piece cannot publish a different identity
+while retaining that origin.
+
+Every accepted revision becomes the piece's advertised source revision for its
+downstream followers. A middle piece in a follow chain first adopts its upstream
+revision and then advertises that accepted local revision downstream. It never
+recompiles the upstream source locally while continuing to claim that origin.
+Its revision records the automatic-update operation and the
+origin-runtime-rebuild cause. A follower that cannot execute the upstream
+fingerprint stays on its last accepted revision and reports an origin
+incompatibility. Its owner may detach or fork before rebuilding locally.
+
+Observing a different runtime fingerprint does not authorize an arbitrary client
+to rewrite a piece. The deployment-selected value comes from the authoritative
+`getExecutableRuntimeFingerprint()` provider defined in
+[module-loading.md](module-loading.md). The empty value remains only a legacy
+source-document interpretation. Coordinating the selected non-empty value
+across clients and hosts remains part of the separate runtime-skew and
+host-reliability work.
 
 When lifecycle history is introduced, the first lifecycle-aware load or
 mutation of an existing piece creates a baseline revision from its current
@@ -244,6 +341,13 @@ pattern and recognized origin metadata. The runtime first verifies and retains
 the current source closure. If it cannot do so, it leaves the piece in its
 legacy state and reports that history migration is blocked. It does not invent
 a revision whose source cannot be restored.
+
+A baseline for an affected legacy identity records the canonical empty identity
+fingerprint. It does not relabel that identity with the current provider value.
+Any subsequent rebuild follows the piece's active-origin rule above and appends
+another revision. If the current runtime cannot execute the legacy fingerprint
+and no authorized transition is available, the piece remains unchanged and the
+UI reports that runtime migration is blocked.
 
 This migration treats an existing space root exactly like any other legacy
 piece. A raw `patternSource` is migration provenance, but it does not alone
@@ -275,13 +379,14 @@ and link that new piece as the space root.
 | Create from a source URL with the command line | The program resolved from the `https://` URL or identifier-only fabric `cf:` URL, including `cf://` | The normalized URL and any required export selector | Append a web URL create, follow, or fabric pattern create revision according to what the URL resolves to |
 | Create from a known source URL in the UI | The program resolved from the `https://` URL or identifier-only fabric `cf:` URL, including `cf://`; an outer authoring layer resolves any alias first | The normalized URL and any required export selector | Append a web URL create, follow, or fabric pattern create revision according to what the URL resolves to |
 | Create the root for a new space | The program resolved from the system-selected default source | Whatever origin the ordinary source-creation rules derive from that source | Append the same creation revision that the equivalent user-created piece would receive |
-| Refresh from an external web URL | The newly fetched program, if its identity or export symbol changed and it passed validation | The same `https://` URL and entry export | Append an automatic-update revision only when the identity or export symbol changes |
-| Load from a content-addressed URL or a pinned entity-FID URL | The exact program named by the identity or trailing pin | The normalized fabric pattern URL and export symbol | Do not append an automatic-update revision because the resolved identity cannot change |
+| Refresh from an external web URL | The newly fetched program, if its executable identity, export symbol, or complete-program digest changed and it passed validation | The same `https://` URL and entry export | Append an automatic-update revision when the executable export or retained authored program changes |
+| Load from a content-addressed URL or a pinned entity-FID URL | The exact executable source graph named by the identity or trailing pin; synthetic retention roots are excluded | The normalized fabric pattern URL and export symbol | Do not append an automatic-update revision because the resolved executable source graph cannot change |
 | Fork a piece | The source currently used by the selected piece | None | Append a fork revision with `forkedFrom`; do not copy the source piece's log |
 | Follow a piece through an unpinned fabric URL | The source currently used by the selected piece | A normalized fabric URL containing a stable reference to that piece | Append a follow revision |
-| Refresh from a mutable fabric entity | The entity's current source, if its identity or export symbol changed and it passed validation | The same stable fabric entity URL | Append an automatic-update revision only when the identity or export symbol changes |
+| Refresh from a mutable fabric entity | The entity's retained authored program, if its source revision changed and it passed validation | The same stable fabric entity URL | Append an automatic-update revision when the accepted origin revision changes, including when its executable identity is unchanged |
 | Directly edit or wish an existing piece to change | The newly authored or generated program, after the user explicitly accepts any structural compatibility warning | None | Append a direct-edit revision; the prior revision retains the former origin |
-| Revert | The exact source named by a selected earlier revision | None | Append a revert revision that names the selected revision |
+| Detach and rebuild current source | The current revision's retained authored program compiled under the current runtime | None | Append a direct-edit revision with `rebuiltFrom` naming the preceding revision |
+| Revert | The exact retained authored program named by a selected earlier revision | None | Append a revert revision that names the selected revision |
 | Repoint | The current source resolved from a selected earlier origin | The selected web or fabric URL | Append a repoint revision |
 
 Direct command-line source updates follow the same detach rule as LLM edits.
@@ -341,10 +446,20 @@ subscription rule if that feature is added. Under the tentative identifier-only
 policy, a shortlink or other human-readable alias resolves outside the
 lifecycle and supplies a fully qualified reference containing the space DID and
 stable entity. Reassigning that alias must not redirect existing followers to a
-different entity. Self-following is rejected. Follow creation walks the
-active-origin chain and rejects a cycle. If an origin in that chain cannot be
-read, creation fails closed rather than accepting a relationship whose cycle
-status is unknown.
+different entity. Self-following is rejected.
+
+Every operation that activates a mutable fabric origin walks the active-origin
+chain with a visited set. This includes follow creation, repoint, and legacy
+migration. Reconciliation repeats the check before accepting an upstream
+revision. An unreadable link or repeated stable entity fails closed.
+
+The guarded transition records the revision head and active origin of every
+piece read during the walk. Its commit verifies the complete read set along with
+the destination piece. Concurrent reciprocal follows therefore conflict instead
+of both committing from stale acyclic snapshots. The operation does not retry
+automatically. If the storage path cannot atomically validate every traversed
+guard, including across hosts, mutable-origin activation remains unavailable on
+that path. This limitation belongs to the open cross-host reliability work.
 
 For an accepted fabric URL that directly names content-addressed pattern
 source, or that contains a trailing pin on an entity FID, the stored reference
@@ -394,12 +509,12 @@ general origin implementation must enforce these rules before it is enabled:
 - Creating or repointing an `https://` origin or a mutable fabric-entity origin
   requires explicit consent to future automatic code changes from that
   endpoint or entity. HTTPS authenticates a web endpoint in transit, while the
-  accepted content identity records the exact bytes. If an origin names an
-  expected publisher identity, each update must also carry a valid signature
-  from that publisher.
+  accepted content identity records the exact executable source graph. If an
+  origin names an expected publisher identity, each update must also carry a
+  valid signature from that publisher.
 - A content-addressed or explicitly pinned fabric origin is a one-time trust
-  decision about exact bytes. It does not grant any publisher, piece, slug, or
-  host permission to replace those bytes later.
+  decision about an exact executable source graph. It does not grant any
+  publisher, piece, slug, or host permission to replace that graph later.
 
 Without a publisher signature, a web URL update is trusted because the user
 granted the HTTPS endpoint permission to change the piece's code. Content
@@ -447,31 +562,39 @@ an affected live session remain open design work.
 Loading a piece with an active origin performs these steps before starting its
 pattern:
 
-1. Read the current `patternIdentity`, active source URL, and stable revision
-   head.
+1. Read the current `patternIdentity`, retained-program digest, active source
+   URL, accepted origin revision, and stable revision head.
 2. Resolve the origin.
    - For an external web URL, apply the network URL policy, fetch the complete
      authored module closure, compute its content identity, and select the
      stored entry export.
    - For an unpinned fabric URL that names a mutable entity, read that entity's
-     current `patternIdentity` and make its verified source closure available
-     in the following piece's space.
+     current source revision, `patternIdentity`, runtime-neutral program digest,
+     and immutable authored-program manifest. Make the manifest and its verified
+     source available in the following piece's space.
    - For a fabric origin normalized from a direct content identity or an
      accepted entity-FID URL with a pin, load and verify that exact source
      closure and select the stored export symbol.
    - Before any cross-space copy, enforce the source's CFC provenance labels
      for the destination and fail closed when the flow is not permitted.
-3. If the resolved identity and symbol equal the current values, start the
-   current pattern without writing a revision.
-4. Compile and verify a changed candidate. Compare its argument and result
-   schemas and retained inputs with the accepted source. Automatic
+3. If the resolved identity, symbol, complete-program digest, and origin revision
+   equal the values accepted by the current revision, start the current pattern
+   without writing a revision. A changed retained program or origin revision is
+   a source transition even when the executable identity is unchanged.
+4. Compile fetched authored source under the authoritative current runtime
+   fingerprint. For a fabric identity published elsewhere, verify every source
+   document under its recorded effective fingerprint and check runtime
+   compatibility without re-identifying it. Compare the candidate's argument
+   and result schemas and retained inputs with the accepted source. Automatic
    reconciliation accepts only a backward-compatible candidate.
-5. Write the verified candidate closure as a durable retention root in the
-   target space and wait for that write to succeed. A failed write fails the
-   transition. It is not converted into a background warning.
+5. Write an immutable authored-program manifest for the verified candidate in
+   the target space. Retain its exact source documents and pinned fabric
+   dependency closures, and wait for every write to succeed. A failed write
+   fails the transition. It is not converted into a background warning.
 6. In one transaction, compare the expected revision head, current pattern,
    and active origin. If all remain current, append the revision, retain the
-   active origin, replace `patternIdentity`, and advance the revision head.
+   active origin and accepted origin revision, set `patternIdentity` to the
+   candidate value even when it is unchanged, and advance the revision head.
 7. Start the accepted pattern on the existing piece result cell.
 
 If reconciliation fails and the current source remains loadable, the runtime
@@ -497,11 +620,12 @@ or skip checks when prior source is unavailable.
 
 Load-time reconciliation recovers updates missed while a following piece was
 stopped. While it is running, the runtime also subscribes when its unpinned
-fabric URL resolves to a stable mutable entity. It observes that entity's
-current `patternIdentity`. A content-addressed or explicitly pinned fabric URL
-has no subscription because its target cannot change. Each notification enters
-the same guarded transition described above. There is no separate unguarded
-update path.
+fabric URL resolves to a stable mutable entity. It observes that entity's source
+revision head rather than only its `patternIdentity`. This propagates an update
+to an unreachable authored file even when the executable identity is unchanged.
+A content-addressed or explicitly pinned fabric URL has no subscription because
+its target cannot change. Each notification enters the same guarded transition
+described above. There is no separate unguarded update path.
 
 The subscription ends when the following piece stops, detaches, or repoints.
 Authorization loss, a prohibited cross-space information flow, unavailable
@@ -515,17 +639,42 @@ or the next load performs reconciliation from the origin's current state.
 
 Revert and repoint answer different questions:
 
-- **Revert** asks, "Run these exact bytes again." It uses an immutable pattern
-  identity from the revision log. It does not contact the revision's former
-  origin and does not resume updates.
+- **Revert** asks, "Restore this retained authored program and its exact pins."
+  It uses the immutable authored-program manifest, selected export, and pinned
+  dependency identities from the revision log. It does not contact the
+  revision's former origin and does not resume updates.
 - **Repoint** asks, "Follow this place again." It selects a source URL from
   history, restores its normalized web or fabric form, resolves that origin
   now, and adopts its current source.
 
+When the current runtime is equal to or explicitly compatible with the
+revision's recorded fingerprint, revert may reuse the historical executable
+identity. Otherwise it restores the same authored program and pins, compiles
+them under the authoritative current fingerprint, and produces a new executable
+identity. Both outcomes append a detached revision with the revert operation and
+a `revertedFrom` reference. The rebuilt outcome also records a runtime-rebuild
+cause. It does not alter the historical revision or claim that the old and new
+executable identities are equal. If the retained source cannot compile under the
+current runtime, the revert fails without changing the piece.
+
+Fingerprint equality is compatible by default. A runtime may execute another
+recorded fingerprint only through an explicit, versioned compatibility
+declaration. Successful compilation alone does not establish compatibility.
+
+A manual **detach and rebuild** uses the current revision's immutable authored
+program manifest. It compiles that program under the authoritative current
+fingerprint, clears the active origin, and appends a direct-edit revision with a
+`rebuiltFrom` reference to the preceding revision. It is not a revert because it
+does not select earlier code. This operation also works for a piece that has only
+its creation revision.
+
 Repointing a content-addressed or explicitly pinned fabric URL adopts the same
-exact source again because that URL is immutable. Repointing an unpinned
-mutable fabric entity URL resumes following that entity's current pattern.
-Repointing an external web URL fetches its current response.
+exact executable identity again because that URL is immutable. It fails if the
+current runtime cannot execute the identity's recorded fingerprint. A user who
+wants its current retained authored program rebuilt locally uses detach and
+rebuild. A user who wants an earlier retained program uses revert. Repointing an
+unpinned mutable fabric entity URL resumes following that entity's current
+pattern. Repointing an external web URL fetches its current response.
 
 This distinction avoids a surprising state in which a user reverts to repair a
 regression and the next load immediately reapplies the origin's broken source.
@@ -540,14 +689,16 @@ Choosing a mutable active origin is an ongoing trust decision. A later program
 from that web endpoint or mutable fabric entity runs with the following piece's
 authority after it passes verification and compatibility checks. A
 content-addressed or explicitly pinned fabric origin cannot change. The content
-identity proves which bytes were accepted and detects corrupted transfer. It
-does not prove that a publisher, piece owner, or URL owner made a safe change.
+identity proves which executable source graph was accepted and detects corrupted
+transfer. It does not prove that a publisher, piece owner, or URL owner made a
+safe change.
 
 Within a space, every cell and document that makes a pattern resolvable,
-including its verified source closure, is protected by that space's ACL. The
-source therefore has the same visibility as the pattern in that space. There
-is no separate source-publication permission. Naming a pattern with a slug or
-revealing its URL or content identity does not broaden the space's ACL.
+including its authored-program manifests, source revision history, and verified
+source documents, is protected by that space's ACL. The source therefore has the
+same visibility as the pattern in that space. There is no separate source
+publication permission. Naming a pattern with a slug or revealing its URL or
+content identity does not broaden the space's ACL.
 
 Forking or following across spaces also moves authored source into the target
 space. Read authorization alone does not authorize that information flow. CFC
@@ -565,8 +716,14 @@ The UI must distinguish detached pieces, immutable fabric-origin pieces, and
 pieces that update automatically. It shows the active source URL and whether
 that URL resolved to a web endpoint, mutable fabric entity, or exact fabric
 pattern. It also shows when a trailing pin made an entity-FID input immutable.
-It offers detach and revert actions near mutable-origin controls. The revision
-log provides an exact rollback target after a bad but valid update.
+It identifies runtime rebuild revisions separately from authored-source changes.
+It offers detach and revert actions near mutable-origin controls. A revert
+preview says whether the runtime can reuse the historical executable identity or
+must rebuild the retained authored source under the current fingerprint. The
+revision log provides an authored-source rollback target after a bad but valid
+update even when its historical runtime is no longer executable. If the current
+immutable origin is incompatible, the UI offers detach and rebuild without
+mislabeling the current creation revision as a revert target.
 
 ## Current implementation
 
@@ -578,13 +735,15 @@ log provides an exact rollback target after a bad but valid update.
 | Use a UI affordance to push a known source URL into an owned space | **Partial** | `fetchProgram` with `compileAndRun`, the omnibox's `fetchAndRunPattern`, and `RuntimeClient.createPage(URL)` can fetch and run indexed web programs. The resulting piece does not receive a general active source URL or a source revision. There is no corresponding fabric URL affordance. |
 | Load or create from an immutable fabric URL | **Immutable URL flow required** | The source cache and fabric resolver can load verified `cf:pattern:<identity>` source and honor a trailing pin on an entity-FID reference. No product operation normalizes that URL and export symbol into immutable piece origin metadata or appends the required revision. |
 | Automatically refresh a mutable URL-origin piece when loaded | **Partial** | The shell reconciles system roots before bootstrap and checks other successfully instantiated same-toolshed system-source patterns in the background. The specialized updater changes `patternIdentity` without the complete pre-apply structural comparison. A running pattern's setup can refuse an incompatible argument shape and keep the old graph, but the metadata pointer has already changed. External web URLs and mutable fabric entity URLs do not use this path. A content-addressed or explicitly pinned fabric URL intentionally has nothing to refresh. |
+| Retain authored declaration files | **Declaration identity work required** | `computeModuleHashes` follows type-import edges, but production engine paths remove authored `.d.ts` files before module identity calculation, source-document construction, and cache persistence. Declaration-only changes can therefore reuse stale executable identities and compiled bytes. |
+| Record and propagate a runtime rebuild | **Provider and lifecycle required** | `computeModuleHashes` accepts `runtimeFingerprint`, and its unit test proves that changing the fingerprint changes a module with an external dependency. Production pattern compilation and source verification use the empty default. There is no authoritative executable-fingerprint provider. Source documents do not retain a non-empty identity fingerprint, and pieces have no revision log, runtime-neutral program digest, runtime-rebuild cause, owner-published propagation contract, or cross-runtime revert handling. |
 | Manage a space root through the ordinary piece lifecycle | **Lifecycle unification required** | A root is already a piece and the specialized updater can replace its pattern in place. Creation still stamps a raw `patternSource`, reconciliation bypasses revision history, and update authority is not durable per piece. Root updates still use a separate controller path. The creation template currently lives on the mutable home root, relative source paths are not ordinary origins, and root linking does not validate a root interface. New-root creation, legacy-root migration, and later transitions do not yet use the ordinary lifecycle path. |
 | Fork an existing piece and detach it | **Fork operation required** | Tooling can recover a piece's verified source closure, and the runtime can create another piece from a program. There is no fork operation or UI, no `forkedFrom` history, and no atomic detach contract. |
-| Follow another piece and receive its source updates | **Follow operation required** | `cf:` resolution can read another piece's current `patternIdentity`, content-addressed source can be replicated, and a running piece watches its own `patternIdentity` for in-place swaps. No operation stores an unpinned, normalized fabric entity URL as the active origin, reconciles it on load, subscribes to the origin while running, or exposes follow and unfollow UI. Cross-host routing also remains incomplete. |
+| Follow another piece and receive its source updates | **Follow operation required** | `cf:` resolution can read another piece's current `patternIdentity`, content-addressed source can be replicated, and a running piece watches its own `patternIdentity` for in-place swaps. No operation stores an unpinned, normalized fabric entity URL as the active origin, retains the accepted origin revision, reconciles it on load, subscribes to the origin's source revision while running, or exposes follow and unfollow UI. Cross-host routing also remains incomplete. |
 | Wish an existing piece to change and detach it | **LLM edit UI required** | `PieceController.setPattern` and `cf piece setsrc` reject incompatible pattern or retained-input schemas unless `dangerouslyAllowIncompatibleSchema` is supplied. The command line exposes that override, but it does not first present the target warning and confirmation flow. There is no LLM-backed edit affordance or revision log. Existing setup writes also preserve `patternSource` and `patternRepository` when replacements omit them, so the required detach behavior is not implemented. |
 | Revert to source previously used by the same piece | **Revert operation required** | Old immutable source documents may still exist by content identity, but the piece has no index of identities it previously used and no revert operation or UI. Cache retention is not a history contract. |
 | Repoint to a web URL, mutable fabric entity URL, or immutable fabric URL previously used | **Repoint operation required** | There is no origin history, general origin resolver at piece load, repoint operation, or UI. |
-| Record every previous source and origin | **History storage required** | `pieceLineageSchema` and `pieceSourceCellSchema` are declarations with no readers or writers. Current pieces retain only the current `patternIdentity`, optional `patternSource`, and optional `patternRepository`. |
+| Record every previous source and origin | **History and manifests required** | `pieceLineageSchema` and `pieceSourceCellSchema` are declarations with no readers or writers. Current pieces retain only the current `patternIdentity`, optional `patternSource`, and optional `patternRepository`. There is no immutable per-revision manifest that binds a complete authored file set. |
 
 The implementation evidence for this table is concentrated in:
 
@@ -651,20 +810,31 @@ The implementation evidence for this table is concentrated in:
 1. Define a discriminated origin schema for external web URLs, stable mutable
    fabric-entity URLs, and immutable fabric URLs created by a direct pattern
    identity or a pin on an entity FID. Add a source-state schema with a stable
-   revision head. Define immutable revision records, including durable source
-   retention and the compatibility descriptors needed without executing an old
-   pattern. Replace the unused lineage declarations or remove them rather than
-   treating dead declarations as a shipped feature.
+   revision head. Define immutable revision records and
+   `cf/authored-program-manifest/v1`. Each manifest binds the canonical main and
+   exact filename-to-source-identity set, including authored `.d.ts` files. It
+   retains every transitive pinned fabric dependency once. Add a complete
+   program enumeration path before import-closure resolution. Revisions also
+   record the accepted runtime fingerprint,
+   runtime-neutral program digest, separate operation and cause fields, and the
+   compatibility descriptors needed without executing an old pattern. Replace
+   the unused lineage declarations or remove them rather than treating dead
+   declarations as a shipped feature. Implement the authoritative version-1
+   executable runtime fingerprint and runtime-neutral program digest defined in
+   [module-loading.md](module-loading.md). Treat an unavailable production
+   fingerprint as an error rather than publishing under the legacy empty value.
 2. Provide one atomic source-transition API used by every caller. It must wait
    for failure-propagating closure persistence and compare the expected
-   revision head, current pattern, and active origin. Add baseline revision
-   migration for existing pieces, including roots whose legacy origin is a raw
-   `patternSource` string. Materialize a durable tracked-or-detached choice; do
-   not infer update authority from the string, rollout flags, or the root role.
-   When no durable active choice can be established, migrate detached. Resolve
-   a relative legacy path against the accepted toolshed host before storing an
-   absolute web origin. Preserve an unconfirmed locator only as inactive
-   historical provenance.
+   revision head, current pattern, and active origin. Mutable-origin activation
+   and reconciliation must guard every revision head and active origin traversed
+   during cycle detection. A path that cannot validate the complete read set
+   atomically fails closed. Add baseline revision migration for existing pieces,
+   including roots whose legacy origin is a raw `patternSource` string.
+   Materialize a durable tracked-or-detached choice; do not infer update
+   authority from the string, rollout flags, or the root role. When no durable
+   active choice can be established, migrate detached. Resolve a relative legacy
+   path against the accepted toolshed host before storing an absolute web origin.
+   Preserve an unconfirmed locator only as inactive historical provenance.
 3. Make local edits explicitly clear active origin metadata. Make source URL
    creation accept and normalize both `https://` and fabric `cf:` inputs,
    including `cf://`. Under the tentative identifier-only policy, produce a
@@ -687,12 +857,16 @@ The implementation evidence for this table is concentrated in:
    that repository.
 4. Add origin reconciliation to the ordinary piece start path. Add an
    event-driven subscription while an unpinned mutable fabric origin is
-   running. Do not subscribe for a content-addressed or explicitly pinned
-   fabric origin. Reuse content verification, schema compatibility, guarded
-   source transitions, and the existing in-place pattern watcher. Automatic
-   transitions must reject a known structural incompatibility and preserve the
-   last accepted lifecycle state. Use this same path for space roots and retire
-   the specialized root reconciler after migration. Move the current home-root
+   running. Observe its source revision rather than only its executable
+   identity, so source-only changes propagate. Do not subscribe for a
+   content-addressed or explicitly pinned fabric origin. Reuse content
+   verification, schema compatibility, guarded source transitions, and the
+   existing in-place pattern watcher. Treat a new runtime fingerprint as a new
+   executable identity even when the runtime-neutral program digest is
+   unchanged. Automatic transitions must reject a known structural
+   incompatibility and preserve the last accepted lifecycle state. Use this same
+   path for space roots and retire the specialized root reconciler after
+   migration. Move the current home-root
    `defaultAppUrl` into durable space-creation configuration outside any root
    piece. Space creation must
    resolve that configured default through the ordinary create transition and
@@ -703,15 +877,18 @@ The implementation evidence for this table is concentrated in:
    content verification, pin handling, durable routing, and provenance checks
    to fabric origins. Store the required export selector and keep credentials
    in separately protected capabilities.
-6. Add command-line URL creation and explicit detach, follow, revert, and
-   repoint operations. Add matching UI affordances, including the LLM-backed
-   create and edit flows. Before a manual source replacement, show structural
-   compatibility findings and require explicit confirmation or a command-line
-   flag to continue. An accepted incompatible replacement must detach. Root
-   role validation remains mandatory after an override.
+6. Add command-line URL creation and explicit detach, detach-and-rebuild,
+   follow, revert, and repoint operations. Add matching UI affordances,
+   including the LLM-backed create and edit flows. Before a manual source
+   replacement, show structural compatibility findings and require explicit
+   confirmation or a command-line flag to continue. An accepted incompatible
+   replacement must detach. Root role validation remains mandatory after an
+   override.
 7. Expose revision history and origin-check failures through runtime-client
-   protocol types and shell views. Do not infer history from source-cache
-   contents.
+   protocol types and shell views. Distinguish runtime rebuilds from authored
+   source changes. Show whether revert can reuse the historical executable
+   identity or must rebuild the exact retained authored program and pins under
+   the current runtime. Do not infer history from source-cache contents.
 8. Enforce CFC provenance on every cross-space source flow, including spaces
    on the same toolshed. Preserve ordinary read authorization and verify every
    replicated source closure by content identity. Connect host-qualified origin
@@ -725,7 +902,8 @@ The implementation evidence for this table is concentrated in:
    prove. Extend the current synthetic system-root replays with general
    version-to-version fixtures. Test each transition, concurrent source and
    origin races, failed and incompatible updates, baseline migration,
-   self-follow and follow cycles,
+   self-follow, repoint and migration cycles, concurrent reciprocal follows
+   where at most one transition commits,
    subscription cancellation, authorization loss, source unavailability,
    cross-space authorization and provenance, web and fabric URL policy,
    mutable versus content-addressed fabric targets, explicit pins, durable host
@@ -733,9 +911,17 @@ The implementation evidence for this table is concentrated in:
    route conflicts after a target opens, space-root creation from a default,
    changes to a default after root creation, tracked and detached root baseline
    migration, source-less legacy roots, relative-path normalization,
-   root-interface rejection, and reload behavior.
-   Tests must prove the current source, active origin, revision head, retained
-   closure, and revision log after each operation.
+   root-interface rejection, runtime-fingerprint rebuilds, authorized upstream
+   rebuild propagation, follower propagation of an enumerated unreachable-file
+   edit with an unchanged executable identity, an authored `.d.ts` edit that
+   changes importer identity and compiled bytes, blocked incompatible
+   immutable-origin repoint, cross-runtime revert under a new executable
+   identity, detach-and-rebuild recovery from an incompatible first
+   immutable-origin revision, two source-only revisions that share an entry
+   identity but restore different unreachable files, and a nested pinned fabric
+   dependency restored after incidental source roots disappear. Tests must prove
+   the current source, active origin, revision head, authored-program manifest,
+   recursively retained dependency graph, and revision log after each operation.
 
 ## Relationship to pattern imports
 

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -8,15 +8,19 @@ This is the design of record for source origins and source history on pieces.
 [`pattern-imports/README.md`](pattern-imports/README.md) remains the design of
 record for static imports inside pattern source.
 [`pattern-imports/pattern-updates.md`](pattern-imports/pattern-updates.md)
-describes the narrower system-root update mechanism that exists today.
+describes the narrower same-toolshed system-source update mechanism that exists
+today and must be migrated into this lifecycle.
 
 ## Status
 
 The content-addressed source and in-place pattern replacement foundations are
 implemented. Local command-line creation is implemented end to end. Automatic
-updates exist only for system space roots. The general origin, history,
-forking, following, reverting, and repointing model in this document requires
-work unless the implementation table says otherwise.
+updates exist only through a specialized path for same-toolshed system sources.
+That path reconciles roots before bootstrap and checks other successfully
+instantiated patterns in the background. It is not the target model: a space
+root is an ordinary piece under this entire lifecycle. The general origin,
+history, forking, following, reverting, and repointing model in this document
+requires work unless the implementation table says otherwise.
 
 Status labels in this document have exact meanings:
 
@@ -43,6 +47,18 @@ module closure under a content-derived identity.
 A **piece** is a stateful instance that runs one exported pattern. Its
 `patternIdentity` metadata contains the identity and export symbol of the exact
 pattern it currently runs.
+
+A **space root** is an ordinary piece selected by the space's `defaultPattern`
+link. When a space is created, the system chooses the new root piece's initial
+source from the configured default. After creation, the root has the same
+source lifecycle as every other piece. The configured default is not a durable
+controller for existing roots.
+
+A **space-creation template** is configuration that the system consults when
+choosing that initial source. It is not stored as lifecycle state on any root
+piece. The current `defaultAppUrl` field lives on the home root; moving that
+value into configuration independent of a mutable root is required before root
+lifecycle unification is complete.
 
 An **origin** is an optional source URL that a piece remembers durably. URL in
 this document includes both web URLs and fabric-internal URLs:
@@ -127,16 +143,25 @@ pieces; it does not generate pattern source.
    piece does not make imports in that piece or in another pattern live.
 9. Creation and every later transition use ordinary authorization for the
    target piece's space. Following grants no write access to the origin piece.
-10. Within a space, every cell and document that makes a pattern resolvable,
+10. A space root follows every ordinary piece lifecycle rule. The system selects
+    its initial source only when creating the space. A mutable default becomes
+    an active origin only through the ordinary explicit-consent rule. A later
+    change to the configured default does not update or repoint an existing
+    root.
+11. The root role has an interface contract even though it has no special source
+    lifecycle. Creating or relinking `defaultPattern` validates that the piece
+    exposes the operations and state the space runtime requires. An arbitrary
+    piece cannot become a root merely because it is a piece.
+12. Within a space, every cell and document that makes a pattern resolvable,
     including its verified source closure, uses that space's ACL. The source
     therefore has the same visibility as the pattern in that space. Anyone
     authorized to resolve the pattern there may read its source. A fabric URL,
     slug, or content identity does not grant access by itself. The same content
     identity can have replicas in spaces with different ACLs.
-11. Moving source between spaces is an information flow, not just a read. The
+13. Moving source between spaces is an information flow, not just a read. The
     operation propagates CFC provenance labels and fails closed before copying
     source when those labels do not permit the destination flow.
-12. A content-addressed or explicitly pinned fabric URL never reports an
+14. A content-addressed or explicitly pinned fabric URL never reports an
     update. Reconciliation verifies and loads the named source, but the URL
     cannot resolve to a different pattern identity later.
 
@@ -185,6 +210,27 @@ the current source closure. If it cannot do so, it leaves the piece in its
 legacy state and reports that history migration is blocked. It does not invent
 a revision whose source cannot be restored.
 
+This migration treats an existing space root exactly like any other legacy
+piece. A raw `patternSource` is migration provenance, but it does not alone
+prove that the piece granted its source permission to supply future code. The
+current implementation stamps that field independently from the flags that
+enable updates. Migration creates an active origin only when a durable tracking
+choice can be established under the ordinary consent rule. Otherwise it records
+the locator as inactive historical provenance and creates a detached baseline.
+
+A legacy relative toolshed path is not retained as a root-only origin kind.
+Migration resolves it against the accepted toolshed host for the root's space
+and persists the resulting absolute web URL. A later host remapping does not
+silently change that origin; changing it requires an ordinary repoint. If the
+host cannot be established, migration does not invent an active origin.
+
+A source-less legacy home root does not gain an origin merely because it is the
+home root. Its specialized updater currently derives `home.tsx`, while a
+source-less non-home root remains pinned. Migration preserves both as detached
+unless a durable tracking choice explicitly supplies and authorizes an origin.
+New spaces create their root through the ordinary source-creation transition
+and link that new piece as the space root.
+
 ## Source transitions
 
 | Interaction | Exact source after the interaction | Active origin after the interaction | History effect |
@@ -193,6 +239,7 @@ a revision whose source cannot be restored.
 | Create from LLM-generated code | The generated program | None | Append a generated-create revision |
 | Create from a source URL with the command line | The program resolved from the `https://` or fabric `cf:` URL, including `cf://` | The normalized URL and any required export selector | Append a web URL create, follow, or fabric pattern create revision according to what the URL resolves to |
 | Create from a known source URL in the UI | The program resolved from the `https://` or fabric `cf:` URL, including `cf://` | The normalized URL and any required export selector | Append a web URL create, follow, or fabric pattern create revision according to what the URL resolves to |
+| Create the root for a new space | The program resolved from the system-selected default source | Whatever origin the ordinary source-creation rules derive from that source | Append the same creation revision that the equivalent user-created piece would receive |
 | Refresh from an external web URL | The newly fetched program, if its identity or export symbol changed and it passed validation | The same `https://` URL and entry export | Append an automatic-update revision only when the identity or export symbol changes |
 | Load from a content-addressed or explicitly pinned fabric URL | The exact program named by the identity or trailing pin | The normalized fabric pattern URL and export symbol | Do not append an automatic-update revision because the resolved identity cannot change |
 | Fork a piece | The source currently used by the selected piece | None | Append a fork revision with `forkedFrom`; do not copy the source piece's log |
@@ -205,6 +252,12 @@ a revision whose source cannot be restored.
 Direct command-line source updates follow the same detach rule as LLM edits.
 Otherwise a later load could silently replace a user's edit with a refresh
 from an origin they no longer intended to follow.
+
+After space creation, the root can detach, follow, update, fork, revert, or
+repoint through the same operations as any other piece. Changing the system's
+default source affects only roots created afterward. Changing an existing
+space's root is an explicit piece lifecycle operation or an explicit relink to
+another ordinary piece that passes the root-interface compatibility check.
 
 For an unpinned fabric URL that resolves to a mutable entity, the stored
 reference names the stable entity, not a slug. A piece is the product case in
@@ -319,11 +372,12 @@ implementation. A legacy piece that has neither a loadable prior source nor
 persisted compatibility descriptors cannot update automatically. The user
 must explicitly choose a detached force update or fork instead.
 
-This order generalizes the system-root repair path that already reconciles a
-persisted root before bootstrap. The system-root updater has a narrower repair
-contract and can replace an obsolete root before loading it. The general path
-does not silently skip state-compatibility checks when prior source is
-unavailable.
+The specialized system-root updater already demonstrates reconciliation before
+bootstrap. It is a transitional implementation. Once this lifecycle is
+available, roots use the same sequence above as every other piece. Retained
+compatibility descriptors let that sequence replace an obsolete implementation
+without executing it first. A root does not receive a narrower repair contract
+or skip checks when prior source is unavailable.
 
 ## Following while a piece is running
 
@@ -409,7 +463,8 @@ log provides an exact rollback target after a bad but valid update.
 | Manually push code from a source URL and create a piece that remembers it | **CLI URL flow required** | The command-line `new` and `setsrc` commands accept local filesystem entries. `RuntimeClient.createPage(URL)` and `HttpProgramResolver` can fetch `http:` and `https:` source. Fabric resolution can resolve content-addressed patterns and same-toolshed piece references to a source identity, but its result does not carry the export symbol as origin state. Neither path gives the command line a general `https://` or `cf://` source-origin operation. `--repository` is descriptive metadata and is not an origin. |
 | Use a UI affordance to push a known source URL into an owned space | **Partial** | `fetchProgram` with `compileAndRun`, the omnibox's `fetchAndRunPattern`, and `RuntimeClient.createPage(URL)` can fetch and run indexed web programs. The resulting piece does not receive a general active source URL or a source revision. There is no corresponding fabric URL affordance. |
 | Load or create from an immutable fabric URL | **Immutable URL flow required** | The source cache and fabric resolver can load verified `cf:pattern:<identity>` source and honor a trailing pin, but no product operation normalizes that URL and export symbol into immutable piece origin metadata or appends the required revision. |
-| Automatically refresh a mutable URL-origin piece when loaded | **Partial** | The shell enables pre-start URL reconciliation for non-home system roots. Home-root updates remain behind `systemPatternAutoUpdateHome`. Ordinary pieces, external web URLs, and mutable fabric entity URLs do not use this path. A content-addressed or explicitly pinned fabric URL intentionally has nothing to refresh. |
+| Automatically refresh a mutable URL-origin piece when loaded | **Partial** | The shell reconciles system roots before bootstrap and checks other successfully instantiated same-toolshed system-source patterns in the background. External web URLs and mutable fabric entity URLs do not use this path. A content-addressed or explicitly pinned fabric URL intentionally has nothing to refresh. |
+| Manage a space root through the ordinary piece lifecycle | **Lifecycle unification required** | A root is already a piece and the specialized updater can replace its pattern in place. Creation still stamps a raw `patternSource`, reconciliation bypasses revision history, and update authority is not durable per piece. Root updates still use a separate controller path. The creation template currently lives on the mutable home root, relative source paths are not ordinary origins, and root linking does not validate a root interface. New-root creation, legacy-root migration, and later transitions do not yet use the ordinary lifecycle path. |
 | Fork an existing piece and detach it | **Fork operation required** | Tooling can recover a piece's verified source closure, and the runtime can create another piece from a program. There is no fork operation or UI, no `forkedFrom` history, and no atomic detach contract. |
 | Follow another piece and receive its source updates | **Follow operation required** | `cf:` resolution can read another piece's current `patternIdentity`, content-addressed source can be replicated, and a running piece watches its own `patternIdentity` for in-place swaps. No operation stores an unpinned, normalized fabric entity URL as the active origin, reconciles it on load, subscribes to the origin while running, or exposes follow and unfollow UI. Cross-host routing also remains incomplete. |
 | Wish an existing piece to change and detach it | **LLM edit UI required** | `PieceController.setPattern` and `cf piece setsrc` replace a pattern in place with schema checks. There is no LLM-backed edit affordance or revision log. Existing setup writes also preserve `patternSource` and `patternRepository` when replacements omit them, so the required detach behavior is not implemented. |
@@ -461,8 +516,11 @@ The implementation evidence for this table is concentrated in:
   references, explicit pins, and same-toolshed mutable references by stable
   entity or slug. Static imports pin mutable references into source.
 - System space roots carry a `patternSource` URL path when created through
-  `ensureDefaultPattern`. Non-home roots can check that source and replace
-  `patternIdentity` before starting.
+  `ensureDefaultPattern`. Roots can check that source and replace
+  `patternIdentity` before starting. Other successfully instantiated
+  same-toolshed system-source patterns are checked in the background. This is a
+  transitional implementation and migration input, not a target lifecycle
+  exception.
 - Tooling exposes the immutable source ref, optional repository locator,
   authored entry path, and optional current `patternSource` origin separately.
 
@@ -478,7 +536,13 @@ The implementation evidence for this table is concentrated in:
 2. Provide one atomic source-transition API used by every caller. It must wait
    for failure-propagating closure persistence and compare the expected
    revision head, current pattern, and active origin. Add baseline revision
-   migration for existing pieces.
+   migration for existing pieces, including roots whose legacy origin is a raw
+   `patternSource` string. Materialize a durable tracked-or-detached choice; do
+   not infer update authority from the string, rollout flags, or the root role.
+   When no durable active choice can be established, migrate detached. Resolve
+   a relative legacy path against the accepted toolshed host before storing an
+   absolute web origin. Preserve an unconfirmed locator only as inactive
+   historical provenance.
 3. Make local edits explicitly clear active origin metadata. Make source URL
    creation accept and normalize both `https://` and fabric `cf:` inputs,
    including `cf://`. Resolve an unpinned fabric slug once, then store either a
@@ -492,7 +556,13 @@ The implementation evidence for this table is concentrated in:
    event-driven subscription while an unpinned mutable fabric origin is
    running. Do not subscribe for a content-addressed or explicitly pinned
    fabric origin. Reuse content verification, schema compatibility, guarded
-   source transitions, and the existing in-place pattern watcher.
+   source transitions, and the existing in-place pattern watcher. Use this same
+   path for space roots and retire the specialized root reconciler after
+   migration. Move the current home-root `defaultAppUrl` into durable
+   space-creation configuration outside any root piece. Space creation must
+   resolve that configured default through the ordinary create transition and
+   then link the resulting piece as the root. Creating or relinking that link
+   must validate the runtime's root-interface contract.
 5. Build the central source URL service. Apply the network policy and explicit
    ongoing-code consent to mutable web origins. Apply fabric authorization,
    content verification, pin handling, durable routing, and provenance checks
@@ -513,7 +583,10 @@ The implementation evidence for this table is concentrated in:
    subscription cancellation, authorization loss, source unavailability,
    cross-space authorization and provenance, web and fabric URL policy,
    mutable versus content-addressed fabric targets, explicit pins, durable host
-   routing after reload, and reload behavior.
+   routing after reload, space-root creation from a default, changes to a
+   default after root creation, tracked and detached root baseline migration,
+   source-less legacy roots, relative-path normalization, root-interface
+   rejection, and reload behavior.
    Tests must prove the current source, active origin, revision head, retained
    closure, and revision log after each operation.
 

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -927,12 +927,16 @@ The implementation evidence for this table is concentrated in:
 
 Pattern imports and piece origins intentionally have different update rules.
 An unpinned mutable `cf:` import is resolved and written back with an immutable
-pin when source is deployed. The deployed importer does not track later
-changes. The same fabric URL used as piece-origin metadata stays live when it
-is unpinned and resolves to a mutable `patternIdentity`-bearing entity. The
-piece can then follow that entity's current pattern. A fabric origin that
-resolves to `pattern:<identity>`, or that was supplied as an entity-FID URL with
-a trailing pin, is immutable and has no later update to discover.
+pin when source is deployed. This includes type-only imports because Common
+Fabric uses imported types to generate runtime schemas. Supported ESM-style
+type imports follow this rule. Unsupported import-equals syntax is rejected
+rather than left mutable. The deployed importer does not track later changes.
+The same fabric URL used as piece-origin metadata stays live when it is unpinned
+and resolves to a mutable
+`patternIdentity`-bearing entity. The piece can then follow that entity's
+current pattern. A fabric origin that resolves to `pattern:<identity>`, or that
+was supplied as an entity-FID URL with a trailing pin, is immutable and has no
+later update to discover.
 
 Piece-origin metadata remains outside authored source. Mutable web and fabric
 entity origins are checked when that piece loads. A content-addressed or pinned

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -127,10 +127,16 @@ pieces; it does not generate pattern source.
    piece does not make imports in that piece or in another pattern live.
 9. Creation and every later transition use ordinary authorization for the
    target piece's space. Following grants no write access to the origin piece.
-10. Moving source between spaces is an information flow, not just a read. The
+10. Within a space, every cell and document that makes a pattern resolvable,
+    including its verified source closure, uses that space's ACL. The source
+    therefore has the same visibility as the pattern in that space. Anyone
+    authorized to resolve the pattern there may read its source. A fabric URL,
+    slug, or content identity does not grant access by itself. The same content
+    identity can have replicas in spaces with different ACLs.
+11. Moving source between spaces is an information flow, not just a read. The
     operation propagates CFC provenance labels and fails closed before copying
     source when those labels do not permit the destination flow.
-11. A content-addressed or explicitly pinned fabric URL never reports an
+12. A content-addressed or explicitly pinned fabric URL never reports an
     update. Reconciliation verifies and loads the named source, but the URL
     cannot resolve to a different pattern identity later.
 
@@ -369,10 +375,23 @@ content-addressed or explicitly pinned fabric origin cannot change. The content
 identity proves which bytes were accepted and detects corrupted transfer. It
 does not prove that a publisher, piece owner, or URL owner made a safe change.
 
+Within a space, every cell and document that makes a pattern resolvable,
+including its verified source closure, is protected by that space's ACL. The
+source therefore has the same visibility as the pattern in that space. There
+is no separate source-publication permission. Naming a pattern with a slug or
+revealing its URL or content identity does not broaden the space's ACL.
+
 Forking or following across spaces also moves authored source into the target
 space. Read authorization alone does not authorize that information flow. CFC
 provenance checks run before replication on the same toolshed as well as
 across toolsheds.
+
+After an allowed copy, the accepted closure and its history revision live under
+the destination space's ACL. The same content identity can therefore have
+different visibility in its origin and destination spaces. If access to a
+mutable origin is later revoked, the follower keeps its last accepted source
+and retained revisions. The revocation prevents reconciliation and future
+updates; it does not erase already accepted history.
 
 The UI must distinguish detached pieces, immutable fabric-origin pieces, and
 pieces that update automatically. It shows the active source URL and whether

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -72,22 +72,48 @@ this document includes both web URLs and fabric-internal URLs:
   applies to another stable, mutable cell that carries `patternIdentity`, such
   as the planned lightweight publication pointer. A URL that directly names a
   content-addressed pattern is immutable and stores the selected export symbol.
-  A trailing `@<identity>` pin also makes any fabric URL immutable, even when
-  the unpinned text names a piece or publication pointer.
+  A trailing `@<identity>` pin also makes an accepted entity-FID URL immutable,
+  even when the unpinned text names a piece or publication pointer. The
+  tentative policy below does not accept a slug-shaped piece origin, even when
+  the slug carries a pin.
 
 For example, a host-qualified fabric URL can resolve through
-`cf://toolshed.example/<space>/of:fid1:<piece-id>` to a piece, or through
-`cf://toolshed.example/<space>/pattern:<identity>` to exact pattern source.
+`cf://toolshed.example/<space-did>/of:fid1:<piece-id>` to a piece, or through
+`cf://toolshed.example/<space-did>/pattern:<identity>` to exact pattern source.
 The shorter `cf:<ref>` and `cf:/<space>/<ref>` forms use the same fabric URL
-grammar. A user can supply a slug or host routing hint, but durable metadata
-normalizes it to the stable piece entity or content-addressed pattern it
-resolved to.
+grammar.
 
-Classification happens before the origin is stored. An explicit pin wins over
-the target's mutable shape and normalizes to `cf:pattern:<identity>` plus the
-selected export symbol. An unpinned URL that resolves to a mutable
-`patternIdentity`-bearing entity normalizes to that stable entity rather than
-its slug.
+The tentative durable fabric-URL policy admits stable identifiers, not names,
+into the lifecycle resolver. In current repository terminology, a canonical
+URL uses a DID for an explicit space, an entity FID for a mutable piece or
+publication pointer, or a content identity for an immutable pattern. A
+current-space shorthand for an unpinned mutable entity is expanded to the
+target space's DID before it becomes origin state. A direct pattern identity or
+an explicit pin on an entity-FID URL instead normalizes to the space-free
+content identity form. A host remains a routing hint under the rules below.
+
+The fabric parser is shared with static imports and may parse a slug-shaped
+reference such as `cf:/<space-did>/<slug>`. The tentative piece-origin
+validator rejects that form, including when it has a trailing pin. It also
+rejects a space-root shorthand with no entity reference. An outer authoring
+layer may resolve a slug or root shorthand, but it must pass the lifecycle a
+canonical piece FID or pattern content identity. Static imports keep their
+existing alias-and-pin behavior because the deployed source records the
+terminal content identity.
+
+A future shortlink service may accept a custom string and return a canonical
+identifier URL before the lifecycle operation begins. The shortlink is not the
+active origin or a repoint target. Whether a revision retains it in a separate
+optional provenance field remains open. The active origin contains only the
+identifier URL. This answer remains tentative while the identifier vocabulary
+and shortlink ownership, reassignment, and history semantics receive further
+study.
+
+Classification happens before the origin is stored. An explicit pin on an
+accepted entity-FID URL wins over the target's mutable shape. It normalizes to
+`cf:pattern:<identity>` plus the selected export symbol. An unpinned URL that
+resolves to a mutable `patternIdentity`-bearing entity normalizes to that stable
+entity rather than its slug.
 
 A host in `cf://...` is a routing hint, not target identity. The transition
 retains the supplied URL in history and must persist the space DID to host route
@@ -246,11 +272,11 @@ and link that new piece as the space root.
 |---|---|---|---|
 | Create from local code with the command line | The pushed local program | None | Append a local-create revision |
 | Create from LLM-generated code | The generated program | None | Append a generated-create revision |
-| Create from a source URL with the command line | The program resolved from the `https://` or fabric `cf:` URL, including `cf://` | The normalized URL and any required export selector | Append a web URL create, follow, or fabric pattern create revision according to what the URL resolves to |
-| Create from a known source URL in the UI | The program resolved from the `https://` or fabric `cf:` URL, including `cf://` | The normalized URL and any required export selector | Append a web URL create, follow, or fabric pattern create revision according to what the URL resolves to |
+| Create from a source URL with the command line | The program resolved from the `https://` URL or identifier-only fabric `cf:` URL, including `cf://` | The normalized URL and any required export selector | Append a web URL create, follow, or fabric pattern create revision according to what the URL resolves to |
+| Create from a known source URL in the UI | The program resolved from the `https://` URL or identifier-only fabric `cf:` URL, including `cf://`; an outer authoring layer resolves any alias first | The normalized URL and any required export selector | Append a web URL create, follow, or fabric pattern create revision according to what the URL resolves to |
 | Create the root for a new space | The program resolved from the system-selected default source | Whatever origin the ordinary source-creation rules derive from that source | Append the same creation revision that the equivalent user-created piece would receive |
 | Refresh from an external web URL | The newly fetched program, if its identity or export symbol changed and it passed validation | The same `https://` URL and entry export | Append an automatic-update revision only when the identity or export symbol changes |
-| Load from a content-addressed or explicitly pinned fabric URL | The exact program named by the identity or trailing pin | The normalized fabric pattern URL and export symbol | Do not append an automatic-update revision because the resolved identity cannot change |
+| Load from a content-addressed URL or a pinned entity-FID URL | The exact program named by the identity or trailing pin | The normalized fabric pattern URL and export symbol | Do not append an automatic-update revision because the resolved identity cannot change |
 | Fork a piece | The source currently used by the selected piece | None | Append a fork revision with `forkedFrom`; do not copy the source piece's log |
 | Follow a piece through an unpinned fabric URL | The source currently used by the selected piece | A normalized fabric URL containing a stable reference to that piece | Append a follow revision |
 | Refresh from a mutable fabric entity | The entity's current source, if its identity or export symbol changed and it passed validation | The same stable fabric entity URL | Append an automatic-update revision only when the identity or export symbol changes |
@@ -311,22 +337,24 @@ of a schema warning does not waive this root-interface contract.
 For an unpinned fabric URL that resolves to a mutable entity, the stored
 reference names the stable entity, not a slug. A piece is the product case in
 this lifecycle. A lightweight publication pointer uses the same resolution and
-subscription rule if that feature is added. If a user begins with a slug, the
-operation resolves it once and stores a fully qualified reference containing
-the space DID and stable entity. Reassigning the slug must not redirect
-existing followers to a different entity. Self-following is rejected. Follow
-creation walks the active-origin chain and rejects a cycle. If an origin in
-that chain cannot be read, creation fails closed rather than accepting a
-relationship whose cycle status is unknown.
+subscription rule if that feature is added. Under the tentative identifier-only
+policy, a shortlink or other human-readable alias resolves outside the
+lifecycle and supplies a fully qualified reference containing the space DID and
+stable entity. Reassigning that alias must not redirect existing followers to a
+different entity. Self-following is rejected. Follow creation walks the
+active-origin chain and rejects a cycle. If an origin in that chain cannot be
+read, creation fails closed rather than accepting a relationship whose cycle
+status is unknown.
 
-For a fabric URL that directly names content-addressed pattern source, or that
-contains a trailing pin, the stored reference names that exact pattern
-identity. Slug reassignment, piece updates, and publication changes cannot move
-it. The selected export symbol is stored beside the URL because one pattern
-source can expose more than one export. A pin fixes the pattern identity, not
-the export symbol. The operation therefore stores an explicit selector or
-loads the pinned source and chooses its normal entry export. It does not copy a
-symbol from a mutable target unless that export exists in the pinned source.
+For an accepted fabric URL that directly names content-addressed pattern
+source, or that contains a trailing pin on an entity FID, the stored reference
+names that exact pattern identity. Slug reassignment, piece updates, and
+publication changes cannot move it. The selected export symbol is stored beside
+the URL because one pattern source can expose more than one export. A pin fixes
+the pattern identity, not the export symbol. The operation therefore stores an
+explicit selector or loads the pinned source and chooses its normal entry
+export. It does not copy a symbol from a mutable target unless that export
+exists in the pinned source.
 
 An external web URL is an absolute, canonical fetch location. Its origin record
 also stores the resolved entry export name. An omitted export uses the
@@ -428,9 +456,9 @@ pattern:
    - For an unpinned fabric URL that names a mutable entity, read that entity's
      current `patternIdentity` and make its verified source closure available
      in the following piece's space.
-   - For a fabric URL that names a content-addressed pattern or contains an
-     explicit pin, load and verify that exact source closure and select the
-     stored export symbol.
+   - For a fabric origin normalized from a direct content identity or an
+     accepted entity-FID URL with a pin, load and verify that exact source
+     closure and select the stored export symbol.
    - Before any cross-space copy, enforce the source's CFC provenance labels
      for the destination and fail closed when the flow is not permitted.
 3. If the resolved identity and symbol equal the current values, start the
@@ -536,7 +564,7 @@ updates; it does not erase already accepted history.
 The UI must distinguish detached pieces, immutable fabric-origin pieces, and
 pieces that update automatically. It shows the active source URL and whether
 that URL resolved to a web endpoint, mutable fabric entity, or exact fabric
-pattern. It also shows when a trailing pin made a piece-looking URL immutable.
+pattern. It also shows when a trailing pin made an entity-FID input immutable.
 It offers detach and revert actions near mutable-origin controls. The revision
 log provides an exact rollback target after a bad but valid update.
 
@@ -548,7 +576,7 @@ log provides an exact rollback target after a bad but valid update.
 | Wish a new pattern into being with an LLM-backed UI | **Partial** | The `write-and-run` example asks an LLM for pattern code and passes it to `compileAndRun`, whose callback lets the browser worker register the new piece in a space. It is not a general product affordance and does not record a source revision. The runtime `wish()` builtin is discovery, not code generation. |
 | Manually push code from a source URL and create a piece that remembers it | **CLI URL flow required** | The command-line `new` and `setsrc` commands accept local filesystem entries. `RuntimeClient.createPage(URL)` and `HttpProgramResolver` can fetch `http:` and `https:` source. Fabric resolution can resolve content-addressed patterns and same-toolshed piece references to a source identity, but its result does not carry the export symbol as origin state. Neither path gives the command line a general `https://` or `cf://` source-origin operation. `--repository` is descriptive metadata and is not an origin. |
 | Use a UI affordance to push a known source URL into an owned space | **Partial** | `fetchProgram` with `compileAndRun`, the omnibox's `fetchAndRunPattern`, and `RuntimeClient.createPage(URL)` can fetch and run indexed web programs. The resulting piece does not receive a general active source URL or a source revision. There is no corresponding fabric URL affordance. |
-| Load or create from an immutable fabric URL | **Immutable URL flow required** | The source cache and fabric resolver can load verified `cf:pattern:<identity>` source and honor a trailing pin, but no product operation normalizes that URL and export symbol into immutable piece origin metadata or appends the required revision. |
+| Load or create from an immutable fabric URL | **Immutable URL flow required** | The source cache and fabric resolver can load verified `cf:pattern:<identity>` source and honor a trailing pin on an entity-FID reference. No product operation normalizes that URL and export symbol into immutable piece origin metadata or appends the required revision. |
 | Automatically refresh a mutable URL-origin piece when loaded | **Partial** | The shell reconciles system roots before bootstrap and checks other successfully instantiated same-toolshed system-source patterns in the background. The specialized updater changes `patternIdentity` without the complete pre-apply structural comparison. A running pattern's setup can refuse an incompatible argument shape and keep the old graph, but the metadata pointer has already changed. External web URLs and mutable fabric entity URLs do not use this path. A content-addressed or explicitly pinned fabric URL intentionally has nothing to refresh. |
 | Manage a space root through the ordinary piece lifecycle | **Lifecycle unification required** | A root is already a piece and the specialized updater can replace its pattern in place. Creation still stamps a raw `patternSource`, reconciliation bypasses revision history, and update authority is not durable per piece. Root updates still use a separate controller path. The creation template currently lives on the mutable home root, relative source paths are not ordinary origins, and root linking does not validate a root interface. New-root creation, legacy-root migration, and later transitions do not yet use the ordinary lifecycle path. |
 | Fork an existing piece and detach it | **Fork operation required** | Tooling can recover a piece's verified source closure, and the runtime can create another piece from a program. There is no fork operation or UI, no `forkedFrom` history, and no atomic detach contract. |
@@ -622,11 +650,11 @@ The implementation evidence for this table is concentrated in:
 
 1. Define a discriminated origin schema for external web URLs, stable mutable
    fabric-entity URLs, and immutable fabric URLs created by a direct pattern
-   identity or trailing pin. Add a source-state schema with a stable revision
-   head. Define immutable revision records, including durable source retention
-   and the compatibility descriptors needed without executing an old pattern.
-   Replace the unused lineage declarations or remove them rather than treating
-   dead declarations as a shipped feature.
+   identity or a pin on an entity FID. Add a source-state schema with a stable
+   revision head. Define immutable revision records, including durable source
+   retention and the compatibility descriptors needed without executing an old
+   pattern. Replace the unused lineage declarations or remove them rather than
+   treating dead declarations as a shipped feature.
 2. Provide one atomic source-transition API used by every caller. It must wait
    for failure-propagating closure persistence and compare the expected
    revision head, current pattern, and active origin. Add baseline revision
@@ -639,17 +667,24 @@ The implementation evidence for this table is concentrated in:
    historical provenance.
 3. Make local edits explicitly clear active origin metadata. Make source URL
    creation accept and normalize both `https://` and fabric `cf:` inputs,
-   including `cf://`. Resolve an unpinned fabric slug once, then store either a
-   stable, fully qualified mutable entity or the exact content-addressed pattern
-   reference. Make a trailing pin override the mutable target. Persist an
+   including `cf://`. Under the tentative identifier-only policy, produce a
+   durable mutable origin with an explicit space DID and a stable entity FID.
+   Produce a durable immutable origin with a space-free content identity.
+   Normalize current-space shorthand for an unpinned mutable entity to the
+   explicit space DID and entity FID. Normalize a direct pattern identity or a
+   pin on an entity FID to its space-free content identity. Keep human-readable
+   alias resolution outside the lifecycle resolver. Persist an
    accepted space-to-host route before removing the host from the canonical
    target. Validate and register the route before writing it to the site table,
    then open the origin space. Fail a conflicting seeded route or previously
    accepted late hint, including before the first open. Once the space opens,
    fail any hint that was not already registered and matching. Do not create a
-   secondary session. Keep the supplied URL in history. Keep
-   `patternRepository` separate and clear it when newly generated or directly
-   edited code no longer belongs to that repository.
+   secondary session. Keep the supplied canonical URL in history. Do not make
+   shortlink retention part of the lifecycle contract until the open provenance
+   question is settled. Any later alias provenance must remain separate from
+   active origins and repoint targets. Keep `patternRepository` separate and
+   clear it when newly generated or directly edited code no longer belongs to
+   that repository.
 4. Add origin reconciliation to the ordinary piece start path. Add an
    event-driven subscription while an unpinned mutable fabric origin is
    running. Do not subscribe for a content-addressed or explicitly pinned
@@ -710,8 +745,8 @@ pin when source is deployed. The deployed importer does not track later
 changes. The same fabric URL used as piece-origin metadata stays live when it
 is unpinned and resolves to a mutable `patternIdentity`-bearing entity. The
 piece can then follow that entity's current pattern. A fabric origin that
-resolves to `pattern:<identity>` or carries a trailing pin is immutable and has
-no later update to discover.
+resolves to `pattern:<identity>`, or that was supplied as an entity-FID URL with
+a trailing pin, is immutable and has no later update to discover.
 
 Piece-origin metadata remains outside authored source. Mutable web and fabric
 entity origins are checked when that piece loads. A content-addressed or pinned

--- a/packages/cli/test/fabric-deps.test.ts
+++ b/packages/cli/test/fabric-deps.test.ts
@@ -112,6 +112,23 @@ describe("cli fabric deps", () => {
     expect(result.program.files[1].contents).toContain(`cf:dep@${ENTRY}`);
   });
 
+  it("rejects subpaths instead of pinning them to the entry", async () => {
+    await writePatternSlug("dep");
+
+    await expect(
+      pinProgramFabricImports(runtime, space, {
+        main: "/main.tsx",
+        files: [
+          {
+            name: "/main.tsx",
+            contents:
+              `import schema from "cf:dep/schemas";\nexport default schema;`,
+          },
+        ],
+      }),
+    ).rejects.toThrow("subpaths not yet supported (M4): cf:dep/schemas");
+  });
+
   it("collectLocalProgram walks local files and dispatches on fabric refs", async () => {
     const resolver = new InMemoryProgram("/main.tsx", {
       "/main.tsx": `import { s } from "./schemas.tsx";\nexport default s;`,

--- a/packages/piece/test/default-app-golden-replay.test.ts
+++ b/packages/piece/test/default-app-golden-replay.test.ts
@@ -13,14 +13,12 @@ import {
   PiecesController,
 } from "../src/ops/pieces-controller.ts";
 
-// Golden replay: the state-survival gate the flag flip (#4619) is waiting on.
+// Golden replay for non-home root state across an in-place update.
 //
-// The other swap tests prove the ENTITY and patternIdentity swap in place; this
-// one proves the thing those don't: durable state seeded under version N is
-// still there, intact, after the root rolls to N+1 — no crash, no loss. It
-// stands in for "open a real non-home space, add some notes, ship a new
-// default-app, reopen" — the scenario both reviewers asked to see mechanically
-// verified before this defaults on.
+// The other swap tests prove that patternIdentity changes while the piece
+// entity stays the same. This test seeds representative durable state under
+// version N and updates the running root to version N+1. It verifies that the
+// state remains intact and that the new code runs over it.
 
 const signer = await Identity.fromPassphrase("default-app golden replay");
 

--- a/packages/runner/src/fabric-ref-resolution.ts
+++ b/packages/runner/src/fabric-ref-resolution.ts
@@ -67,7 +67,7 @@ function resolveRefSpace(
   if (refSpace === undefined) return compilingSpace;
   if (DID_RE.test(refSpace)) return refSpace as MemorySpace;
   throw new Error(
-    "space names require name→DID resolution (open question 2); use a DID",
+    "space names are currently unsupported; resolve the name to a DID first",
   );
 }
 

--- a/packages/runner/src/fabric-ref-resolution.ts
+++ b/packages/runner/src/fabric-ref-resolution.ts
@@ -26,6 +26,9 @@ export async function resolveFabricRefToIdentity(
   ref: FabricRef,
 ): Promise<FabricChaseResult> {
   const specifier = formatFabricRef(ref);
+  if (ref.subpath !== undefined) {
+    throw new Error(`subpaths not yet supported (M4): ${specifier}`);
+  }
   const refSpace = resolveRefSpace(ref.space, compilingSpace);
 
   if (ref.ref.kind === "uri" && ref.ref.scheme === "pattern") {

--- a/packages/runner/src/harness/fabric-resolver.ts
+++ b/packages/runner/src/harness/fabric-resolver.ts
@@ -205,7 +205,7 @@ export class FabricAwareResolver implements ProgramResolver {
     if (refSpace === undefined) return this.ctx.space;
     if (DID_RE.test(refSpace)) return refSpace as MemorySpace;
     throw new Error(
-      "space names require name→DID resolution (open question 2); use a DID",
+      "space names are currently unsupported; resolve the name to a DID first",
     );
   }
 }

--- a/packages/runner/test/fabric-ref-resolution.test.ts
+++ b/packages/runner/test/fabric-ref-resolution.test.ts
@@ -70,11 +70,11 @@ describe("fabric ref resolution", () => {
     });
   });
 
-  it("rejects space names until name to DID resolution exists", async () => {
+  it("rejects space names", async () => {
     await expect(
       resolveFabricRefToIdentity(runtime, space, parse("cf:/kitchen/todo")),
     ).rejects.toThrow(
-      "space names require name→DID resolution (open question 2); use a DID",
+      "space names are currently unsupported; resolve the name to a DID first",
     );
   });
 

--- a/packages/runner/test/fabric-ref-resolution.test.ts
+++ b/packages/runner/test/fabric-ref-resolution.test.ts
@@ -70,6 +70,18 @@ describe("fabric ref resolution", () => {
     });
   });
 
+  it("rejects subpaths before resolving an entry identity", async () => {
+    await expect(
+      resolveFabricRefToIdentity(
+        runtime,
+        space,
+        parse(`cf:pattern:${ENTRY_A}/schemas`),
+      ),
+    ).rejects.toThrow(
+      `subpaths not yet supported (M4): cf:pattern:${ENTRY_A}/schemas`,
+    );
+  });
+
   it("rejects space names", async () => {
     await expect(
       resolveFabricRefToIdentity(runtime, space, parse("cf:/kitchen/todo")),

--- a/packages/runner/test/fabric-resolver.test.ts
+++ b/packages/runner/test/fabric-resolver.test.ts
@@ -318,7 +318,7 @@ describe("FabricAwareResolver", () => {
       ],
       [
         `cf:/kitchen/pattern:${entryIdentity}`,
-        "space names require name→DID resolution (open question 2); use a DID",
+        "space names are currently unsupported; resolve the name to a DID first",
       ],
     ];
 

--- a/packages/toolshed/routes/patterns/patterns.handlers.ts
+++ b/packages/toolshed/routes/patterns/patterns.handlers.ts
@@ -64,9 +64,9 @@ export const getPattern = async (
       );
     }
 
-    // `?identity`: return the file's content-addressed identity (the value the
-    // runtime would store as patternIdentity.identity for this authored import
-    // closure) as plain text, instead of the source itself.
+    // `?identity`: return the complete authored pattern closure's identity (the
+    // value the runtime would store as patternIdentity.identity) as plain text,
+    // instead of the entry file's source.
     if (new URL(c.req.url).searchParams.has("identity")) {
       const identity = await patternsServer.identity(filename);
       return patternResponse(

--- a/packages/toolshed/routes/patterns/patterns.routes.ts
+++ b/packages/toolshed/routes/patterns/patterns.routes.ts
@@ -15,16 +15,17 @@ export const getPattern = createRoute({
     }),
     query: z.object({
       identity: z.string().optional().describe(
-        "When present, return the file's content-addressed identity as " +
-          "text/plain instead of its source.",
+        "When present, return the complete authored pattern closure's " +
+          "content-addressed identity as text/plain instead of the entry " +
+          "file's source.",
       ),
     }),
   },
   responses: {
     200: {
       description:
-        "Pattern file content, or the file's content identity when `identity` " +
-        "is present.",
+        "Pattern file content, or the complete authored pattern closure's " +
+        "content identity when `identity` is present.",
       content: {
         "text/typescript-jsx": {
           schema: z.string(),


### PR DESCRIPTION
Pieces already retain a content-addressed current pattern, and system roots can track a toolshed path. The live documentation did not define how general source origins interact with direct edits, forks, rollback, following, or history. It also treated web URLs and fabric references as separate concepts even though both can identify piece source.

Add a lifecycle specification that separates exact source identity, descriptive repository metadata, and mutable update provenance. Define guarded source and origin transitions, durable historical closure retention, live following, detach behavior, and distinct revert and repoint operations. Audit every product interaction against the current implementation.

Define source URLs as external web URLs or fabric cf: URLs, including cf://. Unpinned references to stable pattern-bearing entities remain live and follow their current pattern. Direct pattern identities and explicitly pinned references normalize to immutable source with a stored export selector. Require durable space-to-host routing before removing a cf:// host from the canonical target, while retaining the supplied URL in revision history.

Narrow the existing pattern-update document to its implemented system-root scope and align the pattern-import documentation with the same mutable-versus-immutable rules. Static imports remain pinned while mutable piece origins reconcile before start and subscribe while running.

Verification: deno task check-docs; deno fmt --check; deno lint


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines the piece source lifecycle with guarded transitions and durable history. Unifies source URLs (`https://`, `cf:`, `cf://` with late-bound host hints), aligns ACLs and publication, and treats roots like ordinary pieces; requires identifier-only origins, pins type imports, adds explicit subpath exports, uses `?identity` for full-closure comparison, and rejects subpaths and named-space refs.

- **New Features**
  - Lifecycle: create/follow/detach/revert/repoint with durable history; runtime-aware rebuild identities.
  - Origins and routing: `https://`, `cf:`, `cf://`; validate/register host hints, commit hostless targets; mutable refs use space DID + entity FID, immutable refs use content identity.
  - Access and publication: pattern and source follow space ACLs; cross-space publication creates a publication cell and source replica under the destination ACL.
  - Compatibility and identity: unattended origin updates reject structural schema mismatches; `GET ?identity` returns the complete authored pattern closure identity; module hash accepts an optional runtime fingerprint.

- **Refactors**
  - Roots: follow the same lifecycle with documented migration; transitional root updater called out.
  - Imports and resolver: pin all ESM type-only fabric refs; define explicit exports for subpaths; reject subpaths before manifest-backed lookup; clearer error for named-space refs; CLI docs clarify explicit pinning vs deployment; status tables use capability-scoped labels.

<sup>Written for commit f8df2b89cbd65b8b2fe06eef2c19c3c0cb0816f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



NEW_COVERAGE_BASELINE