### PR TITLE
test(runner): deterministic coverage for non-settling telemetry

### DIFF
--- a/packages/runner/test/scheduler-execution.test.ts
+++ b/packages/runner/test/scheduler-execution.test.ts
@@ -1,8 +1,12 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import {
+  createSettlingTracker,
+  markExecuteStart,
+  markNonSettlingEpisode,
   planEventInvalidDependencyScheduling,
   pushBoundedHistory,
+  recordExecuteEnd,
 } from "../src/scheduler/execution.ts";
 import type { Action } from "../src/scheduler/types.ts";
 
@@ -32,5 +36,80 @@ describe("scheduler execution planning", () => {
     pushBoundedHistory(history, 3, 2);
 
     expect(history).toEqual([2, 3]);
+  });
+});
+
+// The non-settling heuristic only fires once a busy window crosses wall-clock
+// thresholds (5s / 10s), so integration runs cover these branches only when a
+// CI machine happens to run slow enough — which made the coverage gate flap.
+// These tests pin the branches with explicit `now` values instead.
+describe("settling tracker", () => {
+  it("emits non-settling telemetry once the busy window crosses thresholds", () => {
+    const tracker = createSettlingTracker();
+    markExecuteStart(tracker, 0);
+
+    const update = recordExecuteEnd(tracker, 6_000);
+
+    expect(update.nonSettlingTelemetry).toEqual({
+      busyTime: 6_000,
+      windowDuration: 6_000,
+      busyRatio: 1,
+    });
+    expect(tracker.nonSettlingDetected).toBe(true);
+    expect(tracker.isExecuting).toBe(false);
+  });
+
+  it("reports a non-settling episode at most once", () => {
+    const tracker = createSettlingTracker();
+    markExecuteStart(tracker, 0);
+    recordExecuteEnd(tracker, 6_000);
+
+    // The window restarted at 6s, so 12s keeps it past the 5s threshold with
+    // a saturated busy ratio — only the already-detected guard stays quiet.
+    markExecuteStart(tracker, 6_000);
+    const update = recordExecuteEnd(tracker, 12_000);
+
+    expect(update.nonSettlingTelemetry).toBeUndefined();
+    expect(update.diagnosisBusyTimeMs).toBe(6_000);
+  });
+
+  it("stays quiet while the window is below the detection thresholds", () => {
+    const tracker = createSettlingTracker();
+    markExecuteStart(tracker, 0);
+
+    const update = recordExecuteEnd(tracker, 100);
+
+    expect(update).toEqual({ diagnosisBusyTimeMs: 100 });
+    expect(tracker.nonSettlingDetected).toBe(false);
+  });
+
+  it("slides the window past 10s, halving accumulated busy time", () => {
+    const tracker = createSettlingTracker();
+    // Start at 1, not 0: windowStart === 0 means "unset", and a window that
+    // opens at 0 would be re-opened by the next markExecuteStart.
+    markExecuteStart(tracker, 1);
+    recordExecuteEnd(tracker, 2_001);
+
+    markExecuteStart(tracker, 10_901);
+    const update = recordExecuteEnd(tracker, 11_001);
+
+    // busyRatio 2100/11000 is under 0.3: no telemetry, but the window slides.
+    expect(update.nonSettlingTelemetry).toBeUndefined();
+    expect(tracker.windowStart).toBe(11_001);
+    expect(tracker.busyTime).toBe(1_050);
+  });
+
+  it("marks an externally observed episode, counting in-flight busy time", () => {
+    const tracker = createSettlingTracker();
+    markExecuteStart(tracker, 1_000);
+
+    const telemetry = markNonSettlingEpisode(tracker, 3_000);
+
+    expect(telemetry).toEqual({
+      busyTime: 2_000,
+      windowDuration: 2_000,
+      busyRatio: 1,
+    });
+    expect(markNonSettlingEpisode(tracker, 4_000)).toBeUndefined();
   });
 });

