### PR TITLE
fix(runner): restore Error.isError across SES lockdown

### DIFF
--- a/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
+++ b/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
@@ -722,17 +722,36 @@ Lockdown options are derived from `debug`:
 
 ```typescript
 // Shown for illustration only.
-lockdown({
+const options = {
   errorTaming: debug ? "unsafe" : "safe",
   stackFiltering: debug ? "verbose" : "concise",
   overrideTaming: "severe",
   consoleTaming: "unsafe",
   localeTaming: "unsafe", // paired with the pre-lockdown locale sanitizer
-});
+};
+
+sanitizeLocaleMethods(); // vetted shim; before the intrinsics freeze
+repairIntrinsics(options);
+restoreErrorIsError(); // vetted shim; only this seam has both constructors
+hardenIntrinsics();
 ```
 
 Notes:
 
+- `lockdown(options)` is exactly `repairIntrinsics(options)` followed by
+  `hardenIntrinsics()`. The runtime spells out the two phases because the
+  `Error.isError` shim has nowhere else to run: SES's error taming rebuilds the
+  `Error` constructor and copies forward only `length`, `prototype` and the V8
+  stack surface, so the method exists neither before the repair (the
+  constructors are not minted yet) nor after the harden (they are frozen). Every
+  `ses` release through 2.2.0 drops it, and `permits.js` listing `isError` does
+  not help — a permit lets a property survive, it never adds one. Two
+  constructors need the restoration, not one: `%InitialError%` for the host
+  realm and `%SharedError%` for compartments, the latter reachable only as
+  `Error.prototype.constructor`. See
+  `packages/runner/src/sandbox/error-taming.ts`. The phase call reveals
+  `globalThis.hardenIntrinsics`, which the runtime deletes afterwards so the
+  host realm's global surface matches the one-call form.
 - `overrideTaming: "severe"` remains the compatibility default.
 - `localeTaming: "unsafe"` is load-bearing only together with the pre-lockdown
   vetted shim in `packages/runner/src/sandbox/locale-taming.ts`, which replaces

--- a/packages/runner/src/sandbox/error-taming.ts
+++ b/packages/runner/src/sandbox/error-taming.ts
@@ -44,26 +44,32 @@ const FERAL_IS_ERROR: unknown = (Error as { isError?: unknown }).isError;
 
 /**
  * Reinstall `Error.isError` on both post-repair error constructors. Must be
- * called after `repairIntrinsics()` and before `hardenIntrinsics()`; a no-op
- * on a runtime whose `Error` never had the method.
+ * called after `repairIntrinsics()` and before `hardenIntrinsics()`.
+ *
+ * Installs nothing unless handed a function, which is how a runtime whose
+ * `Error` never had the method declines: `FERAL_IS_ERROR` is `undefined` there
+ * and the default carries it in. Defining the property as `undefined` instead
+ * would fail SES's `isError: fn` permit, so the harden pass would strip it
+ * right back out and report an unpermitted intrinsic on every lockdown.
+ *
+ * `isError` is a parameter only so that path is reachable from a test; callers
+ * pass nothing.
  */
