### PR TITLE
fix(piece): retire the systemPatternAutoUpdateHome gate — home roots ride systemPatternAutoUpdate

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -31,8 +31,7 @@ was last checked against the code.
 | [`persistentSchedulerState`](#persistentschedulerstate) | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` env, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#3646) | graduate to always-on | implemented, off by default, rollout in progress |
 | [`commitPreconditions`](#commitpreconditions) | `RuntimeOptions.experimental` only (mapped `null` — programmatic rollback override — in the canonical env registry) | on | Bernhard Seefeld (#4090) | fold into base scheduler semantics, then delete flag | implemented, on by default |
 | [`eagerSourceAnnotation`](#eagersourceannotation) | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` env, or `RuntimeOptions.experimental` | off in production, on in shell dev builds | gideon (#4458) | permanent debug toggle, not slated for removal | implemented |
-| [`systemPatternAutoUpdate`](#systempatternautoupdate) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental` | on in the shell (non-home roots); off server-side | Bernhard Seefeld (#4611; shell default-on #4619) | graduate to always-on, then delete both auto-update flags | implemented, on in the shell |
-| [`systemPatternAutoUpdateHome`](#systempatternautoupdatehome) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME` env / shell build define, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#4611) | on after the home.tsx stable-addressing audit | implemented, off by default |
+| [`systemPatternAutoUpdate`](#systempatternautoupdate) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental` | on in the shell (all tracked system roots, home included); off server-side | Bernhard Seefeld (#4611; shell default-on #4619) | graduate to always-on, then delete flag | implemented, on in the shell |
 | [`computedCellIds`](#computedcellids) | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental` | off | Robin McCollum (in development) | graduate to always-on with the computed-cell write-conflict policy | in development on robin/feat-computed-cell-identity-p2 (redesigned: `computed:` URI scheme) |
 | [`cfcEnforcementMode`](#cfcenforcementmode) | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse) | `enforce-explicit` | Bernhard Seefeld (#3263) | tighten default toward `enforce-strict` | active; ladder is permanent |
 | [`cfcFlowLabels`](#cfcflowlabels) | `RuntimeOptions.cfcFlowLabels` | `off` | Bernhard Seefeld (#4011) | move toward `persist` | implemented, staged rollout |
@@ -70,11 +69,10 @@ The mapping from environment variable to flag is defined once, canonically, as
 and read by `experimentalOptionsFromEnv(envReader)`. The toolshed, the CLI, and
 the background piece service all go through that one mapping, so their wirings
 cannot drift; the shell reads the same variables from its build-time defines.
-Six flags are env-reachable (`modernCellRep`, `persistentSchedulerState`,
-`eagerSourceAnnotation`, `systemPatternAutoUpdate`,
-`systemPatternAutoUpdateHome`, `computedCellIds`); `commitPreconditions` is
-deliberately mapped to `null` there, which records "not env-reachable" as a
-decision rather than an omission.
+Five flags are env-reachable (`modernCellRep`, `persistentSchedulerState`,
+`eagerSourceAnnotation`, `systemPatternAutoUpdate`, `computedCellIds`);
+`commitPreconditions` is deliberately mapped to `null` there, which records
+"not env-reachable" as a decision rather than an omission.
 The mapping accepts exactly `"true"` and `"false"`; any other value is ignored
 with a warning rather than coerced. See [How flags
 propagate](#how-flags-propagate).
@@ -217,9 +215,10 @@ propagate](#how-flags-propagate).
 - **Added by.** Bernhard Seefeld, in "system-pattern auto-update (in-place
   rollforward, flag-gated)" (#4611, 2026-07-08); defaulted on for the shell in
   #4619 (2026-07-09).
-- **Purpose.** At space open, rolls a space's **non-home** root system pattern
-  (default-app) forward in place when its toolshed serves a newer content
-  identity. Every tracked root uses the client/toolshed version gate and cached
+- **Purpose.** At space open, rolls a space's root system pattern (default-app,
+  and the home root — the home-specific second gate was retired on the strength
+  of home-golden-replay state-survival coverage) forward in place when its
+  toolshed serves a newer content identity. Every tracked root uses the client/toolshed version gate and cached
   `?identity` comparison before an in-place `patternIdentity` swap. The
   identity response, every fetched source/import, and the compiler-produced
   entry must all agree with the same client build and identity. Equal identities
@@ -243,31 +242,13 @@ propagate](#how-flags-propagate).
   define is set to `"false"`, so the deployed product (and local shell dev
   builds) run it on for non-home roots. Server-side processes (toolshed, CLI,
   background piece service) leave it off unless the env var is set. End state:
-  graduate to always-on for system roots once golden-replay coverage has soaked
-  and the home audit lands, then delete both auto-update flags.
-- **Status on 2026-07-21.** Implemented; on in the shell for non-home roots,
-  off elsewhere. Root reconciliation and broken-root repair run before
-  bootstrap.
-- **Path to removal.** Graduate the home root (below), make the check
-  unconditional, and remove both flags together.
-
-### `systemPatternAutoUpdateHome`
-
-- **Toggle via.** `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME` environment
-  variable, the shell build define of the same name, or
-  `RuntimeOptions.experimental.systemPatternAutoUpdateHome`.
-- **Added by.** Bernhard Seefeld, in #4611 (2026-07-08).
-- **Purpose.** Second gate holding the **home** root (home.tsx) out of
-  [`systemPatternAutoUpdate`](#systempatternautoupdate): the home root carries
-  real user data (favorites, journal, the spaces list) and stays pinned until
-  the stable-addressing audit verifies an in-place swap preserves that state.
-  Both flags must be on for a home root to auto-update.
-- **Current default and planned end state.** Off everywhere (no shell-side
-  default-on). End state: flip on after the home.tsx stable-addressing audit,
-  then remove together with `systemPatternAutoUpdate`.
-- **Status on 2026-07-09.** Implemented, off by default.
-- **Path to removal.** Complete the audit, default the home root on, and delete
-  both flags when the check becomes unconditional.
+  graduate to always-on for system roots once golden-replay coverage has
+  soaked, then delete the flag.
+- **Status on 2026-07-21.** Implemented; on in the shell for all tracked system
+  roots, home included ([`systemPatternAutoUpdateHome`](#appendix-a-removed-and-never-shipped-flags)
+  removed), off elsewhere. Root reconciliation and broken-root repair run
+  before bootstrap.
+- **Path to removal.** Make the check unconditional and remove the flag.
 
 ### `computedCellIds`
 
@@ -685,8 +666,7 @@ the per-epic implementation notes).
 The environment-backed flags (`EXPERIMENTAL_MODERN_CELL_REP`,
 `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`,
 `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION`,
-`EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE`,
-`EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME`) reach the runtime through the
+`EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE`) reach the runtime through the
 deployed processes. The runtime-only flags (`commitPreconditions`, the CFC
 dials) reach it only through the `RuntimeOptions` passed to `new Runtime(...)`.
 
@@ -848,6 +828,20 @@ config reaches:
 
 These are recorded so that references to them elsewhere in the tree do not send a
 future reader hunting for a flag that no longer exists.
+
+### `systemPatternAutoUpdateHome` / `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME` (removed)
+
+The second gate that held the **home** root (home.tsx) out of
+[`systemPatternAutoUpdate`](#systempatternautoupdate) while the
+stable-addressing question was open: the home root carries real user data
+(favorites, journal, the spaces list), and an in-place roll had to be proven
+state-preserving first. `home-golden-replay.test.ts` pins exactly that (seed
+representative home data, roll N→N+1 in place, prove every list survives), and
+the 2026-07-21 estuary incident — a runtime migration bricking every
+old-generation home root with no self-repair path because this flag was off —
+made the cost of the extra gate concrete. Removed at the flag owner's direction;
+home roots now ride `systemPatternAutoUpdate` like every other tracked system
+root.
 
 ### `schedulerHistoricalMightWrite` (removed)
 

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -8,9 +8,9 @@ later phase) on demand for **published** patterns. Companion to `README.md`
 
 ## Status
 
-Phase 1 shipped: the `systemPatternAutoUpdate` flag is on in the shell for
-non-home default-app roots (`systemPatternAutoUpdateHome` stays off pending the
-home.tsx stable-addressing audit). URL-based creation and recreation stamp
+Phase 1 shipped: the `systemPatternAutoUpdate` flag is on in the shell for all
+tracked system roots, home included (the home-specific second flag was removed
+once home-golden-replay pinned state survival across an in-place roll). URL-based creation and recreation stamp
 update provenance; a pre-provenance root can recover it only when its stored ref
 exactly equals the build-attested current official entry; and an unloadable
 tracked root is repaired before bootstrap through the same `?identity`-driven
@@ -18,7 +18,8 @@ update path. Identity, source, imports, and the compiled entry must agree on one
 build and content identity. The executed milestone map and corrections found
 during implementation are archived at
 [`docs/history/specs/pattern-imports/system-pattern-updates-implementation-plan.md`](../../history/specs/pattern-imports/system-pattern-updates-implementation-plan.md).
-Home root and published-pattern updates remain design (Phases 2–4).
+The home root (Phase 2) rides the shipped Phase 1 machinery since the second
+flag's removal; published-pattern updates remain design (Phases 3–4).
 
 ## Last Updated
 
@@ -342,4 +343,7 @@ so no build-dependence and no gate.
    user-reload? Start with a banner; auto-restart is a follow-up.
 4. **Home-data stable addressing** — verify `home.tsx` addresses its durable
    state by stable key/cause before enabling always-update on the home root
-   (Phase 2 gate).
+   (Phase 2 gate). Resolved 2026-07-21: `home-golden-replay.test.ts` pins state
+   survival across an in-place N→N+1 roll over representative favorites /
+   journal / spaces data, and the home-specific flag was removed on its
+   strength (with the estuary home-brick incident as the forcing event).

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -32,7 +32,6 @@ export type ExperimentalRuntimeFlags = {
   persistentSchedulerState?: boolean;
   eagerSourceAnnotation?: boolean;
   systemPatternAutoUpdate?: boolean;
-  systemPatternAutoUpdateHome?: boolean;
 };
 
 export type RuntimeCfcEnforcementMode = NonNullable<

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -604,13 +604,11 @@ export class PiecesController<T = unknown> {
     const runtime = this.#manager.runtime;
     const space = this.#manager.getSpace();
 
-    // 1. Flag gate. Home is held behind a second flag until its durable state
-    //    is verified stable-key-addressed (spec § open question 4).
+    // 1. Flag gate. One flag governs every tracked system root, home included:
+    //    home state survival across an in-place roll is pinned by
+    //    home-golden-replay.test.ts, so the home root no longer needs a
+    //    separate opt-in.
     if (!runtime.experimental?.systemPatternAutoUpdate) {
-      return "skipped-disabled";
-    }
-    const isHomeSpace = space === runtime.userIdentityDID;
-    if (isHomeSpace && !runtime.experimental?.systemPatternAutoUpdateHome) {
       return "skipped-disabled";
     }
 

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -861,11 +861,8 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(stub.identityFetches()).toBe(1);
   });
 
-  it("skips a custom home root with both update flags on", async () => {
-    await setupHome({
-      systemPatternAutoUpdate: true,
-      systemPatternAutoUpdateHome: true,
-    });
+  it("skips a custom home root with the update flag on", async () => {
+    await setupHome({ systemPatternAutoUpdate: true });
     await controller.recreateDefaultPattern({
       customProgram: {
         main: "/custom-home.tsx",
@@ -883,16 +880,25 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(stub.identityFetches()).toBe(1);
   });
 
-  it("holds the home root behind its own flag (M4.2)", async () => {
-    // A home space (session space == the identity DID), with the base flag on
-    // but the home flag off, must not auto-update — it short-circuits before
-    // any fetch.
+  it("rolls the home root forward under the one update flag", async () => {
+    // A home space (session space == the identity DID) auto-updates under the
+    // same single flag as every other tracked system root — the home-specific
+    // second gate is gone. Same in-place semantics: no new piece minted.
     await setupHome({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const rootLinkBefore = JSON.stringify(piece.getCell().getAsLink());
+    const idV1 = getPatternIdentityRef(piece.getCell())?.identity;
 
-    expect(await controller.checkAndUpdateDefaultPattern()).toBe(
-      "skipped-disabled",
-    );
-    expect(stub.identityFetches()).toBe(0);
+    stub.setSource(SOURCE_V2);
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
+    await runtime.idle();
+
+    const root = (await manager.getDefaultPattern(false))!;
+    expect(JSON.stringify(root.getAsLink())).toBe(rootLinkBefore);
+    const idV2 = getPatternIdentityRef(root)?.identity;
+    // The home root compiles at HOME_PATTERN_URL — identity includes the entry.
+    expect(idV2).toBe(await identityForSource(SOURCE_V2, {}, HOME_PATTERN_URL));
+    expect(idV2).not.toBe(idV1);
   });
 
   describe("recreateDefaultPattern provenance (CT-1890)", () => {

--- a/packages/piece/test/home-golden-replay.test.ts
+++ b/packages/piece/test/home-golden-replay.test.ts
@@ -18,11 +18,12 @@ import {
 // default-app-golden-replay.test.ts.
 //
 // The home root (home.tsx) carries the user's REAL durable data — favorites,
-// journal, spaces — and is held behind its OWN flag (systemPatternAutoUpdateHome)
-// precisely because losing that data on an update would be unrecoverable. This
-// test is the state-survival evidence that flag would need before it can flip:
-// seed representative home data, roll the home root N→N+1 in place, and prove
-// every list survives intact and the new code runs over it.
+// journal, spaces — where losing data on an update would be unrecoverable.
+// This test is the state-survival evidence that lets home ride the same
+// `systemPatternAutoUpdate` flag as every other tracked system root (the
+// home-specific second gate was retired on its strength): seed representative
+// home data, roll the home root N→N+1 in place, and prove every list survives
+// intact and the new code runs over it.
 //
 // It is deliberately faithful to how real home OWNS its state. home.tsx does:
 //   const favorites = new Writable<Favorite[]>([]).for("favorites");
@@ -155,11 +156,8 @@ describe("home golden replay (durable home state survives an in-place roll-forwa
       apiUrl: new URL("http://toolshed.test"),
       storageManager,
       clientVersion: BUILD_SHA,
-      // The home root needs BOTH flags: the base gate AND the home-specific one.
-      experimental: {
-        systemPatternAutoUpdate: true,
-        systemPatternAutoUpdateHome: true,
-      },
+      // One flag covers every tracked system root, home included.
+      experimental: { systemPatternAutoUpdate: true },
     });
     // A HOME session: space === the user's identity DID, which is what flips
     // `isHomeSpace` on inside the controller (ensureDefaultPattern + the update

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -206,7 +206,6 @@ export const EXPERIMENTAL_ENV_VARS = {
   // override while the flag exists; no environment exposure is needed.
   commitPreconditions: null,
   systemPatternAutoUpdate: "EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE",
-  systemPatternAutoUpdateHome: "EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME",
   computedCellIds: "EXPERIMENTAL_COMPUTED_CELL_IDS",
 } as const satisfies Record<keyof ExperimentalOptions, string | null>;
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -242,17 +242,12 @@ export interface ExperimentalOptions {
   /**
    * Roll a space's system root pattern (default-app / home) forward in place
    * when its toolshed serves a newer content identity. Default off; enabled per
-   * deployment once CI golden-replay coverage exists. The home root has an
-   * additional gate ({@link systemPatternAutoUpdateHome}) pending the
-   * stable-addressing audit. See docs/specs/pattern-imports/pattern-updates.md.
+   * deployment once CI golden-replay coverage exists. Covers the home root too:
+   * home state survival across an in-place roll is pinned by
+   * home-golden-replay.test.ts. See
+   * docs/specs/pattern-imports/pattern-updates.md.
    */
   systemPatternAutoUpdate?: boolean | undefined;
-  /**
-   * Also auto-update the HOME space root (favorites/journal/spaces). Requires
-   * {@link systemPatternAutoUpdate}. Held separately until home.tsx addresses
-   * its durable state by stable key/cause (spec § open question 4).
-   */
-  systemPatternAutoUpdateHome?: boolean | undefined;
 }
 
 /**

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1097,16 +1097,13 @@ describe("RuntimeProcessor blob upload IPC", () => {
 });
 
 describe("RuntimeProcessor home pattern IPC", () => {
-  it("reconciles the home root only when both update flags are enabled", () => {
+  it("reconciles the home root when the update flag is enabled", () => {
     expect(shouldReconcileHomeRoot({ experimental: {} })).toBe(false);
     expect(shouldReconcileHomeRoot({
-      experimental: { systemPatternAutoUpdate: true },
+      experimental: { systemPatternAutoUpdate: false },
     })).toBe(false);
     expect(shouldReconcileHomeRoot({
-      experimental: {
-        systemPatternAutoUpdate: true,
-        systemPatternAutoUpdateHome: true,
-      },
+      experimental: { systemPatternAutoUpdate: true },
     })).toBe(true);
   });
 
@@ -1197,10 +1194,7 @@ describe("RuntimeProcessor home pattern IPC", () => {
     let startedDirectly = false;
     const runtime = {
       userIdentityDID: "did:key:test-home",
-      experimental: {
-        systemPatternAutoUpdate: true,
-        systemPatternAutoUpdateHome: true,
-      },
+      experimental: { systemPatternAutoUpdate: true },
       getHomeSpaceCell: () => ({
         sync: () => Promise.resolve(),
         key: () => ({

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -215,8 +215,7 @@ export function postVersionSkew(info: VersionSkewInfo): void {
 export function shouldReconcileHomeRoot(
   runtime: Pick<Runtime, "experimental">,
 ): boolean {
-  return runtime.experimental?.systemPatternAutoUpdate === true &&
-    runtime.experimental?.systemPatternAutoUpdateHome === true;
+  return runtime.experimental?.systemPatternAutoUpdate === true;
 }
 
 /**

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -168,10 +168,9 @@ export interface InitializationData {
     modernCellRep?: boolean;
     persistentSchedulerState?: boolean;
     eagerSourceAnnotation?: boolean;
-    // Roll a space's system root pattern forward in place when its toolshed
-    // serves a newer identity. Default off; home held behind the second flag.
+    // Roll a space's system root pattern (home included) forward in place
+    // when its toolshed serves a newer identity. Default off.
     systemPatternAutoUpdate?: boolean;
-    systemPatternAutoUpdateHome?: boolean;
   };
   // Commit-boundary CFC mode for the worker runtime.
   cfcEnforcementMode?:

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -69,9 +69,6 @@ const config: Config = {
       "$EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE": Deno.env.get(
         "EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE",
       ),
-      "$EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME": Deno.env.get(
-        "EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME",
-      ),
       "globalThis.__cfCompileCacheRuntimeVersion":
         COMPILE_CACHE_RUNTIME_VERSION,
     },

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -7,7 +7,6 @@ declare global {
   var $EXPERIMENTAL_COMPUTED_CELL_IDS: string | undefined;
   var $EXPERIMENTAL_EAGER_SOURCE_ANNOTATION: string | undefined;
   var $EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE: string | undefined;
-  var $EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME: string | undefined;
 }
 
 const ENVIRONMENT_DEFINE = typeof $ENVIRONMENT === "string"
@@ -36,10 +35,6 @@ const EXPERIMENTAL_EAGER_SOURCE_ANNOTATION_DEFINE =
 const EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_DEFINE =
   typeof $EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE === "string"
     ? $EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE
-    : undefined;
-const EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME_DEFINE =
-  typeof $EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME === "string"
-    ? $EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME
     : undefined;
 
 export const ENVIRONMENT: "development" | "production" =
@@ -72,13 +67,10 @@ export const EXPERIMENTAL = {
   eagerSourceAnnotation:
     flagValue(EXPERIMENTAL_EAGER_SOURCE_ANNOTATION_DEFINE) ??
       (ENVIRONMENT === "development"),
-  // Auto-update the NON-HOME space-root system pattern (default-app) in place.
+  // Auto-update space-root system patterns (default-app AND home) in place.
   // Default ON; a build define (`EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE=false`)
-  // can force it off. The home root stays off — it carries real user data and
-  // needs the second flag, pending the stable-addressing audit.
+  // can force it off. Home state survival across an in-place roll is pinned by
+  // home-golden-replay.test.ts, so the home root no longer needs a second flag.
   systemPatternAutoUpdate:
     flagValue(EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_DEFINE) ?? true,
-  systemPatternAutoUpdateHome: flagValue(
-    EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME_DEFINE,
-  ),
 };

--- a/packages/shell/test/env.test.ts
+++ b/packages/shell/test/env.test.ts
@@ -45,9 +45,8 @@ Deno.test({
       modernCellRep: true,
       persistentSchedulerState: true,
       eagerSourceAnnotation: false,
-      // Default ON for the non-home root; home stays off.
+      // Default ON — one flag covers default-app and home roots alike.
       systemPatternAutoUpdate: true,
-      systemPatternAutoUpdateHome: undefined,
     });
   },
 });


### PR DESCRIPTION
## Why

Berni on today's estuary home-space bricking: *"oh i don't know why that's behind a flag, we should change that."*

The home-specific second flag (#4611) held home roots out of system-pattern auto-update pending the home.tsx stable-addressing audit (spec § open question 4). Two things have since made the gate cost more than it protects:

- **The audit evidence exists**: `home-golden-replay.test.ts` pins state survival across an in-place roll — representative favorites/journal/spaces data, home root rolled N→N+1, every list survives and the new code runs over it (#4865 restored and hardened this machinery).
- **The 2026-07-21 estuary incident**: the first post-#4740 deploy bricked every old-generation home root (`safeDateNow` no longer exports → stored source fails cold-recompile → "Failed to load space root pattern"). Non-home roots self-repaired through `systemPatternAutoUpdate`; homes could not, **and no headless repair path exists for ACL-private homes** — the flag was the only door, and it was closed everywhere.

## What

Removes `systemPatternAutoUpdateHome` entirely (not default-on): home roots now ride the umbrella `systemPatternAutoUpdate` like every other tracked system root. The umbrella flag — shell default-on, `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE=false` kill-switch — remains the single control.

- `pieces-controller.ts`: drop the home short-circuit in `checkAndUpdateDefaultPattern` (and the now-unused `isHomeSpace`).
- `runtime-processor.ts`: `shouldReconcileHomeRoot` reduces to the umbrella flag.
- Type/plumbing removal: runner `ExperimentalOptions`, env-var registry, runtime-client protocol type, lib-shell flags type, shell env define + felt define.
- Tests: the M4.2 "holds the home root behind its own flag" pin is **inverted** — the home root now rolls forward in place under the one flag (same no-new-piece assertions as the non-home roll test); remaining setups drop the second flag.
- Docs (same-change rule): `EXPERIMENTAL_OPTIONS.md` (table, propagation lists, sibling section; home section moved to Appendix A with the removal rationale), `pattern-updates.md` (Phase-2 status + open question 4 marked resolved).

## Verification

- Full workspace `deno task check` green; fmt + lint clean.
- Full package suites green: piece 20/237 steps, runtime-client 47/173, shell 42/74, lib-shell 5/36; runner presets + shell env suites green.
- The inverted home-roll test fails against the old gate by construction (the gate short-circuits to `skipped-disabled` before any fetch).

## Deploy note

Estuary currently serves `0540039478b` with every old-generation home root bricked. Once this lands and estuary redeploys ≥ this commit, each bricked home self-repairs in place on its owner's next load — no per-user action, state preserved. (Until then the flag's env var no longer exists; a deploy from this commit needs no configuration at all.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the `systemPatternAutoUpdateHome` flag so home roots auto-update under `systemPatternAutoUpdate`, enabling in-place roll-forward and self-repair for bricked home roots. The umbrella flag remains the single kill-switch; docs and tests updated to reflect the change.

- **Bug Fixes**
  - Home roots now reconcile and repair like other system roots under `systemPatternAutoUpdate`.
  - In-place updates preserve favorites/journal/spaces (pinned by `home-golden-replay.test.ts`).
  - Fixes the estuary incident where old home roots could not self-repair.

- **Migration**
  - Remove any use of `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE_HOME` (flag and env are deleted).
  - Shell: `systemPatternAutoUpdate` stays default-on; no extra config.
  - Server-side: still off unless `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE=true` is set.

<sup>Written for commit 7a2d3f6f973076b746e975e5326e89dc0dd93f61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

