### PR TITLE
fix(patterns): topics — declare crossrefs optional/undefined, matching the deployed board

### DIFF
--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -83,10 +83,15 @@ export interface TopicPiece {
   lastActivityAt: number;
   /** This topic's own place in the board's prose graph, derived read-side
    * from `mentionable` (the sibling pieces it links, resolved from the
-   * board's own list). Both sets stay empty until `mentionable` is wired. */
-  crossrefs:
+   * board's own list). Both sets stay empty until `mentionable` is wired.
+   * Optional (2026-07-21 deploy): pieces healed before their `mentionable`
+   * link exists carry a session-scoped crossrefs indirection that resolves
+   * undefined outside the minting session; the list projection must accept
+   * that rather than fail argument validation. */
+  crossrefs?:
     | { refsOut: TopicPiece[]; referencedBy: TopicPiece[] }
-    | Default<{ refsOut: []; referencedBy: [] }>;
+    | Default<{ refsOut: []; referencedBy: [] }>
+    | undefined;
   addComment: Stream<{ body: string }>;
   addLink: Stream<{ kind: TopicLinkKind; url: string; label: string }>;
   setBody: Stream<{ body: string }>;


### PR DESCRIPTION
Upstreams the transitional TopicPiece schema the 2026-07-21 board heal deployed, byte-for-byte, so repo main and the live board stop drifting. Direction agreed with Gideon.

## Why

- **Kills a drift trap**: the deployed board runs `crossrefs?: … | undefined`; repo main requires it. Any future re-setsrc from main would re-tighten the schema and re-arm the argument-validation blockage that vetoed board setsrc during the #4740 heal (`"crossrefs: value does not match type object"` — a container's setsrc gated on its children's render/mint state).
- **The loosened declaration is the truthful cold-state type**: a topic whose crossrefs derive has never resolved presents present-key-**undefined**, which neither the required object arm nor `Default<>` admits (defaults fill absent keys only) — and the healed corpus exhibits this for real: ~38 of 39 topics carry session-scoped crossrefs indirections that read undefined outside their minting session.
- The explicit `| undefined` union member is load-bearing: `?:` alone only un-requires the *key*; the schema generator emits the `{type:"undefined"}` arm only for the explicit union (the #4708 three-valued semantics).
- Fits the result-schema-affordances thesis (board topic `fid1:AdxT1VowiEELWrb8OPrnEM9bHDwGGoA0uCMgonEeE_8`): derived affordances shouldn't be hard-required by result schemas.

## Tracked, not calcified

This loosening routes around two runtime findings now filed on the board — validator-gate `fid1:Np25xNUqWtvBsaNjcSwAx5msmNF5uwAhjwGPId4sNso` (should validateArgument read unresolvable as absent / honor Default on undefined?) and session-scoped mints `fid1:aPzlwrNz8iq8zdNG1q3ldA92B8PVazexzvPxtPIr8c8` (derives first-executed unwired mint session-scoped cells permanently). If either ask lands, the `| undefined` arm can be consciously re-narrowed; the code comment records the constraint.

## Verification

`cf check` clean on both `topic.tsx` and `main.tsx`; full topics suites green: `topics.test.tsx` **30/0**, `multi-user.test.tsx` **11/0**. Board UI is unaffected by construction (it computes its own rows and never reads `topics[i].crossrefs`); `main.tsx` needed no change (verified identical to the deployed heal source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `TopicPiece.crossrefs` optional and allow `undefined` to match the deployed board schema and prevent validation errors when crossrefs haven’t resolved. This keeps repo and live board in sync and avoids future setsrc blockages.

- **Bug Fixes**
  - In `packages/patterns/topics/topic.tsx`, changed `crossrefs` to `crossrefs?: { refsOut: TopicPiece[]; referencedBy: TopicPiece[] } | Default<{ refsOut: []; referencedBy: [] }> | undefined`.
  - Supports session-scoped crossrefs that resolve to `undefined` outside the mint session; no UI changes.

<sup>Written for commit 23890a191eb588c8f5dfa0dc67f7d580eb10363a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

