### PR TITLE
fix(patterns): tolerate stored profiles of any vintage — consumer-side compat view + data defaults

### DIFF
--- a/packages/patterns/cfc-group-chat-demo/logic.test.ts
+++ b/packages/patterns/cfc-group-chat-demo/logic.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { sortDisplayMessages } from "./logic.ts";
+
+// Thread order must be deterministic for messages that land in the same
+// millisecond — the tiebreaker chain (author → body → origin) is the contract
+// that keeps two replicas rendering one thread in one order. The pattern tests
+// exercise these branches only when the harness happens to send two messages
+// inside a single millisecond, so this pins the semantics with fixed
+// timestamps instead of a clock race.
+
+type ThreadMessage = {
+  authorName: string;
+  body: string;
+  origin: "sent" | "imported";
+  timestamp: number;
+};
+
+const msg = (
+  authorName: string,
+  body: string,
+  origin: ThreadMessage["origin"],
+  timestamp: number,
+): ThreadMessage => ({ authorName, body, origin, timestamp });
+
+describe("sortDisplayMessages thread order", () => {
+  it("orders by timestamp before anything else", () => {
+    const later = msg("alice", "first alphabetically", "sent", 2_000);
+    const earlier = msg("zed", "zzz", "sent", 1_000);
+    expect(sortDisplayMessages([later, earlier])).toEqual([earlier, later]);
+  });
+
+  it("breaks same-millisecond ties by author name", () => {
+    const bob = msg("bob", "hi", "sent", 1_000);
+    const alice = msg("alice", "hi", "sent", 1_000);
+    expect(sortDisplayMessages([bob, alice])).toEqual([alice, bob]);
+  });
+
+  it("breaks same-author same-millisecond ties by body", () => {
+    const second = msg("alice", "beta", "sent", 1_000);
+    const first = msg("alice", "alpha", "sent", 1_000);
+    expect(sortDisplayMessages([second, first])).toEqual([first, second]);
+  });
+
+  it("breaks identical-content ties by origin", () => {
+    const sent = msg("alice", "hi", "sent", 1_000);
+    const imported = msg("alice", "hi", "imported", 1_000);
+    expect(sortDisplayMessages([sent, imported])).toEqual([imported, sent]);
+  });
+
+  it("yields one thread order from any arrival order", () => {
+    const a = msg("alice", "alpha", "sent", 1_000);
+    const b = msg("bob", "beta", "imported", 1_000);
+    const c = msg("bob", "gamma", "sent", 1_000);
+    const d = msg("carol", "delta", "sent", 2_000);
+    const sorted = sortDisplayMessages([a, b, c, d]);
+    expect(sortDisplayMessages([d, c, b, a])).toEqual(sorted);
+    expect(sortDisplayMessages([c, a, d, b])).toEqual(sorted);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [
+      msg("bob", "hi", "sent", 2_000),
+      msg("alice", "hi", "sent", 1_000),
+    ];
+    const before = [...input];
+    sortDisplayMessages(input);
+    expect(input).toEqual(before);
+  });
+});

--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -18,7 +18,7 @@ import {
   type TrustedProfileMru,
 } from "./profile-create.tsx";
 import ProfilePicker from "./profile-picker.tsx";
