### PR TITLE
fix(piece): replace unloadable stale sourceless roots — the pin protects only a dead page

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -228,7 +228,13 @@ propagate](#how-flags-propagate).
   revision through `COMMIT_SHA`. Persisted roots are resolved without starting.
   A pre-provenance root may be back-filled only when its stored
   `{ identity, symbol }` exactly equals the build-attested current official
-  entry; stale, custom, and repository-pinned sourceless roots remain pinned.
+  entry; stale, custom, and repository-pinned sourceless roots remain pinned —
+  except a stale sourceless **home** root whose stored pattern the current
+  runtime explicitly cannot load (probe resolves `undefined`; a probe error
+  stays pinned, and `cfcEnforcementMode: "disabled"` — where the probe is
+  unsupported — stays pinned too): that root is replaced with the official
+  home.tsx, recording the displaced ref under `displacedPattern` meta (see
+  pattern-updates.md for the full exception semantics).
   URL-based creation and recreation stamp provenance; custom `RuntimeProgram`
   recreation does not. The check remains best-effort; if identity lookup or
   replacement compilation is unavailable, the subsequent root start retains

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -103,6 +103,30 @@ official entry appropriate to the space (`home.tsx` for Home,
 Neither space type nor an author-controlled source filename is provenance: a
 stale, custom, or repository-pinned sourceless root stays pinned.
 
+One exception, scoped to **home spaces** (`space === userIdentityDID`): a stale
+sourceless home root whose stored pattern the current runtime **explicitly
+cannot load** is replaced with the official `home.tsx` (the 2026-07-21 estuary
+migration bricked every pre-provenance home root, and no explicit-migration
+tool can reach a private home whose owner key lives only in a browser). The
+exception's semantics are deliberately narrow:
+
+- Replacement is authorized only when the load probe resolves `undefined` —
+  the artifact unavailable through every supported recovery path. A probe
+  **exception** is a failed check, not evidence: the updater logs and stays
+  pinned.
+- The probe asks "loadable in the **current runtime**" (in-memory artifact
+  index, live evaluated modules, then durable storage) — not "survives a cold
+  restart". A warm artifact can only cause extra pinning, never extra
+  replacement.
+- Under `cfcEnforcementMode: "disabled"` the by-identity probe is unsupported
+  (it returns `undefined` unconditionally), so the updater stays pinned there.
+- Non-home spaces always stay pinned; widening the destructive fallback needs
+  its own evidence and a tested restoration path.
+- The replaced root records the displaced `{ identity, symbol, displacedAt }`
+  under `displacedPattern` meta. This is an audit/forensic pointer — the
+  displaced program's compiled artifacts remain content-addressed in the
+  space — not (yet) an automated restoration mechanism.
+
 System patterns run this loop automatically at space open (always-update);
 published patterns will run it behind an explicit user action (§ Phasing).
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -371,6 +371,9 @@ export type MetaField =
   | "patternSource" // provenance: the source a piece tracks for updates (a
   // toolshed pattern path, or later a `cf:` fabric ref)
   | "patternRepository" // optional caller-supplied repository locator
+  | "displacedPattern" // {identity, symbol, displacedAt}: the prior pattern
+  // reference recorded when system-pattern auto-update replaces an unloadable
+  // sourceless root — the recovery pointer for a displaced custom program
   | "internal"
   | "schema"
   | "slug";

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -708,13 +708,53 @@ export class PiecesController<T = unknown> {
       // A sourceless root is eligible only when its full content identity (which
       // includes authored module paths) is exactly the official current entry.
       // This admits a known system identity, never a lookalike filename. A stale
-      // sourceless root stays pinned until an explicit migration supplies its
-      // durable provenance.
-      if (
-        storedSource === undefined &&
-        (runningRef.identity !== currentId || runningRef.symbol !== "default")
-      ) {
-        return "current";
+      // sourceless root that still LOADS stays pinned: it may be a custom
+      // program (custom recreation deliberately stamps no provenance), and
+      // rolling it forward would overwrite that choice with the system pattern.
+      //
+      // When the stored root cannot cold-load at all, the pin protects only a
+      // dead page: an obsolete system root heals, and a broken custom root
+      // degrades to a WORKING system root with its displaced identity recorded
+      // under `displacedPattern` meta for recovery. (2026-07-21: a runtime
+      // migration bricked every pre-provenance home root, and this pin kept
+      // them bricked after the update flag opened.)
+      const staleSourceless = storedSource === undefined &&
+        (runningRef.identity !== currentId || runningRef.symbol !== "default");
+      if (staleSourceless) {
+        // Home only: the fleet evidence is pre-provenance system HOME roots
+        // bricked by a runtime migration. An arbitrary space's sourceless
+        // root is more plausibly a deliberate custom program; widening the
+        // destructive fallback needs its own evidence and a tested
+        // restoration path.
+        if (space !== runtime.userIdentityDID) return "current";
+        // The probe is only meaningful where by-identity recovery is
+        // supported: under cfcEnforcementMode "disabled" it returns
+        // `undefined` unconditionally, which must not read as "dead".
+        if (runtime.cfcEnforcementMode === "disabled") return "current";
+        try {
+          const staleRoot = await runtime.patternManager.loadPatternByIdentity(
+            runningRef.identity,
+            runningRef.symbol,
+            space,
+          );
+          // Loadable in the current runtime → the pin still protects a live
+          // object. Only an explicit `undefined` — the artifact unavailable
+          // through every supported recovery path — authorizes replacement.
+          if (staleRoot !== undefined) return "current";
+        } catch (error) {
+          // A failed CHECK is not authority to replace an ambiguous root:
+          // fail closed like the enclosing function.
+          pieceUpdateLogger.warn(
+            "stale-root-probe-failed",
+            () => [
+              "checkAndUpdateDefaultPattern: stale-root load probe failed",
+              space,
+              runningRef,
+              error,
+            ],
+          );
+          return "current";
+        }
       }
 
       // 6. Equal identity is not enough to declare the root healthy: persisted
@@ -782,6 +822,17 @@ export class PiecesController<T = unknown> {
       }
       const result = await runtime.editWithRetry((tx) => {
         if (!rootStillMatches(root.withTx(tx))) return false;
+        if (staleSourceless) {
+          // The displaced ref had no provenance, so this swap is the only
+          // record of it. A replaced custom root's compiled artifacts remain
+          // content-addressed in the space; this breadcrumb is the pointer a
+          // recovery needs.
+          root.withTx(tx).setMetaRaw("displacedPattern", {
+            identity: runningRef.identity,
+            symbol: runningRef.symbol,
+            displacedAt: Date.now(),
+          });
+        }
         root.withTx(tx).setMetaRaw("patternIdentity", {
           identity: entryRef.identity,
           symbol: entryRef.symbol,

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -205,6 +205,7 @@ describe("checkAndUpdateDefaultPattern", () => {
   async function setupHome(
     experimental: Record<string, boolean>,
     clientVersion: string | undefined = BUILD_SHA,
+    extraRuntimeOptions: { cfcEnforcementMode?: "disabled" } = {},
   ) {
     versionSkews = [];
     storageManager = StorageManager.emulate({ as: signer });
@@ -214,6 +215,7 @@ describe("checkAndUpdateDefaultPattern", () => {
       clientVersion,
       experimental,
       onVersionSkew: (info) => versionSkews.push(info),
+      ...extraRuntimeOptions,
     });
     const session = await createSession({
       identity: signer,
@@ -922,6 +924,156 @@ describe("checkAndUpdateDefaultPattern", () => {
     // The home root compiles at HOME_PATTERN_URL — identity includes the entry.
     expect(idV2).toBe(await identityForSource(SOURCE_V2, {}, HOME_PATTERN_URL));
     expect(idV2).not.toBe(idV1);
+  });
+
+  // The unloadability tiebreak. A stale sourceless root is ambiguous between
+  // an obsolete system root and a deliberate custom program (custom recreation
+  // stamps no provenance), so a LOADABLE one stays pinned — the test above.
+  // One that cannot cold-load is a dead page under either reading: replace it
+  // with the official system root and record the displaced ref for recovery.
+  // (The 2026-07-21 estuary migration bricked every pre-provenance home root;
+  // the pin alone kept them bricked after the update flag opened.)
+  function shadowLoadProbe(
+    staleIdentity: string,
+    outcome: "undefined" | "reject",
+  ): () => void {
+    const pm = runtime.patternManager as unknown as {
+      loadPatternByIdentity: (
+        identity: string,
+        symbol: string,
+        space: unknown,
+      ) => Promise<unknown>;
+    };
+    const original = pm.loadPatternByIdentity.bind(runtime.patternManager);
+    // The harness compiled the stale program for real, so the probe outcome
+    // (on estuary: a runtime migration invalidated the stored source) is
+    // injected at the probe seam itself.
+    pm.loadPatternByIdentity = (identity, symbol, space) =>
+      identity !== staleIdentity
+        ? original(identity, symbol, space)
+        : outcome === "undefined"
+        ? Promise.resolve(undefined)
+        : Promise.reject(new Error("probe backend unavailable"));
+    return () => {
+      pm.loadPatternByIdentity = original;
+    };
+  }
+
+  it("replaces an unloadable stale sourceless home root", async () => {
+    await setupHome({ systemPatternAutoUpdate: true });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    const staleRef = getPatternIdentityRef(root)!;
+    expect(getPatternSource(root)).toBeUndefined();
+
+    stub.setSource(SOURCE_V2);
+    const restore = shadowLoadProbe(staleRef.identity, "undefined");
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
+    } finally {
+      restore();
+    }
+    await runtime.idle();
+
+    const after = (await manager.getDefaultPattern(false))!;
+    expect(getPatternIdentityRef(after)?.identity).toBe(
+      await identityForSource(SOURCE_V2, {}, HOME_PATTERN_URL),
+    );
+    // Provenance back-filled: the root now tracks the official URL.
+    expect(getPatternSource(after)).toBe(HOME_PATTERN_URL);
+    // The displaced ref is the only record of the replaced sourceless root.
+    const displaced = (after as unknown as {
+      getMetaRaw: (key: string) => unknown;
+    }).getMetaRaw("displacedPattern") as {
+      identity?: string;
+      symbol?: string;
+      displacedAt?: number;
+    };
+    expect(displaced?.identity).toBe(staleRef.identity);
+    expect(displaced?.symbol).toBe(staleRef.symbol);
+    expect(typeof displaced?.displacedAt).toBe("number");
+  });
+
+  it("keeps a non-home stale sourceless root pinned even when unloadable", async () => {
+    // The destructive fallback is scoped to home spaces: fleet evidence
+    // exists for pre-provenance system HOME roots; an arbitrary space's
+    // sourceless root is more plausibly a deliberate custom program.
+    await setup({ systemPatternAutoUpdate: true });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-app.tsx",
+        files: [{ name: "/custom-app.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    const staleRef = getPatternIdentityRef(root)!;
+    expect(getPatternSource(root)).toBeUndefined();
+
+    stub.setSource(SOURCE_V2);
+    const restore = shadowLoadProbe(staleRef.identity, "undefined");
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    } finally {
+      restore();
+    }
+    expect(getPatternIdentityRef(root)).toEqual(staleRef);
+    expect(getPatternSource(root)).toBeUndefined();
+  });
+
+  it("keeps the home root pinned when the load probe fails", async () => {
+    // A thrown probe is a failed CHECK, not evidence of a dead root — a
+    // transient storage/backend failure must not authorize replacing an
+    // ambiguous sourceless root. Fail closed, mutate nothing.
+    await setupHome({ systemPatternAutoUpdate: true });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    const staleRef = getPatternIdentityRef(root)!;
+
+    stub.setSource(SOURCE_V2);
+    const restore = shadowLoadProbe(staleRef.identity, "reject");
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    } finally {
+      restore();
+    }
+    expect(getPatternIdentityRef(root)).toEqual(staleRef);
+    expect(getPatternSource(root)).toBeUndefined();
+    const displaced = (root as unknown as {
+      getMetaRaw: (key: string) => unknown;
+    }).getMetaRaw("displacedPattern");
+    expect(displaced).toBeUndefined();
+  });
+
+  it("keeps the home root pinned when by-identity recovery is disabled", async () => {
+    // Under cfcEnforcementMode "disabled" the probe returns undefined
+    // unconditionally — "probe unsupported" must not read as "artifact
+    // dead". No shadow here: the real probe short-circuits.
+    await setupHome({ systemPatternAutoUpdate: true }, BUILD_SHA, {
+      cfcEnforcementMode: "disabled",
+    });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    const staleRef = getPatternIdentityRef(root)!;
+
+    stub.setSource(SOURCE_V2);
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    expect(getPatternIdentityRef(root)).toEqual(staleRef);
+    expect(getPatternSource(root)).toBeUndefined();
   });
 
   describe("recreateDefaultPattern provenance (CT-1890)", () => {


### PR DESCRIPTION
## Why (the last mile of the home-space heal)

Estuary now runs #4873's merge — and homes are still bricked. The update flag opened, but `checkAndUpdateDefaultPattern` step 5.5 pins **stale sourceless** roots: pre-provenance-era roots (every June-era home in the fleet) have `storedSource === undefined` and a stale identity, so they return `current` before the repair path runs. The pin's reason is real — a sourceless root might be a deliberate **custom program** (custom recreation stamps no provenance, by design), and rolling it forward would overwrite that choice.

## What

An **unloadability tiebreak, scoped to home spaces**: when a stale sourceless *home* root's stored pattern explicitly cannot be loaded by the current runtime (the probe resolves `undefined`), the ambiguity no longer protects a live object — replace it with the official `home.tsx` through the existing attested-fetch + CAS path, recording the displaced `{identity, symbol, displacedAt}` under new `displacedPattern` meta (registered in `MetaField`) as an audit/forensic pointer (the displaced program's compiled artifacts remain content-addressed in the space; automated restoration is deliberately out of scope).

The exception's edges, each pinned by a test (shaped by codex-sol's review — see thread):

- **Probe `undefined` ⇒ replace; probe exception ⇒ pinned** (a failed check is not authority; logs `stale-root-probe-failed`, mutates nothing).
- **`cfcEnforcementMode: "disabled"` ⇒ pinned** (the by-identity probe is unsupported there and returns `undefined` unconditionally — probe-unsupported ≠ artifact-dead).
- **Non-home spaces ⇒ always pinned** (fleet evidence exists only for home; widening needs its own evidence + a tested restoration path).
- **Loadable-in-current-runtime ⇒ pinned**, exactly as before (the existing custom-home test, untouched). The probe is deliberately *current-runtime* loadability, not cold-restart survival: a warm artifact can only cause extra pinning, never extra replacement.

Unloadable roots **with** provenance already reconciled (#4865); sourceless+unloadable+home was the gap — and it is exactly the bricked fleet.

## Docs (same-change rule)

`pattern-updates.md` defines the exception (undefined-vs-exception, current-runtime probe semantics, CFC-disabled behavior, home-only scope, `displacedPattern`'s exact promise); `EXPERIMENTAL_OPTIONS.md`'s pinning sentence carries the same exception with a pointer.

## Verification

- Home replace test (red/green vs unpatched: `current`, no replacement) + three edge pins: probe-reject → unchanged; CFC-disabled → unchanged (real probe, no shadow); non-home unloadable → unchanged.
- The custom-loadable pin test and #4865's provenance'd-unloadable reconcile test pass untouched — the two protections this change must not disturb.
- Full piece suite 20 passed (242 steps) / 0 failed; workspace typecheck, fmt, lint clean.

## Notes for review (@seefeldb)

Draft pending your take — this narrows #4865's explicit "stays pinned until an explicit migration" stance for the one cell of the matrix where the pin protects only a dead page, on the deploy reality that no explicit-migration tool can reach private homes (owner-key-in-browser; no headless path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)