### PR TITLE
refactor(integration): make notification-driven waits own their timeo…

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -81,16 +81,17 @@ Waits split into two groups with different primitives.
 
 **Browser integration tests** have a page to attach an in-page waiter to:
 
-- `waitForCondition(page, predicate, { timeout, args })` installs a single
-  waiter inside the page. A shared MutationObserver hub watches the document and
-  every shadow root — including shadow roots created after the wait began — and
-  re-evaluates the predicate the instant the DOM reflects new state, then signals
-  the test process over a protocol binding. The `timeout` argument is a genuine
-  stuck-condition safety net, not a poll interval; a coarse 500-millisecond
-  in-page backstop covers conditions that flip with no DOM mutation (for example
-  a runtime global being set). The predicate is serialized and runs in the page,
-  so it closes over nothing from the test module — inline any collection it
-  needs, and pass values in through `args`.
+- `waitForCondition(page, predicate, { args })` installs a single waiter inside
+  the page. A shared MutationObserver hub watches the document and every shadow
+  root — including shadow roots created after the wait began — and re-evaluates
+  the predicate the instant the DOM reflects new state, then signals the test
+  process over a protocol binding. It takes no caller-supplied timeout: a
+  built-in five-minute stuck-condition safety net bounds a condition that never
+  holds, and a coarse 500-millisecond in-page backstop covers conditions that
+  flip with no DOM mutation (for example a runtime global being set). The
+  predicate is serialized and runs in the page, so it closes over nothing from
+  the test module — inline any collection it needs, and pass values in through
+  `args`.
 - `awaitViewSettled(page)` resolves once the worker has settled reactively, the
   resulting vdom batch has crossed to the main thread and been applied, and Lit
   has finished its update cycle. This is the "is the control interactive yet"

--- a/packages/integration/presentation/interactions.ts
+++ b/packages/integration/presentation/interactions.ts
@@ -94,7 +94,6 @@ export class PresentationInteractions {
       input?.scrollIntoView({ block: "center", inline: "center" });
     });
     await waitForCondition(this.#page, cfInputIsFillable, {
-      timeout,
       args: [selector],
     });
     await this.#moveCursorToElement(host);

--- a/packages/integration/utils.ts
+++ b/packages/integration/utils.ts
@@ -15,6 +15,13 @@ const DEFAULT_DELAY_MS = (() => {
   }
 })();
 