--- a/packages/runner/test/scheduler-settling-telemetry.test.ts
+++ b/packages/runner/test/scheduler-settling-telemetry.test.ts
@@ -1,0 +1,82 @@
+// The scheduler's non-settling telemetry (facade recordExecuteEndTelemetry)
+// sits behind a wall-clock heuristic: it fires only when a busy window
+// crosses 5s. Integration runs cover it only when a CI machine happens to run
+// slow enough, which made the runner coverage gate flap. This test drives the
+// path deterministically by backdating the private settling tracker — no
+// sleeping, no real busy-looping.
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { SettlingTracker } from "../src/scheduler/execution.ts";
+import type { RuntimeTelemetryEvent } from "../src/telemetry.ts";
+
+const signer = await Identity.fromPassphrase("settling telemetry test");
+
+// The tracker and the execute-end hook are private: backdating the tracker is
+// the only seam that reaches the telemetry branch without real wall-clock
+// busy time.
+type SchedulerInternals = {
+  settlingTracker: SettlingTracker;
+  recordExecuteEndTelemetry(): void;
+  diagnosisEnabled: boolean;
+};
+
+describe("scheduler non-settling telemetry", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  it("submits telemetry and auto-triggers diagnosis for a busy window", async () => {
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const scheduler = runtime.scheduler as unknown as SchedulerInternals;
+      const markers: { busyTime: number; windowDuration: number }[] = [];
+      const listener = (event: Event) => {
+        const { marker } = (event as RuntimeTelemetryEvent).detail;
+        if (marker.type === "scheduler.non-settling") markers.push(marker);
+      };
+      runtime.telemetry.addEventListener("telemetry", listener);
+      try {
+        runtime.scheduler.setAutoTriggerDiagnosis(true);
+        // Backdate the tracker to a window that is unambiguously busy: 8s of
+        // window with 4s busy stays over every threshold (5s window, 1s busy,
+        // 0.3 ratio) no matter how much real time the test itself takes.
+        const now = performance.now();
+        scheduler.settlingTracker.windowStart = now - 8_000;
+        scheduler.settlingTracker.busyTime = 4_000;
+        scheduler.settlingTracker.lastExecuteStart = now;
+        scheduler.settlingTracker.isExecuting = true;
+        expect(runtime.scheduler.isNonSettling()).toBe(false);
+
+        scheduler.recordExecuteEndTelemetry();
+
+        expect(markers.length).toBe(1);
+        expect(markers[0].busyTime).toBeGreaterThanOrEqual(4_000);
+        expect(markers[0].windowDuration).toBeGreaterThanOrEqual(8_000);
+        expect(runtime.scheduler.isNonSettling()).toBe(true);
+        // Auto-trigger switched diagnosis on.
+        expect(scheduler.diagnosisEnabled).toBe(true);
+
+        // A later execute end in the same episode stays quiet (and takes the
+        // diagnosis busy-time accounting branch instead).
+        scheduler.recordExecuteEndTelemetry();
+        expect(markers.length).toBe(1);
+      } finally {
+        runtime.telemetry.removeEventListener("telemetry", listener);
+      }
+    } finally {
+      // Also clears the diagnosis auto-stop timer startDiagnosis armed.
+      await runtime.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The scheduler's non-settling heuristic (`execution.ts` `recordExecuteEnd`, facade `recordExecuteEndTelemetry`) only executes once a busy window crosses **5 seconds of wall clock**, so its 22 lines were covered only when a CI machine happened to run slow enough. That made the `packages/runner` coverage-debt gate flap by ±22 — it flagged #4868 (+22) and has flagged main-to-main runs (+2/+6, and a −16 swing on a docs-only commit), confirmed by diffing the merged LCOV artifacts of the PR and main runs: the entire delta was `execution.ts:66-80,90` and `facade.ts:1964-1968,1973`.

This pins those branches deterministically, following #4856's approach:

- `scheduler-execution.test.ts`: pure settling-tracker tests with explicit `now` values — telemetry past thresholds, once-per-episode, quiet below thresholds, the >10s window slide, and `markNonSettlingEpisode` in-flight accounting.
- `scheduler-settling-telemetry.test.ts`: facade-level test that backdates the private settling tracker (no sleeps, no busy-looping) and asserts the `scheduler.non-settling` marker is submitted once, `isNonSettling()` flips, and auto-trigger enables diagnosis; `runtime.dispose()` clears the diagnosis timer.

## Test plan

- Coverage run of just these tests shows all 22 previously wall-clock-gated lines covered (nothing uncovered in `execution.ts:60-92` or `facade.ts:1958-1975`).
- Full runner suite: 991 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes `packages/runner` coverage by making the scheduler’s non-settling telemetry tests deterministic. Replaces wall-clock paths with explicit time/backdated tracker so the 22 lines are always covered and the coverage gate stops flapping.

- **Bug Fixes**
  - Added deterministic tests in `scheduler-execution.test.ts` using explicit `now`; covers thresholds, single-episode reporting, window slide, and `markNonSettlingEpisode`.
  - Added facade test `scheduler-settling-telemetry.test.ts` that backdates the internal tracker; asserts one `scheduler.non-settling` marker, `isNonSettling()` flips, diagnosis auto-trigger, and cleanup on dispose.

<sup>Written for commit d6e582c2f19eae8591dc129234d93642c9109b5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

