### PR TITLE
feat(cli): search piece data across a space

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -167,6 +167,7 @@
     "multiformats": "npm:multiformats@^14.0.4",
     "ses": "npm:ses@^2.2.0",
     "turndown": "npm:turndown@^7.2.4",
+    "unicode-case-folding": "npm:unicode-case-folding@1.1.1",
     "zod": "npm:zod@^4.4.3"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -135,6 +135,7 @@
     "npm:stoker@^2.0.1": "2.0.1_@hono+zod-openapi@1.5.1__hono@4.12.31__zod@4.4.3_hono@4.12.31",
     "npm:turndown@^7.2.4": "7.2.4",
     "npm:typescript@6.0.3": "6.0.3",
+    "npm:unicode-case-folding@1.1.1": "1.1.1",
     "npm:zod@^4.4.3": "4.4.3"
   },
   "jsr": {
@@ -1908,6 +1909,9 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "bin": true
     },
+    "unicode-case-folding@1.1.1": {
+      "integrity": "sha512-ZAYziAnMTBisO2dT5tyGvBFMNsIfonOS/BZTd3UZaKWtXMOZqK8s8HRUCrlKxGCTeCxCuCjS/6HW+4a6G+rbzw=="
+    },
     "w3c-keyname@2.2.8": {
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
@@ -1983,6 +1987,7 @@
       "npm:multiformats@^14.0.4",
       "npm:ses@^2.2.0",
       "npm:turndown@^7.2.4",
+      "npm:unicode-case-folding@1.1.1",
       "npm:zod@^4.4.3"
     ],
     "members": {

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -70,6 +70,7 @@ Everything a pattern exports (Chapter 3) is drivable without a browser:
 
 ```bash
 deno task cf piece ls -s myspace                       # list pieces
+deno task cf piece search -s myspace "invoice"         # find pieces by their data
 deno task cf piece inspect --piece <ID>                # dump structure/state
 deno task cf piece get --piece <ID> items              # read one exported field
 deno task cf piece call addItem '{"title": "Test"}' --piece <ID>   # send to a stream

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,31 @@
 # @commonfabric/cli
 
+## Piece data search
+
+`cf piece search <query>` reads every piece in the selected space and returns
+the pieces whose input or result data contains the query. Matching uses full
+Unicode case folding and canonical normalization over nested object keys and
+scalar values. Canonically equivalent text matches, and a match cannot stop
+partway through one character's multi-letter fold. Readable nested cell values
+are included when they belong to the piece being searched. A cell owned by
+another piece is searched only with that owner, not with every piece that links
+to it. Data owned by a piece absent from the piece registry is not attributed to
+its referrers. A cell with no piece ownership metadata remains searchable
+through each piece that links to it. Opaque, write-only, comparable, stream, and
+SQLite cell handles are not read. Piece IDs, names, and pattern metadata are
+returned for context, but they do not count as searchable data.
+
+```bash
+cf piece search --space team-space "invoice 1042"
+cf piece search --space team-space --json invoice
+```
+
+The command accepts the same identity, API URL, space, and combined URL options
+as `cf piece ls`. Human-readable output uses the same columns as `piece ls`.
+`--json` returns an array for scripts, including an empty array when no piece
+matches. If part of a piece cannot be read, the command reports a warning on
+standard error and continues searching that piece and the rest of the space.
+
 ## Launcher Contract
 
 `packages/cli/launcher.ts` is the stable Deno launcher for consumers that need

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -103,7 +103,7 @@ export function formatPatternIdentity(
     : `cf:module/${patternRef.identity}#${patternRef.symbol}`;
 }
 
