### PR TITLE
test(patterns): move the always-run default-app browser waits off pol…

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -519,27 +519,22 @@ joined across two different browser pages (both must show both voters).
 binding, so it cannot express a two-page condition; the cross-browser
 propagation wait stays a poll.
 
-### Instrumentation one-shots, and a few unconverted UI waits
+### Instrumentation one-shots
 
 `packages/patterns/integration/default-app.test.ts` keeps `waitFor` for one-shot
-instrumentation: arm a trace, reset a logger, install a telemetry handler. Each
-such call returns false only until a runtime API is present, so it observes
-runtime API readiness rather than a UI condition, and it is profiling scaffolding
-rather than an assertion. Most of them sit behind a `CF_CAPTURE_*` environment
-gate. If converted, await a runtime-ready signal directly rather than installing
-a DOM waiter.
+instrumentation: arm a trace, reset a logger baseline. Each such call returns
+false only until a runtime API is present, so it observes runtime API readiness
+rather than a UI condition, and it is profiling scaffolding rather than an
+assertion. Every one sits behind a `CF_CAPTURE_*` environment gate that defaults
+to off, so a normal run never reaches them.
 
-`packages/patterns/integration/reload/default-app-notebook.test.ts` keeps one
-wait of that shape — it arms the event-invocation telemetry handler, which is the
-one instrumentation wait that runs ungated in both files.
-
-The rest of the waits in these two files are ordinary UI conditions, and a poll
-is not the right tool for them. They are simply not converted yet: both files
-wait for the note modal's "Create Another" button to render, and
-`default-app.test.ts` also retries a piece-link click until the link is found. A
-`waitForCondition` predicate would express each of them. Converting them would
-not take either file off the allowlist, because the instrumentation waits keep
-both files importing `waitFor`.
+The notebook regression test in that same file resets the event-invocation trace
+on every pass, and needs no wait for it. The reset returns false only until the
+runtime exposes its telemetry methods, and the click that opened the note modal
+settled the view, so those methods are already present; the reset is called once
+and its success asserted. A wait on runtime-API readiness would have been no
+better, because that condition flips with no DOM mutation behind it and would
+fall back to the in-page waiter's coarse backstop for something already true.
 
 ### A shared state primitive
 

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -18,7 +18,6 @@ import {
   clickButtonWithExactText,
   clickButtonWithText,
   clickButtonWithTitle,
-  findButtonWithText,
 } from "./note-button-helpers.ts";
 import { describe, it } from "@std/testing/bdd";
 import { Identity } from "@commonfabric/identity";
