### PR TITLE
test(shell): migrate the piece integration suite onto the shared iden…

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -306,8 +306,10 @@ boundary the test can await without adding one to production code.
 - `packages/shell/integration/piece.test.ts` — the one poll that reads a freshly
   reloaded piece (`cc.get(pieceId, true)`) has no registered sink, so it stays a
   bounded poll on its own sync round trip. The other result-cell reads in this
-  file, and every such read in `counter.test.ts` and `nested-counter.test.ts`,
-  resolve a `defer()` from the existing `resultCell.sink(...)`.
+  file wait through `waitForCellValue`, which sinks on the result cell and reads
+  it at quiescence. The equivalent reads in `counter.test.ts` and
+  `nested-counter.test.ts` resolve a `defer()` from an existing
+  `resultCell.sink(...)`.
 
 ### A pull that drives its own loading
 

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -1,13 +1,13 @@
 import { env, waitFor, waitForCondition } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import { describe, it } from "@std/testing/bdd";
-import { dirname, join, resolve } from "@std/path";
+import { join, resolve } from "@std/path";
 import "../src/globals.ts";
-import { Identity } from "@commonfabric/identity";
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import { clickPierce } from "./shadow-dom.ts";
 import { expect } from "@std/expect";
-import { defer, type Deferred } from "@commonfabric/utils/defer";
 
 const { API_URL, SPACE_NAME, FRONTEND_URL } = env;
 const REPO_ROOT = resolve(import.meta.dirname!, "../../..");
