### PR TITLE
fix(runner): preserve WriteAuthorizedBy authority across setsrc updates

### DIFF
--- a/docs/common/workflows/development.md
+++ b/docs/common/workflows/development.md
@@ -25,8 +25,9 @@ deno task cf piece link ... editor-id/items viewer-id/items
 - Deploy once, then use `setsrc` for updates
 - `setsrc` preserves `WriteAuthorizedBy` authority across changed modules when
   the old and new recursive source closures contain the same normalized module
-  path. Renaming or moving a module intentionally does not inherit that
-  authority.
+  path. The handoff is scoped to the space whose authenticated cache documents
+  record it; loading delegation metadata from another space grants no authority.
+  Renaming or moving a module intentionally does not inherit that authority.
 - `setsrc` rejects backward-incompatible argument or result schema changes
   before updating the piece. Existing fields must keep compatible types; new
   fields must be optional or have defaults. Input `anyOf` and type-array unions

--- a/docs/common/workflows/development.md
+++ b/docs/common/workflows/development.md
@@ -23,6 +23,10 @@ deno task cf piece link ... editor-id/items viewer-id/items
 **Tips:**
 - Use `check` first to catch TypeScript errors
 - Deploy once, then use `setsrc` for updates
+- `setsrc` preserves `WriteAuthorizedBy` authority across changed modules when
+  the old and new recursive source closures contain the same normalized module
+  path. Renaming or moving a module intentionally does not inherit that
+  authority.
 - `setsrc` rejects backward-incompatible argument or result schema changes
   before updating the piece. Existing fields must keep compatible types; new
   fields must be optional or have defaults. Input `anyOf` and type-array unions

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -380,10 +380,14 @@ scheme (identity PRs E1–E4; `docs/specs/content-addressed-action-identity.md`
 in the labs repo): implementation identity is the pair **(content hash of the
 verified code artifact, symbol/binding path within it)**. Same artifact hash
 + same symbol = same identity wherever the artifact is loaded; any code
-change changes the hash and with it every identity within the artifact —
-rebinding is re-authorization, not inheritance; `writeAuthorizedBy`
-references resolve against this pair. Replace §8.15.6's "no separate naming
-scheme" claim with the pair definition and state the rebinding rule.
+change changes the hash and with it every identity within the artifact.
+Rebinding does not inherit authority by default. The narrow temporary exception
+is an explicit `piece setsrc` update: canonical-filename matches in the old and
+new recursive module closures persist a cumulative successor-to-predecessor
+delegation. `writeAuthorizedBy` accepts the current module hash or a predecessor
+reachable through that loaded delegation map, but still requires the same
+source file and symbol/binding path. Replace §8.15.6's "no separate naming
+scheme" claim with the pair definition and this explicit delegation rule.
 
 **SC-23 [interpretation] Per-write read-prefix provenance classed as
 decomposition-grade precision — §8.9.1/§8.9.2 (Epic D4).** The runner's

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -385,14 +385,15 @@ Rebinding does not inherit authority by default. The narrow temporary exception
 is an explicit `piece setsrc` update: canonical-filename matches in the old and
 new recursive module closures persist a cumulative successor-to-predecessor
 delegation. `writeAuthorizedBy` accepts the current module hash or a predecessor
-reachable through that loaded delegation map, but still requires the same
-symbol/binding path. Source-file spelling remains diagnostic at verification;
-canonical authored filenames govern whether `setsrc` derives a delegation in
-the first place. Because the delegation list is mutable and outside the source
-Merkle identity, it is authority-bearing only when protected by the compiler's
-integrity attestation (field-level in source documents, root-level in compiled
-documents). Replace §8.15.6's "no separate naming scheme" claim with the pair
-definition and this explicit delegation rule.
+reachable through the delegation map authenticated in the target document's
+space, but still requires the same symbol/binding path. A delegation loaded from
+another space grants no authority. Source-file spelling remains diagnostic at
+verification; canonical authored filenames govern whether `setsrc` derives a
+delegation in the first place. Because the delegation list is mutable and
+outside the source Merkle identity, it is authority-bearing only when protected
+by the compiler's integrity attestation (field-level in source documents,
+root-level in compiled documents). Replace §8.15.6's "no separate naming
+scheme" claim with the pair definition and this explicit delegation rule.
 
 **SC-23 [interpretation] Per-write read-prefix provenance classed as
 decomposition-grade precision — §8.9.1/§8.9.2 (Epic D4).** The runner's

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -386,8 +386,11 @@ is an explicit `piece setsrc` update: canonical-filename matches in the old and
 new recursive module closures persist a cumulative successor-to-predecessor
 delegation. `writeAuthorizedBy` accepts the current module hash or a predecessor
 reachable through that loaded delegation map, but still requires the same
-source file and symbol/binding path. Replace §8.15.6's "no separate naming
-scheme" claim with the pair definition and this explicit delegation rule.
+source file and symbol/binding path. Because the delegation list is mutable and
+outside the source Merkle identity, it is authority-bearing only when protected
+by the compiler's integrity attestation (field-level in source documents,
+root-level in compiled documents). Replace §8.15.6's "no separate naming scheme"
+claim with the pair definition and this explicit delegation rule.
 
 **SC-23 [interpretation] Per-write read-prefix provenance classed as
 decomposition-grade precision — §8.9.1/§8.9.2 (Epic D4).** The runner's

--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -109,9 +109,17 @@ exports by export name, hoisted/non-exported artifacts by their `__cfReg` key
 (see `docs/specs/module-loading.md` and the op-by-identity migration that
 introduced the `$patternRef` sentinel, `builtins/op-pattern-ref.ts`).
 
+`piece setsrc` supplies the one explicit update-chain exception to strict hash
+equality. Its old/new recursive source closures are matched by canonical full
+filename, and successor module documents accumulate the predecessor hashes they
+may act as. A loaded successor can satisfy a `writeAuthorizedBy` claim stamped
+by one of those predecessors only when the normalized source file and binding
+path still match. Ordinary recompilation, renames, and unrelated module loads
+grant no such authority.
+
 ## Last Updated
 
-2026-06-12
+2026-07-21
 
 ## Motivation
 

--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -113,10 +113,11 @@ introduced the `$patternRef` sentinel, `builtins/op-pattern-ref.ts`).
 equality. Its old/new recursive source closures are matched by canonical full
 filename, and successor module documents accumulate the predecessor hashes they
 may act as. A loaded successor can satisfy a `writeAuthorizedBy` claim stamped
-by one of those predecessors only when the binding path still matches. Source
-file spelling is diagnostic at verification; a rename grants no authority
-because canonical filename matching derives no delegation. Ordinary
-recompilation and unrelated module loads grant no such authority.
+by one of those predecessors only in the space whose authenticated module
+documents carry that delegation, and only when the binding path still matches.
+Source file spelling is diagnostic at verification; a rename grants no
+authority because canonical filename matching derives no delegation. Ordinary
+recompilation and unrelated or cross-space module loads grant no such authority.
 
 ## Last Updated
 

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -385,9 +385,9 @@ root compiler stamp. Loaders discard delegation metadata without the applicable
 stamp. The general source/compiled save path computes one union of newly derived
 entries and authenticated entries already stored in either document set under
 `editWithRetry`, writes that same union to both sets, and registers the union
-from the successful commit in the active runtime. It never replaces entries,
-because one content-addressed successor can be shared by patterns updated from
-different predecessors. Because
+from the successful commit under the attesting space in the active runtime. It
+never replaces entries, because one content-addressed successor can be shared by
+patterns updated from different predecessors. Because
 `identity` is a one-way Merkle hash, the `imports` links are load-bearing (stored
 explicitly), but the parent hash commits to its children's identities, so the
 graph wiring is verifiable on load by recomputing identities and checking each
@@ -413,18 +413,26 @@ cold-reload-stable.
 
 Verified source loads register only field-integrity-authenticated lists;
 integrity-valid compiled-cache loads register lists from their root-authenticated
-documents. Each transaction snapshots the resulting successor-to-predecessor
-map's transitive closure. `writeAuthorizedBy` may then match the live writer's
-module hash directly or through that snapshot, while its binding path must still
-match exactly. Source-file spelling is diagnostic at verification because it is
+documents. Registration and transitive closure are scoped by the space carrying
+that attestation. Each transaction snapshots the resulting per-space maps, and
+`writeAuthorizedBy` consults only the map for the target document's space. It may
+then match the live writer's module hash directly or through that space's
+snapshot, while its binding path must still match exactly. Delegation metadata
+loaded from another space grants no authority. Source and compiled closure
+loaders reject a cache graph containing any cross-space import link, so a child
+document's local attestation cannot be flattened into the root's space.
+Source-file spelling is diagnostic at verification because it is
 resolver-dependent; a rename still receives no delegation because old and new
 modules no longer match by canonical authored filename.
 Ambiguous canonical filenames and unauthenticated metadata fail closed by
 receiving no delegation. If a runtime-version miss recompiles from source, the
 compiled-cache repair carries the authenticated map forward so later warm loads
-retain the same authority chain. When multiple patterns converge on one
-successor across restarts, save-time unioning preserves every predecessor in
-both cache sets and in the runtime that performed the later update.
+retain the same authority chain. Cross-space closure replication copies code and
+imports but omits the origin space's delegation metadata; the destination save
+preserves only authority already authenticated in the destination. When multiple
+patterns converge on one successor within a space across restarts, save-time
+unioning preserves every predecessor in both cache sets and in the runtime that
+performed the later update.
 
 ## Verifiable Execution Implications
 
@@ -490,8 +498,11 @@ The cache is designed around this:
   independently loadable there (`PatternManager.replicatePatternToSpace`).
   Chain-of-custody holds — compiled docs are read through the integrity-gated
   loader (only docs already carrying the compiler stamp replicate) and
-  re-stamped on the child-space write by a legitimate child-space writer. Note
-  for the server-compilation end state: a client can then no longer stamp
+  re-stamped on the child-space write by a legitimate child-space writer.
+  Module-update authority does not cross that boundary:
+  `delegatedModuleIdentities` from the origin is omitted during replication,
+  while any entries already authenticated in the destination are preserved.
+  Note for the server-compilation end state: a client can then no longer stamp
   replicated compiled docs, so child spaces will need server-side replication
   or by-identity source recovery instead.
 - **CFC verified-source derives from the source set, not the cached JS.** A

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -382,10 +382,12 @@ current module may exercise. Since content-addressing does not authenticate
 that mutable field, source documents carry the compiler integrity stamp on the
 delegation field alone; compiled documents authenticate it with their existing
 root compiler stamp. Loaders discard delegation metadata without the applicable
-stamp. The general source/compiled save path merges newly derived entries only
-with authenticated stored entries under `editWithRetry`; it never replaces
-entries, because one content-addressed successor can be shared by patterns
-updated from different predecessors. Because
+stamp. The general source/compiled save path computes one union of newly derived
+entries and authenticated entries already stored in either document set under
+`editWithRetry`, writes that same union to both sets, and registers the union
+from the successful commit in the active runtime. It never replaces entries,
+because one content-addressed successor can be shared by patterns updated from
+different predecessors. Because
 `identity` is a one-way Merkle hash, the `imports` links are load-bearing (stored
 explicitly), but the parent hash commits to its children's identities, so the
 graph wiring is verifiable on load by recomputing identities and checking each
@@ -418,7 +420,9 @@ and binding path must still match exactly. A rename does not inherit authority.
 Ambiguous canonical filenames and unauthenticated metadata fail closed by
 receiving no delegation. If a runtime-version miss recompiles from source, the
 compiled-cache repair carries the authenticated map forward so later warm loads
-retain the same authority chain.
+retain the same authority chain. When multiple patterns converge on one
+successor across restarts, save-time unioning preserves every predecessor in
+both cache sets and in the runtime that performed the later update.
 
 ## Verifiable Execution Implications
 

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -373,8 +373,15 @@ under a schema loads the whole import closure transitively from a single request
    upgrade rolls `runtimeVersion`, recompiling this set while the source set
    persists.
 
-Each document holds `{ code, filename, imports: [{ specifier, link }] }`, where
-`link` is a sigil link to the dependency's document in the same set. Because
+Each document holds
+`{ code, filename, imports: [{ specifier, link }], delegatedModuleIdentities? }`,
+where `link` is a sigil link to the dependency's document in the same set.
+`delegatedModuleIdentities` is mutable metadata, excluded from the Merkle
+identity, that records predecessor module hashes whose writer authority the
+current module may exercise. The general source/compiled save path merges this
+set with the stored document under `editWithRetry`; it never replaces entries,
+because one content-addressed successor can be shared by patterns updated from
+different predecessors. Because
 `identity` is a one-way Merkle hash, the `imports` links are load-bearing (stored
 explicitly), but the parent hash commits to its children's identities, so the
 graph wiring is verifiable on load by recomputing identities and checking each
@@ -386,6 +393,25 @@ This replaces the whole-program `PatternMeta` store after the flag flip (the two
 coexist behind the flag until then). The compiler-version `fingerprint` and
 `sesValidated` gating carry over: `runtimeVersion` is the fingerprint, and the
 compiled set is only ever written from verified output (see the threat model).
+
+### Module update delegation (`piece setsrc`)
+
+`piece setsrc` is the temporary authority handoff while pattern files remain
+local, content-addressed modules. Before compiling the replacement it loads the
+current entry's verified recursive source closure. After compilation it matches
+old and new modules by their canonical full authored filename (resolved relative
+imports therefore meet at the same stored path; basenames are never matched).
+For every unambiguous match, the successor records the direct predecessor plus
+the predecessor's cumulative delegation list. This makes an update chain
+cold-reload-stable.
+
+Both verified source loads and integrity-valid compiled-cache loads register the
+stored lists in the runtime as a successor-to-predecessor map. Each transaction
+snapshots its transitive closure. `writeAuthorizedBy` may then match the live
+writer's module hash directly or through that snapshot, while its normalized
+source file and binding path must still match exactly. A rename does not inherit
+authority. Ambiguous canonical filenames fail closed by receiving no
+delegation.
 
 ## Verifiable Execution Implications
 

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -31,7 +31,7 @@ compilation cache were deleted.
 
 ## Last Updated
 
-2026-06-10
+2026-07-21
 
 ## Summary
 

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -378,10 +378,14 @@ Each document holds
 where `link` is a sigil link to the dependency's document in the same set.
 `delegatedModuleIdentities` is mutable metadata, excluded from the Merkle
 identity, that records predecessor module hashes whose writer authority the
-current module may exercise. The general source/compiled save path merges this
-set with the stored document under `editWithRetry`; it never replaces entries,
-because one content-addressed successor can be shared by patterns updated from
-different predecessors. Because
+current module may exercise. Since content-addressing does not authenticate
+that mutable field, source documents carry the compiler integrity stamp on the
+delegation field alone; compiled documents authenticate it with their existing
+root compiler stamp. Loaders discard delegation metadata without the applicable
+stamp. The general source/compiled save path merges newly derived entries only
+with authenticated stored entries under `editWithRetry`; it never replaces
+entries, because one content-addressed successor can be shared by patterns
+updated from different predecessors. Because
 `identity` is a one-way Merkle hash, the `imports` links are load-bearing (stored
 explicitly), but the parent hash commits to its children's identities, so the
 graph wiring is verifiable on load by recomputing identities and checking each
@@ -405,13 +409,16 @@ For every unambiguous match, the successor records the direct predecessor plus
 the predecessor's cumulative delegation list. This makes an update chain
 cold-reload-stable.
 
-Both verified source loads and integrity-valid compiled-cache loads register the
-stored lists in the runtime as a successor-to-predecessor map. Each transaction
-snapshots its transitive closure. `writeAuthorizedBy` may then match the live
-writer's module hash directly or through that snapshot, while its normalized
-source file and binding path must still match exactly. A rename does not inherit
-authority. Ambiguous canonical filenames fail closed by receiving no
-delegation.
+Verified source loads register only field-integrity-authenticated lists;
+integrity-valid compiled-cache loads register lists from their root-authenticated
+documents. Each transaction snapshots the resulting successor-to-predecessor
+map's transitive closure. `writeAuthorizedBy` may then match the live writer's
+module hash directly or through that snapshot, while its normalized source file
+and binding path must still match exactly. A rename does not inherit authority.
+Ambiguous canonical filenames and unauthenticated metadata fail closed by
+receiving no delegation. If a runtime-version miss recompiles from source, the
+compiled-cache repair carries the authenticated map forward so later warm loads
+retain the same authority chain.
 
 ## Verifiable Execution Implications
 
@@ -436,7 +443,10 @@ The cache is designed around this:
   its own contents, so a reader self-checks `hash(content) === <identity>`. A
   tampered source document fails the check; a poisoned-but-different source would
   not hash to the requested identity. Recompiling a source document also re-runs
-  the SES verifier, so a malformed source is rejected on the compile path.
+  the SES verifier, so a malformed source is rejected on the compile path. The
+  one exception is mutable delegation metadata, which is deliberately outside
+  that hash and therefore requires its own field-level compiler integrity stamp
+  before a loader can use it as authority.
 - **Compiled set integrity is a CFC label.** `compileCache:<runtimeVersion>/<identity>`
   is keyed by the *source* identity, which does not bind the *JS* bytes.
   The compiled document therefore carries a **CFC integrity label**, written with

