### PR TITLE
refactor(patterns): drop the redundant scrollIntoView from the cfc cl…

### DIFF
--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -155,11 +155,6 @@ const fillAndVerify = async (
     return false;
   }
 
-  phase("scrolling");
-  input.scrollIntoView({ block: "center", inline: "center" });
-  await new Promise((resolve) =>
-    requestAnimationFrame(() => requestAnimationFrame(resolve))
-  );
   // Rendered, not on-screen: the fill drives the field through focus and
   // dispatched events rather than a coordinate click, so its viewport position
   // never bears on whether the value takes.
@@ -211,27 +206,23 @@ const fillAndVerify = async (
   return verified;
 };
 
-// Scroll the cf-button behind `selector` into view and tag its inner click
-// target so the test can resolve and click exactly that element. A click target
-// that is still detached, or not rendered — laid out, and not display:none or
+// Tag the inner click target of the cf-button behind `selector` so the test can
+// resolve and click exactly that element. A click target that is still
+// detached, or not rendered — laid out, and not display:none or
 // visibility:hidden — is left untagged, so a re-check on the next DOM mutation
 // retries the mark once the control renders. The check is viewport-independent:
 // the click scrolls the element into view itself, so a control below the fold
 // is markable. It reads the click target alone because hiding the host or any
 // ancestor reaches the inner button either way: display:none zeroes its box,
 // and visibility:hidden inherits into its computed visibility.
-const markForClick = async (
+const markForClick = (
   probe: ProbeApi,
   selector: string,
   token: string,
   attr: string,
-): Promise<boolean> => {
+): boolean => {
   const target = probe.collect(selector)[0] as HTMLElement | undefined;
   if (!target) return false;
-  target.scrollIntoView({ block: "center", inline: "center" });
-  await new Promise((resolve) =>
-    requestAnimationFrame(() => requestAnimationFrame(resolve))
-  );
   const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
     | HTMLElement
     | null) ?? target;
@@ -240,26 +231,21 @@ const markForClick = async (
   return true;
 };
 
-// Scroll the `index`-th element matching `selector` into view and tag it once it
-// is rendered. Unlike `markForClick`, the selector here already resolves to the
-// clickable elements, so the match is tagged directly rather than reached
-// through a host's shadow root. The check is viewport-independent for the same
-// reason as `markForClick`: the click scrolls the element into view itself, so
-// requiring it on-screen at tagging time only invites a wait that never
-// satisfies.
-const markNthForClick = async (
+// Tag the `index`-th element matching `selector` once it is rendered. Unlike
+// `markForClick`, the selector here already resolves to the clickable elements,
+// so the match is tagged directly rather than reached through a host's shadow
+// root. The check is viewport-independent for the same reason as `markForClick`:
+// the click scrolls the element into view itself, so requiring it on-screen at
+// tagging time only invites a wait that never satisfies.
+const markNthForClick = (
   probe: ProbeApi,
   selector: string,
   index: number,
   token: string,
   attr: string,
-): Promise<boolean> => {
+): boolean => {
   const target = probe.collect(selector)[index] as HTMLElement | undefined;
   if (!target) return false;
-  target.scrollIntoView({ block: "center", inline: "center" });
-  await new Promise((resolve) =>
-    requestAnimationFrame(() => requestAnimationFrame(resolve))
-  );
   if (!target.isConnected || !probe.isRendered(target)) return false;
   target.setAttribute(attr, token);
   return true;
@@ -273,22 +259,18 @@ const markNthForClick = async (
 // on-screen requirement, since the trusted click scrolls the target into view
 // before dispatching. Disabled-ness is asked of both, because a host can carry
 // an `aria-disabled` its inner control does not.
-const markTrustedAction = async (
+const markTrustedAction = (
   probe: ProbeApi,
   action: string,
   token: string,
   attr: string,
-): Promise<boolean> => {
+): boolean => {
   const isDisabled = (element: HTMLElement): boolean =>
     element.hasAttribute("disabled") ||
     element.getAttribute("aria-disabled") === "true";
 
   for (const element of probe.collect(`[data-ui-action="${action}"]`)) {
     const target = element as HTMLElement;
-    target.scrollIntoView({ block: "center", inline: "center" });
-    await new Promise((resolve) =>
-      requestAnimationFrame(() => requestAnimationFrame(resolve))
-    );
     const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
       | HTMLElement
       | null) ?? target;


### PR DESCRIPTION
…ick/fill predicates

The four in-page waitForCondition predicates in cfc-browser-helpers.ts that tag a control for a later trusted click or drive a fill — markForClick, markNthForClick, markTrustedAction, and fillAndVerify — each began by scrolling the element into view and awaiting two animation frames before checking whether the control was ready.

That scroll was load-bearing when these predicates gated on isVisible, which requires the element to sit inside the viewport: the predicate scrolled the element on-screen so the visibility check would pass. They now gate on isRendered, which is viewport-independent — it asks only for a non-empty layout box that is not display:none or visibility:hidden, not for an on-screen position. The action that follows scrolls the element into view on its own: astral's ElementHandle.click() runs DOM.scrollIntoViewIfNeeded before computing click coordinates, and fillAndVerify drives its field through focus and dispatched events with no coordinate click at all. The predicate's own scroll no longer affects whether the gate passes or whether the action lands.

It was also worse than inert. waitForCondition re-runs a predicate on every DOM mutation, and the shell sets html { scroll-behavior: smooth }, so on a churning page each re-entry re-issued a smooth scroll and restarted the animation — wasted work that never changed the outcome.

Remove the scrollIntoView and the two-frame settle from all four predicates. The isRendered check reads fresh layout itself (getBoundingClientRect forces a synchronous layout), so nothing downstream needs the frame wait. With their only await gone, markForClick, markNthForClick, and markTrustedAction become plain synchronous predicates; fillAndVerify keeps its real awaits (the host commit() round-trip and the post-commit re-render read-back) and stays async.

The separate presentation-mode fill path (typeIntoCfInput / cfInputIsFillable) is untouched: it moves a real cursor to box coordinates and legitimately needs the field on-screen.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787338265&installation_model_id=428580&pr_number=4913&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4913&signature=8f88969a33736d2126e8893f18b596c492fba7287838fb3ff1803a6c2ef400ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant scrolling and animation-frame waits from the cfc click/fill predicates, which now gate on `isRendered`. This avoids smooth-scroll thrash on DOM churn and simplifies the predicates; clicks handle their own scrolling.

- **Refactors**
  - Removed `scrollIntoView` and two-frame settle from `markForClick`, `markNthForClick`, `markTrustedAction`, and `fillAndVerify`.
  - Made `markForClick`, `markNthForClick`, and `markTrustedAction` synchronous; `fillAndVerify` remains async and drives focus/events without coordinate clicks.

<sup>Written for commit ab38e7fab917c0870a036e7cfadf52f09f99f896. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