@@ -53,13 +53,6 @@ async function runCfPieceNewWithSlug(options: {
     throw new Error(`cf piece new did not print a fid1 id:\n${stdout}`);
   }
   return pieceId;
-}
-
-async function writeIdentityKey(identity: Identity): Promise<string> {
-  const dir = await Deno.makeTempDir({ prefix: "shell-slug-piece-" });
-  const path = join(dir, "identity.key");
-  await Deno.writeFile(path, identity.toPkcs8());
-  return path;
 }
 
 async function waitForSlugPieceMarker(
@@ -115,27 +108,13 @@ describe("shell piece tests", () => {
 
   it("can view and interact with a piece", async () => {
     const page = shell.page();
-    const identity = await Identity.generate({ implementation: "noble" });
-    const cc = await PiecesController.initialize({
-      spaceName: SPACE_NAME,
-      apiUrl: new URL(API_URL),
-      identity: identity,
+    const { identity, path: identityPath } = await writeTempIdentity({
+      implementation: "noble",
     });
+    // Initialized as the first step inside the try below, so a failure there
+    // still runs the finally that removes the keyfile.
+    let cc: PiecesController | undefined;
     let piece: PieceController | undefined;
-    let pieceSinkCancel: (() => void) | undefined;
-    let identityPath: string | undefined;
-    // The piece's committed result value, tracked by the result-cell sink set
-    // up below, and a one-shot waiter the sink resolves when the value reaches
-    // a target. A fresh deferred per call keeps the sequential checks (0, then
-    // -1, then -2) independent.
-    let latestResultValue: number | undefined;
-    let resultWaiter: { target: number; deferred: Deferred } | undefined;
-    const awaitResultValue = (target: number): Promise<void> => {
-      if (latestResultValue === target) return Promise.resolve();
-      const deferred = defer();
-      resultWaiter = { target, deferred };
-      return deferred.promise;
-    };
     const logDebugSnapshot = async (label: string) => {
       console.log(label, {
         shellState: await shell.state(),
@@ -208,6 +187,12 @@ describe("shell piece tests", () => {
     };
 
     try {
+      const controller = await PiecesController.initialize({
+        spaceName: SPACE_NAME,
+        apiUrl: new URL(API_URL),
+        identity: identity,
+      });
+      cc = controller;
       const sourcePath = join(
         import.meta.dirname!,
         "..",
@@ -216,30 +201,32 @@ describe("shell piece tests", () => {
         "counter",
         "counter.tsx",
       );
-      identityPath = await writeIdentityKey(identity);
       const slug = `compile-cache-${crypto.randomUUID()}`;
       const pieceId = await runCfPieceNewWithSlug({
         sourcePath,
         identityPath,
         slug,
       });
-      const currentPiece = await cc.get(pieceId, false);
+      const currentPiece = await controller.get(pieceId, false);
       piece = currentPiece;
 
-      const resultCell = cc.manager().getResult(currentPiece.getCell());
-      pieceSinkCancel = resultCell.sink((value) => {
-        latestResultValue = (value as { value?: number } | undefined)?.value;
-        if (resultWaiter && latestResultValue === resultWaiter.target) {
-          resultWaiter.deferred.resolve();
-          resultWaiter = undefined;
-        }
-      });
+      // Read the piece's committed result value at quiescence. Each call sinks
+      // on the result cell, drains the scheduler, and resolves once the value
+      // reaches its target, so the sequential checks (0, then -1, then -2) each
+      // wait on a real committed change rather than a timer.
+      const resultCell = controller.manager().getResult(currentPiece.getCell());
+      const awaitResultValue = (target: number): Promise<unknown> =>
+        waitForCellValue<{ value?: number }>(
+          controller.manager().runtime,
+          resultCell,
+          (value) => value?.value === target,
+        );
 
       await awaitResultValue(0);
       // A fresh reload of the piece has no sink; poll until its own sync round
       // trip reads the committed value back.
       await waitFor(async () => {
-        const reloadedPiece = await cc.get(pieceId, true);
+        const reloadedPiece = await controller.get(pieceId, true);
         return (await reloadedPiece.result.get(["value"])) === 0;
       });
       await shell.goto({
@@ -363,23 +350,18 @@ describe("shell piece tests", () => {
       }
       throw error;
     } finally {
-      pieceSinkCancel?.();
       await shell.disposeRuntime();
-      await cc.dispose();
+      await cc?.dispose();
       await new Promise((resolve) => setTimeout(resolve, 100));
-      if (identityPath) {
-        await Deno.remove(dirname(identityPath), { recursive: true }).catch(
-          () => {},
-        );
-      }
+      await Deno.remove(identityPath).catch(() => {});
     }
   });
 
   it("loads a slug piece and reloads when cf piece new repoints the slug", async () => {
     const slug = `slug-repoint-${crypto.randomUUID()}`;
-    const identity = await Identity.generate({ implementation: "noble" });
-    const identityPath = await writeIdentityKey(identity);
-    const identityDir = dirname(identityPath);
+    const { identity, path: identityPath } = await writeTempIdentity({
+      implementation: "noble",
+    });
     const firstSource = join(
       import.meta.dirname!,
       "fixtures",
@@ -426,15 +408,15 @@ describe("shell piece tests", () => {
       const href = await shell.page().evaluate(() => globalThis.location.href);
       expect(href).toContain(`/${SPACE_NAME}/${slug}`);
     } finally {
-      await Deno.remove(identityDir, { recursive: true });
+      await Deno.remove(identityPath).catch(() => {});
     }
   });
 
   it("tears the runtime down cleanly on logout while a piece is rendered", async () => {
     const slug = `logout-teardown-${crypto.randomUUID()}`;
-    const identity = await Identity.generate({ implementation: "noble" });
-    const identityPath = await writeIdentityKey(identity);
-    const identityDir = dirname(identityPath);
+    const { identity, path: identityPath } = await writeTempIdentity({
+      implementation: "noble",
+    });
     const source = join(
       import.meta.dirname!,
       "fixtures",
@@ -473,7 +455,7 @@ describe("shell piece tests", () => {
         new Promise((resolve) => setTimeout(resolve, 250))
       );
     } finally {
-      await Deno.remove(identityDir, { recursive: true }).catch(() => {});
+      await Deno.remove(identityPath).catch(() => {});
     }
   });
 });


### PR DESCRIPTION
…tity and cell-wait helpers

The shell piece integration suite carried its own copies of two things the integration package now exposes as shared helpers: a throwaway identity keyfile writer, and an event-driven wait for a piece result cell to reach a target value. Both duplicated behaviour that lives once in @commonfabric/integration, and the local wait was the weaker of the two implementations. Move the suite onto the shared helpers.

Identity keyfile. The local writeIdentityKey generated an identity and wrote its PKCS8 keyfile into a freshly made temporary directory, and teardown then removed the whole directory. Replace it with writeTempIdentity, which generates the identity and writes the keyfile to a single temporary file and hands back both. Cleanup now removes just that file rather than reconstructing the parent directory for a recursive delete, and the three tests' teardowns become identical. Shell login serializes the identity, so the noble implementation is requested explicitly.

Result-value wait. A persistent sink on the result cell tracked the latest committed value and resolved a one-shot deferred when it reached a target. Replace that machinery with waitForCellValue, which sinks on the same cell, drains the scheduler, and reads the value only once the runtime is quiescent — stepping over the mid-flight superseded values a raw sink can observe. Each sequential check (0, then -1, then -2) now waits through the shared helper.

One wait stays a bounded poll. Reading a freshly reloaded piece through a fresh controller get exercises a new sync round trip and has no registered sink to wake on, so it cannot be expressed as a waitForCellValue on an existing cell. The file therefore keeps its one polling waitFor and stays on the check-no-waitfor allowlist; the corresponding entry in the waiting-in-tests document is updated to say the file's other result-cell reads now go through waitForCellValue, while the counter and nested-counter suites keep their defer-from-sink reads.

Keyfile cleanup on early failure. Because writeTempIdentity both generates the identity and writes the keyfile, the keyfile now exists before the pieces controller is initialized. Initialize the controller as the first step inside the try block, so a failure there still runs the finally that removes the keyfile instead of orphaning it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the shell piece integration tests to shared helpers from `@commonfabric/integration` for temp identity files and result cell waits. This removes duplicate code, improves wait reliability, and simplifies cleanup.

- **Refactors**
  - Replaced local keyfile writer with `writeTempIdentity`; teardown now removes a single file. Controller init moved inside `try` to ensure keyfile cleanup on early failure. Uses the `noble` implementation to match shell login.
  - Replaced custom sink/defer logic with `waitForCellValue` to read committed result values at quiescence; sequential checks now wait on real commits.
  - Kept one bounded poll for `cc.get(pieceId, true)` where no sink exists; updated `docs/development/waiting-in-tests.md` to reflect this.

<sup>Written for commit 1a1e1a441c6703d8f4e71945d43bf31fb4bdd7fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

