### PR TITLE
refactor(patterns): share the note-button click helpers between the t…

### DIFF
--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -14,6 +14,12 @@ import {
   waitForRuntimeIdle,
   waitForRuntimeSynced,
 } from "./cfc-browser-helpers.ts";
+import {
+  clickButtonWithExactText,
+  clickButtonWithText,
+  clickButtonWithTitle,
+  findButtonWithText,
+} from "./note-button-helpers.ts";
 import { describe, it } from "@std/testing/bdd";
 import { Identity } from "@commonfabric/identity";
 import { assert, assertEquals } from "@std/assert";
@@ -3186,181 +3192,6 @@ async function ensureCapturedConsole(page: Page): Promise<boolean> {
 
     return true;
   });
-}
-
-// Helper to find and click a button by text using piercing selectors
-// Marker attribute a click predicate stamps on the button it resolved, so the
-// test can then resolve that exact element and dispatch a single trusted click
-// on it. Mirrors the CLICK_TARGET_ATTR flow of clickCfButton in
-// cfc-browser-helpers.ts.
-const NOTE_BUTTON_CLICK_TARGET_ATTR = "data-cfc-note-button-target";
-
-// Serialized into the page by waitForCondition: find the first rendered
-// button/link whose text or title matches, scroll it into view, and stamp its
-// inner click target with `token`. "Rendered" means laid out and not
-// display:none/visibility:hidden — the same elements the innerText scan the
-// poll used could see — and is viewport-independent, so a match below the fold
-// is scrolled in rather than skipped. Returns false until a match exists, so
-// the wait re-checks on the next DOM mutation instead of the caller retrying a
-// bare find-and-click loop.
-const markNoteButton = async (
-  probe: ProbeApi,
-  selector: string,
-  match: "includes" | "exact" | "title",
-  needle: string,
-  token: string,
-  attr: string,
-): Promise<boolean> => {
-  const target = probe.collect(selector).find((element) => {
-    if (!probe.isRendered(element)) return false;
-    if (match === "title") return element.getAttribute("title") === needle;
-    const text = (element.textContent ?? "").trim();
-    return match === "exact" ? text === needle : text.includes(needle);
-  }) as HTMLElement | undefined;
-  if (!target) return false;
-  target.scrollIntoView({ block: "center", inline: "center" });
-  await new Promise((resolve) =>
-    requestAnimationFrame(() => requestAnimationFrame(resolve))
-  );
-  const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
-    | HTMLElement
-    | null) ?? target;
-  if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
-  clickTarget.setAttribute(attr, token);
-  return true;
-};
-
-// Remove every element carrying `attr=token`, descending through shadow roots.
-async function clearNoteButtonMark(
-  page: Page,
-  token: string,
-): Promise<void> {
-  await page.evaluate((targetToken, targetAttr) => {
-    function collect(root: Document | ShadowRoot, result: Element[]): void {
-      for (const element of root.querySelectorAll("*")) {
-        if (element.getAttribute(targetAttr) === targetToken) {
-          result.push(element);
-        }
-        if (element.shadowRoot) collect(element.shadowRoot, result);
-      }
-    }
-    const matches: Element[] = [];
-    collect(document, matches);
-    for (const element of matches) element.removeAttribute(targetAttr);
-  }, { args: [token, NOTE_BUTTON_CLICK_TARGET_ATTR] }).catch(() => {});
-}
-
-// Wait for a matching button to be present and interactive, then dispatch a
-// single trusted click on it. Throws if no matching button becomes clickable.
-async function settleAndClickNoteButton(
-  page: Page,
-  selector: string,
-  match: "includes" | "exact" | "title",
-  needle: string,
-): Promise<void> {
-  const markTarget = async (token: string) => {
-    await waitForCondition(page, markNoteButton, {
-      args: [selector, match, needle, token, NOTE_BUTTON_CLICK_TARGET_ATTR],
-    });
-  };
-
-  let token = `cfc-note-button-${crypto.randomUUID()}`;
-  try {
-    await markTarget(token);
-  } catch (cause) {
-    throw new Error(
-      `Unable to find a ${
-        match === "title" ? "button titled" : "button matching"
-      } "${needle}" to click`,
-      { cause },
-    );
-  }
-
-  let lastCause: unknown;
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      const clickTarget = await page.waitForSelector(
-        `[${NOTE_BUTTON_CLICK_TARGET_ATTR}="${token}"]`,
-        { strategy: "pierce" },
-      );
-      await clickTarget.click();
-      return;
-    } catch (cause) {
-      lastCause = cause;
-      const retryable = cause instanceof Error &&
-        cause.message.includes("stable box model");
-      if (!retryable || attempt === 2) break;
-    } finally {
-      await clearNoteButtonMark(page, token);
-    }
-
-    // A root-pattern hot swap can replace the marked button after discovery
-    // but before Astral resolves its box. Re-mark the current rendered node and
-    // retry the coordinate click; only the successful attempt dispatches.
-    token = `cfc-note-button-${crypto.randomUUID()}`;
-    await markTarget(token);
-  }
-
-  throw new Error(`Unable to click the stable "${needle}" button`, {
-    cause: lastCause,
-  });
-}
-
-// The click helpers resolve `true` once the single click has landed (they throw
-// otherwise), so the call sites that assert the click succeeded keep reading.
-async function clickButtonWithText(
-  page: Page,
-  searchText: string,
-): Promise<boolean> {
-  await settleAndClickNoteButton(
-    page,
-    "cf-button, button, a",
-    "includes",
-    searchText,
-  );
-  return true;
-}
-
-async function clickButtonWithExactText(
-  page: Page,
-  searchText: string,
-): Promise<boolean> {
-  await settleAndClickNoteButton(
-    page,
-    "cf-button, button, a",
-    "exact",
-    searchText,
-  );
-  return true;
-}
-
-async function clickButtonWithTitle(
-  page: Page,
-  title: string,
-): Promise<boolean> {
-  await settleAndClickNoteButton(page, "cf-button, button", "title", title);
-  return true;
-}
-
-async function findButtonWithText(
-  page: Page,
-  searchText: string,
-): Promise<any | null> {
-  try {
-    // Search cf-button, button, and a elements with piercing selector
-    const buttons = await page.$$("cf-button, button, a", {
-      strategy: "pierce",
-    });
-    for (const button of buttons) {
-      const text = await button.innerText();
-      if (text?.trim().includes(searchText)) {
-        return button;
-      }
-    }
-    return null;
-  } catch (_) {
-    return null;
-  }
 }
 
 async function collectNotebookRenderState(page: Page): Promise<{

--- a/packages/patterns/integration/note-button-helpers.ts
+++ b/packages/patterns/integration/note-button-helpers.ts
@@ -1,0 +1,178 @@
+import {
+  Page,
+  type ProbeApi,
+  waitForCondition,
+} from "@commonfabric/integration";
+
+// Find-and-click-a-button-by-text helpers shared by the default-app
+// integration tests. A click predicate stamps the button it resolved with a
+// marker attribute, so the test can then resolve that exact element and
+// dispatch a single trusted click on it. Mirrors the CLICK_TARGET_ATTR flow of
+// clickCfButton in cfc-browser-helpers.ts.
+const NOTE_BUTTON_CLICK_TARGET_ATTR = "data-cfc-note-button-target";
+
+// Serialized into the page by waitForCondition: find the first rendered
+// button/link whose text or title matches, scroll it into view, and stamp its
+// inner click target with `token`. "Rendered" means laid out and not
+// display:none/visibility:hidden — the same elements the innerText scan the
+// poll used could see — and is viewport-independent, so a match below the fold
+// is scrolled in rather than skipped. Returns false until a match exists, so
+// the wait re-checks on the next DOM mutation instead of the caller retrying a
+// bare find-and-click loop. Self-contained — it closes over nothing in this
+// module — so it can be serialized and run in the page.
+const markNoteButton = async (
+  probe: ProbeApi,
+  selector: string,
+  match: "includes" | "exact" | "title",
+  needle: string,
+  token: string,
+  attr: string,
+): Promise<boolean> => {
+  const target = probe.collect(selector).find((element) => {
+    if (!probe.isRendered(element)) return false;
+    if (match === "title") return element.getAttribute("title") === needle;
+    const text = (element.textContent ?? "").trim();
+    return match === "exact" ? text === needle : text.includes(needle);
+  }) as HTMLElement | undefined;
+  if (!target) return false;
+  target.scrollIntoView({ block: "center", inline: "center" });
+  await new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  );
+  const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
+    | HTMLElement
+    | null) ?? target;
+  if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
+  clickTarget.setAttribute(attr, token);
+  return true;
+};
+
+// Remove every element carrying `attr=token`, descending through shadow roots.
+async function clearNoteButtonMark(
+  page: Page,
+  token: string,
+): Promise<void> {
+  await page.evaluate((targetToken, targetAttr) => {
+    function collect(root: Document | ShadowRoot, result: Element[]): void {
+      for (const element of root.querySelectorAll("*")) {
+        if (element.getAttribute(targetAttr) === targetToken) {
+          result.push(element);
+        }
+        if (element.shadowRoot) collect(element.shadowRoot, result);
+      }
+    }
+    const matches: Element[] = [];
+    collect(document, matches);
+    for (const element of matches) element.removeAttribute(targetAttr);
+  }, { args: [token, NOTE_BUTTON_CLICK_TARGET_ATTR] }).catch(() => {});
+}
+
+// Wait for a matching button to be present and interactive, then dispatch a
+// single trusted click on it. Throws if no matching button becomes clickable.
+async function settleAndClickNoteButton(
+  page: Page,
+  selector: string,
+  match: "includes" | "exact" | "title",
+  needle: string,
+): Promise<void> {
+  const markTarget = async (token: string) => {
+    await waitForCondition(page, markNoteButton, {
+      args: [selector, match, needle, token, NOTE_BUTTON_CLICK_TARGET_ATTR],
+    });
+  };
+
+  let token = `cfc-note-button-${crypto.randomUUID()}`;
+  try {
+    await markTarget(token);
+  } catch (cause) {
+    throw new Error(
+      `Unable to find a ${
+        match === "title" ? "button titled" : "button matching"
+      } "${needle}" to click`,
+      { cause },
+    );
+  }
+
+  let lastCause: unknown;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const clickTarget = await page.waitForSelector(
+        `[${NOTE_BUTTON_CLICK_TARGET_ATTR}="${token}"]`,
+        { strategy: "pierce" },
+      );
+      await clickTarget.click();
+      return;
+    } catch (cause) {
+      lastCause = cause;
+      const retryable = cause instanceof Error &&
+        cause.message.includes("stable box model");
+      if (!retryable || attempt === 2) break;
+    } finally {
+      await clearNoteButtonMark(page, token);
+    }
+
+    // A root-pattern hot swap can replace the marked button after discovery
+    // but before Astral resolves its box. Re-mark the current rendered node and
+    // retry the coordinate click; only the successful attempt dispatches.
+    token = `cfc-note-button-${crypto.randomUUID()}`;
+    await markTarget(token);
+  }
+
+  throw new Error(`Unable to click the stable "${needle}" button`, {
+    cause: lastCause,
+  });
+}
+
+// The click helpers resolve `true` once the single click has landed (they throw
+// otherwise), so the call sites that assert the click succeeded keep reading.
+export async function clickButtonWithText(
+  page: Page,
+  searchText: string,
+): Promise<boolean> {
+  await settleAndClickNoteButton(
+    page,
+    "cf-button, button, a",
+    "includes",
+    searchText,
+  );
+  return true;
+}
+
+export async function clickButtonWithExactText(
+  page: Page,
+  searchText: string,
+): Promise<boolean> {
+  await settleAndClickNoteButton(
+    page,
+    "cf-button, button, a",
+    "exact",
+    searchText,
+  );
+  return true;
+}
+
+export async function clickButtonWithTitle(
+  page: Page,
+  title: string,
+): Promise<boolean> {
+  await settleAndClickNoteButton(page, "cf-button, button", "title", title);
+  return true;
+}
+
+export async function findButtonWithText(
+  page: Page,
+  searchText: string,
+): Promise<any | null> {
+  try {
+    const buttons = await page.$$("cf-button, button, a", {
+      strategy: "pierce",
+    });
+    for (const button of buttons) {
+      const text = await button.innerText();
+      if (text?.trim().includes(searchText)) return button;
+    }
+    return null;
+  } catch (_) {
+    return null;
+  }
+}

