### PR TITLE
fix(dashboard): publish CI tiles from source snapshots

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -45,13 +45,27 @@ dashboard/
 `server.ts` knows nothing about individual tiles. It runs a single ticker,
 collects each tile that is due (respecting its `intervalMs`), renders the
 results uniformly, mounts any drill-down routes a tile declares, and pushes new
-tile markup as each collection completes. Every registered tile has a gray
-placeholder labelled with its id in its registered position until its first
-collection completes, so slow collectors do not leave holes in the board. A
-tile whose `collect()` throws is desaturated to a gray "unknown" — it keeps its
-last-known value and shows a short reason (e.g. "source unreachable"), with the
-full error in the server log — so one unreachable source never blanks or breaks
-the board.
+tile markup as each independent collection completes. Every registered tile has
+a gray placeholder labelled with its id in its registered position until its
+first collection completes, so slow collectors do not leave holes in the board.
+A tile whose `collect()` throws is desaturated to a gray "unknown" — it keeps
+its last-known value and shows a short reason (e.g. "source unreachable"), with
+the full error in the server log — so one unreachable source never blanks or
+breaks the board.
+
+GitHub CI tiles declare the workflow snapshots they read in `runSources`. The
+scheduler fetches each workflow independently. When a workflow fetch completes,
+the scheduler collects every due tile that reads it from the same stored
+snapshot and publishes those tile updates together. Each workflow can trigger a
+tile once per collection interval. A tile with several workflows can update
+once for each workflow as they arrive. This keeps a repository's build, trust,
+duration, and recent-run views in agreement when their intervals coincide.
+
+The recent-main-runs tile reads both the Labs and Loom snapshots. It rebuilds
+and sorts the combined list whenever either snapshot arrives. If one snapshot
+has not arrived yet, it shows the runs from the available snapshot in gray and
+names the pending source. If a later refresh fails, it keeps the last good
+snapshot for that source and shows the combined list in gray with the error.
 
 Each event connection receives the current tile snapshot before it waits for
 new collections. The browser reconciles that snapshot by tile ID, leaving
