### PR TITLE
fix(toolshed): describe the JSON LLM response as the bare message

### DIFF
--- a/packages/toolshed/lib/configure-open-api.test.ts
+++ b/packages/toolshed/lib/configure-open-api.test.ts
@@ -89,6 +89,31 @@ Deno.test("openapi reference", async (t) => {
     );
   });
 
+  // The non-streaming branch answers with the reply message written straight to
+  // the response body, which the handler produces with `c.json(result.message)`:
+  // an object carrying a `role` and its `content`. The document describes that
+  // message, not a `{type, body}` envelope wrapped around it.
+  await t.step("the JSON LLM response is the bare message", async () => {
+    const doc = await (await app.request("/doc")).json();
+    const schema = doc.paths["/api/ai/llm"].post.responses["200"]
+      .content["application/json"].schema;
+
+    assertEquals(schema.type, "object");
+    assertEquals([...schema.required].sort(), ["content", "role"]);
+    assert(
+      schema.properties.role.enum.includes("assistant"),
+      `the message role is undescribed: ${
+        JSON.stringify(schema.properties.role)
+      }`,
+    );
+    assert(
+      !("type" in schema.properties) && !("body" in schema.properties),
+      `the response carries an envelope: ${
+        JSON.stringify(Object.keys(schema.properties))
+      }`,
+    );
+  });
+
   // Scalar renders the configuration it is handed into the page without
   // validating it, serializing an unknown key as readily as a known one. The
   // document URL is read back out of the page and fetched, so the two routes

--- a/packages/toolshed/routes/ai/llm/llm.routes.ts
+++ b/packages/toolshed/routes/ai/llm/llm.routes.ts
@@ -136,18 +136,17 @@ const StreamResponse = z.string().openapi({
     'complete response, and "error" reports a failure mid-stream.',
 });
 
-const JsonResponse = z.object({
-  type: z.literal("json"),
-  body: MessageSchema.openapi({
-    example: {
-      role: "assistant",
-      content:
-        "Arr! That be a mighty fine tongue-twister ye got there, matey! *adjusts eye patch*\n\nAs any seasoned sea dog would tell ye, a woodchuck (if the scurvy beast could chuck wood) would chuck as much wood as a woodchuck could chuck if a woodchuck could chuck wood! \n\nBut between you and me, shipmate, we pirates care more about how much booty we can plunder than how much wood them landlubbing woodchucks can chuck! Yarr har har! 🏴‍☠️",
-    },
-  }),
+// The non-streaming branch of this route answers with the model's reply message
+// written straight to the response body, with no envelope around it. The message
+// carries a `role` and its `content`, and the client parses those fields
+// directly from the body.
+const JsonResponse = MessageSchema.openapi({
+  example: {
+    role: "assistant",
+    content:
+      "Arr! That be a mighty fine tongue-twister ye got there, matey! *adjusts eye patch*\n\nAs any seasoned sea dog would tell ye, a woodchuck (if the scurvy beast could chuck wood) would chuck as much wood as a woodchuck could chuck if a woodchuck could chuck wood! \n\nBut between you and me, shipmate, we pirates care more about how much booty we can plunder than how much wood them landlubbing woodchucks can chuck! Yarr har har! 🏴‍☠️",
+  },
 });
-
-export type LLMJSONResponse = z.infer<typeof JsonResponse>;
 
 const GetModelsRouteQueryParams = z.object({
   search: z.string().optional(),


### PR DESCRIPTION
The 200 `application/json` response of `POST /api/ai/llm` was documented as an object `{type: "json", body: <message>}`. The handler sends no such envelope: a non-streaming request is answered with `c.json(result.message)`, and the cached branch with `c.json(lastMessage)`, so the response body is the reply message itself, a `role` and its `content`. The client reads those fields straight off the parsed body. The published OpenAPI document therefore told consumers to expect a `type`/`body` wrapper they never receive.

This is the same fiction the sibling `StreamResponse` carried and shed when the streamed branch started breaking `/doc` generation under the zod 4 converter; `JsonResponse` still serialized, so it was left untouched at the time. Correct it the same way: make the schema `MessageSchema` with the existing example attached, so the document describes the object the handler actually returns.

`export type LLMJSONResponse = z.infer<typeof JsonResponse>` had no users anywhere in the repository and only named the discarded envelope; remove it.

Extend the `/doc` regression test to pin the JSON branch alongside the streamed one. It asserts the documented 200 `application/json` schema is the message object: `type: "object"`, required `role` and `content`, a `role` enum that includes `assistant`, and no top-level `type` or `body` property. That fails against the old envelope and passes against the message.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787338477&installation_model_id=428580&pr_number=4914&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4914&signature=e0b97ba4eb632401baa324e8998b59ba97e507434677f95d5a4f8f3580991e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the OpenAPI schema for the JSON LLM response to describe the bare message object (`role`, `content`) instead of a `{type, body}` envelope. This aligns the `POST /api/ai/llm` `application/json` docs with the actual response and prevents client confusion.

- **Bug Fixes**
  - Documented the 200 JSON response as `MessageSchema`; removed the fake `type`/`body` wrapper.
  - Removed the unused `LLMJSONResponse` type.
  - Added a `/doc` regression test to assert the message shape and absence of `type`/`body`.

<sup>Written for commit f9f13827579081753298048918b00b36e6751aa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