--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -16,6 +16,12 @@ import {
   waitForRuntimeIdle,
   waitForRuntimeSynced,
 } from "../cfc-browser-helpers.ts";
+import {
+  clickButtonWithExactText,
+  clickButtonWithText,
+  clickButtonWithTitle,
+  findButtonWithText,
+} from "../note-button-helpers.ts";
 import { resolveSpaceDid } from "@commonfabric/lib-shell";
 
 const { FRONTEND_URL } = env;
@@ -415,177 +421,6 @@ const notebookReloadRendered = async (
   }).length;
   return renderedNoteChips === expectedCount;
 };
-
-// Marker attribute a click predicate stamps on the button it resolved, so the
-// test can then resolve that exact element and dispatch a single trusted click
-// on it. Mirrors the CLICK_TARGET_ATTR flow of clickCfButton in
-// cfc-browser-helpers.ts.
-const NOTE_BUTTON_CLICK_TARGET_ATTR = "data-cfc-note-button-target";
-
-// Serialized into the page by waitForCondition: find the first rendered
-// button/link whose text or title matches, scroll it into view, and stamp its
-// inner click target with `token`. "Rendered" means laid out and not
-// display:none/visibility:hidden — the same elements the innerText scan the
-// poll used could see — and is viewport-independent, so a match below the fold
-// is scrolled in rather than skipped. Returns false until a match exists, so
-// the wait re-checks on the next DOM mutation instead of the caller retrying a
-// bare find-and-click loop.
-const markNoteButton = async (
-  probe: ProbeApi,
-  selector: string,
-  match: "includes" | "exact" | "title",
-  needle: string,
-  token: string,
-  attr: string,
-): Promise<boolean> => {
-  const target = probe.collect(selector).find((element) => {
-    if (!probe.isRendered(element)) return false;
-    if (match === "title") return element.getAttribute("title") === needle;
-    const text = (element.textContent ?? "").trim();
-    return match === "exact" ? text === needle : text.includes(needle);
-  }) as HTMLElement | undefined;
-  if (!target) return false;
-  target.scrollIntoView({ block: "center", inline: "center" });
-  await new Promise((resolve) =>
-    requestAnimationFrame(() => requestAnimationFrame(resolve))
-  );
-  const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
-    | HTMLElement
-    | null) ?? target;
-  if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
-  clickTarget.setAttribute(attr, token);
-  return true;
-};
-
-// Remove every element carrying `attr=token`, descending through shadow roots.
-async function clearNoteButtonMark(
-  page: Page,
-  token: string,
-): Promise<void> {
-  await page.evaluate((targetToken, targetAttr) => {
-    function collect(root: Document | ShadowRoot, result: Element[]): void {
-      for (const element of root.querySelectorAll("*")) {
-        if (element.getAttribute(targetAttr) === targetToken) {
-          result.push(element);
-        }
-        if (element.shadowRoot) collect(element.shadowRoot, result);
-      }
-    }
-    const matches: Element[] = [];
-    collect(document, matches);
-    for (const element of matches) element.removeAttribute(targetAttr);
-  }, { args: [token, NOTE_BUTTON_CLICK_TARGET_ATTR] }).catch(() => {});
-}
-
-// Wait for a matching button to be present and interactive, then dispatch a
-// single trusted click on it. Throws if no matching button becomes clickable.
-async function settleAndClickNoteButton(
-  page: Page,
-  selector: string,
-  match: "includes" | "exact" | "title",
-  needle: string,
-): Promise<void> {
-  const markTarget = async (token: string) => {
-    await waitForCondition(page, markNoteButton, {
-      args: [selector, match, needle, token, NOTE_BUTTON_CLICK_TARGET_ATTR],
-    });
-  };
-
-  let token = `cfc-note-button-${crypto.randomUUID()}`;
-  try {
-    await markTarget(token);
-  } catch (cause) {
-    throw new Error(
-      `Unable to find a ${
-        match === "title" ? "button titled" : "button matching"
-      } "${needle}" to click`,
-      { cause },
-    );
-  }
-
-  let lastCause: unknown;
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      const clickTarget = await page.waitForSelector(
-        `[${NOTE_BUTTON_CLICK_TARGET_ATTR}="${token}"]`,
-        { strategy: "pierce" },
-      );
-      await clickTarget.click();
-      return;
-    } catch (cause) {
-      lastCause = cause;
-      const retryable = cause instanceof Error &&
-        cause.message.includes("stable box model");
-      if (!retryable || attempt === 2) break;
-    } finally {
-      await clearNoteButtonMark(page, token);
-    }
-
-    // A root-pattern hot swap can replace the marked button after discovery
-    // but before Astral resolves its box. Re-mark the current rendered node and
-    // retry the coordinate click; only the successful attempt dispatches.
-    token = `cfc-note-button-${crypto.randomUUID()}`;
-    await markTarget(token);
-  }
-
-  throw new Error(`Unable to click the stable "${needle}" button`, {
-    cause: lastCause,
-  });
-}
-
-// The click helpers resolve `true` once the single click has landed (they throw
-// otherwise), so the call sites that assert the click succeeded keep reading.
-async function clickButtonWithText(
-  page: Page,
-  searchText: string,
-): Promise<boolean> {
-  await settleAndClickNoteButton(
-    page,
-    "cf-button, button, a",
-    "includes",
-    searchText,
-  );
-  return true;
-}
-
-async function clickButtonWithExactText(
-  page: Page,
-  searchText: string,
-): Promise<boolean> {
-  await settleAndClickNoteButton(
-    page,
-    "cf-button, button, a",
-    "exact",
-    searchText,
-  );
-  return true;
-}
-
-async function clickButtonWithTitle(
-  page: Page,
-  title: string,
-): Promise<boolean> {
-  await settleAndClickNoteButton(page, "cf-button, button", "title", title);
-  return true;
-}
-
-async function findButtonWithText(
-  page: Page,
-  searchText: string,
-): Promise<any | null> {
-  try {
-    const buttons = await page.$$("cf-button, button, a", {
-      strategy: "pierce",
-    });
-    for (const button of buttons) {
-      const text = await button.innerText();
-      if (text?.trim().includes(searchText)) return button;
-    }
-    return null;
-  } catch (_) {
-    return null;
-  }
-}
 
 async function collectNotebookRenderState(page: Page): Promise<{
   isNotebook: boolean;


### PR DESCRIPTION
…wo default-app integration tests

The default-app integration tests find and click a button by its text through a small family of helpers: a marker attribute, an in-page predicate that stamps the resolved control (markNoteButton), a routine that clears those marks, the loop that waits for a match and dispatches one trusted click (settleAndClickNoteButton), and the three by-text and by-title entry points the tests actually call. default-app.test.ts and reload/default-app-notebook.test.ts each carried a byte-identical copy of that whole family, plus a findButtonWithText finder that differed only in comment and brace style.

Move the family into a new note-button-helpers.ts beside the existing cfc-browser-helpers.ts. Only the four call-site helpers are exported (clickButtonWithText, clickButtonWithExactText, clickButtonWithTitle, findButtonWithText); the marker attribute, the predicate, the clear routine, and the click loop stay module-private. Both test files now import from it instead of defining their own copies.

markNoteButton is serialized into the page by waitForCondition through its source text, so it must reference nothing from module scope. Its comment now states that constraint, matching the note the sibling cfc-browser-helpers.ts already carries above its own serialized predicates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shared the note-button click helpers across the two default-app integration tests by moving them into a single module. This removes duplicate code and keeps click behavior consistent.

- **Refactors**
  - Added `packages/patterns/integration/note-button-helpers.ts` with shared helpers.
  - Exported `clickButtonWithText`, `clickButtonWithExactText`, `clickButtonWithTitle`, `findButtonWithText`; kept internal marker/predicate/clear/click logic private.
  - Updated `default-app.test.ts` and `reload/default-app-notebook.test.ts` to import the shared helpers.
  - Noted that `markNoteButton` is self-contained for serialization via `waitForCondition`.

<sup>Written for commit ea4f8b0f2bb2c6faab17edb33408a8da04badbfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