@@ -88,6 +102,7 @@ export const myTile: Tile = {
   id: "my-tile",          // unique, stable
   intervalMs: 60_000,     // how often collect() runs
   // wide: true,           // optional full-width placement
+  // runSources: [{ repo: "owner/repo", workflow: "ci.yml" }],
   async collect(ctx): Promise<TileView> {
     // ctx.runs() -> shared CI runs; ctx.env("KEY") -> env var.
     // If a required env var is missing, return a gray "unknown" view — don't throw.
@@ -147,7 +162,7 @@ surveillance tool.
 |---|---|---|
 | labs ci, labs ci trust, labs ci duration | GitHub Actions (`deno.yml` on main in `commontoolsinc/labs`), via the REST API | `GH_TOKEN` (or `GITHUB_TOKEN`) |
 | loom ci, loom ci trust, loom ci duration | the same three tiles for `commontoolsinc/loom` (`test-fast.yml` on main) | `GH_TOKEN` (read access to loom); optional `DASHBOARD_LOOM_REPO` |
-| recent main runs | labs + loom main runs interleaved chronologically, each row tagged with its repo | `GH_TOKEN` |
+| recent main runs | Labs and Loom main-run snapshots, refreshed independently and merged chronologically whenever either arrives; each row is tagged with its repo | `GH_TOKEN` |
 | commit CI Gantt → `/ci-gantt` | job and step timing for every successful main workflow run attached to one commit, linked from run durations in recent main runs | `GH_TOKEN` |
 | CI duration history → `/bench?view=ci` | labs and loom job, shard-group, and end-to-end workflow duration trends. The duration tiles open their matching repository view | `GH_TOKEN` |
 | CI run Gantt → `/bench?view=gantt` | detailed labs or loom job phases from `scripts/ci-gantt.ts`, backed by the CI history cache | `GH_TOKEN` |

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -15,13 +15,58 @@ import {
 } from "./server.ts";
 import { LOOM_CI_WORKFLOW, LOOM_REPO, PORT } from "./config.ts";
 import { TILES } from "./registry.ts";
-import type { Tile, TileView } from "./types.ts";
+import type { Ctx, Run, RunSource, Tile, TileView } from "./types.ts";
 
 const req = (path: string) => new Request(`http://localhost${path}`);
 
 // intervalMs 0 keeps a stand-in due on every tick, whatever earlier tests ran.
 function fake(id: string, collect: () => TileView | Promise<TileView>, intervalMs = 0): Tile {
   return { id, intervalMs, collect: () => Promise.resolve(collect()) };
+}
+
+function sourceRun(id: number, title: string): Run {
+  return {
+    id,
+    status: "completed",
+    conclusion: "success",
+    run_attempt: 1,
+    event: "push",
+    head_sha: `sha-${id}`,
+    display_title: title,
+    run_started_at: new Date(Date.now() - id * 60_000).toISOString(),
+    updated_at: new Date().toISOString(),
+    html_url: "",
+    head_commit: { message: title },
+  };
+}
+
+function deferred<T>() {
+  let resolve = (_value: T) => {};
+  let reject = (_reason: unknown) => {};
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function sourceTile(
+  id: string,
+  label: string,
+  runSources: readonly RunSource[],
+  wide = false,
+): Tile {
+  return {
+    id,
+    intervalMs: 0,
+    runSources,
+    wide,
+    async collect(ctx): Promise<TileView> {
+      const snapshots = await Promise.all(runSources.map((source) => ctx.runsFor(source.repo, source.workflow)));
+      const titles = snapshots.flat().map((run) => run.display_title);
+      return { label, status: "good", value: titles.join(", ") || "empty" };
+    },
+  };
 }
 
 const dec = new TextDecoder();
@@ -145,23 +190,34 @@ Deno.test("per-collector updates keep a red handoff's incident age", async () =>
   assert(redSince !== "null");
 
   let release = (_: TileView) => {};
+  let published = () => {};
+  const firstUpdate = new Promise<void>((resolve) => published = resolve);
+  const client = {
+    enqueue() {
+      published();
+    },
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+  clients.add(client);
   const handoff = tick([
     fake("model-spend", () => modelGood),
     fake("gcp-spend", () => new Promise<TileView>((resolve) => release = resolve)),
   ]);
-  await Promise.resolve();
-  assertStringIncludes(
-    tileHtml("atomic model spend"),
-    `good" data-tile-id="model-spend">`,
-  );
-  assertStringIncludes(
-    tileHtml("atomic gcp spend"),
-    `good" data-tile-id="gcp-spend">`,
-  );
-  assertEquals(faviconRedSinceInPage(), redSince);
-
-  release(gcpBad);
-  await handoff;
+  try {
+    await firstUpdate;
+    assertStringIncludes(
+      tileHtml("atomic model spend"),
+      `good" data-tile-id="model-spend">`,
+    );
+    assertStringIncludes(
+      tileHtml("atomic gcp spend"),
+      `good" data-tile-id="gcp-spend">`,
+    );
+    assertEquals(faviconRedSinceInPage(), redSince);
+  } finally {
+    clients.delete(client);
+    release(gcpBad);
+    await handoff;
+  }
   assertStringIncludes(
     tileHtml("atomic model spend"),
     `good" data-tile-id="model-spend">`,
@@ -234,29 +290,239 @@ Deno.test("a tick that is still running makes the next tick a no-op", async () =
 
 Deno.test("each completed collection is published while slower tiles are still running", async () => {
   const messages: string[] = [];
+  let firstPublished = (_message: string) => {};
+  const firstUpdate = new Promise<string>((resolve) => firstPublished = resolve);
   const client = {
     enqueue(value: Uint8Array) {
-      messages.push(dec.decode(value));
+      const message = dec.decode(value);
+      messages.push(message);
+      if (messages.length === 1) firstPublished(message);
+    },
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+  const slow = deferred<TileView>();
+  clients.add(client);
+  const collection = tick([
+    fake("labs-ci", () => ({ label: "fast", status: "good" })),
+    fake("loom-ci", () => slow.promise),
+  ]);
+  try {
+    const first = await firstUpdate;
+    assertEquals(messages.length, 1);
+    assertStringIncludes(updateFromEvent(first).gridHtml, "fast");
+    slow.resolve({ label: "slow", status: "good" });
+    await collection;
+  } finally {
+    clients.delete(client);
+    slow.resolve({ label: "slow", status: "good" });
+    await collection;
+  }
+  assertEquals(messages.length, 2);
+  assertStringIncludes(updateFromEvent(messages[1]).gridHtml, "slow");
+});
+
+Deno.test("each run source publishes its dependent tiles as one batch", async () => {
+  const labsSource = { repo: "test/labs-incremental", workflow: "ci.yml" };
+  const loomSource = { repo: "test/loom-incremental", workflow: "ci.yml" };
+  const labs = deferred<Run[]>();
+  const loom = deferred<Run[]>();
+  const sourceCtx: Ctx = {
+    runs: () => labs.promise,
+    runsFor: (repo) => repo === labsSource.repo ? labs.promise : loom.promise,
+    env: () => undefined,
+  };
+  const tiles = [
+    sourceTile("labs-ci", "incremental labs ci", [labsSource]),
+    sourceTile("ci-trust", "incremental labs trust", [labsSource]),
+    sourceTile("loom-ci", "incremental loom ci", [loomSource]),
+    sourceTile("loom-ci-trust", "incremental loom trust", [loomSource]),
+    sourceTile("recent-runs", "incremental recent", [labsSource, loomSource], true),
+  ];
+
+  const messages: string[] = [];
+  const waiting: ((message: string) => void)[] = [];
+  const nextMessage = () => new Promise<string>((resolve) => waiting.push(resolve));
+  const client = {
+    enqueue(value: Uint8Array) {
+      const message = dec.decode(value);
+      messages.push(message);
+      waiting.shift()?.(message);
     },
   } as unknown as ReadableStreamDefaultController<Uint8Array>;
   clients.add(client);
-  let beforeSlow: string[] = [];
+  const refresh = tick(tiles, sourceCtx);
   try {
-    await tick([
-      fake("labs-ci", () => ({ label: "fast", status: "good" })),
-      fake("loom-ci", async () => {
-        await Promise.resolve();
-        beforeSlow = [...messages];
-        return { label: "slow", status: "good" };
-      }),
-    ]);
+    const firstMessage = nextMessage();
+    labs.resolve([sourceRun(1, "labs new")]);
+    const first = updateFromEvent(await firstMessage);
+    assertStringIncludes(first.gridHtml, "incremental labs ci");
+    assertStringIncludes(first.gridHtml, "incremental labs trust");
+    assert(!first.gridHtml.includes("incremental loom ci"));
+    assertStringIncludes(first.wideHtml, "incremental recent");
+    assertStringIncludes(first.wideHtml, "labs new");
+    assertStringIncludes(first.wideHtml, "loom-incremental pending");
+    assertEquals(messages.length, 1, "one source arrival produces one broadcast");
+
+    const secondMessage = nextMessage();
+    loom.resolve([sourceRun(2, "loom new")]);
+    const second = updateFromEvent(await secondMessage);
+    assertStringIncludes(second.gridHtml, "incremental loom ci");
+    assertStringIncludes(second.gridHtml, "incremental loom trust");
+    assertStringIncludes(second.wideHtml, "labs new, loom new");
+    assert(!second.wideHtml.includes("pending"));
+    assertEquals(messages.length, 2, "the second source produces the second broadcast");
+    await refresh;
   } finally {
     clients.delete(client);
+    labs.resolve([]);
+    loom.resolve([]);
+    await refresh;
   }
-  assertEquals(beforeSlow.length, 1);
-  assertStringIncludes(updateFromEvent(beforeSlow[0]).gridHtml, "fast");
-  assertEquals(messages.length, 2);
-  assertStringIncludes(updateFromEvent(messages[1]).gridHtml, "slow");
+});
+
+Deno.test("a ready source publishes while an older combined collection is still running", async () => {
+  const labsSource = { repo: "test/labs-independent", workflow: "ci.yml" };
+  const loomSource = { repo: "test/loom-independent", workflow: "ci.yml" };
+  const labs = deferred<Run[]>();
+  const loom = deferred<Run[]>();
+  const oldCollection = deferred<void>();
+  let started = () => {};
+  const oldCollectionStarted = new Promise<void>((resolve) => started = resolve);
+  let publishOld = (_view: TileView) => {};
+  const sourceCtx: Ctx = {
+    runs: () => labs.promise,
+    runsFor: (repo) => repo === labsSource.repo ? labs.promise : loom.promise,
+    env: () => undefined,
+  };
+  const combined: Tile = {
+    id: "recent-runs",
+    intervalMs: 0,
+    runSources: [labsSource, loomSource],
+    wide: true,
+    async collect(ctx, publish): Promise<TileView> {
+      const [labsRuns, loomRuns] = await Promise.all([
+        ctx.runsFor(labsSource.repo, labsSource.workflow),
+        ctx.runsFor(loomSource.repo, loomSource.workflow),
+      ]);
+      if (!loomRuns.length) {
+        publishOld = publish ?? publishOld;
+        started();
+        await oldCollection.promise;
+      }
+      const titles = [...labsRuns, ...loomRuns].map((run) => run.display_title);
+      return { label: "independent recent", status: "good", value: titles.join(", ") };
+    },
+  };
+  const tiles = [
+    sourceTile("labs-ci", "independent labs", [labsSource]),
+    sourceTile("loom-ci", "independent loom", [loomSource]),
+    combined,
+  ];
+
+  const messages: string[] = [];
+  let published = (_message: string) => {};
+  const nextMessage = () => new Promise<string>((resolve) => published = resolve);
+  const client = {
+    enqueue(value: Uint8Array) {
+      const message = dec.decode(value);
+      messages.push(message);
+      published(message);
+    },
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+  clients.add(client);
+  const refresh = tick(tiles, sourceCtx);
+  try {
+    labs.resolve([sourceRun(4, "labs ready")]);
+    await oldCollectionStarted;
+
+    const loomUpdate = nextMessage();
+    loom.resolve([sourceRun(5, "loom ready")]);
+    const first = updateFromEvent(await loomUpdate);
+    assertStringIncludes(first.gridHtml, "independent loom");
+    assertStringIncludes(first.wideHtml, "labs ready, loom ready");
+    assert(!first.gridHtml.includes("independent labs"));
+    publishOld({ label: "independent recent", status: "bad", value: "older cached merge" });
+    assertEquals(messages.length, 1);
+    assertStringIncludes(tileHtml("independent recent"), "labs ready, loom ready");
+
+    const labsUpdate = nextMessage();
+    oldCollection.resolve(undefined);
+    const second = updateFromEvent(await labsUpdate);
+    assertStringIncludes(second.gridHtml, "independent labs");
+    assertStringIncludes(second.wideHtml, "labs ready, loom ready");
+    assertEquals(messages.length, 2);
+    await refresh;
+  } finally {
+    clients.delete(client);
+    labs.resolve([]);
+    loom.resolve([]);
+    oldCollection.resolve(undefined);
+    await refresh;
+  }
+});
+
+Deno.test("a shared run source preserves each dependent tile's per-source interval", async () => {
+  const source = { repo: "test/source-cadence", workflow: "ci.yml" };
+  let fetches = 0;
+  let fastCollections = 0;
+  let slowCollections = 0;
+  const sourceCtx: Ctx = {
+    runs: () => sourceCtx.runsFor(source.repo, source.workflow),
+    runsFor: () => {
+      fetches++;
+      return Promise.resolve([]);
+    },
+    env: () => undefined,
+  };
+  const tiles: Tile[] = [
+    {
+      id: "labs-ci",
+      intervalMs: 0,
+      runSources: [source],
+      collect(): Promise<TileView> {
+        fastCollections++;
+        return Promise.resolve({ label: "fast source cadence", status: "good" });
+      },
+    },
+    {
+      id: "ci-trust",
+      intervalMs: 600_000,
+      runSources: [source],
+      collect(): Promise<TileView> {
+        slowCollections++;
+        return Promise.resolve({ label: "slow source cadence", status: "good" });
+      },
+    },
+  ];
+
+  await tick(tiles, sourceCtx);
+  await tick(tiles, sourceCtx);
+
+  assertEquals(fetches, 2);
+  assertEquals(fastCollections, 2);
+  assertEquals(slowCollections, 1);
+});
+
+Deno.test("a failed run source keeps its last good snapshot", async () => {
+  const source = { repo: "test/stale-source", workflow: "ci.yml" };
+  let failing = false;
+  const sourceCtx: Ctx = {
+    runs: () => sourceCtx.runsFor(source.repo, source.workflow),
+    runsFor: () => failing
+      ? Promise.reject(new Error("error sending request for url"))
+      : Promise.resolve([sourceRun(3, "last good run")]),
+    env: () => undefined,
+  };
+  const tile = sourceTile("labs-ci", "last good source", [source]);
+
+  await tick([tile], sourceCtx);
+  assertStringIncludes(tileHtml("last good source"), "last good run");
+
+  failing = true;
+  await tick([tile], sourceCtx);
+  const stale = tileHtml("last good source");
+  assert(stale.startsWith(`unknown" data-tile-id="labs-ci">`));
+  assertStringIncludes(stale, "last good run");
+  assertStringIncludes(stale, "stale-source source unreachable");
 });
 
 Deno.test("a tile can publish cached data while its collection is still running", async () => {
@@ -313,6 +579,55 @@ Deno.test("a tile can publish cached data while its collection is still running"
       status: "unknown",
       value: "stopped",
     });
+    await collection;
+    clients.delete(client);
+  }
+});
+
+Deno.test("a source-backed tile can publish cached data while its collection is still running", async () => {
+  const source = { repo: "test/intermediate-source", workflow: "ci.yml" };
+  const sourceCtx: Ctx = {
+    runs: () => Promise.resolve([]),
+    runsFor: () => Promise.resolve([]),
+    env: () => undefined,
+  };
+  const messages: string[] = [];
+  const client = {
+    enqueue(value: Uint8Array) {
+      messages.push(dec.decode(value));
+    },
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+  const finalView = deferred<TileView>();
+  let cachedPublished = () => {};
+  const sawCached = new Promise<void>((resolve) => cachedPublished = resolve);
+  let publishIntermediate = (_view: TileView) => {};
+  let collection: Promise<void> | undefined;
+  clients.add(client);
+  try {
+    collection = tick([{
+      id: "benchmark",
+      intervalMs: 0,
+      runSources: [source],
+      async collect(_ctx, publish) {
+        publishIntermediate = publish ?? publishIntermediate;
+        publish?.({ label: "source benchmark", status: "good", value: "cached" });
+        cachedPublished();
+        return await finalView.promise;
+      },
+    }], sourceCtx);
+    await sawCached;
+    assertEquals(messages.length, 1);
+    assertStringIncludes(updateFromEvent(messages[0]).gridHtml, "cached");
+
+    finalView.resolve({ label: "source benchmark", status: "good", value: "refreshed" });
+    await collection;
+    assertEquals(messages.length, 2);
+    assertStringIncludes(updateFromEvent(messages[1]).gridHtml, "refreshed");
+    publishIntermediate({ label: "source benchmark", status: "bad", value: "late cached value" });
+    assertEquals(messages.length, 2);
+    assertStringIncludes(tileHtml("source benchmark"), "refreshed");
+  } finally {
+    finalView.resolve({ label: "source benchmark", status: "unknown", value: "stopped" });
     await collection;
     clients.delete(client);
   }

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -19,18 +19,21 @@
 //   GH_TOKEN                          GitHub tiles; org Members read also powers
 //                                     the organization-users tile
 
-import { PORT } from "./config.ts";
+import { CI_WORKFLOW, PORT, REPO } from "./config.ts";
 import { TILES } from "./registry.ts";
 import { makeCtx } from "./ctx.ts";
 import { friendlyError } from "./lib.ts";
 import { faviconPng, faviconStatus } from "./favicon.ts";
 import type { FaviconStatus } from "./favicon.ts";
 import { renderTile, shell, SHELL_VERSION } from "./render.ts";
-import type { Tile, TileView } from "./types.ts";
+import type { Ctx, Run, RunSource, Tile, TileView } from "./types.ts";
 
 const ctx = makeCtx();
 const views = new Map<string, TileView>();
 const lastRun = new Map<string, number>();
+const runSnapshots = new Map<string, Run[]>();
+const runSourceErrors = new Map<string, string>();
+const lastSourceTileRun = new Map<string, number>();
 let lastChange = 0;
 let faviconRedSince: number | null = null;
 
@@ -108,52 +111,204 @@ export const broadcast = (update: DashboardUpdate) => {
   }
 };
 
+const runSourceKey = (source: RunSource): string => `${source.repo} ${source.workflow}`;
+const runSourceTileKey = (source: RunSource, tile: Tile): string => `${runSourceKey(source)} ${tile.id}`;
+
+interface RunSourceGroup {
+  source: RunSource;
+  tiles: Tile[];
+}
+
+function groupRunSources(tiles: Tile[]): RunSourceGroup[] {
+  const groups = new Map<string, RunSourceGroup>();
+  for (const tile of tiles) {
+    for (const source of tile.runSources ?? []) {
+      const key = runSourceKey(source);
+      const group = groups.get(key);
+      if (group) {
+        if (!group.tiles.includes(tile)) group.tiles.push(tile);
+      } else {
+        groups.set(key, { source, tiles: [tile] });
+      }
+    }
+  }
+  return [...groups.values()];
+}
+
+function snapshotCtx(base: Ctx, snapshots: ReadonlyMap<string, Run[]>): Ctx {
+  const runsFor = (repo: string, workflow: string) =>
+    Promise.resolve(snapshots.get(runSourceKey({ repo, workflow })) ?? []);
+  return {
+    runs: () => runsFor(REPO, CI_WORKFLOW),
+    runsFor,
+    env: base.env,
+  };
+}
+
+function sourceLabel(source: RunSource): string {
+  return source.repo.split("/").at(-1) ?? source.repo;
+}
+
+function withSourceHealth(
+  tile: Tile,
+  view: TileView,
+  snapshots: ReadonlyMap<string, Run[]>,
+  errors: ReadonlyMap<string, string>,
+): TileView {
+  const problems: string[] = [];
+  for (const source of tile.runSources ?? []) {
+    const key = runSourceKey(source);
+    const error = errors.get(key);
+    if (error) problems.push(`${sourceLabel(source)} ${friendlyError(error)}`);
+    else if (!snapshots.has(key)) problems.push(`${sourceLabel(source)} pending`);
+  }
+  return problems.length ? { ...view, status: "unknown", sub: problems.join(" · ") } : view;
+}
+
+async function collectView(
+  tile: Tile,
+  collectionCtx: Ctx,
+  publish?: (view: TileView) => void,
+): Promise<TileView> {
+  let acceptingIntermediate = true;
+  try {
+    try {
+      return await tile.collect(
+        collectionCtx,
+        publish
+          ? (intermediate) => {
+            if (acceptingIntermediate) publish(intermediate);
+          }
+          : undefined,
+      );
+    } finally {
+      acceptingIntermediate = false;
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`tile ${tile.id} failed:`, msg);
+    const prev = views.get(tile.id);
+    return prev
+      ? { ...prev, status: "unknown", sub: friendlyError(msg) }
+      : { label: tile.id, status: "unknown", value: "—", sub: friendlyError(msg) };
+  }
+}
+
+function publishViews(collected: { tile: Tile; view: TileView }[], recoveryIsSettled: boolean): void {
+  const now = Date.now();
+  for (const { tile, view } of collected) {
+    views.set(tile.id, view);
+    lastRun.set(tile.id, now);
+  }
+  lastChange = now;
+  updateFaviconRedSince(now, recoveryIsSettled);
+  broadcast(dashboardUpdate());
+}
+
+function publishIntermediateView(tile: Tile, view: TileView): void {
+  const now = Date.now();
+  views.set(tile.id, view);
+  lastChange = now;
+  updateFaviconRedSince(now, false);
+  broadcast(dashboardUpdate());
+}
+
 // One ticker collects every tile that is due (respecting each tile's interval).
 // A reentrancy guard stops a slow tick from overlapping the next one.
 const TICK_MS = 15_000;
 let ticking = false;
-export async function tick(tiles: Tile[] = TILES) {
+export async function tick(tiles: Tile[] = TILES, sourceCtx: Ctx = ctx) {
   if (ticking) return;
   ticking = true;
   try {
     const now = Date.now();
-    const due = tiles.filter((t) => now - (lastRun.get(t.id) ?? 0) >= t.intervalMs);
-    if (!due.length) return;
-    let remaining = due.length;
-    await Promise.all(due.map(async (t) => {
-      let view: TileView;
-      let acceptingIntermediate = true;
-      try {
-        try {
-          view = await t.collect(ctx, (intermediate) => {
-            if (!acceptingIntermediate) return;
-            views.set(t.id, intermediate);
-            lastChange = Date.now();
-            updateFaviconRedSince(lastChange, false);
-            broadcast(dashboardUpdate());
-          });
-        } finally {
-          acceptingIntermediate = false;
-        }
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        console.error(`tile ${t.id} failed:`, msg); // full detail to the log
-        // A failed collection preserves the previous view in gray and shows a
-        // short error.
-        const prev = views.get(t.id);
-        view = prev
-          ? { ...prev, status: "unknown", sub: friendlyError(msg) }
-          : { label: t.id, status: "unknown", value: "—", sub: friendlyError(msg) };
-      }
-      views.set(t.id, view);
-      lastRun.set(t.id, Date.now());
-      lastChange = Date.now();
+    const sourceGroups = groupRunSources(tiles);
+    const sourceTiles = new Set(sourceGroups.flatMap((group) => group.tiles));
+    const dueTiles = tiles.filter((tile) =>
+      !sourceTiles.has(tile) && now - (lastRun.get(tile.id) ?? 0) >= tile.intervalMs
+    );
+    const dueSources = sourceGroups.flatMap((group) => {
+      const due = group.tiles.filter((tile) =>
+        now - (lastSourceTileRun.get(runSourceTileKey(group.source, tile)) ?? 0) >= tile.intervalMs
+      );
+      return due.length ? [{ source: group.source, tiles: due }] : [];
+    });
+    if (!dueTiles.length && !dueSources.length) return;
+
+    let remaining = dueTiles.length + dueSources.length;
+    const publish = (collected: { tile: Tile; view: TileView }[]) => {
       remaining--;
-      // A non-red intermediate snapshot keeps the incident until every due
-      // collection has settled.
-      updateFaviconRedSince(lastChange, remaining === 0);
-      broadcast(dashboardUpdate());
-    }));
+      publishViews(collected, remaining === 0);
+    };
+
+    // Source fetches and dependent collections run independently. Each tile
+    // retains the completed view with the highest snapshot revision.
+    let sourceRevision = 0;
+    const publishedTileRevision = new Map<string, number>();
+    const refreshSource = async (group: RunSourceGroup) => {
+      let runs: Run[] | undefined;
+      let error: string | undefined;
+      try {
+        runs = await sourceCtx.runsFor(group.source.repo, group.source.workflow);
+      } catch (e) {
+        error = e instanceof Error ? e.message : String(e);
+        console.error(`run source ${runSourceKey(group.source)} failed:`, error);
+      }
+
+      const key = runSourceKey(group.source);
+      if (runs) {
+        runSnapshots.set(key, runs);
+        runSourceErrors.delete(key);
+      } else {
+        runSourceErrors.set(key, error ?? "temporarily unavailable");
+      }
+      const snapshots = new Map(runSnapshots);
+      const errors = new Map(runSourceErrors);
+      const currentCtx = snapshotCtx(sourceCtx, snapshots);
+      const revision = ++sourceRevision;
+      const publishIntermediate = (tile: Tile, view: TileView) => {
+        if (revision < (publishedTileRevision.get(tile.id) ?? 0)) return;
+        publishedTileRevision.set(tile.id, revision);
+        publishIntermediateView(
+          tile,
+          withSourceHealth(tile, view, snapshots, errors),
+        );
+      };
+      const collected = await Promise.all(group.tiles.map(async (tile) => ({
+        tile,
+        view: withSourceHealth(
+          tile,
+          await collectView(
+            tile,
+            currentCtx,
+            (intermediate) => publishIntermediate(tile, intermediate),
+          ),
+          snapshots,
+          errors,
+        ),
+      })));
+      const current = collected.filter(({ tile }) => revision >= (publishedTileRevision.get(tile.id) ?? 0));
+      for (const { tile } of current) publishedTileRevision.set(tile.id, revision);
+      const completedAt = Date.now();
+      for (const tile of group.tiles) {
+        lastSourceTileRun.set(runSourceTileKey(group.source, tile), completedAt);
+      }
+      publish(current);
+    };
+
+    await Promise.all([
+      ...dueTiles.map(async (tile) =>
+        publish([{
+          tile,
+          view: await collectView(
+            tile,
+            sourceCtx,
+            (intermediate) => publishIntermediateView(tile, intermediate),
+          ),
+        }])
+      ),
+      ...dueSources.map(refreshSource),
+    ]);
   } finally {
     ticking = false;
   }

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -3,7 +3,7 @@
 // runs and the token-gated tiles get an empty env (their gray-out contract).
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Ctx, Run } from "./types.ts";
-import { LOOM_REPO, REPO } from "./config.ts";
+import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "./config.ts";
 import { labsCi, loomCi } from "./tiles/main-build.ts";
 import { labsCiTrust, loomCiTrust } from "./tiles/ci-trust.ts";
 import { labsCiDuration, loomCiDuration } from "./tiles/ci-duration.ts";
@@ -297,6 +297,18 @@ Deno.test("tile labels: the labs/loom ci family is renamed and paired", async ()
   assertEquals((await loomCiTrust.collect(one)).label, "loom ci trust");
   assertEquals((await labsCiDuration.collect(one)).label, "labs ci duration");
   assertEquals((await loomCiDuration.collect(one)).label, "loom ci duration");
+});
+
+Deno.test("CI tiles declare the workflow snapshots that drive them", () => {
+  const labsSource = [{ repo: REPO, workflow: CI_WORKFLOW }];
+  const loomSource = [{ repo: LOOM_REPO, workflow: LOOM_CI_WORKFLOW }];
+  for (const tile of [labsCi, labsCiTrust, labsCiDuration]) {
+    assertEquals(tile.runSources, labsSource);
+  }
+  for (const tile of [loomCi, loomCiTrust, loomCiDuration]) {
+    assertEquals(tile.runSources, loomSource);
+  }
+  assertEquals(recentRuns.runSources, [...labsSource, ...loomSource]);
 });
 
 Deno.test("labs ci: an in-flight build renders at the bottom (extra), not the header (aside)", async () => {

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -2,7 +2,7 @@
 // hand-made Ctx. No server, no network, no subprocess — the CI tiles get canned
 // runs and the token-gated tiles get an empty env (their gray-out contract).
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
-import type { Ctx, Run } from "./types.ts";
+import { runSource, type Ctx, type Run } from "./types.ts";
 import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "./config.ts";
 import { labsCi, loomCi } from "./tiles/main-build.ts";
 import { labsCiTrust, loomCiTrust } from "./tiles/ci-trust.ts";
@@ -297,6 +297,13 @@ Deno.test("tile labels: the labs/loom ci family is renamed and paired", async ()
   assertEquals((await loomCiTrust.collect(one)).label, "loom ci trust");
   assertEquals((await labsCiDuration.collect(one)).label, "labs ci duration");
   assertEquals((await loomCiDuration.collect(one)).label, "loom ci duration");
+});
+
+Deno.test("runSource creates workflow snapshot metadata", () => {
+  assertEquals(runSource(REPO, CI_WORKFLOW), {
+    repo: REPO,
+    workflow: CI_WORKFLOW,
+  });
 });
 
 Deno.test("CI tiles declare the workflow snapshots that drive them", () => {

--- a/packages/dashboard/tiles/ci-duration.ts
+++ b/packages/dashboard/tiles/ci-duration.ts
@@ -627,6 +627,7 @@ function makeCiDuration(
   return {
     id: opts.id,
     intervalMs: 30_000,
+    runSources: [{ repo: opts.repo, workflow: opts.workflow }],
     routes: opts.routes,
     async collect(ctx): Promise<TileView> {
       let runs: Run[];

--- a/packages/dashboard/tiles/ci-duration.ts
+++ b/packages/dashboard/tiles/ci-duration.ts
@@ -4,7 +4,14 @@
 // on /bench. The labs instance owns the Gantt image route. The Gantt view
 // exposes scripts/ci-gantt.ts controls for both repositories.
 import { fromFileUrl } from "@std/path";
-import type { Route, Run, Status, Tile, TileView } from "../types.ts";
+import {
+  runSource,
+  type Route,
+  type Run,
+  type Status,
+  type Tile,
+  type TileView,
+} from "../types.ts";
 import { escapeHtml, friendlyError, SPARK_FADE, sparkline } from "../lib.ts";
 import {
   CI_WORKFLOW,
@@ -627,7 +634,7 @@ function makeCiDuration(
   return {
     id: opts.id,
     intervalMs: 30_000,
-    runSources: [{ repo: opts.repo, workflow: opts.workflow }],
+    runSources: [runSource(opts.repo, opts.workflow)],
     routes: opts.routes,
     async collect(ctx): Promise<TileView> {
       let runs: Run[];

--- a/packages/dashboard/tiles/ci-trust.ts
+++ b/packages/dashboard/tiles/ci-trust.ts
@@ -18,6 +18,7 @@ function makeCiTrust(opts: { id: string; label: string; repo: string; workflow: 
   return {
     id: opts.id,
     intervalMs: 30_000,
+    runSources: [{ repo: opts.repo, workflow: opts.workflow }],
     async collect(ctx): Promise<TileView> {
       const runs = await ctx.runsFor(opts.repo, opts.workflow);
       const scored = runs.slice(0, CI_RUNS_MAX).map((run) => ({

--- a/packages/dashboard/tiles/ci-trust.ts
+++ b/packages/dashboard/tiles/ci-trust.ts
@@ -2,7 +2,13 @@
 // flakiness signal), with a history strip for every run in the fetched window.
 // One factory builds both the labs and loom instances against their own repo +
 // workflow.
-import type { Run, Status, Tile, TileView } from "../types.ts";
+import {
+  runSource,
+  type Run,
+  type Status,
+  type Tile,
+  type TileView,
+} from "../types.ts";
 import { strip } from "../lib.ts";
 import { CI_RUNS_MAX, CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO, TRUST_COLS, TRUST_GOOD, TRUST_WARN } from "../config.ts";
 
@@ -18,7 +24,7 @@ function makeCiTrust(opts: { id: string; label: string; repo: string; workflow: 
   return {
     id: opts.id,
     intervalMs: 30_000,
-    runSources: [{ repo: opts.repo, workflow: opts.workflow }],
+    runSources: [runSource(opts.repo, opts.workflow)],
     async collect(ctx): Promise<TileView> {
       const runs = await ctx.runsFor(opts.repo, opts.workflow);
       const scored = runs.slice(0, CI_RUNS_MAX).map((run) => ({

--- a/packages/dashboard/tiles/main-build.ts
+++ b/packages/dashboard/tiles/main-build.ts
@@ -11,6 +11,7 @@ function makeBuildTile(opts: { id: string; label: string; repo: string; workflow
   return {
     id: opts.id,
     intervalMs: 30_000,
+    runSources: [{ repo: opts.repo, workflow: opts.workflow }],
     async collect(ctx): Promise<TileView> {
       const runs = await ctx.runsFor(opts.repo, opts.workflow);
       const completed = runs.filter((r) => r.status === "completed" && r.conclusion);

--- a/packages/dashboard/tiles/main-build.ts
+++ b/packages/dashboard/tiles/main-build.ts
@@ -2,7 +2,7 @@
 // unknown before the first completed run is known. A newer in-flight run is a
 // minor secondary facet. Drills through to the main commit history. One factory
 // builds both the labs and loom instances against their own repo + workflow.
-import type { Status, Tile, TileView } from "../types.ts";
+import { runSource, type Status, type Tile, type TileView } from "../types.ts";
 import { escapeHtml, humanDur } from "../lib.ts";
 import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "../config.ts";
 
@@ -11,7 +11,7 @@ function makeBuildTile(opts: { id: string; label: string; repo: string; workflow
   return {
     id: opts.id,
     intervalMs: 30_000,
-    runSources: [{ repo: opts.repo, workflow: opts.workflow }],
+    runSources: [runSource(opts.repo, opts.workflow)],
     async collect(ctx): Promise<TileView> {
       const runs = await ctx.runsFor(opts.repo, opts.workflow);
       const completed = runs.filter((r) => r.status === "completed" && r.conclusion);

--- a/packages/dashboard/tiles/recent-runs.ts
+++ b/packages/dashboard/tiles/recent-runs.ts
@@ -4,7 +4,13 @@
 // Full-width. The tile's aggregate status is bad if the latest completed run
 // failed, concerning if a failure sits within the recent window but the tip
 // recovered, else good.
-import type { Run, Status, Tile, TileView } from "../types.ts";
+import {
+  runSource,
+  type Run,
+  type Status,
+  type Tile,
+  type TileView,
+} from "../types.ts";
 import { concDot, escapeHtml, landingHref } from "../lib.ts";
 import {
   CI_WORKFLOW,
@@ -80,8 +86,8 @@ export const recentRuns: Tile = {
   intervalMs: 30_000,
   wide: true,
   runSources: [
-    { repo: REPO, workflow: CI_WORKFLOW },
-    { repo: LOOM_REPO, workflow: LOOM_CI_WORKFLOW },
+    runSource(REPO, CI_WORKFLOW),
+    runSource(LOOM_REPO, LOOM_CI_WORKFLOW),
   ],
   async collect(ctx): Promise<TileView> {
     // Two shared bases (labs + loom), merged newest-first and cut to the most

--- a/packages/dashboard/tiles/recent-runs.ts
+++ b/packages/dashboard/tiles/recent-runs.ts
@@ -79,6 +79,10 @@ export const recentRuns: Tile = {
   id: "recent-runs",
   intervalMs: 30_000,
   wide: true,
+  runSources: [
+    { repo: REPO, workflow: CI_WORKFLOW },
+    { repo: LOOM_REPO, workflow: LOOM_CI_WORKFLOW },
+  ],
   async collect(ctx): Promise<TileView> {
     // Two shared bases (labs + loom), merged newest-first and cut to the most
     // recent RECENT_DISPLAY across both.

--- a/packages/dashboard/types.ts
+++ b/packages/dashboard/types.ts
@@ -24,10 +24,18 @@ export interface Route {
   handler(req: Request, url: URL): Response | Promise<Response>;
 }
 
+export interface RunSource {
+  repo: string;
+  workflow: string;
+}
+
 export interface Tile {
   id: string; // unique, stable key for this tile's scheduling + latest-view state
-  intervalMs: number; // how often collect() runs
+  intervalMs: number; // how often collect() runs, per source when runSources is set
   wide?: boolean; // render full-width below the grid, including before collection
+  // GitHub workflow snapshots that drive this tile. The scheduler refreshes
+  // each source independently and publishes its due dependent tiles together.
+  runSources?: readonly RunSource[];
   collect(ctx: Ctx, publish?: (view: TileView) => void): Promise<TileView>; // publish usable data before slower work completes
   routes?: Route[]; // optional drill-down routes this tile owns
 }

--- a/packages/dashboard/types.ts
+++ b/packages/dashboard/types.ts
@@ -24,10 +24,11 @@ export interface Route {
   handler(req: Request, url: URL): Response | Promise<Response>;
 }
 
-export interface RunSource {
-  repo: string;
-  workflow: string;
+export function runSource(repo: string, workflow: string) {
+  return { repo, workflow } as const;
 }
+
+export type RunSource = ReturnType<typeof runSource>;
 
 export interface Tile {
   id: string; // unique, stable key for this tile's scheduling + latest-view state


### PR DESCRIPTION
Refresh each repository workflow independently and retain its last successful run list. CI build, trust, duration, and recent-run tiles declare their workflow dependencies so due tiles can be collected from the same snapshot and published in one dashboard update.

Rebuild the combined recent-run list whenever either repository snapshot arrives. Partial and stale data remains visible in gray, while snapshot revisions prevent slower older collections from replacing newer merges.

Preserve each tile's collection interval per source and retain optional intermediate publication for source-backed collectors. Source health and revision ordering apply to cached views as well as final views.

Add scheduler coverage for incremental arrivals, atomic publication, stale-source retention, independent collections, differing dependent cadences, and source-backed intermediate views.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787336881&installation_model_id=428580&pr_number=4910&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4910&signature=1bfc9ef3fde53387cf1e477c71fc83ef47567057808c2191e1cf66f33a3ed4b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish CI tiles from per-repo workflow snapshots to keep build, trust, duration, and recent runs in sync. The scheduler fetches each workflow independently, batches dependent tile updates per source arrival, preserves the last good snapshot on errors, and shows pending/stale sources in gray.

- New Features
  - CI tiles declare `runSources`; added `runSource()` and `RunSource`, and adopted across tiles.
  - Per-source cadence: each dependent tile updates at most once per source per interval; updates publish as one batch per arriving source.
  - `recent-runs` rebuilds on Labs or Loom snapshot arrival, merges chronologically, grays pending sources, and keeps last good snapshots on failures.
  - Revision ordering and source health apply to final and intermediate views; older or late cached data cannot overwrite newer.
  - Independent collections: a ready source can publish while an older combined collection is still running.
  - README and tests cover incremental arrivals, atomic batch publication, stale-source retention, differing cadences, source-backed intermediate views, and runtime `runSource` coverage.

<sup>Written for commit 2390ce5169f36c2d87b2af408973dc3c9f50c687. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

