### PR TITLE
feat(runner): lazily auto-update system-source patterns

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -31,7 +31,7 @@ was last checked against the code.
 | [`persistentSchedulerState`](#persistentschedulerstate) | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` env, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#3646) | graduate to always-on | implemented, off by default, rollout in progress |
 | [`commitPreconditions`](#commitpreconditions) | `RuntimeOptions.experimental` only (mapped `null` — programmatic rollback override — in the canonical env registry) | on | Bernhard Seefeld (#4090) | fold into base scheduler semantics, then delete flag | implemented, on by default |
 | [`eagerSourceAnnotation`](#eagersourceannotation) | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` env, or `RuntimeOptions.experimental` | off in production, on in shell dev builds | gideon (#4458) | permanent debug toggle, not slated for removal | implemented |
-| [`systemPatternAutoUpdate`](#systempatternautoupdate) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental` | on in the shell (all tracked system roots, home included); off server-side | Bernhard Seefeld (#4611; shell default-on #4619) | graduate to always-on, then delete flag | implemented, on in the shell |
+| [`systemPatternAutoUpdate`](#systempatternautoupdate) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental` | on in the shell (same-toolshed system sources, including all roots); off server-side | Bernhard Seefeld (#4611; shell default-on #4619) | graduate to always-on, then delete flag | implemented, on in the shell |
 | [`computedCellIds`](#computedcellids) | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental` | off | Robin McCollum (in development) | graduate to always-on with the computed-cell write-conflict policy | in development on robin/feat-computed-cell-identity-p2 (redesigned: `computed:` URI scheme) |
 | [`cfcEnforcementMode`](#cfcenforcementmode) | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse) | `enforce-explicit` | Bernhard Seefeld (#3263) | tighten default toward `enforce-strict` | active; ladder is permanent |
 | [`cfcFlowLabels`](#cfcflowlabels) | `RuntimeOptions.cfcFlowLabels` | `off` | Bernhard Seefeld (#4011) | move toward `persist` | implemented, staged rollout |
@@ -215,17 +215,24 @@ propagate](#how-flags-propagate).
 - **Added by.** Bernhard Seefeld, in "system-pattern auto-update (in-place
   rollforward, flag-gated)" (#4611, 2026-07-08); defaulted on for the shell in
   #4619 (2026-07-09).
-- **Purpose.** At space open, rolls a space's root system pattern (default-app,
-  and the home root — the home-specific second gate was retired on the strength
-  of home-golden-replay state-survival coverage) forward in place when its
-  toolshed serves a newer content identity. Every attempt fetches `?identity`.
-  Before replacing or repairing a root, it downloads and compiles the complete
-  authored closure and permits an in-place `patternIdentity` swap only when the
-  compiler-produced entry has exactly the advertised identity. Fetch, compile,
-  evaluation, and identity-mismatch failures leave the original root pointer
-  untouched. Equal identities take the fast path only after the persisted
-  artifact loads; an unloadable root is rebuilt through that same
-  identity-authorized source path before bootstrap.
+- **Purpose.** Rolls same-toolshed system-source patterns forward in place when
+  their source serves a newer content identity. Persisted default-app and home
+  roots reconcile before bootstrap. Every other watched pattern starts first;
+  its successful instantiation commit launches a background check, so network
+  and compilation never delay its current graph. An unstamped non-root recovers
+  its verified authored entry filename and becomes tracked only when that
+  same-origin route implements `?identity`. Missing/failing identity routes are
+  ordinary non-system sources and remain untouched.
+  Every accepted move downloads and compiles the complete authored closure and
+  permits an in-place `patternIdentity` swap only when the compiler-produced
+  entry has exactly the advertised identity and selected export symbol.
+  Ordinary patterns preserve their selected export; default-pattern routes
+  select the official source's `default` export. Fetch, compile, evaluation,
+  identity-mismatch, and commit failures leave the original pointer and running
+  graph untouched. Equal identities let ordinary patterns stop immediately
+  (and persist newly proven source provenance); roots take the fast path only
+  after the persisted artifact loads, so an unloadable root can rebuild through
+  the same identity-authorized source path before bootstrap.
   Persisted roots are resolved without starting. A pre-provenance root may be
   back-filled only when its stored `{ identity, symbol }` exactly equals the
   current official entry's advertised content identity; stale, custom, and
@@ -237,25 +244,31 @@ propagate](#how-flags-propagate).
   system root for the space kind (home.tsx / default-app.tsx), recording the
   displaced ref under `displacedPattern` meta (see pattern-updates.md for the
   full exception semantics).
-  URL-based creation and recreation stamp provenance; custom `RuntimeProgram`
-  recreation does not. The check remains best-effort; if identity lookup or
-  replacement compilation is unavailable, the subsequent root start retains
-  its normal loud failure behavior. The update path does not consult build SHA
-  metadata; a rolling deployment that mixes identity/source/import revisions
-  fails closed at the compiled-identity comparison. See
+  URL-based root creation and recreation stamp provenance; custom
+  `RuntimeProgram` recreation does not. Repository-pinned sourceless patterns,
+  cross-origin sources, default roots reached by the generic post-start hook,
+  and starts that intentionally install no pattern watcher remain excluded. The
+  check remains best-effort; if identity lookup or replacement compilation is
+  unavailable, an ordinary pattern keeps running and the subsequent root start
+  retains its normal loud failure behavior. The update path does not consult
+  build SHA metadata; a rolling deployment that mixes
+  identity/source/import revisions fails closed at the compiled-identity
+  comparison. See
   [`docs/specs/pattern-imports/pattern-updates.md`](../specs/pattern-imports/pattern-updates.md).
 - **Current default and planned end state.** The runner built-in default is off
   like every flag in this category; the shell build injects `true` unless the
   define is set to `"false"`, so the deployed product (and local shell dev
-  builds) run it on for all tracked system roots. Server-side processes
+  builds) run it on for roots and other same-toolshed system-source patterns.
+  Server-side processes
   (toolshed, CLI, background piece service) leave it off unless the env var is
   set. End state:
-  graduate to always-on for system roots once golden-replay coverage has
+  graduate to always-on for system sources once golden-replay coverage has
   soaked, then delete the flag.
 - **Status on 2026-07-22.** Implemented; on in the shell for all tracked system
   roots, home included ([`systemPatternAutoUpdateHome`](#appendix-a-removed-and-never-shipped-flags)
-  removed), off elsewhere. Root reconciliation and broken-root repair run
-  before bootstrap.
+  removed), and for other patterns whose verified source path exposes
+  `?identity`; off elsewhere. Root reconciliation and broken-root repair run
+  before bootstrap, while ordinary-pattern checks run after instantiation.
 - **Path to removal.** Make the check unconditional and remove the flag.
 
 ### `computedCellIds`

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -1,26 +1,30 @@
 # Pattern Updates — rolling a running piece forward
 
 How a running piece moves from the pattern version it was created with to a
-newer one — automatically for **system patterns** (home, default-app), and (a
-later phase) on demand for **published** patterns. Companion to `README.md`
+newer one — automatically for patterns backed by a same-toolshed **system
+source** (including home and default-app), and (a later phase) on demand for
+**published** patterns. Companion to `README.md`
 (which covers `cf:` imports and publishing-as-naming); this doc covers the
 *update propagation* side.
 
 ## Status
 
-Phase 1 shipped: the `systemPatternAutoUpdate` flag is on in the shell for all
-tracked system roots, home included (the home-specific second flag was removed
-once home-golden-replay pinned state survival across an in-place roll).
-URL-based creation and recreation stamp update provenance; a pre-provenance
-root can recover it only when its stored ref exactly equals the current official
-entry's advertised content identity; and an unloadable tracked root is repaired
-before bootstrap through the same `?identity`-driven update path. The downloaded
+The `systemPatternAutoUpdate` flag is on in the shell. Persisted system roots,
+home included, reconcile before bootstrap; every other successfully instantiated
+pattern checks its verified authored entry path in the background. A same-origin
+source becomes tracked only when its `?identity` route works. The downloaded
 source and import closure must compile to the advertised entry identity before
-the persisted root can change. The executed milestone map and corrections found
-during implementation are archived at
+the persisted pointer can change, so startup never waits for an ordinary-piece
+check and failed checks leave its already-running graph intact.
+
+URL-based root creation and recreation stamp update provenance; a
+pre-provenance root can recover it only under the stricter root admission policy,
+and an unloadable tracked root is repaired before bootstrap through the same
+`?identity`-driven update path. The executed root milestone map and corrections
+found during implementation are archived at
 [`docs/history/specs/pattern-imports/system-pattern-updates-implementation-plan.md`](../../history/specs/pattern-imports/system-pattern-updates-implementation-plan.md).
-The home root (Phase 2) rides the shipped Phase 1 machinery since the second
-flag's removal; published-pattern updates remain design (Phases 3–4).
+The home root rides the shipped root machinery since the second flag's removal;
+published-pattern updates remain design.
 
 ## Last Updated
 
@@ -35,6 +39,11 @@ flag's removal; published-pattern updates remain design (Phases 3–4).
   (shell Debugger button / CLI) remains a state-losing escape hatch: it mints a
   new piece and relinks it. URL-based recreation stamps the new root's source so
   the replacement remains eligible for future automatic repair.
+- **The rest of the system source tree must move too.** A non-root pattern may
+  have been compiled from any file served by the toolshed pattern route. Once
+  its current graph is instantiated, the runtime checks that source in the
+  background and lets the existing pattern watcher apply a verified move. The
+  current instantiation never waits for network or compilation.
 - **Two hazard cases to handle explicitly.** (1) We shipped a broken system
   pattern — once a fix ships, recovery must be automatic. (2) An
   schema-incompatible update slips through — the damage must be *bounded*
@@ -51,7 +60,8 @@ flag's removal; published-pattern updates remain design (Phases 3–4).
 - **Lineage / fork detection.** No substrate exists today — `parents` was
   deleted with the pattern-id retirement, and `pieceLineageSchema`
   (`packages/runner/src/schemas.ts`) is dead code, referenced nowhere.
-  Deferred; system roots aren't user-iterated in the common case.
+  Deferred; automatic system-source updates continue to track one exact source
+  path and do not attempt to infer user fork relationships.
 - **CFC provenance of fetched source.** Pattern source can carry private data;
   labeling fetched/replicated source is follow-up work (README § Security),
   not built here.
@@ -64,8 +74,9 @@ flag's removal; published-pattern updates remain design (Phases 3–4).
 
 | Mechanism | Where | Role here |
 |---|---|---|
-| Pattern pointer `patternIdentity = {identity, symbol}` on the piece result cell | write `runner.ts:1012`, read `getPatternIdentityRef` `runner.ts:4441` | The thing an update rewrites |
-| **In-place re-run watcher** — `setupPatternWatcher` sinks the `patternIdentity` meta; on change it cancels the old pattern's nodes and re-instantiates the new pattern **onto the same result cell** | `runner.ts:1246` (enabled unless `doNotUpdateOnPatternChange`, `runner.ts:1341`) | Applies a metadata swap when the piece is already running; at space open, bootstrap reads the reconciled metadata directly |
+| Pattern pointer `patternIdentity = {identity, symbol}` on the piece result cell | `runner.ts` (`applySetupState` / `getPatternIdentityRef`) | The thing an update rewrites |
+| **In-place re-run watcher** — `setupPatternWatcher` sinks the `patternIdentity` meta; on change it cancels the old pattern's nodes and re-instantiates the new pattern **onto the same result cell** | `runner.ts` (enabled unless `doNotUpdateOnPatternChange`) | Applies a metadata swap when the piece is already running; at space open, bootstrap reads the reconciled metadata directly |
+| `PatternUpdater` | `packages/runner/src/pattern-updater.ts` | Shared identity lookup, verified closure compile, provenance repair, and compare-and-swap for awaited roots and background ordinary-piece checks |
 | Space root: `spaceCell.defaultPattern` link → root piece → `patternIdentity` | `packages/piece/src/manager.ts` (`linkDefaultPattern`/`getDefaultPattern`) | What a system update rewrites |
 | `ensureDefaultPattern` (resolve → reconcile → start) / `recreateDefaultPattern` (manual, **not** state-preserving) | `packages/piece/src/ops/pieces-controller.ts` | The automatic self-heal hook (ensure) and the state-losing escape hatch (recreate); both URL-based creation paths stamp `patternSource` |
 | System patterns = **raw TSX served by path**, bundled via `deno compile --include`; **no name→identity manifest** | `packages/toolshed/routes/patterns/patterns-server.ts`, `patterns.routes.ts` | Where the current system source + its identity come from |
@@ -79,8 +90,10 @@ non-hashed, excluded from `verifySourceDocs`) and looks like a natural home for
 the *destination* cell's annotations, and replication does not copy the
 *source's* (`cell-cache.ts:475`). An `updatesAt` written in a publisher's space
 would not appear on a consumer's replicated copy. The **piece** is the reliable
-carrier: it is created in the consumer's space with the ref the creator chose,
-so it travels by construction.
+carrier: explicit source provenance travels with it. For an unstamped non-root
+piece, its verified source-doc closure supplies the authored entry path; the
+runtime persists that path on the piece only after the matching same-toolshed
+`?identity` route succeeds.
 
 ## The model
 
@@ -88,13 +101,17 @@ Two decisions carry the whole design:
 
 1. **Every updatable piece carries a `patternSource` provenance string** — the
    source it tracks for updates. (`patternSource`, *not* `source`: the latter
-   is the doc-level producer annotation the server-primary work uses.)
+   is the doc-level producer annotation the server-primary work uses.) Roots
+   stamp it at URL-based creation. An unstamped non-root may recover its verified
+   authored entry filename and stamp it after that same-origin route proves it
+   implements `?identity`.
 2. **Update = resolve `patternSource` → current identity; if it differs from
    the persisted `patternIdentity.identity`, write the new `{identity, symbol}`
    to the piece's `patternIdentity` meta.** At space open this happens before
-   root bootstrap, so `start()` loads the reconciled identity. For an already
-   running root, the existing watcher (`runner.ts:1246`) re-instantiates in
-   place. No new apply machinery.
+   root bootstrap, so `start()` loads the reconciled identity. Every other
+   pattern starts first; its successful instantiation commit launches a
+   fire-and-forget check, and the existing watcher re-instantiates a verified
+   replacement in place. No new apply machinery.
 
 A root created before provenance stamping may be admitted to this loop only
 when its stored `{ identity, symbol }` exactly equals the advertised current
@@ -129,8 +146,9 @@ The exception's semantics are deliberately narrow:
   displaced program's compiled artifacts remain content-addressed in the
   space — not (yet) an automated restoration mechanism.
 
-System patterns run this loop automatically at space open (always-update);
-published patterns will run it behind an explicit user action (§ Phasing).
+Default system roots run this loop before bootstrap. Every other pattern runs it
+after successful instantiation, without delaying that instantiation. Published
+patterns will use a separate explicit action (§ Phasing).
 
 ### `patternSource`: one field, two variants
 
@@ -146,8 +164,8 @@ Dispatched by the `cf:` prefix:
   host, then fetch and compile whenever the persisted artifact needs an update
   or repair.
 
-**Born-from determinism.** The *string* is frozen at birth (which source); the
-*resolved identity* is live (which version). A non-home space's root
+**Born-from determinism.** Once recorded, the *string* is frozen (which source);
+the *resolved identity* is live (which version). A non-home space's root
 `patternSource` is seeded at creation from home's `defaultAppUrl`, then frozen —
 so editing `defaultAppUrl` later does **not** silently migrate existing spaces
 (pushing a new default app to them is an explicit re-point).
@@ -202,7 +220,7 @@ the **same result cell**.
   one: durable state addressed by stable key/cause, not positionally. We do
   **not** gate on a pre-apply schema dry-run in v1.
 
-## System patterns v1 — the loop
+## System-source patterns — the loop
 
 **Toolshed side (memoized per file for the process lifetime; patterns are fixed
 for a toolshed's lifetime).** Add a `?identity` query param to the pattern route
@@ -257,9 +275,10 @@ transaction, and only then start it:
    fast path.
 5. Revalidate `{host}{url}` and every module in its complete authored import
    closure with the same `no-cache` fetch policy, then compile with
-   `compilePattern(program, { space })`. Apply only when the compiler supplies
-   an entry ref whose identity exactly equals `currentId`; never synthesize a
-   ref or fall back around `?identity`. A fetch, compile, evaluation,
+   the route's official `default` export. Apply only when the compiler supplies
+   an entry ref whose identity exactly equals `currentId` and whose symbol is
+   `default`; never synthesize a ref or fall back around `?identity`. A fetch,
+   compile, evaluation,
    missing-entry-ref, or identity-mismatch failure leaves the root metadata
    unchanged.
 6. Provenance repair and identity replacement are transactional
@@ -268,6 +287,28 @@ transaction, and only then start it:
 7. Start the reconciled root. A newly created root skips the check because it
    was compiled from the current source in the same ensure operation; a root
    discovered after a creation race is treated as persisted and reconciled.
+
+**Runtime side (ordinary pattern instantiation).** The runner registers the
+check on the instantiation transaction's successful commit callback. It never
+awaits the check from `start()`:
+
+1. Exclude the space's `defaultPattern`; that root has already taken the path
+   above. Also exclude starts with `doNotUpdateOnPatternChange`, because they
+   deliberately install no watcher that could apply a pointer change.
+2. Use the piece's stored `patternSource` when present. Otherwise skip a
+   repository-pinned piece, recover the current identity's verified source-doc
+   closure, and take its entry filename as the candidate URL.
+3. Ask that same-origin URL for `?identity`. A missing/failing route means the
+   candidate was not a system source: do nothing and do not stamp provenance.
+   If the advertised identity equals the running identity, transactionally
+   stamp the proven source (when it was inferred) and stop.
+4. On a changed identity, revalidate and compile the whole closure with the
+   running ref's export symbol. Require both the compiler-produced identity and
+   symbol to equal the advertised identity and existing symbol.
+5. Compare-and-swap `{ patternIdentity, patternSource, patternRepository }`.
+   A concurrent setsrc/custom replacement wins. A successful swap wakes the
+   already-installed watcher; fetch, compile, evaluation, mismatch, and commit
+   failures leave the current graph running.
 
 ## End-to-end identity check
 
@@ -279,7 +320,7 @@ with that exact identity.
 
 This also fails closed across a rolling deployment. If `?identity`, the entry
 source, or any import comes from a different revision, the assembled closure
-normally hashes to a different entry identity and the root pointer is not
+normally hashes to a different entry identity and the pattern pointer is not
 written. The same rule covers an identity-algorithm incompatibility between an
 older worker and a newer toolshed: disagreement prevents the update. No
 `/api/meta` request, git-SHA comparison, pattern response build header, or
@@ -302,9 +343,9 @@ binary populates from baked build metadata; the updater does not consult it.
 - **CI golden replay** against the short, controlled system list before
   shipping — the primary defense (feasible precisely because the list is short
   and we own the source).
-- **Self-heal from a borked ship**: fix source → new identity → next space open
-  compiles and swaps it before bootstrap → recovered even when the old identity
-  cannot load.
+- **Self-heal from a borked ship**: fix source → new identity → a root's next
+  space open compiles and swaps it before bootstrap; an ordinary pattern's next
+  instantiation starts its current graph and then rolls it forward in place.
 - **Rollback = redeploy**: ship the prior source → toolshed serves the prior
   identity → the same swap rolls back. No per-piece rollback state needed.
 - **Escape hatch**: manual `recreateDefaultPattern` remains (state-losing; last
@@ -319,13 +360,11 @@ binary populates from baked build metadata; the updater does not consult it.
   `patterns-server.ts`); strong checksum `ETag` + mandatory revalidation for
   identity and source responses; import `computeModuleIdentities` +
   `transformInjectHelperModule` from the runner.
-- **Runtime worker**: an update-check step at space open, next to
-  `handleGetSpaceRootPattern` / `ensureDefaultPattern`
-  (`runtime-client/backends/runtime-processor.ts`, `pieces-controller.ts`):
-  per-space host resolution, exact-identity legacy-provenance recovery,
+- **Runtime worker**: `PatternUpdater` owns per-space host resolution,
   conditionally revalidated `?identity` and source-closure fetches, locally
-  compiled source-closure verification, and an in-place `patternIdentity` swap
-  before bootstrap.
+  compiled source-closure verification, and compare-and-swap. The piece
+  controller awaits it before root bootstrap; `Runner.startCore` schedules it
+  from the successful instantiation commit for every other watched pattern.
 - **Piece**: `patternSource` meta getter/setter; stamped by URL-based creation
   and recreation from the applicable source (system path, or a `cf:` ref derived
   from `defaultAppUrl`). Custom `RuntimeProgram` recreation remains unstamped;
@@ -342,10 +381,13 @@ binary populates from baked build metadata; the updater does not consult it.
    in-place swap + toolshed `?identity` + local compiled-identity check.
 2. **Home root.** Carries real user data (favorites/journal/spaces) → depends
    on the stable-addressing discipline and golden coverage of `home.tsx`.
-3. **Published-pattern updates.** `patternSource` = `cf:` ref; lazy check +
+3. **Other system-source patterns.** Recover a non-root's verified authored
+   entry path at instantiation, recognize a system source by its same-toolshed
+   `?identity` route, and check it without delaying the current graph.
+4. **Published-pattern updates.** `patternSource` = `cf:` ref; lazy check +
    shell "update available" + click-to-apply; fork/lineage handling
    (needs the deferred lineage substrate).
-4. **Cross-host published** + persisted space→host hints + CFC provenance
+5. **Cross-host published** + persisted space→host hints + CFC provenance
    labels on fetched source.
 
 ## Open questions

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -126,6 +126,57 @@ Deno.test("memory v2 client rejects malformed async hello session.open metadata"
   );
 });
 
+Deno.test("memory v2 client does not send a request after close begins", async () => {
+  let receiver = (_payload: string) => {};
+  let lateRequestId: string | undefined;
+  let lateRequestCount = 0;
+  const transport: Transport = {
+    send(payload: string): Promise<void> {
+      const message = decodeMemoryBoundary(payload) as {
+        type?: string;
+        requestId?: string;
+      };
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary(HELLO_OK));
+      } else {
+        lateRequestCount++;
+        lateRequestId = message.requestId;
+      }
+      return Promise.resolve();
+    },
+    close(): Promise<void> {
+      // Keep the pre-fix failure finite: if a request escaped the client's
+      // pending-request rejection sweep, synthesize its terminal response.
+      if (lateRequestId !== undefined) {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: lateRequestId,
+          error: { name: "ConnectionError", message: "transport closed" },
+        }));
+      }
+      return Promise.resolve();
+    },
+    setReceiver(next) {
+      receiver = next;
+    },
+    setCloseReceiver() {},
+  };
+  const client = await connect({ transport });
+
+  const request = client.request({
+    type: "test.request",
+    requestId: "request-after-close",
+  }).then(
+    () => "resolved" as const,
+    () => "rejected" as const,
+  );
+  const close = client.close();
+
+  assertEquals(await request, "rejected");
+  await close;
+  assertEquals(lateRequestCount, 0);
+});
+
 Deno.test("memory v2 client rejects malformed hello session.open metadata", async () => {
   const cases: {
     name: string;

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -172,6 +172,13 @@ export class Client {
 
   async request<Result>(message: Record<string, unknown>): Promise<Result> {
     await this.ensureConnected();
+    // `ensureConnected()` is async even when the transport is already live, so
+    // close() can run while this request is suspended there. Recheck before
+    // registering the request; otherwise it can miss close()'s rejectPending()
+    // sweep and wait forever for a response on the closed transport.
+    if (this.#closed) {
+      throw new Error("memory client is closed");
+    }
     const requestId = message.requestId as string;
     const pending = Promise.withResolvers<unknown>();
     this.#pending.set(requestId, pending);

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -862,14 +862,17 @@ export class PieceManager {
   }
 
   /** Start scheduling and running a prepared piece. */
-  async startPiece<T = unknown>(pieceOrId: string | Cell<T>): Promise<void> {
+  async startPiece<T = unknown>(
+    pieceOrId: string | Cell<T>,
+    options: { schedulePatternUpdate?: boolean } = {},
+  ): Promise<void> {
     const piece = typeof pieceOrId === "string"
       ? await timePiecePhase("startPiece.get", () => this.get<T>(pieceOrId))
       : pieceOrId;
     if (!piece) throw new Error("Piece not found");
     await timePiecePhase(
       "startPiece.runtime.start",
-      () => this.runtime.start(piece),
+      () => this.runtime.start(piece, options),
     );
     await timePiecePhase(
       "startPiece.result.pull",

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -3,13 +3,11 @@ import {
   entityIdFrom,
   type EnvReader,
   experimentalOptionsFromEnv,
-  getPatternIdentityRef,
-  getPatternRepository,
-  getPatternSource,
   type JSONSchema,
   type MemorySpace,
   type ModuleByteCache,
   type PatternCoverageCollector,
+  type PatternUpdateOutcome,
   Runtime,
   runtimePresets,
   RuntimeProgram,
@@ -61,12 +59,8 @@ const pieceUpdateLogger = getLogger("piece.update", {
   level: "warn",
 });
 
-/** The result of a system-pattern update check. */
-export type UpdateOutcome =
-  | "updated"
-  | "repaired-provenance"
-  | "current"
-  | "skipped-disabled";
+/** Backward-compatible name for the result of a pattern update check. */
+export type UpdateOutcome = PatternUpdateOutcome;
 
 // This module can load outside Deno (browser-safe storage import above), so
 // env reads are guarded like PIECE_TRACE_TIMINGS: absent env ⇒ defaults.
@@ -597,234 +591,22 @@ export class PiecesController<T = unknown> {
   ): Promise<UpdateOutcome> {
     const runtime = this.#manager.runtime;
     const space = this.#manager.getSpace();
-
-    // 1. Flag gate. One flag governs every tracked system root, home included:
-    //    home state survival across an in-place roll is pinned by
-    //    home-golden-replay.test.ts, so the home root no longer needs a
-    //    separate opt-in.
     if (!runtime.experimental?.systemPatternAutoUpdate) {
       return "skipped-disabled";
     }
-
     try {
-      // 2. The root piece's result cell, resolved without starting it. Ensure
-      // passes the cell it already found; explicit checks resolve it here.
-      const root = resolvedRoot ??
-        await this.#manager.getDefaultPattern(false);
+      const root = resolvedRoot ?? await this.#manager.getDefaultPattern(false);
       if (!root) return "current";
-
-      // 3. Provenance + per-space host (NOT the global apiUrl — a foreign-homed
-      //    space must resolve against its own toolshed). For a pre-provenance
-      //    root, derive only the official URL whose identity can be tested. The
-      //    URL or an author-controlled filename is not provenance: below, only
-      //    an exact match with the current content identity admits it.
-      const runningRef = getPatternIdentityRef(root);
-      if (runningRef === undefined) return "current";
-      const storedSource = getPatternSource(root);
-      const storedRepository = getPatternRepository(root);
-      if (storedSource === undefined && storedRepository !== undefined) {
-        return "current";
-      }
-      const url = storedSource ?? deriveSystemPatternUrl(space, runtime);
-      const host = runtime.mappedHostFor(space) ?? runtime.apiUrl.href;
-      // Async identity/load/compile work must not authorize a later write to a
-      // root another client has replaced in the meantime. Reading all captured
-      // metadata inside each transaction makes both writes compare-and-swap;
-      // editWithRetry re-runs this predicate after every conflict.
-      const rootStillMatches = (candidate: Cell<NameSchema>): boolean => {
-        const candidateRef = getPatternIdentityRef(candidate);
-        return candidateRef?.identity === runningRef.identity &&
-          candidateRef.symbol === runningRef.symbol &&
-          getPatternSource(candidate) === storedSource &&
-          getPatternRepository(candidate) === storedRepository;
-      };
-      const repairProvenance = async (): Promise<UpdateOutcome> => {
-        const result = await runtime.editWithRetry((tx) => {
-          if (!rootStillMatches(root.withTx(tx))) return false;
-          setPatternSource(root, tx, url);
-          return true;
-        });
-        if (result.error) {
-          pieceUpdateLogger.warn(
-            "provenance-repair-failed",
-            () => [
-              "checkAndUpdateDefaultPattern: provenance repair failed",
-              space,
-              result.error,
-            ],
-          );
-          return "current";
-        }
-        return result.ok ? "repaired-provenance" : "current";
-      };
-
-      // Only same-origin system sources participate in this loop. Cross-origin
-      // published/custom sources use their own update flow.
-      const target = new URL(url, host);
-      if (target.origin !== new URL(host).origin) {
-        return "current";
-      }
-
-      // Revalidate every request in one update attempt. Pattern responses use
-      // content-checksum ETags, so unchanged modules can reuse cached bytes
-      // after a 304 while stale identity, entry, or import bodies cannot pin or
-      // contaminate the update.
-      const revalidatingFetch: typeof globalThis.fetch = (input, init) =>
-        runtime.fetch(input, { ...init, cache: "no-cache" });
-
-      // 4. Ask the source host for the entry's content identity. This request is
-      // deliberately fresh: the host may roll between checks, and the compiled
-      // closure below is the end-to-end consistency proof for this attempt.
-      const identityUrl = new URL(target);
-      identityUrl.searchParams.set("identity", "");
-      const identityResponse = await revalidatingFetch(identityUrl);
-      if (!identityResponse.ok) return "current";
-      const currentId = (await identityResponse.text()).trim();
-      if (currentId.length === 0) return "current";
-
-      // A sourceless root is eligible only when its full content identity (which
-      // includes authored module paths) is exactly the official current entry.
-      // This admits a known system identity, never a lookalike filename. A stale
-      // sourceless root that still LOADS stays pinned: it may be a custom
-      // program (custom recreation deliberately stamps no provenance), and
-      // rolling it forward would overwrite that choice with the system pattern.
-      //
-      // When the stored root cannot cold-load at all, the pin protects only a
-      // dead page: an obsolete system root heals, and a broken custom root
-      // degrades to a WORKING system root with its displaced identity recorded
-      // under `displacedPattern` meta for recovery. (2026-07-21: a runtime
-      // migration bricked every pre-provenance home root, and this pin kept
-      // them bricked after the update flag opened.)
-      const staleSourceless = storedSource === undefined &&
-        (runningRef.identity !== currentId || runningRef.symbol !== "default");
-      if (staleSourceless) {
-        // Applies to every space's DEFAULT pattern (this function is only
-        // ever invoked on the root the space cell's `defaultPattern` ref
-        // names): a root that cannot load is a dead space regardless of
-        // space kind, and the displaced ref recorded below preserves the
-        // recovery pointer for a replaced custom program. Widened from
-        // home-only by the flag owner's call after a non-home field report
-        // (loom vendor update bricked on a stale sourceless space root).
-        // The probe is only meaningful where by-identity recovery is
-        // supported: under cfcEnforcementMode "disabled" it returns
-        // `undefined` unconditionally, which must not read as "dead".
-        if (runtime.cfcEnforcementMode === "disabled") return "current";
-        try {
-          const staleRoot = await runtime.patternManager.loadPatternByIdentity(
-            runningRef.identity,
-            runningRef.symbol,
-            space,
-          );
-          // Loadable in the current runtime → the pin still protects a live
-          // object. Only an explicit `undefined` — the artifact unavailable
-          // through every supported recovery path — authorizes replacement.
-          if (staleRoot !== undefined) return "current";
-        } catch (error) {
-          // A failed CHECK is not authority to replace an ambiguous root:
-          // fail closed like the enclosing function.
-          pieceUpdateLogger.warn(
-            "stale-root-probe-failed",
-            () => [
-              "checkAndUpdateDefaultPattern: stale-root load probe failed",
-              space,
-              runningRef,
-              error,
-            ],
-          );
-          return "current";
-        }
-      }
-
-      // 5. Equal identity is not enough to declare the root healthy: persisted
-      // source/compiled closures or the stored symbol may still be unloadable.
-      // Probe the exact ref; only the successful load takes the fast path.
-      if (currentId === runningRef?.identity) {
-        let loadable = false;
-        try {
-          loadable = await runtime.patternManager.loadPatternByIdentity(
-            runningRef.identity,
-            runningRef.symbol,
-            space,
-          ) !== undefined;
-        } catch {
-          // Continue through the same identity-authorized source path below.
-        }
-        if (loadable) {
-          if (storedSource !== undefined) return "current";
-          return await repairProvenance();
-        }
-      }
-
-      // 6. Resolve and compile the full authored closure locally. Only the
-      // compiler-produced entry ref can authorize a swap: if a rolling deploy
-      // serves identity and source from different revisions, their content
-      // identities differ and the original root remains untouched.
-      const program = await runtime.harness.resolve(
-        new HttpProgramResolver(target.href, revalidatingFetch),
+      return await runtime.patternUpdater.checkDefaultPattern(
+        root,
+        deriveSystemPatternUrl(space, runtime),
       );
-      const pattern = await runtime.patternManager.compilePattern(program, {
-        space,
-      });
-      const entryRef = runtime.patternManager.getArtifactEntryRef(pattern);
-      if (entryRef === undefined || entryRef.identity !== currentId) {
-        pieceUpdateLogger.warn(
-          "compiled-identity-mismatch",
-          () => [
-            "checkAndUpdateDefaultPattern: compiled source did not match " +
-            "the advertised identity",
-            space,
-            currentId,
-            entryRef?.identity,
-          ],
-        );
-        return "current";
-      }
-      if (
-        entryRef.identity === runningRef?.identity &&
-        entryRef.symbol === runningRef.symbol
-      ) {
-        if (storedSource === undefined) {
-          return await repairProvenance();
-        }
-        return "current";
-      }
-      const result = await runtime.editWithRetry((tx) => {
-        if (!rootStillMatches(root.withTx(tx))) return false;
-        if (staleSourceless) {
-          // The displaced ref had no provenance, so this swap is the only
-          // record of it. A replaced custom root's compiled artifacts remain
-          // content-addressed in the space; this breadcrumb is the pointer a
-          // recovery needs.
-          root.withTx(tx).setMetaRaw("displacedPattern", {
-            identity: runningRef.identity,
-            symbol: runningRef.symbol,
-            displacedAt: Date.now(),
-          });
-        }
-        root.withTx(tx).setMetaRaw("patternIdentity", {
-          identity: entryRef.identity,
-          symbol: entryRef.symbol,
-        });
-        setPatternSource(root, tx, url); // back-fill provenance
-        return true;
-      });
-      if (result.error) {
-        pieceUpdateLogger.warn(
-          "swap-failed",
-          () => [
-            "checkAndUpdateDefaultPattern: swap failed",
-            space,
-            result.error,
-          ],
-        );
-        return "current";
-      }
-      return result.ok ? "updated" : "current";
     } catch (error) {
-      pieceUpdateLogger.warn(
-        "check-failed",
-        () => ["checkAndUpdateDefaultPattern: check failed", space, error],
-      );
+      pieceUpdateLogger.warn("root-resolution-failed", () => [
+        "checkAndUpdateDefaultPattern: root resolution failed",
+        space,
+        error,
+      ]);
       return "current";
     }
   }

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -34,6 +34,12 @@ const PIECE_TRACE_TIMINGS = typeof Deno !== "undefined" &&
 export const HOME_PATTERN_URL = "/api/patterns/system/home.tsx";
 export const DEFAULT_APP_PATTERN_URL = "/api/patterns/system/default-app.tsx";
 
+// Default roots have a stronger update policy than ordinary pieces: an
+// existing root is reconciled before start, while a new root is compiled from
+// the current source immediately before creation. Keep the runner's watcher,
+// but do not schedule its duplicate fire-and-forget source check.
+const DEFAULT_ROOT_RUN_OPTIONS = { schedulePatternUpdate: false } as const;
+
 /**
  * The official system space-root pattern URL for a space type — the home DID
  * gets home.tsx, every other space gets the default app. This derivation only
@@ -359,7 +365,13 @@ export class PiecesController<T = unknown> {
       );
 
       // Run pattern setup within same transaction
-      this.#manager.runtime.run(tx, pattern, {}, pieceCell);
+      this.#manager.runtime.run(
+        tx,
+        pattern,
+        {},
+        pieceCell,
+        DEFAULT_ROOT_RUN_OPTIONS,
+      );
 
       // Stamp the provenance the piece tracks for updates, mirroring
       // ensureDefaultPattern (CT-1890). Without this, every recreated root
@@ -399,7 +411,7 @@ export class PiecesController<T = unknown> {
     }
 
     // Start the piece
-    await this.#manager.startPiece(finalPattern);
+    await this.#manager.startPiece(finalPattern, DEFAULT_ROOT_RUN_OPTIONS);
     await this.#manager.runtime.idle();
     await this.#manager.synced();
 
@@ -511,7 +523,13 @@ export class PiecesController<T = unknown> {
           );
 
           // Run pattern setup within same transaction
-          this.#manager.runtime.run(tx, pattern, {}, pieceCell);
+          this.#manager.runtime.run(
+            tx,
+            pattern,
+            {},
+            pieceCell,
+            DEFAULT_ROOT_RUN_OPTIONS,
+          );
 
           // Stamp the provenance the piece tracks for updates (the source it
           // was born from) — the same transaction, one extra meta write.
@@ -562,7 +580,7 @@ export class PiecesController<T = unknown> {
 
     await timePiecesPhase(
       "ensureDefaultPattern.startPiece",
-      () => this.#manager.startPiece(rootToStart),
+      () => this.#manager.startPiece(rootToStart, DEFAULT_ROOT_RUN_OPTIONS),
     );
     await timePiecesPhase(
       "ensureDefaultPattern.runtime.idle",

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -240,6 +240,15 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(stub.identityFetches()).toBe(0);
   });
 
+  it("does not duplicate the update check for a newly created root", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+
+    await controller.ensureDefaultPattern();
+    await runtime.patternUpdater.idle();
+
+    expect(stub.identityFetches()).toBe(0);
+  });
+
   it("contains failures while resolving the default pattern", async () => {
     await setup({ systemPatternAutoUpdate: true });
     const originalGetDefaultPattern = manager.getDefaultPattern;

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -296,7 +296,10 @@ describe("checkAndUpdateDefaultPattern", () => {
     const { error } = await runtime.editWithRetry((tx) => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: staleIdentity,
-        symbol: "default",
+        // The obsolete runtime selected an export the current system source no
+        // longer has. Dead-root recovery must select the official entry's
+        // default export, rather than trying to preserve this broken symbol.
+        symbol: "removed-export",
       });
     });
     expect(error).toBeUndefined();
@@ -314,6 +317,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(getPatternIdentityRef(updated.getCell())?.identity).toBe(
       await identityForSource(SOURCE_V2),
     );
+    expect(getPatternIdentityRef(updated.getCell())?.symbol).toBe("default");
   });
 
   it("repairs persisted artifacts when the served identity is unchanged", async () => {

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -233,6 +233,29 @@ describe("checkAndUpdateDefaultPattern", () => {
     );
   });
 
+  it("returns current when the space has no default pattern", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+
+    expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+    expect(stub.identityFetches()).toBe(0);
+  });
+
+  it("contains failures while resolving the default pattern", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const originalGetDefaultPattern = manager.getDefaultPattern;
+    manager.getDefaultPattern = (() =>
+      Promise.reject(
+        new Error("default-pattern lookup failed"),
+      )) as typeof manager.getDefaultPattern;
+
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
+      expect(stub.identityFetches()).toBe(0);
+    } finally {
+      manager.getDefaultPattern = originalGetDefaultPattern;
+    }
+  });
+
   it("returns current when the identity is unchanged (no write)", async () => {
     await setup({ systemPatternAutoUpdate: true });
     const piece = await controller.ensureDefaultPattern();

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -111,6 +111,10 @@ export {
 } from "./link-utils.ts";
 export * from "./pattern-manager.ts";
 export {
+  type PatternUpdateOutcome,
+  PatternUpdater,
+} from "./pattern-updater.ts";
+export {
   asPatternIdentityRef,
   extractDefaultValues,
   getPatternIdentityRef,

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -157,15 +157,16 @@ export class PatternUpdater {
         if (storedRepository !== undefined) return "current";
         if (mode.kind === "default-root") {
           source = mode.officialSource;
-        } else {
+        }
+        if (mode.kind === "instantiated") {
           // A sourceless default root remains under the stricter, awaited root
           // policy. In particular, do not turn an author-controlled filename
           // into provenance and bypass its legacy/custom-root admission rules.
           const program = await runtime.patternManager
             .getPatternSourceProgramByIdentity(runningRef.identity, space);
           source = program?.main;
-          if (source === undefined) return "current";
         }
+        if (source === undefined) return "current";
       }
 
       // Published `cf:` refs have a different resolver. This pass is exactly

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -15,6 +15,21 @@ const logger = getLogger("runner.pattern-update", {
   level: "warn",
 });
 
+async function abortableFetch(
+  request: () => Promise<Response>,
+  signal: AbortSignal,
+): Promise<Response> {
+  signal.throwIfAborted();
+  const aborted = Promise.withResolvers<never>();
+  const onAbort = () => aborted.reject(signal.reason);
+  signal.addEventListener("abort", onAbort, { once: true });
+  try {
+    return await Promise.race([request(), aborted.promise]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+  }
+}
+
 /** The result of checking one toolshed-backed pattern source. */
 export type PatternUpdateOutcome =
   | "updated"
@@ -143,10 +158,10 @@ export class PatternUpdater {
       if (runningRef === undefined) return "current";
       const storedSource = getPatternSource(resultCell);
       const storedRepository = getPatternRepository(resultCell);
+      if (storedRepository !== undefined) return "current";
 
       let source = storedSource;
       if (source === undefined) {
-        if (storedRepository !== undefined) return "current";
         if (mode.kind === "default-root") {
           source = mode.officialSource;
         }
@@ -208,11 +223,15 @@ export class PatternUpdater {
       // browser may reuse unchanged bytes after a 304, but never without asking
       // the source host whether they are still current.
       const revalidatingFetch: typeof globalThis.fetch = (input, init) =>
-        runtime.fetch(input, {
-          ...init,
-          cache: "no-cache",
+        abortableFetch(
+          () =>
+            runtime.fetch(input, {
+              ...init,
+              cache: "no-cache",
+              signal,
+            }),
           signal,
-        });
+        );
       const identityUrl = new URL(target);
       identityUrl.searchParams.set("identity", "");
       const identityResponse = await revalidatingFetch(identityUrl);

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -15,16 +15,16 @@ const logger = getLogger("runner.pattern-update", {
   level: "warn",
 });
 
-async function abortableFetch(
-  request: () => Promise<Response>,
+async function abortable<T>(
+  operation: () => Promise<T>,
   signal: AbortSignal,
-): Promise<Response> {
+): Promise<T> {
   signal.throwIfAborted();
   const aborted = Promise.withResolvers<never>();
   const onAbort = () => aborted.reject(signal.reason);
   signal.addEventListener("abort", onAbort, { once: true });
   try {
-    return await Promise.race([request(), aborted.promise]);
+    return await Promise.race([operation(), aborted.promise]);
   } finally {
     signal.removeEventListener("abort", onAbort);
   }
@@ -223,7 +223,7 @@ export class PatternUpdater {
       // browser may reuse unchanged bytes after a 304, but never without asking
       // the source host whether they are still current.
       const revalidatingFetch: typeof globalThis.fetch = (input, init) =>
-        abortableFetch(
+        abortable(
           () =>
             runtime.fetch(input, {
               ...init,
@@ -236,7 +236,9 @@ export class PatternUpdater {
       identityUrl.searchParams.set("identity", "");
       const identityResponse = await revalidatingFetch(identityUrl);
       if (!identityResponse.ok) return "current";
-      const advertisedIdentity = (await identityResponse.text()).trim();
+      const advertisedIdentity = (
+        await abortable(() => identityResponse.text(), signal)
+      ).trim();
       if (advertisedIdentity.length === 0) return "current";
 
       // The only sourceless roots admitted to the default-root update path are

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -1,0 +1,347 @@
+import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
+import { getLogger } from "@commonfabric/utils/logger";
+import type { Cell } from "./cell.ts";
+import {
+  getPatternIdentityRef,
+  getPatternRepository,
+  getPatternSource,
+  setPatternSource,
+} from "./runner.ts";
+import type { Runtime } from "./runtime.ts";
+
+const logger = getLogger("runner.pattern-update", {
+  enabled: true,
+  level: "warn",
+});
+
+/** The result of checking one toolshed-backed pattern source. */
+export type PatternUpdateOutcome =
+  | "updated"
+  | "repaired-provenance"
+  | "current"
+  | "skipped-disabled";
+
+type CheckMode =
+  | { kind: "instantiated" }
+  | { kind: "default-root"; officialSource: string };
+
+type PendingCheck = {
+  abort: AbortController;
+  promise: Promise<PatternUpdateOutcome>;
+};
+
+/**
+ * Reconciles content-addressed pattern pointers with toolshed source routes.
+ *
+ * Default roots call the awaited `checkDefaultPattern` path before bootstrap so
+ * an unloadable obsolete root can self-heal. Every other instantiated pattern
+ * uses `schedule`: its current graph is already live before the source check
+ * starts, and a successful pointer swap is applied by Runner's existing
+ * `patternIdentity` watcher.
+ */
+export class PatternUpdater {
+  readonly #runtime: Runtime;
+  readonly #pending = new Map<string, PendingCheck>();
+  #disposed = false;
+
+  constructor(runtime: Runtime) {
+    this.#runtime = runtime;
+  }
+
+  /** Start a best-effort check without making instantiation await it. */
+  schedule(resultCell: Cell<unknown>): void {
+    if (
+      this.#disposed ||
+      !this.#runtime.experimental.systemPatternAutoUpdate
+    ) return;
+    try {
+      void this.#singleFlight(resultCell, { kind: "instantiated" }).catch(
+        (error) => {
+          logger.warn("schedule-failed", () => [
+            "background pattern update check failed",
+            resultCell.space,
+            error,
+          ]);
+        },
+      );
+    } catch (error) {
+      // A best-effort background check must not turn a successful
+      // instantiation commit into a failed start.
+      logger.warn("schedule-failed", () => [
+        "could not schedule background pattern update check",
+        resultCell.space,
+        error,
+      ]);
+    }
+  }
+
+  /**
+   * Reconcile a space's default root before it starts. `officialSource` is only
+   * a candidate for a pre-provenance root; the legacy admission checks below
+   * still decide whether that root may track it.
+   */
+  checkDefaultPattern(
+    resultCell: Cell<unknown>,
+    officialSource: string,
+  ): Promise<PatternUpdateOutcome> {
+    if (!this.#runtime.experimental.systemPatternAutoUpdate) {
+      return Promise.resolve("skipped-disabled");
+    }
+    return this.#singleFlight(resultCell, {
+      kind: "default-root",
+      officialSource,
+    });
+  }
+
+  /** Resolve when the checks currently in flight have settled. */
+  async idle(): Promise<void> {
+    await Promise.allSettled(
+      [...this.#pending.values()].map(({ promise }) => promise),
+    );
+  }
+
+  /** Abort network work and keep it away from storage teardown. */
+  async dispose(): Promise<void> {
+    this.#disposed = true;
+    for (const { abort } of this.#pending.values()) abort.abort();
+    await this.idle();
+  }
+
+  #singleFlight(
+    resultCell: Cell<unknown>,
+    mode: CheckMode,
+  ): Promise<PatternUpdateOutcome> {
+    if (this.#disposed) return Promise.resolve("current");
+    const link = resultCell.getAsNormalizedFullLink();
+    const key = `${mode.kind}\0${link.space}\0${
+      link.scope ?? "space"
+    }\0${link.id}`;
+    const existing = this.#pending.get(key);
+    if (existing !== undefined) return existing.promise;
+
+    const abort = new AbortController();
+    const pending = {} as PendingCheck;
+    pending.abort = abort;
+    pending.promise = this.#check(resultCell, mode, abort.signal)
+      .finally(() => {
+        if (this.#pending.get(key) === pending) this.#pending.delete(key);
+      });
+    this.#pending.set(key, pending);
+    return pending.promise;
+  }
+
+  async #check(
+    resultCell: Cell<unknown>,
+    mode: CheckMode,
+    signal: AbortSignal,
+  ): Promise<PatternUpdateOutcome> {
+    const runtime = this.#runtime;
+    const space = resultCell.space;
+    try {
+      const runningRef = getPatternIdentityRef(resultCell);
+      if (runningRef === undefined) return "current";
+      // Default roots keep their stronger, awaited reconciliation policy. A
+      // fresh root was compiled from the source immediately before start, and
+      // a persisted root was checked before start; scheduling the generic pass
+      // here would only duplicate its identity request.
+      if (
+        mode.kind === "instantiated" &&
+        await this.#isDefaultPattern(resultCell)
+      ) return "current";
+      const storedSource = getPatternSource(resultCell);
+      const storedRepository = getPatternRepository(resultCell);
+
+      let source = storedSource;
+      if (source === undefined) {
+        if (storedRepository !== undefined) return "current";
+        if (mode.kind === "default-root") {
+          source = mode.officialSource;
+        } else {
+          // A sourceless default root remains under the stricter, awaited root
+          // policy. In particular, do not turn an author-controlled filename
+          // into provenance and bypass its legacy/custom-root admission rules.
+          const program = await runtime.patternManager
+            .getPatternSourceProgramByIdentity(runningRef.identity, space);
+          source = program?.main;
+          if (source === undefined) return "current";
+        }
+      }
+
+      // Published `cf:` refs have a different resolver. This pass is exactly
+      // for same-toolshed HTTP sources whose route implements `?identity`.
+      if (source.startsWith("cf:")) return "current";
+      const host = runtime.mappedHostFor(space) ?? runtime.apiUrl.href;
+      const target = new URL(source, host);
+      if (target.origin !== new URL(host).origin) return "current";
+
+      const stillMatches = (candidate: Cell<unknown>): boolean => {
+        const candidateRef = getPatternIdentityRef(candidate);
+        return candidateRef?.identity === runningRef.identity &&
+          candidateRef.symbol === runningRef.symbol &&
+          getPatternSource(candidate) === storedSource &&
+          getPatternRepository(candidate) === storedRepository;
+      };
+      const repairProvenance = async (): Promise<PatternUpdateOutcome> => {
+        const result = await runtime.editWithRetry((tx) => {
+          if (!stillMatches(resultCell.withTx(tx))) return false;
+          setPatternSource(resultCell, tx, source);
+          return true;
+        });
+        if (result.error) {
+          logger.warn("provenance-repair-failed", () => [
+            "pattern source provenance repair failed",
+            space,
+            result.error,
+          ]);
+          return "current";
+        }
+        return result.ok ? "repaired-provenance" : "current";
+      };
+
+      // Every request in an attempt must revalidate its checksum ETag. The
+      // browser may reuse unchanged bytes after a 304, but never without asking
+      // the source host whether they are still current.
+      const revalidatingFetch: typeof globalThis.fetch = (input, init) =>
+        runtime.fetch(input, {
+          ...init,
+          cache: "no-cache",
+          signal,
+        });
+      const identityUrl = new URL(target);
+      identityUrl.searchParams.set("identity", "");
+      const identityResponse = await revalidatingFetch(identityUrl);
+      if (!identityResponse.ok) return "current";
+      const advertisedIdentity = (await identityResponse.text()).trim();
+      if (advertisedIdentity.length === 0) return "current";
+
+      // The only sourceless roots admitted to the default-root update path are
+      // (a) the exact current official default export, whose provenance can be
+      // repaired, or (b) a root the current runtime explicitly cannot load. A
+      // loadable stale/custom root stays pinned; a failed probe is not evidence.
+      const staleSourcelessRoot = mode.kind === "default-root" &&
+        storedSource === undefined &&
+        (runningRef.identity !== advertisedIdentity ||
+          runningRef.symbol !== "default");
+      if (staleSourcelessRoot) {
+        if (runtime.cfcEnforcementMode === "disabled") return "current";
+        try {
+          const staleRoot = await runtime.patternManager.loadPatternByIdentity(
+            runningRef.identity,
+            runningRef.symbol,
+            space,
+          );
+          if (staleRoot !== undefined) return "current";
+        } catch (error) {
+          logger.warn("stale-root-probe-failed", () => [
+            "stale default-pattern load probe failed",
+            space,
+            runningRef,
+            error,
+          ]);
+          return "current";
+        }
+      }
+
+      if (advertisedIdentity === runningRef.identity) {
+        if (mode.kind === "instantiated") {
+          return storedSource === undefined
+            ? await repairProvenance()
+            : "current";
+        }
+        let loadable = false;
+        try {
+          loadable = await runtime.patternManager.loadPatternByIdentity(
+            runningRef.identity,
+            runningRef.symbol,
+            space,
+          ) !== undefined;
+        } catch {
+          // Continue through the identity-authorized source path below.
+        }
+        if (loadable) {
+          return storedSource === undefined
+            ? await repairProvenance()
+            : "current";
+        }
+      }
+
+      if (signal.aborted) return "current";
+      // Default-pattern routes select their official `default` export. Every
+      // ordinary source preserves the piece's selected export across versions.
+      // Besides matching the root creation contract, this lets a root recover
+      // when its persisted symbol itself is obsolete or corrupt.
+      const targetSymbol = mode.kind === "default-root"
+        ? "default"
+        : runningRef.symbol;
+      const resolved = await runtime.harness.resolve(
+        new HttpProgramResolver(target.href, revalidatingFetch),
+      );
+      const pattern = await runtime.patternManager.compilePattern(
+        { ...resolved, mainExport: targetSymbol },
+        { space },
+      );
+      const entryRef = runtime.patternManager.getArtifactEntryRef(pattern);
+      if (
+        entryRef === undefined ||
+        entryRef.identity !== advertisedIdentity ||
+        entryRef.symbol !== targetSymbol
+      ) {
+        logger.warn("compiled-identity-mismatch", () => [
+          "compiled pattern source did not match its advertised identity",
+          space,
+          advertisedIdentity,
+          entryRef,
+        ]);
+        return "current";
+      }
+      if (
+        entryRef.identity === runningRef.identity &&
+        entryRef.symbol === runningRef.symbol
+      ) {
+        return storedSource === undefined
+          ? await repairProvenance()
+          : "current";
+      }
+
+      const result = await runtime.editWithRetry((tx) => {
+        if (!stillMatches(resultCell.withTx(tx))) return false;
+        if (staleSourcelessRoot) {
+          resultCell.withTx(tx).setMetaRaw("displacedPattern", {
+            identity: runningRef.identity,
+            symbol: runningRef.symbol,
+            displacedAt: Date.now(),
+          });
+        }
+        resultCell.withTx(tx).setMetaRaw("patternIdentity", entryRef);
+        setPatternSource(resultCell, tx, source);
+        return true;
+      });
+      if (result.error) {
+        logger.warn("swap-failed", () => [
+          "pattern identity swap failed",
+          space,
+          result.error,
+        ]);
+        return "current";
+      }
+      return result.ok ? "updated" : "current";
+    } catch (error) {
+      if (signal.aborted) return "current";
+      logger.warn("check-failed", () => [
+        "pattern update check failed",
+        space,
+        error,
+      ]);
+      return "current";
+    }
+  }
+
+  async #isDefaultPattern(resultCell: Cell<unknown>): Promise<boolean> {
+    const defaultPatternSlot = this.#runtime.getSpaceCell(resultCell.space)
+      .key("defaultPattern");
+    await defaultPatternSlot.sync();
+    const defaultPattern = defaultPatternSlot.get();
+    return defaultPattern !== undefined &&
+      defaultPattern.resolveAsCell().equals(resultCell.resolveAsCell());
+  }
+}

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -1,6 +1,6 @@
 import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
 import { getLogger } from "@commonfabric/utils/logger";
-import { type Cell, createCell } from "./cell.ts";
+import type { Cell } from "./cell.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import {
   getPatternIdentityRef,
@@ -141,14 +141,6 @@ export class PatternUpdater {
     try {
       const runningRef = getPatternIdentityRef(resultCell);
       if (runningRef === undefined) return "current";
-      // Default roots keep their stronger, awaited reconciliation policy. A
-      // fresh root was compiled from the source immediately before start, and
-      // a persisted root was checked before start; scheduling the generic pass
-      // here would only duplicate its identity request.
-      if (
-        mode.kind === "instantiated" &&
-        this.#isDefaultPattern(resultCell)
-      ) return "current";
       const storedSource = getPatternSource(resultCell);
       const storedRepository = getPatternRepository(resultCell);
 
@@ -348,23 +340,5 @@ export class PatternUpdater {
       ]);
       return "current";
     }
-  }
-
-  #isDefaultPattern(resultCell: Cell<unknown>): boolean {
-    const defaultPatternSlot = this.#runtime.getSpaceCell(resultCell.space)
-      .key("defaultPattern");
-    // Root resolution has already loaded this link before start. Read that
-    // local replica without kicking off another storage sync: this is only an
-    // early duplicate-check gate, while canWrite() transactionally rechecks
-    // the role before either metadata mutation.
-    const localDefaultPatternSlot = createCell<Cell<unknown> | undefined>(
-      this.#runtime,
-      defaultPatternSlot.getAsNormalizedFullLink(),
-      undefined,
-      true,
-    );
-    const defaultPattern = localDefaultPatternSlot.get();
-    return defaultPattern !== undefined &&
-      defaultPattern.resolveAsCell().equals(resultCell.resolveAsCell());
   }
 }

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -1,6 +1,7 @@
 import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
 import { getLogger } from "@commonfabric/utils/logger";
 import type { Cell } from "./cell.ts";
+import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import {
   getPatternIdentityRef,
   getPatternRepository,
@@ -181,9 +182,21 @@ export class PatternUpdater {
           getPatternSource(candidate) === storedSource &&
           getPatternRepository(candidate) === storedRepository;
       };
+      const canWrite = (tx: IExtendedStorageTransaction): boolean => {
+        const candidate = resultCell.withTx(tx);
+        if (!stillMatches(candidate)) return false;
+        if (mode.kind === "default-root") return true;
+        // The default link is independently mutable. Re-read it in the same
+        // transaction as the pointer write so promotion while this generic
+        // check is in flight participates in OCC and fails closed.
+        const defaultPattern = runtime.getSpaceCell(space).withTx(tx)
+          .key("defaultPattern").get();
+        return defaultPattern === undefined ||
+          !defaultPattern.resolveAsCell().equals(candidate.resolveAsCell());
+      };
       const repairProvenance = async (): Promise<PatternUpdateOutcome> => {
         const result = await runtime.editWithRetry((tx) => {
-          if (!stillMatches(resultCell.withTx(tx))) return false;
+          if (!canWrite(tx)) return false;
           setPatternSource(resultCell, tx, source);
           return true;
         });
@@ -304,7 +317,7 @@ export class PatternUpdater {
       }
 
       const result = await runtime.editWithRetry((tx) => {
-        if (!stillMatches(resultCell.withTx(tx))) return false;
+        if (!canWrite(tx)) return false;
         if (staleSourcelessRoot) {
           resultCell.withTx(tx).setMetaRaw("displacedPattern", {
             identity: runningRef.identity,

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -1,6 +1,6 @@
 import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
 import { getLogger } from "@commonfabric/utils/logger";
-import type { Cell } from "./cell.ts";
+import { type Cell, createCell } from "./cell.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import {
   getPatternIdentityRef,
@@ -147,7 +147,7 @@ export class PatternUpdater {
       // here would only duplicate its identity request.
       if (
         mode.kind === "instantiated" &&
-        await this.#isDefaultPattern(resultCell)
+        this.#isDefaultPattern(resultCell)
       ) return "current";
       const storedSource = getPatternSource(resultCell);
       const storedRepository = getPatternRepository(resultCell);
@@ -350,11 +350,20 @@ export class PatternUpdater {
     }
   }
 
-  async #isDefaultPattern(resultCell: Cell<unknown>): Promise<boolean> {
+  #isDefaultPattern(resultCell: Cell<unknown>): boolean {
     const defaultPatternSlot = this.#runtime.getSpaceCell(resultCell.space)
       .key("defaultPattern");
-    await defaultPatternSlot.sync();
-    const defaultPattern = defaultPatternSlot.get();
+    // Root resolution has already loaded this link before start. Read that
+    // local replica without kicking off another storage sync: this is only an
+    // early duplicate-check gate, while canWrite() transactionally rechecks
+    // the role before either metadata mutation.
+    const localDefaultPatternSlot = createCell<Cell<unknown> | undefined>(
+      this.#runtime,
+      defaultPatternSlot.getAsNormalizedFullLink(),
+      undefined,
+      true,
+    );
+    const defaultPattern = localDefaultPatternSlot.get();
     return defaultPattern !== undefined &&
       defaultPattern.resolveAsCell().equals(resultCell.resolveAsCell());
   }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1565,6 +1565,20 @@ export class Runner {
             schedulerRehydration,
           );
         }
+        if (!doNotUpdateOnPatternChange) {
+          // Source reconciliation is lazy for ordinary pieces: the current
+          // pattern is fully instantiated first, and only a successful commit
+          // launches the fire-and-forget check. An aborted setup must neither
+          // fetch nor mutate a piece that never came into existence.
+          actualTx.addCommitCallback((_tx, result) => {
+            if (
+              !result.error && active &&
+              startLifecycleEpoch === this.lifecycleEpoch
+            ) {
+              this.runtime.patternUpdater.schedule(resultCell);
+            }
+          });
+        }
       } finally {
         if (shouldCommit) {
           this.runtime.prepareTxForCommit(actualTx);

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -162,6 +162,7 @@ type InternalCellDescriptor = {
 
 type StartAttempt = {
   readonly lifecycleEpoch: number;
+  readonly schedulePatternUpdate: boolean;
   readonly generationsByDoc: Map<string, number>;
   readonly preResolutionStopKeys: Set<string>;
 };
@@ -651,6 +652,10 @@ function defersInitialRunUntilSynced(
 // Options shared by run()/startWithTx()/startAfterSuccessfulCommit().
 type RunnerRunOptions = {
   doNotUpdateOnPatternChange?: boolean;
+  // Default roots reconcile against their system source before start (or are
+  // compiled from that source during creation), so their caller suppresses
+  // the otherwise-automatic lazy check while retaining identity hot-swaps.
+  schedulePatternUpdate?: boolean;
   // Resumed-from-synced-state: hold each action's initial rehydration/run until
   // the space has finished syncing, so consumers don't race the data.
   awaitSyncBeforeInitialRun?: boolean;
@@ -1425,10 +1430,14 @@ export class Runner {
    * Returns a Promise that resolves to true on success, or rejects with an error.
    * Runs synchronously when data is available (important for tests).
    */
-  start<T = any>(resultCell: Cell<T>): Promise<boolean> {
+  start<T = any>(
+    resultCell: Cell<T>,
+    options: { schedulePatternUpdate?: boolean } = {},
+  ): Promise<boolean> {
     const startKey = this.getDocKey(resultCell);
     const attempt: StartAttempt = {
       lifecycleEpoch: this.lifecycleEpoch,
+      schedulePatternUpdate: options.schedulePatternUpdate ?? true,
       generationsByDoc: new Map(),
       preResolutionStopKeys: new Set(),
     };
@@ -1487,13 +1496,19 @@ export class Runner {
       tx?: IExtendedStorageTransaction;
       givenPattern?: Pattern;
       doNotUpdateOnPatternChange?: boolean;
+      schedulePatternUpdate?: boolean;
       schedulerRehydration?: SchedulerRehydrationSubscriptionOptions;
       // Resumed-from-synced-state: hold each action's initial rehydration/run
       // until the space has finished syncing, so consumers don't race the data.
       awaitSyncBeforeInitialRun?: boolean;
     } = {},
   ): Cancel {
-    const { tx, givenPattern, doNotUpdateOnPatternChange } = options;
+    const {
+      tx,
+      givenPattern,
+      doNotUpdateOnPatternChange,
+      schedulePatternUpdate = true,
+    } = options;
     const key = this.getDocKey(resultCell);
     this.locallyStoppedResults.delete(key);
 
@@ -1565,7 +1580,7 @@ export class Runner {
             schedulerRehydration,
           );
         }
-        if (!doNotUpdateOnPatternChange) {
+        if (!doNotUpdateOnPatternChange && schedulePatternUpdate) {
           // Source reconciliation is lazy for ordinary pieces: the current
           // pattern is fully instantiated first, and only a successful commit
           // launches the fire-and-forget check. An aborted setup must neither
@@ -1858,6 +1873,7 @@ export class Runner {
       try {
         this.startCore(rootCell, {
           givenPattern: resolvedPattern,
+          schedulePatternUpdate: attempt.schedulePatternUpdate,
         });
       } catch (err) {
         return Promise.reject(err);
@@ -1905,6 +1921,7 @@ export class Runner {
       try {
         this.startCore(rootCell, {
           givenPattern: resolvedPattern,
+          schedulePatternUpdate: attempt.schedulePatternUpdate,
           schedulerRehydration: this.schedulerRehydrationOptions(
             rootCell,
             snapshotsByActionId,
@@ -1939,6 +1956,7 @@ export class Runner {
       tx,
       givenPattern,
       doNotUpdateOnPatternChange: options.doNotUpdateOnPatternChange,
+      schedulePatternUpdate: options.schedulePatternUpdate,
       awaitSyncBeforeInitialRun: options.awaitSyncBeforeInitialRun,
     });
   }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -103,6 +103,7 @@ import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { commitPreconditionValueHash } from "@commonfabric/memory/v2";
 import { snapshotQueryResult } from "./query-result-proxy.ts";
 import { PatternManager } from "./pattern-manager.ts";
+import { PatternUpdater } from "./pattern-updater.ts";
 import type { CompiledModuleArtifact } from "./harness/types.ts";
 import { ModuleRegistry } from "./module.ts";
 import { Runner } from "./runner.ts";
@@ -221,11 +222,10 @@ export interface ExperimentalOptions {
    */
   eagerSourceAnnotation?: boolean | undefined;
   /**
-   * Roll a space's system root pattern (default-app / home) forward in place
-   * when its toolshed serves a newer content identity. Default off; enabled per
-   * deployment once CI golden-replay coverage exists. Covers the home root too:
-   * home state survival across an in-place roll is pinned by
-   * home-golden-replay.test.ts. See
+   * Roll toolshed-backed patterns forward in place when their source serves a
+   * newer content identity. Persisted default roots reconcile before start;
+   * other patterns check in the background after instantiation. Default off;
+   * enabled per deployment once CI golden-replay coverage exists. See
    * docs/specs/pattern-imports/pattern-updates.md.
    */
   systemPatternAutoUpdate?: boolean | undefined;
@@ -556,6 +556,7 @@ export class Runtime {
   readonly id: string;
   readonly scheduler: Scheduler;
   readonly patternManager: PatternManager;
+  readonly patternUpdater: PatternUpdater;
   readonly moduleRegistry: ModuleRegistry;
   readonly harness: Engine;
   readonly runner: Runner;
@@ -995,6 +996,7 @@ export class Runtime {
     this.userIdentityDID = options.storageManager.as.did() as DID;
     this.moduleRegistry = new ModuleRegistry(this);
     this.patternManager = new PatternManager(this);
+    this.patternUpdater = new PatternUpdater(this);
     this.runner = new Runner(this);
     this.cfc = new ContextualFlowControl();
     this.cfcEnforcementMode = options.cfcEnforcementMode ??
@@ -1186,6 +1188,10 @@ export class Runtime {
     this.queues.clear();
     // Stop all running docs
     this.runner.stopAll();
+
+    // Background source checks are deliberately outside the scheduler. Abort
+    // and settle them before the storage sessions they may write through close.
+    await this.patternUpdater.dispose();
 
     // Scheduler background work can still be using storage, for example the
     // lifecycle-guarded boot-time persistent-state listing. Let that finish

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1911,20 +1911,29 @@ export class Runtime {
     patternFactory: NodeFactory<T, R>,
     argument: T,
     resultCell: Cell<R>,
+    options?: { schedulePatternUpdate?: boolean },
   ): Cell<R>;
   run<T, R = any>(
     tx: IExtendedStorageTransaction | undefined,
     pattern: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
+    options?: { schedulePatternUpdate?: boolean },
   ): Cell<R>;
   run<T, R = any>(
     tx: IExtendedStorageTransaction | undefined,
     patternOrModule: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
+    options: { schedulePatternUpdate?: boolean } = {},
   ): Cell<R> {
-    return this.runner.run<T, R>(tx, patternOrModule, argument, resultCell);
+    return this.runner.run<T, R>(
+      tx,
+      patternOrModule,
+      argument,
+      resultCell,
+      options,
+    );
   }
 
   runSynced(
@@ -1943,8 +1952,11 @@ export class Runtime {
     return this.runner.runSynced(resultCell, pattern, inputs, options);
   }
 
-  start<T = any>(resultCell: Cell<T>): Promise<boolean> {
-    return this.runner.start(resultCell);
+  start<T = any>(
+    resultCell: Cell<T>,
+    options: { schedulePatternUpdate?: boolean } = {},
+  ): Promise<boolean> {
+    return this.runner.start(resultCell, options);
   }
 
   /**

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -587,6 +587,14 @@ describe("Memory v2 storage notifications", () => {
         source?: unknown,
       ) => Promise<{ ok?: unknown; error?: unknown }>;
     };
+    const repairStarted = defer<void>();
+    const repairHarness = retryRepairHarness(replica);
+    const originalWaitForConflictReadRepair = repairHarness
+      .waitForConflictReadRepair.bind(repairHarness);
+    repairHarness.waitForConflictReadRepair = async (rejection) => {
+      repairStarted.resolve();
+      await originalWaitForConflictReadRepair(rejection);
+    };
     const firstUri = `of:memory-v2-close-retry-a-${Date.now()}` as URI;
     const secondUri = `of:memory-v2-close-retry-b-${Date.now()}` as URI;
     const factAddress = { id: firstUri, type: "application/json" as MIME };
@@ -627,6 +635,10 @@ describe("Memory v2 storage notifications", () => {
     }, staleReadSource(firstUri, 1));
     expect(replica.get(factAddress)?.is).toEqual({ value: { version: 3 } });
 
+    // Close only after the server conflict has reached the read-repair path.
+    // Previously this test relied on a request slipping through concurrently
+    // with Client.close(), so it did not deterministically exercise its title.
+    await repairStarted.promise;
     await storageManager.close();
     const result = await commitPromise;
     expect(result.ok).toBeFalsy();

--- a/packages/runner/test/pattern-auto-update.test.ts
+++ b/packages/runner/test/pattern-auto-update.test.ts
@@ -11,6 +11,7 @@ import {
   Runtime,
   type RuntimeFetch,
   type RuntimeProgram,
+  setPatternRepository,
   setPatternSource,
 } from "../src/index.ts";
 
@@ -262,6 +263,26 @@ describe("lazy system-pattern auto-update", () => {
     ).toBe("current");
   });
 
+  it("disposes when an injected fetch ignores the abort signal", async () => {
+    const identityRequested = defer<AbortSignal | undefined>();
+    const ignoredFetch = defer<Response>();
+    const piece = await preparePiece((_input, init) => {
+      identityRequested.resolve(init?.signal ?? undefined);
+      return ignoredFetch.promise;
+    });
+
+    const start = runtime.start(piece);
+    const signal = await identityRequested.promise;
+    expect(signal).toBeDefined();
+    expect(await start).toBe(true);
+
+    await runtime.patternUpdater.dispose();
+
+    expect(signal!.aborted).toBe(true);
+    expect(getPatternSource(piece)).toBeUndefined();
+    ignoredFetch.resolve(new Response("late response"));
+  });
+
   it("does not resolve source after disposal aborts a completed identity fetch", async () => {
     const v2Identity = await identityFor(source("v2"));
     const identityRequested = defer<AbortSignal | undefined>();
@@ -335,6 +356,27 @@ describe("lazy system-pattern auto-update", () => {
 
     expect(fetches).toBe(0);
     expect(getPatternSource(piece)).toBe("cf:published-pattern");
+  });
+
+  it("leaves repository-pinned patterns untouched when they have a source", async () => {
+    let fetches = 0;
+    const piece = await preparePiece(() => {
+      fetches++;
+      return Promise.resolve(new Response("unexpected"));
+    });
+    const originalRef = getPatternIdentityRef(piece);
+    const update = await runtime.editWithRetry((tx) => {
+      setPatternSource(piece, tx, PARENT_PATH);
+      setPatternRepository(piece, tx, "https://github.com/example/patterns");
+    });
+    expect(update.error).toBeUndefined();
+
+    runtime.patternUpdater.schedule(piece);
+    await runtime.patternUpdater.idle();
+
+    expect(fetches).toBe(0);
+    expect(getPatternIdentityRef(piece)).toEqual(originalRef);
+    expect(getPatternSource(piece)).toBe(PARENT_PATH);
   });
 
   it("does not repair provenance after the piece becomes the default", async () => {

--- a/packages/runner/test/pattern-auto-update.test.ts
+++ b/packages/runner/test/pattern-auto-update.test.ts
@@ -283,38 +283,45 @@ describe("lazy system-pattern auto-update", () => {
     ignoredFetch.resolve(new Response("late response"));
   });
 
-  it("does not resolve source after disposal aborts a completed identity fetch", async () => {
-    const v2Identity = await identityFor(source("v2"));
+  it("disposes when a completed identity response body never settles", async () => {
     const identityRequested = defer<AbortSignal | undefined>();
+    const bodyRead = defer();
     let bodyController:
       | ReadableStreamDefaultController<Uint8Array>
       | undefined;
-    const piece = await preparePiece((_input, init) => {
-      const signal = init?.signal ?? undefined;
-      identityRequested.resolve(signal);
-      return Promise.resolve(
-        new Response(
+    class StuckBodyResponse extends Response {
+      constructor() {
+        super(
           new ReadableStream<Uint8Array>({
             start(controller) {
               bodyController = controller;
             },
           }),
-        ),
-      );
+        );
+      }
+
+      override text(): Promise<string> {
+        bodyRead.resolve();
+        return super.text();
+      }
+    }
+    const piece = await preparePiece((_input, init) => {
+      const signal = init?.signal ?? undefined;
+      identityRequested.resolve(signal);
+      return Promise.resolve(new StuckBodyResponse());
     });
 
     const start = runtime.start(piece);
     const signal = await identityRequested.promise;
     expect(signal).toBeDefined();
     expect(await start).toBe(true);
-    const dispose = runtime.patternUpdater.dispose();
-    expect(signal!.aborted).toBe(true);
-    bodyController!.enqueue(new TextEncoder().encode(v2Identity));
-    bodyController!.close();
-    await dispose;
+    await bodyRead.promise;
+    await runtime.patternUpdater.dispose();
 
+    expect(signal!.aborted).toBe(true);
     expect(getPatternSource(piece)).toBeUndefined();
     expect((await piece.pull())?.marker).toBe("v1");
+    bodyController!.close();
   });
 
   it("skips a sourceless pattern whose compiled source cannot be recovered", async () => {

--- a/packages/runner/test/pattern-auto-update.test.ts
+++ b/packages/runner/test/pattern-auto-update.test.ts
@@ -193,6 +193,39 @@ describe("lazy system-pattern auto-update", () => {
     expect(getPatternSource(piece)).toBe(PARENT_PATH);
   });
 
+  it("checks the locally known default role without a storage round trip", async () => {
+    let fetches = 0;
+    const piece = await preparePiece(() => {
+      fetches++;
+      return Promise.resolve(new Response("unexpected"));
+    });
+    const defaultPattern = runtime.getSpaceCell(piece.space)
+      .key("defaultPattern");
+    const assigned = await runtime.editWithRetry((tx) => {
+      defaultPattern.withTx(tx).set(piece.withTx(tx));
+    });
+    expect(assigned.error).toBeUndefined();
+
+    const originalSyncCell = storageManager.syncCell.bind(storageManager);
+    let defaultPatternSyncs = 0;
+    storageManager.syncCell = ((cell) => {
+      if (
+        cell.resolveAsCell().equals(defaultPattern.resolveAsCell())
+      ) defaultPatternSyncs++;
+      return originalSyncCell(cell);
+    }) as typeof storageManager.syncCell;
+
+    try {
+      expect(await runtime.start(piece)).toBe(true);
+      await runtime.patternUpdater.idle();
+    } finally {
+      storageManager.syncCell = originalSyncCell;
+    }
+
+    expect(defaultPatternSyncs).toBe(0);
+    expect(fetches).toBe(0);
+  });
+
   it("aborts an in-flight identity request during disposal", async () => {
     const identityRequested = defer<AbortSignal | undefined>();
     const abortObserved = defer();

--- a/packages/runner/test/pattern-auto-update.test.ts
+++ b/packages/runner/test/pattern-auto-update.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { defer, type Deferred } from "@commonfabric/utils/defer";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import {
+  getPatternIdentityRef,
+  getPatternSource,
+  resolveEntryIdentity,
+  Runtime,
+  type RuntimeFetch,
+  type RuntimeProgram,
+} from "../src/index.ts";
+
+const signer = await Identity.fromPassphrase("lazy system pattern updates");
+const PARENT_PATH = "/api/patterns/system/lazy-update-parent.tsx";
+const SOURCE_PATH = "/api/patterns/system/lazy-update-test.tsx";
+const SYMBOL = "TrackedPattern";
+
+const parentSource = [
+  `import { ${SYMBOL} } from "./lazy-update-test.tsx";`,
+  `export { ${SYMBOL} };`,
+  `export default ${SYMBOL};`,
+  "",
+].join("\n");
+
+function source(marker: string): string {
+  return [
+    "import { computed, pattern } from 'commonfabric';",
+    `export const ${SYMBOL} = pattern<Record<string, never>, { marker: string }>(() => ({ marker: computed(() => "${marker}") }));`,
+    "",
+  ].join("\n");
+}
+
+function parentProgram(contents: string): RuntimeProgram {
+  return {
+    main: PARENT_PATH,
+    mainExport: SYMBOL,
+    files: [{
+      name: PARENT_PATH,
+      contents: parentSource,
+    }, { name: SOURCE_PATH, contents }],
+  };
+}
+
+function identityFor(contents: string): Promise<string> {
+  const files = new Map(
+    parentProgram(contents).files.map(({ name, contents }) => [name, contents]),
+  );
+  return resolveEntryIdentity(
+    PARENT_PATH,
+    (name) =>
+      files.has(name)
+        ? Promise.resolve(files.get(name)!)
+        : Promise.reject(new Error(`not found: ${name}`)),
+  );
+}
+
+describe("lazy system-pattern auto-update", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let identityGate: Deferred<void> | undefined;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+
+  afterEach(async () => {
+    identityGate?.resolve();
+    await runtime?.patternUpdater.idle();
+    await runtime?.dispose();
+  });
+
+  async function preparePiece(fetch: RuntimeFetch) {
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+      fetch,
+      experimental: { systemPatternAutoUpdate: true },
+    });
+    const space = signer.did();
+    const initialIdentity = await identityFor(source("v1"));
+    const initial = await runtime.patternManager.compilePattern(
+      parentProgram(source("v1")),
+      { space },
+    );
+    const recovered = await runtime.patternManager
+      .getPatternSourceProgramByIdentity(initialIdentity, space);
+    expect(recovered?.main).toBe(PARENT_PATH);
+    const piece = runtime.getCell<{ marker?: string }>(
+      space,
+      `lazy-update-${crypto.randomUUID()}`,
+    );
+    await runtime.setup(undefined, initial, {}, piece);
+    expect(getPatternIdentityRef(piece)).toEqual({
+      identity: initialIdentity,
+      symbol: SYMBOL,
+    });
+    return piece;
+  }
+
+  it("starts immediately, then updates a non-root pattern in the background", async () => {
+    const v2Identity = await identityFor(source("v2"));
+    const identityRequested = defer();
+    identityGate = defer();
+    const requested: Array<{ href: string; cache?: RequestCache }> = [];
+    const piece = await preparePiece(async (input, init) => {
+      const href = input instanceof Request
+        ? input.url
+        : input instanceof URL
+        ? input.href
+        : input;
+      const url = new URL(href);
+      requested.push({ href: url.href, cache: init?.cache });
+      if (
+        url.pathname === PARENT_PATH &&
+        url.searchParams.has("identity")
+      ) {
+        identityRequested.resolve();
+        await identityGate!.promise;
+        return new Response(v2Identity);
+      }
+      const contents = url.pathname === PARENT_PATH
+        ? parentSource
+        : url.pathname === SOURCE_PATH
+        ? source("v2")
+        : undefined;
+      return new Response(contents ?? "not found", {
+        status: contents === undefined ? 404 : 200,
+        headers: { "content-type": "text/typescript-jsx" },
+      });
+    });
+    const v1Ref = getPatternIdentityRef(piece)!;
+
+    const start = runtime.start(piece);
+    await identityRequested.promise;
+    expect(await start).toBe(true);
+    await runtime.idle();
+    expect((await piece.pull())?.marker).toBe("v1");
+    expect(getPatternIdentityRef(piece)).toEqual(v1Ref);
+
+    identityGate.resolve();
+    await runtime.patternUpdater.idle();
+    await runtime.idle();
+
+    expect((await piece.pull())?.marker).toBe("v2");
+    expect(getPatternIdentityRef(piece)).toEqual({
+      identity: v2Identity,
+      symbol: SYMBOL,
+    });
+    expect(getPatternSource(piece)).toBe(PARENT_PATH);
+    expect(requested).toContainEqual({
+      href: `http://toolshed.test${PARENT_PATH}?identity=`,
+      cache: "no-cache",
+    });
+    expect(requested).toContainEqual({
+      href: `http://toolshed.test${PARENT_PATH}`,
+      cache: "no-cache",
+    });
+    expect(requested).toContainEqual({
+      href: `http://toolshed.test${SOURCE_PATH}`,
+      cache: "no-cache",
+    });
+  });
+
+  it("records a proven system source when its identity is already current", async () => {
+    const v1Identity = await identityFor(source("v1"));
+    let sourceFetches = 0;
+    const piece = await preparePiece((input) => {
+      const href = input instanceof Request
+        ? input.url
+        : input instanceof URL
+        ? input.href
+        : input;
+      const url = new URL(href);
+      if (url.pathname !== PARENT_PATH) {
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }
+      if (!url.searchParams.has("identity")) sourceFetches++;
+      return Promise.resolve(
+        url.searchParams.has("identity")
+          ? new Response(v1Identity)
+          : new Response(parentSource),
+      );
+    });
+    const originalRef = getPatternIdentityRef(piece);
+
+    await runtime.start(piece);
+    await runtime.patternUpdater.idle();
+
+    expect(getPatternIdentityRef(piece)).toEqual(originalRef);
+    expect(getPatternSource(piece)).toBe(PARENT_PATH);
+    expect(sourceFetches).toBe(0);
+  });
+
+  it("leaves an ordinary pattern alone when its source has no identity route", async () => {
+    const piece = await preparePiece(() =>
+      Promise.resolve(new Response("not found", { status: 404 }))
+    );
+    const originalRef = getPatternIdentityRef(piece);
+
+    await runtime.start(piece);
+    await runtime.patternUpdater.idle();
+    await runtime.idle();
+
+    expect((await piece.pull())?.marker).toBe("v1");
+    expect(getPatternIdentityRef(piece)).toEqual(originalRef);
+    expect(getPatternSource(piece)).toBeUndefined();
+  });
+
+  it("keeps the running pattern when the advertised source does not compile", async () => {
+    const invalidSource = [
+      "import { pattern } from 'commonfabric';",
+      `export const ${SYMBOL} = pattern(() => ({ marker: ; }));`,
+      "",
+    ].join("\n");
+    const invalidIdentity = await identityFor(invalidSource);
+    const piece = await preparePiece((input) => {
+      const href = input instanceof Request
+        ? input.url
+        : input instanceof URL
+        ? input.href
+        : input;
+      const url = new URL(href);
+      if (url.pathname === PARENT_PATH && url.searchParams.has("identity")) {
+        return Promise.resolve(new Response(invalidIdentity));
+      }
+      if (url.pathname === PARENT_PATH) {
+        return Promise.resolve(new Response(parentSource));
+      }
+      if (url.pathname === SOURCE_PATH) {
+        return Promise.resolve(new Response(invalidSource));
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+    const originalRef = getPatternIdentityRef(piece);
+
+    await runtime.start(piece);
+    await runtime.patternUpdater.idle();
+    await runtime.idle();
+
+    expect((await piece.pull())?.marker).toBe("v1");
+    expect(getPatternIdentityRef(piece)).toEqual(originalRef);
+    expect(getPatternSource(piece)).toBeUndefined();
+  });
+});

--- a/packages/runner/test/pattern-auto-update.test.ts
+++ b/packages/runner/test/pattern-auto-update.test.ts
@@ -4,12 +4,14 @@ import { defer, type Deferred } from "@commonfabric/utils/defer";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import {
+  type Cell,
   getPatternIdentityRef,
   getPatternSource,
   resolveEntryIdentity,
   Runtime,
   type RuntimeFetch,
   type RuntimeProgram,
+  setPatternSource,
 } from "../src/index.ts";
 
 const signer = await Identity.fromPassphrase("lazy system pattern updates");
@@ -71,13 +73,23 @@ describe("lazy system-pattern auto-update", () => {
     await runtime?.dispose();
   });
 
-  async function preparePiece(fetch: RuntimeFetch) {
+  function createRuntime(
+    fetch: RuntimeFetch,
+    systemPatternAutoUpdate = true,
+  ): Runtime {
     runtime = new Runtime({
       apiUrl: new URL("http://toolshed.test"),
       storageManager,
       fetch,
-      experimental: { systemPatternAutoUpdate: true },
+      experimental: systemPatternAutoUpdate
+        ? { systemPatternAutoUpdate: true }
+        : { systemPatternAutoUpdate: false },
     });
+    return runtime;
+  }
+
+  async function preparePiece(fetch: RuntimeFetch) {
+    createRuntime(fetch);
     const space = signer.did();
     const initialIdentity = await identityFor(source("v1"));
     const initial = await runtime.patternManager.compilePattern(
@@ -98,6 +110,279 @@ describe("lazy system-pattern auto-update", () => {
     });
     return piece;
   }
+
+  it("honors disabled and disposed updater lifecycle gates", async () => {
+    createRuntime(
+      () => Promise.reject(new Error("disabled updater fetched source")),
+      false,
+    );
+    const cell = runtime.getCell(signer.did(), crypto.randomUUID());
+
+    expect(
+      await runtime.patternUpdater.checkDefaultPattern(cell, PARENT_PATH),
+    ).toBe("skipped-disabled");
+
+    runtime.experimental.systemPatternAutoUpdate = true;
+    await runtime.patternUpdater.dispose();
+    expect(
+      await runtime.patternUpdater.checkDefaultPattern(cell, PARENT_PATH),
+    ).toBe("current");
+  });
+
+  it("contains synchronous and asynchronous scheduling failures", async () => {
+    createRuntime(() => Promise.reject(new Error("unexpected fetch")));
+    const space = signer.did();
+    const synchronousFailure = {
+      space,
+      getAsNormalizedFullLink: () => {
+        throw new Error("link unavailable");
+      },
+    } as unknown as Cell<unknown>;
+    expect(() => runtime.patternUpdater.schedule(synchronousFailure)).not
+      .toThrow();
+
+    let spaceReads = 0;
+    const asynchronousFailure = {
+      get space() {
+        spaceReads++;
+        if (spaceReads === 1) throw new Error("space unavailable");
+        return space;
+      },
+      getAsNormalizedFullLink: () => ({
+        space,
+        id: "of:async-pattern-update-schedule-failure",
+      }),
+    } as unknown as Cell<unknown>;
+    runtime.patternUpdater.schedule(asynchronousFailure);
+    await runtime.patternUpdater.idle();
+
+    expect(spaceReads).toBe(2);
+  });
+
+  it("shares one in-flight check for duplicate schedules", async () => {
+    const v1Identity = await identityFor(source("v1"));
+    const identityRequested = defer();
+    identityGate = defer();
+    let identityFetches = 0;
+    const piece = await preparePiece(async (input) => {
+      const url = new URL(
+        input instanceof Request
+          ? input.url
+          : input instanceof URL
+          ? input.href
+          : input,
+      );
+      if (url.searchParams.has("identity")) {
+        identityFetches++;
+        identityRequested.resolve();
+        await identityGate!.promise;
+        return new Response(v1Identity);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const start = runtime.start(piece);
+    await identityRequested.promise;
+    expect(await start).toBe(true);
+    runtime.patternUpdater.schedule(piece);
+    expect(identityFetches).toBe(1);
+
+    identityGate.resolve();
+    await runtime.patternUpdater.idle();
+    expect(identityFetches).toBe(1);
+    expect(getPatternSource(piece)).toBe(PARENT_PATH);
+  });
+
+  it("aborts an in-flight identity request during disposal", async () => {
+    const identityRequested = defer<AbortSignal | undefined>();
+    const abortObserved = defer();
+    const piece = await preparePiece((_input, init) => {
+      const signal = init?.signal ?? undefined;
+      identityRequested.resolve(signal);
+      if (signal === undefined) {
+        return Promise.reject(
+          new Error("identity request had no abort signal"),
+        );
+      }
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener("abort", () => {
+          abortObserved.resolve();
+          reject(new DOMException("aborted", "AbortError"));
+        }, { once: true });
+      });
+    });
+
+    const start = runtime.start(piece);
+    const signal = await identityRequested.promise;
+    expect(signal).toBeDefined();
+    expect(await start).toBe(true);
+    const dispose = runtime.patternUpdater.dispose();
+    await abortObserved.promise;
+    await dispose;
+
+    expect(signal!.aborted).toBe(true);
+    expect(getPatternSource(piece)).toBeUndefined();
+    expect(
+      await runtime.patternUpdater.checkDefaultPattern(piece, PARENT_PATH),
+    ).toBe("current");
+  });
+
+  it("does not resolve source after disposal aborts a completed identity fetch", async () => {
+    const v2Identity = await identityFor(source("v2"));
+    const identityRequested = defer<AbortSignal | undefined>();
+    let bodyController:
+      | ReadableStreamDefaultController<Uint8Array>
+      | undefined;
+    const piece = await preparePiece((_input, init) => {
+      const signal = init?.signal ?? undefined;
+      identityRequested.resolve(signal);
+      return Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              bodyController = controller;
+            },
+          }),
+        ),
+      );
+    });
+
+    const start = runtime.start(piece);
+    const signal = await identityRequested.promise;
+    expect(signal).toBeDefined();
+    expect(await start).toBe(true);
+    const dispose = runtime.patternUpdater.dispose();
+    expect(signal!.aborted).toBe(true);
+    bodyController!.enqueue(new TextEncoder().encode(v2Identity));
+    bodyController!.close();
+    await dispose;
+
+    expect(getPatternSource(piece)).toBeUndefined();
+    expect((await piece.pull())?.marker).toBe("v1");
+  });
+
+  it("skips a sourceless pattern whose compiled source cannot be recovered", async () => {
+    let fetches = 0;
+    const piece = await preparePiece(() => {
+      fetches++;
+      return Promise.resolve(new Response("unexpected"));
+    });
+    const originalGetSource = runtime.patternManager
+      .getPatternSourceProgramByIdentity;
+    runtime.patternManager.getPatternSourceProgramByIdentity =
+      (() => Promise.resolve(undefined)) as typeof originalGetSource;
+
+    try {
+      runtime.patternUpdater.schedule(piece);
+      await runtime.patternUpdater.idle();
+    } finally {
+      runtime.patternManager.getPatternSourceProgramByIdentity =
+        originalGetSource;
+    }
+
+    expect(fetches).toBe(0);
+    expect(getPatternSource(piece)).toBeUndefined();
+  });
+
+  it("leaves cf sources to their own resolver", async () => {
+    let fetches = 0;
+    const piece = await preparePiece(() => {
+      fetches++;
+      return Promise.resolve(new Response("unexpected"));
+    });
+    const update = await runtime.editWithRetry((tx) => {
+      setPatternSource(piece, tx, "cf:published-pattern");
+    });
+    expect(update.error).toBeUndefined();
+
+    runtime.patternUpdater.schedule(piece);
+    await runtime.patternUpdater.idle();
+
+    expect(fetches).toBe(0);
+    expect(getPatternSource(piece)).toBe("cf:published-pattern");
+  });
+
+  it("does not repair provenance after the piece becomes the default", async () => {
+    const v1Identity = await identityFor(source("v1"));
+    const identityRequested = defer();
+    identityGate = defer();
+    const piece = await preparePiece(async (input) => {
+      const url = new URL(
+        input instanceof Request
+          ? input.url
+          : input instanceof URL
+          ? input.href
+          : input,
+      );
+      if (url.searchParams.has("identity")) {
+        identityRequested.resolve();
+        await identityGate!.promise;
+        return new Response(v1Identity);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const start = runtime.start(piece);
+    await identityRequested.promise;
+    expect(await start).toBe(true);
+    const promoted = await runtime.editWithRetry((tx) => {
+      runtime.getSpaceCell(piece.space).withTx(tx).key("defaultPattern")
+        .set(piece.withTx(tx));
+    });
+    expect(promoted.error).toBeUndefined();
+
+    identityGate.resolve();
+    await runtime.patternUpdater.idle();
+
+    expect(getPatternSource(piece)).toBeUndefined();
+    expect(getPatternIdentityRef(piece)?.symbol).toBe(SYMBOL);
+  });
+
+  it("does not swap identity after the piece becomes the default", async () => {
+    const v2Identity = await identityFor(source("v2"));
+    const identityRequested = defer();
+    identityGate = defer();
+    const piece = await preparePiece(async (input) => {
+      const url = new URL(
+        input instanceof Request
+          ? input.url
+          : input instanceof URL
+          ? input.href
+          : input,
+      );
+      if (url.pathname === PARENT_PATH && url.searchParams.has("identity")) {
+        identityRequested.resolve();
+        await identityGate!.promise;
+        return new Response(v2Identity);
+      }
+      const contents = url.pathname === PARENT_PATH
+        ? parentSource
+        : url.pathname === SOURCE_PATH
+        ? source("v2")
+        : undefined;
+      return new Response(contents ?? "not found", {
+        status: contents === undefined ? 404 : 200,
+      });
+    });
+    const originalRef = getPatternIdentityRef(piece);
+
+    const start = runtime.start(piece);
+    await identityRequested.promise;
+    expect(await start).toBe(true);
+    const promoted = await runtime.editWithRetry((tx) => {
+      runtime.getSpaceCell(piece.space).withTx(tx).key("defaultPattern")
+        .set(piece.withTx(tx));
+    });
+    expect(promoted.error).toBeUndefined();
+
+    identityGate.resolve();
+    await runtime.patternUpdater.idle();
+    await runtime.idle();
+
+    expect(getPatternIdentityRef(piece)).toEqual(originalRef);
+    expect(getPatternSource(piece)).toBeUndefined();
+    expect((await piece.pull())?.marker).toBe("v1");
+  });
 
   it("starts immediately, then updates a non-root pattern in the background", async () => {
     const v2Identity = await identityFor(source("v2"));

--- a/packages/runner/test/pattern-auto-update.test.ts
+++ b/packages/runner/test/pattern-auto-update.test.ts
@@ -193,7 +193,7 @@ describe("lazy system-pattern auto-update", () => {
     expect(getPatternSource(piece)).toBe(PARENT_PATH);
   });
 
-  it("checks the locally known default role without a storage round trip", async () => {
+  it("does not schedule a generic check for an explicitly handled root", async () => {
     let fetches = 0;
     const piece = await preparePiece(() => {
       fetches++;
@@ -216,7 +216,9 @@ describe("lazy system-pattern auto-update", () => {
     }) as typeof storageManager.syncCell;
 
     try {
-      expect(await runtime.start(piece)).toBe(true);
+      expect(
+        await runtime.start(piece, { schedulePatternUpdate: false }),
+      ).toBe(true);
       await runtime.patternUpdater.idle();
     } finally {
       storageManager.syncCell = originalSyncCell;

--- a/packages/runner/test/scheduler-event-lineage.test.ts
+++ b/packages/runner/test/scheduler-event-lineage.test.ts
@@ -16,7 +16,11 @@ import type {
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { useCancelGroup, useDeferredCancelOwnership } from "../src/cancel.ts";
+import {
+  cancel as cancelCancellable,
+  useCancelGroup,
+  useDeferredCancelOwnership,
+} from "../src/cancel.ts";
 import { RetryImmediately } from "../src/scheduler/retry-immediately.ts";
 
 const secondSigner = await Identity.fromPassphrase(
@@ -1112,6 +1116,15 @@ describe("scheduler event lineage", () => {
 });
 
 describe("cancel group lifecycle", () => {
+  it("invokes an optional cancellable cleanup", () => {
+    let calls = 0;
+
+    cancelCancellable({ cancel: () => calls++ });
+    cancelCancellable({});
+
+    expect(calls).toBe(1);
+  });
+
   it("hands an installed cleanup through an already-cancelled owner once", () => {
     let calls = 0;
     const installedCancel = () => calls++;


### PR DESCRIPTION
## Summary

- move identity-safe system-source reconciliation into a shared runner `PatternUpdater`
- schedule a fire-and-forget check after each successful non-root pattern instantiation
- recover unstamped source provenance from the verified source-doc closure and recognize system sources through same-toolshed `?identity`
- keep persisted default roots on their stronger pre-start reconciliation path

## Why

The existing update hook lived in `PiecesController.ensureDefaultPattern`, so only space roots participated. Other patterns compiled from toolshed system routes retained their original content identity indefinitely, even though those routes expose the same authoritative `?identity` contract.

## Safety and behavior

Ordinary pieces start their current graph without waiting for network or compilation. A changed source is downloaded with cache revalidation, compiled as a complete import closure, and accepted only when the compiler-produced identity and selected export match the advertised identity. The final metadata write is compare-and-swap, so concurrent source/repository/pattern changes win. Fetch, compile, mismatch, and commit failures leave the original pointer and running graph untouched.

Default roots still reconcile before start so an unloadable persisted root can recover. Their creation and ensure paths explicitly suppress the generic post-start hook to avoid duplicate requests.

## Validation

- `deno task check`
- `deno task --cwd packages/runner test` — 997 tests / 5,330 steps
- `deno task --cwd packages/piece test` — 21 tests / 243 steps
- focused updater and default-root suites after syncing with current `main`
- `deno lint` on all touched TypeScript files
- `deno fmt` and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lazy auto-update for same-toolshed system-source patterns via a shared `PatternUpdater`, with single-flight, no-cache, abortable background checks. Roots still reconcile before start; other patterns check after instantiation without blocking, and default-root duplicate checks are suppressed.

- **New Features**
  - Added `PatternUpdater` (shared by root reconcile and lazy checks) to single-flight background check system sources via `?identity`; uses no-cache fetch and aborts in-flight requests and identity response reads; exposes `idle()`/`dispose()`.
  - Skips non-eligible starts: `doNotUpdateOnPatternChange`, default root paths, `cf:` sources, repository-pinned pieces, and cross-origin URLs.
  - Repairs and stamps `patternSource` for unstamped non-roots only when the verified entry path supports `?identity`; roots compile the official `default` export, ordinary patterns preserve the selected export symbol.
  - Safety and wiring: compare-and-swap writes with default-link re-read to fail closed on promotion; `Runner.start` schedules checks after a successful commit; `schedulePatternUpdate` is threaded through `Runtime.run`/`Runtime.start` and set to `false` for default-root creation and ensure paths.

- **Bug Fixes**
  - Updater honors cancellation on dispose, aborts identity body reads, and ignores repository-pinned patterns; contains default-pattern resolution failures without side effects.
  - Memory v2 client now rejects requests that begin while `close()` is in flight, preventing orphaned pending requests.

<sup>Written for commit 9738ac2455bfc9e18a229d2dba6a1df274694775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

