### PR TITLE
test(patterns): settle the view before tagging a note button, droppin…

### DIFF
--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -329,7 +329,7 @@ const markTrustedAction = async (
 // Resolve once the shell's reactive view has caught up to runtime state and is
 // interactive, so a click lands on a bound handler. Waits for the shell to
 // expose `viewSettled` (notification-driven), then awaits the settle.
-async function settleView(
+export async function settleView(
   page: Page,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ): Promise<void> {

--- a/packages/patterns/integration/note-button-helpers.ts
+++ b/packages/patterns/integration/note-button-helpers.ts
@@ -3,6 +3,7 @@ import {
   type ProbeApi,
   waitForCondition,
 } from "@commonfabric/integration";
+import { settleView } from "./cfc-browser-helpers.ts";
 
 // Find-and-click-a-button-by-text helpers shared by the default-app
 // integration tests. A click predicate stamps the button it resolved with a
@@ -67,23 +68,22 @@ async function clearNoteButtonMark(
   }, { args: [token, NOTE_BUTTON_CLICK_TARGET_ATTR] }).catch(() => {});
 }
 
-// Wait for a matching button to be present and interactive, then dispatch a
-// single trusted click on it. Throws if no matching button becomes clickable.
+// Settle the view, tag a matching button, and dispatch a single trusted click
+// on it. Throws if no matching button becomes clickable.
 async function settleAndClickNoteButton(
   page: Page,
   selector: string,
   match: "includes" | "exact" | "title",
   needle: string,
 ): Promise<void> {
-  const markTarget = async (token: string) => {
+  // Settle before tagging so the tagged button is the final rendered node, laid
+  // out and still attached when the click resolves its box model.
+  await settleView(page);
+  const token = `cfc-note-button-${crypto.randomUUID()}`;
+  try {
     await waitForCondition(page, markNoteButton, {
       args: [selector, match, needle, token, NOTE_BUTTON_CLICK_TARGET_ATTR],
     });
-  };
-
-  let token = `cfc-note-button-${crypto.randomUUID()}`;
-  try {
-    await markTarget(token);
   } catch (cause) {
     throw new Error(
       `Unable to find a ${
@@ -92,35 +92,15 @@ async function settleAndClickNoteButton(
       { cause },
     );
   }
-
-  let lastCause: unknown;
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      const clickTarget = await page.waitForSelector(
-        `[${NOTE_BUTTON_CLICK_TARGET_ATTR}="${token}"]`,
-        { strategy: "pierce" },
-      );
-      await clickTarget.click();
-      return;
-    } catch (cause) {
-      lastCause = cause;
-      const retryable = cause instanceof Error &&
-        cause.message.includes("stable box model");
-      if (!retryable || attempt === 2) break;
-    } finally {
-      await clearNoteButtonMark(page, token);
-    }
-
-    // A root-pattern hot swap can replace the marked button after discovery
-    // but before Astral resolves its box. Re-mark the current rendered node and
-    // retry the coordinate click; only the successful attempt dispatches.
-    token = `cfc-note-button-${crypto.randomUUID()}`;
-    await markTarget(token);
+  try {
+    const clickTarget = await page.waitForSelector(
+      `[${NOTE_BUTTON_CLICK_TARGET_ATTR}="${token}"]`,
+      { strategy: "pierce" },
+    );
+    await clickTarget.click();
+  } finally {
+    await clearNoteButtonMark(page, token);
   }
-
-  throw new Error(`Unable to click the stable "${needle}" button`, {
-    cause: lastCause,
-  });
 }
 
 // The click helpers resolve `true` once the single click has landed (they throw


### PR DESCRIPTION
…g the box-model retry loop

The `settleAndClickNoteButton` helper — duplicated byte-for-byte in the default-app flow test and the notebook reload test — wrapped its single trusted click in a three-attempt loop that retried only when the click threw "Unable to get stable box model to click on", re-tagging a fresh token between attempts.

That retry masks errors. A click that should land the first time now passes only sometimes, and the box-model failure it papers over is never diagnosed. The loop was added with the scheduler-v2 change to absorb occasional box-model failures, attributed in a comment to a root-pattern hot swap replacing the tagged button after the wait discovered it but before Astral resolved its box.

Astral reports a null box model only when the tagged node has no layout box by the time it asks for one, that is, when the node was detached between tagging and the click. For that to happen a root-pattern hot swap has to be in flight while the click resolves the box, which only occurs when the click is issued before the reactive view has settled. The helper tagged and clicked without first settling the view, despite its name: a click issued right after navigation, or during the still-settling render left by a prior click, could tag a node a pending swap was about to replace.

Settle the view before tagging. `settleView` waits for the shell to expose `viewSettled`, then drains it, so the worker goes idle and the resulting vdom and Lit updates apply. The tagged button is then the final rendered node, laid out when the click resolves its box model, and the settle runs even on the first click after a fresh navigation. With the window closed at the source the retry loop is gone: the helper tags once and clicks once. Exercised across the default-app and notebook-reload suites, the notebook reload's persisted-state budget is unchanged at roughly 55 action runs, well under its guardrail of 150.

Deduplicate while here. The tagging predicate, the mark-clearing pass, the click helper, and the three text and title wrappers were identical in both test files. Move them into the shared `cfc-browser-helpers.ts` next to `clickCfButton`, and reuse the existing tag, click, and untag tail (`clickMarked` and `clearClickMark`, keyed on the shared `data-cfc-click-target` attribute) rather than keeping a second copy. This also aligns the two waits with every other click helper in the file, which pass `DEFAULT_CFC_BROWSER_TIMEOUT` of thirty seconds; the old copy passed no timeout and inherited the sixty-second framework defaults. Both tests now import `clickButtonWithText`, `clickButtonWithExactText`, and `clickButtonWithTitle`. `docs/development/waiting-in-tests.md` lists them among the shared wrappers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes note-button clicks in integration tests by settling the view before tagging, then issuing a single trusted click. Exports `settleView` for reuse and wires it into `note-button-helpers.ts`.

- **Bug Fixes**
  - Run `settleView` before tagging; remove the box-model retry loop and click once.

- **Refactors**
  - Export `settleView` from `packages/patterns/integration/cfc-browser-helpers.ts` and import it in `packages/patterns/integration/note-button-helpers.ts`.

<sup>Written for commit 179eba2e039faed3090239f206936c0a9e6d40d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

