### PR TITLE
test(patterns): migrate computed() assertions to assert()

### DIFF
--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -96,8 +96,9 @@ export default pattern(() => {
 ## Key Points
 
 - write new assertions with `assert()` rather than `computed()`; a step accepts
-  either, and most existing test patterns still use `computed()`, but a failed
-  `assert()` reports its operands and a failed `computed()` cannot
+  either, and most test patterns in the repository use `assert()` for their
+  assertions, but a failed `assert()` reports its operands and a failed
+  `computed()` cannot
 - trigger actions with `.send()` when the output exposes streams
 - use direct property access for assertions rather than `.get()` unless the API
   truly requires writable access

--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -178,8 +178,9 @@ const assert_game_ready = assert(() => {
 ### Prefer `assert()` over `computed()`
 
 Write new assertions with `assert()`. Most test patterns in the repository
-still use `computed()`, which a step also accepts — but a failing `computed()`
-assertion can only ever report the boolean it produced:
+use `assert()` for their assertions; a step also accepts a `computed()` boolean,
+but a failing `computed()` assertion can only ever report the boolean it
+produced:
 
 ```
 ✗ assertion_1

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2249,12 +2249,24 @@ export type ActionFunction = {
 export type ComputedFunction = <T>(fn: () => T) => Reactive<T>;
 
 /**
- * One operand recorded while an `assert` body ran: the operand's authored
- * source text, and its value rendered with `toCompactDebugString`.
+ * One operand of a failed `assert` body: the operand's authored source text,
+ * and its value rendered with `toCompactDebugString`. Only a failing assertion
+ * carries these; a passing one records nothing to render.
  */
 export type AssertPart = {
   src: string;
   rendered: string;
+};
+
+/**
+ * One operand captured while an `assert` body runs, holding the resolved value
+ * itself rather than a rendering of it. The value is rendered into an
+ * `AssertPart` only if the assertion fails, so a passing assertion never pays
+ * for rendering an operand it will not report.
+ */
+export type AssertRawPart = {
+  src: string;
+  value: unknown;
 };
 
 /**
@@ -2289,15 +2301,29 @@ export type AssertFunction = (fn: () => boolean) => Reactive<AssertRecord>;
 
 /**
  * Records one operand of an `assert` body and returns it unchanged, so that
- * wrapping an operand does not change evaluation order or semantics. The
- * assert-diagnostics transformer emits the calls; authored code does not call
- * it directly.
+ * wrapping an operand does not change evaluation order or semantics. It stores
+ * the resolved value; rendering is deferred to `assertRenderParts`, which runs
+ * only when the assertion fails. The assert-diagnostics transformer emits the
+ * calls; authored code does not call it directly.
  */
 export type AssertCaptureFunction = <T>(
-  parts: AssertPart[],
+  parts: AssertRawPart[],
   src: string,
   value: T,
 ) => T;
+
+/**
+ * Renders the operands captured while an `assert` body ran into the record's
+ * `parts`, but only when the assertion failed: for a passing assertion
+ * (`ok === true`) it returns an empty list without rendering anything, so the
+ * common case pays nothing for diagnostics it will not show. The
+ * assert-diagnostics transformer emits the call around the record's `parts`;
+ * authored code does not call it directly.
+ */
+export type AssertRenderPartsFunction = (
+  ok: boolean,
+  parts: AssertRawPart[],
+) => AssertPart[];
 
 export type StrFunction = (
   strings: TemplateStringsArray,

--- a/packages/patterns/airtable/airtable-importer.test.tsx
+++ b/packages/patterns/airtable/airtable-importer.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/airtable/airtable-importer.test.tsx --root packages/patterns --verbose
  */
-import { computed, pattern, UI } from "commonfabric";
+import { assert, pattern, UI } from "commonfabric";
 import { hasText } from "../test/vnode-helpers.ts";
 import AirtableImporter from "./airtable-importer.tsx";
 
@@ -16,19 +16,19 @@ export default pattern(() => {
     selectedTableId: "",
   });
 
-  const assert_initial_data_empty = computed(() =>
+  const assert_initial_data_empty = assert(() =>
     importer.bases.length === 0 &&
     importer.tables.length === 0 &&
     importer.records.length === 0 &&
     importer.recordCount === 0
   );
 
-  const assert_selected_names_empty = computed(() =>
+  const assert_selected_names_empty = assert(() =>
     importer.selectedBaseName === "" &&
     importer.selectedTableName === ""
   );
 
-  const assert_waiting_message_is_rendered = computed(() =>
+  const assert_waiting_message_is_rendered = assert(() =>
     hasText(importer[UI], "Waiting for Airtable connection") &&
     hasText(
       importer[UI],
@@ -36,7 +36,7 @@ export default pattern(() => {
     )
   );
 
-  const assert_fetch_controls_are_hidden_until_auth = computed(() =>
+  const assert_fetch_controls_are_hidden_until_auth = assert(() =>
     !hasText(importer[UI], "Load Bases") &&
     !hasText(importer[UI], "Load Tables") &&
     !hasText(importer[UI], "Fetch Records")

--- a/packages/patterns/airtable/core/util/airtable-auth-manager.test.tsx
+++ b/packages/patterns/airtable/core/util/airtable-auth-manager.test.tsx
@@ -5,7 +5,7 @@
  *
  * Run: deno task cf test packages/patterns/airtable/core/util/airtable-auth-manager.test.tsx --root packages/patterns --verbose
  */
-import { computed, pattern } from "commonfabric";
+import { assert, pattern } from "commonfabric";
 import { hasText } from "../../../test/vnode-helpers.ts";
 import {
   AirtableAuthManager,
@@ -22,23 +22,23 @@ export default pattern<Record<string, never>, TestOutput>(() => {
     requiredScopes: ["data.records:read", "schema.bases:read"],
   });
 
-  const assert_loading_state = computed(() =>
+  const assert_loading_state = assert(() =>
     manager.currentState === "loading" &&
     manager.isReady !== true
   );
 
-  const assert_availability_is_loading = computed(() =>
+  const assert_availability_is_loading = assert(() =>
     manager.availability.state === "loading" &&
     manager.availability.auth === null
   );
 
-  const assert_auth_info_matches_availability = computed(() =>
+  const assert_auth_info_matches_availability = assert(() =>
     manager.authInfo.state === manager.currentState &&
     manager.authInfo.availability.state === "loading" &&
     manager.authInfo.email === ""
   );
 
-  const assert_ui_names_required_scopes = computed(() =>
+  const assert_ui_names_required_scopes = assert(() =>
     hasText(manager.fullUI, "Connect Your Airtable Account") &&
     hasText(manager.fullUI, "Read records, Read base schemas")
   );

--- a/packages/patterns/auth/create-auth-manager.test.tsx
+++ b/packages/patterns/auth/create-auth-manager.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/auth/create-auth-manager.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import type { AuthManagerDescriptor } from "./auth-manager-descriptor.ts";
 import { AuthManagerBase } from "./create-auth-manager.tsx";
 import { hasText } from "../test/vnode-helpers.ts";
@@ -49,34 +49,34 @@ export default pattern(() => {
     accountType: "work",
   });
 
-  const assert_loading_state = computed(() =>
+  const assert_loading_state = assert(() =>
     manager.currentState === "loading" &&
     manager.isReady !== true
   );
 
-  const assert_availability_is_loading = computed(() =>
+  const assert_availability_is_loading = assert(() =>
     manager.availability.state === "loading" &&
     manager.availability.auth === null
   );
 
-  const assert_auth_info_matches_state = computed(() =>
+  const assert_auth_info_matches_state = assert(() =>
     manager.authInfo.state === "loading" &&
     manager.authInfo.availability.state === "loading" &&
     manager.authInfo.email === "" &&
     manager.authInfo.hasRequiredScopes === false
   );
 
-  const assert_full_ui_explains_connection = computed(() =>
+  const assert_full_ui_explains_connection = assert(() =>
     hasText(manager.fullUI, "Connect Your Test Account") &&
     hasText(manager.fullUI, "Read things") &&
     hasText(manager.fullUI, "Connect Test Account")
   );
 
-  const assert_status_ui_shows_loading = computed(() =>
+  const assert_status_ui_shows_loading = assert(() =>
     hasText(manager.statusUI, "Loading auth...")
   );
 
-  const assert_work_variant_uses_same_loading_contract = computed(() =>
+  const assert_work_variant_uses_same_loading_contract = assert(() =>
     workManager.fullUI !== undefined &&
     workManager.statusUI !== undefined &&
     workManager.pickerUI !== undefined

--- a/packages/patterns/auth/ready-auth.test.tsx
+++ b/packages/patterns/auth/ready-auth.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/auth/ready-auth.test.tsx --verbose
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, assert, computed, pattern, Writable } from "commonfabric";
 import {
   type AuthAvailability,
   authIsReady,
@@ -83,11 +83,11 @@ export default pattern(() => {
 
   const assert_auth_unavailable = authReady ? false : true;
   const assert_auth_available = authReady ? true : false;
-  const assert_ready_reads_current_token = computed(() =>
+  const assert_ready_reads_current_token = assert(() =>
     availability.state === "ready" &&
     availability.auth?.get?.()?.token === "initial"
   );
-  const assert_refresh_writes_original_cell = computed(() =>
+  const assert_refresh_writes_original_cell = assert(() =>
     authCell.get().token === "refreshed" &&
     availability.state === "ready" &&
     availability.auth?.get?.()?.token === "refreshed"

--- a/packages/patterns/battleship/multiplayer/lobby.test.tsx
+++ b/packages/patterns/battleship/multiplayer/lobby.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/battleship/multiplayer/lobby.test.tsx --verbose
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, assert, pattern, Writable } from "commonfabric";
 import BattleshipLobby from "./lobby.tsx";
 import {
   createInitialShots,
@@ -82,26 +82,26 @@ export default pattern(() => {
   // ==========================================================================
 
   // Game name defaults to "Battleship"
-  const assert_initial_game_name = computed(
+  const assert_initial_game_name = assert(
     () => lobby.gameName === "Battleship",
   );
 
   // Both players are initially null
-  const assert_initial_player1_null = computed(() => lobby.player1 === null);
-  const assert_initial_player2_null = computed(() => lobby.player2 === null);
+  const assert_initial_player1_null = assert(() => lobby.player1 === null);
+  const assert_initial_player2_null = assert(() => lobby.player2 === null);
 
   // Game state phase is "waiting"
-  const assert_initial_phase_waiting = computed(
+  const assert_initial_phase_waiting = assert(
     () => lobby.gameState.phase === "waiting",
   );
 
   // Game state currentTurn is 1 initially
-  const assert_initial_current_turn = computed(
+  const assert_initial_current_turn = assert(
     () => lobby.gameState.currentTurn === 1,
   );
 
   // Game state winner is null initially
-  const assert_initial_winner_null = computed(
+  const assert_initial_winner_null = assert(
     () => lobby.gameState.winner === null,
   );
 
@@ -110,10 +110,10 @@ export default pattern(() => {
   // ==========================================================================
 
   // Player 1 has joined with correct name
-  const assert_player1_name = computed(() => lobby.player1?.name === "Alice");
+  const assert_player1_name = assert(() => lobby.player1?.name === "Alice");
 
   // Player 1 has ships assigned
-  const assert_player1_has_ships = computed(
+  const assert_player1_has_ships = assert(
     () =>
       lobby.player1 !== null &&
       Array.isArray(lobby.player1.ships) &&
@@ -121,7 +121,7 @@ export default pattern(() => {
   );
 
   // Player 1 has a color
-  const assert_player1_has_color = computed(
+  const assert_player1_has_color = assert(
     () =>
       lobby.player1 !== null &&
       typeof lobby.player1.color === "string" &&
@@ -129,10 +129,10 @@ export default pattern(() => {
   );
 
   // Player 2 is still null
-  const assert_player2_still_null = computed(() => lobby.player2 === null);
+  const assert_player2_still_null = assert(() => lobby.player2 === null);
 
   // Game state is still waiting (only 1 player joined)
-  const assert_still_waiting_one_player = computed(
+  const assert_still_waiting_one_player = assert(
     () => lobby.gameState.phase === "waiting",
   );
 
@@ -141,10 +141,10 @@ export default pattern(() => {
   // ==========================================================================
 
   // Player 2 has joined with correct name
-  const assert_player2_name = computed(() => lobby.player2?.name === "Bob");
+  const assert_player2_name = assert(() => lobby.player2?.name === "Bob");
 
   // Player 2 has ships assigned
-  const assert_player2_has_ships = computed(
+  const assert_player2_has_ships = assert(
     () =>
       lobby.player2 !== null &&
       Array.isArray(lobby.player2.ships) &&
@@ -152,12 +152,12 @@ export default pattern(() => {
   );
 
   // Game state phase changes to "playing"
-  const assert_phase_playing = computed(
+  const assert_phase_playing = assert(
     () => lobby.gameState.phase === "playing",
   );
 
   // Game state currentTurn is set to 1 when game starts
-  const assert_current_turn_player1 = computed(
+  const assert_current_turn_player1 = assert(
     () => lobby.gameState.currentTurn === 1,
   );
 
@@ -166,29 +166,29 @@ export default pattern(() => {
   // ==========================================================================
 
   // Both players are back to null
-  const assert_reset_player1_null = computed(() => lobby.player1 === null);
-  const assert_reset_player2_null = computed(() => lobby.player2 === null);
+  const assert_reset_player1_null = assert(() => lobby.player1 === null);
+  const assert_reset_player2_null = assert(() => lobby.player2 === null);
 
   // Game state returns to "waiting"
-  const assert_reset_phase_waiting = computed(
+  const assert_reset_phase_waiting = assert(
     () => lobby.gameState.phase === "waiting",
   );
 
   // Winner is null after reset
-  const assert_reset_winner_null = computed(
+  const assert_reset_winner_null = assert(
     () => lobby.gameState.winner === null,
   );
 
   // ==========================================================================
   // Edge Case: Stale per-user slot should not block rejoin
   // ==========================================================================
-  const assert_stale_slot_rejoined = computed(() =>
+  const assert_stale_slot_rejoined = assert(() =>
     lobby.player1?.name === "Carol" &&
     lobby.myName === "Carol" &&
     lobby.myPlayerNumber === 1
   );
 
-  const assert_stale_slot_prepared = computed(() =>
+  const assert_stale_slot_prepared = assert(() =>
     lobby.player1 === null &&
     lobby.myName === "Alice" &&
     lobby.myPlayerNumber === 1
@@ -197,7 +197,7 @@ export default pattern(() => {
   // ==========================================================================
   // Edge Case: Empty name should be ignored
   // ==========================================================================
-  const assert_empty_name_ignored = computed(() => lobby.player1 === null);
+  const assert_empty_name_ignored = assert(() => lobby.player1 === null);
 
   // ==========================================================================
   // Test Sequence

--- a/packages/patterns/battleship/multiplayer/room.test.tsx
+++ b/packages/patterns/battleship/multiplayer/room.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/battleship/multiplayer/room.test.tsx --root packages/patterns/battleship --verbose
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, assert, computed, pattern, Writable } from "commonfabric";
 import BattleshipRoom from "./room.tsx";
 import {
   createInitialShots,
@@ -121,15 +121,15 @@ export default pattern(() => {
   // Assertions - Initial State
   // ==========================================================================
 
-  const assert_initial_turn_is_player1 = computed(
+  const assert_initial_turn_is_player1 = assert(
     () => gameStateCell.get().currentTurn === 1,
   );
 
-  const assert_initial_phase_playing = computed(
+  const assert_initial_phase_playing = assert(
     () => gameStateCell.get().phase === "playing",
   );
 
-  const assert_initial_no_shots = computed(() => {
+  const assert_initial_no_shots = assert(() => {
     const shots = shotsCell.get();
     // All cells should be "empty"
     return shots[1].every((row) => row.every((cell) => cell === "empty")) &&
@@ -140,17 +140,17 @@ export default pattern(() => {
   // Assertions - After Miss
   // ==========================================================================
 
-  const assert_miss_recorded = computed(() => {
+  const assert_miss_recorded = assert(() => {
     const shots = shotsCell.get();
     // Player 1 fired at player 2's board, so shots[2][5][5] should be "miss"
     return shots[2][5][5] === "miss";
   });
 
-  const assert_turn_switched_to_player2 = computed(
+  const assert_turn_switched_to_player2 = assert(
     () => gameStateCell.get().currentTurn === 2,
   );
 
-  const assert_message_contains_miss = computed(() =>
+  const assert_message_contains_miss = assert(() =>
     gameStateCell.get().lastMessage.includes("Miss")
   );
 
@@ -159,12 +159,12 @@ export default pattern(() => {
   // ==========================================================================
 
   // After firing at same spot, nothing should change (still player 2's turn)
-  const assert_still_player2_turn = computed(
+  const assert_still_player2_turn = assert(
     () => gameStateCell.get().currentTurn === 2,
   );
 
   // After firing when not your turn, nothing should change
-  const assert_no_new_shot_recorded = computed(() => {
+  const assert_no_new_shot_recorded = assert(() => {
     const shots = shotsCell.get();
     // row 1, col 1 should still be empty (shot was ignored)
     return shots[2][1][1] === "empty";

--- a/packages/patterns/battleship/pass-and-play/main.test.tsx
+++ b/packages/patterns/battleship/pass-and-play/main.test.tsx
@@ -29,7 +29,7 @@
  *
  * Run: deno task cf test packages/patterns/battleship/pass-and-play/main.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import Battleship, { type SquareState } from "./main.tsx";
 
 export default pattern(() => {
@@ -70,74 +70,74 @@ export default pattern(() => {
   // ==========================================================================
 
   // Initial state assertions
-  const assert_initial_phase_playing = computed(
+  const assert_initial_phase_playing = assert(
     () => game.game.get().phase === "playing",
   );
-  const assert_initial_turn_player1 = computed(
+  const assert_initial_turn_player1 = assert(
     () => game.game.get().currentTurn === 1,
   );
-  const assert_initial_viewingAs_null = computed(
+  const assert_initial_viewingAs_null = assert(
     () => game.game.get().viewingAs === null,
   );
-  const assert_initial_winner_null = computed(
+  const assert_initial_winner_null = assert(
     () => game.game.get().winner === null,
   );
-  const assert_initial_not_awaiting_pass = computed(
+  const assert_initial_not_awaiting_pass = assert(
     () => game.game.get().awaitingPass === false,
   );
 
   // After playerReady - Player 1 is now viewing
-  const assert_viewingAs_player1 = computed(
+  const assert_viewingAs_player1 = assert(
     () => game.game.get().viewingAs === 1,
   );
-  const assert_still_turn_player1 = computed(
+  const assert_still_turn_player1 = assert(
     () => game.game.get().currentTurn === 1,
   );
 
   // After firing a miss
-  const assert_shot_recorded_miss = computed(() => {
+  const assert_shot_recorded_miss = assert(() => {
     return game.game.get().player2.shots[9][0] === "miss";
   });
-  const assert_turn_switched_to_player2 = computed(
+  const assert_turn_switched_to_player2 = assert(
     () => game.game.get().currentTurn === 2,
   );
-  const assert_awaiting_pass_after_shot = computed(
+  const assert_awaiting_pass_after_shot = assert(
     () => game.game.get().awaitingPass === true,
   );
 
   // After passDevice
-  const assert_viewingAs_null_after_pass = computed(
+  const assert_viewingAs_null_after_pass = assert(
     () => game.game.get().viewingAs === null,
   );
-  const assert_not_awaiting_pass_after_pass = computed(
+  const assert_not_awaiting_pass_after_pass = assert(
     () => game.game.get().awaitingPass === false,
   );
 
   // After player 2 ready
-  const assert_viewingAs_player2 = computed(
+  const assert_viewingAs_player2 = assert(
     () => game.game.get().viewingAs === 2,
   );
 
   // After player 2 fires a hit
-  const assert_shot_recorded_hit = computed(() => {
+  const assert_shot_recorded_hit = assert(() => {
     // Player 2 fires at Player 1's carrier at row 0, col 0
     return game.game.get().player1.shots[0][0] === "hit";
   });
-  const assert_turn_back_to_player1 = computed(
+  const assert_turn_back_to_player1 = assert(
     () => game.game.get().currentTurn === 1,
   );
 
   // After reset
-  const assert_reset_phase_playing = computed(
+  const assert_reset_phase_playing = assert(
     () => game.game.get().phase === "playing",
   );
-  const assert_reset_turn_player1 = computed(
+  const assert_reset_turn_player1 = assert(
     () => game.game.get().currentTurn === 1,
   );
-  const assert_reset_viewingAs_null = computed(
+  const assert_reset_viewingAs_null = assert(
     () => game.game.get().viewingAs === null,
   );
-  const assert_reset_shots_cleared = computed(() => {
+  const assert_reset_shots_cleared = assert(() => {
     // All shots should be empty after reset
     const p1Clear = game.game.get().player1.shots.every((row: SquareState[]) =>
       row.every((cell: SquareState) => cell === "empty")

--- a/packages/patterns/budget-tracker/expense-form.test.tsx
+++ b/packages/patterns/budget-tracker/expense-form.test.tsx
@@ -16,7 +16,7 @@
  */
 import {
   action,
-  computed,
+  assert,
   equals,
   handler,
   pattern,
@@ -84,38 +84,34 @@ export default pattern(() => {
   // Assertions
   // ==========================================================================
 
-  const assert_food_created = computed(() => {
+  const assert_food_created = assert(() => {
     const cur = budgetsCell.get();
     return cur.length === 1 && cur[0]?.category === "Food" &&
       cur[0]?.limit === 100;
   });
 
-  const assert_held_stashed = computed(() => {
+  const assert_held_stashed = assert(() => {
     const h = heldBudget.get();
     return h.category === "Food" && equals(budgetsCell.get()[0], h);
   });
 
-  const assert_food_updated_in_place = computed(() => {
+  const assert_food_updated_in_place = assert(() => {
     const cur = budgetsCell.get();
     return cur.length === 1 && cur[0]?.category === "Food" &&
       cur[0]?.limit === 250;
   });
   // KEY: the stale-but-once-valid reference still equals()-matches the
   // budget AFTER setBudget updated its limit.
-  const assert_held_survives_update = computed(() => {
+  const assert_held_survives_update = assert(() => {
     const h = heldBudget.get();
     return equals(budgetsCell.get()[0], h);
   });
   // The held reference also READS the update (it would show the stale,
   // orphaned entity if setBudget had re-minted identity).
-  const assert_held_reads_update = computed(() =>
-    heldBudget.get().limit === 250
-  );
+  const assert_held_reads_update = assert(() => heldBudget.get().limit === 250);
 
   // KEY: the held reference still DRIVES an equals()-located removal.
-  const assert_removed_via_held = computed(() =>
-    budgetsCell.get().length === 0
-  );
+  const assert_removed_via_held = assert(() => budgetsCell.get().length === 0);
 
   // ==========================================================================
   // Test Sequence

--- a/packages/patterns/calendar/calendar.test.tsx
+++ b/packages/patterns/calendar/calendar.test.tsx
@@ -12,7 +12,7 @@
  *
  * Run: deno task cf test packages/patterns/calendar/calendar.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import Calendar from "./calendar.tsx";
 
 export default pattern(() => {
@@ -81,28 +81,28 @@ export default pattern(() => {
   // Assertions - Initial State
   // ==========================================================================
 
-  const assert_initial_empty = computed(() => cal.events.length === 0);
+  const assert_initial_empty = assert(() => cal.events.length === 0);
 
   // ==========================================================================
   // Assertions - After Adding
   // ==========================================================================
 
-  const assert_has_one = computed(() => cal.events.length === 1);
-  const assert_first_title = computed(
+  const assert_has_one = assert(() => cal.events.length === 1);
+  const assert_first_title = assert(
     () => cal.events[0]?.title === "Team Meeting",
   );
-  const assert_first_date = computed(
+  const assert_first_date = assert(
     () => cal.events[0]?.date === "2025-03-15",
   );
-  const assert_first_time = computed(
+  const assert_first_time = assert(
     () => cal.events[0]?.time === "10:00",
   );
 
-  const assert_has_two = computed(() => cal.events.length === 2);
-  const assert_has_three = computed(() => cal.events.length === 3);
+  const assert_has_two = assert(() => cal.events.length === 2);
+  const assert_has_three = assert(() => cal.events.length === 3);
 
   // Still three after empty/whitespace attempts
-  const assert_still_three = computed(() => cal.events.length === 3);
+  const assert_still_three = assert(() => cal.events.length === 3);
 
   // ==========================================================================
   // Assertions - Sorting
@@ -110,13 +110,13 @@ export default pattern(() => {
 
   // Events added: Team Meeting (03-15 10:00), Lunch (03-15 12:00), Kickoff (03-10 09:00)
   // Sorted order should be: Kickoff (03-10), Team Meeting (03-15 10:00), Lunch (03-15 12:00)
-  const assert_sorted_first_is_kickoff = computed(
+  const assert_sorted_first_is_kickoff = assert(
     () => cal.sortedEvents[0]?.title === "Kickoff",
   );
-  const assert_sorted_second_is_meeting = computed(
+  const assert_sorted_second_is_meeting = assert(
     () => cal.sortedEvents[1]?.title === "Team Meeting",
   );
-  const assert_sorted_third_is_lunch = computed(
+  const assert_sorted_third_is_lunch = assert(
     () => cal.sortedEvents[2]?.title === "Lunch",
   );
 
@@ -124,7 +124,7 @@ export default pattern(() => {
   // Assertions - After Notes Update
   // ==========================================================================
 
-  const assert_notes_updated = computed(
+  const assert_notes_updated = assert(
     () => cal.events[0]?.notes === "Discuss Q2 roadmap",
   );
 
@@ -132,9 +132,9 @@ export default pattern(() => {
   // Assertions - After Removing
   // ==========================================================================
 
-  const assert_has_two_after_remove = computed(() => cal.events.length === 2);
-  const assert_has_one_after_remove = computed(() => cal.events.length === 1);
-  const assert_back_to_empty = computed(() => cal.events.length === 0);
+  const assert_has_two_after_remove = assert(() => cal.events.length === 2);
+  const assert_has_one_after_remove = assert(() => cal.events.length === 1);
+  const assert_back_to_empty = assert(() => cal.events.length === 0);
 
   // ==========================================================================
   // Test Sequence

--- a/packages/patterns/calendar/event-detail.test.tsx
+++ b/packages/patterns/calendar/event-detail.test.tsx
@@ -7,7 +7,7 @@
  *
  * Run: deno task cf test packages/patterns/calendar/event-detail.test.tsx --verbose
  */
-import { action, computed, NAME, pattern } from "commonfabric";
+import { action, assert, NAME, pattern } from "commonfabric";
 import EventDetail from "./event-detail.tsx";
 
 export default pattern(() => {
@@ -46,17 +46,17 @@ export default pattern(() => {
   // Assertions - Initial State
   // ==========================================================================
 
-  const assert_name = computed(
+  const assert_name = assert(
     () => item[NAME] === "Event: Team Meeting",
   );
-  const assert_initial_title = computed(
+  const assert_initial_title = assert(
     () => item.title === "Team Meeting",
   );
-  const assert_initial_date = computed(
+  const assert_initial_date = assert(
     () => item.date === "2025-03-15",
   );
-  const assert_initial_time = computed(() => item.time === "10:00");
-  const assert_initial_notes = computed(
+  const assert_initial_time = assert(() => item.time === "10:00");
+  const assert_initial_notes = assert(
     () => item.notes === "Weekly sync",
   );
 
@@ -64,20 +64,20 @@ export default pattern(() => {
   // Assertions - After Edits
   // ==========================================================================
 
-  const assert_name_after_rename = computed(
+  const assert_name_after_rename = assert(
     () => item[NAME] === "Event: Renamed Meeting",
   );
-  const assert_title_changed = computed(
+  const assert_title_changed = assert(
     () => item.title === "Renamed Meeting",
   );
-  const assert_date_changed = computed(
+  const assert_date_changed = assert(
     () => item.date === "2025-04-01",
   );
-  const assert_time_changed = computed(() => item.time === "14:30");
-  const assert_notes_changed = computed(
+  const assert_time_changed = assert(() => item.time === "14:30");
+  const assert_notes_changed = assert(
     () => item.notes === "Updated agenda items",
   );
-  const assert_notes_cleared = computed(() => item.notes === "");
+  const assert_notes_cleared = assert(() => item.notes === "");
 
   // ==========================================================================
   // Test Sequence

--- a/packages/patterns/card-piles/main.test.tsx
+++ b/packages/patterns/card-piles/main.test.tsx
@@ -14,7 +14,7 @@
  *
  * Run: deno task cf test packages/patterns/card-piles/main.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import CardPiles, { defaultPile1, defaultPile2 } from "./main.tsx";
 
 export default pattern(() => {
@@ -50,18 +50,18 @@ export default pattern(() => {
   // =========================================================================
   // Initial state assertions — defaults
   // =========================================================================
-  const assert_defaults_pile1_count = computed(
+  const assert_defaults_pile1_count = assert(
     () => defaults.pile1.length === 3,
   );
-  const assert_defaults_pile2_count = computed(
+  const assert_defaults_pile2_count = assert(
     () => defaults.pile2.length === 3,
   );
-  const assert_defaults_pile1_first_card = computed(
+  const assert_defaults_pile1_first_card = assert(
     () =>
       defaults.pile1[0]?.suit === "hearts" &&
       defaults.pile1[0]?.rank === "A",
   );
-  const assert_defaults_pile2_first_card = computed(
+  const assert_defaults_pile2_first_card = assert(
     () =>
       defaults.pile2[0]?.suit === "clubs" &&
       defaults.pile2[0]?.rank === "Q",
@@ -70,24 +70,24 @@ export default pattern(() => {
   // =========================================================================
   // Initial state assertions — custom inputs
   // =========================================================================
-  const assert_custom_pile1_count = computed(() => piles.pile1.length === 2);
-  const assert_custom_pile2_count = computed(() => piles.pile2.length === 1);
-  const assert_custom_total = computed(
+  const assert_custom_pile1_count = assert(() => piles.pile1.length === 2);
+  const assert_custom_pile2_count = assert(() => piles.pile2.length === 1);
+  const assert_custom_total = assert(
     () => piles.pile1.length + piles.pile2.length === 3,
   );
-  const assert_custom_pile1_has_ace = computed(
+  const assert_custom_pile1_has_ace = assert(
     () => piles.pile1[0]?.suit === "hearts" && piles.pile1[0]?.rank === "A",
   );
-  const assert_custom_pile2_has_queen = computed(
+  const assert_custom_pile2_has_queen = assert(
     () => piles.pile2[0]?.suit === "clubs" && piles.pile2[0]?.rank === "Q",
   );
 
   // =========================================================================
   // Initial state assertions — single card edge case
   // =========================================================================
-  const assert_single_pile1_count = computed(() => single.pile1.length === 1);
-  const assert_single_pile2_empty = computed(() => single.pile2.length === 0);
-  const assert_single_total = computed(
+  const assert_single_pile1_count = assert(() => single.pile1.length === 1);
+  const assert_single_pile2_empty = assert(() => single.pile2.length === 0);
+  const assert_single_total = assert(
     () => single.pile1.length + single.pile2.length === 1,
   );
 
@@ -99,7 +99,7 @@ export default pattern(() => {
   });
 
   // Shuffle preserves total card count
-  const assert_total_preserved_after_shuffle = computed(
+  const assert_total_preserved_after_shuffle = assert(
     () => piles.pile1.length + piles.pile2.length === 3,
   );
 
@@ -108,7 +108,7 @@ export default pattern(() => {
     piles.shuffle.send();
   });
 
-  const assert_total_preserved_after_second_shuffle = computed(
+  const assert_total_preserved_after_second_shuffle = assert(
     () => piles.pile1.length + piles.pile2.length === 3,
   );
 
@@ -117,7 +117,7 @@ export default pattern(() => {
     single.shuffle.send();
   });
 
-  const assert_single_total_after_shuffle = computed(
+  const assert_single_total_after_shuffle = assert(
     () => single.pile1.length + single.pile2.length === 1,
   );
 
@@ -136,13 +136,13 @@ export default pattern(() => {
     ],
   });
 
-  const assert_move_initial_pile1 = computed(
+  const assert_move_initial_pile1 = assert(
     () => movePiles.pile1.length === 2,
   );
-  const assert_move_initial_pile2 = computed(
+  const assert_move_initial_pile2 = assert(
     () => movePiles.pile2.length === 2,
   );
-  const assert_move_initial_total = computed(
+  const assert_move_initial_total = assert(
     () => movePiles.pile1.length + movePiles.pile2.length === 4,
   );
 
@@ -153,23 +153,23 @@ export default pattern(() => {
     });
   });
 
-  const assert_after_move_to_pile1_count1 = computed(
+  const assert_after_move_to_pile1_count1 = assert(
     () => movePiles.pile1.length === 3,
   );
-  const assert_after_move_to_pile1_count2 = computed(
+  const assert_after_move_to_pile1_count2 = assert(
     () => movePiles.pile2.length === 1,
   );
-  const assert_after_move_to_pile1_total = computed(
+  const assert_after_move_to_pile1_total = assert(
     () => movePiles.pile1.length + movePiles.pile2.length === 4,
   );
   // Queen of Clubs should now be at end of pile1
-  const assert_queen_moved_to_pile1 = computed(
+  const assert_queen_moved_to_pile1 = assert(
     () =>
       movePiles.pile1[2]?.suit === "clubs" &&
       movePiles.pile1[2]?.rank === "Q",
   );
   // Original pile1 cards should still be in order
-  const assert_pile1_originals_intact = computed(
+  const assert_pile1_originals_intact = assert(
     () =>
       movePiles.pile1[0]?.suit === "hearts" &&
       movePiles.pile1[0]?.rank === "A" &&
@@ -177,7 +177,7 @@ export default pattern(() => {
       movePiles.pile1[1]?.rank === "K",
   );
   // pile2 should only have diamonds/10 left
-  const assert_pile2_has_only_ten = computed(
+  const assert_pile2_has_only_ten = assert(
     () =>
       movePiles.pile2[0]?.suit === "diamonds" &&
       movePiles.pile2[0]?.rank === "10",
@@ -193,23 +193,23 @@ export default pattern(() => {
     });
   });
 
-  const assert_after_move_to_pile2_count1 = computed(
+  const assert_after_move_to_pile2_count1 = assert(
     () => movePiles.pile1.length === 2,
   );
-  const assert_after_move_to_pile2_count2 = computed(
+  const assert_after_move_to_pile2_count2 = assert(
     () => movePiles.pile2.length === 2,
   );
-  const assert_after_move_to_pile2_total = computed(
+  const assert_after_move_to_pile2_total = assert(
     () => movePiles.pile1.length + movePiles.pile2.length === 4,
   );
   // hearts/A should now be at end of pile2
-  const assert_ace_moved_to_pile2 = computed(
+  const assert_ace_moved_to_pile2 = assert(
     () =>
       movePiles.pile2[1]?.suit === "hearts" &&
       movePiles.pile2[1]?.rank === "A",
   );
   // pile1 should still have spades/K and clubs/Q (ace removed from front)
-  const assert_pile1_after_move_to_pile2 = computed(
+  const assert_pile1_after_move_to_pile2 = assert(
     () =>
       movePiles.pile1[0]?.suit === "spades" &&
       movePiles.pile1[0]?.rank === "K" &&
@@ -232,9 +232,9 @@ export default pattern(() => {
     });
   });
 
-  const assert_pile2_empty = computed(() => movePiles.pile2.length === 0);
-  const assert_pile1_has_all = computed(() => movePiles.pile1.length === 4);
-  const assert_empty_pile_total = computed(
+  const assert_pile2_empty = assert(() => movePiles.pile2.length === 0);
+  const assert_pile1_has_all = assert(() => movePiles.pile1.length === 4);
+  const assert_empty_pile_total = assert(
     () => movePiles.pile1.length + movePiles.pile2.length === 4,
   );
 
@@ -247,8 +247,8 @@ export default pattern(() => {
     });
   });
 
-  const assert_pile2_restored = computed(() => movePiles.pile2.length === 1);
-  const assert_pile1_after_restore = computed(
+  const assert_pile2_restored = assert(() => movePiles.pile2.length === 1);
+  const assert_pile1_after_restore = assert(
     () => movePiles.pile1.length === 3,
   );
 
@@ -259,7 +259,7 @@ export default pattern(() => {
     movePiles.shuffle.send();
   });
 
-  const assert_total_after_shuffle_moves = computed(
+  const assert_total_after_shuffle_moves = assert(
     () => movePiles.pile1.length + movePiles.pile2.length === 4,
   );
 

--- a/packages/patterns/catalog/stories/cf-calendar-story.test.tsx
+++ b/packages/patterns/catalog/stories/cf-calendar-story.test.tsx
@@ -1,4 +1,4 @@
-import { computed, NAME, pattern, UI } from "commonfabric";
+import { assert, NAME, pattern, UI } from "commonfabric";
 import CalendarStory from "./cf-calendar-story.tsx";
 
 // Lane-2 pattern test (run by `cf test`): instantiating the story runs its body
@@ -15,7 +15,7 @@ import CalendarStory from "./cf-calendar-story.tsx";
 // controls JSX for coverage either way, so a `controls` assertion adds nothing.
 export default pattern(() => {
   const story = CalendarStory({});
-  const assert_story_built = computed(() =>
+  const assert_story_built = assert(() =>
     story[NAME] === "cf-calendar Story" &&
     story[UI] != null
   );

--- a/packages/patterns/catalog/stories/cf-submit-input-story.test.tsx
+++ b/packages/patterns/catalog/stories/cf-submit-input-story.test.tsx
@@ -1,4 +1,4 @@
-import { computed, NAME, pattern, UI } from "commonfabric";
+import { assert, NAME, pattern, UI } from "commonfabric";
 import SubmitInputStory from "./cf-submit-input-story.tsx";
 
 // Lane-2 pattern test (run by `cf test`): instantiating the story runs its body
@@ -7,7 +7,7 @@ import SubmitInputStory from "./cf-submit-input-story.tsx";
 // renderer expects.
 export default pattern(() => {
   const story = SubmitInputStory({});
-  const assert_story_built = computed(() =>
+  const assert_story_built = assert(() =>
     story[NAME] === "cf-submit-input Story" &&
     story[UI] != null &&
     story.controls != null

--- a/packages/patterns/cfc-authorized-save/main.test.tsx
+++ b/packages/patterns/cfc-authorized-save/main.test.tsx
@@ -1,4 +1,4 @@
-import { computed, handler, pattern, Writable } from "commonfabric";
+import { assert, handler, pattern, Writable } from "commonfabric";
 import {
   SAVE_TITLE_ACTION,
   TRUSTED_SAVE_SURFACE,
@@ -38,17 +38,17 @@ export default pattern(() => {
     title: "Second title",
   });
 
-  const assert_initial_saved_empty = computed(() => savedTitle.get() === "");
-  const assert_first_draft_visible = computed(() =>
+  const assert_initial_saved_empty = assert(() => savedTitle.get() === "");
+  const assert_first_draft_visible = assert(() =>
     draftTitle.get() === "First title"
   );
-  const assert_first_save_committed = computed(() =>
+  const assert_first_save_committed = assert(() =>
     savedTitle.get() === "First title"
   );
-  const assert_second_draft_does_not_autosave = computed(() =>
+  const assert_second_draft_does_not_autosave = assert(() =>
     savedTitle.get() === "First title"
   );
-  const assert_second_save_committed = computed(() =>
+  const assert_second_save_committed = assert(() =>
     savedTitle.get() === "Second title"
   );
 

--- a/packages/patterns/cfc-authorship-chat/main.test.tsx
+++ b/packages/patterns/cfc-authorship-chat/main.test.tsx
@@ -1,16 +1,16 @@
-import { computed, pattern } from "commonfabric";
+import { assert, pattern } from "commonfabric";
 import AuthorshipChat from "./main.tsx";
 
 export default pattern(() => {
   const instance = AuthorshipChat({});
 
-  const assert_verified_fixture_names_alice = computed(() =>
+  const assert_verified_fixture_names_alice = assert(() =>
     instance.verifiedAuthor === "Alice Nguyen"
   );
-  const assert_forged_fixture_names_bob = computed(() =>
+  const assert_forged_fixture_names_bob = assert(() =>
     instance.forgedClaim === "Bob Patel"
   );
-  const assert_unsigned_fixture_names_casey = computed(() =>
+  const assert_unsigned_fixture_names_casey = assert(() =>
     instance.unsignedState === "Casey Morgan"
   );
 

--- a/packages/patterns/cfc-exchange-rules/direct-release.test.tsx
+++ b/packages/patterns/cfc-exchange-rules/direct-release.test.tsx
@@ -1,14 +1,14 @@
-import { computed, pattern } from "commonfabric";
+import { assert, pattern } from "commonfabric";
 import DirectRelease from "./direct-release.tsx";
 
 export default pattern(() => {
   const defaultRelease = DirectRelease({});
   const customRelease = DirectRelease({ message: "Review-ready summary" });
 
-  const assert_default_message = computed(() =>
+  const assert_default_message = assert(() =>
     defaultRelease.message === "Private until reader evidence is present"
   );
-  const assert_custom_message = computed(() =>
+  const assert_custom_message = assert(() =>
     customRelease.message === "Review-ready summary"
   );
 

--- a/packages/patterns/cfc-exchange-rules/imported-policy.test.tsx
+++ b/packages/patterns/cfc-exchange-rules/imported-policy.test.tsx
@@ -1,4 +1,4 @@
-import { computed, pattern } from "commonfabric";
+import { assert, pattern } from "commonfabric";
 import ImportedPolicy from "./imported-policy.tsx";
 
 export default pattern(() => {
@@ -8,13 +8,13 @@ export default pattern(() => {
   return {
     tests: [
       {
-        assertion: computed(() =>
+        assertion: assert(() =>
           defaultPolicy.message ===
             "Protected by the defining module's rules"
         ),
       },
       {
-        assertion: computed(() =>
+        assertion: assert(() =>
           customPolicy.message === "Imported policy message"
         ),
       },

--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, Default, pattern, UI, Writable } from "commonfabric";
+import { action, assert, Default, pattern, UI, Writable } from "commonfabric";
 import {
   findNodeById,
   findNodeByProp,
@@ -159,11 +159,11 @@ export default pattern(() => {
     });
   });
 
-  const assert_initially_empty = computed(() =>
+  const assert_initially_empty = assert(() =>
     (myProfile.get() as MyProfileValue | undefined)?.profile === undefined &&
     (messages.get()?.length ?? 0) === 0
   );
-  const assert_admin_view_waits_for_profile = computed(() => {
+  const assert_admin_view_waits_for_profile = assert(() => {
     const managerChip = findNodeById(chat[UI], "group-chat-manager-chip");
     const panelStatus = findNodeById(
       chat[UI],
@@ -173,20 +173,20 @@ export default pattern(() => {
       propValue(panelStatus, "label") ===
         "Save a profile to manage admins";
   });
-  const assert_profile_created = computed(() =>
+  const assert_profile_created = assert(() =>
     chat.currentProfileName === "Alice"
   );
-  const assert_profile_bootstraps_admin = computed(() =>
+  const assert_profile_bootstraps_admin = assert(() =>
     chat.currentUserIsAdmin === true &&
     chat.currentUserCanManageAdmins === true &&
     chatAdminRolesValue(adminRegistry).length === 0
   );
-  const assert_alice_sees_bob_without_bob_message = computed(() => {
+  const assert_alice_sees_bob_without_bob_message = assert(() => {
     const participants = participantClaimsValue(profiles, myProfile, messages);
     return participants.some((participant) => participant.name === "Alice") &&
       participants.some((participant) => participant.name === "Bob");
   });
-  const assert_admin_view_everyone_enabled = computed(() => {
+  const assert_admin_view_everyone_enabled = assert(() => {
     const toggleButton = findNodeByProp(
       chat[UI],
       "data-ui-control",
@@ -208,20 +208,20 @@ export default pattern(() => {
       propValue(toggleButton, "disabled") === true &&
       nodeIncludesText(toggleButton, "Admin via everyone");
   });
-  const assert_bootstrap_admin_can_add_room = computed(() => {
+  const assert_bootstrap_admin_can_add_room = assert(() => {
     const roomList = roomsValue(rooms);
     return roomList.length === 1 &&
       roomList[0]?.name === "Ops" &&
       roomDraft.get() === "";
   });
-  const assert_everyone_disabled_seeds_alice = computed(() =>
+  const assert_everyone_disabled_seeds_alice = assert(() =>
     chat.currentUserIsAdmin === true &&
     bobChat.currentUserIsAdmin !== true &&
     chatAdminRolesValue(adminRegistry).length === 1 &&
     (adminRegistry.get() as { everyoneIsAdmin?: boolean }).everyoneIsAdmin ===
       false
   );
-  const assert_admin_view_explicit_alice = computed(() => {
+  const assert_admin_view_explicit_alice = assert(() => {
     const toggleButton = findNodeByProp(
       chat[UI],
       "data-ui-control",
@@ -234,61 +234,61 @@ export default pattern(() => {
         "Admin",
       );
   });
-  const assert_admin_view_lists_bob_after_lockdown = computed(() => {
+  const assert_admin_view_lists_bob_after_lockdown = assert(() => {
     const userList = findNodeById(chat[UI], "trusted-admin-user-list");
     return nodeIncludesText(userList, "Bob") &&
       nodeIncludesText(userList, "Make admin");
   });
-  const assert_last_admin_removal_blocked = computed(() =>
+  const assert_last_admin_removal_blocked = assert(() =>
     chat.currentUserIsAdmin === true &&
     bobChat.currentUserIsAdmin !== true &&
     chatAdminRolesValue(adminRegistry).length === 1 &&
     (adminRegistry.get() as { everyoneIsAdmin?: boolean }).everyoneIsAdmin ===
       false
   );
-  const assert_bob_cannot_add_room_after_lockdown = computed(() =>
+  const assert_bob_cannot_add_room_after_lockdown = assert(() =>
     roomsValue(rooms).length === 1
   );
-  const assert_bob_admin_enabled = computed(() =>
+  const assert_bob_admin_enabled = assert(() =>
     bobChat.currentUserIsAdmin === true &&
     bobChat.currentUserCanManageAdmins === true &&
     chatAdminRolesValue(adminRegistry).length === 2 &&
     (adminRegistry.get() as { everyoneIsAdmin?: boolean }).everyoneIsAdmin ===
       false
   );
-  const assert_bob_can_add_room = computed(() => {
+  const assert_bob_can_add_room = assert(() => {
     const roomList = roomsValue(rooms);
     return roomList.length === 2 &&
       roomList[1]?.name === "Bob room" &&
       bobRoomDraft.get() === "";
   });
-  const assert_alice_can_still_add_room = computed(() => {
+  const assert_alice_can_still_add_room = assert(() => {
     const roomList = roomsValue(rooms);
     return roomList.length === 3 &&
       roomList[2]?.name === "Ops 2" &&
       roomDraft.get() === "";
   });
-  const assert_message_sent_and_draft_cleared = computed(() =>
+  const assert_message_sent_and_draft_cleared = assert(() =>
     messages.get().length === 1 &&
     messages.get()[0]?.origin === "sent" &&
     messages.get()[0]?.authorName === "Alice" &&
     messages.get()[0]?.body === "Hello from Alice" &&
     messageDraft.get() === ""
   );
-  const assert_profile_renamed = computed(() =>
+  const assert_profile_renamed = assert(() =>
     chat.currentProfileName === "Alice Renamed"
   );
-  const assert_message_snapshot_stable = computed(() =>
+  const assert_message_snapshot_stable = assert(() =>
     messages.get().length >= 1 &&
     messages.get()[0]?.authorName === "Alice"
   );
-  const assert_second_message_uses_current_name = computed(() =>
+  const assert_second_message_uses_current_name = assert(() =>
     messages.get().length === 2 &&
     messages.get()[1]?.origin === "sent" &&
     messages.get()[1]?.authorName === "Alice Renamed" &&
     messages.get()[1]?.body === "After rename"
   );
-  const assert_imported_messages_injected = computed(() => {
+  const assert_imported_messages_injected = assert(() => {
     const messageList = Array.from(messages.get() as SharedChatMessage[]);
     const importedMessages = messageList.filter((message) =>
       message.origin === "imported"
@@ -301,25 +301,25 @@ export default pattern(() => {
         message.authorProfile !== undefined
       );
   });
-  const assert_thread_order_sortable = computed(() => {
+  const assert_thread_order_sortable = assert(() => {
     const ordered = sortDisplayMessages(messages.get() as SharedChatMessage[]);
     return ordered.length === 4 &&
       ordered.every((message, index) =>
         index === 0 || ordered[index - 1]!.timestamp <= message.timestamp
       );
   });
-  const assert_verified_imports_do_not_duplicate_participants = computed(() =>
+  const assert_verified_imports_do_not_duplicate_participants = assert(() =>
     participantClaimsValue(profiles, myProfile, messages).filter((
       participant,
     ) => participant.name === "Alice Renamed").length === 1
   );
-  const assert_same_name_unverified_imports_are_distinct = computed(() => {
+  const assert_same_name_unverified_imports_are_distinct = assert(() => {
     const participants = participantClaimsValue(profiles, myProfile, messages);
     return participants.filter((participant) =>
       participant.name === "Sam" && participant.profile === undefined
     ).length === 2;
   });
-  const assert_messages_and_rooms_do_not_store_ids = computed(() =>
+  const assert_messages_and_rooms_do_not_store_ids = assert(() =>
     (messages.get() as SharedChatMessage[]).every((message) =>
       !("id" in message)
     ) &&

--- a/packages/patterns/cfc-render-policy-demo/main.test.tsx
+++ b/packages/patterns/cfc-render-policy-demo/main.test.tsx
@@ -1,4 +1,4 @@
-import { computed, handler, pattern, Stream, Writable } from "commonfabric";
+import { assert, handler, pattern, Stream, Writable } from "commonfabric";
 import RenderPolicyDemo, { TrustedHealthDisclosureSurface } from "./main.tsx";
 
 const trigger = handler<void, { stream: Stream<unknown> }>((_, { stream }) => {
@@ -16,11 +16,9 @@ export default pattern(() => {
   const action_reveal = trigger({ stream: trustedDisclosure.reveal });
   const action_conceal = trigger({ stream: trustedDisclosure.conceal });
 
-  const assert_initially_hidden = computed(() =>
-    revealSensitive.get() === false
-  );
-  const assert_revealed = computed(() => revealSensitive.get() === true);
-  const assert_concealed = computed(() => revealSensitive.get() === false);
+  const assert_initially_hidden = assert(() => revealSensitive.get() === false);
+  const assert_revealed = assert(() => revealSensitive.get() === true);
+  const assert_concealed = assert(() => revealSensitive.get() === false);
 
   return {
     tests: [

--- a/packages/patterns/cfc-spec-gallery/main.test.tsx
+++ b/packages/patterns/cfc-spec-gallery/main.test.tsx
@@ -1,4 +1,4 @@
-import { computed, handler, pattern, Stream } from "commonfabric";
+import { assert, handler, pattern, Stream } from "commonfabric";
 import Gallery from "./main.tsx";
 
 const trigger = handler<void, { stream: Stream<void> }>((_, { stream }) => {
@@ -62,32 +62,30 @@ export default pattern(() => {
       "https://source.example.com/private/source?token=debug&draft=internal",
   });
 
-  const assert_count = computed(() => instance.totalExamples === 16);
-  const assert_forward_prepared = computed(() => instance.completedCount === 0);
-  const assert_forward_committed = computed(() =>
+  const assert_count = assert(() => instance.totalExamples === 16);
+  const assert_forward_prepared = assert(() => instance.completedCount === 0);
+  const assert_forward_committed = assert(() =>
     instance.completedCount === 1 &&
     instance.lastCompleted === "forward-hotel-note"
   );
-  const assert_research_captured = computed(() =>
+  const assert_research_captured = assert(() =>
     instance.completedCount === 1 &&
     instance.lastCompleted === "forward-hotel-note"
   );
-  const assert_research_prepared = computed(() =>
-    instance.completedCount === 1
-  );
-  const assert_research_sent = computed(() =>
+  const assert_research_prepared = assert(() => instance.completedCount === 1);
+  const assert_research_sent = assert(() =>
     instance.completedCount === 2 &&
     instance.lastCompleted === "authorize-research-send"
   );
-  const assert_safe_link_prepared = computed(() =>
+  const assert_safe_link_prepared = assert(() =>
     instance.completedCount === 2 &&
     instance.lastCompleted === "authorize-research-send"
   );
-  const assert_safe_link_released = computed(() =>
+  const assert_safe_link_released = assert(() =>
     instance.completedCount === 3 &&
     instance.lastCompleted === "release-safe-link"
   );
-  const assert_remaining_actions_do_not_regress_completed_flow = computed(() =>
+  const assert_remaining_actions_do_not_regress_completed_flow = assert(() =>
     instance.completedCount >= 3 &&
     instance.lastCompleted !== ""
   );

--- a/packages/patterns/cfc-staged-publish/main.test.tsx
+++ b/packages/patterns/cfc-staged-publish/main.test.tsx
@@ -1,4 +1,4 @@
-import { computed, handler, pattern, Writable } from "commonfabric";
+import { assert, handler, pattern, Writable } from "commonfabric";
 import {
   PUBLISH_SNAPSHOT_ACTION,
   REVIEW_SNAPSHOT_ACTION,
@@ -56,23 +56,23 @@ export default pattern(() => {
     body: "Edited after save but before review.",
   });
 
-  const assert_initial_stage = computed(() => instance.stage === "drafting");
-  const assert_saved_snapshot = computed(() =>
+  const assert_initial_stage = assert(() => instance.stage === "drafting");
+  const assert_saved_snapshot = assert(() =>
     savedTitle.get() === "Launch checklist" &&
     savedBody.get() === "Ship the staged publish demo with trusted UI gates." &&
     instance.stage === "saved"
   );
-  const assert_saved_stays_stable_after_edit = computed(() =>
+  const assert_saved_stays_stable_after_edit = assert(() =>
     savedTitle.get() === "Launch checklist" &&
     savedBody.get() === "Ship the staged publish demo with trusted UI gates."
   );
-  const assert_reviewed_snapshot = computed(() =>
+  const assert_reviewed_snapshot = assert(() =>
     reviewedTitle.get() === "Launch checklist" &&
     reviewedBody.get() ===
       "Ship the staged publish demo with trusted UI gates." &&
     instance.stage === "reviewed"
   );
-  const assert_published_snapshot = computed(() =>
+  const assert_published_snapshot = assert(() =>
     publishedTitle.get() === "Launch checklist" &&
     publishedBody.get() ===
       "Ship the staged publish demo with trusted UI gates." &&

--- a/packages/patterns/cfc-trusted-component-examples/confirmation-release-examples.test.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/confirmation-release-examples.test.tsx
@@ -1,4 +1,4 @@
-import { computed, handler, pattern } from "commonfabric";
+import { assert, handler, pattern } from "commonfabric";
 import {
   CustomerSupportRecipientConfirmExample,
   FinanceRecipientConfirmExample,
@@ -49,25 +49,25 @@ export default pattern(() => {
   const patient = PatientCaseRedactedReleaseExample({});
   const incident = SecurityIncidentRedactedReleaseExample({});
 
-  const assert_finance_confirmed = computed(() =>
+  const assert_finance_confirmed = assert(() =>
     finance.decoyStatus === "Host finance send shortcut is untrusted." &&
     finance.confirmedRecipientRelease!.includes("finance@example.com") &&
     finance.confirmedRecipientRelease!.includes("budget packet")
   );
 
-  const assert_support_confirmed = computed(() =>
+  const assert_support_confirmed = assert(() =>
     support.decoyStatus === "Host support reply shortcut is untrusted." &&
     support.confirmedRecipientRelease!.includes("support lead") &&
     support.confirmedRecipientRelease!.includes("case transcript excerpt")
   );
 
-  const assert_patient_redacted = computed(() =>
+  const assert_patient_redacted = assert(() =>
     patient.decoyStatus === "Host patient export did not release content." &&
     patient.releasedRedactedContent!.includes("[redacted-secret]") &&
     patient.releasedRedactedContent!.includes("[redacted-id]")
   );
 
-  const assert_incident_redacted = computed(() =>
+  const assert_incident_redacted = assert(() =>
     incident.decoyStatus === "Host incident export did not release content." &&
     incident.releasedRedactedContent!.includes("Released redacted incident") &&
     incident.releasedRedactedContent!.includes("[redacted-secret]")

--- a/packages/patterns/cfc-trusted-component-examples/disclaimer-examples.test.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/disclaimer-examples.test.tsx
@@ -1,4 +1,4 @@
-import { computed, handler, pattern, Writable } from "commonfabric";
+import { assert, handler, pattern, Writable } from "commonfabric";
 import {
   DISCLAIMER_EXAMPLE_COUNT,
   DISCLAIMER_RENDERED_EXAMPLE_COUNT,
@@ -107,30 +107,30 @@ export default pattern(() => {
     fakeStatus: lookalikeFakeStatus,
   });
 
-  const assert_influence_disclosure_is_render_only = computed(() =>
+  const assert_influence_disclosure_is_render_only = assert(() =>
     influenceFakeStatus.get() ===
       "The lookalike influence notice did not update trusted state." &&
     influenceAcknowledged.get() === ""
   );
 
-  const assert_provenance_disclosure_is_render_only = computed(() =>
+  const assert_provenance_disclosure_is_render_only = assert(() =>
     provenanceFakeStatus.get() ===
       "The lookalike provenance card did not update the reviewed text." &&
     reviewedProvenance.get() === ""
   );
 
-  const assert_fact_check_disclosure_is_render_only = computed(() =>
+  const assert_fact_check_disclosure_is_render_only = assert(() =>
     factCheckFakeStatus.get() ===
       "The lookalike fact-check gate did not approve the brief." &&
     factCheckResult.get() === ""
   );
 
-  const assert_lookalike_stays_untrusted = computed(() =>
+  const assert_lookalike_stays_untrusted = assert(() =>
     lookalikeFakeStatus.get() ===
       "The host lookalike never changed the trusted output." &&
     lookalikeAcknowledged.get() === ""
   );
-  const assert_gallery_renders_catalog = computed(() =>
+  const assert_gallery_renders_catalog = assert(() =>
     DISCLAIMER_EXAMPLE_COUNT === 14 &&
     DISCLAIMER_RENDERED_EXAMPLE_COUNT === DISCLAIMER_EXAMPLE_COUNT
   );

--- a/packages/patterns/cfc-trusted-component-examples/main.test.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/main.test.tsx
@@ -1,9 +1,9 @@
-import { computed, pattern } from "commonfabric";
+import { assert, pattern } from "commonfabric";
 import TrustedComponentExamples from "./main.tsx";
 
 export default pattern(() => {
   const gallery = TrustedComponentExamples({});
-  const assert_total_examples = computed(() => gallery.totalExamples === 52);
+  const assert_total_examples = assert(() => gallery.totalExamples === 52);
 
   return {
     tests: [{ assertion: assert_total_examples }],

--- a/packages/patterns/cfc-trusted-component-examples/process-examples.test.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/process-examples.test.tsx
@@ -1,4 +1,4 @@
-import { computed, handler, pattern } from "commonfabric";
+import { assert, handler, pattern } from "commonfabric";
 import {
   BatchPhotoUploadJobExample,
   CalendarAvailabilityPolicyExample,
@@ -38,19 +38,19 @@ export default pattern(() => {
   const photoJob = BatchPhotoUploadJobExample({});
   const exportJob = DocumentExportJobExample({});
 
-  const assert_song_id_only = computed(() =>
+  const assert_song_id_only = assert(() =>
     song.decoyStatus ===
       "Host raw-audio shortcut did not authorize recording; only song ID can be written." &&
     song.identifiedSongId!.includes("Mock song id")
   );
 
-  const assert_policy_saved = computed(() =>
+  const assert_policy_saved = assert(() =>
     policy.decoyStatus ===
       "Host full-calendar shortcut did not save policy; trusted surface scopes the contribution." &&
     policy.savedSharePolicy!.includes("free/busy windows only")
   );
 
-  const assert_photo_job_visible_and_cancelable = computed(() =>
+  const assert_photo_job_visible_and_cancelable = assert(() =>
     photoJob.decoyStatus ===
       "Host all-photo shortcut did not authorize the job; the trusted job stays visible and cancelable." &&
     photoJob.jobStatus === "Cancelled" &&
@@ -58,7 +58,7 @@ export default pattern(() => {
     photoJob.jobCancellation!.includes("Batch photo upload")
   );
 
-  const assert_document_export_authorized = computed(() =>
+  const assert_document_export_authorized = assert(() =>
     exportJob.decoyStatus ===
       "Host one-click export did not authorize the job; the trusted job surface controls export." &&
     exportJob.jobStatus === "Running" &&

--- a/packages/patterns/cfc-trusted-component-examples/send-publish-examples.test.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/send-publish-examples.test.tsx
@@ -1,4 +1,4 @@
-import { computed, handler, pattern } from "commonfabric";
+import { assert, handler, pattern } from "commonfabric";
 import {
   ChatThreadSendExample,
   DirectMessageSendExample,
@@ -45,7 +45,7 @@ export default pattern(() => {
   const lookalike = HostLookalikeControlExample({});
   const directMessage = DirectMessageSendExample({});
 
-  const assertChatThread = computed(() =>
+  const assertChatThread = assert(() =>
     chatThread.decoyResult ===
       "Host shortcut ignored; only the trusted send surface counts." &&
     chatThread.sentMessage!.includes(
@@ -53,7 +53,7 @@ export default pattern(() => {
     )
   );
 
-  const assertProjectUpdate = computed(() =>
+  const assertProjectUpdate = assert(() =>
     projectUpdate.decoyResult ===
       "Project publish banner is only decorative." &&
     projectUpdate.preparedAudiencePublish!.includes("project board") &&
@@ -61,7 +61,7 @@ export default pattern(() => {
       projectUpdate.preparedAudiencePublish
   );
 
-  const assertLookalike = computed(() =>
+  const assertLookalike = assert(() =>
     lookalike.decoyResult ===
       "Lookalike host control updated, not the protected output." &&
     directMessage.decoyResult ===
@@ -71,7 +71,7 @@ export default pattern(() => {
     directMessage.preparedBrief!.includes("Prepared outbound draft") &&
     directMessage.authorizedSend!.includes("Authorized outbound message")
   );
-  const assertGalleryRendersCatalog = computed(() =>
+  const assertGalleryRendersCatalog = assert(() =>
     SEND_PUBLISH_EXAMPLE_COUNT === 30 &&
     SEND_PUBLISH_RENDERED_EXAMPLE_COUNT === SEND_PUBLISH_EXAMPLE_COUNT
   );

--- a/packages/patterns/cfc/trusted-surfaces/main.test.tsx
+++ b/packages/patterns/cfc/trusted-surfaces/main.test.tsx
@@ -1,4 +1,4 @@
-import { computed, handler, pattern, Stream, Writable } from "commonfabric";
+import { assert, handler, pattern, Stream, Writable } from "commonfabric";
 import {
   SAVE_DRAFT_ACTION,
   SAVE_TITLE_ACTION,
@@ -309,82 +309,82 @@ export default pattern(() => {
     stream: trustedRedactedRelease.releaseRedactedContent,
   });
 
-  const assert_saved = computed(() =>
+  const assert_saved = assert(() =>
     savedTitle.get() === "Saved from trusted surface"
   );
-  const assert_saved_draft = computed(() =>
+  const assert_saved_draft = assert(() =>
     savedDraftTitle.get() === "Saved from trusted surface" &&
     savedBody.get() === "Draft body"
   );
-  const assert_forward_prepared = computed(() =>
+  const assert_forward_prepared = assert(() =>
     forwardPrepared.get() ===
       "Prepared for night-audit@hotel.example: Guest arrives late and needs the bell desk to hold room access after midnight. Only the bounded itinerary excerpt will be forwarded."
   );
-  const assert_forward_committed = computed(() =>
+  const assert_forward_committed = assert(() =>
     forwardedNote.get() === forwardPrepared.get()
   );
-  const assert_command_captured = computed(() =>
+  const assert_command_captured = assert(() =>
     capturedCommand.get() ===
       "Research Common Fabric launch updates and email a three-bullet brief to team@example.com"
   );
-  const assert_brief_prepared = computed(() =>
+  const assert_brief_prepared = assert(() =>
     preparedBrief.get() ===
       'Prepared outbound draft: concise summary for "Research Common Fabric launch updates and email a three-bullet brief to team@example.com". The send action stays separately gated.'
   );
-  const assert_send_authorized = computed(() =>
+  const assert_send_authorized = assert(() =>
     authorizedSend.get() ===
       'Authorized outbound message for "Research Common Fabric launch updates and email a three-bullet brief to team@example.com": Prepared outbound draft: concise summary for "Research Common Fabric launch updates and email a three-bullet brief to team@example.com". The send action stays separately gated.'
   );
-  const assert_safe_link_prepared = computed(() =>
+  const assert_safe_link_prepared = assert(() =>
     preparedSafeLink.get() ===
       "https://source.example.com/private/report?view=summary"
   );
-  const assert_safe_link_released = computed(() =>
+  const assert_safe_link_released = assert(() =>
     releasedSafeLink.get() ===
       "Released safe link https://source.example.com/private/report?view=summary"
   );
-  const assert_conversation_sent = computed(() =>
+  const assert_conversation_sent = assert(() =>
     sentMessage.get() ===
       "Sent in Project Sync to product thread: Ship the reviewed update only."
   );
-  const assert_audience_prepared = computed(() =>
+  const assert_audience_prepared = assert(() =>
     preparedAudiencePublish.get() ===
       "Prepared publish for public: Release note — Summarize the trusted review before publish."
   );
-  const assert_audience_published = computed(() =>
+  const assert_audience_published = assert(() =>
     publishedAudiencePost.get() === preparedAudiencePublish.get()
   );
-  const assert_disclaimer_acknowledged = computed(() =>
+  const assert_disclaimer_acknowledged = assert(() =>
     acknowledgedDisclaimer.get() ===
       "Acknowledged trusted disclaimer: Disclosure before use is required."
   );
-  const assert_provenance_reviewed = computed(() =>
+  const assert_provenance_reviewed = assert(() =>
     reviewedProvenance.get() ===
       "Reviewed provenance: Rendered provenance from trusted source."
   );
-  const assert_fact_check_released = computed(() =>
+  const assert_fact_check_released = assert(() =>
     factCheckResult.get() ===
       "Fact-check gate opened for: Claim checked against trusted facts."
   );
-  const assert_song_id_recorded = computed(() =>
+  const assert_song_id_recorded = assert(() =>
     identifiedSongId.get() === "Mock song id: midnight-bloom"
   );
-  const assert_share_policy_saved = computed(() =>
+  const assert_share_policy_saved = assert(() =>
     savedSharePolicy.get() === "Share policy saved for team (share-only)"
   );
-  const assert_job_authorized = computed(() =>
+  const assert_job_authorized = assert(() =>
     jobStatus.get() === "Running" &&
     jobAuthorization.get() === "Authorized long-running job: nightly export"
   );
-  const assert_job_cancelled = computed(() =>
+  const assert_job_cancelled = assert(() =>
     jobStatus.get() === "Cancelled" &&
     jobCancellation.get() === "Cancelled long-running job: nightly export"
   );
-  const assert_recipient_confirmed = computed(() =>
+  const assert_recipient_confirmed = assert(() =>
     confirmedRecipientRelease.get() ===
       "Confirmed release to finance@example.com: Quarterly budget packet"
   );
-  const assert_redacted_released = computed(() =>
+  const assert_redacted_released = assert(() =>
     releasedRedactedContent.get() ===
       "Released redacted support case: Customer [redacted-secret] code [redacted-id] may be released after redaction."
   );

--- a/packages/patterns/contacts/contact-book.test.tsx
+++ b/packages/patterns/contacts/contact-book.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/counter/counter.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import { default as ContactBook, matchesSearch } from "./contact-book.tsx";
 import { type Contact } from "./contact-detail.tsx";
 
@@ -31,19 +31,19 @@ const testContact: Contact = {
 
 export default pattern(() => {
   // Initial state assertions
-  const assert_empty_query_matches_all = computed(() =>
+  const assert_empty_query_matches_all = assert(() =>
     matchesSearch(testContact, "")
   );
 
-  const assert_name_query_matches = computed(() =>
+  const assert_name_query_matches = assert(() =>
     matchesSearch(testContact, "conrad")
   );
 
-  const assert_email_query_matches = computed(() =>
+  const assert_email_query_matches = assert(() =>
     matchesSearch(testContact, "testmail")
   );
 
-  const assert_company_query_matches = computed(() =>
+  const assert_company_query_matches = assert(() =>
     matchesSearch(testContact, "widgets")
   );
 
@@ -53,7 +53,7 @@ export default pattern(() => {
     contactBook.onAddContact.send();
   });
 
-  const assert_one_contact = computed(
+  const assert_one_contact = assert(
     () => len(contactBook.contacts) == 1,
   );
 

--- a/packages/patterns/counter/counter.test.tsx
+++ b/packages/patterns/counter/counter.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/counter/counter.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import Counter from "./counter.tsx";
 
 export default pattern(() => {
@@ -59,36 +59,34 @@ export default pattern(() => {
   // ==========================================================================
 
   // Initial state assertions
-  const assert_initial_value_is_0 = computed(() => counter.value === 0);
-  const assert_initial_value_is_5 = computed(() =>
+  const assert_initial_value_is_0 = assert(() => counter.value === 0);
+  const assert_initial_value_is_5 = assert(() =>
     counterStartingAt5.value === 5
   );
 
   // After first increment
-  const assert_value_is_1 = computed(() => counter.value === 1);
+  const assert_value_is_1 = assert(() => counter.value === 1);
 
   // After second increment
-  const assert_value_is_2 = computed(() => counter.value === 2);
+  const assert_value_is_2 = assert(() => counter.value === 2);
 
   // After decrement (back to 1)
-  const assert_value_is_1_again = computed(() => counter.value === 1);
+  const assert_value_is_1_again = assert(() => counter.value === 1);
 
   // After decrementing twice more (goes to -1)
-  const assert_value_is_negative_1 = computed(() => counter.value === -1);
+  const assert_value_is_negative_1 = assert(() => counter.value === -1);
 
   // Counter starting at 5: after decrement should be 4
-  const assert_from_5_is_4 = computed(() => counterStartingAt5.value === 4);
+  const assert_from_5_is_4 = assert(() => counterStartingAt5.value === 4);
 
   // Counter starting at 5: after increment should be 5 again
-  const assert_from_5_back_to_5 = computed(() =>
-    counterStartingAt5.value === 5
-  );
+  const assert_from_5_back_to_5 = assert(() => counterStartingAt5.value === 5);
 
   // After another increment should be 6
   const action_increment_to_6 = action(() => {
     counterStartingAt5.increment.send();
   });
-  const assert_from_5_is_6 = computed(() => counterStartingAt5.value === 6);
+  const assert_from_5_is_6 = assert(() => counterStartingAt5.value === 6);
 
   // ==========================================================================
   // Test Sequence

--- a/packages/patterns/cozy-poll/main.test.tsx
+++ b/packages/patterns/cozy-poll/main.test.tsx
@@ -11,7 +11,7 @@
  * are covered by multi-user.test.tsx.
  */
 
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import CozyPoll from "./main.tsx";
 
 export default pattern(() => {
@@ -89,7 +89,7 @@ export default pattern(() => {
   // Alex is in users, no admin name was claimed by anyone else, and the
   // "Should not appear" option is absent (implied by chipotle assertions
   // later — options.length === 1 after only Chipotle is added).
-  const assert_joined_as_alex = computed(() =>
+  const assert_joined_as_alex = assert(() =>
     poll.users.length === 1 &&
     poll.users[0]?.name === "Alex" &&
     poll.myName === "Alex" &&
@@ -98,49 +98,49 @@ export default pattern(() => {
     poll.isAdmin === true
   );
 
-  const assert_immutable_after_join = computed(() =>
+  const assert_immutable_after_join = assert(() =>
     poll.users.length === 1 &&
     poll.myName === "Alex"
   );
 
-  const assert_chipotle_added = computed(() =>
+  const assert_chipotle_added = assert(() =>
     poll.options.length === 1 &&
     poll.options[0]?.title === "Chipotle" &&
     poll.options[0]?.addedByName === "Alex"
   );
 
-  const assert_two_options = computed(() => poll.options.length === 2);
+  const assert_two_options = assert(() => poll.options.length === 2);
 
-  const assert_green_vote_recorded = computed(() => {
+  const assert_green_vote_recorded = assert(() => {
     const v = poll.votes[0];
     return poll.votes.length === 1 &&
       v?.voteType === "green" &&
       v?.voterName === "Alex";
   });
 
-  const assert_changed_to_yellow = computed(() => {
+  const assert_changed_to_yellow = assert(() => {
     const v = poll.votes[0];
     return poll.votes.length === 1 &&
       v?.voteType === "yellow";
   });
 
-  const assert_changed_to_red = computed(() => {
+  const assert_changed_to_red = assert(() => {
     const v = poll.votes[0];
     return poll.votes.length === 1 &&
       v?.voteType === "red";
   });
 
-  const assert_revote_green_cleared = computed(() => poll.votes.length === 0);
+  const assert_revote_green_cleared = assert(() => poll.votes.length === 0);
 
-  const assert_votes_reset = computed(() => poll.votes.length === 0);
+  const assert_votes_reset = assert(() => poll.votes.length === 0);
 
-  const assert_option_removed_with_its_votes = computed(() =>
+  const assert_option_removed_with_its_votes = assert(() =>
     poll.options.length === 1 &&
     poll.options[0]?.title === "Thai Kitchen" &&
     poll.votes.length === 0
   );
 
-  const assert_still_alex_host = computed(() =>
+  const assert_still_alex_host = assert(() =>
     poll.adminName === "Alex" && poll.isAdmin === true
   );
 

--- a/packages/patterns/dice.test.tsx
+++ b/packages/patterns/dice.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import Dice from "./dice.tsx";
 
 // The roll handler draws from Math.random(), which the capability gate allows in
@@ -12,14 +12,14 @@ export default pattern(() => {
   const action_roll_default = action(() => {
     dice.roll.send({});
   });
-  const assert_default_roll_is_a_d6 = computed(() =>
+  const assert_default_roll_is_a_d6 = assert(() =>
     Number.isInteger(dice.value) && dice.value >= 1 && dice.value <= 6
   );
 
   const action_roll_d20 = action(() => {
     dice.roll.send({ sides: 20 });
   });
-  const assert_d20_roll_is_in_range = computed(() =>
+  const assert_d20_roll_is_in_range = assert(() =>
     Number.isInteger(dice.value) && dice.value >= 1 && dice.value <= 20
   );
 
@@ -27,11 +27,11 @@ export default pattern(() => {
   const action_roll_invalid_sides = action(() => {
     dice.roll.send({ sides: -3 });
   });
-  const assert_invalid_sides_falls_back_to_a_d6 = computed(() =>
+  const assert_invalid_sides_falls_back_to_a_d6 = assert(() =>
     Number.isInteger(dice.value) && dice.value >= 1 && dice.value <= 6
   );
 
-  const assert_nested_output_is_readable = computed(() =>
+  const assert_nested_output_is_readable = assert(() =>
     dice.something.nested === "a secret surprise!"
   );
 

--- a/packages/patterns/do-list/do-list.test.tsx
+++ b/packages/patterns/do-list/do-list.test.tsx
@@ -19,7 +19,7 @@
  *
  * Run: deno task cf test packages/patterns/do-list/do-list.test.tsx --verbose
  */
-import { action, computed, equals, pattern, Writable } from "commonfabric";
+import { action, assert, equals, pattern, Writable } from "commonfabric";
 import DoList, { type DoItem } from "./do-list.tsx";
 
 export default pattern(() => {
@@ -120,71 +120,71 @@ export default pattern(() => {
   // Assertions
   // ==========================================================================
 
-  const assert_initial_empty = computed(() => doList.itemCount === 0);
+  const assert_initial_empty = assert(() => doList.itemCount === 0);
 
-  const assert_three = computed(() => doList.itemCount === 3);
-  const assert_titles = computed(() =>
+  const assert_three = assert(() => doList.itemCount === 3);
+  const assert_titles = assert(() =>
     doList.items[0]?.title === "Alpha" &&
     doList.items[1]?.title === "Beta" &&
     doList.items[2]?.title === "Gamma"
   );
 
-  const assert_first_done = computed(() => doList.items[0]?.done === true);
-  const assert_first_renamed = computed(() =>
+  const assert_first_done = assert(() => doList.items[0]?.done === true);
+  const assert_first_renamed = assert(() =>
     doList.items[0]?.title === "Alpha!" && doList.items[0]?.done === true
   );
-  const assert_others_untouched = computed(() =>
+  const assert_others_untouched = assert(() =>
     doList.items[1]?.title === "Beta" && doList.items[1]?.done === false &&
     doList.items[2]?.title === "Gamma" && doList.items[2]?.done === false
   );
 
-  const assert_beta_renamed_done = computed(() =>
+  const assert_beta_renamed_done = assert(() =>
     doList.items[1]?.title === "Beta2" && doList.items[1]?.done === true
   );
 
-  const assert_five = computed(() => doList.itemCount === 5);
-  const assert_all_dups_done = computed(() => {
+  const assert_five = assert(() => doList.itemCount === 5);
+  const assert_all_dups_done = assert(() => {
     const dups = doList.items.filter((i: DoItem) => i.title === "Dup");
     return dups.length === 2 && dups.every((i: DoItem) => i.done === true);
   });
 
   // Held-reference survival (reference-addressed update).
-  const assert_six = computed(() => doList.itemCount === 6);
-  const assert_held_stashed = computed(() => {
+  const assert_six = assert(() => doList.itemCount === 6);
+  const assert_held_stashed = assert(() => {
     const h = held.get();
     return h !== null && equals(doList.items[5], h);
   });
-  const assert_held_renamed = computed(() =>
+  const assert_held_renamed = assert(() =>
     doList.items[5]?.title === "HeldRenamed"
   );
   // KEY: the stale-but-once-valid reference still equals()-matches the item
   // AFTER updateItem patched it.
-  const assert_held_survives_update = computed(() => {
+  const assert_held_survives_update = assert(() => {
     const h = held.get();
     return h !== null && equals(doList.items[5], h);
   });
   // KEY: the held reference still DRIVES mutations after the update.
-  const assert_done_via_held = computed(() => doList.items[5]?.done === true);
-  const assert_removed_via_held = computed(() =>
+  const assert_done_via_held = assert(() => doList.items[5]?.done === true);
+  const assert_removed_via_held = assert(() =>
     doList.itemCount === 5 &&
     doList.items.find((i: DoItem) => i.title === "HeldRenamed") === undefined
   );
 
   // Held-reference survival (title-addressed update).
-  const assert_six_again = computed(() => doList.itemCount === 6);
-  const assert_title_held_stashed = computed(() => {
+  const assert_six_again = assert(() => doList.itemCount === 6);
+  const assert_title_held_stashed = assert(() => {
     const h = heldByTitle.get();
     return h !== null && equals(doList.items[5], h);
   });
-  const assert_title_held_renamed = computed(() =>
+  const assert_title_held_renamed = assert(() =>
     doList.items[5]?.title === "TitleHeldRenamed" &&
     doList.items[5]?.done === true
   );
-  const assert_title_held_survives_update = computed(() => {
+  const assert_title_held_survives_update = assert(() => {
     const h = heldByTitle.get();
     return h !== null && equals(doList.items[5], h);
   });
-  const assert_removed_via_title_held = computed(() =>
+  const assert_removed_via_title_held = assert(() =>
     doList.itemCount === 5 &&
     doList.items.find((i: DoItem) => i.title === "TitleHeldRenamed") ===
       undefined

--- a/packages/patterns/examples/clock.test.tsx
+++ b/packages/patterns/examples/clock.test.tsx
@@ -1,4 +1,4 @@
-import { computed, pattern } from "commonfabric";
+import { assert, pattern } from "commonfabric";
 import Clock from "./clock.tsx";
 
 // The clock's labels derive from the reactive #now clock. They read the
@@ -8,10 +8,10 @@ import Clock from "./clock.tsx";
 export default pattern(() => {
   const clock = Clock();
 
-  const assert_time_is_clock_shaped = computed(() =>
+  const assert_time_is_clock_shaped = assert(() =>
     /^\d{2}:\d{2}:\d{2}$/.test(clock.time)
   );
-  const assert_date_is_non_empty = computed(() => clock.date.length > 0);
+  const assert_date_is_non_empty = assert(() => clock.date.length > 0);
 
   return {
     tests: [

--- a/packages/patterns/examples/fetch-delay.test.tsx
+++ b/packages/patterns/examples/fetch-delay.test.tsx
@@ -2,7 +2,7 @@
 // a mock can return after a fixed real-time delay, so a fetchJson isn't resolved
 // instantly. `runtime.settled()` (driven by `{ settle: true }`) still awaits the
 // delayed fetch, so the result is observed deterministically once it lands.
-import { computed, fetchJson, pattern } from "commonfabric";
+import { assert, computed, fetchJson, pattern } from "commonfabric";
 
 export const fetchMocks = [
   {
@@ -16,7 +16,7 @@ export const fetchMocks = [
 export default pattern(() => {
   const url = computed(() => "https://example.test/api/slow");
   const fetched = fetchJson<{ v: number }>({ url });
-  const result_is_7 = computed(() => fetched.result?.v === 7);
+  const result_is_7 = assert(() => fetched.result?.v === 7);
   return {
     tests: [
       { settle: true }, // awaits the delayed fetch to completion

--- a/packages/patterns/examples/fetch-mock.test.tsx
+++ b/packages/patterns/examples/fetch-mock.test.tsx
@@ -7,7 +7,7 @@
 //
 // LLM calls (generateText/generateObject) mock separately via @commonfabric/llm;
 // this seam is for generic `fetchJson` HTTP.
-import { computed, fetchJson, pattern } from "commonfabric";
+import { assert, computed, fetchJson, pattern } from "commonfabric";
 
 export const fetchMocks = [
   {
@@ -26,12 +26,12 @@ export default pattern(() => {
   // Values gated on the `fetchJson` result — observable only once the mocked
   // request is driven to completion. Inline-boolean assertions so the reads are
   // reliable (an intermediate observer computed would infer `unknown`).
-  const result_answer_is_42 = computed(() => fetched.result?.answer === 42);
-  const result_label_is_mocked = computed(() =>
+  const result_answer_is_42 = assert(() => fetched.result?.answer === 42);
+  const result_label_is_mocked = assert(() =>
     fetched.result?.label === "mocked"
   );
-  const not_pending = computed(() => fetched.pending === false);
-  const no_error = computed(() => fetched.error === undefined);
+  const not_pending = assert(() => fetched.pending === false);
+  const no_error = assert(() => fetched.error === undefined);
 
   return {
     tests: [

--- a/packages/patterns/examples/instantiate-pattern.test.tsx
+++ b/packages/patterns/examples/instantiate-pattern.test.tsx
@@ -1,4 +1,4 @@
-import { computed, NAME, pattern } from "commonfabric";
+import { assert, NAME, pattern } from "commonfabric";
 import Factory, { Counter } from "./instantiate-pattern.tsx";
 
 // Covers both patterns this example file defines: the Counter it hands to
@@ -10,12 +10,12 @@ export default pattern(() => {
   const counter = Counter({ value: 3 });
   const factory = Factory({ allPieces: [] });
 
-  const assert_counter_reports_its_value = computed(() => counter.value === 3);
+  const assert_counter_reports_its_value = assert(() => counter.value === 3);
   // The name is a computed over the same cell, so it tracks the value.
-  const assert_counter_name_tracks_the_value = computed(() =>
+  const assert_counter_name_tracks_the_value = assert(() =>
     counter[NAME] === "Simple counter: 3"
   );
-  const assert_factory_instantiates = computed(() =>
+  const assert_factory_instantiates = assert(() =>
     factory[NAME] === "Counter Factory"
   );
 

--- a/packages/patterns/examples/reactive-now.test.tsx
+++ b/packages/patterns/examples/reactive-now.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import ReactiveNow from "./reactive-now.tsx";
 
 // The time labels derive from the reactive #now clock: they read "…" until #now
@@ -12,20 +12,20 @@ import ReactiveNow from "./reactive-now.tsx";
 export default pattern(() => {
   const demo = ReactiveNow();
 
-  const assert_loaded_at_is_clock_shaped = computed(() =>
+  const assert_loaded_at_is_clock_shaped = assert(() =>
     /^\d{2}:\d{2}:\d{2}$/.test(demo.loadedAt)
   );
-  const assert_now_is_clock_shaped = computed(() =>
+  const assert_now_is_clock_shaped = assert(() =>
     /^\d{2}:\d{2}:\d{2}$/.test(demo.now)
   );
-  const assert_since_load_is_ago_shaped = computed(() =>
+  const assert_since_load_is_ago_shaped = assert(() =>
     /^\d+s ago$/.test(demo.sinceLoad)
   );
 
   const action_tap = action(() => {
     demo.tap.send({});
   });
-  const assert_tap_delivered = computed(() => demo.taps >= 1);
+  const assert_tap_delivered = assert(() => demo.taps >= 1);
 
   // Keystroke path: driving the text box updates the derived char count and echo.
   // Like the tap, the delivery SHAPING is not exercised here (a headless test
@@ -33,8 +33,8 @@ export default pattern(() => {
   const action_type = action(() => {
     demo.type.send({ value: "hello" });
   });
-  const assert_char_count = computed(() => demo.charCount === 5);
-  const assert_echo = computed(() => demo.echo === "HELLO");
+  const assert_char_count = assert(() => demo.charCount === 5);
+  const assert_echo = assert(() => demo.echo === "HELLO");
 
   return {
     tests: [

--- a/packages/patterns/experimental/folksonomy-aggregator.test.tsx
+++ b/packages/patterns/experimental/folksonomy-aggregator.test.tsx
@@ -16,7 +16,7 @@
  * instead of action() closures to avoid "reactive reference outside
  * reactive context" errors when accessing reactive proxy objects.
  */
-import { Cell, computed, handler, pattern, Stream } from "commonfabric";
+import { assert, Cell, handler, pattern, Stream } from "commonfabric";
 import AggregatorPattern from "./folksonomy-aggregator.tsx";
 
 export interface TagEvent {
@@ -383,7 +383,7 @@ export default pattern(() => {
   // ========================================================================
 
   // --- Initial state ---
-  const assert_initial_empty = computed(() => {
+  const assert_initial_empty = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -396,7 +396,7 @@ export default pattern(() => {
   });
 
   // --- Test 1: Basic correctness ---
-  const assert_basic_has_typescript = computed(() => {
+  const assert_basic_has_typescript = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -408,7 +408,7 @@ export default pattern(() => {
   });
 
   // --- Test 2: Multi-scope isolation ---
-  const assert_scope_a_has_alpha = computed(() => {
+  const assert_scope_a_has_alpha = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -416,7 +416,7 @@ export default pattern(() => {
     return (suggs["scope-a"] || []).some((s) => s.tag === "alpha");
   });
 
-  const assert_scope_a_has_beta = computed(() => {
+  const assert_scope_a_has_beta = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -424,7 +424,7 @@ export default pattern(() => {
     return (suggs["scope-a"] || []).some((s) => s.tag === "beta");
   });
 
-  const assert_scope_b_has_gamma = computed(() => {
+  const assert_scope_b_has_gamma = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -432,7 +432,7 @@ export default pattern(() => {
     return (suggs["scope-b"] || []).some((s) => s.tag === "gamma");
   });
 
-  const assert_scope_a_no_gamma = computed(() => {
+  const assert_scope_a_no_gamma = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -440,7 +440,7 @@ export default pattern(() => {
     return !(suggs["scope-a"] || []).some((s) => s.tag === "gamma");
   });
 
-  const assert_scope_b_no_alpha = computed(() => {
+  const assert_scope_b_no_alpha = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -448,7 +448,7 @@ export default pattern(() => {
     return !(suggs["scope-b"] || []).some((s) => s.tag === "alpha");
   });
 
-  const assert_scope_a_alpha_count_5 = computed(() => {
+  const assert_scope_a_alpha_count_5 = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -458,7 +458,7 @@ export default pattern(() => {
   });
 
   // --- Test 3: Preferential attachment ---
-  const assert_popular_first = computed(() => {
+  const assert_popular_first = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -467,7 +467,7 @@ export default pattern(() => {
     return pSuggs.length >= 2 && pSuggs[0].tag === "popular";
   });
 
-  const assert_popular_count_higher = computed(() => {
+  const assert_popular_count_higher = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -479,7 +479,7 @@ export default pattern(() => {
   });
 
   // --- Test 4: Remove handling ---
-  const assert_removable_count_2 = computed(() => {
+  const assert_removable_count_2 = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -490,7 +490,7 @@ export default pattern(() => {
     return removable?.count === 2; // 5 adds - 3 removes = 2
   });
 
-  const assert_permanent_count_1 = computed(() => {
+  const assert_permanent_count_1 = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -502,7 +502,7 @@ export default pattern(() => {
   });
 
   // --- Test 5: Large batch ---
-  const assert_batch_multiple_scopes = computed(() => {
+  const assert_batch_multiple_scopes = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -516,7 +516,7 @@ export default pattern(() => {
     return scopeCount >= 5; // Should have all 10 batch scopes populated
   });
 
-  const assert_batch_has_tags = computed(() => {
+  const assert_batch_has_tags = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -526,7 +526,7 @@ export default pattern(() => {
   });
 
   // --- Test 6: Invalid events ---
-  const assert_empty_after_invalid = computed(() => {
+  const assert_empty_after_invalid = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -537,7 +537,7 @@ export default pattern(() => {
     return true;
   });
 
-  const assert_recovery_after_invalid = computed(() => {
+  const assert_recovery_after_invalid = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -548,7 +548,7 @@ export default pattern(() => {
   });
 
   // --- Test 7: Dense scope ---
-  const assert_dense_100_tags = computed(() => {
+  const assert_dense_100_tags = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]
@@ -556,7 +556,7 @@ export default pattern(() => {
     return (suggs["cookbook"] || []).length === 100;
   });
 
-  const assert_dense_sorted = computed(() => {
+  const assert_dense_sorted = assert(() => {
     const suggs = (aggregator.suggestions || {}) as Record<
       string,
       CommunityTagSuggestion[]

--- a/packages/patterns/factory-outputs/lot-watch/main.test.tsx
+++ b/packages/patterns/factory-outputs/lot-watch/main.test.tsx
@@ -22,7 +22,7 @@
  *
  * NOTE: Uses .filter(() => true).length for array lengths per reactivity tracking note.
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, assert, pattern, Writable } from "commonfabric";
 import LotWatch from "./main.tsx";
 import type { KnownVehicle, PlateGroup, Sighting } from "./main.tsx";
 import { classifyPlate, plateKey } from "./main.tsx";
@@ -103,10 +103,10 @@ export default pattern(() => {
   });
 
   // Initial state: no sightings
-  const assert_s1_empty = computed(() => len(s1.sightings) === 0);
+  const assert_s1_empty = assert(() => len(s1.sightings) === 0);
 
   // After first capture: plate normalized to uppercase alphanumerics
-  const assert_s1_normalized_plate = computed(() => {
+  const assert_s1_normalized_plate = assert(() => {
     const all = s1.sightings;
     if (len(all) !== 1) return false;
     const s = all[0];
@@ -119,8 +119,8 @@ export default pattern(() => {
   });
 
   // After second capture
-  const assert_s1_two_sightings = computed(() => len(s1.sightings) === 2);
-  const assert_s1_second_plate = computed(() => {
+  const assert_s1_two_sightings = assert(() => len(s1.sightings) === 2);
+  const assert_s1_second_plate = assert(() => {
     const all = s1.sightings;
     const second = all.find((s: Sighting) => s.spotNumber === "5");
     return second?.plateNumber === "XYZ999" && second?.plateState === "NY";
@@ -214,7 +214,7 @@ export default pattern(() => {
   // classifyPlate is a pure exported function — test it directly using the
   // pre-seeded data. This avoids needing to read back from the live computed
   // sightingRows (which requires admin mode to surface classification labels).
-  const assert_s2_ours_classification = computed(() =>
+  const assert_s2_ours_classification = assert(() =>
     classifyPlate(
       "OUR001",
       "CA",
@@ -223,7 +223,7 @@ export default pattern(() => {
     ) === "ours"
   );
 
-  const assert_s2_offender_classification = computed(() =>
+  const assert_s2_offender_classification = assert(() =>
     classifyPlate(
       "OFF001",
       "CA",
@@ -232,7 +232,7 @@ export default pattern(() => {
     ) === "offender"
   );
 
-  const assert_s2_guest_classification = computed(() =>
+  const assert_s2_guest_classification = assert(() =>
     classifyPlate(
       "GST001",
       "CA",
@@ -241,7 +241,7 @@ export default pattern(() => {
     ) === "guest"
   );
 
-  const assert_s2_unknown_classification = computed(() =>
+  const assert_s2_unknown_classification = assert(() =>
     classifyPlate(
       "UNK999",
       "CA",
@@ -251,9 +251,9 @@ export default pattern(() => {
   );
 
   // Verify plates appear in sightings with correct normalized plate numbers
-  const assert_s2_four_sightings = computed(() => len(s2.sightings) === 4);
+  const assert_s2_four_sightings = assert(() => len(s2.sightings) === 4);
 
-  const assert_s2_ours_in_sightings = computed(() =>
+  const assert_s2_ours_in_sightings = assert(() =>
     s2.sightings.some((s: Sighting) =>
       s.plateNumber === "OUR001" && s.spotNumber === "1"
     )
@@ -279,13 +279,13 @@ export default pattern(() => {
   });
 
   // The sighting was captured (capture is NOT admin-gated)
-  const assert_s3_sighting_captured = computed(() =>
+  const assert_s3_sighting_captured = assert(() =>
     s3.sightings.some((s: Sighting) => s.plateNumber === "BAD001")
   );
 
   // Before adding to known registry, plate classifies as unknown (pure function)
   const emptyKnown: KnownVehicle[] = [];
-  const assert_s3_initial_classification = computed(() =>
+  const assert_s3_initial_classification = assert(() =>
     classifyPlate("BAD001", "CA", [], emptyKnown) === "unknown"
   );
 
@@ -302,7 +302,7 @@ export default pattern(() => {
       label: "daily parker",
     },
   ];
-  const assert_s3_retro_classified = computed(() =>
+  const assert_s3_retro_classified = assert(() =>
     classifyPlate("BAD001", "CA", [], knownWithOffender) === "offender"
   );
 
@@ -316,7 +316,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s3_mark_no_admin_noop = computed(() =>
+  const assert_s3_mark_no_admin_noop = assert(() =>
     len(s3.knownVehicles) === 0
   );
 
@@ -376,20 +376,20 @@ export default pattern(() => {
   ];
 
   // Same-plate group has count=2, isRepeat=true
-  const assert_s4_repeat_plate_group_count = computed(() => {
+  const assert_s4_repeat_plate_group_count = assert(() => {
     const groups = groupSightingsByPlate(sightingsForGrouping);
     const g = groups.find((pg: PlateGroup) => pg.plate === "RPT001");
     return g?.count === 2 && g?.isRepeat === true;
   });
 
   // Only one group (blank plate skipped)
-  const assert_s4_only_one_group = computed(() => {
+  const assert_s4_only_one_group = assert(() => {
     const groups = groupSightingsByPlate(sightingsForGrouping);
     return len(groups) === 1;
   });
 
   // Blank-plate sightings are excluded from grouping
-  const assert_s4_blank_plate_not_grouped = computed(() => {
+  const assert_s4_blank_plate_not_grouped = assert(() => {
     const groups = groupSightingsByPlate(sightingsForGrouping);
     return groups.every((pg: PlateGroup) => pg.plate !== "");
   });
@@ -495,14 +495,14 @@ export default pattern(() => {
   ];
 
   // Repeat plates: only AAA111 (3x) and BBB222 (2x), not CCC333 (1x)
-  const assert_s5_repeat_groups = computed(() => {
+  const assert_s5_repeat_groups = assert(() => {
     const groups = groupSightingsByPlate(sightingsForReport);
     const repeats = groups.filter((g: PlateGroup) => g.isRepeat);
     return len(repeats) === 2;
   });
 
   // Leaderboard ordering: sorted by count descending → AAA111 first, BBB222 second
-  const assert_s5_leaderboard_order = computed(() => {
+  const assert_s5_leaderboard_order = assert(() => {
     const groups = groupSightingsByPlate(sightingsForReport);
     const sorted = groups
       .filter((g: PlateGroup) => g.isRepeat)
@@ -517,7 +517,7 @@ export default pattern(() => {
   });
 
   // Spot occupancy: spot 1 has 3 sightings, spot 5 has 2, spot 12 has 1
-  const assert_s5_spot_occupancy = computed(() => {
+  const assert_s5_spot_occupancy = assert(() => {
     const spot1 = sightingsForReport.filter((s) => s.spotNumber === "1");
     const spot5 = sightingsForReport.filter((s) => s.spotNumber === "5");
     const spot12 = sightingsForReport.filter((s) => s.spotNumber === "12");
@@ -558,7 +558,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s6_mark_no_admin_noop = computed(() =>
+  const assert_s6_mark_no_admin_noop = assert(() =>
     len(s6.knownVehicles) === 0
   );
 
@@ -568,9 +568,7 @@ export default pattern(() => {
     s6.deleteSighting.send({ id });
   });
 
-  const assert_s6_delete_no_admin_noop = computed(() =>
-    len(s6.sightings) === 1
-  );
+  const assert_s6_delete_no_admin_noop = assert(() => len(s6.sightings) === 1);
 
   // Now establish admin: enableAdminManager makes the current user a manager
   const action_s6_enable_admin_manager = action(() => {
@@ -589,7 +587,7 @@ export default pattern(() => {
 
   // After Alice is toggled admin, markVehicle called by non-matching reporter
   // (blank reporter) should still be a no-op for knownVehicles.
-  const assert_s6_still_no_known_vehicles = computed(() =>
+  const assert_s6_still_no_known_vehicles = assert(() =>
     len(s6.knownVehicles) === 0
   );
 
@@ -609,7 +607,7 @@ export default pattern(() => {
     },
   ];
 
-  const assert_s7_ours_beats_offender = computed(() =>
+  const assert_s7_ours_beats_offender = assert(() =>
     classifyPlate("BOTH01", "CA", conflictOurs, conflictKnown) === "ours"
   );
 
@@ -634,12 +632,12 @@ export default pattern(() => {
     },
   ];
 
-  const assert_s7_offender_beats_guest = computed(() =>
+  const assert_s7_offender_beats_guest = assert(() =>
     classifyPlate("PRIO01", "CA", [], priorityKnown) === "offender"
   );
 
   // Empty plate number → always unknown
-  const assert_s7_empty_plate_unknown = computed(() =>
+  const assert_s7_empty_plate_unknown = assert(() =>
     classifyPlate("", "CA", conflictOurs, conflictKnown) === "unknown"
   );
 
@@ -691,7 +689,7 @@ export default pattern(() => {
   const action_s8_save_guest_no_admin = action(() => {
     s8.saveGuest.send();
   });
-  const assert_s8_save_guest_no_admin_noop = computed(() =>
+  const assert_s8_save_guest_no_admin_noop = assert(() =>
     len(s8.knownVehicles) === 0
   );
 
@@ -706,7 +704,7 @@ export default pattern(() => {
   const action_s8_assign_no_admin = action(() => {
     s8.assignToPerson.send();
   });
-  const assert_s8_assign_no_admin_noop = computed(() => {
+  const assert_s8_assign_no_admin_noop = assert(() => {
     const alice = s8.people.find((p) => p.name === "Alice");
     return alice !== undefined && (alice.vehicles ?? []).length === 0;
   });
@@ -729,7 +727,7 @@ export default pattern(() => {
       org: "Local Butcher Shop",
     });
   });
-  const assert_s8_mark_succeeds = computed(() => {
+  const assert_s8_mark_succeeds = assert(() => {
     const kvs = [...s8.knownVehicles];
     return kvs.some((kv) =>
       kv.plateNumber === "X1" && kv.category === "offender"
@@ -744,7 +742,7 @@ export default pattern(() => {
   const action_s8_save_guest_admin = action(() => {
     s8.saveGuest.send();
   });
-  const assert_s8_save_guest_succeeds = computed(() => {
+  const assert_s8_save_guest_succeeds = assert(() => {
     const kvs = [...s8.knownVehicles];
     return kvs.some((kv) => kv.plateNumber === "Y1" && kv.category === "guest");
   });
@@ -759,7 +757,7 @@ export default pattern(() => {
   const action_s8_assign_admin = action(() => {
     s8.assignToPerson.send();
   });
-  const assert_s8_assign_succeeds = computed(() => {
+  const assert_s8_assign_succeeds = assert(() => {
     const alice = s8.people.find((p) => p.name === "Alice");
     if (!alice) return false;
     return (alice.vehicles ?? []).some((v) =>

--- a/packages/patterns/factory-outputs/parking-coordinator/main.test.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.test.tsx
@@ -14,7 +14,7 @@
  *
  * NOTE: Uses .filter(() => true).length for array lengths per reactivity tracking note.
  */
-import { action, computed, pattern, UI, wish } from "commonfabric";
+import { action, assert, computed, pattern, UI, wish } from "commonfabric";
 import {
   findNodeById,
   findNodeByProp,
@@ -69,7 +69,7 @@ export default pattern(() => {
     s1.enableAdminManager.send()
   );
 
-  const assert_s1_manager_can_start_people_flow = computed(() =>
+  const assert_s1_manager_can_start_people_flow = assert(() =>
     s1.currentUserCanManageAdmins === true &&
     nodeIncludesText(
       findNodeById(s1[UI], "parking-admin-add-person-open"),
@@ -119,41 +119,41 @@ export default pattern(() => {
   });
 
   // Initial state
-  const assert_s1_no_people = computed(() => len(s1.people) === 0);
-  const assert_s1_three_spots = computed(() => len(s1.spots) === 3);
+  const assert_s1_no_people = assert(() => len(s1.people) === 0);
+  const assert_s1_three_spots = assert(() => len(s1.spots) === 3);
 
   // After adding Alice
-  const assert_s1_alice_exists = computed(() =>
+  const assert_s1_alice_exists = assert(() =>
     s1.people.some((p: Person) => p.name === "Alice")
   );
-  const assert_s1_alice_default_spot = computed(() => {
+  const assert_s1_alice_default_spot = assert(() => {
     const alice = s1.people.find((p: Person) => p.name === "Alice");
     return alice?.defaultSpot === "5";
   });
-  const assert_s1_alice_preferences = computed(() => {
+  const assert_s1_alice_preferences = assert(() => {
     const alice = s1.people.find((p: Person) => p.name === "Alice");
-    return alice?.spotPreferences.some((s) => s === "5") &&
-      alice?.spotPreferences.some((s) => s === "1");
+    return alice?.spotPreferences.some((s) => s === "5") === true &&
+      alice?.spotPreferences.some((s) => s === "1") === true;
   });
-  const assert_s1_one_person = computed(() => len(s1.people) === 1);
-  const assert_s1_alice_unchanged = computed(() => {
+  const assert_s1_one_person = assert(() => len(s1.people) === 1);
+  const assert_s1_alice_unchanged = assert(() => {
     const alice = s1.people.find((p: Person) => p.name === "Alice");
     return len(s1.people) === 1 && alice?.email === "alice@co.com";
   });
 
   // After adding Bob
-  const assert_s1_two_people = computed(() => len(s1.people) === 2);
-  const assert_s1_bob_preferences = computed(() => {
+  const assert_s1_two_people = assert(() => len(s1.people) === 2);
+  const assert_s1_bob_preferences = assert(() => {
     const bob = s1.people.find((p: Person) => p.name === "Bob");
     return bob?.spotPreferences.some((s) => s === "12") === true;
   });
 
   // Duplicate rejected
-  const assert_s1_still_two = computed(() => len(s1.people) === 2);
+  const assert_s1_still_two = assert(() => len(s1.people) === 2);
 
   // After removing Bob
-  const assert_s1_one_after_remove = computed(() => len(s1.people) === 1);
-  const assert_s1_bob_gone = computed(() =>
+  const assert_s1_one_after_remove = assert(() => len(s1.people) === 1);
+  const assert_s1_bob_gone = assert(() =>
     !s1.people.some((p: Person) => p.name === "Bob")
   );
 
@@ -198,24 +198,24 @@ export default pattern(() => {
     s2.movePersonDown.send({ name: "Alice" })
   );
 
-  const assert_s2_alice_rank1 = computed(() => {
+  const assert_s2_alice_rank1 = assert(() => {
     return s2.people.find((p: Person) => p.name === "Alice")?.priorityRank ===
       1;
   });
-  const assert_s2_carol_rank3 = computed(() => {
+  const assert_s2_carol_rank3 = assert(() => {
     return s2.people.find((p: Person) => p.name === "Carol")?.priorityRank ===
       3;
   });
   // After moving Carol up (should swap Carol rank 3 with Bob rank 2)
-  const assert_s2_carol_rank2 = computed(() => {
+  const assert_s2_carol_rank2 = assert(() => {
     return s2.people.find((p: Person) => p.name === "Carol")?.priorityRank ===
       2;
   });
-  const assert_s2_bob_rank3 = computed(() => {
+  const assert_s2_bob_rank3 = assert(() => {
     return s2.people.find((p: Person) => p.name === "Bob")?.priorityRank === 3;
   });
   // After moving Alice down (rank 1 should swap with rank 2 = Carol now)
-  const assert_s2_alice_rank2 = computed(() => {
+  const assert_s2_alice_rank2 = assert(() => {
     return s2.people.find((p: Person) => p.name === "Alice")?.priorityRank ===
       2;
   });
@@ -259,26 +259,26 @@ export default pattern(() => {
     s3.editSpot.send(undefined as never);
   });
 
-  const assert_s3_three_spots = computed(() => len(s3.spots) === 3);
-  const assert_s3_non_admin_spot_blocked = computed(() => len(s3.spots) === 3);
-  const assert_s3_can_manage_admins = computed(() =>
+  const assert_s3_three_spots = assert(() => len(s3.spots) === 3);
+  const assert_s3_non_admin_spot_blocked = assert(() => len(s3.spots) === 3);
+  const assert_s3_can_manage_admins = assert(() =>
     s3.currentUserCanManageAdmins === true
   );
-  const assert_s3_alice_is_admin = computed(() =>
+  const assert_s3_alice_is_admin = assert(() =>
     s3.currentPersonIsAdmin === true
   );
-  const assert_s3_four_spots = computed(() => len(s3.spots) === 4);
-  const assert_s3_spot7_label = computed(() => {
+  const assert_s3_four_spots = assert(() => len(s3.spots) === 4);
+  const assert_s3_spot7_label = assert(() => {
     const s = s3.spots.find((sp: ParkingSpot) => sp.spotNumber === "7");
     return s?.label === "Level 2" && s?.active === true;
   });
-  const assert_s3_spot7_unchanged = computed(() => {
+  const assert_s3_spot7_unchanged = assert(() => {
     const s = s3.spots.find((sp: ParkingSpot) => sp.spotNumber === "7");
     return len(s3.spots) === 4 && s?.label === "Level 2" && s?.active === true;
   });
-  const assert_s3_still_four = computed(() => len(s3.spots) === 4); // dup rejected
-  const assert_s3_three_after_remove = computed(() => len(s3.spots) === 3);
-  const assert_s3_spot5_gone = computed(() =>
+  const assert_s3_still_four = assert(() => len(s3.spots) === 4); // dup rejected
+  const assert_s3_three_after_remove = assert(() => len(s3.spots) === 3);
+  const assert_s3_spot5_gone = assert(() =>
     !s3.spots.some((sp: ParkingSpot) => sp.spotNumber === "5")
   );
 
@@ -343,10 +343,10 @@ export default pattern(() => {
     s4.submitRequest.send({ personName: "Alice", date: nextTestDate });
   });
 
-  const assert_s4_no_requests = computed(() => len(s4.requests) === 0);
+  const assert_s4_no_requests = assert(() => len(s4.requests) === 0);
 
   // After Alice requests the test date
-  const assert_s4_alice_allocated = computed(() => {
+  const assert_s4_alice_allocated = assert(() => {
     const req = s4.requests.find((r: SpotRequest) =>
       r.personName === "Alice" && r.date === testDate
     );
@@ -355,7 +355,7 @@ export default pattern(() => {
   });
 
   // After Bob requests the test date
-  const assert_s4_bob_allocated_pref = computed(() => {
+  const assert_s4_bob_allocated_pref = assert(() => {
     const req = s4.requests.find((r: SpotRequest) =>
       r.personName === "Bob" && r.date === testDate
     );
@@ -363,7 +363,7 @@ export default pattern(() => {
   });
 
   // After Carol requests the test date (only "12" left)
-  const assert_s4_carol_allocated = computed(() => {
+  const assert_s4_carol_allocated = assert(() => {
     const req = s4.requests.find((r: SpotRequest) =>
       r.personName === "Carol" && r.date === testDate
     );
@@ -371,7 +371,7 @@ export default pattern(() => {
   });
 
   // Alice dupe: still only one request for the test date
-  const assert_s4_alice_still_one_today = computed(() => {
+  const assert_s4_alice_still_one_today = assert(() => {
     const aliceToday = s4.requests.filter((r: SpotRequest) =>
       r.personName === "Alice" && r.date === testDate
     );
@@ -379,12 +379,12 @@ export default pattern(() => {
   });
 
   // Duplicate shows in result message
-  const assert_s4_dupe_result = computed(() =>
+  const assert_s4_dupe_result = assert(() =>
     s4.requestResult.toLowerCase().includes("already")
   );
 
   // Alice's following-date request gets allocated (any spot)
-  const assert_s4_alice_tomorrow_allocated = computed(() => {
+  const assert_s4_alice_tomorrow_allocated = assert(() => {
     const req = s4.requests.find((r: SpotRequest) =>
       r.personName === "Alice" && r.date === nextTestDate
     );
@@ -438,7 +438,7 @@ export default pattern(() => {
     s5.submitRequest.send({ personName: "Dave", date: testDate });
   });
 
-  const assert_s5_dave_denied = computed(() => {
+  const assert_s5_dave_denied = assert(() => {
     const req = s5.requests.find((r: SpotRequest) =>
       r.personName === "Dave" && r.date === testDate
     );
@@ -467,11 +467,11 @@ export default pattern(() => {
     s6.cancelRequest.send({ requestId: "rx1" })
   );
 
-  const assert_s6_allocated = computed(() => {
+  const assert_s6_allocated = assert(() => {
     return s6.requests.find((r: SpotRequest) => r.id === "rx1")?.status ===
       "allocated";
   });
-  const assert_s6_cancelled = computed(() => {
+  const assert_s6_cancelled = assert(() => {
     return s6.requests.find((r: SpotRequest) => r.id === "rx1")?.status ===
       "cancelled";
   });
@@ -506,16 +506,16 @@ export default pattern(() => {
     });
   });
 
-  const assert_s7_non_admin_override_blocked = computed(() =>
+  const assert_s7_non_admin_override_blocked = assert(() =>
     len(s7.requests) === 0
   );
-  const assert_s7_can_manage_admins = computed(() =>
+  const assert_s7_can_manage_admins = assert(() =>
     s7.currentUserCanManageAdmins === true
   );
-  const assert_s7_alice_is_admin = computed(() =>
+  const assert_s7_alice_is_admin = assert(() =>
     s7.currentPersonIsAdmin === true
   );
-  const assert_s7_bob_override = computed(() => {
+  const assert_s7_bob_override = assert(() => {
     return s7.requests.some(
       (r: SpotRequest) =>
         r.personName === "Bob" && r.date === testDate &&
@@ -533,7 +533,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s7_alice_has_spot5 = computed(() => {
+  const assert_s7_alice_has_spot5 = assert(() => {
     return s7.requests.some(
       (r: SpotRequest) =>
         r.personName === "Alice" && r.assignedSpot === "5" &&
@@ -541,7 +541,7 @@ export default pattern(() => {
     );
   });
 
-  const assert_s7_bob_spot5_cancelled = computed(() => {
+  const assert_s7_bob_spot5_cancelled = assert(() => {
     // Bob's original spot 5 allocation should be cancelled
     return s7.requests.some(
       (r: SpotRequest) =>
@@ -567,8 +567,8 @@ export default pattern(() => {
     s8.togglePersonAdmin.send({ name: "Alice" })
   );
 
-  const assert_s8_admin_off = computed(() => s8.adminMode === false);
-  const assert_s8_admin_view_locked = computed(() => {
+  const assert_s8_admin_off = assert(() => s8.adminMode === false);
+  const assert_s8_admin_view_locked = assert(() => {
     const adminAccess = findNodeById(s8[UI], "parking-admin-access");
     const enableManager = findNodeById(
       s8[UI],
@@ -587,10 +587,10 @@ export default pattern(() => {
       propValue(adminToggle, "disabled") === true &&
       findNodeById(s8[UI], "parking-admin-people-section") === undefined;
   });
-  const assert_s8_can_manage_admins = computed(() =>
+  const assert_s8_can_manage_admins = assert(() =>
     s8.currentUserCanManageAdmins === true
   );
-  const assert_s8_admin_view_manager_enabled = computed(() => {
+  const assert_s8_admin_view_manager_enabled = assert(() => {
     const adminAccess = findNodeById(s8[UI], "parking-admin-access");
     const enableManager = findNodeById(
       s8[UI],
@@ -606,10 +606,10 @@ export default pattern(() => {
       propValue(enableManager, "disabled") === true &&
       propValue(aliceAdminToggle, "disabled") === false;
   });
-  const assert_s8_alice_is_admin = computed(() =>
+  const assert_s8_alice_is_admin = assert(() =>
     s8.currentPersonIsAdmin === true
   );
-  const assert_s8_admin_view_alice_admin = computed(() => {
+  const assert_s8_admin_view_alice_admin = assert(() => {
     const adminToggle = findNodeById(s8[UI], "parking-admin-mode-toggle");
     const aliceRow = findNodeByProp(
       s8[UI],
@@ -626,8 +626,8 @@ export default pattern(() => {
       propValue(adminToggle, "disabled") === false &&
       nodeIncludesText(adminToggle, "Admin: OFF");
   });
-  const assert_s8_admin_on = computed(() => s8.adminMode === true);
-  const assert_s8_admin_view_admin_mode_visible = computed(() =>
+  const assert_s8_admin_on = assert(() => s8.adminMode === true);
+  const assert_s8_admin_view_admin_mode_visible = assert(() =>
     nodeIncludesText(
       findNodeById(s8[UI], "parking-admin-mode-toggle"),
       "Admin: ON",
@@ -676,7 +676,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s9a_zara_has_vehicles = computed(() => {
+  const assert_s9a_zara_has_vehicles = assert(() => {
     const zara = s9a.people.find((p: Person) => p.name === "Zara");
     const vs: Vehicle[] = zara?.vehicles ?? [];
     return (
@@ -713,7 +713,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s9b_blank_plate_dropped = computed(() => {
+  const assert_s9b_blank_plate_dropped = assert(() => {
     const ben = s9b.people.find((p: Person) => p.name === "Ben");
     const vs: Vehicle[] = ben?.vehicles ?? [];
     return len(vs) === 1 && vs[0].plateId === "ABC123" &&
@@ -738,7 +738,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s9c_no_vehicles_default = computed(() => {
+  const assert_s9c_no_vehicles_default = assert(() => {
     const carol = s9c.people.find((p: Person) => p.name === "Carol");
     const vs: Vehicle[] = carol?.vehicles ?? [];
     return len(vs) === 0;
@@ -772,7 +772,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s9e_model_dropped = computed(() => {
+  const assert_s9e_model_dropped = assert(() => {
     const eve = s9e.people.find((p: Person) => p.name === "Eve");
     const vs: Vehicle[] = eve?.vehicles ?? [];
     return len(vs) === 1 && vs[0].make === "Honda" && vs[0].model === "";
@@ -805,7 +805,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s9f_valid_combo_kept = computed(() => {
+  const assert_s9f_valid_combo_kept = assert(() => {
     const frank = s9f.people.find((p: Person) => p.name === "Frank");
     const vs: Vehicle[] = frank?.vehicles ?? [];
     return len(vs) === 1 && vs[0].make === "Honda" && vs[0].model === "Civic";
@@ -845,7 +845,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s9g_deduped = computed(() => {
+  const assert_s9g_deduped = assert(() => {
     const grace = s9g.people.find((p: Person) => p.name === "Grace");
     const vs: Vehicle[] = grace?.vehicles ?? [];
     // First occurrence kept, second dropped
@@ -879,7 +879,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s9h_invalid_color_cleared = computed(() => {
+  const assert_s9h_invalid_color_cleared = assert(() => {
     const hank = s9h.people.find((p: Person) => p.name === "Hank");
     const vs: Vehicle[] = hank?.vehicles ?? [];
     return len(vs) === 1 && vs[0].color === "";
@@ -930,7 +930,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s9d_vehicles_replaced = computed(() => {
+  const assert_s9d_vehicles_replaced = assert(() => {
     const dana = s9d.people.find((p: Person) => p.name === "Dana");
     const vs: Vehicle[] = dana?.vehicles ?? [];
     return len(vs) === 1 && vs[0].plateId === "NEW456" &&
@@ -951,7 +951,7 @@ export default pattern(() => {
     });
   });
 
-  const assert_s9d_vehicles_preserved = computed(() => {
+  const assert_s9d_vehicles_preserved = assert(() => {
     const dana = s9d.people.find((p: Person) => p.name === "Dana");
     const vs: Vehicle[] = dana?.vehicles ?? [];
     // vehicles from previous edit still present, email changed

--- a/packages/patterns/fair-share/main.test.tsx
+++ b/packages/patterns/fair-share/main.test.tsx
@@ -23,7 +23,7 @@
  */
 import {
   action,
-  computed,
+  assert,
   equals,
   handler,
   pattern,
@@ -111,43 +111,43 @@ export default pattern(() => {
   // Assertions
   // ==========================================================================
 
-  const assert_ann_added = computed(() => {
+  const assert_ann_added = assert(() => {
     const cur = peopleCell.get();
     return cur.length === 1 && cur[0]?.name === "Ann" && !cur[0]?.avatar;
   });
-  const assert_my_name_ann = computed(() => myNameCell.get() === "Ann");
+  const assert_my_name_ann = assert(() => myNameCell.get() === "Ann");
 
-  const assert_held_stashed = computed(() => {
+  const assert_held_stashed = assert(() => {
     const h = held.get();
     return h.name === "Ann" && equals(peopleCell.get()[0], h);
   });
 
-  const assert_avatar_backfilled = computed(() =>
+  const assert_avatar_backfilled = assert(() =>
     peopleCell.get()[0]?.avatar === "🙂"
   );
   // KEY: the stale-but-once-valid reference still equals()-matches the
   // person AFTER the backfill wrote through the element's cell.
-  const assert_held_survives_backfill = computed(() => {
+  const assert_held_survives_backfill = assert(() => {
     const h = held.get();
     return equals(peopleCell.get()[0], h);
   });
   // The held reference also READS the update (it would show the stale,
   // orphaned entity if the backfill had re-minted identity).
-  const assert_held_reads_backfill = computed(() => held.get().avatar === "🙂");
+  const assert_held_reads_backfill = assert(() => held.get().avatar === "🙂");
 
-  const assert_avatar_not_clobbered = computed(() =>
+  const assert_avatar_not_clobbered = assert(() =>
     peopleCell.get()[0]?.avatar === "🙂"
   );
 
-  const assert_bob_added_with_avatar = computed(() => {
+  const assert_bob_added_with_avatar = assert(() => {
     const cur = peopleCell.get();
     return cur.length === 2 && cur[1]?.name === "Bob" &&
       cur[1]?.avatar === "🐱";
   });
-  const assert_my_name_bob = computed(() => myNameCell.get() === "Bob");
+  const assert_my_name_bob = assert(() => myNameCell.get() === "Bob");
 
   // KEY: the held reference still DRIVES an equals()-located removal.
-  const assert_removed_via_held = computed(() => {
+  const assert_removed_via_held = assert(() => {
     const cur = peopleCell.get();
     return cur.length === 1 && cur[0]?.name === "Bob";
   });

--- a/packages/patterns/gideon-tests/array-length-repro.test.tsx
+++ b/packages/patterns/gideon-tests/array-length-repro.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/gideon-tests/array-length-repro.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import ArrayLengthRepro from "./array-length-repro.tsx";
 
 export default pattern(() => {
@@ -22,38 +22,38 @@ export default pattern(() => {
   });
 
   // === Approach 1: Direct .length ===
-  const assert_initial_length_direct = computed(
+  const assert_initial_length_direct = assert(
     () => subject.items.length === 0,
   );
 
-  const assert_one_item_length_direct = computed(
+  const assert_one_item_length_direct = assert(
     () => subject.items.length === 1,
   );
 
   // === Approach 2: .filter().length ===
-  const assert_initial_length_filter = computed(
+  const assert_initial_length_filter = assert(
     () => subject.items.filter(() => true).length === 0,
   );
 
-  const assert_one_item_length_filter = computed(
+  const assert_one_item_length_filter = assert(
     () => subject.items.filter(() => true).length === 1,
   );
 
   // === Approach 3: Check via array method that iterates ===
-  const assert_initial_empty_some = computed(
+  const assert_initial_empty_some = assert(
     () => !subject.items.some(() => true),
   );
 
-  const assert_one_item_some = computed(
+  const assert_one_item_some = assert(
     () => subject.items.some(() => true),
   );
 
   // === Approach 4: Via string templates ===
-  const assert_initial_empty_template = computed(
+  const assert_initial_empty_template = assert(
     () => `length: ${subject.items.length}` === "length: 0",
   );
 
-  const assert_one_item_template = computed(
+  const assert_one_item_template = assert(
     () => `length: ${subject.items.length}` === "length: 1",
   );
 

--- a/packages/patterns/gideon-tests/ct-1811-mapped-subpattern-derived-output.test.tsx
+++ b/packages/patterns/gideon-tests/ct-1811-mapped-subpattern-derived-output.test.tsx
@@ -25,6 +25,7 @@
  * that never reads the mapped output would not trigger it.
  */
 import {
+  assert,
   computed,
   NAME,
   pattern,
@@ -117,7 +118,7 @@ export default pattern(() => {
   // Reading the rendered tree forces the map to materialize; each Child then
   // renders its derived-internal `doubled` output (2, 4, 6). Without the fix,
   // binding throws before any of this and the harness fails the run.
-  const rendered = computed(() => {
+  const rendered = assert(() => {
     const values = leafValues(ui);
     return values.includes("2") && values.includes("4") &&
       values.includes("6");

--- a/packages/patterns/gideon-tests/proxy-length-repro.test.tsx
+++ b/packages/patterns/gideon-tests/proxy-length-repro.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/gideon-tests/proxy-length-repro.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import ProxyLengthRepro from "./proxy-length-repro.tsx";
 
 export default pattern(() => {
@@ -26,70 +26,70 @@ export default pattern(() => {
   // =========================================================================
 
   // Direct .length on array output
-  const assert_items_length_direct = computed(
+  const assert_items_length_direct = assert(
     () => subject.items.length === 0,
   );
 
   // Spread workaround on array output
-  const assert_items_length_spread = computed(
+  const assert_items_length_spread = assert(
     () => [...subject.items].length === 0,
   );
 
   // Direct .length on COMPUTED array output
-  const assert_filtered_length_direct = computed(
+  const assert_filtered_length_direct = assert(
     () => subject.filteredItems.length === 0,
   );
 
   // Spread workaround on computed array output
-  const assert_filtered_length_spread = computed(
+  const assert_filtered_length_spread = assert(
     () => [...subject.filteredItems].length === 0,
   );
 
   // Direct .length on string output
-  const assert_label_length_direct = computed(
+  const assert_label_length_direct = assert(
     () => subject.label.length === 8, // "Total: 0" = 8 chars
   );
 
   // String comparison workaround
-  const assert_label_not_empty = computed(() => subject.label !== "");
+  const assert_label_not_empty = assert(() => subject.label !== "");
 
   // Numeric output (no .length needed — control test)
-  const assert_count_direct = computed(() => subject.itemCount === 0);
+  const assert_count_direct = assert(() => subject.itemCount === 0);
 
   // =========================================================================
   // Group 2: After adding one item
   // =========================================================================
 
   // Direct .length on array output after add
-  const assert_items_length_direct_after = computed(
+  const assert_items_length_direct_after = assert(
     () => subject.items.length === 1,
   );
 
   // Spread workaround after add
-  const assert_items_length_spread_after = computed(
+  const assert_items_length_spread_after = assert(
     () => [...subject.items].length === 1,
   );
 
   // Direct .length on COMPUTED array after add
-  const assert_filtered_length_direct_after = computed(
+  const assert_filtered_length_direct_after = assert(
     () => subject.filteredItems.length === 1,
   );
 
   // Spread workaround on computed array after add
-  const assert_filtered_length_spread_after = computed(
+  const assert_filtered_length_spread_after = assert(
     () => [...subject.filteredItems].length === 1,
   );
 
   // Direct .length on string after add
-  const assert_label_length_direct_after = computed(
+  const assert_label_length_direct_after = assert(
     () => subject.label.length === 8, // "Total: 1" = 8 chars
   );
 
   // String comparison after add
-  const assert_label_after = computed(() => subject.label === "Total: 1");
+  const assert_label_after = assert(() => subject.label === "Total: 1");
 
   // Numeric output after add (control)
-  const assert_count_after = computed(() => subject.itemCount === 1);
+  const assert_count_after = assert(() => subject.itemCount === 1);
 
   return {
     tests: [

--- a/packages/patterns/gideon-tests/test-handler-capture-key-equals.test.tsx
+++ b/packages/patterns/gideon-tests/test-handler-capture-key-equals.test.tsx
@@ -11,7 +11,7 @@
  * Run:
  *   deno task cf test packages/patterns/gideon-tests/test-handler-capture-key-equals.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import {
   CellInboxItemCapturePattern,
   WritableInboxItemCapturePattern,
@@ -41,15 +41,15 @@ export default pattern(() => {
     handlers[1]?.send();
   });
 
-  const assert_writable_initial_handlers = computed(() => {
+  const assert_writable_initial_handlers = assert(() => {
     return writableSubject.deleteHandlers.filter(() => true).length === 3;
   });
 
-  const assert_cell_initial_handlers = computed(() => {
+  const assert_cell_initial_handlers = assert(() => {
     return cellSubject.deleteHandlers.filter(() => true).length === 3;
   });
 
-  const assert_writable_initial_items = computed(() => {
+  const assert_writable_initial_items = assert(() => {
     const items = writableSubject.inboxItems.filter(() => true);
     return items.length === 3 &&
       items[0]?.id === "a" &&
@@ -57,7 +57,7 @@ export default pattern(() => {
       items[2]?.id === "c";
   });
 
-  const assert_cell_initial_items = computed(() => {
+  const assert_cell_initial_items = assert(() => {
     const items = cellSubject.inboxItems.filter(() => true);
     return items.length === 3 &&
       items[0]?.id === "a" &&
@@ -65,7 +65,7 @@ export default pattern(() => {
       items[2]?.id === "c";
   });
 
-  const assert_writable_removed_middle = computed(() => {
+  const assert_writable_removed_middle = assert(() => {
     const items = writableSubject.inboxItems.filter(() => true);
     return items.length === 2 &&
       items[0]?.id === "a" &&
@@ -73,7 +73,7 @@ export default pattern(() => {
       !items.some((item) => item.id === "b");
   });
 
-  const assert_cell_removed_middle = computed(() => {
+  const assert_cell_removed_middle = assert(() => {
     const items = cellSubject.inboxItems.filter(() => true);
     return items.length === 2 &&
       items[0]?.id === "a" &&

--- a/packages/patterns/gideon-tests/test-reactivity-jsx-automatic.test.tsx
+++ b/packages/patterns/gideon-tests/test-reactivity-jsx-automatic.test.tsx
@@ -7,7 +7,7 @@
  *
  * Run: deno task cf test packages/patterns/gideon-tests/test-reactivity-jsx-automatic.test.tsx --root packages/patterns --verbose
  */
-import { action, computed, pattern, UI } from "commonfabric";
+import { action, assert, pattern, UI } from "commonfabric";
 import {
   findElementByText,
   propsOf,
@@ -30,48 +30,46 @@ export default pattern(() => {
     }
   });
 
-  const assert_initial_count = computed(() => subject.count === 0);
-  const assert_initial_user = computed(() => subject.user.name === "Alice");
-  const assert_initial_items = computed(() => [...subject.items].length === 3);
+  const assert_initial_count = assert(() => subject.count === 0);
+  const assert_initial_user = assert(() => subject.user.name === "Alice");
+  const assert_initial_items = assert(() => [...subject.items].length === 3);
 
   // The pattern's claim is that an expression in JSX tracks its inputs with no
   // computed() wrapper, so read it from the rendered tree rather than from the
   // output.
-  const assert_initial_inline_expression = computed(() =>
+  const assert_initial_inline_expression = assert(() =>
     textContent(findElementByText(subject[UI], "div", "Count x 2 ="))
       .includes("Count x 2 = 0")
   );
 
-  const assert_count_after_first = computed(() => subject.count === 1);
-  const assert_user_after_first = computed(() => subject.user.name === "Bob");
-  const assert_inline_expression_after_first = computed(() =>
+  const assert_count_after_first = assert(() => subject.count === 1);
+  const assert_user_after_first = assert(() => subject.user.name === "Bob");
+  const assert_inline_expression_after_first = assert(() =>
     textContent(findElementByText(subject[UI], "div", "Count x 2 ="))
       .includes("Count x 2 = 2")
   );
 
   // The append derives the new title from the same snapshot the length guard
   // read, so the fourth item is titled from a length of 3.
-  const assert_items_after_first = computed(() => {
+  const assert_items_after_first = assert(() => {
     const items = [...subject.items];
     return items.length === 4 && items[3].title === "Item 4";
   });
 
   // Each further click appends one item, titled from the growing snapshot,
   // until the guard stops the append at five.
-  const assert_items_after_second = computed(() => {
+  const assert_items_after_second = assert(() => {
     const items = [...subject.items];
     return items.length === 5 && items[4].title === "Item 5";
   });
-  const assert_user_after_second = computed(() =>
-    subject.user.name === "Alice"
-  );
+  const assert_user_after_second = assert(() => subject.user.name === "Alice");
 
   // At five entries the guard takes the other branch and truncates to three.
-  const assert_items_after_third = computed(() => {
+  const assert_items_after_third = assert(() => {
     const items = [...subject.items];
     return items.length === 3 && items[2].title === "Item 3";
   });
-  const assert_count_after_third = computed(() => subject.count === 3);
+  const assert_count_after_third = assert(() => subject.count === 3);
 
   return {
     tests: [

--- a/packages/patterns/gideon-tests/wish-default.test.tsx
+++ b/packages/patterns/gideon-tests/wish-default.test.tsx
@@ -6,7 +6,15 @@
  *
  * Run: deno task cf test packages/patterns/gideon-tests/wish-default.test.tsx --verbose
  */
-import { action, computed, NAME, pattern, wish, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  computed,
+  NAME,
+  pattern,
+  wish,
+  Writable,
+} from "commonfabric";
 
 interface MinimalPiece {
   [NAME]?: string;
@@ -32,12 +40,12 @@ export default pattern(() => {
   });
 
   // Assertions
-  const assert_allPieces_exists = computed(() => !!allPieces);
-  const assert_initial_empty = computed(() => initialLength === 0);
-  const assert_after_push_one = computed(
+  const assert_allPieces_exists = assert(() => !!allPieces);
+  const assert_initial_empty = assert(() => initialLength === 0);
+  const assert_after_push_one = assert(
     () => allPieces?.get?.()?.length === 1,
   );
-  const assert_after_push_two = computed(
+  const assert_after_push_two = assert(
     () => allPieces?.get?.()?.length === 2,
   );
 

--- a/packages/patterns/google/core/auth-pieces.test.tsx
+++ b/packages/patterns/google/core/auth-pieces.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/auth-pieces.test.tsx --root packages/patterns --verbose
  */
-import { computed, pattern, UI, Writable } from "commonfabric";
+import { assert, pattern, UI, Writable } from "commonfabric";
 import AirtableAuth, {
   type AirtableAuth as AirtableAuthData,
 } from "../../airtable/core/airtable-auth.tsx";
@@ -92,14 +92,14 @@ export default pattern(() => {
     },
   });
 
-  const assert_google_scopes_include_selected_permissions = computed(() =>
+  const assert_google_scopes_include_selected_permissions = assert(() =>
     google.scopes.includes("email") &&
     google.scopes.includes("profile") &&
     google.scopes.includes("https://www.googleapis.com/auth/gmail.readonly") &&
     google.scopes.includes("https://www.googleapis.com/auth/calendar.readonly")
   );
 
-  const assert_personal_and_work_wrappers_show_account_type = computed(() =>
+  const assert_personal_and_work_wrappers_show_account_type = assert(() =>
     personal.accountType === "personal" &&
     work.accountType === "work" &&
     hasText(personal[UI], "PERSONAL") &&
@@ -108,13 +108,13 @@ export default pattern(() => {
     hasText(work[UI], "work@example.com")
   );
 
-  const assert_switcher_prompts_for_classification = computed(() =>
+  const assert_switcher_prompts_for_classification = assert(() =>
     hasText(switcher[UI], "What type of account is this?") &&
     hasText(switcher[UI], "Personal Account") &&
     hasText(switcher[UI], "Work Account")
   );
 
-  const assert_airtable_scopes_include_selected_permissions = computed(() =>
+  const assert_airtable_scopes_include_selected_permissions = assert(() =>
     airtable.scopes.includes("user.email:read") &&
     airtable.scopes.includes("data.records:read") &&
     airtable.scopes.includes("schema.bases:read")

--- a/packages/patterns/google/core/experimental/calendar-event-manager.test.tsx
+++ b/packages/patterns/google/core/experimental/calendar-event-manager.test.tsx
@@ -5,7 +5,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/experimental/calendar-event-manager.test.tsx --root packages/patterns --verbose
  */
-import { computed, pattern, UI } from "commonfabric";
+import { assert, pattern, UI } from "commonfabric";
 import {
   findElementByText,
   hasText,
@@ -28,7 +28,7 @@ export default pattern(() => {
     existingEvent: null,
   });
 
-  const assert_auth_requirement_is_visible = computed(
+  const assert_auth_requirement_is_visible = assert(
     () =>
       hasText(manager[UI], "Connect Your Google Account") &&
       hasText(
@@ -37,12 +37,12 @@ export default pattern(() => {
       ),
   );
 
-  const assert_create_button_disabled_without_auth = computed(() => {
+  const assert_create_button_disabled_without_auth = assert(() => {
     const button = findElementByText(manager[UI], "button", "Create Event");
     return readValue(propsOf(button)?.disabled) === true;
   });
 
-  const assert_confirmation_is_not_rendered_without_auth = computed(() =>
+  const assert_confirmation_is_not_rendered_without_auth = assert(() =>
     !hasText(manager[UI], "Confirm Calendar Operation") &&
     !hasText(manager[UI], "Create this event")
   );

--- a/packages/patterns/google/core/experimental/gmail-agentic-search.test.tsx
+++ b/packages/patterns/google/core/experimental/gmail-agentic-search.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/experimental/gmail-agentic-search.test.tsx --root packages/patterns --verbose
  */
-import { computed, pattern, Writable } from "commonfabric";
+import { assert, pattern, Writable } from "commonfabric";
 import GmailAgenticSearch, { type Auth } from "./gmail-agentic-search.tsx";
 
 const gmailScope = "https://www.googleapis.com/auth/gmail.readonly";
@@ -58,38 +58,38 @@ export default pattern(() => {
   // ==========================================================================
 
   // Should not be scanning initially
-  const assert_not_scanning = computed(() => searcher.isScanning === false);
+  const assert_not_scanning = assert(() => searcher.isScanning === false);
 
   // Search progress should be idle
-  const assert_progress_idle = computed(
+  const assert_progress_idle = assert(
     () => searcher.searchProgress.status === "idle",
   );
 
   // Search count should be 0
-  const assert_search_count_zero = computed(
+  const assert_search_count_zero = assert(
     () => searcher.searchProgress.searchCount === 0,
   );
 
   // Debug log should be empty initially
-  const assert_debug_log_empty = computed(() => {
+  const assert_debug_log_empty = assert(() => {
     const log = searcher.debugLog;
     return Array.isArray(log) && log.length === 0;
   });
 
   // Local queries should be empty initially
-  const assert_local_queries_empty = computed(() => {
+  const assert_local_queries_empty = assert(() => {
     const queries = searcher.localQueries;
     return Array.isArray(queries) && queries.length === 0;
   });
 
   // Pending submissions should be empty initially
-  const assert_pending_empty = computed(() => {
+  const assert_pending_empty = assert(() => {
     const pending = searcher.pendingSubmissions;
     return Array.isArray(pending) && pending.length === 0;
   });
 
   // Agent should not be pending initially
-  const assert_agent_not_pending = computed(
+  const assert_agent_not_pending = assert(
     () => searcher.agentPending === false,
   );
 
@@ -98,33 +98,33 @@ export default pattern(() => {
   // ==========================================================================
 
   // UI pieces should exist
-  const assert_has_ui_auth = computed(() => searcher.ui.auth !== undefined);
-  const assert_has_ui_controls = computed(
+  const assert_has_ui_auth = assert(() => searcher.ui.auth !== undefined);
+  const assert_has_ui_controls = assert(
     () => searcher.ui.controls !== undefined,
   );
-  const assert_has_ui_progress = computed(
+  const assert_has_ui_progress = assert(
     () => searcher.ui.progress !== undefined,
   );
 
   // Actions should exist (streams)
-  const assert_has_startScan = computed(
+  const assert_has_startScan = assert(
     () => searcher.startScan !== undefined,
   );
-  const assert_has_stopScan = computed(() => searcher.stopScan !== undefined);
+  const assert_has_stopScan = assert(() => searcher.stopScan !== undefined);
 
   // ==========================================================================
   // Custom config instance
   // ==========================================================================
 
-  const assert_custom_not_scanning = computed(
+  const assert_custom_not_scanning = assert(
     () => customSearcher.isScanning === false,
   );
 
-  const assert_custom_progress_idle = computed(
+  const assert_custom_progress_idle = assert(
     () => customSearcher.searchProgress.status === "idle",
   );
 
-  const assert_direct_auth_is_used = computed(() =>
+  const assert_direct_auth_is_used = assert(() =>
     directAuthSearcher.authSource === "direct"
   );
 

--- a/packages/patterns/google/core/experimental/gmail-label-manager.test.tsx
+++ b/packages/patterns/google/core/experimental/gmail-label-manager.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/experimental/gmail-label-manager.test.tsx --root packages/patterns --verbose
  */
-import { action, computed, pattern, UI } from "commonfabric";
+import { action, assert, pattern, UI } from "commonfabric";
 import {
   findElementByExactText,
   findElementByText,
@@ -47,7 +47,7 @@ export default pattern(() => {
     }
   });
 
-  const assert_waiting_message_is_rendered = computed(() =>
+  const assert_waiting_message_is_rendered = assert(() =>
     hasText(manager[UI], "Waiting for Google connection") &&
     hasText(
       manager[UI],
@@ -55,11 +55,11 @@ export default pattern(() => {
     )
   );
 
-  const assert_refresh_control_is_hidden = computed(() =>
+  const assert_refresh_control_is_hidden = assert(() =>
     !hasText(manager[UI], "Refresh Labels")
   );
 
-  const assert_apply_button_disabled_without_auth = computed(() => {
+  const assert_apply_button_disabled_without_auth = assert(() => {
     const button = findElementByText(
       manager[UI],
       "button",
@@ -68,12 +68,12 @@ export default pattern(() => {
     return readValue(propsOf(button)?.disabled) === true;
   });
 
-  const assert_confirmation_uses_label_ids_when_names_unloaded = computed(() =>
+  const assert_confirmation_uses_label_ids_when_names_unloaded = assert(() =>
     hasText(manager[UI], "Confirm Label Changes") &&
     hasText(manager[UI], "Label_1")
   );
 
-  const assert_auth_error_result_is_reported = computed(() =>
+  const assert_auth_error_result_is_reported = assert(() =>
     manager.result?.success === false &&
     manager.result.messageCount === 1 &&
     manager.result.error === "Connect Google before applying label changes."

--- a/packages/patterns/google/core/experimental/gmail-sender.test.tsx
+++ b/packages/patterns/google/core/experimental/gmail-sender.test.tsx
@@ -5,7 +5,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/experimental/gmail-sender.test.tsx --root packages/patterns --verbose
  */
-import { action, computed, pattern, UI } from "commonfabric";
+import { action, assert, pattern, UI } from "commonfabric";
 import {
   findElementByText,
   propsOf,
@@ -38,9 +38,9 @@ export default pattern(() => {
     }
   });
 
-  const assert_result_initially_empty = computed(() => sender.result === null);
+  const assert_result_initially_empty = assert(() => sender.result === null);
 
-  const assert_review_button_disabled_without_auth = computed(() => {
+  const assert_review_button_disabled_without_auth = assert(() => {
     const reviewButton = findElementByText(
       sender[UI],
       "button",
@@ -49,7 +49,7 @@ export default pattern(() => {
     return readValue(propsOf(reviewButton)?.disabled) === true;
   });
 
-  const assert_confirmation_explains_missing_auth = computed(() =>
+  const assert_confirmation_explains_missing_auth = assert(() =>
     findElementByText(sender[UI], "div", "Google connection required") !==
       undefined &&
     findElementByText(
@@ -60,7 +60,7 @@ export default pattern(() => {
       undefined
   );
 
-  const assert_send_button_disabled_without_auth = computed(() => {
+  const assert_send_button_disabled_without_auth = assert(() => {
     const sendButton = findElementByText(sender[UI], "button", "Send Email");
     return readValue(propsOf(sendButton)?.disabled) === true;
   });

--- a/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.test.tsx
+++ b/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/experimental/google-docs-comment-orchestrator.test.tsx --root packages/patterns --verbose
  */
-import { computed, pattern, UI, Writable } from "commonfabric";
+import { assert, pattern, UI, Writable } from "commonfabric";
 import { hasText } from "../../../test/vnode-helpers.ts";
 import GoogleDocsCommentOrchestrator from "./google-docs-comment-orchestrator.tsx";
 
@@ -34,11 +34,11 @@ export default pattern(() => {
     isExecuting: new Writable(false),
   });
 
-  const assert_fetch_waits_for_auth = computed(() =>
+  const assert_fetch_waits_for_auth = assert(() =>
     hasText(orchestrator[UI], "Connect Google")
   );
 
-  const assert_auth_ui_explains_required_scopes = computed(() =>
+  const assert_auth_ui_explains_required_scopes = assert(() =>
     hasText(orchestrator[UI], "Connect Your Google Account") &&
     hasText(
       orchestrator[UI],
@@ -46,7 +46,7 @@ export default pattern(() => {
     )
   );
 
-  const assert_no_comments_initially = computed(() =>
+  const assert_no_comments_initially = assert(() =>
     orchestrator.openCommentCount === 0 &&
     orchestrator.comments.length === 0
   );

--- a/packages/patterns/google/core/extractor-building-blocks.test.tsx
+++ b/packages/patterns/google/core/extractor-building-blocks.test.tsx
@@ -7,7 +7,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/extractor-building-blocks.test.tsx --root packages/patterns/google --verbose
  */
-import { computed, pattern, wish, Writable } from "commonfabric";
+import { assert, pattern, wish, Writable } from "commonfabric";
 import BillExtractor, { processBills } from "./bill-extractor/index.tsx";
 import { createBillKey } from "./bill-extractor/helpers.ts";
 import GmailExtractor, {
@@ -59,7 +59,7 @@ export default pattern(() => {
     supportsAutoDetect: false,
   });
 
-  const assert_gmail_extractor_starts_disconnected = computed(() =>
+  const assert_gmail_extractor_starts_disconnected = assert(() =>
     extractor.isConnected === false &&
     extractor.emailCount === 0 &&
     extractor.rawAnalyses.length === 0 &&
@@ -67,13 +67,13 @@ export default pattern(() => {
     extractor.completedCount === 0
   );
 
-  const assert_gmail_extractor_ui_bundle_exists = computed(() =>
+  const assert_gmail_extractor_ui_bundle_exists = assert(() =>
     extractor.ui.authStatusUI !== undefined &&
     extractor.ui.connectionStatusUI !== undefined &&
     extractor.ui.previewUI !== undefined
   );
 
-  const assert_bill_extractor_starts_empty = computed(() =>
+  const assert_bill_extractor_starts_empty = assert(() =>
     billExtractor.bills.length === 0 &&
     billExtractor.unpaidBills.length === 0 &&
     billExtractor.paidBills.length === 0 &&
@@ -82,14 +82,14 @@ export default pattern(() => {
     billExtractor.isConnected === false
   );
 
-  const assert_bill_extractor_config_is_preserved = computed(() =>
+  const assert_bill_extractor_config_is_preserved = assert(() =>
     billExtractor.title === "Example Bill Tracker" &&
     billExtractor.shortName === "Example" &&
     billExtractor.brandColor === "#2563eb" &&
     billExtractor.supportsAutoDetect === false
   );
 
-  const assert_analysis_helpers_count_states = computed(() => {
+  const assert_analysis_helpers_count_states = assert(() => {
     const analyses: AnalysisItem<{ ok: boolean }>[] = [
       { analysis: { pending: true } },
       { analysis: { pending: false, result: { ok: true } } },
@@ -100,7 +100,7 @@ export default pattern(() => {
     return countPending(analyses) === 1 && countCompleted(analyses) === 1;
   });
 
-  const assert_template_interpolation_sanitizes_content = computed(() => {
+  const assert_template_interpolation_sanitizes_content = assert(() => {
     const email: Email = {
       id: "msg-1",
       threadId: "thread-1",
@@ -140,7 +140,7 @@ export default pattern(() => {
 
   const nowCell = wish<number>({ query: "#now" });
 
-  const assert_process_bills_applies_payment_rules = computed(() => {
+  const assert_process_bills_applies_payment_rules = assert(() => {
     const nowMs = nowCell.result;
     if (nowMs == null) return false;
     const upcomingDueDate = isoDateDaysFromNow(nowMs, 10);

--- a/packages/patterns/google/core/gmail-importer.test.tsx
+++ b/packages/patterns/google/core/gmail-importer.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/gmail-importer.test.tsx --root packages/patterns --verbose
  */
-import { computed, pattern, UI, Writable } from "commonfabric";
+import { assert, pattern, UI, Writable } from "commonfabric";
 import GmailImporter, { type Auth } from "./gmail-importer.tsx";
 import { hasText } from "../../test/vnode-helpers.ts";
 
@@ -71,34 +71,34 @@ export default pattern(() => {
   // ==========================================================================
 
   // Emails should start empty
-  const assert_emails_empty = computed(() => {
+  const assert_emails_empty = assert(() => {
     const emails = importer.emails;
     return Array.isArray(emails) && emails.length === 0;
   });
 
   // Email count should be 0
-  const assert_count_zero = computed(() => importer.emailCount === 0);
+  const assert_count_zero = assert(() => importer.emailCount === 0);
 
   // With custom settings - should also start empty
-  const assert_settings_emails_empty = computed(() => {
+  const assert_settings_emails_empty = assert(() => {
     const emails = importerWithSettings.emails;
     return Array.isArray(emails) && emails.length === 0;
   });
 
-  const assert_settings_count_zero = computed(
+  const assert_settings_count_zero = assert(
     () => importerWithSettings.emailCount === 0,
   );
 
   // Output structure checks
-  const assert_has_emails_property = computed(
+  const assert_has_emails_property = assert(
     () => importer.emails !== undefined,
   );
 
-  const assert_has_emailCount_property = computed(
+  const assert_has_emailCount_property = assert(
     () => importer.emailCount !== undefined,
   );
 
-  const assert_override_auth_marks_importer_ready = computed(() =>
+  const assert_override_auth_marks_importer_ready = assert(() =>
     importerWithOverrideAuth.isReady === true &&
     hasText(importerWithOverrideAuth[UI], "Fetch Emails")
   );

--- a/packages/patterns/google/core/google-calendar-importer.test.tsx
+++ b/packages/patterns/google/core/google-calendar-importer.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/google-calendar-importer.test.tsx --root packages/patterns --verbose
  */
-import { computed, pattern, UI, Writable } from "commonfabric";
+import { assert, pattern, UI, Writable } from "commonfabric";
 import { hasText } from "../../test/vnode-helpers.ts";
 import GoogleCalendarImporter, {
   type Auth,
@@ -40,13 +40,13 @@ export default pattern(() => {
     overrideAuth: directAuth,
   });
 
-  const assert_initial_data_empty = computed(() =>
+  const assert_initial_data_empty = assert(() =>
     importer.events.length === 0 &&
     importer.calendars.length === 0 &&
     importer.eventCount === 0
   );
 
-  const assert_direct_auth_exposes_fetch_control = computed(() =>
+  const assert_direct_auth_exposes_fetch_control = assert(() =>
     hasText(importer[UI], "Fetch Calendar Events")
   );
 

--- a/packages/patterns/google/core/util/google-auth-manager.test.tsx
+++ b/packages/patterns/google/core/util/google-auth-manager.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/util/google-auth-manager.test.tsx --verbose
  */
-import { computed, pattern } from "commonfabric";
+import { assert, pattern } from "commonfabric";
 import {
   GoogleAuthManager,
   type GoogleAuthManagerOutput,
@@ -52,54 +52,52 @@ export default pattern<Record<string, never>, TestOutput>(() => {
   // ==========================================================================
 
   // When no auth pieces exist, state should be loading
-  const assert_default_not_ready = computed(() =>
-    authDefault.isReady === false
-  );
+  const assert_default_not_ready = assert(() => authDefault.isReady === false);
 
-  const assert_default_state_initial = computed(() => {
+  const assert_default_state_initial = assert(() => {
     const state = authDefault.currentState;
     // Initial state is "loading" (wish in progress or no matches)
     return state === "loading";
   });
 
-  const assert_default_availability_loading = computed(() =>
+  const assert_default_availability_loading = assert(() =>
     authDefault.availability.state === "loading" &&
     authDefault.availability.auth === null
   );
 
-  const assert_authInfo_exists = computed(
+  const assert_authInfo_exists = assert(
     () => authDefault.authInfo != null,
   );
 
-  const assert_authInfo_state_matches = computed(
+  const assert_authInfo_state_matches = assert(
     () => authDefault.authInfo.state === authDefault.currentState,
   );
 
-  const assert_authInfo_email_empty = computed(
+  const assert_authInfo_email_empty = assert(
     () => authDefault.authInfo.email === "",
   );
 
   // With scopes - should still be not ready (no auth found)
-  const assert_withScopes_not_ready = computed(
+  const assert_withScopes_not_ready = assert(
     () => authWithScopes.isReady === false,
   );
 
   // Debug mode instance should behave the same
-  const assert_debug_not_ready = computed(() => authDebug.isReady === false);
+  const assert_debug_not_ready = assert(() => authDebug.isReady === false);
 
   // Work account type instance should behave the same
-  const assert_work_not_ready = computed(() => authWork.isReady === false);
+  const assert_work_not_ready = assert(() => authWork.isReady === false);
 
   // UI components should exist (even if empty/null when no auth)
-  const assert_fullUI_exists = computed(() => authDefault.fullUI !== undefined);
-  const assert_statusUI_exists = computed(
+  const assert_fullUI_exists = assert(() => authDefault.fullUI !== undefined);
+  const assert_statusUI_exists = assert(
     () => authDefault.statusUI !== undefined,
   );
-  const assert_pickerUI_exists = computed(
+  const assert_pickerUI_exists = assert(
     () => authDefault.pickerUI !== undefined,
   );
 
-  const assert_fullUI_names_google_permissions = computed(() =>
+  const assert_fullUI_names_google_permissions = assert(() =>
     hasText(authWithScopes.fullUI, "Connect Your Google Account") &&
     hasText(
       authWithScopes.fullUI,

--- a/packages/patterns/google/extractors/auth-availability.test.tsx
+++ b/packages/patterns/google/extractors/auth-availability.test.tsx
@@ -5,7 +5,7 @@
  * branch. Empty auth keeps API calls inactive while exercising their initial
  * missing-auth state.
  */
-import { computed, pattern, Writable } from "commonfabric";
+import { assert, pattern, Writable } from "commonfabric";
 import type { Auth } from "../core/gmail-importer.tsx";
 import EmailNotes from "./email-notes.tsx";
 import ExpectResponseFollowup from "./expect-response-followup.tsx";
@@ -28,17 +28,17 @@ export default pattern(() => {
   const followup = ExpectResponseFollowup({});
   const taskEngine = EmailTaskEngine({ overrideAuth: emptyAuth() });
 
-  const assert_notes_start_empty = computed(() =>
+  const assert_notes_start_empty = assert(() =>
     notes.noteCount === 0 && notes.notes.length === 0
   );
 
-  const assert_followups_start_empty = computed(() =>
+  const assert_followups_start_empty = assert(() =>
     followup.threadCount === 0 &&
     followup.dueCount === 0 &&
     followup.threads.length === 0
   );
 
-  const assert_task_engine_starts_empty = computed(() =>
+  const assert_task_engine_starts_empty = assert(() =>
     taskEngine.taskCount === 0 &&
     taskEngine.taskEmails.length === 0 &&
     taskEngine.analyses.length === 0

--- a/packages/patterns/google/extractors/email-pattern-launcher.test.tsx
+++ b/packages/patterns/google/extractors/email-pattern-launcher.test.tsx
@@ -12,7 +12,7 @@
  *
  * Run: deno task cf test packages/patterns/google/extractors/email-pattern-launcher.test.tsx --root packages/patterns/google --verbose
  */
-import { computed, pattern } from "commonfabric";
+import { assert, pattern } from "commonfabric";
 
 // =============================================================================
 // HELPER FUNCTIONS (duplicated for testing - same as in main pattern)
@@ -78,7 +78,7 @@ export default pattern(() => {
   // ==========================================================================
 
   // Test: wildcard pattern matches any email at domain
-  const assert_wildcard_matches_domain = computed(() => {
+  const assert_wildcard_matches_domain = assert(() => {
     return matchesEmailPattern(
       "notices@library.berkeleypubliclibrary.org",
       "*@library.berkeleypubliclibrary.org",
@@ -86,7 +86,7 @@ export default pattern(() => {
   });
 
   // Test: wildcard pattern matches different usernames
-  const assert_wildcard_matches_different_user = computed(() => {
+  const assert_wildcard_matches_different_user = assert(() => {
     return matchesEmailPattern(
       "info@library.berkeleypubliclibrary.org",
       "*@library.berkeleypubliclibrary.org",
@@ -94,7 +94,7 @@ export default pattern(() => {
   });
 
   // Test: pattern should not match different domain
-  const assert_no_match_different_domain = computed(() => {
+  const assert_no_match_different_domain = assert(() => {
     return !matchesEmailPattern(
       "notices@library.sfpl.org",
       "*@library.berkeleypubliclibrary.org",
@@ -102,7 +102,7 @@ export default pattern(() => {
   });
 
   // Test: USPS pattern matching
-  const assert_usps_pattern_matches = computed(() => {
+  const assert_usps_pattern_matches = assert(() => {
     return matchesEmailPattern(
       "USPSInformeddelivery@email.informeddelivery.usps.com",
       "*@email.informeddelivery.usps.com",
@@ -110,7 +110,7 @@ export default pattern(() => {
   });
 
   // Test: case insensitive matching
-  const assert_case_insensitive = computed(() => {
+  const assert_case_insensitive = assert(() => {
     return matchesEmailPattern(
       "NOTICES@LIBRARY.BERKELEYPUBLICLIBRARY.ORG",
       "*@library.berkeleypubliclibrary.org",
@@ -118,12 +118,12 @@ export default pattern(() => {
   });
 
   // Test: empty email returns false
-  const assert_empty_email_false = computed(() => {
+  const assert_empty_email_false = assert(() => {
     return !matchesEmailPattern("", "*@domain.com");
   });
 
   // Test: empty pattern returns false
-  const assert_empty_pattern_false = computed(() => {
+  const assert_empty_pattern_false = assert(() => {
     return !matchesEmailPattern("user@domain.com", "");
   });
 
@@ -132,7 +132,7 @@ export default pattern(() => {
   // ==========================================================================
 
   // Test: build query from single entry
-  const assert_single_entry_query = computed(() => {
+  const assert_single_entry_query = assert(() => {
     const entries: RegistryEntry[] = [
       {
         patternUri: "google/test.tsx",
@@ -144,7 +144,7 @@ export default pattern(() => {
   });
 
   // Test: build query from multiple entries
-  const assert_multiple_entries_query = computed(() => {
+  const assert_multiple_entries_query = assert(() => {
     const entries: RegistryEntry[] = [
       {
         patternUri: "google/usps.tsx",
@@ -164,13 +164,13 @@ export default pattern(() => {
   });
 
   // Test: empty entries returns default query
-  const assert_empty_entries_default = computed(() => {
+  const assert_empty_entries_default = assert(() => {
     const query = buildGmailQuery([]);
     return query === "in:INBOX";
   });
 
   // Test: deduplicates domains
-  const assert_deduplicates_domains = computed(() => {
+  const assert_deduplicates_domains = assert(() => {
     const entries: RegistryEntry[] = [
       {
         patternUri: "google/pattern1.tsx",

--- a/packages/patterns/google/extractors/email-style-extractor.test.tsx
+++ b/packages/patterns/google/extractors/email-style-extractor.test.tsx
@@ -5,14 +5,14 @@
  *
  * Run: deno task cf test packages/patterns/google/extractors/email-style-extractor.test.tsx --root packages/patterns --verbose
  */
-import { computed, pattern, UI } from "commonfabric";
+import { assert, pattern, UI } from "commonfabric";
 import { hasText } from "../../test/vnode-helpers.ts";
 import EmailStyleExtractor from "./email-style-extractor.tsx";
 
 export default pattern(() => {
   const extractor = EmailStyleExtractor({});
 
-  const assert_initial_state_empty = computed(() =>
+  const assert_initial_state_empty = assert(() =>
     extractor.style === null &&
     extractor.stylePrompt === "" &&
     extractor.emailsAnalyzed === 0 &&
@@ -20,7 +20,7 @@ export default pattern(() => {
     extractor.isAnalyzing === false
   );
 
-  const assert_waiting_for_auth = computed(() =>
+  const assert_waiting_for_auth = assert(() =>
     hasText(extractor[UI], "Waiting for Google auth...")
   );
 

--- a/packages/patterns/google/extractors/wrapper-patterns.test.tsx
+++ b/packages/patterns/google/extractors/wrapper-patterns.test.tsx
@@ -4,7 +4,7 @@
  * Exercises the thin extractor wrappers that pass a shared Google auth cell
  * through to GmailImporter, GmailExtractor, and BillExtractor children.
  */
-import { computed, NAME, pattern, Writable } from "commonfabric";
+import { assert, NAME, pattern, Writable } from "commonfabric";
 import type { Auth } from "../core/gmail-importer.tsx";
 import BofABillTracker from "./bofa-bill-tracker.tsx";
 import ChaseBillTracker from "./chase-bill-tracker.tsx";
@@ -27,7 +27,7 @@ export default pattern(() => {
   const chase = ChaseBillTracker({ overrideAuth: emptyAuth() });
   const pge = PGEBillTracker({ overrideAuth: emptyAuth() });
 
-  const assert_bill_wrappers_start_empty = computed(() =>
+  const assert_bill_wrappers_start_empty = assert(() =>
     bofa[NAME] === "BofA Bill Tracker" &&
     (bofa.bills ?? []).length === 0 &&
     bofa.totalUnpaid === 0 &&

--- a/packages/patterns/habit-tracker/habit-tracker.test.tsx
+++ b/packages/patterns/habit-tracker/habit-tracker.test.tsx
@@ -22,7 +22,7 @@
  */
 import {
   action,
-  computed,
+  assert,
   equals,
   handler,
   pattern,
@@ -114,132 +114,132 @@ export default pattern(() => {
   // === Assertions ===
 
   // Initial state
-  const assert_initial_no_habits = computed(
+  const assert_initial_no_habits = assert(
     () => len(subject.habits) === 0,
   );
 
-  const assert_initial_no_logs = computed(
+  const assert_initial_no_logs = assert(
     () => len(subject.logs) === 0,
   );
 
-  const assert_today_date_format = computed(() => {
+  const assert_today_date_format = assert(() => {
     const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
     return dateRegex.test(subject.todayDate);
   });
 
   // After adding first habit
-  const assert_one_habit = computed(
+  const assert_one_habit = assert(
     () => len(subject.habits) === 1,
   );
 
-  const assert_exercise_name = computed(
+  const assert_exercise_name = assert(
     () => subject.habits[0]?.name === "Exercise",
   );
 
-  const assert_exercise_icon = computed(
+  const assert_exercise_icon = assert(
     () => subject.habits[0]?.icon === "🏃",
   );
 
-  const assert_exercise_default_color = computed(
+  const assert_exercise_default_color = assert(
     () => subject.habits[0]?.color === "#3b82f6",
   );
 
   // Empty name should not add habit
-  const assert_still_one_habit_after_empty = computed(
+  const assert_still_one_habit_after_empty = assert(
     () => len(subject.habits) === 1,
   );
 
   // Default icon when empty string provided
-  const assert_two_habits = computed(
+  const assert_two_habits = assert(
     () => len(subject.habits) === 2,
   );
 
-  const assert_meditate_default_icon = computed(() => {
+  const assert_meditate_default_icon = assert(() => {
     const meditate = subject.habits.find((h: Habit) => h.name === "Meditate");
     return meditate?.icon === "✓";
   });
 
   // After toggling habit (creates log)
-  const assert_one_log = computed(
+  const assert_one_log = assert(
     () => len(subject.logs) === 1,
   );
 
-  const assert_log_completed = computed(() => {
+  const assert_log_completed = assert(() => {
     const log = subject.logs.find((l: HabitLog) => l.habitName === "Exercise");
     return log?.completed === true;
   });
 
-  const assert_log_habitName = computed(
+  const assert_log_habitName = assert(
     () => subject.logs[0]?.habitName === "Exercise",
   );
 
-  const assert_log_date_is_today = computed(
+  const assert_log_date_is_today = assert(
     () => subject.logs[0]?.date === subject.todayDate,
   );
 
   // Toggling nonexistent habit should not create log
-  const assert_still_one_log_after_nonexistent = computed(
+  const assert_still_one_log_after_nonexistent = assert(
     () => len(subject.logs) === 1,
   );
 
   // After toggling again (uncompletes)
-  const assert_log_uncompleted = computed(() => {
+  const assert_log_uncompleted = assert(() => {
     const log = subject.logs.find((l: HabitLog) => l.habitName === "Exercise");
     return log?.completed === false;
   });
 
-  const assert_still_one_log_after_toggle = computed(
+  const assert_still_one_log_after_toggle = assert(
     () => len(subject.logs) === 1,
   );
 
   // After adding second habit
-  const assert_three_habits = computed(
+  const assert_three_habits = assert(
     () => len(subject.habits) === 3,
   );
 
-  const assert_read_exists = computed(
+  const assert_read_exists = assert(
     () => subject.habits.some((h: Habit) => h.name === "Read"),
   );
 
   // After deleting habit
-  const assert_two_habits_after_delete = computed(
+  const assert_two_habits_after_delete = assert(
     () => len(subject.habits) === 2,
   );
 
-  const assert_read_deleted = computed(
+  const assert_read_deleted = assert(
     () => !subject.habits.some((h: Habit) => h.name === "Read"),
   );
 
-  const assert_exercise_remains = computed(
+  const assert_exercise_remains = assert(
     () => subject.habits.some((h: Habit) => h.name === "Exercise"),
   );
 
   // Deleting nonexistent should not change count
-  const assert_still_two_habits = computed(
+  const assert_still_two_habits = assert(
     () => len(subject.habits) === 2,
   );
 
   // === Held-reference survival assertions (CT-1715) ===
-  const assert_held_log_stashed = computed(() => {
+  const assert_held_log_stashed = assert(() => {
     const h = heldLog.get();
     return h.habitName === "Exercise" && equals(logsCell.get()[0], h);
   });
-  const assert_log_completed_again = computed(
+  const assert_log_completed_again = assert(
     () => logsCell.get()[0]?.completed === true,
   );
   // KEY: the stale-but-once-valid reference still equals()-matches the log
   // AFTER the toggle updated it.
-  const assert_held_log_survives_toggle = computed(() => {
+  const assert_held_log_survives_toggle = assert(() => {
     const h = heldLog.get();
     return equals(logsCell.get()[0], h);
   });
   // The held reference also READS the update (it would show the stale,
   // orphaned entity if the toggle had re-minted identity).
-  const assert_held_log_reads_toggle = computed(
+  const assert_held_log_reads_toggle = assert(
     () => heldLog.get().completed === true,
   );
   // KEY: the held reference still DRIVES an equals()-located removal.
-  const assert_removed_via_held = computed(
+  const assert_removed_via_held = assert(
     () => len(subject.logs) === 0,
   );
 

--- a/packages/patterns/lobby/main.test.tsx
+++ b/packages/patterns/lobby/main.test.tsx
@@ -1,4 +1,4 @@
-import { computed, pattern, UI, Writable } from "commonfabric";
+import { assert, computed, pattern, UI, Writable } from "commonfabric";
 import Lobby, {
   addSelfToLobby,
   commitTrustedLobbyAction,
@@ -150,7 +150,7 @@ export default pattern(() => {
 
   const lobby = Lobby({ roster, adminRegistry } as LobbyInputArg);
 
-  const assert_selected_profile_drives_viewer_state = computed(() =>
+  const assert_selected_profile_drives_viewer_state = assert(() =>
     selectedViewer.myName === "Selected Profile" &&
     selectedViewer.hasProfile === true &&
     selectedViewer.hasJoined === false &&
@@ -169,7 +169,7 @@ export default pattern(() => {
     missingProfileViewer.joinDisabled === true &&
     missingProfileViewer.currentUserIsAdmin === false
   );
-  const assert_selected_profile_joined = computed(() =>
+  const assert_selected_profile_joined = assert(() =>
     participantNames(viewerRoster).join(",") === "Selected Profile" &&
     lobbyParticipantsValue(viewerRoster)[0]?.profile.get()
         ?.externalLinks?.[0]?.url === "https://github.com/octocat" &&
@@ -180,7 +180,7 @@ export default pattern(() => {
     selectedViewer.joinDisabled === true &&
     selectedViewer.currentUserIsAdmin === true
   );
-  const assert_selected_admin_lockdown = computed(() =>
+  const assert_selected_admin_lockdown = assert(() =>
     selectedViewer.everyoneIsAdmin === false &&
     selectedViewer.currentUserIsAdmin === true &&
     selectedViewer.adminSummary ===
@@ -189,70 +189,70 @@ export default pattern(() => {
     selectedViewer.adminBadgeLabel === "Explicit admins"
   );
 
-  const assert_initial_open_fallback = computed(() =>
+  const assert_initial_open_fallback = assert(() =>
     lobbyParticipantsValue(roster).length === 0 &&
     lobbyAdminRolesValue(adminRegistry).length === 0 &&
     lobbyEveryoneIsAdmin(adminRegistry) === true
   );
-  const assert_alice_joined_once = computed(() =>
+  const assert_alice_joined_once = assert(() =>
     participantNames(roster).join(",") === "Alice" &&
     currentLobbyUserIsAdmin(aliceProfile, roster, adminRegistry)
   );
-  const assert_blank_profile_rejected = computed(() =>
+  const assert_blank_profile_rejected = assert(() =>
     participantNames(roster).join(",") === "Alice"
   );
-  const assert_both_are_admin_by_fallback = computed(() =>
+  const assert_both_are_admin_by_fallback = assert(() =>
     participantNames(roster).join(",") === "Alice,Bob" &&
     currentLobbyUserIsAdmin(aliceProfile, roster, adminRegistry) &&
     currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry)
   );
-  const assert_bob_removed_alice_while_open = computed(() =>
+  const assert_bob_removed_alice_while_open = assert(() =>
     participantNames(roster).join(",") === "Bob"
   );
-  const assert_lockdown_bootstraps_alice = computed(() => {
+  const assert_lockdown_bootstraps_alice = assert(() => {
     const roles = lobbyAdminRolesValue(adminRegistry);
     return lobbyEveryoneIsAdmin(adminRegistry) === false &&
       roles.length === 1 &&
       currentLobbyUserIsAdmin(aliceProfile, roster, adminRegistry) &&
       !currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry);
   });
-  const assert_non_admin_remove_is_blocked = computed(() =>
+  const assert_non_admin_remove_is_blocked = assert(() =>
     participantNames(roster).join(",") === "Bob,Alice"
   );
-  const assert_bob_promoted = computed(() =>
+  const assert_bob_promoted = assert(() =>
     lobbyAdminRolesValue(adminRegistry).length === 2 &&
     currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry)
   );
-  const assert_public_output_explicit_policy = computed(() =>
+  const assert_public_output_explicit_policy = assert(() =>
     lobby.everyoneIsAdmin === false &&
     lobby.allParticipants[0]?.isAdmin === true &&
     lobby.allParticipants[1]?.isAdmin === true
   );
-  const assert_bob_removed_alice_and_role = computed(() =>
+  const assert_bob_removed_alice_and_role = assert(() =>
     participantNames(roster).join(",") === "Bob" &&
     lobbyAdminRolesValue(adminRegistry).length === 1 &&
     currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry)
   );
-  const assert_last_admin_removal_blocked = computed(() =>
+  const assert_last_admin_removal_blocked = assert(() =>
     lobbyAdminRolesValue(adminRegistry).length === 1 &&
     currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry)
   );
-  const assert_open_policy_restored = computed(() =>
+  const assert_open_policy_restored = assert(() =>
     lobbyEveryoneIsAdmin(adminRegistry) === true &&
     currentLobbyUserIsAdmin(bobProfile, roster, adminRegistry)
   );
-  const assert_same_name_profiles_both_join = computed(() =>
+  const assert_same_name_profiles_both_join = assert(() =>
     participantNames(roster).filter((name) => name === "Alex").length === 2
   );
-  const assert_public_output_count = computed(() =>
+  const assert_public_output_count = assert(() =>
     lobby.participantCount === 3 &&
     lobby.allParticipants.length === 3 &&
     lobby.participants.length === 3
   );
-  const assert_public_output_policy = computed(() =>
+  const assert_public_output_policy = assert(() =>
     lobby.everyoneIsAdmin === true
   );
-  const assert_public_output_is_profile_free = computed(() =>
+  const assert_public_output_is_profile_free = assert(() =>
     lobby.allParticipants[0]?.name === "Bob" &&
     lobby.allParticipants[1]?.name === "Alex" &&
     lobby.allParticipants[2]?.name === "Alex" &&

--- a/packages/patterns/lunch-poll/lunch-stats.test.tsx
+++ b/packages/patterns/lunch-poll/lunch-stats.test.tsx
@@ -15,7 +15,7 @@
  *   - pre-yellow query had no `yellows` field at all (=> undefined !== 1)
  */
 
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import CozyPoll from "./main.tsx";
 
 export default pattern(() => {
@@ -46,7 +46,7 @@ export default pattern(() => {
   });
 
   // Only Thai was visited, so placeStats has exactly its row.
-  const assert_thai_stats_scoped_and_yellow = computed(() => {
+  const assert_thai_stats_scoped_and_yellow = assert(() => {
     const s = (poll.placeStats ?? [])[0];
     return !!s &&
       s.title === "Thai" &&

--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -11,7 +11,7 @@
  * are covered by multi-user.test.tsx.
  */
 
-import { action, computed, pattern, UI, wish } from "commonfabric";
+import { action, assert, computed, pattern, UI, wish } from "commonfabric";
 import {
   findNode,
   hasExactText,
@@ -407,7 +407,7 @@ export default pattern(() => {
   // Alex is in users, no admin name was claimed by anyone else, and the
   // "Should not appear" option is absent (implied by chipotle assertions
   // later — options.length === 1 after only Chipotle is added).
-  const assert_joined_as_alex = computed(() =>
+  const assert_joined_as_alex = assert(() =>
     poll.users.length === 1 &&
     poll.users[0]?.name === "Alex" &&
     poll.myName === "Alex" &&
@@ -416,20 +416,20 @@ export default pattern(() => {
     poll.isAdmin === true
   );
 
-  const assert_immutable_after_join = computed(() =>
+  const assert_immutable_after_join = assert(() =>
     poll.users.length === 1 &&
     poll.myName === "Alex"
   );
 
-  const assert_chipotle_added = computed(() =>
+  const assert_chipotle_added = assert(() =>
     poll.options.length === 1 &&
     poll.options[0]?.title === "Chipotle" &&
     poll.options[0]?.addedByName === "Alex"
   );
 
-  const assert_two_options = computed(() => poll.options.length === 2);
+  const assert_two_options = assert(() => poll.options.length === 2);
 
-  const assert_green_vote_recorded = computed(() => {
+  const assert_green_vote_recorded = assert(() => {
     const v = poll.votes[0];
     return poll.votes.length === 1 &&
       v?.voteType === "green" &&
@@ -446,33 +446,33 @@ export default pattern(() => {
   // to a proxy-vs-proxy `===` (always false), so the filter dropped every vote
   // and the swatches silently stopped rendering: after Alex's green vote, his
   // swatch must appear in the rendered UI tree.
-  const assert_alex_swatch_renders = computed(() =>
+  const assert_alex_swatch_renders = assert(() =>
     findNodeByProp(poll[UI], "data-vote-swatch-name", "Alex") !== undefined
   );
 
-  const assert_changed_to_yellow = computed(() => {
+  const assert_changed_to_yellow = assert(() => {
     const v = poll.votes[0];
     return poll.votes.length === 1 &&
       v?.voteType === "yellow";
   });
 
-  const assert_changed_to_red = computed(() => {
+  const assert_changed_to_red = assert(() => {
     const v = poll.votes[0];
     return poll.votes.length === 1 &&
       v?.voteType === "red";
   });
 
-  const assert_revote_green_cleared = computed(() => poll.votes.length === 0);
+  const assert_revote_green_cleared = assert(() => poll.votes.length === 0);
 
-  const assert_votes_reset = computed(() => poll.votes.length === 0);
+  const assert_votes_reset = assert(() => poll.votes.length === 0);
 
-  const assert_option_removed_with_its_votes = computed(() =>
+  const assert_option_removed_with_its_votes = assert(() =>
     poll.options.length === 1 &&
     poll.options[0]?.title === "Thai Kitchen" &&
     poll.votes.length === 0
   );
 
-  const assert_still_alex_host = computed(() =>
+  const assert_still_alex_host = assert(() =>
     poll.adminName === "Alex" && poll.isAdmin === true
   );
 
@@ -484,7 +484,7 @@ export default pattern(() => {
   // to the host (the frozen `loggedByName` snapshot). If the pre-join attempt
   // ("Sneaky") had not been gated, an entry would exist before this — so this
   // implicitly verifies the host gate too.
-  const assert_thai_logged = computed(() => {
+  const assert_thai_logged = assert(() => {
     const rows = poll.recentVisits ?? [];
     return rows.length === 1 &&
       rows[0]?.title === "Thai Kitchen" &&
@@ -493,7 +493,7 @@ export default pattern(() => {
       poll.mostRecentTitle === "Thai Kitchen";
   });
 
-  const assert_recent_visit_row_renders = computed(() =>
+  const assert_recent_visit_row_renders = assert(() =>
     findNodeByProp(
       poll[UI],
       "data-recent-visit-title",
@@ -503,12 +503,12 @@ export default pattern(() => {
 
   // The live green vote on Thai was snapshotted into the entry's `votes` when
   // Thai was logged → exactly one embedded snapshot.
-  const assert_vote_snapshot = computed(() => poll.voteHistoryCount === 1);
+  const assert_vote_snapshot = assert(() => poll.voteHistoryCount === 1);
 
   // Second entry is the backdated Chipotle log; newest-first sort puts it after
   // today's Thai, so it's rows[1]. `wentAt` is a plain ms-epoch number now, so
   // the backdated value compares directly (no TEXT encoding to round-trip).
-  const assert_two_history = computed(() => {
+  const assert_two_history = assert(() => {
     const rows = poll.recentVisits ?? [];
     return rows.length === 2 &&
       rows[1]?.title === "Chipotle" &&
@@ -521,7 +521,7 @@ export default pattern(() => {
   // the row content directly (which entry survived), not just the count — and
   // that the entry's live `loggedBy` link survives the array round-trip (push
   // on log + the set-subset filter on delete).
-  const assert_one_history_after_remove = computed(() => {
+  const assert_one_history_after_remove = assert(() => {
     const rows = poll.recentVisits ?? [];
     return poll.historyCount === 1 &&
       rows.length === 1 &&
@@ -531,7 +531,7 @@ export default pattern(() => {
   });
 
   // Clearing visits also drops the embedded vote snapshots.
-  const assert_history_cleared = computed(() =>
+  const assert_history_cleared = assert(() =>
     poll.historyCount === 0 &&
     poll.voteHistoryCount === 0
   );
@@ -541,13 +541,13 @@ export default pattern(() => {
   // The header renders the current date, and `todayDate` exposes the local
   // day key the votes are filtered to. The `todayKey !== ""` guard holds the
   // assertion false until this pattern's `#now` wish resolves.
-  const assert_today_header_renders = computed(() =>
+  const assert_today_header_renders = assert(() =>
     todayKey !== "" &&
     findNodeByProp(poll[UI], "data-poll-today", true) !== undefined &&
     poll.todayDate === todayKey
   );
 
-  const assert_colliding_initials_are_disambiguated = computed(() => {
+  const assert_colliding_initials_are_disambiguated = assert(() => {
     const ui = initialsPoll[UI];
     const daffodil = findNodeByProp(
       ui,
@@ -625,7 +625,7 @@ export default pattern(() => {
       hasExactText(accentBob, "E\u0301B");
   });
 
-  const assert_vote_swatches_have_accessible_names = computed(() => {
+  const assert_vote_swatches_have_accessible_names = assert(() => {
     const ui = initialsPoll[UI];
     const daffodil = findNodeByProp(
       ui,
@@ -651,7 +651,7 @@ export default pattern(() => {
   // the poll's own (via `todayDate`) — so it passes only once the day filter
   // is live and the vote really is dated yesterday, not merely during the
   // load window's empty vote view.
-  const assert_stale_vote_hidden = computed(() =>
+  const assert_stale_vote_hidden = assert(() =>
     todayKey !== "" &&
     stalePoll.todayDate === todayKey &&
     stalePoll.votes.length === 1 &&
@@ -684,7 +684,7 @@ export default pattern(() => {
   // A same-color click on a stale vote RE-CASTS it for today (fresh castAt)
   // instead of toggling off a vote the voter cannot see; the vote becomes
   // visible again (list, count, and swatch).
-  const assert_stale_recast_visible = computed(() => {
+  const assert_stale_recast_visible = assert(() => {
     const v = stalePoll.todaysVotes[0];
     return todayKey !== "" &&
       stalePoll.todaysVotes.length === 1 &&
@@ -698,7 +698,7 @@ export default pattern(() => {
   });
 
   // A second same-color click is the normal today-toggle-off.
-  const assert_stale_recast_cleared = computed(() =>
+  const assert_stale_recast_cleared = assert(() =>
     stalePoll.todaysVotes.length === 0 &&
     stalePoll.todayVoteCount === 0
   );

--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -664,7 +664,7 @@ export default pattern(() => {
   // Options saved before generated art was introduced have no `imageUrl`
   // property. They must still satisfy the card's map/pattern contract and
   // render normally rather than passing a present-but-undefined value.
-  const assert_legacy_option_without_image_renders = computed(() =>
+  const assert_legacy_option_without_image_renders = assert(() =>
     findNodeByProp(
       stalePoll[UI],
       "data-option-title",

--- a/packages/patterns/lunch-poll/participant-identity-card.test.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, Default, pattern, UI, Writable } from "commonfabric";
+import { action, assert, Default, pattern, UI, Writable } from "commonfabric";
 import ParticipantIdentityCard from "./participant-identity-card.tsx";
 import type { User } from "./main.tsx";
 import {
@@ -60,7 +60,7 @@ export default pattern(() => {
     participantIdentity.claimHost.send({});
   });
 
-  const assert_initial = computed(() =>
+  const assert_initial = assert(() =>
     users.get().length === 0 &&
     participantIdentity.me === "" &&
     participantIdentity.isJoined === false &&
@@ -72,7 +72,7 @@ export default pattern(() => {
   // join becomes the host." hint shows, and neither profile-first control (the
   // "Use a different name" toggle nor the "Cancel" escape hatch) is present.
   // Walking the tree materializes showManualEntry, hasProfile, and joinHint.
-  const assert_manual_fallback_renders = computed(() => {
+  const assert_manual_fallback_renders = assert(() => {
     const ui = participantIdentity[UI];
     const input = findByProp(ui, "id", "lp-join-name");
     const joinButton = findByProp(ui, "id", "lp-join-button");
@@ -89,13 +89,13 @@ export default pattern(() => {
       hasText(ui, "First to join becomes the host.");
   });
 
-  const assert_empty_send_noop = computed(() =>
+  const assert_empty_send_noop = assert(() =>
     users.get().length === 0 &&
     participantIdentity.me === "" &&
     participantIdentity.isJoined === false
   );
 
-  const assert_joined_as_alex = computed(() => {
+  const assert_joined_as_alex = assert(() => {
     const currentUsers = users.get();
     return currentUsers.length === 1 &&
       currentUsers[0]?.name === "Alex" &&
@@ -107,14 +107,14 @@ export default pattern(() => {
       participantIdentity.isAdmin === true;
   });
 
-  const assert_rejoin_noop = computed(() => {
+  const assert_rejoin_noop = assert(() => {
     const currentUsers = users.get();
     return currentUsers.length === 1 &&
       currentUsers[0]?.name === "Alex" &&
       myName.get() === "Alex";
   });
 
-  const assert_blair_is_not_host = computed(() =>
+  const assert_blair_is_not_host = assert(() =>
     users.get().length === 2 &&
     participantIdentity.me === "Blair" &&
     adminName.get() === "Alex" &&
@@ -122,7 +122,7 @@ export default pattern(() => {
     participantIdentity.isAdmin === false
   );
 
-  const assert_blair_claimed_host = computed(() =>
+  const assert_blair_claimed_host = assert(() =>
     adminName.get() === "Blair" &&
     participantIdentity.me === "Blair" &&
     participantIdentity.isAdmin === true

--- a/packages/patterns/lunch-poll/poll-option-card.test.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.test.tsx
@@ -1,5 +1,6 @@
 import {
   action,
+  assert,
   computed,
   handler,
   pattern,
@@ -118,7 +119,7 @@ export default pattern(() => {
     setOptionImage,
   });
 
-  const assert_my_green_vote_label_renders = computed(() =>
+  const assert_my_green_vote_label_renders = assert(() =>
     findNodeByProp(
       card[UI],
       "aria-label",
@@ -126,23 +127,23 @@ export default pattern(() => {
     ) !== undefined
   );
 
-  const assert_unset_rank_renders_placeholder = computed(() =>
+  const assert_unset_rank_renders_placeholder = assert(() =>
     hasText(card[UI], "—") && !hasText(card[UI], "#0")
   );
 
   const action_resolve_rank = action(() => rank.set(1));
 
-  const assert_resolved_rank_renders = computed(() =>
+  const assert_resolved_rank_renders = assert(() =>
     hasText(card[UI], "#1") && !hasText(card[UI], "—")
   );
 
   const action_set_zero_rank = action(() => rank.set(0));
 
-  const assert_zero_rank_renders_placeholder = computed(() =>
+  const assert_zero_rank_renders_placeholder = assert(() =>
     hasText(card[UI], "—") && !hasText(card[UI], "#0")
   );
 
-  const assert_my_green_vote_styles_buttons = computed(() => {
+  const assert_my_green_vote_styles_buttons = assert(() => {
     const green = findNodeByProp(
       card[UI],
       "aria-label",
@@ -160,18 +161,18 @@ export default pattern(() => {
       propValue(red, "style") === "opacity: 0.4;";
   });
 
-  const assert_remove_control_contains_only_link_text = computed(() => {
+  const assert_remove_control_contains_only_link_text = assert(() => {
     const remove = findElementByExactText(card[UI], "button", "remove");
     return remove !== undefined &&
       propValue(remove, "aria-label") === "Remove option (host)";
   });
 
-  const assert_remove_control_is_clickable = computed(() => {
+  const assert_remove_control_is_clickable = assert(() => {
     const remove = findElementByExactText(card[UI], "button", "remove");
     return propsOf(remove)?.onClick !== undefined;
   });
 
-  const assert_remove_control_is_underlined = computed(() => {
+  const assert_remove_control_is_underlined = assert(() => {
     const remove = findElementByExactText(card[UI], "button", "remove");
     const removeStyle = propValue(remove, "style");
     return typeof removeStyle === "object" && removeStyle !== null &&
@@ -180,7 +181,7 @@ export default pattern(() => {
         ) === "underline";
   });
 
-  const assert_remove_separator_is_plain = computed(() => {
+  const assert_remove_separator_is_plain = assert(() => {
     const separator = findElementByExactText(card[UI], "span", "·");
     const separatorAriaHidden = propValue(separator, "aria-hidden");
     const separatorStyle = propValue(separator, "style");
@@ -202,7 +203,7 @@ export default pattern(() => {
         separatorTextDecorationLine === "none");
   });
 
-  const assert_log_visit_control_renders = computed(() =>
+  const assert_log_visit_control_renders = assert(() =>
     findNodeByProp(
       card[UI],
       "aria-label",

--- a/packages/patterns/lunch-poll/poll-option-card.test.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.test.tsx
@@ -212,7 +212,7 @@ export default pattern(() => {
   );
 
   // Stored art ⇒ artSyncState "stored" ⇒ no keep affordance.
-  const assert_no_keep_button_when_stored = computed(() =>
+  const assert_no_keep_button_when_stored = assert(() =>
     readValue(card.artSyncState) === "stored" &&
     findNodeByProp(
         card[UI],
@@ -238,7 +238,7 @@ export default pattern(() => {
     setOptionImage,
   });
 
-  const assert_keep_button_when_generated = computed(() =>
+  const assert_keep_button_when_generated = assert(() =>
     readValue(generatingCard.artSyncState) === "generated" &&
     findNodeByProp(
         generatingCard[UI],
@@ -259,7 +259,7 @@ export default pattern(() => {
     }
   });
 
-  const assert_keep_sends_generated_image = computed(() => {
+  const assert_keep_sends_generated_image = assert(() => {
     const event = readValue(lastSetOptionImage);
     return typeof event === "object" && event !== null &&
       readValue((event as SetOptionImageEvent).optionId) === "opt-tacos" &&

--- a/packages/patterns/map-demo.test.tsx
+++ b/packages/patterns/map-demo.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/map-demo.test.tsx --root packages/patterns --verbose
  */
-import { action, computed, pattern, UI } from "commonfabric";
+import { action, assert, pattern, UI } from "commonfabric";
 import { findElementByText, propsOf } from "./test/vnode-helpers.ts";
 import MapDemo from "./map-demo.tsx";
 
@@ -54,11 +54,11 @@ export default pattern(() => {
     }
   });
 
-  const assert_no_areas_initially = computed(() =>
+  const assert_no_areas_initially = assert(() =>
     [...subject.areasOfInterest].length === 0
   );
 
-  const assert_first_area = computed(() => {
+  const assert_first_area = assert(() => {
     const areas = [...subject.areasOfInterest];
     if (areas.length !== 1) return false;
     const area = areas[0];
@@ -70,7 +70,7 @@ export default pattern(() => {
 
   // With no centre tracked yet the handler falls back to its own default rather
   // than leaving the area without a position.
-  const assert_first_area_uses_default_center = computed(() => {
+  const assert_first_area_uses_default_center = assert(() => {
     const areas = [...subject.areasOfInterest];
     return areas.length === 1 &&
       areas[0].center.lat === 37.6 &&
@@ -79,21 +79,21 @@ export default pattern(() => {
 
   // The second add reads a one-entry list, so it titles itself "Area 2" and
   // takes the next colour. Both have to match the slot it appends into.
-  const assert_second_area = computed(() => {
+  const assert_second_area = assert(() => {
     const areas = [...subject.areasOfInterest];
     if (areas.length !== 2) return false;
     return areas[1].title === "Area 2" && areas[1].color === COLORS[1];
   });
 
   // The first area is untouched by the second add.
-  const assert_first_area_unchanged = computed(() => {
+  const assert_first_area_unchanged = assert(() => {
     const areas = [...subject.areasOfInterest];
     return areas.length === 2 &&
       areas[0].title === "Area 1" &&
       areas[0].color === COLORS[0];
   });
 
-  const assert_third_area = computed(() => {
+  const assert_third_area = assert(() => {
     const areas = [...subject.areasOfInterest];
     if (areas.length !== 3) return false;
     return areas[2].title === "Area 3" && areas[2].color === COLORS[2];
@@ -101,21 +101,21 @@ export default pattern(() => {
 
   // Every area's title numbers the slot it sits in, which is what the append
   // has to preserve.
-  const assert_titles_match_positions = computed(() => {
+  const assert_titles_match_positions = assert(() => {
     const areas = [...subject.areasOfInterest];
     return areas.every((area, index) => area.title === `Area ${index + 1}`);
   });
 
-  const assert_area_count_tracks_list = computed(() =>
+  const assert_area_count_tracks_list = assert(() =>
     [...subject.areasOfInterest].length === 3
   );
 
   // The map component watches this counter rather than taking a call, so the
   // button's only job is to move it.
-  const assert_fit_bounds_not_triggered = computed(() =>
+  const assert_fit_bounds_not_triggered = assert(() =>
     subject.fitBoundsTrigger === 0
   );
-  const assert_fit_bounds_triggered = computed(() =>
+  const assert_fit_bounds_triggered = assert(() =>
     subject.fitBoundsTrigger === 1
   );
 

--- a/packages/patterns/notes/note-md.test.tsx
+++ b/packages/patterns/notes/note-md.test.tsx
@@ -12,7 +12,7 @@
  *
  * Run: deno task cf test packages/patterns/notes/note-md.test.tsx --verbose
  */
-import { action, computed, NAME, pattern, Writable } from "commonfabric";
+import { action, assert, NAME, pattern, Writable } from "commonfabric";
 import NoteMd from "./note-md.tsx";
 import Note from "./note.tsx";
 
@@ -229,14 +229,14 @@ export default pattern(() => {
   // Assertions - Static properties
   // ==========================================================================
 
-  const assert_is_hidden = computed(() => md.isHidden === true);
-  const assert_is_not_mentionable = computed(() => md.isMentionable === false);
+  const assert_is_hidden = assert(() => md.isHidden === true);
+  const assert_is_not_mentionable = assert(() => md.isMentionable === false);
 
   // ==========================================================================
   // Assertions - Note passthrough
   // ==========================================================================
 
-  const assert_note_title = computed(
+  const assert_note_title = assert(
     () => md.note?.title === "Test Note",
   );
 
@@ -244,7 +244,7 @@ export default pattern(() => {
   // Assertions - NAME computed
   // ==========================================================================
 
-  const assert_name = computed(
+  const assert_name = assert(
     () => md[NAME] === "📖 Test Note",
   );
 
@@ -253,19 +253,19 @@ export default pattern(() => {
   // ==========================================================================
 
   // Content with wiki-links should be converted
-  const assert_wiki_links_converted = computed(
+  const assert_wiki_links_converted = assert(
     () =>
       mdWiki.processedContent ===
         "See [Alice](/of:abc123) and [Bob](/of:def456) for details",
   );
 
   // Content without wiki-links passes through unchanged
-  const assert_plain_passthrough = computed(
+  const assert_plain_passthrough = assert(
     () => mdPlain.processedContent === "No links here, just plain text.",
   );
 
   // After updating wiki content, new links should be converted
-  const assert_multi_wiki_converted = computed(
+  const assert_multi_wiki_converted = assert(
     () =>
       mdWiki.processedContent ===
         "Link to [Charlie](/of:ghi789) and back to [Alice](/of:abc123)",
@@ -275,28 +275,28 @@ export default pattern(() => {
   // Assertions - Checkbox toggle
   // ==========================================================================
 
-  const assert_initial_checkboxes = computed(
+  const assert_initial_checkboxes = assert(
     () =>
       mdCheckbox.processedContent ===
         "- [ ] Task one\n- [x] Task two\n- [ ] Task three",
   );
 
   // After checking first: "- [x] Task one\n- [x] Task two\n- [ ] Task three"
-  const assert_first_checked = computed(
+  const assert_first_checked = assert(
     () =>
       mdCheckbox.processedContent ===
         "- [x] Task one\n- [x] Task two\n- [ ] Task three",
   );
 
   // After unchecking second: "- [x] Task one\n- [ ] Task two\n- [ ] Task three"
-  const assert_second_unchecked = computed(
+  const assert_second_unchecked = assert(
     () =>
       mdCheckbox.processedContent ===
         "- [x] Task one\n- [ ] Task two\n- [ ] Task three",
   );
 
   // After checking third: "- [x] Task one\n- [ ] Task two\n- [x] Task three"
-  const assert_third_checked = computed(
+  const assert_third_checked = assert(
     () =>
       mdCheckbox.processedContent ===
         "- [x] Task one\n- [ ] Task two\n- [x] Task three",
@@ -306,7 +306,7 @@ export default pattern(() => {
   // Assertions - hasBacklinks computed
   // ==========================================================================
 
-  const assert_no_backlinks_initially = computed(
+  const assert_no_backlinks_initially = assert(
     () => md.hasBacklinks === false,
   );
 
@@ -314,13 +314,13 @@ export default pattern(() => {
   // Assertions - Edge cases - wiki-links
   // ==========================================================================
 
-  const assert_regular_links_passthrough = computed(
+  const assert_regular_links_passthrough = assert(
     () =>
       mdRegularLinks.processedContent ===
         "Use [regular markdown](http://example.com) links",
   );
 
-  const assert_special_chars_converted = computed(
+  const assert_special_chars_converted = assert(
     () =>
       mdSpecialChars.processedContent === "See [Alice & Bob](/of:special-123)",
   );
@@ -329,27 +329,27 @@ export default pattern(() => {
   // Assertions - Edge cases - checkboxes
   // ==========================================================================
 
-  const assert_no_checkbox_content = computed(
+  const assert_no_checkbox_content = assert(
     () => mdNoCheckbox.processedContent === "Just regular text\nNo checkboxes",
   );
 
-  const assert_no_checkbox_unchanged = computed(
+  const assert_no_checkbox_unchanged = assert(
     () => mdNoCheckbox.processedContent === "Just regular text\nNo checkboxes",
   );
 
-  const assert_mixed_initial = computed(
+  const assert_mixed_initial = assert(
     () =>
       mdMixed.processedContent ===
         "# Title\n\n- [ ] First task\n\nSome text\n\n- [x] Second task",
   );
 
-  const assert_mixed_first_checked = computed(
+  const assert_mixed_first_checked = assert(
     () =>
       mdMixed.processedContent ===
         "# Title\n\n- [x] First task\n\nSome text\n\n- [x] Second task",
   );
 
-  const assert_mixed_second_unchecked = computed(
+  const assert_mixed_second_unchecked = assert(
     () =>
       mdMixed.processedContent ===
         "# Title\n\n- [x] First task\n\nSome text\n\n- [ ] Second task",
@@ -359,11 +359,11 @@ export default pattern(() => {
   // Assertions - Edge cases - empty/missing content
   // ==========================================================================
 
-  const assert_empty_content = computed(
+  const assert_empty_content = assert(
     () => mdEmpty.processedContent === "",
   );
 
-  const assert_whitespace_preserved = computed(
+  const assert_whitespace_preserved = assert(
     () => mdWhitespace.processedContent === "   \n\n   ",
   );
 
@@ -371,25 +371,25 @@ export default pattern(() => {
   // Assertions - sourceNoteRef path
   // ==========================================================================
 
-  const assert_source_name = computed(
+  const assert_source_name = assert(
     () => mdWithSource[NAME] === "📖 Source Note",
   );
 
-  const assert_source_content = computed(
+  const assert_source_content = assert(
     () => mdWithSource.processedContent === "Content from source",
   );
 
-  const assert_source_is_hidden = computed(
+  const assert_source_is_hidden = assert(
     () => mdWithSource.isHidden === true,
   );
 
   // Verify state is stable after goToEdit with sourceNoteRef
-  const assert_source_stable_after_edit = computed(
+  const assert_source_stable_after_edit = assert(
     () => mdWithSource.processedContent === "Content from source",
   );
 
   // Verify state is stable after goToEdit without sourceNoteRef (wish fallback)
-  const assert_no_source_stable_after_edit = computed(
+  const assert_no_source_stable_after_edit = assert(
     () => mdWithoutSource.processedContent === "Direct content",
   );
 

--- a/packages/patterns/notes/note.test.tsx
+++ b/packages/patterns/notes/note.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/notes/note.test.tsx --verbose
  */
-import { action, computed, NAME, pattern } from "commonfabric";
+import { action, assert, NAME, pattern } from "commonfabric";
 import Note, { bareMentionId } from "./note.tsx";
 import Notebook from "./notebook.tsx";
 
@@ -141,21 +141,21 @@ export default pattern(() => {
   // Assertions - Initial State
   // ==========================================================================
 
-  const assert_name = computed(
+  const assert_name = assert(
     () => note[NAME] === "📝 Test Note",
   );
-  const assert_initial_title = computed(() => note.title === "Test Note");
-  const assert_initial_content = computed(
+  const assert_initial_title = assert(() => note.title === "Test Note");
+  const assert_initial_content = assert(
     () => note.content === "Line one\nLine two\nLine three",
   );
-  const assert_initial_not_hidden = computed(() => note.isHidden === false);
-  const assert_initial_no_parent = computed(
+  const assert_initial_not_hidden = assert(() => note.isHidden === false);
+  const assert_initial_no_parent = assert(
     () => !note.parentNotebook,
   );
-  const assert_initial_empty_backlinks = computed(
+  const assert_initial_empty_backlinks = assert(
     () => note.backlinks.length === 0,
   );
-  const assert_initial_empty_mentioned = computed(
+  const assert_initial_empty_mentioned = assert(
     () => note.mentioned.length === 0,
   );
 
@@ -164,46 +164,46 @@ export default pattern(() => {
   // ==========================================================================
 
   // Note created with parent A should have it set
-  const assert_has_parent = computed(
+  const assert_has_parent = assert(
     () => !!noteWithParent.parentNotebook,
   );
 
-  const assert_parent_is_notebook_a = computed(
+  const assert_parent_is_notebook_a = assert(
     () => noteWithParent.parentNotebook?.title === "Notebook A",
   );
 
   // Note created with parent B should point to B
-  const assert_note_b_has_parent = computed(
+  const assert_note_b_has_parent = assert(
     () => !!noteInNotebookB.parentNotebook,
   );
 
-  const assert_parent_is_notebook_b = computed(
+  const assert_parent_is_notebook_b = assert(
     () => noteInNotebookB.parentNotebook?.title === "Notebook B",
   );
 
   // Different notes have different parents
-  const assert_different_parents = computed(
+  const assert_different_parents = assert(
     () =>
       noteWithParent.parentNotebook?.title !== noteInNotebookB.parentNotebook
         ?.title,
   );
 
   // Note created without parent should have no parent
-  const assert_orphan_no_parent = computed(
+  const assert_orphan_no_parent = assert(
     () => !noteNoParent.parentNotebook,
   );
 
   // Child notes should be hidden (set at creation)
-  const assert_child_a_hidden = computed(
+  const assert_child_a_hidden = assert(
     () => noteWithParent.isHidden === true,
   );
 
-  const assert_child_b_hidden = computed(
+  const assert_child_b_hidden = assert(
     () => noteInNotebookB.isHidden === true,
   );
 
   // Orphan note should not be hidden
-  const assert_orphan_not_hidden = computed(
+  const assert_orphan_not_hidden = assert(
     () => noteNoParent.isHidden === false,
   );
 
@@ -211,35 +211,35 @@ export default pattern(() => {
   // Assertions - After Content Edit
   // ==========================================================================
 
-  const assert_content_updated = computed(
+  const assert_content_updated = assert(
     () => note.content === "Updated content here",
   );
-  const assert_content_multiline = computed(
+  const assert_content_multiline = assert(
     () => note.content === "First line\nSecond line\nThird line",
   );
-  const assert_content_cleared = computed(() => note.content === "");
+  const assert_content_cleared = assert(() => note.content === "");
 
   // ==========================================================================
   // Assertions - Menu Toggle
   // ==========================================================================
 
-  const assert_initial_menu_closed = computed(
+  const assert_initial_menu_closed = assert(
     () => note.menuOpen === false,
   );
 
-  const assert_menu_open = computed(
+  const assert_menu_open = assert(
     () => note.menuOpen === true,
   );
 
-  const assert_menu_closed_after_toggle = computed(
+  const assert_menu_closed_after_toggle = assert(
     () => note.menuOpen === false,
   );
 
-  const assert_menu_open_before_close = computed(
+  const assert_menu_open_before_close = assert(
     () => note.menuOpen === true,
   );
 
-  const assert_menu_closed_via_close = computed(
+  const assert_menu_closed_via_close = assert(
     () => note.menuOpen === false,
   );
 
@@ -247,15 +247,15 @@ export default pattern(() => {
   // Assertions - Title Editing
   // ==========================================================================
 
-  const assert_initial_not_editing = computed(
+  const assert_initial_not_editing = assert(
     () => note.isEditingTitle === false,
   );
 
-  const assert_editing_title = computed(
+  const assert_editing_title = assert(
     () => note.isEditingTitle === true,
   );
 
-  const assert_stopped_editing = computed(
+  const assert_stopped_editing = assert(
     () => note.isEditingTitle === false,
   );
 
@@ -264,12 +264,12 @@ export default pattern(() => {
   // ==========================================================================
 
   // After creating new note, original note should be unchanged
-  const assert_note_unchanged_after_create = computed(
+  const assert_note_unchanged_after_create = assert(
     () => note.title === "Test Note",
   );
 
   // After creating new note from parented note, original should be unchanged
-  const assert_parented_note_unchanged = computed(
+  const assert_parented_note_unchanged = assert(
     () => noteWithParent.title === "Child Note",
   );
 
@@ -280,23 +280,23 @@ export default pattern(() => {
   // appendLink appends `[[<NAME> (<entityId>)]]` to the content, with the
   // target's entityId stringified via the cell-rep chokepoint, and pushes the
   // target onto `mentioned`.
-  const assert_link_appended = computed(() =>
+  const assert_link_appended = assert(() =>
     /\[\[📝 Link Target \([^)]+\)\]\]/.test(note.content)
   );
-  const assert_mentioned_after_link = computed(
+  const assert_mentioned_after_link = assert(
     () => note.mentioned.length === 1,
   );
 
   // The wiki-link embed contract: `of:` strips (the renderer re-adds it),
   // bare ids pass through, and `computed:` is REJECTED — the bare embed
   // format cannot carry the scheme, and the scheme is part of the identity.
-  const assert_mention_id_strips_of = computed(
+  const assert_mention_id_strips_of = assert(
     () => bareMentionId("of:fid1:abc") === "fid1:abc",
   );
-  const assert_mention_id_passes_bare = computed(
+  const assert_mention_id_passes_bare = assert(
     () => bareMentionId("fid1:abc") === "fid1:abc",
   );
-  const assert_computed_mention_rejected = computed(() => {
+  const assert_computed_mention_rejected = assert(() => {
     try {
       bareMentionId("computed:fid1:tripwire");
       return false;

--- a/packages/patterns/notes/notebook-drop.test.tsx
+++ b/packages/patterns/notes/notebook-drop.test.tsx
@@ -14,7 +14,7 @@
  *
  * Run: deno task cf test packages/patterns/notes/notebook-drop.test.tsx --root packages/patterns --verbose
  */
-import { action, computed, pattern, UI } from "commonfabric";
+import { action, assert, pattern, UI } from "commonfabric";
 import { findNode, propsOf, readValue } from "../test/vnode-helpers.ts";
 import Notebook from "./notebook.tsx";
 import Note from "./note.tsx";
@@ -102,7 +102,7 @@ export default pattern(() => {
     sendDropOntoRow(subject, "Second Note", looseNote)
   );
 
-  const assert_initial_order = computed(() => {
+  const assert_initial_order = assert(() => {
     const titles = noteTitlesOf(subject);
     return titles.length === 2 && titles[0] === "First Note" &&
       titles[1] === "Second Note";
@@ -111,7 +111,7 @@ export default pattern(() => {
   // An in-notebook drop of an already-present note is a no-op: same
   // memberships, same order. (Removing then re-adding would file the note
   // back at the tail.)
-  const assert_re_drop_keeps_order = computed(() => {
+  const assert_re_drop_keeps_order = assert(() => {
     const titles = noteTitlesOf(subject);
     return titles.length === 2 && titles[0] === "First Note" &&
       titles[1] === "Second Note";
@@ -119,24 +119,24 @@ export default pattern(() => {
 
   // A multi-select drop within the notebook must not remove the selection
   // from the notebook it is already in.
-  const assert_multi_drop_keeps_notes = computed(() => {
+  const assert_multi_drop_keeps_notes = assert(() => {
     const titles = noteTitlesOf(subject);
     return titles.length === 2 && titles[0] === "First Note" &&
       titles[1] === "Second Note";
   });
 
   // The selection is consumed by the drop either way.
-  const assert_multi_drop_clears_selection = computed(() =>
+  const assert_multi_drop_clears_selection = assert(() =>
     [...(subject.selectedNoteIndices ?? [])].length === 0
   );
 
   // A note from outside the notebook is added once and hidden from the
   // space-wide list.
-  const assert_loose_note_added = computed(() => {
+  const assert_loose_note_added = assert(() => {
     const titles = noteTitlesOf(subject);
     return titles.length === 3 && titles[2] === "Loose Note";
   });
-  const assert_loose_note_hidden = computed(() => looseNote.isHidden === true);
+  const assert_loose_note_hidden = assert(() => looseNote.isHidden === true);
 
   return {
     tests: [

--- a/packages/patterns/notes/notebook.test.tsx
+++ b/packages/patterns/notes/notebook.test.tsx
@@ -21,7 +21,7 @@
  *
  * Run: deno task cf test packages/patterns/notes/notebook.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import { NAME } from "commonfabric";
 import Notebook from "./notebook.tsx";
 import Note from "./note.tsx";
@@ -172,19 +172,17 @@ export default pattern(() => {
   // Assertions - Initial State
   // ==========================================================================
 
-  const assert_initial_title = computed(() =>
-    notebook.title === "Test Notebook"
-  );
-  const assert_initial_note_count = computed(() => notebook.noteCount === 2);
-  const assert_is_notebook_flag = computed(() => notebook.isNotebook === true);
-  const assert_initial_not_hidden = computed(() => notebook.isHidden === false);
-  const assert_notes_array_length = computed(() => notebook.notes.length === 2);
+  const assert_initial_title = assert(() => notebook.title === "Test Notebook");
+  const assert_initial_note_count = assert(() => notebook.noteCount === 2);
+  const assert_is_notebook_flag = assert(() => notebook.isNotebook === true);
+  const assert_initial_not_hidden = assert(() => notebook.isHidden === false);
+  const assert_notes_array_length = assert(() => notebook.notes.length === 2);
 
   // Empty notebook assertions
-  const assert_empty_notebook_count = computed(() =>
+  const assert_empty_notebook_count = assert(() =>
     emptyNotebook.noteCount === 0
   );
-  const assert_empty_notebook_notes = computed(() =>
+  const assert_empty_notebook_notes = assert(() =>
     emptyNotebook.notes.length === 0
   );
 
@@ -192,29 +190,27 @@ export default pattern(() => {
   // Assertions - After Rename
   // ==========================================================================
 
-  const assert_title_renamed = computed(() =>
+  const assert_title_renamed = assert(() =>
     notebook.title === "Renamed Notebook"
   );
-  const assert_title_final = computed(() => notebook.title === "Final Name");
+  const assert_title_final = assert(() => notebook.title === "Final Name");
 
   // ==========================================================================
   // Assertions - After Creating Notes via Stream
   // ==========================================================================
 
   // After createNote, should have 3 notes
-  const assert_note_count_after_create = computed(() =>
-    notebook.noteCount === 3
-  );
+  const assert_note_count_after_create = assert(() => notebook.noteCount === 3);
 
   // The third note (index 2) was created via stream - verify it has parentNotebook
-  const assert_created_note_has_parent = computed(() => {
+  const assert_created_note_has_parent = assert(() => {
     const notesList = notebook.notes;
     if (notesList.length < 3) return false;
     const createdNote = notesList[2] as any; // Cast to any to access parentNotebook
     return !!createdNote?.parentNotebook;
   });
 
-  const assert_created_note_parent_title = computed(() => {
+  const assert_created_note_parent_title = assert(() => {
     const notesList = notebook.notes;
     if (notesList.length < 3) return false;
     const createdNote = notesList[2] as any; // Cast to any to access parentNotebook
@@ -222,25 +218,25 @@ export default pattern(() => {
   });
 
   // After createNotes with 2 notes, should have 5 total
-  const assert_note_count_after_bulk = computed(() => notebook.noteCount === 5);
+  const assert_note_count_after_bulk = assert(() => notebook.noteCount === 5);
 
   // ==========================================================================
   // Assertions - Selection System
   // ==========================================================================
 
-  const assert_selection_initial = computed(() =>
+  const assert_selection_initial = assert(() =>
     selectionNotebook.selectedNoteIndices.length === 0 &&
     selectionNotebook.hasSelection === false &&
     selectionNotebook.selectedCount === 0
   );
 
-  const assert_all_selected = computed(() =>
+  const assert_all_selected = assert(() =>
     selectionNotebook.selectedNoteIndices.length === 2 &&
     selectionNotebook.hasSelection === true &&
     selectionNotebook.selectedCount === 2
   );
 
-  const assert_none_selected = computed(() =>
+  const assert_none_selected = assert(() =>
     selectionNotebook.selectedNoteIndices.length === 0 &&
     selectionNotebook.hasSelection === false &&
     selectionNotebook.selectedCount === 0
@@ -250,25 +246,25 @@ export default pattern(() => {
   // Assertions - Modal State Management
   // ==========================================================================
 
-  const assert_initial_modal_state = computed(() =>
+  const assert_initial_modal_state = assert(() =>
     notebook.showNewNotePrompt === false &&
     notebook.showNewNotebookPrompt === false &&
     notebook.showNewNestedNotebookPrompt === false
   );
 
-  const assert_new_note_modal_shown = computed(() =>
+  const assert_new_note_modal_shown = assert(() =>
     notebook.showNewNotePrompt === true
   );
 
-  const assert_new_note_modal_hidden = computed(() =>
+  const assert_new_note_modal_hidden = assert(() =>
     notebook.showNewNotePrompt === false
   );
 
-  const assert_new_notebook_modal_shown = computed(() =>
+  const assert_new_notebook_modal_shown = assert(() =>
     notebook.showNewNestedNotebookPrompt === true
   );
 
-  const assert_new_notebook_modal_hidden = computed(() =>
+  const assert_new_notebook_modal_hidden = assert(() =>
     notebook.showNewNestedNotebookPrompt === false
   );
 
@@ -276,13 +272,13 @@ export default pattern(() => {
   // Assertions - Title Editing
   // ==========================================================================
 
-  const assert_not_editing_title = computed(() =>
+  const assert_not_editing_title = assert(() =>
     notebook.isEditingTitle === false
   );
 
-  const assert_editing_title = computed(() => notebook.isEditingTitle === true);
+  const assert_editing_title = assert(() => notebook.isEditingTitle === true);
 
-  const assert_stopped_editing_title = computed(() =>
+  const assert_stopped_editing_title = assert(() =>
     notebook.isEditingTitle === false
   );
 
@@ -290,7 +286,7 @@ export default pattern(() => {
   // Assertions - Delete Selected
   // ==========================================================================
 
-  const assert_notes_deleted = computed(() =>
+  const assert_notes_deleted = assert(() =>
     selectionNotebook.noteCount === 0 &&
     selectionNotebook.notes.length === 0 &&
     selectionNotebook.selectedNoteIndices.length === 0
@@ -328,19 +324,19 @@ export default pattern(() => {
     dupNotebook.duplicateSelected.send();
   });
 
-  const assert_dup_initial_count = computed(() => dupNotebook.noteCount === 2);
+  const assert_dup_initial_count = assert(() => dupNotebook.noteCount === 2);
 
-  const assert_dup_all_selected = computed(() =>
+  const assert_dup_all_selected = assert(() =>
     dupNotebook.selectedNoteIndices.length === 2
   );
 
-  const assert_duplicated = computed(() =>
+  const assert_duplicated = assert(() =>
     dupNotebook.noteCount === 4 &&
     dupNotebook.selectedNoteIndices.length === 0
   );
 
   // Verify duplicated notes have parent set
-  const assert_dup_notes_have_parent = computed(() => {
+  const assert_dup_notes_have_parent = assert(() => {
     const notesList = dupNotebook.notes;
     if (notesList.length < 4) return false;
     // Notes at index 2 and 3 are the duplicates
@@ -353,7 +349,7 @@ export default pattern(() => {
   // Assertions - NAME Computed Format
   // ==========================================================================
 
-  const assert_name_format = computed(() => {
+  const assert_name_format = assert(() => {
     const name = notebook[NAME];
     return typeof name === "string" &&
       name.includes("📓") &&
@@ -367,7 +363,7 @@ export default pattern(() => {
 
   // createNotebook pushes to allPieces, not to this notebook's notes array.
   // So the notebook's own noteCount should remain unchanged at 3.
-  const assert_notebook_count_unchanged = computed(() =>
+  const assert_notebook_count_unchanged = assert(() =>
     notebook.noteCount === 3
   );
 

--- a/packages/patterns/project-list/main.test.tsx
+++ b/packages/patterns/project-list/main.test.tsx
@@ -14,7 +14,7 @@
  */
 import {
   action,
-  computed,
+  assert,
   equals,
   handler,
   pattern,
@@ -88,37 +88,35 @@ export default pattern(() => {
   // Assertions
   // ==========================================================================
 
-  const assert_seeded = computed(() => {
+  const assert_seeded = assert(() => {
     const cur = itemsCell.get();
     return cur.length === 2 && cur[0]?.title === "First" &&
       cur[1]?.title === "Second";
   });
 
-  const assert_held_stashed = computed(() => {
+  const assert_held_stashed = assert(() => {
     const h = heldItem.get();
     return h.title === "First" && equals(itemsCell.get()[0], h);
   });
 
-  const assert_first_done = computed(() => itemsCell.get()[0]?.done === true);
-  const assert_second_untouched = computed(() =>
+  const assert_first_done = assert(() => itemsCell.get()[0]?.done === true);
+  const assert_second_untouched = assert(() =>
     itemsCell.get()[1]?.done === false
   );
   // KEY: the stale-but-once-valid reference still equals()-matches the item
   // AFTER the toggle updated it.
-  const assert_held_survives_toggle = computed(() => {
+  const assert_held_survives_toggle = assert(() => {
     const h = heldItem.get();
     return equals(itemsCell.get()[0], h);
   });
   // The held reference also READS the update (it would show the stale,
   // orphaned entity if the toggle had re-minted identity).
-  const assert_held_reads_toggle = computed(() => heldItem.get().done === true);
+  const assert_held_reads_toggle = assert(() => heldItem.get().done === true);
 
-  const assert_toggled_back = computed(() =>
-    itemsCell.get()[0]?.done === false
-  );
+  const assert_toggled_back = assert(() => itemsCell.get()[0]?.done === false);
 
   // KEY: the held reference still DRIVES an equals()-located removal.
-  const assert_removed_via_held = computed(() => {
+  const assert_removed_via_held = assert(() => {
     const cur = itemsCell.get();
     return cur.length === 1 && cur[0]?.title === "Second";
   });

--- a/packages/patterns/reading-list/reading-item-detail.test.tsx
+++ b/packages/patterns/reading-list/reading-item-detail.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/reading-list/reading-item-detail.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import ReadingItemDetail from "./reading-item-detail.tsx";
 
 export default pattern(() => {
@@ -73,41 +73,41 @@ export default pattern(() => {
   // Assertions - Initial State
   // ==========================================================================
 
-  const assert_initial_title = computed(() => item.title === "Test Book");
-  const assert_initial_author = computed(() => item.author === "Test Author");
-  const assert_initial_type = computed(() => item.type === "book");
-  const assert_initial_status = computed(() => item.status === "want");
-  const assert_initial_rating = computed(() => item.rating === null);
-  const assert_initial_notes = computed(() => item.notes === "");
+  const assert_initial_title = assert(() => item.title === "Test Book");
+  const assert_initial_author = assert(() => item.author === "Test Author");
+  const assert_initial_type = assert(() => item.type === "book");
+  const assert_initial_status = assert(() => item.status === "want");
+  const assert_initial_rating = assert(() => item.rating === null);
+  const assert_initial_notes = assert(() => item.notes === "");
 
   // ==========================================================================
   // Assertions - Status Changes
   // ==========================================================================
 
-  const assert_status_reading = computed(() => item.status === "reading");
-  const assert_status_finished = computed(() => item.status === "finished");
-  const assert_status_abandoned = computed(() => item.status === "abandoned");
-  const assert_status_want = computed(() => item.status === "want");
+  const assert_status_reading = assert(() => item.status === "reading");
+  const assert_status_finished = assert(() => item.status === "finished");
+  const assert_status_abandoned = assert(() => item.status === "abandoned");
+  const assert_status_want = assert(() => item.status === "want");
 
   // ==========================================================================
   // Assertions - Rating Changes
   // ==========================================================================
 
-  const assert_rating_5 = computed(() => item.rating === 5);
-  const assert_rating_3 = computed(() => item.rating === 3);
-  const assert_rating_null = computed(() => item.rating === null);
+  const assert_rating_5 = assert(() => item.rating === 5);
+  const assert_rating_3 = assert(() => item.rating === 3);
+  const assert_rating_null = assert(() => item.rating === null);
 
   // ==========================================================================
   // Assertions - Notes Changes
   // ==========================================================================
 
-  const assert_notes_added = computed(
+  const assert_notes_added = assert(
     () => item.notes === "Great read, highly recommend!",
   );
-  const assert_notes_updated = computed(
+  const assert_notes_updated = assert(
     () => item.notes === "Updated: Even better on second read.",
   );
-  const assert_notes_cleared = computed(() => item.notes === "");
+  const assert_notes_cleared = assert(() => item.notes === "");
 
   // ==========================================================================
   // Test Sequence

--- a/packages/patterns/reading-list/reading-list.test.tsx
+++ b/packages/patterns/reading-list/reading-list.test.tsx
@@ -13,7 +13,7 @@
  *
  * Run: deno task cf test packages/patterns/reading-list/reading-list.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import ReadingList from "./reading-list.tsx";
 
 export default pattern(() => {
@@ -159,20 +159,16 @@ export default pattern(() => {
   // Assertions - Initial State
   // ==========================================================================
 
-  const assert_initial_empty = computed(() => list.totalCount === 0);
-  const assert_initial_filter_all = computed(() =>
-    list.currentFilter === "all"
-  );
-  const assert_initial_filtered_empty = computed(() =>
-    list.filteredCount === 0
-  );
+  const assert_initial_empty = assert(() => list.totalCount === 0);
+  const assert_initial_filter_all = assert(() => list.currentFilter === "all");
+  const assert_initial_filtered_empty = assert(() => list.filteredCount === 0);
 
   // ==========================================================================
   // Assertions - After Adding Items
   // ==========================================================================
 
-  const assert_has_one = computed(() => list.totalCount === 1);
-  const assert_first_is_article = computed(() => {
+  const assert_has_one = assert(() => list.totalCount === 1);
+  const assert_first_is_article = assert(() => {
     return (
       list.items[0]?.title === "Great Article" &&
       list.items[0]?.type === "article" &&
@@ -181,8 +177,8 @@ export default pattern(() => {
     );
   });
 
-  const assert_has_two = computed(() => list.totalCount === 2);
-  const assert_second_is_book = computed(() => {
+  const assert_has_two = assert(() => list.totalCount === 2);
+  const assert_second_is_book = assert(() => {
     return (
       list.items[1]?.title === "Amazing Book" &&
       list.items[1]?.type === "book" &&
@@ -190,32 +186,32 @@ export default pattern(() => {
     );
   });
 
-  const assert_has_three = computed(() => list.totalCount === 3);
-  const assert_has_four = computed(() => list.totalCount === 4);
+  const assert_has_three = assert(() => list.totalCount === 3);
+  const assert_has_four = assert(() => list.totalCount === 4);
 
-  const assert_video_has_empty_author = computed(() => {
+  const assert_video_has_empty_author = assert(() => {
     return (
       list.items[3]?.title === "Tutorial Video" && list.items[3]?.author === ""
     );
   });
 
   // Empty/whitespace shouldn't add
-  const assert_still_four = computed(() => list.totalCount === 4);
+  const assert_still_four = assert(() => list.totalCount === 4);
 
   // ==========================================================================
   // Assertions - After Status Changes
   // ==========================================================================
 
-  const assert_first_is_reading = computed(
+  const assert_first_is_reading = assert(
     () => list.items[0]?.status === "reading",
   );
-  const assert_second_is_finished = computed(
+  const assert_second_is_finished = assert(
     () => list.items[1]?.status === "finished",
   );
-  const assert_third_is_abandoned = computed(
+  const assert_third_is_abandoned = assert(
     () => list.items[2]?.status === "abandoned",
   );
-  const assert_fourth_is_want = computed(
+  const assert_fourth_is_want = assert(
     () => list.items[3]?.status === "want",
   );
 
@@ -223,8 +219,8 @@ export default pattern(() => {
   // Assertions - After Property Changes
   // ==========================================================================
 
-  const assert_book_has_rating = computed(() => list.items[1]?.rating === 5);
-  const assert_article_has_notes = computed(() =>
+  const assert_book_has_rating = assert(() => list.items[1]?.rating === 5);
+  const assert_article_has_notes = assert(() =>
     list.items[0]?.notes ===
       "Really insightful piece about reactive programming"
   );
@@ -234,39 +230,39 @@ export default pattern(() => {
   // ==========================================================================
 
   // When filter is "all", should show all 4 items
-  const assert_filter_all_shows_four = computed(() => {
+  const assert_filter_all_shows_four = assert(() => {
     return list.currentFilter === "all" && list.filteredCount === 4;
   });
 
   // When filter is "want", should show 1 item (video)
-  const assert_filter_want_shows_one = computed(() => {
+  const assert_filter_want_shows_one = assert(() => {
     return list.currentFilter === "want" && list.filteredCount === 1;
   });
-  const assert_filter_want_correct_item = computed(() => {
+  const assert_filter_want_correct_item = assert(() => {
     return list.filteredItems[0]?.title === "Tutorial Video";
   });
 
   // When filter is "reading", should show 1 item (article)
-  const assert_filter_reading_shows_one = computed(() => {
+  const assert_filter_reading_shows_one = assert(() => {
     return list.currentFilter === "reading" && list.filteredCount === 1;
   });
-  const assert_filter_reading_correct_item = computed(() => {
+  const assert_filter_reading_correct_item = assert(() => {
     return list.filteredItems[0]?.title === "Great Article";
   });
 
   // When filter is "finished", should show 1 item (book)
-  const assert_filter_finished_shows_one = computed(() => {
+  const assert_filter_finished_shows_one = assert(() => {
     return list.currentFilter === "finished" && list.filteredCount === 1;
   });
-  const assert_filter_finished_correct_item = computed(() => {
+  const assert_filter_finished_correct_item = assert(() => {
     return list.filteredItems[0]?.title === "Amazing Book";
   });
 
   // When filter is "abandoned", should show 1 item (paper)
-  const assert_filter_abandoned_shows_one = computed(() => {
+  const assert_filter_abandoned_shows_one = assert(() => {
     return list.currentFilter === "abandoned" && list.filteredCount === 1;
   });
-  const assert_filter_abandoned_correct_item = computed(() => {
+  const assert_filter_abandoned_correct_item = assert(() => {
     return list.filteredItems[0]?.title === "Research Paper";
   });
 
@@ -274,14 +270,14 @@ export default pattern(() => {
   // Assertions - After Removal
   // ==========================================================================
 
-  const assert_has_three_after_remove = computed(() => list.totalCount === 3);
-  const assert_first_is_now_book = computed(() => {
+  const assert_has_three_after_remove = assert(() => list.totalCount === 3);
+  const assert_first_is_now_book = assert(() => {
     return list.items[0]?.title === "Amazing Book";
   });
 
-  const assert_has_two_after_remove = computed(() => list.totalCount === 2);
-  const assert_has_one_after_remove = computed(() => list.totalCount === 1);
-  const assert_back_to_empty = computed(() => list.totalCount === 0);
+  const assert_has_two_after_remove = assert(() => list.totalCount === 2);
+  const assert_has_one_after_remove = assert(() => list.totalCount === 1);
+  const assert_back_to_empty = assert(() => list.totalCount === 0);
 
   // ==========================================================================
   // Test Sequence

--- a/packages/patterns/record.test.tsx
+++ b/packages/patterns/record.test.tsx
@@ -29,7 +29,7 @@
  *
  * Run: deno task cf test packages/patterns/record.test.tsx --root packages/patterns --verbose
  */
-import { action, computed, pattern, UI, Writable } from "commonfabric";
+import { action, assert, pattern, UI, Writable } from "commonfabric";
 import RecordPattern from "./record.tsx";
 
 interface AddResult {
@@ -56,13 +56,13 @@ export default pattern(() => {
   });
 
   // Before anything reads the module list, the seeder has not run.
-  const assert_rendered_starts_empty = computed(() =>
+  const assert_rendered_starts_empty = assert(() =>
     [...(renderedSubject.subPieces ?? [])].length === 0
   );
 
   // After a render step demands the module list, the Record holds exactly the
   // seeded pair: a pinned Notes module followed by the TypePicker.
-  const assert_rendered_seeded = computed(() => {
+  const assert_rendered_seeded = assert(() => {
     const entries = [...(renderedSubject.subPieces ?? [])];
     return entries.length === 2 &&
       entries[0]?.type === "notes" && entries[0]?.pinned === true &&
@@ -75,14 +75,14 @@ export default pattern(() => {
   const action_rendered_add_email = action(() => {
     renderedSubject.addModule!.send({ type: "email", result: renderedAdd });
   });
-  const assert_rendered_add_after_seeds = computed(() => {
+  const assert_rendered_add_after_seeds = assert(() => {
     const entries = [...(renderedSubject.subPieces ?? [])];
     return entries.length === 3 &&
       entries[0]?.type === "notes" &&
       entries[1]?.type === "type-picker" &&
       entries[2]?.type === "email";
   });
-  const assert_rendered_add_result = computed(() =>
+  const assert_rendered_add_result = assert(() =>
     renderedAdd.get()?.moduleIndex === 2
   );
 
@@ -129,16 +129,16 @@ export default pattern(() => {
     subject.addModule!.send({ type: "notes", result: notesType });
   });
 
-  const assert_starts_empty = computed(() =>
+  const assert_starts_empty = assert(() =>
     [...(subject.subPieces ?? [])].length === 0
   );
 
   // The first add lands in the empty list and reports slot 0.
-  const assert_first_email_appended = computed(() => {
+  const assert_first_email_appended = assert(() => {
     const current = [...(subject.subPieces ?? [])];
     return current.length === 1 && current[0].type === "email";
   });
-  const assert_first_email_result = computed(() => {
+  const assert_first_email_result = assert(() => {
     const result = firstEmail.get();
     return result?.success === true &&
       result?.type === "email" &&
@@ -147,27 +147,27 @@ export default pattern(() => {
 
   // The second add reads a list that already holds the first, so it has to
   // report the next slot rather than the one it read.
-  const assert_second_email_appended = computed(() => {
+  const assert_second_email_appended = assert(() => {
     const current = [...(subject.subPieces ?? [])];
     return current.length === 2 && current[1].type === "email";
   });
-  const assert_second_email_result = computed(() =>
+  const assert_second_email_result = assert(() =>
     secondEmail.get()?.moduleIndex === 1
   );
 
-  const assert_phone_appended = computed(() => {
+  const assert_phone_appended = assert(() => {
     const current = [...(subject.subPieces ?? [])];
     return current.length === 3 && current[2].type === "phone";
   });
-  const assert_phone_result = computed(() => phone.get()?.moduleIndex === 2);
+  const assert_phone_result = assert(() => phone.get()?.moduleIndex === 2);
 
-  const assert_initial_data_accepted = computed(() => {
+  const assert_initial_data_accepted = assert(() => {
     const result = withInitialData.get();
     return result?.success === true && result?.moduleIndex === 3;
   });
 
   // Adds land in the order they were sent, and nothing earlier moved.
-  const assert_entries_in_add_order = computed(() => {
+  const assert_entries_in_add_order = assert(() => {
     const types = [...(subject.subPieces ?? [])].map((entry) => entry.type);
     return types.length === 4 &&
       types[0] === "email" &&
@@ -177,7 +177,7 @@ export default pattern(() => {
   });
 
   // Every reported index addresses the module that its own add created.
-  const assert_reported_indices_address_their_modules = computed(() => {
+  const assert_reported_indices_address_their_modules = assert(() => {
     const current = [...(subject.subPieces ?? [])];
     const reported = [
       { index: firstEmail.get()?.moduleIndex, type: "email" },
@@ -193,50 +193,50 @@ export default pattern(() => {
   // The smart-default label walks the standard list as successive modules of
   // the same type are added; a different type starts its own sequence; an
   // explicit label in initialData overrides the default.
-  const assert_first_email_label_personal = computed(() =>
+  const assert_first_email_label_personal = assert(() =>
     [...(subject.subPieces ?? [])][0]?.label === "Personal"
   );
-  const assert_second_email_label_work = computed(() =>
+  const assert_second_email_label_work = assert(() =>
     [...(subject.subPieces ?? [])][1]?.label === "Work"
   );
-  const assert_phone_label_mobile = computed(() =>
+  const assert_phone_label_mobile = assert(() =>
     [...(subject.subPieces ?? [])][2]?.label === "Mobile"
   );
-  const assert_address_label_override = computed(() =>
+  const assert_address_label_override = assert(() =>
     [...(subject.subPieces ?? [])][3]?.label === "Chosen"
   );
 
   // A third email add reads two prior emails (Personal, Work) and picks the
   // next unused standard label. This fails if getNextUnusedLabel cannot see the
   // labels the earlier adds assigned.
-  const assert_third_email_appended = computed(() => {
+  const assert_third_email_appended = assert(() => {
     const current = [...(subject.subPieces ?? [])];
     return current.length === 5 && current[4].type === "email";
   });
-  const assert_third_email_label_school = computed(() =>
+  const assert_third_email_label_school = assert(() =>
     [...(subject.subPieces ?? [])][4]?.label === "School"
   );
 
   // The rejection paths report the reason and leave the list alone.
-  const assert_unknown_type_rejected = computed(() => {
+  const assert_unknown_type_rejected = assert(() => {
     const result = unknownType.get();
     return result?.success === false &&
       typeof result?.error === "string" &&
       result.error.includes("Unknown module type");
   });
-  const assert_missing_type_rejected = computed(() => {
+  const assert_missing_type_rejected = assert(() => {
     const result = missingType.get();
     return result?.success === false &&
       typeof result?.error === "string" &&
       result.error.includes("Module type is required");
   });
-  const assert_notes_type_rejected = computed(() => {
+  const assert_notes_type_rejected = assert(() => {
     const result = notesType.get();
     return result?.success === false &&
       typeof result?.error === "string" &&
       result.error.includes("Notes modules must be added via UI");
   });
-  const assert_rejections_appended_nothing = computed(() =>
+  const assert_rejections_appended_nothing = assert(() =>
     [...(subject.subPieces ?? [])].length === 4
   );
 

--- a/packages/patterns/regression/ct1639-equals-removal.test.tsx
+++ b/packages/patterns/regression/ct1639-equals-removal.test.tsx
@@ -18,7 +18,7 @@
  * Run: deno task cf test packages/patterns/regression/ct1639-equals-removal.test.tsx
  */
 import {
-  computed,
+  assert,
   Default,
   equals,
   handler,
@@ -75,21 +75,21 @@ export default pattern(() => {
   ]);
   const repro = Repro({ items: itemsCell });
 
-  const assertStartsThree = computed(() => repro.items.length === 3);
+  const assertStartsThree = assert(() => repro.items.length === 3);
 
   // Remove the middle item ("b") via equals()-located findIndex.
   const removeMiddle = removeAt({ items: itemsCell, which: 1 });
-  const assertTwoAfterRemove = computed(() => repro.items.length === 2);
-  const assertMiddleGone = computed(() =>
+  const assertTwoAfterRemove = assert(() => repro.items.length === 2);
+  const assertMiddleGone = assert(() =>
     repro.items.findIndex((i: Item) => i.label === "b") === -1
   );
-  const assertEndsRemain = computed(() =>
+  const assertEndsRemain = assert(() =>
     repro.items[0]?.label === "a" && repro.items[1]?.label === "c"
   );
 
   // Removing by a linkless plain value must NOT match → "a" stays.
   const removeByValue = removeByPlainValue({ items: itemsCell, label: "a" });
-  const assertPlainValueNoops = computed(() =>
+  const assertPlainValueNoops = assert(() =>
     repro.items.findIndex((i: Item) => i.label === "a") !== -1
   );
 

--- a/packages/patterns/scoped-group-chat/main.test.tsx
+++ b/packages/patterns/scoped-group-chat/main.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, assert, pattern, Writable } from "commonfabric";
 import ScopedGroupChat, {
   type Conversation,
   type SelectedRoom,
@@ -32,21 +32,21 @@ export default pattern(() => {
     });
   });
 
-  const assert_initial_scoped_fields = computed(() => chat.roomCount === 0);
+  const assert_initial_scoped_fields = assert(() => chat.roomCount === 0);
 
-  const assert_added_room_is_selected = computed(() =>
+  const assert_added_room_is_selected = assert(() =>
     chat.roomCount === 1 &&
     chat.selectedRoom.room?.name === "Garden" &&
     chat.messageCount === 0
   );
 
-  const assert_second_room_is_selected = computed(() =>
+  const assert_second_room_is_selected = assert(() =>
     chat.roomCount === 2 &&
     chat.selectedRoom.room?.name === "Library" &&
     chat.messageCount === 0
   );
 
-  const assert_selected_room_reference_changed = computed(() =>
+  const assert_selected_room_reference_changed = assert(() =>
     chat.selectedRoom.room?.name === "Garden"
   );
 

--- a/packages/patterns/scoped-user-directory/main.test.tsx
+++ b/packages/patterns/scoped-user-directory/main.test.tsx
@@ -14,7 +14,7 @@
  *
  * Run: deno task cf test packages/patterns/scoped-user-directory/main.test.tsx
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, assert, pattern, Writable } from "commonfabric";
 import ScopedUserDirectory, {
   type Directory,
   type UserPointer,
@@ -39,26 +39,26 @@ export default pattern(() => {
   // === Assertions ===
 
   // Initial state
-  const assert_users_empty = computed(() => subject.userCount === 0);
-  const assert_me_undefined = computed(() => me.get().user === undefined);
+  const assert_users_empty = assert(() => subject.userCount === 0);
+  const assert_me_undefined = assert(() => me.get().user === undefined);
 
   // After joining as "Alex"
-  const assert_one_user = computed(() => subject.userCount === 1);
-  const assert_me_is_alex = computed(() =>
+  const assert_one_user = assert(() => subject.userCount === 1);
+  const assert_me_is_alex = assert(() =>
     subject.me.user?.displayName === "Alex"
   );
   // Note: reactive traversal through subject.directory.users[0]?.displayName
   // returns undefined (PerSpace array element reactive traversal does not work).
   // Raw .get() on the underlying cell works correctly:
-  const assert_directory_first_is_alex = computed(() =>
+  const assert_directory_first_is_alex = assert(() =>
     directory.get().users[0]?.displayName === "Alex"
   );
 
   // After renaming via me.user link (proves it's a link, not a copy)
-  const assert_directory_first_is_alexander = computed(() =>
+  const assert_directory_first_is_alexander = assert(() =>
     directory.get().users[0]?.displayName === "Alexander"
   );
-  const assert_me_is_alexander = computed(() =>
+  const assert_me_is_alexander = assert(() =>
     subject.me.user?.displayName === "Alexander"
   );
 

--- a/packages/patterns/scrabble/scrabble.test.tsx
+++ b/packages/patterns/scrabble/scrabble.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, computed, pattern } from "commonfabric";
 import Scrabble, { type Letter } from "./scrabble.tsx";
 
 const tile = (char: string, id: string): Letter => ({
@@ -66,7 +66,7 @@ export default pattern(() => {
     scrabble.resetGame.send();
   });
 
-  const assert_off_center_word_rejected = computed(() =>
+  const assert_off_center_word_rejected = assert(() =>
     scrabble.players.length === 1 &&
     scrabble.players[0]?.name === "Alice" &&
     scrabble.board.length === 0 &&
@@ -76,7 +76,7 @@ export default pattern(() => {
     scrabble.message === "The first word must cover the center star."
   );
 
-  const assert_joined_name_is_immutable = computed(() =>
+  const assert_joined_name_is_immutable = assert(() =>
     scrabble.players.length === 1 &&
     scrabble.players[0]?.name === "Alice" &&
     scrabble.myName === "Alice" &&
@@ -104,13 +104,13 @@ export default pattern(() => {
       scrabble.message.startsWith("Scored 4:");
   });
 
-  const assert_clear_returns_tiles = computed(() =>
+  const assert_clear_returns_tiles = assert(() =>
     scrabble.placed.length === 0 &&
     scrabble.rack.length === 7 &&
     scrabble.message === "Cleared your unsubmitted tiles."
   );
 
-  const assert_reset_clears_game = computed(() =>
+  const assert_reset_clears_game = assert(() =>
     scrabble.board.length === 0 &&
     scrabble.players.length === 0 &&
     scrabble.gameEvents.length === 0 &&

--- a/packages/patterns/self-improving-classifier.test.tsx
+++ b/packages/patterns/self-improving-classifier.test.tsx
@@ -11,7 +11,7 @@
  * instead of action() with closures to avoid "reactive reference outside
  * reactive context" errors when accessing proxy objects like subject.submitItem.
  */
-import { Cell, computed, handler, pattern, Stream } from "commonfabric";
+import { assert, Cell, handler, pattern, Stream } from "commonfabric";
 import SelfImprovingClassifier, {
   type ClassificationRule,
   type LabeledExample,
@@ -127,26 +127,26 @@ export default pattern(() => {
   // ============= ASSERTIONS =============
 
   // Initial state assertions
-  const assert_initial_examples_empty = computed(() => {
+  const assert_initial_examples_empty = assert(() => {
     return subject.examples.length === 0;
   });
 
-  const assert_initial_rules_empty = computed(() => {
+  const assert_initial_rules_empty = assert(() => {
     return subject.rules.length === 0;
   });
 
   // After setup assertions
-  const assert_config_set = computed(() => {
+  const assert_config_set = assert(() => {
     return subject.config.question === "Is this email a bill?";
   });
 
-  const assert_rule_added = computed(() => {
+  const assert_rule_added = assert(() => {
     return subject.rules.length === 1 &&
       subject.rules[0].name === "Invoice Pattern";
   });
 
   // After submitting matching item - check first example is auto-classified
-  const assert_auto_classified = computed(() => {
+  const assert_auto_classified = assert(() => {
     if (subject.examples.length === 0) return false;
     const example = subject.examples[0];
     return (
@@ -157,7 +157,7 @@ export default pattern(() => {
   });
 
   // Stats should reflect auto-classification
-  const assert_stats_updated = computed(() => {
+  const assert_stats_updated = assert(() => {
     return subject.stats.totalExamples === 1 &&
       subject.stats.autoClassified === 1;
   });
@@ -165,14 +165,14 @@ export default pattern(() => {
   // After clearing and submitting non-matching item
   // Non-matching items go to LLM path, not auto-classified
   // In test environment without LLM, examples should remain empty
-  const assert_examples_still_empty_after_non_match = computed(() => {
+  const assert_examples_still_empty_after_non_match = assert(() => {
     return subject.examples.length === 0;
   });
 
   // After auto-classification, rule metrics should be higher than the initial values
   // Initial rule was set with evaluationCount: 50, truePositives: 40
   // After two successful auto-classifications, should be 52 and 42
-  const assert_rule_metrics_updated = computed(() => {
+  const assert_rule_metrics_updated = assert(() => {
     if (subject.rules.length === 0) return false;
     const rule = subject.rules[0];
     // Check metrics are higher than initial values (50 and 40)

--- a/packages/patterns/self.test.tsx
+++ b/packages/patterns/self.test.tsx
@@ -14,7 +14,7 @@
  *
  * Run: deno task cf test packages/patterns/self.test.tsx --verbose
  */
-import { computed, handler, pattern, Writable } from "commonfabric";
+import { assert, computed, handler, pattern, Writable } from "commonfabric";
 import Self, {
   addValueCardFromForm,
   appendResponse,
@@ -106,31 +106,31 @@ export default pattern(() => {
 
   // A1: append when model is empty
   const after_append_mbti = upsertNeurotype(EMPTY_SELF_MODEL, MBTI_INTJ);
-  const assert_append_count = computed(
+  const assert_append_count = assert(
     () => after_append_mbti.neurotypes.length === 1,
   );
-  const assert_append_result = computed(
+  const assert_append_result = assert(
     () => after_append_mbti.neurotypes[0]?.result === "INTJ",
   );
-  const assert_append_system = computed(
+  const assert_append_system = assert(
     () => after_append_mbti.neurotypes[0]?.system === "mbti",
   );
 
   // A2: upsert replaces same system, count stays 1
   const after_upsert_mbti = upsertNeurotype(after_append_mbti, MBTI_ENTP);
-  const assert_upsert_count = computed(
+  const assert_upsert_count = assert(
     () => after_upsert_mbti.neurotypes.length === 1,
   );
-  const assert_upsert_result = computed(
+  const assert_upsert_result = assert(
     () => after_upsert_mbti.neurotypes[0]?.result === "ENTP",
   );
 
   // A3: different system coexists — two entries
   const after_add_enneagram = upsertNeurotype(after_upsert_mbti, ENNEAGRAM_5W4);
-  const assert_coexist_count = computed(
+  const assert_coexist_count = assert(
     () => after_add_enneagram.neurotypes.length === 2,
   );
-  const assert_enneagram_present = computed(
+  const assert_enneagram_present = assert(
     () =>
       after_add_enneagram.neurotypes.some(
         (n) => n.system === "enneagram" && n.result === "5w4",
@@ -141,19 +141,19 @@ export default pattern(() => {
 
   // A4: append first value card
   const after_add_curiosity = appendValue(EMPTY_SELF_MODEL, CURIOSITY_CARD);
-  const assert_value_count_1 = computed(
+  const assert_value_count_1 = assert(
     () => after_add_curiosity.values.length === 1,
   );
-  const assert_value_title_curiosity = computed(
+  const assert_value_title_curiosity = assert(
     () => after_add_curiosity.values[0]?.title === "Curiosity",
   );
 
   // A5: append second value card — two entries, order preserved
   const after_add_autonomy = appendValue(after_add_curiosity, AUTONOMY_CARD);
-  const assert_value_count_2 = computed(
+  const assert_value_count_2 = assert(
     () => after_add_autonomy.values.length === 2,
   );
-  const assert_value_order = computed(
+  const assert_value_order = assert(
     () =>
       after_add_autonomy.values[0]?.title === "Curiosity" &&
       after_add_autonomy.values[1]?.title === "Autonomy",
@@ -163,13 +163,13 @@ export default pattern(() => {
 
   // A6: append a response
   const after_add_response = appendResponse(EMPTY_SELF_MODEL, MEANING_RESPONSE);
-  const assert_response_count = computed(
+  const assert_response_count = assert(
     () => after_add_response.responses.length === 1,
   );
-  const assert_response_track = computed(
+  const assert_response_track = assert(
     () => after_add_response.responses[0]?.track === "meaning",
   );
-  const assert_response_prompt_id = computed(
+  const assert_response_prompt_id = assert(
     () => after_add_response.responses[0]?.promptId === "p1",
   );
 
@@ -180,10 +180,10 @@ export default pattern(() => {
     after_add_enneagram,
     "enneagram",
   );
-  const assert_remove_neuro_count = computed(
+  const assert_remove_neuro_count = assert(
     () => after_remove_enneagram.neurotypes.length === 1,
   );
-  const assert_mbti_remains = computed(
+  const assert_mbti_remains = assert(
     () => after_remove_enneagram.neurotypes[0]?.system === "mbti",
   );
 
@@ -192,7 +192,7 @@ export default pattern(() => {
     after_remove_enneagram,
     "big5",
   );
-  const assert_remove_absent_noop = computed(
+  const assert_remove_absent_noop = assert(
     () => after_remove_absent.neurotypes.length === 1,
   );
 
@@ -200,16 +200,16 @@ export default pattern(() => {
 
   // A9: remove first value (index 0) — only Autonomy remains
   const after_remove_first = withoutValueAt(after_add_autonomy, 0);
-  const assert_remove_value_count = computed(
+  const assert_remove_value_count = assert(
     () => after_remove_first.values.length === 1,
   );
-  const assert_autonomy_remains = computed(
+  const assert_autonomy_remains = assert(
     () => after_remove_first.values[0]?.title === "Autonomy",
   );
 
   // A10: remove last value (index 0 of single-item list) — empty
   const after_remove_last = withoutValueAt(after_remove_first, 0);
-  const assert_values_empty = computed(
+  const assert_values_empty = assert(
     () => after_remove_last.values.length === 0,
   );
 
@@ -231,13 +231,13 @@ export default pattern(() => {
   const selfOwned = Self({});
   const ownedModel = computed(() => selfOwned.selfModel);
 
-  const assert_owned_responses_empty = computed(
+  const assert_owned_responses_empty = assert(
     () => ownedModel.get().responses.length === 0,
   );
-  const assert_owned_values_empty = computed(
+  const assert_owned_values_empty = assert(
     () => ownedModel.get().values.length === 0,
   );
-  const assert_owned_neurotypes_empty = computed(
+  const assert_owned_neurotypes_empty = assert(
     () => ownedModel.get().neurotypes.length === 0,
   );
 
@@ -254,7 +254,7 @@ export default pattern(() => {
     index: 0,
   });
 
-  const assert_values_empty_after_remove = computed(
+  const assert_values_empty_after_remove = assert(
     () => selfModelValues.get().values.length === 0,
   );
 
@@ -273,7 +273,7 @@ export default pattern(() => {
     resultField,
   });
 
-  const assert_form_recorded_enneagram = computed(() =>
+  const assert_form_recorded_enneagram = assert(() =>
     selfModel2
       .get()
       .neurotypes.some(
@@ -284,7 +284,7 @@ export default pattern(() => {
       )
   );
 
-  const assert_result_field_cleared = computed(
+  const assert_result_field_cleared = assert(
     () => resultField.get() === "",
   );
 
@@ -305,13 +305,13 @@ export default pattern(() => {
     resultField: resultField2b,
   });
 
-  const assert_form_upsert_length_one = computed(
+  const assert_form_upsert_length_one = assert(
     () =>
       selfModel2.get().neurotypes.filter((n) => n.system === "mbti").length ===
         1,
   );
 
-  const assert_form_upsert_result_enfp = computed(
+  const assert_form_upsert_result_enfp = assert(
     () =>
       selfModel2
         .get()
@@ -324,7 +324,7 @@ export default pattern(() => {
     system: "enneagram",
   });
 
-  const assert_only_mbti_after_remove = computed(() => {
+  const assert_only_mbti_after_remove = assert(() => {
     const neurotypes = selfModel2.get().neurotypes;
     return neurotypes.length === 1 && neurotypes[0]?.system === "mbti";
   });
@@ -336,16 +336,16 @@ export default pattern(() => {
   const selfModel3 = new Writable<SelfModel>(EMPTY_SELF_MODEL);
 
   // Test 9: MEANING_PROMPTS sanity — 8 entries, correct kinds present
-  const assert_meaning_prompts_count = computed(
+  const assert_meaning_prompts_count = assert(
     () => MEANING_PROMPTS.length === 8,
   );
-  const assert_meaning_prompts_has_open = computed(
+  const assert_meaning_prompts_has_open = assert(
     () => MEANING_PROMPTS.some((p) => p.kind === "open"),
   );
-  const assert_meaning_prompts_has_scissor = computed(
+  const assert_meaning_prompts_has_scissor = assert(
     () => MEANING_PROMPTS.some((p) => p.kind === "scissor"),
   );
-  const assert_meaning_prompts_has_closing = computed(
+  const assert_meaning_prompts_has_closing = assert(
     () => MEANING_PROMPTS.some((p) => p.kind === "closing"),
   );
 
@@ -362,24 +362,24 @@ export default pattern(() => {
     answerField: answerField10,
   });
 
-  const assert_reflection_appended = computed(
+  const assert_reflection_appended = assert(
     () => selfModel3.get().responses.length === 1,
   );
-  const assert_reflection_track_meaning = computed(
+  const assert_reflection_track_meaning = assert(
     () => selfModel3.get().responses[0]?.track === "meaning",
   );
-  const assert_reflection_prompt_id = computed(
+  const assert_reflection_prompt_id = assert(
     () => selfModel3.get().responses[0]?.promptId === promptId10,
   );
-  const assert_reflection_prompt_text = computed(
+  const assert_reflection_prompt_text = assert(
     () => selfModel3.get().responses[0]?.prompt === MEANING_PROMPTS[0].text,
   );
-  const assert_reflection_answer = computed(
+  const assert_reflection_answer = assert(
     () =>
       selfModel3.get().responses[0]?.answer ===
         "I work as a designer and live with my partner.",
   );
-  const assert_answer_field_cleared = computed(
+  const assert_answer_field_cleared = assert(
     () => answerField10.get() === "",
   );
 
@@ -402,21 +402,21 @@ export default pattern(() => {
     contextTagsField: contextTagsField11,
   });
 
-  const assert_value_appended = computed(
+  const assert_value_appended = assert(
     () => selfModel4.get().values.length === 1,
   );
-  const assert_value_title = computed(
+  const assert_value_title = assert(
     () => selfModel4.get().values[0]?.title === "Direct feedback",
   );
-  const assert_value_attending_to = computed(
+  const assert_value_attending_to = assert(
     () =>
       selfModel4.get().values[0]?.attendingTo ===
         "a disagreement at the moment it is live",
   );
-  const assert_value_stance = computed(
+  const assert_value_stance = assert(
     () => selfModel4.get().values[0]?.stance === "descriptive",
   );
-  const assert_value_context_tags = computed(() => {
+  const assert_value_context_tags = assert(() => {
     const tags = selfModel4.get().values[0]?.contextTags;
     return (
       Array.isArray(tags) &&
@@ -425,11 +425,11 @@ export default pattern(() => {
       tags[1] === "team"
     );
   });
-  const assert_title_field_cleared = computed(() => titleField11.get() === "");
-  const assert_attending_field_cleared = computed(
+  const assert_title_field_cleared = assert(() => titleField11.get() === "");
+  const assert_attending_field_cleared = assert(
     () => attendingToField11.get() === "",
   );
-  const assert_context_tags_field_cleared = computed(
+  const assert_context_tags_field_cleared = assert(
     () => contextTagsField11.get() === "",
   );
 
@@ -470,10 +470,10 @@ export default pattern(() => {
     index: 0,
   });
 
-  const assert_only_second_remains = computed(
+  const assert_only_second_remains = assert(
     () => selfModel5.get().values.length === 1,
   );
-  const assert_second_value_title = computed(
+  const assert_second_value_title = assert(
     () => selfModel5.get().values[0]?.title === "Second value",
   );
 

--- a/packages/patterns/shopping-list.test.tsx
+++ b/packages/patterns/shopping-list.test.tsx
@@ -18,7 +18,7 @@
  */
 import {
   action,
-  computed,
+  assert,
   equals,
   handler,
   pattern,
@@ -164,75 +164,69 @@ Fresh vegetables and fruits
   // ==========================================================================
 
   // Initial state - use totalCount which is computed from items.get().length
-  const assert_initial_empty = computed(() => list.totalCount === 0);
-  const assert_initial_total_zero = computed(() => list.totalCount === 0);
-  const assert_initial_done_zero = computed(() => list.doneCount === 0);
-  const assert_initial_remaining_zero = computed(() =>
-    list.remainingCount === 0
-  );
+  const assert_initial_empty = assert(() => list.totalCount === 0);
+  const assert_initial_total_zero = assert(() => list.totalCount === 0);
+  const assert_initial_done_zero = assert(() => list.doneCount === 0);
+  const assert_initial_remaining_zero = assert(() => list.remainingCount === 0);
 
   // After adding one item
-  const assert_one_item = computed(() => list.totalCount === 1);
-  const assert_total_one = computed(() => list.totalCount === 1);
-  const assert_remaining_one = computed(() => list.remainingCount === 1);
-  const assert_first_item_milk = computed(() =>
-    list.items[0]?.title === "Milk"
-  );
+  const assert_one_item = assert(() => list.totalCount === 1);
+  const assert_total_one = assert(() => list.totalCount === 1);
+  const assert_remaining_one = assert(() => list.remainingCount === 1);
+  const assert_first_item_milk = assert(() => list.items[0]?.title === "Milk");
 
   // After adding three items
-  const assert_three_items = computed(() => list.totalCount === 3);
-  const assert_total_three = computed(() => list.totalCount === 3);
-  const assert_remaining_three = computed(() => list.remainingCount === 3);
-  const assert_done_still_zero = computed(() => list.doneCount === 0);
+  const assert_three_items = assert(() => list.totalCount === 3);
+  const assert_total_three = assert(() => list.totalCount === 3);
+  const assert_remaining_three = assert(() => list.remainingCount === 3);
+  const assert_done_still_zero = assert(() => list.doneCount === 0);
 
   // After marking first done
-  const assert_done_one = computed(() => list.doneCount === 1);
-  const assert_remaining_two = computed(() => list.remainingCount === 2);
-  const assert_first_is_done = computed(() => list.items[0]?.done === true);
+  const assert_done_one = assert(() => list.doneCount === 1);
+  const assert_remaining_two = assert(() => list.remainingCount === 2);
+  const assert_first_is_done = assert(() => list.items[0]?.done === true);
 
   // After removing first item
-  const assert_two_items = computed(() => list.totalCount === 2);
-  const assert_total_two = computed(() => list.totalCount === 2);
-  const assert_done_zero_after_remove = computed(() => list.doneCount === 0);
-  const assert_first_now_bread = computed(() =>
-    list.items[0]?.title === "Bread"
-  );
+  const assert_two_items = assert(() => list.totalCount === 2);
+  const assert_total_two = assert(() => list.totalCount === 2);
+  const assert_done_zero_after_remove = assert(() => list.doneCount === 0);
+  const assert_first_now_bread = assert(() => list.items[0]?.title === "Bread");
 
   // Store layout
-  const assert_no_layout_initially = computed(() =>
+  const assert_no_layout_initially = assert(() =>
     String(list.storeLayout).trim().length === 0
   );
-  const assert_has_layout = computed(() =>
+  const assert_has_layout = assert(() =>
     String(list.storeLayout).trim().length > 0
   );
-  const assert_layout_cleared = computed(() =>
+  const assert_layout_cleared = assert(() =>
     String(list.storeLayout).trim().length === 0
   );
 
   // === Held-reference survival assertions (CT-1715) ===
-  const assert_held_stashed = computed(() => {
+  const assert_held_stashed = assert(() => {
     const h = heldItem.get();
     return h.title === "Bread" && equals(itemsCell.get()[0], h);
   });
-  const assert_override_set = computed(() =>
+  const assert_override_set = assert(() =>
     itemsCell.get()[0]?.aisleOverride === "Aisle 2"
   );
-  const assert_correction_closed = computed(() =>
+  const assert_correction_closed = assert(() =>
     correctionIndexCell.get() === -1
   );
   // KEY: the stale-but-once-valid reference still equals()-matches the item
   // AFTER selectAisle updated it.
-  const assert_held_survives_correction = computed(() => {
+  const assert_held_survives_correction = assert(() => {
     const h = heldItem.get();
     return equals(itemsCell.get()[0], h);
   });
   // The held reference also READS the update (it would show the stale,
   // orphaned entity if selectAisle had re-minted identity).
-  const assert_held_reads_correction = computed(() =>
+  const assert_held_reads_correction = assert(() =>
     heldItem.get().aisleOverride === "Aisle 2"
   );
   // KEY: the held reference still DRIVES an equals()-located removal.
-  const assert_removed_via_held = computed(() =>
+  const assert_removed_via_held = assert(() =>
     list.totalCount === 1 && list.items[0]?.title === "Eggs"
   );
 

--- a/packages/patterns/simple-list/simple-list.test.tsx
+++ b/packages/patterns/simple-list/simple-list.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/simple-list/simple-list.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import SimpleListModule from "./simple-list.tsx";
 
 export default pattern(() => {
@@ -87,85 +87,85 @@ export default pattern(() => {
   // ==========================================================================
 
   // Initial state
-  const assert_initial_empty = computed(() => {
+  const assert_initial_empty = assert(() => {
     return list.items.filter(() => true).length === 0;
   });
 
   // After adding items
-  const assert_has_one = computed(() => {
+  const assert_has_one = assert(() => {
     return list.items.filter(() => true).length === 1;
   });
 
-  const assert_first_text = computed(() => {
+  const assert_first_text = assert(() => {
     return list.items[0]?.text === "First item";
   });
 
-  const assert_first_not_indented = computed(() => {
+  const assert_first_not_indented = assert(() => {
     return list.items[0]?.indented === false;
   });
 
-  const assert_first_not_done = computed(() => {
+  const assert_first_not_done = assert(() => {
     return list.items[0]?.done === false;
   });
 
-  const assert_has_two = computed(() => {
+  const assert_has_two = assert(() => {
     return list.items.filter(() => true).length === 2;
   });
 
-  const assert_has_three = computed(() => {
+  const assert_has_three = assert(() => {
     return list.items.filter(() => true).length === 3;
   });
 
   // Empty string shouldn't add
-  const assert_still_three = computed(() => {
+  const assert_still_three = assert(() => {
     return list.items.filter(() => true).length === 3;
   });
 
   // After toggle indent on first item
-  const assert_first_indented = computed(() => {
+  const assert_first_indented = assert(() => {
     return list.items[0]?.indented === true;
   });
 
   // After toggle again (back to not indented)
-  const assert_first_not_indented_again = computed(() => {
+  const assert_first_not_indented_again = assert(() => {
     return list.items[0]?.indented === false;
   });
 
   // After setIndent on second item
-  const assert_second_indented = computed(() => {
+  const assert_second_indented = assert(() => {
     return list.items[1]?.indented === true;
   });
 
-  const assert_second_not_indented = computed(() => {
+  const assert_second_not_indented = assert(() => {
     return list.items[1]?.indented === false;
   });
 
   // After deleting middle item
-  const assert_back_to_two = computed(() => {
+  const assert_back_to_two = assert(() => {
     return list.items.filter(() => true).length === 2;
   });
 
-  const assert_second_is_third = computed(() => {
+  const assert_second_is_third = assert(() => {
     // After deleting "Second item", "Third item" should now be at index 1
     return list.items[1]?.text === "Third item";
   });
 
   // After deleting first item
-  const assert_down_to_one = computed(() => {
+  const assert_down_to_one = assert(() => {
     return list.items.filter(() => true).length === 1;
   });
 
-  const assert_remaining_is_third = computed(() => {
+  const assert_remaining_is_third = assert(() => {
     return list.items[0]?.text === "Third item";
   });
 
   // After deleting last item
-  const assert_back_to_empty = computed(() => {
+  const assert_back_to_empty = assert(() => {
     return list.items.filter(() => true).length === 0;
   });
 
   // After invalid operations (should still be empty, no crash)
-  const assert_still_empty = computed(() => {
+  const assert_still_empty = assert(() => {
     return list.items.filter(() => true).length === 0;
   });
 

--- a/packages/patterns/store-mapper.test.tsx
+++ b/packages/patterns/store-mapper.test.tsx
@@ -27,7 +27,7 @@
  */
 import {
   action,
-  computed,
+  assert,
   equals,
   handler,
   pattern,
@@ -228,72 +228,68 @@ export default pattern(() => {
   // ==========================================================================
 
   // Initial state - use computed count values for reliable reactive array length checks
-  const assert_initial_store_name = computed(() =>
+  const assert_initial_store_name = assert(() =>
     String(store.storeName) === "Test Store"
   );
-  const assert_initial_no_aisles = computed(() =>
-    Number(store.aisleCount) === 0
-  );
+  const assert_initial_no_aisles = assert(() => Number(store.aisleCount) === 0);
   // With auto-populated default departments (7 total)
-  const assert_initial_default_departments = computed(() =>
+  const assert_initial_default_departments = assert(() =>
     Number(store.deptCount) === 7
   );
-  const assert_initial_no_corrections = computed(() =>
+  const assert_initial_no_corrections = assert(() =>
     Number(store.correctionCount) === 0
   );
 
   // After adding aisles - use computed aisleCount for reliable reactive array length checks
-  const assert_one_aisle = computed(() => Number(store.aisleCount) === 1);
-  const assert_two_aisles = computed(() => Number(store.aisleCount) === 2);
-  const assert_three_aisles = computed(() => Number(store.aisleCount) === 3);
-  const assert_first_aisle_is_1 = computed(() => store.aisles[0]?.name === "1");
+  const assert_one_aisle = assert(() => Number(store.aisleCount) === 1);
+  const assert_two_aisles = assert(() => Number(store.aisleCount) === 2);
+  const assert_three_aisles = assert(() => Number(store.aisleCount) === 3);
+  const assert_first_aisle_is_1 = assert(() => store.aisles[0]?.name === "1");
 
   // After setting description
-  const assert_aisle_1_has_description = computed(() =>
+  const assert_aisle_1_has_description = assert(() =>
     store.aisles[0]?.description === "Dairy & Eggs"
   );
 
   // After loading departments - use computed deptCount for reliable reactive array length checks
-  const assert_three_departments = computed(() =>
-    Number(store.deptCount) === 3
-  );
-  const assert_bakery_exists = computed(() =>
+  const assert_three_departments = assert(() => Number(store.deptCount) === 3);
+  const assert_bakery_exists = assert(() =>
     store.departments[0]?.name === "Bakery"
   );
-  const assert_bakery_unassigned = computed(() =>
+  const assert_bakery_unassigned = assert(() =>
     store.departments[0]?.location === "unassigned"
   );
 
   // After assigning location
-  const assert_bakery_assigned = computed(() =>
+  const assert_bakery_assigned = assert(() =>
     store.departments[0]?.location === "front-left"
   );
 
   // After adding correction - use computed correctionCount for reliable reactive array length checks
-  const assert_one_correction = computed(() =>
+  const assert_one_correction = assert(() =>
     Number(store.correctionCount) === 1
   );
-  const assert_coffee_correction = computed(() =>
+  const assert_coffee_correction = assert(() =>
     store.itemLocations[0]?.itemName === "Coffee" &&
     store.itemLocations[0]?.correctAisle === "Aisle 5"
   );
 
   // Outline generation
-  const assert_outline_contains_aisle_1 = computed(() =>
+  const assert_outline_contains_aisle_1 = assert(() =>
     String(store.outline).includes("# Aisle 1")
   );
-  const assert_outline_contains_description = computed(() =>
+  const assert_outline_contains_description = assert(() =>
     String(store.outline).includes("Dairy & Eggs")
   );
-  const assert_outline_contains_bakery = computed(() =>
+  const assert_outline_contains_bakery = assert(() =>
     String(store.outline).includes("# Bakery")
   );
-  const assert_outline_contains_coffee = computed(() =>
+  const assert_outline_contains_coffee = assert(() =>
     String(store.outline).includes("Coffee")
   );
 
   // Store name change
-  const assert_store_name_changed = computed(() =>
+  const assert_store_name_changed = assert(() =>
     String(store.storeName) === "My Grocery Store"
   );
 
@@ -369,93 +365,91 @@ export default pattern(() => {
   // ==========================================================================
 
   // After adding extracted aisle 8
-  const assert_four_aisles = computed(() => Number(store.aisleCount) === 4);
-  const assert_aisle_8_exists = computed(() =>
+  const assert_four_aisles = assert(() => Number(store.aisleCount) === 4);
+  const assert_aisle_8_exists = assert(() =>
     store.aisles.some((a: Aisle) => a.name === "8")
   );
-  const assert_aisle_8_has_products = computed(() => {
+  const assert_aisle_8_has_products = assert(() => {
     const aisle8 = store.aisles.find((a: Aisle) => a.name === "8");
-    return aisle8 &&
+    return aisle8 !== undefined &&
       String(aisle8.description).includes("Bread") &&
       String(aisle8.description).includes("Cereal") &&
       String(aisle8.description).includes("Coffee");
   });
 
   // After adding extracted aisle 9 with null products
-  const assert_five_aisles = computed(() => Number(store.aisleCount) === 5);
-  const assert_aisle_9_exists = computed(() =>
+  const assert_five_aisles = assert(() => Number(store.aisleCount) === 5);
+  const assert_aisle_9_exists = assert(() =>
     store.aisles.some((a: Aisle) => a.name === "9")
   );
-  const assert_aisle_9_empty_description = computed(() => {
+  const assert_aisle_9_empty_description = assert(() => {
     const aisle9 = store.aisles.find((a: Aisle) => a.name === "9");
-    return aisle9 && String(aisle9.description) === "";
+    return aisle9 !== undefined && String(aisle9.description) === "";
   });
 
   // After attempting to add duplicate aisle 8 (count should remain 5)
-  const assert_still_five_aisles = computed(() =>
-    Number(store.aisleCount) === 5
-  );
-  const assert_aisle_8_unchanged = computed(() => {
+  const assert_still_five_aisles = assert(() => Number(store.aisleCount) === 5);
+  const assert_aisle_8_unchanged = assert(() => {
     const aisle8 = store.aisles.find((a: Aisle) => a.name === "8");
     // Description should NOT contain Snacks or Chips from the duplicate attempt
-    return aisle8 &&
+    return aisle8 !== undefined &&
       !String(aisle8.description).includes("Snacks") &&
       !String(aisle8.description).includes("Chips");
   });
 
   // After merging into aisle 8
-  const assert_aisle_8_merged = computed(() => {
+  const assert_aisle_8_merged = assert(() => {
     const aisle8 = store.aisles.find((a: Aisle) => a.name === "8");
     // Should have original items plus Tea and Sugar, but Coffee only once
-    return aisle8 &&
+    return aisle8 !== undefined &&
       String(aisle8.description).includes("Bread") &&
       String(aisle8.description).includes("Tea") &&
       String(aisle8.description).includes("Sugar");
   });
-  const assert_aisle_8_no_duplicate_coffee = computed(() => {
+  const assert_aisle_8_no_duplicate_coffee = assert(() => {
     const aisle8 = store.aisles.find((a: Aisle) => a.name === "8");
     if (!aisle8) return false;
     // Count occurrences of "Coffee" in description
     const matches = String(aisle8.description).match(/Coffee/g);
-    return matches && matches.length === 1;
+    return matches !== null && matches.length === 1;
   });
 
   // ==========================================================================
   // Held-reference survival assertions (CT-1715)
   // ==========================================================================
 
-  const assert_held_dept_stashed = computed(() => {
+  const assert_held_dept_stashed = assert(() => {
     const h = heldDept.get();
     return h.name !== "" && equals(store.departments[0], h);
   });
-  const assert_dept_relocated = computed(() =>
+  const assert_dept_relocated = assert(() =>
     store.departments[0]?.location === "back-center"
   );
   // KEY: the stale-but-once-valid reference still equals()-matches the
   // department AFTER setDepartmentLocation updated it.
-  const assert_held_dept_survives = computed(() => {
+  const assert_held_dept_survives = assert(() => {
     const h = heldDept.get();
     return h.name !== "" && equals(store.departments[0], h);
   });
   // KEY: the held reference still DRIVES the handler after the update.
-  const assert_dept_relocated_via_held = computed(() =>
+  const assert_dept_relocated_via_held = assert(() =>
     store.departments[0]?.location === "right-back"
   );
 
-  const assert_held_aisle_stashed = computed(() => {
+  const assert_held_aisle_stashed = assert(() => {
     const h = heldAisle.get();
     return h.name !== "" && equals(store.aisles[3], h);
   });
-  const assert_aisle_8_has_honey = computed(() => {
+  const assert_aisle_8_has_honey = assert(() => {
     const aisle8 = store.aisles.find((a: Aisle) => a.name === "8");
     return aisle8 !== undefined &&
       String(aisle8.description).includes("Honey");
   });
-  const assert_held_aisle_survives = computed(() => {
+  const assert_held_aisle_survives = assert(() => {
     const h = heldAisle.get();
     return h.name !== "" && equals(store.aisles[3], h);
   });
-  const assert_aisle_8_removed_via_held = computed(() =>
+  const assert_aisle_8_removed_via_held = assert(() =>
     Number(store.aisleCount) === 4 &&
     store.aisles.find((a: Aisle) => a.name === "8") === undefined
   );

--- a/packages/patterns/system/default-app.test.tsx
+++ b/packages/patterns/system/default-app.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/system/default-app.test.tsx --root packages/patterns --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import DefaultApp from "./default-app.tsx";
 import Note from "../notes/note.tsx";
 
@@ -43,19 +43,19 @@ export default pattern(() => {
     addPieceOf(subject, otherNote)
   );
 
-  const assert_starts_empty = computed(() => piecesLengthOf(subject) === 0);
+  const assert_starts_empty = assert(() => piecesLengthOf(subject) === 0);
 
-  const assert_first_registration_lands = computed(() =>
+  const assert_first_registration_lands = assert(() =>
     piecesLengthOf(subject) === 1
   );
 
   // The same piece cell again must resolve to the same membership entry.
-  const assert_duplicate_registration_is_noop = computed(() =>
+  const assert_duplicate_registration_is_noop = assert(() =>
     piecesLengthOf(subject) === 1
   );
 
   // Dedup is by identity, not a cap: a distinct piece still lands.
-  const assert_distinct_piece_lands = computed(() =>
+  const assert_distinct_piece_lands = assert(() =>
     piecesLengthOf(subject) === 2
   );
 

--- a/packages/patterns/system/home.test.tsx
+++ b/packages/patterns/system/home.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, NAME, pattern, Writable } from "commonfabric";
+import { action, assert, NAME, pattern, Writable } from "commonfabric";
 import Home from "./home.tsx";
 
 export default pattern(() => {
@@ -7,7 +7,7 @@ export default pattern(() => {
   // A stable piece cell to favorite and unfavorite by identity.
   const piece = new Writable<{ [NAME]?: string }>({ [NAME]: "Fav Piece" });
 
-  const assert_initial_profile_missing = computed(() =>
+  const assert_initial_profile_missing = assert(() =>
     ((home.profiles as unknown[])?.length ?? 0) === 0
   );
 

--- a/packages/patterns/system/profile-create.test.tsx
+++ b/packages/patterns/system/profile-create.test.tsx
@@ -26,7 +26,7 @@
  *
  * Run: deno task cf test packages/patterns/system/profile-create.test.tsx --verbose
  */
-import { computed, pattern, UI, Writable } from "commonfabric";
+import { assert, pattern, UI, Writable } from "commonfabric";
 import ProfileCreate, {
   TRUSTED_PROFILE_CREATE_ACTION,
 } from "./profile-create.tsx";
@@ -83,13 +83,13 @@ export default pattern(() => {
   });
 
   // === Assertions: no defaultName → no prefill, surface untouched ===
-  const assert_no_default_has_no_initial_value = computed(() => {
+  const assert_no_default_has_no_initial_value = assert(() => {
     const input = findByTag(withoutDefault[UI], "cf-submit-input");
     if (!input) return false;
     const initialValue = propValue(input.props.initialValue);
     return initialValue === undefined || initialValue === "";
   });
-  const assert_no_default_action_wired = computed(() => {
+  const assert_no_default_action_wired = assert(() => {
     const input = findByTag(withoutDefault[UI], "cf-submit-input");
     if (!input) return false;
     return propValue(input.props["data-ui-action"]) ===
@@ -97,12 +97,12 @@ export default pattern(() => {
   });
 
   // === Assertions: defaultName prefills, everything else unchanged ===
-  const assert_default_seeds_initial_value = computed(() => {
+  const assert_default_seeds_initial_value = assert(() => {
     const input = findByTag(withDefault[UI], "cf-submit-input");
     if (!input) return false;
     return propValue(input.props.initialValue) === "Ada";
   });
-  const assert_default_action_still_wired = computed(() => {
+  const assert_default_action_still_wired = assert(() => {
     const input = findByTag(withDefault[UI], "cf-submit-input");
     if (!input) return false;
     return propValue(input.props["data-ui-action"]) ===
@@ -114,13 +114,13 @@ export default pattern(() => {
   // prefill was supplied: the exported `createProfile` stream exists and the
   // field's onClick is bound. (Firing the stream — the cross-space create —
   // is covered in the runner lane; see the header comment.)
-  const assert_no_default_create_wiring = computed(() => {
+  const assert_no_default_create_wiring = assert(() => {
     const input = findByTag(withoutDefault[UI], "cf-submit-input");
     return input !== undefined &&
       input.props.onClick !== undefined &&
       withoutDefault.createProfile !== undefined;
   });
-  const assert_default_create_wiring = computed(() => {
+  const assert_default_create_wiring = assert(() => {
     const input = findByTag(withDefault[UI], "cf-submit-input");
     return input !== undefined &&
       input.props.onClick !== undefined &&
@@ -129,10 +129,10 @@ export default pattern(() => {
 
   // Neither instance creates a profile at render time — the prefill is not
   // auto-submitted.
-  const assert_no_default_no_autocreate = computed(() =>
+  const assert_no_default_no_autocreate = assert(() =>
     (profilesNoDefault.get()?.length ?? 0) === 0
   );
-  const assert_default_no_autocreate = computed(() =>
+  const assert_default_no_autocreate = assert(() =>
     (profilesWithDefault.get()?.length ?? 0) === 0
   );
 

--- a/packages/patterns/system/profile-embed.test.tsx
+++ b/packages/patterns/system/profile-embed.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import ProfileEmbed from "./profile-embed.tsx";
 import ProfileHome from "./profile-home.tsx";
 
@@ -24,12 +24,8 @@ export default pattern(() => {
   // (1) Fallback branch: with no profile resolvable in lane-2, the embed reports
   // no profile and is not in edit mode; the `[UI]` renders the wish fallback.
   const embed = ProfileEmbed({});
-  const assert_no_profile_in_harness = computed(() =>
-    embed.hasProfile === false
-  );
-  const assert_not_editing_by_default = computed(() =>
-    embed.isEditing === false
-  );
+  const assert_no_profile_in_harness = assert(() => embed.hasProfile === false);
+  const assert_not_editing_by_default = assert(() => embed.isEditing === false);
 
   // (2) Amend contract: a real profile the embed's save handlers write through.
   const profile = ProfileHome({ initialName: "Ada Lovelace" });
@@ -65,21 +61,21 @@ export default pattern(() => {
     profile.setBio.send({ bio: "" });
   });
 
-  const assert_initial_name = computed(() =>
+  const assert_initial_name = assert(() =>
     profile.initialNameApplied === "Ada Lovelace"
   );
-  const assert_name_amended = computed(() =>
+  const assert_name_amended = assert(() =>
     profile.initialNameApplied === "Grace Hopper"
   );
-  const assert_name_survives_empty = computed(() =>
+  const assert_name_survives_empty = assert(() =>
     profile.initialNameApplied === "Grace Hopper"
   );
-  const assert_avatar_amended = computed(() => profile.avatar === "GH");
-  const assert_avatar_survives_empty = computed(() => profile.avatar === "GH");
-  const assert_bio_amended = computed(() =>
+  const assert_avatar_amended = assert(() => profile.avatar === "GH");
+  const assert_avatar_survives_empty = assert(() => profile.avatar === "GH");
+  const assert_bio_amended = assert(() =>
     profile.bio === "Countess of computing."
   );
-  const assert_bio_cleared = computed(() => profile.bio === "");
+  const assert_bio_cleared = assert(() => profile.bio === "");
 
   return {
     tests: [

--- a/packages/patterns/system/profile-home.test.tsx
+++ b/packages/patterns/system/profile-home.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import ProfileHome from "./profile-home.tsx";
 
 export default pattern(() => {
@@ -29,15 +29,15 @@ export default pattern(() => {
   // distinct from the edit form) is verified in the browser.
 
   // Visiting a profile starts in the read-only presentation, not the edit form.
-  const assert_not_editing = computed(() => profile.isEditing === false);
+  const assert_not_editing = assert(() => profile.isEditing === false);
   // The toggle flips into the edit form, then back.
-  const assert_editing = computed(() => profile.isEditing === true);
+  const assert_editing = assert(() => profile.isEditing === true);
 
   // The avatar the badge binds resolves (single context — owner-protected reads
   // are clean here; cross-stamp masking is the browser-only CT-1740 issue).
-  const assert_avatar_set = computed(() => profile.avatar === "AL");
+  const assert_avatar_set = assert(() => profile.avatar === "AL");
   // CT-1828: an empty send must not clear a previously-set avatar.
-  const assert_avatar_unchanged_after_empty = computed(() =>
+  const assert_avatar_unchanged_after_empty = assert(() =>
     profile.avatar === "AL"
   );
 
@@ -101,38 +101,38 @@ export default pattern(() => {
     });
   });
 
-  const assert_initial_state = computed(() =>
+  const assert_initial_state = assert(() =>
     profile.initialNameApplied === "Ada Lovelace" &&
     profile.externalLinks.length === 0 &&
     profile.verifiedIdentities.length === 0 &&
     profile.elements.length === 0
   );
 
-  const assert_name_set = computed(() =>
+  const assert_name_set = assert(() =>
     profile.initialNameApplied === "Grace Hopper"
   );
 
   // The prior (non-empty) name must survive both an empty and a
   // whitespace-only send.
-  const assert_name_unchanged_after_empty = computed(() =>
+  const assert_name_unchanged_after_empty = assert(() =>
     profile.initialNameApplied === "Grace Hopper"
   );
 
-  const assert_external_profile_link_added = computed(() =>
+  const assert_external_profile_link_added = assert(() =>
     profile.externalLinks.length === 1 &&
     profile.externalLinks[0]?.label === "GitHub" &&
     profile.externalLinks[0]?.url === "https://github.com/gracehopper"
   );
 
-  const assert_unsafe_external_profile_link_rejected = computed(() =>
+  const assert_unsafe_external_profile_link_rejected = assert(() =>
     profile.externalLinks.length === 1
   );
 
-  const assert_external_profile_link_removed = computed(() =>
+  const assert_external_profile_link_removed = assert(() =>
     profile.externalLinks.length === 0
   );
 
-  const assert_added_element = computed(() => {
+  const assert_added_element = assert(() => {
     const element = profile.elements[0];
     return profile.elements.length === 1 &&
       element?.tag === "#profileCard" &&
@@ -140,7 +140,7 @@ export default pattern(() => {
       element?.userTags.includes("person") === true;
   });
 
-  const assert_removed_element = computed(() => profile.elements.length === 0);
+  const assert_removed_element = assert(() => profile.elements.length === 0);
 
   return {
     tests: [

--- a/packages/patterns/test/non-idempotent/accumulator.test.tsx
+++ b/packages/patterns/test/non-idempotent/accumulator.test.tsx
@@ -7,7 +7,7 @@
  *
  * Run: deno task cf test packages/patterns/test/non-idempotent/accumulator.test.tsx --verbose
  */
-import { computed, pattern, Writable } from "commonfabric";
+import { assert, computed, pattern, Writable } from "commonfabric";
 
 export default pattern(() => {
   const value = new Writable("hello");
@@ -20,7 +20,7 @@ export default pattern(() => {
   });
 
   // Trivial assertion: log should have at least one entry after initial run
-  const hasEntries = computed(() => log.get().length > 0);
+  const hasEntries = assert(() => log.get().length > 0);
 
   return {
     tests: [{ assertion: hasEntries }],

--- a/packages/patterns/test/non-idempotent/set-to-array.test.tsx
+++ b/packages/patterns/test/non-idempotent/set-to-array.test.tsx
@@ -15,7 +15,7 @@
  *
  * Run: deno task cf test packages/patterns/test/non-idempotent/set-to-array.test.tsx --verbose
  */
-import { computed, pattern, Writable } from "commonfabric";
+import { assert, computed, pattern, Writable } from "commonfabric";
 
 export default pattern(() => {
   const items = new Writable([
@@ -38,7 +38,7 @@ export default pattern(() => {
     uniqueTags.set([...set]);
   });
 
-  const hasTags = computed(() => uniqueTags.get().length > 0);
+  const hasTags = assert(() => uniqueTags.get().length > 0);
 
   return {
     tests: [{ assertion: hasTags }],

--- a/packages/patterns/test/non-idempotent/shuffle.test.tsx
+++ b/packages/patterns/test/non-idempotent/shuffle.test.tsx
@@ -12,7 +12,7 @@
  *
  * Run: deno task cf test packages/patterns/test/non-idempotent/shuffle.test.tsx --verbose
  */
-import { computed, pattern, Writable } from "commonfabric";
+import { assert, computed, pattern, Writable } from "commonfabric";
 
 export default pattern(() => {
   const items = new Writable(["alpha", "bravo", "charlie", "delta", "echo"]);
@@ -38,7 +38,7 @@ export default pattern(() => {
     lastDraw.set(stamp);
   });
 
-  const hasItems = computed(() => shuffled.get().length > 0);
+  const hasItems = assert(() => shuffled.get().length > 0);
 
   return {
     tests: [{ assertion: hasItems }],

--- a/packages/patterns/test/non-idempotent/timestamp.test.tsx
+++ b/packages/patterns/test/non-idempotent/timestamp.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/test/non-idempotent/timestamp.test.tsx --verbose
  */
-import { computed, pattern, Writable } from "commonfabric";
+import { assert, computed, pattern, Writable } from "commonfabric";
 
 export default pattern(() => {
   const items = new Writable([{ title: "Task A" }, { title: "Task B" }]);
@@ -30,7 +30,7 @@ export default pattern(() => {
     );
   });
 
-  const hasItems = computed(() => processed.get().length > 0);
+  const hasItems = assert(() => processed.get().length > 0);
 
   return {
     tests: [{ assertion: hasItems }],

--- a/packages/patterns/todo-list/todo-list.test.tsx
+++ b/packages/patterns/todo-list/todo-list.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/todo-list/todo-list.test.tsx --verbose
  */
-import { action, computed, pattern } from "commonfabric";
+import { action, assert, pattern } from "commonfabric";
 import TodoList from "./todo-list.tsx";
 
 export default pattern(() => {
@@ -79,90 +79,90 @@ export default pattern(() => {
   // ==========================================================================
 
   // Initial state
-  const assert_initial_empty = computed(() => {
+  const assert_initial_empty = assert(() => {
     return todoList.items.filter(() => true).length === 0;
   });
 
-  const assert_initial_count_0 = computed(() => {
+  const assert_initial_count_0 = assert(() => {
     return todoList.itemCount === 0;
   });
 
   // After adding first item
-  const assert_has_one_item = computed(() => {
+  const assert_has_one_item = assert(() => {
     return todoList.items.filter(() => true).length === 1;
   });
 
-  const assert_count_is_1 = computed(() => {
+  const assert_count_is_1 = assert(() => {
     return todoList.itemCount === 1;
   });
 
-  const assert_first_item_title = computed(() => {
+  const assert_first_item_title = assert(() => {
     return todoList.items[0]?.title === "Buy groceries";
   });
 
-  const assert_first_item_not_done = computed(() => {
+  const assert_first_item_not_done = assert(() => {
     return todoList.items[0]?.done === false;
   });
 
   // After adding second item
-  const assert_has_two_items = computed(() => {
+  const assert_has_two_items = assert(() => {
     return todoList.items.filter(() => true).length === 2;
   });
 
-  const assert_count_is_2 = computed(() => {
+  const assert_count_is_2 = assert(() => {
     return todoList.itemCount === 2;
   });
 
-  const assert_second_item_title = computed(() => {
+  const assert_second_item_title = assert(() => {
     return todoList.items[1]?.title === "Walk the dog";
   });
 
   // After adding third item
-  const assert_has_three_items = computed(() => {
+  const assert_has_three_items = assert(() => {
     return todoList.items.filter(() => true).length === 3;
   });
 
-  const assert_count_is_3 = computed(() => {
+  const assert_count_is_3 = assert(() => {
     return todoList.itemCount === 3;
   });
 
   // After trying to add empty string (count should still be 3)
-  const assert_still_three_items = computed(() => {
+  const assert_still_three_items = assert(() => {
     return todoList.items.filter(() => true).length === 3;
   });
 
   // After removing second item
-  const assert_back_to_two_items = computed(() => {
+  const assert_back_to_two_items = assert(() => {
     return todoList.items.filter(() => true).length === 2;
   });
 
-  const assert_walk_dog_removed = computed(() => {
+  const assert_walk_dog_removed = assert(() => {
     return !todoList.items.some((item) => item.title === "Walk the dog");
   });
 
-  const assert_groceries_still_exists = computed(() => {
+  const assert_groceries_still_exists = assert(() => {
     return todoList.items.some((item) => item.title === "Buy groceries");
   });
 
-  const assert_book_still_exists = computed(() => {
+  const assert_book_still_exists = assert(() => {
     return todoList.items.some((item) => item.title === "Read a book");
   });
 
   // After removing first item
-  const assert_down_to_one_item = computed(() => {
+  const assert_down_to_one_item = assert(() => {
     return todoList.items.filter(() => true).length === 1;
   });
 
-  const assert_groceries_removed = computed(() => {
+  const assert_groceries_removed = assert(() => {
     return !todoList.items.some((item) => item.title === "Buy groceries");
   });
 
   // After removing last item
-  const assert_back_to_empty = computed(() => {
+  const assert_back_to_empty = assert(() => {
     return todoList.items.filter(() => true).length === 0;
   });
 
-  const assert_final_count_0 = computed(() => {
+  const assert_final_count_0 = assert(() => {
     return todoList.itemCount === 0;
   });
 

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -9,7 +9,7 @@
  * fids pasted in bodies, comments, and link URLs; never persisted), and the
  * exported pure helpers.
  */
-import { action, computed, Default, NAME, UI, Writable } from "commonfabric";
+import { action, assert, Default, NAME, UI, Writable } from "commonfabric";
 import { pattern } from "commonfabric";
 import Topics, {
   crossrefChipRow,
@@ -265,16 +265,16 @@ export default pattern(() => {
 
   // --- assertions ---
 
-  const assert_initial = computed(() =>
+  const assert_initial = assert(() =>
     board.topicCount === 0 &&
     (board.topics ?? []).length === 0 &&
     (board.mentionable ?? []).length === 0
   );
 
   // Blank titles are rejected by the addTopic guard.
-  const assert_still_empty = computed(() => board.topicCount === 0);
+  const assert_still_empty = assert(() => board.topicCount === 0);
 
-  const assert_first_topic = computed(() =>
+  const assert_first_topic = assert(() =>
     board.topicCount === 1 &&
     board.topics?.[0]?.title === "First topic" &&
     board.topics?.[0]?.createdBy?.kind === "agent" &&
@@ -286,11 +286,11 @@ export default pattern(() => {
     board.topics?.[0]?.[NAME] === "First topic"
   );
 
-  const assert_blank_comment_rejected = computed(() =>
+  const assert_blank_comment_rejected = assert(() =>
     board.topics?.[0]?.commentCount === 0
   );
 
-  const assert_comment_landed = computed(() =>
+  const assert_comment_landed = assert(() =>
     board.topics?.[0]?.commentCount === 1 &&
     board.topics?.[0]?.comments?.[0]?.author?.kind === "agent" &&
     board.topics?.[0]?.comments?.[0]?.author?.name === "Sol" &&
@@ -301,7 +301,7 @@ export default pattern(() => {
       (board.topics?.[0]?.createdAt ?? 0)
   );
 
-  const assert_body_set = computed(() =>
+  const assert_body_set = assert(() =>
     board.topics?.[0]?.body === "line one\nline two" &&
     board.topics?.[0]?.bodyUpdatedBy?.kind === "agent" &&
     board.topics?.[0]?.bodyUpdatedBy?.name === "Sol" &&
@@ -310,10 +310,10 @@ export default pattern(() => {
 
   // javascript: and blank URLs are rejected; a valid https link with a blank
   // label defaults its label to the URL.
-  const assert_links_guarded = computed(() =>
+  const assert_links_guarded = assert(() =>
     (board.topics?.[0]?.links ?? []).length === 0
   );
-  const assert_link_added = computed(() =>
+  const assert_link_added = assert(() =>
     (board.topics?.[0]?.links ?? []).length === 1 &&
     board.topics?.[0]?.links?.[0]?.kind === "pr" &&
     board.topics?.[0]?.links?.[0]?.label ===
@@ -322,7 +322,7 @@ export default pattern(() => {
     (board.topics?.[0]?.links?.[0]?.addedAt ?? 0) > 0
   );
 
-  const assert_second_topic = computed(() =>
+  const assert_second_topic = assert(() =>
     board.topicCount === 2 &&
     board.topics?.[1]?.title === "Second topic" &&
     board.topics?.[1]?.createdBy?.kind === "agent" &&
@@ -330,28 +330,28 @@ export default pattern(() => {
     board[NAME] === "Topics (2)"
   );
 
-  const assert_third_topic = computed(() =>
+  const assert_third_topic = assert(() =>
     board.topicCount === 3 &&
     board.topics?.[2]?.title === "Composed topic" &&
     board.topics?.[2]?.createdBy?.name === "Sol"
   );
 
-  const assert_blank_draft_rejected = computed(() =>
+  const assert_blank_draft_rejected = assert(() =>
     directTopic.commentCount === 0
   );
 
   // startEditBody copied the current body into the draft and opened the editor.
-  const assert_editing = computed(() =>
+  const assert_editing = assert(() =>
     directTopic.editingBody === true &&
     directTopic.bodyDraft.get() === "line one\nline two"
   );
 
-  const assert_edit_cancelled = computed(() =>
+  const assert_edit_cancelled = assert(() =>
     directTopic.editingBody === false &&
     directTopic.body === "line one\nline two"
   );
 
-  const assert_legacy_fields_load = computed(() =>
+  const assert_legacy_fields_load = assert(() =>
     legacy.createdByName === "Legacy Person" &&
     legacy.createdBy === undefined &&
     legacy.comments?.[0]?.authorName === "Old Agent" &&
@@ -364,36 +364,36 @@ export default pattern(() => {
       ) === "Old Agent"
   );
 
-  const assert_legacy_name_set = computed(() =>
+  const assert_legacy_name_set = assert(() =>
     legacyBoard.myName === "Legacy User"
   );
 
-  const assert_legacy_topic_created = computed(() =>
+  const assert_legacy_topic_created = assert(() =>
     legacyBoard.topicCount === 1 &&
     legacyBoard.topics?.[0]?.title === "Legacy-shaped topic" &&
     legacyBoard.topics?.[0]?.createdBy === undefined &&
     legacyBoard.topics?.[0]?.createdByName === "Legacy User"
   );
 
-  const assert_legacy_comment_landed = computed(() =>
+  const assert_legacy_comment_landed = assert(() =>
     legacyBoard.topics?.[0]?.comments?.[0]?.author === undefined &&
     legacyBoard.topics?.[0]?.comments?.[0]?.authorName === "Legacy User" &&
     legacyBoard.topics?.[0]?.comments?.[0]?.body === "legacy comment"
   );
 
-  const assert_legacy_link_landed = computed(() =>
+  const assert_legacy_link_landed = assert(() =>
     legacyBoard.topics?.[0]?.links?.[0]?.addedBy === undefined &&
     legacyBoard.topics?.[0]?.links?.[0]?.label === "legacy link"
   );
 
-  const assert_legacy_body_landed = computed(() =>
+  const assert_legacy_body_landed = assert(() =>
     legacyBoard.topicCount === 1 &&
     legacyBoard.topics?.[0]?.body === "legacy body" &&
     (legacyBoard.topics?.[0]?.bodyUpdatedBy?.name ?? "") === "" &&
     (legacyBoard.topics?.[0]?.bodyUpdatedAt ?? 0) === 0
   );
 
-  const assert_profile_topic_submitted = computed(() => {
+  const assert_profile_topic_submitted = assert(() => {
     const list = profileTopics.get() ?? [];
     return list.length === 1 &&
       list[0]?.title === "Profile topic" &&
@@ -404,7 +404,7 @@ export default pattern(() => {
       profileTitleDraft.get() === "";
   });
 
-  const assert_profile_comment_submitted = computed(() => {
+  const assert_profile_comment_submitted = assert(() => {
     const list = profileComments.get() ?? [];
     return list.length === 1 &&
       list[0]?.body === "via the profile composer" &&
@@ -416,7 +416,7 @@ export default pattern(() => {
       profileCommentDraft.get() === "";
   });
 
-  const assert_profile_body_saved = computed(() =>
+  const assert_profile_body_saved = assert(() =>
     profileBody.get() === "profile-edited body" &&
     profileBodyUpdatedBy.get()?.kind === "person" &&
     profileBodyUpdatedBy.get()?.name === "Ada" &&
@@ -424,7 +424,7 @@ export default pattern(() => {
     profileEditingBody.get() === false
   );
 
-  const assert_profile_link_submitted = computed(() => {
+  const assert_profile_link_submitted = assert(() => {
     const list = profileLinks.get() ?? [];
     return list.length === 1 &&
       list[0]?.kind === "session" &&
@@ -440,7 +440,7 @@ export default pattern(() => {
   });
 
   // A fresh comment on the FIRST topic makes it the most recently active.
-  const assert_pure_helpers = computed(() =>
+  const assert_pure_helpers = assert(() =>
     snippet("a b  c", 3) === "a b…" &&
     snippet("hi", 10) === "hi" &&
     whenLabel(0) === "" &&
@@ -460,7 +460,7 @@ export default pattern(() => {
   // Runs at the two-topic point: the edge that follows must exist while the
   // harness still evaluates the board's card-list computed, so the chip
   // branches render (and count as covered), not just the data layer.
-  const assert_crossrefs_baseline = computed(() =>
+  const assert_crossrefs_baseline = assert(() =>
     (board.crossrefs ?? []).length === 2 &&
     board.crossrefs?.[0]?.fid?.startsWith("fid1:") === true &&
     (board.crossrefs?.[0]?.fid ?? "").length > 25 &&
@@ -480,7 +480,7 @@ export default pattern(() => {
       agentName: "Sol",
     });
   });
-  const assert_body_edge = computed(() =>
+  const assert_body_edge = assert(() =>
     (board.crossrefs?.[1]?.refsOut ?? []).length === 1 &&
     board.crossrefs?.[1]?.refsOut?.[0]?.title === "First topic" &&
     (board.crossrefs?.[0]?.referencedBy ?? []).length === 1 &&
@@ -492,7 +492,7 @@ export default pattern(() => {
   // own row from the mentionable siblings wired at creation (piece-valued,
   // resolved from `mentionable` = the board's own list), while a piece with no
   // mentionable derives empty sets.
-  const assert_detail_edges = computed(() => {
+  const assert_detail_edges = assert(() => {
     return board.topics?.[1]?.crossrefs?.refsOut?.[0]?.title ===
         "First topic" &&
       (board.topics?.[1]?.crossrefs?.refsOut ?? []).length === 1 &&
@@ -503,7 +503,7 @@ export default pattern(() => {
       (board.topics?.[0]?.crossrefs?.refsOut ?? []).length === 0;
   });
 
-  const assert_lone_edgeless = computed(() => {
+  const assert_lone_edgeless = assert(() => {
     return (lone.crossrefs?.refsOut ?? []).length === 0 &&
       (lone.crossrefs?.referencedBy ?? []).length === 0;
   });
@@ -513,7 +513,7 @@ export default pattern(() => {
   // binds included — and an edgeless row collapses to null so the card
   // renders nothing for it. The real in-card path renders too: this suite
   // exports [UI], so the harness demands the vdom continuously (#4715).
-  const assert_chip_row_markup = computed(() => {
+  const assert_chip_row_markup = assert(() => {
     const list = (board.topics ?? []) as TopicPiece[];
     if (list.length < 2) return false;
     const row = crossrefChipRow("references →", false, [list[0], list[1]]);
@@ -529,7 +529,7 @@ export default pattern(() => {
       agentName: "Sol",
     });
   });
-  const assert_comment_edge = computed(() =>
+  const assert_comment_edge = assert(() =>
     (board.crossrefs?.[2]?.refsOut ?? []).length === 1 &&
     board.crossrefs?.[2]?.refsOut?.[0]?.title === "First topic" &&
     (board.crossrefs?.[0]?.referencedBy ?? []).length === 2
@@ -546,7 +546,7 @@ export default pattern(() => {
       agentName: "Sol",
     });
   });
-  const assert_link_edge = computed(() =>
+  const assert_link_edge = assert(() =>
     (board.crossrefs?.[2]?.refsOut ?? []).length === 2 &&
     board.crossrefs?.[2]?.refsOut?.[1]?.title === "Second topic" &&
     (board.crossrefs?.[1]?.referencedBy ?? []).length === 1 &&
@@ -561,7 +561,7 @@ export default pattern(() => {
       agentName: "Sol",
     });
   });
-  const assert_self_unknown_ignored = computed(() =>
+  const assert_self_unknown_ignored = assert(() =>
     (board.crossrefs?.[0]?.refsOut ?? []).length === 0 &&
     (board.crossrefs?.[0]?.referencedBy ?? []).length === 2
   );
@@ -573,7 +573,7 @@ export default pattern(() => {
       agentName: "Sol",
     });
   });
-  const assert_edge_removed = computed(() =>
+  const assert_edge_removed = assert(() =>
     (board.crossrefs?.[1]?.refsOut ?? []).length === 0 &&
     (board.crossrefs?.[0]?.referencedBy ?? []).length === 1 &&
     board.crossrefs?.[0]?.referencedBy?.[0]?.title === "Composed topic"
@@ -583,7 +583,7 @@ export default pattern(() => {
   // percent-encoded) plus the non-matches (short payloads, non-fid hashes).
   const P1 = "A".repeat(43);
   const P2 = "B".repeat(43);
-  const assert_crossref_helpers = computed(() =>
+  const assert_crossref_helpers = assert(() =>
     extractFidPayloads(
         `a fid1:${P1} b of:fid1:${P2} c fid1%3A${P1}`,
       ).join(",") === `${P1},${P2},${P1}` &&
@@ -600,7 +600,7 @@ export default pattern(() => {
   // path retires): one payload→entry map, one scan per corpus. First-mention
   // order out, ascending referrers in; repeats, self-mentions, and payloads
   // no entry owns all drop.
-  const assert_crossref_join = computed(() => {
+  const assert_crossref_join = assert(() => {
     const P3 = "C".repeat(43);
     const joined = crossrefJoin(
       [

--- a/packages/patterns/type-picker.test.tsx
+++ b/packages/patterns/type-picker.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern, UI, Writable } from "commonfabric";
+import { action, assert, pattern, UI, Writable } from "commonfabric";
 import TypePickerModule from "./type-picker.tsx";
 import type { SubPieceEntry, TrashedSubPieceEntry } from "./record/types.ts";
 import { findElementByText, propsOf } from "./test/vnode-helpers.ts";
@@ -19,14 +19,14 @@ export default pattern(() => {
 
   const picker = TypePickerModule({ entries, trashedEntries, dismissed });
 
-  const assert_starts_undismissed = computed(() => picker.dismissed === false);
+  const assert_starts_undismissed = assert(() => picker.dismissed === false);
 
   // `dismissed` is passed straight through, so the output follows the cell
   // rather than a value snapshotted at instantiation.
   const action_dismiss = action(() => {
     dismissed.set(true);
   });
-  const assert_dismissed_follows_the_cell = computed(() =>
+  const assert_dismissed_follows_the_cell = assert(() =>
     picker.dismissed === true
   );
 
@@ -42,16 +42,16 @@ export default pattern(() => {
   // The Person template creates an email and a phone. Each is recorded on its
   // entry with its standard default label, so a later add of the same type can
   // see it. Without that, the added module would default to the same label.
-  const assert_template_email_label = computed(() =>
+  const assert_template_email_label = assert(() =>
     (entries.get() ?? []).find((e) => e.type === "email")?.label === "Personal"
   );
-  const assert_template_phone_label = computed(() =>
+  const assert_template_phone_label = assert(() =>
     (entries.get() ?? []).find((e) => e.type === "phone")?.label === "Mobile"
   );
 
   // The consequence the recorded label buys: the next email add reads the
   // template's email label and picks the next unused one rather than "Personal".
-  const assert_next_email_label_is_work = computed(() =>
+  const assert_next_email_label_is_work = assert(() =>
     getNextUnusedLabel("email", entries.get() ?? []) === "Work"
   );
 

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -31,6 +31,7 @@ import {
   action,
   assert,
   assertCapture,
+  assertRenderParts,
   byRef,
   computed,
   handler,
@@ -184,8 +185,11 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     assert: trustedAssert,
 
     // Operand recording for transformer-instrumented `assert` bodies. Plain
-    // data in, plain data out — no builder artifact to trust.
+    // data in, plain data out — no builder artifact to trust. `assertCapture`
+    // stashes each operand's value; `assertRenderParts` renders them only when
+    // the assertion failed.
     assertCapture,
+    assertRenderParts,
 
     // Built-in modules
     str: trustedStr,

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -1,5 +1,6 @@
 import type {
   AssertPart,
+  AssertRawPart,
   AssertRecord,
   CellScope,
   FactoryInput,
@@ -523,18 +524,36 @@ export const computed: <T>(fn: () => T) => Reactive<T> = <T>(fn: () => T) =>
 /**
  * Records one operand of an `assert` body and returns it unchanged.
  *
- * The value is rendered here, while it is still the resolved value the body
- * computed. The array is local to a single evaluation of the body and is
- * discarded unless the assertion fails.
+ * It stores the resolved value the body computed rather than rendering it. The
+ * array is local to a single evaluation of the body and is discarded unless the
+ * assertion fails, so `assertRenderParts` renders these only on that failing
+ * path — a passing assertion never renders an operand.
  */
 export const assertCapture = <T>(
-  parts: AssertPart[],
+  parts: AssertRawPart[],
   src: string,
   value: T,
 ): T => {
-  parts.push({ src, rendered: toCompactDebugString(value) });
+  parts.push({ src, value });
   return value;
 };
+
+/**
+ * Renders the operands captured by `assertCapture` into the record's `parts`.
+ *
+ * A passing assertion (`ok === true`) returns an empty list without touching
+ * the values, so the common case pays nothing to render diagnostics it will
+ * never show. Only a failing assertion renders each captured value with
+ * `toCompactDebugString`.
+ */
+export const assertRenderParts = (
+  ok: boolean,
+  parts: AssertRawPart[],
+): AssertPart[] =>
+  ok ? [] : parts.map(({ src, value }) => ({
+    src,
+    rendered: toCompactDebugString(value),
+  }));
 
 /**
  * assert: a `computed` for pattern-test assertions that reports its operands.

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -11,6 +11,7 @@ import type {
   AsReadonlyCell,
   AssertCaptureFunction,
   AssertFunction,
+  AssertRenderPartsFunction,
   AsStream,
   AsWriteonlyCell,
   ByRefFunction,
@@ -113,6 +114,7 @@ export type {
   AsOpaqueCell,
   AsReadonlyCell,
   AssertPart,
+  AssertRawPart,
   AssertRecord,
   AsStream,
   AsWriteonlyCell,
@@ -360,9 +362,12 @@ export interface BuilderFunctionsAndConstants {
   assert: AssertFunction;
 
   // Operand recording for `assert` bodies. The assert-diagnostics transformer
-  // emits calls to this against the injected `__cfHelpers` object; it is not
-  // meant to be called from authored code.
+  // emits calls to these against the injected `__cfHelpers` object; they are
+  // not meant to be called from authored code. `assertCapture` stashes each
+  // operand's resolved value; `assertRenderParts` renders them into the
+  // record's `parts`, but only when the assertion failed.
   assertCapture: AssertCaptureFunction;
+  assertRenderParts: AssertRenderPartsFunction;
 
   // Built-in modules
   str: StrFunction;

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { type AssertRecord, JSONSchemaObj } from "@commonfabric/api";
+import {
+  type AssertRawPart,
+  type AssertRecord,
+  JSONSchemaObj,
+} from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
 import {
   type Frame,
@@ -17,6 +21,7 @@ import {
   action,
   assert,
   assertCapture,
+  assertRenderParts,
   handler,
   isEagerSourceAnnotationEnabled,
   lift,
@@ -184,29 +189,58 @@ describe("module", () => {
     // back untouched, or wrapping an operand would change what the assertion
     // computes.
     it("returns the value it was given", () => {
-      const parts: { src: string; rendered: string }[] = [];
+      const parts: AssertRawPart[] = [];
       expect(assertCapture(parts, "a + b", 3)).toBe(3);
 
       const object = { name: "Coffee" };
       expect(assertCapture(parts, "item", object)).toBe(object);
     });
 
-    it("records the source text and the rendered value", () => {
-      const parts: { src: string; rendered: string }[] = [];
+    it("records the source text and the raw value, without rendering it", () => {
+      // Rendering is deferred to `assertRenderParts`, so the value is stashed
+      // as-is here — a passing assertion never renders it.
+      const parts: AssertRawPart[] = [];
+      const object = { name: "Coffee" };
       assertCapture(parts, "a + b", 3);
-      assertCapture(parts, "items", [1, -2]);
+      assertCapture(parts, "item", object);
 
       expect(parts).toEqual([
-        { src: "a + b", rendered: "3" },
-        { src: "items", rendered: "[1,-2]" },
+        { src: "a + b", value: 3 },
+        { src: "item", value: object },
       ]);
+      // The recorded value is the object itself, not a copy or a rendering.
+      expect(parts[1]!.value).toBe(object);
     });
 
     it("appends in the order it is called", () => {
-      const parts: { src: string; rendered: string }[] = [];
+      const parts: AssertRawPart[] = [];
       assertCapture(parts, "first", 1);
       assertCapture(parts, "second", 2);
       expect(parts.map((part) => part.src)).toEqual(["first", "second"]);
+    });
+  });
+
+  describe("assertRenderParts function", () => {
+    // The record's `parts` runs through this. On the passing path it renders
+    // nothing — that is what keeps a passing assertion from paying to render
+    // operands it will never report.
+    it("renders nothing for a passing assertion", () => {
+      const parts: AssertRawPart[] = [
+        { src: "a + b", value: 3 },
+        { src: "items", value: [1, -2] },
+      ];
+      expect(assertRenderParts(true, parts)).toEqual([]);
+    });
+
+    it("renders each captured value for a failing assertion", () => {
+      const parts: AssertRawPart[] = [
+        { src: "a + b", value: 3 },
+        { src: "items", value: [1, -2] },
+      ];
+      expect(assertRenderParts(false, parts)).toEqual([
+        { src: "a + b", rendered: "3" },
+        { src: "items", rendered: "[1,-2]" },
+      ]);
     });
   });
 

--- a/packages/ts-transformers/README.md
+++ b/packages/ts-transformers/README.md
@@ -171,13 +171,24 @@ assert(() => a + b <= c);
 // Output (outline): each operand of the top-level operator is recorded under
 // its authored source text, and `assertCapture` returns it unchanged.
 assert((): { ok: boolean; source: string; parts: ... } => {
-  const __cfAssertParts: { src: string; rendered: string }[] = [];
+  const __cfAssertParts: { src: string; value: unknown }[] = [];
   const __cfAssertOk: boolean =
     __cfHelpers.assertCapture(__cfAssertParts, "a + b", a + b) <=
     __cfHelpers.assertCapture(__cfAssertParts, "c", c);
-  return { ok: __cfAssertOk, source: "a + b <= c", parts: __cfAssertParts };
+  return {
+    ok: __cfAssertOk,
+    source: "a + b <= c",
+    parts: __cfHelpers.assertRenderParts(__cfAssertOk, __cfAssertParts),
+  };
 });
 ```
+
+`assertCapture` stashes each operand's resolved value rather than rendering it.
+`assertRenderParts` renders those values into the record's `parts`, but only
+when the assertion failed: it returns an empty list when `ok` is true. A passing
+assertion — the common case — therefore never renders an operand it would not
+report, which keeps assertion-heavy tests from paying a diagnostics cost on
+every evaluation.
 
 Recorded: the operands of a comparison or arithmetic operator, the arguments of
 a call, the operand of `!`, and, for `&&`, `||`, `??` and `?:`, each side along

--- a/packages/ts-transformers/src/core/commonfabric-runtime-registry.ts
+++ b/packages/ts-transformers/src/core/commonfabric-runtime-registry.ts
@@ -83,6 +83,16 @@ export const COMMONFABRIC_RUNTIME_EXPORT_REGISTRY = [
     category: "ignored",
     reactiveOrigin: false,
   },
+  // `assertRenderParts` renders the operands `assertCapture` recorded into the
+  // assert record's `parts`, and only when the assertion failed.
+  // AssertDiagnosticsTransformer emits the call; authored code does not. It
+  // takes plain data and returns plain data, so like `assertCapture` it
+  // originates nothing reactive and is a plain call.
+  {
+    exportName: "assertRenderParts",
+    category: "ignored",
+    reactiveOrigin: false,
+  },
   {
     exportName: "render",
     category: "builder",

--- a/packages/ts-transformers/src/transformers/assert-diagnostics.ts
+++ b/packages/ts-transformers/src/transformers/assert-diagnostics.ts
@@ -17,11 +17,18 @@ import { unwrapExpression } from "../utils/expression.ts";
  *       const __cfAssertOk: boolean =
  *         __cfHelpers.assertCapture(__cfAssertParts, "a + b", a + b) <=
  *         __cfHelpers.assertCapture(__cfAssertParts, "c", c);
- *       return { ok: __cfAssertOk, source: "a + b <= c", parts: __cfAssertParts };
+ *       return {
+ *         ok: __cfAssertOk,
+ *         source: "a + b <= c",
+ *         parts: __cfHelpers.assertRenderParts(__cfAssertOk, __cfAssertParts),
+ *       };
  *     })
  *
  * `assertCapture` returns its value unchanged, so operand order and semantics
- * are untouched. Everything after this stage lowers the call as a `computed`
+ * are untouched. It stashes each operand's resolved value rather than rendering
+ * it; `assertRenderParts` renders them into the record's `parts`, but only when
+ * the assertion failed — a passing assertion never pays to render an operand it
+ * would not report. Everything after this stage lowers the call as a `computed`
  * (the runtime export registry maps `assert` onto `computed`), which rewrites
  * `a + b` into `a.get() + b.get()` inside the capture arguments as usual.
  *
@@ -249,7 +256,18 @@ function createRecordReturn(
           "source",
           factory.createStringLiteral(sourceTextOf(resultExpression)),
         ),
-        factory.createPropertyAssignment("parts", partsIdentifier),
+        // Rendering the recorded operands is deferred to here, and to only the
+        // failing path: `assertRenderParts` returns an empty list when `ok` is
+        // true, so a passing assertion never renders an operand.
+        factory.createPropertyAssignment(
+          "parts",
+          context.cfHelpers.createHelperCall(
+            "assertRenderParts",
+            resultExpression,
+            undefined,
+            [okIdentifier, partsIdentifier],
+          ),
+        ),
       ], true),
     ),
   ], true);
@@ -264,7 +282,7 @@ function isOwnReturnScope(node: ts.Node): boolean {
     ts.isClassExpression(node);
 }
 
-/** `const __cfAssertParts: { src: string; rendered: string }[] = [];` */
+/** `const __cfAssertParts: { src: string; value: unknown }[] = [];` */
 function createPartsDeclaration(
   partsIdentifier: ts.Identifier,
   context: TransformationContext,
@@ -276,11 +294,34 @@ function createPartsDeclaration(
       factory.createVariableDeclaration(
         partsIdentifier,
         undefined,
-        factory.createArrayTypeNode(createPartTypeNode(context)),
+        factory.createArrayTypeNode(createRawPartTypeNode(context)),
         factory.createArrayLiteralExpression([], false),
       ),
     ], ts.NodeFlags.Const),
   );
+}
+
+/**
+ * `{ src: string; value: unknown }` — the shape `assertCapture` records into
+ * the intermediate array before `assertRenderParts` renders it. The value is
+ * held raw so a passing assertion never renders it.
+ */
+function createRawPartTypeNode(context: TransformationContext): ts.TypeNode {
+  const { factory } = context;
+  return factory.createTypeLiteralNode([
+    factory.createPropertySignature(
+      undefined,
+      "src",
+      undefined,
+      factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+    ),
+    factory.createPropertySignature(
+      undefined,
+      "value",
+      undefined,
+      factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+    ),
+  ]);
 }
 
 /**

--- a/packages/ts-transformers/test/assert-diagnostics.test.ts
+++ b/packages/ts-transformers/test/assert-diagnostics.test.ts
@@ -239,15 +239,57 @@ Deno.test("assert does not capture a body's own binding of its local names", asy
     { src: "__cfAssertParts", value: "__cfAssertParts" },
   ]);
 
-  // The record's `parts` refers to the emitted local, not the author's.
+  // The record's `parts` renders the emitted local, not the author's binding.
+  // It reads `assertRenderParts(ok, __cfAssertParts_N)`, so the recorded array
+  // is the render call's second argument.
   const parts = collect(root, ts.isPropertyAssignment).find((property) =>
     ts.isIdentifier(property.name) && property.name.text === "parts"
   );
-  const partsTarget = parts && ts.isIdentifier(parts.initializer)
-    ? parts.initializer.text
+  const partsArg = parts && ts.isCallExpression(parts.initializer)
+    ? parts.initializer.arguments[1]
+    : undefined;
+  const partsTarget = partsArg && ts.isIdentifier(partsArg)
+    ? partsArg.text
     : undefined;
   assertEquals(partsTarget !== "__cfAssertParts", true);
   assertEquals(partsTarget?.startsWith("__cfAssertParts"), true);
+});
+
+Deno.test("assert defers operand rendering to a failing-path helper", async () => {
+  const root = await transformed(patternSource(`
+  const check = assert(() => a.get() <= c.get());
+  return { check };`));
+
+  // The record's `parts` is not the recorded array itself but a call that
+  // renders it only when the assertion failed. `assertRenderParts(ok, parts)`
+  // returns an empty list when `ok` is true, so a passing assertion pays
+  // nothing to render operands it will never report.
+  const parts = collect(root, ts.isPropertyAssignment).find((property) =>
+    ts.isIdentifier(property.name) && property.name.text === "parts"
+  );
+  const call = parts?.initializer;
+  assertEquals(call !== undefined && ts.isCallExpression(call), true);
+
+  const callExpr = call as ts.CallExpression;
+  assertEquals(
+    ts.isPropertyAccessExpression(callExpr.expression) &&
+      callExpr.expression.name.text === "assertRenderParts",
+    true,
+  );
+
+  // The verdict decides whether to render, and the recorded operands are what
+  // it renders: `assertRenderParts(__cfAssertOk, __cfAssertParts)`.
+  const [okArg, partsArg] = callExpr.arguments;
+  assertEquals(
+    okArg !== undefined && ts.isIdentifier(okArg) &&
+      okArg.text.startsWith("__cfAssertOk"),
+    true,
+  );
+  assertEquals(
+    partsArg !== undefined && ts.isIdentifier(partsArg) &&
+      partsArg.text.startsWith("__cfAssertParts"),
+    true,
+  );
 });
 
 Deno.test("a local assert is not mistaken for the commonfabric one", async () => {


### PR DESCRIPTION
A pattern test declares each check as a reactive boolean under a step's `{ assertion: X }`. When that value comes from `computed(() => ...)`, a failure can only report the boolean the closure produced — the runner sees `Expected true, got false` and nothing about which comparison failed or what the operands were. The `assert(() => ...)` builder solves this: the transformer rewrites its body so a failure reports each operand's authored source text and runtime value.

This converts the assertions across the pattern test suite from `computed()` to `assert()` so their failures are diagnosable. The conversion is a mechanical AST codemod driven by reference analysis, not a blind rename: a `computed()` is converted only when its value is used *solely* as a test step's `{ assertion: X }`. This matters because `assert()` returns a `Reactive< AssertRecord>` (an object, always truthy) rather than a `Reactive<boolean>`, so converting a value that is also read as a condition or a data field would silently change behavior. The analysis resolves references by symbol identity, so it distinguishes same-named assertions declared in sibling scopes and keeps `computed()` for values that feed a fixture, a `debugState`-style output field, or another computation.

Where an assertion body returned `boolean | undefined` or `boolean | null` — a `&&` chain guarded by a `find()` result or a `String.match()` result — the guard is made explicit (`x !== undefined`, `matches !== null`, `=== true`) so the body satisfies `assert`'s `() => boolean` signature. Each rewrite preserves the original pass/fail outcome: the only non-boolean value was the falsy short-circuit case, which the explicit guard maps to `false`.

Two categories of assertion are deliberately left on `computed()`:

- Multi-user tests (`multi-user.test.tsx`). Converting these makes the test hang at the first cross-user assertion. `assert()` returns a fresh `AssertRecord` (with a fresh `parts` array) on every evaluation, so its reactive value never stabilizes by identity, and the multi-user harness's cross-user settle wait does not complete. Single-process tests are unaffected.

- One `scrabble` assertion that reads a nested field only as a method-call receiver (`lastEvent.details.includes(...)`). Wrapping that read in the diagnostics helper hides the field from schema generation, so the field is projected away and the read throws at runtime. The surrounding assertions in the same file still convert.

Also updates the two pattern-testing documents whose wording described the old state ("most test patterns still use computed()").

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated pattern tests from `computed(() => ...)` to `assert(() => ...)` for clearer failures, and made `assert()` render diagnostics only on failures to restore test performance.

- **Refactors**
  - Converted step assertions in `packages/patterns/**` from `computed()` to `assert()` via a scoped codemod that rewrites only values used as `{ assertion: X }`; added boolean guards where needed. Also converted lunch‑poll assertions added upstream during rebase.
  - Left multi-user harness tests and one `scrabble` assertion on `computed()` due to settle/identity and schema constraints.
  - Updated docs to prefer `assert()` for new tests.

- **Performance**
  - `assert()` now captures operands as `AssertRawPart` and renders via `assertRenderParts(ok, parts)` only when `ok === false`; passing assertions render nothing. Failure diagnostics are unchanged.

<sup>Written for commit e5b8b604980ef00c4beaa00b96c31a56cf50478d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

