### PR TITLE
fix(runner): version generated cell identities by pattern

### DIFF
--- a/docs/specs/computed-cell-identity.md
+++ b/docs/specs/computed-cell-identity.md
@@ -119,6 +119,31 @@ Generated entries record and match their `patternIdentity` in addition to
 partial cause and kind; named entries continue to match by partial cause and kind
 (`packages/runner/src/runner.ts`, `materializeDerivedInternalCells`).
 
+There is one rollout compatibility rule. A piece materialized before generated
+causes were versioned has generated manifest entries with no
+`patternIdentity`. While that piece still points at the same pattern artifact,
+the runner continues to use its legacy ids instead of resetting it merely
+because the runtime changed. The next real pattern update atomically
+materializes pattern-versioned cells and moves the result projection to them.
+Old documents are not deleted; once no current manifest or projection names
+them, they are orphaned historical data.
+
+The transformer emits stable `.for(...)` causes for many authored declarations
+and result paths, but not for every reactive value. Dynamic computed properties,
+some callback-created values, and direct child-pattern calls can still fall
+through to `$generated`. Most observed examples are replayable UI
+intermediates or streams, but this is not a semantic guarantee: an untagged
+non-replayable builtin result can also be generated, and named state below a
+generated child-pattern result inherits that generated ancestor's churn.
+Durable state survives an update only when its complete identity ancestry is
+stable.
+
+Pattern-versioned identity is a runtime format change. A client that predates
+it cannot derive the new ids after an update. Automatic updates therefore need
+a coordinated runtime rollout: unchanged legacy pieces remain compatible, but
+an old client must not keep executing a piece after a newer client has moved
+that piece to a pattern-versioned generated graph.
+
 ### Transaction provenance
 
 The runner already distinguishes recompute transactions from event-handler

--- a/docs/specs/computed-cell-identity.md
+++ b/docs/specs/computed-cell-identity.md
@@ -85,15 +85,23 @@ changes, and only for entities whose ids carry the computed scheme.
 
 ### Internal cell identity
 
-The pattern builder assigns each internal root cell a `partialCause` —
-the cell's declared name, or an anonymous `{ $generated: N }` counter, with
+The pattern builder assigns each internal root cell a `partialCause` — the
+cell's declared name, or an anonymous `{ $generated: N }` counter, with
 `$kind: "stream"` mixed in for stream cells
-(`packages/runner/src/builder/pattern.ts`). At instantiation the runner
-mints the entity id from the piece's result cell and that partial cause:
+(`packages/runner/src/builder/pattern.ts`). Generated counters are local to one
+compiled pattern, so at instantiation the runner namespaces generated causes by
+the pattern's content-addressed `{ identity, symbol }`. Explicitly named causes
+remain unversioned so deliberate durable state survives pattern upgrades:
 
 ```ts
 // Shown for illustration only.
-createRef({}, { parent, type: "internal", cause: descriptor.partialCause })
+createRef({}, {
+  parent,
+  type: "internal",
+  cause: generated
+    ? { patternIdentity, partialCause: descriptor.partialCause }
+    : descriptor.partialCause,
+})
 ```
 
 (`packages/runner/src/link-utils.ts`, `getDerivedInternalCellLink`). The
@@ -106,8 +114,9 @@ a single chokepoint (`packages/data-model/src/value-hash.ts`). The URI layer
 (`packages/runner/src/uri-utils.ts`, `toURI`/`fromURI`) prefixes an entity
 scheme onto the tagged hash — historically always `of:`.
 
-The manifest of materialized internal cells is stored in result-cell
-metadata and matched by partial cause plus kind
+The manifest of materialized internal cells is stored in result-cell metadata.
+Generated entries record and match their `patternIdentity` in addition to
+partial cause and kind; named entries continue to match by partial cause and kind
 (`packages/runner/src/runner.ts`, `materializeDerivedInternalCells`).
 
 ### Transaction provenance
@@ -422,13 +431,13 @@ contents are meaningless under the new kind, and the manifest's
 partial-cause matching materializes the new cell and drops the stale entry
 naturally.
 
-Internal-cell identity is already refactor-fragile — anonymous cells re-mint
-on reorder via the `$generated` counter, named cells on rename — so kind
+Internal-cell identity is already refactor-fragile — generated cells re-mint on
+every pattern identity change, while named cells re-mint on rename — so kind
 flips add a trigger to an existing hazard class (durable cross-piece links
-pointing at an orphaned entity), not a new class. The flipped classifier
-polarity widens the set of cells that flip when a pattern edit adds or
-removes a disqualifier (e.g. introducing a writable handler capture of a
-previously computed cell), which is the same hazard at higher frequency.
+pointing at an orphaned entity), not a new class. The flipped classifier polarity
+widens the set of cells that flip when a pattern edit adds or removes a
+disqualifier (e.g. introducing a writable handler capture of a previously
+computed cell), which is the same hazard at higher frequency.
 
 ### Trust model
 

--- a/docs/specs/computed-cell-identity.md
+++ b/docs/specs/computed-cell-identity.md
@@ -85,15 +85,23 @@ changes, and only for entities whose ids carry the computed scheme.
 
 ### Internal cell identity
 
-The pattern builder assigns each internal root cell a `partialCause` —
-the cell's declared name, or an anonymous `{ $generated: N }` counter, with
+The pattern builder assigns each internal root cell a `partialCause` — the
+cell's declared name, or an anonymous `{ $generated: N }` counter, with
 `$kind: "stream"` mixed in for stream cells
-(`packages/runner/src/builder/pattern.ts`). At instantiation the runner
-mints the entity id from the piece's result cell and that partial cause:
+(`packages/runner/src/builder/pattern.ts`). Generated counters are local to one
+compiled pattern, so at instantiation the runner namespaces generated causes by
+the pattern's content-addressed `{ identity, symbol }`. Explicitly named causes
+remain unversioned so deliberate durable state survives pattern upgrades:
 
 ```ts
 // Shown for illustration only.
-createRef({}, { parent, type: "internal", cause: descriptor.partialCause })
+createRef({}, {
+  parent,
+  type: "internal",
+  cause: generated
+    ? { patternIdentity, partialCause: descriptor.partialCause }
+    : descriptor.partialCause,
+})
 ```
 
 (`packages/runner/src/link-utils.ts`, `getDerivedInternalCellLink`). The
@@ -106,8 +114,9 @@ a single chokepoint (`packages/data-model/src/value-hash.ts`). The URI layer
 (`packages/runner/src/uri-utils.ts`, `toURI`/`fromURI`) prefixes an entity
 scheme onto the tagged hash — historically always `of:`.
 
-The manifest of materialized internal cells is stored in result-cell
-metadata and matched by partial cause plus kind
+The manifest of materialized internal cells is stored in result-cell metadata.
+Generated entries record and match their `patternIdentity` in addition to
+partial cause and kind; named entries continue to match by partial cause and kind
 (`packages/runner/src/runner.ts`, `materializeDerivedInternalCells`).
 
 ### Transaction provenance
@@ -423,13 +432,13 @@ contents are meaningless under the new kind, and the manifest's
 partial-cause matching materializes the new cell and drops the stale entry
 naturally.
 
-Internal-cell identity is already refactor-fragile — anonymous cells re-mint
-on reorder via the `$generated` counter, named cells on rename — so kind
+Internal-cell identity is already refactor-fragile — generated cells re-mint on
+every pattern identity change, while named cells re-mint on rename — so kind
 flips add a trigger to an existing hazard class (durable cross-piece links
-pointing at an orphaned entity), not a new class. The flipped classifier
-polarity widens the set of cells that flip when a pattern edit adds or
-removes a disqualifier (e.g. introducing a writable handler capture of a
-previously computed cell), which is the same hazard at higher frequency.
+pointing at an orphaned entity), not a new class. The flipped classifier polarity
+widens the set of cells that flip when a pattern edit adds or removes a
+disqualifier (e.g. introducing a writable handler capture of a previously
+computed cell), which is the same hazard at higher frequency.
 
 ### Trust model
 

--- a/docs/specs/memory-v2/01-data-model.md
+++ b/docs/specs/memory-v2/01-data-model.md
@@ -124,7 +124,9 @@ Canonical examples:
 containing a manifest array whose entries have a `partialCause` and a sigil
 `link` to one derived internal cell. Entries for compiler-generated causes also
 carry the owning `patternIdentity`; named causes omit it and retain their cell
-identity across pattern upgrades. The older `source` property, when present,
+identity across pattern upgrades. Legacy generated entries created before
+pattern versioning also omit it; they remain valid while the piece's pattern is
+unchanged. The older `source` property, when present,
 uses the separate short-link form `{"/":"<short-id>"}` and resolves to
 `of:<short-id>` in the same space. CFC metadata also uses its own compact stored
 shape and is converted to a CID sigil link during traversal. When the server