--- a/packages/api/cfc.ts
+++ b/packages/api/cfc.ts
@@ -129,13 +129,13 @@ export const CFC_RUNTIME_SUBJECT = "did:web:commonfabric.org#runtime";
 export const CFC_COMPILED_BY_ATOM_PREFIX = "cf-compiled-by:" as const;
 
 /**
- * The single attestation stamped on compile-cache docs: the doc was emitted by
- * the system compiler. Deliberately NOT bound to a user identity — the atom
- * attests to the code that produced the doc, not to who ran it, so a shared
- * space's compile cache is readable by every member. The hard (cryptographic)
- * guarantee lands when compilation becomes server-only and the server attaches
- * real attestation data; until then minting is gated to builtin-authored
- * writes (see prefix doc above).
+ * The single compiler attestation: stamped on compiled-cache document roots and
+ * on mutable source-document delegation metadata. Deliberately NOT bound to a
+ * user identity — the atom attests to the system compiler's write, not to who
+ * ran it, so every member of a shared space can reuse the result. The hard
+ * (cryptographic) guarantee lands when compilation becomes server-only and the
+ * server attaches real attestation data; until then minting is gated to
+ * builtin-authored writes (see prefix doc above).
  */
 export const CFC_COMPILED_BY_ATOM = "cf-compiled-by:cf-compiler" as const;
 

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -2717,7 +2717,9 @@ export class PieceController<T = unknown> {
     await this.#runMutation(mutationVersion, async () => {
       const { pattern: previousPattern, ref: previousRef } = await this
         .#loadCurrentPattern();
-      const pattern = await compileProgram(this.#manager, program);
+      const pattern = await compileProgram(this.#manager, program, {
+        previousEntryIdentity: previousRef.identity,
+      });
       if (!options?.dangerouslyAllowIncompatibleSchema) {
         assertPatternSchemasBackwardCompatible(previousPattern, pattern);
       }

--- a/packages/piece/src/ops/utils.ts
+++ b/packages/piece/src/ops/utils.ts
@@ -7,11 +7,17 @@ import { PieceManager } from "../manager.ts";
 export async function compileProgram(
   manager: PieceManager,
   program: RuntimeProgram | string,
+  options: { previousEntryIdentity?: string } = {},
 ) {
   const pattern = await compileAndSavePattern(
     manager.runtime,
     program,
-    { space: manager.getSpace() },
+    {
+      space: manager.getSpace(),
+      ...(options.previousEntryIdentity === undefined
+        ? {}
+        : { previousEntryIdentity: options.previousEntryIdentity }),
+    },
   );
   return pattern;
 }

--- a/packages/piece/test/setsrc-module-delegation.test.ts
+++ b/packages/piece/test/setsrc-module-delegation.test.ts
@@ -176,7 +176,8 @@ describe("setsrc module delegation", () => {
 
         const registeredTx = mergeRuntime.edit();
         const registeredDelegations = registeredTx.getCfcState()
-          .moduleDelegations.get(successorRef.identity) ?? [];
+          .moduleDelegations.get(patternSpace)?.get(successorRef.identity) ??
+          [];
         registeredTx.abort();
         expect(registeredDelegations).toContain(firstRef.identity);
         expect(registeredDelegations).toContain(intermediateRef.identity);

--- a/packages/piece/test/setsrc-module-delegation.test.ts
+++ b/packages/piece/test/setsrc-module-delegation.test.ts
@@ -9,7 +9,6 @@ import {
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   loadCompiledClosure,
-  loadSourceClosure,
   loadVerifiedSourceClosure,
   setCompileCacheRuntimeVersionForTesting,
 } from "../../runner/src/compilation-cache/cell-cache.ts";
@@ -113,17 +112,19 @@ describe("setsrc module delegation", () => {
     expect(await invokeSetName(first, "middle")).toBe("v2:middle");
     await first.setPattern(authorizedWriterProgram("v3"));
     expect(await invokeSetName(first, "after")).toBe("v3:after");
-    await second.setPattern(authorizedWriterProgram("v3"));
+    const successorRef = getPatternIdentityRef(first.getCell())!;
 
-    const successorRef = getPatternIdentityRef(second.getCell())!;
-    expect(getPatternIdentityRef(first.getCell())).toEqual(successorRef);
+    await runtime.patternManager.flushCompileCacheWrites();
+    await manager.synced();
+    const patternSpace = manager.getSpace();
+    const patternSpaceName = manager.getSpaceName()!;
 
-    const loadClosure = async (identity: string) => {
-      const tx = runtime.edit();
+    const loadClosure = async (targetRuntime: Runtime, identity: string) => {
+      const tx = targetRuntime.edit();
       try {
         return await loadVerifiedSourceClosure(
-          runtime,
-          manager.getSpace(),
+          targetRuntime,
+          patternSpace,
           identity,
           tx,
         );
@@ -131,30 +132,6 @@ describe("setsrc module delegation", () => {
         tx.abort();
       }
     };
-    const firstClosure = await loadClosure(firstRef.identity);
-    const intermediateClosure = await loadClosure(intermediateRef.identity);
-    const secondClosure = await loadClosure(secondRef.identity);
-    const successorClosure = await loadClosure(successorRef.identity);
-
-    const byName = (closure: NonNullable<typeof firstClosure>) =>
-      new Map([...closure].map(([identity, doc]) => [doc.filename, identity]));
-    const firstByName = byName(firstClosure!);
-    const intermediateByName = byName(intermediateClosure!);
-    const secondByName = byName(secondClosure!);
-
-    for (const [identity, doc] of successorClosure!) {
-      if (!doc.filename.startsWith("/")) continue;
-      const delegated = (doc as typeof doc & {
-        delegatedModuleIdentities?: readonly string[];
-      }).delegatedModuleIdentities ?? [];
-      expect(delegated).toContain(firstByName.get(doc.filename));
-      expect(delegated).toContain(intermediateByName.get(doc.filename));
-      expect(delegated).toContain(secondByName.get(doc.filename));
-      expect(delegated).not.toContain(identity);
-    }
-
-    await runtime.patternManager.flushCompileCacheWrites();
-    await manager.synced();
     const freshRuntimes: Runtime[] = [];
     try {
       const createFreshRuntime = () => {
@@ -171,80 +148,105 @@ describe("setsrc module delegation", () => {
       const createFreshManager = async (freshRuntime: Runtime) => {
         const freshSession = await createSession({
           identity: signer,
-          spaceName: manager.getSpaceName()!,
+          spaceName: patternSpaceName,
         });
         const freshManager = new PieceManager(freshSession, freshRuntime);
         await freshManager.synced();
         return freshManager;
       };
 
-      // The ordinary compiled-cache cold start still exercises delegation at
-      // the authorization boundary.
-      const coldRuntime = createFreshRuntime();
-      const coldManager = await createFreshManager(coldRuntime);
-      const coldPiece = await new PiecesController(coldManager).get(
-        first.id,
-        true,
-      );
-      expect(await invokeSetName(coldPiece, "cold")).toBe("v3:cold");
-
-      const bumpedRuntimeVersion = "setsrc-delegation-version-b";
+      // Restart before the second pattern converges on the already-stored
+      // successor. Use a fresh compiled-cache variant so the source document
+      // contributes the first pattern's chain while the second update
+      // contributes the new chain. Both sets must persist their authenticated
+      // union, and that committed union must be installed in this runtime.
+      const bumpedRuntimeVersion = "setsrc-delegation-shared-successor";
       const restoreRuntimeVersion = setCompileCacheRuntimeVersionForTesting(
         bumpedRuntimeVersion,
       );
       try {
-        const repairRuntime = createFreshRuntime();
-        const inspectTx = repairRuntime.edit();
-        let authenticatedSourceClosure: Awaited<
-          ReturnType<typeof loadSourceClosure>
-        >;
-        try {
-          authenticatedSourceClosure = await loadSourceClosure(
-            repairRuntime,
-            manager.getSpace(),
-            successorRef.identity,
-            inspectTx,
+        const mergeRuntime = createFreshRuntime();
+        const mergeManager = await createFreshManager(mergeRuntime);
+        const mergePieces = new PiecesController(mergeManager);
+        const mergeSecond = await mergePieces.get(second.id, true);
+        await mergeSecond.setPattern(authorizedWriterProgram("v3"));
+        expect(getPatternIdentityRef(mergeSecond.getCell())).toEqual(
+          successorRef,
+        );
+
+        const registeredTx = mergeRuntime.edit();
+        const registeredDelegations = registeredTx.getCfcState()
+          .moduleDelegations.get(successorRef.identity) ?? [];
+        registeredTx.abort();
+        expect(registeredDelegations).toContain(firstRef.identity);
+        expect(registeredDelegations).toContain(intermediateRef.identity);
+        expect(registeredDelegations).toContain(secondRef.identity);
+
+        // This resolves through the successor module already evaluated for
+        // mergeSecond. It therefore depends on save-time registration of the
+        // complete A+B union; reloading a closure cannot rescue a partial map.
+        const mergeFirst = await mergePieces.get(first.id, true);
+        expect(await invokeSetName(mergeFirst, "merged")).toBe("v3:merged");
+
+        await mergeRuntime.patternManager.flushCompileCacheWrites();
+        await mergeManager.synced();
+
+        const firstClosure = await loadClosure(mergeRuntime, firstRef.identity);
+        const intermediateClosure = await loadClosure(
+          mergeRuntime,
+          intermediateRef.identity,
+        );
+        const secondClosure = await loadClosure(
+          mergeRuntime,
+          secondRef.identity,
+        );
+        const successorClosure = await loadClosure(
+          mergeRuntime,
+          successorRef.identity,
+        );
+        const byName = (closure: NonNullable<typeof firstClosure>) =>
+          new Map(
+            [...closure].map(([identity, doc]) => [doc.filename, identity]),
           );
-          expect(
-            authenticatedSourceClosure?.get(successorRef.identity)
-              ?.delegatedModuleIdentities?.length,
-          ).toBeGreaterThan(0);
-        } finally {
-          inspectTx.abort();
+        const firstByName = byName(firstClosure!);
+        const intermediateByName = byName(intermediateClosure!);
+        const secondByName = byName(secondClosure!);
+
+        for (const [identity, doc] of successorClosure!) {
+          if (!doc.filename.startsWith("/")) continue;
+          const delegated = doc.delegatedModuleIdentities ?? [];
+          expect(delegated).toContain(firstByName.get(doc.filename));
+          expect(delegated).toContain(intermediateByName.get(doc.filename));
+          expect(delegated).toContain(secondByName.get(doc.filename));
+          expect(delegated).not.toContain(identity);
         }
 
-        const repairManager = await createFreshManager(repairRuntime);
-        await new PiecesController(repairManager).get(
-          first.id,
-          true,
-        );
-        const delegationTx = repairRuntime.edit();
-        expect(
-          delegationTx.getCfcState().moduleDelegations.get(
-            successorRef.identity,
-          )?.length,
-        ).toBeGreaterThan(0);
-        delegationTx.abort();
-        await repairRuntime.patternManager.flushCompileCacheWrites();
-        await repairManager.synced();
-
-        const compiledTx = repairRuntime.edit();
+        const compiledTx = mergeRuntime.edit();
         try {
-          const repairedClosure = await loadCompiledClosure(
-            repairRuntime,
-            manager.getSpace(),
+          const compiledClosure = await loadCompiledClosure(
+            mergeRuntime,
+            patternSpace,
             successorRef.identity,
             { runtimeVersion: bumpedRuntimeVersion },
             compiledTx,
           );
-          for (const [identity, sourceDoc] of authenticatedSourceClosure!) {
-            expect(
-              repairedClosure.get(identity)?.delegatedModuleIdentities,
-            ).toEqual(sourceDoc.delegatedModuleIdentities);
+          for (const [identity, sourceDoc] of successorClosure!) {
+            expect(compiledClosure.get(identity)?.delegatedModuleIdentities)
+              .toEqual(sourceDoc.delegatedModuleIdentities);
           }
         } finally {
           compiledTx.abort();
         }
+
+        // A later cold runtime can warm-hit only the repaired compiled set;
+        // both predecessor chains still have to authorize the first pattern.
+        const coldRuntime = createFreshRuntime();
+        const coldManager = await createFreshManager(coldRuntime);
+        const coldPiece = await new PiecesController(coldManager).get(
+          first.id,
+          true,
+        );
+        expect(await invokeSetName(coldPiece, "cold")).toBe("v3:cold");
       } finally {
         restoreRuntimeVersion();
       }

--- a/packages/piece/test/setsrc-module-delegation.test.ts
+++ b/packages/piece/test/setsrc-module-delegation.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import {
+  getPatternIdentityRef,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { loadVerifiedSourceClosure } from "../../runner/src/compilation-cache/cell-cache.ts";
+import { PieceManager } from "../src/manager.ts";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("setsrc module delegation");
+
+function authorizedWriterProgram(version: string): RuntimeProgram {
+  return {
+    main: "/app/main.tsx",
+    files: [
+      {
+        name: "/app/main.tsx",
+        contents: `/// <cts-enable />
+import {
+  handler,
+  pattern,
+  Writable,
+  WriteAuthorizedBy,
+} from "commonfabric";
+import { revision } from "../shared/revision.ts";
+
+const setName = handler<
+  { name: string },
+  { name: Writable<string> }
+>((event, state) => {
+  state.name.set(revision + ":" + event.name);
+});
+
+export default pattern<{ seed?: string }>(() => {
+  const name = new Writable<
+    WriteAuthorizedBy<string, typeof setName>
+  >("initial").for("name");
+  return { name, setName: setName({ name }) };
+});
+`,
+      },
+      {
+        name: "/shared/revision.ts",
+        contents: `/// <cts-enable />
+export const revision = ${JSON.stringify(version)};
+`,
+      },
+    ],
+  };
+}
+
+describe("setsrc module delegation", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "setsrc-delegation-" + crypto.randomUUID(),
+    });
+    manager = new PieceManager(session, runtime);
+    await manager.synced();
+    pieces = new PiecesController(manager);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("merges predecessor chains into an already-stored successor closure", async () => {
+    const first = await pieces.create(authorizedWriterProgram("v1"), {
+      input: {},
+    });
+    const second = await pieces.create(authorizedWriterProgram("v4"), {
+      input: {},
+    });
+
+    const firstRef = getPatternIdentityRef(first.getCell())!;
+    const secondRef = getPatternIdentityRef(second.getCell())!;
+
+    const invokeSetName = async (
+      piece: typeof first,
+      name: string,
+    ): Promise<string> => {
+      const result = await piece.result.getCell();
+      result.key("setName").send({ name });
+      await result.pull();
+      return await piece.result.get(["name"]) as string;
+    };
+
+    expect(await invokeSetName(first, "before")).toBe("v1:before");
+
+    await first.setPattern(authorizedWriterProgram("v2"));
+    const intermediateRef = getPatternIdentityRef(first.getCell())!;
+    expect(await invokeSetName(first, "middle")).toBe("v2:middle");
+    await first.setPattern(authorizedWriterProgram("v3"));
+    expect(await invokeSetName(first, "after")).toBe("v3:after");
+    await second.setPattern(authorizedWriterProgram("v3"));
+
+    const successorRef = getPatternIdentityRef(second.getCell())!;
+    expect(getPatternIdentityRef(first.getCell())).toEqual(successorRef);
+
+    const loadClosure = async (identity: string) => {
+      const tx = runtime.edit();
+      try {
+        return await loadVerifiedSourceClosure(
+          runtime,
+          manager.getSpace(),
+          identity,
+          tx,
+        );
+      } finally {
+        tx.abort();
+      }
+    };
+    const firstClosure = await loadClosure(firstRef.identity);
+    const intermediateClosure = await loadClosure(intermediateRef.identity);
+    const secondClosure = await loadClosure(secondRef.identity);
+    const successorClosure = await loadClosure(successorRef.identity);
+
+    const byName = (closure: NonNullable<typeof firstClosure>) =>
+      new Map([...closure].map(([identity, doc]) => [doc.filename, identity]));
+    const firstByName = byName(firstClosure!);
+    const intermediateByName = byName(intermediateClosure!);
+    const secondByName = byName(secondClosure!);
+
+    for (const [identity, doc] of successorClosure!) {
+      if (!doc.filename.startsWith("/")) continue;
+      const delegated = (doc as typeof doc & {
+        delegatedModuleIdentities?: readonly string[];
+      }).delegatedModuleIdentities ?? [];
+      expect(delegated).toContain(firstByName.get(doc.filename));
+      expect(delegated).toContain(intermediateByName.get(doc.filename));
+      expect(delegated).toContain(secondByName.get(doc.filename));
+      expect(delegated).not.toContain(identity);
+    }
+
+    await runtime.patternManager.flushCompileCacheWrites();
+    await manager.synced();
+    const freshSession = await createSession({
+      identity: signer,
+      spaceName: manager.getSpaceName()!,
+    });
+    const freshRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const freshManager = new PieceManager(freshSession, freshRuntime);
+      await freshManager.synced();
+      const freshPiece = await new PiecesController(freshManager).get(
+        first.id,
+        true,
+      );
+      expect(await invokeSetName(freshPiece, "cold")).toBe("v3:cold");
+    } finally {
+      await freshRuntime.dispose();
+    }
+  });
+});

--- a/packages/piece/test/setsrc-module-delegation.test.ts
+++ b/packages/piece/test/setsrc-module-delegation.test.ts
@@ -7,7 +7,12 @@ import {
   type RuntimeProgram,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { loadVerifiedSourceClosure } from "../../runner/src/compilation-cache/cell-cache.ts";
+import {
+  loadCompiledClosure,
+  loadSourceClosure,
+  loadVerifiedSourceClosure,
+  setCompileCacheRuntimeVersionForTesting,
+} from "../../runner/src/compilation-cache/cell-cache.ts";
 import { PieceManager } from "../src/manager.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 
@@ -150,25 +155,103 @@ describe("setsrc module delegation", () => {
 
     await runtime.patternManager.flushCompileCacheWrites();
     await manager.synced();
-    const freshSession = await createSession({
-      identity: signer,
-      spaceName: manager.getSpaceName()!,
-    });
-    const freshRuntime = new Runtime({
-      apiUrl: new URL("http://toolshed.test"),
-      storageManager,
-      cfcEnforcementMode: "enforce-explicit",
-    });
+    const freshRuntimes: Runtime[] = [];
     try {
-      const freshManager = new PieceManager(freshSession, freshRuntime);
-      await freshManager.synced();
-      const freshPiece = await new PiecesController(freshManager).get(
+      const createFreshRuntime = () => {
+        const freshRuntime = new Runtime({
+          apiUrl: new URL("http://toolshed.test"),
+          storageManager,
+          cfcEnforcementMode: "enforce-explicit",
+        });
+        // Runtime.dispose() closes the shared emulated storage manager, so all
+        // cold-start runtimes stay alive until the assertions are complete.
+        freshRuntimes.push(freshRuntime);
+        return freshRuntime;
+      };
+      const createFreshManager = async (freshRuntime: Runtime) => {
+        const freshSession = await createSession({
+          identity: signer,
+          spaceName: manager.getSpaceName()!,
+        });
+        const freshManager = new PieceManager(freshSession, freshRuntime);
+        await freshManager.synced();
+        return freshManager;
+      };
+
+      // The ordinary compiled-cache cold start still exercises delegation at
+      // the authorization boundary.
+      const coldRuntime = createFreshRuntime();
+      const coldManager = await createFreshManager(coldRuntime);
+      const coldPiece = await new PiecesController(coldManager).get(
         first.id,
         true,
       );
-      expect(await invokeSetName(freshPiece, "cold")).toBe("v3:cold");
+      expect(await invokeSetName(coldPiece, "cold")).toBe("v3:cold");
+
+      const bumpedRuntimeVersion = "setsrc-delegation-version-b";
+      const restoreRuntimeVersion = setCompileCacheRuntimeVersionForTesting(
+        bumpedRuntimeVersion,
+      );
+      try {
+        const repairRuntime = createFreshRuntime();
+        const inspectTx = repairRuntime.edit();
+        let authenticatedSourceClosure: Awaited<
+          ReturnType<typeof loadSourceClosure>
+        >;
+        try {
+          authenticatedSourceClosure = await loadSourceClosure(
+            repairRuntime,
+            manager.getSpace(),
+            successorRef.identity,
+            inspectTx,
+          );
+          expect(
+            authenticatedSourceClosure?.get(successorRef.identity)
+              ?.delegatedModuleIdentities?.length,
+          ).toBeGreaterThan(0);
+        } finally {
+          inspectTx.abort();
+        }
+
+        const repairManager = await createFreshManager(repairRuntime);
+        await new PiecesController(repairManager).get(
+          first.id,
+          true,
+        );
+        const delegationTx = repairRuntime.edit();
+        expect(
+          delegationTx.getCfcState().moduleDelegations.get(
+            successorRef.identity,
+          )?.length,
+        ).toBeGreaterThan(0);
+        delegationTx.abort();
+        await repairRuntime.patternManager.flushCompileCacheWrites();
+        await repairManager.synced();
+
+        const compiledTx = repairRuntime.edit();
+        try {
+          const repairedClosure = await loadCompiledClosure(
+            repairRuntime,
+            manager.getSpace(),
+            successorRef.identity,
+            { runtimeVersion: bumpedRuntimeVersion },
+            compiledTx,
+          );
+          for (const [identity, sourceDoc] of authenticatedSourceClosure!) {
+            expect(
+              repairedClosure.get(identity)?.delegatedModuleIdentities,
+            ).toEqual(sourceDoc.delegatedModuleIdentities);
+          }
+        } finally {
+          compiledTx.abort();
+        }
+      } finally {
+        restoreRuntimeVersion();
+      }
     } finally {
-      await freshRuntime.dispose();
+      for (const freshRuntime of freshRuntimes.reverse()) {
+        await freshRuntime.dispose();
+      }
     }
   });
 });

--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -328,6 +328,25 @@ export const canonicalizePreparedDigestInput = (
   ).sort(compareWritePolicyInput),
   implementationIdentity: input.implementationIdentity,
   trustSnapshot: input.trustSnapshot,
+  ...(input.moduleDelegations !== undefined &&
+      input.moduleDelegations.length > 0
+    ? {
+      moduleDelegations: [...input.moduleDelegations]
+        .map((entry) => ({
+          moduleIdentity: entry.moduleIdentity,
+          delegatedModuleIdentities: [
+            ...entry.delegatedModuleIdentities,
+          ].sort(),
+        }))
+        .sort((left, right) =>
+          left.moduleIdentity < right.moduleIdentity
+            ? -1
+            : left.moduleIdentity > right.moduleIdentity
+            ? 1
+            : 0
+        ),
+    }
+    : {}),
   // Already canonical: a digest-only projection of the frozen policy
   // snapshot (Epic B5). Absent (no policies configured) stays absent so
   // pre-B5 digests are unchanged.

--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -333,13 +333,18 @@ export const canonicalizePreparedDigestInput = (
     ? {
       moduleDelegations: [...input.moduleDelegations]
         .map((entry) => ({
+          space: entry.space,
           moduleIdentity: entry.moduleIdentity,
           delegatedModuleIdentities: [
             ...entry.delegatedModuleIdentities,
           ].sort(),
         }))
         .sort((left, right) =>
-          left.moduleIdentity < right.moduleIdentity
+          left.space < right.space
+            ? -1
+            : left.space > right.space
+            ? 1
+            : left.moduleIdentity < right.moduleIdentity
             ? -1
             : left.moduleIdentity > right.moduleIdentity
             ? 1

--- a/packages/runner/src/cfc/implementation-identity.ts
+++ b/packages/runner/src/cfc/implementation-identity.ts
@@ -61,9 +61,11 @@ const resolveProvenanceImplementationIdentity = (
 
   // `.src` (the debug source location) is NO LONGER consulted for identity: the
   // WeakMap provenance lookup above IS the anti-spoof proof (an attacker-supplied
-  // function has no entry), and every field the `writeAuthorizedBy` gate checks
-  // (`moduleIdentity`, `sourceFile`, `bindingPath` — prepare.ts) is provenance-
-  // derived, never `.src`-derived. The former `identityFromCanonicalSource(.src)
+  // function has no entry), and the policy-facing identity fields are provenance-
+  // derived, never `.src`-derived. `writeAuthorizedBy` verifies the direct or
+  // delegated `moduleIdentity` plus the exact `bindingPath`; `sourceFile` remains
+  // diagnostic at verification time and participates only when claims are minted
+  // or reconciled. The former `identityFromCanonicalSource(.src)
   // === provenance.identity` consistency check was defense-in-depth, not the
   // security boundary; it is dropped so that making `.src` lazy/debug-only
   // (skipped at boot) cannot flip a genuinely-verified implementation to

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -507,6 +507,7 @@ const writeAuthorizedByReason = (
   tx: IExtendedStorageTransaction,
   schema: JSONSchema,
   path: readonly string[],
+  targetSpace: MemorySpace,
   targetIdentity?: ImplementationIdentity,
 ): string | undefined => {
   if (!isRecord(schema) || !isRecord(schema.ifc)) {
@@ -568,9 +569,9 @@ const writeAuthorizedByReason = (
     typeof writerModuleIdentity === "string" &&
     writerModuleIdentity.length > 0 &&
     (writerModuleIdentity === claimedModuleIdentity ||
-      tx.getCfcState().moduleDelegations.get(writerModuleIdentity)?.includes(
-          claimedModuleIdentity,
-        ) === true);
+      tx.getCfcState().moduleDelegations.get(targetSpace)?.get(
+          writerModuleIdentity,
+        )?.includes(claimedModuleIdentity) === true);
   if (
     !identityArmMatches ||
     !arraysEqual(identity.bindingPath, bindingIdentity.path)
@@ -3457,6 +3458,7 @@ const verifyInputRequirements = (
       tx,
       entry.schema,
       entry.path,
+      target.space,
       identityForPath(entry.path),
     );
     const setupProjection = setupProjectionSourceMatchesValue(

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -555,11 +555,15 @@ const writeAuthorizedByReason = (
   // must match the live identity's. The legacy bundleId-only arm (stored
   // pre-#4009 claims) retired with the legacy read path (identity E5,
   // data-wipe decision): a claim without a moduleIdentity is rejected.
-  const identityArmMatches =
-    typeof bindingIdentity.moduleIdentity === "string" &&
-    typeof identity.moduleIdentity === "string" &&
-    identity.moduleIdentity.length > 0 &&
-    identity.moduleIdentity === bindingIdentity.moduleIdentity;
+  const claimedModuleIdentity = bindingIdentity.moduleIdentity;
+  const writerModuleIdentity = identity.moduleIdentity;
+  const identityArmMatches = typeof claimedModuleIdentity === "string" &&
+    typeof writerModuleIdentity === "string" &&
+    writerModuleIdentity.length > 0 &&
+    (writerModuleIdentity === claimedModuleIdentity ||
+      tx.getCfcState().moduleDelegations.get(writerModuleIdentity)?.includes(
+          claimedModuleIdentity,
+        ) === true);
   if (
     !identityArmMatches ||
     normalizeIdentitySource(identity.sourceFile) !==

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -101,9 +101,10 @@ const writerClaimWithoutStampAndFile = (
  * stamp (`moduleIdentity`, or a legacy `bundleId` on pre-migration claims),
  * the existing side when neither does or both carry the SAME stamp (stored
  * spelling wins — stability), and `undefined` when the claims genuinely
- * conflict (different bindings, or two different stamps — claim rotation
- * across module versions stays fail-closed pending the setsrc-history
- * delegation design).
+ * conflict (different bindings, or two different stamps). A legitimate
+ * `setsrc` update does not rotate this stamp: the stored claim keeps its
+ * predecessor identity, and authenticated module delegation authorizes the
+ * successor at verification time.
  */
 const reconcileWriterClaimStamp = (
   existing: unknown,

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -381,6 +381,11 @@ export type TrustSnapshot = {
   revision?: string;
 };
 
+export type ModuleDelegationSnapshotEntry = {
+  readonly moduleIdentity: string;
+  readonly delegatedModuleIdentities: readonly string[];
+};
+
 // `WritePolicyInput` is field-level `readonly` rather than `Immutable<>`
 // because its `link-write` variant carries a `CfcLabelView` whose
 // implementation-side helpers (`cloneCfcLabelView()`,
@@ -477,6 +482,8 @@ export type PreparedDigestInput = {
   readonly writePolicyInputs: readonly WritePolicyInput[];
   readonly implementationIdentity?: ImplementationIdentity;
   readonly trustSnapshot?: TrustSnapshot;
+  /** Update-authority aliases consulted by writeAuthorizedBy verification. */
+  readonly moduleDelegations?: readonly ModuleDelegationSnapshotEntry[];
   // Digest of the policy snapshot the boundary decisions evaluated under
   // (Epic B5): anything that can change a boundary decision must be in the
   // digest, so a decision made under one rule set cannot be committed under
@@ -680,6 +687,9 @@ export type CfcTxState = {
     identity?: ImplementationIdentity;
   };
   trustSnapshot?: TrustSnapshot;
+  // Transitive successor -> predecessor writer-authority aliases, snapshotted
+  // from the Runtime when the transaction is created and write-once pinned.
+  moduleDelegations: ReadonlyMap<string, readonly string[]>;
   implementationIdentity?: ImplementationIdentity;
   outbox: PostCommitSideEffect[];
   diagnostics: string[];

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -382,6 +382,7 @@ export type TrustSnapshot = {
 };
 
 export type ModuleDelegationSnapshotEntry = {
+  readonly space: MemorySpace;
   readonly moduleIdentity: string;
   readonly delegatedModuleIdentities: readonly string[];
 };
@@ -687,9 +688,13 @@ export type CfcTxState = {
     identity?: ImplementationIdentity;
   };
   trustSnapshot?: TrustSnapshot;
-  // Transitive successor -> predecessor writer-authority aliases, snapshotted
-  // from the Runtime when the transaction is created and write-once pinned.
-  moduleDelegations: ReadonlyMap<string, readonly string[]>;
+  // Attesting space -> transitive successor -> predecessor writer-authority
+  // aliases, snapshotted from the Runtime when the transaction is created and
+  // write-once pinned. Authorization consults only the target document's space.
+  moduleDelegations: ReadonlyMap<
+    MemorySpace,
+    ReadonlyMap<string, readonly string[]>
+  >;
   implementationIdentity?: ImplementationIdentity;
   outbox: PostCommitSideEffect[];
   diagnostics: string[];

--- a/packages/runner/src/cfc/writer-claim-correspondence.ts
+++ b/packages/runner/src/cfc/writer-claim-correspondence.ts
@@ -25,8 +25,10 @@
  * reconcile-adoption edge, a hostile verified module whose forged path
  * differs from a stored unstamped claim's by one leading segment is accepted
  * where before it needed the exact spelling — a marginal widening of the
- * pre-existing path-forgeability that mint-time identity binding /
- * authenticated `piece setsrc` delegation now closes for legitimate updates.
+ * pre-existing path-forgeability that #4871's mint-time identity binding closes
+ * at the source for newly engine-minted claims (aged unstamped claims remain
+ * compatibility state), with authenticated `piece setsrc` delegation carrying
+ * authority across legitimate updates (this PR).
  *
  * The correspondence is deliberately no wider than the divergence the
  * toolchain actually produced: equal after slash-normalization, or exactly

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -818,7 +818,7 @@ export function writeSourceDocs(
  * already-loaded linked cells synchronously — no per-cell `sync()`. Returns the
  * raw documents keyed by their **stored** identity (verify with
  * {@link verifySourceDocs} before trusting). Resolves to `undefined` if the
- * entry document is absent.
+ * entry document is absent or any cache import link crosses out of `space`.
  */
 export async function loadSourceClosure(
   runtime: Runtime,
@@ -851,7 +851,12 @@ export async function loadSourceClosure(
       // `link` is already a loaded Cell (the entry sync pulled it). View it
       // under the recursive schema so its own links resolve as cells too.
       if (!isCell(imp.link)) continue;
-      const childCell = (imp.link as Cell<unknown>).asSchema(
+      const linkedCell = imp.link as Cell<unknown>;
+      // Cache attestations are space-local. A cross-space child may be validly
+      // compiler-stamped in its own space, but must never be flattened into
+      // the requested space's verified closure (and delegation registry).
+      if (linkedCell.space !== space) return undefined;
+      const childCell = linkedCell.asSchema(
         SOURCE_DOC_SCHEMA,
       );
       const child = childCell.get() as StoredSourceDoc | undefined;
@@ -935,7 +940,10 @@ export async function loadVerifiedSourceClosure(
     ]);
     return undefined;
   }
-  runtime.registerModuleDelegations(moduleDelegationsFromDocs(closure));
+  runtime.registerModuleDelegations(
+    space,
+    moduleDelegationsFromDocs(closure),
+  );
   return closure;
 }
 
@@ -1341,10 +1349,11 @@ export function writeSourceAndCompiledDocs(
  * (never re-deriving a cell from a stored `identity` field), and a cell's stored
  * doc is used only after its own persisted CFC label is confirmed to carry the
  * compiler integrity atom. So every document in the result — and every import
- * edge — came from an integrity-stamped cell that the parent's sigil link
- * actually points at; an unstamped/tampered child is dropped along with the edge
- * to it (treated as a cache miss, so the caller recompiles). The entry is the
- * one cell looked up by key, from the caller's trusted `entryIdentity`.
+ * edge — came from an integrity-stamped cell in `space` that the parent's sigil
+ * link actually points at; an unstamped/tampered child is dropped along with
+ * the edge to it (treated as a cache miss, so the caller recompiles), while a
+ * mixed-space link rejects the whole closure. The entry is the one cell looked
+ * up by key, from the caller's trusted `entryIdentity`.
  *
  * Resolves to the valid documents keyed by their stored identity (empty map if
  * the entry itself is missing/unstamped).
@@ -1416,9 +1425,12 @@ export async function loadCompiledClosure(
       // `link` is an already-loaded Cell (the entry sync pulled it). View it
       // under the recursive schema so its own links resolve as cells too, then
       // integrity-check + read synchronously — no re-lookup by id, no sync.
-      const child = verifiedDoc(
-        (imp.link as Cell<unknown>).asSchema(COMPILED_DOC_SCHEMA),
-      );
+      const linkedCell = imp.link as Cell<unknown>;
+      // Compiled-cache integrity and module delegation authority are attested
+      // only in the linked cell's space. Mixed-space cache graphs fail closed
+      // instead of rebasing a child space's attestation onto `space`.
+      if (linkedCell.space !== space) return new Map();
+      const child = verifiedDoc(linkedCell.asSchema(COMPILED_DOC_SCHEMA));
       if (child === undefined) continue;
       imports.push({ specifier: imp.specifier, identity: child.identity });
       if (!visited.has(child.identity)) queue.push({ doc: child });
@@ -1455,6 +1467,6 @@ export async function loadCompiledClosure(
       imports,
     });
   }
-  runtime.registerModuleDelegations(moduleDelegationsFromDocs(out));
+  runtime.registerModuleDelegations(space, moduleDelegationsFromDocs(out));
   return out;
 }

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -2,6 +2,7 @@ import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
 import { CFC_COMPILED_BY_ATOM } from "@commonfabric/api/cfc";
 import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
+import { normalize } from "@std/path/posix";
 import { computeModuleHashes } from "../harness/module-identity.ts";
 import { ensureCompilerStack } from "../harness/deferred-compiler-stack.ts";
 import { deriveModuleRecordFields } from "../sandbox/module-record-compiler.ts";
@@ -52,6 +53,19 @@ export interface ModuleImportRef {
   readonly identity: string;
 }
 
+/**
+ * Per-module update authority: a module identity maps to the predecessor
+ * identities whose writer authority it may exercise. Values are cumulative;
+ * save paths merge them with the document already stored under the
+ * content-addressed key.
+ */
+export type ModuleDelegationMap = ReadonlyMap<
+  string,
+  ReadonlySet<string>
+>;
+
+const EMPTY_MODULE_DELEGATIONS: ModuleDelegationMap = new Map();
+
 interface ModuleDocBase {
   /** Module code: authored TS (source set) or compiled JS (compiled set). */
   readonly code: string;
@@ -59,6 +73,8 @@ interface ModuleDocBase {
   readonly filename: string;
   /** Resolved internal imports; each points at another document by identity. */
   readonly imports: readonly ModuleImportRef[];
+  /** Predecessor module identities whose writer authority this module inherits. */
+  readonly delegatedModuleIdentities?: readonly string[];
 }
 
 /** A source-set document (`pattern:<identity>`). */
@@ -100,6 +116,91 @@ export interface CompiledDoc extends ModuleDocBase {
    * reports nothing.
    */
   readonly patternCoverageSpans?: readonly PatternCoverageSpan[];
+}
+
+const canonicalModuleFilename = (filename: string): string =>
+  normalize(filename.replaceAll("\\", "/"));
+
+const validDelegatedModuleIdentities = (
+  identity: string,
+  ...values: readonly unknown[]
+): string[] => {
+  const merged = new Set<string>();
+  for (const value of values) {
+    if (!Array.isArray(value)) continue;
+    for (const candidate of value) {
+      if (
+        typeof candidate === "string" && candidate.length > 0 &&
+        candidate !== identity
+      ) {
+        merged.add(candidate);
+      }
+    }
+  }
+  return [...merged].sort();
+};
+
+/**
+ * Match a previous verified source closure to a newly emitted module set by
+ * canonical full filename. Matching deliberately uses the whole normalized
+ * path, never a basename: `../shared/writer.ts` has already resolved to the
+ * stored module filename, while two different `writer.ts` files remain
+ * distinct. Ambiguous duplicate canonical names are skipped fail-closed.
+ *
+ * Each successor inherits both its direct predecessor and that predecessor's
+ * cumulative delegation list, preserving update chains across a cold reload.
+ */
+export function deriveModuleDelegations(
+  previous: ReadonlyMap<string, SourceDoc>,
+  next: readonly CacheableModule[],
+): Map<string, ReadonlySet<string>> {
+  const previousByName = new Map<
+    string,
+    { identity: string; doc: SourceDoc }[]
+  >();
+  for (const [identity, doc] of previous) {
+    const name = canonicalModuleFilename(doc.filename);
+    const entries = previousByName.get(name) ?? [];
+    entries.push({ identity, doc });
+    previousByName.set(name, entries);
+  }
+
+  const nextNameCounts = new Map<string, number>();
+  for (const module of next) {
+    const name = canonicalModuleFilename(module.filename);
+    nextNameCounts.set(name, (nextNameCounts.get(name) ?? 0) + 1);
+  }
+
+  const delegations = new Map<string, ReadonlySet<string>>();
+  for (const module of next) {
+    const name = canonicalModuleFilename(module.filename);
+    const matches = previousByName.get(name);
+    if (matches?.length !== 1 || nextNameCounts.get(name) !== 1) continue;
+    const predecessor = matches[0];
+    const inherited = validDelegatedModuleIdentities(
+      module.identity,
+      predecessor.identity === module.identity ? [] : [predecessor.identity],
+      predecessor.doc.delegatedModuleIdentities,
+    );
+    if (inherited.length > 0) {
+      delegations.set(module.identity, new Set(inherited));
+    }
+  }
+  return delegations;
+}
+
+function delegationMapFromDocs(
+  docs: ReadonlyMap<string, ModuleDocBase>,
+): Map<string, ReadonlySet<string>> {
+  const result = new Map<string, ReadonlySet<string>>();
+  for (const [identity, doc] of docs) {
+    const delegated = validDelegatedModuleIdentities(
+      identity,
+      doc.delegatedModuleIdentities,
+    );
+    if (delegated.length > 0) result.set(identity, new Set(delegated));
+  }
+  return result;
 }
 
 /**
@@ -330,10 +431,15 @@ function storedImportRefs(
 export function buildSourceDocs(
   modules: readonly CacheableModule[],
   entryIdentity: string,
+  moduleDelegations: ModuleDelegationMap = EMPTY_MODULE_DELEGATIONS,
 ): Map<string, SourceDoc> {
   const extraRoots = unreachedRoots(modules, entryIdentity);
   const out = new Map<string, SourceDoc>();
   for (const module of modules) {
+    const delegatedModuleIdentities = validDelegatedModuleIdentities(
+      module.identity,
+      [...(moduleDelegations.get(module.identity) ?? [])],
+    );
     out.set(module.identity, {
       kind: "source",
       code: module.source,
@@ -341,6 +447,9 @@ export function buildSourceDocs(
       imports: storedImportRefs(module, entryIdentity, extraRoots, {
         includeFabricEdges: false,
       }),
+      ...(delegatedModuleIdentities.length > 0
+        ? { delegatedModuleIdentities }
+        : {}),
     });
   }
   return out;
@@ -480,6 +589,7 @@ interface StoredSourceDoc {
   code: string;
   filename: string;
   imports: { specifier: string; link: unknown }[];
+  delegatedModuleIdentities?: string[];
   // Optional product annotations — see {@link SourceDoc.annotations}. Stored
   // verbatim; never part of the content identity.
   annotations?: Record<string, unknown>;
@@ -511,6 +621,10 @@ export const SOURCE_DOC_SCHEMA = {
             },
           },
         },
+        delegatedModuleIdentities: {
+          type: "array",
+          items: { type: "string" },
+        },
         // Optional, non-normative product annotations (see SourceDoc).
         annotations: { type: "object" },
       },
@@ -539,6 +653,10 @@ export const SOURCE_DOC_SCHEMA = {
 export const WRITE_TARGET_EDGE_SYNC_SCHEMA = {
   type: "object",
   properties: {
+    delegatedModuleIdentities: {
+      type: "array",
+      items: { type: "string" },
+    },
     imports: {
       type: "array",
       items: {
@@ -564,9 +682,10 @@ export function writeSourceDocs(
   modules: readonly CacheableModule[],
   entryIdentity: string,
   tx: IExtendedStorageTransaction,
+  moduleDelegations: ModuleDelegationMap = EMPTY_MODULE_DELEGATIONS,
 ): void {
   assertNoUnpinnedFabricImports(modules);
-  const docs = buildSourceDocs(modules, entryIdentity);
+  const docs = buildSourceDocs(modules, entryIdentity, moduleDelegations);
   for (const [identity, doc] of docs) {
     // Write with an untyped cell (the recursive read schema would over-constrain
     // `set`); reads address the same entity via SOURCE_DOC_SCHEMA.
@@ -579,9 +698,15 @@ export function writeSourceDocs(
     // Preserve product annotations on the entry doc only. Annotations are only
     // written there; reading every dependency doc here turns unrelated stale
     // cache cells into writeback conflict preconditions.
+    const existing = cell.get();
     const existingAnnotations = identity === entryIdentity
-      ? cell.get()?.annotations
+      ? existing?.annotations
       : undefined;
+    const delegatedModuleIdentities = validDelegatedModuleIdentities(
+      identity,
+      existing?.delegatedModuleIdentities,
+      doc.delegatedModuleIdentities,
+    );
     cell.set({
       kind: "source",
       identity,
@@ -592,6 +717,9 @@ export function writeSourceDocs(
         link: runtime.getCell(space, sourceDocKey(imp.identity), undefined, tx)
           .getAsLink(),
       })),
+      ...(delegatedModuleIdentities.length > 0
+        ? { delegatedModuleIdentities }
+        : {}),
       ...(isRecord(existingAnnotations)
         ? { annotations: existingAnnotations }
         : {}),
@@ -649,6 +777,15 @@ export async function loadSourceClosure(
       code: doc.code,
       filename: doc.filename,
       imports,
+      ...(() => {
+        const delegatedModuleIdentities = validDelegatedModuleIdentities(
+          doc.identity,
+          doc.delegatedModuleIdentities,
+        );
+        return delegatedModuleIdentities.length > 0
+          ? { delegatedModuleIdentities }
+          : {};
+      })(),
       ...(isRecord(doc.annotations) ? { annotations: doc.annotations } : {}),
     });
     for (const child of childDocs) {
@@ -706,6 +843,7 @@ export async function loadVerifiedSourceClosure(
     ]);
     return undefined;
   }
+  runtime.registerModuleDelegations(delegationMapFromDocs(closure));
   return closure;
 }
 
@@ -735,6 +873,10 @@ const compiledDocProperties = {
   policyManifests: {
     type: "array",
     items: { type: "object", additionalProperties: true },
+  },
+  delegatedModuleIdentities: {
+    type: "array",
+    items: { type: "string" },
   },
   imports: {
     type: "array",
@@ -771,6 +913,10 @@ export const COMPILED_DOC_SCHEMA = {
         policyManifests: {
           type: "array",
           items: { type: "object", additionalProperties: true },
+        },
+        delegatedModuleIdentities: {
+          type: "array",
+          items: { type: "string" },
         },
         imports: {
           type: "array",
@@ -811,6 +957,7 @@ interface StoredCompiledDoc {
   importSpecs?: readonly string[];
   patternCoverageSpansJson?: string;
   policyManifests?: readonly unknown[];
+  delegatedModuleIdentities?: string[];
   imports: { specifier: string; link: unknown }[];
 }
 
@@ -893,7 +1040,10 @@ export function writeCompiledDocs(
   space: MemorySpace,
   modules: readonly CacheableModule[],
   entryIdentity: string,
-  opts: { runtimeVersion: string },
+  opts: {
+    runtimeVersion: string;
+    moduleDelegations?: ModuleDelegationMap;
+  },
   tx: IExtendedStorageTransaction,
 ): void {
   assertNoUnpinnedFabricImports(modules);
@@ -919,6 +1069,12 @@ export function writeCompiledDocs(
       // Fix B: derive the record surface from the compiled body once, here, so
       // the boot-time record build reads it instead of re-parsing per load.
       const derived = deriveModuleRecordFields(module.js);
+      const existing = cell.get() as StoredCompiledDoc | undefined;
+      const delegatedModuleIdentities = validDelegatedModuleIdentities(
+        module.identity,
+        existing?.delegatedModuleIdentities,
+        [...(opts.moduleDelegations?.get(module.identity) ?? [])],
+      );
       const policyManifests = module.policyManifests?.map((input) => {
         const artifact = validateCfcPolicyArtifactManifest(input);
         if (artifact.manifest.moduleIdentity !== module.identity) {
@@ -948,6 +1104,9 @@ export function writeCompiledDocs(
           ),
         }),
         ...(policyManifests === undefined ? {} : { policyManifests }),
+        ...(delegatedModuleIdentities.length > 0
+          ? { delegatedModuleIdentities }
+          : {}),
         imports: storedImportRefs(module, entryIdentity, extraRoots, {
           includeFabricEdges: true,
         }).map((ref) => ({
@@ -1079,8 +1238,18 @@ export async function loadCompiledClosure(
       ...(doc.policyManifests !== undefined
         ? { policyManifests: doc.policyManifests }
         : {}),
+      ...(() => {
+        const delegatedModuleIdentities = validDelegatedModuleIdentities(
+          doc.identity,
+          doc.delegatedModuleIdentities,
+        );
+        return delegatedModuleIdentities.length > 0
+          ? { delegatedModuleIdentities }
+          : {};
+      })(),
       imports,
     });
   }
+  runtime.registerModuleDelegations(delegationMapFromDocs(out));
   return out;
 }

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -66,6 +66,15 @@ export type ModuleDelegationMap = ReadonlyMap<
 
 const EMPTY_MODULE_DELEGATIONS: ModuleDelegationMap = new Map();
 
+/**
+ * Runtime-minted compiler attestation. Compiled documents carry it at their
+ * root; source documents carry it only on delegation metadata, whose mutable
+ * value is otherwise excluded from the source Merkle identity.
+ */
+export const COMPILED_INTEGRITY_ATOM: string = CFC_COMPILED_BY_ATOM;
+
+const SOURCE_DELEGATION_PATH = ["delegatedModuleIdentities"] as const;
+
 interface ModuleDocBase {
   /** Module code: authored TS (source set) or compiled JS (compiled set). */
   readonly code: string;
@@ -189,7 +198,7 @@ export function deriveModuleDelegations(
   return delegations;
 }
 
-function delegationMapFromDocs(
+export function moduleDelegationsFromDocs(
   docs: ReadonlyMap<string, ModuleDocBase>,
 ): Map<string, ReadonlySet<string>> {
   const result = new Map<string, ReadonlySet<string>>();
@@ -634,6 +643,57 @@ export const SOURCE_DOC_SCHEMA = {
 } as const satisfies JSONSchema;
 
 /**
+ * Flat source-document write schema. Only delegation metadata receives the
+ * runtime-minted compiler attestation: source code/imports remain
+ * self-verifying through their content identity, while annotations remain
+ * independently mutable.
+ */
+function sourceDocWriteSchema(): JSONSchema {
+  return {
+    type: "object",
+    properties: {
+      kind: { type: "string" },
+      identity: { type: "string" },
+      code: { type: "string" },
+      filename: { type: "string" },
+      imports: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            specifier: { type: "string" },
+            link: true,
+          },
+        },
+      },
+      delegatedModuleIdentities: {
+        type: "array",
+        items: { type: "string" },
+        ifc: { addIntegrity: [COMPILED_INTEGRITY_ATOM] },
+      },
+      annotations: { type: "object" },
+    },
+  };
+}
+
+/** Attribute cache-document writes to the trusted compiler builtin. */
+function withCompileCacheBuiltin<T>(
+  tx: IExtendedStorageTransaction,
+  action: () => T,
+): T {
+  const priorIdentity = tx.getCfcState().implementationIdentity;
+  tx.setCfcImplementationIdentity({
+    kind: "builtin",
+    builtinId: "compile-cache",
+  });
+  try {
+    return action();
+  } finally {
+    tx.setCfcImplementationIdentity(priorIdentity);
+  }
+}
+
+/**
  * One-hop selector for pre-syncing write-back targets (CT-1848). A stored
  * source/compiled doc's `imports` array holds LIVE links to per-edge element
  * docs (the cell layer hoists each `{specifier, link}` element into its own
@@ -686,45 +746,61 @@ export function writeSourceDocs(
 ): void {
   assertNoUnpinnedFabricImports(modules);
   const docs = buildSourceDocs(modules, entryIdentity, moduleDelegations);
-  for (const [identity, doc] of docs) {
-    // Write with an untyped cell (the recursive read schema would over-constrain
-    // `set`); reads address the same entity via SOURCE_DOC_SCHEMA.
-    const cell = runtime.getCell<StoredSourceDoc>(
-      space,
-      sourceDocKey(identity),
-      undefined,
-      tx,
-    );
-    // Preserve product annotations on the entry doc only. Annotations are only
-    // written there; reading every dependency doc here turns unrelated stale
-    // cache cells into writeback conflict preconditions.
-    const existing = cell.get();
-    const existingAnnotations = identity === entryIdentity
-      ? existing?.annotations
-      : undefined;
-    const delegatedModuleIdentities = validDelegatedModuleIdentities(
-      identity,
-      existing?.delegatedModuleIdentities,
-      doc.delegatedModuleIdentities,
-    );
-    cell.set({
-      kind: "source",
-      identity,
-      code: doc.code,
-      filename: doc.filename,
-      imports: doc.imports.map((imp) => ({
-        specifier: imp.specifier,
-        link: runtime.getCell(space, sourceDocKey(imp.identity), undefined, tx)
-          .getAsLink(),
-      })),
-      ...(delegatedModuleIdentities.length > 0
-        ? { delegatedModuleIdentities }
-        : {}),
-      ...(isRecord(existingAnnotations)
-        ? { annotations: existingAnnotations }
-        : {}),
-    } as StoredSourceDoc);
-  }
+  withCompileCacheBuiltin(tx, () => {
+    for (const [identity, doc] of docs) {
+      // Flat write schema: source recursion is a read concern; the delegation
+      // field alone receives compiler integrity.
+      const cell = runtime.getCell<StoredSourceDoc>(
+        space,
+        sourceDocKey(identity),
+        sourceDocWriteSchema(),
+        tx,
+      );
+      // Preserve product annotations on the entry doc only. Annotations are
+      // only written there; reading every dependency doc here turns unrelated
+      // stale cache cells into writeback conflict preconditions.
+      const existing = cell.get();
+      const existingAnnotations = identity === entryIdentity
+        ? existing?.annotations
+        : undefined;
+      // Never turn arbitrary mutable source metadata into trusted authority:
+      // only merge predecessor entries carrying the compiler's field label.
+      const authenticatedExistingDelegations = cellCarriesIntegrity(
+          cell,
+          COMPILED_INTEGRITY_ATOM,
+          tx,
+          SOURCE_DELEGATION_PATH,
+        )
+        ? existing?.delegatedModuleIdentities
+        : undefined;
+      const delegatedModuleIdentities = validDelegatedModuleIdentities(
+        identity,
+        authenticatedExistingDelegations,
+        doc.delegatedModuleIdentities,
+      );
+      cell.set({
+        kind: "source",
+        identity,
+        code: doc.code,
+        filename: doc.filename,
+        imports: doc.imports.map((imp) => ({
+          specifier: imp.specifier,
+          link: runtime.getCell(
+            space,
+            sourceDocKey(imp.identity),
+            undefined,
+            tx,
+          ).getAsLink(),
+        })),
+        ...(delegatedModuleIdentities.length > 0
+          ? { delegatedModuleIdentities }
+          : {}),
+        ...(isRecord(existingAnnotations)
+          ? { annotations: existingAnnotations }
+          : {}),
+      } as StoredSourceDoc);
+    }
+  });
 }
 
 /**
@@ -755,41 +831,50 @@ export async function loadSourceClosure(
   if (!root || typeof root.identity !== "string") return undefined;
 
   const out = new Map<string, SourceDoc>();
-  const queue: StoredSourceDoc[] = [root];
+  const queue: { doc: StoredSourceDoc; cell: Cell<unknown> }[] = [{
+    doc: root,
+    cell: entry,
+  }];
   while (queue.length > 0) {
-    const doc = queue.shift()!;
+    const { doc, cell } = queue.shift()!;
     if (out.has(doc.identity)) continue;
     const imports: ModuleImportRef[] = [];
-    const childDocs: StoredSourceDoc[] = [];
+    const childDocs: { doc: StoredSourceDoc; cell: Cell<unknown> }[] = [];
     for (const imp of doc.imports ?? []) {
       // `link` is already a loaded Cell (the entry sync pulled it). View it
       // under the recursive schema so its own links resolve as cells too.
       if (!isCell(imp.link)) continue;
-      const child = (imp.link as Cell<unknown>)
-        .asSchema(SOURCE_DOC_SCHEMA)
-        .get() as StoredSourceDoc | undefined;
+      const childCell = (imp.link as Cell<unknown>).asSchema(
+        SOURCE_DOC_SCHEMA,
+      );
+      const child = childCell.get() as StoredSourceDoc | undefined;
       if (!child || typeof child.identity !== "string") continue;
       imports.push({ specifier: imp.specifier, identity: child.identity });
-      childDocs.push(child);
+      childDocs.push({ doc: child, cell: childCell });
     }
+    const delegatedModuleIdentities = cellCarriesIntegrity(
+        cell,
+        COMPILED_INTEGRITY_ATOM,
+        tx,
+        SOURCE_DELEGATION_PATH,
+      )
+      ? validDelegatedModuleIdentities(
+        doc.identity,
+        doc.delegatedModuleIdentities,
+      )
+      : [];
     out.set(doc.identity, {
       kind: "source",
       code: doc.code,
       filename: doc.filename,
       imports,
-      ...(() => {
-        const delegatedModuleIdentities = validDelegatedModuleIdentities(
-          doc.identity,
-          doc.delegatedModuleIdentities,
-        );
-        return delegatedModuleIdentities.length > 0
-          ? { delegatedModuleIdentities }
-          : {};
-      })(),
+      ...(delegatedModuleIdentities.length > 0
+        ? { delegatedModuleIdentities }
+        : {}),
       ...(isRecord(doc.annotations) ? { annotations: doc.annotations } : {}),
     });
     for (const child of childDocs) {
-      if (!out.has(child.identity)) queue.push(child);
+      if (!out.has(child.doc.identity)) queue.push(child);
     }
   }
   return out;
@@ -843,22 +928,11 @@ export async function loadVerifiedSourceClosure(
     ]);
     return undefined;
   }
-  runtime.registerModuleDelegations(delegationMapFromDocs(closure));
+  runtime.registerModuleDelegations(moduleDelegationsFromDocs(closure));
   return closure;
 }
 
 // --- Compiled-set store (4.3.3): `compileCache:<rtver>/<identity>` + CFC ------
-
-/**
- * The CFC integrity atom stamped on a compiled document: the constant
- * `cf-compiled-by:cf-compiler`, attesting that the doc was emitted by the
- * system compiler. The atom covers the code that produced the doc, so every
- * member of a shared space can read the same compiled cache entry. Minting is
- * gated: prepare strips `cf-compiled-by:` atoms from any write not authored by a
- * trusted builtin, and `writeCompiledDocs` below is the legitimate minter. The
- * server-side attestation model is described in docs/specs/module-loading.md.
- */
-export const COMPILED_INTEGRITY_ATOM: string = CFC_COMPILED_BY_ATOM;
 
 const compiledDocProperties = {
   kind: { type: "string" },
@@ -1007,11 +1081,12 @@ function storedCoverageSpans(
   return out;
 }
 
-/** Whether a cell's persisted CFC label carries `atom` at its root path. */
+/** Whether a cell's persisted CFC label carries `atom` at `path`. */
 function cellCarriesIntegrity(
   cell: Cell<unknown>,
   atom: string,
   tx: IExtendedStorageTransaction,
+  path: readonly (string | number)[] = [],
 ): boolean {
   const link = cell.getAsNormalizedFullLink();
   const metadata = readStoredCfcMetadata(tx, {
@@ -1021,7 +1096,8 @@ function cellCarriesIntegrity(
   });
   if (metadata === undefined) return false;
   return metadata.labelMap.entries.some((entry) =>
-    entry.path.length === 0 &&
+    entry.path.length === path.length &&
+    entry.path.every((segment, index) => segment === path[index]) &&
     Array.isArray(entry.label.integrity) &&
     entry.label.integrity.some((a) => a === atom)
   );
@@ -1049,16 +1125,7 @@ export function writeCompiledDocs(
   assertNoUnpinnedFabricImports(modules);
   const extraRoots = unreachedRoots(modules, entryIdentity);
   const schema = compiledDocWriteSchema();
-  // Attribute these writes to the compile-cache builtin for the duration of
-  // the doc writes: prepare's runtime-minted-evidence gate strips the
-  // `cf-compiled-by:` atom from any write whose recorded author is not a
-  // trusted builtin, and the author is captured per write at record time.
-  const priorIdentity = tx.getCfcState().implementationIdentity;
-  tx.setCfcImplementationIdentity({
-    kind: "builtin",
-    builtinId: "compile-cache",
-  });
-  try {
+  withCompileCacheBuiltin(tx, () => {
     for (const module of modules) {
       const cell = runtime.getCell(
         space,
@@ -1070,9 +1137,16 @@ export function writeCompiledDocs(
       // the boot-time record build reads it instead of re-parsing per load.
       const derived = deriveModuleRecordFields(module.js);
       const existing = cell.get() as StoredCompiledDoc | undefined;
+      const authenticatedExistingDelegations = cellCarriesIntegrity(
+          cell,
+          COMPILED_INTEGRITY_ATOM,
+          tx,
+        )
+        ? existing?.delegatedModuleIdentities
+        : undefined;
       const delegatedModuleIdentities = validDelegatedModuleIdentities(
         module.identity,
-        existing?.delegatedModuleIdentities,
+        authenticatedExistingDelegations,
         [...(opts.moduleDelegations?.get(module.identity) ?? [])],
       );
       const policyManifests = module.policyManifests?.map((input) => {
@@ -1120,9 +1194,7 @@ export function writeCompiledDocs(
         })),
       } as StoredCompiledDoc);
     }
-  } finally {
-    tx.setCfcImplementationIdentity(priorIdentity);
-  }
+  });
 }
 
 /**
@@ -1250,6 +1322,6 @@ export async function loadCompiledClosure(
       imports,
     });
   }
-  runtime.registerModuleDelegations(delegationMapFromDocs(out));
+  runtime.registerModuleDelegations(moduleDelegationsFromDocs(out));
   return out;
 }

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -734,7 +734,8 @@ export const WRITE_TARGET_EDGE_SYNC_SCHEMA = {
  * Write every emitted module as a `pattern:<identity>` cell into `space`, each
  * import a sigil link to its dependency cell (the entry additionally linking any
  * otherwise-unreachable module). Idempotent (content-addressed keys). The caller
- * owns the transaction's commit.
+ * owns the transaction's commit. Returns the authenticated delegation union
+ * actually staged by this write.
  */
 export function writeSourceDocs(
   runtime: Runtime,
@@ -743,9 +744,21 @@ export function writeSourceDocs(
   entryIdentity: string,
   tx: IExtendedStorageTransaction,
   moduleDelegations: ModuleDelegationMap = EMPTY_MODULE_DELEGATIONS,
-): void {
+): ModuleDelegationMap {
   assertNoUnpinnedFabricImports(modules);
-  const docs = buildSourceDocs(modules, entryIdentity, moduleDelegations);
+  const effectiveModuleDelegations = effectiveModuleDelegationsForWrite(
+    runtime,
+    space,
+    modules,
+    tx,
+    moduleDelegations,
+    { source: true },
+  );
+  const docs = buildSourceDocs(
+    modules,
+    entryIdentity,
+    effectiveModuleDelegations,
+  );
   withCompileCacheBuiltin(tx, () => {
     for (const [identity, doc] of docs) {
       const baseCell = runtime.getCell<StoredSourceDoc>(
@@ -761,21 +774,9 @@ export function writeSourceDocs(
       const existingAnnotations = identity === entryIdentity
         ? existing?.annotations
         : undefined;
-      // Never turn arbitrary mutable source metadata into trusted authority:
-      // only merge predecessor entries carrying the compiler's field label.
-      const authenticatedExistingDelegations = cellCarriesIntegrity(
-          baseCell,
-          COMPILED_INTEGRITY_ATOM,
-          tx,
-          SOURCE_DELEGATION_PATH,
-        )
-        ? existing?.delegatedModuleIdentities
-        : undefined;
-      const delegatedModuleIdentities = validDelegatedModuleIdentities(
-        identity,
-        authenticatedExistingDelegations,
-        doc.delegatedModuleIdentities,
-      );
+      const delegatedModuleIdentities = [
+        ...(doc.delegatedModuleIdentities ?? []),
+      ];
       // A source document without delegation metadata remains an ordinary,
       // self-verifying cache write. Attaching an addIntegrity schema even when
       // the field is absent would make every legacy/direct source-cache write
@@ -806,6 +807,7 @@ export function writeSourceDocs(
       } as StoredSourceDoc);
     }
   });
+  return effectiveModuleDelegations;
 }
 
 /**
@@ -1109,12 +1111,89 @@ function cellCarriesIntegrity(
 }
 
 /**
+ * Compute the authority that a cache write may persist. Requested delegations
+ * are unioned with only compiler-authenticated metadata already stored at the
+ * selected source/compiled targets. Combined source+compiled saves use both
+ * targets so the two document sets cannot diverge when shared successors are
+ * updated by different patterns.
+ */
+function effectiveModuleDelegationsForWrite(
+  runtime: Runtime,
+  space: MemorySpace,
+  modules: readonly CacheableModule[],
+  tx: IExtendedStorageTransaction,
+  requested: ModuleDelegationMap,
+  targets: {
+    source?: boolean;
+    compiledRuntimeVersion?: string;
+  },
+): Map<string, ReadonlySet<string>> {
+  const effective = new Map<string, ReadonlySet<string>>();
+  for (const module of modules) {
+    const candidates: unknown[] = [
+      [...(requested.get(module.identity) ?? [])],
+    ];
+    if (targets.source) {
+      const sourceCell = runtime.getCell<StoredSourceDoc>(
+        space,
+        sourceDocKey(module.identity),
+        undefined,
+        tx,
+      );
+      const existing = sourceCell.get();
+      // Mutable source metadata is authority only when the compiler attested
+      // this exact field; the source code/import graph verifies separately.
+      if (
+        cellCarriesIntegrity(
+          sourceCell,
+          COMPILED_INTEGRITY_ATOM,
+          tx,
+          SOURCE_DELEGATION_PATH,
+        )
+      ) {
+        candidates.push(existing?.delegatedModuleIdentities);
+      }
+    }
+    if (targets.compiledRuntimeVersion !== undefined) {
+      const compiledCell = runtime.getCell<StoredCompiledDoc>(
+        space,
+        compiledDocKey(
+          targets.compiledRuntimeVersion,
+          module.identity,
+        ),
+        undefined,
+        tx,
+      );
+      const existing = compiledCell.get();
+      if (
+        cellCarriesIntegrity(
+          compiledCell,
+          COMPILED_INTEGRITY_ATOM,
+          tx,
+        )
+      ) {
+        candidates.push(existing?.delegatedModuleIdentities);
+      }
+    }
+    const delegated = validDelegatedModuleIdentities(
+      module.identity,
+      ...candidates,
+    );
+    if (delegated.length > 0) {
+      effective.set(module.identity, new Set(delegated));
+    }
+  }
+  return effective;
+}
+
+/**
  * Write every emitted module's compiled body as a
  * `compileCache:<runtimeVersion>/<identity>` cell into `space`, stamped with the
  * compiler integrity atom, imports linked to dependency compiled cells (the
  * entry additionally linking any otherwise-unreachable module). The caller must
  * `prepareCfc()` + commit the tx under an enforcing CFC mode for the integrity
- * label to persist.
+ * label to persist. Returns the authenticated delegation union actually staged
+ * by this write.
  */
 export function writeCompiledDocs(
   runtime: Runtime,
@@ -1126,8 +1205,16 @@ export function writeCompiledDocs(
     moduleDelegations?: ModuleDelegationMap;
   },
   tx: IExtendedStorageTransaction,
-): void {
+): ModuleDelegationMap {
   assertNoUnpinnedFabricImports(modules);
+  const effectiveModuleDelegations = effectiveModuleDelegationsForWrite(
+    runtime,
+    space,
+    modules,
+    tx,
+    opts.moduleDelegations ?? EMPTY_MODULE_DELEGATIONS,
+    { compiledRuntimeVersion: opts.runtimeVersion },
+  );
   const extraRoots = unreachedRoots(modules, entryIdentity);
   const schema = compiledDocWriteSchema();
   withCompileCacheBuiltin(tx, () => {
@@ -1141,18 +1228,9 @@ export function writeCompiledDocs(
       // Fix B: derive the record surface from the compiled body once, here, so
       // the boot-time record build reads it instead of re-parsing per load.
       const derived = deriveModuleRecordFields(module.js);
-      const existing = cell.get() as StoredCompiledDoc | undefined;
-      const authenticatedExistingDelegations = cellCarriesIntegrity(
-          cell,
-          COMPILED_INTEGRITY_ATOM,
-          tx,
-        )
-        ? existing?.delegatedModuleIdentities
-        : undefined;
       const delegatedModuleIdentities = validDelegatedModuleIdentities(
         module.identity,
-        authenticatedExistingDelegations,
-        [...(opts.moduleDelegations?.get(module.identity) ?? [])],
+        [...(effectiveModuleDelegations.get(module.identity) ?? [])],
       );
       const policyManifests = module.policyManifests?.map((input) => {
         const artifact = validateCfcPolicyArtifactManifest(input);
@@ -1200,6 +1278,56 @@ export function writeCompiledDocs(
       } as StoredCompiledDoc);
     }
   });
+  return effectiveModuleDelegations;
+}
+
+/**
+ * Save matching source and compiled document sets with one authenticated
+ * delegation union. This is the cache write path for compilation and repair:
+ * an authority chain already present in either set is preserved in both, and
+ * the returned map is the exact committed authority the caller must install in
+ * its runtime after the transaction succeeds.
+ */
+export function writeSourceAndCompiledDocs(
+  runtime: Runtime,
+  space: MemorySpace,
+  modules: readonly CacheableModule[],
+  entryIdentity: string,
+  opts: {
+    runtimeVersion: string;
+    moduleDelegations?: ModuleDelegationMap;
+  },
+  tx: IExtendedStorageTransaction,
+): ModuleDelegationMap {
+  assertNoUnpinnedFabricImports(modules);
+  const effectiveModuleDelegations = effectiveModuleDelegationsForWrite(
+    runtime,
+    space,
+    modules,
+    tx,
+    opts.moduleDelegations ?? EMPTY_MODULE_DELEGATIONS,
+    {
+      source: true,
+      compiledRuntimeVersion: opts.runtimeVersion,
+    },
+  );
+  writeSourceDocs(
+    runtime,
+    space,
+    modules,
+    entryIdentity,
+    tx,
+    effectiveModuleDelegations,
+  );
+  writeCompiledDocs(
+    runtime,
+    space,
+    modules,
+    entryIdentity,
+    { ...opts, moduleDelegations: effectiveModuleDelegations },
+    tx,
+  );
+  return effectiveModuleDelegations;
 }
 
 /**

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -748,25 +748,23 @@ export function writeSourceDocs(
   const docs = buildSourceDocs(modules, entryIdentity, moduleDelegations);
   withCompileCacheBuiltin(tx, () => {
     for (const [identity, doc] of docs) {
-      // Flat write schema: source recursion is a read concern; the delegation
-      // field alone receives compiler integrity.
-      const cell = runtime.getCell<StoredSourceDoc>(
+      const baseCell = runtime.getCell<StoredSourceDoc>(
         space,
         sourceDocKey(identity),
-        sourceDocWriteSchema(),
+        undefined,
         tx,
       );
       // Preserve product annotations on the entry doc only. Annotations are
       // only written there; reading every dependency doc here turns unrelated
       // stale cache cells into writeback conflict preconditions.
-      const existing = cell.get();
+      const existing = baseCell.get();
       const existingAnnotations = identity === entryIdentity
         ? existing?.annotations
         : undefined;
       // Never turn arbitrary mutable source metadata into trusted authority:
       // only merge predecessor entries carrying the compiler's field label.
       const authenticatedExistingDelegations = cellCarriesIntegrity(
-          cell,
+          baseCell,
           COMPILED_INTEGRITY_ATOM,
           tx,
           SOURCE_DELEGATION_PATH,
@@ -778,6 +776,13 @@ export function writeSourceDocs(
         authenticatedExistingDelegations,
         doc.delegatedModuleIdentities,
       );
+      // A source document without delegation metadata remains an ordinary,
+      // self-verifying cache write. Attaching an addIntegrity schema even when
+      // the field is absent would make every legacy/direct source-cache write
+      // CFC-relevant and require an otherwise-unnecessary prepare step.
+      const cell = delegatedModuleIdentities.length > 0
+        ? baseCell.asSchema(sourceDocWriteSchema())
+        : baseCell;
       cell.set({
         kind: "source",
         identity,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -31,9 +31,11 @@ import type {
 import {
   buildSourceDocs,
   compiledDocKey,
+  deriveModuleDelegations,
   getCompileCacheRuntimeVersion,
   loadCompiledClosure,
   loadVerifiedSourceClosure,
+  type ModuleDelegationMap,
   ROOT_LINK_SPECIFIER,
   type SourceDoc,
   sourceDocKey,
@@ -91,8 +93,17 @@ function compileCachePersistenceSlotKey(
 
 function compileCacheClosureSignature(
   moduleIdentities: readonly string[],
+  moduleDelegations: ModuleDelegationMap = new Map(),
 ): string {
-  return JSON.stringify([...new Set(moduleIdentities)].sort());
+  return JSON.stringify({
+    modules: [...new Set(moduleIdentities)].sort(),
+    delegations: [...moduleDelegations]
+      .map(([identity, predecessors]) => [
+        identity,
+        [...predecessors].sort(),
+      ])
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0),
+  });
 }
 
 function expectedSourceClosureIdentities(
@@ -111,6 +122,22 @@ function expectedSourceClosureIdentities(
     }
   }
   return reachable;
+}
+
+function closureIncludesModuleDelegations(
+  docs: ReadonlyMap<
+    string,
+    { readonly delegatedModuleIdentities?: readonly string[] }
+  >,
+  required: ModuleDelegationMap,
+): boolean {
+  for (const [identity, predecessors] of required) {
+    const stored = new Set(docs.get(identity)?.delegatedModuleIdentities ?? []);
+    for (const predecessor of predecessors) {
+      if (!stored.has(predecessor)) return false;
+    }
+  }
+  return true;
 }
 
 function compileCacheRecoveryKey(
@@ -461,6 +488,7 @@ export class PatternManager {
       throw new Error("coverage spans unavailable in origin space");
     }
     const modules: CacheableModule[] = [];
+    const moduleDelegations = new Map<string, ReadonlySet<string>>();
     const fabricDependencies = new Set<string>();
     for (const [identity, doc] of sourceDocs) {
       const compiled = compiledDocs?.get(identity);
@@ -468,6 +496,11 @@ export class PatternManager {
         throw new Error(`compiled doc missing for ${identity}`);
       }
       const fabricImports = fabricImportRefsFromSource(doc);
+      const delegated = new Set([
+        ...(doc.delegatedModuleIdentities ?? []),
+        ...(compiled?.delegatedModuleIdentities ?? []),
+      ].filter((candidate) => candidate !== identity));
+      if (delegated.size > 0) moduleDelegations.set(identity, delegated);
       for (const imp of fabricImports) {
         fabricDependencies.add(imp.targetIdentity);
       }
@@ -499,13 +532,19 @@ export class PatternManager {
       });
     }
     if (runtimeVersion === undefined) {
-      await this.persistSourceCacheTracked(toSpace, modules, entryIdentity);
+      await this.persistSourceCacheTracked(
+        toSpace,
+        modules,
+        entryIdentity,
+        moduleDelegations,
+      );
     } else {
       await this.persistCompileCacheTracked(
         toSpace,
         modules,
         entryIdentity,
         { runtimeVersion },
+        moduleDelegations,
       );
     }
 
@@ -516,6 +555,30 @@ export class PatternManager {
         toSpace,
         visited,
       );
+    }
+  }
+
+  private async loadPreviousSourceClosure(
+    space: MemorySpace,
+    entryIdentity: string,
+  ): Promise<Map<string, SourceDoc>> {
+    const tx = this.runtime.edit();
+    try {
+      const closure = await loadVerifiedSourceClosure(
+        this.runtime,
+        space,
+        entryIdentity,
+        tx,
+      );
+      if (!closure?.has(entryIdentity)) {
+        throw new Error(
+          `cannot authorize module update from ${entryIdentity}: ` +
+            "verified source closure is unavailable",
+        );
+      }
+      return closure;
+    } finally {
+      tx.abort?.("setsrc predecessor source load complete");
     }
   }
 
@@ -532,6 +595,10 @@ export class PatternManager {
       // compile (warm-by-identity or cold). Lets the caller persist it (e.g.
       // into pattern metadata) so subsequent loads can take the fast path.
       onEntryIdentity?: (entryIdentity: string) => void;
+      // `piece setsrc` predecessor. Its verified recursive source closure is
+      // matched to the emitted module set by canonical filename, producing the
+      // per-module update-authority delegations persisted with the successor.
+      previousEntryIdentity?: string;
     },
   ): Promise<Pattern> {
     let program: RuntimeProgram;
@@ -661,10 +728,17 @@ export class PatternManager {
       tx?: IExtendedStorageTransaction;
       knownEntryIdentity?: string;
       onEntryIdentity?: (entryIdentity: string) => void;
+      previousEntryIdentity?: string;
     },
   ): Promise<Pattern> {
     const harness = this.runtime.harness;
     const { space } = cacheCtx;
+    const previousSourceDocs = cacheCtx.previousEntryIdentity === undefined
+      ? undefined
+      : await this.loadPreviousSourceClosure(
+        space,
+        cacheCtx.previousEntryIdentity,
+      );
     const patternCoverage = this.patternCoverageFor();
     // The instrumented compile is a distinct cached variant: the coverage suffix
     // keeps its compiled bytes from colliding with an ordinary compile of the
@@ -685,7 +759,15 @@ export class PatternManager {
             ...(patternCoverage ? { patternCoverage } : {}),
           },
         );
-      await this.persistSourceCacheTracked(space, modules, entryIdentity);
+      const moduleDelegations = previousSourceDocs === undefined
+        ? new Map<string, ReadonlySet<string>>()
+        : deriveModuleDelegations(previousSourceDocs, modules);
+      await this.persistSourceCacheTracked(
+        space,
+        modules,
+        entryIdentity,
+        moduleDelegations,
+      );
       cacheCtx.onEntryIdentity?.(entryIdentity);
       // Yield ahead of the synchronous SES evaluation (see compilePattern).
       await interleaveCompileYield();
@@ -705,7 +787,7 @@ export class PatternManager {
     // entirely. Falls through to the compile path on any miss/incompleteness
     // (evaluateCachedModules re-verifies the graph, so an incomplete closure
     // throws and we recompile).
-    if (cacheCtx.knownEntryIdentity) {
+    if (cacheCtx.knownEntryIdentity && previousSourceDocs === undefined) {
       const byIdentity = await this.tryWarmLoadByIdentity(
         cacheCtx.knownEntryIdentity,
         space,
@@ -845,6 +927,9 @@ export class PatternManager {
       readTx.abort?.("compile-cache read complete");
     }
     const { id, graph, mainSpecifier, entryIdentity, modules } = compiled;
+    const moduleDelegations = previousSourceDocs === undefined
+      ? new Map<string, ReadonlySet<string>>()
+      : deriveModuleDelegations(previousSourceDocs, modules);
     cacheCtx.onEntryIdentity?.(entryIdentity);
 
     // Populate the process byte cache with this program's module bytes (freshly
@@ -870,6 +955,8 @@ export class PatternManager {
       this.esmCacheStats.hits++;
     } else {
       this.esmCacheStats[compiledBodiesServed ? "hits" : "misses"]++;
+    }
+    if (!warmHit || moduleDelegations.size > 0) {
       // Persist the module set into this space. AWAITED (identity E4): refs-only
       // pattern JSON makes artifact persistence part of the compilation
       // contract — a cell can only carry a `$patternRef` after compilePattern
@@ -886,6 +973,7 @@ export class PatternManager {
         modules,
         entryIdentity,
         cacheOpts,
+        moduleDelegations,
       );
     }
 
@@ -1518,6 +1606,7 @@ export class PatternManager {
     modules: CacheableModule[],
     entryIdentity: string,
     opts: { runtimeVersion: string },
+    moduleDelegations: ModuleDelegationMap = new Map(),
   ): Promise<void> {
     const persistenceSlotKey = compileCachePersistenceSlotKey(
       space,
@@ -1526,6 +1615,7 @@ export class PatternManager {
     );
     const closureSignature = compileCacheClosureSignature(
       modules.map((module) => module.identity),
+      moduleDelegations,
     );
     const predecessor = this.inProgressCompileCacheWrites.get(
       persistenceSlotKey,
@@ -1551,6 +1641,7 @@ export class PatternManager {
           modules,
           entryIdentity,
           opts,
+          moduleDelegations,
         ).catch(() => false);
         if (stored) {
           this.failedCompileCacheRecoveries.delete(
@@ -1566,6 +1657,7 @@ export class PatternManager {
         modules,
         entryIdentity,
         opts,
+        moduleDelegations,
       );
       this.persistedCompileCacheClosures.set(
         persistenceSlotKey,
@@ -1600,6 +1692,7 @@ export class PatternManager {
     modules: readonly CacheableModule[],
     entryIdentity: string,
     opts: { runtimeVersion: string },
+    moduleDelegations: ModuleDelegationMap = new Map(),
   ): Promise<boolean> {
     const readTx = this.runtime.edit();
     try {
@@ -1618,6 +1711,9 @@ export class PatternManager {
       ) {
         if (!source.has(identity)) return false;
       }
+      if (!closureIncludesModuleDelegations(source, moduleDelegations)) {
+        return false;
+      }
 
       const compiled = await loadCompiledClosure(
         this.runtime,
@@ -1632,6 +1728,9 @@ export class PatternManager {
       ) {
         return false;
       }
+      if (!closureIncludesModuleDelegations(compiled, moduleDelegations)) {
+        return false;
+      }
       return modules.every((module) => compiled.has(module.identity));
     } finally {
       readTx.abort?.("compile-cache persistence check complete");
@@ -1642,8 +1741,14 @@ export class PatternManager {
     space: MemorySpace,
     modules: CacheableModule[],
     entryIdentity: string,
+    moduleDelegations: ModuleDelegationMap = new Map(),
   ): Promise<void> {
-    const writeBack = this.writeBackSourceCache(space, modules, entryIdentity);
+    const writeBack = this.writeBackSourceCache(
+      space,
+      modules,
+      entryIdentity,
+      moduleDelegations,
+    );
     this.compileCacheWrites.add(writeBack);
     this.pendingCacheWriteBacks.add(writeBack);
     try {
@@ -1658,11 +1763,19 @@ export class PatternManager {
     space: MemorySpace,
     modules: CacheableModule[],
     entryIdentity: string,
+    moduleDelegations: ModuleDelegationMap = new Map(),
   ): Promise<void> {
     const writebackStart = performance.now();
     await this.syncSourceCacheWriteTargets(space, modules);
     const { error } = await this.runtime.editWithRetry((tx) => {
-      writeSourceDocs(this.runtime, space, modules, entryIdentity, tx);
+      writeSourceDocs(
+        this.runtime,
+        space,
+        modules,
+        entryIdentity,
+        tx,
+        moduleDelegations,
+      );
     });
     logger.time(writebackStart, "compile-cache", "source-writeback");
     if (error) {
@@ -1672,6 +1785,7 @@ export class PatternManager {
       ]);
       throw throwableStorageError(error);
     }
+    this.runtime.registerModuleDelegations(moduleDelegations);
   }
 
   /**
@@ -1687,6 +1801,7 @@ export class PatternManager {
     modules: CacheableModule[],
     entryIdentity: string,
     opts: { runtimeVersion: string },
+    moduleDelegations: ModuleDelegationMap = new Map(),
   ): Promise<void> {
     const writebackStart = performance.now();
     await this.syncCompileCacheWriteTargets(space, modules, opts);
@@ -1707,8 +1822,22 @@ export class PatternManager {
     const importEdges = modules.reduce((n, m) => n + m.imports.length, 0);
     const writebackMaxRetries = Math.max(16, 2 * importEdges + 8);
     const { error } = await this.runtime.editWithRetry((tx) => {
-      writeSourceDocs(this.runtime, space, modules, entryIdentity, tx);
-      writeCompiledDocs(this.runtime, space, modules, entryIdentity, opts, tx);
+      writeSourceDocs(
+        this.runtime,
+        space,
+        modules,
+        entryIdentity,
+        tx,
+        moduleDelegations,
+      );
+      writeCompiledDocs(
+        this.runtime,
+        space,
+        modules,
+        entryIdentity,
+        { ...opts, moduleDelegations },
+        tx,
+      );
     }, writebackMaxRetries);
     logger.time(writebackStart, "compile-cache", "writeback");
     if (error) {
@@ -1718,6 +1847,7 @@ export class PatternManager {
       ]);
       throw throwableStorageError(error);
     }
+    this.runtime.registerModuleDelegations(moduleDelegations);
   }
 
   // Write-target pre-syncs carry the one-hop edge selector (CT-1848): a

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -36,6 +36,7 @@ import {
   loadCompiledClosure,
   loadVerifiedSourceClosure,
   type ModuleDelegationMap,
+  moduleDelegationsFromDocs,
   ROOT_LINK_SPECIFIER,
   type SourceDoc,
   sourceDocKey,
@@ -1304,6 +1305,7 @@ export class PatternManager {
     if (sourceDocs === undefined) return undefined;
     const entry = sourceDocs.get(entryIdentity);
     if (entry === undefined) return undefined;
+    const moduleDelegations = moduleDelegationsFromDocs(sourceDocs);
 
     const sourceFiles: Source[] = [...sourceDocs.values()].map((doc) => ({
       name: doc.filename,
@@ -1356,6 +1358,7 @@ export class PatternManager {
           compiled.modules,
           entryIdentity,
           cacheOpts,
+          moduleDelegations,
         ).then(() => {
           this.failedCompileCacheRecoveries.delete(recoveryKey);
         }).catch((error) => {

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -422,7 +422,10 @@ export class PatternManager {
    * `toSpace`, rebuilding the emitted-module shape the write functions expect.
    * All-or-nothing: a partial compiled closure can never be served (the loaders
    * require a full, integrity-valid hit), so an incomplete origin set throws
-   * instead of persisting an unservable copy.
+   * instead of persisting an unservable copy. Delegation metadata is deliberately
+   * not copied across spaces: it carries writer authority and is valid only in
+   * the space whose cache documents attest it. The ordinary save path still
+   * preserves any authenticated delegation already present in `toSpace`.
    */
   private async replicateClosures(
     entryIdentity: string,
@@ -489,7 +492,6 @@ export class PatternManager {
       throw new Error("coverage spans unavailable in origin space");
     }
     const modules: CacheableModule[] = [];
-    const moduleDelegations = new Map<string, ReadonlySet<string>>();
     const fabricDependencies = new Set<string>();
     for (const [identity, doc] of sourceDocs) {
       const compiled = compiledDocs?.get(identity);
@@ -497,11 +499,6 @@ export class PatternManager {
         throw new Error(`compiled doc missing for ${identity}`);
       }
       const fabricImports = fabricImportRefsFromSource(doc);
-      const delegated = new Set([
-        ...(doc.delegatedModuleIdentities ?? []),
-        ...(compiled?.delegatedModuleIdentities ?? []),
-      ].filter((candidate) => candidate !== identity));
-      if (delegated.size > 0) moduleDelegations.set(identity, delegated);
       for (const imp of fabricImports) {
         fabricDependencies.add(imp.targetIdentity);
       }
@@ -537,7 +534,6 @@ export class PatternManager {
         toSpace,
         modules,
         entryIdentity,
-        moduleDelegations,
       );
     } else {
       await this.persistCompileCacheTracked(
@@ -545,7 +541,6 @@ export class PatternManager {
         modules,
         entryIdentity,
         { runtimeVersion },
-        moduleDelegations,
       );
     }
 
@@ -1789,7 +1784,7 @@ export class PatternManager {
       ]);
       throw throwableStorageError(error);
     }
-    this.runtime.registerModuleDelegations(committedModuleDelegations);
+    this.runtime.registerModuleDelegations(space, committedModuleDelegations);
   }
 
   /**
@@ -1844,7 +1839,7 @@ export class PatternManager {
       ]);
       throw throwableStorageError(error);
     }
-    this.runtime.registerModuleDelegations(committedModuleDelegations);
+    this.runtime.registerModuleDelegations(space, committedModuleDelegations);
   }
 
   // Write-target pre-syncs carry the one-hop edge selector (CT-1848): a

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -41,7 +41,7 @@ import {
   type SourceDoc,
   sourceDocKey,
   WRITE_TARGET_EDGE_SYNC_SCHEMA,
-  writeCompiledDocs,
+  writeSourceAndCompiledDocs,
   writeSourceDocs,
 } from "./compilation-cache/cell-cache.ts";
 import {
@@ -1770,8 +1770,9 @@ export class PatternManager {
   ): Promise<void> {
     const writebackStart = performance.now();
     await this.syncSourceCacheWriteTargets(space, modules);
+    let committedModuleDelegations = moduleDelegations;
     const { error } = await this.runtime.editWithRetry((tx) => {
-      writeSourceDocs(
+      committedModuleDelegations = writeSourceDocs(
         this.runtime,
         space,
         modules,
@@ -1788,7 +1789,7 @@ export class PatternManager {
       ]);
       throw throwableStorageError(error);
     }
-    this.runtime.registerModuleDelegations(moduleDelegations);
+    this.runtime.registerModuleDelegations(committedModuleDelegations);
   }
 
   /**
@@ -1824,16 +1825,9 @@ export class PatternManager {
     // recovery after a compiler-version bump.
     const importEdges = modules.reduce((n, m) => n + m.imports.length, 0);
     const writebackMaxRetries = Math.max(16, 2 * importEdges + 8);
+    let committedModuleDelegations = moduleDelegations;
     const { error } = await this.runtime.editWithRetry((tx) => {
-      writeSourceDocs(
-        this.runtime,
-        space,
-        modules,
-        entryIdentity,
-        tx,
-        moduleDelegations,
-      );
-      writeCompiledDocs(
+      committedModuleDelegations = writeSourceAndCompiledDocs(
         this.runtime,
         space,
         modules,
@@ -1850,7 +1844,7 @@ export class PatternManager {
       ]);
       throw throwableStorageError(error);
     }
-    this.runtime.registerModuleDelegations(moduleDelegations);
+    this.runtime.registerModuleDelegations(committedModuleDelegations);
   }
 
   // Write-target pre-syncs carry the one-hop edge selector (CT-1848): a

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -105,6 +105,7 @@ export async function compileAndSavePattern(
   patternSrc: string | RuntimeProgram,
   options: {
     space: MemorySpace;
+    previousEntryIdentity?: string;
   },
 ): Promise<Pattern> {
   if (typeof patternSrc === "string") {
@@ -118,6 +119,9 @@ export async function compileAndSavePattern(
   // subsequent loads (CT-1623).
   const pattern = await runtime.patternManager.compilePattern(patternSrc, {
     space: options.space,
+    ...(options.previousEntryIdentity === undefined
+      ? {}
+      : { previousEntryIdentity: options.previousEntryIdentity }),
   });
   if (!pattern) {
     throw new Error("No default pattern found in the compiled exports.");

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -645,6 +645,48 @@ export class Runtime {
   private cfcStats: CfcRuntimeStats = initialCfcRuntimeStats();
   readonly #policyManifests = new Map<string, PolicyArtifactManifestV1>();
   readonly #policyManifestSpaces = new Map<string, Set<MemorySpace>>();
+  // Successor module identity -> direct predecessor identities whose writer
+  // authority it inherits. Entries come only from verified source closures or
+  // integrity-valid compiled closures. Transactions receive a transitive,
+  // immutable snapshot at creation so an in-flight authorization decision
+  // cannot change when another module loads.
+  readonly #moduleDelegations = new Map<string, Set<string>>();
+
+  registerModuleDelegations(
+    delegations: ReadonlyMap<string, ReadonlySet<string>>,
+  ): void {
+    for (const [identity, predecessors] of delegations) {
+      if (typeof identity !== "string" || identity.length === 0) continue;
+      const merged = this.#moduleDelegations.get(identity) ?? new Set<string>();
+      for (const predecessor of predecessors) {
+        if (
+          typeof predecessor === "string" && predecessor.length > 0 &&
+          predecessor !== identity
+        ) {
+          merged.add(predecessor);
+        }
+      }
+      if (merged.size > 0) this.#moduleDelegations.set(identity, merged);
+    }
+  }
+
+  private moduleDelegationSnapshot(): Map<string, readonly string[]> {
+    const snapshot = new Map<string, readonly string[]>();
+    for (const identity of this.#moduleDelegations.keys()) {
+      const inherited = new Set<string>();
+      const pending = [...(this.#moduleDelegations.get(identity) ?? [])];
+      while (pending.length > 0) {
+        const predecessor = pending.pop()!;
+        if (predecessor === identity || inherited.has(predecessor)) continue;
+        inherited.add(predecessor);
+        pending.push(...(this.#moduleDelegations.get(predecessor) ?? []));
+      }
+      if (inherited.size > 0) {
+        snapshot.set(identity, [...inherited].sort());
+      }
+    }
+    return snapshot;
+  }
 
   registerCfcPolicyManifests(
     space: MemorySpace | undefined,
@@ -1288,6 +1330,7 @@ export class Runtime {
     wrapped.setCfcSinkMaxConfidentiality(this.cfcSinkMaxConfidentiality);
     wrapped.setCfcPolicySnapshot(this.cfcPolicySnapshot);
     wrapped.setCfcTrustConfig(this.cfcTrustConfig);
+    wrapped.setCfcModuleDelegations(this.moduleDelegationSnapshot());
     wrapped.setCfcTrustSnapshot(this.trustSnapshotProvider());
     return wrapped;
   }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -643,19 +643,27 @@ export class Runtime {
   private cfcStats: CfcRuntimeStats = initialCfcRuntimeStats();
   readonly #policyManifests = new Map<string, PolicyArtifactManifestV1>();
   readonly #policyManifestSpaces = new Map<string, Set<MemorySpace>>();
-  // Successor module identity -> direct predecessor identities whose writer
-  // authority it inherits. Entries come only from verified source closures or
-  // integrity-valid compiled closures. Transactions receive a transitive,
-  // immutable snapshot at creation so an in-flight authorization decision
-  // cannot change when another module loads.
-  readonly #moduleDelegations = new Map<string, Set<string>>();
+  // Attesting space -> successor module identity -> direct predecessor
+  // identities whose writer authority it inherits. Entries come only from
+  // verified source closures or integrity-valid compiled closures in that same
+  // space. Transactions receive a transitive, immutable snapshot at creation
+  // so an in-flight authorization decision cannot change when another module
+  // loads, and authorization in one space can never borrow another space's
+  // delegation metadata.
+  readonly #moduleDelegations = new Map<
+    MemorySpace,
+    Map<string, Set<string>>
+  >();
 
   registerModuleDelegations(
+    space: MemorySpace,
     delegations: ReadonlyMap<string, ReadonlySet<string>>,
   ): void {
+    if (typeof space !== "string" || space.length === 0) return;
+    const spaceDelegations = this.#moduleDelegations.get(space) ?? new Map();
     for (const [identity, predecessors] of delegations) {
       if (typeof identity !== "string" || identity.length === 0) continue;
-      const merged = this.#moduleDelegations.get(identity) ?? new Set<string>();
+      const merged = spaceDelegations.get(identity) ?? new Set<string>();
       for (const predecessor of predecessors) {
         if (
           typeof predecessor === "string" && predecessor.length > 0 &&
@@ -664,23 +672,38 @@ export class Runtime {
           merged.add(predecessor);
         }
       }
-      if (merged.size > 0) this.#moduleDelegations.set(identity, merged);
+      if (merged.size > 0) spaceDelegations.set(identity, merged);
+    }
+    if (spaceDelegations.size > 0) {
+      this.#moduleDelegations.set(space, spaceDelegations);
     }
   }
 
-  private moduleDelegationSnapshot(): Map<string, readonly string[]> {
-    const snapshot = new Map<string, readonly string[]>();
-    for (const identity of this.#moduleDelegations.keys()) {
-      const inherited = new Set<string>();
-      const pending = [...(this.#moduleDelegations.get(identity) ?? [])];
-      while (pending.length > 0) {
-        const predecessor = pending.pop()!;
-        if (predecessor === identity || inherited.has(predecessor)) continue;
-        inherited.add(predecessor);
-        pending.push(...(this.#moduleDelegations.get(predecessor) ?? []));
+  private moduleDelegationSnapshot(): Map<
+    MemorySpace,
+    ReadonlyMap<string, readonly string[]>
+  > {
+    const snapshot = new Map<
+      MemorySpace,
+      ReadonlyMap<string, readonly string[]>
+    >();
+    for (const [space, spaceDelegations] of this.#moduleDelegations) {
+      const spaceSnapshot = new Map<string, readonly string[]>();
+      for (const identity of spaceDelegations.keys()) {
+        const inherited = new Set<string>();
+        const pending = [...(spaceDelegations.get(identity) ?? [])];
+        while (pending.length > 0) {
+          const predecessor = pending.pop()!;
+          if (predecessor === identity || inherited.has(predecessor)) continue;
+          inherited.add(predecessor);
+          pending.push(...(spaceDelegations.get(predecessor) ?? []));
+        }
+        if (inherited.size > 0) {
+          spaceSnapshot.set(identity, [...inherited].sort());
+        }
       }
-      if (inherited.size > 0) {
-        snapshot.set(identity, [...inherited].sort());
+      if (spaceSnapshot.size > 0) {
+        snapshot.set(space, spaceSnapshot);
       }
     }
     return snapshot;

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -292,6 +292,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     writePolicyInputs: [],
     writePolicyInputIdentities: new Map(),
     writeIdentity: { sawWrite: false, multiple: false },
+    moduleDelegations: new Map(),
     outbox: [],
     diagnostics: [],
     unprivilegedSystemWrites: [],
@@ -333,6 +334,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   // Set on the FIRST call (always the Runtime's, in edit()), regardless of
   // value.
   #cfcTrustConfigPinned = false;
+  #cfcModuleDelegationsPinned = false;
   // Depth of the runtime's privileged system-write scope. The runtime's own
   // label/schema persistence (prepareBoundaryCommit) runs inside it; any write
   // to a protected system path outside it is recorded as unprivileged (S18).
@@ -650,6 +652,21 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.#cfcState.trustConfig = config === undefined
       ? undefined
       : deepFreeze(config);
+  }
+
+  // Module-update authority is runtime-learned trust state. Snapshot and pin
+  // it once at transaction creation: later module loads affect future
+  // transactions, never an authorization decision already in flight.
+  setCfcModuleDelegations(
+    delegations: ReadonlyMap<string, readonly string[]>,
+  ): void {
+    if (this.#cfcModuleDelegationsPinned) return;
+    this.#cfcModuleDelegationsPinned = true;
+    const snapshot = new Map<string, readonly string[]>();
+    for (const [identity, predecessors] of delegations) {
+      snapshot.set(identity, [...predecessors]);
+    }
+    this.#cfcState.moduleDelegations = snapshot;
   }
 
   markCfcRelevant(reason?: string): void {
@@ -1225,6 +1242,22 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       writePolicyInputs: [...this.#cfcState.writePolicyInputs],
       implementationIdentity: this.#cfcState.implementationIdentity,
       trustSnapshot: this.#cfcState.trustSnapshot,
+      ...(this.#cfcState.moduleDelegations.size > 0
+        ? {
+          moduleDelegations: [...this.#cfcState.moduleDelegations]
+            .map(([moduleIdentity, delegatedModuleIdentities]) => ({
+              moduleIdentity,
+              delegatedModuleIdentities: [...delegatedModuleIdentities].sort(),
+            }))
+            .sort((left, right) =>
+              left.moduleIdentity < right.moduleIdentity
+                ? -1
+                : left.moduleIdentity > right.moduleIdentity
+                ? 1
+                : 0
+            ),
+        }
+        : {}),
       // Digest-only projection: the decision-relevant identity of the policy
       // set (Epic B5). The snapshot itself is frozen Runtime config; only its
       // identity needs to invalidate.

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -658,13 +658,23 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   // it once at transaction creation: later module loads affect future
   // transactions, never an authorization decision already in flight.
   setCfcModuleDelegations(
-    delegations: ReadonlyMap<string, readonly string[]>,
+    delegations: ReadonlyMap<
+      MemorySpace,
+      ReadonlyMap<string, readonly string[]>
+    >,
   ): void {
     if (this.#cfcModuleDelegationsPinned) return;
     this.#cfcModuleDelegationsPinned = true;
-    const snapshot = new Map<string, readonly string[]>();
-    for (const [identity, predecessors] of delegations) {
-      snapshot.set(identity, [...predecessors]);
+    const snapshot = new Map<
+      MemorySpace,
+      ReadonlyMap<string, readonly string[]>
+    >();
+    for (const [space, spaceDelegations] of delegations) {
+      const spaceSnapshot = new Map<string, readonly string[]>();
+      for (const [identity, predecessors] of spaceDelegations) {
+        spaceSnapshot.set(identity, [...predecessors]);
+      }
+      if (spaceSnapshot.size > 0) snapshot.set(space, spaceSnapshot);
     }
     this.#cfcState.moduleDelegations = snapshot;
   }
@@ -1245,12 +1255,24 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       ...(this.#cfcState.moduleDelegations.size > 0
         ? {
           moduleDelegations: [...this.#cfcState.moduleDelegations]
-            .map(([moduleIdentity, delegatedModuleIdentities]) => ({
-              moduleIdentity,
-              delegatedModuleIdentities: [...delegatedModuleIdentities].sort(),
-            }))
+            .flatMap(([space, spaceDelegations]) =>
+              [...spaceDelegations].map(([
+                moduleIdentity,
+                delegatedModuleIdentities,
+              ]) => ({
+                space,
+                moduleIdentity,
+                delegatedModuleIdentities: [
+                  ...delegatedModuleIdentities,
+                ].sort(),
+              }))
+            )
             .sort((left, right) =>
-              left.moduleIdentity < right.moduleIdentity
+              left.space < right.space
+                ? -1
+                : left.space > right.space
+                ? 1
+                : left.moduleIdentity < right.moduleIdentity
                 ? -1
                 : left.moduleIdentity > right.moduleIdentity
                 ? 1

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -32,6 +32,8 @@ import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
 import { buildCfcPolicyArtifactManifest } from "../src/cfc/policy.ts";
+import { PatternCoverageCollector } from "../src/pattern-coverage.ts";
+import { pattern } from "../src/builder/pattern.ts";
 
 // These tests drive the sync parse internals directly (below the async flow
 // boundaries that normally load the deferred compiler stack), so load it here.
@@ -796,6 +798,14 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     expect((await coldLoad()).get(entryIdentity)?.patternCoverageSpans)
       .toBeUndefined();
 
+    // Valid JSON still has to describe an array of span records.
+    await replaceSpans({ patternCoverageSpansJson: JSON.stringify({}) });
+    expect((await coldLoad()).get(entryIdentity)?.patternCoverageSpans)
+      .toBeUndefined();
+    await replaceSpans({ patternCoverageSpansJson: JSON.stringify([null]) });
+    expect((await coldLoad()).get(entryIdentity)?.patternCoverageSpans)
+      .toBeUndefined();
+
     // The durable format accepts only the scalar JSON field.
     await replaceSpans({ patternCoverageSpans: spans });
     expect((await coldLoad()).get(entryIdentity)?.patternCoverageSpans)
@@ -1249,6 +1259,42 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     }
   });
 
+  it("skips same-space and keyless pattern replication", async () => {
+    const keyed = pattern(() => ({}));
+    const keyless = pattern(() => ({}));
+    const ref = { identity: "same-space-entry", symbol: "default" };
+    runtime.patternManager.associatePatternIdentity(keyed, ref);
+    expect(runtime.patternManager.getArtifactEntryRef(keyed)).toEqual(ref);
+    expect(runtime.patternManager.getArtifactEntryRef(keyless)).toBeUndefined();
+
+    const manager = runtime.patternManager as unknown as {
+      replicateClosures(
+        entryIdentity: string,
+        fromSpace: string,
+        toSpace: string,
+      ): Promise<void>;
+    };
+    const originalReplicateClosures = manager.replicateClosures;
+    let replicationCalls = 0;
+    manager.replicateClosures = () => {
+      replicationCalls++;
+      return Promise.resolve();
+    };
+    try {
+      runtime.patternManager.replicatePatternToSpace(keyed, spaceA, spaceA);
+      runtime.patternManager.replicatePatternToSpace(
+        keyless,
+        "did:key:z6MkCellCacheKeylessReplicationTarget",
+        spaceA,
+      );
+
+      await runtime.patternManager.flushCompileCacheWrites();
+      expect(replicationCalls).toBe(0);
+    } finally {
+      manager.replicateClosures = originalReplicateClosures;
+    }
+  });
+
   it("replicates fabric dependencies even though source closures exclude them", async () => {
     const spaceB = "did:key:z6MkCellCacheFabricReplicationTarget";
     const { modules, importerIdentity, depIdentity } = fabricLinkedModules();
@@ -1394,6 +1440,100 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     repairedTx.abort?.();
     expect(repairedSource?.has(importerIdentity)).toBe(true);
     expect(repairedCompiled.has(importerIdentity)).toBe(true);
+  });
+
+  it("rejects replication from an incomplete origin closure", async () => {
+    const targetSpace = "did:key:z6MkCellCacheIncompleteReplicationTarget";
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const manager = runtime.patternManager as unknown as {
+      replicateClosures(
+        entryIdentity: string,
+        fromSpace: string,
+        toSpace: string,
+        visited?: Set<string>,
+      ): Promise<void>;
+    };
+
+    const visitKey = `${spaceA}\0${targetSpace}\0${entryIdentity}`;
+    await expect(
+      manager.replicateClosures(
+        entryIdentity,
+        spaceA,
+        targetSpace,
+        new Set([visitKey]),
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      manager.replicateClosures(entryIdentity, spaceA, targetSpace),
+    ).rejects.toThrow("source closure unavailable in origin space");
+
+    const sourceOnlyWrite = runtime.edit();
+    writeSourceDocs(
+      runtime,
+      spaceA,
+      modules,
+      entryIdentity,
+      sourceOnlyWrite,
+    );
+    sourceOnlyWrite.prepareCfc();
+    expect((await sourceOnlyWrite.commit()).error).toBeUndefined();
+
+    await expect(
+      manager.replicateClosures(entryIdentity, spaceA, targetSpace),
+    ).rejects.toThrow(`compiled doc missing for ${entryIdentity}`);
+  });
+
+  it("rejects coverage replication when compiled spans are absent", async () => {
+    const coverageStorageManager = StorageManager.emulate({ as: signer });
+    const coverageRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: coverageStorageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      trustSnapshotProvider: () => ({
+        id: "cell-cache-coverage-replication-test",
+        actingPrincipal: signer.did(),
+      }),
+      patternCoverage: new PatternCoverageCollector(),
+    });
+    const targetSpace = "did:key:z6MkCellCacheCoverageReplicationTarget";
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const coverageRuntimeVersion = `${runtimeVersion}/pattern-coverage`;
+
+    try {
+      const writeTx = coverageRuntime.edit();
+      writeSourceDocs(
+        coverageRuntime,
+        spaceA,
+        modules,
+        entryIdentity,
+        writeTx,
+      );
+      writeCompiledDocs(
+        coverageRuntime,
+        spaceA,
+        modules,
+        entryIdentity,
+        { runtimeVersion: coverageRuntimeVersion },
+        writeTx,
+      );
+      writeTx.prepareCfc();
+      expect((await writeTx.commit()).error).toBeUndefined();
+
+      const manager = coverageRuntime.patternManager as unknown as {
+        replicateClosures(
+          entryIdentity: string,
+          fromSpace: string,
+          toSpace: string,
+        ): Promise<void>;
+      };
+      await expect(
+        manager.replicateClosures(entryIdentity, spaceA, targetSpace),
+      ).rejects.toThrow("coverage spans unavailable in origin space");
+    } finally {
+      await coverageRuntime.dispose();
+      await coverageStorageManager.close();
+    }
   });
 
   it("does not reuse a closure missing required delegation metadata", async () => {

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -11,6 +11,7 @@ import {
   resolveModuleImports,
 } from "../src/harness/module-identity.ts";
 import type { CacheableModule, RuntimeProgram } from "../src/harness/types.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
 
 import {
   buildSourceDocs,
@@ -508,6 +509,75 @@ describe("cell-cache: source-set store (per space, link-following)", () => {
       { specifier: "./child.ts", identity: childIdentity },
       { specifier: "./again.ts", identity: childIdentity },
     ]);
+  });
+
+  it("rejects a source closure linked to another space's attestation", async () => {
+    const attackerSpace = "did:key:z6MkSourceClosureAttacker";
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const utilIdentity = identityOf(PROGRAM, "/util.ts");
+    const predecessorIdentity = "victim-source-predecessor";
+    const delegations = new Map([
+      [utilIdentity, new Set([predecessorIdentity])],
+    ]);
+
+    const attackerTx = runtime.edit();
+    writeSourceDocs(
+      runtime,
+      attackerSpace,
+      modules,
+      entryIdentity,
+      attackerTx,
+      delegations,
+    );
+    runtime.prepareTxForCommit(attackerTx);
+    expect((await attackerTx.commit()).error).toBeUndefined();
+
+    const victimTx = runtime.edit();
+    writeSourceDocs(runtime, spaceA, modules, entryIdentity, victimTx);
+    runtime.prepareTxForCommit(victimTx);
+    expect((await victimTx.commit()).error).toBeUndefined();
+
+    const entryModule = modules.find((module) =>
+      module.identity === entryIdentity
+    )!;
+    const rewireTx = runtime.edit();
+    runtime.getCell(
+      spaceA,
+      sourceDocKey(entryIdentity),
+      undefined,
+      rewireTx,
+    ).set({
+      kind: "source",
+      identity: entryIdentity,
+      code: entryModule.source,
+      filename: entryModule.filename,
+      imports: entryModule.imports.map((imp) => ({
+        specifier: imp.specifier,
+        link: runtime.getCell(
+          imp.targetIdentity === utilIdentity ? attackerSpace : spaceA,
+          sourceDocKey(imp.targetIdentity),
+          undefined,
+          rewireTx,
+        ).getAsLink(),
+      })),
+    });
+    runtime.prepareTxForCommit(rewireTx);
+    expect((await rewireTx.commit()).error).toBeUndefined();
+
+    const loadTx = runtime.edit();
+    const loaded = await loadVerifiedSourceClosure(
+      runtime,
+      spaceA,
+      entryIdentity,
+      loadTx,
+    );
+    loadTx.abort?.("mixed-space source closure rejected");
+    expect(loaded).toBeUndefined();
+
+    const snapshotTx = runtime.edit();
+    expect(snapshotTx.getCfcState().moduleDelegations.get(spaceA))
+      .toBeUndefined();
+    snapshotTx.abort?.("mixed-space source snapshot inspected");
   });
 
   it("skips source imports that do not point to source documents", async () => {
@@ -1017,6 +1087,90 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     ]);
   });
 
+  it("rejects a compiled closure linked to another space's attestation", async () => {
+    const attackerSpace = "did:key:z6MkCompiledClosureAttacker";
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const utilIdentity = identityOf(PROGRAM, "/util.ts");
+    const predecessorIdentity = "victim-compiled-predecessor";
+    const delegations = new Map([
+      [utilIdentity, new Set([predecessorIdentity])],
+    ]);
+
+    const attackerTx = runtime.edit();
+    writeCompiledDocs(
+      runtime,
+      attackerSpace,
+      modules,
+      entryIdentity,
+      { ...opts(), moduleDelegations: delegations },
+      attackerTx,
+    );
+    attackerTx.prepareCfc();
+    expect((await attackerTx.commit()).error).toBeUndefined();
+
+    const victimTx = runtime.edit();
+    writeCompiledDocs(
+      runtime,
+      spaceA,
+      modules,
+      entryIdentity,
+      opts(),
+      victimTx,
+    );
+    victimTx.prepareCfc();
+    expect((await victimTx.commit()).error).toBeUndefined();
+
+    const entryModule = modules.find((module) =>
+      module.identity === entryIdentity
+    )!;
+    const rewireTx = runtime.edit();
+    const previousIdentity = rewireTx.getCfcState().implementationIdentity;
+    rewireTx.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: "compile-cache",
+    });
+    try {
+      const entryCell = runtime.getCell<Record<string, unknown>>(
+        spaceA,
+        compiledDocKey(RTVER, entryIdentity),
+        compiledDocWriteSchema(),
+        rewireTx,
+      );
+      entryCell.set({
+        ...entryCell.get(),
+        imports: entryModule.imports.map((imp) => ({
+          specifier: imp.specifier,
+          link: runtime.getCell(
+            imp.targetIdentity === utilIdentity ? attackerSpace : spaceA,
+            compiledDocKey(RTVER, imp.targetIdentity),
+            undefined,
+            rewireTx,
+          ).getAsLink(),
+        })),
+      });
+    } finally {
+      rewireTx.setCfcImplementationIdentity(previousIdentity);
+    }
+    rewireTx.prepareCfc();
+    expect((await rewireTx.commit()).error).toBeUndefined();
+
+    const loadTx = runtime.edit();
+    const loaded = await loadCompiledClosure(
+      runtime,
+      spaceA,
+      entryIdentity,
+      opts(),
+      loadTx,
+    );
+    loadTx.abort?.("mixed-space compiled closure rejected");
+    expect(loaded.size).toBe(0);
+
+    const snapshotTx = runtime.edit();
+    expect(snapshotTx.getCfcState().moduleDelegations.get(spaceA))
+      .toBeUndefined();
+    snapshotTx.abort?.("mixed-space compiled snapshot inspected");
+  });
+
   it("skips compiled import links without integrity", async () => {
     const entryIdentity = "compiled-entry-with-unstamped-import";
     const missingIdentity = "compiled-unstamped-child";
@@ -1295,7 +1449,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     }
   });
 
-  it("replicates fabric dependencies even though source closures exclude them", async () => {
+  it("replicates fabric dependencies without importing authority", async () => {
     const spaceB = "did:key:z6MkCellCacheFabricReplicationTarget";
     const { modules, importerIdentity, depIdentity } = fabricLinkedModules();
     const coverageSpans = [{
@@ -1392,10 +1546,65 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
       policyManifest,
     ]);
     expect(importerSource?.get(importerIdentity)?.delegatedModuleIdentities)
-      .toEqual([predecessorIdentity]);
-    expect(compiled.get(importerIdentity)?.delegatedModuleIdentities).toEqual([
-      predecessorIdentity,
-    ]);
+      .toBeUndefined();
+    expect(compiled.get(importerIdentity)?.delegatedModuleIdentities)
+      .toBeUndefined();
+
+    const snapshotTx = runtime.edit();
+    expect(
+      snapshotTx.getCfcState().moduleDelegations.get(spaceA)?.get(
+        importerIdentity,
+      ),
+    ).toEqual([predecessorIdentity]);
+    expect(snapshotTx.getCfcState().moduleDelegations.get(spaceB))
+      .toBeUndefined();
+    snapshotTx.abort?.("cross-space replication snapshot inspected");
+
+    const protectedSchema = {
+      type: "object",
+      properties: {
+        value: {
+          type: "string",
+          ifc: {
+            writeAuthorizedBy: {
+              __ctWriterIdentityOf: {
+                moduleIdentity: predecessorIdentity,
+                file: "/main.tsx",
+                path: ["setValue"],
+              },
+            },
+          },
+        },
+      },
+      required: ["value"],
+    } as unknown as JSONSchema;
+    const protectedCell = runtime.getCell<{ value: string }>(
+      spaceB,
+      "cell-cache-cross-space-replication-authority",
+      protectedSchema,
+    );
+    const seed = await runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: predecessorIdentity,
+        sourceFile: "/main.tsx",
+        bindingPath: ["setValue"],
+      });
+      protectedCell.withTx(tx).set({ value: "seed" });
+    });
+    expect(seed.error).toBeUndefined();
+
+    const denied = await runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: importerIdentity,
+        sourceFile: "/main.tsx",
+        bindingPath: ["setValue"],
+      });
+      protectedCell.withTx(tx).set({ value: "replicated" });
+    }, 0);
+    expect(denied.error?.message).toContain("writeAuthorizedBy failed");
+    expect(protectedCell.get()).toEqual({ value: "seed" });
 
     const damageTx = runtime.edit();
     const previousIdentity = damageTx.getCfcState().implementationIdentity;

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -1280,14 +1280,25 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     const replicationOpts = {
       runtimeVersion,
     };
+    const predecessorIdentity = "replicated-predecessor";
+    const moduleDelegations = new Map([
+      [importerIdentity, new Set([predecessorIdentity])],
+    ]);
     const wtx = runtime.edit();
-    writeSourceDocs(runtime, spaceA, modules, importerIdentity, wtx);
+    writeSourceDocs(
+      runtime,
+      spaceA,
+      modules,
+      importerIdentity,
+      wtx,
+      moduleDelegations,
+    );
     writeCompiledDocs(
       runtime,
       spaceA,
       modules,
       importerIdentity,
-      replicationOpts,
+      { ...replicationOpts, moduleDelegations },
       wtx,
     );
     wtx.prepareCfc();
@@ -1334,6 +1345,11 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     expect(compiled.get(importerIdentity)?.policyManifests).toEqual([
       policyManifest,
     ]);
+    expect(importerSource?.get(importerIdentity)?.delegatedModuleIdentities)
+      .toEqual([predecessorIdentity]);
+    expect(compiled.get(importerIdentity)?.delegatedModuleIdentities).toEqual([
+      predecessorIdentity,
+    ]);
 
     const damageTx = runtime.edit();
     const previousIdentity = damageTx.getCfcState().implementationIdentity;
@@ -1378,6 +1394,138 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     repairedTx.abort?.();
     expect(repairedSource?.has(importerIdentity)).toBe(true);
     expect(repairedCompiled.has(importerIdentity)).toBe(true);
+  });
+
+  it("does not reuse a closure missing required delegation metadata", async () => {
+    const targetSpace = "did:key:z6MkCellCacheDelegationPersistenceTarget";
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const requiredDelegations = new Map([
+      [entryIdentity, new Set(["required-predecessor"])],
+    ]);
+    const manager = runtime.patternManager as unknown as {
+      hasStoredCompileCacheClosure(
+        space: string,
+        modules: readonly CacheableModule[],
+        entryIdentity: string,
+        opts: { runtimeVersion: string },
+        moduleDelegations: ReadonlyMap<string, ReadonlySet<string>>,
+      ): Promise<boolean>;
+    };
+
+    const initialWrite = runtime.edit();
+    writeSourceDocs(
+      runtime,
+      targetSpace,
+      modules,
+      entryIdentity,
+      initialWrite,
+    );
+    writeCompiledDocs(
+      runtime,
+      targetSpace,
+      modules,
+      entryIdentity,
+      opts(),
+      initialWrite,
+    );
+    initialWrite.prepareCfc();
+    expect((await initialWrite.commit()).error).toBeUndefined();
+
+    const missingModule: CacheableModule = {
+      identity: "missing-source-module",
+      filename: "/missing.ts",
+      source: "export {};",
+      js: "export {};",
+      imports: [],
+    };
+    expect(
+      await manager.hasStoredCompileCacheClosure(
+        targetSpace,
+        [...modules, missingModule],
+        entryIdentity,
+        opts(),
+        new Map(),
+      ),
+    ).toBe(false);
+
+    const coverageRuntimeVersion = `${RTVER}/pattern-coverage`;
+    const uninstrumentedCoverageWrite = runtime.edit();
+    writeCompiledDocs(
+      runtime,
+      targetSpace,
+      modules,
+      entryIdentity,
+      { runtimeVersion: coverageRuntimeVersion },
+      uninstrumentedCoverageWrite,
+    );
+    uninstrumentedCoverageWrite.prepareCfc();
+    expect((await uninstrumentedCoverageWrite.commit()).error).toBeUndefined();
+    expect(
+      await manager.hasStoredCompileCacheClosure(
+        targetSpace,
+        modules,
+        entryIdentity,
+        { runtimeVersion: coverageRuntimeVersion },
+        new Map(),
+      ),
+    ).toBe(false);
+
+    // The source set does not yet carry the requested authority.
+    expect(
+      await manager.hasStoredCompileCacheClosure(
+        targetSpace,
+        modules,
+        entryIdentity,
+        opts(),
+        requiredDelegations,
+      ),
+    ).toBe(false);
+
+    const sourceOnlyRepair = runtime.edit();
+    writeSourceDocs(
+      runtime,
+      targetSpace,
+      modules,
+      entryIdentity,
+      sourceOnlyRepair,
+      requiredDelegations,
+    );
+    sourceOnlyRepair.prepareCfc();
+    expect((await sourceOnlyRepair.commit()).error).toBeUndefined();
+
+    // A source-only repair is insufficient: a later warm load could trust the
+    // still-stale compiled set without ever consulting source metadata.
+    expect(
+      await manager.hasStoredCompileCacheClosure(
+        targetSpace,
+        modules,
+        entryIdentity,
+        opts(),
+        requiredDelegations,
+      ),
+    ).toBe(false);
+
+    const compiledRepair = runtime.edit();
+    writeCompiledDocs(
+      runtime,
+      targetSpace,
+      modules,
+      entryIdentity,
+      { ...opts(), moduleDelegations: requiredDelegations },
+      compiledRepair,
+    );
+    compiledRepair.prepareCfc();
+    expect((await compiledRepair.commit()).error).toBeUndefined();
+
+    expect(
+      await manager.hasStoredCompileCacheClosure(
+        targetSpace,
+        modules,
+        entryIdentity,
+        opts(),
+        requiredDelegations,
+      ),
+    ).toBe(true);
   });
 
   it("distinguishes persisted closures that share an entry module", async () => {

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -25,6 +25,7 @@ import {
   canonicalizePreparedDigestInput,
   canonicalizeWritePolicyInput,
   logicalPathToPointer,
+  preparedDigestFor,
 } from "../src/cfc/mod.ts";
 import {
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
@@ -207,6 +208,62 @@ describe("CFC canonicalization helpers", () => {
         item.kind === "custom" ? item.name : ""
       ),
     ).toEqual(["a", "b"]);
+  });
+
+  it("binds delegation space while canonicalizing delegation order", () => {
+    const spaceA = signer.did();
+    const spaceB = "did:key:z6MkPreparedDigestOtherSpace" as MemorySpace;
+    const base = {
+      consumedReads: [],
+      attemptedWrites: [],
+      writes: [],
+      writeAttemptLog: [],
+      dereferenceTraces: [],
+      triggerReads: [],
+      writePolicyInputs: [],
+    };
+
+    expect(preparedDigestFor({
+      ...base,
+      moduleDelegations: [{
+        space: spaceA,
+        moduleIdentity: "successor",
+        delegatedModuleIdentities: ["predecessor"],
+      }],
+    })).not.toBe(preparedDigestFor({
+      ...base,
+      moduleDelegations: [{
+        space: spaceB,
+        moduleIdentity: "successor",
+        delegatedModuleIdentities: ["predecessor"],
+      }],
+    }));
+
+    const ordered = preparedDigestFor({
+      ...base,
+      moduleDelegations: [{
+        space: spaceB,
+        moduleIdentity: "z-successor",
+        delegatedModuleIdentities: ["z-predecessor", "a-predecessor"],
+      }, {
+        space: spaceA,
+        moduleIdentity: "a-successor",
+        delegatedModuleIdentities: ["predecessor"],
+      }],
+    });
+    const reversed = preparedDigestFor({
+      ...base,
+      moduleDelegations: [{
+        space: spaceA,
+        moduleIdentity: "a-successor",
+        delegatedModuleIdentities: ["predecessor"],
+      }, {
+        space: spaceB,
+        moduleIdentity: "z-successor",
+        delegatedModuleIdentities: ["a-predecessor", "z-predecessor"],
+      }],
+    });
+    expect(reversed).toBe(ordered);
   });
 
   it("canonicalizes link-write policy input paths", () => {

--- a/packages/runner/test/content-addressed-identity-adversarial.test.ts
+++ b/packages/runner/test/content-addressed-identity-adversarial.test.ts
@@ -343,7 +343,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
       });
       cell.set({ owned: "stolen" });
 
-      // moduleIdentity, file, AND path must all match; none do → fail closed.
+      // moduleIdentity and path must match; neither does. File is diagnostic.
       const digest = tx.prepareCfc();
       expect(digest).toBe("");
       const result = await tx.commit();
@@ -548,7 +548,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
       return { digest, result };
     };
 
-    it("a claim with moduleIdentity matching but file/path NOT fails closed", async () => {
+    it("a claim with moduleIdentity matching but bindingPath different fails closed", async () => {
       const { digest, result } = await driveClaim(
         {
           __ctWriterIdentityOf: {
@@ -560,7 +560,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
         {
           kind: "verified",
           moduleIdentity: "m1", // matches
-          sourceFile: "/attacker.tsx", // does NOT
+          sourceFile: "/attacker.tsx", // diagnostic at verification time
           bindingPath: ["attackerHandler"], // does NOT
         },
         "attack5-id-match-pathmismatch",

--- a/packages/runner/test/module-delegation.test.ts
+++ b/packages/runner/test/module-delegation.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { CacheableModule, RuntimeProgram } from "../src/harness/types.ts";
+import { computeModuleHashes } from "../src/harness/module-identity.ts";
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+import {
+  deriveModuleDelegations,
+  loadVerifiedSourceClosure,
+  type SourceDoc,
+  sourceDocKey,
+  writeSourceDocs,
+} from "../src/compilation-cache/cell-cache.ts";
+
+await ensureCompilerStack();
+
+const signer = await Identity.fromPassphrase("module delegation");
+const space = signer.did();
+
+const moduleProgram = (revision: string): RuntimeProgram => ({
+  main: "/writer.ts",
+  files: [{
+    name: "/writer.ts",
+    contents: `export const revision = ${JSON.stringify(revision)};`,
+  }],
+});
+
+function moduleFor(program: RuntimeProgram): CacheableModule {
+  return {
+    identity: computeModuleHashes(program).get(program.main)!,
+    filename: program.main,
+    source: program.files[0].contents,
+    js: "export const revision = 'compiled';",
+    imports: [],
+  };
+}
+
+const protectedSchema = {
+  type: "object",
+  properties: {
+    value: {
+      type: "string",
+      ifc: {
+        writeAuthorizedBy: {
+          __ctWriterIdentityOf: {
+            moduleIdentity: computeModuleHashes(moduleProgram("old")).get(
+              "/writer.ts",
+            )!,
+            file: "/writer.ts",
+            path: ["setValue"],
+          },
+        },
+      },
+    },
+  },
+  required: ["value"],
+} as unknown as JSONSchema;
+
+describe("module identity delegation", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("matches canonical full paths and carries the predecessor chain", () => {
+    const previous = new Map<string, SourceDoc>([
+      ["old-a", {
+        kind: "source",
+        code: "export {};",
+        filename: "/features/./writer.ts",
+        imports: [],
+        delegatedModuleIdentities: ["ancestor-a"],
+      }],
+      ["old-b", {
+        kind: "source",
+        code: "export {};",
+        filename: "/other/writer.ts",
+        imports: [],
+      }],
+    ]);
+    const next: CacheableModule[] = [
+      {
+        identity: "new-a",
+        filename: "/features/writer.ts",
+        source: "export {};",
+        js: "export {};",
+        imports: [],
+      },
+      {
+        identity: "new-b",
+        filename: "/other/writer.ts",
+        source: "export {};",
+        js: "export {};",
+        imports: [],
+      },
+    ];
+
+    const delegations = deriveModuleDelegations(previous, next);
+    expect(delegations.get("new-a")).toEqual(
+      new Set(["ancestor-a", "old-a"]),
+    );
+    expect(delegations.get("new-b")).toEqual(new Set(["old-b"]));
+  });
+
+  it("skips ambiguous canonical filenames instead of delegating by basename", () => {
+    const previous = new Map<string, SourceDoc>([
+      ["old-a", {
+        kind: "source",
+        code: "export {};",
+        filename: "/features/../writer.ts",
+        imports: [],
+      }],
+      ["old-b", {
+        kind: "source",
+        code: "export {};",
+        filename: "/writer.ts",
+        imports: [],
+      }],
+    ]);
+    const delegations = deriveModuleDelegations(previous, [{
+      identity: "new",
+      filename: "/writer.ts",
+      source: "export {};",
+      js: "export {};",
+      imports: [],
+    }]);
+
+    expect(delegations.has("new")).toBe(false);
+  });
+
+  it("allows a loaded successor module to satisfy its predecessor's writer claim", async () => {
+    const oldIdentity = computeModuleHashes(moduleProgram("old")).get(
+      "/writer.ts",
+    )!;
+    const successor = moduleFor(moduleProgram("new"));
+
+    const sourceTx = runtime.edit();
+    writeSourceDocs(runtime, space, [successor], successor.identity, sourceTx);
+    const sourceCell = runtime.getCell<Record<string, unknown>>(
+      space,
+      sourceDocKey(successor.identity),
+      undefined,
+      sourceTx,
+    );
+    sourceCell.set({
+      ...sourceCell.get(),
+      delegatedModuleIdentities: [oldIdentity],
+    });
+    runtime.prepareTxForCommit(sourceTx);
+    expect((await sourceTx.commit()).error).toBeUndefined();
+
+    const protectedCell = runtime.getCell<{ value: string }>(
+      space,
+      "module-delegation-protected-value",
+      protectedSchema,
+    );
+    const seed = await runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: oldIdentity,
+        sourceFile: "/writer.ts",
+        bindingPath: ["setValue"],
+      });
+      protectedCell.withTx(tx).set({ value: "seed" });
+    });
+    expect(seed.error).toBeUndefined();
+
+    const denied = await runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: successor.identity,
+        sourceFile: "/writer.ts",
+        bindingPath: ["setValue"],
+      });
+      protectedCell.withTx(tx).set({ value: "before-load" });
+    }, 0);
+    expect(denied.error?.message).toContain("writeAuthorizedBy failed");
+
+    const loadTx = runtime.edit();
+    const closure = await loadVerifiedSourceClosure(
+      runtime,
+      space,
+      successor.identity,
+      loadTx,
+    );
+    loadTx.abort?.("module-delegation source load complete");
+    expect(closure?.get(successor.identity)).toBeDefined();
+
+    const allowed = await runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: successor.identity,
+        sourceFile: "/writer.ts",
+        bindingPath: ["setValue"],
+      });
+      protectedCell.withTx(tx).set({ value: "after-load" });
+    }, 0);
+    expect(allowed.error).toBeUndefined();
+    expect(protectedCell.get()).toEqual({ value: "after-load" });
+  });
+});

--- a/packages/runner/test/module-delegation.test.ts
+++ b/packages/runner/test/module-delegation.test.ts
@@ -214,7 +214,7 @@ describe("module identity delegation", () => {
     expect(denied.error?.message).toContain("writeAuthorizedBy failed");
   });
 
-  it("allows a loaded successor module to satisfy its predecessor's writer claim", async () => {
+  it("allows a loaded successor module while keeping the binding path exact", async () => {
     const oldIdentity = computeModuleHashes(moduleProgram("old")).get(
       "/writer.ts",
     )!;
@@ -280,5 +280,35 @@ describe("module identity delegation", () => {
     }, 0);
     expect(allowed.error).toBeUndefined();
     expect(protectedCell.get()).toEqual({ value: "after-load" });
+
+    // Resolver-dependent source-file spelling is diagnostic once the
+    // successor's authenticated delegation has established module authority.
+    const differentFileAllowed = await runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: successor.identity,
+        sourceFile: "/resolver-prefix/writer.ts",
+        bindingPath: ["setValue"],
+      });
+      protectedCell.withTx(tx).set({ value: "different-file" });
+    }, 0);
+    expect(differentFileAllowed.error).toBeUndefined();
+    expect(protectedCell.get()).toEqual({ value: "different-file" });
+
+    // Delegation grants only module authority; it must not relax which binding
+    // inside that module may write the protected field.
+    const wrongPathDenied = await runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: successor.identity,
+        sourceFile: "/writer.ts",
+        bindingPath: ["otherBinding"],
+      });
+      protectedCell.withTx(tx).set({ value: "wrong-binding" });
+    }, 0);
+    expect(wrongPathDenied.error?.message).toContain(
+      "writeAuthorizedBy failed",
+    );
+    expect(protectedCell.get()).toEqual({ value: "different-file" });
   });
 });

--- a/packages/runner/test/module-delegation.test.ts
+++ b/packages/runner/test/module-delegation.test.ts
@@ -78,30 +78,48 @@ describe("module identity delegation", () => {
   });
 
   it("filters invalid identities and pins each transaction's trust snapshot", () => {
+    const otherSpace = "did:key:z6MkModuleDelegationOtherSpace";
     runtime.registerModuleDelegations(
+      space,
       new Map([
         ["", new Set(["ignored-predecessor"])],
         ["successor", new Set(["predecessor"])],
+        ["predecessor", new Set(["ancestor"])],
       ]),
+    );
+    runtime.registerModuleDelegations(
+      otherSpace,
+      new Map([["predecessor", new Set(["attacker"])]]),
     );
 
     const tx = runtime.edit();
-    expect(tx.getCfcState().moduleDelegations.has("")).toBe(false);
-    expect(tx.getCfcState().moduleDelegations.get("successor")).toEqual([
+    const spaceDelegations = tx.getCfcState().moduleDelegations.get(space)!;
+    expect(spaceDelegations.has("")).toBe(false);
+    expect(spaceDelegations.get("successor")).toEqual([
+      "ancestor",
       "predecessor",
     ]);
+    expect(
+      tx.getCfcState().moduleDelegations.get(otherSpace)?.get("predecessor"),
+    ).toEqual(["attacker"]);
 
     // The Runtime pins this trust snapshot when it creates the transaction.
     // Code that reaches the concrete transaction must not replace it later.
     const delegationSetter = tx as unknown as {
       setCfcModuleDelegations(
-        delegations: ReadonlyMap<string, readonly string[]>,
+        delegations: ReadonlyMap<
+          string,
+          ReadonlyMap<string, readonly string[]>
+        >,
       ): void;
     };
     delegationSetter.setCfcModuleDelegations(
-      new Map([["successor", ["attacker"]]]),
+      new Map([[space, new Map([["successor", ["attacker"]]])]]),
     );
-    expect(tx.getCfcState().moduleDelegations.get("successor")).toEqual([
+    expect(
+      tx.getCfcState().moduleDelegations.get(space)?.get("successor"),
+    ).toEqual([
+      "ancestor",
       "predecessor",
     ]);
     tx.abort?.("module-delegation snapshot pin test complete");
@@ -356,5 +374,76 @@ describe("module identity delegation", () => {
       "writeAuthorizedBy failed",
     );
     expect(protectedCell.get()).toEqual({ value: "different-file" });
+  });
+
+  it("does not import module authority from another space", async () => {
+    const attacker = await Identity.fromPassphrase(
+      "module delegation attacker space",
+    );
+    const attackerSpace = attacker.did();
+    const oldIdentity = computeModuleHashes(moduleProgram("old")).get(
+      "/writer.ts",
+    )!;
+    const successor = moduleFor(moduleProgram("new"));
+
+    const sourceTx = runtime.edit();
+    writeSourceDocs(
+      runtime,
+      attackerSpace,
+      [successor],
+      successor.identity,
+      sourceTx,
+      new Map([[successor.identity, new Set([oldIdentity])]]),
+    );
+    runtime.prepareTxForCommit(sourceTx);
+    expect((await sourceTx.commit()).error).toBeUndefined();
+
+    const loadTx = runtime.edit();
+    const closure = await loadVerifiedSourceClosure(
+      runtime,
+      attackerSpace,
+      successor.identity,
+      loadTx,
+    );
+    loadTx.abort?.("cross-space module-delegation source load complete");
+    expect(closure?.get(successor.identity)).toBeDefined();
+
+    const snapshotTx = runtime.edit();
+    expect(
+      snapshotTx.getCfcState().moduleDelegations.get(attackerSpace)?.get(
+        successor.identity,
+      ),
+    ).toEqual([oldIdentity]);
+    expect(snapshotTx.getCfcState().moduleDelegations.get(space))
+      .toBeUndefined();
+    snapshotTx.abort?.("cross-space module-delegation snapshot inspected");
+
+    const protectedCell = runtime.getCell<{ value: string }>(
+      space,
+      "module-delegation-cross-space-value",
+      protectedSchema,
+    );
+    const seed = await runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: oldIdentity,
+        sourceFile: "/writer.ts",
+        bindingPath: ["setValue"],
+      });
+      protectedCell.withTx(tx).set({ value: "seed" });
+    });
+    expect(seed.error).toBeUndefined();
+
+    const denied = await runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: successor.identity,
+        sourceFile: "/writer.ts",
+        bindingPath: ["setValue"],
+      });
+      protectedCell.withTx(tx).set({ value: "cross-space" });
+    }, 0);
+    expect(denied.error?.message).toContain("writeAuthorizedBy failed");
+    expect(protectedCell.get()).toEqual({ value: "seed" });
   });
 });

--- a/packages/runner/test/module-delegation.test.ts
+++ b/packages/runner/test/module-delegation.test.ts
@@ -143,7 +143,7 @@ describe("module identity delegation", () => {
     expect(delegations.has("new")).toBe(false);
   });
 
-  it("allows a loaded successor module to satisfy its predecessor's writer claim", async () => {
+  it("does not trust delegation metadata without compiler integrity", async () => {
     const oldIdentity = computeModuleHashes(moduleProgram("old")).get(
       "/writer.ts",
     )!;
@@ -151,16 +151,84 @@ describe("module identity delegation", () => {
 
     const sourceTx = runtime.edit();
     writeSourceDocs(runtime, space, [successor], successor.identity, sourceTx);
+    runtime.prepareTxForCommit(sourceTx);
+    expect((await sourceTx.commit()).error).toBeUndefined();
+
+    // A later ordinary write can mutate the Merkle-excluded metadata but must
+    // not inherit the compiler-only attestation from the original cache write.
+    const forgeTx = runtime.edit();
     const sourceCell = runtime.getCell<Record<string, unknown>>(
       space,
       sourceDocKey(successor.identity),
       undefined,
-      sourceTx,
+      forgeTx,
     );
+    await sourceCell.sync();
     sourceCell.set({
-      ...sourceCell.get(),
+      kind: "source",
+      identity: successor.identity,
+      code: successor.source,
+      filename: successor.filename,
+      imports: [],
       delegatedModuleIdentities: [oldIdentity],
     });
+    runtime.prepareTxForCommit(forgeTx);
+    expect((await forgeTx.commit()).error).toBeUndefined();
+
+    const protectedCell = runtime.getCell<{ value: string }>(
+      space,
+      "module-delegation-untrusted-source",
+      protectedSchema,
+    );
+    const seed = await runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: oldIdentity,
+        sourceFile: "/writer.ts",
+        bindingPath: ["setValue"],
+      });
+      protectedCell.withTx(tx).set({ value: "seed" });
+    });
+    expect(seed.error).toBeUndefined();
+
+    const loadTx = runtime.edit();
+    const closure = await loadVerifiedSourceClosure(
+      runtime,
+      space,
+      successor.identity,
+      loadTx,
+    );
+    loadTx.abort?.("untrusted module-delegation source load complete");
+    expect(closure?.get(successor.identity)?.delegatedModuleIdentities)
+      .toBeUndefined();
+
+    const denied = await runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: successor.identity,
+        sourceFile: "/writer.ts",
+        bindingPath: ["setValue"],
+      });
+      protectedCell.withTx(tx).set({ value: "forged" });
+    }, 0);
+    expect(denied.error?.message).toContain("writeAuthorizedBy failed");
+  });
+
+  it("allows a loaded successor module to satisfy its predecessor's writer claim", async () => {
+    const oldIdentity = computeModuleHashes(moduleProgram("old")).get(
+      "/writer.ts",
+    )!;
+    const successor = moduleFor(moduleProgram("new"));
+
+    const sourceTx = runtime.edit();
+    writeSourceDocs(
+      runtime,
+      space,
+      [successor],
+      successor.identity,
+      sourceTx,
+      new Map([[successor.identity, new Set([oldIdentity])]]),
+    );
     runtime.prepareTxForCommit(sourceTx);
     expect((await sourceTx.commit()).error).toBeUndefined();
 

--- a/packages/runner/test/module-delegation.test.ts
+++ b/packages/runner/test/module-delegation.test.ts
@@ -77,6 +77,52 @@ describe("module identity delegation", () => {
     await storageManager?.close();
   });
 
+  it("filters invalid identities and pins each transaction's trust snapshot", () => {
+    runtime.registerModuleDelegations(
+      new Map([
+        ["", new Set(["ignored-predecessor"])],
+        ["successor", new Set(["predecessor"])],
+      ]),
+    );
+
+    const tx = runtime.edit();
+    expect(tx.getCfcState().moduleDelegations.has("")).toBe(false);
+    expect(tx.getCfcState().moduleDelegations.get("successor")).toEqual([
+      "predecessor",
+    ]);
+
+    // The Runtime pins this trust snapshot when it creates the transaction.
+    // Code that reaches the concrete transaction must not replace it later.
+    const delegationSetter = tx as unknown as {
+      setCfcModuleDelegations(
+        delegations: ReadonlyMap<string, readonly string[]>,
+      ): void;
+    };
+    delegationSetter.setCfcModuleDelegations(
+      new Map([["successor", ["attacker"]]]),
+    );
+    expect(tx.getCfcState().moduleDelegations.get("successor")).toEqual([
+      "predecessor",
+    ]);
+    tx.abort?.("module-delegation snapshot pin test complete");
+  });
+
+  it("rejects an update when the predecessor source closure is unavailable", async () => {
+    const manager = runtime.patternManager as unknown as {
+      loadPreviousSourceClosure(
+        space: string,
+        entryIdentity: string,
+      ): Promise<Map<string, SourceDoc>>;
+    };
+
+    await expect(
+      manager.loadPreviousSourceClosure(space, "missing-predecessor"),
+    ).rejects.toThrow(
+      "cannot authorize module update from missing-predecessor: " +
+        "verified source closure is unavailable",
+    );
+  });
+
   it("matches canonical full paths and carries the predecessor chain", () => {
     const previous = new Map<string, SourceDoc>([
       ["old-a", {

--- a/packages/runner/test/src-garble-identity-invariant.test.ts
+++ b/packages/runner/test/src-garble-identity-invariant.test.ts
@@ -189,8 +189,9 @@ Deno.test(
   () => {
     // Part B (workstream C prerequisite) re-rooted CFC verified-source identity
     // OFF `.src`: the WeakMap provenance lookup IS the anti-spoof proof, and every
-    // field the `writeAuthorizedBy` arm checks (moduleIdentity / sourceFile /
-    // bindingPath) is provenance-derived. So garbling or REMOVING `.src` must NOT
+    // policy-facing identity field is provenance-derived. `writeAuthorizedBy`
+    // verifies moduleIdentity + bindingPath; sourceFile is diagnostic there. So
+    // garbling or REMOVING `.src` must NOT
     // change the resolved identity — that is exactly what makes lazy/debug-only
     // `.src` (skipped at boot) safe for authorized writes. If a future change
     // re-introduces a `.src` dependency in CFC identity, this test trips.


### PR DESCRIPTION
## Summary

- teach `piece setsrc` to compare the previous and replacement recursive module closures by normalized full filename
- persist cumulative successor-to-predecessor module delegations in source and compiled cache documents, merging metadata with `editWithRetry` when a content-addressed successor already exists
- register loaded delegations in the runtime and snapshot their transitive closure for CFC checks
- allow `WriteAuthorizedBy` to follow a trusted module delegation while retaining an exact binding-path check; resolver-specific source-file spelling remains diagnostic at verification
- document the temporary setsrc delegation contract and add focused chain, shared-module, authorization, and cold-reload regressions

## Why

`WriteAuthorizedBy` records a writer's content-addressed module identity. Updating a pattern changes that identity, so the replacement handler could no longer update data labeled by its predecessor. Content-addressed modules may also be shared across patterns, which means the same successor document can need delegations from multiple predecessor closures.

This change makes an explicit `setsrc` update bless that chain. Renamed, moved, or ambiguously matched modules still fail closed.

## User impact

Patterns updated through `cf piece setsrc` retain their existing `WriteAuthorizedBy` authority across module revisions, including after a cold reload and when multiple patterns converge on the same successor module.

## Validation

- `deno task check`
- `deno task check-docs` (519 code blocks)
- `deno lint` and `deno fmt --check` on changed TypeScript and docs
- focused and adjacent Piece, compilation-cache, identity, and CFC suites (364 test steps)
- post-merge regressions:
  - `deno test --no-check --allow-all packages/runner/test/module-delegation.test.ts packages/piece/test/setsrc-module-delegation.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach `piece setsrc` to preserve `WriteAuthorizedBy` authority by delegating writer identity when old and new modules share the same canonical authored filename, with compiler-authenticated metadata stored in source/compiled caches and registered in the runtime. Delegations are space-scoped and snapshotted per transaction; renames or ambiguous matches do not inherit authority.

- **New Features**
  - Add per-module `delegatedModuleIdentities` to source and compiled docs; derive by canonical full filename, skip ambiguous names, merge the authenticated union into both sets in one write, register it in the runtime, and snapshot it per transaction/digest.
  - Allow `writeAuthorizedBy` to match the live module hash or a delegated predecessor; the binding path must still match exactly, and file spelling is diagnostic at verification.
  - Thread `previousEntryIdentity` through `compileProgram` → `compileAndSavePattern` → `patternManager.compilePattern` to derive delegations during `setsrc`.
  - Scope delegations by space: bind entries to the attesting space, include them in prepared-digest canonicalization, and ignore metadata loaded from other spaces.

- **Bug Fixes**
  - Keep ordinary source-cache writes self-verifying by stamping compiler integrity only when delegation metadata exists; loaders ignore unstamped data.
  - Do not reuse cached closures missing required delegation metadata; persistence checks require delegations in both source and compiled sets. Preserve merged authority when multiple patterns converge on the same successor and across cold/warm loads and runtime-version recompiles.
  - Guard closure replication and cross-space mixing: skip same-space/keyless replication; reject origin/compiled closures that are incomplete or linked to another space’s attestation; require compiled coverage spans.

<sup>Written for commit 5f5f1d4049f03fb8e41e78ee97f110c56c0787a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

