### PR TITLE
docs(history): record that pattern-survey Bug 3 does not reproduce

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -194,6 +194,11 @@ One line per archived document; each document's header carries the fuller
 
 ### Investigations, journals, and working notes
 
+- [bug3-suggestion-alias-verification-2026-07.md](packages/patterns/bug3-suggestion-alias-verification-2026-07.md)
+  — verification that the December 2025 survey's Bug 3 (Counter values
+  rendering as raw `$alias` objects when instantiated via `fetchAndRunPattern`)
+  does not reproduce; the dynamically-compiled render path resolves reactive and
+  computed values correctly, July 2026.
 - [reverse-invalidation-deadlock.md](packages/fuse/reverse-invalidation-deadlock.md)
   — root cause of the FUSE daemon hang that flaked the CLI FUSE integration
   suite: synchronous reverse invalidation deadlocking the request thread,

--- a/docs/history/packages/patterns/bug3-suggestion-alias-verification-2026-07.md
+++ b/docs/history/packages/patterns/bug3-suggestion-alias-verification-2026-07.md
@@ -1,0 +1,102 @@
+---
+status: historical
+created: 2026-07-21
+archived: 2026-07-21
+reason: "Verification of the December 2025 survey's Bug 3; the $alias render defect does not reproduce."
+---
+
+# Bug 3 verification: dynamically-instantiated pattern values no longer render as `$alias`
+
+This record closes out the second of the two findings in the December 2025
+pattern bug survey
+([`PREEXISTING_BUGS.md`](PREEXISTING_BUGS.md)). The first finding, Bug 1
+(compiler.tsx "Navigate To Piece"), was verified working in July 2026 and its
+stale catalog note removed; that work landed upstream as PR #4733. Bug 3 had
+never been checked until this investigation.
+
+## What Bug 3 claimed
+
+When the Suggestion pattern instantiated a Counter (or any other pattern)
+through `fetchAndRunPattern`, the survey reported that reactive cell values in
+the Counter's rendered UI appeared as raw alias objects instead of resolved
+values. The concrete example given was the Counter's caption rendering as
+`"Counter is the {"$alias":...} number"` — the literal serialized alias — where
+the intended output was the resolved ordinal, for example `"Counter is the 1st
+number"`. The survey suspected the cause lay in how patterns are dynamically
+instantiated through the large-language-model tool-call path inside
+`fetchAndRunPattern`.
+
+## Why the symptom is a render-time question
+
+For the `$alias` string to appear, the Counter must have rendered at all: the
+surrounding template text (`Counter is the … number`) was present, and only the
+embedded reactive value failed to resolve. The defect is therefore in how a
+dynamically-compiled pattern's reactive user-interface values are resolved and
+subscribed to at render time. That render path is downstream of `compileAndRun`
+and of the pattern that produced the program. It does not depend on where the
+program source came from (a fetched URL versus inline source) and it does not
+depend on the large-language-model tool-call wiring. Whatever supplies the
+compiled program, the reconciler renders the same pattern instance with the same
+alias structure.
+
+## How it was verified
+
+The survey's own reproduction recipe no longer matches the tree: the Suggestion
+patterns moved to `packages/patterns/system/suggestion.tsx` and
+`packages/patterns/examples/suggestion-test.tsx`, and the recipe's port was
+stale. More importantly, the full Suggestion path is awkward to drive in
+isolation: it depends on home-space system wishes (`#summaryIndex`,
+`#mentionable`, `#recent`, `#patternIndex`, `#learnedSummary`) that a fresh,
+isolated space does not provide, and it hard-codes a model name the local
+gateway no longer offers.
+
+The verification instead exercised the exact render mechanism the defect lived
+in, with a self-contained pattern deployed to a local space and rendered in the
+shell. The pattern compiled an inline Counter source with `compileAndRun` — the
+same builtin `fetchAndRunPattern` wraps — and rendered the resulting cell inline
+through `cf-cell-context`, mirroring how `suggestion.tsx` renders its
+large-language-model result. The inline Counter reproduced the reported template
+exactly: a direct cell value shown as `{value}`, and a `computed` ordinal shown
+as `Counter is the {ordinalDisplay} number`.
+
+Observed result:
+
+- On first render the direct value resolved to `0` and the ordinal resolved to
+  `Counter is the 0th number`. No `$alias` text appeared anywhere in the
+  rendered document.
+- After incrementing the compiled Counter three times, the direct value became
+  `3` and the ordinal updated to `Counter is the 3rd number`. The resolved
+  values are live subscriptions across the compiled-pattern boundary, not
+  one-time snapshots, and still no `$alias` appeared.
+
+Both a plain cell reference and a derived `computed` — the two shapes a reactive
+value can take in a pattern's user interface — resolve correctly when the
+pattern is produced by `compileAndRun` and rendered inline. The reported Bug 3
+symptom does not reproduce.
+
+## An orthogonal observation, recorded so it is not mistaken for Bug 3
+
+A separate reproduction that drove `fetchProgram` against a program URL (the
+GitHub raw URL the pattern index points at) never left the "fetching" state:
+`fetchProgram` stayed pending indefinitely, with no error surfaced to the
+pattern, so `compileAndRun` never received inputs and the Counter never ran.
+
+This is the Common Fabric capability layer's outbound-request gate behaving as
+designed, not a defect in the render path. `fetchProgram` dispatches its network
+request as a "sink-request" through `enqueueSinkRequestPostCommitEffect`
+(`packages/runner/src/cfc/sink-request.ts`). When the release check
+(`verifySinkRequestRelease`) is not satisfied, that effect fails closed: the
+actual fetch is never sent, and the failure is noted to capability statistics
+rather than raised to the pattern. In an isolated test space without the
+capability preparation the normal product flow performs, the outbound program
+fetch is therefore withheld and the fetch cell remains pending. This is a
+property of the isolated test environment and the capability policy, and it is
+independent of the `$alias` question, which concerns rendering after a program
+has already compiled and run. The inline-source verification above deliberately
+avoids the outbound fetch so the render path can be exercised on its own.
+
+## Outcome
+
+Bug 3 does not reproduce. Unlike Bug 1, no live document advertised Bug 3 — the
+pattern catalog carries no note about `suggestion.tsx` — so there is nothing to
+correct or remove. No runtime change was made.