@@ -489,9 +488,7 @@ describe("default-app flow test", () => {
       }
 
       console.log(`Navigate back to space page (note ${noteIndex})...`);
-      await waitFor(async () => {
-        return await clickPieceLinkWithText(page, spaceName);
-      });
+      await clickPieceLinkWithText(page, spaceName);
       try {
         await shell.waitForState({ view: { spaceName }, identity });
       } catch (error) {
@@ -752,13 +749,16 @@ describe("default-app flow test", () => {
         await clickButtonWithTitle(page, "New Note"),
         "Expected New Note click to succeed",
       );
-      // The click is delivered; wait until its effect — the open modal with its
-      // "Create Another" button — has rendered and become interactive.
-      await waitFor(async () => {
-        await awaitViewSettled(page);
-        return !!(await findButtonWithText(page, "Create Another"));
-      });
-      await waitFor(async () => await resetEventInvocationTrace(page));
+      // Arm the event-invocation trace before the note creations, whose markers
+      // this test's failure diagnostics read. clickButtonWithTitle settled the
+      // view, so the runtime has exposed its telemetry methods and the reset
+      // runs once with its success asserted. The first "Create Another" click
+      // below settles the view and waits for the button to render, so no
+      // separate wait for the modal is needed here.
+      assert(
+        await resetEventInvocationTrace(page),
+        "Expected the event invocation trace to reset",
+      );
 
       const noteCreates = 7;
       for (let i = 0; i < noteCreates - 1; i++) {
@@ -3356,48 +3356,51 @@ async function collectNavigationDiagnostics(page: Page): Promise<unknown> {
   });
 }
 
+// Serialized into the page by waitForCondition: find the space link whose
+// visible text contains `searchText` and activate it, reporting whether one was
+// found. Prefers the shell breadcrumb before falling back to generic anchors:
+// the selectors are tried one at a time, because a combined selector matches in
+// document order and lets an unrelated descendant <a> containing the space name
+// win. Activation uses DOM click() rather than an Astral coordinate click,
+// which can hit a transient overlay even after resolving the right node. The
+// predicate finds and clicks in one page-side pass, so the click lands on the
+// element the search just resolved with no window for a re-render in between;
+// waitForCondition stops the instant it returns true, so the click fires once.
+const findAndClickPieceLink = (
+  probe: ProbeApi,
+  searchText: string,
+): boolean => {
+  for (
+    const selector of [
+      ".header-space",
+      "#header-space-link",
+      "#header-space",
+      "a",
+    ]
+  ) {
+    const link = probe.collect(selector).find((element) =>
+      (element as HTMLElement).innerText?.trim().includes(searchText)
+    ) as HTMLElement | undefined;
+    if (link) {
+      link.click();
+      return true;
+    }
+  }
+  return false;
+};
+
+// Wait for the space link to render, then activate it once.
 async function clickPieceLinkWithText(
   page: Page,
   searchText: string,
-): Promise<boolean> {
+): Promise<void> {
   try {
-    return await page.evaluate((searchText: string) => {
-      const roots: Array<Document | ShadowRoot> = [document];
-      for (let index = 0; index < roots.length; index++) {
-        for (const element of roots[index].querySelectorAll("*")) {
-          if ((element as HTMLElement).shadowRoot) {
-            roots.push((element as HTMLElement).shadowRoot!);
-          }
-        }
-      }
-
-      // Prefer the shell breadcrumb before falling back to generic anchors.
-      // A combined selector is returned in document order, so an unrelated
-      // descendant <a> containing the space name can otherwise win the race.
-      for (
-        const selector of [
-          ".header-space",
-          "#header-space-link",
-          "#header-space",
-          "a",
-        ]
-      ) {
-        for (const root of roots) {
-          for (const link of root.querySelectorAll<HTMLElement>(selector)) {
-            if (link.innerText.trim().includes(searchText)) {
-              // Use the DOM activation behavior. Astral's coordinate click can
-              // hit a transient overlay even after resolving the right node.
-              link.click();
-              return true;
-            }
-          }
-        }
-      }
-
-      return false;
-    }, { args: [searchText] });
-  } catch (_) {
-    return false;
+    await waitForCondition(page, findAndClickPieceLink, { args: [searchText] });
+  } catch (cause) {
+    throw new Error(
+      `Unable to find a space link matching "${searchText}" to click`,
+      { cause },
+    );
   }
 }
 

--- a/packages/patterns/integration/note-button-helpers.ts
+++ b/packages/patterns/integration/note-button-helpers.ts
@@ -138,21 +138,3 @@ export async function clickButtonWithTitle(
   await settleAndClickNoteButton(page, "cf-button, button", "title", title);
   return true;
 }
-
-export async function findButtonWithText(
-  page: Page,
-  searchText: string,
-): Promise<any | null> {
-  try {
-    const buttons = await page.$$("cf-button, button, a", {
-      strategy: "pierce",
-    });
-    for (const button of buttons) {
-      const text = await button.innerText();
-      if (text?.trim().includes(searchText)) return button;
-    }
-    return null;
-  } catch (_) {
-    return null;
-  }
-}

--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -3,7 +3,6 @@ import {
   env,
   Page,
   type ProbeApi,
-  waitFor,
   waitForCondition,
 } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
@@ -20,7 +19,6 @@ import {
   clickButtonWithExactText,
   clickButtonWithText,
   clickButtonWithTitle,
-  findButtonWithText,
 } from "../note-button-helpers.ts";
 import { resolveSpaceDid } from "@commonfabric/lib-shell";
 
@@ -97,11 +95,6 @@ describe("default-app notebook reload integration test", () => {
       await clickButtonWithTitle(page, "New Note"),
       "Expected New Note click to succeed",
     );
-    await waitFor(async () => {
-      await awaitViewSettled(page);
-      return !!(await findButtonWithText(page, "Create Another"));
-    });
-    await waitFor(async () => await resetEventInvocationTrace(page));
 
     const noteCreates = 7;
     for (let i = 0; i < noteCreates - 1; i++) {
@@ -248,45 +241,6 @@ async function collectBrowserLoadMetrics(page: Page): Promise<{
       ),
       postRenderStableMs: round(postRenderStableMs)!,
     };
-  });
-}
-
-async function resetEventInvocationTrace(page: Page): Promise<boolean> {
-  return await page.evaluate(async () => {
-    const api = globalThis.commonfabric as {
-      rt?: {
-        setTelemetryEnabled?: (enabled: boolean) => Promise<void>;
-        on?: (event: string, handler: (marker: unknown) => void) => void;
-        off?: (event: string, handler: (marker: unknown) => void) => void;
-        idle?: () => Promise<void>;
-      };
-      __eventInvocationTrace?: unknown[];
-      __eventInvocationTraceHandler?: (marker: unknown) => void;
-    } | undefined;
-    const rt = api?.rt;
-    if (!api || !rt?.setTelemetryEnabled || !rt.on || !rt.off) return false;
-
-    if (api.__eventInvocationTraceHandler) {
-      rt.off("telemetry", api.__eventInvocationTraceHandler);
-    }
-
-    api.__eventInvocationTrace = [];
-    api.__eventInvocationTraceHandler = (marker: unknown) => {
-      const type = marker && typeof marker === "object"
-        ? (marker as { type?: unknown }).type
-        : undefined;
-      if (
-        type === "scheduler.invocation" ||
-        type === "scheduler.event.commit" ||
-        type === "scheduler.event.preflight"
-      ) {
-        api.__eventInvocationTrace?.push(marker);
-      }
-    };
-    rt.on("telemetry", api.__eventInvocationTraceHandler);
-    await rt.setTelemetryEnabled(true);
-    await rt.idle?.();
-    return true;
   });
 }
 

