### PR TITLE
feat(ts-transformers,runner): explicit writer-identity spelling contract + claims born stamped (CT-1886 follow-up)

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -535,7 +535,7 @@ inside those payloads.
 | `MaxConfidentiality<T, C>` | `{ maxConfidentiality: C }` |
 | `AnyOf<X>` | when nested in an IFC label tuple, one atom `{ anyOf: X }` |
 | `PolicyOf<typeof rules>` | when nested in an IFC label tuple, a policy atom carrying a compile-time module-binding marker; the ts-transformer resolves it to `{ type, policyRefKind: "module", subject, moduleIdentity, symbol, policyDigest }` |
-| `WriteAuthorizedBy<T, typeof b>` | `{ writeAuthorizedBy: { __ctWriterIdentityOf: { file, path: [binding] } } }` (`:1444-1532`) |
+| `WriteAuthorizedBy<T, typeof b>` | `{ writeAuthorizedBy: { __ctWriterIdentityOf: { file, path: [binding], moduleIdentity? } } }` (`:1444-1539`) |
 | `TrustedActionWriteWithIntegrity<…>` | writeAuthorizedBy metadata + `uiContract { helper: "UiAction", action, trustedPattern, requiredEventIntegrity }` (`:1340-1347,1455-1478`) |
 | `TrustedActionWrite<…>` | same, with `requiredEventIntegrity` defaulting to `[trustedPattern]` (`:1349-1358`) |
 | `TrustedActionUiContract<…>` | `{ uiContract: { helper: "UiAction", action, trustedPattern, requiredEventIntegrity? } }` (`:1359-1371`) |
@@ -566,13 +566,17 @@ Mechanics:
   (`mergeIfcMetadata`, `:1554-1570`); boolean schemas become `{ ifc }` /
   `{ not: true, ifc }`.
 - `WriteAuthorizedBy` writer identity resolves through import aliases to the
-  declaring file; the file name is normalized (backslashes → `/`, first path
-  segment stripped — `normalizeWriterIdentityFile`, `:2237-2241`). The
-  transformer **duplicates** this attachment for
-  `toSchema<WriteAuthorizedBy<T, typeof b>>()`
-  (`ts-transformers/.../schema-generator.ts:29-40,126-131,347-428`), with a
-  marker AST form so the identity survives literal emission (`:170-171,
-  399-422`).
+  declaring file. A transformer caller supplies
+  `writerIdentityForSourceFile`, which maps that compile name to its authored
+  spelling and can attach the defining source's content-addressed
+  `moduleIdentity`; the runner supplies both, so engine-minted claims are born
+  stamped. A transformer identity map that omits the defining source is a
+  compile error, rather than a silent downgrade to an unstamped claim.
+  Standalone schema-generator callers that omit the callback retain
+  the legacy fallback (backslashes → `/`, first path segment stripped by
+  `normalizeWriterIdentityFile`). The transformer also handles the direct-root
+  `toSchema<WriteAuthorizedBy<T, typeof b>>()` form specially so the wrapper's
+  value schema remains the root while the same identity marker is attached.
 - `SchemaGeneratorTransformer.resolvePolicyOfMarkers` replaces a valid policy
   marker with the compiled module identity, exported symbol, and policy digest.
   If it cannot match a compiler-verified exported `exchangeRules()` binding,

--- a/docs/specs/ts-transformer/cfc_authoring_contract.md
+++ b/docs/specs/ts-transformer/cfc_authoring_contract.md
@@ -183,18 +183,30 @@ Normative behavior:
    - a local function declaration
 4. The transformer must report `cfc-write-authorized-by` if any of the above
    conditions fail.
-5. The schema-generator must preserve the identity through a marker payload,
-   then rehydrate it back into emitted schema AST as `<binding> as any`.
+5. The schema-generator must preserve the declaring source and binding path in
+   `__ctWriterIdentityOf`. The transformer maps the declaring compile name to
+   the caller's authored file spelling. When `moduleIdentities` contains that
+   defining source, the marker must also carry its content-addressed
+   `moduleIdentity`, so engine-authored claims are stamped when minted.
+6. If `moduleIdentities` is supplied but omits the defining source, compilation
+   must fail instead of silently minting an unstamped claim.
 
 One valid marker shape is:
 
 ```ts
 // Shown for illustration only.
-{ __ctWriterIdentityOf: <ts.EntityName> }
+{
+  __ctWriterIdentityOf: {
+    file: "/authored/path.tsx",
+    path: ["binding"],
+    moduleIdentity: "cf:module/content-identity"
+  }
+}
 ```
 
-That marker is an implementation detail, but the implementation still needs an
-equivalent cross-stage identity channel.
+`moduleIdentity` is absent for compatibility callers that do not supply source
+identities and for aged stored claims. The marker is an implementation detail,
+but the implementation still needs an equivalent cross-stage identity channel.
 
 ## Pipeline Contract
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1381,7 +1381,9 @@ Special path:
   `AnyOf<...>` becomes an IFC `anyOf` atom, and `PolicyOf<typeof policy>`
   becomes a policy-reference marker that `SchemaGeneratorTransformer`
   resolves to module identity, symbol, and digest. `WriteAuthorizedBy`
-  rehydrates as `ifc.writeAuthorizedBy.__ctWriterIdentityOf = { file, path }`,
+  rehydrates as `ifc.writeAuthorizedBy.__ctWriterIdentityOf = { file, path }`
+  (plus a mint-time `moduleIdentity` stamp when the compiler was given
+  `moduleIdentities` — see §17.3 file normalization),
   and router-seeded `cfcUiContract` hints emit as `ifc.uiContract`. See §6.8;
   pinned by `test/cfc-authoring.test.ts`,
   `packages/schema-generator/test/schema/cfc-authoring.test.ts`, and
