### PR TITLE
fix(runner): run the setup phase before instantiating a hot-swapped pattern

### DIFF
--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -23,12 +23,26 @@ const signer = await Identity.fromPassphrase("check update default pattern");
 const patternSource = (marker: string) =>
   [
     "import { pattern } from 'commonfabric';",
-    `export default pattern<{ items: string[] }>(({ items }) => ({ items, marker: "${marker}" }));`,
+    `export default pattern<{ items?: string[] }>(({ items }) => ({ items, marker: "${marker}" }));`,
     "",
   ].join("\n");
 
 const SOURCE_V1 = patternSource("v1");
 const SOURCE_V2 = patternSource("v2");
+// A roll target WITH a handler: handler nodes need their { "$stream": true }
+// markers materialized on the (reused) root doc — the dimension the plain
+// sources above never exercise, and the estuary post-swap failure class.
+const SOURCE_V3_HANDLER = [
+  "import { Writable, handler, pattern } from 'commonfabric';",
+  "const bump = handler<void, { count: Writable<number> }>((_, { count }) => {",
+  "  count.set((count.get() ?? 0) + 1);",
+  "});",
+  "export default pattern<{ items?: string[] }>(({ items }) => {",
+  "  const count = new Writable<number>(0).for('count');",
+  "  return { items, count, bump: bump({ count }) };",
+  "});",
+  "",
+].join("\n");
 
 const BUILD_SHA = "build-sha-1";
 const IMPORTED_MODULE_URL = "/api/patterns/system/update-marker.ts";
@@ -475,7 +489,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     stub.setSource([
       "import { pattern } from 'commonfabric';",
       "import { marker } from './update-marker.ts';",
-      "export default pattern<{ items: string[] }>(({ items }) => ({ items, marker }));",
+      "export default pattern<{ items?: string[] }>(({ items }) => ({ items, marker }));",
       "",
     ].join("\n"));
     stub.setImportBuildSha("rolling-deploy-build");
@@ -997,6 +1011,85 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(displaced?.identity).toBe(staleRef.identity);
     expect(displaced?.symbol).toBe(staleRef.symbol);
     expect(typeof displaced?.displacedAt).toBe("number");
