### PR TITLE
fix(cf-code-editor): drop the inert cancel() and its inverted comment

### DIFF
--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -826,9 +826,6 @@ export class CFCodeEditor extends BaseElement {
       return;
     }
 
-    // External updates override local edits, so drop any pending debounced write.
-    this._cellController.cancel();
-
     // Apply external update to editor, preserving cursor position.
     // Clamp cursor to new document length in case content is shorter.
     const currentSelection = this._editorView.state.selection.main;


### PR DESCRIPTION
_updateEditorFromCellValue carried this call and comment:

    // External updates override local edits, so drop any pending
    // debounced write.
    this._cellController.cancel();

Both describe the semantics the component had before CellController grew pending-local-edit tracking. Under the current semantics they are wrong, and the call never does any work in a reachable state.

The comment is inverted. A pending local edit now wins over external deliveries until its write settles: getValue() returns the local edit while one is pending, and the classifier suppresses stale bound-state deliveries. External updates do not override a pending local edit — the edit overrides them.

The call is reached only past the content-match guard above it, that is, only when getValue() differs from the editor's current text. Walking the reachable states:

- No pending local edit (an external update while the user is not typing, or after the debounce already settled). getValue() returns bound state, which differs from the editor, so cancel() runs — but there is nothing to cancel. A scheduled debounced write only ever exists alongside a set local edit, because setValue records the edit synchronously and only clears it once the write fires or settles. With no pending edit there is no pending write, and the settled-awaiting-release flag is false too. cancel() is a no-op.

- Pending local edit, unsettled. getValue() returns the local edit. The CodeMirror update listener re-runs setValue on every keystroke, so the local edit tracks the editor text and the content-match guard returns before cancel() is reached.

- Pending local edit, settled but unconverged, superseding delivery. CellController's own subscription is registered by bind() before the editor's sync subscription, so it processes the delivery first and its classifier releases the local edit. By the time _updateEditorFromCellValue runs, no edit is pending, which is the no-op case above.

So no reachable state at this point holds a real pending debounced write, and removing the call cannot leave a stale write to clobber an applied external update. The behavior is unchanged; the misleading comment and the dead call are gone. The content-match guard remains the sole mechanism, backed by the controller's pending-local-edit classifier.

Coverage already exists: the integration test "should preserve a pending local edit over an external update during the debounce window" pins the edit-wins path, and the cell-controller unit suite pins the classifier and cancel() semantics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an inert cancel() call and its misleading comment in the editor update path. Behavior is unchanged: pending local edits already take precedence over external updates, and there’s no pending write to cancel in reachable states.

<sup>Written for commit 956e2c237ce339f818f6b06893d815370a6fff6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