+// Built-in safety net for a genuinely stuck condition in waitForCondition. The
+// wait is notification-driven and resolves the instant its predicate holds, so
+// this bound is never the common-case latency; it is generous enough to cover
+// the slowest legitimate wait (a runtime resync after a reload) without capping
+// a condition that is still making progress.
+const WAIT_FOR_CONDITION_TIMEOUT = 300_000; // 5 minutes
+
 /**
  * Receives an async predicate function to executed repeatedly
  * until either the predicate returns `true`, or throws once
@@ -362,14 +369,15 @@ function installWaiter(
  * step idles until its condition is actually satisfied — like `select(2)` or
  * `wait` — and then proceeds immediately.
  *
- * On timeout it throws; callers add the context and rich probe for the failure
- * message. `timeout` is a safety net for a genuinely stuck condition, not the
- * common-case latency.
+ * On a stuck condition it throws once the built-in `WAIT_FOR_CONDITION_TIMEOUT`
+ * safety net elapses; callers add the context and rich probe for the failure
+ * message. There is no caller-supplied timeout: the wait resolves on the
+ * condition, and the safety net is not the common-case latency.
  */
 export const waitForCondition = async <A extends readonly unknown[]>(
   page: Page,
   predicate: PageCondition<A>,
-  { timeout = 60_000, args }: { timeout?: number; args?: A } = {},
+  { args }: { args?: A } = {},
 ): Promise<void> => {
   const bindingName = `__cfcWait_${crypto.randomUUID().replace(/-/g, "")}`;
   let resolveSignal!: () => void;
@@ -390,9 +398,11 @@ export const waitForCondition = async <A extends readonly unknown[]>(
       timer = setTimeout(
         () =>
           reject(
-            new Error(`waitForCondition did not resolve within ${timeout}ms`),
+            new Error(
+              `waitForCondition did not resolve within ${WAIT_FOR_CONDITION_TIMEOUT}ms`,
+            ),
           ),
-        timeout,
+        WAIT_FOR_CONDITION_TIMEOUT,
       );
     });
     await Promise.race([signalled, timedOut]);

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -328,12 +328,11 @@ const markTrustedAction = async (
 
 // Resolve once the shell's reactive view has caught up to runtime state and is
 // interactive, so a click lands on a bound handler. Waits for the shell to
-// expose `viewSettled` (notification-driven), then awaits the settle.
-export async function settleView(
-  page: Page,
-  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
-): Promise<void> {
-  await waitForCondition(page, viewSettledReady, { timeout });
+// expose `viewSettled` (notification-driven), then awaits the settle. Neither
+// wait takes a timeout: the readiness poll carries `waitForCondition`'s built-in
+// safety net, and the settle itself awaits a real promise.
+export async function settleView(page: Page): Promise<void> {
+  await waitForCondition(page, viewSettledReady);
   await awaitViewSettled(page);
 }
 
@@ -386,7 +385,6 @@ export async function clickTrustedAction(
     // click it exactly once. Marking attaches the provenance listener, so the
     // single click is the trusted dispatch we record.
     await waitForCondition(page, markTrustedAction, {
-      timeout,
       args: [action, token, CLICK_TARGET_ATTR],
     });
     const button = await page.waitForSelector(
@@ -426,7 +424,7 @@ export async function submitViaEnter(
   inputSelector: string,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
-  await settleView(page, { timeout });
+  await settleView(page);
   const input = await page.waitForSelector(inputSelector, {
     strategy: "pierce",
     timeout,
@@ -442,11 +440,6 @@ export async function clickTrustedActionAndWaitForText(
   text: string,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
-  // Single timeout budget shared across the fast path, settle, click, and the
-  // wait for the effect.
-  const deadline = Date.now() + timeout;
-  const remaining = () => Math.max(1, deadline - Date.now());
-
   let actionProbe: TrustedActionProbe | undefined;
   let textProbe: TextProbe | undefined;
 
@@ -460,8 +453,8 @@ export async function clickTrustedActionAndWaitForText(
   // trusted click lands; re-dispatching on a later tick is what double-fires
   // and corrupts the event provenance, so we never re-click.
   try {
-    await settleView(page, { timeout: remaining() });
-    await clickTrustedAction(page, action, { timeout: remaining() });
+    await settleView(page);
+    await clickTrustedAction(page, action, { timeout });
   } catch (cause) {
     actionProbe = await readTrustedActionProbe(page, action).catch(() =>
       undefined
@@ -480,9 +473,7 @@ export async function clickTrustedActionAndWaitForText(
   // optimistic perUser/perSpace write whose chip trails the commit is caught by
   // the same wait.
   try {
-    await waitForTextWhileSettling(page, selector, text, {
-      timeout: remaining(),
-    });
+    await waitForTextWhileSettling(page, selector, text, { timeout });
   } catch (cause) {
     actionProbe ??= await readTrustedActionProbe(page, action).catch(() =>
       undefined
@@ -501,11 +492,9 @@ export async function waitForText(
   page: Page,
   selector: string,
   text: string,
-  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
   try {
     await waitForCondition(page, textPresent, {
-      timeout,
       args: [selector, text],
     });
   } catch (cause) {
@@ -523,11 +512,9 @@ export async function waitForTextAbsent(
   page: Page,
   selector: string,
   text: string,
-  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
   try {
     await waitForCondition(page, textAbsent, {
-      timeout,
       args: [selector, text],
     });
   } catch (cause) {
@@ -553,7 +540,6 @@ export async function fillCfInput(
       await presentation.typeIntoCfInput(selector, value, timeout);
     } else {
       await waitForCondition(page, fillAndVerify, {
-        timeout,
         args: [selector, value],
       });
     }
@@ -600,18 +586,15 @@ export async function readCfInputValue(
 
 export async function waitForRuntimeIdle(
   page: Page,
-  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
-  await waitForCondition(page, runtimeIdle, { timeout });
+  await waitForCondition(page, runtimeIdle);
 }
 
 export async function waitForActiveSpaceRoot(
   page: Page,
   expectedSpace: string,
-  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
   await waitForCondition(page, activeSpaceRootReady, {
-    timeout,
     args: [expectedSpace],
   });
 }
@@ -620,11 +603,9 @@ export async function waitForDisabled(
   page: Page,
   selector: string,
   disabled: boolean,
-  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
   try {
     await waitForCondition(page, buttonDisabledIs, {
-      timeout,
       args: [selector, disabled],
     });
   } catch (cause) {
@@ -651,7 +632,6 @@ export async function clickCfButton(
     // exactly once; the mark is the predicate, so the re-check on each DOM
     // mutation retries finding the button without re-clicking anything.
     await waitForCondition(page, markForClick, {
-      timeout,
       args: [selector, token, CLICK_TARGET_ATTR],
     });
   } catch (cause) {
@@ -687,7 +667,6 @@ export async function clickNthCfButton(
   const token = `cf-nth-button-${crypto.randomUUID()}`;
   try {
     await waitForCondition(page, markNthForClick, {
-      timeout,
       args: [selector, index, token, CLICK_TARGET_ATTR],
     });
   } catch (cause) {
@@ -733,10 +712,6 @@ export async function clickCfButtonAndWaitForText(
   text: string,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
-  // Single timeout budget shared across settle, click, and wait-for-effect.
-  const deadline = Date.now() + timeout;
-  const remaining = () => Math.max(1, deadline - Date.now());
-
   let textProbe: TextProbe | undefined;
 
   // Fast path: the effect may already be present (idempotent re-entry).
@@ -752,8 +727,8 @@ export async function clickCfButtonAndWaitForText(
   // can double-fire, and against a dismissable overlay the repeat clicks
   // dismiss it). See docs/development/UI_TESTING.md.
   try {
-    await settleView(page, { timeout: remaining() });
-    await clickCfButton(page, buttonSelector, { timeout: remaining() });
+    await settleView(page);
+    await clickCfButton(page, buttonSelector, { timeout });
   } catch (cause) {
     textProbe = await readTextProbe(page, textSelector).catch(() => undefined);
     throw new Error(
@@ -769,9 +744,7 @@ export async function clickCfButtonAndWaitForText(
   // few cycles after the click — including an optimistic perUser/perSpace write
   // whose chip trails the commit — is captured without ever re-clicking.
   try {
-    await waitForTextWhileSettling(page, textSelector, text, {
-      timeout: remaining(),
-    });
+    await waitForTextWhileSettling(page, textSelector, text, { timeout });
   } catch (cause) {
     textProbe = await readTextProbe(page, textSelector).catch(() => undefined);
     throw new Error(
@@ -785,11 +758,10 @@ export async function clickCfButtonAndWaitForText(
 
 export async function waitForRuntimeSynced(
   page: Page,
-  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
   // Quiescence isn't a per-space question: allSynced awaits every space the
   // worker has opened.
-  await waitForCondition(page, runtimeSynced, { timeout });
+  await waitForCondition(page, runtimeSynced);
 }
 
 export type SchedulerLoadSummary = {

--- a/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
@@ -164,9 +164,7 @@ describe(
           "runtime idle (all)",
           () =>
             Promise.all(
-              pages.map((page) =>
-                waitForRuntimeIdle(page, { timeout: PROPAGATION_TIMEOUT })
-              ),
+              pages.map((page) => waitForRuntimeIdle(page)),
             ),
         );
         await timer.run(
@@ -174,9 +172,7 @@ describe(
           () =>
             Promise.all(
               pages.map((page) =>
-                waitForText(page, "#group-chat-manager-chip", "No profile", {
-                  timeout: PROPAGATION_TIMEOUT,
-                })
+                waitForText(page, "#group-chat-manager-chip", "No profile")
               ),
             ),
         );
@@ -185,9 +181,7 @@ describe(
         // browser's input — the profile draft is per-user state.
         await fillCfInput(pages[0], "#trusted-profile-name", userNames[0]);
         await Promise.all(
-          pages.map((page) =>
-            waitForRuntimeIdle(page, { timeout: PROPAGATION_TIMEOUT })
-          ),
+          pages.map((page) => waitForRuntimeIdle(page)),
         );
         for (let index = 1; index < pages.length; index++) {
           assertEquals(
@@ -215,9 +209,7 @@ describe(
             ),
         );
         await Promise.all(
-          pages.map((page) =>
-            waitForRuntimeIdle(page, { timeout: PROPAGATION_TIMEOUT })
-          ),
+          pages.map((page) => waitForRuntimeIdle(page)),
         );
         for (let index = 1; index < pages.length; index++) {
           await waitForText(
@@ -242,12 +234,9 @@ describe(
                 pages[index],
                 "#trusted-admin-user-list",
                 userNames[index - 1],
-                { timeout: PROPAGATION_TIMEOUT },
               ),
           );
-          await waitForRuntimeIdle(pages[index], {
-            timeout: PROPAGATION_TIMEOUT,
-          });
+          await waitForRuntimeIdle(pages[index]);
           await fillCfInput(
             pages[index],
             "#trusted-profile-name",
@@ -281,14 +270,12 @@ describe(
                   page,
                   "#trusted-admin-user-list",
                   userNames[other],
-                  { timeout: PROPAGATION_TIMEOUT },
                 );
               }
               await waitForText(
                 page,
                 "#trusted-profile-status",
                 userNames[index],
-                { timeout: PROPAGATION_TIMEOUT },
               );
             })),
         );
@@ -308,7 +295,6 @@ describe(
                   page,
                   "#trusted-conversation-preview",
                   helloMessage,
-                  { timeout: PROPAGATION_TIMEOUT },
                 )
               ),
             ),
@@ -322,7 +308,6 @@ describe(
           pages[0],
           "#group-chat-manager-chip",
           "Can manage admins",
-          { timeout: PROPAGATION_TIMEOUT },
         );
         await timer.run(
           "lockdown propagation (first -> others)",
@@ -333,7 +318,6 @@ describe(
                   page,
                   "#trusted-room-admin-hint",
                   "Ask an admin manager to make you an admin",
-                  { timeout: PROPAGATION_TIMEOUT },
                 )
               ),
             ),
@@ -356,7 +340,6 @@ describe(
               pages[0],
               "#trusted-conversation-preview",
               lockdownMessage,
-              { timeout: PROPAGATION_TIMEOUT },
             ),
         );
 
@@ -369,11 +352,7 @@ describe(
           "room propagation (first -> all)",
           () =>
             Promise.all(
-              others(0).map((page) =>
-                waitForText(page, "#rooms-panel", "Ops", {
-                  timeout: PROPAGATION_TIMEOUT,
-                })
-              ),
+              others(0).map((page) => waitForText(page, "#rooms-panel", "Ops")),
             ),
         );
       } finally {

--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -349,7 +349,6 @@ async function waitForAuthorshipState(
         });
       },
       {
-        timeout: CFC_GROUP_CHAT_TIMEOUT,
         args: [containerSelector, expectedText],
       },
     );
@@ -449,7 +448,6 @@ async function waitForInvalidAuthorshipState(
         });
       },
       {
-        timeout: CFC_GROUP_CHAT_TIMEOUT,
         args: [containerSelector, IMPORTED_MESSAGE_MARKERS],
       },
     );

--- a/packages/patterns/integration/chatbot.test.ts
+++ b/packages/patterns/integration/chatbot.test.ts
@@ -160,7 +160,6 @@ describe("Chat pattern test", () => {
       await waitForCondition(
         page,
         (probe) => probe.collect("cf-chat-message").length >= 2,
-        { timeout: 30000 },
       );
 
       // Get all chat messages using pierce strategy
@@ -228,7 +227,6 @@ describe("Chat pattern test", () => {
       await waitForCondition(
         page,
         (probe) => probe.collect("cf-chat-message").length >= 4,
-        { timeout: 60000 },
       );
 
       // Get all chat messages to verify sequence

--- a/packages/patterns/integration/lunch-poll-vote.test.ts
+++ b/packages/patterns/integration/lunch-poll-vote.test.ts
@@ -161,8 +161,8 @@ describe("lunch poll: two users vote on a shared option", () => {
         "both runtimes idle",
         () =>
           Promise.all([
-            waitForRuntimeIdle(hostPage, { timeout: PROPAGATION_TIMEOUT }),
-            waitForRuntimeIdle(guestPage, { timeout: PROPAGATION_TIMEOUT }),
+            waitForRuntimeIdle(hostPage),
+            waitForRuntimeIdle(guestPage),
           ]),
       );
 
@@ -175,8 +175,7 @@ describe("lunch poll: two users vote on a shared option", () => {
       await clickCfButton(hostPage, "#lp-join-button");
       await timer.run(
         "host joined (name in roster)",
-        () =>
-          waitForText(hostPage, "body", HOST, { timeout: PROPAGATION_TIMEOUT }),
+        () => waitForText(hostPage, "body", HOST),
       );
 
       // Guest joins second. The board shows a participant count, not a full
@@ -188,12 +187,8 @@ describe("lunch poll: two users vote on a shared option", () => {
         "both join lands (count reaches 2)",
         () =>
           Promise.all([
-            waitForText(hostPage, "body", "2 joined", {
-              timeout: PROPAGATION_TIMEOUT,
-            }),
-            waitForText(guestPage, "body", GUEST, {
-              timeout: PROPAGATION_TIMEOUT,
-            }),
+            waitForText(hostPage, "body", "2 joined"),
+            waitForText(guestPage, "body", GUEST),
           ]),
       );
 
@@ -204,12 +199,8 @@ describe("lunch poll: two users vote on a shared option", () => {
         "option A propagates to both",
         () =>
           Promise.all([
-            waitForText(hostPage, "body", OPTION_A, {
-              timeout: PROPAGATION_TIMEOUT,
-            }),
-            waitForText(guestPage, "body", OPTION_A, {
-              timeout: PROPAGATION_TIMEOUT,
-            }),
+            waitForText(hostPage, "body", OPTION_A),
+            waitForText(guestPage, "body", OPTION_A),
           ]),
       );
 
@@ -231,12 +222,8 @@ describe("lunch poll: two users vote on a shared option", () => {
         "both browsers see 2 love it (merge)",
         () =>
           Promise.all([
-            waitForText(hostPage, "body", "2 love it", {
-              timeout: PROPAGATION_TIMEOUT,
-            }),
-            waitForText(guestPage, "body", "2 love it", {
-              timeout: PROPAGATION_TIMEOUT,
-            }),
+            waitForText(hostPage, "body", "2 love it"),
+            waitForText(guestPage, "body", "2 love it"),
           ]),
       );
 
@@ -262,12 +249,8 @@ describe("lunch poll: two users vote on a shared option", () => {
       await fillCfInput(hostPage, "#lp-add-option-input", OPTION_B);
       await clickCfButton(hostPage, "#lp-add-option-button");
       await Promise.all([
-        waitForText(hostPage, "body", OPTION_B, {
-          timeout: PROPAGATION_TIMEOUT,
-        }),
-        waitForText(guestPage, "body", OPTION_B, {
-          timeout: PROPAGATION_TIMEOUT,
-        }),
+        waitForText(hostPage, "body", OPTION_B),
+        waitForText(guestPage, "body", OPTION_B),
       ]);
       await clickCfButton(guestPage, voteButton(OPTION_B, "red"));
       // The third vote (red on option B) lands on both browsers — the count
@@ -278,15 +261,9 @@ describe("lunch poll: two users vote on a shared option", () => {
         "option B vote lands (3 votes); option A unchanged",
         () =>
           Promise.all([
-            waitForText(hostPage, "body", "3 votes", {
-              timeout: PROPAGATION_TIMEOUT,
-            }),
-            waitForText(guestPage, "body", "3 votes", {
-              timeout: PROPAGATION_TIMEOUT,
-            }),
-            waitForText(hostPage, "body", "2 love it", {
-              timeout: PROPAGATION_TIMEOUT,
-            }),
+            waitForText(hostPage, "body", "3 votes"),
+            waitForText(guestPage, "body", "3 votes"),
+            waitForText(hostPage, "body", "2 love it"),
           ]),
       );
     } finally {

--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -29,7 +29,6 @@ const { FRONTEND_URL } = env;
 // slightly while still exercising persisted scheduler-state reuse.
 const NOTEBOOK_RELOAD_TOTAL_ACTION_RUN_LIMIT = 150;
 const NOTEBOOK_RELOAD_COMPUTATION_RUN_LIMIT = 90;
-const NOTEBOOK_RELOAD_TIMEOUT_MS = 180_000;
 
 const EXPECT_PERSISTENT_SCHEDULER_STATE = (() => {
   const raw = Deno.env.get("CF_EXPECT_PERSISTENT_SCHEDULER_STATE");
@@ -118,10 +117,9 @@ describe("default-app notebook reload integration test", () => {
 
     await waitForCondition(page, notebookSourceStateMatches, {
       args: [noteCreates],
-      timeout: NOTEBOOK_RELOAD_TIMEOUT_MS,
     });
 
-    await waitForRuntimeSynced(page, { timeout: NOTEBOOK_RELOAD_TIMEOUT_MS });
+    await waitForRuntimeSynced(page);
 
     const startedAt = performance.now();
     await page.reload({ waitUntil: "load" });
@@ -130,9 +128,8 @@ describe("default-app notebook reload integration test", () => {
 
     await waitForCondition(page, notebookReloadRendered, {
       args: [noteCreates],
-      timeout: NOTEBOOK_RELOAD_TIMEOUT_MS,
     });
-    await waitForRuntimeIdle(page, { timeout: NOTEBOOK_RELOAD_TIMEOUT_MS });
+    await waitForRuntimeIdle(page);
 
     const reloadRenderState = await collectNotebookRenderState(page);
     assertEquals(reloadRenderState.noteCount, noteCreates);


### PR DESCRIPTION
…ut, not callers

The browser integration test helpers threaded caller-supplied timeouts through every layer of a wait. `waitForCondition` — the notification-driven primitive that resolves the instant its predicate holds — took a `timeout`; `settleView` took one and passed it down; and the "settle, then click, then wait for the effect" helpers ran a single shared budget, turning a caller timeout into a deadline and handing each step whatever time was left via `Math.max(1, deadline - Date.now())`.

That shared budget misattributed failures. A settle that legitimately consumed most of the budget starved the later steps, which were left with one millisecond and timed out immediately, and the failure was reported against the wrong step: a slow settle surfaced as a spurious "failed to click" or "text never appeared" rather than as a settle failure. Meanwhile every caller, down to individual tests, had to choose and thread timeout values whose only purpose was to widen a stuck-condition backstop.

Move the backstop to where the wait lives, and let the wait resolve on its condition:

- Remove `waitForCondition`'s `timeout` parameter and give it a single built-in safety net of five minutes, sized above the slowest legitimate wait in the suite (a runtime resync after a reload, previously bounded at 180s). The wait still resolves the instant its predicate holds; the built-in bound only fires when a condition is genuinely stuck. No test relied on a short timeout to prove absence — the negative assertions use predicates, not fast failures — so widening the backstop only delays a broken condition's failure, never turns a healthy wait into one.
- Drop `settleView`'s `timeout` parameter (it now relies on the same built-in net) and remove the shared-budget bookkeeping from `submitViaEnter`, `clickTrustedActionAndWaitForText`, and `clickCfButtonAndWaitForText`. Each remaining step carries its own timeout independent of how long the settle took, and every caller re-throws settle and step failures immediately, so a timeout is always surfaced against the step that actually exceeded it and is never swallowed by a later, innocent step.

Propagate the `waitForCondition` removal through every caller:

- The wrapper helpers whose `timeout` fed only `waitForCondition` lose the parameter entirely: `waitForText`, `waitForTextAbsent`, `waitForRuntimeIdle`, `waitForRuntimeSynced`, `waitForActiveSpaceRoot`, `waitForDisabled`.
- Helpers that also drive an astral `waitForSelector` keep their `timeout` for that selector wait and stop forwarding it to `waitForCondition`: `clickTrustedAction`, `clickCfButton`, `clickNthCfButton`, `fillCfInput`, and the presentation `typeIntoCfInput` helper.
- The test call sites that passed a timeout drop it, and the now-unused `NOTEBOOK_RELOAD_TIMEOUT_MS` constant is deleted.

Update docs/development/waiting-in-tests.md to describe the parameter-free `waitForCondition` signature and its built-in net.

Verified with deno check, deno lint, and deno fmt --check across the integration, patterns, and shell packages' affected files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Timeout ownership moves into the notification-driven waits. `waitForCondition` now has a built‑in 5‑minute safety net and callers no longer pass timeouts, fixing misattributed test failures and simplifying integration helpers.

- **Refactors**
  - `waitForCondition` removes `timeout`; adds a 5‑minute `WAIT_FOR_CONDITION_TIMEOUT`; still resolves as soon as the predicate holds.
  - `settleView` drops its `timeout`; click+wait helpers remove shared “budget” logic; selector waits keep their own `page.waitForSelector` timeouts.
  - Docs updated: `waitForCondition(page, predicate, { args })`.

- **Migration**
  - Stop passing `timeout` to `waitForCondition`, `settleView`, `waitForText`, `waitForTextAbsent`, `waitForRuntimeIdle`, `waitForRuntimeSynced`, `waitForActiveSpaceRoot`, and `waitForDisabled`.
  - Keep timeouts only where a selector wait is involved: `clickTrustedAction`, `clickCfButton`, `clickNthCfButton`, `fillCfInput`, and `typeIntoCfInput`.
  - Remove uses of `NOTEBOOK_RELOAD_TIMEOUT_MS` in reload tests.

<sup>Written for commit d0a56677b1be42a7d9c6fdd31c74e969c7b5abbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

