### PR TITLE
fix(patterns): record — read smart-default labels from the entry, not…

### DIFF
--- a/packages/patterns/record.test.tsx
+++ b/packages/patterns/record.test.tsx
@@ -1,5 +1,6 @@
 /**
- * Test: adding a module reports the position the module actually occupies.
+ * Test: adding a module reports the position the module actually occupies and
+ * assigns the next unused standard label.
  *
  * handleAddModule reads the sub-piece list once and depends on that read twice:
  * getNextUnusedLabel derives the new module's label by scanning the existing
@@ -8,10 +9,14 @@
  * these tests drive successive adds and check each reported index against the
  * entry sitting at it.
  *
- * The label half is not asserted. An entry holds its module as a piece typed
- * `unknown`, which carries no schema, so the runner reads a module's label back
- * as undefined and a test cannot see which label the handler chose. Replacing
- * getNextUnusedLabel's body with `return undefined` still passes these tests.
+ * The label half is asserted through the entry's own `label` field. The chosen
+ * label is recorded on the SubPieceEntry at creation time; the label on the
+ * sub-piece itself is not readable, because SubPieceEntry.piece is typed
+ * `unknown`, whose schema the runner reads back as undefined. Successive adds of
+ * the same type walk the standard label list (email: Personal, Work, School,
+ * Other), a different type starts its own sequence, and an explicit label in
+ * initialData overrides the default. Replacing getNextUnusedLabel's body with
+ * `return undefined` now fails the label assertions.
  *
  * The list starts empty. The lift that seeds a notes module and a type picker
  * assigns its result to a variable nothing reads, and an unconsumed lift does
@@ -41,6 +46,7 @@ export default pattern(() => {
   // apart rather than reading whichever one wrote last.
   const firstEmail = new Writable<AddResult>();
   const secondEmail = new Writable<AddResult>();
+  const thirdEmail = new Writable<AddResult>();
   const phone = new Writable<AddResult>();
   const withInitialData = new Writable<AddResult>();
   const unknownType = new Writable<AddResult>();
@@ -52,6 +58,9 @@ export default pattern(() => {
   });
   const action_add_second_email = action(() => {
     subject.addModule!.send({ type: "email", result: secondEmail });
+  });
+  const action_add_third_email = action(() => {
+    subject.addModule!.send({ type: "email", result: thirdEmail });
   });
   const action_add_phone = action(() => {
     subject.addModule!.send({ type: "phone", result: phone });
@@ -137,6 +146,33 @@ export default pattern(() => {
     );
   });
 
+  // The smart-default label walks the standard list as successive modules of
+  // the same type are added; a different type starts its own sequence; an
+  // explicit label in initialData overrides the default.
+  const assert_first_email_label_personal = computed(() =>
+    [...(subject.subPieces ?? [])][0]?.label === "Personal"
+  );
+  const assert_second_email_label_work = computed(() =>
+    [...(subject.subPieces ?? [])][1]?.label === "Work"
+  );
+  const assert_phone_label_mobile = computed(() =>
+    [...(subject.subPieces ?? [])][2]?.label === "Mobile"
+  );
+  const assert_address_label_override = computed(() =>
+    [...(subject.subPieces ?? [])][3]?.label === "Chosen"
+  );
+
+  // A third email add reads two prior emails (Personal, Work) and picks the
+  // next unused standard label. This fails if getNextUnusedLabel cannot see the
+  // labels the earlier adds assigned.
+  const assert_third_email_appended = computed(() => {
+    const current = [...(subject.subPieces ?? [])];
+    return current.length === 5 && current[4].type === "email";
+  });
+  const assert_third_email_label_school = computed(() =>
+    [...(subject.subPieces ?? [])][4]?.label === "School"
+  );
+
   // The rejection paths report the reason and leave the list alone.
   const assert_unknown_type_rejected = computed(() => {
     const result = unknownType.get();
@@ -181,6 +217,11 @@ export default pattern(() => {
       { assertion: assert_entries_in_add_order },
       { assertion: assert_reported_indices_address_their_modules },
 
+      { assertion: assert_first_email_label_personal },
+      { assertion: assert_second_email_label_work },
+      { assertion: assert_phone_label_mobile },
+      { assertion: assert_address_label_override },
+
       { action: action_add_unknown },
       { assertion: assert_unknown_type_rejected },
       { action: action_add_missing_type },
@@ -188,6 +229,10 @@ export default pattern(() => {
       { action: action_add_notes },
       { assertion: assert_notes_type_rejected },
       { assertion: assert_rejections_appended_nothing },
+
+      { action: action_add_third_email },
+      { assertion: assert_third_email_appended },
+      { assertion: assert_third_email_label_school },
     ],
     subject,
   };

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -31,6 +31,7 @@ import {
   getAddableTypes,
   getDefinition,
 } from "./record/registry.ts";
+import { getNextUnusedLabel } from "./record/standard-labels.ts";
 // Import Note directly - we create it inline with proper linkPattern
 // (avoids global state for passing Record's pattern JSON)
 import Note from "./notes/note.tsx";
@@ -39,38 +40,6 @@ import { TypePickerModule } from "./type-picker.tsx";
 import { ExtractorModule } from "./record/extraction/extractor-module.tsx";
 import { getResultSchema } from "./record/extraction/schema-utils.ts";
 import type { SubPieceEntry, TrashedSubPieceEntry } from "./record/types.ts";
-
-// ===== Standard Labels for Smart Defaults =====
-// When adding a second module of same type, pick next unused standard label
-const STANDARD_LABELS: Record<string, string[]> = {
-  email: ["Personal", "Work", "School", "Other"],
-  phone: ["Mobile", "Home", "Work", "Other"],
-  address: ["Home", "Work", "Billing", "Shipping", "Other"],
-};
-
-// Helper to get next unused standard label for a module type
-function getNextUnusedLabel(
-  type: string,
-  existingPieces: readonly SubPieceEntry[],
-): string | undefined {
-  const standards = STANDARD_LABELS[type];
-  if (!standards || standards.length === 0) return undefined;
-
-  // Collect labels already assigned to modules of this type. The label is read
-  // from the entry, which records the label chosen when the module was created.
-  // The label on the sub-piece itself is not readable here: SubPieceEntry.piece
-  // is typed `unknown`, whose schema (`{ type: "unknown" }`) the runner reads
-  // back as undefined rather than materializing.
-  const usedLabels = new Set<string>();
-  for (const entry of existingPieces) {
-    if (entry.type === type && typeof entry.label === "string" && entry.label) {
-      usedLabels.add(entry.label);
-    }
-  }
-
-  // Return first unused standard label (or undefined if all used)
-  return standards.find((label) => !usedLabels.has(label));
-}
 
 // ===== Types =====
 

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -56,22 +56,15 @@ function getNextUnusedLabel(
   const standards = STANDARD_LABELS[type];
   if (!standards || standards.length === 0) return undefined;
 
-  // Collect labels already used by modules of this type
+  // Collect labels already assigned to modules of this type. The label is read
+  // from the entry, which records the label chosen when the module was created.
+  // The label on the sub-piece itself is not readable here: SubPieceEntry.piece
+  // is typed `unknown`, whose schema (`{ type: "unknown" }`) the runner reads
+  // back as undefined rather than materializing.
   const usedLabels = new Set<string>();
   for (const entry of existingPieces) {
-    if (entry.type === type) {
-      try {
-        // Access the label field from the piece pattern output
-        // Property access is reactive - framework handles Cell unwrapping
-        // deno-lint-ignore no-explicit-any
-        const piece = entry.piece as any;
-        const labelValue = piece?.label;
-        if (typeof labelValue === "string" && labelValue) {
-          usedLabels.add(labelValue);
-        }
-      } catch {
-        // Ignore errors from pieces without label field
-      }
+    if (entry.type === type && typeof entry.label === "string" && entry.label) {
+      usedLabels.add(entry.label);
     }
   }
 
@@ -302,6 +295,7 @@ const addSubPiece = handler<
     collapsed: false,
     piece,
     schema,
+    label: nextLabel,
   }]);
   sat.set("");
 });
@@ -603,12 +597,17 @@ const handleAddModule = handler<
 
   const current = sc.get() || [];
 
-  // Get smart default label for modules that support it
+  // Get smart default label for modules that support it. initialData may carry
+  // an explicit label that overrides the smart default; record the effective
+  // label on the entry so the next add can see it.
   const nextLabel = getNextUnusedLabel(type, current);
   const initialValues = {
     ...(nextLabel ? { label: nextLabel } : {}),
     ...initialData,
   };
+  const entryLabel = typeof initialValues.label === "string"
+    ? initialValues.label
+    : undefined;
 
   // Create the module - special cases handled
   let piece: unknown;
@@ -641,6 +640,7 @@ const handleAddModule = handler<
     collapsed: false,
     piece,
     schema,
+    label: entryLabel,
   }]);
 
   if (result) {
@@ -816,6 +816,7 @@ const createSibling = handler<
     pinned: false,
     collapsed: false,
     piece,
+    label: nextLabel,
   });
   sc.set(updated);
 });

--- a/packages/patterns/record/standard-labels.test.ts
+++ b/packages/patterns/record/standard-labels.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for getNextUnusedLabel / STANDARD_LABELS.
+ * Plain Deno.test — NOT a pattern. These exercise the pure label-selection
+ * logic that record.tsx and template-registry.ts share.
+ */
+import { assertEquals } from "@std/assert";
+import { getNextUnusedLabel, STANDARD_LABELS } from "./standard-labels.ts";
+import type { SubPieceEntry } from "./types.ts";
+
+// Build a minimal entry. The label logic only reads `type` and `label`; `piece`
+// is required by the type but never inspected here.
+function entry(type: string, label?: string): SubPieceEntry {
+  return { type, pinned: false, piece: null, ...(label ? { label } : {}) };
+}
+
+Deno.test("empty list yields the first standard label", () => {
+  assertEquals(getNextUnusedLabel("email", []), "Personal");
+  assertEquals(getNextUnusedLabel("phone", []), "Mobile");
+  assertEquals(getNextUnusedLabel("address", []), "Home");
+});
+
+Deno.test("skips labels already taken by same-type entries", () => {
+  const entries = [entry("email", "Personal")];
+  assertEquals(getNextUnusedLabel("email", entries), "Work");
+});
+
+Deno.test("walks the whole list as more labels are taken", () => {
+  const entries = [
+    entry("email", "Personal"),
+    entry("email", "Work"),
+  ];
+  assertEquals(getNextUnusedLabel("email", entries), "School");
+});
+
+Deno.test("returns undefined once every standard label is used", () => {
+  const entries = STANDARD_LABELS.email.map((label) => entry("email", label));
+  assertEquals(getNextUnusedLabel("email", entries), undefined);
+});
+
+Deno.test("a different type starts its own sequence", () => {
+  // Two emails are present, but a phone is unaffected by them.
+  const entries = [entry("email", "Personal"), entry("email", "Work")];
+  assertEquals(getNextUnusedLabel("phone", entries), "Mobile");
+});
+
+Deno.test("entries of other types do not consume labels", () => {
+  // A phone labelled "Work" must not make the email skip "Work".
+  const entries = [entry("phone", "Work")];
+  assertEquals(getNextUnusedLabel("email", entries), "Personal");
+});
+
+Deno.test("entries without a usable label are ignored", () => {
+  const entries = [
+    entry("email"), // no label field
+    entry("email", ""), // empty-string label
+  ];
+  assertEquals(getNextUnusedLabel("email", entries), "Personal");
+});
+
+Deno.test("a used label out of order is still skipped", () => {
+  // "Work" taken but "Personal" free: the first free label wins, in list order.
+  const entries = [entry("email", "Work")];
+  assertEquals(getNextUnusedLabel("email", entries), "Personal");
+});
+
+Deno.test("types without standard labels return undefined", () => {
+  assertEquals(getNextUnusedLabel("notes", []), undefined);
+  assertEquals(getNextUnusedLabel("birthday", []), undefined);
+  assertEquals(getNextUnusedLabel("", []), undefined);
+});