-import type { ProfileHomeOutput } from "./profile-home.tsx";
+import type { BackwardsCompatibleProfile } from "./profile-home.tsx";
 
 // Types from favorites-manager.tsx
 type Favorite = {
@@ -177,10 +177,14 @@ export default pattern<Record<string, never>, HomeOutput>((_) => {
   // space. `profiles` is the durable list (appended on create). `defaultProfile`
   // is the one `#profile` resolves to in headless mode and orders first in the
   // picker; `mru` is the recency-ordered list driving the rest of the ordering.
-  const profiles = new Writable<ProfileHomeOutput[]>([]).for("profiles");
-  const defaultProfile = new Writable<ProfileHomeOutput | undefined>(undefined)
+  const profiles = new Writable<BackwardsCompatibleProfile[]>([]).for(
+    "profiles",
+  );
+  const defaultProfile = new Writable<BackwardsCompatibleProfile | undefined>(
+    undefined,
+  )
     .for("defaultProfile");
-  const mru = new Writable<ProfileHomeOutput[]>([]).for("mru");
+  const mru = new Writable<BackwardsCompatibleProfile[]>([]).for("mru");
   // Untrusted-write regression surface: this stream is exported so tests can
   // verify that sending it from outside the trusted create surface does NOT
   // create a profile. The actual create UI lives in the profile picker below.

--- a/packages/patterns/system/profile-create.tsx
+++ b/packages/patterns/system/profile-create.tsx
@@ -11,7 +11,10 @@ import {
   Writable,
   WriteAuthorizedBy,
 } from "commonfabric";
-import ProfileHome, { type ProfileHomeOutput } from "./profile-home.tsx";
+import ProfileHome, {
+  type BackwardsCompatibleProfile,
+  type ProfileHomeOutput,
+} from "./profile-home.tsx";
 
 // Trusted UI surfaces / actions. The create surface authorizes appending a new
 // profile to the home `profiles` list; the picker surface authorizes setting the
@@ -71,7 +74,7 @@ export type CreateProfileEvent = {
 export const submitProfileCreation = handler<
   CreateProfileEvent,
   {
-    profiles: Writable<ProfileHomeOutput[]>;
+    profiles: Writable<BackwardsCompatibleProfile[]>;
   }
 >((event, { profiles }) => {
   // The submitted name rides the event: the create surface is a
@@ -91,6 +94,10 @@ export const submitProfileCreation = handler<
     profiles.push(
       ProfileHome.inSpace()({
         initialName: name,
+        // The freshly created profile is current-vintage by construction — it
+        // carries every stream and field, so the strict producer type is the
+        // honest cast here (BackwardsCompatibleProfile is for stored docs of
+        // unknown vintage).
       }) as ProfileHomeOutput,
     );
   }
@@ -102,14 +109,14 @@ export const submitProfileCreation = handler<
 export const setDefaultProfile = handler<
   unknown,
   {
-    defaultProfile: Writable<ProfileHomeOutput | undefined>;
+    defaultProfile: Writable<BackwardsCompatibleProfile | undefined>;
     // Take the profile as a LINK cell, not a resolved value: the handler only
     // needs the link to write into defaultProfile, and a link argument doesn't
     // require the profile's cross-space values to be loaded at event time —
     // resolving the full value here would fail required-field validation
     // ("stream action argument is undefined … not running") whenever the
     // profile's space hasn't materialized locally yet.
-    profile: Cell<ProfileHomeOutput>;
+    profile: Cell<BackwardsCompatibleProfile>;
   }
 >((_, { defaultProfile, profile }) => {
   if (profile) {
@@ -122,10 +129,10 @@ export const setDefaultProfile = handler<
 export const setMruProfile = handler<
   unknown,
   {
-    mru: Writable<ProfileHomeOutput[]>;
+    mru: Writable<BackwardsCompatibleProfile[]>;
     // Link cell, not a resolved value — same event-time-validation reason as
     // setDefaultProfile above.
-    profile: Cell<ProfileHomeOutput>;
+    profile: Cell<BackwardsCompatibleProfile>;
   }
 >((_, { mru, profile }) => {
   if (!profile) return;
@@ -133,7 +140,7 @@ export const setMruProfile = handler<
   // links into an unloaded space doesn't collapse the whole read to `undefined`
   // and silently wipe MRU history. Dedup by link identity via `equals`.
   const current = ((mru as any).asSchema(profileLinkListSchema()).get() ??
-    []) as ProfileHomeOutput[];
+    []) as BackwardsCompatibleProfile[];
   const filtered = current.filter((entry) => !equals(entry, profile));
   mru.set([profile, ...filtered] as any);
 });
@@ -144,7 +151,10 @@ export const setMruProfile = handler<
 // carries `writeAuthorizedBy` to gate structural changes (see TrustedProfileList
 // below).
 export type TrustedProfileLink = Cfc<
-  WriteAuthorizedBy<Cell<ProfileHomeOutput>, typeof submitProfileCreation>,
+  WriteAuthorizedBy<
+    Cell<BackwardsCompatibleProfile>,
+    typeof submitProfileCreation
+  >,
   {
     addIntegrity: ["profile-link"];
     uiContract: {
@@ -174,7 +184,7 @@ export type TrustedProfileList = Cfc<
 
 // A profile link written via the trusted picker surface (default / MRU writes).
 type PickerProfileLink<Binding, Action extends string> = Cfc<
-  WriteAuthorizedBy<Cell<ProfileHomeOutput>, Binding>,
+  WriteAuthorizedBy<Cell<BackwardsCompatibleProfile>, Binding>,
   {
     addIntegrity: ["profile-link"];
     uiContract: {
@@ -209,7 +219,7 @@ export type TrustedProfileMru = Cfc<
 >;
 
 export type ProfileCreateInput = {
-  profiles: Writable<ProfileHomeOutput[]>;
+  profiles: Writable<BackwardsCompatibleProfile[]>;
   inputId?: string;
   // Optional prefill for the create field. Embedders often already know the
   // user's name (e.g. Loom asks at setup) — without this, first-run re-asks a

--- a/packages/patterns/system/profile-embed.tsx
+++ b/packages/patterns/system/profile-embed.tsx
@@ -10,7 +10,7 @@ import {
   Writable,
 } from "commonfabric";
 import type {
-  ProfileHomeOutput,
+  BackwardsCompatibleProfile,
   SetProfileAvatarEvent,
   SetProfileBioEvent,
   SetProfileNameEvent,
@@ -52,7 +52,7 @@ import type {
 // The wish `result` for `#profile` is the profile-home pattern's output: it
 // carries the readable `name`/`avatar`/`bio` fields AND the exported
 // owner-protected write streams we amend through.
-type ProfileResult = ProfileHomeOutput;
+type ProfileResult = BackwardsCompatibleProfile;
 
 const trimmed = (value?: string): string => (value ?? "").trim();
 

--- a/packages/patterns/system/profile-home.owner-gated.test.ts
+++ b/packages/patterns/system/profile-home.owner-gated.test.ts
@@ -43,9 +43,43 @@ describe("host embedding contract: profile pinning is owner-gated", () => {
   });
 
   it("exposes addPiece as a Stream — the sanctioned headless pin path", () => {
+    // Required in the PRODUCER type on purpose: ProfileHomeOutput describes a
+    // RUNNING profile, which always binds every stream. Stored-doc tolerance
+    // lives in BackwardsCompatibleProfile (pinned below), not here.
     expect(home).toContain("addPiece: Stream<MutateProfileElementsEvent>");
     // The stream is bound to mutateElements in the "addPiece" mode.
     expect(home).toContain('mode: "addPiece"');
+  });
+
+  it("exports BackwardsCompatibleProfile with every post-genesis stream optional", () => {
+    // The consumer-side seam of the 2026-07-22 fleet heal (#4901): consumers
+    // of STORED profiles must take this weakened view, where streams added
+    // after profile genesis are optional — a required stream in a consumer
+    // schema bricks every doc predating the field at argument validation.
+    // A stream missing from this union re-bricks old docs; removing the type
+    // re-bricks everything. Red here = that regression.
+    expect(home).toContain(
+      "export type BackwardsCompatibleProfile = PartialBy<",
+    );
+    for (
+      const lateStream of [
+        "setBio",
+        "addExternalLink",
+        "removeExternalLink",
+        "publishVerifiedIdentities",
+        "revokeVerifiedIdentities",
+        "addPiece",
+        "toggleEditing",
+      ]
+    ) {
+      expect(home).toContain(`| "${lateStream}"`);
+    }
+    // The two post-genesis DATA fields ride Default<> instead (validation
+    // fills absent keys on old docs) — the data-vs-affordance split.
+    expect(home).toContain(
+      'bio: Default<OwnerProtectedProfileWrite<string, typeof setBio>, "">',
+    );
+    expect(home).toContain("isEditing: Default<boolean, false>");
   });
 
   it("recognizes every one of the viewer's profiles as owner-editable", () => {

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -163,7 +163,12 @@ export type ProfileHomeOutput = {
   // (CT-1648). Owner-protected like name/avatar; the canonical shared-profile
   // bio (distinct from Home's legacy `learned.summary`). Readable from the
   // profile result and via `wish({ query: "#profileBio" })`.
-  bio: OwnerProtectedProfileWrite<string, typeof setBio>;
+  // Default outside the wrapper, like externalLinks below: bio arrived
+  // 2026-06-17, so stored profiles predating it have no such property — a
+  // required field here fails consumer argument validation on those docs
+  // (masked until now only because `addExternalLink` sorts earlier in the
+  // required check).
+  bio: Default<OwnerProtectedProfileWrite<string, typeof setBio>, "">;
   // Public web profiles the owner has chosen to associate with this profile.
   // The owner-protected list is distinct from `elements`, whose entries are
   // Common Fabric piece references.
@@ -187,6 +192,12 @@ export type ProfileHomeOutput = {
     []
   >;
   elements: OwnerProtectedProfileWrite<ProfileElement[], typeof mutateElements>;
+  // The mutation streams are REQUIRED here on purpose: this type describes
+  // what a RUNNING current profile provides, and a live profile always binds
+  // every stream. Consumers that read stored profiles of any vintage must not
+  // reuse this type — they take `BackwardsCompatibleProfile` (below), which
+  // makes the post-genesis streams optional, because streams are affordances
+  // and never exist on a stored doc that predates them.
   setName: Stream<SetProfileNameEvent>;
   setAvatar: Stream<SetProfileAvatarEvent>;
   setBio: Stream<SetProfileBioEvent>;
@@ -205,13 +216,44 @@ export type ProfileHomeOutput = {
   // presentation and the edit form. UI state — not owner-protected.
   toggleEditing: Stream<void>;
   // Current view mode: false = read-only presentation, true = edit form.
-  isEditing: boolean;
+  // Data field, so backwards compatibility rides Default<> (like bio and
+  // externalLinks): stored profiles predating CT-1748 (2026-06-16) have no
+  // such property, and validation fills the default instead of failing.
+  isEditing: Default<boolean, false>;
   initialNameApplied: string;
 };
 
 export type ProfileHomeInput = {
   initialName?: string;
 };
+
+type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+// The consumer-side view of a profile: every field a stored profile doc of ANY
+// supported vintage satisfies. Streams added after profile genesis (2026-05-31,
+// #3762) are optional here — a stored doc written before a stream existed has
+// no such property, and a consumer schema that requires it bricks at argument
+// validation (fleet incident 2026-07-22: `profiles: 0: missing required
+// property addExternalLink` for June-era profiles). Genesis streams stay
+// required: every doc has them.
+//
+// Standard idiom (seefeld, #4901 review): the producer type keeps its honest,
+// required shape; consumers of stored docs take this weakened view and handle
+// absence (`profile.addPiece?.send(...)`). ADD EVERY FUTURE STREAM TO THIS
+// LIST in the same change that adds it to ProfileHomeOutput — a new stream
+// missing here re-bricks old docs at every consumer seam.
+// Introduction dates: setBio/addPiece 2026-06-17, toggleEditing 2026-06-16,
+// external links #4731 and verified identities #4745 both 2026-07-15.
+export type BackwardsCompatibleProfile = PartialBy<
+  ProfileHomeOutput,
+  | "setBio"
+  | "addExternalLink"
+  | "removeExternalLink"
+  | "publishVerifiedIdentities"
+  | "revokeVerifiedIdentities"
+  | "addPiece"
+  | "toggleEditing"
+>;
 
 const trimInitialName = (initialName?: string): string =>
   (initialName ?? "").trim();

--- a/packages/patterns/system/profile-picker.tsx
+++ b/packages/patterns/system/profile-picker.tsx
@@ -15,7 +15,7 @@ import ProfileCreate, {
   TRUSTED_PROFILE_SET_DEFAULT_ACTION,
   TRUSTED_PROFILE_SET_MRU_ACTION,
 } from "./profile-create.tsx";
-import type { ProfileHomeOutput } from "./profile-home.tsx";
+import type { BackwardsCompatibleProfile } from "./profile-home.tsx";
 
 // The profile picker rendered as the `[UI]` of a #profile wish when the user
 // has 2+ profiles and no valid default. It renders each profile natively
@@ -35,9 +35,9 @@ import type { ProfileHomeOutput } from "./profile-home.tsx";
 // computeds were vestigial after CT-1829 (#4512) and are removed (CT-1843).
 
 type ProfilePickerInput = {
-  profiles: Writable<ProfileHomeOutput[]>;
-  defaultProfile: Writable<ProfileHomeOutput | undefined>;
-  mru: Writable<ProfileHomeOutput[]>;
+  profiles: Writable<BackwardsCompatibleProfile[]>;
+  defaultProfile: Writable<BackwardsCompatibleProfile | undefined>;
+  mru: Writable<BackwardsCompatibleProfile[]>;
 };
 
 // Whether two profile cells name the SAME profile — compared by the profile's


### PR DESCRIPTION
## Why

Post-#4899, healed estuary homes died at start on June-era profiles: `profiles: 0: missing required property addExternalLink`. Streams are affordances a RUNNING profile provides — a stored doc written before a stream existed legitimately lacks it. Any consumer schema that requires such a field bricks on old docs at argument validation, first-absence-wins, so each fixed field just unmasks the next vintage's failure.

## What (per review — the consumer-side inversion)

The first push made the fields optional on `ProfileHomeOutput` itself. Per @seefeldb's review, that was the wrong side of the seam: **the producer type stays honest** (a live profile always binds every stream, so they stay required), and **consumers of stored docs take a weakened view**:

- **`BackwardsCompatibleProfile`** = `PartialBy<ProfileHomeOutput, …the seven post-genesis streams…>` (`setBio`, `addExternalLink`, `removeExternalLink`, `publishVerifiedIdentities`, `revokeVerifiedIdentities`, `addPiece`, `toggleEditing`; genesis streams — `setName`/`setAvatar`/`addElement`/`removeElement` — stay required since every doc has them; introduction dates in the doc comment). Adopted at every stored-doc seam: home's `profiles`/`defaultProfile`/`mru`, the `TrustedProfileLink`/`TrustedProfileList`/picker contracts in profile-create, profile-picker, and profile-embed's `ProfileResult`. profile-create's freshly-built profile keeps the strict type — current-vintage by construction.
- **The two post-genesis DATA fields ride `Default<>`** like their existing siblings (`externalLinks`/`verifiedIdentities`): `isEditing` (CT-1748) and — caught during this rework — **`bio`** (2026-06-17), which was required-with-no-default and was the *next brick in line*, masked only because `addExternalLink` sorts earlier in the required check.

Data-vs-affordance split in one line: data fields get defaults (validation fills), streams get consumer-side optionality (consumers `?.send`).

## Verification

- **Emission** (`cf check --show-transformed`): the `BackwardsCompatibleProfile` $def's `required[]` = `[$NAME, $UI, name, avatar, bio, externalLinks, verifiedIdentities, elements, setName, setAvatar, addElement, removeElement, isEditing, initialNameApplied]` — no late stream; `bio`/`isEditing` carry defaults; CFC `ifc` annotations stay in place. (Plain `?:` via `PartialBy` — a `| undefined` union would relocate annotations into `anyOf` branches; `profile-owner-cfc` pins that.) A generator probe confirmed `Omit & Partial<Pick>` emits correctly before adopting it.
- **Contract pin**: `profile-home.owner-gated.test.ts` now asserts the compat union contains all seven late streams and that `bio`/`isEditing` carry `Default<>` — a future stream added to `ProfileHomeOutput` but not to the compat list goes red.
- **Suites**: profile-home 15/15, profile-embed 9/9, profile-create 8/8 (lane-2); full runner 999 (5342 steps) incl. profile-owner-cfc; patterns lane-1 59; full workspace check, fmt, lint clean.
- Second commit: the coverage-gate deflake (chat thread-order tiebreaker test) — unrelated to the heal, kept separate and cherry-pickable.

## Follow-ups (not this PR)

- Standardize the compat-view idiom (seefeld → Hixie): differently-named backwards-compatible export per consumer-facing type.
- Auto-updating non-default system-derived patterns (who triggers, ownership) — the other half of the review discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)