### PR TITLE
fix(utils,data-model): satisfy `noUncheckedIndexedAccess`, and turn it on

### DIFF
--- a/packages/data-model/deno.jsonc
+++ b/packages/data-model/deno.jsonc
@@ -1,5 +1,8 @@
 {
   "name": "@commonfabric/data-model",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true
+  },
   "imports": {
     "@/": "./src/"
   },

--- a/packages/data-model/src/codec-json/JsonEncodingContext.ts
+++ b/packages/data-model/src/codec-json/JsonEncodingContext.ts
@@ -37,7 +37,7 @@ const defaultRegistry: CodecRegistry = createDefaultRegistry();
 function isEncodedInstance(v: JsonWireValue): boolean {
   if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
   const keys = Object.keys(v);
-  return keys.length === 1 && keys[0].startsWith("/");
+  return keys.length === 1 && keys[0]!.startsWith("/");
 }
 
 /**
@@ -67,7 +67,7 @@ function unquote(v: JsonWireValue): JsonWireValue {
     const result = v.map(unquote) as JsonWireValue;
     return Object.freeze(result);
   } else if (isEncodedInstance(v) && Object.keys(v)[0] === "/quote") {
-    return (v as Record<string, JsonWireValue>)["/quote"];
+    return (v as Record<string, JsonWireValue>)["/quote"]!;
   } else {
     const result = Object.fromEntries(
       Object.entries(v).map(([k, val]) => [k, unquote(val as JsonWireValue)]),
@@ -179,9 +179,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
     // `isEncodedInstance()` guaranteed a single-property object, so this
     // destructures that one entry. (`isPlainObject()` is not a type guard, so
     // narrow explicitly for the type-checker.)
-    const [[key, value]] = Object.entries(
+    const [key, value] = Object.entries(
       data as Record<string, JsonWireValue>,
-    );
+    )[0]!;
     return { tag: key.slice(1), state: value };
   }
 

--- a/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
@@ -563,7 +563,7 @@ describe("JsonEncodingContext", () => {
         string,
         Record<string, FabricValue>
       >;
-      expect(result.outer.inner).toBe(42);
+      expect(result.outer!.inner).toBe(42);
     });
 
     it("preserves `undefined` values in objects", () => {
@@ -693,7 +693,7 @@ describe("JsonEncodingContext", () => {
           string,
           Record<string, FabricValue>
         >;
-        expect(result["/x"]["a"]).toBe(1);
+        expect(result["/x"]!["a"]).toBe(1);
       });
     });
 
@@ -709,7 +709,7 @@ describe("JsonEncodingContext", () => {
           string,
           Record<string, FabricValue>
         >;
-        expect(result["/x"]["/y"]).toBe(123);
+        expect(result["/x"]!["/y"]).toBe(123);
       });
 
       it("boundary contrast: literal subtree uses `/quote`, Fabric type uses `/object`", () => {
@@ -809,7 +809,7 @@ describe("JsonEncodingContext", () => {
           string,
           Record<string, FabricValue>
         >;
-        expect(result["outer"]["/inner"]).toBe(1);
+        expect(result["outer"]!["/inner"]).toBe(1);
       });
 
       it("single-key `/`-prefixed object still routes through `unwrapTag()` (no regression)", () => {
@@ -842,7 +842,7 @@ describe("JsonEncodingContext", () => {
           string,
           Record<string, FabricValue>
         >;
-        expect(result["/x"]["/quote"]).toBe("inner");
+        expect(result["/x"]!["/quote"]).toBe("inner");
       });
     });
   });
@@ -1191,9 +1191,9 @@ describe("JsonEncodingContext", () => {
 
       expect(isDeepFrozen(result)).toBe(true);
       expect(Object.isFrozen(result.outer)).toBe(true);
-      expect(Object.isFrozen(result.outer.inner)).toBe(true);
+      expect(Object.isFrozen(result.outer!.inner)).toBe(true);
       expect(() => {
-        (result.outer.inner as unknown as number[])[0] = 99;
+        (result.outer!.inner as unknown as number[])[0] = 99;
       }).toThrow();
       expect(() => {
         (result.outer as Record<string, unknown>).added = true;
@@ -1211,9 +1211,9 @@ describe("JsonEncodingContext", () => {
       ) as Record<string, Record<string, Array<Record<string, FabricValue>>>>;
 
       expect(isDeepFrozen(result)).toBe(true);
-      expect(Object.isFrozen(result.outer.inner[0])).toBe(true);
+      expect(Object.isFrozen(result.outer!.inner![0])).toBe(true);
       expect(() => {
-        (result.outer.inner[0] as Record<string, unknown>).deep = 2;
+        (result.outer!.inner![0] as Record<string, unknown>).deep = 2;
       }).toThrow();
     });
 

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -1076,7 +1076,7 @@ describe("native-conversion", () => {
       it("recursively processes nested arrays", () => {
         const date = new Date("2024-01-15T12:00:00.000Z");
         const result = fabricFromNativeValue([[date]]) as unknown[][];
-        expect(result[0][0]).toBeInstanceOf(FabricEpochNsec);
+        expect(result[0]![0]).toBeInstanceOf(FabricEpochNsec);
       });
     });
 
@@ -1449,7 +1449,7 @@ describe("native-conversion", () => {
         sparse[0] = 1;
         sparse[2] = 3;
         const result = fabricFromNativeValue([[sparse]]) as unknown[][][];
-        const inner = result[0][0];
+        const inner = result[0]![0]!;
         expect(inner[0]).toBe(1);
         expect(1 in inner).toBe(false); // hole preserved
         expect(inner[2]).toBe(3);
@@ -1698,7 +1698,7 @@ describe("native-conversion", () => {
           Record<string, unknown>
         >;
         expect(Object.getPrototypeOf(result.nested)).toBe(null);
-        expect(result.nested.val).toBe(42);
+        expect(result.nested!.val).toBe(42);
       });
     });
   });

--- a/packages/utils/bench/bigint.bench.ts
+++ b/packages/utils/bench/bigint.bench.ts
@@ -115,7 +115,7 @@ const IMPLS: ReadonlyArray<{
 ];
 
 for (const { name: implName, biToMtc, biFromMtc } of IMPLS) {
-  const isBaselineImpl = implName === IMPLS[0].name;
+  const isBaselineImpl = implName === IMPLS[0]!.name;
 
   const encodeBatch = (values: bigint[]): Uint8Array[] => {
     return values.map((v) => biToMtc(v));
@@ -153,7 +153,7 @@ for (const { name: implName, biToMtc, biFromMtc } of IMPLS) {
       baseline: isBaselineImpl,
       fn() {
         for (let i = 0; i < BATCH; i++) {
-          biToMtc(positives[i]);
+          biToMtc(positives[i]!);
         }
       },
     });
@@ -163,7 +163,7 @@ for (const { name: implName, biToMtc, biFromMtc } of IMPLS) {
       group: encodeGroup,
       fn() {
         for (let i = 0; i < BATCH; i++) {
-          biToMtc(negatives[i]);
+          biToMtc(negatives[i]!);
         }
       },
     });
@@ -174,7 +174,7 @@ for (const { name: implName, biToMtc, biFromMtc } of IMPLS) {
       baseline: isBaselineImpl,
       fn() {
         for (let i = 0; i < BATCH; i++) {
-          biFromMtc(positiveBytes[i]);
+          biFromMtc(positiveBytes[i]!);
         }
       },
     });
@@ -184,7 +184,7 @@ for (const { name: implName, biToMtc, biFromMtc } of IMPLS) {
       group: decodeGroup,
       fn() {
         for (let i = 0; i < BATCH; i++) {
-          biFromMtc(negativeBytes[i]);
+          biFromMtc(negativeBytes[i]!);
         }
       },
     });

--- a/packages/utils/deno.jsonc
+++ b/packages/utils/deno.jsonc
@@ -1,5 +1,8 @@
 {
   "name": "@commonfabric/utils",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true
+  },
   "tasks": {
     // --no-check: this package is type-checked by `deno task check` (tasks/check.sh).
     "test": "deno test --no-check",

--- a/packages/utils/src/bigint-shared-impl.ts
+++ b/packages/utils/src/bigint-shared-impl.ts
@@ -71,7 +71,7 @@ export function encode5To8Bytes(value: bigint, negative: boolean): Uint8Array {
   // because by virtue of the caller's up-front check, there's definitely a
   // non-skipped byte).
   for (let i = 0; true; i++) {
-    const byte = dv64Bytes[i];
+    const byte = dv64Bytes[i]!;
     if (byte !== skipByte) {
       // Adjust starting index backwards if the non-skipped byte would flip
       // the sign of the result.

--- a/packages/utils/src/bigint-uint8-direct.ts
+++ b/packages/utils/src/bigint-uint8-direct.ts
@@ -131,55 +131,57 @@ export function bigintFromMtcDirect(bytes: Uint8Array): bigint {
 
     case 1: {
       // `(x << 24) >> 24` to sign extend. Similar below.
-      return BigInt((bytes[0] << 24) >> 24);
+      return BigInt((bytes[0]! << 24) >> 24);
     }
 
     case 2: {
-      return BigInt(((bytes[0] << 24) | (bytes[1] << 16)) >> 16);
+      return BigInt(((bytes[0]! << 24) | (bytes[1]! << 16)) >> 16);
     }
 
     case 3: {
       return BigInt(
-        ((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8)) >> 8,
+        ((bytes[0]! << 24) | (bytes[1]! << 16) | (bytes[2]! << 8)) >> 8,
       );
     }
 
     case 4: {
       return BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+        (bytes[0]! << 24) | (bytes[1]! << 16) | (bytes[2]! << 8) | bytes[3]!,
       );
     }
 
     case 5: {
       const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+        (bytes[0]! << 24) | (bytes[1]! << 16) | (bytes[2]! << 8) | bytes[3]!,
       );
-      const subResult2 = BigInt(bytes[4]);
+      const subResult2 = BigInt(bytes[4]!);
       return (subResult1 << 8n) | subResult2;
     }
 
     case 6: {
       const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+        (bytes[0]! << 24) | (bytes[1]! << 16) | (bytes[2]! << 8) | bytes[3]!,
       );
-      const subResult2 = BigInt((bytes[4] << 8) | bytes[5]);
+      const subResult2 = BigInt((bytes[4]! << 8) | bytes[5]!);
       return (subResult1 << 16n) | subResult2;
     }
 
     case 7: {
       const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+        (bytes[0]! << 24) | (bytes[1]! << 16) | (bytes[2]! << 8) | bytes[3]!,
       );
-      const subResult2 = BigInt((bytes[4] << 16) | (bytes[5] << 8) | bytes[6]);
+      const subResult2 = BigInt(
+        (bytes[4]! << 16) | (bytes[5]! << 8) | bytes[6]!,
+      );
       return (subResult1 << 24n) | subResult2;
     }
 
     case 8: {
       const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+        (bytes[0]! << 24) | (bytes[1]! << 16) | (bytes[2]! << 8) | bytes[3]!,
       );
       const subResult2 = BigInt(
-        (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
+        (bytes[4]! << 24) | (bytes[5]! << 16) | (bytes[6]! << 8) | bytes[7]!,
       ) & 0xffff_ffffn;
       return (subResult1 << 32n) | subResult2;
     }
@@ -202,15 +204,15 @@ export function bigintFromMtcDirect(bytes: Uint8Array): bigint {
     result = negative ? -1n : 0n;
   } else if (partials <= 4) {
     const partial = BigInt(
-      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      (bytes[0]! << 24) | (bytes[1]! << 16) | (bytes[2]! << 8) | bytes[3]!,
     );
     result = partial >> BigInt(32 - (partials * 8));
   } else {
     const partial1 = BigInt(
-      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      (bytes[0]! << 24) | (bytes[1]! << 16) | (bytes[2]! << 8) | bytes[3]!,
     );
     const partial2 = BigInt(
-      (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
+      (bytes[4]! << 24) | (bytes[5]! << 16) | (bytes[6]! << 8) | bytes[7]!,
     ) & 0xffff_ffffn;
     result = ((partial1 << 32n) | partial2) >> BigInt(64 - (partials * 8));
   }
@@ -224,12 +226,13 @@ export function bigintFromMtcDirect(bytes: Uint8Array): bigint {
     // using a `DataView` to extract `uint64`s from `bytes`.
     for (let i = partials; i < bytes.length; i += 8) {
       const subResult1 = BigInt(
-        (bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
-          bytes[i + 3],
+        (bytes[i]! << 24) | (bytes[i + 1]! << 16) | (bytes[i + 2]! << 8) |
+          bytes[i + 3]!,
       ) & 0xffff_ffffn;
       const subResult2 = BigInt(
-        (bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
-          bytes[i + 7],
+        (bytes[i + 4]! << 24) | (bytes[i + 5]! << 16) |
+          (bytes[i + 6]! << 8) |
+          bytes[i + 7]!,
       ) & 0xffff_ffffn;
       result = (result << 64n) | (subResult1 << 32n) | subResult2;
     }
@@ -245,12 +248,13 @@ export function bigintFromMtcDirect(bytes: Uint8Array): bigint {
 
     for (let i = partials; i < bytes.length; i += 8) {
       const subResult1 = BigInt(
-        ~((bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
-          bytes[i + 3]),
+        ~((bytes[i]! << 24) | (bytes[i + 1]! << 16) | (bytes[i + 2]! << 8) |
+          bytes[i + 3]!),
       ) & 0xffff_ffffn;
       const subResult2 = BigInt(
-        ~((bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
-          bytes[i + 7]),
+        ~((bytes[i + 4]! << 24) | (bytes[i + 5]! << 16) |
+          (bytes[i + 6]! << 8) |
+          bytes[i + 7]!),
       ) & 0xffff_ffffn;
       result = (result << 64n) | (subResult1 << 32n) | subResult2;
     }

--- a/packages/utils/src/bigint-uint8-hex-string.ts
+++ b/packages/utils/src/bigint-uint8-hex-string.ts
@@ -99,7 +99,7 @@ export function bigintToMtcHex(value: bigint): Uint8Array {
 
     if (resultLength < 128) {
       for (let i = 0; i < resultLength; i++) {
-        result[i] = ~result[i];
+        result[i] = ~result[i]!;
       }
     } else {
       // At around 128 bytes (measured in benchmarks), it becomes faster to
@@ -110,11 +110,11 @@ export function bigintToMtcHex(value: bigint): Uint8Array {
       const resultUint32 = new Uint32Array(result.buffer, 0, resultLength >> 2);
 
       for (let i = 0; i < resultUint32.length; i++) {
-        resultUint32[i] = ~resultUint32[i];
+        resultUint32[i] = ~resultUint32[i]!;
       }
 
       for (let i = resultLength - byteRemainder; i < resultLength; i++) {
-        result[i] = ~result[i];
+        result[i] = ~result[i]!;
       }
     }
 
@@ -134,7 +134,7 @@ export function bigintFromMtcHex(bytes: Uint8Array): bigint {
   const hexString = bytes.toHex();
   const positiveResult = BigInt(`0x${hexString}`);
 
-  if (bytes[0] <= 0x7f) {
+  if (bytes[0]! <= 0x7f) {
     return positiveResult;
   } else {
     // Negative number. We make the initial positive result of conversion

--- a/packages/utils/test/bigint.test.ts
+++ b/packages/utils/test/bigint.test.ts
@@ -266,7 +266,7 @@ for (
     describe(`${biToMtc.name}()`, () => {
       it(`correctly encodes ${sliceLabel}`, () => {
         for (let i = 0; i < slice.length; i++) {
-          const { value, encoded, label } = slice[i];
+          const { value, encoded, label } = slice[i]!;
           try {
             expect(biToMtc(value)).toEqual(encoded);
           } catch (e) {
@@ -279,7 +279,7 @@ for (
     describe(`${biFromMtc.name}()`, () => {
       it(`correctly decodes ${sliceLabel}`, () => {
         for (let i = 0; i < slice.length; i++) {
-          const { value, encoded, label } = slice[i];
+          const { value, encoded, label } = slice[i]!;
           try {
             expect(biFromMtc(encoded)).toBe(value);
           } catch (e) {
@@ -292,7 +292,7 @@ for (
     describe(`${biToMtc.name}()->${biFromMtc.name}() round trip through base64url`, () => {
       it(`correctly round-trips ${sliceLabel}`, () => {
         for (let i = 0; i < slice.length; i++) {
-          const { value, label } = slice[i];
+          const { value, label } = slice[i]!;
           const bytes = biToMtc(value);
           const b64 = toUnpaddedBase64url(bytes);
           const decodedBytes = fromBase64url(b64);

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -44,10 +44,10 @@ describe("logger", () => {
     color: string,
     level: string,
   ) {
-    expect(calls[index][0]).toMatch(
+    expect(calls[index]![0]).toMatch(
       new RegExp(`^%c\\[${level}\\]\\[\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]$`),
     );
-    expect(calls[index][1]).toBe(color);
+    expect(calls[index]![1]).toBe(color);
   }
 
   // Helper to check styled module::timestamp format
@@ -61,8 +61,8 @@ describe("logger", () => {
     const pattern = new RegExp(
       `^%c\\[${level}\\]\\[${module}::\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]$`,
     );
-    expect(calls[index][0]).toMatch(pattern);
-    expect(calls[index][1]).toBe(color);
+    expect(calls[index]![0]).toMatch(pattern);
+    expect(calls[index]![1]).toBe(color);
   }
 
   // Helper to capture console output
@@ -101,7 +101,7 @@ describe("logger", () => {
 
       expect(calls).toHaveLength(1);
       expectStyledTimestamp(calls, 0, LOG_COLORS.info, "INFO");
-      expect(calls[0].slice(2)).toEqual(["test-key", "hello", "world"]);
+      expect(calls[0]!.slice(2)).toEqual(["test-key", "hello", "world"]);
     });
 
     it("should handle multiple arguments", () => {
@@ -111,7 +111,7 @@ describe("logger", () => {
 
       expect(calls).toHaveLength(1);
       expectStyledTimestamp(calls, 0, LOG_COLORS.info, "INFO");
-      expect(calls[0].slice(2)).toEqual(["test-key", "a", 1, true, {
+      expect(calls[0]!.slice(2)).toEqual(["test-key", "a", 1, true, {
         key: "value",
       }]);
     });
@@ -130,7 +130,7 @@ describe("logger", () => {
       expect(evaluated).toBe(true);
       expect(calls).toHaveLength(1);
       expectStyledTimestamp(calls, 0, LOG_COLORS.info, "INFO");
-      expect(calls[0].slice(2)).toEqual(["test-key", "static", "lazy value"]);
+      expect(calls[0]!.slice(2)).toEqual(["test-key", "static", "lazy value"]);
     });
 
     it("should handle mixed static and lazy messages", () => {
@@ -147,7 +147,7 @@ describe("logger", () => {
 
       expect(calls).toHaveLength(1);
       expectStyledTimestamp(calls, 0, LOG_COLORS.info, "INFO");
-      expect(calls[0].slice(2)).toEqual([
+      expect(calls[0]!.slice(2)).toEqual([
         "test-key",
         "start",
         "lazy1",
@@ -169,7 +169,7 @@ describe("logger", () => {
 
       expect(calls).toHaveLength(1);
       expectStyledTimestamp(calls, 0, LOG_COLORS.info, "INFO");
-      expect(calls[0].slice(2)).toEqual([
+      expect(calls[0]!.slice(2)).toEqual([
         "test-key",
         "prefix",
         "array",
@@ -189,7 +189,7 @@ describe("logger", () => {
 
       expect(calls).toHaveLength(1);
       expectStyledTimestamp(calls, 0, LOG_COLORS.debug, "DEBUG");
-      expect(calls[0].slice(2)).toEqual(["test-key", "debug message"]);
+      expect(calls[0]!.slice(2)).toEqual(["test-key", "debug message"]);
     });
 
     it("should log info messages", () => {
@@ -199,7 +199,7 @@ describe("logger", () => {
 
       expect(calls).toHaveLength(1);
       expectStyledTimestamp(calls, 0, LOG_COLORS.info, "INFO");
-      expect(calls[0].slice(2)).toEqual(["test-key", "info message"]);
+      expect(calls[0]!.slice(2)).toEqual(["test-key", "info message"]);
     });
 
     it("should log warning messages", () => {
@@ -209,7 +209,7 @@ describe("logger", () => {
 
       expect(calls).toHaveLength(1);
       expectStyledTimestamp(calls, 0, LOG_COLORS.warn, "WARN");
-      expect(calls[0].slice(2)).toEqual(["test-key", "warning message"]);
+      expect(calls[0]!.slice(2)).toEqual(["test-key", "warning message"]);
     });
 
     it("should log error messages", () => {
@@ -219,7 +219,7 @@ describe("logger", () => {
 
       expect(calls).toHaveLength(1);
       expectStyledTimestamp(calls, 0, LOG_COLORS.error, "ERROR");
-      expect(calls[0].slice(2)).toEqual(["test-key", "error message"]);
+      expect(calls[0]!.slice(2)).toEqual(["test-key", "error message"]);
     });
 
     it("should default to info level when using log.info()", () => {
@@ -229,7 +229,7 @@ describe("logger", () => {
 
       expect(calls).toHaveLength(1);
       expectStyledTimestamp(calls, 0, LOG_COLORS.info, "INFO");
-      expect(calls[0].slice(2)).toEqual(["test-key", "default message"]);
+      expect(calls[0]!.slice(2)).toEqual(["test-key", "default message"]);
     });
 
     it("should support log.log() as alias for info", () => {
@@ -239,7 +239,7 @@ describe("logger", () => {
 
       expect(calls).toHaveLength(1);
       expectStyledTimestamp(calls, 0, LOG_COLORS.info, "INFO");
-      expect(calls[0].slice(2)).toEqual(["test-key", "message via log()"]);
+      expect(calls[0]!.slice(2)).toEqual(["test-key", "message via log()"]);
     });
   });
 
@@ -264,10 +264,10 @@ describe("logger", () => {
         log.error("test-key", lazyError);
       });
 
-      expect(debugCalls[0].slice(2)).toEqual(["test-key", "lazy debug"]);
-      expect(infoCalls[0].slice(2)).toEqual(["test-key", "lazy info"]);
-      expect(warnCalls[0].slice(2)).toEqual(["test-key", "lazy warn"]);
-      expect(errorCalls[0].slice(2)).toEqual(["test-key", "lazy error"]);
+      expect(debugCalls[0]!.slice(2)).toEqual(["test-key", "lazy debug"]);
+      expect(infoCalls[0]!.slice(2)).toEqual(["test-key", "lazy info"]);
+      expect(warnCalls[0]!.slice(2)).toEqual(["test-key", "lazy warn"]);
+      expect(errorCalls[0]!.slice(2)).toEqual(["test-key", "lazy error"]);
     });
 
     it("should not evaluate lazy functions when disabled", () => {
@@ -386,7 +386,7 @@ describe("logger", () => {
         LOG_COLORS.taggedInfo,
         "INFO",
       );
-      expect(calls[0].slice(2)).toEqual(["test-key", "test message"]);
+      expect(calls[0]!.slice(2)).toEqual(["test-key", "test message"]);
     });
 
     it("should support log() method as alias for info()", () => {
@@ -403,7 +403,10 @@ describe("logger", () => {
         LOG_COLORS.taggedInfo,
         "INFO",
       );
-      expect(calls[0].slice(2)).toEqual(["test-key", "test message via log()"]);
+      expect(calls[0]!.slice(2)).toEqual([
+        "test-key",
+        "test message via log()",
+      ]);
     });
 
     it("should support all log levels in tagged logger", () => {
@@ -501,7 +504,7 @@ describe("logger", () => {
         LOG_COLORS.taggedInfo,
         "INFO",
       );
-      expect(calls[0].slice(2)).toEqual(["test-key", "lazy tagged message"]);
+      expect(calls[0]!.slice(2)).toEqual(["test-key", "lazy tagged message"]);
     });
 
     it("should support disabled state in tagged logger", () => {
@@ -572,16 +575,16 @@ describe("logger", () => {
       expect(taggedCalls).toHaveLength(1);
 
       // Global should not have module name
-      expect(globalCalls[0][0]).toMatch(
+      expect(globalCalls[0]![0]).toMatch(
         /^%c\[INFO\]\[\d{2}:\d{2}:\d{2}\.\d{3}\]$/,
       );
-      expect(globalCalls[0][1]).toBe(LOG_COLORS.info);
+      expect(globalCalls[0]![1]).toBe(LOG_COLORS.info);
 
       // Tagged should have module name
-      expect(taggedCalls[0][0]).toMatch(
+      expect(taggedCalls[0]![0]).toMatch(
         /^%c\[INFO\]\[test-module::\d{2}:\d{2}:\d{2}\.\d{3}\]$/,
       );
-      expect(taggedCalls[0][1]).toBe(LOG_COLORS.taggedInfo);
+      expect(taggedCalls[0]![1]).toBe(LOG_COLORS.taggedInfo);
     });
 
     it("should have independent log levels", () => {
@@ -953,9 +956,9 @@ describe("logger", () => {
       const breakdown = getLoggerCountsBreakdown();
 
       // Now returns nested structure with message keys
-      expect(breakdown["breakdown-test-1"].total).toBe(2);
-      expect(breakdown["breakdown-test-2"].total).toBe(3);
-      expect(breakdown["breakdown-test-3"].total).toBe(1);
+      expect(breakdown["breakdown-test-1"]!.total).toBe(2);
+      expect(breakdown["breakdown-test-2"]!.total).toBe(3);
+      expect(breakdown["breakdown-test-3"]!.total).toBe(1);
       expect(breakdown.total).toBe(6);
     });
 
@@ -977,13 +980,13 @@ describe("logger", () => {
       const logger = getLogger("breakdown-update-test");
 
       let breakdown = getLoggerCountsBreakdown();
-      expect(breakdown["breakdown-update-test"].total).toBe(0);
+      expect(breakdown["breakdown-update-test"]!.total).toBe(0);
       expect(breakdown.total).toBe(0);
 
       captureConsole("log", () => logger.info("test-key", "test"));
 
       breakdown = getLoggerCountsBreakdown();
-      expect(breakdown["breakdown-update-test"].total).toBe(1);
+      expect(breakdown["breakdown-update-test"]!.total).toBe(1);
       expect(breakdown.total).toBe(1);
     });
 
@@ -998,15 +1001,15 @@ describe("logger", () => {
       });
 
       let breakdown = getLoggerCountsBreakdown();
-      expect(breakdown["breakdown-reset-1"].total).toBe(1);
-      expect(breakdown["breakdown-reset-2"].total).toBe(2);
+      expect(breakdown["breakdown-reset-1"]!.total).toBe(1);
+      expect(breakdown["breakdown-reset-2"]!.total).toBe(2);
       expect(breakdown.total).toBe(3);
 
       resetAllLoggerCounts();
 
       breakdown = getLoggerCountsBreakdown();
-      expect(breakdown["breakdown-reset-1"].total).toBe(0);
-      expect(breakdown["breakdown-reset-2"].total).toBe(0);
+      expect(breakdown["breakdown-reset-1"]!.total).toBe(0);
+      expect(breakdown["breakdown-reset-2"]!.total).toBe(0);
       expect(breakdown.total).toBe(0);
     });
 
@@ -1045,7 +1048,7 @@ describe("logger", () => {
         call.some((arg) => String(arg).includes("100 log calls made"))
       );
       expect(summaryLogs).toHaveLength(1);
-      expect(summaryLogs[0].some((arg) => String(arg).includes("info: 100")))
+      expect(summaryLogs[0]!.some((arg) => String(arg).includes("info: 100")))
         .toBe(true);
     });
 
@@ -1109,13 +1112,19 @@ describe("logger", () => {
 
       // Check each threshold
       expect(
-        summaryLogs[0].some((arg) => String(arg).includes("25 log calls made")),
+        summaryLogs[0]!.some((arg) =>
+          String(arg).includes("25 log calls made")
+        ),
       ).toBe(true);
       expect(
-        summaryLogs[1].some((arg) => String(arg).includes("50 log calls made")),
+        summaryLogs[1]!.some((arg) =>
+          String(arg).includes("50 log calls made")
+        ),
       ).toBe(true);
       expect(
-        summaryLogs[2].some((arg) => String(arg).includes("75 log calls made")),
+        summaryLogs[2]!.some((arg) =>
+          String(arg).includes("75 log calls made")
+        ),
       ).toBe(true);
     });
 
@@ -1162,7 +1171,7 @@ describe("logger", () => {
       expect(summaryLogs).toHaveLength(1);
 
       // Check breakdown
-      const summaryText = summaryLogs[0].join(" ");
+      const summaryText = summaryLogs[0]!.join(" ");
       expect(summaryText).toContain("debug: 2");
       expect(summaryText).toContain("info: 3");
       expect(summaryText).toContain("warn: 2");
@@ -1245,14 +1254,14 @@ describe("logger", () => {
 
       const byKey = logger.countsByKey;
 
-      expect(byKey["user-login"].debug).toBe(2);
-      expect(byKey["user-login"].info).toBe(1);
-      expect(byKey["user-login"].warn).toBe(1);
-      expect(byKey["user-login"].error).toBe(0);
-      expect(byKey["user-login"].total).toBe(4);
+      expect(byKey["user-login"]!.debug).toBe(2);
+      expect(byKey["user-login"]!.info).toBe(1);
+      expect(byKey["user-login"]!.warn).toBe(1);
+      expect(byKey["user-login"]!.error).toBe(0);
+      expect(byKey["user-login"]!.total).toBe(4);
 
-      expect(byKey["data-fetch"].info).toBe(1);
-      expect(byKey["data-fetch"].total).toBe(1);
+      expect(byKey["data-fetch"]!.info).toBe(1);
+      expect(byKey["data-fetch"]!.total).toBe(1);
     });
 
     it("should track different keys independently", () => {
@@ -1266,9 +1275,9 @@ describe("logger", () => {
       });
 
       const byKey = logger.countsByKey;
-      expect(byKey["key-a"].total).toBe(2);
-      expect(byKey["key-b"].total).toBe(1);
-      expect(byKey["key-c"].total).toBe(1);
+      expect(byKey["key-a"]!.total).toBe(2);
+      expect(byKey["key-b"]!.total).toBe(1);
+      expect(byKey["key-c"]!.total).toBe(1);
     });
 
     it("should reset countsByKey when resetCounts is called", () => {
@@ -1279,8 +1288,8 @@ describe("logger", () => {
         logger.info("key-2", "Message 2");
       });
 
-      expect(logger.countsByKey["key-1"].total).toBe(1);
-      expect(logger.countsByKey["key-2"].total).toBe(1);
+      expect(logger.countsByKey["key-1"]!.total).toBe(1);
+      expect(logger.countsByKey["key-2"]!.total).toBe(1);
 
       logger.resetCounts();
 
@@ -1295,7 +1304,7 @@ describe("logger", () => {
         logger.info("key-disabled", "Should count again");
       });
 
-      expect(logger.countsByKey["key-disabled"].total).toBe(2);
+      expect(logger.countsByKey["key-disabled"]!.total).toBe(2);
     });
   });
 
@@ -1316,13 +1325,13 @@ describe("logger", () => {
       const breakdown = getLoggerCountsBreakdown();
 
       // Check logger1 breakdown
-      expect(breakdown["breakdown-keys-1"]["login"].total).toBe(2);
-      expect(breakdown["breakdown-keys-1"]["logout"].total).toBe(1);
-      expect(breakdown["breakdown-keys-1"].total).toBe(3);
+      expect(breakdown["breakdown-keys-1"]!["login"]!.total).toBe(2);
+      expect(breakdown["breakdown-keys-1"]!["logout"]!.total).toBe(1);
+      expect(breakdown["breakdown-keys-1"]!.total).toBe(3);
 
       // Check logger2 breakdown
-      expect(breakdown["breakdown-keys-2"]["fetch"].total).toBe(3);
-      expect(breakdown["breakdown-keys-2"].total).toBe(3);
+      expect(breakdown["breakdown-keys-2"]!["fetch"]!.total).toBe(3);
+      expect(breakdown["breakdown-keys-2"]!.total).toBe(3);
 
       // Check global total
       expect(breakdown.total).toBe(6);
@@ -1348,7 +1357,7 @@ describe("logger", () => {
       });
 
       const breakdown = getLoggerCountsBreakdown();
-      const testOp = breakdown["breakdown-levels"]["test-op"];
+      const testOp = breakdown["breakdown-levels"]!["test-op"]!;
 
       expect(testOp.debug).toBe(2);
       expect(testOp.info).toBe(1);
@@ -1370,10 +1379,10 @@ describe("logger", () => {
 
       const breakdown = getLoggerCountsBreakdown();
 
-      expect(breakdown["multi-1"]["action-a"].total).toBe(1);
-      expect(breakdown["multi-1"]["action-b"].total).toBe(1);
-      expect(breakdown["multi-2"]["action-a"].total).toBe(1);
-      expect(breakdown["multi-2"]["action-c"].total).toBe(1);
+      expect(breakdown["multi-1"]!["action-a"]!.total).toBe(1);
+      expect(breakdown["multi-1"]!["action-b"]!.total).toBe(1);
+      expect(breakdown["multi-2"]!["action-a"]!.total).toBe(1);
+      expect(breakdown["multi-2"]!["action-c"]!.total).toBe(1);
       expect(breakdown.total).toBe(4);
     });
   });
@@ -1463,7 +1472,7 @@ describe("logger", () => {
         ) => entry.name === "logger:timing-measure:operation");
 
         expect(measures).toHaveLength(1);
-        expect(measures[0].duration).toBe(15);
+        expect(measures[0]!.duration).toBe(15);
       });
 
       it("should not emit performance measures when timing config does not match", () => {
@@ -1495,12 +1504,12 @@ describe("logger", () => {
         });
 
         expect(calls).toHaveLength(1);
-        expect(calls[0][0]).toMatch(
+        expect(calls[0]![0]).toMatch(
           /^\%c\[TIMING\]\[timing-console::\d{2}:\d{2}:\d{2}\.\d{3}\]$/,
         );
-        expect(calls[0][1]).toBe(LOG_COLORS.debug);
-        expect(calls[0][2]).toBe("operation");
-        expect(calls[0][3]).toBe("12.500ms");
+        expect(calls[0]![1]).toBe(LOG_COLORS.debug);
+        expect(calls[0]![2]).toBe("operation");
+        expect(calls[0]![3]).toBe("12.500ms");
       });
 
       it("should respect minimum duration threshold for timing output", () => {
@@ -1689,8 +1698,8 @@ describe("logger", () => {
 
         expect(breakdown["timing-breakdown-1"]).toBeDefined();
         expect(breakdown["timing-breakdown-2"]).toBeDefined();
-        expect(breakdown["timing-breakdown-1"]["op1"]?.count).toBe(1);
-        expect(breakdown["timing-breakdown-2"]["op2"]?.count).toBe(1);
+        expect(breakdown["timing-breakdown-1"]!["op1"]?.count).toBe(1);
+        expect(breakdown["timing-breakdown-2"]!["op2"]?.count).toBe(1);
       });
 
       it("should not include loggers with no timing data", () => {


### PR DESCRIPTION
Turns on the `noUncheckedIndexedAccess` TypeScript option in `packages/utils`
and `packages/data-model`, and fixes the errors that surfaced. Every edit is
type-only; nothing here survives to runtime.

Pre-PR for the schema-generator golden-format work.

## Why

`schema-generator` sets `noUncheckedIndexedAccess` in its `compilerOptions`,
and Deno applies a workspace member's `compilerOptions` across the entire
module graph that member pulls in — not just its own files. So that flag was
in effect a constraint on everything `schema-generator` is allowed to import,
and today it cannot import `data-model` at all.

This is not a test-harness artifact. A two-line file inside
`packages/schema-generator` consisting only of

```ts
import { jsonFromValue } from "@commonfabric/data-model/codec-json";
export const x = jsonFromValue;
```

produced **72 errors**, none of them in `schema-generator`:

| package | file | sites |
| --- | --- | --- |
| utils | `src/bigint-uint8-direct.ts` | 64 |
| utils | `src/bigint-uint8-hex-string.ts` | 4 |
| utils | `src/bigint-shared-impl.ts` | 1 |
| data-model | `src/codec-json/JsonEncodingContext.ts` | 3 |

Turning the flag on in the two packages themselves surfaced the rest — their
own tests and one bench — which is the point: these should hold up on their own
terms, not only when a stricter consumer happens to look at them.

## What

Every error is an index into a `Uint8Array` (or a fixed-shape test fixture) at
a position already established in range — by an enclosing `switch
(bytes.length)`, a bounds-checked loop, or a length test a line or two above.
Those take a non-null assertion. That is already the idiom in this code:
`bigint-uint8-direct.ts` had one such site before this change, because the file
is already consumed by an environment running with this same flag.

The bigint code is performance-sensitive, so the diff is deliberately
mechanical — no restructuring, no algorithm changes, nothing that survives to
runtime.

Two sites took something other than a bare assertion:

- `JsonEncodingContext` destructured `[[key, value]]` straight out of
  `Object.entries()`. It now indexes `[0]!` and destructures the pair, which
  states the single-entry invariant (already described in the comment above it)
  without asserting through two levels at once.
- `bigint-shared-impl.encode5To8Bytes` asserts at the binding rather than at
  each use, leaving the loop body untouched.

`noUncheckedIndexedAccess` is now enabled for both packages.

## Verification

- `./tasks/check.sh` (full repo, 400 paths) — `Type check complete.`, exit 0
- `packages/utils` — `ok | 91 passed (504 steps) | 0 failed`
- `packages/data-model` — `ok | 47 passed (2040 steps) | 0 failed`
- The motivating probe above now type-checks clean from inside
  `schema-generator`: **72 errors → 0**.

## Follow-on (queued, not built)

Moves the `schema-generator` fixture goldens onto the fabric JSON encoding.
`JSON.stringify` cannot represent three values the generator is allowed to
produce — it renders `-0` as `0` and both `NaN` and the infinities as `null` —
and it throws outright on a bigint, which schemas will carry before long. A
golden that cannot hold a value cannot guard it, and the failure is silent:
golden and buggy output agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4s5BjnzfVbJS6VVydhZPR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `noUncheckedIndexedAccess` in `@commonfabric/utils` and `@commonfabric/data-model`, and add targeted non-null assertions in bigint codec and JSON encoding to satisfy the flag. No runtime changes; this removes type-only errors and lets `schema-generator` import `data-model` cleanly.

- **Refactors**
  - Turned on `noUncheckedIndexedAccess` in each package’s `deno.jsonc`.
  - Added `!` to safe `Uint8Array` and fixed-shape index sites; algorithms unchanged.
  - Updated `JsonEncodingContext` to destructure via `Object.entries(...)[0]!` and adjusted tests.
  - Moved a non-null assertion to the binding in `encode5To8Bytes` for clarity.

<sup>Written for commit 46a523f5029644cc7d8e8c4efb7b0de9ac3f31f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


