### PR TITLE
fix(dashboard): align CI trust grids with scoring

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -494,8 +494,8 @@ Notes:
 Everything below is a tunable constant in `config.ts`:
 
 - **Status thresholds:** `TRUST_GOOD`/`TRUST_WARN` (first-try-green %), `DUR_GOOD`/`DUR_WARN` (median CI minutes).
-- **Data windows:** the shared fetch is `min(CI_RUNS_MAX=200 commits, CI_RUNS_MAX_AGE_DAYS=60)`; ci-trust uses all of it, ci-duration's median uses `max(DUR_MIN_RUNS=20, DUR_MAX_AGE_HOURS=6)` and says which basis it's on, recent-runs shows `RECENT_DISPLAY=50`.
-- **ci-trust cell grid:** `TRUST_COLS=40` columns, count rounded down to whole rows, up to `TRUST_STRIP=200` cells.
+- **Data windows:** The shared fetch returns at most `CI_RUNS_MAX=200` workflow runs and stops at `CI_RUNS_MAX_AGE_DAYS=60` days. CI trust uses the entire fetched window. CI duration uses whichever is larger: `DUR_MIN_RUNS=20` passing runs or `DUR_MAX_AGE_HOURS=6` hours. Recent runs shows `RECENT_DISPLAY=50` entries.
+- **ci-trust cell grid:** `TRUST_COLS=40` sets the column count. The grid has up to `CI_RUNS_MAX=200` cells, one for every fetched run. First-try successes are green. In-progress runs are blue. Completed runs that lower the trust percentage are red. Ignored runs are gray.
 
 ## Local development
 

--- a/packages/dashboard/config.ts
+++ b/packages/dashboard/config.ts
@@ -15,16 +15,16 @@ export const LOOM_REPO = Deno.env.get("DASHBOARD_LOOM_REPO") ?? "commontoolsinc/
 export const LOOM_CI_WORKFLOW = "test-fast.yml";
 
 // Shared fetch window — the widest any tile needs (ci-trust's): the fetch stops
-// at whichever of these two yields fewer commits. Every CI tile slices from it.
-export const CI_RUNS_MAX = 200; // commits
+// at whichever of these two yields fewer workflow runs. Every CI tile slices
+// from it.
+export const CI_RUNS_MAX = 200; // workflow runs
 export const CI_RUNS_MAX_AGE_DAYS = 60; // ~2 months
 
 // Status thresholds (tune here).
 export const TRUST_GOOD = 90, TRUST_WARN = 75; // first-try-green %
 export const TRUST_COLS = 40; // columns in the ci-trust cell grid (more = smaller cells)
-export const TRUST_STRIP = 200; // max cells; the count is rounded down to a whole number of rows
 export const DUR_GOOD = 12, DUR_WARN = 20; // median CI minutes
-// ci-duration median window — the larger of these two (more commits wins).
+// ci-duration median window — the larger of these two (more runs wins).
 export const DUR_MIN_RUNS = 20;
 export const DUR_MAX_AGE_HOURS = 6;
 export const RECENT_WINDOW = 10; // recent completed runs scanned for the recent-runs status

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -414,13 +414,13 @@ export function thin<T>(arr: T[], max: number): T[] {
   return out;
 }
 
-// A grid of small pass/fail cells (one per run, oldest first) laid out in `cols`
-// fixed columns; each cell links to that run's CI results. The caller sizes the
-// cells to a whole number of rows, so the grid is always complete (no half-empty
-// final row). Cells shrink to fit width.
+// A grid of small run-outcome cells (one per run, oldest first) laid out in
+// `cols` fixed columns. Each cell links to that run's CI results. Cells shrink
+// to fit width.
 export function strip(cells: { outcome: string; href: string }[], cols: number): string {
   if (!cells.length) return "";
-  const col = (d: string) => d === "green" ? "#43c574" : d === "red" ? "#e2504a" : "#7c828c";
+  const col = (d: string) =>
+    d === "green" ? "#43c574" : d === "red" ? "#e2504a" : d === "run" ? "#6ea8fe" : "#7c828c";
   const html = cells.map((c) =>
     `<a class="cell" href="${escapeHtml(c.href)}" target="_blank" rel="noopener" style="background:${col(c.outcome)}"></a>`
   ).join("");

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -3,7 +3,7 @@
 // runs and the token-gated tiles get an empty env (their gray-out contract).
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Ctx, Run } from "./types.ts";
-import { LOOM_REPO, REPO, TRUST_COLS } from "./config.ts";
+import { LOOM_REPO, REPO } from "./config.ts";
 import { labsCi, loomCi } from "./tiles/main-build.ts";
 import { labsCiTrust, loomCiTrust } from "./tiles/ci-trust.ts";
 import { labsCiDuration, loomCiDuration } from "./tiles/ci-duration.ts";
