### PR TITLE
test(runner): wait on events instead of sleeping in five runner tests

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -350,6 +350,13 @@ control, and there is no single "it converged" promise to await.
   point. These are race checkpoints the surrounding interleaving depends on;
   bounded polling expresses "wait until the sabotage/replay happened" without
   coupling test control to the race window.
+- `packages/runner/test/memory-v2-stacked-commit.test.ts` — the wait for a
+  conflict rejection to reach the runner, read as the `commit-conflict` logger
+  count. `pushCommit`'s catch moves that count synchronously before it calls
+  `finalizeRejection`, and the logger exposes counts through readers only, with
+  no subscription, so nothing fires when one moves. The commit the test is
+  watching must not settle — that is the assertion — so its own promise is not
+  the signal either.
 - `packages/runner/integration/sqlite-cfc-commit-eval.test.ts` — the predicates
   read derived pattern result cells that settle only after a full server round
   trip (handler send, scheduler run, server commit, server-side re-derivation,

--- a/packages/runner/test/home-add-favorite.test.ts
+++ b/packages/runner/test/home-add-favorite.test.ts
@@ -5,6 +5,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { favoriteKey } from "@commonfabric/home-schemas";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import type { Cell } from "../src/cell.ts";
@@ -70,16 +71,25 @@ describe("home favorites handlers", () => {
     return { piece: target.getAsLink(), id };
   }
 
-  async function readFavorites(): Promise<FavoriteEntry[]> {
-    let favorites: FavoriteEntry[] = [];
-    for (let i = 0; i < 50; i++) {
-      await runtime.idle();
-      favorites =
-        (home.key("favorites").get() as FavoriteEntry[] | undefined) ?? [];
-      if (favorites.length > 0) break;
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
-    return favorites;
+  // Each handler send below runs through the scheduler, so the rewritten list
+  // arrives on a committed change the sink reports. The pattern starts
+  // `favorites` at an empty list, which the emptiness predicate matches, so each
+  // caller of readFavoritesUntilEmpty first establishes that the list holds an
+  // entry.
+  function readFavorites(): Promise<FavoriteEntry[]> {
+    return waitForCellValue<FavoriteEntry[]>(
+      runtime,
+      home.key("favorites"),
+      (favorites) => (favorites?.length ?? 0) > 0,
+    );
+  }
+
+  function readFavoritesUntilEmpty(): Promise<FavoriteEntry[]> {
+    return waitForCellValue<FavoriteEntry[]>(
+      runtime,
+      home.key("favorites"),
+      (favorites) => favorites?.length === 0,
+    );
   }
 
   it("stores the discovery tags it is given", async () => {
@@ -118,16 +128,7 @@ describe("home favorites handlers", () => {
 
     // Unfavoriting removes the membership entry by identity.
     home.key("removeFavorite").send({ piece, id });
-    for (let i = 0; i < 20; i++) {
-      await runtime.idle();
-      const favorites =
-        (home.key("favorites").get() as FavoriteEntry[] | undefined) ?? [];
-      if (favorites.length === 0) break;
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
-    expect(
-      (home.key("favorites").get() as FavoriteEntry[] | undefined) ?? [],
-    ).toEqual([]);
+    expect(await readFavoritesUntilEmpty()).toEqual([]);
   });
 
   it("removes a legacy favorite (no keyed entity) via the piece-cell fallback", async () => {
@@ -154,15 +155,6 @@ describe("home favorites handlers", () => {
     // The keyed removal cannot reach it, so removeFavorite falls back to
     // matching the piece cell and still deletes it.
     home.key("removeFavorite").send({ piece, id });
-    for (let i = 0; i < 20; i++) {
-      await runtime.idle();
-      const favs =
-        (home.key("favorites").get() as FavoriteEntry[] | undefined) ?? [];
-      if (favs.length === 0) break;
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
-    expect(
-      (home.key("favorites").get() as FavoriteEntry[] | undefined) ?? [],
-    ).toEqual([]);
+    expect(await readFavoritesUntilEmpty()).toEqual([]);
   });
 });

--- a/packages/runner/test/observation-adoption-live.test.ts
+++ b/packages/runner/test/observation-adoption-live.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
@@ -94,22 +95,10 @@ function opRuns(
 }
 
 // The subscription push is timer-batched server-side (5ms default) and the
-// integrate lands asynchronously; poll the receiving replica (plain local
-// reads — pull() would fetch out-of-band and mask a missing push).
-async function waitForLocalValue(
-  runtime: Runtime,
-  read: () => unknown,
-  expected: unknown,
-  timeoutMs = 5_000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    await runtime.idle();
-    if (JSON.stringify(read()) === JSON.stringify(expected)) return;
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-  expect(read()).toEqual(expected);
-}
+// integrate lands asynchronously, so a receiving replica reaches the value
+// after the sending runtime has already settled. The waits below therefore sink
+// on the receiver's own cell through `waitForCellValue`, which reads it locally
+// with get(); pull() would fetch out-of-band and mask a missing push.
 
 describe("incremental observation adoption (live)", () => {
   let server: MemoryV2Server.Server;
@@ -190,11 +179,13 @@ describe("incremental observation adoption (live)", () => {
       await rt1.idle();
       await rt1.storageManager.synced();
 
-      await waitForLocalValue(
-        rt2,
-        () => resultCell2.key("doubled").getAsQueryResult(),
-        20,
-      );
+      expect(
+        await waitForCellValue<number>(
+          rt2,
+          resultCell2.key("doubled"),
+          (v) => v === 20,
+        ),
+      ).toBe(20);
       const liveTrace = rt2.scheduler.getActionRunTrace();
       expect(opRuns(liveTrace)).toEqual([]);
       expect(adoptOkCount()).toBeGreaterThan(adoptedBefore);
@@ -209,11 +200,13 @@ describe("incremental observation adoption (live)", () => {
       expect((await txRepeated.commit()).error).toBeUndefined();
       await rt1.idle();
       await rt1.storageManager.synced();
-      await waitForLocalValue(
-        rt2,
-        () => resultCell2.key("doubled").getAsQueryResult(),
-        22,
-      );
+      expect(
+        await waitForCellValue<number>(
+          rt2,
+          resultCell2.key("doubled"),
+          (v) => v === 22,
+        ),
+      ).toBe(22);
       expect(
         opRuns(
           rt2.scheduler.getActionRunTrace().slice(beforeRepeated),
@@ -235,17 +228,21 @@ describe("incremental observation adoption (live)", () => {
       expect(
         opRuns(rt2.scheduler.getActionRunTrace().slice(beforeLocal)).length,
       ).toBeGreaterThan(0);
-      await waitForLocalValue(
-        rt2,
-        () => resultCell2.key("doubled").getAsQueryResult(),
-        14,
-      );
+      expect(
+        await waitForCellValue<number>(
+          rt2,
+          resultCell2.key("doubled"),
+          (v) => v === 14,
+        ),
+      ).toBe(14);
 
-      await waitForLocalValue(
-        rt1,
-        () => r1.key("doubled").getAsQueryResult(),
-        14,
-      );
+      expect(
+        await waitForCellValue<number>(
+          rt1,
+          r1.key("doubled"),
+          (v) => v === 14,
+        ),
+      ).toBe(14);
 
       cancelSink1();
       cancelSink2();

--- a/packages/runner/test/resume-republish-unit.test.ts
+++ b/packages/runner/test/resume-republish-unit.test.ts
@@ -344,16 +344,14 @@ describe("resume-republish unit", () => {
 
 // trackUntilSettled receives a fresh promise per re-await, so draining once is
 // not enough: await the current batch, then await any promises the rebuild
-// scheduled while settling, until the queue stops growing.
+// scheduled while settling, until the queue stops growing. The republisher
+// tracks a re-defer from inside the callback that resolves the promise it was
+// re-deferred from, so a batch that has settled has already pushed whatever
+// follows it.
 async function drain(tracked: Promise<unknown>[]): Promise<void> {
-  let seen = 0;
-  // A bounded number of passes; the re-defer chain here is at most a few deep.
-  for (let pass = 0; pass < 10; pass++) {
-    if (tracked.length === seen) break;
+  for (let seen = 0; seen < tracked.length;) {
     const batch = tracked.slice(seen);
     seen = tracked.length;
     await Promise.allSettled(batch);
-    // Let any microtasks the settled batch queued run before the next pass.
-    await new Promise((r) => setTimeout(r, 0));
   }
 }

--- a/packages/runner/test/scheduler-cold-replica.test.ts
+++ b/packages/runner/test/scheduler-cold-replica.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import type { RuntimeProgram } from "../src/harness/types.ts";
@@ -67,21 +68,6 @@ const newRuntime = (storageManager: SharedServerStorageManager) =>
     apiUrl: new URL(import.meta.url),
     storageManager,
   });
-
-async function waitForProjectedResult(
-  runtime: Runtime,
-  read: () => unknown,
-  expected: unknown,
-): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt++) {
-    await runtime.idle();
-    if (JSON.stringify(read()) === JSON.stringify(expected)) return;
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-
-  await runtime.idle();
-  expect(read()).toEqual(expected);
-}
 
 describe("scheduler cold-replica startup", () => {
   let server: MemoryV2Server.Server;
@@ -167,11 +153,12 @@ describe("scheduler cold-replica startup", () => {
       await writerTx.commit();
       await writer.storageManager.synced();
 
-      await waitForProjectedResult(
+      const projected = await waitForCellValue<{ observed: string }>(
         reader,
-        () => resultCell.getAsQueryResult(),
-        { observed: "arrived" },
+        resultCell,
+        (value) => value?.observed === "arrived",
       );
+      expect(projected).toEqual({ observed: "arrived" });
       cancelSink();
       expect(seen.at(-1)).toEqual({ observed: "arrived" });
     } finally {


### PR DESCRIPTION
Five runner tests each hand-rolled a wait built on a timer sleep. Four were sleeping because nobody had connected them to the signal they were really waiting for; the fifth waits on something that has no signal at all. This converts the four and documents the fifth.

Three of the four waited for a cell to reach a value, re-reading it every 5 to 20 milliseconds until it did. Each observes a cell value, so the change hands them to the shared `waitForCellValue` helper, which sleeps on a sink of that cell and applies its predicate to the cell only at quiescence. Two of the three already had a sink on the cell they polled; the third, home-add-favorite, registered none and takes its only sink from the helper. Either way the helper brings no timer, no deadline and no iteration cap, and it returns the value its predicate accepted so the caller asserts against the state the wait approved rather than re-reading and hoping.

- scheduler-cold-replica.test.ts and observation-adoption-live.test.ts wait for a value produced on one runtime to arrive at another over the in-process server. Both keep reading the receiving replica locally with get(), since a pull() would fetch out-of-band and hide a push that never came.
- home-add-favorite.test.ts waits for a handler's rewrite of the favorites list. Its two removal waits, which the original spelled out twice in full, now share one helper. The emptiness predicate requires the list to exist, which rules out the not-yet-synced state; it does not rule out the pattern's initial empty list, so each caller first establishes that the list holds an entry.

The fourth, resume-republish-unit.test.ts, drains a queue of promises that a mocked trackUntilSettled collects. It awaited each batch and then slept on a zero-delay timer to flush the microtasks that batch queued, bounded by ten passes. Neither the sleep nor the bound was doing anything: the republisher tracks a re-defer from inside the callback that resolves the promise it was re-deferred from, so a batch that has settled has already pushed whatever follows it, and looping until the queue stops growing is enough. The drain now awaits the real promises and terminates on its own.

memory-v2-stacked-commit.test.ts keeps its poll, and the waiting-in-tests note now says why. It waits for a conflict rejection to reach the runner by watching a logger count that pushCommit's catch moves synchronously, and the logger offers readers with no subscription, so nothing fires when a count moves. The commit under observation must not settle -- that is the assertion -- so its promise is not the signal either. This is the shape the note already catalogues under "Race, backpressure, and convergence tests": a bound whose early fire fails the run, kept because no event reports the condition it waits on.

Each converted wait was checked against an unsatisfiable predicate to confirm it still fails rather than passing vacuously, and each failed in seconds with "Promise resolution is still pending but the event loop has already resolved" rather than hanging, which is why none of them needs a timeout backstop. The drain was checked by making it a no-op, which fails two of its tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace sleep-based polling with event-driven waits in five runner tests to improve reliability and remove flakiness. Tests now wait on the actual signals they depend on, not timers.

- **Refactors**
  - Switched `scheduler-cold-replica.test.ts`, `observation-adoption-live.test.ts`, and `home-add-favorite.test.ts` to `waitForCellValue` from `@commonfabric/integration/wait-for-cell-value`; waits now sink on the observed cell and use local `get()` reads.
  - Consolidated favorites removal waits in `home-add-favorite.test.ts`; added a predicate that first ensures the list is non-empty, then waits for empty.
  - Simplified `drain` in `resume-republish-unit.test.ts` to await real promises until the queue stops growing; removed zero-delay sleeps and loop bounds.
  - Kept the bounded poll in `memory-v2-stacked-commit.test.ts` (no event exists for the condition) and documented the rationale in `docs/development/waiting-in-tests.md`.

<sup>Written for commit 1ebe785a34fb50e7b1cad7c5a71c1b708bf2dea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