-export function restoreErrorIsError(): void {
-  if (typeof FERAL_IS_ERROR !== "function") return;
+export function restoreErrorIsError(isError: unknown = FERAL_IS_ERROR): void {
+  if (typeof isError !== "function") return;
 
-  // `%SharedError%` — the constructor compartments get — is not a global, but
-  // repair leaves it as the shared `Error.prototype.constructor`.
-  const initialError: object = Error;
-  const sharedError: unknown = Error.prototype.constructor;
-  const constructors = sharedError === initialError
-    ? [initialError]
-    : [initialError, sharedError as object];
-
-  for (const constructor of constructors) {
+  // Both constructors, and they are always distinct: repair mints
+  // `%InitialError%` for the host realm and the powerless `%SharedError%` for
+  // compartments. Only the first is a global; repair leaves the second as the
+  // shared `Error.prototype.constructor`.
+  for (
+    const constructor of [Error, Error.prototype.constructor as object]
+  ) {
     // Matches the descriptor a standard built-in method carries. Harden makes
     // it non-writable and non-configurable a moment later, as it does for the
     // stack-surface properties SES itself defines here.
     Object.defineProperty(constructor, "isError", {
-      value: FERAL_IS_ERROR,
+      value: isError,
       writable: true,
       enumerable: false,
       configurable: true,

--- a/packages/runner/src/sandbox/error-taming.ts
+++ b/packages/runner/src/sandbox/error-taming.ts
@@ -1,0 +1,72 @@
+/**
+ * Restoration of `Error.isError` — a vetted mid-lockdown shim.
+ *
+ * SES's error taming rebuilds the `Error` constructor from scratch rather than
+ * patching the original, and copies forward only `length`, `prototype`, and
+ * the V8 stack surface (`stackTraceLimit`, `prepareStackTrace`,
+ * `captureStackTrace`). `Error.isError` is not among them, so lockdown leaves
+ * the realm — host code included, not just compartments — without it. Every
+ * `ses` release through 2.2.0 behaves this way; `permits.js` does list
+ * `isError` under both `%InitialError%` and `%SharedError%`, but a permit only
+ * says a property MAY survive, never that it gets added, so no version bump
+ * fixes this on its own.
+ *
+ * The gap is silent until something calls it: `Error.isError(value)` throws
+ * `TypeError: Error.isError is not a function`, and only in the post-lockdown
+ * process. Code that classifies unknown values — data-model's
+ * `tagFromNativeValue`, for one — reaches for it precisely because it is the
+ * only correct error test across realms, `instanceof` being the thing it
+ * exists to replace.
+ *
+ * We restore the genuine intrinsic rather than polyfill it. Captured at module
+ * evaluation (before any lockdown), it is a pure predicate over the
+ * `[[ErrorData]]` internal slot: no powers to withhold, no realm affinity, and
+ * it answers correctly for the tamed constructors' instances because those are
+ * still constructed from the original `Error`.
+ *
+ * Two consequences to be aware of:
+ *
+ * - This must run BETWEEN `repairIntrinsics()` and `hardenIntrinsics()`. The
+ *   constructors do not exist before the repair phase and freeze during the
+ *   harden phase, so the two-phase form of lockdown is the only seam where
+ *   they are both present and extensible. `ensureSESInitialized` sequences it.
+ * - There are two constructors to patch, not one. Repair mints `%InitialError%`
+ *   for the host realm and a powerless `%SharedError%` for compartments;
+ *   patching only the global would leave pattern code without it.
+ */
+
+/**
+ * The real `Error.isError`, captured before lockdown can replace the
+ * constructor holding it. `undefined` on a runtime that predates the method,
+ * in which case there is nothing to restore and nothing to fake.
+ */
+const FERAL_IS_ERROR: unknown = (Error as { isError?: unknown }).isError;
+
+/**
+ * Reinstall `Error.isError` on both post-repair error constructors. Must be
+ * called after `repairIntrinsics()` and before `hardenIntrinsics()`; a no-op
+ * on a runtime whose `Error` never had the method.
+ */
+export function restoreErrorIsError(): void {
+  if (typeof FERAL_IS_ERROR !== "function") return;
+
+  // `%SharedError%` — the constructor compartments get — is not a global, but
+  // repair leaves it as the shared `Error.prototype.constructor`.
+  const initialError: object = Error;
+  const sharedError: unknown = Error.prototype.constructor;
+  const constructors = sharedError === initialError
+    ? [initialError]
+    : [initialError, sharedError as object];
+
+  for (const constructor of constructors) {
+    // Matches the descriptor a standard built-in method carries. Harden makes
+    // it non-writable and non-configurable a moment later, as it does for the
+    // stack-surface properties SES itself defines here.
+    Object.defineProperty(constructor, "isError", {
+      value: FERAL_IS_ERROR,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+}

--- a/packages/runner/src/sandbox/ses-runtime.ts
+++ b/packages/runner/src/sandbox/ses-runtime.ts
@@ -336,14 +336,13 @@ function ensureSESInitialized(lockdownEnabled: boolean): void {
   repairFn(DEFAULT_LOCKDOWN_OPTIONS);
   // Vetted shim — must sit between the two phases; see error-taming.ts.
   restoreErrorIsError();
-  const globalWithPhases = globalThis as {
-    hardenIntrinsics?: () => void;
-  };
-  const hardenFn = globalWithPhases.hardenIntrinsics;
-  if (typeof hardenFn !== "function") {
-    throw new Error("SES hardenIntrinsics() is unavailable");
-  }
-  hardenFn();
+  // Asserted, not guarded: the repair call above is what reveals
+  // `hardenIntrinsics`, so its absence is not an environment question the way
+  // `repairIntrinsics` itself is — it would mean ses broke its own contract.
+  // Were that ever to happen this throws, which is the outcome that matters;
+  // the one thing lockdown must never do is quietly skip the harden.
+  const globalWithPhases = globalThis as { hardenIntrinsics?: () => void };
+  globalWithPhases.hardenIntrinsics!();
   // `lockdown()` never reveals `hardenIntrinsics`, so drop it again: the host
   // realm's global surface should differ from the one-call form only by the
   // restored `Error.isError`. It is spent either way — the phases have run —

--- a/packages/runner/src/sandbox/ses-runtime.ts
+++ b/packages/runner/src/sandbox/ses-runtime.ts
@@ -6,6 +6,7 @@ import {
 import { getLogger } from "@commonfabric/utils/logger";
 import "ses";
 import { createCallbackCompartmentGlobals } from "./compartment-globals.ts";
+import { restoreErrorIsError } from "./error-taming.ts";
 import { hardenVerifiedFunction } from "./function-hardening.ts";
 import { sanitizeLocaleMethods } from "./locale-taming.ts";
 
@@ -317,16 +318,37 @@ function ensureSESInitialized(lockdownEnabled: boolean): void {
     sesInitialized = true;
     return;
   }
-  const lockdownFn = (globalThis as {
-    lockdown?: (options?: SESLockdownOptions) => void;
-  }).lockdown;
-  if (typeof lockdownFn !== "function") {
-    throw new Error("SES lockdown() is unavailable");
+  // `lockdown()` is `repairIntrinsics()` then `hardenIntrinsics()`; we run the
+  // two phases ourselves because restoreErrorIsError() needs the seam between
+  // them — the error constructors exist only after the first and freeze during
+  // the second. `hardenIntrinsics` is revealed by the repair call, so it can
+  // only be read afterwards.
+  const repairFn = (globalThis as {
+    repairIntrinsics?: (options?: SESLockdownOptions) => void;
+  }).repairIntrinsics;
+  if (typeof repairFn !== "function") {
+    throw new Error("SES repairIntrinsics() is unavailable");
   }
-  // Vetted shim — must precede lockdown() (the prototypes freeze there).
+  // Vetted shim — must precede the repair, which is where SES's locale taming
+  // would otherwise clobber these methods (and after which they freeze).
   // Pairs with `localeTaming: "unsafe"` below; see locale-taming.ts.
   sanitizeLocaleMethods();
-  lockdownFn(DEFAULT_LOCKDOWN_OPTIONS);
+  repairFn(DEFAULT_LOCKDOWN_OPTIONS);
+  // Vetted shim — must sit between the two phases; see error-taming.ts.
+  restoreErrorIsError();
+  const globalWithPhases = globalThis as {
+    hardenIntrinsics?: () => void;
+  };
+  const hardenFn = globalWithPhases.hardenIntrinsics;
+  if (typeof hardenFn !== "function") {
+    throw new Error("SES hardenIntrinsics() is unavailable");
+  }
+  hardenFn();
+  // `lockdown()` never reveals `hardenIntrinsics`, so drop it again: the host
+  // realm's global surface should differ from the one-call form only by the
+  // restored `Error.isError`. It is spent either way — the phases have run —
+  // but leaving it would let host code re-enter the harden pass.
+  delete globalWithPhases.hardenIntrinsics;
   globalState.lockdownInitialized = true;
   sesInitialized = true;
 }

--- a/packages/runner/test/error-taming.test.ts
+++ b/packages/runner/test/error-taming.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `Error.isError` survives SES lockdown (error-taming.ts).
+ *
+ * SES's error taming rebuilds the `Error` constructor and copies forward only
+ * the stack surface, so lockdown used to leave the realm without
+ * `Error.isError` entirely — host code and compartments alike. That is a
+ * silent gap until something calls it, at which point classification code that
+ * uses the cross-realm-correct error test (data-model's `tagFromNativeValue`,
+ * for one) throws `TypeError: Error.isError is not a function`.
+ *
+ * Both halves matter and fail independently: repair mints a separate
+ * constructor for the host realm and for compartments, and each has to carry
+ * the method. The host assertions run first because they are the ones that
+ * would regress if the restoration were dropped from the wrong constructor.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { tagFromNativeValue } from "@commonfabric/data-model/native-type-tags";
+import {
+  ensureSESLockdown,
+  evaluateFunctionSourceInSES,
+} from "../src/sandbox/ses-runtime.ts";
+
+/** Post-lockdown `Error.isError`, without asserting its presence to the type. */
+const hostIsError = (value: unknown): unknown =>
+  (Error as { isError?: (value: unknown) => boolean }).isError?.(value);
+
+const inSES = (expr: string): unknown =>
+  evaluateFunctionSourceInSES(`(() => (${expr}))()`, { lockdown: true });
+
+describe("Error.isError under SES lockdown", () => {
+  describe("the host realm", () => {
+    it("still has the method after lockdown", () => {
+      ensureSESLockdown();
+      expect(typeof (Error as { isError?: unknown }).isError).toBe("function");
+    });
+
+    it("recognizes errors and rejects non-errors", () => {
+      ensureSESLockdown();
+      expect(hostIsError(new Error("x"))).toBe(true);
+      expect(hostIsError(new TypeError("x"))).toBe(true);
+      expect(hostIsError({})).toBe(false);
+      expect(hostIsError(null)).toBe(false);
+      // The distinction that makes it more than an `instanceof` shorthand:
+      // a prototype object is not itself error data.
+      expect(hostIsError(Error.prototype)).toBe(false);
+    });
+
+    it("is hardened along with the rest of the intrinsics", () => {
+      ensureSESLockdown();
+      expect(Object.isFrozen(Error)).toBe(true);
+      const descriptor = Object.getOwnPropertyDescriptor(Error, "isError");
+      expect(descriptor?.writable).toBe(false);
+      expect(descriptor?.configurable).toBe(false);
+      expect(descriptor?.enumerable).toBe(false);
+    });
+  });
+
+  describe("a compartment", () => {
+    it("sees the method on its own (powerless) Error constructor", () => {
+      expect(inSES(`typeof Error.isError`)).toBe("function");
+    });
+
+    it("recognizes errors it constructed itself", () => {
+      expect(inSES(`Error.isError(new Error("x"))`)).toBe(true);
+      expect(inSES(`Error.isError(new RangeError("x"))`)).toBe(true);
+      expect(inSES(`Error.isError({ name: "Error", message: "x" })`)).toBe(
+        false,
+      );
+    });
+
+    it("recognizes an error handed in from the host", () => {
+      // The reason to restore the genuine intrinsic rather than polyfill with
+      // `instanceof`: the compartment's `Error` is not the host's, so only the
+      // internal-slot test answers this correctly.
+      const check = evaluateFunctionSourceInSES(
+        `function (value) { return Error.isError(value); }`,
+        { lockdown: true },
+      ) as (value: unknown) => boolean;
+      expect(check(new Error("from the host"))).toBe(true);
+      expect(check({})).toBe(false);
+    });
+  });
+
+  describe("the caller this shim exists for", () => {
+    it("classifies a constructor-less error post-lockdown", () => {
+      // data-model's `tagFromNativeValue` reaches `Error.isError` for values
+      // whose constructor is unreachable, and reaches it before its other
+      // fallbacks — so under lockdown the missing method turned a
+      // classification into a `TypeError` thrown from deep inside conversion,
+      // taking pattern setup down with it. Cross-package on purpose: only the
+      // runner runs lockdown, and only data-model makes the call.
+      ensureSESLockdown();
+      const severed = new Error("severed");
+      Object.setPrototypeOf(severed, null);
+      expect(tagFromNativeValue(severed)).toBe("Error");
+    });
+  });
+});

--- a/packages/runner/test/error-taming.test.ts
+++ b/packages/runner/test/error-taming.test.ts
@@ -17,6 +17,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { tagFromNativeValue } from "@commonfabric/data-model/native-type-tags";
+import { restoreErrorIsError } from "../src/sandbox/error-taming.ts";
 import {
   ensureSESLockdown,
   evaluateFunctionSourceInSES,
@@ -54,6 +55,25 @@ describe("Error.isError under SES lockdown", () => {
       expect(descriptor?.writable).toBe(false);
       expect(descriptor?.configurable).toBe(false);
       expect(descriptor?.enumerable).toBe(false);
+    });
+
+    it("installs nothing when handed a non-function", () => {
+      // How a runtime without `Error.isError` declines. Every runtime we run
+      // on has it, but an older browser would not, and there the shim must
+      // define nothing rather than define the property as `undefined` — which
+      // fails SES's `isError: fn` permit and gets stripped back out with an
+      // unpermitted-intrinsic report on every lockdown.
+      //
+      // `null` rather than the `undefined` a real such runtime would supply:
+      // an explicit `undefined` argument re-triggers the parameter default and
+      // would install the method after all. Production passes no argument, so
+      // it gets the default honestly; the guard under test is the same one.
+      //
+      // That the call is a no-op is also what makes it safe here at all —
+      // `Error` is frozen by now, and defining onto it throws.
+      ensureSESLockdown();
+      restoreErrorIsError(null);
+      expect(typeof (Error as { isError?: unknown }).isError).toBe("function");
     });
   });
 


### PR DESCRIPTION
## The gap

SES's error taming rebuilds the `Error` constructor from scratch rather than patching the original, copying forward only `length`, `prototype`, and the V8 stack surface (`stackTraceLimit`, `prepareStackTrace`, `captureStackTrace`). `Error.isError` is not among them, so `lockdown()` left the **whole realm** without it — host code included, not just compartments.

Silent until something calls it, at which point it throws `TypeError: Error.isError is not a function`. Which is exactly how it surfaced: data-model's `tagFromNativeValue` reaches for `Error.isError` to classify values whose constructor is unreachable (severed prototype, another realm), and the throw took pattern setup down with it.

**No `ses` release fixes this.** Verified through 2.2.0 and master: `tame-error-constructor.js` never copies the method. `permits.js` *does* list `isError` under `%InitialError%`/`%SharedError%`, but a permit only lets a property survive — it never adds one. A version bump is a dead end.

## The fix

`lockdown(options)` is exactly `repairIntrinsics(options)` followed by `hardenIntrinsics()`, and ses exposes both phases as globals. Between them the error constructors exist and are still extensible — the only seam where both are true. So:

```
sanitizeLocaleMethods();   // existing vetted shim
repairIntrinsics(options);
restoreErrorIsError();     // new vetted shim
hardenIntrinsics();
```

We restore the **genuine intrinsic**, captured at module evaluation before any lockdown. It's a pure predicate over the `[[ErrorData]]` internal slot: no powers to withhold, no realm affinity, and correct for the tamed constructors' instances because those are still built from the original `Error`. That's also why it beats an `instanceof` polyfill — a compartment's `Error` is not the host's, so only the slot test answers correctly for an error handed across the boundary.

Two details worth knowing:

- **Two constructors, not one.** Repair mints `%InitialError%` for the host realm and a powerless `%SharedError%` for compartments. Patching only the global left compartments broken; the shared one isn't a global, it's `Error.prototype.constructor`.
- **`globalThis.hardenIntrinsics` is deleted afterwards.** The phase call reveals it and `lockdown()` never does, so dropping it keeps the host realm's global surface differing from the one-call form only by the restored method. It's spent either way, but leaving it would let host code re-enter the harden pass.

## Verification

- New `error-taming.test.ts`: host realm (presence, semantics incl. `Error.prototype` -> `false`, hardened descriptor), compartments (own constructor, own errors, **host error across the boundary**), plus a cross-package guard that `tagFromNativeValue` classifies a constructor-less error post-lockdown — the caller this shim exists for.
- **Guard discipline:** commenting out the single `restoreErrorIsError()` call fails all 8 assertions; restoring it passes. The test cannot go vacuous.
- Compartment global surface confirmed unchanged (`repairIntrinsics`/`hardenIntrinsics` invisible inside; `lockdown`/`harden` as before).
- Runner suite **1000 passed / 0 failed**. `deno fmt --check`, `deno lint`, `deno check` clean. `deno task check-docs`: 519 blocks pass.

## Docs

`docs/specs/sandboxing/SES_SANDBOXING_SPEC.md` §5.1 updated — it showed the one-call `lockdown()` and named only the locale shim.

## Follow-on, not in this PR

data-model's `tagFromNativeValue` checks `Error.isError` *before* `instanceof FabricInstance`. This PR makes that ordering harmless, but reordering so known types classify first is arguably correct on its own merits and independent of SES. Queued, not built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJLpGQpmCdPQCcF4M2inS8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `Error.isError` across `ses` lockdown to prevent TypeErrors and keep cross‑realm error checks working (e.g., data‑model’s `tagFromNativeValue`). Installs the original intrinsic between `repairIntrinsics()` and `hardenIntrinsics()` so both host and compartment constructors expose it.

- **Bug Fixes**
  - Add `restoreErrorIsError()` shim using the pre‑lockdown function; patches `%InitialError%` and `%SharedError%`.
  - Switch to two‑phase lockdown: `sanitizeLocaleMethods()` → `repairIntrinsics(options)` → `restoreErrorIsError()` → `hardenIntrinsics()`, then delete `globalThis.hardenIntrinsics`.
  - Drop unreachable shim branches and assert `hardenIntrinsics` (revealed by repair); remove `%InitialError%`/`%SharedError%` dedupe.
  - Tests cover host, compartment, cross‑realm behavior, hardened descriptor, and the no‑install path when given a non‑function; docs updated with the sequence and rationale.

<sup>Written for commit 9addf1890b0cdd726acc1603c61cbf5390825e21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

