### PR TITLE
fix(cli): show positional arguments in piece help

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -394,7 +394,7 @@ export const piece = new Command()
   .action(searchPiecesFromCommand)
   /* piece new */
   .command("new", "Create a new piece with a pattern.")
-  .usage(spaceUsage)
+  .usage(`${spaceUsage} <main>`)
   .example(
     cliText(`cf piece new ${EX_ID} ${EX_COMP} ./main.tsx`),
     `Create a new piece, using ./main.tsx as source.`,
@@ -452,7 +452,7 @@ export const piece = new Command()
     "set-slug",
     "Set a slug redirect to a piece or cell link.",
   )
-  .usage(spaceUsage)
+  .usage(`${spaceUsage} <slug> <source>`)
   .example(
     cliText(`cf piece set-slug ${EX_ID} ${EX_COMP} project-notes fid1:piece1`),
     `Set slug "project-notes" to piece "fid1:piece1".`,
@@ -516,7 +516,7 @@ export const piece = new Command()
   )
   /* piece getsrc */
   .command("getsrc", "Retrieve the pattern source for the given piece.")
-  .usage(pieceUsage)
+  .usage(`${pieceUsage} <outpath>`)
   .example(
     cliText(`cf piece getsrc ${EX_ID} ${EX_COMP_PIECE} ./out`),
     `Retrieve the source for "${RAW_EX_COMP.piece!}" and place in ./out`,
@@ -532,7 +532,7 @@ export const piece = new Command()
   )
   /* piece setsrc */
   .command("setsrc", "Update the pattern source for the given piece.")
-  .usage(pieceUsage)
+  .usage(`${pieceUsage} <main>`)
   .example(
     cliText(`cf piece setsrc ${EX_ID} ${EX_COMP_PIECE} ./main.tsx`),
     `Update the source for "${RAW_EX_COMP.piece!}" with ./main.tsx`,
@@ -773,7 +773,7 @@ Source Origin: ${pieceData.patternRef?.source.origin ?? "<unknown>"}
 WELL-KNOWN IDS: System-level data (like allPieces) can be linked using
 well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
   )
