### PR TITLE
fix(cli): materialize piece reads in one session

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -16,6 +16,7 @@ import {
   MapFormat,
   newPiece,
   PieceConfig,
+  PieceResultProjectionError,
   recreateSpaceRootPattern,
   removePiece,
   resetHomePattern,
@@ -784,8 +785,16 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     cliText(`cf piece get ${EX_ID} ${EX_COMP_PIECE}`),
     `Get the full result of piece "${RAW_EX_COMP.piece!}".`,
   )
+  .example(
+    cliText(`cf piece get ${EX_ID} ${EX_COMP_PIECE} --step`),
+    `Start, recompute, and get the result in one CLI session.`,
+  )
   .option("-c,--piece <piece:string>", "The target piece ID.")
   .option("--input", "Read from the piece's input cell instead of result cell")
+  .option(
+    "--step",
+    "Start and recompute the piece in this session before reading",
+  )
   .arguments("[path:string]")
   .action(async (options, pathString) => {
     const pieceConfig = parsePieceOptions(options);
@@ -793,10 +802,12 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     try {
       const value = await getCellValue(pieceConfig, pathSegments, {
         input: options.input,
+        step: options.step,
       });
       render(value, { json: true });
     } catch (error) {
       if (
+        error instanceof PieceResultProjectionError ||
         error instanceof Error && error.message.startsWith("Cannot access path")
       ) {
         throw new ValidationError(error.message, { exitCode: 1 });

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1400,6 +1400,15 @@ export async function getCellValue(
   try {
     if (shouldStep) {
       await piece.getCell().pull();
+      const rootCell =
+        await (options.input ? piece.input.getCell() : piece.result.getCell());
+      let targetCell = rootCell;
+      for (const segment of path) {
+        targetCell = targetCell.key(segment as keyof unknown) as Cell<unknown>;
+      }
+      await targetCell.pull();
+      await manager.synced();
+      await manager.runtime.idle();
       await manager.synced();
     }
 

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -16,6 +16,7 @@ import {
   UI,
   VNode,
 } from "@commonfabric/runner";
+import { validateSchemaValue } from "@commonfabric/runner/cfc";
 import type { CellScope } from "@commonfabric/api";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
 import {
@@ -77,6 +78,49 @@ export interface PieceConfig extends SpaceConfig {
 
 export interface SetPiecePatternOptions {
   dangerouslyAllowIncompatibleSchema?: boolean;
+}
+
+export interface GetCellValueOptions {
+  input?: boolean;
+  step?: boolean;
+}
+
+export class PieceResultProjectionError extends Error {
+  constructor(path: readonly (string | number)[], stepped: boolean) {
+    const location = path.length === 0 ? "<root>" : path.join("/");
+    const stepHint = stepped
+      ? " The piece was stepped, but the required value still did not " +
+        "materialize."
+      : " Use --step to start the piece and materialize session-scoped " +
+        "computed values before reading.";
+    super(
+      `Cannot read piece result at "${location}": stored data is present, ` +
+        `but its schema could not resolve all required values.${stepHint}`,
+    );
+    this.name = "PieceResultProjectionError";
+  }
+}
+
+async function resultProjectionFailedAtPath(
+  piece: {
+    result: { getCell(): Promise<Cell<unknown>> };
+  },
+  path: readonly (string | number)[],
+): Promise<boolean> {
+  const rootCell = await piece.result.getCell();
+  let targetCell = rootCell;
+  for (const segment of path) {
+    targetCell = targetCell.key(segment as keyof unknown) as Cell<unknown>;
+  }
+  const schema = targetCell.schema;
+  if (targetCell.getRaw() === undefined || schema === undefined) {
+    return false;
+  }
+  return validateSchemaValue(
+    schema,
+    undefined,
+    rootCell.schema ?? schema,
+  ) !== undefined;
 }
 
 export interface ResolvedPieceCallable extends CallableResolution {
@@ -1334,21 +1378,59 @@ export function formatViewTree(view: unknown): string {
 export async function getCellValue(
   config: PieceConfig,
   path: (string | number)[],
-  options?: { input?: boolean },
+  options: GetCellValueOptions = {},
+  deps: PieceOperationDependencies = {},
 ): Promise<unknown> {
-  const manager = await loadManager(config);
-  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
-  const pieces = new PiecesController(manager);
+  const manager = await (deps.loadManager ?? loadManager)(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(
+    config,
+    manager,
+    deps.resolvePieceAddress,
+  );
+  const pieces = deps.createController?.(manager) ??
+    new PiecesController(manager);
+  const shouldStep = options.step === true;
   const piece = await pieces.get(
     resolvedConfig.piece,
-    false,
+    shouldStep,
     undefined,
     resolvedConfig.pieceScope,
   );
-  if (options?.input) {
-    return await piece.input.get(path);
-  } else {
-    return await piece.result.get(path);
+
+  try {
+    if (shouldStep) {
+      await piece.getCell().pull();
+      await manager.synced();
+    }
+
+    let value: unknown;
+    try {
+      value = options.input
+        ? await piece.input.get(path)
+        : await piece.result.get(path);
+    } catch (error) {
+      if (
+        !options.input && error instanceof Error &&
+        error.message.startsWith("Cannot access path") &&
+        await resultProjectionFailedAtPath(piece, path)
+      ) {
+        throw new PieceResultProjectionError(path, shouldStep);
+      }
+      throw error;
+    }
+
+    if (
+      !options.input && value === undefined &&
+      await resultProjectionFailedAtPath(piece, path)
+    ) {
+      throw new PieceResultProjectionError(path, shouldStep);
+    }
+
+    return value;
+  } finally {
+    if (shouldStep) {
+      await pieces.stop(resolvedConfig.piece);
+    }
   }
 }
 

--- a/packages/cli/test/fixtures/session-derived-result.tsx
+++ b/packages/cli/test/fixtures/session-derived-result.tsx
@@ -1,0 +1,7 @@
+import { computed, pattern, Writable } from "commonfabric";
+
+export default pattern(() => {
+  const sessionValue = new Writable.perSession("session-ready");
+  const value = computed(() => sessionValue.get());
+  return { value };
+});

--- a/packages/cli/test/fixtures/session-derived-result.tsx
+++ b/packages/cli/test/fixtures/session-derived-result.tsx
@@ -1,7 +1,8 @@
-import { computed, pattern, Writable } from "commonfabric";
+import { computed, Default, pattern, Writable } from "commonfabric";
 
-export default pattern(() => {
-  const sessionValue = new Writable.perSession("session-ready");
-  const value = computed(() => sessionValue.get());
+export default pattern<{
+  values: Writable<string[] | Default<["session-ready"]>>;
+}>(({ values }) => {
+  const value = computed(() => values.get()[0] ?? "");
   return { value };
 });

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -26,6 +26,8 @@ const API_URL = Deno.env.get("API_URL");
 
 const REPO_ROOT = resolve(import.meta.dirname!, "../../..");
 const NOTE_PATTERN = `${REPO_ROOT}/packages/patterns/notes/note.tsx`;
+const SESSION_RESULT_PATTERN =
+  `${REPO_ROOT}/packages/cli/test/fixtures/session-derived-result.tsx`;
 
 const NOTE_CONTENT = "Hello world";
 const REPOSITORY = "https://github.com/commontoolsinc/labs";
@@ -37,6 +39,7 @@ const noteEntry: EntryConfig = {
 };
 
 let pieceId = "";
+let sessionResultPieceId = "";
 let flags = "";
 let identityPath = "";
 let spaceConfig: SpaceConfig;
@@ -82,6 +85,10 @@ describe("cf piece get (integration)", { ignore: !API_URL }, () => {
       identity: identityPath,
     };
     pieceId = await newPiece(spaceConfig, noteEntry);
+    sessionResultPieceId = await newPiece(spaceConfig, {
+      mainPath: SESSION_RESULT_PATTERN,
+      rootPath: REPO_ROOT,
+    });
     await callPieceHandler(
       { ...spaceConfig, piece: pieceId },
       "setTitle",
@@ -124,6 +131,27 @@ describe("cf piece get (integration)", { ignore: !API_URL }, () => {
     expect(code).toBe(0);
     const json = JSON.parse(stdout.join(""));
     expect(typeof json).toBe("object");
+  });
+
+  it("reports present result data that cannot project in a fresh session", async () => {
+    const sessionFlags =
+      `--api-url ${API_URL} --identity ${identityPath} --space ${spaceConfig.space} --piece ${sessionResultPieceId}`;
+    const { code, stderr } = await integrationCf(
+      `piece get ${sessionFlags}`,
+    );
+    expect(code).toBe(1);
+    expect(stderr.join("\n")).toContain("stored data is present");
+    expect(stderr.join("\n")).toContain("--step");
+  });
+
+  it("steps and reads session-scoped computed results atomically", async () => {
+    const sessionFlags =
+      `--api-url ${API_URL} --identity ${identityPath} --space ${spaceConfig.space} --piece ${sessionResultPieceId}`;
+    const { code, stdout } = await integrationCf(
+      `piece get ${sessionFlags} --step`,
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout.join(""))).toEqual({ value: "session-ready" });
   });
 
   it("list and inspect expose the running pattern reference", async () => {

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -88,7 +88,7 @@ describe("cf piece get (integration)", { ignore: !API_URL }, () => {
     sessionResultPieceId = await newPiece(spaceConfig, {
       mainPath: SESSION_RESULT_PATTERN,
       rootPath: REPO_ROOT,
-    });
+    }, { start: false });
     await callPieceHandler(
       { ...spaceConfig, piece: pieceId },
       "setTitle",
@@ -147,10 +147,10 @@ describe("cf piece get (integration)", { ignore: !API_URL }, () => {
   it("steps and reads session-scoped computed results atomically", async () => {
     const sessionFlags =
       `--api-url ${API_URL} --identity ${identityPath} --space ${spaceConfig.space} --piece ${sessionResultPieceId}`;
-    const { code, stdout } = await integrationCf(
+    const { code, stdout, stderr } = await integrationCf(
       `piece get ${sessionFlags} --step`,
     );
-    expect(code).toBe(0);
+    expect(code, stderr.join("\n")).toBe(0);
     expect(JSON.parse(stdout.join(""))).toEqual({ value: "session-ready" });
   });
 

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -2,9 +2,11 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { cf, checkStderr, stripAnsi } from "./utils.ts";
 import {
+  getCellValue,
   inspectPiece,
   listPieces,
   newPiece,
+  PieceResultProjectionError,
   recreateSpaceRootPattern,
   resolveLinkEndpointAddress,
   resolvePieceConfig,
@@ -465,6 +467,206 @@ describe("cli piece parsing", () => {
     expect(optionFlags("setsrc")).toContain(
       "--dangerously-allow-incompatible-schema",
     );
+  });
+
+  it("offers a one-session step option for piece result reads", () => {
+    const getFlags = piece.getCommand("get")!.getOptions().flatMap((option) =>
+      option.flags
+    );
+    expect(getFlags).toContain("--step");
+  });
+
+  it("steps, reads, syncs, and stops in one get operation", async () => {
+    const order: string[] = [];
+    const controller = {
+      get: (
+        id: string,
+        runIt: boolean,
+        _schema: unknown,
+        scope: string | undefined,
+      ) => {
+        order.push(`get:${id}:${runIt}:${scope}`);
+        return Promise.resolve({
+          input: { get: () => Promise.resolve(undefined) },
+          getCell: () => ({
+            pull: () => {
+              order.push("piece.pull");
+              return Promise.resolve();
+            },
+          }),
+          result: {
+            get: () => {
+              order.push("result.get");
+              return Promise.resolve({ value: "ready" });
+            },
+          },
+        });
+      },
+      stop: (id: string) => {
+        order.push(`stop:${id}`);
+        return Promise.resolve();
+      },
+    };
+    const manager = {
+      synced: () => {
+        order.push("manager.synced");
+        return Promise.resolve();
+      },
+    };
+
+    const value = await getCellValue(
+      {
+        apiUrl: API_URL,
+        space: SPACE,
+        identity: ID,
+        piece: PIECE,
+        pieceScope: "session",
+      },
+      [],
+      { step: true },
+      {
+        loadManager: () => Promise.resolve(manager as any),
+        resolvePieceAddress: (_manager, id) => Promise.resolve(id),
+        createController: () => controller as any,
+      },
+    );
+
+    expect(value).toEqual({ value: "ready" });
+    expect(order).toEqual([
+      `get:${PIECE}:true:session`,
+      "piece.pull",
+      "manager.synced",
+      "result.get",
+      `stop:${PIECE}`,
+    ]);
+  });
+
+  it("reports schema projection failure when raw result data exists", async () => {
+    const rawCell = {
+      schema: { type: "object" },
+      getRaw: () => ({ value: { "/": "missing-session-value" } }),
+    };
+    const controller = {
+      get: () =>
+        Promise.resolve({
+          input: { get: () => Promise.resolve(undefined) },
+          result: {
+            get: () => Promise.resolve(undefined),
+            getCell: () => Promise.resolve(rawCell),
+          },
+        }),
+    };
+
+    const error = await getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      [],
+      {},
+      {
+        loadManager: () => Promise.resolve({} as any),
+        resolvePieceAddress: (_manager, id) => Promise.resolve(id),
+        createController: () => controller as any,
+      },
+    ).catch((error) => error);
+    expect(error).toBeInstanceOf(PieceResultProjectionError);
+    expect((error as Error).message).toContain("Use --step");
+  });
+
+  it("preserves undefined when no raw result data exists", async () => {
+    const rawCell = {
+      schema: { type: "object" },
+      getRaw: () => undefined,
+    };
+    const controller = {
+      get: () =>
+        Promise.resolve({
+          input: { get: () => Promise.resolve(undefined) },
+          result: {
+            get: () => Promise.resolve(undefined),
+            getCell: () => Promise.resolve(rawCell),
+          },
+        }),
+    };
+
+    await expect(getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      [],
+      {},
+      {
+        loadManager: () => Promise.resolve({} as any),
+        resolvePieceAddress: (_manager, id) => Promise.resolve(id),
+        createController: () => controller as any,
+      },
+    )).resolves.toBeUndefined();
+  });
+
+  it("reports a missing path backed by an unresolved raw link", async () => {
+    const childCell = {
+      schema: { type: "number" },
+      getRaw: () => ({ "/": "missing-session-count" }),
+    };
+    const rootCell = {
+      schema: {
+        type: "object",
+        properties: { count: { type: "number" } },
+        required: ["count"],
+      },
+      getRaw: () => ({ count: { "/": "missing-session-count" } }),
+      key: () => childCell,
+    };
+    const controller = {
+      get: () =>
+        Promise.resolve({
+          input: { get: () => Promise.resolve(undefined) },
+          result: {
+            get: () =>
+              Promise.reject(
+                new Error('Cannot access path "count" - property not found'),
+              ),
+            getCell: () => Promise.resolve(rootCell),
+          },
+        }),
+    };
+
+    await expect(getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      ["count"],
+      {},
+      {
+        loadManager: () => Promise.resolve({} as any),
+        resolvePieceAddress: (_manager, id) => Promise.resolve(id),
+        createController: () => controller as any,
+      },
+    )).rejects.toThrow(PieceResultProjectionError);
+  });
+
+  it("preserves schema-valid undefined over present raw data", async () => {
+    const rawCell = {
+      schema: {
+        anyOf: [{ type: "object" }, { type: "undefined" }],
+      },
+      getRaw: () => ({ "/": "optional-session-value" }),
+    };
+    const controller = {
+      get: () =>
+        Promise.resolve({
+          input: { get: () => Promise.resolve(undefined) },
+          result: {
+            get: () => Promise.resolve(undefined),
+            getCell: () => Promise.resolve(rawCell),
+          },
+        }),
+    };
+
+    await expect(getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      [],
+      {},
+      {
+        loadManager: () => Promise.resolve({} as any),
+        resolvePieceAddress: (_manager, id) => Promise.resolve(id),
+        createController: () => controller as any,
+      },
+    )).resolves.toBeUndefined();
   });
 
   it("rejects repository metadata when resetting the home pattern", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -495,9 +495,21 @@ describe("cli piece parsing", () => {
             },
           }),
           result: {
+            getCell: () =>
+              Promise.resolve({
+                key: (segment: string) => {
+                  order.push(`result.key:${segment}`);
+                  return {
+                    pull: () => {
+                      order.push("result.pull");
+                      return Promise.resolve();
+                    },
+                  };
+                },
+              }),
             get: () => {
               order.push("result.get");
-              return Promise.resolve({ value: "ready" });
+              return Promise.resolve("ready");
             },
           },
         });
@@ -508,6 +520,12 @@ describe("cli piece parsing", () => {
       },
     };
     const manager = {
+      runtime: {
+        idle: () => {
+          order.push("runtime.idle");
+          return Promise.resolve();
+        },
+      },
       synced: () => {
         order.push("manager.synced");
         return Promise.resolve();
@@ -522,7 +540,7 @@ describe("cli piece parsing", () => {
         piece: PIECE,
         pieceScope: "session",
       },
-      [],
+      ["value"],
       { step: true },
       {
         loadManager: () => Promise.resolve(manager as any),
@@ -531,10 +549,14 @@ describe("cli piece parsing", () => {
       },
     );
 
-    expect(value).toEqual({ value: "ready" });
+    expect(value).toBe("ready");
     expect(order).toEqual([
       `get:${PIECE}:true:session`,
       "piece.pull",
+      "result.key:value",
+      "result.pull",
+      "manager.synced",
+      "runtime.idle",
       "manager.synced",
       "result.get",
       `stop:${PIECE}`,

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -84,6 +84,7 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Update existing   | `deno task cf piece setsrc pattern.tsx --root . --repository REPO --piece ID -i key -a url -s space` |
 | Inspect state     | `deno task cf piece inspect --piece ID ...`                                                          |
 | Get field         | `deno task cf piece get --piece ID fieldPath ...`                                                    |
+| Step + get        | `deno task cf piece get --piece ID fieldPath --step ...`                                             |
 | Set field         | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
 | Call handler      | `deno task cf piece call --piece ID handlerName ...`                                                 |
 | Trigger recompute | `deno task cf piece step --piece ID ...`                                                             |
@@ -169,13 +170,19 @@ echo '{"name": "John"}' | deno task cf piece set ... user
 ## Gotcha: Always `step` After `set` or `call`
 
 Neither `piece set` nor `piece call` triggers recomputation automatically. You
-**must** run `piece step` after either one to get fresh computed values.
+**must** run `piece step` after either one to get fresh computed values. When
+the value is session-scoped, use `piece get --step` so recomputation and the
+read happen in the same CLI session; a separate `piece step` process cannot
+carry session-local materialization into the following `piece get` process.
 
 ```bash
 # After setting data:
 echo '[...]' | deno task cf piece set --piece ID expenses ...
 deno task cf piece step --piece ID ...  # Required!
 deno task cf piece get --piece ID totalSpent ...
+
+# Equivalent one-session read (required for session-scoped computed output):
+deno task cf piece get --piece ID totalSpent --step ...
 
 # After calling a handler:
 deno task cf piece call --piece ID addItem '{"title": "Test"}'


### PR DESCRIPTION
## Summary

- add `cf piece get --step` to start, pull, synchronize, read, and stop a piece in one CLI process
- return a nonzero, actionable diagnostic when durable raw result data exists but schema-aware projection cannot resolve a required value
- preserve legitimate `undefined` results when no raw value exists or the schema permits `undefined`
- document the one-session read workflow in the `cf` skill

## Why

`cf piece get` currently loads pieces with `runIt: false`. A separate `cf piece step` process cannot carry session-scoped computed values into the later `get` process, so a durable result containing session links can project as `undefined` in a fresh CLI session. The path traversal layer can also turn that unresolved required value into a successful `undefined` result, which hides the distinction between absent data and failed materialization.

`--step` gives callers an atomic start/pull/sync/read/stop lifecycle. Without it, the CLI now detects the specific raw-present/schema-invalid case and suggests `--step`; it still prints `undefined` for genuinely absent or schema-valid undefined values.

## Tests

- `deno fmt --check` on changed files
- `deno check` on changed TypeScript files
- focused `packages/cli/test/piece.test.ts`: 42 steps passed
- full `packages/cli` suite: 1,291 tests (419 steps) passed
- exact `piece-integration.test.ts` shard against an isolated local Toolshed: 6 steps passed, including fresh-session failure and successful `get --step` materialization

## Live check

The Estuary board check reached the remote sync boundary but timed out before the read path ran, so it was not counted as validation for this patch. The regression is pinned locally at the unit boundary and in the CLI integration suite.
