### PR TITLE
fix(tasks): collect coverage profiles without a stack-overflowing spread

### DIFF
--- a/tasks/write-coverage-lcov.test.ts
+++ b/tasks/write-coverage-lcov.test.ts
@@ -1,7 +1,10 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { dirname, fromFileUrl, join } from "@std/path";
 import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
-import { normalizeLcovInstancePaths } from "./write-coverage-lcov.ts";
+import {
+  collectCoverageProfileFiles,
+  normalizeLcovInstancePaths,
+} from "./write-coverage-lcov.ts";
 
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 const SCRIPT = join(REPO_ROOT, "tasks/write-coverage-lcov.ts");
@@ -156,6 +159,68 @@ Deno.test("write-coverage-lcov converts real profiles to a normalized LCOV repor
       "instance query survived normalization",
     );
     assertStringIncludes(result.stdout, "Wrote LCOV");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+function dirEntry(name: string, isDirectory: boolean): Deno.DirEntry {
+  return { name, isDirectory, isFile: !isDirectory, isSymlink: false };
+}
+
+// A full coverage run can leave far more profile files in one directory than
+// the number of arguments V8 lets a single call take (a ceiling near 130,000).
+// Present the collector a directory that large through an injected reader — no
+// real files — and confirm it gathers every profile. A collector that merged a
+// subdirectory's list into its parent with a spread would overflow here; a
+// walk that appends into one shared array does not, whatever the stack size.
+Deno.test("collectCoverageProfileFiles gathers a directory larger than the argument limit", async () => {
+  const COUNT = 200_000;
+  const root = "/coverage-root";
+  const sub = join(root, "sub");
+  const readDir = (dir: string): AsyncIterable<Deno.DirEntry> => {
+    async function* entries(): AsyncGenerator<Deno.DirEntry> {
+      if (dir === root) {
+        yield dirEntry("sub", true);
+      } else if (dir === sub) {
+        for (let i = 0; i < COUNT; i++) yield dirEntry(`p${i}.json`, false);
+      }
+    }
+    return entries();
+  };
+
+  const files = await collectCoverageProfileFiles(root, readDir);
+
+  assertEquals(files.length, COUNT);
+  assertEquals(files[0], join(sub, "p0.json"));
+  assertEquals(files.at(-1), join(sub, `p${COUNT - 1}.json`));
+});
+
+Deno.test("collectCoverageProfileFiles walks nested directories and keeps only .json", async () => {
+  const root = await Deno.makeTempDir({ prefix: "write-lcov-collect-" });
+  try {
+    await Deno.writeTextFile(join(root, "top.json"), "{}");
+    await Deno.writeTextFile(join(root, "ignored.txt"), "");
+    const nested = join(root, "nested", "deeper");
+    await Deno.mkdir(nested, { recursive: true });
+    await Deno.writeTextFile(join(nested, "leaf.json"), "{}");
+    await Deno.writeTextFile(join(nested, "notes.md"), "");
+
+    const files = await collectCoverageProfileFiles(root);
+
+    assertEquals(files.sort(), [
+      join(root, "nested", "deeper", "leaf.json"),
+      join(root, "top.json"),
+    ]);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("collectCoverageProfileFiles returns empty for a missing directory", async () => {
+  const root = await Deno.makeTempDir({ prefix: "write-lcov-collect-" });
+  try {
+    assertEquals(await collectCoverageProfileFiles(join(root, "missing")), []);
   } finally {
     await Deno.remove(root, { recursive: true });
   }

--- a/tasks/write-coverage-lcov.ts
+++ b/tasks/write-coverage-lcov.ts
@@ -19,22 +19,43 @@ export function normalizeLcovInstancePaths(lcov: string): string {
   ).join("\n");
 }
 
-async function collectCoverageProfileFiles(dir: string): Promise<string[]> {
+/**
+ * Collect every `.json` coverage profile file under `dir`, descending into
+ * subdirectories. A missing directory, including one removed mid-walk, yields
+ * an empty result rather than an error.
+ *
+ * A full local coverage run can leave several hundred thousand profile files
+ * under one directory. The walk appends each path to a single shared array, so
+ * no step ever passes a several-hundred-thousand-element array to a variadic
+ * call such as `push(...items)`; doing so overflows the call stack, because
+ * each element becomes a separate argument and V8 caps how many arguments one
+ * call takes.
+ *
+ * `readDir` defaults to `Deno.readDir`; it is a parameter so a test can present
+ * a very large directory without creating that many real files.
+ */
+export async function collectCoverageProfileFiles(
+  dir: string,
+  readDir: (dir: string) => AsyncIterable<Deno.DirEntry> = Deno.readDir,
+): Promise<string[]> {
   const files: string[] = [];
-  try {
-    for await (const entry of Deno.readDir(dir)) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory) {
-        files.push(...await collectCoverageProfileFiles(fullPath));
-      } else if (entry.name.endsWith(".json")) {
-        files.push(fullPath);
+  async function walk(current: string): Promise<void> {
+    try {
+      for await (const entry of readDir(current)) {
+        const fullPath = path.join(current, entry.name);
+        if (entry.isDirectory) {
+          await walk(fullPath);
+        } else if (entry.name.endsWith(".json")) {
+          files.push(fullPath);
+        }
       }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return;
+      throw error;
     }
-  } catch (error) {
-    if (error instanceof Deno.errors.NotFound) return [];
-    throw error;
   }
 
+  await walk(dir);
   return files;
 }
 


### PR DESCRIPTION
`tasks/write-coverage-lcov.ts` walks a coverage profile directory to gather every `.json` profile file. For each nested directory it spread the recursively collected list into `Array.prototype.push`:

    files.push(...await collectCoverageProfileFiles(fullPath));

Spreading an array into a call passes each element as a separate argument, and V8 caps how many arguments one call may take. That ceiling sits near 130,000 elements, so once a directory holds that many profile files the spread throws `RangeError: Maximum call stack size exceeded` and the whole LCOV conversion aborts. The recursion depth is not the problem; the width of a single spread is.

CI never hits this because each job shards its profile directory, so no single directory grows large enough. It does bite anyone converting a full local run's profile to LCOV: a complete local test run can leave several hundred thousand profile files under one directory.

Rewrite the walk so the overflow is impossible by construction. An inner `walk` closure pushes every profile path directly onto a single shared array that outlives the recursion, so no intermediate per-directory array is ever built and no large array is ever spread.

Add a directory-reader parameter that defaults to `Deno.readDir`, so a test can present a directory holding more entries than V8's argument-count ceiling without creating that many real files. The regression test drives the real recursion over such a synthetic directory and asserts it returns every path; a collector that merged a subdirectory's list with a spread overflows on that input, so the test fails if the bug is reintroduced at the call site. The assertion checks the returned result rather than that a spread throws, so it does not depend on V8's configured stack size.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LCOV conversion crashing on very large coverage directories by removing a spread that hits V8’s argument limit. The collector now appends to a shared array and safely handles hundreds of thousands of profiles.

- **Bug Fixes**
  - Rewrote the directory walk to append into one shared array; no `files.push(...items)` spreads, avoiding V8 arg-limit overflows.
  - Exported `collectCoverageProfileFiles(dir, readDir?)`; defaults to `Deno.readDir` and returns `[]` for missing directories.
  - Added regression tests: synthetic 200k-file directory via injected reader, nested walk with `.json` filtering, and missing-dir case.

<sup>Written for commit 34fe9092206374fd7b9901a19c53c128333f0e90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

