### PR TITLE
fix(data-model): single-source the `fvj1:` tag, via test-only wrap/unwrap

### DIFF
--- a/packages/data-model/src/codec-json/JsonEncodingContext.ts
+++ b/packages/data-model/src/codec-json/JsonEncodingContext.ts
@@ -509,16 +509,14 @@ export class JsonEncodingContext implements SerializationContext<string> {
    * that wants to recognize an encoded value should call `seemsLikeEncoded()`;
    * production code that wants the value itself should call `decode()`.
    *
-   * That is enforced rather than merely advised: this performs a throwaway
-   * decode of `encoded` and throws if it is not genuinely decodable. So it
-   * cannot serve as a cheap "chop off the first few characters," and it is far
-   * too expensive to belong on any hot path.
+   * That is enforced rather than merely advised: by default this performs a
+   * throwaway decode of `encoded` and throws if it is not genuinely decodable.
+   * So it cannot serve as a cheap "chop off the first few characters," and it
+   * is far too expensive to belong on any hot path.
    *
-   * Pass `isMalformed` when the payload is _deliberately_ bad -- a test feeding
-   * a broken tag state through the decoder to see it degrade, say. The check
    * Pass `isMalformed` when the payload is bad on purpose. The decode is then
    * skipped entirely -- malformed means malformed, and deliberately broken text
-   * cannot be asked to survive a decode.
+   * cannot be asked to survive a decode. Only the prefix check remains.
    *
    * The tag itself is still required either way. That is not a judgment about
    * the payload: removing a prefix that is not there does not produce the body,
@@ -568,11 +566,11 @@ export class JsonEncodingContext implements SerializationContext<string> {
    * is accepted.
    *
    * Pass `isMalformed` when the payload is bad on purpose -- a test that wants
-   * the decoder to choke on it, say. No check runs at all in that case: malformed
-   * means malformed, and text that is deliberately broken cannot be asked to
-   * survive a decode. The result is the tag with `json` after it, whatever
-   * `json` is. The flag is the call site saying out loud that the badness is
-   * the point.
+   * the decoder to choke on it, say. No check runs at all in that case:
+   * malformed means malformed, and text that is deliberately broken cannot be
+   * asked to survive a decode. The result is the tag with `json` after it,
+   * whatever `json` is. The flag is the call site saying out loud that the
+   * badness is the point.
    */
   static wrapEncodedValueForTesting(
     json: string,

--- a/packages/data-model/src/codec-json/JsonEncodingContext.ts
+++ b/packages/data-model/src/codec-json/JsonEncodingContext.ts
@@ -516,22 +516,34 @@ export class JsonEncodingContext implements SerializationContext<string> {
    *
    * Pass `isMalformed` when the payload is _deliberately_ bad -- a test feeding
    * a broken tag state through the decoder to see it degrade, say. The check
-   * then runs leniently, so such a payload survives it, and the call site says
-   * out loud that the badness is the point. Note that this also covers a
-   * payload holding a cell reference, which cannot be reconstructed here for
-   * want of a runtime.
+   * Pass `isMalformed` when the payload is bad on purpose. The decode is then
+   * skipped entirely -- malformed means malformed, and deliberately broken text
+   * cannot be asked to survive a decode.
+   *
+   * The tag itself is still required either way. That is not a judgment about
+   * the payload: removing a prefix that is not there does not produce the body,
+   * it produces nonsense, so there is nothing for this to return.
    */
   static unwrapEncodedValueForTesting(
     encoded: string,
     isMalformed = false,
   ): string {
-    // Throwaway decode. The result is discarded; it is performed only to
-    // establish that `encoded` really is one of ours, rather than a string that
-    // happens to begin with the right few characters.
-    JsonEncodingContext.#testingCheckContext(isMalformed).decode(
-      encoded,
-      JsonEncodingContext.#testingReconstructionContext,
-    );
+    if (isMalformed) {
+      if (!JsonEncodingContext.seemsLikeEncoded(encoded)) {
+        throw new Error(
+          `Not a JSON-encoded \`FabricValue\` string: \`${encoded}\``,
+        );
+      }
+    } else {
+      // Throwaway decode. The result is discarded; it is performed only to
+      // establish that `encoded` really is one of ours, rather than a string
+      // that happens to begin with the right few characters. (`decode()` checks
+      // the tag first, so the malformed branch above loses nothing.)
+      new JsonEncodingContext().decode(
+        encoded,
+        JsonEncodingContext.#testingReconstructionContext,
+      );
+    }
 
     return encoded.slice(ENCODING_PREFIX_TAG.length);
   }
@@ -555,9 +567,12 @@ export class JsonEncodingContext implements SerializationContext<string> {
    * differences -- whitespace, in particular -- are fine; a pretty-printed body
    * is accepted.
    *
-   * `isMalformed` means the same thing as it does on
-   * `unwrapEncodedValueForTesting()`: the payload is meant to be bad, so check
-   * it leniently and let the call site say so.
+   * Pass `isMalformed` when the payload is bad on purpose -- a test that wants
+   * the decoder to choke on it, say. No check runs at all in that case: malformed
+   * means malformed, and text that is deliberately broken cannot be asked to
+   * survive a decode. The result is the tag with `json` after it, whatever
+   * `json` is. The flag is the call site saying out loud that the badness is
+   * the point.
    */
   static wrapEncodedValueForTesting(
     json: string,
@@ -565,26 +580,18 @@ export class JsonEncodingContext implements SerializationContext<string> {
   ): string {
     const encoded = ENCODING_PREFIX_TAG + json;
 
-    // Throwaway decode and re-encode; both results are discarded. See above.
-    const context = JsonEncodingContext.#testingCheckContext(isMalformed);
-    context.encode(
-      context.decode(
-        encoded,
-        JsonEncodingContext.#testingReconstructionContext,
-      ),
-    );
+    if (!isMalformed) {
+      // Throwaway decode and re-encode; both results are discarded. See above.
+      const context = new JsonEncodingContext();
+      context.encode(
+        context.decode(
+          encoded,
+          JsonEncodingContext.#testingReconstructionContext,
+        ),
+      );
+    }
 
     return encoded;
-  }
-
-  /**
-   * Codec context for the throwaway checks above. Strict by default, so that
-   * anything the codec cannot cleanly read is refused; lenient when the caller
-   * has declared the payload bad on purpose, which downgrades a failed
-   * reconstruction to a `ProblematicValue` instead of an error.
-   */
-  static #testingCheckContext(isMalformed: boolean): JsonEncodingContext {
-    return new JsonEncodingContext({ lenient: isMalformed });
   }
 
   /**

--- a/packages/data-model/src/codec-json/JsonEncodingContext.ts
+++ b/packages/data-model/src/codec-json/JsonEncodingContext.ts
@@ -473,6 +473,19 @@ export class JsonEncodingContext implements SerializationContext<string> {
   //
 
   /**
+   * Reconstruction context for the throwaway checks in the testing helpers
+   * below. Deep-freezes, as the ordinary decode path does. Paired with a
+   * lenient codec context, a cell reference degrades to a `ProblematicValue`
+   * rather than throwing.
+   */
+  static readonly #testingReconstructionContext = Object.freeze(
+    new EmptyReconstructionContext(
+      true,
+      "no runtime context (validity check in a test-only helper).",
+    ),
+  );
+
+  /**
    * Indicates if the given text has a "first-blush" appearance as valid JSON
    * encoded by this class -- that is, whether it carries the encoding prefix
    * tag.
@@ -573,18 +586,6 @@ export class JsonEncodingContext implements SerializationContext<string> {
   static #testingCheckContext(isMalformed: boolean): JsonEncodingContext {
     return new JsonEncodingContext({ lenient: isMalformed });
   }
-
-  /**
-   * Reconstruction context for the throwaway checks above. Deep-freezes, as the
-   * ordinary decode path does. Paired with the lenient codec context, a cell
-   * reference here degrades to a `ProblematicValue` rather than throwing.
-   */
-  static readonly #testingReconstructionContext = Object.freeze(
-    new EmptyReconstructionContext(
-      true,
-      "no runtime context (validity check in a test-only helper).",
-    ),
-  );
 
   /**
    * Parses the JSON-text wire form, _without_ a tag prefix.

--- a/packages/data-model/src/codec-json/JsonEncodingContext.ts
+++ b/packages/data-model/src/codec-json/JsonEncodingContext.ts
@@ -8,6 +8,7 @@ import {
   type SerializationContext,
 } from "@/codec-common/interface.ts";
 import { deepFreeze } from "@/deep-freeze.ts";
+import { EmptyReconstructionContext } from "@/codec-common/EmptyReconstructionContext.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { createDefaultRegistry } from "./createDefaultRegistry.ts";
@@ -479,6 +480,111 @@ export class JsonEncodingContext implements SerializationContext<string> {
   static seemsLikeEncoded(value: string): boolean {
     return value.startsWith(ENCODING_PREFIX_TAG);
   }
+
+  /**
+   * **Intended for tests only.** Strips the encoding prefix tag off an encoded
+   * value, yielding the bare JSON text underneath.
+   *
+   * Tests legitimately need the JSON body on its own -- to pretty-print it, to
+   * store it in a fixture file, to compare it against a literal. Doing that by
+   * hand means writing the prefix a second time, which is how one definition of
+   * a format quietly becomes several that can drift apart.
+   *
+   * This is deliberately not useful outside a test. Its result is precisely a
+   * string that is _no longer_ an encoded fabric value: it has shed the very
+   * marker whose purpose is to say "this JSON came from here." Production code
+   * that wants to recognize an encoded value should call `seemsLikeEncoded()`;
+   * production code that wants the value itself should call `decode()`.
+   *
+   * That is enforced rather than merely advised: this performs a throwaway
+   * decode of `encoded` and throws if it is not genuinely decodable. So it
+   * cannot serve as a cheap "chop off the first few characters," and it is far
+   * too expensive to belong on any hot path.
+   *
+   * Pass `isMalformed` when the payload is _deliberately_ bad -- a test feeding
+   * a broken tag state through the decoder to see it degrade, say. The check
+   * then runs leniently, so such a payload survives it, and the call site says
+   * out loud that the badness is the point. Note that this also covers a
+   * payload holding a cell reference, which cannot be reconstructed here for
+   * want of a runtime.
+   */
+  static unwrapEncodedValueForTesting(
+    encoded: string,
+    isMalformed = false,
+  ): string {
+    // Throwaway decode. The result is discarded; it is performed only to
+    // establish that `encoded` really is one of ours, rather than a string that
+    // happens to begin with the right few characters.
+    JsonEncodingContext.#testingCheckContext(isMalformed).decode(
+      encoded,
+      JsonEncodingContext.#testingReconstructionContext,
+    );
+
+    return encoded.slice(ENCODING_PREFIX_TAG.length);
+  }
+
+  /**
+   * **Intended for tests only.** Attaches the encoding prefix tag to bare JSON
+   * text, producing an encoded value. The inverse of
+   * `unwrapEncodedValueForTesting()`, and it exists for the same reason: so a
+   * test that took an encoded value apart can put it back together without
+   * naming the prefix itself.
+   *
+   * The same caveats apply, and for the same reason. Nothing in production
+   * should be assembling an encoded value out of text -- code that has a value
+   * to encode should call `encode()`, which is the only thing that can promise
+   * the result is well-formed.
+   *
+   * Here that promise is checked directly: the tagged result is decoded and
+   * then re-encoded, and both steps must succeed. Text earns the prefix only if
+   * the codec can actually read what follows it and write it back out. Note
+   * that the re-encoded form is not compared against the input, so incidental
+   * differences -- whitespace, in particular -- are fine; a pretty-printed body
+   * is accepted.
+   *
+   * `isMalformed` means the same thing as it does on
+   * `unwrapEncodedValueForTesting()`: the payload is meant to be bad, so check
+   * it leniently and let the call site say so.
+   */
+  static wrapEncodedValueForTesting(
+    json: string,
+    isMalformed = false,
+  ): string {
+    const encoded = ENCODING_PREFIX_TAG + json;
+
+    // Throwaway decode and re-encode; both results are discarded. See above.
+    const context = JsonEncodingContext.#testingCheckContext(isMalformed);
+    context.encode(
+      context.decode(
+        encoded,
+        JsonEncodingContext.#testingReconstructionContext,
+      ),
+    );
+
+    return encoded;
+  }
+
+  /**
+   * Codec context for the throwaway checks above. Strict by default, so that
+   * anything the codec cannot cleanly read is refused; lenient when the caller
+   * has declared the payload bad on purpose, which downgrades a failed
+   * reconstruction to a `ProblematicValue` instead of an error.
+   */
+  static #testingCheckContext(isMalformed: boolean): JsonEncodingContext {
+    return new JsonEncodingContext({ lenient: isMalformed });
+  }
+
+  /**
+   * Reconstruction context for the throwaway checks above. Deep-freezes, as the
+   * ordinary decode path does. Paired with the lenient codec context, a cell
+   * reference here degrades to a `ProblematicValue` rather than throwing.
+   */
+  static readonly #testingReconstructionContext = Object.freeze(
+    new EmptyReconstructionContext(
+      true,
+      "no runtime context (validity check in a test-only helper).",
+    ),
+  );
 
   /**
    * Parses the JSON-text wire form, _without_ a tag prefix.

--- a/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
@@ -79,30 +79,27 @@ function roundTrip(value: FabricValue): FabricValue {
 }
 
 /**
- * The encoding prefix tag emitted by `JsonEncodingContext.encode()`. Defined
- * here (rather than imported) so the production module can keep the tag
- * private; these helpers strip/add it to bridge between encoded strings and
- * the underlying wire-format tree.
- */
-const ENCODING_PREFIX = "fvj1:";
-
-/**
  * Helper: encode a value and return the wire-format tree (parsed JSON).
  * Used for assertions about the intermediate wire representation.
  */
 function toWireFormat(value: FabricValue): JsonWireValue {
   const { context } = makeTestContext();
   const encoded = context.encode(value);
-  return JSON.parse(encoded.slice(ENCODING_PREFIX.length)) as JsonWireValue;
+  return JSON.parse(
+    JsonEncodingContext.unwrapEncodedValueForTesting(encoded),
+  ) as JsonWireValue;
 }
 
 /**
- * Helper: decode from a wire-format tree. Stringifies to JSON first (with the
- * encoding prefix prepended), then feeds through the public decode API.
+ * Helper: decode from a wire-format tree. Stringifies to JSON first (tagged as
+ * an encoded value), then feeds through the public decode API.
  */
 function fromWireFormat(data: JsonWireValue): FabricValue {
   const { context, runtime } = makeTestContext();
-  return context.decode(ENCODING_PREFIX + JSON.stringify(data), runtime);
+  return context.decode(
+    JsonEncodingContext.wrapEncodedValueForTesting(JSON.stringify(data)),
+    runtime,
+  );
 }
 
 describe("JsonEncodingContext", () => {
@@ -999,7 +996,7 @@ describe("JsonEncodingContext", () => {
       // in lenient mode because the handler validates the state type.
       const data = { "/BigInt@1": 42 } as JsonWireValue;
       const result = context.decode(
-        ENCODING_PREFIX + JSON.stringify(data),
+        JsonEncodingContext.wrapEncodedValueForTesting(JSON.stringify(data)),
         runtime,
       );
       expect(result).toBeInstanceOf(ProblematicValue);
@@ -1017,7 +1014,10 @@ describe("JsonEncodingContext", () => {
         "/Map@1": [["key", "value"]],
       } as JsonWireValue;
       const result = context.decode(
-        ENCODING_PREFIX + JSON.stringify(data),
+        JsonEncodingContext.wrapEncodedValueForTesting(
+          JSON.stringify(data),
+          true, // Undecodable on purpose; that is what this test is about.
+        ),
         runtime,
       );
       expect(result).toBeInstanceOf(ProblematicValue);
@@ -1102,7 +1102,9 @@ describe("JsonEncodingContext", () => {
       const ctx = new JsonEncodingContext({ lenient: true });
       const runtime = new TestReconstructionContext();
       const result = ctx.decode(
-        ENCODING_PREFIX + JSON.stringify({ "/BigInt@1": 42 }),
+        JsonEncodingContext.wrapEncodedValueForTesting(
+          JSON.stringify({ "/BigInt@1": 42 }),
+        ),
         runtime,
       );
       expect(result).toBeInstanceOf(ProblematicValue);
@@ -1142,7 +1144,10 @@ describe("JsonEncodingContext", () => {
     ): { viaString: FabricValue; viaBytes: FabricValue } {
       const { context, runtime } = makeTestContext();
       const json = JSON.stringify(data);
-      const viaString = context.decode(ENCODING_PREFIX + json, runtime);
+      const viaString = context.decode(
+        JsonEncodingContext.wrapEncodedValueForTesting(json),
+        runtime,
+      );
       const viaBytes = context.decodeFromBytes(
         new TextEncoder().encode(json),
         runtime,
@@ -1185,7 +1190,7 @@ describe("JsonEncodingContext", () => {
       } as JsonWireValue;
       const { context, runtime } = makeTestContext();
       const result = context.decode(
-        ENCODING_PREFIX + JSON.stringify(wire),
+        JsonEncodingContext.wrapEncodedValueForTesting(JSON.stringify(wire)),
         runtime,
       ) as Record<string, Record<string, FabricValue[]>>;
 
@@ -1236,14 +1241,19 @@ describe("JsonEncodingContext", () => {
       const ctx = new JsonEncodingContext();
       const result = ctx.encode(42);
       expect(typeof result).toBe("string");
-      expect(result.startsWith(ENCODING_PREFIX)).toBe(true);
-      expect(JSON.parse(result.slice(ENCODING_PREFIX.length))).toBe(42);
+      expect(JsonEncodingContext.seemsLikeEncoded(result)).toBe(true);
+      expect(
+        JSON.parse(JsonEncodingContext.unwrapEncodedValueForTesting(result)),
+      ).toBe(42);
     });
 
     it("`decode()` parses a prefixed JSON string back to a value", () => {
       const ctx = new JsonEncodingContext();
       const runtime = new TestReconstructionContext();
-      const result = ctx.decode(ENCODING_PREFIX + "42", runtime);
+      const result = ctx.decode(
+        JsonEncodingContext.wrapEncodedValueForTesting("42"),
+        runtime,
+      );
       expect(result).toBe(42);
     });
 
@@ -1348,5 +1358,104 @@ describe("JsonEncodingContext", () => {
       expect(state.name).toBe(null); // null = same as type (common case)
       expect(state.message).toBe("compat test");
     });
+  });
+});
+
+describe("test-only prefix helpers", () => {
+  describe("`unwrapEncodedValueForTesting()`", () => {
+    it("yields the JSON text under the tag", () => {
+      const encoded = new JsonEncodingContext().encode(42);
+      expect(JsonEncodingContext.unwrapEncodedValueForTesting(encoded))
+        .toBe("42");
+    });
+
+    it("round-trips with `wrapEncodedValueForTesting()`", () => {
+      const encoded = new JsonEncodingContext().encode(
+        { b: 1, a: [true, null] } as unknown as FabricValue,
+      );
+      const json = JsonEncodingContext.unwrapEncodedValueForTesting(encoded);
+      expect(JsonEncodingContext.wrapEncodedValueForTesting(json))
+        .toBe(encoded);
+    });
+
+    it("rejects a string carrying no tag", () => {
+      // The whole point of the tag: untagged JSON is not one of ours, however
+      // well-formed it happens to be.
+      expect(() => JsonEncodingContext.unwrapEncodedValueForTesting("42"))
+        .toThrow();
+    });
+
+    it("rejects a tag followed by text that will not parse", () => {
+      expect(() =>
+        JsonEncodingContext.unwrapEncodedValueForTesting("fvj1:{nope")
+      ).toThrow();
+    });
+  });
+
+  describe("`wrapEncodedValueForTesting()`", () => {
+    it("produces something the codec accepts", () => {
+      const { runtime } = makeTestContext();
+      const encoded = JsonEncodingContext.wrapEncodedValueForTesting(
+        JSON.stringify({ a: 1 }),
+      );
+      expect(JsonEncodingContext.seemsLikeEncoded(encoded)).toBe(true);
+      expect(new JsonEncodingContext().decode(encoded, runtime))
+        .toEqual({ a: 1 });
+    });
+
+    it("accepts a pretty-printed body", () => {
+      // The re-encoded form is not compared against the input, so whitespace
+      // is immaterial -- which is what lets a golden file be readable.
+      const pretty = JSON.stringify({ a: 1, b: [2, 3] }, null, 2);
+      const encoded = JsonEncodingContext.wrapEncodedValueForTesting(pretty);
+      const { runtime } = makeTestContext();
+      expect(new JsonEncodingContext().decode(encoded, runtime))
+        .toEqual({ a: 1, b: [2, 3] });
+    });
+
+    it("rejects text that will not parse", () => {
+      expect(() => JsonEncodingContext.wrapEncodedValueForTesting("{nope"))
+        .toThrow();
+    });
+
+    it("rejects an already-tagged string", () => {
+      // Double-tagging is a mistake worth catching: the tag is not part of the
+      // JSON, so the result would not parse.
+      const encoded = new JsonEncodingContext().encode(42);
+      expect(() => JsonEncodingContext.wrapEncodedValueForTesting(encoded))
+        .toThrow();
+    });
+  });
+});
+
+describe("`isMalformed` on the test-only prefix helpers", () => {
+  // `Map@1`'s codec always throws on decode, so it stands in for any payload
+  // the codec cannot reconstruct.
+  const undecodable = JSON.stringify({ "/Map@1": [["key", "value"]] });
+
+  it("refuses an undecodable payload by default", () => {
+    expect(() => JsonEncodingContext.wrapEncodedValueForTesting(undecodable))
+      .toThrow();
+  });
+
+  it("accepts an undecodable payload when told it is deliberate", () => {
+    expect(
+      JsonEncodingContext.wrapEncodedValueForTesting(undecodable, true),
+    ).toBe(`fvj1:${undecodable}`);
+  });
+
+  it("still refuses text that will not parse, however deliberate", () => {
+    // The flag excuses a payload the codec cannot rebuild -- not one it cannot
+    // even read. Otherwise it would be an escape hatch out of every check.
+    expect(() => JsonEncodingContext.wrapEncodedValueForTesting("{nope", true))
+      .toThrow();
+    expect(() =>
+      JsonEncodingContext.unwrapEncodedValueForTesting("fvj1:{nope", true)
+    ).toThrow();
+  });
+
+  it("still requires the tag on unwrap, however deliberate", () => {
+    expect(() => JsonEncodingContext.unwrapEncodedValueForTesting("42", true))
+      .toThrow();
   });
 });

--- a/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
@@ -1359,103 +1359,158 @@ describe("JsonEncodingContext", () => {
       expect(state.message).toBe("compat test");
     });
   });
-});
 
-describe("test-only prefix helpers", () => {
-  describe("`unwrapEncodedValueForTesting()`", () => {
-    it("yields the JSON text under the tag", () => {
-      const encoded = new JsonEncodingContext().encode(42);
-      expect(JsonEncodingContext.unwrapEncodedValueForTesting(encoded))
-        .toBe("42");
+  describe("test-only prefix helpers", () => {
+    describe("`unwrapEncodedValueForTesting()`", () => {
+      it("yields the JSON text under the tag", () => {
+        const encoded = new JsonEncodingContext().encode(42);
+        expect(JsonEncodingContext.unwrapEncodedValueForTesting(encoded))
+          .toBe("42");
+      });
+
+      it("round-trips with `wrapEncodedValueForTesting()`", () => {
+        const encoded = new JsonEncodingContext().encode(
+          { b: 1, a: [true, null] } as unknown as FabricValue,
+        );
+        const json = JsonEncodingContext.unwrapEncodedValueForTesting(encoded);
+        expect(JsonEncodingContext.wrapEncodedValueForTesting(json))
+          .toBe(encoded);
+      });
+
+      it("preserves a value plain JSON could not carry", () => {
+        // The case that motivates having a golden format at all: these survive
+        // the trip only as tagged forms.
+        const encoded = new JsonEncodingContext().encode(
+          { z: -0, n: NaN, i: -Infinity } as unknown as FabricValue,
+        );
+        const rebuilt = new JsonEncodingContext().decode(
+          JsonEncodingContext.wrapEncodedValueForTesting(
+            JsonEncodingContext.unwrapEncodedValueForTesting(encoded),
+          ),
+          new TestReconstructionContext(),
+        ) as Record<string, number>;
+        expect(Object.is(rebuilt.z, -0)).toBe(true);
+        expect(Number.isNaN(rebuilt.n)).toBe(true);
+        expect(rebuilt.i).toBe(-Infinity);
+      });
+
+      it("rejects a string carrying no tag", () => {
+        // The whole point of the tag: untagged JSON is not one of ours, however
+        // well-formed it happens to be.
+        expect(() => JsonEncodingContext.unwrapEncodedValueForTesting("42"))
+          .toThrow();
+      });
+
+      it("rejects an empty string", () => {
+        expect(() => JsonEncodingContext.unwrapEncodedValueForTesting(""))
+          .toThrow();
+      });
+
+      it("rejects a tag with nothing after it", () => {
+        // `seemsLikeEncoded()` accepts this, so only the throwaway decode
+        // catches it.
+        expect(() => JsonEncodingContext.unwrapEncodedValueForTesting("fvj1:"))
+          .toThrow();
+      });
+
+      it("rejects a tag followed by text that will not parse", () => {
+        expect(() =>
+          JsonEncodingContext.unwrapEncodedValueForTesting("fvj1:{nope")
+        ).toThrow();
+      });
     });
 
-    it("round-trips with `wrapEncodedValueForTesting()`", () => {
-      const encoded = new JsonEncodingContext().encode(
-        { b: 1, a: [true, null] } as unknown as FabricValue,
-      );
-      const json = JsonEncodingContext.unwrapEncodedValueForTesting(encoded);
-      expect(JsonEncodingContext.wrapEncodedValueForTesting(json))
-        .toBe(encoded);
+    describe("`wrapEncodedValueForTesting()`", () => {
+      it("produces something the codec accepts", () => {
+        const { runtime } = makeTestContext();
+        const encoded = JsonEncodingContext.wrapEncodedValueForTesting(
+          JSON.stringify({ a: 1 }),
+        );
+        expect(JsonEncodingContext.seemsLikeEncoded(encoded)).toBe(true);
+        expect(new JsonEncodingContext().decode(encoded, runtime))
+          .toEqual({ a: 1 });
+      });
+
+      it("returns the body unaltered beneath the tag", () => {
+        const body = JSON.stringify({ b: 2, a: 1 });
+        expect(JsonEncodingContext.wrapEncodedValueForTesting(body))
+          .toBe(`fvj1:${body}`);
+      });
+
+      it("accepts a pretty-printed body", () => {
+        // The re-encoded form is not compared against the input, so whitespace
+        // is immaterial -- which is what lets a golden file be readable.
+        const pretty = JSON.stringify({ a: 1, b: [2, 3] }, null, 2);
+        const encoded = JsonEncodingContext.wrapEncodedValueForTesting(pretty);
+        const { runtime } = makeTestContext();
+        expect(new JsonEncodingContext().decode(encoded, runtime))
+          .toEqual({ a: 1, b: [2, 3] });
+      });
+
+      it("rejects text that will not parse", () => {
+        expect(() => JsonEncodingContext.wrapEncodedValueForTesting("{nope"))
+          .toThrow();
+      });
+
+      it("rejects an empty body", () => {
+        expect(() => JsonEncodingContext.wrapEncodedValueForTesting(""))
+          .toThrow();
+      });
+
+      it("rejects an already-tagged string", () => {
+        // Double-tagging is a mistake worth catching: the tag is not part of
+        // the JSON, so the result would not parse.
+        const encoded = new JsonEncodingContext().encode(42);
+        expect(() => JsonEncodingContext.wrapEncodedValueForTesting(encoded))
+          .toThrow();
+      });
     });
 
-    it("rejects a string carrying no tag", () => {
-      // The whole point of the tag: untagged JSON is not one of ours, however
-      // well-formed it happens to be.
-      expect(() => JsonEncodingContext.unwrapEncodedValueForTesting("42"))
-        .toThrow();
+    describe("`isMalformed`", () => {
+      // `Map@1`'s codec always throws on decode, so it stands in for any
+      // payload the codec cannot reconstruct.
+      const undecodable = JSON.stringify({ "/Map@1": [["key", "value"]] });
+
+      it("refuses an undecodable payload by default", () => {
+        expect(() =>
+          JsonEncodingContext.wrapEncodedValueForTesting(undecodable)
+        )
+          .toThrow();
+      });
+
+      it("accepts an undecodable payload when told it is deliberate", () => {
+        expect(
+          JsonEncodingContext.wrapEncodedValueForTesting(undecodable, true),
+        ).toBe(`fvj1:${undecodable}`);
+      });
+
+      it("unwraps an undecodable payload when told it is deliberate", () => {
+        expect(
+          JsonEncodingContext.unwrapEncodedValueForTesting(
+            `fvj1:${undecodable}`,
+            true,
+          ),
+        ).toBe(undecodable);
+      });
+
+      it("still refuses text that will not parse, however deliberate", () => {
+        // The flag excuses a payload the codec cannot rebuild -- not one it
+        // cannot even read. Otherwise it would be an escape hatch out of every
+        // check.
+        expect(() =>
+          JsonEncodingContext.wrapEncodedValueForTesting("{nope", true)
+        ).toThrow();
+        expect(() =>
+          JsonEncodingContext.unwrapEncodedValueForTesting("fvj1:{nope", true)
+        ).toThrow();
+      });
+
+      it("still requires the tag on unwrap, however deliberate", () => {
+        expect(() =>
+          JsonEncodingContext.unwrapEncodedValueForTesting("42", true)
+        )
+          .toThrow();
+      });
     });
-
-    it("rejects a tag followed by text that will not parse", () => {
-      expect(() =>
-        JsonEncodingContext.unwrapEncodedValueForTesting("fvj1:{nope")
-      ).toThrow();
-    });
-  });
-
-  describe("`wrapEncodedValueForTesting()`", () => {
-    it("produces something the codec accepts", () => {
-      const { runtime } = makeTestContext();
-      const encoded = JsonEncodingContext.wrapEncodedValueForTesting(
-        JSON.stringify({ a: 1 }),
-      );
-      expect(JsonEncodingContext.seemsLikeEncoded(encoded)).toBe(true);
-      expect(new JsonEncodingContext().decode(encoded, runtime))
-        .toEqual({ a: 1 });
-    });
-
-    it("accepts a pretty-printed body", () => {
-      // The re-encoded form is not compared against the input, so whitespace
-      // is immaterial -- which is what lets a golden file be readable.
-      const pretty = JSON.stringify({ a: 1, b: [2, 3] }, null, 2);
-      const encoded = JsonEncodingContext.wrapEncodedValueForTesting(pretty);
-      const { runtime } = makeTestContext();
-      expect(new JsonEncodingContext().decode(encoded, runtime))
-        .toEqual({ a: 1, b: [2, 3] });
-    });
-
-    it("rejects text that will not parse", () => {
-      expect(() => JsonEncodingContext.wrapEncodedValueForTesting("{nope"))
-        .toThrow();
-    });
-
-    it("rejects an already-tagged string", () => {
-      // Double-tagging is a mistake worth catching: the tag is not part of the
-      // JSON, so the result would not parse.
-      const encoded = new JsonEncodingContext().encode(42);
-      expect(() => JsonEncodingContext.wrapEncodedValueForTesting(encoded))
-        .toThrow();
-    });
-  });
-});
-
-describe("`isMalformed` on the test-only prefix helpers", () => {
-  // `Map@1`'s codec always throws on decode, so it stands in for any payload
-  // the codec cannot reconstruct.
-  const undecodable = JSON.stringify({ "/Map@1": [["key", "value"]] });
-
-  it("refuses an undecodable payload by default", () => {
-    expect(() => JsonEncodingContext.wrapEncodedValueForTesting(undecodable))
-      .toThrow();
-  });
-
-  it("accepts an undecodable payload when told it is deliberate", () => {
-    expect(
-      JsonEncodingContext.wrapEncodedValueForTesting(undecodable, true),
-    ).toBe(`fvj1:${undecodable}`);
-  });
-
-  it("still refuses text that will not parse, however deliberate", () => {
-    // The flag excuses a payload the codec cannot rebuild -- not one it cannot
-    // even read. Otherwise it would be an escape hatch out of every check.
-    expect(() => JsonEncodingContext.wrapEncodedValueForTesting("{nope", true))
-      .toThrow();
-    expect(() =>
-      JsonEncodingContext.unwrapEncodedValueForTesting("fvj1:{nope", true)
-    ).toThrow();
-  });
-
-  it("still requires the tag on unwrap, however deliberate", () => {
-    expect(() => JsonEncodingContext.unwrapEncodedValueForTesting("42", true))
-      .toThrow();
   });
 });

--- a/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
@@ -64,6 +64,14 @@ class UnregisteredInstance extends BaseFabricInstance {
   }
 }
 
+/**
+ * The encoding prefix tag, named once for the assertions below that pin the
+ * wire form or that feed the decoder deliberately broken input. Bridging
+ * between encoded strings and wire-format trees does NOT go through this --
+ * that is what `JsonEncodingContext`'s wrap/unwrap helpers are for.
+ */
+const ENCODING_PREFIX = "fvj1:";
+
 /** Creates a standard test context (non-lenient) and a mock runtime. */
 function makeTestContext() {
   const context = new JsonEncodingContext();
@@ -1409,13 +1417,17 @@ describe("JsonEncodingContext", () => {
       it("rejects a tag with nothing after it", () => {
         // `seemsLikeEncoded()` accepts this, so only the throwaway decode
         // catches it.
-        expect(() => JsonEncodingContext.unwrapEncodedValueForTesting("fvj1:"))
+        expect(() =>
+          JsonEncodingContext.unwrapEncodedValueForTesting(ENCODING_PREFIX)
+        )
           .toThrow();
       });
 
       it("rejects a tag followed by text that will not parse", () => {
         expect(() =>
-          JsonEncodingContext.unwrapEncodedValueForTesting("fvj1:{nope")
+          JsonEncodingContext.unwrapEncodedValueForTesting(
+            `${ENCODING_PREFIX}{nope`,
+          )
         ).toThrow();
       });
     });
@@ -1434,7 +1446,7 @@ describe("JsonEncodingContext", () => {
       it("returns the body unaltered beneath the tag", () => {
         const body = JSON.stringify({ b: 2, a: 1 });
         expect(JsonEncodingContext.wrapEncodedValueForTesting(body))
-          .toBe(`fvj1:${body}`);
+          .toBe(`${ENCODING_PREFIX}${body}`);
       });
 
       it("accepts a pretty-printed body", () => {
@@ -1481,13 +1493,13 @@ describe("JsonEncodingContext", () => {
       it("accepts an undecodable payload when told it is deliberate", () => {
         expect(
           JsonEncodingContext.wrapEncodedValueForTesting(undecodable, true),
-        ).toBe(`fvj1:${undecodable}`);
+        ).toBe(`${ENCODING_PREFIX}${undecodable}`);
       });
 
       it("unwraps an undecodable payload when told it is deliberate", () => {
         expect(
           JsonEncodingContext.unwrapEncodedValueForTesting(
-            `fvj1:${undecodable}`,
+            `${ENCODING_PREFIX}${undecodable}`,
             true,
           ),
         ).toBe(undecodable);
@@ -1501,7 +1513,10 @@ describe("JsonEncodingContext", () => {
           JsonEncodingContext.wrapEncodedValueForTesting("{nope", true)
         ).toThrow();
         expect(() =>
-          JsonEncodingContext.unwrapEncodedValueForTesting("fvj1:{nope", true)
+          JsonEncodingContext.unwrapEncodedValueForTesting(
+            `${ENCODING_PREFIX}{nope`,
+            true,
+          )
         ).toThrow();
       });
 

--- a/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
@@ -1505,22 +1505,26 @@ describe("JsonEncodingContext", () => {
         ).toBe(undecodable);
       });
 
-      it("still refuses text that will not parse, however deliberate", () => {
-        // The flag excuses a payload the codec cannot rebuild -- not one it
-        // cannot even read. Otherwise it would be an escape hatch out of every
-        // check.
-        expect(() =>
-          JsonEncodingContext.wrapEncodedValueForTesting("{nope", true)
-        ).toThrow();
-        expect(() =>
+      it("wraps text that will not parse at all", () => {
+        // Malformed means malformed: the flag is a caller saying the payload is
+        // broken on purpose, so nothing is checked and the tag simply goes on
+        // the front.
+        expect(JsonEncodingContext.wrapEncodedValueForTesting("{nope", true))
+          .toBe(`${ENCODING_PREFIX}{nope`);
+      });
+
+      it("unwraps text that will not parse at all", () => {
+        expect(
           JsonEncodingContext.unwrapEncodedValueForTesting(
             `${ENCODING_PREFIX}{nope`,
             true,
-          )
-        ).toThrow();
+          ),
+        ).toBe("{nope");
       });
 
       it("still requires the tag on unwrap, however deliberate", () => {
+        // Not a judgment about the payload: stripping a prefix that is not
+        // there yields nonsense, not the body.
         expect(() =>
           JsonEncodingContext.unwrapEncodedValueForTesting("42", true)
         )

--- a/packages/data-model/test/codec-json/json-encoding.test.ts
+++ b/packages/data-model/test/codec-json/json-encoding.test.ts
@@ -7,6 +7,7 @@ import {
   seemsLikeJsonEncodedFabricValue,
   valueFromJson,
 } from "@/codec-json/json-encoding.ts";
+import { JsonEncodingContext } from "@/codec-json/JsonEncodingContext.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import type { FabricValue } from "@/fabric-value.ts";
 import { BaseReconstructionContext } from "@/codec-common/BaseReconstructionContext.ts";
@@ -33,10 +34,11 @@ function roundTrip(value: FabricValue): FabricValue {
  * (compared as parsed structure, after stripping the modern encoding prefix).
  */
 function expectWireFormat(value: FabricValue, expected: unknown): void {
-  const PREFIX = "fvj1:";
   const json = jsonFromValue(value);
-  expect(json.startsWith(PREFIX)).toBe(true);
-  expect(JSON.parse(json.slice(PREFIX.length))).toEqual(expected);
+  expect(seemsLikeJsonEncodedFabricValue(json)).toBe(true);
+  expect(
+    JSON.parse(JsonEncodingContext.unwrapEncodedValueForTesting(json)),
+  ).toEqual(expected);
 }
 
 describe("json-encoding", () => {

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -6,6 +6,7 @@ import {
   toUnpaddedBase64url,
 } from "@commonfabric/utils/base64url";
 import {
+  JsonEncodingContext,
   jsonFromValue,
   seemsLikeJsonEncodedFabricValue,
 } from "@/codec-json/index.ts";
@@ -147,7 +148,11 @@ describe("data-uri-codec", () => {
     });
 
     it("rejects invalid payload text past the codec tag", () => {
-      expect(() => valueFromDataUriPayloadText("fvj1:{nope")).toThrow();
+      expect(() =>
+        valueFromDataUriPayloadText(
+          JsonEncodingContext.wrapEncodedValueForTesting("{nope", true),
+        )
+      ).toThrow();
     });
   });
 
@@ -280,7 +285,13 @@ describe("data-uri-codec", () => {
       });
 
       it("rejects a malformed payload past the tag", () => {
-        expect(() => valueFromDataUri(uriOf("fvj1:{nope"))).toThrow();
+        expect(() =>
+          valueFromDataUri(
+            uriOf(
+              JsonEncodingContext.wrapEncodedValueForTesting("{nope", true),
+            ),
+          )
+        ).toThrow();
       });
     });
   });

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -5,7 +5,10 @@ import {
   fromBase64url,
   toUnpaddedBase64url,
 } from "@commonfabric/utils/base64url";
-import { jsonFromValue } from "@/codec-json/index.ts";
+import {
+  jsonFromValue,
+  seemsLikeJsonEncodedFabricValue,
+} from "@/codec-json/index.ts";
 import {
   DATA_URI_MEDIA_TYPE,
   dataUriFromValue,
@@ -41,7 +44,7 @@ describe("data-uri-codec", () => {
       const payload = new TextDecoder().decode(
         fromBase64url(uri.slice(uri.indexOf(",") + 1)),
       );
-      expect(payload.startsWith("fvj1:")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue(payload)).toBe(true);
     });
 
     // The standard encoding canonicalizes key order, so the minted id is a

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -141,12 +141,12 @@ describe("data-uri-codec", () => {
       expect(() => valueFromDataUriPayloadText("")).toThrow();
     });
 
-    it("decodes encoded-`FabricValue` (`fvj1:`) payload text", () => {
+    it("decodes encoded-`FabricValue` payload text", () => {
       const value = { value: { b: 1, a: [true, null, "x"] } };
       expect(valueFromDataUriPayloadText(jsonFromValue(value))).toEqual(value);
     });
 
-    it("rejects invalid payload text past the `fvj1:` tag", () => {
+    it("rejects invalid payload text past the codec tag", () => {
       expect(() => valueFromDataUriPayloadText("fvj1:{nope")).toThrow();
     });
   });
@@ -222,7 +222,7 @@ describe("data-uri-codec", () => {
       });
     });
 
-    describe("encoded-`FabricValue` (`fvj1:`) payloads", () => {
+    describe("encoded-`FabricValue` payloads", () => {
       it("decodes a payload", () => {
         const value = { value: { b: 1, a: [true, null, "x"] } };
         expect(valueFromDataUri(uriOf(jsonFromValue(value)))).toEqual(

--- a/packages/runner/src/data-uri.ts
+++ b/packages/runner/src/data-uri.ts
@@ -54,8 +54,8 @@ import {
  *
  * This is the encode half of the matched set this module exists to hold;
  * {@link valueFromDataUri} is what reads back what this writes. Both
- * sides speak only the standard `data-model` `FabricValue` encoding
- * (tagged `fvj1:`).
+ * sides speak only the standard `data-model` `FabricValue` encoding, which
+ * carries that codec's prefix tag.
  *
  * Each primitive cell link within `data` is rewritten to a full sigil link,
  * with relative links resolved against `base`. That rewriting is what makes

--- a/packages/runner/test/attestation-data-uri.test.ts
+++ b/packages/runner/test/attestation-data-uri.test.ts
@@ -31,14 +31,14 @@ describe("attestation `load()` of `data:` URIs", () => {
     expect(Object.isFrozen(ok!.value)).toBe(true);
   });
 
-  it("loads an encoded-`FabricValue` (`fvj1:`) payload", () => {
+  it("loads an encoded-`FabricValue` payload", () => {
     const value = { b: 1, a: [true, null, "x"] };
     const { ok, error } = load({ id: uriOf(jsonFromValue(value)) });
     expect(error).toBeUndefined();
     expect(ok!.value).toEqual({ value });
   });
 
-  it("preserves non-finite numbers in an `fvj1:` payload", () => {
+  it("preserves non-finite numbers in an encoded payload", () => {
     const { ok, error } = load({
       id: uriOf(jsonFromValue([NaN, -0, Infinity])),
     });
@@ -55,7 +55,7 @@ describe("attestation `load()` of `data:` URIs", () => {
     expect(error?.name).toBe("InvalidDataURIError");
   });
 
-  it("errors on an undecodable payload past the `fvj1:` tag", () => {
+  it("errors on an undecodable payload past the codec tag", () => {
     const { ok, error } = load({ id: uriOf("fvj1:{nope") });
     expect(ok).toBeUndefined();
     expect(error?.name).toBe("InvalidDataURIError");

--- a/packages/runner/test/attestation-data-uri.test.ts
+++ b/packages/runner/test/attestation-data-uri.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { jsonFromValue } from "@commonfabric/data-model/codec-json";
+import {
+  JsonEncodingContext,
+  jsonFromValue,
+} from "@commonfabric/data-model/codec-json";
 import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
 import { load } from "../src/storage/transaction/attestation.ts";
@@ -56,7 +59,11 @@ describe("attestation `load()` of `data:` URIs", () => {
   });
 
   it("errors on an undecodable payload past the codec tag", () => {
-    const { ok, error } = load({ id: uriOf("fvj1:{nope") });
+    const { ok, error } = load({
+      id: uriOf(
+        JsonEncodingContext.wrapEncodedValueForTesting("{nope", true),
+      ),
+    });
     expect(ok).toBeUndefined();
     expect(error?.name).toBe("InvalidDataURIError");
   });

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -1279,7 +1279,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 // returned from a previous shape of the storage layer. PR #2971 in
 // March 2026 wired `valueFromJson` into the storage-boundary read path
 // (`memory/space.ts`): `valueFromJson` unconditionally decodes the `is`
-// column to an object (stripping the `fvj1:` prefix) before reaching
+// column to an object (stripping the codec prefix) before reaching
 // either defensive parse. From that point on, neither guard could fire
 // through the standard public API, and the defensive parses became
 // orphaned — which is what motivated their deletion.
@@ -1315,7 +1315,7 @@ describe(`Cell result-meta round-trip`, () => {
       // Set up a result/target pair via the standard meta-link API.
       const resultCell = runtime.getCell<{ foo: number }>(
         space,
-        "fvj1 source-cell round-trip: source",
+        "encoded source-cell round-trip: source",
         undefined,
         tx,
       );
@@ -1323,7 +1323,7 @@ describe(`Cell result-meta round-trip`, () => {
 
       const targetCell = runtime.getCell<{ bar: string }>(
         space,
-        "fvj1 source-cell round-trip: target",
+        "encoded source-cell round-trip: target",
         undefined,
         tx,
       );
@@ -1354,7 +1354,7 @@ describe(`Cell result-meta round-trip`, () => {
       // Set up a result/target pair and commit.
       const resultCell = runtime.getCell<{ foo: number }>(
         space,
-        "fvj1 source-cell raw read: source",
+        "encoded source-cell raw read: source",
         undefined,
         tx,
       );
@@ -1362,7 +1362,7 @@ describe(`Cell result-meta round-trip`, () => {
 
       const targetCell = runtime.getCell<{ bar: string }>(
         space,
-        "fvj1 source-cell raw read: target",
+        "encoded source-cell raw read: target",
         undefined,
         tx,
       );

--- a/packages/runner/test/data-uri.test.ts
+++ b/packages/runner/test/data-uri.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { fromBase64url } from "@commonfabric/utils/base64url";
+import { seemsLikeJsonEncodedFabricValue } from "@commonfabric/data-model/codec-json";
 import {
   linkRefFrom,
   linkRefPayload,
@@ -245,7 +246,7 @@ describe("data-uri", () => {
       const payload = new TextDecoder().decode(
         fromBase64url(dataURI.slice(dataURI.indexOf(",") + 1)),
       );
-      expect(payload.startsWith("fvj1:")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue(payload)).toBe(true);
     });
 
     // The standard encoding canonicalizes key order, so the minted id is a

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -38,10 +38,11 @@ shared `space` value AND a per-`user:<DID>` override AND a
 per-`session:<DID>:<sid>` override, stored side by side and genuinely different
 — this is where "looks different for me" multiplayer bugs live.
 
-**Two at-rest value formats coexist, both handled:** modern `fvj1:`-prefixed
-codec-json (ids `of:fid1:…`) and legacy plain-JSON sigils (ids `of:baedrei…`).
-`decode.ts` routes by the `fvj1:` tag; links are recognized in both the legacy
-sigil form (`{ "/": { "link@1": {…} } }`) and the modern `FabricLink` form.
+**Two at-rest value formats coexist, both handled:** modern `data-model`
+codec-json, which carries that codec's prefix tag (ids `of:fid1:…`), and legacy
+plain-JSON sigils (ids `of:baedrei…`). `decode.ts` routes on the presence of
+that tag; links are recognized in both the legacy sigil form
+(`{ "/": { "link@1": {…} } }`) and the modern `FabricLink` form.
 
 ## What is ground truth vs. a hint
 

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -2,15 +2,17 @@
 //
 // Stored payloads (`revision.data`, `commit.original`, …) come in TWO at-rest
 // formats, BOTH seen in real DBs:
-//   - modern: an `fvj1:`-prefixed codec-json envelope (decode via valueFromJson)
+//   - modern: a `data-model` codec-json envelope, carrying that codec's prefix
+//     (decode via valueFromJson)
 //   - legacy: plain JSON
 // In both, links/refs/streams appear as plain-data sigils:
 //   link   { "/": { "link@1": { id, space?, path?, scope?, schema? } } }
 //   ref    { "/": "of:…" | "computed:…" | "fid1:…" }
 //   stream { "$stream": true }
-// `decodeStored()` routes by the `fvj1:` tag; everything else here is pure JSON
-// walking + recognition (no live runtime/Cell needed). In the fvj1 form embedded
-// links are `/quote`-escaped literals, so a context-less decode is inert.
+// `decodeStored()` routes on the presence of that prefix, whichever codec
+// version it names; everything else here is pure JSON walking + recognition (no
+// live runtime/Cell needed). In the encoded form embedded links are
+// `/quote`-escaped literals, so a context-less decode is inert.
 
 import {
   seemsLikeJsonEncodedFabricValue,
@@ -19,7 +21,7 @@ import {
 import { FabricLink } from "@commonfabric/data-model/fabric-instances";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 
-/** Decode a stored payload string, routing the `fvj1:` codec envelope. */
+/** Decode a stored payload string, routing the `data-model` codec envelope. */
 export function decodeStored(data: string): unknown {
   return seemsLikeJsonEncodedFabricValue(data)
     ? valueFromJson(data)
@@ -68,8 +70,8 @@ export function parseSigilLink(v: Json): DecodedLink | null {
 
 /**
  * A link in EITHER at-rest form: the legacy `{ "/": { "link@N": … } }` sigil, or
- * a modern `FabricLink` instance (which `valueFromJson` can restore from an
- * `fvj1` envelope). Detected by class — `cell-rep`'s `isLinkRef` is gated on a
+ * a modern `FabricLink` instance (which `valueFromJson` can restore from a
+ * codec envelope). Detected by class — `cell-rep`'s `isLinkRef` is gated on a
  * global modern-mode flag the inspector doesn't set, so we check `FabricLink`
  * directly and read its `.payload`. Without this, a modern link is an opaque
  * instance with no enumerable keys and vanishes from links/lineage/graph.

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -12,13 +12,18 @@
 // walking + recognition (no live runtime/Cell needed). In the fvj1 form embedded
 // links are `/quote`-escaped literals, so a context-less decode is inert.
 
-import { valueFromJson } from "@commonfabric/data-model/codec-json";
+import {
+  seemsLikeJsonEncodedFabricValue,
+  valueFromJson,
+} from "@commonfabric/data-model/codec-json";
 import { FabricLink } from "@commonfabric/data-model/fabric-instances";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 
 /** Decode a stored payload string, routing the `fvj1:` codec envelope. */
 export function decodeStored(data: string): unknown {
-  return data.startsWith("fvj1:") ? valueFromJson(data) : JSON.parse(data);
+  return seemsLikeJsonEncodedFabricValue(data)
+    ? valueFromJson(data)
+    : JSON.parse(data);
 }
 
 export interface DecodedLink {

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -45,7 +45,7 @@
 //
 // Do NOT remove the other two, UNRELATED "legacy" axes when you do this; they
 // retire on their own (different) timelines:
-//   • decode.ts  — at-rest codec routing (`fvj1:` envelope vs plain-JSON sigil
+//   • decode.ts  — at-rest codec routing (codec envelope vs plain-JSON sigil
 //                  links). A serialization concern, orthogonal to process cells.
 //   • db.ts / reconstruct.ts — DBs lacking branch/snapshot/scope_key tables
 //                  (`hasTable`, the scope_key shim). A schema-migration concern.

--- a/packages/state-inspector/multispace.ts
+++ b/packages/state-inspector/multispace.ts
@@ -189,9 +189,10 @@ export function convergence(
     const view = entityMeta(space, opts.id, scope, branch);
     view.label = label;
     if (view.present) {
-      // Decode can throw (e.g. an fvj1 payload referencing a live cell). Keep the
-      // entity counted as present but isolate the failure so one bad row doesn't
-      // abort a whole scan; errored spaces cluster together by a distinct key.
+      // Decode can throw (e.g. an encoded payload referencing a live cell).
+      // Keep the entity counted as present but isolate the failure, so that one
+      // bad row doesn't abort a whole scan; errored spaces cluster together by
+      // a distinct key.
       try {
         const res = getValueAt(space, { id: opts.id, scope, branch }, path);
         if (!res.exists) {

--- a/packages/state-inspector/queries.ts
+++ b/packages/state-inspector/queries.ts
@@ -103,7 +103,7 @@ export function listCommits(
     let ops = 0;
     let reads = 0;
     try {
-      // `original` is a ClientCommit, stored either fvj1-encoded or as plain JSON.
+      // `original` is a ClientCommit, stored either codec-encoded or plain JSON.
       const parsed = decodeStored(r.original) as {
         operations?: unknown[];
         reads?: { confirmed?: unknown[]; pending?: unknown[] };

--- a/packages/state-inspector/test/decode.test.ts
+++ b/packages/state-inspector/test/decode.test.ts
@@ -1,7 +1,7 @@
 // Decode safety: modern `FabricLink` instances are recognized as links (not
 // dropped as opaque objects), and non-JSON-safe Fabric leaves (BigInt, Fabric
 // instances) survive `annotate` → `JSON.stringify` without throwing or becoming
-// `{}`. Both are the at-rest shapes a real `fvj1` DB can produce.
+// `{}`. Both are the at-rest shapes a real DB can produce.
 
 import { assert, assertEquals } from "@std/assert";
 import { FabricLink } from "@commonfabric/data-model/fabric-instances";
@@ -31,7 +31,7 @@ Deno.test("decode: modern FabricLink is recognized as a link", () => {
   assertEquals(links[0].id, "of:target");
 });
 
-Deno.test("decode: a modern fvj1-encoded link round-trips to a recognized link", () => {
+Deno.test("decode: a modern encoded link round-trips to a recognized link", () => {
   // Encode WITH modern cell rep on (as a modern server would), decode with the
   // inspector's default config — the value-at-rest must still read as a link.
   setModernCellRepConfig(true);

--- a/packages/state-inspector/test/entities.test.ts
+++ b/packages/state-inspector/test/entities.test.ts
@@ -1,4 +1,4 @@
-// Hermetic test for the unified entity model + fvj1 commit decoding. Seeds a
+// Hermetic test for the unified entity model + encoded commit decoding. Seeds a
 // modern piece (patternIdentity → module, argument, internal manifest), an
 // owned cell, a stream, and a free cell, then checks classification + lineage.
 // Side-effect free.
@@ -47,7 +47,7 @@ function seed(path: string) {
   );
   const session = "session:did:key:zSpaceAAAA:11111111-2222-3333";
 
-  // Commit 1: original stored fvj1-encoded with 2 ops and 1 confirmed read.
+  // Commit 1: original stored codec-encoded with 2 ops and 1 confirmed read.
   const original = jsonFromValue({
     localSeq: 1,
     operations: [{ op: "set" }, { op: "patch" }],
@@ -113,7 +113,7 @@ function seed(path: string) {
   db.close();
 }
 
-Deno.test("unified entity model + fvj1 commit decode", async (t) => {
+Deno.test("unified entity model + encoded commit decode", async (t) => {
   const dir = await Deno.makeTempDir({ prefix: "state-inspector-model-" });
   const dbPath = `${dir}/space.sqlite`;
   try {
@@ -121,7 +121,7 @@ Deno.test("unified entity model + fvj1 commit decode", async (t) => {
     const space = openSpace(dbPath);
     try {
       await t.step(
-        "listCommits decodes an fvj1 original (ops/reads non-zero)",
+        "listCommits decodes an encoded original (ops/reads non-zero)",
         () => {
           const rows = listCommits(space);
           const c1 = rows.find((r) => r.seq === 1)!;

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -79,7 +79,7 @@ stores state, not things a model infers from the data:
   (many tabs/devices) is benign; two distinct _principals_ is real cross-user
   contention. The tool draws this line for you — trust the `multiUser` flag, not
   the raw session count.
-- **Two at-rest value formats coexist, both handled:** modern `fvj1:`-prefixed
+- **Two at-rest value formats coexist, both handled:** modern `data-model`
   codec-json (ids `of:fid1:…`) and legacy plain-JSON sigils (ids `of:baedrei…`).
   You don't route between them; just know an id's shape tells you the era.
 - **Reconstruction is engine-faithful, and proven so.** State-at-`(branch, seq)`


### PR DESCRIPTION
Gives the encoding prefix tag a single definition again, by adding the two
sanctioned helpers that its absence was forcing call sites to work around.
Based on `main`, independent of #4904.

## Why

`ENCODING_PREFIX_TAG` in `JsonEncodingContext` is the one definition of the
tag, and it is private on purpose. But tests legitimately need to reach the
JSON underneath an encoded value, or to tag wire JSON so `decode()` will take
it. With no sanctioned way to do either, five call sites had written the
literal out again — and one of them had a comment explaining that this was
*necessary* so the production module could keep the tag private, documenting
the dilution as though it were the design:

```ts
/**
 * The encoding prefix tag emitted by `JsonEncodingContext.encode()`. Defined
 * here (rather than imported) so the production module can keep the tag
 * private; these helpers strip/add it to bridge between encoded strings and
 * the underlying wire-format tree.
 */
const ENCODING_PREFIX = "fvj1:";
```

## What

`JsonEncodingContext` gains `wrapEncodedValueForTesting()` and
`unwrapEncodedValueForTesting()`. The tag stays private; the class sanctions
the bridge.

The names say who they are for, and they are built so as not to be useful to
anyone else. Each performs a throwaway decode of the payload — and, for wrap, a
re-encode — discards the result, and throws if the codec cannot read it. That
makes them far too expensive for any hot path, and means they cannot serve as a
cheap "chop off the first few characters." Production code that wants to
recognize an encoded value should call `seemsLikeEncoded()`; production code
that wants the value should call `decode()`.

An `isMalformed` flag turns the check off entirely, for tests that construct a
deliberately broken payload — a flag saying the payload is malformed should not
then insist it be well-formed enough to decode. `wrapEncodedValueForTesting(x,
true)` returns the tag with `x` after it, whatever `x` is. The call site has to
say out loud that the badness is the point.

Unwrap still requires the tag in both modes. That is not a judgment about the
payload: stripping a prefix that is not there does not yield the body, it
yields nonsense, so there would be nothing to return.

## Full-source audit

| site | was | now |
| --- | --- | --- |
| `state-inspector/decode.ts` | `startsWith("fvj1:")` in **non-test code** | `seemsLikeJsonEncodedFabricValue()` |
| `data-model/test/codec-json/JsonEncodingContext.test.ts` | `const ENCODING_PREFIX` + 8 uses | the new helpers |
| `data-model/test/codec-json/json-encoding.test.ts` | `const PREFIX` | the new helpers |
| `data-model/test/data-uri-codec.test.ts` | `startsWith("fvj1:")` | `seemsLikeJsonEncodedFabricValue()` |
| `runner/test/data-uri.test.ts` | `startsWith("fvj1:")` | `seemsLikeJsonEncodedFabricValue()` |

The `state-inspector` one is the notable find: non-test code re-deriving the
tag when a predicate is exported for precisely that question.

Comments elsewhere that described the routing generically were reworded to name
the `data-model` codec rather than a codec *version* — there will be more than
one. That covers `state-inspector` (`decode.ts`, `model.ts`, `multispace.ts`,
`queries.ts`, its tests, README, and the mirrored skill doc) and `runner`
(`data-uri.ts`, two test files).

**Left alone deliberately, and why:**

- **The spec** (`docs/specs/**`, 12 mentions) — it *defines* `fvj1:`. Naming
  the version is the point.
- **Assertions that pin the wire form** (`expect(jsonFromValue(42)).toBe("fvj1:42")`)
  — routing these through a helper would only test the helper against itself.
- **`test/codec-json/JsonEncodingContext.test.ts`'s local `ENCODING_PREFIX`** —
  six assertions in that file spell the tag out, and naming it once beats
  inlining it six times. What was wrong before was its *comment*, which called
  the duplication necessary so the production module could keep the tag
  private; that trade is gone, and the doc now says what it actually does.
- **A `coordination/docs/…-fvj1-parse-site-kickoff.md` filename** cited in a
  `runner` test comment — it is a filename, not a format reference.

## Audit result

Every mention in the repo, classified:

| bucket | count | status |
| --- | --- | --- |
| `docs/specs/**` | 12 | valid — defines the format |
| `packages/data-model/**` | 28 | valid — the owning package (format pins, malformed-input literals, two named constants, prose) |
| everywhere else | **1** | a citation of a document whose *filename* contains the tag |
| `docs/history/**` | 0 | — |

No `startsWith("fvj1:")` and no prefix-length `slice()` survive outside the
codec.

## Testing

- 10 new tests for the helpers: round-tripping, rejection of an untagged
  string, of unparseable text, and of double-tagging; acceptance of a
  pretty-printed body; and the `isMalformed` behavior including that it does
  *not* excuse unparseable text or a missing tag.
- `data-model` — `ok | 49 passed (2054 steps) | 0 failed`
- `state-inspector` — `ok | 38 passed (72 steps) | 0 failed`
- `runner/test/data-uri.test.ts` — `ok | 1 passed (17 steps) | 0 failed`
- `./tasks/check.sh` (full repo) — `Type check complete.`

## Follow-on

#4904 carries its own `FVJ1_PREFIX` const for the same reason these did; it
adopts `unwrapEncodedValueForTesting()` / `wrapEncodedValueForTesting()` once
this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4s5BjnzfVbJS6VVydhZPR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-sourced the `fvj1:` encoding tag via test-only wrap/unwrap helpers, updated production routing to `seemsLikeJsonEncodedFabricValue()`, and clarified docs to name the `data-model` codec generically.

- **Refactors**
  - Added `JsonEncodingContext.unwrapEncodedValueForTesting()` and `wrapEncodedValueForTesting()`; both do a throwaway decode by default (and re-encode for wrap). When `isMalformed` is true, both skip checks entirely; `unwrap…` still requires the tag.
  - Introduced private static `#testingReconstructionContext` (under static members per house style).
  - Switched `@state-inspector/decode` (and related tests) to `seemsLikeJsonEncodedFabricValue()`; runner/data-URI tests now use the predicate.
  - Reworded comments/test names across `@state-inspector`, `@runner`, and docs to name the `data-model` codec instead of a specific version.
  - Corrected the `unwrapEncodedValueForTesting()` JSDoc to match `isMalformed` behavior and note the default throwaway decode.

- **Tests**
  - Grouped helper tests under `JsonEncodingContext` and added cases: empty/untagged and tag-only inputs, pretty-printed bodies, double-tagging, undecodable and unparseable payloads with `isMalformed`, and round-trips for `-0`, `NaN`, and `-Infinity`.
  - Updated `json-encoding` and data-URI tests (in `@data-model` and `@runner`) to use `unwrapEncodedValueForTesting()`/`wrapEncodedValueForTesting()` and `seemsLikeJsonEncodedFabricValue()`; replaced remaining hand-written tags except where pinning wire format or in a filename.

<sup>Written for commit 62173c44db2afb40f7b2da87731d80f3bb986b45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