--- a/packages/patterns/record/standard-labels.ts
+++ b/packages/patterns/record/standard-labels.ts
@@ -1,0 +1,44 @@
+// standard-labels.ts - Smart-default labels for multi-instance modules.
+//
+// When a second module of a label-bearing type (email, phone, address) is
+// added to a Record, the new module defaults to the next standard label not
+// already in use, so successive quick-adds get distinct labels instead of all
+// defaulting to the same one.
+//
+// This module only depends on the SubPieceEntry type, so it can be imported
+// and unit-tested without pulling in the Common Fabric runtime.
+
+import type { SubPieceEntry } from "./types.ts";
+
+// Standard labels offered for each label-bearing module type, in the order they
+// are handed out.
+export const STANDARD_LABELS: Record<string, string[]> = {
+  email: ["Personal", "Work", "School", "Other"],
+  phone: ["Mobile", "Home", "Work", "Other"],
+  address: ["Home", "Work", "Billing", "Shipping", "Other"],
+};
+
+// The first standard label for a type that no existing entry of that type has
+// already taken, or undefined when the type has no standard labels or all of
+// them are in use.
+//
+// The label is read from the entry, which records the label chosen when the
+// module was created. The label on the sub-piece itself is not readable here:
+// SubPieceEntry.piece is typed `unknown`, whose schema (`{ type: "unknown" }`)
+// the runner reads back as undefined rather than materializing.
+export function getNextUnusedLabel(
+  type: string,
+  existingPieces: readonly SubPieceEntry[],
+): string | undefined {
+  const standards = STANDARD_LABELS[type];
+  if (!standards || standards.length === 0) return undefined;
+
+  const usedLabels = new Set<string>();
+  for (const entry of existingPieces) {
+    if (entry.type === type && typeof entry.label === "string" && entry.label) {
+      usedLabels.add(entry.label);
+    }
+  }
+
+  return standards.find((label) => !usedLabels.has(label));
+}

