### PR TITLE
test(iframe-sandbox,deno-web-test): barrier the CSP negatives, fail a…

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -69,8 +69,11 @@ keep a bound whose early fire fails the run. They exist because no event reports
 the condition they wait on, so a large-enough clock jump can trip one on a
 healthy run and fail it. That is a fragility we accept for want of an
 alternative, sized so only a multi-minute jump reaches it — not one we have
-designed away. When an event boundary does exist, use it, and neither kind of
-exception arises.
+designed away. The deno-web-test per-test stuck detector
+([below](#browser-hosted-unit-tests-have-a-harness-backstop)) is another bound of
+this kind, and the most exposed: a competing ceiling keeps it from being sized
+that high, as its own section explains. When an event boundary does exist, use
+it, and neither kind of exception arises.
 
 ## The primitives to use instead
 
@@ -199,6 +202,61 @@ probe is such a client. It disposes its controller once the wait returns, which
 also keeps a finished wait from holding the loop open for the rest of the
 suite.
 
+### Browser-hosted unit tests have a harness backstop
+
+That fail-fast is Deno's, and the browser-hosted unit tests that
+`packages/deno-web-test` runs do not get it — `iframe-sandbox`, `identity`,
+`static`, and the `ui` browser tests. Their waits are the
+`defer()`-from-a-callback shape described above, but they run inside a page,
+whose event loop the page itself holds open, so a wait that never resolves hangs
+rather than failing.
+
+One bound at the harness level covers them. `deno-web-test` stops waiting on a
+test after `testTimeout` — 40 seconds by default, set per suite in
+`deno-web-test.config.ts` — and fails that test with a message naming it and
+saying how long it waited, leaving the rest of the run to report as usual.
+Without it a stuck test ran until astral's retried deadline on `page.evaluate`
+ran out of attempts, 53 to 57 seconds later, and threw a `RetryError` that named
+no test, printed no summary, and abandoned every test file still queued.
+
+This is the distinction `waitForCondition`'s `timeout` draws, one level up: a
+stuck-condition safety net rather than a bound at the call site. It is why a
+wait inside one of these tests still takes no timeout of its own — adding one
+per call site would cap what each wait can observe, which is the thing being
+avoided, while the harness bound only decides when to stop believing a test will
+ever finish.
+
+By the test in [Wall-clock time is not a measure of
+progress](#wall-clock-time-is-not-a-measure-of-progress), its early fire is not
+safe: it fails a passing test. So it is a bound kept for want of an alternative,
+alongside the polling waits and the FUSE teardown bound — there is no event for
+"this test will never finish." It is the worst-placed member of that group, and
+the reason is worth stating plainly. Those other bounds sit so far above their
+work that only a multi-minute clock jump reaches them. This one cannot: astral's
+own deadline runs out around fifty seconds and takes the run down unnamed, so
+the bound has to fire below that, and a clock jump between the bound and fifty
+seconds fails a healthy test. Astral's retry would have ridden that jump out — it
+re-wraps the same evaluate across five attempts, so a test that finishes late is
+still returned — where this single timer does not. The bound is kept only
+because astral's un-named, whole-run failure is the worse outcome on a genuine
+hang, not because it escapes the clock-jump fault.
+
+That trade is what sets the default, and it sets it high rather than low. The
+window in which this bound fires but astral would not is exactly the gap between
+the bound and astral's floor, so the bound wants to sit as close under that
+floor as reliable naming allows — the opposite of the "leave a wide margin"
+instinct, which here only widens the exposure. Astral's floor is a hard fifty
+seconds, five ten-second timers that no machine runs through faster, so forty
+seconds clears it with room for the retry's backoff on top while keeping the
+clock-jump window down to about ten seconds. The slowest healthy test in any of
+these suites is about a second, and that one is deliberately waiting out a timer,
+so real work never approaches forty. A suite that somehow needs more should raise
+`testTimeout`, and keep it under the fifty-second floor.
+
+`packages/deno-web-test/README.md` records what the bound does not cover: a test
+blocking the event loop outright, and the stuck test's own work, which goes on
+running in the page afterwards.
+
 ## Waiting for the scheduler and for the worker reconciler
 
 Two pieces of machinery come up often enough in unit tests, and dispatch
@@ -238,6 +296,59 @@ no later batch can falsify the absence. Those tests need it. A wait on the
 `onOps` callback would never return for them, since a change that emits no ops
 produces no batch, and they pass vacuously when nothing has flushed at all —
 their teeth come from the wait being long enough to have seen an unwanted op.
+
+## Proving a negative
+
+A test that asserts something never happens has no event of its own to wait for.
+Waiting a fixed interval and then declaring success is the shape to avoid. It
+puts a floor under what the test costs and a ceiling on what it can catch, since
+whatever arrives after the interval is missed, and it reports the same pass
+either way — the assertion never depends on the wait having been long enough.
+
+Send something that must arrive after the thing being ruled out, wait for that,
+then assert the thing never came. Any channel that preserves order carries this.
+A `postMessage` between a fixed pair of windows does, and so does a chain of
+them: `packages/iframe-sandbox/test/iframe-csp.test.ts` has each guest document
+write a marker back to the host once its load event fires, and a CSP error from
+the same guest travels the same two hops — guest to outer frame, outer frame to
+host — so a test holding the marker holds any error that fired. The "subscribes"
+and "cancels subscriptions between documents" tests in
+`packages/iframe-sandbox/test/iframe.test.ts` use the same idea against the
+update stream: write to a key that is still subscribed, and once the guest
+reports it, an update for the unsubscribed key would already have arrived had
+one been sent.
+
+Two things decide whether this works, and both are worth checking rather than
+assuming.
+
+The barrier has to be genuinely ordered after the event, which is a claim about
+the specific mechanism and not about elapsed time. The CSP suite is a good
+illustration of how far that varies for one browser and one policy: a blocked
+`<img>` or `<link rel=stylesheet>` reports its violation before the document's
+load event, while a blocked `<script src>`, an image a stylesheet asks for, and a
+`fetch()` all report theirs after it. A `fetch()` is the extreme — its violation
+lands a macrotask turn after the request has already rejected, so no marker the
+page can post is ordered after it. Where no such ordering exists, say so and
+leave the case on its interval rather than inventing a barrier that only looks
+like one; `unbarrierable` in that file records the cases that stay.
+
+A barrier that is not really ordered after the event fails silently: the test
+goes on passing while asserting nothing. Pair the conversion with a control — the
+same fixture and the same wait against input that does trigger the event, which
+must observe it by the time the barrier lands. `barrierControls` in the CSP suite
+is that check. Moving its barrier earlier leaves every negative case green while
+the controls that can speak to ordering go red, which is the point of having
+them.
+
+Which controls those are is worth working out rather than assuming, because a
+control can be written so that it cannot fail. Only an event that can arrive
+after the page's own scripts have run tests the ordering at all. Two of that
+suite's eight controls are of that kind; the other six raise their error from a
+synchronous throw while the document parses, which no barrier could be posted
+before, so they stay green however early the barrier moves. They still earn
+their place — they show the error channel is live for their fixture's shape —
+but they are evidence of that and not of ordering. Sort them deliberately and
+say which is which, or the group reads as proof it does not supply.
 
 ## Guard against new usage
 

--- a/packages/deno-web-test/README.md
+++ b/packages/deno-web-test/README.md
@@ -27,11 +27,43 @@ export default {
   product: "chrome",
   args: ["--enable-experimental-web-platform-features"],
   pipeConsole: true,
+  testTimeout: 40_000,
   include: {
     "path/static-asset.json": "static/asset.json",
   },
 };
 ```
+
+## Stuck tests
+
+A test that waits on something which never arrives would otherwise hang until
+astral's retried deadline on `page.evaluate` ran out of attempts, 53 to 57
+seconds later, with a `RetryError` that named no test, printed no summary, and
+abandoned every test file still queued. The harness stops waiting on a test
+after `testTimeout` (40 seconds by default) and fails that test with a message
+naming it and saying how long it waited. The rest of the run continues, so one
+stuck test costs one failure rather than the whole suite's results.
+
+This is a stuck detector, not a bound on how long a test may take. Astral does
+not re-run a test that runs long: it awaits each test through a single
+`page.evaluate`, and when its own ten-second deadline elapses it re-waits on
+that same in-flight call rather than failing, up to five times. So the test body
+runs once, and a slow one is returned by whichever attempt is live when it
+finishes — which is why tests well past 40 seconds pass today. This detector is
+the first hard bound over them, and its early fire fails a passing test, so it
+sits high on purpose. Astral's five attempts run out at a hard fifty-second
+floor, and the detector has to fire below that to name the test before astral
+takes the run down unnamed — but the lower it fires, the wider the window in
+which a clock jump (a suspend, a CI pause) trips it on a healthy test that
+astral's re-waiting would have ridden out. Forty seconds is as high as reliably
+beats the floor. Raise `testTimeout` for a suite with genuinely long tests, and
+keep it under fifty seconds.
+
+Two limits are worth knowing. Nothing can cancel the test's own promise, so a
+stuck test keeps running in the page afterwards and can still disturb later
+tests. And the detector is a timer in the page, so it cannot fire against a test
+that blocks the event loop outright — a spinning loop still reaches astral's
+deadline.
 
 Finally, run `deno-web-test/cli.ts`, which takes a glob of files to test.
 

--- a/packages/deno-web-test/browser.ts
+++ b/packages/deno-web-test/browser.ts
@@ -8,7 +8,7 @@ import {
 import { Manifest } from "./manifest.ts";
 import { tsToJs } from "./utils.ts";
 import { TestResult } from "./interface.ts";
-import { extractAstralConfig } from "./config.ts";
+import { DEFAULT_TEST_TIMEOUT_MS, extractAstralConfig } from "./config.ts";
 import { sleep } from "@commonfabric/utils/sleep";
 
 const LAUNCH_RETRY_ATTEMPTS = 5;
@@ -61,8 +61,10 @@ export class BrowserController extends EventTarget {
   async load(filePath: string) {
     const rootUrl = `http://localhost:${this.serverPort}`;
     const jsTestPath = tsToJs(filePath);
-    const testUrl = `${rootUrl}/?test=/${jsTestPath}`;
     const config = this.manifest.config;
+    const testTimeout = config.testTimeout ?? DEFAULT_TEST_TIMEOUT_MS;
+    const testUrl =
+      `${rootUrl}/?test=/${jsTestPath}&testTimeout=${testTimeout}`;
 
     if (this.page) {
       await this.page.goto(testUrl);

--- a/packages/deno-web-test/config.ts
+++ b/packages/deno-web-test/config.ts
@@ -14,6 +14,11 @@ export type Config = {
   args?: string[];
   // Whether or not console commands should be propagated to the deno-web-test process.
   pipeConsole?: boolean;
+  // How long a single test may run, in ms, before the harness stops waiting on
+  // it and fails it as stuck. Default: `DEFAULT_TEST_TIMEOUT_MS`. Raise it for
+  // a suite with genuinely long tests; it is a stuck-test detector, so it
+  // belongs well above anything the suite does when it is healthy.
+  testTimeout?: number;
   // A map of relative file paths to copy to the static server during testing.
   // The keys are relative file paths and the values are the destination from
   // the server root.
@@ -21,12 +26,61 @@ export type Config = {
   esbuildConfig?: Parameters<typeof build>[0];
 };
 
+// How long a test may run before the harness calls it stuck.
+//
+// This is a safety net, not a latency bound. Its early fire fails a passing
+// test, so by the reasoning in docs/development/waiting-in-tests.md it is a
+// bound whose early fire is not safe, kept only because the alternative is
+// worse. The alternative is astral's own deadline: each test is awaited through
+// one `page.evaluate`, which astral wraps in `retry(() => deadline(evaluate,
+// 10_000))`. That does not re-run a slow test. The evaluate is issued once, and
+// each of the five attempts re-waits on that same in-flight call with a fresh
+// ten-second deadline, so the test body runs once and a slow one is returned by
+// whichever attempt is live when it settles. A test that never settles exhausts
+// the attempts around fifty seconds — five ten-second timers no machine runs
+// through faster, plus the retry's backoff, measured at 53 to 57 seconds — and
+// throws a `RetryError` that names no test, prints no summary, and abandons
+// every test file still queued. Firing before that, by name, and letting the
+// run continue is the whole point.
+//
+// That fifty-second floor also caps this bound, and the cap is what sizes it.
+// The bound can trip early on a healthy test whenever the clock jumps — a
+// suspend, a CI pause, a live-migration — by more than the bound. Astral's
+// re-waiting rides such a jump out, since a later attempt returns the same call
+// once it settles, where this single timer does not. The window in which this
+// bound fires but astral would not is the gap between the
+// bound and the floor, so the bound wants to sit as high under the floor as
+// still reliably beats it, not low: a large margin here is a wider failure
+// window, not safety. Forty seconds clears the fifty-second floor with room for
+// the backoff on top and holds the clock-jump window to about ten seconds. The
+// slowest healthy test in any suite using this runner is about a second, and
+// that one is deliberately waiting out a timer, so real work never approaches
+// forty. A suite that somehow needs more should raise `testTimeout` and keep it
+// under the fifty-second floor.
+export const DEFAULT_TEST_TIMEOUT_MS = 40_000;
+
 export const applyDefaults = (config: object): Config => {
-  return Object.assign({
+  const applied: Config = Object.assign({
     headless: true,
     devtools: false,
     pipeConsole: true,
+    testTimeout: DEFAULT_TEST_TIMEOUT_MS,
   }, config);
+
+  // A `testTimeout` that is not a positive, finite number cannot mean anything
+  // the detector can act on. Zero and a negative both ask `setTimeout` to fire
+  // at once and would fail every test in the suite; `Infinity` is clamped to
+  // the same thing. Say so here rather than let the harness quietly substitute
+  // its own default and run with a bound the config did not ask for.
+  const { testTimeout } = applied;
+  if (!Number.isFinite(testTimeout) || (testTimeout as number) <= 0) {
+    throw new Error(
+      `deno-web-test.config.ts: \`testTimeout\` must be a positive number of ` +
+        `milliseconds, got ${testTimeout}.`,
+    );
+  }
+
+  return applied;
 };
 
 export const extractAstralConfig = (config: Config): LaunchOptions => {

--- a/packages/deno-web-test/harness/harness.js
+++ b/packages/deno-web-test/harness/harness.js
@@ -6,9 +6,10 @@ const formatError = (e) => ({
 });
 
 class Test {
-  constructor(name, fn, el) {
+  constructor(name, fn, el, timeoutMs) {
     this.name = name;
     this.fn = fn;
+    this.timeoutMs = timeoutMs;
     this.success = null;
     this.duration = null;
     this.error = null;
@@ -16,16 +17,43 @@ class Test {
     this.el.innerText = name;
   }
 
+  // Rejects once the test has run for `timeoutMs` without finishing. A test
+  // that waits on an event which never arrives would otherwise sit here until
+  // the driver's own deadline killed the whole run without naming it.
+  #stuck() {
+    return new Promise((_, reject) => {
+      this.timer = setTimeout(() => {
+        reject(
+          new Error(
+            `Timed out after ${this.timeoutMs}ms. The harness stops waiting on ` +
+              `a test at that point and calls it stuck; it is not a bound on ` +
+              `how long a test may legitimately take. Either this test is ` +
+              `waiting for something that never arrived, or the suite needs a ` +
+              `larger \`testTimeout\` in its deno-web-test.config.ts.`,
+          ),
+        );
+      }, this.timeoutMs);
+    });
+  }
+
   async run() {
     const start = performance.now();
     try {
-      await this.fn();
+      // Nothing can cancel the test's own promise, so a stuck test goes on
+      // running in the page after this returns. Keep a handler on it either
+      // way, so that settling late does not surface as an unhandled rejection
+      // against whichever test is running by then.
+      const running = (async () => await this.fn())();
+      running.catch(() => {});
+      await Promise.race([running, this.#stuck()]);
       this.success = true;
       this.el.setAttribute("state", "success");
     } catch (e) {
       this.success = false;
       this.error = formatError(e);
       this.el.setAttribute("state", "error");
+    } finally {
+      clearTimeout(this.timer);
     }
     this.duration = performance.now() - start;
     // This matches `TestResult` in typescript
@@ -70,7 +98,12 @@ class TestController {
 
 class TestHarness {
   constructor() {
-    this.testFile = new URL(globalThis.location.href).searchParams.get("test");
+    const params = new URL(globalThis.location.href).searchParams;
+    this.testFile = params.get("test");
+    // `BrowserController` always sends this; the fallback only covers the page
+    // being opened by hand. Keep it in step with `DEFAULT_TEST_TIMEOUT_MS`,
+    // which this file cannot import.
+    this.testTimeout = Number(params.get("testTimeout")) || 40_000;
     this.tests = [];
     this.currentTest = 0;
     this.loadError = null;
@@ -106,7 +139,7 @@ class TestHarness {
     }
     const el = document.createElement("li");
     $("#tests").appendChild(el);
-    this.tests.push(new Test(name, fn, el));
+    this.tests.push(new Test(name, fn, el, this.testTimeout));
   }
 
   async runNext() {

--- a/packages/deno-web-test/test/timeout-project/deno-web-test.config.ts
+++ b/packages/deno-web-test/test/timeout-project/deno-web-test.config.ts
@@ -1,0 +1,6 @@
+// Far below the default, so the stuck test in this project is detected in
+// about a second rather than thirty. The detector's behavior is what is under
+// test here, not the size of the default.
+export default {
+  testTimeout: 1000,
+};

--- a/packages/deno-web-test/test/timeout-project/deno.jsonc
+++ b/packages/deno-web-test/test/timeout-project/deno.jsonc
@@ -1,0 +1,9 @@
+{
+  "name": "deno-web-test-timeout-project",
+  "tasks": {
+    "test": "<@see deno-web-test/test/utils.ts#runDenoWebTest>"
+  },
+  "exports": {
+    ".": "./mod.ts"
+  }
+}

--- a/packages/deno-web-test/test/timeout-project/hang.test.ts
+++ b/packages/deno-web-test/test/timeout-project/hang.test.ts
@@ -1,0 +1,9 @@
+import { hang } from "./mod.ts";
+
+Deno.test("before-hang", function () {});
+
+Deno.test("hangs-forever", async function () {
+  await hang();
+});
+
+Deno.test("after-hang", function () {});

--- a/packages/deno-web-test/test/timeout-project/mod.ts
+++ b/packages/deno-web-test/test/timeout-project/mod.ts
@@ -1,0 +1,1 @@
+export const hang = (): Promise<never> => new Promise(() => {});

--- a/packages/deno-web-test/test/timeout.test.ts
+++ b/packages/deno-web-test/test/timeout.test.ts
@@ -1,0 +1,63 @@
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { applyDefaults, DEFAULT_TEST_TIMEOUT_MS } from "../config.ts";
+import { decode } from "@commonfabric/utils/encoding";
+import { runDenoWebTest } from "./utils.ts";
+
+// A test that waits on something which never arrives used to take the whole run
+// down: astral's own deadline on `page.evaluate` eventually threw a `RetryError`
+// that named no test, printed no summary, and skipped every test file after it.
+// The harness now stops waiting on a test of its own accord, so a stuck test is
+// one named failure among otherwise normal results.
+Deno.test("a stuck test fails by name and the run continues", async function () {
+  const { success, stdout } = await runDenoWebTest("timeout-project");
+  const stdoutText = decode(stdout);
+
+  assert(!success, "the run fails");
+  assert(/hangs-forever \.\.\. .*FAILED/.test(stdoutText), "names the test");
+  assert(
+    /Timed out after 1000ms/.test(stdoutText),
+    "reports how long it waited",
+  );
+  assert(
+    /a test at that point and calls it stuck/.test(stdoutText),
+    "explains that this is a stuck-test detector",
+  );
+
+  // The point of failing the test rather than the run: everything else still
+  // reports, including the tests queued behind the stuck one.
+  assert(/before-hang \.\.\. .*ok/.test(stdoutText), "earlier test ran");
+  assert(/after-hang \.\.\. .*ok/.test(stdoutText), "later test still ran");
+  assert(/2 passed \| 1 failed/.test(stdoutText), "summary is printed");
+  assert(
+    !/RetryError/.test(stdoutText),
+    "the harness reports before astral's deadline",
+  );
+});
+
+// The detector is only worth having while it fires before astral does. Astral
+// gives each `page.evaluate` five retried 10-second deadlines and throws a
+// `RetryError` once they run out, measured at 53 to 57 seconds; past that the
+// run dies without naming the test. Raising the default above that would put
+// the diagnostic back out of reach, so the relationship is pinned here rather
+// than left in a comment.
+Deno.test("the default fires before astral's retries run out", function () {
+  assert(
+    DEFAULT_TEST_TIMEOUT_MS < 50_000,
+    `${DEFAULT_TEST_TIMEOUT_MS}ms leaves no room before astral's RetryError`,
+  );
+});
+
+Deno.test("testTimeout must be a usable number", function () {
+  assertEquals(applyDefaults({}).testTimeout, DEFAULT_TEST_TIMEOUT_MS);
+  assertEquals(applyDefaults({ testTimeout: 5000 }).testTimeout, 5000);
+
+  // Each of these would otherwise reach `setTimeout` as an immediate fire and
+  // fail every test in the suite, or be silently swapped for the default.
+  for (const testTimeout of [0, -1, Infinity, NaN]) {
+    assertThrows(
+      () => applyDefaults({ testTimeout }),
+      Error,
+      "must be a positive number",
+    );
+  }
+});

--- a/packages/iframe-sandbox/test/iframe-csp.test.ts
+++ b/packages/iframe-sandbox/test/iframe-csp.test.ts
@@ -1,10 +1,13 @@
 import {
   assert,
+  assertDeepEquals,
   assertEquals,
   cleanupFixtures,
+  ContextShim,
   invertPromise,
   render,
   setIframeTestHandler,
+  waitForContextValue,
   waitForEvent,
 } from "./utils.ts";
 
@@ -57,6 +60,38 @@ window.onerror = function (message, source, lineno, colno, error) {
 </script>
 `;
 
+// Writes "barrier" into the context once the guest has passed the point where
+// a case's error would already have been posted.
+//
+// An error leaves the guest as a postMessage to the outer frame, which forwards
+// it to the host on a second fixed pair of windows; the barrier write takes
+// that same path. Each hop preserves the order it received messages in, so a
+// barrier posted after an error arrives after it, and a test that has seen the
+// barrier has seen any error that fired.
+//
+// The load event is the point the cases below share. It fires once the document
+// has parsed and its subresources have settled, and it lands after the
+// violation for the two kinds of subresource those cases load: an `<img>`
+// element and a `<link rel=stylesheet>`.
+//
+// It is not a general barrier for CSP violations, and the cases below stay
+// inside what it covers. A blocked `<script src>`, a request a stylesheet
+// starts such as a `background-image`, and a `fetch()` each report their
+// violation only after the load event has already fired. A negative case of one
+// of those shapes belongs in `unbarrierable` below rather than here.
+//
+// `barrierControls` below holds the conversions to it honest.
+const BARRIER = `
+<script>
+addEventListener('load', () => {
+  window.parent.postMessage({
+    type: 'write',
+    data: ['barrier', true],
+  }, '*');
+});
+</script>
+`;
+
 const HTML_URL = "https://common.tools";
 const SCRIPT_URL = "https://common.tools/static/sketch.js";
 const STYLE_URL = "https://common.tools/static/main.css";
@@ -80,13 +115,29 @@ anchor.click();
 </script>`;
 }
 
+// `openWindow` with its guard inverted: throws when the window did not open,
+// which is the outcome the real cases assert. Used by `barrierControls`.
+function invertedOpenWindow(target: string) {
+  return `<script>
+    let win = window.open("${HTML_URL}", "${target}");
+    if (!win) throw new Error("Window Opened");</script>`;
+}
+
+// `clickAnchor` with a throw at the point the click happens, which the real
+// cases reach without raising anything. Used by `barrierControls`.
+function throwingClickAnchor(target: string) {
+  return `
+<a id="anchor-test" href="${HTML_URL}" target="${target}">
+<script>
+const anchor = document.querySelector("#anchor-test");
+anchor.click();
+throw new Error("clicked");
+</script>`;
+}
+
 const cases: TestCase[] = [[
   "allows inline script",
   `<script>console.log("foo")</script><style>* { background-color: red; }</style><div>foo</div>`,
-  null,
-], [
-  "allows 1P fetch",
-  `<script>fetch("${ORIGIN_URL}/foo.js")</script>`,
   null,
 ], [
   "allows 1P img",
@@ -109,20 +160,12 @@ const cases: TestCase[] = [[
   openWindow("_parent"),
   null,
 ], [
-  "disallows opening windows (_self)",
-  openWindow("_self"),
-  null,
-], [
   "disallows opening windows (_top)",
   openWindow("_top"),
   null,
 ], [
   "disallows anchor link target (_parent)",
   clickAnchor("_parent"),
-  null,
-], [
-  "disallows anchor link target (_self)",
-  clickAnchor("_self"),
   null,
 ], [
   "disallows anchor link target (_top)",
@@ -178,6 +221,128 @@ const cases: TestCase[] = [[
   /Uncaught SecurityError/,
 ]];
 
+// These negative cases keep the fixed-duration wait. For each of them nothing
+// the guest can post is ordered after the error the case rules out, so there is
+// no marker to barrier on, and each stays only as good as its timeout makes it:
+// an error arriving later than the wait is missed.
+//
+// "allows 1P fetch" is bounded by the browser rather than by the guest. A
+// `fetch()` does not hold the document's load event, and a blocked request
+// reports its violation a macrotask turn after the request has already
+// rejected — later than the load event as well. The outcome of the request
+// cannot stand in for the violation either: the guest runs on an opaque
+// origin, so the host's own origin is cross-origin to it, and both a 1P and a
+// 3P request reject with "TypeError: Failed to fetch" once CORS fails the
+// response. The violation is the only thing that separates allowed from
+// blocked, and the browser reports it after every guest continuation for the
+// request has run.
+//
+// "disallows anchor link target (_self)" navigates the guest's own frame, and
+// the navigation tears the guest document down, so no guest code is left to
+// report a marker. It raises no error either, and so asserts only that the
+// guest reported nothing before it was torn down.
+const unbarrierable: TestCase[] = [[
+  "allows 1P fetch",
+  `<script>fetch("${ORIGIN_URL}/foo.js")</script>`,
+  null,
+], [
+  "disallows anchor link target (_self)",
+  clickAnchor("_self"),
+  null,
+]];
+
+// /!\ This test cannot assert what its name says, so it does not run.
+//
+// It is here rather than in `cases` because its guard is unsound.
+// `window.open(url, "_self")` targets the current browsing context, so it hands
+// that window back whether or not the navigation is allowed, and the fixture's
+// `if (win) throw` therefore always throws. The host does dispatch the
+// resulting "Uncaught Error: Window Opened": a listener installed before the
+// load sees it every time. The case only ever passed because it began listening
+// after `render` had resolved, by which point the error had already been
+// dispatched, and reading the resulting silence as "no window was opened".
+//
+// What it set out to check is not observable from the host. The `_self`
+// navigation tears the guest down before any guest code could report on it, and
+// whether the navigation is ultimately blocked cannot be seen from out here.
+// That is the same wall "disallows navigation" in `falseNegatives` below runs
+// into — it drives the same self-navigation through `location.href`, is blocked
+// in practice, and reports nothing — which is why it does not run either.
+//
+// Deciding what should be asserted about `_self` navigation is a question about
+// the sandbox's intended policy, not about how this test waits.
+const unsoundAssertions: TestCase[] = [[
+  "disallows opening windows (_self)",
+  openWindow("_self"),
+  null,
+]];
+
+// Every negative case above proves the same thing: no error had fired by the
+// time the barrier arrived. Each control here runs one of those fixtures'
+// shapes through the same body and the same wait, against html that does raise
+// an error, and requires the error to be in hand by barrier time. The third
+// element is the description it must carry, so a control cannot pass on an
+// unrelated error.
+//
+// The controls are not all doing the same job, and the difference decides what
+// each is evidence of.
+//
+// Ordering only needs proving for a case whose error can arrive after the
+// guest's own scripts have run, and the two subresource controls are the ones
+// that prove it. Post the barrier during parse instead of on load and they go
+// red, because the violation for a blocked `<img>` or `<link rel=stylesheet>`
+// is reported after the parser has passed the barrier script.
+//
+// The other six raise their error from a synchronous throw while the document
+// parses, before the barrier script has been reached at all. No barrier the
+// guest could post can come first, so they cannot fail on ordering and say
+// nothing about it. Their converted cases do not need them to: the error those
+// cases rule out is raised the same way, during parse, so any barrier is
+// already after it. What these six check instead is that the error channel is
+// live for their shape — that `CSP_REPORTER` is installed, and that the guest
+// is still there to report. That is the property separating the `_parent` and
+// `_top` cases from the `_self` ones, which tear the guest down before it can
+// report anything.
+const barrierControls: [string, string, string][] = [[
+  // "allows inline script": an error raised while the document parses.
+  "inline script throws",
+  `<script>throw new Error("boom")</script>`,
+  "Uncaught Error: boom",
+], [
+  // "allows 1P img" and "allows data: img".
+  "3P img element",
+  `<img src="${IMG_URL}" />`,
+  "CSP:img-src",
+], [
+  // "allows 1P CSS".
+  "3P CSS link",
+  `<link rel="stylesheet" href="${STYLE_URL}">`,
+  "CSP:style-src-elem",
+], [
+  // The three `openWindow` cases, with the guard inverted so the fixture
+  // throws on the path the real cases leave silent.
+  "openWindow (_blank) throws",
+  invertedOpenWindow("_blank"),
+  "Uncaught Error: Window Opened",
+], [
+  "openWindow (_parent) throws",
+  invertedOpenWindow("_parent"),
+  "Uncaught Error: Window Opened",
+], [
+  "openWindow (_top) throws",
+  invertedOpenWindow("_top"),
+  "Uncaught Error: Window Opened",
+], [
+  // The two `clickAnchor` cases, throwing where the click happens.
+  "clickAnchor (_parent) throws",
+  throwingClickAnchor("_parent"),
+  "Uncaught Error: clicked",
+], [
+  "clickAnchor (_top) throws",
+  throwingClickAnchor("_top"),
+  "Uncaught Error: clicked",
+]];
+
 // /!\ These tests do not report correctly.
 // /!\ Not sure why! But they correctly are blocked
 // /!\ in practice. How can we ensure this is properly tested?
@@ -214,6 +379,15 @@ const unknownStatuses: TestCase[] = [
 for (const [name, html, expected] of cases) {
   defineTest(name, html, expected);
 }
+for (const [name, html, expected] of unbarrierable) {
+  defineTimedNegativeTest(name, html, expected);
+}
+for (const [name, html, expected] of unsoundAssertions) {
+  definePending(name, html, expected);
+}
+for (const [name, html, expected] of barrierControls) {
+  defineBarrierControl(name, html, expected);
+}
 for (const [name, html, expected] of falseNegatives) {
   definePending(name, html, expected);
 }
@@ -231,14 +405,30 @@ function defineTest(
 ) {
   Deno.test(name, async () => {
     cleanupFixtures();
+    // The event bubbles and is composed, so the document sees it. Listening
+    // there rather than on the element catches an error the host dispatches
+    // before `render` hands the element back.
+    const errors: unknown[] = [];
+    const onError = (event: Event) => {
+      errors.push((event as CustomEvent).detail.description);
+    };
+    document.addEventListener("common-iframe-error", onError);
     try {
+      const context = new ContextShim();
       const body = `
           ${CSP_REPORTER}
           ${html}
+          ${BARRIER}
         `;
-      const iframe = await render(body);
+      const iframe = await render(body, context);
       if (expected == null) {
-        await invertPromise(waitForEvent(iframe, "common-iframe-error"));
+        await waitForContextValue(
+          context,
+          iframe,
+          "barrier",
+          (value) => value === true,
+        );
+        assertDeepEquals(errors, []);
       } else {
         const event = await waitForEvent(
           iframe,
@@ -250,6 +440,71 @@ function defineTest(
           assert(expected.test(event.detail.description));
         }
       }
+    } finally {
+      document.removeEventListener("common-iframe-error", onError);
+      cleanupFixtures();
+    }
+  });
+}
+
+// Runs a `barrierControls` case: same body and same wait as a negative case in
+// `defineTest`, against html that does break the policy. The error must be in
+// hand at the moment the barrier arrives.
+function defineBarrierControl(
+  name: string,
+  html: string,
+  expected: string,
+) {
+  Deno.test(`barrier control: ${name}`, async () => {
+    cleanupFixtures();
+    const errors: unknown[] = [];
+    const onError = (event: Event) => {
+      errors.push((event as CustomEvent).detail.description);
+    };
+    document.addEventListener("common-iframe-error", onError);
+    try {
+      const context = new ContextShim();
+      const body = `
+          ${CSP_REPORTER}
+          ${html}
+          ${BARRIER}
+        `;
+      const iframe = await render(body, context);
+      await waitForContextValue(
+        context,
+        iframe,
+        "barrier",
+        (value) => value === true,
+      );
+      assertDeepEquals(errors, [expected]);
+    } finally {
+      document.removeEventListener("common-iframe-error", onError);
+      cleanupFixtures();
+    }
+  });
+}
+
+// The pre-barrier shape, kept for the `unbarrierable` cases: wait out
+// `waitForEvent`'s timeout and read the rejection as "no error fired". It
+// bounds how late an error can arrive and still be caught, and it starts
+// listening only once `render` has resolved.
+function defineTimedNegativeTest(
+  name: string,
+  html: string,
+  expected: string | null | RegExp,
+) {
+  if (expected != null) {
+    throw new Error(`${name}: expected a negative case.`);
+  }
+  Deno.test(name, async () => {
+    cleanupFixtures();
+    try {
+      const body = `
+          ${CSP_REPORTER}
+          ${html}
+        `;
+      const iframe = await render(body);
+      await invertPromise(waitForEvent(iframe, "common-iframe-error"));
     } finally {
       cleanupFixtures();
     }


### PR DESCRIPTION
… hung test by name

Two changes to how the browser-hosted unit tests wait, sharing one principle — a test should wait on a real event, and the only legitimate timeout is a stuck-detector — and coupled at the edges. The first removes the per-case timeouts the CSP suite used to prove a negative, leaving those waits event-driven and therefore able to hang if an event never comes. The second gives the harness the one stuck-detector that makes such a hang fail cleanly instead of taking the run down.

The CSP negatives were proved by timeout. Every negative case in `packages/iframe-sandbox/test/iframe-csp.test.ts` proved "no CSP error fires" by waiting out `waitForEvent`'s 1000ms timeout and reading the rejection as success. Twelve cases did this, and they were the entire wall-clock cost of the package: about 12.4 seconds of a 12.4 second suite, against roughly 113ms for the rest. The wait also bounded what the cases could catch — an error arriving after the timeout was missed — and reported the same pass either way.

Each converted case now has its guest write a "barrier" marker back into the context from its load handler, and asserts no error was collected by the time the marker arrives. An error and the marker leave the guest the same way and travel the same two ordered postMessage hops, so a test holding the marker holds any error that fired. The error listener moves from the element to the document, which the event reaches by bubbling and composition, so an error dispatched during load — before `render` resolves — is no longer missed.

Nine of the twelve convert. Two keep the fixed wait under `unbarrierable`, because nothing the guest can post is ordered after the error they rule out. A blocked `fetch()` reports its violation a macrotask turn after it has already rejected and after the load event, and its own outcome cannot stand in, since an opaque-origin guest rejects 1P and 3P requests alike with "Failed to fetch". The `_self` anchor tears the guest down before any marker could be sent. The load event covers a blocked `<img>` or `<link rel=stylesheet>`, which report before it, but not a `<script src>`, a stylesheet's `background-image`, or a `fetch()`, which report after.

Because a barrier that is not really ordered after the error fails silently, `barrierControls` runs the same fixtures against html that does break the policy. Two of them, the blocked subresources, raise their error after the guest's own scripts run, so moving the barrier to parse time turns them red — they prove the ordering. The other six throw synchronously during parse, before any barrier could be posted, so they cannot fail on ordering; what they check is that the error channel is live for their fixture's shape, the property separating the `_parent` and `_top` cases from the `_self` ones. The comment sorts the two.

"disallows opening windows (_self)" no longer runs. It asserted "no error fired" while an error fires every time — `window.open(url, "_self")` hands back a window whether or not the navigation is allowed, so the fixture's `if (win) throw` always throws and the host dispatches it — and it passed only by listening after `render` had resolved. Leaving it green among the unbarrierable cases would keep a broken security assertion reading as a pass, so it moves to `definePending`, where the file already puts cases that cannot assert what their names say, including "disallows navigation", which drives the same `_self` navigation through `location.href`. What that case should assert is a question about the sandbox's intended policy, recorded for whoever takes it up. The CSP suite drops to about 2.4 seconds.

The harness had no per-test bound anywhere. A wait whose event never arrives could not fail: the browser-hosted suites hold their own event loop open, so a stuck test hung until astral's retry ran out. astral awaits each test through one `page.evaluate` wrapped in `retry(() => deadline(evaluate, 10_000))`, which does not re-run a slow test — it re-waits on the same in-flight call across five ten-second attempts — and a test that never settles exhausts them around fifty to fifty-seven seconds and throws a `RetryError`. That is an unhandled rejection: it names no test, prints no summary, skips every remaining test file, and leaves the browser open.

The harness now stops waiting after `testTimeout` and fails that test by name, saying how long it waited, and lets the run continue — one failure instead of the run's results. It is configurable per suite and deliberately not per test, since a per-test knob is the shape being avoided and a test that needs more than its suite's bound is far likelier stuck than slow.

This is a bound whose early fire fails a passing test, which `docs/development/waiting-in-tests.md` calls the kind to make event-driven instead. Here there is no event — nothing reports that a test will never finish — so it is kept for want of an alternative, alongside the polling waits and the FUSE teardown bound, and it is the most exposed of them. Those can be sized so only a multi-minute clock jump reaches them; this cannot, because astral's fifty-second floor sits below a minute and the detector has to fire under it. A clock jump between the bound and that floor fails a healthy test, and astral's re-waiting on the same call would have ridden the same jump out. The bound is kept only because astral's unnamed, whole-run failure is the worse outcome.

That exposure argues for a high value, not a generous margin: the failure window is the gap between the bound and the floor. Astral's floor is a hard fifty seconds — five ten-second timers no machine runs through faster, plus the retry's backoff — so forty seconds clears it while holding the clock-jump window to about ten seconds. The slowest healthy test in any suite using this runner is about a second, and that one is deliberately waiting out a timer. `applyDefaults` rejects a `testTimeout` that is not a positive finite number, and a test pins the default below astral's floor. `test/timeout-project` is a fixture whose middle test never finishes, and `test/timeout.test.ts` asserts the reader gets the stuck test named and FAILED, the tests either side of it passing, a summary, and no `RetryError`.

`docs/development/waiting-in-tests.md` gains a "Proving a negative" section for the barrier shape and a "Browser-hosted unit tests have a harness backstop" section for the detector, and extends the imported "Wall-clock time is not a measure of progress" section to name the detector as its most-exposed bound.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked CSP negative tests to be event‑driven with a postMessage “barrier,” and added a per‑test stuck detector to `deno-web-test` that fails hung tests by name. This speeds the CSP suite and prevents unnamed, whole‑run failures.

- **New Features**
  - `deno-web-test`: Added `testTimeout` (default `40_000` ms) to fail a test that never finishes; failure names the test and the wait time, and the run continues. Value is validated and passed via `?testTimeout=`; harness races the test with a timer. Docs and tests added.
  - CSP suite: Converted negatives in `packages/iframe-sandbox/test/iframe-csp.test.ts` to wait on a guest “barrier” write after load and assert no errors arrived; errors now listened on `document` to catch early dispatch. Added ordering controls, left two unbarrierable cases on a timed wait, and moved the unsound `_self` window case to pending. Runtime drops ~12.4s → ~2.4s.

- **Migration**
  - If your suite has legitimately long tests, set `testTimeout` in `deno-web-test.config.ts` (keep it below ~50_000 ms). No other changes needed.

<sup>Written for commit fbbce8e2c31c2ed5b9a4bb3557b0d7cc5f2e0635. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