--- a/tasks/check-no-waitfor.ts
+++ b/tasks/check-no-waitfor.ts
@@ -45,11 +45,9 @@ export const ALLOWLIST: ReadonlySet<string> = new Set([
   // MockDoc rendered-HTML reads and fresh cell.sync() round-trips, with no
   // completion callback the test can hook.
   "packages/runtime-client/integration/client.test.ts",
-  // Instrumentation one-shots that arm a trace or install a telemetry handler,
-  // plus a piece-link click retry and a wait for the note modal to render.
+  // Env-gated profiling scaffolding: one-shot waits that arm a trace or reset a
+  // logger baseline, gated behind CF_CAPTURE_* variables that default to off.
   "packages/patterns/integration/default-app.test.ts",
-  // A telemetry-handler install, and a wait for the note modal to render.
-  "packages/patterns/integration/reload/default-app-notebook.test.ts",
   // Human-in-the-loop OAuth flow: a person completes the consent step in a real
   // browser, and no CI lane runs the file.
   "packages/patterns/google/core/integration/google-calendar-importer.test.ts",


### PR DESCRIPTION
…ling waitFor

The browser suites have been migrating from the polling `waitFor` helper onto event-driven waits. `waitFor` re-runs its predicate on a fixed interval, and in a browser test every tick is a DevTools Protocol round-trip. The interval puts a floor on how fast a wait can notice its condition, and the timeout puts a ceiling on what it can observe at all.

Five polling waits were left in the default-app suites that run on every pass. Four convert to event-driven waits and the fifth turns out to be dead. The rest of the calls in default-app.test.ts are profiling scaffolding sitting behind CF_CAPTURE_* variables that default to off, and they stay as they are.

Waiting for the new-note modal. Both files polled an `awaitViewSettled` round-trip plus a shadow-piercing scan that read each button's text one call at a time, until a "Create Another" button turned up. This becomes a `waitForCondition` predicate that looks for the rendered button inside the page and resolves the moment it renders, followed by a single `awaitViewSettled`. The order is now "wait for the button, then settle" rather than "settle, then look", which is the guarantee the following clicks actually need: the modal binds its handlers and drops `pointer-events: none` one Lit update cycle after it opens, and the click helpers in these files do not settle the view themselves. The predicate applies the same rendered test that `markNoteButton` applies to the button it goes on to click, so the wait and the click agree on what counts as a match. The check matters on both axes here: a closed cf-modal hides its container through `visibility`, which leaves the button with a non-zero rect, so a layout test alone would not gate it.

Navigating back through the space link. The wait around the space-link click polled a predicate that clicked: it found the shell breadcrumb and activated it inside one page evaluation, so every tick was a full shadow-piercing DOM walk. It becomes a single `waitForCondition` predicate that finds the link and clicks it in one page-side pass. Two properties of the old code are kept. The link is activated through DOM `click()` rather than an Astral coordinate click, which can land on a transient overlay even once the right node is resolved. And the four selectors are still tried one at a time, because a combined selector matches in document order and would let a descendant anchor containing the space name beat the breadcrumb. Dispatching the click from inside the predicate is safe because `waitForCondition` stops the instant the predicate returns true — its evaluator guards re-entry while a run is in flight and honors a queued re-run only when the predicate returned false — so the click fires exactly once, with no window between finding the node and clicking it.

Resetting the event-invocation trace. In default-app.test.ts, where the trace is read by the notebook regression's failure diagnostics, the poll ran the reset call itself, which reports false only until the runtime exposes its telemetry methods. Those methods are instance methods of the runtime client, and the shell installs the client on the page global in the same step it installs the view-settle hook; the `awaitViewSettled` just above already awaits that hook, so the methods are present without fail by the time the reset runs. The wait is dropped and the reset is called once with its success asserted, which surfaces a genuinely absent API as a named assertion failure rather than a timeout.

The notebook reload test's copy of that reset is deleted instead, because nothing reads what it collects. It armed a handler filtering scheduler markers into `globalThis.commonfabric.__eventInvocationTrace`, and every reference to that array sat inside the function populating it. The trace once had a reader that recovered the notebook's entity id by scanning commit markers for a write to the notes path; "Remove Process Cell" (#3522) moved that discovery onto the serialized view's piece id, which is how the test finds the notebook today, and deleted the reader while leaving the writer. Nothing could read it now even in principle, because the array fills before `page.reload()` and the reload replaces the JavaScript realm.

Deleting it does not disturb the budgets that test asserts. They come from `collectSchedulerLoadSummary`, which reads the scheduler's own per-action run counters through `getGraphSnapshot` and the logger timing breakdown through `getLoggerCounts`; neither consults a telemetry flag. `setTelemetryEnabled` only gates emission, and the single site reading its scheduler-side flag gates a `telemetry.submit` call, after the preflight and the skip decision have already run. The question is moot regardless: the summary is collected after the reload, so the fresh runtime starts with telemetry off and the budgets were always measured that way. Run with the assertions enabled, three runs before and three after report identical numbers — 916 nodes, 52 action runs, 49 computation runs. What telemetry did cost fell on the seven rapid note creations before the reload, which shape the persisted scheduler state those budgets then measure.

With that, reload/default-app-notebook.test.ts no longer imports `waitFor` and comes off the allowlist in tasks/check-no-waitfor.ts, which the guard's stale-entry test requires. default-app.test.ts stays on the allowlist, and its entry now describes only the CF_CAPTURE_* profiling scaffolding left there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the always-run waits in the default-app browser tests off polling to reduce flakiness and DevTools round-trips. Removed the modal render wait, converted space-link navigation to an event-driven wait, and cleaned up a dead telemetry reset and the allowlist.

- **Refactors**
  - Modal: delete the pre-wait for "Create Another"; rely on click helpers to settle and wait; remove `findButtonWithText`.
  - Navigation: replace space-link polling with `waitForCondition(findAndClickPieceLink)`; keep DOM `click()` and one-at-a-time selector order.
  - Telemetry: in `default-app.test.ts`, reset the event-invocation trace once and assert; delete the unused reset from the reload test.
  - Allowlist: remove `reload/default-app-notebook.test.ts` from `tasks/check-no-waitfor.ts`; keep `default-app.test.ts` allowlisted only for `CF_CAPTURE_*`-gated profiling scaffolding.
  - Docs: update `docs/development/waiting-in-tests.md` to explain instrumentation one-shots and the no-wait reset pattern.

<sup>Written for commit 3bd78209bff5fd927bb87f99214fb6bf9291bb76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

