### PR TITLE
test: make four assertions fail when the value under test is wrong

### DIFF
--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -131,6 +131,8 @@ describe("cf piece get (integration)", { ignore: !API_URL }, () => {
     expect(code).toBe(0);
     const json = JSON.parse(stdout.join(""));
     expect(typeof json).toBe("object");
+    expect(json).not.toBeNull();
+    expect(json.content).toBe(NOTE_CONTENT);
   });
 
   it("reports present result data that cannot project in a fresh session", async () => {

--- a/packages/piece/test/ensure-default-pattern.test.ts
+++ b/packages/piece/test/ensure-default-pattern.test.ts
@@ -110,6 +110,9 @@ describe("PiecesController.ensureDefaultPattern", () => {
     // The cell should have a reference linked
     const value = defaultPatternCell.get();
     expect(value).toBeDefined();
+    expect(
+      defaultPatternCell.asSchema<{ name?: string }>().key("name").get(),
+    ).toBe("MockDefaultPattern");
   });
 
   it("should find defaultPattern when its untyped schema view is undefined", async () => {
@@ -179,6 +182,9 @@ describe("PiecesController.ensureDefaultPattern", () => {
       const defaultPatternCell = spaceCell.key("defaultPattern");
       const value = defaultPatternCell.get();
       expect(value).toBeDefined();
+      expect(
+        defaultPatternCell.asSchema<{ name?: string }>().key("name").get(),
+      ).toBe("MockDefaultPattern");
     });
 
     it("should replace existing pattern when linking a different one", async () => {
@@ -205,6 +211,9 @@ describe("PiecesController.ensureDefaultPattern", () => {
       const defaultPatternCell = spaceCell.key("defaultPattern");
       const firstValue = defaultPatternCell.get();
       expect(firstValue).toBeDefined();
+      expect(
+        defaultPatternCell.asSchema<{ name?: string }>().key("name").get(),
+      ).toBe("MockDefaultPattern1");
       const firstJson = JSON.stringify(firstValue);
 
       // Link second pattern (replacing first)
@@ -213,6 +222,9 @@ describe("PiecesController.ensureDefaultPattern", () => {
       // Verify second pattern is now linked
       const secondValue = defaultPatternCell.get();
       expect(secondValue).toBeDefined();
+      expect(
+        defaultPatternCell.asSchema<{ name?: string }>().key("name").get(),
+      ).toBe("MockDefaultPattern2");
       const secondJson = JSON.stringify(secondValue);
 
       // The links should be different (different patterns)

--- a/packages/runner/test/pattern-breakpoint.test.ts
+++ b/packages/runner/test/pattern-breakpoint.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { patternBreakpoint } from "../src/pattern-breakpoint.ts";
+
+// patternBreakpoint stands in for `fn(argument)` when a debugger breakpoint is
+// set: it logs context, pauses at `debugger` (a no-op with no debugger
+// attached), then calls through only when the argument validated.
+describe("patternBreakpoint", () => {
+  it("calls the function with the argument when the argument is valid", () => {
+    const logs: unknown[][] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args);
+    };
+    try {
+      const seen: number[] = [];
+      const result = patternBreakpoint(
+        (value: number) => {
+          seen.push(value);
+          return value * 2;
+        },
+        true,
+        21,
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(result).toBe(42);
+      expect(seen).toEqual([21]);
+      expect(logs.length).toBe(1);
+      expect(logs[0][0]).toContain("[Breakpoint]");
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it("returns undefined without calling the function when the argument is invalid", () => {
+    const originalLog = console.log;
+    console.log = () => {};
+    try {
+      let called = false;
+      const result = patternBreakpoint(
+        () => {
+          called = true;
+          return "ran";
+        },
+        false,
+        { bad: true },
+        { type: "object" },
+        { type: "string" },
+        undefined,
+      );
+      expect(result).toBeUndefined();
+      expect(called).toBe(false);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+});

--- a/packages/runner/test/queue.test.ts
+++ b/packages/runner/test/queue.test.ts
@@ -140,4 +140,53 @@ describe("AsyncSemaphoreQueue", () => {
     // After bumping to 3, all 3 should have run concurrently
     expect(maxConcurrent).toBeGreaterThan(1);
   });
+
+  it("abortPending rejects queued items and leaves the active one running", async () => {
+    const queue = new AsyncSemaphoreQueue({ maxConcurrency: 1 });
+    const blocker = Promise.withResolvers<string>();
+    const active = queue.enqueue(() => blocker.promise);
+    const pendingA = queue.enqueue(() => Promise.resolve("a"));
+    const pendingB = queue.enqueue(() => Promise.resolve("b"));
+
+    expect(queue.stats.active).toBe(1);
+    expect(queue.stats.pending).toBe(2);
+
+    queue.abortPending();
+
+    await expect(pendingA).rejects.toThrow("Queue aborted");
+    await expect(pendingB).rejects.toThrow("Queue aborted");
+    expect(queue.stats.pending).toBe(0);
+    expect(queue.stats.failed).toBe(2);
+
+    blocker.resolve("done");
+    expect(await active).toBe("done");
+    expect(queue.stats.completed).toBe(1);
+  });
+
+  it("abortPending rejects with a caller-supplied reason", async () => {
+    const queue = new AsyncSemaphoreQueue({ maxConcurrency: 1 });
+    const blocker = Promise.withResolvers<void>();
+    queue.enqueue(() => blocker.promise);
+    const pending = queue.enqueue(() => Promise.resolve("never"));
+
+    queue.abortPending(new Error("shutting down"));
+
+    await expect(pending).rejects.toThrow("shutting down");
+    blocker.resolve();
+  });
+
+  it("rejects a job whose function throws synchronously", async () => {
+    const queue = new AsyncSemaphoreQueue({ maxConcurrency: 1 });
+    await expect(
+      queue.enqueue(() => {
+        throw new Error("sync boom");
+      }),
+    ).rejects.toThrow("sync boom");
+    expect(queue.stats.failed).toBe(1);
+    expect(queue.stats.active).toBe(0);
+
+    // The queue keeps draining after a synchronous failure.
+    expect(await queue.enqueue(() => Promise.resolve("ok"))).toBe("ok");
+    expect(queue.stats.completed).toBe(1);
+  });
 });

--- a/packages/runner/test/scheduler-diagnosis.test.ts
+++ b/packages/runner/test/scheduler-diagnosis.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  type DiagnosisRecord,
+  findDifferingWriteKeys,
+  findNonIdempotentPair,
+  makeAddressKey,
+} from "../src/scheduler/diagnosis.ts";
+import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
+
+const SPACE = "did:key:zDiagnosis" as IMemorySpaceAddress["space"];
+
+function address(id: string, path: string[]): IMemorySpaceAddress {
+  return { space: SPACE, id: id as IMemorySpaceAddress["id"], path };
+}
+
+function record(
+  reads: Record<string, FabricValue>,
+  writes: Record<string, FabricValue>,
+): DiagnosisRecord {
+  return {
+    readValues: new Map(Object.entries(reads)),
+    writeValues: new Map(Object.entries(writes)),
+    timestamp: 0,
+  };
+}
+
+describe("makeAddressKey", () => {
+  it("joins space, id, and path with slashes", () => {
+    expect(makeAddressKey(address("of:e1", ["a", "b"]))).toBe(
+      "did:key:zDiagnosis/of:e1/a/b",
+    );
+  });
+
+  it("leaves a trailing slash for an empty path", () => {
+    expect(makeAddressKey(address("of:e1", []))).toBe(
+      "did:key:zDiagnosis/of:e1/",
+    );
+  });
+});
+
+describe("findDifferingWriteKeys", () => {
+  it("flags keys present in only one map", () => {
+    const previous = new Map<string, FabricValue>([["a", 1]]);
+    const latest = new Map<string, FabricValue>([["b", 2]]);
+    expect(findDifferingWriteKeys(previous, latest).sort()).toEqual(["a", "b"]);
+  });
+
+  it("flags keys whose value changed and ignores equal values", () => {
+    const previous = new Map<string, FabricValue>([["a", 1], ["b", { x: 1 }]]);
+    const latest = new Map<string, FabricValue>([["a", 2], ["b", { x: 1 }]]);
+    expect(findDifferingWriteKeys(previous, latest)).toEqual(["a"]);
+  });
+
+  it("restricts the compared keys to the latest map when asked", () => {
+    const previous = new Map<string, FabricValue>([["a", 1], ["gone", 9]]);
+    const latest = new Map<string, FabricValue>([["a", 1], ["b", 2]]);
+    // Union counts the key that only the previous map holds; "latest" does not.
+    expect(findDifferingWriteKeys(previous, latest).sort()).toEqual([
+      "b",
+      "gone",
+    ]);
+    expect(
+      findDifferingWriteKeys(previous, latest, { keySet: "latest" }),
+    ).toEqual(["b"]);
+  });
+});
+
+describe("findNonIdempotentPair", () => {
+  it("returns undefined with fewer than two records", () => {
+    expect(findNonIdempotentPair([])).toBeUndefined();
+    expect(findNonIdempotentPair([record({ r: 1 }, { w: 1 })])).toBeUndefined();
+  });
+
+  it("finds a pair with equal reads but differing writes", () => {
+    const previous = record({ r: 1 }, { w: 1 });
+    const latest = record({ r: 1 }, { w: 2 });
+    const pair = findNonIdempotentPair([previous, latest]);
+    expect(pair).toBeDefined();
+    expect(pair!.previous).toBe(previous);
+    expect(pair!.latest).toBe(latest);
+    expect(pair!.differingWriteKeys).toEqual(["w"]);
+  });
+
+  it("returns undefined when reads differ between the runs", () => {
+    const previous = record({ r: 1 }, { w: 1 });
+    const latest = record({ r: 2 }, { w: 2 });
+    expect(findNonIdempotentPair([previous, latest])).toBeUndefined();
+  });
+
+  it("returns undefined when reads and writes both match", () => {
+    const previous = record({ r: 1 }, { w: 1 });
+    const latest = record({ r: 1 }, { w: 1 });
+    expect(findNonIdempotentPair([previous, latest])).toBeUndefined();
+  });
+});

--- a/packages/runner/test/space-cell.test.ts
+++ b/packages/runner/test/space-cell.test.ts
@@ -89,6 +89,9 @@ describe("Runtime.getSpaceCell", () => {
       const loadedDefaultPattern = spaceCell2.key("defaultPattern");
       const loadedValue = loadedDefaultPattern.get();
       expect(loadedValue).toBeDefined();
+      expect(
+        loadedDefaultPattern.asSchema<{ name?: string }>().key("name").get(),
+      ).toBe("TestDefaultPattern");
     });
 
     it("should return different space cells for different spaces", async () => {

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -3469,11 +3469,10 @@ describe("wish built-in", () => {
       const pieceData = result.key("pieceData").get()?.result;
       expect(pieceData).toBeDefined();
       expect(typeof pieceData).toBe("object");
+      expect(pieceData).not.toBeNull();
 
       // The piece should be running and have its state accessible.
-      if (typeof pieceData === "object" && pieceData !== null) {
-        expect("count" in pieceData).toBe(true);
-      }
+      expect(pieceData).toHaveProperty("count");
     });
 
     // Host-embedding contract seam 1 (docs/development/HOST_EMBEDDING.md §1):


### PR DESCRIPTION
Five assertions across four tests reported success for values that a working system would never produce, because the check they used cannot see the failure it exists to catch.

`typeof null` is "object", so `expect(typeof value).toBe("object")` holds when the value is null, and `expect(value).toBeDefined()` holds too, since only undefined fails it. A test whose only check on a value is one of those two cannot tell a real result from a null one.

The wish test read a started piece's data and checked its "count" key inside `if (typeof pieceData === "object" && pieceData !== null)`. A null skipped the branch, so the test's only assertion about the result never ran and the test passed. It now asserts the value is not null and checks the key unconditionally. With the value forced to null, the old test passed and the new one fails.

The `cf piece get` test parsed the whole-result JSON and checked only that `typeof` was "object", which both null and an empty object satisfy. It now asserts the note content the surrounding test already sets and waits for. Against a running toolshed, making `piece get` return null, and separately an empty object, each fails the test.

Three tests wrote a default pattern into a space cell, read it back, and checked only `expect(value).toBeDefined()`. `Runtime.getSpaceCell` applies a schema marking `defaultPattern` as a cell reference, so reading the key returns a cell whether or not anything was ever linked: on a fresh space the read is already defined. The runner's "should persist defaultPattern when set" rested entirely on that, so removing the write it performs left it green. The piece package reads the space cell without a schema, so `toBeDefined()` there does establish that a link exists and its target arrived, but not which piece was linked: with `linkDefaultPattern` altered to link a cell other than the one handed to it, "should link defaultPattern cell successfully" and "should succeed when linking the same pattern twice" both still passed. Each of these now reads the linked piece's name through the reference and asserts it. The replace test compared the serialized links before and after and required them to differ, which shows the link moved but not where to; it now names the expected pattern on each side.

The name is read through `asSchema<{name?:string}>().key("name")` because the space-cell schema projects `name` away, so a schema'd read returns an empty object. The neighbouring test that reads `[NAME]` goes through a cell whose mock writes that key; these mocks write a plain `name`.

Two further sites keep their existing check. The shell debug globals and the schema sanitization compatibility check keep `typeof` alone: their producers return object literals and the declared types exclude null. The unlink test's precondition keeps `toBeDefined()` alone: its claim is that the link is gone afterwards, not which pattern preceded it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened test assertions to fail on null or wrong values, and added coverage for runner helpers (async queue, pattern breakpoint, idempotency diagnosis) to prevent false greens and boost coverage.

- **Bug Fixes**
  - `packages/cli/test/piece-integration.test.ts`: assert JSON is not null and `content` equals `NOTE_CONTENT`.
  - `packages/runner/test/wish.test.ts`: assert `pieceData` is not null and has `count`.
  - `packages/runner/test/space-cell.test.ts`, `packages/piece/test/ensure-default-pattern.test.ts`: read linked pattern `name` via `.asSchema<{ name?: string }>().key("name")` and assert expected names, including replacement.

- **Tests**
  - `packages/runner/test/queue.test.ts`: cover `abortPending` (default and custom reasons) and sync-throw behavior; stats validated.
  - `packages/runner/test/pattern-breakpoint.test.ts`: calls through on valid input; returns `undefined` and does not call on invalid input.
  - `packages/runner/test/scheduler-diagnosis.test.ts`: cover `makeAddressKey`, `findDifferingWriteKeys` (union vs latest-only), and `findNonIdempotentPair`.

<sup>Written for commit 80a1611f6338e2d26b20f9c7a7d4a71d8e5e2ed5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