--- a/packages/patterns/record/template-registry.ts
+++ b/packages/patterns/record/template-registry.ts
@@ -2,6 +2,7 @@
 // Defines common record types and their associated modules
 
 import { createSubPiece } from "./registry.ts";
+import { getNextUnusedLabel } from "./standard-labels.ts";
 import type { SubPieceEntry } from "./types.ts";
 
 // ===== Template Types =====
@@ -178,6 +179,12 @@ export function createTemplateModules(
 
   for (const moduleType of template.modules) {
     try {
+      // Smart-default label for label-bearing types (email/phone/address), so a
+      // later add of the same type sees this entry's label and picks the next
+      // unused one instead of duplicating it. Recorded on the entry and passed
+      // to the module so its visible label matches.
+      const label = getNextUnusedLabel(moduleType, entries);
+
       // Special case: use factory for notes if provided
       // Notes needs linkPattern which requires Record's pattern JSON
       let piece: unknown;
@@ -185,12 +192,13 @@ export function createTemplateModules(
         if (!notesPiece) continue;
         piece = notesPiece;
       } else {
-        piece = createSubPiece(moduleType);
+        piece = createSubPiece(moduleType, label ? { label } : undefined);
       }
       entries.push({
         type: moduleType,
         pinned: template.defaultPinned.includes(moduleType),
         piece,
+        label,
       });
     } catch (error) {
       console.warn(

--- a/packages/patterns/record/types.ts
+++ b/packages/patterns/record/types.ts
@@ -33,6 +33,7 @@ export interface SubPieceEntry {
   piece: unknown; // Reference to the actual sub-piece pattern instance
   schema?: JSONSchema; // Schema captured at creation time for dynamic discovery
   note?: string; // User annotation about this module (visible to LLM reads, not extraction)
+  label?: string; // Standard label chosen for this module at creation (e.g. email "Personal"/"Work"), used to pick the next unused default
 }
 
 /**

--- a/packages/patterns/type-picker.test.tsx
+++ b/packages/patterns/type-picker.test.tsx
@@ -1,11 +1,14 @@
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, UI, Writable } from "commonfabric";
 import TypePickerModule from "./type-picker.tsx";
 import type { SubPieceEntry, TrashedSubPieceEntry } from "./record/types.ts";
+import { findElementByText, propsOf } from "./test/vnode-helpers.ts";
+import { getNextUnusedLabel } from "./record/standard-labels.ts";
 
 // The picker renders the template list and passes its dismissed state through.
-// Its apply/dismiss handlers are bound to buttons in the UI rather than exposed
-// as result streams, so a headless test drives the state cell rather than those
-// clicks.
+// Its dismiss handler is bound to a button in the UI rather than exposed as a
+// result stream, so a headless test drives the state cell for that. Its apply
+// handler is reached the other way: walk the rendered tree to the template
+// button and send the stream on its onClick, the same event a click delivers.
 export default pattern(() => {
   const entries = new Writable<SubPieceEntry[]>([
     { type: "notes", pinned: false, piece: null },
@@ -27,11 +30,40 @@ export default pattern(() => {
     picker.dismissed === true
   );
 
+  // Apply the Person template by sending the stream bound to its button.
+  const action_apply_person = action(() => {
+    const button = findElementByText(picker[UI], "button", "Person");
+    const onClick = propsOf(button)?.onClick;
+    if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+      (onClick as { send: (event: Record<string, never>) => void }).send({});
+    }
+  });
+
+  // The Person template creates an email and a phone. Each is recorded on its
+  // entry with its standard default label, so a later add of the same type can
+  // see it. Without that, the added module would default to the same label.
+  const assert_template_email_label = computed(() =>
+    (entries.get() ?? []).find((e) => e.type === "email")?.label === "Personal"
+  );
+  const assert_template_phone_label = computed(() =>
+    (entries.get() ?? []).find((e) => e.type === "phone")?.label === "Mobile"
+  );
+
+  // The consequence the recorded label buys: the next email add reads the
+  // template's email label and picks the next unused one rather than "Personal".
+  const assert_next_email_label_is_work = computed(() =>
+    getNextUnusedLabel("email", entries.get() ?? []) === "Work"
+  );
+
   return {
     tests: [
       { assertion: assert_starts_undismissed },
       { action: action_dismiss },
       { assertion: assert_dismissed_follows_the_cell },
+      { action: action_apply_person },
+      { assertion: assert_template_email_label },
+      { assertion: assert_template_phone_label },
+      { assertion: assert_next_email_label_is_work },
     ],
     picker,
   };

--- a/packages/patterns/type-picker.tsx
+++ b/packages/patterns/type-picker.tsx
@@ -22,6 +22,7 @@ import {
   NAME,
   pattern,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 import type { ModuleMetadata } from "./container-protocol.ts";
@@ -56,6 +57,7 @@ interface TypePickerInput {
 
 export interface TypePickerOutput {
   dismissed?: boolean | Default<false>;
+  [UI]: VNode;
 }
 
 // ===== Handlers =====


### PR DESCRIPTION
… the unreadable piece

When a second module of a label-bearing type (email, phone, address) is added to a Record, getNextUnusedLabel is meant to pick the next unused standard label so the new module does not default to the same label as an existing one — the second email should default to "Work" after the first took "Personal", and so on.

That never happened. getNextUnusedLabel collected the labels already in use by reading entry.piece.label for each existing entry of the same type. SubPieceEntry.piece is typed `unknown`, which lowers to the schema `{ type: "unknown" }`; the runner reads such a field back as undefined rather than materializing it (see the short-circuit in the runner's schema traversal and the transformer's reactive-capture:unknown-type diagnostic). So every entry.piece.label read as undefined, the used-label set was always empty, and the function always returned the first standard label. Every email defaulted to "Personal", every phone to "Mobile", every address to "Home". The read-modify-write introduced earlier to stop two concurrent adds from choosing the same label was inert, because the labels were never readable to begin with.

Record the chosen label on the SubPieceEntry itself, in a new optional `label` field with a real string schema that materializes, and have getNextUnusedLabel read entry.label instead of entry.piece.label. The label is written at all three creation sites: the "+ Add" dropdown handler, the LLM-callable add handler (which records the effective label, since caller-supplied initialData may override the smart default), and the per-module "add another" button. Restoring a module from trash keeps the label, since it rides the entry through the trash round-trip.

This mirrors the label at creation time. A later manual relabel of a module through its own UI updates the sub-piece's own label but not the entry's copy, so a subsequent add can still pick a label that collides with the renamed one. Reading the live label is not possible while piece is typed `unknown`; the mirror gives correct distinct defaults for the common case of successive quick-adds, which is what the feature is for.

The test now pins the label sequence across successive same-type adds: email adds walk Personal, Work, School; a phone starts its own sequence at Mobile; and an explicit label in initialData overrides the default. Stubbing getNextUnusedLabel to return undefined fails exactly these label assertions, so they guard the behavior rather than an incidental.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787338136&installation_model_id=428580&pr_number=4912&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4912&signature=fd381b7a4cb0c474dfda4176f16ac4d252a1f3c451e133987b07a5ef96673c8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes smart-default labels for Record modules by recording the chosen label on each entry and reading it when selecting the next one. Applies to adds and templates so subsequent modules pick the next unused standard label (emails: Personal → Work → School), while explicit overrides still work.

- **Bug Fixes**
  - Added `label?: string` to `SubPieceEntry` and switched reads to `entry.label`; removed reliance on unreadable `piece.label`.
  - Write the effective label at all creation points: "+ Add", LLM add handler, "add another", and template creation; pass it to the module so the visible label matches; label survives trash restore.
  - Respect `initialData.label` to override the smart default.

- **Refactors**
  - Moved `getNextUnusedLabel` and `STANDARD_LABELS` to `record/standard-labels.ts`; used by `record.tsx` and `template-registry.ts`.
  - Added `record/standard-labels.test.ts`; extended `record.test.tsx` and `type-picker.test.tsx` to cover label sequences and templates; `TypePickerOutput` now exposes `[UI]` to drive apply in tests.

<sup>Written for commit 5c419d11539114e26adc70f8aa9d18247a46d0af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

