### PR TITLE
test(dashboard): prove CI trust excludes retry success

### DIFF
--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -61,15 +61,17 @@ Deno.test("labs ci:no completed runs -> unknown", async () => {
   assertEquals(v.value, "—");
 });
 
-Deno.test("labs ci trust: first-try-green rate drives status", async () => {
-  // 2 of 3 completed passed first try -> 66.7% -> below the warn threshold -> bad.
+Deno.test("labs ci trust: only first-attempt success counts as green", async () => {
+  // Two of four completed runs passed first try. A success on retry remains in
+  // the denominator but does not count as first-try green.
   const runs = [
     run({ conclusion: "success", run_attempt: 1 }),
     run({ conclusion: "success", run_attempt: 1 }),
+    run({ conclusion: "success", run_attempt: 2 }),
     run({ conclusion: "failure" }),
   ];
   const v = await labsCiTrust.collect(ctx(runs));
-  assertStringIncludes(v.value ?? "", "66.7%");
+  assertEquals(v.value, "50.0%");
   assertEquals(v.status, "bad");
 });
 


### PR DESCRIPTION
The CI trust collector measures first-attempt success, but its rate test only used successful first attempts and an outright failure. A change that counted every eventual success would therefore keep the test green.

Include a successful second attempt alongside first-attempt successes and a failure. Assert the exact 50.0% result, so counting the retry as green or dropping it from the denominator fails.

Verified with the dashboard test suite and browser test, plus repository-wide deno fmt --check and deno lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the CI trust metric test to ensure only first-attempt successes count toward the rate. Adds a successful second attempt and asserts a 50.0% result (status bad), so counting retries or excluding them from the denominator fails the test.

<sup>Written for commit 416b0a0999a94123b6933d294379dfbf7a7eea93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

