### PR TITLE
fix(runner): surface sync failures that resolve as silent absence

### DIFF
--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1104,6 +1104,11 @@ export class StorageManager implements IStorageManager {
     waiters: Set<(failure: unknown) => void>;
   }>();
   #nextPendingLoadGeneration = 1;
+  // Sync failures already logged, keyed by (space, error identity). A denied
+  // space repeats the identical failure for every doc pulled from it; one line
+  // per distinct failure keeps the surfacing readable. Bounded: at the cap the
+  // set resets, trading a repeated line for an unbounded set.
+  #loggedSyncFailures = new Set<string>();
 
   private registerPendingLoad(
     address: { space: MemorySpace; scope: CellScope; id: URI },
@@ -1127,6 +1132,32 @@ export class StorageManager implements IStorageManager {
       for (const waiter of entry.waiters) waiter(entry.failure);
       entry.waiters.clear();
     };
+  }
+
+  /** Log a sync failure that would otherwise resolve silently, once per
+   * distinct (space, error) pair. The error name and message are the wire
+   * server's own words — for an ACL denial that includes the principal and
+   * space (`Principal <did> lacks READ on space <did>`), which is exactly
+   * what a caller staring at an unexplained `undefined` needs. */
+  private logSyncLoadFailure(
+    space: MemorySpace,
+    id: URI,
+    failure: unknown,
+  ): void {
+    // Pull errors arrive as plain result objects (IConnectionError et al.),
+    // not Error instances — read the fields structurally.
+    const named = failure as { name?: unknown; message?: unknown } | undefined;
+    const name = typeof named?.name === "string" ? named.name : "Error";
+    const message = typeof named?.message === "string"
+      ? named.message
+      : String(failure);
+    const key = `${space}|${name}|${message}`;
+    if (this.#loggedSyncFailures.has(key)) return;
+    if (this.#loggedSyncFailures.size >= 256) this.#loggedSyncFailures.clear();
+    this.#loggedSyncFailures.add(key);
+    logger.error("sync-load-failure", () => [
+      `sync completed without data for ${id} in ${space}: ${name}: ${message}`,
+    ]);
   }
 
   pendingLoadAddresses(): readonly {
@@ -1220,6 +1251,14 @@ export class StorageManager implements IStorageManager {
         }).get?.(id, scope),
       );
       loadFailure ??= schemaFailure;
+      // A pull that "succeeds" while carrying an error (an ACL denial, a
+      // transport failure) otherwise resolves this sync() normally and the
+      // caller reads the doc as absent — deny, error, and absent all collapse
+      // into the same silent undefined. Surface the failure; the pending-load
+      // ledger below still carries it to scheduler waiters.
+      if (loadFailure !== undefined) {
+        this.logSyncLoadFailure(space, id, loadFailure);
+      }
       return cell;
     } catch (error) {
       loadFailure = error;
@@ -1259,6 +1298,11 @@ export class StorageManager implements IStorageManager {
     }
     return work.then(
       (result) => {
+        // Same silent-collapse hazard as syncCell: a link-target pull that
+        // resolves while carrying an error reads as an absent target.
+        if (result.error !== undefined) {
+          this.logSyncLoadFailure(address.space, address.id, result.error);
+        }
         releaseLoad(result.error);
         return result;
       },

--- a/packages/runner/test/sync-load-failure-surfacing.test.ts
+++ b/packages/runner/test/sync-load-failure-surfacing.test.ts
@@ -1,0 +1,237 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import { entityIdFrom } from "../src/create-ref.ts";
+import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
+
+// The silent-collapse pin for sync-layer failures.
+//
+// A denied read never delivers data: the memory client throws the server's
+// typed AuthorizationError from mount, the watch-refresh machinery wraps it
+// into the pull result's `error`, and `sync()` still RESOLVES — the caller
+// reads the doc as absent. Deny, transport failure, and genuine absence all
+// collapse into the same silent `undefined` (the 2026-07-21 estuary
+// investigation pinned this at the wire). These tests pin the surfacing:
+// sync() keeps resolving (callers depend on that), but the failure is logged
+// under storage.v2/"sync-load-failure" — once per distinct (space, error),
+// carrying the server's own principal-naming message.
+
+const signer = await Identity.fromPassphrase("sync load failure surfacing");
+
+const denialFor = (space: string): Error =>
+  Object.assign(
+    new Error(`Principal ${signer.did()} lacks READ on space ${space}`),
+    { name: "AuthorizationError" },
+  );
+
+/** Denies every mount the way a real enforce-mode server does: the memory
+ * client's `request()` throws the response's typed error from `mount`. */
+class DenyingFactory implements SessionFactory {
+  create(spaceId: string): never {
+    throw denialFor(spaceId);
+  }
+}
+
+class DeniedStorageManager extends StorageManager {
+  static make(as: Identity) {
+    return new DeniedStorageManager(
+      { as, memoryHost: new URL("memory://") } as Options,
+    );
+  }
+  private constructor(options: Options) {
+    super(options, new DenyingFactory());
+  }
+  override registerSpaceHost(): boolean {
+    return false;
+  }
+}
+
+const FID_A = `fid1:${"A".repeat(43)}`;
+const FID_B = `fid1:${"B".repeat(43)}`;
+
+const surfacedErrorCount = (): number =>
+  (getLoggerCountsBreakdown() as Record<
+    string,
+    Record<string, { error?: number }>
+  >)["storage.v2"]?.["sync-load-failure"]?.error ?? 0;
+
+describe("sync load failure surfacing", () => {
+  it("logs a denied sync once per space and still resolves", async () => {
+    const storageManager = DeniedStorageManager.make(signer);
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const space = signer.did();
+    const emitted: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      emitted.push(args.map(String).join(" "));
+      originalError(...args);
+    };
+    try {
+      const before = surfacedErrorCount();
+
+      const cell = runtime.getCellFromEntityId(
+        space,
+        entityIdFrom(FID_A),
+        [],
+        undefined,
+      );
+      // The existing contract: a failed pull does NOT reject sync().
+      await cell.sync();
+      // ...and the caller sees no data — the exact silent shape being pinned.
+      expect(cell.getRawUntyped()).toBe(undefined);
+      expect(surfacedErrorCount()).toBe(before + 1);
+      // The surfaced line carries the server's own words — the principal and
+      // the space — not a generic wrapper string.
+      expect(
+        emitted.some((line) =>
+          line.includes("sync-load-failure") &&
+          line.includes(`lacks READ on space ${space}`)
+        ),
+      ).toBe(true);
+
+      // A second doc in the same denied space repeats the identical failure:
+      // deduplicated, no second line.
+      const sibling = runtime.getCellFromEntityId(
+        space,
+        entityIdFrom(FID_B),
+        [],
+        undefined,
+      );
+      await sibling.sync();
+      expect(surfacedErrorCount()).toBe(before + 1);
+    } finally {
+      console.error = originalError;
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("surfaces a denied link-target pull", async () => {
+    // The second seam: a doc's VALUE links into a space the reader cannot
+    // mount (the cross-space shape from the estuary incident). The data-URI
+    // cell path walks embedded links through the same link-target pull
+    // tracker as pulled documents, so it drives that seam without a server.
+    const storageManager = DeniedStorageManager.make(signer);
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const linkedSpace = (await Identity.fromPassphrase("linked denied space"))
+      .did();
+    try {
+      const before = surfacedErrorCount();
+      const sigilLink = {
+        "/": {
+          [LINK_V1_TAG]: {
+            id: `of:${FID_A}`,
+            path: [],
+            space: linkedSpace,
+          },
+        },
+      };
+      const dataURI = dataUriFromValueWithResolvedLinks({ ref: sigilLink });
+      const cell = runtime.getCellFromEntityId(
+        signer.did(),
+        dataURI,
+        [],
+        undefined,
+      );
+      // The data value itself is local; only the linked space is pulled —
+      // and denied. sync() still resolves.
+      await cell.sync();
+      expect(surfacedErrorCount()).toBe(before + 1);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("resets the dedup set at the cap rather than growing it", async () => {
+    const storageManager = DeniedStorageManager.make(signer);
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    // The factory rejects before any real use of the space, so fabricated
+    // space ids suffice — each yields a distinct denial message, hence a
+    // distinct dedup key.
+    const fakeSpace = (i: number) => `did:key:zFakeSpace${i}` as MemorySpace;
+    try {
+      const before = surfacedErrorCount();
+      for (let i = 0; i < 256; i++) {
+        await runtime.getCellFromEntityId(
+          fakeSpace(i),
+          entityIdFrom(FID_A),
+          [],
+          undefined,
+        ).sync();
+      }
+      expect(surfacedErrorCount()).toBe(before + 256);
+      // The 257th distinct failure resets the full set and still logs...
+      await runtime.getCellFromEntityId(
+        fakeSpace(256),
+        entityIdFrom(FID_A),
+        [],
+        undefined,
+      ).sync();
+      expect(surfacedErrorCount()).toBe(before + 257);
+      // ...so an early repeat logs again — the accepted trade for a bound.
+      await runtime.getCellFromEntityId(
+        fakeSpace(0),
+        entityIdFrom(FID_B),
+        [],
+        undefined,
+      ).sync();
+      expect(surfacedErrorCount()).toBe(before + 258);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("logs distinct failures for distinct spaces", async () => {
+    const storageManager = DeniedStorageManager.make(signer);
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const otherSpace = (await Identity.fromPassphrase("another space")).did();
+    try {
+      const before = surfacedErrorCount();
+
+      const mine = runtime.getCellFromEntityId(
+        signer.did(),
+        entityIdFrom(FID_A),
+        [],
+        undefined,
+      );
+      await mine.sync();
+      const foreign = runtime.getCellFromEntityId(
+        otherSpace,
+        entityIdFrom(FID_A),
+        [],
+        undefined,
+      );
+      await foreign.sync();
+
+      // One line per space: the denial message names the space, so the
+      // dedup key differs even though the error name matches.
+      expect(surfacedErrorCount()).toBe(before + 2);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
## Why

Yesterday's estuary investigation pinned this at the wire: a foreign CLI read of an ACL-private home gets an explicit typed response from the server —

```
AuthorizationError: Principal did:key:z6MkpT5… lacks READ on space did:key:z6Mks3qW…
```

— and the storage client drops it on the floor. The watch-refresh machinery wraps the mount throw into the pull result's `error`; `syncCell` captures that into pending-load bookkeeping (which only scheduler waiters consume) and resolves `sync()` normally. A direct caller — the CLI, a probe, an agent — reads the doc as absent. **Denied, transport-failed, and genuinely absent all collapse into the same silent `undefined`**, at every log level. This is the concrete mechanism behind the "loud sync-state" board topic (`fid1:yNXW3zia…`), and it cost real hours during the home-space bricking triage.

## What

- Log the carried failure at both seams where it currently vanishes — `syncCell` and the link-target pull tracker (`trackPendingProviderSync`) — under `storage.v2` / `sync-load-failure`, at error level (visible by default).
- **Deduplicate per (space, error identity)**: a denied space repeats the identical failure for every doc pulled from it; one line per distinct failure keeps a 39-doc walk of a denied space at one line, not 39. Bounded set (reset at 256) so pathological error diversity can't grow it unboundedly.
- Read `name`/`message` structurally: pull errors are plain result objects (`IConnectionError` et al.), not `Error` instances — `instanceof`-based extraction printed `[object Object]`.
- **No contract change**: `sync()` still resolves rather than rejects on a carried error — pinned by the new test alongside the surfacing.

## Verification

- New `packages/runner/test/sync-load-failure-surfacing.test.ts` (mock denying `SessionFactory`, per the list-shrink harness pattern): denial logs exactly once per space with the server's principal-naming text (content asserted, not just counts); second doc in the same space deduplicates; distinct spaces log distinctly; `sync()` resolves and reads undefined throughout. **Red/green verified**: both steps fail on unpatched `v2.ts`.
- Full runner suite: **997 passed (5324 steps), 0 failed** — no healthy-path test trips the new line, which doubles as the loudness-hazard check (transient reactive voids never reach this seam; only pulls that complete *carrying* an error do).
- Live probe against estuary: the exact silent case from the investigation now prints the doc, space, and the server's denial text.

## Non-goals / follow-ups (the loud-sync-state topic's larger asks)

- Typed classification for callers (absent vs denied vs transport as a programmatic result) — needs an interface decision; the denial text is in the message today because `toConnectionError` flattens the original error name.
- Inspector / pending-load API exposure so tooling like #4874's CLI diagnostics can distinguish "no raw because denied" from "no raw because absent" — composes with this change, designed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log sync failures that previously appeared as silent absence, without changing the `sync()` contract. ACL denials and transport errors are now logged once per space/error pair to make access issues visible.

- **Bug Fixes**
  - Log carried failures in `packages/runner/src/storage/v2.ts` at both seams (`syncCell` and the link-target pull tracker) under `storage.v2`/`sync-load-failure` at error level, including doc id, space, and server error name/message.
  - Deduplicate by (space, error identity) using a bounded set (256); clear on cap to avoid growth.
  - Read `name` and `message` from plain result objects instead of relying on `instanceof Error`.
  - Keep `sync()` resolve-not-reject behavior; add `packages/runner/test/sync-load-failure-surfacing.test.ts` covering per-space dedup, link-target pulls, and the dedup cap reset.

<sup>Written for commit 81684ff993e65b30bf1afe4a5b13a6f94075cda5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