@@ -2549,7 +2551,12 @@ the annotated value itself and, when the value carries a function-valued
 (`src/utils/writer-identity-file.ts`, shared with
 `src/transformers/schema-generator.ts`, which emits the matching claim into
 schemas as `ifc: { writeAuthorizedBy: { __ctWriterIdentityOf: { file, path
-} } }` — `attachWriteAuthorizedByMarker` / `extractWriteAuthorizedByIdentity`)
+} } }`, plus `moduleIdentity` when `TransformerOptions.moduleIdentities` maps
+this compile name — claims are then *born stamped* with their own module's
+content-addressed identity, so the capturable unstamped state is never minted
+(labs#4772 residual); the engine supplies the map, computed from pristine
+sources before the TS compile — `attachWriteAuthorizedByMarker` /
+`extractWriteAuthorizedByIdentity`)
 normalizes backslashes → slashes and then applies the caller-supplied
 `canonicalWriterIdentityFile` option (`TransformerOptions`), the compile-name →
 authored-name unmapping. The runner's engine passes its `storedFilenameFor`
@@ -2576,10 +2583,15 @@ CFC's implementation identity surfaces it as `sourceFile`/`bindingPath`
 moduleIdentity to equal the claim's directly or name an authenticated
 `piece setsrc` predecessor, plus an equal binding path — the file SPELLING is
 deliberately not load-bearing at verification (it is resolver-dependent;
-labs#4772). Stamp MINTING (`rebindWriteAuthorizedByClaims`) still requires exact
-slash-normalized file equality, and stored-claim reconciliation tolerates
-spellings one leading segment apart
-(`packages/runner/src/cfc/writer-claim-correspondence.ts`). The
+labs#4772). Stamp MINTING (`rebindWriteAuthorizedByClaims`) still requires
+exact slash-normalized file equality, and stored-claim reconciliation
+tolerates spellings one leading segment apart
+(`packages/runner/src/cfc/writer-claim-correspondence.ts`); when both sides
+of a reconcile carry stamps for the same binding, the STORED stamp always
+wins — a republished module's born-stamped claim never rotates the stored
+one at merge time (its field writes are authorized at verification by
+authenticated `piece setsrc` module delegation, or fail closed loudly
+without one), and the envelope's sibling writes keep committing. The
 non-exported case reaches provenance through the `__cfReg` registration sink
 — the gap guarded by
 `packages/runner/test/cfc-nonexported-binding-identity.test.ts`.

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1806,7 +1806,7 @@ values it can classify as `builder | data | function | import`, and rejects raw
 mutable literals and arbitrary call results at module scope
 (`classifyExpressionText`,
 `packages/runner/src/sandbox/compiled-bundle-verifier.ts`; policy narrative in
-`docs/specs/module-loading-verifier-and-engine-design.md` §"Security
+`docs/specs/module-loading.md` §"Security
 classification"). `__cf_data(...)` is the canonical "verified module-safe
 data" wrapper of that grammar: the verifier pattern-matches the wrapper
 boundary without interpreting the payload, and at module load the runtime
@@ -2030,7 +2030,7 @@ admits the module-safe subset (plain objects, arrays, `Map`→`FrozenMap`,
 (`SES_SANDBOXING_SPEC.md` §4.2.3; `packages/runner/src/sandbox/plain-data.ts`).
 The same classification serves both the AMD factory body and the per-module
 ESM record body (`classifyModuleItems` doc comment;
-`docs/specs/module-loading-verifier-and-engine-design.md`); on the ESM path,
+`docs/specs/module-loading.md`); on the ESM path,
 write-once exports neutralize side effects smuggled into an accepted wrapper
 argument (`__cf_data((exports.x = evil, 1))`), and pipeline-compiled bodies are
 required precisely because bare `ts.transpileModule` cannot produce the
@@ -2547,22 +2547,28 @@ the annotated value itself and, when the value carries a function-valued
 `.implementation` (builder factories do), on that implementation function too
 (`createBindingIdentityHelper` / `createDefineBindingMetadataCall`).
 
-**File normalization.** `normalizeWriterIdentityFile`
-(`src/utils/writer-identity-file.ts`, shared with
-`src/transformers/schema-generator.ts`, which emits the matching claim into
-schemas as `ifc: { writeAuthorizedBy: { __ctWriterIdentityOf: { file, path
-} } }`, plus `moduleIdentity` when `TransformerOptions.moduleIdentities` maps
-this compile name — claims are then *born stamped* with their own module's
-content-addressed identity, so the capturable unstamped state is never minted
-(labs#4772 residual); the engine supplies the map, computed from pristine
-sources before the TS compile — `attachWriteAuthorizedByMarker` /
-`extractWriteAuthorizedByIdentity`)
-normalizes backslashes → slashes and then applies the caller-supplied
+**File normalization and mint-time stamps.**
+`normalizeWriterIdentityFile` (`src/utils/writer-identity-file.ts`) normalizes
+backslashes → slashes and then applies the caller-supplied
 `canonicalWriterIdentityFile` option (`TransformerOptions`), the compile-name →
-authored-name unmapping. The runner's engine passes its `storedFilenameFor`
+authored-name unmapping. `src/transformers/schema-generator.ts` uses it while
+emitting `ifc: { writeAuthorizedBy: { __ctWriterIdentityOf: { file, path } } }`.
+General nested/interface/alias claims are constructed by the schema-generator's
+`CommonFabricFormatter`; the transformer passes it the same writer-source
+resolver used by the direct-root special case. When
+`TransformerOptions.moduleIdentities` contains the binding's defining compile
+source, the payload also carries that source's `moduleIdentity`. The engine's
+map covers its authored sources and is computed from pristine source before
+the TS compile, so engine-minted claims are *born stamped* and the capturable
+unstamped state is never minted (labs#4772 residual —
+`writerIdentityForSourceFile` / `extractWriteAuthorizedByIdentity`). Supplying
+an identity map that lacks the binding's defining source fails compilation;
+only callers that omit the map entirely retain unstamped compatibility output.
+
+The runner's engine passes its `storedFilenameFor`
 (stripping the per-load `/${id}` module-path prefix and unmapping fabric-mount
 paths — see the prefix/identity-source-normalization discussion in
-`docs/specs/module-loading-verifier-and-engine-design.md`), keeping claim and
+`docs/specs/module-loading.md`), keeping claim and
 provenance spellings load-independent and equal. Without the option the name
 is recorded verbatim: direct compiles (HTTP resolver, piece manifests) already
 present authored paths. Historical behavior — blindly stripping the first
@@ -2702,7 +2708,7 @@ until the verifier agrees (also stated in
   `registerFunctionStatement`). The design doc states the rule directly:
   "canonical function-hardening (`__cfHardenFn(fn)`) and binding-identity
   statements recognized by byte-equality to `sandbox-contract.ts` sources"
-  (`docs/specs/module-loading-verifier-and-engine-design.md`). A same-named
+  (`docs/specs/module-loading.md`). A same-named
   helper with a different body is just an ordinary function — and the module
   then fails on its call sites: pinned by the adversarial case "fake
   (non-canonical) __cfHardenFn laundering a callback"

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -2545,16 +2545,25 @@ the annotated value itself and, when the value carries a function-valued
 `.implementation` (builder factories do), on that implementation function too
 (`createBindingIdentityHelper` / `createDefineBindingMetadataCall`).
 
-**File normalization.** `normalizeWriterIdentityFile` (backslashes → slashes,
-then strip the first path segment when the path has more than one) is
-deliberately duplicated, character-for-character, in
+**File normalization.** `normalizeWriterIdentityFile`
+(`src/utils/writer-identity-file.ts`, shared with
 `src/transformers/schema-generator.ts`, which emits the matching claim into
 schemas as `ifc: { writeAuthorizedBy: { __ctWriterIdentityOf: { file, path
-} } }` (`attachWriteAuthorizedByMarker` / `extractWriteAuthorizedByIdentity`).
-The stripped leading segment corresponds to the engine's per-load `/${id}`
-module-path prefix (see the prefix/identity-source-normalization discussion
-in `docs/specs/module-loading-verifier-and-engine-design.md`), keeping both
-sides load-independent and equal.
+} } }` — `attachWriteAuthorizedByMarker` / `extractWriteAuthorizedByIdentity`)
+normalizes backslashes → slashes and then applies the caller-supplied
+`canonicalWriterIdentityFile` option (`TransformerOptions`), the compile-name →
+authored-name unmapping. The runner's engine passes its `storedFilenameFor`
+(stripping the per-load `/${id}` module-path prefix and unmapping fabric-mount
+paths — see the prefix/identity-source-normalization discussion in
+`docs/specs/module-loading-verifier-and-engine-design.md`), keeping claim and
+provenance spellings load-independent and equal. Without the option the name
+is recorded verbatim: direct compiles (HTTP resolver, piece manifests) already
+present authored paths. Historical behavior — blindly stripping the first
+segment of any absolute multi-segment name as a presumed engine prefix —
+mis-spelled modules from direct compiles whose first segment was a real path
+segment, shearing claims from provenance across compile stacks (labs#4772 /
+CT-1886); stores hold claims minted under those spellings (see the
+spelling-compat note in the normalizer's doc comment).
 
 **Runtime consumption.** After a verified evaluation,
 `Engine.recordModuleProvenance` reads the annotation off each exported or
@@ -2881,7 +2890,7 @@ re-listing it. The enforced sources of truth:
 | Module-scope `__cf_data` wrap/exclusion name sets + verifier error strings (§15) | `TRUSTED_BUILDERS` / `TRUSTED_DATA_HELPERS` (`packages/utils/src/sandbox-contract.ts`); `CF_DATA_CONSTRUCTOR_NAMES` (`src/transformers/module-scope-cf-data.ts`); `TOP_LEVEL_CALL_RESULT_ERROR` (`packages/runner/src/sandbox/policy.ts`) | one module feeds both transformer and runner verifier — cross-package contract; runtime freezer semantics live in `packages/runner/src/sandbox/plain-data.ts` |
 | Coverage instrumentation + span schema (§16) | `PatternCoverageTransformer` (`src/transformers/pattern-coverage.ts`); `PatternCoverageSpan` / `PatternCoverageOptions` / `PATTERN_COVERAGE_GLOBAL` (`src/core/transformers.ts`) | line remapping pins the one-line helper prelude: `HELPERS_STMT` (`src/core/cf-helpers.ts`) ↔ `patternCoverageOptionsForCompile` (`packages/runner/src/harness/engine.ts`) — change them together |
 | Hardening/binding helper names, metadata field, canonical helper bodies (§17) | `FUNCTION_HARDENING_HELPER_NAME` / `BINDING_IDENTITY_HELPER_NAME` / `VERIFIED_BINDING_METADATA_FIELD` and `createFunctionHardeningHelperSource` / `createBindingIdentityHelperSource` (`packages/utils/src/sandbox-contract.ts`) | the runner verifier recognizes helper declarations by trivia-stripped byte equality to these sources (`CANONICAL_HARDENING_HELPER` in `packages/runner/src/sandbox/compiled-bundle-verifier.ts`); the transformer's AST-built twins (`createFunctionHardeningHelper` / `createBindingIdentityHelper` in `src/transformers/module-scope-function-hardening.ts`) must compile to exactly that text — drift fails every module load |
-| Trusted-binding type names + binding positions (§17.3) | seed map in `discoverWriteAuthorizedByBindingPositions` (`src/transformers/module-scope-function-hardening.ts`) | keep in sync with `WriteAuthorizedByValidationTransformer` (§6.8) and the schema generator's `__ctWriterIdentityOf` claim emission; `normalizeWriterIdentityFile` is intentionally duplicated in `schema-generator.ts` and must stay identical |
+| Trusted-binding type names + binding positions (§17.3) | seed map in `discoverWriteAuthorizedByBindingPositions` (`src/transformers/module-scope-function-hardening.ts`) | keep in sync with `WriteAuthorizedByValidationTransformer` (§6.8) and the schema generator's `__ctWriterIdentityOf` claim emission; both spell files via the shared `normalizeWriterIdentityFile` (`src/utils/writer-identity-file.ts`) so claim and provenance spellings cannot drift |
 
 A drift-resistant habit: when a section enumerates a set, cite the constant /
 function that defines it so a reader can confirm the live set, and keep prose

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1663,6 +1663,7 @@ export type JSONSchemaObj = {
           readonly bundleId?: string;
           readonly file?: string;
           readonly path?: readonly string[];
+          readonly moduleIdentity?: string;
         };
       };
     readonly exactCopyOf?: readonly string[];