### PR DESCRIPTION
The December 2025 pattern bug survey (now archived at docs/history/packages/patterns/PREEXISTING_BUGS.md) listed two runtime findings. Bug 1 was verified working and un-documented earlier; Bug 3 had never been checked.

Bug 3 claimed that a Counter instantiated through fetchAndRunPattern rendered its reactive cell values as raw $alias objects — for example the caption "Counter is the {"$alias":...} number" instead of the resolved ordinal. For that literal alias string to appear, the Counter must already have rendered, so the defect is a render-time question about resolving reactive values in a dynamically-compiled pattern's UI. That render path is downstream of compileAndRun and independent of where the program source came from and of the large-language-model tool-call wiring.

Verification exercised exactly that path: a pattern compiled an inline Counter with compileAndRun and rendered the resulting cell inline through cf-cell-context, reproducing the reported template (a direct cell value plus a computed ordinal). Both resolved correctly on first render — "0" and "Counter is the 0th number" — and updated reactively after incrementing to "3" and "Counter is the 3rd number", with no $alias anywhere. The symptom does not reproduce.

A separate observation is recorded so it is not mistaken for Bug 3: a fetch of a program by URL stays pending because the capability layer's outbound sink-request release fails closed in an isolated test space, withholding the fetch. That is the capability gate behaving as designed, orthogonal to the alias-rendering question, which is why the verification used inline source.

No live document advertised Bug 3, so there is nothing to correct in the catalog and no runtime change was needed. The finding is recorded as a point-in-time history document per the documentation lifecycle rules.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records that the pattern-survey Bug 3 does not reproduce: Counter values do not render as raw `$alias` when instantiated via `fetchAndRunPattern` or `compileAndRun`. Adds a history doc and updates the archive index; no runtime or catalog changes.

<sup>Written for commit d4e7634b03a5c88cc5e0bf7fb0cb7c11fc251fba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