--- a/docs/specs/memory-v2/01-data-model.md
+++ b/docs/specs/memory-v2/01-data-model.md
@@ -61,6 +61,7 @@ interface SigilLink {
 
 interface InternalManifestEntry {
   partialCause: FabricValue;
+  patternIdentity?: { identity: string; symbol: string }; // Generated causes only.
   link: SigilLink;
 }
 
@@ -121,7 +122,9 @@ Canonical examples:
 `argument`, and `result` use the same sigil form as graph/entity links:
 `{"/":{"link@1":{...}}}`. The `internal` field is different: it is raw metadata
 containing a manifest array whose entries have a `partialCause` and a sigil
-`link` to one derived internal cell. The older `source` property, when present,
+`link` to one derived internal cell. Entries for compiler-generated causes also
+carry the owning `patternIdentity`; named causes omit it and retain their cell
+identity across pattern upgrades. The older `source` property, when present,
 uses the separate short-link form `{"/":"<short-id>"}` and resolves to
 `of:<short-id>` in the same space. CFC metadata also uses its own compact stored
 shape and is converted to a CID sigil link during traversal. When the server

--- a/docs/specs/memory-v2/01-data-model.md
+++ b/docs/specs/memory-v2/01-data-model.md
@@ -61,6 +61,7 @@ type SigilLink = {
 
 type InternalManifestEntry = {
   partialCause: FabricValue;
+  patternIdentity?: { identity: string; symbol: string }; // Generated causes only.
   link: SigilLink;
 };
 
@@ -121,7 +122,9 @@ Canonical examples:
 `argument`, and `result` use the same sigil form as graph/entity links:
 `{"/":{"link@1":{...}}}`. The `internal` field is different: it is raw metadata
 containing a manifest array whose entries have a `partialCause` and a sigil
-`link` to one derived internal cell. The older `source` property, when present,
+`link` to one derived internal cell. Entries for compiler-generated causes also
+carry the owning `patternIdentity`; named causes omit it and retain their cell
+identity across pattern upgrades. The older `source` property, when present,
 uses the separate short-link form `{"/":"<short-id>"}` and resolves to
 `of:<short-id>` in the same space. CFC metadata also uses its own compact stored
 shape and is converted to a CID sigil link during traversal. When the server

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -28,7 +28,7 @@ published-pattern updates remain design.
 
 ## Last Updated
 
-2026-07-22
+2026-07-23
 
 ## Motivation
 
@@ -75,7 +75,7 @@ published-pattern updates remain design.
 | Mechanism | Where | Role here |
 |---|---|---|
 | Pattern pointer `patternIdentity = {identity, symbol}` on the piece result cell | `runner.ts` (`applySetupState` / `getPatternIdentityRef`) | The thing an update rewrites |
-| **In-place re-run watcher** — `setupPatternWatcher` sinks the `patternIdentity` meta; on change it cancels the old pattern's nodes and re-instantiates the new pattern **onto the same result cell** | `runner.ts` (enabled unless `doNotUpdateOnPatternChange`) | Applies a metadata swap when the piece is already running; at space open, bootstrap reads the reconciled metadata directly |
+| **In-place re-run watcher** — `setupPatternWatcher` sinks the `patternIdentity` meta; on change it cancels the old pattern's nodes and re-instantiates the new pattern **onto the same result cell** | `runner.ts` (enabled unless `doNotUpdateOnPatternChange`) | Activates a replacement graph after its setup metadata and projection commit atomically with the pointer; at space open, bootstrap reads that prepared state directly |
 | `PatternUpdater` | `packages/runner/src/pattern-updater.ts` | Shared identity lookup, verified closure compile, provenance repair, and compare-and-swap for awaited roots and background ordinary-piece checks |
 | Space root: `spaceCell.defaultPattern` link → root piece → `patternIdentity` | `packages/piece/src/manager.ts` (`linkDefaultPattern`/`getDefaultPattern`) | What a system update rewrites |
 | `ensureDefaultPattern` (resolve → reconcile → start) / `recreateDefaultPattern` (manual, **not** state-preserving) | `packages/piece/src/ops/pieces-controller.ts` | The automatic self-heal hook (ensure) and the state-losing escape hatch (recreate); both URL-based creation paths stamp `patternSource` |
@@ -106,12 +106,14 @@ Two decisions carry the whole design:
    authored entry filename and stamp it after that same-origin route proves it
    implements `?identity`.
 2. **Update = resolve `patternSource` → current identity; if it differs from
-   the persisted `patternIdentity.identity`, write the new `{identity, symbol}`
-   to the piece's `patternIdentity` meta.** At space open this happens before
-   root bootstrap, so `start()` loads the reconciled identity. Every other
-   pattern starts first; its successful instantiation commit launches a
-   fire-and-forget check, and the existing watcher re-instantiates a verified
-   replacement in place. No new apply machinery.
+   the persisted `patternIdentity.identity`, run the replacement pattern's
+   setup in the compare-and-swap transaction.** Setup writes the new
+   `{identity, symbol}` together with its internal-cell manifest, defaults,
+   backlinks, schemas, and result projection. At space open this happens before
+   root bootstrap, so `start()` loads prepared state. Every other pattern starts
+   first; its successful instantiation commit launches a fire-and-forget check,
+   and the existing watcher re-instantiates the verified, already-prepared
+   replacement in place.
 
 A root created before provenance stamping may be admitted to this loop only
 when its stored `{ identity, symbol }` exactly equals the advertised current
@@ -204,13 +206,17 @@ cf:[[//toolshed.url]/space/][slug]
 ## In-place apply
 
 The apply is: ensure the new closure is loadable in the space
-(`compilePattern(program, { space })` writes source + compiled docs), then
-write `{ identity, symbol }` to the piece's `patternIdentity` meta. During space
-open, `ensureDefaultPattern` performs this write before calling `startPiece`,
+(`compilePattern(program, { space })` writes source + compiled docs), then run
+its setup in the same compare-and-swap transaction that changes
+`patternIdentity`. This atomically installs the new internal-cell manifest and
+defaults, reciprocal result backlinks, schemas, and result projection. A bare
+pointer write is not a supported update operation: it can make new nodes write
+cells that the old projection does not expose. During space open,
+`ensureDefaultPattern` applies the prepared state before calling `startPiece`,
 so an obsolete pattern that cannot load can be replaced before bootstrap. If
-the piece is already running, the
-watcher cancels its old reactive nodes and re-instantiates the new pattern onto
-the **same result cell**.
+the piece is already running, the watcher observes the committed pointer,
+cancels its old reactive nodes, and re-instantiates the new pattern onto the
+**same result cell**.
 
 - **Survives**: the result cell's entity and inbound links; any state cells the
   new pattern still reads (addressed by stable key/cause).
@@ -281,9 +287,11 @@ transaction, and only then start it:
    compile, evaluation,
    missing-entry-ref, or identity-mismatch failure leaves the root metadata
    unchanged.
-6. Provenance repair and identity replacement are transactional
-   compare-and-swap writes: the captured identity, source, and repository must
-   still match on every retry, so a concurrent custom-root replacement wins.
+6. Provenance repair and replacement setup are transactional compare-and-swap
+   writes: the captured identity, source, and repository must still match on
+   every retry, so a concurrent custom-root replacement wins. Replacement setup
+   commits the pointer, internal manifest/defaults/backlinks, schemas, and
+   result projection together.
 7. Start the reconciled root. A newly created root skips the check because it
    was compiled from the current source in the same ensure operation; a root
    discovered after a creation race is treated as persisted and reconciled.
@@ -305,10 +313,11 @@ awaits the check from `start()`:
 4. On a changed identity, revalidate and compile the whole closure with the
    running ref's export symbol. Require both the compiler-produced identity and
    symbol to equal the advertised identity and existing symbol.
-5. Compare-and-swap `{ patternIdentity, patternSource, patternRepository }`.
-   A concurrent setsrc/custom replacement wins. A successful swap wakes the
-   already-installed watcher; fetch, compile, evaluation, mismatch, and commit
-   failures leave the current graph running.
+5. Compare-and-swap `{ patternIdentity, patternSource, patternRepository }`
+   while running replacement setup in that same transaction. A concurrent
+   setsrc/custom replacement wins. A successful prepared swap wakes the
+   already-installed watcher; fetch, compile, evaluation, setup validation,
+   mismatch, and commit failures leave the current graph running.
 
 ## End-to-end identity check
 

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -37,7 +37,7 @@ into the same active-origin and revision model.
 
 ## Last Updated
 
-2026-07-22
+2026-07-23
 
 ## Motivation
 
@@ -88,7 +88,7 @@ into the same active-origin and revision model.
 | Mechanism | Where | Role here |
 |---|---|---|
 | Pattern pointer `patternIdentity = {identity, symbol}` on the piece result cell | `runner.ts` (`applySetupState` / `getPatternIdentityRef`) | The thing an update rewrites |
-| **In-place re-run watcher** — `setupPatternWatcher` sinks the `patternIdentity` meta; on change it cancels the old pattern's nodes and re-instantiates the new pattern **onto the same result cell** | `runner.ts` (enabled unless `doNotUpdateOnPatternChange`) | Applies a metadata swap when the piece is already running; at space open, bootstrap reads the reconciled metadata directly |
+| **In-place re-run watcher** — `setupPatternWatcher` sinks the `patternIdentity` meta; on change it cancels the old pattern's nodes and re-instantiates the new pattern **onto the same result cell** | `runner.ts` (enabled unless `doNotUpdateOnPatternChange`) | Activates a replacement graph after its setup metadata and projection commit atomically with the pointer; at space open, bootstrap reads that prepared state directly |
 | `PatternUpdater` | `packages/runner/src/pattern-updater.ts` | Shared identity lookup, verified closure compile, provenance repair, and compare-and-swap for awaited roots and background ordinary-piece checks |
 | Space root: `spaceCell.defaultPattern` link → root piece → `patternIdentity` | `packages/piece/src/manager.ts` (`linkDefaultPattern`/`getDefaultPattern`) | What a system update rewrites |
 | `ensureDefaultPattern` (resolve → reconcile → start) / `recreateDefaultPattern` (manual, **not** state-preserving) | `packages/piece/src/ops/pieces-controller.ts` | The automatic self-heal hook (ensure) and the state-losing escape hatch (recreate); both URL-based creation paths stamp `patternSource` |
@@ -124,12 +124,14 @@ Two decisions carry the whole design:
    `?identity`. A filename that names no route is not a claim about a source,
    and the piece stays unstamped.
 2. **Update = resolve `patternSource` → current identity; if it differs from
-   the persisted `patternIdentity.identity`, write the new `{identity, symbol}`
-   to the piece's `patternIdentity` meta.** At space open this happens before
-   root bootstrap, so `start()` loads the reconciled identity. Every other
-   pattern starts first; its successful instantiation commit launches a
-   fire-and-forget check, and the existing watcher re-instantiates a verified
-   replacement in place. No new apply machinery.
+   the persisted `patternIdentity.identity`, run the replacement pattern's
+   setup in the compare-and-swap transaction.** Setup writes the new
+   `{identity, symbol}` together with its internal-cell manifest, defaults,
+   backlinks, schemas, and result projection. At space open this happens before
+   root bootstrap, so `start()` loads prepared state. Every other pattern starts
+   first; its successful instantiation commit launches a fire-and-forget check,
+   and the existing watcher re-instantiates the verified, already-prepared
+   replacement in place.
 
    The awaited default-root reconcile has a second entry point beyond space
    open: `PieceManager.getDefaultPattern` — the resolution every registry
@@ -310,15 +312,20 @@ it has a pin.
 
 The apply is: ensure the new closure is loadable in the space
 (`compilePattern(program, { space })` writes source + compiled docs), then use
-the normal pattern setup path to install the new result schema, result
+the normal pattern setup path in the same compare-and-swap transaction as the
+source transition. That atomically installs the internal-cell manifest and
+defaults, reciprocal result backlinks, argument and result schemas, result
 projection, `{ identity, symbol }`, and `patternSetupIdentity` completion marker
-on the existing result cell. The completion marker is not a pattern pointer;
-it records which identity had its complete setup staged. It is also what tells
-an apply from a same-version replay when the pointer moved first — the
-roll-forward materialize commits the new `{ identity, symbol }` and then runs
-setup, and an identity moved with no setup at all leaves the same shape. The
-pointer then reads as unchanged, while the marker still names the version that
-staged the state.
+on the existing result cell. A bare pointer write is not a supported update
+operation: it can make new nodes write cells that the old manifest or projection
+does not expose.
+
+The completion marker is not a pattern pointer; it records which identity had
+its complete setup staged. It is also what tells an apply from a same-version
+replay when the pointer moved first — the roll-forward materialize commits the
+new `{ identity, symbol }` and then runs setup, and an identity moved with no
+setup at all leaves the same shape. The pointer then reads as unchanged, while
+the marker still names the version that staged the state.
 
 Setup re-points the piece's stored argument at the incoming argument schema and
 validates it in the same transaction, so an apply whose durable argument the new
@@ -451,11 +458,13 @@ transaction, and only then start it:
    compile, evaluation,
    missing-entry-ref, or identity-mismatch failure leaves the root metadata
    unchanged. Use the normal pattern setup path to install the candidate result
-   schema, projection, identity, and setup completion marker.
+   schema, projection, identity, setup completion marker, internal-cell
+   manifest/defaults, and reciprocal backlinks.
 6. Provenance repair and pattern setup are transactional compare-and-swap
    writes: the captured identity, setup completion marker, source, and
    repository must still match on every retry, so a concurrent custom-root
-   replacement wins.
+   replacement wins. Replacement setup commits the pointer and all of that
+   staged state together.
 7. Start the reconciled root. A newly created root skips the check because it
    was compiled from the current source in the same ensure operation; a root
    discovered after a creation race is treated as persisted and reconciled.
@@ -477,10 +486,11 @@ awaits the check from `start()`:
 4. On a changed identity, revalidate and compile the whole closure with the
    running ref's export symbol. Require both the compiler-produced identity and
    symbol to equal the advertised identity and existing symbol.
-5. Compare-and-swap `{ patternIdentity, patternSource, patternRepository }`.
-   A concurrent setsrc/custom replacement wins. A successful swap wakes the
-   already-installed watcher; fetch, compile, evaluation, mismatch, and commit
-   failures leave the current graph running.
+5. Compare-and-swap `{ patternIdentity, patternSource, patternRepository }`
+   while running replacement setup in that same transaction. A concurrent
+   setsrc/custom replacement wins. A successful prepared swap wakes the
+   already-installed watcher; fetch, compile, evaluation, setup validation,
+   mismatch, and commit failures leave the current graph running.
 
 ## End-to-end identity check
 

--- a/docs/specs/space-model/2-storage-format.md
+++ b/docs/specs/space-model/2-storage-format.md
@@ -42,7 +42,8 @@ piece ownership graph:
   internal: [          // manifest of derived internal cells
     {
       partialCause: JSONValue,
-      patternIdentity?: { identity: string, symbol: string }, // generated causes only
+      // Generated causes only; absent on named and legacy generated entries.
+      patternIdentity?: { identity: string, symbol: string },
       link: SigilLink
     }
   ],

--- a/docs/specs/space-model/2-storage-format.md
+++ b/docs/specs/space-model/2-storage-format.md
@@ -42,6 +42,7 @@ piece ownership graph:
   internal: [          // manifest of derived internal cells
     {
       partialCause: JSONValue,
+      patternIdentity?: { identity: string, symbol: string }, // generated causes only
       link: SigilLink
     }
   ],

--- a/docs/specs/space-model/4-cells.md
+++ b/docs/specs/space-model/4-cells.md
@@ -99,7 +99,8 @@ cell:
   argument: SigilLink, // link to input data cell
   internal: Array<{
     partialCause: JSONValue,
-    patternIdentity?: { identity: string, symbol: string }, // generated causes only
+    // Generated causes only; absent on named and legacy generated entries.
+    patternIdentity?: { identity: string, symbol: string },
     link: SigilLink
   }>,                 // manifest of derived internal cells
   schema?: JSONSchema

--- a/docs/specs/space-model/4-cells.md
+++ b/docs/specs/space-model/4-cells.md
@@ -99,6 +99,7 @@ cell:
   argument: SigilLink, // link to input data cell
   internal: Array<{
     partialCause: JSONValue,
+    patternIdentity?: { identity: string, symbol: string }, // generated causes only
     link: SigilLink
   }>,                 // manifest of derived internal cells
   schema?: JSONSchema

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -585,17 +585,14 @@ export class PiecesController<T = unknown> {
         () => this.#manager.startPiece(rootToStart, DEFAULT_ROOT_RUN_OPTIONS),
       );
     } catch (startError) {
-      // Cold-start setup repair. checkAndUpdateDefaultPattern moves
-      // patternIdentity WITHOUT running the setup phase ("Never calls run()"),
-      // and Runner.start() of a not-running piece instantiates the stored
-      // identity directly — also without setup. A root whose identity moved
-      // while it was not running (the bricked-space heal: no watcher existed
-      // to swap it in place) therefore boots over a doc that never
-      // materialized the pattern's internal cells — handler
-      // `{ "$stream": true }` markers included — and dies at instantiation
-      // ("Handler used as lift", the 2026-07-22 estuary failure). This also
-      // covers docs ALREADY left in that state by an earlier session: their
-      // identity compares current, so no further swap will ever fire.
+      // Cold-start setup repair for legacy split-brain documents.
+      // PatternUpdater now commits replacement setup and patternIdentity
+      // atomically. Older runtimes moved only the pointer, however, so a root
+      // can already exist whose stored identity names a graph that was never
+      // set up. Runner.start() instantiates that stored identity directly and
+      // can fail because internal cells — handler `{ "$stream": true }`
+      // markers included — are missing. Since the identity already compares
+      // current, no later update check will repair such a document.
       //
       // run() (setup + start) is the sanctioned repair: with an unchanged
       // pattern pointer the setup phase is idempotent — it only materializes

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -636,17 +636,14 @@ export class PiecesController<T = unknown> {
         () => this.#manager.startPiece(rootToStart, DEFAULT_ROOT_RUN_OPTIONS),
       );
     } catch (startError) {
-      // Cold-start setup repair. checkAndUpdateDefaultPattern moves
-      // patternIdentity WITHOUT running the setup phase ("Never calls run()"),
-      // and Runner.start() of a not-running piece instantiates the stored
-      // identity directly — also without setup. A root whose identity moved
-      // while it was not running (the bricked-space heal: no watcher existed
-      // to swap it in place) therefore boots over a doc that never
-      // materialized the pattern's internal cells — handler
-      // `{ "$stream": true }` markers included — and dies at instantiation
-      // ("Handler used as lift", the 2026-07-22 estuary failure). This also
-      // covers docs ALREADY left in that state by an earlier session: their
-      // identity compares current, so no further swap will ever fire.
+      // Cold-start setup repair for legacy split-brain documents.
+      // PatternUpdater now commits replacement setup and patternIdentity
+      // atomically. Older runtimes moved only the pointer, however, so a root
+      // can already exist whose stored identity names a graph that was never
+      // set up. Runner.start() instantiates that stored identity directly and
+      // can fail because internal cells — handler `{ "$stream": true }`
+      // markers included — are missing. Since the identity already compares
+      // current, no later update check will repair such a document.
       //
       // run() (setup + start) is the sanctioned repair. With an unchanged
       // pattern pointer the setup phase is near-idempotent: it materializes

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -1073,10 +1073,10 @@ describe("checkAndUpdateDefaultPattern", () => {
   });
 
   it("failed swap-setup leaves the running pattern in place", async () => {
-    // The fail-closed half of the swap-setup contract: when the incoming
-    // pattern's argument schema rejects the existing argument, the watcher
-    // logs pattern-swap-setup-error and must NOT tear down the running
-    // nodes — a bad update leaves a working piece, not a dead one.
+    // The fail-closed half of the atomic swap-setup contract: when the incoming
+    // pattern's argument schema rejects the existing argument, the update
+    // transaction itself must be rejected. A bad update leaves the old pointer,
+    // graph, and running nodes intact.
     const SOURCE_INCOMPATIBLE = [
       "import { pattern } from 'commonfabric';",
       "export default pattern<{ mustHave: string }>(({ mustHave }) => ({",
@@ -1097,19 +1097,16 @@ describe("checkAndUpdateDefaultPattern", () => {
     stub.setSource(SOURCE_INCOMPATIBLE);
     const restore = shadowLoadProbe(staleRef.identity, "undefined");
     try {
-      // The update itself proceeds (identity swaps at the meta layer)…
-      expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("current");
     } finally {
       restore();
     }
     await runtime.idle();
-    // …but the swap-setup for the incompatible program fails closed: the
-    // piece is not left dead (starting it does not throw), and the failure
-    // was logged rather than swallowed.
     const after = (await manager.getDefaultPattern(true))!;
     await runtime.idle();
-    // Functional pin, not just existence: the OLD pattern's nodes are still
-    // the ones running — its result reads back — after the refused swap.
+    expect(getPatternIdentityRef(after)).toEqual(staleRef);
+    // Functional pin, not just metadata: the old pattern's nodes remain live
+    // after the candidate setup is rejected.
     expect(after.key("marker").get()).toBe("v1");
   });
 
@@ -1209,7 +1206,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(afterEvent.key("count").get()).toBe(1);
   });
 
-  it("failed cold-start repair stays fail-closed and leaves the doc healable", async () => {
+  it("failed legacy cold-start repair stays fail-closed and leaves the doc healable", async () => {
     // The repair's own failure contract: when the one-shot setup repair
     // cannot commit, the ORIGINAL start error must surface (not the repair's),
     // and the doc must be left exactly as it was — the next boot's repair
@@ -1225,11 +1222,24 @@ describe("checkAndUpdateDefaultPattern", () => {
       },
     });
     const root = (await manager.getDefaultPattern(false))!;
-    const staleRef = getPatternIdentityRef(root)!;
     await manager.stopPiece(root);
 
     stub.setSource(SOURCE_V3_HANDLER);
-    const restoreProbe = shadowLoadProbe(staleRef.identity, "undefined");
+    const targetId = await identityForSource(
+      SOURCE_V3_HANDLER,
+      {},
+      HOME_PATTERN_URL,
+    );
+    // Forge the legacy split-brain state produced by the old pointer-only
+    // updater: the identity moved, but replacement setup never ran.
+    const { error } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).setMetaRaw("patternIdentity", {
+        identity: targetId,
+        symbol: "default",
+      });
+    });
+    expect(error).toBeUndefined();
+
     const rt = runtime as unknown as {
       runSynced: (...args: unknown[]) => Promise<unknown>;
     };
@@ -1243,7 +1253,6 @@ describe("checkAndUpdateDefaultPattern", () => {
       thrown = error;
     } finally {
       rt.runSynced = originalRunSynced;
-      restoreProbe();
     }
     // The original start failure surfaces, not the repair's own error.
     expect(String(thrown)).toContain("Handler used as lift");

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -1667,6 +1667,8 @@ describe("checkAndUpdateDefaultPattern", () => {
     const after = (await manager.getDefaultPattern(true))!;
     await runtime.idle();
     expect(getPatternIdentityRef(after)).toEqual(staleRef);
+    // Functional pin, not just metadata: the old pattern's nodes remain live
+    // after the candidate setup is rejected.
     expect(after.key("marker").get()).toBe("v1");
   });
 
@@ -1797,8 +1799,8 @@ describe("checkAndUpdateDefaultPattern", () => {
     // an unloadable identity — a different failure than the one under test.
     const targetPattern = await runtime.patternManager.compilePattern(
       {
-        main: HOME_PATTERN_URL,
-        files: [{ name: HOME_PATTERN_URL, contents: SOURCE_V3_HANDLER }],
+        main: HOME_PATTERN_PATH,
+        files: [{ name: HOME_PATTERN_PATH, contents: SOURCE_V3_HANDLER }],
       },
       { space: manager.getSpace() },
     );
@@ -1808,7 +1810,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     const targetId = await identityForSource(
       SOURCE_V3_HANDLER,
       {},
-      HOME_PATTERN_URL,
+      HOME_PATTERN_PATH,
     );
     expect(targetRef.identity).toBe(targetId);
     const { error } = await runtime.editWithRetry((tx) => {

--- a/packages/runner/src/builder/pattern-metadata.ts
+++ b/packages/runner/src/builder/pattern-metadata.ts
@@ -106,6 +106,39 @@ const entryRefByValue = new WeakMap<
   { identity: string; symbol: string }
 >();
 
+type PatternIdentityRef = { identity: string; symbol: string };
+
+// Compiler-generated internal-cell causes (`{ $generated: N, ... }`) are only
+// stable within one pattern artifact. Associate their descriptor objects with
+// the artifact identity out-of-band so the normal link-minting path can
+// namespace them without adding serializable builder metadata or changing the
+// identity of explicitly named cells.
+const patternIdentityByGeneratedInternalDescriptor = new WeakMap<
+  object,
+  PatternIdentityRef
+>();
+
+function hasGeneratedCause(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  return "$generated" in value;
+}
+
+function associateGeneratedInternalDescriptors(
+  value: unknown,
+  ref: PatternIdentityRef,
+): void {
+  if (!isPattern(value)) return;
+  for (const descriptor of value.derivedInternalCells ?? []) {
+    if (!hasGeneratedCause(descriptor.partialCause)) continue;
+    const key = asKey(descriptor);
+    if (key && !patternIdentityByGeneratedInternalDescriptor.has(key)) {
+      patternIdentityByGeneratedInternalDescriptor.set(key, ref);
+    }
+  }
+}
+
 /**
  * Resolve a (possibly derived) value to its root original. Identity for
  * values that were never copied. Bounded: the chain is a tree toward the
@@ -147,7 +180,10 @@ export function noteDerivedCopy(copy: unknown, original: unknown): void {
   if (trustedPatterns.has(root)) trustedPatterns.add(c);
   if (trustedBuilderArtifacts().has(root)) trustedBuilderArtifacts().add(c);
   const ref = entryRefByValue.get(root);
-  if (ref && !entryRefByValue.has(c)) entryRefByValue.set(c, ref);
+  if (ref) {
+    if (!entryRefByValue.has(c)) entryRefByValue.set(c, ref);
+    associateGeneratedInternalDescriptors(copy, ref);
+  }
 }
 
 /**
@@ -161,7 +197,9 @@ export function setArtifactEntryRef(
   ref: { identity: string; symbol: string },
 ): void {
   const key = asKey(value);
-  if (key && !entryRefByValue.has(key)) entryRefByValue.set(key, ref);
+  if (!key) return;
+  if (!entryRefByValue.has(key)) entryRefByValue.set(key, ref);
+  associateGeneratedInternalDescriptors(value, entryRefByValue.get(key)!);
 }
 
 /**
@@ -174,8 +212,24 @@ export function getArtifactEntryRef(
 ): { identity: string; symbol: string } | undefined {
   const key = asKey(value);
   if (!key) return undefined;
-  return entryRefByValue.get(key) ??
+  const ref = entryRefByValue.get(key) ??
     entryRefByValue.get(resolveOriginal(key) as object);
+  if (ref) associateGeneratedInternalDescriptors(value, ref);
+  return ref;
+}
+
+/**
+ * The owning pattern identity for a compiler-generated internal-cell
+ * descriptor. Explicitly named/manual causes intentionally return undefined so
+ * their durable identities continue across pattern upgrades.
+ */
+export function getGeneratedInternalCellPatternIdentity(
+  descriptor: unknown,
+): PatternIdentityRef | undefined {
+  const key = asKey(descriptor);
+  return key
+    ? patternIdentityByGeneratedInternalDescriptor.get(key)
+    : undefined;
 }
 
 /**

--- a/packages/runner/src/builder/pattern-metadata.ts
+++ b/packages/runner/src/builder/pattern-metadata.ts
@@ -106,6 +106,39 @@ const entryRefByValue = new WeakMap<
   { identity: string; symbol: string }
 >();
 
+type PatternIdentityRef = { identity: string; symbol: string };
+
+// Compiler-generated internal-cell causes (`{ $generated: N, ... }`) are only
+// stable within one pattern artifact. Associate their descriptor objects with
+// the artifact identity out-of-band so the normal link-minting path can
+// namespace them without adding serializable builder metadata or changing the
+// identity of explicitly named cells.
+const patternIdentityByGeneratedInternalDescriptor = new WeakMap<
+  object,
+  PatternIdentityRef
+>();
+
+function hasGeneratedCause(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  return "$generated" in value;
+}
+
+function associateGeneratedInternalDescriptors(
+  value: unknown,
+  ref: PatternIdentityRef,
+): void {
+  if (!isPattern(value)) return;
+  for (const descriptor of value.derivedInternalCells ?? []) {
+    if (!hasGeneratedCause(descriptor.partialCause)) continue;
+    const key = asKey(descriptor);
+    if (key && !patternIdentityByGeneratedInternalDescriptor.has(key)) {
+      patternIdentityByGeneratedInternalDescriptor.set(key, ref);
+    }
+  }
+}
+
 /**
  * Resolve a (possibly derived) value to its root original. Identity for
  * values that were never copied. Bounded: the chain is a tree toward the
@@ -147,7 +180,10 @@ export function noteDerivedCopy(copy: unknown, original: unknown): void {
   if (trustedPatterns.has(root)) trustedPatterns.add(c);
   if (trustedBuilderArtifacts().has(root)) trustedBuilderArtifacts().add(c);
   const ref = entryRefByValue.get(root);
-  if (ref && !entryRefByValue.has(c)) entryRefByValue.set(c, ref);
+  if (ref) {
+    if (!entryRefByValue.has(c)) entryRefByValue.set(c, ref);
+    associateGeneratedInternalDescriptors(copy, ref);
+  }
 }
 
 /**
@@ -161,7 +197,9 @@ export function setArtifactEntryRef(
   ref: { identity: string; symbol: string },
 ): void {
   const key = asKey(value);
-  if (key && !entryRefByValue.has(key)) entryRefByValue.set(key, ref);
+  if (!key) return;
+  if (!entryRefByValue.has(key)) entryRefByValue.set(key, ref);
+  associateGeneratedInternalDescriptors(value, entryRefByValue.get(key)!);
 }
 
 /**
@@ -174,8 +212,24 @@ export function getArtifactEntryRef(
 ): { identity: string; symbol: string } | undefined {
   const key = asKey(value);
   if (!key) return undefined;
-  return entryRefByValue.get(key) ??
+  const ref = entryRefByValue.get(key) ??
     entryRefByValue.get(resolveOriginal(key) as object);
+  if (ref) associateGeneratedInternalDescriptors(value, ref);
+  return ref;
+}
+
+/**
+ * The owning pattern identity for a compiler-generated internal-cell
+ * descriptor. Explicitly named/manual causes intentionally return undefined so
+ * their durable identities continue across pattern upgrades.
+ */
+export function getGeneratedInternalCellPatternIdentity(
+  descriptor: unknown,
+): PatternIdentityRef | undefined {
+  const key = asKey(descriptor);
+  return key
+    ? patternIdentityByGeneratedInternalDescriptor.get(key)
+    : undefined;
 }
 
 // The authored file a pattern was defined in, per live builder artifact.

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -43,6 +43,7 @@ import {
 import { MetaLinkField } from "@commonfabric/api";
 import { ignoreReadForScheduling } from "./scheduler.ts";
 import { createRef } from "./create-ref.ts";
+import { getGeneratedInternalCellPatternIdentity } from "./builder/pattern-metadata.ts";
 
 export * from "./link-types.ts";
 
@@ -614,6 +615,7 @@ export function getDerivedInternalCellLink(
 ): NormalizedFullLink {
   const resultCellLink = resultCell.getAsNormalizedFullLink();
   const parent = resultCell.entityId ?? resultCell;
+  const patternIdentity = getGeneratedInternalCellPatternIdentity(descriptor);
   return {
     space: resultCellLink.space,
     // The kind's ONLY representation is the URI scheme applied here by
@@ -625,7 +627,10 @@ export function getDerivedInternalCellLink(
         {
           parent,
           type: "internal",
-          cause: descriptor.partialCause,
+          cause: patternIdentity === undefined ? descriptor.partialCause : {
+            patternIdentity,
+            partialCause: descriptor.partialCause,
+          },
         },
       ),
       descriptor.kind,

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -1,4 +1,5 @@
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
 import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
 import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
@@ -46,6 +47,11 @@ import { createRef } from "./create-ref.ts";
 import { getGeneratedInternalCellPatternIdentity } from "./builder/pattern-metadata.ts";
 
 export * from "./link-types.ts";
+
+const legacyGeneratedEntriesByManifest = new WeakMap<
+  object,
+  Map<JSONValue, unknown[]>
+>();
 
 /**
  * A type reflecting all possible link formats, including cells themselves.
@@ -615,7 +621,10 @@ export function getDerivedInternalCellLink(
 ): NormalizedFullLink {
   const resultCellLink = resultCell.getAsNormalizedFullLink();
   const parent = resultCell.entityId ?? resultCell;
-  const patternIdentity = getGeneratedInternalCellPatternIdentity(descriptor);
+  const patternIdentity = getEffectiveGeneratedInternalCellPatternIdentity(
+    resultCell,
+    descriptor,
+  );
   return {
     space: resultCellLink.space,
     // The kind's ONLY representation is the URI scheme applied here by
@@ -639,6 +648,89 @@ export function getDerivedInternalCellLink(
     scope: descriptor.scope ?? resultCellLink.scope,
     ...(descriptor.schema !== undefined && { schema: descriptor.schema }),
   };
+}
+
+/**
+ * Return the pattern namespace that should participate in a generated
+ * internal cell's identity.
+ *
+ * Pieces materialized before generated causes were pattern-versioned have
+ * manifest entries without `patternIdentity`. Keep using those legacy ids
+ * while the piece still points at the same pattern artifact. This makes the
+ * format rollout read-compatible and avoids resetting an unchanged piece.
+ *
+ * A real pattern update runs setup before changing `patternIdentity`; while
+ * that transaction is being prepared the stored pointer still names the old
+ * artifact, so the new descriptor does not take this compatibility path and
+ * receives its new, pattern-versioned id.
+ */
+export function getEffectiveGeneratedInternalCellPatternIdentity(
+  resultCell: AnyCell<unknown>,
+  descriptor: DerivedInternalCellDescriptor,
+): { identity: string; symbol: string } | undefined {
+  const patternIdentity = getGeneratedInternalCellPatternIdentity(descriptor);
+  if (patternIdentity === undefined) return undefined;
+
+  // Builder-facing AnyCell capabilities intentionally omit metadata methods,
+  // but every runtime cell reaching the identity mint is the CellImpl-backed
+  // internal form.
+  const metadataCell = resultCell as Cell<unknown>;
+  const currentPattern = metadataCell.getMetaRaw("patternIdentity", {
+    meta: ignoreReadForScheduling,
+  });
+  if (
+    !isRecord(currentPattern) ||
+    currentPattern.identity !== patternIdentity.identity ||
+    currentPattern.symbol !== patternIdentity.symbol
+  ) {
+    return patternIdentity;
+  }
+
+  const internal = metadataCell.getMetaRaw("internal", {
+    meta: ignoreReadForScheduling,
+  });
+  if (!Array.isArray(internal)) return patternIdentity;
+
+  let legacyByOrdinal = legacyGeneratedEntriesByManifest.get(internal);
+  if (legacyByOrdinal === undefined) {
+    legacyByOrdinal = new Map();
+    for (const entry of internal) {
+      if (
+        !isRecord(entry) ||
+        entry.patternIdentity !== undefined ||
+        !isRecord(entry.partialCause)
+      ) continue;
+      const ordinal = entry.partialCause.$generated;
+      if (
+        ordinal === null ||
+        (typeof ordinal !== "string" &&
+          typeof ordinal !== "number" &&
+          typeof ordinal !== "boolean")
+      ) continue;
+      const entries = legacyByOrdinal.get(ordinal) ?? [];
+      entries.push(entry);
+      legacyByOrdinal.set(ordinal, entries);
+    }
+    legacyGeneratedEntriesByManifest.set(internal, legacyByOrdinal);
+  }
+  const descriptorOrdinalValue = isRecord(descriptor.partialCause)
+    ? descriptor.partialCause.$generated
+    : undefined;
+  const descriptorOrdinal: JSONValue | undefined =
+    descriptorOrdinalValue === null ||
+      typeof descriptorOrdinalValue === "string" ||
+      typeof descriptorOrdinalValue === "number" ||
+      typeof descriptorOrdinalValue === "boolean"
+      ? descriptorOrdinalValue
+      : undefined;
+  const legacyEntry = descriptorOrdinal === undefined
+    ? undefined
+    : legacyByOrdinal.get(descriptorOrdinal)?.find((entry) =>
+      isRecord(entry) &&
+      deepEqual(entry.partialCause, descriptor.partialCause) &&
+      entry.kind === descriptor.kind
+    );
+  return legacyEntry === undefined ? patternIdentity : undefined;
 }
 
 export function getStableInternalPathSegment(

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -339,7 +339,12 @@ export class PatternUpdater {
             displacedAt: Date.now(),
           });
         }
-        resultCell.withTx(tx).setMetaRaw("patternIdentity", entryRef);
+        // Prepare the complete replacement graph atomically with the pointer:
+        // internal-cell manifests/defaults/backlinks, argument/result schemas,
+        // and the result projection must all agree before the watcher can
+        // instantiate the new nodes. setup() performs its transaction-bound
+        // work synchronously and returns an already-resolved promise here.
+        void runtime.setup(tx, pattern, undefined, resultCell);
         setPatternSource(resultCell, tx, source);
         return true;
       });

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -505,7 +505,10 @@ export class PatternUpdater {
             ...(setupNeedsRepair ? { reapplyStoredSetup: true } : {}),
           });
         } else {
-          candidate.setMetaRaw("patternIdentity", entryRef);
+          // Prepare the complete replacement graph atomically with the source
+          // transition and pointer. A bare pointer write could let the watcher
+          // start new nodes against an old manifest, schema, or projection.
+          void runtime.setup(tx, pattern, undefined, candidate);
         }
         return true;
       });

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -50,6 +50,7 @@ import {
   createSigilLinkFromParsedLink,
   getDerivedInternalCell,
   getDerivedInternalCellLink,
+  getEffectiveGeneratedInternalCellPatternIdentity,
   getMetaCell,
   getMetaLink,
   isAliasBinding,
@@ -110,7 +111,6 @@ import { runInActionExecution } from "./builder/action-context.ts";
 import { getVerifiedProvenance } from "./harness/verified-provenance.ts";
 import {
   getArtifactEntryRef,
-  getGeneratedInternalCellPatternIdentity,
   isTrustedBuilderArtifact,
   resolveOriginal,
 } from "./builder/pattern-metadata.ts";
@@ -1148,7 +1148,8 @@ export class Runner {
     const manifest: InternalCellDescriptor[] = [];
 
     for (const descriptor of descriptors) {
-      const patternIdentity = getGeneratedInternalCellPatternIdentity(
+      const patternIdentity = getEffectiveGeneratedInternalCellPatternIdentity(
+        resultCell,
         descriptor,
       );
       const derivedCell = getDerivedInternalCell(
@@ -2781,18 +2782,13 @@ export class Runner {
     // batched instantiation commit loses and reverts — stranding the optimistic
     // writes that the resumed actions then depend on. Pulling them here keeps
     // that commit read-mostly.
-    // Resolving each sub-pattern node's output redirect chain needs a
-    // transaction (resolveLink reads link metadata). The walk only reads, so the
-    // transaction is discarded afterward.
-    const resolveTx = this.runtime.edit();
-    this.collectResumeOwnedCells(
+    await this.collectResumeOwnedCells(
       pattern,
       resultCell,
       cells,
       new Set(),
-      resolveTx,
+      false,
     );
-    resolveTx.abort("collectResumeOwnedCells: read-only resolution");
 
     // Sync all the previously computed results.
     if (pattern.resultSchema !== undefined) {
@@ -2897,100 +2893,110 @@ export class Runner {
   // result cell to bound the walk against a cyclic reference. This only pulls
   // cells, so a node shape it cannot resolve contributes nothing rather than
   // misbehaving.
-  private collectResumeOwnedCells(
+  private async collectResumeOwnedCells(
     pattern: Pattern,
     resultCell: Cell<any>,
     out: Cell<any>[],
     seen: Set<string>,
-    tx: IExtendedStorageTransaction,
-  ): void {
+    syncResultCell = true,
+  ): Promise<void> {
+    // Copies of nested patterns can be created before their module artifact is
+    // indexed. Resolving the ref propagates the owning identity lazily to the
+    // copy's generated descriptors before we derive the cells to pre-sync.
+    void getArtifactEntryRef(pattern);
+
     const link = resultCell.getAsNormalizedFullLink();
     const key = `${link.space}\0${link.id}\0${link.scope ?? "space"}`;
     if (seen.has(key)) return;
     seen.add(key);
 
+    if (syncResultCell) await resultCell.sync();
     for (const descriptor of pattern.derivedInternalCells ?? []) {
       out.push(getDerivedInternalCell(resultCell, descriptor));
     }
 
-    // May be undefined: this walk runs before setup writes the meta on fresh
-    // first runs, and child result cells are not synced yet on a cold-cache
-    // resume. That is fine for binding — unwrapOneLevelAndBindtoDoc only needs
-    // the argument link when an output actually aliases the argument doc, and
-    // throws otherwise. Substituting a different document instead would derive
-    // the wrong `resultFor` identity and pre-sync the wrong owned-cell subtree
-    // (CT-1897).
+    // May be undefined on a fresh first run. That is fine for binding —
+    // unwrapOneLevelAndBindtoDoc only needs the argument link when an output
+    // actually aliases the argument doc, and throws otherwise. Substituting a
+    // different document would derive the wrong `resultFor` identity and
+    // pre-sync the wrong owned-cell subtree (CT-1897).
     const argumentLink = getMetaLink(resultCell, "argument");
-
-    for (const node of pattern.nodes) {
-      const module = node.module;
-      if (module.type !== "pattern" || !isPattern(module.implementation)) {
-        continue;
-      }
-      const childPattern = module.implementation;
-      const targetSpace = module.targetSpace ?? resultCell.space;
-      const childScope = patternDefaultScope(childPattern) ??
-        module.defaultScope;
-      // Resolve the node's reserved output spot the way instantiatePatternNode
-      // does: unwrap one level (so a deferred-alias output is decremented and
-      // followed) and follow the write-redirect chain to its resolved end (a
-      // pattern node reserves one result cell). The minting path keys the child
-      // result cell on the fully resolved redirect, so deriving from the same
-      // resolved spot yields the same `resultFor` identity the child's setup
-      // mints; the unresolved head of a multi-hop binding would be a different
-      // cell, pre-syncing the wrong owned-cell subtree.
-      let spotLink: NormalizedFullLink | undefined;
-      try {
-        const unwrappedOutputs = unwrapOneLevelAndBindtoDoc(
-          this.runtime.cfc,
-          node.outputs,
-          argumentLink,
-          resultCell,
-        );
-        spotLink = firstResolvedOutputRedirect(
-          this.runtime,
-          tx,
-          unwrappedOutputs,
-          resultCell,
-        );
-      } catch (error) {
-        // A node whose outputs cannot be bound (e.g. they alias the argument
-        // doc while the argument link is unavailable) or resolved contributes
-        // nothing rather than breaking the resume walk; log it so a resume
-        // that silently skips its owned-cell pre-sync is diagnosable.
-        logger.warn("resume-owned-cells", () => [
-          "skipping a sub-pattern node whose outputs did not bind or resolve",
-          error,
-        ]);
-        continue;
-      }
-      if (spotLink === undefined) continue;
-      let childResultCell = this.runtime.getCell(
-        targetSpace,
-        {
-          resultFor: {
-            space: spotLink.space,
-            id: spotLink.id,
-            path: [...spotLink.path],
+    const children: Array<{ pattern: Pattern; resultCell: Cell<any> }> = [];
+    // Resolving sub-pattern output redirects reads link metadata through a
+    // transaction. Finish those reads before awaiting the recursive syncs.
+    const tx = this.runtime.edit();
+    try {
+      for (const node of pattern.nodes) {
+        const module = node.module;
+        if (module.type !== "pattern" || !isPattern(module.implementation)) {
+          continue;
+        }
+        const childPattern = module.implementation;
+        const targetSpace = module.targetSpace ?? resultCell.space;
+        const childScope = patternDefaultScope(childPattern) ??
+          module.defaultScope;
+        // Resolve the node's reserved output spot the way
+        // instantiatePatternNode does: unwrap one level (so a deferred-alias
+        // output is decremented and followed) and follow the write-redirect
+        // chain to its resolved end (a pattern node reserves one result cell).
+        let spotLink: NormalizedFullLink | undefined;
+        try {
+          const unwrappedOutputs = unwrapOneLevelAndBindtoDoc(
+            this.runtime.cfc,
+            node.outputs,
+            argumentLink,
+            resultCell,
+          );
+          spotLink = firstResolvedOutputRedirect(
+            this.runtime,
+            tx,
+            unwrappedOutputs,
+            resultCell,
+          );
+        } catch (error) {
+          // A node whose outputs cannot be bound or resolved contributes
+          // nothing rather than breaking the best-effort resume walk.
+          logger.warn("resume-owned-cells", () => [
+            "skipping a sub-pattern node whose outputs did not bind or resolve",
+            error,
+          ]);
+          continue;
+        }
+        if (spotLink === undefined) continue;
+        let childResultCell = this.runtime.getCell(
+          targetSpace,
+          {
+            resultFor: {
+              space: spotLink.space,
+              id: spotLink.id,
+              path: [...spotLink.path],
+            },
           },
-        },
-        childPattern.resultSchema,
-      );
-      if (childScope !== undefined && childScope !== "space") {
-        const childLink = childResultCell.getAsNormalizedFullLink();
-        childResultCell = this.runtime.getCellFromLink({
-          ...childLink,
-          scope: childScope,
-        });
+          childPattern.resultSchema,
+        );
+        if (childScope !== undefined && childScope !== "space") {
+          const childLink = childResultCell.getAsNormalizedFullLink();
+          childResultCell = this.runtime.getCellFromLink({
+            ...childLink,
+            scope: childScope,
+          });
+        }
+        children.push({ pattern: childPattern, resultCell: childResultCell });
       }
-      this.collectResumeOwnedCells(
-        childPattern,
-        childResultCell,
-        out,
-        seen,
-        tx,
-      );
+    } finally {
+      tx.abort("collectResumeOwnedCells: read-only resolution");
     }
+
+    await Promise.all(
+      children.map((child) =>
+        this.collectResumeOwnedCells(
+          child.pattern,
+          child.resultCell,
+          out,
+          seen,
+        )
+      ),
+    );
   }
 
   /**

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -110,6 +110,7 @@ import { runInActionExecution } from "./builder/action-context.ts";
 import { getVerifiedProvenance } from "./harness/verified-provenance.ts";
 import {
   getArtifactEntryRef,
+  getGeneratedInternalCellPatternIdentity,
   isTrustedBuilderArtifact,
   resolveOriginal,
 } from "./builder/pattern-metadata.ts";
@@ -154,9 +155,15 @@ const EAGER_RESULT_BUILTIN_REFS = new Set([
 type InternalCellDescriptor = {
   partialCause: JSONValue;
   /**
+   * Present only for compiler-generated causes. Generated ordinals are local
+   * to one pattern artifact, so this is part of their manifest match key.
+   */
+  patternIdentity?: { identity: string; symbol: string };
+  /**
    * Entity kind of the materialized cell's id. Part of the manifest match
-   * key alongside `partialCause`: a kind flip across pattern versions must
-   * re-materialize the cell under its new id rather than reuse the old link.
+   * key alongside `partialCause` and, for generated causes,
+   * `patternIdentity`: a kind flip across pattern versions must re-materialize
+   * the cell under its new id rather than reuse the old link.
    */
   kind?: EntityKind;
   link: SigilLink;
@@ -1141,6 +1148,9 @@ export class Runner {
     const manifest: InternalCellDescriptor[] = [];
 
     for (const descriptor of descriptors) {
+      const patternIdentity = getGeneratedInternalCellPatternIdentity(
+        descriptor,
+      );
       const derivedCell = getDerivedInternalCell(
         resultCell,
         descriptor,
@@ -1148,6 +1158,7 @@ export class Runner {
       );
       const manifestMatch = existingManifest.findIndex((existingDescriptor) =>
         deepEqual(existingDescriptor.partialCause, descriptor.partialCause) &&
+        deepEqual(existingDescriptor.patternIdentity, patternIdentity) &&
         existingDescriptor.kind === descriptor.kind
       );
       // Re-emit the manifest link and backlink from the current descriptor on
@@ -1160,6 +1171,7 @@ export class Runner {
       });
       manifest.push({
         partialCause: descriptor.partialCause,
+        ...(patternIdentity !== undefined && { patternIdentity }),
         ...(descriptor.kind !== undefined && { kind: descriptor.kind }),
         link: derivedSigilLink,
       });

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -58,6 +58,7 @@ import {
   createSigilLinkFromParsedLink,
   getDerivedInternalCell,
   getDerivedInternalCellLink,
+  getEffectiveGeneratedInternalCellPatternIdentity,
   getMetaCell,
   getMetaLink,
   isAliasBinding,
@@ -1753,7 +1754,8 @@ export class Runner {
     const manifest: InternalCellDescriptor[] = [];
 
     for (const descriptor of descriptors) {
-      const patternIdentity = getGeneratedInternalCellPatternIdentity(
+      const patternIdentity = getEffectiveGeneratedInternalCellPatternIdentity(
+        resultCell,
         descriptor,
       );
       const derivedCell = getDerivedInternalCell(
@@ -3908,18 +3910,13 @@ export class Runner {
     // batched instantiation commit loses and reverts — stranding the optimistic
     // writes that the resumed actions then depend on. Pulling them here keeps
     // that commit read-mostly.
-    // Resolving each sub-pattern node's output redirect chain needs a
-    // transaction (resolveLink reads link metadata). The walk only reads, so the
-    // transaction is discarded afterward.
-    const resolveTx = this.runtime.edit();
-    this.collectResumeOwnedCells(
+    await this.collectResumeOwnedCells(
       pattern,
       resultCell,
       cells,
       new Set(),
-      resolveTx,
+      false,
     );
-    resolveTx.abort("collectResumeOwnedCells: read-only resolution");
 
     // Sync all the previously computed results.
     if (pattern.resultSchema !== undefined) {
@@ -4042,18 +4039,24 @@ export class Runner {
   // result cell to bound the walk against a cyclic reference. This only pulls
   // cells, so a node shape it cannot resolve contributes nothing rather than
   // misbehaving.
-  private collectResumeOwnedCells(
+  private async collectResumeOwnedCells(
     pattern: Pattern,
     resultCell: Cell<any>,
     out: Cell<any>[],
     seen: Set<string>,
-    tx: IExtendedStorageTransaction,
-  ): void {
+    syncResultCell = true,
+  ): Promise<void> {
+    // Copies of nested patterns can be created before their module artifact is
+    // indexed. Resolving the ref propagates the owning identity lazily to the
+    // copy's generated descriptors before we derive the cells to pre-sync.
+    void getArtifactEntryRef(pattern);
+
     const link = resultCell.getAsNormalizedFullLink();
     const key = `${link.space}\0${link.id}\0${link.scope ?? "space"}`;
     if (seen.has(key)) return;
     seen.add(key);
 
+    if (syncResultCell) await resultCell.sync();
     for (const descriptor of pattern.derivedInternalCells ?? []) {
       out.push(getDerivedInternalCell(resultCell, descriptor));
     }
@@ -4066,104 +4069,97 @@ export class Runner {
     // the wrong `resultFor` identity and pre-sync the wrong owned-cell subtree
     // (CT-1897).
     const argumentLink = getMetaLink(resultCell, "argument");
-
-    for (const [nodeIndex, node] of pattern.nodes.entries()) {
-      const module = node.module;
-      if (module.type !== "pattern" || !isPattern(module.implementation)) {
-        continue;
-      }
-      const childPattern = module.implementation;
-      const targetSpace = module.targetSpace ?? resultCell.space;
-      const childScope = patternDefaultScope(childPattern) ??
-        module.defaultScope;
-      // Resolve the node's reserved output spot the way instantiatePatternNode
-      // does: unwrap one level (so a deferred-alias output is decremented and
-      // followed) and follow the write-redirect chain to its resolved end (a
-      // pattern node reserves one result cell). The minting path keys the child
-      // result cell on the fully resolved redirect, so deriving from the same
-      // resolved spot yields the same `resultFor` identity the child's setup
-      // mints; the unresolved head of a multi-hop binding would be a different
-      // cell, pre-syncing the wrong owned-cell subtree.
-      let spotLink: NormalizedFullLink | undefined;
-      try {
-        const unwrappedOutputs = unwrapOneLevelAndBindToDoc(
-          node.outputs,
-          argumentLink,
-          resultCell,
-        );
-        spotLink = firstResolvedOutputRedirect(
-          this.runtime,
-          tx,
-          unwrappedOutputs,
-          resultCell,
-        );
-      } catch (error) {
-        // A node whose outputs cannot be bound (e.g. they alias the argument
-        // doc while the argument link is unavailable) or resolved contributes
-        // nothing rather than breaking the resume walk; log it so a resume
-        // that silently skips its owned-cell pre-sync is diagnosable.
-        logger.warn("resume-owned-cells", () => [
-          "skipping a sub-pattern node whose outputs did not bind or resolve",
-          error,
-          describeSkippedSubPatternNode(link, nodeIndex, node, childPattern),
-        ]);
-        continue;
-      }
-      if (spotLink === undefined) {
-        // The same two skips as the catch above — this node's owned-cell
-        // pre-sync AND the recursion that would reach the child's own
-        // `derivedInternalCells` manifest — reached without an error: the
-        // outputs bound, but held no write redirect the scan could resolve
-        // (e.g. they consist only of deferred partialCause aliases, which
-        // denote a deeper level's derived internal cells rather than this
-        // node's reserved result spot).
-        //
-        // DEBUG, not warn: this is the BY-DESIGN outcome for such outputs, not
-        // a failure. #5143 deliberately moved that case off the throwing path,
-        // and ordinary healthy runs of the home pattern take this exit several
-        // times per resume — warning here would be noise, not signal. It still
-        // hides a skipped subtree, so it carries the same key and the same
-        // identity payload as its sibling, and turning this logger up to debug
-        // brings it back for someone tracing a stranded piece:
-        // `commonfabric.logger["runner"].level = "debug"` on the main thread,
-        // `commonfabric.rt.setLoggerLevel("debug", "runner")` for the worker
-        // the runner actually lives in. (`CF_LOG_LEVEL` will NOT do it: it is a
-        // floor, and this logger's own configured level — `warn` — is the more
-        // restrictive of the two.) A console filter on `resume-owned-cells`
-        // then catches both exits. `resume-owned-cells-skip-log.test.ts` pins
-        // the level in both directions.
-        logger.debug("resume-owned-cells", () => [
-          "skipping a sub-pattern node whose outputs resolved to no write redirect",
-          describeSkippedSubPatternNode(link, nodeIndex, node, childPattern),
-        ]);
-        continue;
-      }
-      let childResultCell = this.runtime.getCell(
-        targetSpace,
-        {
-          resultFor: {
-            space: spotLink.space,
-            id: spotLink.id,
-            path: [...spotLink.path],
+    const children: Array<{ pattern: Pattern; resultCell: Cell<any> }> = [];
+    // Resolving sub-pattern output redirects reads link metadata through a
+    // transaction. Finish those reads before awaiting the recursive syncs.
+    const tx = this.runtime.edit();
+    try {
+      for (const [nodeIndex, node] of pattern.nodes.entries()) {
+        const module = node.module;
+        if (module.type !== "pattern" || !isPattern(module.implementation)) {
+          continue;
+        }
+        const childPattern = module.implementation;
+        const targetSpace = module.targetSpace ?? resultCell.space;
+        const childScope = patternDefaultScope(childPattern) ??
+          module.defaultScope;
+        // Resolve the node's reserved output spot the way instantiatePatternNode
+        // does: unwrap one level (so a deferred-alias output is decremented and
+        // followed) and follow the write-redirect chain to its resolved end (a
+        // pattern node reserves one result cell). The minting path keys the child
+        // result cell on the fully resolved redirect, so deriving from the same
+        // resolved spot yields the same `resultFor` identity the child's setup
+        // mints; the unresolved head of a multi-hop binding would be a different
+        // cell, pre-syncing the wrong owned-cell subtree.
+        let spotLink: NormalizedFullLink | undefined;
+        try {
+          const unwrappedOutputs = unwrapOneLevelAndBindToDoc(
+            node.outputs,
+            argumentLink,
+            resultCell,
+          );
+          spotLink = firstResolvedOutputRedirect(
+            this.runtime,
+            tx,
+            unwrappedOutputs,
+            resultCell,
+          );
+        } catch (error) {
+          // A node whose outputs cannot be bound (e.g. they alias the argument
+          // doc while the argument link is unavailable) or resolved contributes
+          // nothing rather than breaking the resume walk; log it so a resume
+          // that silently skips its owned-cell pre-sync is diagnosable.
+          logger.warn("resume-owned-cells", () => [
+            "skipping a sub-pattern node whose outputs did not bind or resolve",
+            error,
+            describeSkippedSubPatternNode(link, nodeIndex, node, childPattern),
+          ]);
+          continue;
+        }
+        if (spotLink === undefined) {
+          // Deferred partialCause aliases can legitimately resolve to no
+          // redirect at this level. Keep the skip diagnosable without warning
+          // on an ordinary healthy resume.
+          logger.debug("resume-owned-cells", () => [
+            "skipping a sub-pattern node whose outputs resolved to no write redirect",
+            describeSkippedSubPatternNode(link, nodeIndex, node, childPattern),
+          ]);
+          continue;
+        }
+        let childResultCell = this.runtime.getCell(
+          targetSpace,
+          {
+            resultFor: {
+              space: spotLink.space,
+              id: spotLink.id,
+              path: [...spotLink.path],
+            },
           },
-        },
-        childPattern.resultSchema,
-      );
-      if (childScope !== undefined && childScope !== "space") {
-        const childLink = childResultCell.getAsNormalizedFullLink();
-        childResultCell = this.runtime.getCellFromLink({
-          ...childLink,
-          scope: childScope,
-        });
+          childPattern.resultSchema,
+        );
+        if (childScope !== undefined && childScope !== "space") {
+          const childLink = childResultCell.getAsNormalizedFullLink();
+          childResultCell = this.runtime.getCellFromLink({
+            ...childLink,
+            scope: childScope,
+          });
+        }
+        children.push({ pattern: childPattern, resultCell: childResultCell });
       }
-      this.collectResumeOwnedCells(
-        childPattern,
-        childResultCell,
-        out,
-        seen,
-        tx,
-      );
+    } finally {
+      tx.abort("collectResumeOwnedCells: read-only resolution");
     }
+
+    await Promise.all(
+      children.map((child) =>
+        this.collectResumeOwnedCells(
+          child.pattern,
+          child.resultCell,
+          out,
+          seen,
+        )
+      ),
+    );
   }
 
   /**

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -128,6 +128,7 @@ import { runInActionExecution } from "./builder/action-context.ts";
 import { getVerifiedProvenance } from "./harness/verified-provenance.ts";
 import {
   getArtifactEntryRef,
+  getGeneratedInternalCellPatternIdentity,
   getPatternProgram,
   getPatternSourcePath,
   isTrustedBuilderArtifact,
@@ -187,9 +188,15 @@ const EAGER_RESULT_BUILTIN_REFS = new Set([
 type InternalCellDescriptor = {
   partialCause: JSONValue;
   /**
+   * Present only for compiler-generated causes. Generated ordinals are local
+   * to one pattern artifact, so this is part of their manifest match key.
+   */
+  patternIdentity?: { identity: string; symbol: string };
+  /**
    * Entity kind of the materialized cell's id. Part of the manifest match
-   * key alongside `partialCause`: a kind flip across pattern versions must
-   * re-materialize the cell under its new id rather than reuse the old link.
+   * key alongside `partialCause` and, for generated causes,
+   * `patternIdentity`: a kind flip across pattern versions must re-materialize
+   * the cell under its new id rather than reuse the old link.
    */
   kind?: EntityKind;
   link: SigilLink;
@@ -1746,6 +1753,9 @@ export class Runner {
     const manifest: InternalCellDescriptor[] = [];
 
     for (const descriptor of descriptors) {
+      const patternIdentity = getGeneratedInternalCellPatternIdentity(
+        descriptor,
+      );
       const derivedCell = getDerivedInternalCell(
         resultCell,
         descriptor,
@@ -1753,6 +1763,7 @@ export class Runner {
       );
       const manifestMatch = existingManifest.findIndex((existingDescriptor) =>
         deepEqual(existingDescriptor.partialCause, descriptor.partialCause) &&
+        deepEqual(existingDescriptor.patternIdentity, patternIdentity) &&
         existingDescriptor.kind === descriptor.kind
       );
       // Re-emit the manifest link and backlink from the current descriptor on
@@ -1765,6 +1776,7 @@ export class Runner {
       });
       manifest.push({
         partialCause: descriptor.partialCause,
+        ...(patternIdentity !== undefined && { patternIdentity }),
         ...(descriptor.kind !== undefined && { kind: descriptor.kind }),
         link: derivedSigilLink,
       });

--- a/packages/runner/test/derived-copy-identity.test.ts
+++ b/packages/runner/test/derived-copy-identity.test.ts
@@ -4,6 +4,7 @@ import {
   brandTrustedBuilderArtifact,
   brandTrustedPattern,
   getArtifactEntryRef,
+  getGeneratedInternalCellPatternIdentity,
   isTrustedBuilderArtifact,
   isTrustedPattern,
   noteDerivedCopy,
@@ -28,6 +29,14 @@ const patternShape = () => ({
   resultSchema: { type: "object" as const },
   nodes: [],
   result: {},
+});
+
+const patternWithInternals = () => ({
+  ...patternShape(),
+  derivedInternalCells: [
+    { partialCause: { $generated: 0 } },
+    { partialCause: "named-state" },
+  ],
 });
 
 describe("noteDerivedCopy trust carry", () => {
@@ -100,5 +109,37 @@ describe("entry-ref resolution through copies", () => {
       identity: "first",
       symbol: "a",
     });
+  });
+});
+
+describe("generated internal-cell pattern identity", () => {
+  it("associates only generated descriptors with the artifact ref", () => {
+    const pattern = brandTrustedPattern(patternWithInternals());
+    const ref = { identity: "pattern-v1", symbol: "default" };
+    setArtifactEntryRef(pattern, ref);
+
+    expect(
+      getGeneratedInternalCellPatternIdentity(
+        pattern.derivedInternalCells[0],
+      ),
+    ).toEqual(ref);
+    expect(
+      getGeneratedInternalCellPatternIdentity(
+        pattern.derivedInternalCells[1],
+      ),
+    ).toBeUndefined();
+  });
+
+  it("associates a pre-index copy lazily when its ref is resolved", () => {
+    const original = brandTrustedPattern(patternWithInternals());
+    const copy = patternWithInternals();
+    noteDerivedCopy(copy, original);
+    const ref = { identity: "pattern-v2", symbol: "op" };
+    setArtifactEntryRef(original, ref);
+
+    expect(getArtifactEntryRef(copy)).toEqual(ref);
+    expect(
+      getGeneratedInternalCellPatternIdentity(copy.derivedInternalCells[0]),
+    ).toEqual(ref);
   });
 });

--- a/packages/runner/test/derived-copy-identity.test.ts
+++ b/packages/runner/test/derived-copy-identity.test.ts
@@ -81,6 +81,7 @@ describe("entry-ref resolution through copies", () => {
     const ref = { identity: "ignored", symbol: "default" };
     setArtifactEntryRef("not-an-artifact", ref);
     expect(getArtifactEntryRef("not-an-artifact")).toBeUndefined();
+    expect(resolveOriginal("not-an-artifact")).toBe("not-an-artifact");
   });
 
   it("resolves a ref registered BEFORE the copy (eager)", () => {

--- a/packages/runner/test/derived-copy-identity.test.ts
+++ b/packages/runner/test/derived-copy-identity.test.ts
@@ -11,6 +11,7 @@ import {
   resolveOriginal,
   setArtifactEntryRef,
 } from "../src/builder/pattern-metadata.ts";
+import { getEffectiveGeneratedInternalCellPatternIdentity } from "../src/link-utils.ts";
 
 /**
  * Derived-copy identity carry (PR B of
@@ -76,6 +77,12 @@ describe("noteDerivedCopy trust carry", () => {
 });
 
 describe("entry-ref resolution through copies", () => {
+  it("ignores non-object artifacts", () => {
+    const ref = { identity: "ignored", symbol: "default" };
+    setArtifactEntryRef("not-an-artifact", ref);
+    expect(getArtifactEntryRef("not-an-artifact")).toBeUndefined();
+  });
+
   it("resolves a ref registered BEFORE the copy (eager)", () => {
     const original = brandTrustedPattern(patternShape());
     setArtifactEntryRef(original, { identity: "id-eager", symbol: "default" });
@@ -140,6 +147,27 @@ describe("generated internal-cell pattern identity", () => {
     expect(getArtifactEntryRef(copy)).toEqual(ref);
     expect(
       getGeneratedInternalCellPatternIdentity(copy.derivedInternalCells[0]),
+    ).toEqual(ref);
+  });
+
+  it("uses the versioned identity when the current manifest is absent", () => {
+    const pattern = brandTrustedPattern(patternWithInternals());
+    const ref = { identity: "pattern-v3", symbol: "default" };
+    setArtifactEntryRef(pattern, ref);
+
+    const resultCell = {
+      getMetaRaw(field: string) {
+        return field === "patternIdentity" ? ref : undefined;
+      },
+    } as unknown as Parameters<
+      typeof getEffectiveGeneratedInternalCellPatternIdentity
+    >[0];
+
+    expect(
+      getEffectiveGeneratedInternalCellPatternIdentity(
+        resultCell,
+        pattern.derivedInternalCells[0],
+      ),
     ).toEqual(ref);
   });
 });

--- a/packages/runner/test/derived-copy-identity.test.ts
+++ b/packages/runner/test/derived-copy-identity.test.ts
@@ -106,6 +106,7 @@ describe("entry-ref resolution through copies", () => {
     const ref = { identity: "ignored", symbol: "default" };
     setArtifactEntryRef("not-an-artifact", ref);
     expect(getArtifactEntryRef("not-an-artifact")).toBeUndefined();
+    expect(resolveOriginal("not-an-artifact")).toBe("not-an-artifact");
   });
 
   it("resolves a ref registered BEFORE the copy (eager)", () => {

--- a/packages/runner/test/derived-copy-identity.test.ts
+++ b/packages/runner/test/derived-copy-identity.test.ts
@@ -11,6 +11,7 @@ import {
   resolveOriginal,
   setArtifactEntryRef,
 } from "../src/builder/pattern-metadata.ts";
+import { getEffectiveGeneratedInternalCellPatternIdentity } from "../src/link-utils.ts";
 
 /**
  * Derived-copy identity carry (PR B of
@@ -101,6 +102,12 @@ describe("noteDerivedCopy trust carry", () => {
 });
 
 describe("entry-ref resolution through copies", () => {
+  it("ignores non-object artifacts", () => {
+    const ref = { identity: "ignored", symbol: "default" };
+    setArtifactEntryRef("not-an-artifact", ref);
+    expect(getArtifactEntryRef("not-an-artifact")).toBeUndefined();
+  });
+
   it("resolves a ref registered BEFORE the copy (eager)", () => {
     const original = brandTrustedPattern(patternShape());
     setArtifactEntryRef(original, { identity: "id-eager", symbol: "default" });
@@ -165,6 +172,27 @@ describe("generated internal-cell pattern identity", () => {
     expect(getArtifactEntryRef(copy)).toEqual(ref);
     expect(
       getGeneratedInternalCellPatternIdentity(copy.derivedInternalCells[0]),
+    ).toEqual(ref);
+  });
+
+  it("uses the versioned identity when the current manifest is absent", () => {
+    const pattern = brandTrustedPattern(patternWithInternals());
+    const ref = { identity: "pattern-v3", symbol: "default" };
+    setArtifactEntryRef(pattern, ref);
+
+    const resultCell = {
+      getMetaRaw(field: string) {
+        return field === "patternIdentity" ? ref : undefined;
+      },
+    } as unknown as Parameters<
+      typeof getEffectiveGeneratedInternalCellPatternIdentity
+    >[0];
+
+    expect(
+      getEffectiveGeneratedInternalCellPatternIdentity(
+        resultCell,
+        pattern.derivedInternalCells[0],
+      ),
     ).toEqual(ref);
   });
 });

--- a/packages/runner/test/derived-copy-identity.test.ts
+++ b/packages/runner/test/derived-copy-identity.test.ts
@@ -4,6 +4,7 @@ import {
   brandTrustedBuilderArtifact,
   brandTrustedPattern,
   getArtifactEntryRef,
+  getGeneratedInternalCellPatternIdentity,
   isTrustedBuilderArtifact,
   isTrustedPattern,
   noteDerivedCopy,
@@ -28,6 +29,14 @@ const patternShape = () => ({
   resultSchema: { type: "object" as const },
   nodes: [],
   result: {},
+});
+
+const patternWithInternals = () => ({
+  ...patternShape(),
+  derivedInternalCells: [
+    { partialCause: { $generated: 0 } },
+    { partialCause: "named-state" },
+  ],
 });
 
 describe("noteDerivedCopy trust carry", () => {
@@ -125,5 +134,37 @@ describe("entry-ref resolution through copies", () => {
       identity: "first",
       symbol: "a",
     });
+  });
+});
+
+describe("generated internal-cell pattern identity", () => {
+  it("associates only generated descriptors with the artifact ref", () => {
+    const pattern = brandTrustedPattern(patternWithInternals());
+    const ref = { identity: "pattern-v1", symbol: "default" };
+    setArtifactEntryRef(pattern, ref);
+
+    expect(
+      getGeneratedInternalCellPatternIdentity(
+        pattern.derivedInternalCells[0],
+      ),
+    ).toEqual(ref);
+    expect(
+      getGeneratedInternalCellPatternIdentity(
+        pattern.derivedInternalCells[1],
+      ),
+    ).toBeUndefined();
+  });
+
+  it("associates a pre-index copy lazily when its ref is resolved", () => {
+    const original = brandTrustedPattern(patternWithInternals());
+    const copy = patternWithInternals();
+    noteDerivedCopy(copy, original);
+    const ref = { identity: "pattern-v2", symbol: "op" };
+    setArtifactEntryRef(original, ref);
+
+    expect(getArtifactEntryRef(copy)).toEqual(ref);
+    expect(
+      getGeneratedInternalCellPatternIdentity(copy.derivedInternalCells[0]),
+    ).toEqual(ref);
   });
 });

--- a/packages/runner/test/list-builtin-edge-paths.test.ts
+++ b/packages/runner/test/list-builtin-edge-paths.test.ts
@@ -14,7 +14,7 @@ import {
   StorageManager as StorageManagerV2,
 } from "../src/storage/v2.ts";
 import { createBuilder } from "../src/builder/factory.ts";
-import type { Pattern } from "../src/builder/types.ts";
+import type { Cell, Pattern } from "../src/builder/types.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
@@ -419,6 +419,66 @@ describe("resume owned-cell walk: scoped sub-pattern", () => {
     await sm1?.close();
     await sm2?.close();
     await server?.close();
+  });
+
+  it("deduplicates shared child results and ignores children without outputs", async () => {
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm1,
+    });
+    try {
+      const root = runtime.getCell(space, "resume-owned-dedup-root");
+      const sharedSpot = runtime.getCell(space, "resume-owned-shared-spot");
+      const sharedOutput = sharedSpot.getAsWriteRedirectLink({ base: root });
+      const child: Pattern = {
+        argumentSchema: {},
+        resultSchema: {},
+        derivedInternalCells: [{ partialCause: "owned" }],
+        result: {},
+        nodes: [],
+      };
+      const childNode = {
+        module: { type: "pattern" as const, implementation: child },
+        inputs: {},
+        outputs: sharedOutput as unknown as Pattern["nodes"][number]["outputs"],
+      };
+      const outer: Pattern = {
+        argumentSchema: {},
+        resultSchema: {},
+        result: {},
+        nodes: [
+          childNode,
+          childNode,
+          {
+            module: { type: "pattern", implementation: child },
+            inputs: {},
+            outputs: {},
+          },
+        ],
+      };
+      const owned: Cell<unknown>[] = [];
+      const runner = runtime.runner as unknown as {
+        collectResumeOwnedCells(
+          pattern: Pattern,
+          resultCell: Cell<unknown>,
+          out: Cell<unknown>[],
+          seen: Set<string>,
+          syncResultCell?: boolean,
+        ): Promise<void>;
+      };
+
+      await runner.collectResumeOwnedCells(
+        outer,
+        root,
+        owned,
+        new Set(),
+        false,
+      );
+
+      expect(owned).toHaveLength(1);
+    } finally {
+      await runtime.dispose();
+    }
   });
 
   it("re-scopes a user-scoped nested sub-pattern across a cold resume", async () => {

--- a/packages/runner/test/list-builtin-edge-paths.test.ts
+++ b/packages/runner/test/list-builtin-edge-paths.test.ts
@@ -14,6 +14,7 @@ import {
   StorageManager as StorageManagerV2,
 } from "../src/storage/v2.ts";
 import { createBuilder } from "../src/builder/factory.ts";
+import type { Pattern } from "../src/builder/types.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
@@ -379,8 +380,9 @@ const SCOPED_PROGRAM: RuntimeProgram = {
     contents: [
       "import { lift, pattern, UI } from 'commonfabric';",
       "const scale = lift((n: number) => n * 10);",
-      "const inner = pattern<{ n: number }>(({ n }) => {",
-      "  return { scaled: scale(n) };",
+      "const inner = pattern<{ n: number }, { scaled: number[] }>(({ n }) => {",
+      "  const scaled = ['slot'].map(() => scale(n));",
+      "  return { scaled };",
       "});",
       // The explicit Output type omits UI, so the inferred result schema has no
       // $UI property even though the result object carries one. That makes the
@@ -388,8 +390,8 @@ const SCOPED_PROGRAM: RuntimeProgram = {
       "export default pattern<{ seed: number }, { value: number }>(({ seed }) => {",
       "  const child = inner.asScope('user')({ n: seed });",
       "  return {",
-      "    value: child.scaled,",
-      "    [UI]: <div>{child.scaled}</div>,",
+      "    value: child.scaled[0],",
+      "    [UI]: <div>{child.scaled[0]}</div>,",
       "  };",
       "});",
     ].join("\n"),
@@ -427,6 +429,16 @@ describe("resume owned-cell walk: scoped sub-pattern", () => {
     const compiled1 = await rt1.patternManager.compilePattern(SCOPED_PROGRAM, {
       space,
     });
+    const childPattern = compiled1.nodes.find((node) =>
+      node.module.type === "pattern"
+    )?.module.implementation as Pattern | undefined;
+    expect(
+      childPattern?.derivedInternalCells?.some((descriptor) =>
+        typeof descriptor.partialCause === "object" &&
+        descriptor.partialCause !== null &&
+        "$generated" in descriptor.partialCause
+      ),
+    ).toBe(true);
     const tx0 = rt1.edit();
     const rc1 = rt1.getCell<{ value: number }>(
       space,

--- a/packages/runner/test/pattern-auto-update.test.ts
+++ b/packages/runner/test/pattern-auto-update.test.ts
@@ -7,6 +7,7 @@ import {
   type Cell,
   getPatternIdentityRef,
   getPatternSource,
+  parseLink,
   resolveEntryIdentity,
   Runtime,
   type RuntimeFetch,
@@ -30,7 +31,13 @@ const parentSource = [
 function source(marker: string): string {
   return [
     "import { computed, pattern } from 'commonfabric';",
-    `export const ${SYMBOL} = pattern<Record<string, never>, { marker: string }>(() => ({ marker: computed(() => "${marker}") }));`,
+    `export const ${SYMBOL} = pattern<Record<string, never>, { marker: string; generatedMarkers: string[] }>(() => {`,
+    `  const generatedMarkers = ["slot"].map(() => computed(() => "${marker}"));`,
+    "  return {",
+    `    marker: computed(() => "${marker}"),`,
+    "    generatedMarkers,",
+    "  };",
+    "});",
     "",
   ].join("\n");
 }
@@ -100,7 +107,10 @@ describe("lazy system-pattern auto-update", () => {
     const recovered = await runtime.patternManager
       .getPatternSourceProgramByIdentity(initialIdentity, space);
     expect(recovered?.main).toBe(PARENT_PATH);
-    const piece = runtime.getCell<{ marker?: string }>(
+    const piece = runtime.getCell<{
+      marker?: string;
+      generatedMarkers?: string[];
+    }>(
       space,
       `lazy-update-${crypto.randomUUID()}`,
     );
@@ -469,6 +479,7 @@ describe("lazy system-pattern auto-update", () => {
   });
 
   it("starts immediately, then updates a non-root pattern in the background", async () => {
+    const v1Identity = await identityFor(source("v1"));
     const v2Identity = await identityFor(source("v2"));
     const identityRequested = defer();
     identityGate = defer();
@@ -499,24 +510,56 @@ describe("lazy system-pattern auto-update", () => {
         headers: { "content-type": "text/typescript-jsx" },
       });
     });
-    const v1Ref = getPatternIdentityRef(piece)!;
+    const v1Ref = { identity: v1Identity, symbol: SYMBOL };
 
     const start = runtime.start(piece);
     await identityRequested.promise;
     expect(await start).toBe(true);
     await runtime.idle();
     expect((await piece.pull())?.marker).toBe("v1");
+    expect((await piece.pull())?.generatedMarkers).toEqual(["v1"]);
     expect(getPatternIdentityRef(piece)).toEqual(v1Ref);
+    const v1Manifest = piece.getMetaRaw("internal") as Array<{
+      partialCause: unknown;
+      patternIdentity?: { identity: string; symbol: string };
+      link: unknown;
+    }>;
+    const v1Generated = v1Manifest.find((entry) =>
+      typeof entry.partialCause === "object" &&
+      entry.partialCause !== null &&
+      "$generated" in entry.partialCause
+    );
+    expect(v1Generated?.patternIdentity).toEqual(v1Ref);
+    const v1GeneratedLink = parseLink(v1Generated?.link, piece);
+    expect(v1GeneratedLink).toBeDefined();
 
     identityGate.resolve();
     await runtime.patternUpdater.idle();
     await runtime.idle();
 
     expect((await piece.pull())?.marker).toBe("v2");
+    expect((await piece.pull())?.generatedMarkers).toEqual(["v2"]);
     expect(getPatternIdentityRef(piece)).toEqual({
       identity: v2Identity,
       symbol: SYMBOL,
     });
+    const v2Manifest = piece.getMetaRaw("internal") as Array<{
+      partialCause: unknown;
+      patternIdentity?: { identity: string; symbol: string };
+      link: unknown;
+    }>;
+    const v2Generated = v2Manifest.find((entry) =>
+      typeof entry.partialCause === "object" &&
+      entry.partialCause !== null &&
+      "$generated" in entry.partialCause
+    );
+    expect(v2Generated?.patternIdentity).toEqual({
+      identity: v2Identity,
+      symbol: SYMBOL,
+    });
+    expect(parseLink(v2Generated?.link, piece)?.id).not.toBe(
+      v1GeneratedLink?.id,
+    );
     expect(getPatternSource(piece)).toBe(PARENT_PATH);
     expect(requested).toContainEqual({
       href: `http://toolshed.test${PARENT_PATH}?identity=`,

--- a/packages/runner/test/pattern-auto-update.test.ts
+++ b/packages/runner/test/pattern-auto-update.test.ts
@@ -8,6 +8,7 @@ import {
   getPatternIdentityRef,
   getPatternSource,
   getPieceSourceRevisions,
+  parseLink,
   resolveEntryIdentity,
   Runtime,
   type RuntimeFetch,
@@ -35,7 +36,13 @@ const parentSource = [
 function source(marker: string): string {
   return [
     "import { computed, pattern } from 'commonfabric';",
-    `export const ${SYMBOL} = pattern<Record<string, never>, { marker: string }>(() => ({ marker: computed(() => "${marker}") }));`,
+    `export const ${SYMBOL} = pattern<Record<string, never>, { marker: string; generatedMarkers: string[] }>(() => {`,
+    `  const generatedMarkers = ["slot"].map(() => computed(() => "${marker}"));`,
+    "  return {",
+    `    marker: computed(() => "${marker}"),`,
+    "    generatedMarkers,",
+    "  };",
+    "});",
     "",
   ].join("\n");
 }
@@ -129,7 +136,10 @@ describe("lazy system-pattern auto-update", () => {
     const recovered = await runtime.patternManager
       .getPatternSourceProgramByIdentity(initialIdentity, space);
     expect(recovered?.main).toBe(PARENT_PATH);
-    const piece = runtime.getCell<{ marker?: string }>(
+    const piece = runtime.getCell<{
+      marker?: string;
+      generatedMarkers?: string[];
+    }>(
       space,
       `lazy-update-${crypto.randomUUID()}`,
     );
@@ -498,6 +508,7 @@ describe("lazy system-pattern auto-update", () => {
   });
 
   it("starts immediately, then updates a non-root pattern in the background", async () => {
+    const v1Identity = await identityFor(source("v1"));
     const v2Identity = await identityFor(source("v2"));
     const identityRequested = defer();
     identityGate = defer();
@@ -528,24 +539,56 @@ describe("lazy system-pattern auto-update", () => {
         headers: { "content-type": "text/typescript-jsx" },
       });
     });
-    const v1Ref = getPatternIdentityRef(piece)!;
+    const v1Ref = { identity: v1Identity, symbol: SYMBOL };
 
     const start = runtime.start(piece);
     await identityRequested.promise;
     expect(await start).toBe(true);
     await runtime.idle();
     expect((await piece.pull())?.marker).toBe("v1");
+    expect((await piece.pull())?.generatedMarkers).toEqual(["v1"]);
     expect(getPatternIdentityRef(piece)).toEqual(v1Ref);
+    const v1Manifest = piece.getMetaRaw("internal") as Array<{
+      partialCause: unknown;
+      patternIdentity?: { identity: string; symbol: string };
+      link: unknown;
+    }>;
+    const v1Generated = v1Manifest.find((entry) =>
+      typeof entry.partialCause === "object" &&
+      entry.partialCause !== null &&
+      "$generated" in entry.partialCause
+    );
+    expect(v1Generated?.patternIdentity).toEqual(v1Ref);
+    const v1GeneratedLink = parseLink(v1Generated?.link, piece);
+    expect(v1GeneratedLink).toBeDefined();
 
     identityGate.resolve();
     await runtime.patternUpdater.idle();
     await runtime.idle();
 
     expect((await piece.pull())?.marker).toBe("v2");
+    expect((await piece.pull())?.generatedMarkers).toEqual(["v2"]);
     expect(getPatternIdentityRef(piece)).toEqual({
       identity: v2Identity,
       symbol: SYMBOL,
     });
+    const v2Manifest = piece.getMetaRaw("internal") as Array<{
+      partialCause: unknown;
+      patternIdentity?: { identity: string; symbol: string };
+      link: unknown;
+    }>;
+    const v2Generated = v2Manifest.find((entry) =>
+      typeof entry.partialCause === "object" &&
+      entry.partialCause !== null &&
+      "$generated" in entry.partialCause
+    );
+    expect(v2Generated?.patternIdentity).toEqual({
+      identity: v2Identity,
+      symbol: SYMBOL,
+    });
+    expect(parseLink(v2Generated?.link, piece)?.id).not.toBe(
+      v1GeneratedLink?.id,
+    );
     expect(getPatternSource(piece)).toBe(PARENT_SOURCE);
     expect(requested).toContainEqual({
       href: `http://toolshed.test${PARENT_PATH}?identity=`,

--- a/packages/runner/test/rehydrate-internal-default.test.ts
+++ b/packages/runner/test/rehydrate-internal-default.test.ts
@@ -5,7 +5,11 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Cell, type Pattern } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
-import { getMetaLink, parseLink } from "../src/link-utils.ts";
+import {
+  getDerivedInternalCell,
+  getMetaLink,
+  parseLink,
+} from "../src/link-utils.ts";
 import { trustExecutable } from "./support/trusted-builder.ts";
 import { JSONValue } from "@commonfabric/runner/shared";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
@@ -163,6 +167,89 @@ describe("rehydrate internal default (CT-1666)", () => {
 
       const internal2 = internalCellOf(rt2, rc2, "activeTab")!;
       expect(internal2.get()).toEqual("profile");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  it("keeps a pre-versioning generated id for an unchanged pattern", async () => {
+    const generatedCause = { $generated: 0 };
+    const generatedPattern: Pattern = {
+      argumentSchema: {},
+      resultSchema: {
+        type: "object",
+        properties: { active: { type: "string" } },
+      },
+      derivedInternalCells: [{
+        partialCause: generatedCause,
+        schema: { type: "string", default: "spaces" },
+      }],
+      result: {
+        active: { $alias: { partialCause: generatedCause, path: [] } },
+      },
+      nodes: [],
+    };
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm2,
+    });
+    try {
+      const rc1 = rt1.getCell<{ active: string }>(
+        space,
+        "legacy-generated-result",
+      );
+      await rt1.runSynced(
+        rc1,
+        trustExecutable(rt1, generatedPattern),
+        {},
+      );
+      await rc1.pull();
+
+      // Forge the exact pre-#4916 manifest shape. The fresh descriptor has no
+      // out-of-band artifact association, so it derives the legacy id whose
+      // preimage contains only the generated partial cause.
+      const legacyCell = getDerivedInternalCell(rc1, {
+        partialCause: { $generated: 0 },
+        schema: { type: "string", default: "spaces" },
+      });
+      const legacyLink = legacyCell.getAsWriteRedirectLink({
+        base: rc1,
+        includeSchema: true,
+      });
+      const tx = rt1.edit();
+      legacyCell.withTx(tx).set("profile");
+      rc1.withTx(tx).setMetaRaw("internal", [{
+        partialCause: generatedCause,
+        link: legacyLink,
+      }]);
+      await tx.commit();
+      await sm1.synced();
+
+      const rc2 = rt2.getCell<{ active: string }>(
+        space,
+        "legacy-generated-result",
+      );
+      await rt2.runSynced(
+        rc2,
+        trustExecutable(rt2, generatedPattern),
+        {},
+      );
+      expect((await rc2.pull()).active).toBe("profile");
+
+      const resumedManifest = rc2.getMetaRaw("internal");
+      expect(Array.isArray(resumedManifest)).toBe(true);
+      const resumedEntry = Array.isArray(resumedManifest)
+        ? resumedManifest[0]
+        : undefined;
+      expect(resumedEntry?.patternIdentity).toBeUndefined();
+      expect(parseLink(resumedEntry?.link, rc2)?.id).toBe(
+        parseLink(legacyLink, rc1).id,
+      );
     } finally {
       await rt2.dispose();
       await rt1.dispose();

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -247,6 +247,96 @@ describe("runPattern", () => {
     expect(nextLink?.schema).toEqual(narrow);
   });
 
+  it("versions generated internal cells while preserving named cells", async () => {
+    const resultCell = runtime.getCell(
+      space,
+      "version generated internal cells",
+    );
+    const pattern = (generatedDefault: string): Pattern => ({
+      argumentSchema: { type: "object", properties: {} },
+      resultSchema: { type: "object" },
+      derivedInternalCells: [
+        {
+          partialCause: { $generated: 0 },
+          schema: { type: "string", default: generatedDefault },
+          scope: "space",
+        },
+        {
+          partialCause: "named-state",
+          schema: { type: "string", default: "durable" },
+          scope: "space",
+        },
+      ],
+      result: {
+        generated: {
+          $alias: { partialCause: { $generated: 0 }, path: [] },
+        },
+        named: { $alias: { partialCause: "named-state", path: [] } },
+      },
+      nodes: [],
+    });
+
+    await setupTrusted(
+      runtime,
+      undefined,
+      pattern("version-one"),
+      {},
+      resultCell,
+    );
+    const firstManifest = resultCell.getMetaRaw("internal") as Array<{
+      partialCause: unknown;
+      patternIdentity?: { identity: string; symbol: string };
+      link: unknown;
+    }>;
+    const firstGenerated = firstManifest.find((entry) =>
+      typeof entry.partialCause === "object"
+    )!;
+    const firstNamed = firstManifest.find((entry) =>
+      entry.partialCause === "named-state"
+    )!;
+    const firstGeneratedLink = parseLink(firstGenerated.link, resultCell)!;
+    const firstNamedLink = parseLink(firstNamed.link, resultCell)!;
+
+    expect(firstGenerated.patternIdentity).toBeDefined();
+    expect(firstNamed.patternIdentity).toBeUndefined();
+    expect(await runtime.getCellFromLink(firstGeneratedLink).pull()).toBe(
+      "version-one",
+    );
+
+    await setupTrusted(
+      runtime,
+      undefined,
+      pattern("version-two"),
+      {},
+      resultCell,
+    );
+    const secondManifest = resultCell.getMetaRaw("internal") as Array<{
+      partialCause: unknown;
+      patternIdentity?: { identity: string; symbol: string };
+      link: unknown;
+    }>;
+    const secondGenerated = secondManifest.find((entry) =>
+      typeof entry.partialCause === "object"
+    )!;
+    const secondNamed = secondManifest.find((entry) =>
+      entry.partialCause === "named-state"
+    )!;
+    const secondGeneratedLink = parseLink(secondGenerated.link, resultCell)!;
+    const secondNamedLink = parseLink(secondNamed.link, resultCell)!;
+
+    expect(secondGenerated.patternIdentity).not.toEqual(
+      firstGenerated.patternIdentity,
+    );
+    expect(secondGeneratedLink.id).not.toBe(firstGeneratedLink.id);
+    expect(secondNamedLink.id).toBe(firstNamedLink.id);
+    expect(await runtime.getCellFromLink(secondGeneratedLink).pull()).toBe(
+      "version-two",
+    );
+    expect(await runtime.getCellFromLink(firstGeneratedLink).pull()).toBe(
+      "version-one",
+    );
+  });
+
   it("sets scoped write-redirect metadata links for argument and internal cells", async () => {
     const argumentSchema = {
       type: "object",

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -248,6 +248,96 @@ describe("runPattern", () => {
     expect(nextLink?.schema).toEqual(narrow);
   });
 
+  it("versions generated internal cells while preserving named cells", async () => {
+    const resultCell = runtime.getCell(
+      space,
+      "version generated internal cells",
+    );
+    const pattern = (generatedDefault: string): Pattern => ({
+      argumentSchema: { type: "object", properties: {} },
+      resultSchema: { type: "object" },
+      derivedInternalCells: [
+        {
+          partialCause: { $generated: 0 },
+          schema: { type: "string", default: generatedDefault },
+          scope: "space",
+        },
+        {
+          partialCause: "named-state",
+          schema: { type: "string", default: "durable" },
+          scope: "space",
+        },
+      ],
+      result: {
+        generated: {
+          $alias: { partialCause: { $generated: 0 }, path: [] },
+        },
+        named: { $alias: { partialCause: "named-state", path: [] } },
+      },
+      nodes: [],
+    });
+
+    await setupTrusted(
+      runtime,
+      undefined,
+      pattern("version-one"),
+      {},
+      resultCell,
+    );
+    const firstManifest = resultCell.getMetaRaw("internal") as Array<{
+      partialCause: unknown;
+      patternIdentity?: { identity: string; symbol: string };
+      link: unknown;
+    }>;
+    const firstGenerated = firstManifest.find((entry) =>
+      typeof entry.partialCause === "object"
+    )!;
+    const firstNamed = firstManifest.find((entry) =>
+      entry.partialCause === "named-state"
+    )!;
+    const firstGeneratedLink = parseLink(firstGenerated.link, resultCell)!;
+    const firstNamedLink = parseLink(firstNamed.link, resultCell)!;
+
+    expect(firstGenerated.patternIdentity).toBeDefined();
+    expect(firstNamed.patternIdentity).toBeUndefined();
+    expect(await runtime.getCellFromLink(firstGeneratedLink).pull()).toBe(
+      "version-one",
+    );
+
+    await setupTrusted(
+      runtime,
+      undefined,
+      pattern("version-two"),
+      {},
+      resultCell,
+    );
+    const secondManifest = resultCell.getMetaRaw("internal") as Array<{
+      partialCause: unknown;
+      patternIdentity?: { identity: string; symbol: string };
+      link: unknown;
+    }>;
+    const secondGenerated = secondManifest.find((entry) =>
+      typeof entry.partialCause === "object"
+    )!;
+    const secondNamed = secondManifest.find((entry) =>
+      entry.partialCause === "named-state"
+    )!;
+    const secondGeneratedLink = parseLink(secondGenerated.link, resultCell)!;
+    const secondNamedLink = parseLink(secondNamed.link, resultCell)!;
+
+    expect(secondGenerated.patternIdentity).not.toEqual(
+      firstGenerated.patternIdentity,
+    );
+    expect(secondGeneratedLink.id).not.toBe(firstGeneratedLink.id);
+    expect(secondNamedLink.id).toBe(firstNamedLink.id);
+    expect(await runtime.getCellFromLink(secondGeneratedLink).pull()).toBe(
+      "version-two",
+    );
+    expect(await runtime.getCellFromLink(firstGeneratedLink).pull()).toBe(
+      "version-one",
+    );
+  });
+
   it("sets scoped write-redirect metadata links for argument and internal cells", async () => {
     const argumentSchema = {
       type: "object",


### PR DESCRIPTION
## Why

Compiler-generated causes such as `{ $generated: 0 }` are only meaningful within one pattern artifact, but their durable cell IDs were derived from only the result cell and generated ordinal. Two pattern versions could therefore mint the same internal-cell IDs for semantically different graph positions.

When old and new graphs overlap during an upgrade, they can repeatedly write different values to those shared entities. This creates unnecessary revisions, storage work, synchronization traffic, and client updates.

## What

- Associate compiler-generated internal-cell descriptors with their pattern's content-addressed `{ identity, symbol }`.
- Include that pattern identity in the generated cell's hash preimage.
- Record and match the pattern identity in the internal-cell manifest so an upgraded generated cell is initialized under its new ID.
- Preserve the existing identity behavior for explicitly named/manual cells so intentional durable state survives pattern upgrades.
- Carry generated-cell identity metadata across builder-derived pattern copies and cold rehydration.
- Update the live storage and cell-identity specifications.

## Impact

A pattern upgrade now rotates compiler-generated internal-cell IDs once instead of allowing old and new graphs to contend on the same entities. Explicitly named cells remain stable.

This PR addresses the identity collision itself. Immediate cancellation of an old graph during an asynchronous pattern load and server-side producer fencing remain separate follow-up defenses.

## Testing

- `deno task check`
- `deno task check-docs` — 519 checked code blocks
- Focused runner, generated-cell, computed-cell, map identity, cross-space reload, owned-cell resume, and rehydration safety suites — 150 steps passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787344428&installation_model_id=428580&pr_number=4916&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4916&signature=42a6e0c9dfb6d294e78de501aa6f50415810a34748ec9b2ba2533376b092912b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Namespaces compiler-generated internal-cell IDs by the owning pattern’s `{ identity, symbol }` to stop cross-version collisions and churn. Named/manual cell IDs stay stable; legacy generated IDs remain until a real pattern update, and updates now stage setup atomically with the pointer.

- **Bug Fixes**
  - Generated identity: add `patternIdentity` to hashing and manifest matching for generated causes; keep legacy generated entries without it while the piece still points at the same artifact; propagate through derived copies and rehydrate.
  - Atomic updates: run replacement setup in the same compare-and-swap as the pointer; commit manifest, defaults, backlinks, schemas, and projection together; rejected setup leaves the pointer and running graph unchanged.
  - Resume hardening: pre-sync result cells; resolve child outputs in a read-only txn; deduplicate shared child results; ignore children with no outputs; lazily associate generated descriptors for nested pattern copies.
  - Legacy cold-start repair: retain one-shot repair for pointer-only docs from older runtimes; failed repair surfaces the original start error without further mutations.

<sup>Written for commit 9e29077b0e7c1b427c757d3658486b5f9a95e4bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