-  .usage(spaceUsage)
+  .usage(`${spaceUsage} <source> <target>`)
   .example(
     cliText(
       `cf piece link ${EX_ID} ${EX_COMP} fid1:piece1/outputEmails fid1:piece2/emails`,
@@ -895,7 +895,7 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
 PATH FORMAT: Use forward slashes and numeric indices for arrays.
   ✓ items/0/name    ✓ config/db/host    ✗ items[0].name`,
   )
-  .usage(pieceUsage)
+  .usage(`${pieceUsage} [path]`)
   .example(
     cliText(`cf piece get ${EX_ID} ${EX_COMP_PIECE} name`),
     `Get the "name" field from piece result "${RAW_EX_COMP.piece!}".`,
@@ -961,7 +961,7 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
 
 JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
   )
-  .usage(pieceUsage)
+  .usage(`${pieceUsage} <path>`)
   .example(
     cliText(`echo '"New Name"' | cf piece set ${EX_ID} ${EX_COMP_PIECE} name`),
     `Set the "name" field in piece result "${RAW_EX_COMP.piece!}".`,
@@ -1014,8 +1014,15 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
     render(map);
   })
   /* piece call */
-  .command("call", "Invoke a callable within a piece")
-  .usage(pieceUsage)
+  .command(
+    "call",
+    `Invoke a callable within a piece.
+
+INPUT: Pass one inline JSON value, or put "--" before flags generated from the
+callable's input schema. Handlers interpret piped input using their input
+schema. Tools read piped JSON when called with "-- --json".`,
+  )
+  .usage(`${pieceUsage} <callable> [input]`)
   .example(
     cliText(`cf piece call ${EX_ID} ${EX_COMP_PIECE} increment`),
     `Call the "increment" handler on piece "${RAW_EX_COMP.piece!}".`,

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1018,9 +1018,10 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
     "call",
     `Invoke a callable within a piece.
 
-INPUT: Pass one inline JSON value, or put "--" before flags generated from the
-callable's input schema. Handlers interpret piped input using their input
-schema. Tools read piped JSON when called with "-- --json".`,
+INPUT: Pass one inline JSON value, pass "-" to read JSON from stdin, or put
+"--" before flags generated from the callable's input schema. Handlers also
+interpret piped input when no input argument is present. For tools, use "-" or
+"-- --json" to read piped JSON.`,
   )
   .usage(`${pieceUsage} <callable> [input]`)
   .example(

--- a/packages/cli/test/main-command.test.ts
+++ b/packages/cli/test/main-command.test.ts
@@ -3,7 +3,7 @@ import { expect } from "@std/expect";
 import { join } from "@std/path";
 import { exec } from "../commands/exec.ts";
 import { test as testCommand } from "../commands/test-command.ts";
-import { withEnv } from "./utils.ts";
+import { cf, checkStderr, stripAnsi, withEnv } from "./utils.ts";
 
 class ExitError extends Error {
   constructor(readonly code: number) {
@@ -49,6 +49,120 @@ async function withCapturedErrors(
 }
 
 describe("main command", () => {
+  it("keeps command usage aligned with accepted positional syntax", async () => {
+    const { main } = await import(
+      "../commands/main.ts?main-command-usage-test"
+    );
+    const commands = [main];
+    const mismatchedUsage: string[] = [];
+    const customUsageCommands = new Set(["cf piece call"]);
+
+    for (const command of commands) {
+      commands.push(...command.getCommands());
+      if (customUsageCommands.has(command.getPath())) continue;
+
+      const typedArguments = command.getArgsDefinition();
+      if (!typedArguments) continue;
+
+      const untypedArguments = typedArguments.replaceAll(/:[^>\]]+/g, "");
+      const usage = command.getUsage();
+      const expectedArguments = [typedArguments, untypedArguments];
+      const matches = expectedArguments.some((expected) =>
+        usage.endsWith(expected)
+      );
+      if (!matches) {
+        mismatchedUsage.push(
+          `${command.getPath()}: expected usage to end with ${
+            expectedArguments.join(" or ")
+          }, got ${usage}`,
+        );
+      }
+    }
+
+    expect(mismatchedUsage).toEqual([]);
+  });
+
+  it("describes and parses piece call's accepted input forms", async () => {
+    const { piece } = await import(
+      "../commands/piece.ts?piece-call-usage-test"
+    );
+    const call = piece.getCommand("call")!;
+    const expectedUsage =
+      "--identity <identity> --url <url> --api-url <api-url> --space <space> --piece <piece> <callable> [input]";
+
+    expect(call.getArgsDefinition()).toBe(
+      "<callable:string> [tail...:string]",
+    );
+    expect(call.getUsage()).toBe(expectedUsage);
+    const { code, stdout, stderr } = await cf("piece call --help");
+    checkStderr(stderr);
+    const help = stripAnsi(stdout.join("\n"));
+    const renderedUsage = help.split("\n").find((line) =>
+      line.trimStart().startsWith("Usage:")
+    );
+    expect(renderedUsage?.replaceAll(/\s+/g, " ").trim()).toBe(
+      `Usage: cf piece call ${expectedUsage}`,
+    );
+    const normalizedHelp = help.replaceAll(/\s+/g, " ");
+    expect(normalizedHelp).toContain(
+      `INPUT: Pass one inline JSON value, or put "--" before flags generated from the callable's input schema. Handlers interpret piped input using their input schema. Tools read piped JSON when called with "-- --json".`,
+    );
+    expect(code).toBe(0);
+
+    const parsedCalls: Array<{
+      positionals: unknown[];
+      literalArguments: string[];
+    }> = [];
+    call.action(function (_options, ...positionals) {
+      parsedCalls.push({
+        positionals,
+        literalArguments: this.getLiteralArgs(),
+      });
+    });
+    await piece.parse(["call", "search", '{"query":"tea"}']);
+    await piece.parse(["call", "search", "--help"]);
+    await piece.parse(["call", "search", "--", "--json"]);
+    expect(parsedCalls).toEqual([
+      {
+        positionals: ["search", '{"query":"tea"}'],
+        literalArguments: [],
+      },
+      { positionals: ["search", "--help"], literalArguments: [] },
+      { positionals: ["search"], literalArguments: ["--json"] },
+    ]);
+  });
+
+  it("rejects multiple inline inputs to piece call", async () => {
+    const { main } = await import(
+      "../commands/main.ts?piece-call-inline-validation-test"
+    );
+    const errors = await withCapturedErrors(async () => {
+      const code = await withMockExit(async () => {
+        await main.parse([
+          "piece",
+          "--identity",
+          "./identity.key",
+          "--api-url",
+          "https://cf.dev",
+          "--space",
+          "common-knowledge",
+          "call",
+          "--piece",
+          "abcdefghijklmnopqrstuvwxyz",
+          "search",
+          '{"query":"tea"}',
+          '{"limit":5}',
+        ]);
+      });
+
+      expect(code).toBe(1);
+    });
+
+    expect(errors).toEqual([
+      'Use a single inline JSON argument or "--" before schema-derived flags.',
+    ]);
+  });
+
   it("registers view and reports configured environment defaults", async () => {
     await withEnv("CF_IDENTITY", "./identity.key", async () => {
       await withEnv("CF_API_URL", "http://127.0.0.1:8000", async () => {

--- a/packages/cli/test/main-command.test.ts
+++ b/packages/cli/test/main-command.test.ts
@@ -105,7 +105,7 @@ describe("main command", () => {
     );
     const normalizedHelp = help.replaceAll(/\s+/g, " ");
     expect(normalizedHelp).toContain(
-      `INPUT: Pass one inline JSON value, or put "--" before flags generated from the callable's input schema. Handlers interpret piped input using their input schema. Tools read piped JSON when called with "-- --json".`,
+      `INPUT: Pass one inline JSON value, pass "-" to read JSON from stdin, or put "--" before flags generated from the callable's input schema. Handlers also interpret piped input when no input argument is present. For tools, use "-" or "-- --json" to read piped JSON.`,
     );
     expect(code).toBe(0);
 
@@ -121,6 +121,7 @@ describe("main command", () => {
     });
     await piece.parse(["call", "search", '{"query":"tea"}']);
     await piece.parse(["call", "search", "--help"]);
+    await piece.parse(["call", "search", "-"]);
     await piece.parse(["call", "search", "--", "--json"]);
     expect(parsedCalls).toEqual([
       {
@@ -128,6 +129,7 @@ describe("main command", () => {
         literalArguments: [],
       },
       { positionals: ["search", "--help"], literalArguments: [] },
+      { positionals: ["search", "-"], literalArguments: [] },
       { positionals: ["search"], literalArguments: ["--json"] },
     ]);
   });


### PR DESCRIPTION
Several piece commands override Cliffy's generated usage because identity, server, space, and piece values can come from options or environment variables. Cliffy treats that override as the complete synopsis, so declared positional operands disappeared from help. This hid the optional path accepted by piece get and affected seven other piece subcommands.

Append each command's positional operands to its overridden usage. Give piece call a concise callable-and-input synopsis, then explain its input forms accurately: handlers interpret bare piped input using their schema, while tools read piped JSON through -- --json.

Add a command-tree regression test that compares declared positional syntax with custom usage. Add focused assertions for piece call's complete rendered help and Cliffy routing of inline JSON, callable-specific help, and arguments after the literal separator.

Verified with the complete CLI test suite, repository-wide formatting and lint checks, and the repository type check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787337227&installation_model_id=428580&pr_number=4911&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4911&signature=39f5d0ad1fe3532eb8ae207d861da1dee83932440f715e031bb63dd9b1691bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CLI help to show positional arguments for `cf piece` commands and fully document `piece call` input, including inline JSON, `-`, `-- --json`, and implicit handler input. Restores accurate usage and locks it with tests.

- **Bug Fixes**
  - Append positional operands to overridden usage for `piece` subcommands: `new <main>`, `set-slug <slug> <source>`, `getsrc <outpath>`, `setsrc <main>`, `link <source> <target>`, `get [path]`, `set <path>`, `call <callable> [input]`.
  - Update `piece call` help: describe inline JSON, `-` for stdin, `--` before schema-derived flags, handler implicit input, and tool stdin via `-` or `-- --json`.
  - Add tests: enforce command-tree usage matches declared positionals; verify `piece call` help/usage and parsing (inline JSON, `-` as optional positional, `--` before schema-derived flags, literal args, implicit handler input, both tool stdin forms); reject multiple inline inputs with a clear error.

<sup>Written for commit 766790d530baf616a4ead109618cc21a3a0921ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