--- a/packages/api/test/json-schema-writer-identity.test.ts
+++ b/packages/api/test/json-schema-writer-identity.test.ts
@@ -1,0 +1,39 @@
+import { assertEquals } from "@std/assert";
+import type { JSONSchema } from "../index.ts";
+
+const stampedSchema = {
+  type: "string",
+  ifc: {
+    writeAuthorizedBy: {
+      __ctWriterIdentityOf: {
+        file: "/patterns/profile-home.tsx",
+        path: ["setBio"],
+        moduleIdentity: "cf:module/profile-home-v1",
+      },
+    },
+  },
+} as const satisfies JSONSchema;
+
+const agedUnstampedSchema = {
+  type: "string",
+  ifc: {
+    writeAuthorizedBy: {
+      __ctWriterIdentityOf: {
+        file: "/patterns/profile-home.tsx",
+        path: ["setBio"],
+      },
+    },
+  },
+} as const satisfies JSONSchema;
+
+Deno.test("JSONSchema represents stamped and aged unstamped writer claims", () => {
+  assertEquals(
+    stampedSchema.ifc.writeAuthorizedBy.__ctWriterIdentityOf.moduleIdentity,
+    "cf:module/profile-home-v1",
+  );
+  assertEquals(
+    "moduleIdentity" in
+      agedUnstampedSchema.ifc.writeAuthorizedBy.__ctWriterIdentityOf,
+    false,
+  );
+});

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -223,8 +223,9 @@ const mergeSetLikeIfcArray = (
           // authoring identity's provenance stamp and one recorded without an
           // identity (unstamped). The BINDING (file + path) is what the claim
           // means; the stamp is provenance added per input — keep the stamped
-          // claim. Two DIFFERENT stamps (or different bindings) still
-          // conflict.
+          // claim. For two different stamps of the same binding, keep the
+          // stored stamp (a version boundary, never a rotation here). Different
+          // bindings still conflict.
           if (key === "writeAuthorizedBy") {
             const reconciled = reconcileWriterClaimStamp(existing, candidate);
             if (reconciled !== undefined) {

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -99,12 +99,15 @@ const writerClaimWithoutStampAndFile = (
  * (equal or one-leading-segment apart), and everything outside file + stamp
  * is equal. Returns the stamped side when exactly one carries the provenance
  * stamp (`moduleIdentity`, or a legacy `bundleId` on pre-migration claims),
- * the existing side when neither does or both carry the SAME stamp (stored
- * spelling wins — stability), and `undefined` when the claims genuinely
- * conflict (different bindings, or two different stamps). A legitimate
- * `setsrc` update does not rotate this stamp: the stored claim keeps its
- * predecessor identity, and authenticated module delegation authorizes the
- * successor at verification time.
+ * and the existing side otherwise — both-unstamped, both same stamp, and
+ * both stamped DIFFERENTLY (a version boundary: born-stamped claims make a
+ * republished module re-present this binding under its new moduleIdentity
+ * on every envelope write; the stored stamp is kept, never rotated, and the
+ * successor's field writes are authorized at verification time by
+ * authenticated `piece setsrc` module delegation — or fail closed loudly
+ * without one — while the envelope's sibling writes keep committing).
+ * `undefined` only when the claims name different bindings
+ * (non-corresponding files or paths).
  */
 const reconcileWriterClaimStamp = (
   existing: unknown,
@@ -144,13 +147,18 @@ const reconcileWriterClaimStamp = (
   const existingStamped = writerClaimIsStamped(existingIdentity);
   const candidateStamped = writerClaimIsStamped(candidateIdentity);
   if (existingStamped && candidateStamped) {
-    // Both stamped: same stamp → the stored claim (spelling included) wins;
-    // different stamps → genuine conflict, never silently rotated.
-    return WRITER_CLAIM_STAMP_KEYS.every((key) =>
-        deepEqual(existingIdentity[key], candidateIdentity[key])
-      )
-      ? existing
-      : undefined;
+    // Both stamped, same binding: the stored claim wins either way. With
+    // equal stamps this is plain stability (spelling included). With
+    // DIFFERENT stamps it is a version boundary — claims are minted born
+    // stamped, so a republished module re-presents this binding under its
+    // new moduleIdentity on every envelope write. Keeping the stored stamp
+    // (instead of conflict-aborting the transaction) preserves the
+    // fail-closed posture at the right granularity: the new version's
+    // writes to THIS field are rejected loudly at verification until the
+    // setsrc-history delegation design authorizes the rotation, while the
+    // envelope's sibling fields keep committing. Rotation never happens
+    // here in either direction.
+    return existing;
   }
   if (!existingStamped && !candidateStamped) {
     return existing;

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -409,6 +409,10 @@ export class Engine extends EventTarget implements Harness {
               .CommonFabricTransformerPipeline)({
               patternCoverage,
               moduleIdentities: identityByPath,
+              // Writer identities record authored paths: unmap the engine's
+              // per-load `/<id>` prefix (and mount paths) before spelling.
+              canonicalWriterIdentityFile: (name) =>
+                storedFilenameFor(name, id, mounts),
             });
             return {
               factories: pipeline.toFactories(program),
@@ -631,8 +635,10 @@ export class Engine extends EventTarget implements Harness {
     const runTransform = options.transform ?? true;
     const unioned = new Map<string, Source>();
     const mains: string[] = [];
+    const batchIds: string[] = [];
     for (const program of programs) {
       const id = computeId(program);
+      batchIds.push(id);
       const mapped = pretransformProgramForModules(program, id);
       const resolver = new EngineProgramResolver(
         mapped,
@@ -660,7 +666,18 @@ export class Engine extends EventTarget implements Harness {
               [...unioned.keys()].map((name) => [name, `check:${name}`]),
             );
             const pipeline = new (compilerStack()
-              .CommonFabricTransformerPipeline)({ moduleIdentities });
+              .CommonFabricTransformerPipeline)({
+              moduleIdentities,
+              // The union carries a different `/<id>` prefix per batched
+              // program; strip whichever one matches.
+              canonicalWriterIdentityFile: (name) => {
+                for (const batchId of batchIds) {
+                  const stripped = stripModuleIdPrefix(name, batchId);
+                  if (stripped !== name) return stripped;
+                }
+                return name;
+              },
+            });
             return {
               factories: pipeline.toFactories(program),
               getDiagnostics: () => pipeline.getDiagnostics(),
@@ -809,6 +826,10 @@ export class Engine extends EventTarget implements Harness {
           .CommonFabricTransformerPipeline)({
           patternCoverage,
           moduleIdentities: identityByPath,
+          // Names on this path are already stored-shaped (no `/<id>` prefix);
+          // only mount paths need unmapping to authored spellings.
+          canonicalWriterIdentityFile: (name) =>
+            storedFilenameFor(name, undefined, mounts),
         });
         return {
           factories: pipeline.toFactories(program),

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -547,7 +547,14 @@ describe("mergeCfcSchemaEnvelopes", () => {
     }
   });
 
-  it("rejects writeAuthorizedBy claims with conflicting identity stamps", () => {
+  it("keeps the stored stamp when identity stamps conflict (version boundary, no rotation)", () => {
+    // Same binding, two different stamps: a version boundary, not a merge
+    // conflict. Claims are minted born stamped, so a republished module
+    // re-presents this binding under its new moduleIdentity on every
+    // envelope write — the stored stamp wins (never rotated; the new
+    // version's field writes stay fail-closed at verification pending
+    // setsrc-history delegation) and the envelope's sibling writes keep
+    // committing instead of aborting the whole transaction.
     const claimFor = (moduleIdentity: string) => ({
       __ctWriterIdentityOf: {
         file: "/system/profile-home.tsx",
@@ -555,25 +562,26 @@ describe("mergeCfcSchemaEnvelopes", () => {
         moduleIdentity,
       },
     });
-    expect(() =>
-      mergeCfcSchemaEnvelopes({
-        type: "object",
-        properties: {
-          elements: {
-            type: "array",
-            ifc: { writeAuthorizedBy: claimFor("fid1:left") },
-          },
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "object",
+      properties: {
+        elements: {
+          type: "array",
+          ifc: { writeAuthorizedBy: claimFor("fid1:left") },
         },
-      }, {
-        type: "object",
-        properties: {
-          elements: {
-            type: "array",
-            ifc: { writeAuthorizedBy: claimFor("fid1:right") },
-          },
+      },
+    }, {
+      type: "object",
+      properties: {
+        elements: {
+          type: "array",
+          ifc: { writeAuthorizedBy: claimFor("fid1:right") },
         },
-      })
-    ).toThrow(/writeAuthorizedBy must remain stable/);
+      },
+    });
+    // deno-lint-ignore no-explicit-any
+    expect((merged as any).properties.elements.ifc.writeAuthorizedBy)
+      .toEqual(claimFor("fid1:left"));
   });
 
   it("rejects writeAuthorizedBy claims with different bindings", () => {

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -577,11 +577,16 @@ describe("mergeCfcSchemaEnvelopes", () => {
           type: "array",
           ifc: { writeAuthorizedBy: claimFor("fid1:right") },
         },
+        displayName: { type: "string" },
       },
     });
     // deno-lint-ignore no-explicit-any
     expect((merged as any).properties.elements.ifc.writeAuthorizedBy)
       .toEqual(claimFor("fid1:left"));
+    // This is the production reason for reconciling instead of aborting: the
+    // candidate envelope can still contribute an unrelated sibling schema.
+    // deno-lint-ignore no-explicit-any
+    expect((merged as any).properties.displayName).toEqual({ type: "string" });
   });
 
   it("rejects writeAuthorizedBy claims with different bindings", () => {

--- a/packages/runner/test/cfc-writer-claim-correspondence.test.ts
+++ b/packages/runner/test/cfc-writer-claim-correspondence.test.ts
@@ -319,21 +319,30 @@ describe("stored-claim reconciliation across spellings", () => {
     });
   });
 
-  it("still conflicts on two different stamps (no silent cross-version rotation)", () => {
-    expect(() =>
-      mergeCfcSchemaEnvelopes(
-        envelope({
-          moduleIdentity: "profile-home-module-identity-v1",
-          file: PIECE_SPELLING,
-          path: ["setBio"],
-        }),
-        envelope({
-          moduleIdentity: "profile-home-module-identity-v2",
-          file: HTTP_SPELLING,
-          path: ["setBio"],
-        }),
-      )
-    ).toThrow("writeAuthorizedBy must remain stable");
+  it("keeps the stored stamp on two different stamps (version boundary: no rotation, no abort)", () => {
+    // Claims are minted born stamped, so a republished module re-presents
+    // this binding under its new moduleIdentity on every envelope write.
+    // The stored stamp wins — the new version's field writes fail closed at
+    // verification (pending setsrc-history delegation) while the envelope's
+    // sibling writes keep committing; a merge-time conflict abort here
+    // would brick the whole envelope on every pattern update.
+    const merged = mergeCfcSchemaEnvelopes(
+      envelope({
+        moduleIdentity: "profile-home-module-identity-v1",
+        file: PIECE_SPELLING,
+        path: ["setBio"],
+      }),
+      envelope({
+        moduleIdentity: "profile-home-module-identity-v2",
+        file: HTTP_SPELLING,
+        path: ["setBio"],
+      }),
+    );
+    expect(claimOf(merged)).toEqual({
+      moduleIdentity: "profile-home-module-identity-v1",
+      file: PIECE_SPELLING,
+      path: ["setBio"],
+    });
   });
 
   it("still conflicts on different binding paths", () => {

--- a/packages/runner/test/cfc-writer-claim-correspondence.test.ts
+++ b/packages/runner/test/cfc-writer-claim-correspondence.test.ts
@@ -256,7 +256,10 @@ describe("writeAuthorizedBy across resolver spellings (labs#4772)", () => {
 });
 
 describe("stored-claim reconciliation across spellings", () => {
-  const envelope = (identity: Record<string, unknown>): JSONSchemaObj =>
+  const envelope = (
+    identity: Record<string, unknown>,
+    siblingProperties: Record<string, JSONSchemaObj> = {},
+  ): JSONSchemaObj =>
     ({
       type: "object",
       properties: {
@@ -266,6 +269,7 @@ describe("stored-claim reconciliation across spellings", () => {
             writeAuthorizedBy: { __ctWriterIdentityOf: identity },
           },
         },
+        ...siblingProperties,
       },
     }) as unknown as JSONSchemaObj;
 
@@ -336,13 +340,15 @@ describe("stored-claim reconciliation across spellings", () => {
         moduleIdentity: "profile-home-module-identity-v2",
         file: HTTP_SPELLING,
         path: ["setBio"],
-      }),
+      }, { displayName: { type: "string" } }),
     );
     expect(claimOf(merged)).toEqual({
       moduleIdentity: "profile-home-module-identity-v1",
       file: PIECE_SPELLING,
       path: ["setBio"],
     });
+    // deno-lint-ignore no-explicit-any
+    expect((merged as any).properties.displayName).toEqual({ type: "string" });
   });
 
   it("still conflicts on different binding paths", () => {

--- a/packages/runner/test/fabric-imports-engine.test.ts
+++ b/packages/runner/test/fabric-imports-engine.test.ts
@@ -247,6 +247,72 @@ describe("Engine fabric imports", () => {
     expect(reference?.moduleIdentity).not.toBe(compiled.entryIdentity);
   });
 
+  it("binds nested writer claims to a pinned import's defining identity", async () => {
+    const dependency = await publish({
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: `/// <cts-enable />
+          import { handler, Writable, WriteAuthorizedBy } from "commonfabric";
+          export const commitMessage = handler<string, { message: Writable<string> }>(
+            (value, { message }) => message.set(value),
+          );
+          export type ProtectedMessage = WriteAuthorizedBy<
+            string,
+            typeof commitMessage
+          >;
+        `,
+      }],
+    });
+    const specifier = `cf:pattern:${dependency.entryIdentity}`;
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: `/// <cts-enable />
+          import { toSchema } from "commonfabric";
+          import type { ProtectedMessage } from "${specifier}";
+          interface Output { message: ProtectedMessage; }
+          export const schema = toSchema<Output>();
+        `,
+      }],
+    };
+
+    const compiled = await engine.compileToRecordGraph(program, {
+      fabricImports: { space },
+    });
+    const evaluated = engine.evaluateRecordGraph(
+      compiled.id,
+      compiled.graph,
+      compiled.mainSpecifier,
+      program.files,
+    );
+    const findWriterIdentity = (
+      value: unknown,
+    ): Record<string, unknown> | undefined => {
+      if (!value || typeof value !== "object") return undefined;
+      const record = value as Record<string, unknown>;
+      const marker = record.__ctWriterIdentityOf;
+      if (marker && typeof marker === "object") {
+        return marker as Record<string, unknown>;
+      }
+      for (const child of Object.values(record)) {
+        const found = findWriterIdentity(child);
+        if (found) return found;
+      }
+      return undefined;
+    };
+
+    expect(findWriterIdentity(evaluated.main?.schema)).toEqual({
+      // The mounted dependency and importer intentionally share this authored
+      // spelling; the content identity is what keeps the claim unambiguous.
+      file: "/main.tsx",
+      path: ["commitMessage"],
+      moduleIdentity: dependency.entryIdentity,
+    });
+    expect(dependency.entryIdentity).not.toBe(compiled.entryIdentity);
+  });
+
   it("uses the mounted source for TypeScript diagnostics", async () => {
     const dependency = await publish(dependencyProgram(1));
     const specifier = `cf:pattern:${dependency.entryIdentity}`;

--- a/packages/runner/test/module-identity-engine.test.ts
+++ b/packages/runner/test/module-identity-engine.test.ts
@@ -121,6 +121,70 @@ describe("Engine implementation identity", () => {
     expect(entryIdentity).toBe(pristineId);
   });
 
+  it("mints nested writer claims with the engine's authored path and module identity", async () => {
+    const fileName = "/api/patterns/system/profile-home.tsx";
+    const program: RuntimeProgram = {
+      main: fileName,
+      files: [{
+        name: fileName,
+        contents: `/// <cts-enable />
+          import { handler, toSchema, Writable, WriteAuthorizedBy } from "commonfabric";
+          const setBio = handler<string, { bio: Writable<string> }>(
+            (value, { bio }) => bio.set(value),
+          );
+          type ProtectedBio = WriteAuthorizedBy<string, typeof setBio>;
+          interface Output { bio: ProtectedBio; }
+          export const schema = toSchema<Output>();
+        `,
+      }],
+    };
+
+    const compiled = await engine.compileToRecordGraph(program);
+    const evaluated = engine.evaluateRecordGraph(
+      compiled.id,
+      compiled.graph,
+      compiled.mainSpecifier,
+      program.files,
+    );
+    const findWriterIdentity = (
+      value: unknown,
+    ): Record<string, unknown> | undefined => {
+      if (!value || typeof value !== "object") return undefined;
+      const record = value as Record<string, unknown>;
+      const marker = record.__ctWriterIdentityOf;
+      if (marker && typeof marker === "object") {
+        return marker as Record<string, unknown>;
+      }
+      for (const child of Object.values(record)) {
+        const found = findWriterIdentity(child);
+        if (found) return found;
+      }
+      return undefined;
+    };
+    const identity = findWriterIdentity(evaluated.main?.schema);
+
+    expect(identity).toEqual({
+      file: fileName,
+      path: ["setBio"],
+      moduleIdentity: compiled.entryIdentity,
+    });
+
+    // The source-cache recovery compiler is a separate pipeline construction
+    // site; pin the same born-stamped payload there as well.
+    const recovered = await engine.compileResolvedToRecordGraph(
+      program.files,
+      program.main,
+    );
+    expect(recovered.entryIdentity).toBe(compiled.entryIdentity);
+    const recoveredBody = recovered.modules.find((module) =>
+      module.filename === fileName
+    )?.js;
+    expect(recoveredBody).toContain(`file: "${fileName}"`);
+    expect(recoveredBody).toContain(
+      `moduleIdentity: "${compiled.entryIdentity}"`,
+    );
+  });
+
   it("changes the identity when the shared module's source changes", async () => {
     const program = (body: string): RuntimeProgram => ({
       main: "/shared.ts",

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -1506,7 +1506,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     context: GenerationContext,
     bindingName: ts.Identifier,
     normalizeFile = true,
-  ): { file: string; path: string[] } {
+  ): { file: string; path: string[]; moduleIdentity?: string } {
     const symbol = context.typeChecker.getSymbolAtLocation(bindingName);
     const declarationSymbol = symbol && (symbol.flags & ts.SymbolFlags.Alias)
       ? context.typeChecker.getAliasedSymbol(symbol)
@@ -1524,6 +1524,13 @@ export class CommonFabricFormatter implements TypeFormatter {
       bindingName.getSourceFile().fileName ??
       context.sourceFileName ??
       "unknown";
+
+    if (normalizeFile && context.writerIdentityForSourceFile) {
+      return {
+        ...context.writerIdentityForSourceFile(sourceFileName),
+        path: [declaredName],
+      };
+    }
 
     return {
       file: normalizeFile

--- a/packages/schema-generator/src/index.ts
+++ b/packages/schema-generator/src/index.ts
@@ -3,5 +3,9 @@ export { SchemaGenerator } from "./schema-generator.ts";
 export { createSchemaTransformerV2 } from "./plugin.ts";
 
 // Public types for API consumers
-export type { SchemaGenerator as ISchemaGenerator } from "./interface.ts";
+export type {
+  SchemaGenerationOptions,
+  SchemaGenerator as ISchemaGenerator,
+  WriterSourceIdentity,
+} from "./interface.ts";
 export type { JSONSchemaObjMutable } from "@commonfabric/api";

--- a/packages/schema-generator/src/interface.ts
+++ b/packages/schema-generator/src/interface.ts
@@ -7,6 +7,26 @@ import { type Mutable } from "@commonfabric/utils/types";
  */
 export type SchemaDefinition = Mutable<JSONSchema>;
 
+/** File and optional content identity attached to a writer-binding claim. */
+export interface WriterSourceIdentity {
+  readonly file: string;
+  readonly moduleIdentity?: string;
+}
+
+/** Options that affect schema generation without changing the authored type. */
+export interface SchemaGenerationOptions {
+  readonly widenLiterals?: boolean;
+  /**
+   * Resolves a TypeScript source-file name to the writer identity that should
+   * be embedded in `WriteAuthorizedBy` metadata. Transformer callers use this
+   * to apply their compile-name-to-authored-name mapping and, when available,
+   * attach the defining module's content identity at mint time.
+   */
+  readonly writerIdentityForSourceFile?: (
+    fileName: string,
+  ) => WriterSourceIdentity;
+}
+
 /**
  * Unified context for schema generation - contains all state in one place
  */
@@ -42,6 +62,10 @@ export interface GenerationContext {
   typeRegistry?: WeakMap<ts.Node, ts.Type>;
   /** Widen literal types to base types during schema generation */
   widenLiterals?: boolean;
+  /** Resolve writer-claim file spelling and optional mint-time identity. */
+  writerIdentityForSourceFile?: (
+    fileName: string,
+  ) => WriterSourceIdentity;
   /** Schema hints for overriding default behavior (keyed by TypeNode) */
   schemaHints?: WeakMap<
     ts.Node,
@@ -91,7 +115,7 @@ export interface SchemaGenerator {
     type: ts.Type,
     checker: ts.TypeChecker,
     typeNode?: ts.TypeNode,
-    options?: { widenLiterals?: boolean },
+    options?: SchemaGenerationOptions,
     schemaHints?: WeakMap<
       ts.Node,
       {
@@ -139,5 +163,6 @@ export interface SchemaGenerator {
       }
     >,
     sourceFile?: ts.SourceFile,
+    options?: SchemaGenerationOptions,
   ): SchemaDefinition;
 }

--- a/packages/schema-generator/src/plugin.ts
+++ b/packages/schema-generator/src/plugin.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 import { SchemaGenerator } from "./schema-generator.ts";
+import type { SchemaGenerationOptions } from "./interface.ts";
 
 /**
  * Plugin function that creates a schema transformer with access to both
@@ -13,7 +14,7 @@ export function createSchemaTransformerV2() {
       type: ts.Type,
       checker: ts.TypeChecker,
       typeArg?: ts.TypeNode,
-      options?: { widenLiterals?: boolean },
+      options?: SchemaGenerationOptions,
       schemaHints?: WeakMap<ts.Node, { items?: unknown }>,
       sourceFile?: ts.SourceFile,
     ) {
@@ -33,6 +34,7 @@ export function createSchemaTransformerV2() {
       typeRegistry?: WeakMap<ts.Node, ts.Type>,
       schemaHints?: WeakMap<ts.Node, { items?: unknown }>,
       sourceFile?: ts.SourceFile,
+      options?: SchemaGenerationOptions,
     ) {
       return generator.generateSchemaFromSyntheticTypeNode(
         typeNode,
@@ -40,6 +42,7 @@ export function createSchemaTransformerV2() {
         typeRegistry,
         schemaHints,
         sourceFile,
+        options,
       );
     },
   };
@@ -49,5 +52,10 @@ export function createSchemaTransformerV2() {
  * Alternative export for direct usage
  */
 export { SchemaGenerator };
-export type { GenerationContext, TypeFormatter } from "./interface.ts";
+export type {
+  GenerationContext,
+  SchemaGenerationOptions,
+  TypeFormatter,
+  WriterSourceIdentity,
+} from "./interface.ts";
 export type { JSONSchemaObjMutable } from "@commonfabric/api";

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -7,6 +7,7 @@ import type {
 } from "@commonfabric/api";
 import type {
   GenerationContext,
+  SchemaGenerationOptions,
   SchemaGenerator as ISchemaGenerator,
   TypeFormatter,
 } from "./interface.ts";
@@ -55,7 +56,7 @@ export class SchemaGenerator implements ISchemaGenerator {
     type: ts.Type,
     checker: ts.TypeChecker,
     typeNode?: ts.TypeNode,
-    options?: { widenLiterals?: boolean },
+    options?: SchemaGenerationOptions,
     schemaHints?: WeakMap<
       ts.Node,
       {
@@ -111,6 +112,7 @@ export class SchemaGenerator implements ISchemaGenerator {
       }
     >,
     sourceFile?: ts.SourceFile,
+    options?: SchemaGenerationOptions,
   ): JSONSchemaMutable {
     // Pass 'any' type with the typeNode - auto-detection will choose node-based analysis
     const anyType = checker.getAnyType();
@@ -119,7 +121,7 @@ export class SchemaGenerator implements ISchemaGenerator {
       checker,
       typeNode,
       typeRegistry,
-      undefined,
+      options,
       schemaHints,
       sourceFile,
     );
@@ -134,7 +136,7 @@ export class SchemaGenerator implements ISchemaGenerator {
     checker: ts.TypeChecker,
     typeNode?: ts.TypeNode,
     typeRegistry?: WeakMap<ts.Node, ts.Type>,
-    options?: { widenLiterals?: boolean },
+    options?: SchemaGenerationOptions,
     schemaHints?: WeakMap<
       ts.Node,
       {
@@ -179,6 +181,9 @@ export class SchemaGenerator implements ISchemaGenerator {
       }),
       ...(typeRegistry && { typeRegistry }),
       ...(options?.widenLiterals && { widenLiterals: true }),
+      ...(options?.writerIdentityForSourceFile && {
+        writerIdentityForSourceFile: options.writerIdentityForSourceFile,
+      }),
       ...(schemaHints && { schemaHints }),
     };
 

--- a/packages/schema-generator/test/schema/cfc-authoring.test.ts
+++ b/packages/schema-generator/test/schema/cfc-authoring.test.ts
@@ -517,8 +517,22 @@ describe("Schema: CFC authoring aliases", () => {
       "/main.ts",
       "SchemaRoot",
     );
+    const seenWriterSources: string[] = [];
     const schema = asObjectSchema(
-      createSchemaTransformerV2().generateSchema(type, checker),
+      createSchemaTransformerV2().generateSchema(
+        type,
+        checker,
+        undefined,
+        {
+          writerIdentityForSourceFile: (fileName) => {
+            seenWriterSources.push(fileName);
+            return {
+              file: `/authored${fileName}`,
+              moduleIdentity: `identity:${fileName}`,
+            };
+          },
+        },
+      ),
     );
 
     const writeAuthorizedByClaims: unknown[] = [];
@@ -542,10 +556,12 @@ describe("Schema: CFC authoring aliases", () => {
 
     expect(writeAuthorizedByClaims).toContainEqual({
       __ctWriterIdentityOf: {
-        file: "/trusted.ts",
+        file: "/authored/trusted.ts",
         path: ["commitTrustedMessageSend"],
+        moduleIdentity: "identity:/trusted.ts",
       },
     });
+    expect(seenWriterSources).toContain("/trusted.ts");
   });
 
   it("falls back to ordinary schema generation when a canonical alias expansion cannot be resolved", async () => {

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -142,6 +142,16 @@ export interface TransformationOptions {
   readonly assertDiagnostics?: boolean;
   /** Content identity assigned by the compiler for every authored source. */
   readonly moduleIdentities?: ReadonlyMap<string, string>;
+  /**
+   * Compile-name → authored-name mapping for CFC writer-identity file
+   * spellings (claim minting, provenance stamping, `PolicyOf` source
+   * matching). Callers whose program file names are not already authored
+   * paths — the runner's engine prefixes every module with a per-load
+   * `/<id>` segment — must supply their own unmapping here (the engine
+   * passes its `storedFilenameFor`). When absent, file names are recorded
+   * verbatim (modulo path-separator normalization).
+   */
+  readonly canonicalWriterIdentityFile?: (fileName: string) => string;
 }
 
 export type DiagnosticSeverity = "error" | "warning";

--- a/packages/ts-transformers/src/transformers/module-scope-function-hardening.ts
+++ b/packages/ts-transformers/src/transformers/module-scope-function-hardening.ts
@@ -20,7 +20,10 @@ export class ModuleScopeFunctionHardeningTransformer extends Transformer {
     const trustedBindingNames = collectWriteAuthorizedByBindingNames(
       sourceFile,
     );
-    const sourceFileName = normalizeWriterIdentityFile(sourceFile.fileName);
+    const sourceFileName = normalizeWriterIdentityFile(
+      sourceFile.fileName,
+      context.options.canonicalWriterIdentityFile,
+    );
 
     const statements = sourceFile.statements.flatMap((statement) =>
       transformTopLevelStatement(statement, context, {

--- a/packages/ts-transformers/src/transformers/module-scope-function-hardening.ts
+++ b/packages/ts-transformers/src/transformers/module-scope-function-hardening.ts
@@ -6,6 +6,7 @@ import {
 } from "@commonfabric/utils/sandbox-contract";
 import { TransformationContext, Transformer } from "../core/mod.ts";
 import { unwrapExpression } from "../utils/expression.ts";
+import { normalizeWriterIdentityFile } from "../utils/writer-identity-file.ts";
 
 export class ModuleScopeFunctionHardeningTransformer extends Transformer {
   override transform(context: TransformationContext): ts.SourceFile {
@@ -676,12 +677,6 @@ function collectTypeQueryIdentifiers(
     names.add(node.exprName.text);
   }
   ts.forEachChild(node, (child) => collectTypeQueryIdentifiers(child, names));
-}
-
-function normalizeWriterIdentityFile(fileName: string): string {
-  const normalized = fileName.replace(/\\/g, "/");
-  const strippedPrefixed = normalized.match(/^\/[^/]+(\/.+)$/)?.[1];
-  return strippedPrefixed ?? normalized;
 }
 
 function isDirectFunctionExpression(expression: ts.Expression): boolean {

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -33,6 +33,14 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
           typeArg,
           sourceFile.fileName,
           context.options.canonicalWriterIdentityFile,
+          // Mint-time identity binding: when the compiler knows the module
+          // identities (the engine computes them from pristine sources BEFORE
+          // the TS compile), the claim is born stamped with its own module's
+          // content-addressed identity — the unstamped state, whose first
+          // stamp is capturable by whoever writes first (labs#4772 residual),
+          // is never minted. The lookup is by this file's own compile name:
+          // claims always name a binding in the minting module.
+          context.options.moduleIdentities?.get(sourceFile.fileName),
         );
         let schemaTypeArg: ts.TypeNode = typeArg;
         if (
@@ -318,7 +326,7 @@ function createNumericAst(
 
 function attachWriteAuthorizedByMarker(
   schema: boolean | Record<string, unknown>,
-  identity: { file: string; path: string[] },
+  identity: { file: string; path: string[]; moduleIdentity?: string },
 ): boolean | Record<string, unknown> {
   if (typeof schema === "boolean") return schema;
   const ifc = schema.ifc && typeof schema.ifc === "object"
@@ -441,7 +449,8 @@ function extractWriteAuthorizedByIdentity(
   typeNode: ts.TypeNode,
   sourceFileName: string,
   canonicalize?: (fileName: string) => string,
-): { file: string; path: string[] } | undefined {
+  moduleIdentity?: string,
+): { file: string; path: string[]; moduleIdentity?: string } | undefined {
   if (!isWriteAuthorizedByType(typeNode)) {
     return undefined;
   }
@@ -455,6 +464,7 @@ function extractWriteAuthorizedByIdentity(
   return {
     file: normalizeWriterIdentityFile(sourceFileName, canonicalize),
     path: [bindingNode.exprName.text],
+    ...(moduleIdentity ? { moduleIdentity } : {}),
   };
 }
 
@@ -491,25 +501,40 @@ function isWriterIdentityPayload(
 }
 
 function createWriteAuthorizedByMarkerAst(
-  schema: { __ctWriterIdentityOf: { file: string; path: string[] } },
+  schema: {
+    __ctWriterIdentityOf: {
+      file: string;
+      path: string[];
+      moduleIdentity?: string;
+    };
+  },
   factory: ts.NodeFactory,
 ): ts.Expression {
+  const identity = schema.__ctWriterIdentityOf;
   return factory.createObjectLiteralExpression([
     factory.createPropertyAssignment(
       createPropertyName("__ctWriterIdentityOf", factory),
       factory.createObjectLiteralExpression([
         factory.createPropertyAssignment(
           createPropertyName("file", factory),
-          factory.createStringLiteral(schema.__ctWriterIdentityOf.file),
+          factory.createStringLiteral(identity.file),
         ),
         factory.createPropertyAssignment(
           createPropertyName("path", factory),
           factory.createArrayLiteralExpression(
-            schema.__ctWriterIdentityOf.path.map((segment) =>
+            identity.path.map((segment) =>
               factory.createStringLiteral(segment)
             ),
           ),
         ),
+        ...(typeof identity.moduleIdentity === "string"
+          ? [
+            factory.createPropertyAssignment(
+              createPropertyName("moduleIdentity", factory),
+              factory.createStringLiteral(identity.moduleIdentity),
+            ),
+          ]
+          : []),
       ], true),
     ),
   ], true);

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -32,6 +32,7 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
         const writeAuthorizedByIdentity = extractWriteAuthorizedByIdentity(
           typeArg,
           sourceFile.fileName,
+          context.options.canonicalWriterIdentityFile,
         );
         let schemaTypeArg: ts.TypeNode = typeArg;
         if (
@@ -198,7 +199,10 @@ function resolvePolicyOfMarkers(
     const normalizedSourceEntries = file === undefined
       ? []
       : identityEntries.filter(([sourceName]) =>
-        normalizeWriterIdentityFile(sourceName) === file
+        normalizeWriterIdentityFile(
+          sourceName,
+          context.options.canonicalWriterIdentityFile,
+        ) === file
       );
     const sourceEntry = exactSourceEntry ??
       (normalizedSourceEntries.length === 1
@@ -436,6 +440,7 @@ function attachUiContractToSchemaRecord(
 function extractWriteAuthorizedByIdentity(
   typeNode: ts.TypeNode,
   sourceFileName: string,
+  canonicalize?: (fileName: string) => string,
 ): { file: string; path: string[] } | undefined {
   if (!isWriteAuthorizedByType(typeNode)) {
     return undefined;
@@ -448,7 +453,7 @@ function extractWriteAuthorizedByIdentity(
     return undefined;
   }
   return {
-    file: normalizeWriterIdentityFile(sourceFileName),
+    file: normalizeWriterIdentityFile(sourceFileName, canonicalize),
     path: [bindingNode.exprName.text],
   };
 }

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -4,7 +4,10 @@ import {
   HelpersOnlyTransformer,
   TransformationContext,
 } from "../core/mod.ts";
-import { createSchemaTransformerV2 } from "@commonfabric/schema-generator";
+import {
+  createSchemaTransformerV2,
+  type SchemaGenerationOptions,
+} from "@commonfabric/schema-generator";
 import { numberFromExpression } from "@commonfabric/schema-generator/numeric-expression";
 import {
   getNodeText,
@@ -22,6 +25,22 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
     const { logger, state } = context.options;
     const typeRegistry = state?.typeRegistry;
     const schemaHints = state?.schemaHints;
+    const writerIdentityForSourceFile = (fileName: string) => {
+      const moduleIdentities = context.options.moduleIdentities;
+      const moduleIdentity = moduleIdentities?.get(fileName);
+      if (moduleIdentities && moduleIdentity === undefined) {
+        throw new Error(
+          `Cannot mint WriteAuthorizedBy claim: no module identity for defining source '${fileName}'`,
+        );
+      }
+      return {
+        file: normalizeWriterIdentityFile(
+          fileName,
+          context.options.canonicalWriterIdentityFile,
+        ),
+        ...(moduleIdentity !== undefined ? { moduleIdentity } : {}),
+      };
+    };
 
     const visit: ts.Visitor = (node) => {
       if (isToSchemaNode(node)) {
@@ -29,18 +48,16 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
         const typeArguments = ts.isTypeReferenceNode(typeArg)
           ? typeArg.typeArguments
           : undefined;
+        // Mint-time identity binding: when the compiler knows module
+        // identities (the engine computes them from pristine source BEFORE
+        // the TS compile), this direct-root claim is born stamped with its own
+        // module's content identity. General nested claims use the same
+        // resolver from inside the schema-generator and resolve imported
+        // bindings against their defining source.
         const writeAuthorizedByIdentity = extractWriteAuthorizedByIdentity(
           typeArg,
           sourceFile.fileName,
-          context.options.canonicalWriterIdentityFile,
-          // Mint-time identity binding: when the compiler knows the module
-          // identities (the engine computes them from pristine sources BEFORE
-          // the TS compile), the claim is born stamped with its own module's
-          // content-addressed identity — the unstamped state, whose first
-          // stamp is capturable by whoever writes first (labs#4772 residual),
-          // is never minted. The lookup is by this file's own compile name:
-          // claims always name a binding in the minting module.
-          context.options.moduleIdentities?.get(sourceFile.fileName),
+          writerIdentityForSourceFile,
         );
         let schemaTypeArg: ts.TypeNode = typeArg;
         if (
@@ -89,9 +106,14 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
         }
 
         // Build options for schema generation
-        const generationOptions = widenLiterals !== undefined
-          ? { widenLiterals }
-          : undefined;
+        const generationOptions: SchemaGenerationOptions = {
+          ...(widenLiterals !== undefined ? { widenLiterals } : {}),
+          // The schema-generator owns the general/nested CFC alias path. Give
+          // it the same spelling and stamp source used by the direct
+          // WriteAuthorizedBy special case below, including for bindings
+          // declared in imported authored modules.
+          writerIdentityForSourceFile,
+        };
 
         // If Type resolved to 'any' or the synthetic TypeNode intentionally
         // contains unknown, use the synthetic-node generator so the checker
@@ -110,6 +132,7 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
             typeRegistry,
             schemaHints,
             sourceFile,
+            generationOptions,
           );
         } else {
           // Normal Type path
@@ -448,8 +471,10 @@ function attachUiContractToSchemaRecord(
 function extractWriteAuthorizedByIdentity(
   typeNode: ts.TypeNode,
   sourceFileName: string,
-  canonicalize?: (fileName: string) => string,
-  moduleIdentity?: string,
+  writerIdentityForSourceFile: (fileName: string) => {
+    file: string;
+    moduleIdentity?: string;
+  },
 ): { file: string; path: string[]; moduleIdentity?: string } | undefined {
   if (!isWriteAuthorizedByType(typeNode)) {
     return undefined;
@@ -462,9 +487,8 @@ function extractWriteAuthorizedByIdentity(
     return undefined;
   }
   return {
-    file: normalizeWriterIdentityFile(sourceFileName, canonicalize),
+    ...writerIdentityForSourceFile(sourceFileName),
     path: [bindingNode.exprName.text],
-    ...(moduleIdentity ? { moduleIdentity } : {}),
   };
 }
 

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -12,6 +12,7 @@ import {
   visitEachChildWithJsx,
 } from "../ast/mod.ts";
 import { createPropertyName } from "../utils/identifiers.ts";
+import { normalizeWriterIdentityFile } from "../utils/writer-identity-file.ts";
 import { compileCfcPolicyManifestsForSource } from "./cfc-policy-authoring.ts";
 
 export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
@@ -197,7 +198,7 @@ function resolvePolicyOfMarkers(
     const normalizedSourceEntries = file === undefined
       ? []
       : identityEntries.filter(([sourceName]) =>
-        normalizeSourceFilePath(sourceName) === file
+        normalizeWriterIdentityFile(sourceName) === file
       );
     const sourceEntry = exactSourceEntry ??
       (normalizedSourceEntries.length === 1
@@ -249,11 +250,6 @@ function resolvePolicyOfMarkers(
       resolvePolicyOfMarkers(entry, context, diagnosticNode),
     ]),
   );
-}
-
-function normalizeSourceFilePath(fileName: string): string {
-  const normalized = fileName.replace(/\\/g, "/");
-  return normalized.match(/^\/[^/]+(\/.+)$/)?.[1] ?? normalized;
 }
 
 function createSchemaAst(
@@ -452,7 +448,7 @@ function extractWriteAuthorizedByIdentity(
     return undefined;
   }
   return {
-    file: normalizeSourceFilePath(sourceFileName),
+    file: normalizeWriterIdentityFile(sourceFileName),
     path: [bindingNode.exprName.text],
   };
 }

--- a/packages/ts-transformers/src/utils/writer-identity-file.ts
+++ b/packages/ts-transformers/src/utils/writer-identity-file.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical spelling of a module's source file inside CFC writer identities.
+ *
+ * This single normalizer feeds every surface that records or matches a
+ * writer's source file, so the spellings cannot drift apart:
+ * - `WriteAuthorizedBy` claim minting (schema-generator's
+ *   `extractWriteAuthorizedByIdentity`),
+ * - runtime provenance stamping (module-scope-function-hardening's baked
+ *   `sourceFileName`),
+ * - `PolicyOf` source matching (schema-generator's normalized fallback).
+ *
+ * The compiler sees file names exactly as the program resolver spelled them,
+ * and resolvers disagree: `FileSystemProgramResolver` and
+ * `HttpProgramResolver` emit `/`-prefixed root-relative names (fs-root vs
+ * server-root), while piece manifests reach `StaticProgramResolver` with
+ * bare-relative keys. Stripping the first segment of absolute names below
+ * re-spells the same module differently across resolvers (labs#4772 /
+ * CT-1886): the runner compares these spellings with exact equality, so a
+ * claim minted under one resolver never corresponds to a live identity from
+ * the other.
+ *
+ * Do not change the emitted spelling until the runner's claim↔identity
+ * comparison is spelling-tolerant (anchored on `moduleIdentity`): stored
+ * claims keep their mint-time spelling forever, so a spelling change alone
+ * re-shears every aged store against the new live provenance.
+ */
+export function normalizeWriterIdentityFile(fileName: string): string {
+  const normalized = fileName.replace(/\\/g, "/");
+  return normalized.match(/^\/[^/]+(\/.+)$/)?.[1] ?? normalized;
+}

--- a/packages/ts-transformers/src/utils/writer-identity-file.ts
+++ b/packages/ts-transformers/src/utils/writer-identity-file.ts
@@ -9,22 +9,33 @@
  *   `sourceFileName`),
  * - `PolicyOf` source matching (schema-generator's normalized fallback).
  *
- * The compiler sees file names exactly as the program resolver spelled them,
- * and resolvers disagree: `FileSystemProgramResolver` and
- * `HttpProgramResolver` emit `/`-prefixed root-relative names (fs-root vs
- * server-root), while piece manifests reach `StaticProgramResolver` with
- * bare-relative keys. Stripping the first segment of absolute names below
- * re-spells the same module differently across resolvers (labs#4772 /
- * CT-1886): the runner compares these spellings with exact equality, so a
- * claim minted under one resolver never corresponds to a live identity from
- * the other.
+ * The compiler sees file names exactly as the caller spelled them, and the
+ * spellings differ by compile stack: the runner's engine prefixes every
+ * module with a per-load `/<id>` segment (and mounts fabric imports under
+ * `cf-mount/<identity>/`), while direct compiles hand the resolver's names
+ * straight through — `/`-prefixed root-relative from `FileSystemProgramResolver`
+ * and `HttpProgramResolver`, bare-relative from piece manifests via
+ * `StaticProgramResolver`.
  *
- * Do not change the emitted spelling until the runner's claim↔identity
- * comparison is spelling-tolerant (anchored on `moduleIdentity`): stored
- * claims keep their mint-time spelling forever, so a spelling change alone
- * re-shears every aged store against the new live provenance.
+ * Writer identities must record the *authored* path — load- and
+ * resolver-independent — so callers whose compile names are not already
+ * authored paths pass `canonicalize`, their own compile-name → authored-name
+ * mapping (the engine passes its `storedFilenameFor`). Without `canonicalize`
+ * the name is recorded verbatim (modulo separators). The historical behavior —
+ * blindly stripping the first segment of any absolute name as a presumed
+ * engine prefix — mis-spelled modules from direct compiles whose first
+ * segment was a real path segment (`/api/...`), shearing claim minting away
+ * from provenance stamping across compile stacks (labs#4772 / CT-1886).
+ *
+ * Spelling-compat note: stored claims keep their mint-time spelling forever.
+ * Until the runner's claim↔identity comparison is spelling-tolerant (anchored
+ * on `moduleIdentity`; labs#4772), any change to the spellings this function
+ * emits shears aged stores against new live provenance.
  */
-export function normalizeWriterIdentityFile(fileName: string): string {
+export function normalizeWriterIdentityFile(
+  fileName: string,
+  canonicalize?: (fileName: string) => string,
+): string {
   const normalized = fileName.replace(/\\/g, "/");
-  return normalized.match(/^\/[^/]+(\/.+)$/)?.[1] ?? normalized;
+  return canonicalize ? canonicalize(normalized) : normalized;
 }

--- a/packages/ts-transformers/test/utils.ts
+++ b/packages/ts-transformers/test/utils.ts
@@ -27,6 +27,7 @@ export interface TransformOptions {
   policyManifests?: unknown[];
   state?: CrossStageState;
   assertDiagnostics?: boolean;
+  canonicalWriterIdentityFile?: (fileName: string) => string;
 }
 
 export interface BatchTypeCheckResult {
@@ -582,6 +583,7 @@ export async function transformFiles(
     moduleIdentities: options.moduleIdentities,
     state: options.state,
     assertDiagnostics: options.assertDiagnostics,
+    canonicalWriterIdentityFile: options.canonicalWriterIdentityFile,
   });
 
   const out: Record<string, string> = {};
@@ -859,6 +861,7 @@ export async function validateFiles(
     moduleIdentities: options.moduleIdentities,
     state: options.state,
     assertDiagnostics: options.assertDiagnostics,
+    canonicalWriterIdentityFile: options.canonicalWriterIdentityFile,
   });
 
   const outputs: Record<string, string> = {};

--- a/packages/ts-transformers/test/writer-identity-file.test.ts
+++ b/packages/ts-transformers/test/writer-identity-file.test.ts
@@ -80,3 +80,37 @@ Deno.test("claim spelling: engine-prefixed compile canonicalizes to the same aut
     "/api/patterns/system/profile-embed.tsx",
   );
 });
+
+Deno.test("claim minting: born stamped with the module's identity when the compiler knows it", async () => {
+  // Mint-time identity binding (labs#4772 follow-up): with moduleIdentities
+  // supplied (the engine computes them from pristine sources before the TS
+  // compile), the emitted claim carries its own module's content-addressed
+  // identity — the capturable unstamped state is never minted.
+  const fileName = "/api/patterns/system/profile-embed.tsx";
+  const output = await transformFiles({ [fileName]: CLAIM_SOURCE }, {
+    types: COMMONFABRIC_TYPES,
+    moduleIdentities: new Map([[fileName, "profile-embed-module-identity"]]),
+  });
+  const at = output[fileName]!.indexOf("__ctWriterIdentityOf");
+  assert(at >= 0, "expected a writer-identity marker");
+  const marker = output[fileName]!.slice(at, at + 400);
+  const match = marker.match(/moduleIdentity:\s*"([^"]+)"/);
+  assert(match, "expected a mint-time moduleIdentity stamp in the marker");
+  assertEquals(match[1], "profile-embed-module-identity");
+});
+
+Deno.test("claim minting: stays unstamped when no module identities are supplied", async () => {
+  // Direct compiles without an identity map (older callers, unit harnesses)
+  // keep minting unstamped claims; the runner's reconcile-adoption remains
+  // their healing path.
+  const fileName = "/api/patterns/system/profile-embed.tsx";
+  const output = await transformFiles({ [fileName]: CLAIM_SOURCE }, {
+    types: COMMONFABRIC_TYPES,
+  });
+  const at = output[fileName]!.indexOf("__ctWriterIdentityOf");
+  assert(at >= 0, "expected a writer-identity marker");
+  assertEquals(
+    output[fileName]!.slice(at, at + 400).includes("moduleIdentity"),
+    false,
+  );
+});

--- a/packages/ts-transformers/test/writer-identity-file.test.ts
+++ b/packages/ts-transformers/test/writer-identity-file.test.ts
@@ -1,0 +1,82 @@
+import { assert, assertEquals } from "@std/assert";
+import { normalizeWriterIdentityFile } from "../src/utils/writer-identity-file.ts";
+import { transformFiles } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// The claim-minting + provenance-stamping source used across the cases: the
+// `typeof saver` type-query mints an `__ctWriterIdentityOf` marker carrying
+// this module's writer-identity file spelling.
+const CLAIM_SOURCE = `/// <cts-enable />
+import { toSchema, WriteAuthorizedBy, handler } from "commonfabric";
+const saver = handler({}, {}, () => {});
+const s = toSchema<WriteAuthorizedBy<{ title: string }, typeof saver>>();
+export { s };
+`;
+
+function markerFile(output: string): string {
+  const at = output.indexOf("__ctWriterIdentityOf");
+  assert(at >= 0, "expected a writer-identity marker in the output");
+  const match = output.slice(at).match(/file:\s*"([^"]+)"/);
+  assert(match, "expected a file spelling inside the marker");
+  return match[1]!;
+}
+
+Deno.test("writer-identity file spelling is verbatim without a canonicalizer", () => {
+  // Direct compiles (HTTP resolver, piece manifests) hand authored paths
+  // straight through; nothing may be guessed away from them. The historical
+  // first-segment strip turned this name into "/patterns/system/x.tsx",
+  // shearing claims from provenance across compile stacks (labs#4772).
+  assertEquals(
+    normalizeWriterIdentityFile("/api/patterns/system/x.tsx"),
+    "/api/patterns/system/x.tsx",
+  );
+  assertEquals(
+    normalizeWriterIdentityFile("api/patterns/system/x.tsx"),
+    "api/patterns/system/x.tsx",
+  );
+  assertEquals(normalizeWriterIdentityFile("/main.ts"), "/main.ts");
+});
+
+Deno.test("canonicalizer runs on the separator-normalized name", () => {
+  const seen: string[] = [];
+  const result = normalizeWriterIdentityFile(
+    "\\load-1\\api\\x.tsx",
+    (name) => {
+      seen.push(name);
+      return name.replace(/^\/load-1/, "");
+    },
+  );
+  assertEquals(seen, ["/load-1/api/x.tsx"]);
+  assertEquals(result, "/api/x.tsx");
+});
+
+Deno.test("claim spelling: direct absolute compile records the authored path", async () => {
+  const fileName = "/api/patterns/system/profile-embed.tsx";
+  const output = await transformFiles({ [fileName]: CLAIM_SOURCE }, {
+    types: COMMONFABRIC_TYPES,
+  });
+  assertEquals(markerFile(output[fileName]!), fileName);
+  // The pre-fix mis-spelling must not appear anywhere in the emitted module.
+  assertEquals(
+    output[fileName]!.includes('"/patterns/system/profile-embed.tsx"'),
+    false,
+  );
+});
+
+Deno.test("claim spelling: engine-prefixed compile canonicalizes to the same authored path", async () => {
+  // The engine compiles under a per-load `/<id>` prefix and passes its
+  // unmapping (storedFilenameFor) as the canonicalizer. The recorded spelling
+  // must equal the direct compile's — load-independent and shear-free.
+  const fileName = "/load-abc123/api/patterns/system/profile-embed.tsx";
+  const output = await transformFiles({ [fileName]: CLAIM_SOURCE }, {
+    types: COMMONFABRIC_TYPES,
+    canonicalWriterIdentityFile: (name) =>
+      name.startsWith("/load-abc123/")
+        ? name.slice("/load-abc123".length)
+        : name,
+  });
+  assertEquals(
+    markerFile(output[fileName]!),
+    "/api/patterns/system/profile-embed.tsx",
+  );
+});

--- a/packages/ts-transformers/test/writer-identity-file.test.ts
+++ b/packages/ts-transformers/test/writer-identity-file.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { normalizeWriterIdentityFile } from "../src/utils/writer-identity-file.ts";
 import { transformFiles } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
@@ -13,11 +13,29 @@ const s = toSchema<WriteAuthorizedBy<{ title: string }, typeof saver>>();
 export { s };
 `;
 
+// Production schemas (including profile-home) normally carry writer claims on
+// properties behind an interface and user alias. This path is emitted by the
+// schema-generator's CommonFabricFormatter, not the direct root special case.
+const NESTED_CLAIM_SOURCE = `/// <cts-enable />
+import { toSchema, WriteAuthorizedBy, handler } from "commonfabric";
+const saver = handler({}, {}, () => {});
+type ProtectedTitle = WriteAuthorizedBy<string, typeof saver>;
+interface Output { title: ProtectedTitle; }
+const s = toSchema<Output>();
+export { s };
+`;
+
 function markerFile(output: string): string {
   const at = output.indexOf("__ctWriterIdentityOf");
   assert(at >= 0, "expected a writer-identity marker in the output");
   const match = output.slice(at).match(/file:\s*"([^"]+)"/);
   assert(match, "expected a file spelling inside the marker");
+  return match[1]!;
+}
+
+function bindingSourceFile(output: string): string {
+  const match = output.match(/sourceFile:\s*"([^"]+)"/);
+  assert(match, "expected binding provenance with a sourceFile");
   return match[1]!;
 }
 
@@ -63,6 +81,14 @@ Deno.test("claim spelling: direct absolute compile records the authored path", a
   );
 });
 
+Deno.test("nested claim spelling keeps a direct compile's authored path", async () => {
+  const fileName = "/api/patterns/system/profile-home.tsx";
+  const output = await transformFiles({ [fileName]: NESTED_CLAIM_SOURCE }, {
+    types: COMMONFABRIC_TYPES,
+  });
+  assertEquals(markerFile(output[fileName]!), fileName);
+});
+
 Deno.test("claim spelling: engine-prefixed compile canonicalizes to the same authored path", async () => {
   // The engine compiles under a per-load `/<id>` prefix and passes its
   // unmapping (storedFilenameFor) as the canonicalizer. The recorded spelling
@@ -99,6 +125,29 @@ Deno.test("claim minting: born stamped with the module's identity when the compi
   assertEquals(match[1], "profile-embed-module-identity");
 });
 
+Deno.test("nested claims share canonical spelling and stamp with binding provenance", async () => {
+  const fileName = "/load-abc123/api/patterns/system/profile-home.tsx";
+  const authoredName = "/api/patterns/system/profile-home.tsx";
+  const moduleIdentity = "profile-home-module-identity";
+  const output = await transformFiles({ [fileName]: NESTED_CLAIM_SOURCE }, {
+    types: COMMONFABRIC_TYPES,
+    canonicalWriterIdentityFile: (name) =>
+      name.startsWith("/load-abc123/")
+        ? name.slice("/load-abc123".length)
+        : name,
+    moduleIdentities: new Map([[fileName, moduleIdentity]]),
+  });
+  const emitted = output[fileName]!;
+  const at = emitted.indexOf("__ctWriterIdentityOf");
+  assert(at >= 0, "expected a nested writer-identity marker");
+  assertEquals(markerFile(emitted), authoredName);
+  assertEquals(bindingSourceFile(emitted), authoredName);
+  assert(
+    emitted.slice(at, at + 500).includes(`moduleIdentity: "${moduleIdentity}"`),
+    "expected the nested claim to carry its defining module identity",
+  );
+});
+
 Deno.test("claim minting: stays unstamped when no module identities are supplied", async () => {
   // Direct compiles without an identity map (older callers, unit harnesses)
   // keep minting unstamped claims; the runner's reconcile-adoption remains
@@ -112,5 +161,18 @@ Deno.test("claim minting: stays unstamped when no module identities are supplied
   assertEquals(
     output[fileName]!.slice(at, at + 400).includes("moduleIdentity"),
     false,
+  );
+});
+
+Deno.test("claim minting: rejects an incomplete supplied identity map", async () => {
+  const fileName = "/api/patterns/system/profile-embed.tsx";
+  await assertRejects(
+    () =>
+      transformFiles({ [fileName]: CLAIM_SOURCE }, {
+        types: COMMONFABRIC_TYPES,
+        moduleIdentities: new Map([["/other.tsx", "other-identity"]]),
+      }),
+    Error,
+    `no module identity for defining source '${fileName}'`,
   );
 });


### PR DESCRIPTION
## Why

Follow-up to #4852 (CT-1886), which anchored `writeAuthorizedBy` verification
on `moduleIdentity` + `bindingPath` and made the runner tolerant of the
resolver-dependent file spellings. This PR fixes the spelling divergence at
its source and closes the remaining soft spot #4852 documented: the
*unstamped* stored claim, whose first stamp is capturable by whoever writes
first (see the P1 discussion on #4852).

## What

Three commits, in dependency order:

**1. Unify the duplicated writer-identity normalizers** (pure refactor).
`normalizeSourceFilePath` (schema-generator) and `normalizeWriterIdentityFile`
(module-scope-function-hardening) were byte-identical copies feeding the two
halves of the claim↔provenance correspondence — a drift hazard the behavior
spec explicitly tracked ("must stay identical"). One shared
`src/utils/writer-identity-file.ts` now feeds all three call sites. Zero
behavior change.

**2. Spell writer-identity files from the caller's declared mapping, not a
first-segment guess.** The historical normalization stripped the first path
segment of any absolute file name, presuming the engine's per-load `/<id>`
module-path prefix. That presumption only holds for engine-driven compiles
(`pretransformProgramForModules` prefixes every module); direct compiles hand
resolver names straight through — absolute URL pathnames from
`HttpProgramResolver`, bare-relative piece-manifest keys — so the strip ate
real path segments (`/api/patterns/...` → `/patterns/...`), which is exactly
the shear behind #4772. The guess is replaced with an explicit contract:
`TransformerOptions.canonicalWriterIdentityFile` carries the caller's
compile-name → authored-name unmapping; the engine passes its existing
`storedFilenameFor` (exact `/<id>` strip + fabric-mount unmapping) at all
three pipeline sites; callers whose names are already authored paths pass
nothing and get verbatim spellings. **The land-gate this commit shipped with
("do not land before the tolerant compare") is satisfied — #4852 is merged.**
Aged stores keep their mint-time spellings; the runner's correspondence
tolerance is precisely the compat shim for them.

**3. Mint claims born stamped; treat two-stamp reconciliation as a version
boundary.** The engine computes `moduleIdentities` from pristine sources
*before* the TS compile, so the claim minter can look up its own module's
content-addressed identity and emit it in the marker:
`__ctWriterIdentityOf: { file, path, moduleIdentity }`. Claims are then born
stamped — the capturable unstamped state is no longer minted at all,
shrinking #4852's documented residual to aged data (which continues to heal
through reconcile-adoption). Two consequences handled:

- CT-1740's foreign-seed hazard evaporates for new mints: a seeded envelope's
  claims carry the *defining* module's identity by construction, regardless
  of who performs the seeding write.
- A republished module now re-presents its claims under a new
  `moduleIdentity` on every envelope write, so `reconcileWriterClaimStamp`'s
  both-stamped-different case changes from conflict-abort to **keep the
  stored stamp**: rotation still never happens, the new version's writes to
  the protected field stay fail-closed *at verification* (loudly, per #4852's
  drop reporting) pending the setsrc-history delegation design (board topic,
  index 38) — but the envelope's sibling writes keep committing instead of
  the whole transaction aborting on every pattern update.

## Verification

- ts-transformers: new tests pin the direct-absolute spelling (old
  mis-spelling asserted absent), engine-prefixed ≡ direct equivalence, the
  born stamp with `moduleIdentities` supplied, and unstamped compat without.
  Full suite + spec-sync green.
- runner: the #4852 correspondence tests all hold unchanged except the
  deliberate version-boundary pin (both-stamped-different → keep stored, in
  both the #4852 test file and the older schema-merge suite, with rationale
  in-test). Engine-driven CFC suites (boundary, CT-1740
  profile-create-real-card-add, content-addressed identity + adversarial)
  pass **unmodified** — born stamps equal runtime provenance identities by
  construction, and the adversarial fail-closed pins hold.
- Behavior spec updated in-change: §6.8 marker shape, §17.3 file
  normalization + born-stamp emission, runtime-consumption paragraph
  (version-boundary reconcile).

## Sequencing

Lands after #4852 (merged). The remaining CT-1886 legs after this: the loom
vendor bump re-runs the PR4b bio criterion end-to-end, and the setsrc-history
delegation design (Berni + Hixie, board topic index 38) takes cross-version
rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes writer-identity spelling explicit and consistent across compiles, and mints `WriteAuthorizedBy` claims born‑stamped with `moduleIdentity` so provenance stays stable; the runner now keeps the stored stamp across versions to avoid aborting schema merges. This follows CT-1886 and stabilizes claim ↔ provenance while removing the foreign‑seed hazard for new mints.

- **New Features**
  - `ts-transformers`: added `TransformationOptions.canonicalWriterIdentityFile` to map compile names to authored paths; the engine supplies this at record‑graph compile, stored‑source recompile, and batched type checks; direct compiles record verbatim paths.
  - `ts-transformers`/`schema-generator`: claims are born stamped; `__ctWriterIdentityOf` includes optional `moduleIdentity` and is applied to nested/imported bindings via `SchemaGenerationOptions.writerIdentityForSourceFile`; if `moduleIdentities` is provided but omits the defining source, compilation fails.
  - `runner`: when both sides are stamped for the same binding, keep the stored stamp (version boundary); protected‑field writes remain fail‑closed at verification while sibling writes continue.
  - `api`: JSON schema types now allow an optional `moduleIdentity` in `ifc.writeAuthorizedBy.__ctWriterIdentityOf`.

- **Refactors**
  - Consolidated the writer‑identity normalizer into `src/utils/writer-identity-file.ts` and used it for claim minting, provenance stamping, and `PolicyOf` source matching.

<sup>Written for commit aef9aa46ca1ee8ae4c86c7bbaf9a8be7222e49b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Overriding the coverage ratchet because I do not have time to do a better thing :(

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: coverage-debt: packages/schema-generator uncovered lines = 992 lines
NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 6950 lines
---END COPY-PASTE---