+  });
+
+  it("swapped-in pattern with handlers starts over the reused root doc", async () => {
+    // The estuary post-#4883 failure class: the swap engages, writes the new
+    // patternIdentity onto the EXISTING result cell, and the replacement
+    // pattern must then start over that reused doc — including materializing
+    // { "$stream": true } markers for handler nodes the old program never
+    // had. A handler-less roll target (every other test here) cannot see
+    // this; home.tsx is handler-rich.
+    await setupHome({ systemPatternAutoUpdate: true });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    const staleRef = getPatternIdentityRef(root)!;
+
+    stub.setSource(SOURCE_V3_HANDLER);
+    const restore = shadowLoadProbe(staleRef.identity, "undefined");
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
+    } finally {
+      restore();
+    }
+    await runtime.idle();
+
+    // The swap alone is not the contract — the replacement must RUN. Start
+    // it the way bootstrap would and let the scheduler settle; a missing
+    // stream marker surfaces as "Handler used as lift" at instantiation and
+    // the pattern body never executes, so the functional read below is the
+    // pin: `count` only reads 0 if the swapped-in program actually ran its
+    // setup (internal cells materialized) and instantiated.
+    const after = (await manager.getDefaultPattern(true))!;
+    await runtime.idle();
+    expect(getPatternIdentityRef(after)?.identity).toBe(
+      await identityForSource(SOURCE_V3_HANDLER, {}, HOME_PATTERN_URL),
+    );
+    expect(after.key("count").get()).toBe(0);
+  });
+
+  it("failed swap-setup leaves the running pattern in place", async () => {
+    // The fail-closed half of the swap-setup contract: when the incoming
+    // pattern's argument schema rejects the existing argument, the watcher
+    // logs pattern-swap-setup-error and must NOT tear down the running
+    // nodes — a bad update leaves a working piece, not a dead one.
+    const SOURCE_INCOMPATIBLE = [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ mustHave: string }>(({ mustHave }) => ({",
+      "  mustHave,",
+      "}));",
+      "",
+    ].join("\n");
+    await setupHome({ systemPatternAutoUpdate: true });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    const staleRef = getPatternIdentityRef(root)!;
+
+    stub.setSource(SOURCE_INCOMPATIBLE);
+    const restore = shadowLoadProbe(staleRef.identity, "undefined");
+    try {
+      // The update itself proceeds (identity swaps at the meta layer)…
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
+    } finally {
+      restore();
+    }
+    await runtime.idle();
+    // …but the swap-setup for the incompatible program fails closed: the
+    // piece is not left dead (starting it does not throw), and the failure
+    // was logged rather than swallowed.
+    const after = (await manager.getDefaultPattern(true))!;
+    await runtime.idle();
+    expect(after).toBeDefined();
   });
 
   it("replaces an unloadable stale sourceless space root", async () => {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1577,6 +1577,43 @@ export class Runner {
     // (the only pattern pointer); a keyless pattern writes none, so its watcher
     // is inert by design (keyless patterns change only via a fresh run()).
     const setupPatternWatcher = () => {
+      // A hot-swap targets a DIFFERENT program over this piece's existing doc:
+      // the incoming pattern's internal cells — handler { "$stream": true }
+      // markers included — and its argument-schema defaults have never been
+      // materialized here. A fresh start() does that in its setup phase;
+      // skipping it makes every handler node of the incoming pattern fail as
+      // "Handler used as lift" at instantiation (the 2026-07-22 estuary
+      // home-root swap failure). Run the same setup state first, and only
+      // tear down the old nodes once it commits — a failed setup leaves the
+      // running pattern in place instead of a dead piece.
+      const swapToPattern = (
+        loaded: Pattern | NodeFactory<unknown, unknown>,
+        newRef: { identity: string; symbol: string },
+      ) => {
+        const pattern = this.resolveToPattern(loaded as Pattern);
+        const setupTx = this.runtime.edit();
+        try {
+          this.applySetupState(
+            setupTx,
+            pattern,
+            newRef,
+            false,
+            undefined,
+            resultCell,
+          );
+          this.runtime.prepareTxForCommit(setupTx);
+          setupTx.commit();
+        } catch (error) {
+          logger.error(
+            "pattern-swap-setup-error",
+            `Setup for swapped-in pattern ${newRef.identity}#${newRef.symbol} failed`,
+            error,
+          );
+          return;
+        }
+        cancelNodes?.();
+        instantiatePattern(pattern);
+      };
       addCancel(
         resultCell.sinkMeta("patternIdentity", (newValue) => {
           if (!active || startLifecycleEpoch !== this.lifecycleEpoch) return;
@@ -1592,8 +1629,7 @@ export class Runner {
             newRef.symbol,
           ) as Pattern | undefined;
           if (live) {
-            cancelNodes?.();
-            instantiatePattern(this.resolveToPattern(live));
+            swapToPattern(live, newRef);
             return;
           }
           // Async load for a pattern change after initial start. Errors are
@@ -1620,8 +1656,7 @@ export class Runner {
               logger.info("pattern changed", {
                 to: { ref: newRef, pattern: loaded },
               });
-              cancelNodes?.();
-              instantiatePattern(this.resolveToPattern(loaded));
+              swapToPattern(loaded, newRef);
             })
             .catch((err) => {
               if (!active || startLifecycleEpoch !== this.lifecycleEpoch) {


### PR DESCRIPTION
## Why (the actual last mile of the home-space heal)

Estuary runs #4883 (and #4899 is deploying), yet bricked homes stay broken — with a **new** error:

```
[AppView] Failed to load space root pattern: Handler used as lift: node's $event
input resolves to of:fid1:…, which reads undefined — the { "$stream": true }
marker was never written there.
```

Reproduced end-to-end on live estuary (throwaway identity, home deliberately re-bricked with a `safeDateNow`-importing custom root, watched through the deployed build) and then in-harness with a full stack trace. The chain: the auto-update swap **works** — eligibility (#4883/#4899), probe, attested compile, CAS identity write all succeed — and then the `patternIdentity` **watcher re-instantiates the new pattern's nodes directly, skipping the setup phase** a fresh `start()` performs. Setup (`applySetupState`) is what materializes the incoming pattern's internal cells — handler stream markers included — and merges its argument-schema defaults. The old program had none of the new program's handlers, so the swapped-in `home.tsx` (handler-rich) dies at instantiation. **Every existing roll/swap test used a handler-less stub pattern**, which is why the suite never saw this.

## What

- The watcher now runs `applySetupState` for the incoming pattern **before** touching the running nodes, and tears the old nodes down only after that setup commits. A failed setup — e.g. the existing argument doesn't satisfy the new pattern's schema — logs `pattern-swap-setup-error` loudly and leaves the running pattern in place instead of a dead piece (fail-closed, same posture as the #4883 probe rules).
- Both swap branches (live in-memory artifact and async-loaded) funnel through the one `swapToPattern` helper.

## Verification

- New regression test: handler-bearing roll target (`SOURCE_V3_HANDLER`), replace an unloadable custom home root, then **start the replacement and assert it actually runs** (functional pin: `count` reads its initial value — under the bug, instantiation throws and the pattern body never executes; the swap-only identity assertions all still passed, which is why the pin is functional). **Red/green**: fails against the unfixed watcher, passes with the fix.
- Harness honesty fix surfaced by the new setup-validation: the suite's stub patterns declared a required no-default argument that fresh creation never validates but swap-setup correctly does — stubs now declare it optional (identity expectations are all derived at runtime; no goldens involved).
- Full runner suite **999 passed / 5342 steps / 0 failed** (the watcher's existing same-lineage consumers undisturbed); full piece suite 21/244; workspace typecheck, fmt, lint clean.

## Rollout

This is the third and, per the live repro, final layer of the fleet home-brick: #4873 opened the flag, #4883/#4899 made bricked roots eligible, this makes the replacement actually **run**. After merge + estuary deploy, my standing throwaway repro (a bricked home on estuary) validates the full heal with one reload before anyone's real home is on the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the setup phase before instantiating a hot-swapped pattern so swaps actually start and don’t crash on handler nodes. This writes handler stream markers and default args to the reused root doc; on setup failure, we keep the current pattern running.

- **Bug Fixes**
  - `packages/runner/src/runner.ts`: Added `swapToPattern` to run `applySetupState` and commit before tearing down old nodes and instantiating the new pattern. Logs `pattern-swap-setup-error` on setup failure and aborts the swap. Unified live and async swap paths through `swapToPattern`.
  - `packages/piece/test/check-update-default-pattern.test.ts`: Made `items` optional in stubs. Added a handler-bearing roll target (`SOURCE_V3_HANDLER`) that verifies the swapped-in pattern actually runs (`count` starts at 0). Added a failure case to confirm incompatible swap-setup leaves the current pattern running.

<sup>Written for commit fcb8324915615f6d4bc97e9dc362fb408172838d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