@@ -90,21 +90,50 @@ Deno.test("labs ci trust: only first-attempt success counts as green", async () 
   const v = await labsCiTrust.collect(ctx(runs));
   assertEquals(v.value, "50.0%");
   assertEquals(v.status, "bad");
+  assertEquals(v.sub, "first-try green · last 4 runs");
 });
 
-Deno.test("labs ci trust grid: cell count is a whole number of rows (no half-empty final row)", async () => {
-  const runs = Array.from(
-    { length: 130 },
-    () => run({ conclusion: "success" }),
-  );
-  const cells =
-    ((await labsCiTrust.collect(ctx(runs))).extra ?? "").match(/class="cell"/g)
-      ?.length ?? 0;
-  assert(
-    cells > 0 && cells % TRUST_COLS === 0,
-    `expected a multiple of ${TRUST_COLS}, got ${cells}`,
-  );
-  assertEquals(cells, 120); // floor(130 / 40) * 40
+Deno.test(
+  "labs ci trust grid: every run in the latest 200-run window has a cell",
+  async () => {
+    const runs = [
+      run({ status: "in_progress", conclusion: null }),
+      ...Array.from({ length: 199 }, () => run({ conclusion: "success" })),
+      run({ conclusion: "failure" }),
+    ];
+    const view = await labsCiTrust.collect(ctx(runs));
+    const cells = (view.extra ?? "").match(/class="cell"/g)?.length ?? 0;
+    assertEquals(cells, 200);
+    assertEquals(
+      view.sub,
+      "first-try green · 199 counted of last 200 runs",
+    );
+    assert(
+      !(view.extra ?? "").includes("#e2504a"),
+      "the 201st run must be outside the grid and percentage window",
+    );
+  },
+);
+
+Deno.test("labs ci trust grid: cell colors match trust scoring", async () => {
+  const runs = [
+    run({ conclusion: "success", run_attempt: 1 }),
+    run({ conclusion: "success", run_attempt: 2 }),
+    run({ conclusion: "failure" }),
+    run({ conclusion: "cancelled" }),
+    run({ status: "in_progress", conclusion: null }),
+    run({ status: "queued", conclusion: null }),
+    run({ status: "completed", conclusion: null }),
+  ];
+  const view = await labsCiTrust.collect(ctx(runs));
+  const colors = [
+    ...(view.extra ?? "").matchAll(/background:(#[0-9a-f]+)/g),
+  ].map((match) => match[1]);
+  assertEquals(view.value, "25.0%");
+  assertEquals(colors.filter((color) => color === "#43c574").length, 1);
+  assertEquals(colors.filter((color) => color === "#e2504a").length, 3);
+  assertEquals(colors.filter((color) => color === "#6ea8fe").length, 1);
+  assertEquals(colors.filter((color) => color === "#7c828c").length, 2);
 });
 
 Deno.test("ci-duration window: the 6h window when it has >= 20 runs, else the most recent 20", async () => {

--- a/packages/dashboard/tiles/ci-trust.ts
+++ b/packages/dashboard/tiles/ci-trust.ts
@@ -1,9 +1,18 @@
 // ci trust: share of recent completed runs that passed on the first attempt (a
-// flakiness signal), with a per-run pass/fail history strip. One factory builds
-// both the labs and loom instances against their own repo + workflow.
-import type { Status, Tile, TileView } from "../types.ts";
-import { concDot, strip } from "../lib.ts";
-import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO, TRUST_COLS, TRUST_GOOD, TRUST_STRIP, TRUST_WARN } from "../config.ts";
+// flakiness signal), with a history strip for every run in the fetched window.
+// One factory builds both the labs and loom instances against their own repo +
+// workflow.
+import type { Run, Status, Tile, TileView } from "../types.ts";
+import { strip } from "../lib.ts";
+import { CI_RUNS_MAX, CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO, TRUST_COLS, TRUST_GOOD, TRUST_WARN } from "../config.ts";
+
+type TrustOutcome = "green" | "red" | "run" | "grey";
+
+function trustOutcome(run: Run): TrustOutcome {
+  if (run.status === "in_progress") return "run";
+  if (run.status !== "completed" || !run.conclusion) return "grey";
+  return run.conclusion === "success" && run.run_attempt === 1 ? "green" : "red";
+}
 
 function makeCiTrust(opts: { id: string; label: string; repo: string; workflow: string }): Tile {
   return {
@@ -11,25 +20,28 @@ function makeCiTrust(opts: { id: string; label: string; repo: string; workflow: 
     intervalMs: 30_000,
     async collect(ctx): Promise<TileView> {
       const runs = await ctx.runsFor(opts.repo, opts.workflow);
-      const completed = runs.filter((r) => r.status === "completed" && r.conclusion);
-      const firstTryGreen = completed.filter((r) => r.conclusion === "success" && r.run_attempt === 1).length;
-      const pct = completed.length ? (firstTryGreen / completed.length) * 100 : 0;
-      const s: Status = completed.length === 0
+      const scored = runs.slice(0, CI_RUNS_MAX).map((run) => ({
+        run,
+        outcome: trustOutcome(run),
+      }));
+      const counted = scored.filter(({ outcome }) => outcome === "green" || outcome === "red");
+      const firstTryGreen = counted.filter(({ outcome }) => outcome === "green").length;
+      const pct = counted.length ? (firstTryGreen / counted.length) * 100 : 0;
+      const s: Status = counted.length === 0
         ? "unknown"
         : pct >= TRUST_GOOD ? "good" : pct >= TRUST_WARN ? "warn" : "bad";
-      // Round the cell count down to a whole number of rows so the grid is always
-      // complete; only show a single short row when that's all the data there is.
-      const cap = Math.min(TRUST_STRIP, completed.length);
-      const n = cap < TRUST_COLS ? cap : Math.floor(cap / TRUST_COLS) * TRUST_COLS;
-      const cells = [...completed].reverse().slice(-n).map((r) => ({
-        outcome: concDot(r.conclusion, r.run_attempt),
-        href: r.html_url,
+      const runSummary = counted.length === scored.length
+        ? `last ${scored.length} runs`
+        : `${counted.length} counted of last ${scored.length} runs`;
+      const cells = [...scored].reverse().map(({ run, outcome }) => ({
+        outcome,
+        href: run.html_url,
       }));
       return {
         label: opts.label,
         status: s,
         value: `${pct.toFixed(1)}%`,
-        sub: `first-try green · last ${completed.length} runs`,
+        sub: `first-try green · ${runSummary}`,
         extra: strip(cells, TRUST_COLS),
       };
     },


### PR DESCRIPTION
The CI trust percentage could be calculated from 199 completed runs while the grid rounded down to 160 cells. Successful retries and other completed non-green conclusions were also gray even though they lowered the displayed percentage.

Classify each of the latest 200 workflow runs once and use that classification for both scoring and rendering. First-attempt successes are green, in-progress runs are blue, counted non-green outcomes are red, and excluded runs are gray. Use the shared fetch limit for the grid so its window cannot drift from the percentage.

Show 'last N runs' when every displayed run contributes to the percentage. State the counted total only when in-progress or otherwise ignored runs make it differ from the displayed total.

Add exact tests for the 200-run boundary, every color category, and both subtitle forms. Verified with the dashboard test suite, deno fmt --check, and deno lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align CI trust grid with scoring so the displayed cells and percentage use the same 200-run window and classification. This removes mismatches and makes the subtitle accurately reflect what’s counted.

- **Bug Fixes**
  - Use one classification for each of the latest `CI_RUNS_MAX=200` workflow runs for both scoring and grid.
  - Grid now shows one cell per fetched run (`TRUST_COLS` columns); no row rounding or drifting window.
  - Color rules: first-attempt successes are green, counted non-green outcomes are red, in-progress runs are blue, excluded runs are gray.
  - Subtitle shows “last N runs” when all displayed runs are counted; otherwise “X counted of last N runs”.
  - Add tests for the 200-run boundary, color categories, and both subtitle variants.

<sup>Written for commit a365ee8a8cad9bc9dda9c9c68ed435309adb3395. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

