### PR TITLE
fix(piece): widen unloadable-root replacement to every space's default pattern

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -229,12 +229,13 @@ propagate](#how-flags-propagate).
   A pre-provenance root may be back-filled only when its stored
   `{ identity, symbol }` exactly equals the build-attested current official
   entry; stale, custom, and repository-pinned sourceless roots remain pinned —
-  except a stale sourceless **home** root whose stored pattern the current
-  runtime explicitly cannot load (probe resolves `undefined`; a probe error
-  stays pinned, and `cfcEnforcementMode: "disabled"` — where the probe is
+  except a stale sourceless root whose stored pattern the current runtime
+  explicitly cannot load (probe resolves `undefined`; a probe error stays
+  pinned, and `cfcEnforcementMode: "disabled"` — where the probe is
   unsupported — stays pinned too): that root is replaced with the official
-  home.tsx, recording the displaced ref under `displacedPattern` meta (see
-  pattern-updates.md for the full exception semantics).
+  system root for the space kind (home.tsx / default-app.tsx), recording the
+  displaced ref under `displacedPattern` meta (see pattern-updates.md for the
+  full exception semantics).
   URL-based creation and recreation stamp provenance; custom `RuntimeProgram`
   recreation does not. The check remains best-effort; if identity lookup or
   replacement compilation is unavailable, the subsequent root start retains

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -103,12 +103,16 @@ official entry appropriate to the space (`home.tsx` for Home,
 Neither space type nor an author-controlled source filename is provenance: a
 stale, custom, or repository-pinned sourceless root stays pinned.
 
-One exception, scoped to **home spaces** (`space === userIdentityDID`): a stale
-sourceless home root whose stored pattern the current runtime **explicitly
-cannot load** is replaced with the official `home.tsx` (the 2026-07-21 estuary
-migration bricked every pre-provenance home root, and no explicit-migration
-tool can reach a private home whose owner key lives only in a browser). The
-exception's semantics are deliberately narrow:
+One exception, covering every space's **default pattern** (the root the space
+cell's `defaultPattern` ref names — never a non-root piece): a stale sourceless
+root whose stored pattern the current runtime **explicitly cannot load** is
+replaced with the official system root for the space kind (`home.tsx` for
+Home, `default-app.tsx` otherwise). The 2026-07-21 estuary migration bricked
+every pre-provenance home root — no explicit-migration tool can reach a
+private home whose owner key lives only in a browser — and a loom vendor
+update then hit the same wall on a non-home space root, so the exception
+covers both (originally home-only; widened at the flag owner's direction).
+The exception's semantics are deliberately narrow:
 
 - Replacement is authorized only when the load probe resolves `undefined` —
   the artifact unavailable through every supported recovery path. A probe
@@ -120,8 +124,6 @@ exception's semantics are deliberately narrow:
   replacement.
 - Under `cfcEnforcementMode: "disabled"` the by-identity probe is unsupported
   (it returns `undefined` unconditionally), so the updater stays pinned there.
-- Non-home spaces always stay pinned; widening the destructive fallback needs
-  its own evidence and a tested restoration path.
 - The replaced root records the displaced `{ identity, symbol, displacedAt }`
   under `displacedPattern` meta. This is an audit/forensic pointer — the
   displaced program's compiled artifacts remain content-addressed in the

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -721,12 +721,13 @@ export class PiecesController<T = unknown> {
       const staleSourceless = storedSource === undefined &&
         (runningRef.identity !== currentId || runningRef.symbol !== "default");
       if (staleSourceless) {
-        // Home only: the fleet evidence is pre-provenance system HOME roots
-        // bricked by a runtime migration. An arbitrary space's sourceless
-        // root is more plausibly a deliberate custom program; widening the
-        // destructive fallback needs its own evidence and a tested
-        // restoration path.
-        if (space !== runtime.userIdentityDID) return "current";
+        // Applies to every space's DEFAULT pattern (this function is only
+        // ever invoked on the root the space cell's `defaultPattern` ref
+        // names): a root that cannot load is a dead space regardless of
+        // space kind, and the displaced ref recorded below preserves the
+        // recovery pointer for a replaced custom program. Widened from
+        // home-only by the flag owner's call after a non-home field report
+        // (loom vendor update bricked on a stale sourceless space root).
         // The probe is only meaningful where by-identity recovery is
         // supported: under cfcEnforcementMode "disabled" it returns
         // `undefined` unconditionally, which must not read as "dead".

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -999,10 +999,12 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(typeof displaced?.displacedAt).toBe("number");
   });
 
-  it("keeps a non-home stale sourceless root pinned even when unloadable", async () => {
-    // The destructive fallback is scoped to home spaces: fleet evidence
-    // exists for pre-provenance system HOME roots; an arbitrary space's
-    // sourceless root is more plausibly a deliberate custom program.
+  it("replaces an unloadable stale sourceless space root", async () => {
+    // The fallback covers every space's DEFAULT pattern, not just home
+    // (widened by the flag owner after a non-home field report): a root
+    // that cannot load is a dead space regardless of kind. The displaced
+    // ref is recorded for non-home too — it is the recovery pointer if
+    // the replaced root was a custom program.
     await setup({ systemPatternAutoUpdate: true });
     await controller.recreateDefaultPattern({
       customProgram: {
@@ -1017,12 +1019,27 @@ describe("checkAndUpdateDefaultPattern", () => {
     stub.setSource(SOURCE_V2);
     const restore = shadowLoadProbe(staleRef.identity, "undefined");
     try {
-      expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
     } finally {
       restore();
     }
-    expect(getPatternIdentityRef(root)).toEqual(staleRef);
-    expect(getPatternSource(root)).toBeUndefined();
+    await runtime.idle();
+
+    const after = (await manager.getDefaultPattern(false))!;
+    expect(getPatternIdentityRef(after)?.identity).toBe(
+      await identityForSource(SOURCE_V2),
+    );
+    expect(getPatternSource(after)).toBe(DEFAULT_APP_PATTERN_URL);
+    const displaced = (after as unknown as {
+      getMetaRaw: (key: string) => unknown;
+    }).getMetaRaw("displacedPattern") as {
+      identity?: string;
+      symbol?: string;
+      displacedAt?: number;
+    };
+    expect(displaced?.identity).toBe(staleRef.identity);
+    expect(displaced?.symbol).toBe(staleRef.symbol);
+    expect(typeof displaced?.displacedAt).toBe("number");
   });
 
   it("keeps the home root pinned when the load probe fails", async () => {


### PR DESCRIPTION
## Why

@seefeldb on the loom field report (a vendor update bricked on a stale sourceless **non-home** space root, which #4883 deliberately kept pinned): *"ah, yes, we need to allow any default pattern that doesn't load to be replaced."*

This is the widening #4883's review explicitly deferred to the flag owner's call — the call is now made, and the evidence for non-home exists.

## What

Drop the home-only eligibility gate from the unloadable-stale-sourceless replacement. A default pattern that cannot load is a dead space regardless of space kind; it is replaced with the official system root for the kind (`home.tsx` for Home, `default-app.tsx` otherwise).

**Scope stays exactly "default patterns"**: `checkAndUpdateDefaultPattern` is only ever invoked on the root the space cell's `defaultPattern` ref names — non-root pieces have no auto-update machinery and are untouched by construction.

Every other discipline from #4883's review round holds, unchanged and still pinned by tests:

- Replacement requires the load probe to **explicitly resolve `undefined`** — a thrown probe is a failed check and stays pinned.
- `cfcEnforcementMode: "disabled"` (probe unsupported) stays pinned.
- **Loadable** stale sourceless roots stay pinned (the custom-program protection).
- The displaced `{identity, symbol, displacedAt}` is recorded under `displacedPattern` meta — now asserted for the non-home path too, since it is the recovery pointer if the replaced root was a custom-app program.

## Verification

- The former non-home scoping pin is inverted into a replacement test (outcome `updated`, identity == build-attested official `default-app.tsx`, provenance back-filled, displaced ref recorded). **Red/green**: fails against main's controller (`current`, no mutation).
- All #4883 tests pass unchanged (home replace, probe-throw pinned, CFC-disabled pinned, loadable-custom pinned, #4865's provenance'd reconcile).
- Full piece suite 21 passed (243 steps) / 0 failed; workspace typecheck, fmt, lint clean.
- Live docs updated in-PR: `pattern-updates.md` exception block + `EXPERIMENTAL_OPTIONS.md` now state the all-spaces default-pattern scope and its provenance (home-only origin, owner-directed widening).

## Follow-up noted, not included

The rigorous long-term companion remains **historical-official-identity attestation** (a registry of content identities past official system patterns compiled to), which would let *loadable* historically-official stale roots roll forward too and shrink the unloadability heuristic's role — sketched in the incident thread; separate design conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened the unloadable-root replacement from home-only to every space’s default pattern so dead default roots are auto-repaired with the correct system root, preventing bricked spaces.

- **Bug Fixes**
  - `checkAndUpdateDefaultPattern` now replaces any stale, sourceless default root that the runtime cannot load with the official system root (`home.tsx` for Home, `default-app.tsx` otherwise).
  - Scope remains default patterns only; non-root pieces are unchanged.
  - Safety rules unchanged: only when the probe returns `undefined`; probe errors or `cfcEnforcementMode: "disabled"` stay pinned; loadable stale roots stay pinned.
  - Records `displacedPattern` meta for recovery.
  - Updated docs (`pattern-updates.md`, `EXPERIMENTAL_OPTIONS.md`) and tests to cover non-home spaces.

<sup>Written for commit d25665767fcad9e98892d9bbaac5993ccb61fc76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