-function renderPieceSummaries(
+export function renderPieceSummaries(
   pieces: Array<{
     id: string;
     name?: string;

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -268,10 +268,7 @@ export const piece = new Command()
     `Display a list of all pieces in "${RAW_EX_COMP.space}".`,
   )
   .option("--json", "Output machine-readable JSON.")
-  .action(async (options) => {
-    const pieces = await listPieces(parseSpaceOptions(options));
-    renderPieceSummaries(pieces, !!options.json);
-  })
+  .action(listPiecesFromCommand)
   /* piece search */
   .command("search", "Search readable input and result data in every piece.")
   .usage(`${spaceUsage} <query>`)
@@ -285,10 +282,7 @@ export const piece = new Command()
   )
   .arguments("<query:string>")
   .option("--json", "Output machine-readable JSON.")
-  .action(async (options, query) => {
-    const pieces = await searchPieces(parseSpaceOptions(options), query);
-    renderPieceSummaries(pieces, !!options.json);
-  })
+  .action(searchPiecesFromCommand)
   /* piece new */
   .command("new", "Create a new piece with a pattern.")
   .usage(spaceUsage)
@@ -1073,6 +1067,42 @@ export interface PieceCLIOptions {
   repository?: string;
   root?: string;
   dangerouslyAllowIncompatibleSchema?: boolean;
+}
+
+export interface PieceSummaryCLIOptions extends PieceCLIOptions {
+  json?: boolean;
+}
+
+export interface PieceListCommandDependencies {
+  listPieces?: typeof listPieces;
+  renderPieceSummaries?: typeof renderPieceSummaries;
+}
+
+export async function listPiecesFromCommand(
+  options: PieceSummaryCLIOptions,
+  deps: PieceListCommandDependencies = {},
+): Promise<void> {
+  const pieces = await (deps.listPieces ?? listPieces)(
+    parseSpaceOptions(options),
+  );
+  (deps.renderPieceSummaries ?? renderPieceSummaries)(pieces, !!options.json);
+}
+
+export interface PieceSearchCommandDependencies {
+  searchPieces?: typeof searchPieces;
+  renderPieceSummaries?: typeof renderPieceSummaries;
+}
+
+export async function searchPiecesFromCommand(
+  options: PieceSummaryCLIOptions,
+  query: string,
+  deps: PieceSearchCommandDependencies = {},
+): Promise<void> {
+  const pieces = await (deps.searchPieces ?? searchPieces)(
+    parseSpaceOptions(options),
+    query,
+  );
+  (deps.renderPieceSummaries ?? renderPieceSummaries)(pieces, !!options.json);
 }
 
 /** Injectable dependencies for testing the `piece setsrc` command boundary. */

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -21,6 +21,7 @@ import {
   removePiece,
   resetHomePattern,
   savePiecePattern,
+  searchPieces,
   setCellValue,
   setHomePattern,
   setPiecePattern,
@@ -100,6 +101,38 @@ export function formatPatternIdentity(
   return patternRef === undefined
     ? "<unknown>"
     : `cf:module/${patternRef.identity}#${patternRef.symbol}`;
+}
+
+function renderPieceSummaries(
+  pieces: Array<{
+    id: string;
+    name?: string;
+    patternRef?: PiecePatternRef;
+    error?: string;
+  }>,
+  json: boolean,
+): void {
+  if (json) {
+    render(
+      pieces.map((piece) => ({
+        id: piece.id,
+        name: piece.name ?? null,
+        patternRef: piece.patternRef ?? null,
+      })),
+      { json: true },
+    );
+    return;
+  }
+
+  const rows = [
+    ["ID", "NAME", "PATTERN"],
+    ...pieces.map((piece) => [
+      piece.id,
+      piece.error ? `<error: ${piece.error}>` : (piece.name ?? "<unnamed>"),
+      piece.error ? "" : formatPatternRef(piece.patternRef),
+    ]),
+  ];
+  if (rows.length > 1) render(Table.from(rows).toString());
 }
 
 export function localPatternEntry(
@@ -237,34 +270,24 @@ export const piece = new Command()
   .option("--json", "Output machine-readable JSON.")
   .action(async (options) => {
     const pieces = await listPieces(parseSpaceOptions(options));
-    if (options.json) {
-      render(
-        pieces.map((p) => ({
-          id: p.id,
-          name: p.name ?? null,
-          patternRef: p.patternRef ?? null,
-        })),
-        { json: true },
-      );
-      return;
-    }
-    const piecesData = [
-      ["ID", "NAME", "PATTERN"],
-      ...(pieces.map(
-        (data) => [
-          data.id,
-          data.error ? `<error: ${data.error}>` : (data.name ?? "<unnamed>"),
-          data.error ? "" : formatPatternRef(data.patternRef),
-        ],
-      )),
-    ];
-    if (piecesData.length === 1) {
-      // Only header fields -- render nothing.
-      return;
-    }
-    render(
-      Table.from(piecesData).toString(),
-    );
+    renderPieceSummaries(pieces, !!options.json);
+  })
+  /* piece search */
+  .command("search", "Search readable input and result data in every piece.")
+  .usage(`${spaceUsage} <query>`)
+  .example(
+    cliText(`cf piece search ${EX_ID} ${EX_COMP} "meeting notes"`),
+    `Find pieces containing "meeting notes" in nested input or result data.`,
+  )
+  .example(
+    cliText(`cf piece search ${EX_ID} ${EX_URL} invoice --json`),
+    `Return matching pieces as machine-readable JSON.`,
+  )
+  .arguments("<query:string>")
+  .option("--json", "Output machine-readable JSON.")
+  .action(async (options, query) => {
+    const pieces = await searchPieces(parseSpaceOptions(options), query);
+    renderPieceSummaries(pieces, !!options.json);
   })
   /* piece new */
   .command("new", "Create a new piece with a pattern.")

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -275,7 +275,29 @@ run_piece_values() {
 
   # Test input flag operations
   test_json_value "Input flag set" "userData" '{"user":{"name":"test"}}' "--input"
-  test_value "Nested input path" "userData/user/name" '"inputValue"' '"inputValue"' "--input"
+  test_value \
+    "Nested input path" \
+    "userData/user/name" \
+    '"piece-search-input-value-7301"' \
+    '"piece-search-input-value-7301"' \
+    "--input"
+
+  echo '"piece-search-result-value-9146"' |
+    cf piece set $SPACE_ARGS --piece $PIECE_ID stringField
+  SEARCH_INPUT=$(cf piece search $SPACE_ARGS --json "INPUT-VALUE-7301")
+  echo "$SEARCH_INPUT" | jq -e --arg id "$PIECE_ID" \
+    'length == 1 and .[0].id == $id' > /dev/null ||
+    error "Piece search should find nested input data case-insensitively"
+  SEARCH_RESULT=$(cf piece search $SPACE_ARGS --json "RESULT-VALUE-9146")
+  echo "$SEARCH_RESULT" | jq -e --arg id "$PIECE_ID" \
+    'length == 1 and .[0].id == $id' > /dev/null ||
+    error "Piece search should find nested result data case-insensitively"
+  SEARCH_NONE=$(cf piece search $SPACE_ARGS --json "piece-search-absent-5283")
+  echo "$SEARCH_NONE" | jq -e 'length == 0' > /dev/null ||
+    error "Piece search should return an empty JSON array when nothing matches"
+  SEARCH_NAME=$(cf piece search $SPACE_ARGS --json "Simple counter:")
+  echo "$SEARCH_NAME" | jq -e 'length == 0' > /dev/null ||
+    error "Piece search should not match a piece name"
 
   echo "Testing piece step..."
 

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1,12 +1,18 @@
 import { createSession, isDID, Session } from "@commonfabric/identity";
 import { ensureDir } from "@std/fs";
+import { caseFold } from "unicode-case-folding";
 import { loadIdentity } from "./identity.ts";
 import {
   Cell,
   entityIdFrom,
   experimentalOptionsFromEnv,
   formatFabricRef,
+  getCellOrThrow,
+  getMetaLink,
   getPatternIdentityRef,
+  isCell,
+  isCellResult,
+  isReadableCell,
   isSlugAddress,
   NAME,
   Runtime,
@@ -34,7 +40,12 @@ import {
 import { dirname, join } from "@std/path";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { setLLMUrl } from "@commonfabric/llm";
-import { isRecord } from "@commonfabric/utils/types";
+import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
+import { codecOf } from "@commonfabric/data-model/codec-common";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { getCarriedCfcLabelView } from "@commonfabric/runner/cfc";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
+import { isPlainObject, isRecord } from "@commonfabric/utils/types";
 import { pinProgramFabricImports, renderPinRewrite } from "./fabric-deps.ts";
 import { isHandlerCell } from "../../fuse/callables.ts";
 import { awaitSyncWithTimeout } from "./utils.ts";
@@ -68,6 +79,13 @@ export interface SpaceConfig {
   apiUrl: string;
   space: string;
   identity: string;
+}
+
+/** Metadata returned for a piece whose stored data matches a search query. */
+export interface PieceSearchResult {
+  id: string;
+  name?: string;
+  patternRef?: PiecePatternRef;
 }
 
 export interface PieceConfig extends SpaceConfig {
@@ -160,6 +178,11 @@ interface PieceOperationDependencies extends PieceResolutionDeps {
   getProgramFromFile?: typeof getProgramFromFile;
   getPinnedProgramFromFile?: typeof getPinnedProgramFromFile;
   createController?: (manager: PieceManager) => PiecesController;
+  reportSearchError?: (
+    pieceId: string,
+    source: "input data" | "result data" | "metadata",
+    error: unknown,
+  ) => void;
 }
 
 const CLI_TRACE_TIMINGS = Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
@@ -399,6 +422,560 @@ export async function listPieces(
         };
       }
     }),
+  );
+}
+
+const PIECE_SEARCH_CONCURRENCY = 4;
+const NO_IGNORED_ROOT_KEYS = new Set<string>();
+const RESULT_IGNORED_ROOT_KEYS = new Set([NAME]);
+const SEARCH_GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+function foldSearchText(value: string): string {
+  return caseFold(value.normalize("NFD")).normalize("NFD");
+}
+
+function foldedSearchTextContains(value: string, query: string): boolean {
+  const foldedSegments: string[] = [];
+  const boundaries = new Set<number>([0]);
+  let foldedLength = 0;
+
+  for (
+    const { segment } of SEARCH_GRAPHEME_SEGMENTER.segment(
+      value.normalize("NFC"),
+    )
+  ) {
+    const foldedSegment = foldSearchText(segment);
+    const segmentStart = foldedLength;
+    foldedSegments.push(foldedSegment);
+    foldedLength += foldedSegment.length;
+    boundaries.add(foldedLength);
+
+    const foldedCodePoints = Array.from(segment, foldSearchText);
+    if (foldedCodePoints.join("") === foldedSegment) {
+      let codePointBoundary = segmentStart;
+      for (let index = 0; index < foldedCodePoints.length - 1; index++) {
+        codePointBoundary += foldedCodePoints[index].length;
+        boundaries.add(codePointBoundary);
+      }
+    }
+  }
+
+  const foldedValue = foldedSegments.join("");
+  for (
+    let match = foldedValue.indexOf(query);
+    match !== -1;
+    match = foldedValue.indexOf(query, match + 1)
+  ) {
+    if (boundaries.has(match) && boundaries.has(match + query.length)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function cellTraversalKey(cell: Cell<unknown>): string {
+  const link = cell.getAsNormalizedFullLink();
+  return hashStringOf({
+    link,
+    cfcLabelView: getCarriedCfcLabelView(cell),
+  });
+}
+
+function cellDocumentTraversalKey(cell: Cell<unknown>): string {
+  const { space, id, scope } = cell.getAsNormalizedFullLink();
+  return hashStringOf({
+    link: { space, id, scope, path: [] },
+    cfcLabelView: getCarriedCfcLabelView(cell),
+  });
+}
+
+function cellValueTraversalKey(cell: Cell<unknown>): string {
+  const { space, id, scope, path } = cell.getAsNormalizedFullLink();
+  return hashStringOf({
+    link: { space, id, scope, path },
+    cfcLabelView: getCarriedCfcLabelView(cell),
+  });
+}
+
+interface PieceOwnerCache {
+  cells: Map<string, Promise<string | undefined>>;
+  documents: Map<string, string | null>;
+}
+
+async function resolveRegisteredDocumentOwner(
+  cell: Cell<unknown>,
+  registeredPieceIds: ReadonlySet<string>,
+  ownerCache: PieceOwnerCache,
+): Promise<string | undefined> {
+  let current = cell;
+  const visited = new Set<string>();
+  const traversed: string[] = [];
+
+  const finish = (owner: string | undefined): string | undefined => {
+    for (const key of traversed) {
+      ownerCache.documents.set(key, owner ?? null);
+    }
+    return owner;
+  };
+
+  while (true) {
+    const key = cellDocumentTraversalKey(current);
+    if (visited.has(key)) {
+      throw new Error(
+        `Cycle found while resolving piece ownership for ${
+          pieceId(cell) ?? "an unknown Cell"
+        }`,
+      );
+    }
+    if (ownerCache.documents.has(key)) {
+      return finish(ownerCache.documents.get(key) ?? undefined);
+    }
+    visited.add(key);
+    traversed.push(key);
+
+    const currentId = pieceId(current);
+    // Nested piece results can point to a parent result. Stop at the nearest
+    // registered result before following its parent metadata.
+    if (currentId !== undefined && registeredPieceIds.has(currentId)) {
+      return finish(currentId);
+    }
+
+    await current.sync();
+    const argumentLink = getMetaLink(current, "argument");
+    if (
+      currentId !== undefined &&
+      (getPatternIdentityRef(current) !== undefined ||
+        argumentLink !== undefined)
+    ) {
+      return finish(currentId);
+    }
+    const resultLink = getMetaLink(current, "result");
+    if (resultLink === undefined) return finish(undefined);
+
+    current = current.runtime.getCellFromLink(
+      { ...resultLink, path: [], schema: undefined },
+      undefined,
+      current.tx,
+      getCarriedCfcLabelView(current),
+    );
+  }
+}
+
+function registeredDocumentOwner(
+  cell: Cell<unknown>,
+  registeredPieceIds: ReadonlySet<string>,
+  ownerCache: PieceOwnerCache,
+): Promise<string | undefined> {
+  const key = cellDocumentTraversalKey(cell);
+  if (ownerCache.documents.has(key)) {
+    return Promise.resolve(ownerCache.documents.get(key) ?? undefined);
+  }
+  return resolveRegisteredDocumentOwner(
+    cell,
+    registeredPieceIds,
+    ownerCache,
+  );
+}
+
+async function resolveRegisteredPieceOwner(
+  cell: Cell<unknown>,
+  registeredPieceIds: ReadonlySet<string>,
+  ownerCache: PieceOwnerCache,
+  cellIsMaterialized: boolean,
+): Promise<string | undefined> {
+  if (!cellIsMaterialized) await cell.sync();
+  return registeredDocumentOwner(
+    cell.resolveAsCell(),
+    registeredPieceIds,
+    ownerCache,
+  );
+}
+
+function registeredPieceOwner(
+  cell: Cell<unknown>,
+  registeredPieceIds: ReadonlySet<string>,
+  ownerCache: PieceOwnerCache,
+  cellIsMaterialized: boolean,
+): Promise<string | undefined> {
+  const key = cellTraversalKey(cell);
+  let owner = ownerCache.cells.get(key);
+  if (owner === undefined) {
+    owner = resolveRegisteredPieceOwner(
+      cell,
+      registeredPieceIds,
+      ownerCache,
+      cellIsMaterialized,
+    );
+    ownerCache.cells.set(key, owner);
+  }
+  return owner;
+}
+
+interface SearchOwnership {
+  pieceId: string;
+  registeredPieceIds: ReadonlySet<string>;
+  ownerCache: PieceOwnerCache;
+}
+
+type SearchEntry =
+  | { key: string }
+  | {
+    value: unknown;
+    ownershipEstablished?: boolean;
+    sourceCell?: Cell<unknown>;
+    isRoot?: boolean;
+  };
+
+function* singleSearchEntry(
+  value: unknown,
+  ownershipEstablished = false,
+  sourceCell?: Cell<unknown>,
+  isRoot = false,
+): IterableIterator<SearchEntry> {
+  yield { value, ownershipEstablished, sourceCell, isRoot };
+}
+
+function* arraySearchEntries(
+  value: unknown[],
+  ignoredKeys: ReadonlySet<string>,
+  sourceCell?: Cell<unknown>,
+  reportReadError?: (error: unknown) => void,
+): IterableIterator<SearchEntry> {
+  for (const key in value) {
+    try {
+      if (!Object.hasOwn(value, key) || ignoredKeys.has(key)) continue;
+      if (isArrayIndexPropertyName(key)) {
+        const index = Number(key);
+        const nested = value[index];
+        yield { value: nested, sourceCell: sourceCell?.key(index) };
+      } else {
+        yield { key };
+        const nested = (value as unknown as Record<string, unknown>)[key];
+        yield { value: nested, sourceCell: sourceCell?.key(key) };
+      }
+    } catch (error) {
+      reportReadError?.(error);
+    }
+  }
+}
+
+function* objectSearchEntries(
+  value: object,
+  ignoredKeys: ReadonlySet<string>,
+  sourceCell?: Cell<unknown>,
+  reportReadError?: (error: unknown) => void,
+): IterableIterator<SearchEntry> {
+  const record = value as Record<string, unknown>;
+  for (const key in value) {
+    try {
+      if (!Object.hasOwn(value, key) || ignoredKeys.has(key)) continue;
+      yield { key };
+      const nested = record[key];
+      yield { value: nested, sourceCell: sourceCell?.key(key) };
+    } catch (error) {
+      reportReadError?.(error);
+    }
+  }
+}
+
+async function searchTextMatches(
+  rootCell: Cell<unknown>,
+  query: string,
+  ownership: SearchOwnership,
+  ignoredRootKeys: ReadonlySet<string> = NO_IGNORED_ROOT_KEYS,
+  reportReadError?: (error: unknown) => void,
+): Promise<boolean> {
+  if (isCell(rootCell)) {
+    const owner = await registeredPieceOwner(
+      rootCell,
+      ownership.registeredPieceIds,
+      ownership.ownerCache,
+      false,
+    );
+    if (owner !== undefined && owner !== ownership.pieceId) return false;
+  }
+
+  const value = await rootCell.pull();
+  const pending: Iterator<SearchEntry>[] = [
+    singleSearchEntry(
+      value,
+      true,
+      isCell(rootCell) ? rootCell : undefined,
+      true,
+    ),
+  ];
+  const seen = new WeakSet<object>();
+  const seenCells = new Set<string>();
+
+  while (pending.length > 0) {
+    let next: IteratorResult<SearchEntry>;
+    try {
+      next = pending[pending.length - 1].next();
+    } catch (error) {
+      pending.pop();
+      reportReadError?.(error);
+      continue;
+    }
+    if (next.done) {
+      pending.pop();
+      continue;
+    }
+
+    if ("key" in next.value) {
+      if (foldedSearchTextContains(next.value.key, query)) return true;
+      continue;
+    }
+    const current = next.value.value;
+
+    if (current !== null && typeof current === "object" && isCell(current)) {
+      if (!isReadableCell(current)) continue;
+
+      try {
+        const cellKey = cellTraversalKey(current);
+        if (seenCells.has(cellKey)) continue;
+        seenCells.add(cellKey);
+
+        if (!next.value.ownershipEstablished) {
+          const owner = await registeredPieceOwner(
+            current,
+            ownership.registeredPieceIds,
+            ownership.ownerCache,
+            false,
+          );
+          if (owner !== undefined && owner !== ownership.pieceId) continue;
+        }
+
+        const nested = await current.pull();
+        if (nested !== current) {
+          pending.push(singleSearchEntry(nested, true, current));
+        }
+      } catch (error) {
+        reportReadError?.(error);
+      }
+      continue;
+    }
+
+    let sourceCell = next.value.sourceCell;
+    let ownershipEstablished = next.value.ownershipEstablished ?? false;
+    if (sourceCell !== undefined && !ownershipEstablished) {
+      try {
+        const owner = await registeredPieceOwner(
+          sourceCell,
+          ownership.registeredPieceIds,
+          ownership.ownerCache,
+          true,
+        );
+        if (owner !== undefined && owner !== ownership.pieceId) continue;
+        ownershipEstablished = true;
+      } catch (error) {
+        reportReadError?.(error);
+        continue;
+      }
+    }
+
+    if (current === null || typeof current !== "object") {
+      if (
+        typeof current !== "function" &&
+        foldedSearchTextContains(String(current), query)
+      ) {
+        return true;
+      }
+      continue;
+    }
+
+    if (isCellResult(current)) {
+      try {
+        const backingCell = getCellOrThrow(current);
+        const valueWasPulledFromBackingCell = sourceCell !== undefined &&
+          cellValueTraversalKey(sourceCell) ===
+            cellValueTraversalKey(backingCell);
+        sourceCell = backingCell;
+        if (!ownershipEstablished) {
+          const owner = await registeredPieceOwner(
+            sourceCell,
+            ownership.registeredPieceIds,
+            ownership.ownerCache,
+            true,
+          );
+          if (owner !== undefined && owner !== ownership.pieceId) continue;
+          ownershipEstablished = true;
+        }
+
+        if (!valueWasPulledFromBackingCell) {
+          const cellKey = cellTraversalKey(sourceCell);
+          if (seenCells.has(cellKey)) continue;
+          seenCells.add(cellKey);
+
+          const materializedCell = sourceCell.asSchema(true);
+          const nested = await materializedCell.pull();
+          pending.push(singleSearchEntry(
+            nested,
+            true,
+            materializedCell,
+            next.value.isRoot,
+          ));
+          continue;
+        }
+      } catch (error) {
+        reportReadError?.(error);
+        continue;
+      }
+    }
+
+    if (seen.has(current)) continue;
+    seen.add(current);
+
+    if (Array.isArray(current)) {
+      pending.push(arraySearchEntries(
+        current,
+        next.value.isRoot ? ignoredRootKeys : NO_IGNORED_ROOT_KEYS,
+        sourceCell,
+        reportReadError,
+      ));
+      continue;
+    }
+
+    if (current instanceof FabricSpecialObject) {
+      const representations: SearchEntry[] = [];
+      if (current.toString !== Object.prototype.toString) {
+        try {
+          representations.push({ value: String(current) });
+        } catch (error) {
+          reportReadError?.(error);
+        }
+      }
+      try {
+        representations.push({ value: codecOf(current).encode(current) });
+      } catch (error) {
+        reportReadError?.(error);
+      }
+      if (representations.length > 0) {
+        pending.push(representations[Symbol.iterator]());
+      }
+      continue;
+    }
+
+    if (!isPlainObject(current)) continue;
+    pending.push(objectSearchEntries(
+      current,
+      next.value.isRoot ? ignoredRootKeys : NO_IGNORED_ROOT_KEYS,
+      sourceCell,
+      reportReadError,
+    ));
+  }
+
+  return false;
+}
+
+/**
+ * Find pieces with a full Unicode case-insensitive substring in their input or
+ * result data. Matches begin and end at canonically normalized code-point
+ * boundaries. Object keys and scalar values are searched recursively. Piece
+ * metadata is returned for matching pieces but does not participate in
+ * matching.
+ */
+export async function searchPieces(
+  config: SpaceConfig,
+  query: string,
+  deps: PieceOperationDependencies = {},
+): Promise<PieceSearchResult[]> {
+  if (query.length === 0) {
+    throw new Error("Search query must not be empty.");
+  }
+
+  const normalizedQuery = foldSearchText(query);
+  // TODO(@ianh): Add an API for clients to initiate server-side searches
+  // against a server-hosted index.
+  const manager = await (deps.loadManager ?? loadManager)(config);
+  const pieces = deps.createController?.(manager) ??
+    new PiecesController(manager);
+  const allPieces = await pieces.getAllPieces();
+  const registeredPieceIds = new Set(allPieces.map((piece) => piece.id));
+  const ownerCache: PieceOwnerCache = {
+    cells: new Map(),
+    documents: new Map(),
+  };
+  const matches: Array<PieceSearchResult | undefined> = new Array(
+    allPieces.length,
+  );
+  const reportSearchError = deps.reportSearchError ??
+    ((
+      pieceId: string,
+      source: "input data" | "result data" | "metadata",
+      error: unknown,
+    ) => {
+      console.warn(
+        `Warning: Could not read ${source} for piece ${pieceId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    });
+  let nextPieceIndex = 0;
+
+  const searchNextPiece = async (): Promise<void> => {
+    while (nextPieceIndex < allPieces.length) {
+      const index = nextPieceIndex++;
+      const piece = allPieces[index];
+
+      let inputMatches = false;
+      try {
+        const inputCell = await piece.input.getCell();
+        inputMatches = await searchTextMatches(
+          inputCell,
+          normalizedQuery,
+          { pieceId: piece.id, registeredPieceIds, ownerCache },
+          NO_IGNORED_ROOT_KEYS,
+          (error) => reportSearchError(piece.id, "input data", error),
+        );
+      } catch (error) {
+        reportSearchError(piece.id, "input data", error);
+      }
+
+      let resultMatches = false;
+      if (!inputMatches) {
+        try {
+          const resultCell = await piece.result.getCell();
+          resultMatches = await searchTextMatches(
+            resultCell,
+            normalizedQuery,
+            { pieceId: piece.id, registeredPieceIds, ownerCache },
+            RESULT_IGNORED_ROOT_KEYS,
+            (error) => reportSearchError(piece.id, "result data", error),
+          );
+        } catch (error) {
+          reportSearchError(piece.id, "result data", error);
+        }
+      }
+
+      if (inputMatches || resultMatches) {
+        let name: string | undefined;
+        try {
+          name = piece.name();
+        } catch (error) {
+          reportSearchError(piece.id, "metadata", error);
+        }
+        let patternRef: PiecePatternRef | undefined;
+        try {
+          patternRef = await piece.getPatternRef();
+        } catch (error) {
+          reportSearchError(piece.id, "metadata", error);
+        }
+        matches[index] = { id: piece.id, name, patternRef };
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(PIECE_SEARCH_CONCURRENCY, allPieces.length) },
+      searchNextPiece,
+    ),
+  );
+
+  return matches.filter((piece): piece is PieceSearchResult =>
+    piece !== undefined
   );
 }
 

--- a/packages/cli/test/piece-summary.test.ts
+++ b/packages/cli/test/piece-summary.test.ts
@@ -1,0 +1,61 @@
+import { expect } from "@std/expect";
+import { decode } from "@commonfabric/utils/encoding";
+import { renderPieceSummaries } from "../commands/piece.ts";
+
+function captureStdout(fn: () => void): string {
+  let captured = "";
+  const original = Deno.stdout.writeSync;
+  Deno.stdout.writeSync = (data: Uint8Array): number => {
+    captured += decode(data);
+    return data.length;
+  };
+  try {
+    fn();
+  } finally {
+    Deno.stdout.writeSync = original;
+  }
+  return captured;
+}
+
+Deno.test("piece summaries render human and JSON output", () => {
+  const identity = "R".repeat(43);
+  const patternRef = {
+    identity,
+    symbol: "default",
+    source: {
+      ref: `cf:pattern:${identity}`,
+      repository: "https://github.com/commontoolsinc/labs",
+      entry: "/packages/patterns/notes.tsx",
+    },
+  };
+
+  const json = captureStdout(() =>
+    renderPieceSummaries([
+      { id: "of:notes", name: "Notes", patternRef },
+      { id: "of:unnamed" },
+    ], true)
+  );
+  expect(JSON.parse(json)).toEqual([
+    { id: "of:notes", name: "Notes", patternRef },
+    { id: "of:unnamed", name: null, patternRef: null },
+  ]);
+
+  const table = captureStdout(() =>
+    renderPieceSummaries([
+      { id: "of:notes", name: "Notes", patternRef },
+      { id: "of:unreadable", error: "stored data is unavailable" },
+      { id: "of:unnamed" },
+    ], false)
+  );
+  expect(table).toContain("ID");
+  expect(table).toContain("of:notes");
+  expect(table).toContain("Notes");
+  expect(table).toContain(
+    "https://github.com/commontoolsinc/labs#/packages/patterns/notes.tsx",
+  );
+  expect(table).toContain("<error: stored data is unavailable>");
+  expect(table).toContain("<unnamed>");
+  expect(table).toContain("<unknown>");
+
+  expect(captureStdout(() => renderPieceSummaries([], false))).toBe("");
+});

--- a/packages/cli/test/piece-summary.test.ts
+++ b/packages/cli/test/piece-summary.test.ts
@@ -1,6 +1,10 @@
 import { expect } from "@std/expect";
 import { decode } from "@commonfabric/utils/encoding";
-import { renderPieceSummaries } from "../commands/piece.ts";
+import {
+  listPiecesFromCommand,
+  renderPieceSummaries,
+  searchPiecesFromCommand,
+} from "../commands/piece.ts";
 
 function captureStdout(fn: () => void): string {
   let captured = "";
@@ -58,4 +62,91 @@ Deno.test("piece summaries render human and JSON output", () => {
   expect(table).toContain("<unknown>");
 
   expect(captureStdout(() => renderPieceSummaries([], false))).toBe("");
+});
+
+Deno.test("piece search command parses options and renders matches", async () => {
+  const matches = [{ id: "of:notes", name: "Notes" }];
+  let searched:
+    | {
+      config: {
+        apiUrl: string;
+        space: string;
+        identity: string;
+      };
+      query: string;
+    }
+    | undefined;
+  let rendered:
+    | {
+      pieces: Parameters<typeof renderPieceSummaries>[0];
+      json: boolean;
+    }
+    | undefined;
+
+  await searchPiecesFromCommand(
+    {
+      apiUrl: "https://cf.dev/",
+      space: "common-knowledge",
+      identity: "/tmp/estuary.key",
+      json: true,
+    },
+    "Hixie",
+    {
+      searchPieces: (config, query) => {
+        searched = { config, query };
+        return Promise.resolve(matches);
+      },
+      renderPieceSummaries: (pieces, json) => {
+        rendered = { pieces, json };
+      },
+    },
+  );
+
+  expect(searched).toEqual({
+    config: {
+      apiUrl: "https://cf.dev",
+      space: "common-knowledge",
+      identity: "/tmp/estuary.key",
+    },
+    query: "Hixie",
+  });
+  expect(rendered).toEqual({ pieces: matches, json: true });
+});
+
+Deno.test("piece list command parses options and renders pieces", async () => {
+  const pieces = [{ id: "of:tasks", name: "Tasks" }];
+  let listedConfig: {
+    apiUrl: string;
+    space: string;
+    identity: string;
+  } | undefined;
+  let rendered:
+    | {
+      pieces: Parameters<typeof renderPieceSummaries>[0];
+      json: boolean;
+    }
+    | undefined;
+
+  await listPiecesFromCommand(
+    {
+      url: "https://cf.dev/common-knowledge",
+      identity: "/tmp/estuary.key",
+    },
+    {
+      listPieces: (config) => {
+        listedConfig = config;
+        return Promise.resolve(pieces);
+      },
+      renderPieceSummaries: (summaries, json) => {
+        rendered = { pieces: summaries, json };
+      },
+    },
+  );
+
+  expect(listedConfig).toEqual({
+    apiUrl: "https://cf.dev",
+    space: "common-knowledge",
+    identity: "/tmp/estuary.key",
+  });
+  expect(rendered).toEqual({ pieces, json: false });
 });

--- a/packages/cli/test/piece-summary.test.ts
+++ b/packages/cli/test/piece-summary.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { decode } from "@commonfabric/utils/encoding";
 import {
   listPiecesFromCommand,
+  piece,
   renderPieceSummaries,
   searchPiecesFromCommand,
 } from "../commands/piece.ts";
@@ -62,6 +63,18 @@ Deno.test("piece summaries render human and JSON output", () => {
   expect(table).toContain("<unknown>");
 
   expect(captureStdout(() => renderPieceSummaries([], false))).toBe("");
+});
+
+Deno.test("piece registers its list and search command handlers", () => {
+  const actionHandler = (name: string): unknown =>
+    (piece.getCommand(name) as unknown as
+      | { actionHandler?: unknown }
+      | undefined)?.actionHandler;
+
+  expect(actionHandler("ls")).toBe(listPiecesFromCommand);
+  expect(actionHandler("search")).toBe(
+    searchPiecesFromCommand,
+  );
 });
 
 Deno.test("piece search command parses options and renders matches", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1,5 +1,22 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import {
+  type Cell,
+  getCellOrThrow,
+  ID as FABRIC_ID,
+  isCell,
+  isCellResult,
+  type JSONSchema,
+  Runtime,
+} from "@commonfabric/runner";
+import {
+  EmulatedStorageManager,
+  StorageManager,
+} from "@commonfabric/runner/storage/cache.deno";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 import { cf, checkStderr, stripAnsi } from "./utils.ts";
 import {
   getCellValue,
@@ -10,12 +27,14 @@ import {
   recreateSpaceRootPattern,
   resolveLinkEndpointAddress,
   resolvePieceConfig,
+  searchPieces,
   setHomePattern,
   setPiecePattern,
   type SpaceConfig,
   withRuntimeCleanupOnFailure,
 } from "../lib/piece.ts";
-import { SlugResolutionError } from "@commonfabric/piece";
+import { pieceId, SlugResolutionError } from "@commonfabric/piece";
+import { setResultCell } from "../../runner/src/result-utils.ts";
 import {
   formatPatternIdentity,
   formatPatternRef,
@@ -377,6 +396,19 @@ describe("cli piece parsing", () => {
       "Recreate the root pattern for the explicitly targeted space.",
     );
     expect(output).toContain("--space <space>");
+    expect(code).toBe(0);
+  });
+
+  it("shows search as a space-scoped command with JSON output", async () => {
+    const { code, stdout, stderr } = await cf("piece search --help");
+    checkStderr(stderr);
+    const output = stripAnsi(stdout.join("\n"));
+    expect(output).toContain(
+      "Search readable input and result data in every piece.",
+    );
+    expect(output).toContain("<query>");
+    expect(output).toContain("--space <space>");
+    expect(output).toContain("--json");
     expect(code).toBe(0);
   });
 
@@ -797,6 +829,1132 @@ describe("cli piece parsing", () => {
       { id: "of:readable", name: "Readable", patternRef },
       { id: "of:unreadable", error: "not readable" },
     ]);
+  });
+
+  it("searches nested input and result data without matching metadata", async () => {
+    const patternRef = {
+      identity: "S".repeat(43),
+      symbol: "default",
+      source: { ref: `cf:pattern:${"S".repeat(43)}` },
+    };
+    const cyclicInput: Record<string, unknown> = {
+      nested: { message: "A NeEdLe in the input" },
+    };
+    cyclicInput.self = cyclicInput;
+    class InternalObject {
+      needleInternalField = "not piece data";
+    }
+    const fabricHash = new FabricHash(
+      new Uint8Array([1, 2, 3, 4]),
+      "fid1",
+    );
+
+    const searchablePiece = (
+      id: string,
+      name: string,
+      input: unknown,
+      result: unknown,
+    ) => {
+      const cell = (value: unknown) => ({
+        pull: () => Promise.resolve(value),
+      });
+      return {
+        id,
+        name: () => name,
+        getPatternRef: () => Promise.resolve(patternRef),
+        input: { getCell: () => Promise.resolve(cell(input)) },
+        result: { getCell: () => Promise.resolve(cell(result)) },
+      };
+    };
+    const controller = {
+      getAllPieces: () =>
+        Promise.resolve([
+          searchablePiece(
+            "of:input-match",
+            "Input match",
+            cyclicInput,
+            {},
+          ),
+          searchablePiece(
+            "of:key-match",
+            "Key match",
+            {},
+            { nested: { needleStatus: false } },
+          ),
+          searchablePiece(
+            "of:needle-metadata-only",
+            "Needle appears only in metadata",
+            { content: "haystack" },
+            { $NAME: "Needle appears only in metadata" },
+          ),
+          searchablePiece(
+            "of:class-internals",
+            "Class internals",
+            new InternalObject(),
+            {},
+          ),
+          searchablePiece(
+            "of:internal-symbol",
+            "Internal symbol metadata",
+            { [FABRIC_ID]: "Needle in internal identity metadata" },
+            {},
+          ),
+          searchablePiece(
+            "of:fabric-special-object",
+            "Fabric special object",
+            new FabricError({
+              type: "Error",
+              name: "Error",
+              message: "Needle in encoded Fabric data",
+              stack: undefined,
+              cause: undefined,
+            }),
+            {},
+          ),
+          searchablePiece(
+            "of:fabric-hash",
+            "Fabric hash",
+            fabricHash,
+            {},
+          ),
+        ]),
+    };
+    const config = { apiUrl: API_URL, space: SPACE, identity: ID };
+    const deps = {
+      loadManager: () => Promise.resolve({} as any),
+      createController: () => controller as any,
+    };
+
+    const matches = await searchPieces(config, "NEEDLE", deps);
+
+    expect(matches).toEqual([
+      { id: "of:input-match", name: "Input match", patternRef },
+      { id: "of:key-match", name: "Key match", patternRef },
+      {
+        id: "of:fabric-special-object",
+        name: "Fabric special object",
+        patternRef,
+      },
+    ]);
+    expect(await searchPieces(config, fabricHash.toString(), deps)).toEqual([{
+      id: "of:fabric-hash",
+      name: "Fabric hash",
+      patternRef,
+    }]);
+  });
+
+  it("searches scalar data and rejects an empty query", async () => {
+    const cell = (value: unknown) => ({
+      pull: () => Promise.resolve(value),
+    });
+    const controller = {
+      getAllPieces: () =>
+        Promise.resolve([{
+          id: "of:number-match",
+          name: () => "Number match",
+          getPatternRef: () => Promise.resolve(undefined),
+          input: { getCell: () => Promise.resolve(cell(2048)) },
+          result: { getCell: () => Promise.resolve(cell(null)) },
+        }]),
+    };
+    const config = { apiUrl: API_URL, space: SPACE, identity: ID };
+    const deps = {
+      loadManager: () => Promise.resolve({} as any),
+      createController: () => controller as any,
+    };
+
+    expect(await searchPieces(config, "048", deps)).toEqual([{
+      id: "of:number-match",
+      name: "Number match",
+      patternRef: undefined,
+    }]);
+    await expect(searchPieces(config, "", deps)).rejects.toThrow(
+      "Search query must not be empty.",
+    );
+  });
+
+  it("uses full Unicode case folding and canonical normalization", async () => {
+    const cell = (value: unknown) => ({
+      pull: () => Promise.resolve(value),
+    });
+    const piece = (id: string, input: unknown) => ({
+      id,
+      name: () => id,
+      getPatternRef: () => Promise.resolve(undefined),
+      input: { getCell: () => Promise.resolve(cell(input)) },
+      result: { getCell: () => Promise.resolve(cell({})) },
+    });
+    const controller = {
+      getAllPieces: () =>
+        Promise.resolve([
+          piece("of:full-fold", "Maße"),
+          piece("of:canonical-equivalence", "café"),
+          piece("of:indic-substring", "क्ष"),
+          piece("of:unicode-17", "\u{16EA0}"),
+          piece("of:unrelated", "needle"),
+        ]),
+    };
+    const config = { apiUrl: API_URL, space: SPACE, identity: ID };
+    const deps = {
+      loadManager: () => Promise.resolve({} as any),
+      createController: () => controller as any,
+    };
+
+    expect(await searchPieces(config, "MASSE", deps)).toEqual([{
+      id: "of:full-fold",
+      name: "of:full-fold",
+      patternRef: undefined,
+    }]);
+    expect(await searchPieces(config, "CAFE\u0301", deps)).toEqual([{
+      id: "of:canonical-equivalence",
+      name: "of:canonical-equivalence",
+      patternRef: undefined,
+    }]);
+    expect(await searchPieces(config, "\u{16EBB}", deps)).toEqual([{
+      id: "of:unicode-17",
+      name: "of:unicode-17",
+      patternRef: undefined,
+    }]);
+    expect(await searchPieces(config, "ष", deps)).toEqual([{
+      id: "of:indic-substring",
+      name: "of:indic-substring",
+      patternRef: undefined,
+    }]);
+    expect(await searchPieces(config, "s", deps)).toEqual([]);
+    expect(await searchPieces(config, "CAFE", deps)).toEqual([]);
+  });
+
+  it("materializes nested runtime cells without searching cell internals", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cf piece search nested cell test",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+
+    try {
+      const space = signer.did();
+      const nestedSchema = {
+        type: "object",
+        properties: { text: { type: "string" } },
+        required: ["text"],
+        additionalProperties: false,
+      } as const;
+      const inputSchema = {
+        type: "object",
+        properties: {
+          nested: { ...nestedSchema, asCell: ["cell"] },
+          hidden: { ...nestedSchema, asCell: ["opaque"] },
+        },
+        required: ["nested", "hidden"],
+        additionalProperties: false,
+      } as const;
+      const tx = runtime.edit();
+      const nested = runtime.getCell(
+        space,
+        "piece-search-nested-visible",
+        nestedSchema,
+        tx,
+      );
+      nested.set({ text: "needle in a nested runtime cell" });
+      const hidden = runtime.getCell(
+        space,
+        "piece-search-nested-hidden",
+        nestedSchema,
+        tx,
+      );
+      hidden.set({ text: "opaque-search-secret" });
+      const input = runtime.getCell(
+        space,
+        "piece-search-input",
+        inputSchema,
+        tx,
+      );
+      input.set({ nested, hidden });
+      const result = runtime.getCell(
+        space,
+        "piece-search-result",
+        undefined,
+        tx,
+      );
+      result.set({ $NAME: "needle only in the piece name" });
+      await tx.commit();
+      await runtime.idle();
+
+      const inputValue = await input.pull();
+      expect(isCell(inputValue.nested)).toBe(true);
+      if (!isCell(inputValue.nested)) {
+        throw new Error("Expected nested input data to remain a Cell");
+      }
+      expect(await inputValue.nested.pull()).toEqual({
+        text: "needle in a nested runtime cell",
+      });
+
+      const controller = {
+        getAllPieces: () =>
+          Promise.resolve([{
+            id: "of:runtime-cell-piece",
+            name: () => "needle only in the piece name",
+            getPatternRef: () => Promise.resolve(undefined),
+            input: { getCell: () => Promise.resolve(input) },
+            result: { getCell: () => Promise.resolve(result) },
+          }]),
+      };
+      const config = { apiUrl: API_URL, space: SPACE, identity: ID };
+      const deps = {
+        loadManager: () => Promise.resolve({} as any),
+        createController: () => controller as any,
+      };
+
+      expect(await searchPieces(config, "nested runtime", deps)).toEqual([{
+        id: "of:runtime-cell-piece",
+        name: "needle only in the piece name",
+        patternRef: undefined,
+      }]);
+      expect(await searchPieces(config, "opaque-search-secret", deps)).toEqual(
+        [],
+      );
+      expect(await searchPieces(config, "_link", deps)).toEqual([]);
+      expect(await searchPieces(config, "unique to the context", deps))
+        .toEqual([]);
+      expect(await searchPieces(config, "piece name", deps)).toEqual([]);
+
+      const narrowView = runtime.getCell(
+        space,
+        "piece-search-nested-visible",
+        {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+      );
+      const wideView = runtime.getCell(
+        space,
+        "piece-search-nested-visible",
+        nestedSchema,
+      );
+      const viewController = {
+        getAllPieces: () =>
+          Promise.resolve([{
+            id: "of:multiple-runtime-cell-views",
+            name: () => "Multiple runtime cell views",
+            getPatternRef: () => Promise.resolve(undefined),
+            input: {
+              getCell: () =>
+                Promise.resolve({
+                  pull: () => Promise.resolve([narrowView, wideView]),
+                }),
+            },
+            result: {
+              getCell: () =>
+                Promise.resolve({ pull: () => Promise.resolve({}) }),
+            },
+          }]),
+      };
+      expect(
+        await searchPieces(config, "nested runtime cell", {
+          loadManager: () => Promise.resolve({} as any),
+          createController: () => viewController as any,
+        }),
+      ).toEqual([{
+        id: "of:multiple-runtime-cell-views",
+        name: "Multiple runtime cell views",
+        patternRef: undefined,
+      }]);
+
+      const brokenNested = runtime.getCell(
+        space,
+        "piece-search-broken-nested",
+        nestedSchema,
+      );
+      Object.defineProperty(brokenNested, "pull", {
+        value: () => Promise.reject(new Error("nested cell unavailable")),
+      });
+      const nestedErrors: unknown[] = [];
+      const partialController = {
+        getAllPieces: () =>
+          Promise.resolve([{
+            id: "of:partial-runtime-cell-piece",
+            name: () => "Partial runtime cell piece",
+            getPatternRef: () => Promise.resolve(undefined),
+            input: {
+              getCell: () =>
+                Promise.resolve({
+                  pull: () =>
+                    Promise.resolve([
+                      brokenNested,
+                      "surviving nested cell data",
+                    ]),
+                }),
+            },
+            result: {
+              getCell: () =>
+                Promise.resolve({ pull: () => Promise.resolve({}) }),
+            },
+          }]),
+      };
+      expect(
+        await searchPieces(config, "surviving nested", {
+          loadManager: () => Promise.resolve({} as any),
+          createController: () => partialController as any,
+          reportSearchError: (_pieceId, _source, error) =>
+            nestedErrors.push(error),
+        }),
+      ).toEqual([{
+        id: "of:partial-runtime-cell-piece",
+        name: "Partial runtime cell piece",
+        patternRef: undefined,
+      }]);
+      expect(nestedErrors).toEqual([new Error("nested cell unavailable")]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("attributes linked data to its owner and preserves ownerless data", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cf piece search linked cell owner test",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+
+    try {
+      const space = signer.did();
+      const sharedSchema = {
+        type: "object",
+        properties: { text: { type: "string" } },
+        required: ["text"],
+        additionalProperties: false,
+      } as const;
+      const scalarSchema = { type: "string" } as const;
+      const emptySchema = {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      } as const;
+      const inputSchema = {
+        type: "object",
+        properties: {
+          sharedCell: { ...sharedSchema, asCell: ["cell"] },
+          sharedValue: sharedSchema,
+          sharedScalar: scalarSchema,
+          ownerlessCell: { ...sharedSchema, asCell: ["cell"] },
+          ownerlessValue: sharedSchema,
+          unregisteredPieceValue: sharedSchema,
+          unregisteredKeylessValue: sharedSchema,
+        },
+        required: [
+          "sharedCell",
+          "sharedValue",
+          "sharedScalar",
+          "ownerlessCell",
+          "ownerlessValue",
+          "unregisteredPieceValue",
+          "unregisteredKeylessValue",
+        ],
+        additionalProperties: false,
+      } as const;
+      const tx = runtime.edit();
+      const sharedCell = runtime.getCell(
+        space,
+        "piece-search-owned-cell-data",
+        sharedSchema,
+        tx,
+      );
+      const sharedValue = runtime.getCell(
+        space,
+        "piece-search-owned-proxy-data",
+        sharedSchema,
+        tx,
+      );
+      const sharedScalar = runtime.getCell(
+        space,
+        "piece-search-owned-scalar-data",
+        scalarSchema,
+        tx,
+      );
+      const ownerlessCell = runtime.getCell(
+        space,
+        "piece-search-ownerless-cell-data",
+        sharedSchema,
+        tx,
+      );
+      const ownerlessValue = runtime.getCell(
+        space,
+        "piece-search-ownerless-proxy-data",
+        sharedSchema,
+        tx,
+      );
+      const unregisteredPieceValue = runtime.getCell(
+        space,
+        "piece-search-unregistered-piece-data",
+        sharedSchema,
+        tx,
+      );
+      const unregisteredKeylessValue = runtime.getCell(
+        space,
+        "piece-search-unregistered-keyless-data",
+        sharedSchema,
+        tx,
+      );
+      const unregisteredKeylessArgument = runtime.getCell(
+        space,
+        "piece-search-unregistered-keyless-argument",
+        emptySchema,
+        tx,
+      );
+      const ownerResult = runtime.getCell(
+        space,
+        "piece-search-owner-result",
+        emptySchema,
+        tx,
+      );
+      const ownerInput = runtime.getCell(
+        space,
+        "piece-search-owner-input",
+        inputSchema,
+        tx,
+      );
+      const referrerResult = runtime.getCell(
+        space,
+        "piece-search-referrer-result",
+        emptySchema,
+        tx,
+      );
+      const referrerInput = runtime.getCell(
+        space,
+        "piece-search-referrer-input",
+        inputSchema,
+        tx,
+      );
+      const aliasInput = runtime.getCell(
+        space,
+        "piece-search-alias-input",
+        emptySchema,
+        tx,
+      );
+      const aliasResult = runtime.getCell(
+        space,
+        "piece-search-alias-result",
+        sharedSchema,
+        tx,
+      );
+
+      sharedCell.set({ text: "explicit ownership match" });
+      sharedValue.set({ text: "proxy ownership match" });
+      sharedScalar.set("scalar ownership match");
+      ownerlessCell.set({ text: "ownerless explicit match" });
+      ownerlessValue.set({ text: "ownerless proxy match" });
+      unregisteredPieceValue.set({ text: "unregistered piece match" });
+      unregisteredPieceValue.setMetaRaw("patternIdentity", {
+        identity: "P".repeat(43),
+        symbol: "default",
+      });
+      unregisteredKeylessValue.set({ text: "unregistered keyless match" });
+      unregisteredKeylessArgument.set({});
+      unregisteredKeylessValue.setMetaRaw(
+        "argument",
+        unregisteredKeylessArgument.getAsWriteRedirectLink(),
+      );
+      ownerResult.set({});
+      ownerInput.set({
+        sharedCell,
+        sharedValue,
+        sharedScalar,
+        ownerlessCell,
+        ownerlessValue,
+        unregisteredPieceValue,
+        unregisteredKeylessValue,
+      });
+      referrerResult.set({});
+      referrerInput.set({
+        sharedCell,
+        sharedValue,
+        sharedScalar,
+        ownerlessCell,
+        ownerlessValue,
+        unregisteredPieceValue,
+        unregisteredKeylessValue,
+      });
+      aliasInput.set({});
+      aliasResult.set(sharedValue);
+      setResultCell(sharedCell, ownerResult);
+      setResultCell(sharedValue, ownerResult);
+      setResultCell(sharedScalar, ownerResult);
+      setResultCell(ownerInput, ownerResult);
+      setResultCell(ownerResult, referrerResult);
+      setResultCell(referrerInput, referrerResult);
+      setResultCell(aliasInput, aliasResult);
+      await tx.commit();
+      await runtime.idle();
+
+      const referrerInputValue = await referrerInput.pull();
+      expect(isCell(referrerInputValue.sharedCell)).toBe(true);
+      expect(isCellResult(referrerInputValue.sharedValue)).toBe(true);
+      expect(referrerInputValue.sharedScalar).toBe("scalar ownership match");
+      expect(isCell(referrerInputValue.ownerlessCell)).toBe(true);
+      expect(isCellResult(referrerInputValue.ownerlessValue)).toBe(true);
+      expect(isCellResult(referrerInputValue.unregisteredPieceValue)).toBe(
+        true,
+      );
+      expect(isCellResult(referrerInputValue.unregisteredKeylessValue)).toBe(
+        true,
+      );
+      const linkedValueCell = getCellOrThrow(referrerInputValue.sharedValue);
+      expect(pieceId(linkedValueCell)).toBe(pieceId(referrerInput));
+      expect(pieceId(linkedValueCell.resolveAsCell())).toBe(
+        pieceId(sharedValue),
+      );
+
+      const ownerId = pieceId(ownerResult);
+      const referrerId = pieceId(referrerResult);
+      const aliasId = pieceId(aliasResult);
+      if (
+        ownerId === undefined || referrerId === undefined ||
+        aliasId === undefined
+      ) {
+        throw new Error("Expected result cells to have piece IDs");
+      }
+      const piece = (
+        id: string,
+        name: string,
+        input: Cell<unknown>,
+        result: Cell<unknown>,
+      ) => ({
+        id,
+        name: () => name,
+        getPatternRef: () => Promise.resolve(undefined),
+        input: { getCell: () => Promise.resolve(input) },
+        result: { getCell: () => Promise.resolve(result) },
+      });
+      const controller = {
+        getAllPieces: () =>
+          Promise.resolve([
+            piece(referrerId, "Referrer", referrerInput, referrerResult),
+            piece(aliasId, "Top-level alias", aliasInput, aliasResult),
+            piece(ownerId, "Owner", ownerInput, ownerResult),
+          ]),
+      };
+      const config = { apiUrl: API_URL, space: SPACE, identity: ID };
+      const deps = {
+        loadManager: () => Promise.resolve({} as any),
+        createController: () => controller as any,
+      };
+
+      expect(
+        await searchPieces(config, "explicit ownership", deps),
+      ).toEqual([{
+        id: ownerId,
+        name: "Owner",
+        patternRef: undefined,
+      }]);
+      expect(
+        await searchPieces(config, "proxy ownership", deps),
+      ).toEqual([{
+        id: ownerId,
+        name: "Owner",
+        patternRef: undefined,
+      }]);
+      expect(
+        await searchPieces(config, "scalar ownership", deps),
+      ).toEqual([{
+        id: ownerId,
+        name: "Owner",
+        patternRef: undefined,
+      }]);
+      const referrerAndOwner = [
+        { id: referrerId, name: "Referrer", patternRef: undefined },
+        { id: ownerId, name: "Owner", patternRef: undefined },
+      ];
+      expect(
+        await searchPieces(config, "ownerless explicit", deps),
+      ).toEqual(referrerAndOwner);
+      expect(
+        await searchPieces(config, "ownerless proxy", deps),
+      ).toEqual(referrerAndOwner);
+      expect(
+        await searchPieces(config, "unregistered piece", deps),
+      ).toEqual([]);
+      expect(
+        await searchPieces(config, "unregistered keyless", deps),
+      ).toEqual([]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("reports cyclic Cell ownership without attributing the data", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cf piece search cyclic cell owner test",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+
+    try {
+      const space = signer.did();
+      const schema = {
+        type: "object",
+        properties: { text: { type: "string" } },
+        required: ["text"],
+        additionalProperties: false,
+      } as const;
+      const tx = runtime.edit();
+      const first = runtime.getCell(
+        space,
+        "piece-search-owner-cycle-first",
+        schema,
+        tx,
+      );
+      const second = runtime.getCell(
+        space,
+        "piece-search-owner-cycle-second",
+        schema,
+        tx,
+      );
+      first.set({ text: "cyclic ownership match" });
+      second.set({ text: "other cycle value" });
+      setResultCell(first, second);
+      setResultCell(second, first);
+      await tx.commit();
+      await runtime.idle();
+
+      const cell = (value: unknown) => ({
+        pull: () => Promise.resolve(value),
+      });
+      const controller = {
+        getAllPieces: () =>
+          Promise.resolve([{
+            id: "of:cycle-referrer",
+            name: () => "Cycle referrer",
+            getPatternRef: () => Promise.resolve(undefined),
+            input: {
+              getCell: () => Promise.resolve(cell({ linked: first })),
+            },
+            result: { getCell: () => Promise.resolve(cell({})) },
+          }]),
+      };
+      const errors: unknown[] = [];
+
+      expect(
+        await searchPieces(
+          { apiUrl: API_URL, space: SPACE, identity: ID },
+          "cyclic ownership",
+          {
+            loadManager: () => Promise.resolve({} as any),
+            createController: () => controller as any,
+            reportSearchError: (_pieceId, _source, error) => errors.push(error),
+          },
+        ),
+      ).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(String(errors[0])).toContain(
+        "Cycle found while resolving piece ownership",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("loads nested cells from a cold runtime before searching them", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cf piece search cold runtime test",
+    );
+    const space = signer.did();
+    const audience = "did:key:z6Mk-runner-emulated-memory";
+    const server = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+      sessionOpenAuth: { audience },
+    });
+
+    class SharedStorage extends EmulatedStorageManager {
+      static connect(server: MemoryV2Server.Server): SharedStorage {
+        const manager = new SharedStorage(
+          { as: signer, memoryHost: new URL("memory://") } as any,
+          () => server,
+        );
+        manager.#server = server;
+        return manager;
+      }
+
+      #server!: MemoryV2Server.Server;
+
+      protected override server(): MemoryV2Server.Server {
+        return this.#server;
+      }
+    }
+
+    const leafSchema = {
+      type: "object",
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    } as const satisfies JSONSchema;
+    const middleSchema = {
+      type: "object",
+      properties: { leaf: { ...leafSchema, asCell: ["cell"] } },
+      required: ["leaf"],
+    } as const satisfies JSONSchema;
+    const rootSchema = {
+      type: "object",
+      properties: { middle: { ...middleSchema, asCell: ["cell"] } },
+      required: ["middle"],
+    } as const satisfies JSONSchema;
+    const writerStorage = SharedStorage.connect(server);
+    const writer = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager: writerStorage,
+    });
+    const writeTx = writer.edit();
+    const leaf = writer.getCell(
+      space,
+      "piece-search-cold-leaf",
+      leafSchema,
+      writeTx,
+    );
+    const middle = writer.getCell(
+      space,
+      "piece-search-cold-middle",
+      middleSchema,
+      writeTx,
+    );
+    const root = writer.getCell(
+      space,
+      "piece-search-cold-root",
+      rootSchema,
+      writeTx,
+    );
+    leaf.set({ text: "cold-cache-needle" });
+    middle.set({ leaf });
+    root.set({ middle });
+    await writeTx.commit();
+    await writerStorage.synced();
+
+    const readerStorage = SharedStorage.connect(server);
+    const reader = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager: readerStorage,
+    });
+    try {
+      const readerRoot = reader.getCell(
+        space,
+        "piece-search-cold-root",
+        rootSchema,
+      );
+      const empty = reader.getCell(space, "piece-search-cold-empty", true);
+      const controller = {
+        getAllPieces: () =>
+          Promise.resolve([{
+            id: "of:cold-runtime-piece",
+            name: () => "Cold runtime piece",
+            getPatternRef: () => Promise.resolve(undefined),
+            input: { getCell: () => Promise.resolve(readerRoot) },
+            result: { getCell: () => Promise.resolve(empty) },
+          }]),
+      };
+
+      expect(
+        await searchPieces(
+          {
+            apiUrl: API_URL,
+            space: SPACE,
+            identity: ID,
+          },
+          "cold-cache-needle",
+          {
+            loadManager: () => Promise.resolve({} as any),
+            createController: () => controller as any,
+          },
+        ),
+      ).toEqual([{
+        id: "of:cold-runtime-piece",
+        name: "Cold runtime piece",
+        patternRef: undefined,
+      }]);
+    } finally {
+      await reader.dispose();
+      await readerStorage.close();
+      await writer.dispose();
+      await writerStorage.close();
+      await server.close();
+    }
+  });
+
+  it("searches arrays with a large sparse length", async () => {
+    const values: unknown[] = [];
+    values.length = 0xffff_ffff;
+    values[0xffff_fffe] = "large-array-needle";
+    const cell = (value: unknown) => ({
+      pull: () => Promise.resolve(value),
+    });
+    const controller = {
+      getAllPieces: () =>
+        Promise.resolve([{
+          id: "of:large-array",
+          name: () => "Large array",
+          getPatternRef: () => Promise.resolve(undefined),
+          input: { getCell: () => Promise.resolve(cell(values)) },
+          result: { getCell: () => Promise.resolve(cell({})) },
+        }]),
+    };
+
+    expect(
+      await searchPieces(
+        {
+          apiUrl: API_URL,
+          space: SPACE,
+          identity: ID,
+        },
+        "large-array-needle",
+        {
+          loadManager: () => Promise.resolve({} as any),
+          createController: () => controller as any,
+        },
+      ),
+    ).toEqual([{
+      id: "of:large-array",
+      name: "Large array",
+      patternRef: undefined,
+    }]);
+  });
+
+  it("searches current data after a query proxy changes shape", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cf piece search stale array proxy test",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+
+    try {
+      const tx = runtime.edit();
+      const arrayToObjectSource = runtime.getCell<unknown>(
+        signer.did(),
+        "piece-search-array-to-object-proxy",
+        undefined,
+        tx,
+      );
+      arrayToObjectSource.set(["old array value"]);
+      const arrayToObjectProxy = arrayToObjectSource.getAsQueryResult();
+      arrayToObjectSource.set({
+        changedShape: "shape-change-value",
+        length: "hidden-length-value",
+      });
+
+      const arrayToScalarSource = runtime.getCell<unknown>(
+        signer.did(),
+        "piece-search-array-to-scalar-proxy",
+        undefined,
+        tx,
+      );
+      arrayToScalarSource.set(["other old array value"]);
+      const arrayToScalarProxy = arrayToScalarSource.getAsQueryResult();
+      arrayToScalarSource.set("scalar-shape-value");
+
+      const objectToArraySource = runtime.getCell<unknown>(
+        signer.did(),
+        "piece-search-object-to-array-proxy",
+        undefined,
+        tx,
+      );
+      objectToArraySource.set({ oldObjectValue: true });
+      const objectToArrayProxy = objectToArraySource.getAsQueryResult();
+      objectToArraySource.set(["array-shape-value"]);
+      await tx.commit();
+      await runtime.idle();
+
+      const cell = (value: unknown) => ({
+        pull: () => Promise.resolve(value),
+      });
+      const controller = {
+        getAllPieces: () =>
+          Promise.resolve([{
+            id: "of:stale-array-proxy",
+            name: () => "Stale array proxy",
+            getPatternRef: () => Promise.resolve(undefined),
+            input: {
+              getCell: () =>
+                Promise.resolve(cell({
+                  arrayToObject: arrayToObjectProxy,
+                  arrayToScalar: arrayToScalarProxy,
+                  objectToArray: objectToArrayProxy,
+                })),
+            },
+            result: { getCell: () => Promise.resolve(cell({})) },
+          }]),
+      };
+      const config = { apiUrl: API_URL, space: SPACE, identity: ID };
+      const deps = {
+        loadManager: () => Promise.resolve({} as any),
+        createController: () => controller as any,
+      };
+      const match = [{
+        id: "of:stale-array-proxy",
+        name: "Stale array proxy",
+        patternRef: undefined,
+      }];
+
+      expect(
+        await searchPieces(config, "changedShape", deps),
+      ).toEqual(match);
+      expect(
+        await searchPieces(config, "shape-change-value", deps),
+      ).toEqual(match);
+      expect(
+        await searchPieces(config, "hidden-length-value", deps),
+      ).toEqual(match);
+      expect(
+        await searchPieces(config, "scalar-shape-value", deps),
+      ).toEqual(match);
+      expect(
+        await searchPieces(config, "array-shape-value", deps),
+      ).toEqual(match);
+      expect(
+        await searchPieces(config, "0", deps),
+      ).toEqual([]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("continues after an unreadable piece and preserves match order", async () => {
+    const errors: Array<{
+      pieceId: string;
+      source: "input data" | "result data" | "metadata";
+      error: unknown;
+    }> = [];
+    const cell = (value: unknown) => ({
+      pull: () => Promise.resolve(value),
+    });
+    const matchingPiece = (id: string) => ({
+      id,
+      name: () => id,
+      getPatternRef: () => Promise.resolve(undefined),
+      input: { getCell: () => Promise.resolve(cell("needle")) },
+      result: { getCell: () => Promise.resolve(cell({})) },
+    });
+    const partiallyReadableObject = {
+      get broken(): unknown {
+        throw new Error("object property not readable");
+      },
+      survives: "needle after unreadable object property",
+    };
+    const partiallyReadableArray = [undefined, "needle after unreadable array"];
+    Object.defineProperty(partiallyReadableArray, 0, {
+      enumerable: true,
+      get: () => {
+        throw new Error("array element not readable");
+      },
+    });
+    const controller = {
+      getAllPieces: () =>
+        Promise.resolve([
+          matchingPiece("of:first-match"),
+          {
+            id: "of:unreadable",
+            name: () => "Result-only match",
+            getPatternRef: () => Promise.resolve(undefined),
+            input: {
+              getCell: () => Promise.reject(new Error("not readable")),
+            },
+            result: { getCell: () => Promise.resolve(cell("needle")) },
+          },
+          {
+            id: "of:partial-object",
+            name: () => "Partial object",
+            getPatternRef: () => Promise.resolve(undefined),
+            input: {
+              getCell: () => Promise.resolve(cell(partiallyReadableObject)),
+            },
+            result: { getCell: () => Promise.resolve(cell({})) },
+          },
+          {
+            id: "of:partial-array",
+            name: () => "Partial array",
+            getPatternRef: () => Promise.resolve(undefined),
+            input: {
+              getCell: () => Promise.resolve(cell(partiallyReadableArray)),
+            },
+            result: { getCell: () => Promise.resolve(cell({})) },
+          },
+          matchingPiece("of:second-match"),
+        ]),
+    };
+
+    expect(
+      await searchPieces(
+        {
+          apiUrl: API_URL,
+          space: SPACE,
+          identity: ID,
+        },
+        "needle",
+        {
+          loadManager: () => Promise.resolve({} as any),
+          createController: () => controller as any,
+          reportSearchError: (pieceId, source, error) =>
+            errors.push({ pieceId, source, error }),
+        },
+      ),
+    ).toEqual([
+      {
+        id: "of:first-match",
+        name: "of:first-match",
+        patternRef: undefined,
+      },
+      {
+        id: "of:unreadable",
+        name: "Result-only match",
+        patternRef: undefined,
+      },
+      {
+        id: "of:partial-object",
+        name: "Partial object",
+        patternRef: undefined,
+      },
+      {
+        id: "of:partial-array",
+        name: "Partial array",
+        patternRef: undefined,
+      },
+      {
+        id: "of:second-match",
+        name: "of:second-match",
+        patternRef: undefined,
+      },
+    ]);
+    expect(errors).toHaveLength(3);
+    expect(errors).toContainEqual({
+      pieceId: "of:unreadable",
+      source: "input data",
+      error: new Error("not readable"),
+    });
+    expect(errors).toContainEqual({
+      pieceId: "of:partial-object",
+      source: "input data",
+      error: new Error("object property not readable"),
+    });
+    expect(errors).toContainEqual({
+      pieceId: "of:partial-array",
+      source: "input data",
+      error: new Error("array element not readable"),
+    });
   });
 
   it("forwards repository metadata through piece creation and updates", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1752,6 +1752,32 @@ describe("cli piece parsing", () => {
       await runtime.idle();
 
       const sourceError = new Error("source ownership unavailable");
+      let repeatedCellPulls = 0;
+      const repeatedCellView = new Proxy(repeatedCell, {
+        get(target, property) {
+          if (property === "pull") {
+            return async () => {
+              repeatedCellPulls++;
+              return await target.pull();
+            };
+          }
+          const value = Reflect.get(target, property, target);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+      let repeatedProxyMaterializations = 0;
+      const repeatedProxyCellView = new Proxy(repeatedProxySource, {
+        get(target, property) {
+          if (property === "asSchema") {
+            return (schema?: JSONSchema) => {
+              repeatedProxyMaterializations++;
+              return target.asSchema(schema);
+            };
+          }
+          const value = Reflect.get(target, property, target);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
       const brokenSourceView = new Proxy(brokenSource, {
         get(target, property) {
           if (property === "resolveAsCell") {
@@ -1780,7 +1806,9 @@ describe("cli piece parsing", () => {
       if (ownerId === undefined) {
         throw new Error("Expected the owner result to have a piece ID");
       }
-      const repeatedProxy = repeatedProxySource.getAsQueryResult();
+      const repeatedProxy = {
+        [toCell]: () => repeatedProxyCellView,
+      };
       const ownedProxy = ownedProxySource.getAsQueryResult();
       const cell = (value: unknown) => ({
         pull: () => Promise.resolve(value),
@@ -1798,8 +1826,8 @@ describe("cli piece parsing", () => {
             piece("of:owned-proxy-referrer", "Referrer", [ownedProxy]),
             piece(ownerId, "Owner", "owned proxy coverage needle"),
             piece("of:repeated-cell", "Repeated cell", [
-              repeatedCell,
-              repeatedCell,
+              repeatedCellView,
+              repeatedCellView,
             ]),
             piece("of:repeated-proxy", "Repeated proxy", [
               repeatedProxy,
@@ -1819,23 +1847,29 @@ describe("cli piece parsing", () => {
         source: "input data" | "result data" | "metadata";
         error: unknown;
       }> = [];
+      const searchDeps = {
+        loadManager: () => Promise.resolve({} as any),
+        createController: () => controller as any,
+        reportSearchError: (
+          pieceId: string,
+          source: "input data" | "result data" | "metadata",
+          error: unknown,
+        ) => errors.push({ pieceId, source, error }),
+      };
 
       expect(
         await searchPieces(
           { apiUrl: API_URL, space: SPACE, identity: ID },
           "owned proxy coverage needle",
-          {
-            loadManager: () => Promise.resolve({} as any),
-            createController: () => controller as any,
-            reportSearchError: (pieceId, source, error) =>
-              errors.push({ pieceId, source, error }),
-          },
+          searchDeps,
         ),
       ).toEqual([{
         id: ownerId,
         name: "Owner",
         patternRef: undefined,
       }]);
+      expect(repeatedCellPulls).toBe(1);
+      expect(repeatedProxyMaterializations).toBe(1);
       expect(errors.length).toBeGreaterThan(0);
       expect(
         errors.every(({ pieceId, source, error }) =>
@@ -1843,6 +1877,20 @@ describe("cli piece parsing", () => {
           error === sourceError
         ),
       ).toBe(true);
+
+      errors.length = 0;
+      expect(
+        await searchPieces(
+          { apiUrl: API_URL, space: SPACE, identity: ID },
+          "unreachable source value",
+          searchDeps,
+        ),
+      ).toEqual([]);
+      expect(errors).toContainEqual({
+        pieceId: "of:broken-source-owner",
+        source: "input data",
+        error: sourceError,
+      });
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -16,6 +16,7 @@ import {
 } from "@commonfabric/runner/storage/cache.deno";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
 import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 import { cf, checkStderr, stripAnsi } from "./utils.ts";
 import {
@@ -35,6 +36,7 @@ import {
 } from "../lib/piece.ts";
 import { pieceId, SlugResolutionError } from "@commonfabric/piece";
 import { setResultCell } from "../../runner/src/result-utils.ts";
+import { toCell } from "../../runner/src/back-to-cell.ts";
 import {
   formatPatternIdentity,
   formatPatternRef,
@@ -973,6 +975,188 @@ describe("cli piece parsing", () => {
     );
   });
 
+  it("searches named array properties and skips result metadata", async () => {
+    const input: unknown[] = ["ordinary array value"];
+    Object.defineProperty(input, "annotation", {
+      enumerable: true,
+      value: "needle in a named array property",
+    });
+    const result: unknown[] = [];
+    Object.defineProperty(result, "$NAME", {
+      enumerable: true,
+      value: "needle only in ignored result metadata",
+    });
+    const cell = (value: unknown) => ({
+      pull: () => Promise.resolve(value),
+    });
+    const controller = {
+      getAllPieces: () =>
+        Promise.resolve([{
+          id: "of:named-array-property",
+          name: () => "Named array property",
+          getPatternRef: () => Promise.resolve(undefined),
+          input: { getCell: () => Promise.resolve(cell(input)) },
+          result: { getCell: () => Promise.resolve(cell(result)) },
+        }]),
+    };
+    const config = { apiUrl: API_URL, space: SPACE, identity: ID };
+    const deps = {
+      loadManager: () => Promise.resolve({} as any),
+      createController: () => controller as any,
+    };
+
+    expect(
+      await searchPieces(config, "named array property", deps),
+    ).toEqual([{
+      id: "of:named-array-property",
+      name: "Named array property",
+      patternRef: undefined,
+    }]);
+    expect(
+      await searchPieces(config, "ignored result metadata", deps),
+    ).toEqual([]);
+  });
+
+  it("reports unreadable iterators, cell proxies, and Fabric values", async () => {
+    const iteratorError = new Error("array keys are not readable");
+    const unreadableArray = new Proxy<unknown[]>([], {
+      ownKeys: () => {
+        throw iteratorError;
+      },
+    });
+    const cellProxyError = new Error("cell proxy lost its backing cell");
+    const unreadableCellProxy = {
+      [toCell]: () => {
+        throw cellProxyError;
+      },
+    };
+    const stringError = new Error("Fabric string representation unavailable");
+    class UnrepresentableFabricValue extends FabricSpecialObject {
+      override toString(): string {
+        throw stringError;
+      }
+    }
+    const fabricValue = new UnrepresentableFabricValue();
+    const cell = (value: unknown) => ({
+      pull: () => Promise.resolve(value),
+    });
+    const piece = (id: string, input: unknown) => ({
+      id,
+      name: () => id,
+      getPatternRef: () => Promise.resolve(undefined),
+      input: { getCell: () => Promise.resolve(cell(input)) },
+      result: { getCell: () => Promise.resolve(cell({})) },
+    });
+    const controller = {
+      getAllPieces: () =>
+        Promise.resolve([
+          piece("of:unreadable-array-iterator", unreadableArray),
+          piece("of:unreadable-cell-proxy", unreadableCellProxy),
+          piece("of:unrepresentable-fabric-value", fabricValue),
+        ]),
+    };
+    const errors: unknown[] = [];
+
+    expect(
+      await searchPieces(
+        { apiUrl: API_URL, space: SPACE, identity: ID },
+        "absent search value",
+        {
+          loadManager: () => Promise.resolve({} as any),
+          createController: () => controller as any,
+          reportSearchError: (_pieceId, _source, error) => errors.push(error),
+        },
+      ),
+    ).toEqual([]);
+    expect(errors).toContain(iteratorError);
+    expect(errors).toContain(cellProxyError);
+    expect(errors).toContain(stringError);
+    expect(errors.map(String).some((error) => error.includes("no `[CODEC]`")))
+      .toBe(true);
+  });
+
+  it("warns when input and result data cannot be read", async () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...values: unknown[]) => warnings.push(values.join(" "));
+    try {
+      const controller = {
+        getAllPieces: () =>
+          Promise.resolve([{
+            id: "of:unreadable-data",
+            name: () => "Unreadable data",
+            getPatternRef: () => Promise.resolve(undefined),
+            input: {
+              getCell: () => Promise.reject(new Error("input unavailable")),
+            },
+            result: {
+              getCell: () => Promise.reject("result unavailable"),
+            },
+          }]),
+      };
+
+      expect(
+        await searchPieces(
+          { apiUrl: API_URL, space: SPACE, identity: ID },
+          "needle",
+          {
+            loadManager: () => Promise.resolve({} as any),
+            createController: () => controller as any,
+          },
+        ),
+      ).toEqual([]);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(warnings).toEqual([
+      "Warning: Could not read input data for piece of:unreadable-data: input unavailable",
+      "Warning: Could not read result data for piece of:unreadable-data: result unavailable",
+    ]);
+  });
+
+  it("returns a match when its metadata cannot be read", async () => {
+    const nameError = new Error("piece name unavailable");
+    const patternError = new Error("pattern reference unavailable");
+    const cell = (value: unknown) => ({
+      pull: () => Promise.resolve(value),
+    });
+    const controller = {
+      getAllPieces: () =>
+        Promise.resolve([{
+          id: "of:unreadable-metadata",
+          name: () => {
+            throw nameError;
+          },
+          getPatternRef: () => Promise.reject(patternError),
+          input: { getCell: () => Promise.resolve(cell("needle")) },
+          result: { getCell: () => Promise.resolve(cell({})) },
+        }]),
+    };
+    const errors: Array<{ source: string; error: unknown }> = [];
+
+    expect(
+      await searchPieces(
+        { apiUrl: API_URL, space: SPACE, identity: ID },
+        "needle",
+        {
+          loadManager: () => Promise.resolve({} as any),
+          createController: () => controller as any,
+          reportSearchError: (_pieceId, source, error) =>
+            errors.push({ source, error }),
+        },
+      ),
+    ).toEqual([{
+      id: "of:unreadable-metadata",
+      name: undefined,
+      patternRef: undefined,
+    }]);
+    expect(errors).toEqual([
+      { source: "metadata", error: nameError },
+      { source: "metadata", error: patternError },
+    ]);
+  });
+
   it("uses full Unicode case folding and canonical normalization", async () => {
     const cell = (value: unknown) => ({
       pull: () => Promise.resolve(value),
@@ -1484,6 +1668,181 @@ describe("cli piece parsing", () => {
       expect(
         await searchPieces(config, "unregistered keyless", deps),
       ).toEqual([]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("deduplicates cells and rejects values whose owner cannot be read", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cf piece search traversal edge coverage test",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+
+    try {
+      const space = signer.did();
+      const textSchema = {
+        type: "object",
+        properties: { text: { type: "string" } },
+        required: ["text"],
+        additionalProperties: false,
+      } as const;
+      const emptySchema = {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      } as const;
+      const rootSchema = {
+        type: "object",
+        properties: { field: { type: "string" } },
+        required: ["field"],
+        additionalProperties: false,
+      } as const;
+      const tx = runtime.edit();
+      const repeatedCell = runtime.getCell(
+        space,
+        "piece-search-repeated-cell",
+        textSchema,
+        tx,
+      );
+      repeatedCell.set({ text: "repeated cell haystack" });
+      const repeatedProxySource = runtime.getCell(
+        space,
+        "piece-search-repeated-proxy",
+        textSchema,
+        tx,
+      );
+      repeatedProxySource.set({ text: "repeated proxy haystack" });
+      const ownedProxySource = runtime.getCell(
+        space,
+        "piece-search-owned-proxy-coverage",
+        textSchema,
+        tx,
+      );
+      ownedProxySource.set({ text: "owned proxy coverage needle" });
+      const ownerResult = runtime.getCell(
+        space,
+        "piece-search-owner-result-coverage",
+        emptySchema,
+        tx,
+      );
+      ownerResult.set({});
+      setResultCell(ownedProxySource, ownerResult);
+
+      const brokenRoot = runtime.getCell(
+        space,
+        "piece-search-broken-source-root",
+        rootSchema,
+        tx,
+      );
+      brokenRoot.set({ field: "unreachable source value" });
+      const brokenSource = runtime.getCell(
+        space,
+        "piece-search-broken-source-child",
+        { type: "string" },
+        tx,
+      );
+      brokenSource.set("unreachable source value");
+      await tx.commit();
+      await runtime.idle();
+
+      const sourceError = new Error("source ownership unavailable");
+      const brokenSourceView = new Proxy(brokenSource, {
+        get(target, property) {
+          if (property === "resolveAsCell") {
+            return () => {
+              throw sourceError;
+            };
+          }
+          const value = Reflect.get(target, property, target);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+      const brokenRootView = new Proxy(brokenRoot, {
+        get(target, property) {
+          if (property === "key") {
+            return () => brokenSourceView;
+          }
+          if (property === "pull") {
+            return () => Promise.resolve({ field: "unreachable source value" });
+          }
+          const value = Reflect.get(target, property, target);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const ownerId = pieceId(ownerResult);
+      if (ownerId === undefined) {
+        throw new Error("Expected the owner result to have a piece ID");
+      }
+      const repeatedProxy = repeatedProxySource.getAsQueryResult();
+      const ownedProxy = ownedProxySource.getAsQueryResult();
+      const cell = (value: unknown) => ({
+        pull: () => Promise.resolve(value),
+      });
+      const piece = (id: string, name: string, input: unknown) => ({
+        id,
+        name: () => name,
+        getPatternRef: () => Promise.resolve(undefined),
+        input: { getCell: () => Promise.resolve(cell(input)) },
+        result: { getCell: () => Promise.resolve(cell({})) },
+      });
+      const controller = {
+        getAllPieces: () =>
+          Promise.resolve([
+            piece("of:owned-proxy-referrer", "Referrer", [ownedProxy]),
+            piece(ownerId, "Owner", "owned proxy coverage needle"),
+            piece("of:repeated-cell", "Repeated cell", [
+              repeatedCell,
+              repeatedCell,
+            ]),
+            piece("of:repeated-proxy", "Repeated proxy", [
+              repeatedProxy,
+              repeatedProxy,
+            ]),
+            {
+              id: "of:broken-source-owner",
+              name: () => "Broken source owner",
+              getPatternRef: () => Promise.resolve(undefined),
+              input: { getCell: () => Promise.resolve(brokenRootView) },
+              result: { getCell: () => Promise.resolve(cell({})) },
+            },
+          ]),
+      };
+      const errors: Array<{
+        pieceId: string;
+        source: "input data" | "result data" | "metadata";
+        error: unknown;
+      }> = [];
+
+      expect(
+        await searchPieces(
+          { apiUrl: API_URL, space: SPACE, identity: ID },
+          "owned proxy coverage needle",
+          {
+            loadManager: () => Promise.resolve({} as any),
+            createController: () => controller as any,
+            reportSearchError: (pieceId, source, error) =>
+              errors.push({ pieceId, source, error }),
+          },
+        ),
+      ).toEqual([{
+        id: ownerId,
+        name: "Owner",
+        patternRef: undefined,
+      }]);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(
+        errors.every(({ pieceId, source, error }) =>
+          pieceId === "of:broken-source-owner" && source === "input data" &&
+          error === sourceError
+        ),
+      ).toBe(true);
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -27,6 +27,7 @@ import {
   isInternedSchema,
 } from "@commonfabric/data-model/schema-hash";
 import type { MemorySpace } from "@commonfabric/memory/interface";
+import type { ReadonlyCell } from "@commonfabric/api";
 import type { SqliteParamsWire } from "@commonfabric/memory/v2";
 import { isCfLinkColumn } from "@commonfabric/memory/sqlite/columns";
 import { encodeCellToSigilString } from "./builtins/sqlite/cf-link-codec.ts";
@@ -691,6 +692,10 @@ export class CellImpl<T extends FabricValue>
 
     this._kind = kind ?? "cell";
     this._cfcLabelView = cloneCfcLabelView(_cfcLabelView);
+  }
+
+  isReadableCell(): boolean {
+    return this._kind === "cell" || this._kind === "readonly";
   }
 
   [cfcLabelViewSymbol](): CfcLabelView | undefined {
@@ -3180,6 +3185,13 @@ export function convertCellsToLinks(
  */
 export function isCell(value: any): value is Cell<any> {
   return value instanceof CellImpl;
+}
+
+/** Check whether a cell capability permits reading its stored value. */
+export function isReadableCell(
+  value: any,
+): value is Cell<any> | ReadonlyCell<any> {
+  return value instanceof CellImpl && value.isReadableCell();
 }
 
 /**

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -56,7 +56,12 @@ export {
   summarizeTransaction,
   type TransactionSummary,
 } from "./storage/transaction-summary.ts";
-export { convertCellsToLinks, isCell, isStream } from "./cell.ts";
+export {
+  convertCellsToLinks,
+  isCell,
+  isReadableCell,
+  isStream,
+} from "./cell.ts";
 export {
   getCellOrThrow,
   isCellResult,

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -533,10 +533,13 @@ export function createQueryResultProxy<T>(
     ownKeys: () => {
       const readTx = runtime.readTx(tx);
       const current = readTx.readValueOrThrow(link, SHAPE_READ);
-      if (isRecord(current) || Array.isArray(current)) {
-        return Reflect.ownKeys(current);
+      const keys = isRecord(current) || Array.isArray(current)
+        ? Reflect.ownKeys(current)
+        : Reflect.ownKeys(value);
+      if (Array.isArray(proxyTarget) && !keys.includes("length")) {
+        keys.push("length");
       }
-      return Reflect.ownKeys(value);
+      return keys;
     },
     getOwnPropertyDescriptor: (target, prop) => {
       if (Array.isArray(target) && prop === "length") {

--- a/packages/runner/test/query-result-proxy-enumeration.test.ts
+++ b/packages/runner/test/query-result-proxy-enumeration.test.ts
@@ -193,6 +193,29 @@ describe("CT-1240: query result proxy enumeration", () => {
     expect(keys).toContain("2");
   });
 
+  it("array proxy retains its length key after the stored shape changes", () => {
+    const cell = runtime.getCell<unknown>(
+      space,
+      "test-array-shape-change",
+      undefined,
+      tx,
+    );
+    cell.set([10, 20]);
+
+    const proxy = createQueryResultProxy<unknown[]>(
+      runtime,
+      tx,
+      cell.getAsNormalizedFullLink(),
+      0,
+      false,
+    );
+
+    cell.set({ changed: true });
+
+    expect(Reflect.ownKeys(proxy)).toContain("length");
+    expect(Object.keys(proxy)).toContain("changed");
+  });
+
   it("empty object returns empty keys", () => {
     const cell = runtime.getCell<Record<string, never>>(
       space,

--- a/packages/runner/test/readable-cell-capability.test.ts
+++ b/packages/runner/test/readable-cell-capability.test.ts
@@ -1,0 +1,48 @@
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { CellKind, JSONSchema } from "@commonfabric/api";
+import { isReadableCell, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+const signer = await Identity.fromPassphrase("readable cell capability test");
+
+Deno.test("isReadableCell follows the runtime cell capability", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+  });
+
+  try {
+    const kinds = [
+      "cell",
+      "readonly",
+      "comparable",
+      "opaque",
+      "sqlite",
+      "stream",
+      "writeonly",
+    ] as const satisfies readonly CellKind[];
+    const schema = {
+      type: "object",
+      properties: Object.fromEntries(
+        kinds.map((kind) => [kind, { type: "number", asCell: [kind] }]),
+      ),
+      additionalProperties: false,
+    } satisfies JSONSchema;
+    const root = runtime.getCell(
+      signer.did(),
+      "readable-cell-capability",
+      schema,
+    );
+
+    expect(isReadableCell(root.key("cell"))).toBe(true);
+    expect(isReadableCell(root.key("readonly"))).toBe(true);
+    for (const kind of kinds.slice(2)) {
+      expect(isReadableCell(root.key(kind))).toBe(false);
+    }
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});


### PR DESCRIPTION
Add cf piece search to enumerate every piece in the selected space and recursively inspect input and result data. Return matching piece summaries through the same human-readable and JSON output as piece ls.

Search nested object keys, scalar values, readable cells, arrays, and Fabric special values while excluding piece metadata and internal symbol data. Keep unreadable handles opaque, bound whole-space work to four pieces at a time, preserve source order, and isolate read failures so one damaged piece does not end the search.

Use the exact-pinned unicode-case-folding package with canonical normalization and normalized code-point boundaries. This handles multi-character folds, canonically equivalent text, current Unicode data, and substrings inside multi-code-point graphemes without matching only part of one folded character.

Add unit and live CLI coverage for input and result matches, nested cells and schemas, cycles, sparse and wide containers, unreadable data, failure isolation, metadata exclusion, stable ordering, output formats, and Unicode behavior. Document the command and its search semantics.

Record a follow-up for an API that lets clients initiate searches against an index hosted by the server.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cf piece search` to scan all pieces in a space and find matches in readable input/result data with Unicode-aware, case-insensitive matching. Outputs the same piece summaries as `piece ls` in table or `--json`.

- **New Features**
  - Ownership-aware: attributes linked data to the nearest registered owner via result metadata; keeps ownerless data searchable by referrers; skips data owned by unregistered pieces; reports cycles.
  - Scope: searches nested keys/values, arrays, readable Cells, and Fabric values; excludes piece names/metadata and internal symbols; re-reads current backing Cell values when a query proxy’s shape changes; preserves array `length`.
  - Reliability: preserves source order, limits concurrency to 4, continues on read errors with warnings; supports large sparse containers.
  - Runner/CLI: adds `isReadableCell`; preserves query-proxy own-key invariants (incl. `length`); shares summary rendering between `piece ls` and `piece search`; `--json` returns an array (empty when no matches); docs and tests cover ownership, Unicode behavior, proxy changes, cycles, and failure isolation.

- **Dependencies**
  - Added `unicode-case-folding@1.1.1`.

<sup>Written for commit c8c5dcb90efa1afe43e2f09d4fea12e886e9e9aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

