### PR TITLE
topics: make agent attribution atomic and profile-native

### DIFF
--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -12,8 +12,8 @@ percent-encoded share link) becomes a navigable "references →" / "← referenc
 by" chip on the topic's card, and the graph is exported as the `crossrefs`
 output for headless consumers. Each topic also derives its own row of the graph
 on its detail page (a **Connections** card) from the `mentionable` input — a
-reference to the board's own topics list, wired at creation like `myName` and
-backfillable as a one-time link-bind on pre-existing pieces.
+reference to the board's own topics list, wired at creation and backfillable as
+a one-time link-bind on pre-existing pieces.
 
 Deliberately absent until reached for: statuses (not even open/closed), labels,
 assignees, attachments, nesting. What a topic grows next is part of the
@@ -26,16 +26,28 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
 
 ## Design commitments
 
-- **Wish-free handlers.** Nothing gates event dispatch on a `wish()` binding
-  (unresolved wish bindings drop events silently — CT-1879). Authorship is a
-  fallback chain: `myName` snapshot at write → identity → profile enrichment
-  later, when the cross-host profile story lands.
+- **One principal, explicit actor.** Fabric authenticates every write with the
+  identity key that made it. In the short-term agent model, that key belongs to
+  the human user; an agent also supplies `agentName` in the same mutation event.
+  Topics stores a structured `{ kind: "agent", name }` snapshot so the UI can
+  say “Sol (agent)” without pretending the agent has a separate principal.
+- **Profile-native browser authorship.** Human-facing controls use the current
+  viewer's canonical `#profile` name/avatar and store a `{ kind: "person", … }`
+  snapshot. There is no free-text “commenting as” field.
+- **Wish-free agent handlers.** CLI streams do not depend on profile wishes.
+  Blank `agentName` values reject the mutation, and the signature is carried in
+  the same event as the content, avoiding shared mutable attribution state.
 - **Mergeable writes everywhere users collide**: comments, links, and topics are
   `push` appends; concurrent writers all land. The body is a large string
   (whole-value conflict semantics), so body edits go through an explicit
   Edit→Save toggle rather than a live-bound textarea.
-- **`myName` is `PerUser` on the shared piece** — one tracker, one name per
-  authenticated identity, shared with every topic the tracker creates.
+- **Fabric owns history and concurrency.** Topics adds neither an activity-log
+  duplicate nor an application-level revision/CAS protocol. If Fabric cannot
+  preserve history or safely arbitrate concurrent body writes, this dogfood
+  surface should expose the framework gap rather than conceal it mechanically.
+- **Storage compatibility is read-only.** `myName`, `createdByName`, and
+  `authorName` remain optional in accepted schemas so existing boards/topics
+  load and render. New code does not read `myName` or write any legacy field.
 - **`mentionable` is a structural reference, not derived data.** The board
   passes its own topics list at creation; the topic derives its Connections
   read-side from it (SELF + equals to find its own row). Requires the
@@ -59,13 +71,16 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
 Agents are first-class participants. Against a deployed board piece:
 
 ```bash
-cf piece call --piece <board> setMyName '{"name":"Fable"}'
-cf piece call --piece <board> addTopic '{"title":"..."}'
+cf piece call --piece <board> addTopic '{"title":"...","agentName":"Sol"}'
 cf piece get  --piece <board> topics --input      # then address a topic piece
-cf piece call --piece <topic> addComment '{"body":"..."}'
+cf piece call --piece <topic> addComment \
+  '{"body":"point-in-time progress update","agentName":"Sol"}'
+cf piece call --piece <topic> setBody \
+  '{"body":"latest state plus the topic narrative","agentName":"Sol"}'
+cf piece call --piece <topic> addLink \
+  '{"kind":"pr","url":"https://github.com/org/repo/pull/123","label":"PR #123","agentName":"Sol"}'
 ```
 
-Do **not** run `cf piece step` from a fresh CLI replica: a replica with a
-partial view persists deriveds computed from that partial view. Writes commit
-fine on their own; renderers derive for themselves. Verify writes via a renderer
-or post-materialization fid reads.
+Every agent-authored mutation carries `agentName`; there is no preceding “set
+current name” call. Fabric's operation history retains the authenticated human
+principal, while the stored snapshot disambiguates which agent acted.

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -3,6 +3,7 @@ import {
   computed,
   Default,
   entityRefToString,
+  handler,
   NAME,
   pattern,
   type PerSession,
@@ -103,6 +104,29 @@ export interface TopicsOutput {
 // tests keep importing them from the tracker.
 export { crossrefChipRow, openTopic } from "./topic.tsx";
 
+/** Browser composer submit. Profile wishes are resolved by the pattern and
+ * bound into this handler as plain snapshot values, which keeps the mutation
+ * independently testable without weakening the canonical Profile path. */
+export const submitProfileTopic = handler<void, {
+  topics: Writable<TopicPiece[] | Default<[]>>;
+  mentionable: Writable<TopicPiece[] | Default<[]>>;
+  newTitle: Writable<string>;
+  profileName: string;
+  profileAvatar: string;
+}>((_, { topics, mentionable, newTitle, profileName, profileAvatar }) => {
+  const trimmed = (newTitle.get() ?? "").trim();
+  const author = topicAuthorFromPerson(profileName, profileAvatar);
+  if (!trimmed || !author) return;
+  const piece = Topic({
+    title: trimmed,
+    createdAt: Date.now(),
+    createdBy: author,
+    mentionable,
+  });
+  topics.push(piece);
+  newTitle.set("");
+});
+
 export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
   const newTitle = new Writable.perSession("");
 
@@ -116,7 +140,9 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
   const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
   const profileName = computed(() => profileNameWish.result ?? "");
   const profileAvatar = computed(() => profileAvatarWish.result ?? "");
-  const hasProfile = computed(() => profileName.trim().length > 0);
+  const hasProfile = computed(() =>
+    profileName.trim().length > 0 && profileWish.result !== undefined
+  );
 
   const addTopic = action(({ title, agentName }: AddTopicEvent) => {
     const trimmed = (title ?? "").trim();
@@ -136,18 +162,12 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
     newTitle.set("");
   });
 
-  const submitTopic = action(() => {
-    const trimmed = (newTitle.get() ?? "").trim();
-    const author = topicAuthorFromPerson(profileName, profileAvatar);
-    if (!trimmed || !author) return;
-    const piece = Topic({
-      title: trimmed,
-      createdAt: Date.now(),
-      createdBy: author,
-      mentionable: topics,
-    });
-    topics.push(piece);
-    newTitle.set("");
+  const submitTopic = submitProfileTopic({
+    topics,
+    mentionable: topics,
+    newTitle,
+    profileName,
+    profileAvatar,
   });
 
   const topicCount = computed(() => asArray(topics.get()).length);

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -10,6 +10,7 @@ import {
   Stream,
   UI,
   type VNode,
+  wish,
   Writable,
 } from "commonfabric";
 
@@ -20,6 +21,9 @@ import Topic, {
   fidPayload,
   openTopic,
   snippet,
+  topicAuthorFromAgent,
+  topicAuthorFromPerson,
+  topicAuthorLabel,
   topicCorpus,
   type TopicPiece,
   TOPICS_THEME,
@@ -28,6 +32,11 @@ import Topic, {
 
 // Re-export the shared types for consumers and tests.
 export type {
+  AddCommentEvent,
+  AddLinkEvent,
+  AgentAuthoredEvent,
+  SetBodyEvent,
+  TopicAuthor,
   TopicComment,
   TopicInput,
   TopicLink,
@@ -38,9 +47,17 @@ export type {
 
 export interface TopicsInput {
   topics?: Writable<TopicPiece[] | Default<[]>>;
-  /** The viewer's display name, set once per user and shared with every topic
-   * this tracker creates ("commenting as"). */
+  /** @deprecated Accepted so boards created before profile-backed authorship
+   * continue to load. New code never reads or writes this field. */
   myName?: PerUser<Writable<string | Default<"">>>;
+}
+
+export interface AddTopicEvent {
+  title: string;
+  /** The agent making this mutation. The authenticated principal remains the
+   * human whose identity key invoked the stream; this is the agent's explicit
+   * content-level signature under that shared principal. */
+  agentName: string;
 }
 
 /** One topic's place in the prose reference graph. Derived at read time from
@@ -73,14 +90,11 @@ export interface TopicsOutput {
    * (non-null) entry of `topics`. Rows carry their topic, so consumers never
    * need to correlate by index — indices are not a stable address. */
   crossrefs: TopicCrossref[] | Default<[]>;
-  /** The viewer's display name (normalized to "" until set). */
-  myName: string;
   /** Session-local draft for the footer composer (exposed for embedding and
    * headless driving, like the chat exemplar's drafts). */
   newTitle?: PerSession<Writable<string>>;
-  addTopic: Stream<{ title: string }>;
-  setMyName: Stream<{ name: string }>;
-  /** Submit the footer composer: reads newTitle, delegates to addTopic. */
+  addTopic: Stream<AddTopicEvent>;
+  /** Submit the footer composer as the current viewer's canonical Profile. */
   submitTopic: Stream<void>;
 }
 
@@ -89,17 +103,29 @@ export interface TopicsOutput {
 // tests keep importing them from the tracker.
 export { crossrefChipRow, openTopic } from "./topic.tsx";
 
-export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
+export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
   const newTitle = new Writable.perSession("");
 
-  const addTopic = action(({ title }: { title: string }) => {
+  // Browser authorship comes from the current viewer's canonical Profile.
+  // CLI streams below remain wish-free: agents sign each mutation in the
+  // event payload, while Fabric records the human principal behind the key.
+  const profileWish = wish<{ name?: string; avatar?: string }>({
+    query: "#profile",
+  });
+  const profileNameWish = wish<string>({ query: "#profileName" });
+  const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
+  const profileName = computed(() => profileNameWish.result ?? "");
+  const profileAvatar = computed(() => profileAvatarWish.result ?? "");
+  const hasProfile = computed(() => profileName.trim().length > 0);
+
+  const addTopic = action(({ title, agentName }: AddTopicEvent) => {
     const trimmed = (title ?? "").trim();
-    if (!trimmed) return;
+    const author = topicAuthorFromAgent(agentName);
+    if (!trimmed || !author) return;
     const piece = Topic({
       title: trimmed,
       createdAt: Date.now(),
-      createdByName: (myName.get() ?? "").trim() || "someone",
-      myName,
+      createdBy: author,
       // The board's own list, so the detail page can derive its connections
       // and the editor has a mention universe (backfilled as a one-time
       // link-bind on pieces created before this input existed).
@@ -110,17 +136,19 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
     newTitle.set("");
   });
 
-  const setMyName = action(({ name }: { name: string }) => {
-    myName.set((name ?? "").trim());
-  });
-
   const submitTopic = action(() => {
-    addTopic.send({ title: newTitle.get() });
+    const trimmed = (newTitle.get() ?? "").trim();
+    const author = topicAuthorFromPerson(profileName, profileAvatar);
+    if (!trimmed || !author) return;
+    const piece = Topic({
+      title: trimmed,
+      createdAt: Date.now(),
+      createdBy: author,
+      mentionable: topics,
+    });
+    topics.push(piece);
+    newTitle.set("");
   });
-
-  // Normalized snapshot: a never-written PerUser cell reads as undefined in
-  // other runtimes; assertions need a real, stable value.
-  const myNameView = computed(() => myName.get() ?? "");
 
   const topicCount = computed(() => asArray(topics.get()).length);
 
@@ -179,9 +207,18 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
                   {topicCount} topics · durable units of shared attention
                 </cf-text>
               </cf-vstack>
-              <cf-field label="Commenting as" style="width: 180px;">
-                <cf-input $value={myName} placeholder="Your name" />
-              </cf-field>
+              <cf-hstack gap="2" align="center">
+                <cf-text variant="caption" tone="muted">Acting as</cf-text>
+                {hasProfile
+                  ? (
+                    <cf-profile-badge
+                      $profile={profileWish.result}
+                      size="sm"
+                      noNavigate
+                    />
+                  )
+                  : <div>{profileWish[UI]}</div>}
+              </cf-hstack>
             </cf-hstack>
           </cf-vstack>
 
@@ -218,7 +255,8 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
                           : null}
                         <cf-text variant="caption" tone="muted">
                           {t.commentCount} comments · by{" "}
-                          {t.createdByName || "someone"} ·{" "}
+                          {topicAuthorLabel(t.createdBy, t.createdByName)} ·
+                          {" "}
                           {whenLabel(t.lastActivityAt)}
                         </cf-text>
                         {crossrefChipRow("references →", false, row.refsOut)}
@@ -255,7 +293,11 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
                   placeholder="What deserves shared attention?"
                 />
               </cf-field>
-              <cf-button variant="primary" onClick={submitTopic}>
+              <cf-button
+                variant="primary"
+                disabled={computed(() => !hasProfile)}
+                onClick={submitTopic}
+              >
                 Start
               </cf-button>
             </cf-hstack>
@@ -267,10 +309,8 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
     mentionable: topics,
     topicCount,
     crossrefs,
-    myName: myNameView,
     newTitle,
     addTopic,
-    setMyName,
     submitTopic,
   };
 });

--- a/packages/patterns/topics/multi-user.test.tsx
+++ b/packages/patterns/topics/multi-user.test.tsx
@@ -4,12 +4,11 @@
  *
  * One shared Topics board across two worker-isolated runtimes. Covers the
  * board's core multi-user promises:
- * - per-user display-name isolation (`myName` is PerUser: one shared piece,
- *   two identities, two values),
+ * - every headless mutation carries its agent signature atomically,
  * - concurrent comment appends from different users both land (mergeable
  *   `push` — no clobbering),
- * - topics created by either user propagate to the other, with authorship
- *   snapshots (`createdByName`, `authorName`) taken at write time.
+ * - topics created by either user propagate to the other, with structured
+ *   authorship snapshots taken at write time.
  *
  * Cross-runtime reads use INLINE literal accesses (topics[0].comments[0]) —
  * `.map()`, loop-variable indexing, and helper calls over another runtime's
@@ -30,27 +29,26 @@ export const setup = pattern(() => ({
 export const gideon = pattern<{ setup: Setup }>(({ setup }) => {
   const board = setup.board;
 
-  const action_set_name = action(() => {
-    board.setMyName.send({ name: "Gideon" });
-  });
   const action_start_topic = action(() => {
-    board.addTopic.send({ title: "First topic" });
+    board.addTopic.send({ title: "First topic", agentName: "Sol" });
   });
   const action_comment = action(() => {
     const topic = board.topics?.[0];
-    if (topic) topic.addComment.send({ body: "opening the thread" });
+    if (topic) {
+      topic.addComment.send({ body: "opening the thread", agentName: "Sol" });
+    }
   });
-
-  const assert_named = computed(() => board.myName === "Gideon");
 
   const assert_topic_created = computed(() =>
     (board.topics ?? []).length === 1 &&
     board.topics?.[0]?.title === "First topic" &&
-    board.topics?.[0]?.createdByName === "Gideon"
+    board.topics?.[0]?.createdBy?.kind === "agent" &&
+    board.topics?.[0]?.createdBy?.name === "Sol"
   );
 
   const assert_own_comment = computed(() =>
-    board.topics?.[0]?.comments?.[0]?.authorName === "Gideon" &&
+    board.topics?.[0]?.comments?.[0]?.author?.kind === "agent" &&
+    board.topics?.[0]?.comments?.[0]?.author?.name === "Sol" &&
     board.topics?.[0]?.comments?.[0]?.body === "opening the thread" &&
     board.topics?.[0]?.commentCount === 1
   );
@@ -59,17 +57,14 @@ export const gideon = pattern<{ setup: Setup }>(({ setup }) => {
   // here, as required for cross-runtime reads above; aggregate length and
   // commentCount reads can remain stale until this runtime performs a write.
   const assert_sees_fable_comment = computed(() =>
-    board.topics?.[0]?.comments?.[1]?.authorName === "Fable"
+    board.topics?.[0]?.comments?.[1]?.author?.name === "Fable"
   );
   const assert_fable_topic_authorship = computed(() =>
-    board.topics?.[1]?.createdByName === "Fable"
+    board.topics?.[1]?.createdBy?.name === "Fable"
   );
-  const assert_name_still_isolated = computed(() => board.myName === "Gideon");
 
   return {
     tests: [
-      { action: action_set_name },
-      { assertion: assert_named },
       { action: action_start_topic },
       { assertion: assert_topic_created },
       { action: action_comment },
@@ -78,7 +73,6 @@ export const gideon = pattern<{ setup: Setup }>(({ setup }) => {
       { await: "fable-done" },
       { assertion: assert_sees_fable_comment },
       { assertion: assert_fable_topic_authorship },
-      { assertion: assert_name_still_isolated },
     ],
   };
 });
@@ -86,51 +80,42 @@ export const gideon = pattern<{ setup: Setup }>(({ setup }) => {
 export const fable = pattern<{ setup: Setup }>(({ setup }) => {
   const board = setup.board;
 
-  const action_set_name = action(() => {
-    board.setMyName.send({ name: "Fable" });
-  });
   const action_comment = action(() => {
     const topic = board.topics?.[0];
-    if (topic) topic.addComment.send({ body: "seconding this" });
+    if (topic) {
+      topic.addComment.send({ body: "seconding this", agentName: "Fable" });
+    }
   });
   const action_start_second = action(() => {
-    board.addTopic.send({ title: "Second topic" });
+    board.addTopic.send({ title: "Second topic", agentName: "Fable" });
   });
 
-  // Gideon's topic + comment propagated from his runtime.
-  const assert_sees_gideon_setup = computed(() =>
+  // Sol's topic + comment propagated from the other runtime.
+  const assert_sees_sol_setup = computed(() =>
     (board.topics ?? []).length === 1 &&
     board.topics?.[0]?.title === "First topic" &&
-    board.topics?.[0]?.comments?.[0]?.authorName === "Gideon" &&
+    board.topics?.[0]?.comments?.[0]?.author?.name === "Sol" &&
     board.topics?.[0]?.commentCount === 1
   );
-
-  // PerUser isolation: Gideon's name must not leak into this identity.
-  const assert_not_named_yet = computed(() => board.myName === "");
-
-  const assert_named = computed(() => board.myName === "Fable");
 
   // Both comments landed (mergeable append, no clobber), in thread order.
   const assert_both_comments = computed(() =>
     board.topics?.[0]?.commentCount === 2 &&
-    board.topics?.[0]?.comments?.[0]?.authorName === "Gideon" &&
-    board.topics?.[0]?.comments?.[1]?.authorName === "Fable" &&
+    board.topics?.[0]?.comments?.[0]?.author?.name === "Sol" &&
+    board.topics?.[0]?.comments?.[1]?.author?.name === "Fable" &&
     board.topics?.[0]?.comments?.[1]?.body === "seconding this"
   );
 
   const assert_second_topic = computed(() =>
     (board.topics ?? []).length === 2 &&
     board.topics?.[1]?.title === "Second topic" &&
-    board.topics?.[1]?.createdByName === "Fable"
+    board.topics?.[1]?.createdBy?.name === "Fable"
   );
 
   return {
     tests: [
       { await: "gideon-commented" },
-      { assertion: assert_sees_gideon_setup },
-      { assertion: assert_not_named_yet },
-      { action: action_set_name },
-      { assertion: assert_named },
+      { assertion: assert_sees_sol_setup },
       { action: action_comment },
       { assertion: assert_both_comments },
       { action: action_start_second },

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -379,6 +379,93 @@ const LINK_KIND_ITEMS = [
   { label: "Agent session", value: "session" },
 ];
 
+/** Browser comment submit with Profile fields already resolved by the pattern.
+ * Keeping the mutation in a module-scope handler lets tests bind deterministic
+ * Profile snapshots while production still sources them only from wishes. */
+export const submitProfileComment = handler<void, {
+  comments: Writable<TopicComment[] | Default<[]>>;
+  commentDraft: Writable<string>;
+  profileName: string;
+  profileAvatar: string;
+}>((_, { comments, commentDraft, profileName, profileAvatar }) => {
+  const text = commentDraft.get();
+  const author = topicAuthorFromPerson(profileName, profileAvatar);
+  if (!text.trim() || !author) return;
+  comments.push({
+    author,
+    body: text.trim(),
+    sentAt: Date.now(),
+  });
+  commentDraft.set("");
+});
+
+/** Browser body save under the current Profile snapshot. */
+export const saveProfileBody = handler<void, {
+  body: Writable<string | Default<"">>;
+  bodyDraft: Writable<string>;
+  editingBody: Writable<boolean>;
+  bodyUpdatedBy: Writable<
+    TopicAuthor | Default<{ kind: "person"; name: "" }>
+  >;
+  bodyUpdatedAt: Writable<number | Default<0>>;
+  profileName: string;
+  profileAvatar: string;
+}>((
+  _,
+  {
+    body,
+    bodyDraft,
+    editingBody,
+    bodyUpdatedBy,
+    bodyUpdatedAt,
+    profileName,
+    profileAvatar,
+  },
+) => {
+  const author = topicAuthorFromPerson(profileName, profileAvatar);
+  if (!author) return;
+  // One whole-value set per explicit save keeps the conflict window small; a
+  // live-bound textarea on a shared string would conflict per keystroke.
+  body.set(bodyDraft.get());
+  bodyUpdatedBy.set(author);
+  bodyUpdatedAt.set(Date.now());
+  editingBody.set(false);
+});
+
+/** Browser link submit under the current Profile snapshot. */
+export const submitProfileLink = handler<void, {
+  links: Writable<TopicLink[] | Default<[]>>;
+  linkUrlDraft: Writable<string>;
+  linkLabelDraft: Writable<string>;
+  linkKindDraft: Writable<TopicLinkKind>;
+  profileName: string;
+  profileAvatar: string;
+}>((
+  _,
+  {
+    links,
+    linkUrlDraft,
+    linkLabelDraft,
+    linkKindDraft,
+    profileName,
+    profileAvatar,
+  },
+) => {
+  const url = linkUrlDraft.get();
+  const author = topicAuthorFromPerson(profileName, profileAvatar);
+  if (!url.trim() || !isSafeLinkUrl(url) || !author) return;
+  links.push({
+    kind: linkKindDraft.get(),
+    url: url.trim(),
+    label: linkLabelDraft.get().trim() || url.trim(),
+    addedBy: author,
+    addedAt: Date.now(),
+  });
+  linkUrlDraft.set("");
+  linkLabelDraft.set("");
+  linkKindDraft.set("web");
+});
+
 // ===== The pattern =====
 
 export default pattern<TopicInput, TopicOutput>(
@@ -415,7 +502,9 @@ export default pattern<TopicInput, TopicOutput>(
     const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
     const profileName = computed(() => profileNameWish.result ?? "");
     const profileAvatar = computed(() => profileAvatarWish.result ?? "");
-    const hasProfile = computed(() => profileName.trim().length > 0);
+    const hasProfile = computed(() =>
+      profileName.trim().length > 0 && profileWish.result !== undefined
+    );
 
     // --- Streams (external API; also usable headlessly via CLI) ---
 
@@ -456,16 +545,11 @@ export default pattern<TopicInput, TopicOutput>(
 
     // --- UI-side actions (close over session drafts) ---
 
-    const submitComment = action(() => {
-      const text = commentDraft.get();
-      const author = topicAuthorFromPerson(profileName, profileAvatar);
-      if (!text.trim() || !author) return;
-      comments.push({
-        author,
-        body: text.trim(),
-        sentAt: Date.now(),
-      });
-      commentDraft.set("");
+    const submitComment = submitProfileComment({
+      comments,
+      commentDraft,
+      profileName,
+      profileAvatar,
     });
 
     const startEditBody = action(() => {
@@ -473,35 +557,27 @@ export default pattern<TopicInput, TopicOutput>(
       editingBody.set(true);
     });
 
-    const saveBody = action(() => {
-      const author = topicAuthorFromPerson(profileName, profileAvatar);
-      if (!author) return;
-      // One whole-value set per explicit save keeps the conflict window small;
-      // a live-bound textarea on a shared string would conflict per keystroke.
-      body.set(bodyDraft.get());
-      bodyUpdatedBy.set(author);
-      bodyUpdatedAt.set(Date.now());
-      editingBody.set(false);
+    const saveBody = saveProfileBody({
+      body,
+      bodyDraft,
+      editingBody,
+      bodyUpdatedBy,
+      bodyUpdatedAt,
+      profileName,
+      profileAvatar,
     });
 
     const cancelEditBody = action(() => {
       editingBody.set(false);
     });
 
-    const submitLink = action(() => {
-      const url = linkUrlDraft.get();
-      const author = topicAuthorFromPerson(profileName, profileAvatar);
-      if (!url.trim() || !isSafeLinkUrl(url) || !author) return;
-      links.push({
-        kind: linkKindDraft.get(),
-        url: url.trim(),
-        label: linkLabelDraft.get().trim() || url.trim(),
-        addedBy: author,
-        addedAt: Date.now(),
-      });
-      linkUrlDraft.set("");
-      linkLabelDraft.set("");
-      linkKindDraft.set("web");
+    const submitLink = submitProfileLink({
+      links,
+      linkUrlDraft,
+      linkLabelDraft,
+      linkKindDraft,
+      profileName,
+      profileAvatar,
     });
 
     // --- Derived values ---

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -14,6 +14,7 @@ import {
   Stream,
   UI,
   type VNode,
+  wish,
   Writable,
 } from "commonfabric";
 
@@ -21,12 +22,44 @@ import {
 
 export type TopicLinkKind = "pr" | "topic" | "session" | "web";
 
+/** A display snapshot attached atomically to content. Fabric remains the
+ * authority for which principal/key performed the write. `kind: "agent"`
+ * disambiguates an agent acting with its human user's key. */
+export interface TopicAuthor {
+  kind: "person" | "agent";
+  name: string;
+  avatar?: string;
+}
+
+export interface AgentAuthoredEvent {
+  /** Explicit content-level signature for an agent using its human user's
+   * identity key. Blank names are rejected with the mutation. */
+  agentName: string;
+}
+
+export interface AddCommentEvent extends AgentAuthoredEvent {
+  body: string;
+}
+
+export interface AddLinkEvent extends AgentAuthoredEvent {
+  kind: TopicLinkKind;
+  url: string;
+  label: string;
+}
+
+export interface SetBodyEvent extends AgentAuthoredEvent {
+  body: string;
+}
+
 export interface TopicComment {
   /** Snapshot taken at write time (profile enrichment comes later; never gate
    * authorship on a profile wish — CT-1879). Comments carry no minted id:
    * array elements have stable entity identity; future editing addresses
    * elements by reference (`equals()`), not by a synthetic key. */
-  authorName: string | Default<"">;
+  author?: TopicAuthor;
+  /** @deprecated Read-only fallback for comments written before structured
+   * authorship. New mutations never write this field. */
+  authorName?: string | Default<"">;
   body: string | Default<"">;
   sentAt: number | Default<0>;
 }
@@ -35,6 +68,8 @@ export interface TopicLink {
   kind: TopicLinkKind | Default<"web">;
   url: string | Default<"">;
   label: string | Default<"">;
+  addedBy?: TopicAuthor;
+  addedAt?: number | Default<0>;
 }
 
 export interface TopicInput {
@@ -45,11 +80,17 @@ export interface TopicInput {
   comments?: Writable<TopicComment[] | Default<[]>>;
   links?: Writable<TopicLink[] | Default<[]>>;
   createdAt?: number | Default<0>;
+  createdBy?: TopicAuthor;
+  /** @deprecated Read-only fallback for topics written before structured
+   * authorship. New mutations never write this field. */
   createdByName?: string | Default<"">;
-  /** The viewer's display name. Per-user: each authenticated identity gets its
-   * own value on the same shared piece. The tracker passes its cell down so one
-   * name covers the whole board. */
+  /** @deprecated Accepted so pre-migration topic inputs continue to load. New
+   * code never reads or writes this per-user free-text identity field. */
   myName?: PerUser<Writable<string | Default<"">>>;
+  bodyUpdatedBy?: Writable<
+    TopicAuthor | Default<{ kind: "person"; name: "" }>
+  >;
+  bodyUpdatedAt?: Writable<number | Default<0>>;
   /** The board's own topics list — the sibling set for this topic's derived
    * crossrefs and the mention universe for authoring. A reference to the
    * tracker's array, wired at creation like `myName` (and backfillable as a
@@ -77,9 +118,13 @@ export interface TopicPiece {
   comments: TopicComment[];
   links: TopicLink[];
   createdAt: number;
-  createdByName: string;
+  createdBy?: TopicAuthor;
+  /** @deprecated Read-only fallback for pre-migration stored topics. */
+  createdByName?: string;
+  bodyUpdatedBy?: TopicAuthor;
+  bodyUpdatedAt?: number;
   commentCount: number;
-  /** Max of createdAt and the newest comment — the tracker sorts by this. */
+  /** Max of creation, comments, body saves, and link additions. */
   lastActivityAt: number;
   /** This topic's own place in the board's prose graph, derived read-side
    * from `mentionable` (the sibling pieces it links, resolved from the
@@ -92,9 +137,9 @@ export interface TopicPiece {
     | { refsOut: TopicPiece[]; referencedBy: TopicPiece[] }
     | Default<{ refsOut: []; referencedBy: [] }>
     | undefined;
-  addComment: Stream<{ body: string }>;
-  addLink: Stream<{ kind: TopicLinkKind; url: string; label: string }>;
-  setBody: Stream<{ body: string }>;
+  addComment: Stream<AddCommentEvent>;
+  addLink: Stream<AddLinkEvent>;
+  setBody: Stream<SetBodyEvent>;
 }
 
 /** The complete result available when a Topic is instantiated directly. */
@@ -173,6 +218,37 @@ export const whenLabel = (ts: number): string => {
 export const snippet = (text: string, max: number): string => {
   const t = (text ?? "").trim().replace(/\s+/g, " ");
   return t.length > max ? `${t.slice(0, max)}…` : t;
+};
+
+/** Build the content-level signature required by headless mutation streams.
+ * The authenticated human principal is deliberately not copied here: Fabric
+ * already owns that authority and history. */
+export const topicAuthorFromAgent = (
+  agentName: string,
+): TopicAuthor | undefined => {
+  const name = (agentName ?? "").trim();
+  return name ? { kind: "agent", name } : undefined;
+};
+
+/** Snapshot the canonical Profile fields used by browser mutations. */
+export const topicAuthorFromPerson = (
+  profileName: string,
+  profileAvatar = "",
+): TopicAuthor | undefined => {
+  const name = (profileName ?? "").trim();
+  if (!name) return undefined;
+  const avatar = (profileAvatar ?? "").trim();
+  return avatar ? { kind: "person", name, avatar } : { kind: "person", name };
+};
+
+/** Structured author first, legacy string second. Agent snapshots are labelled
+ * explicitly because they share the authenticated principal's identity key. */
+export const topicAuthorLabel = (
+  author: TopicAuthor | undefined,
+  legacyName: string | undefined = "",
+): string => {
+  const name = (author?.name ?? legacyName ?? "").trim() || "someone";
+  return author?.kind === "agent" ? `${name} (agent)` : name;
 };
 
 /** Only http(s) URLs may become live anchors — a user-supplied `javascript:`
@@ -313,8 +389,10 @@ export default pattern<TopicInput, TopicOutput>(
       comments,
       links,
       createdAt,
+      createdBy,
       createdByName,
-      myName,
+      bodyUpdatedBy,
+      bodyUpdatedAt,
       mentionable,
       [SELF]: self,
     },
@@ -327,47 +405,66 @@ export default pattern<TopicInput, TopicOutput>(
     const linkLabelDraft = new Writable.perSession("");
     const linkKindDraft = new Writable.perSession<TopicLinkKind>("web");
 
+    // Browser mutations snapshot the current viewer's canonical Profile.
+    // Agent-facing streams below deliberately remain wish-free and accept the
+    // agent's content-level signature in the same event as the mutation.
+    const profileWish = wish<{ name?: string; avatar?: string }>({
+      query: "#profile",
+    });
+    const profileNameWish = wish<string>({ query: "#profileName" });
+    const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
+    const profileName = computed(() => profileNameWish.result ?? "");
+    const profileAvatar = computed(() => profileAvatarWish.result ?? "");
+    const hasProfile = computed(() => profileName.trim().length > 0);
+
     // --- Streams (external API; also usable headlessly via CLI) ---
 
-    const addComment = action(({ body: text }: { body: string }) => {
+    const addComment = action(({ body: text, agentName }: AddCommentEvent) => {
       const trimmed = (text ?? "").trim();
-      if (!trimmed) return;
+      const author = topicAuthorFromAgent(agentName);
+      if (!trimmed || !author) return;
       // Mergeable append: concurrent comments from different users all land.
       comments.push({
-        // `?? ""`: a never-written PerUser cell can read as undefined (e.g. a
-        // headless caller that never set a name) — same guard as myNameView.
-        authorName: (myName.get() ?? "").trim() || "someone",
+        author,
         body: trimmed,
         sentAt: Date.now(),
       });
     });
 
     const addLink = action(
-      ({ kind, url, label }: {
-        kind: TopicLinkKind;
-        url: string;
-        label: string;
-      }) => {
+      ({ kind, url, label, agentName }: AddLinkEvent) => {
         const trimmedUrl = (url ?? "").trim();
-        if (!trimmedUrl || !isSafeLinkUrl(trimmedUrl)) return;
+        const author = topicAuthorFromAgent(agentName);
+        if (!trimmedUrl || !isSafeLinkUrl(trimmedUrl) || !author) return;
         links.push({
           kind: kind ?? "web",
           url: trimmedUrl,
           label: (label ?? "").trim() || trimmedUrl,
+          addedBy: author,
+          addedAt: Date.now(),
         });
       },
     );
 
-    const setBody = action(({ body: text }: { body: string }) => {
+    const setBody = action(({ body: text, agentName }: SetBodyEvent) => {
+      const author = topicAuthorFromAgent(agentName);
+      if (!author) return;
       body.set(text ?? "");
+      bodyUpdatedBy.set(author);
+      bodyUpdatedAt.set(Date.now());
     });
 
     // --- UI-side actions (close over session drafts) ---
 
     const submitComment = action(() => {
       const text = commentDraft.get();
-      if (!text.trim()) return;
-      addComment.send({ body: text });
+      const author = topicAuthorFromPerson(profileName, profileAvatar);
+      if (!text.trim() || !author) return;
+      comments.push({
+        author,
+        body: text.trim(),
+        sentAt: Date.now(),
+      });
       commentDraft.set("");
     });
 
@@ -377,9 +474,13 @@ export default pattern<TopicInput, TopicOutput>(
     });
 
     const saveBody = action(() => {
+      const author = topicAuthorFromPerson(profileName, profileAvatar);
+      if (!author) return;
       // One whole-value set per explicit save keeps the conflict window small;
       // a live-bound textarea on a shared string would conflict per keystroke.
       body.set(bodyDraft.get());
+      bodyUpdatedBy.set(author);
+      bodyUpdatedAt.set(Date.now());
       editingBody.set(false);
     });
 
@@ -389,11 +490,14 @@ export default pattern<TopicInput, TopicOutput>(
 
     const submitLink = action(() => {
       const url = linkUrlDraft.get();
-      if (!url.trim()) return;
-      addLink.send({
+      const author = topicAuthorFromPerson(profileName, profileAvatar);
+      if (!url.trim() || !isSafeLinkUrl(url) || !author) return;
+      links.push({
         kind: linkKindDraft.get(),
-        url,
-        label: linkLabelDraft.get(),
+        url: url.trim(),
+        label: linkLabelDraft.get().trim() || url.trim(),
+        addedBy: author,
+        addedAt: Date.now(),
       });
       linkUrlDraft.set("");
       linkLabelDraft.set("");
@@ -405,9 +509,16 @@ export default pattern<TopicInput, TopicOutput>(
     const commentCount = computed(() => asArray(comments.get()).length);
 
     const lastActivityAt = computed(() => {
-      const newest = asArray(comments.get())
+      const newestComment = asArray(comments.get())
         .reduce((max, c) => Math.max(max, c?.sentAt ?? 0), 0);
-      return Math.max(createdAt ?? 0, newest);
+      const newestLink = asArray(links.get())
+        .reduce((max, link) => Math.max(max, link?.addedAt ?? 0), 0);
+      return Math.max(
+        createdAt ?? 0,
+        newestComment,
+        newestLink,
+        bodyUpdatedAt.get() ?? 0,
+      );
     });
 
     const commentsView = computed(() =>
@@ -461,10 +572,24 @@ export default pattern<TopicInput, TopicOutput>(
                 placeholder="Topic title…"
                 style="font-size: 1.25rem; font-weight: 600;"
               />
-              <cf-text variant="caption" tone="muted">
-                started by {createdByName || "someone"}
-                {createdAt ? ` · ${whenLabel(createdAt)}` : ""}
-              </cf-text>
+              <cf-hstack justify="between" align="center">
+                <cf-text variant="caption" tone="muted">
+                  started by {topicAuthorLabel(createdBy, createdByName)}
+                  {createdAt ? ` · ${whenLabel(createdAt)}` : ""}
+                </cf-text>
+                <cf-hstack gap="2" align="center">
+                  <cf-text variant="caption" tone="muted">Acting as</cf-text>
+                  {hasProfile
+                    ? (
+                      <cf-profile-badge
+                        $profile={profileWish.result}
+                        size="sm"
+                        noNavigate
+                      />
+                    )
+                    : <div>{profileWish[UI]}</div>}
+                </cf-hstack>
+              </cf-hstack>
             </cf-vstack>
 
             <cf-vstack gap="3" padding="4">
@@ -473,13 +598,15 @@ export default pattern<TopicInput, TopicOutput>(
                 <cf-vstack gap="2">
                   <cf-hstack justify="between" align="center">
                     <cf-heading level={5}>Body</cf-heading>
-                    {editingBody
-                      ? null
-                      : (
-                        <cf-button variant="secondary" onClick={startEditBody}>
-                          Edit
-                        </cf-button>
-                      )}
+                    {editingBody ? null : (
+                      <cf-button
+                        variant="secondary"
+                        disabled={computed(() => !hasProfile)}
+                        onClick={startEditBody}
+                      >
+                        Edit
+                      </cf-button>
+                    )}
                   </cf-hstack>
 
                   {editingBody
@@ -496,7 +623,11 @@ export default pattern<TopicInput, TopicOutput>(
                           style="min-height: 12rem;"
                         />
                         <cf-hstack gap="2">
-                          <cf-button variant="primary" onClick={saveBody}>
+                          <cf-button
+                            variant="primary"
+                            disabled={computed(() => !hasProfile)}
+                            onClick={saveBody}
+                          >
                             Save
                           </cf-button>
                           <cf-button variant="ghost" onClick={cancelEditBody}>
@@ -514,6 +645,15 @@ export default pattern<TopicInput, TopicOutput>(
                         below holds the deliberation.
                       </cf-text>
                     )}
+                  {bodyUpdatedAt.get()
+                    ? (
+                      <cf-text variant="caption" tone="muted">
+                        Last updated by {topicAuthorLabel(bodyUpdatedBy.get())}
+                        {" · "}
+                        {whenLabel(bodyUpdatedAt.get() ?? 0)}
+                      </cf-text>
+                    )
+                    : null}
                 </cf-vstack>
               </cf-card>
 
@@ -546,6 +686,13 @@ export default pattern<TopicInput, TopicOutput>(
                                     {link.label || link.url}
                                   </cf-text>
                                 )}
+                              {link.addedBy
+                                ? (
+                                  <cf-text variant="caption" tone="muted">
+                                    by {topicAuthorLabel(link.addedBy)}
+                                  </cf-text>
+                                )
+                                : null}
                             </cf-hstack>
                           ))
                         )}
@@ -572,7 +719,11 @@ export default pattern<TopicInput, TopicOutput>(
                         placeholder="optional"
                       />
                     </cf-field>
-                    <cf-button variant="secondary" onClick={submitLink}>
+                    <cf-button
+                      variant="secondary"
+                      disabled={computed(() => !hasProfile)}
+                      onClick={submitLink}
+                    >
                       Add
                     </cf-button>
                   </cf-hstack>
@@ -615,8 +766,19 @@ export default pattern<TopicInput, TopicOutput>(
                               style="border-left: 2px solid var(--cf-theme-color-border); padding-left: 0.75rem;"
                             >
                               <cf-hstack gap="2" align="center">
+                                <cf-avatar
+                                  src={comment.author?.avatar || ""}
+                                  name={topicAuthorLabel(
+                                    comment.author,
+                                    comment.authorName,
+                                  )}
+                                  size="xs"
+                                />
                                 <cf-text style="font-weight: 600;">
-                                  {comment.authorName || "someone"}
+                                  {topicAuthorLabel(
+                                    comment.author,
+                                    comment.authorName,
+                                  )}
                                 </cf-text>
                                 <cf-text variant="caption" tone="muted">
                                   {whenLabel(comment.sentAt)}
@@ -637,9 +799,6 @@ export default pattern<TopicInput, TopicOutput>(
                     )}
 
                   <cf-hstack gap="2" align="end">
-                    <cf-field label="Commenting as" style="width: 160px;">
-                      <cf-input $value={myName} placeholder="Your name" />
-                    </cf-field>
                     <cf-field label="Comment" style="flex: 1;">
                       <cf-textarea
                         $value={commentDraft}
@@ -647,7 +806,11 @@ export default pattern<TopicInput, TopicOutput>(
                         placeholder="Add to the thread…"
                       />
                     </cf-field>
-                    <cf-button variant="primary" onClick={submitComment}>
+                    <cf-button
+                      variant="primary"
+                      disabled={computed(() => !hasProfile)}
+                      onClick={submitComment}
+                    >
                       Send
                     </cf-button>
                   </cf-hstack>
@@ -662,7 +825,10 @@ export default pattern<TopicInput, TopicOutput>(
       comments,
       links,
       createdAt,
+      createdBy,
       createdByName,
+      bodyUpdatedBy,
+      bodyUpdatedAt,
       commentCount,
       lastActivityAt,
       crossrefs,

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -76,6 +76,17 @@ export default pattern(() => {
   const profileLinkUrlDraft = new Writable("https://example.com/profile-link");
   const profileLinkLabelDraft = new Writable("profile link");
   const profileLinkKindDraft = new Writable<TopicLinkKind>("session");
+  // Render the same cells the deterministic Profile handlers mutate. This
+  // keeps their behavior and the detail UI in one end-to-end test path without
+  // inventing a fallback identity for the pattern-test runtime.
+  const profileTopic = Topic({
+    title: "Profile-authored topic",
+    body: profileBody,
+    comments: profileComments,
+    links: profileLinks,
+    bodyUpdatedBy: profileBodyUpdatedBy,
+    bodyUpdatedAt: profileBodyUpdatedAt,
+  });
 
   const profileSubmitTopic = submitProfileTopic({
     topics: profileTopics,
@@ -189,6 +200,9 @@ export default pattern(() => {
   });
   const action_submit_profile_link = action(() => {
     profileSubmitLink.send();
+  });
+  const action_start_profile_body_edit = action(() => {
+    profileTopic.startEditBody.send();
   });
 
   // --- UI-affordance flows (the same paths the rendered controls drive) ---
@@ -575,6 +589,11 @@ export default pattern(() => {
       { assertion: assert_profile_body_saved },
       { action: action_submit_profile_link },
       { assertion: assert_profile_link_submitted },
+      // Render the Profile-authored rows after their mutations land, then the
+      // edit state whose Save control is disabled until #profile resolves.
+      { render: profileTopic[UI] },
+      { action: action_start_profile_body_edit },
+      { render: profileTopic[UI] },
       { action: action_add_blank_topic },
       { assertion: assert_still_empty },
       { action: action_add_unsigned_topic },

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -9,11 +9,12 @@
  * fids pasted in bodies, comments, and link URLs; never persisted), and the
  * exported pure helpers.
  */
-import { action, computed, NAME, UI } from "commonfabric";
+import { action, computed, Default, NAME, UI, Writable } from "commonfabric";
 import { pattern } from "commonfabric";
 import Topics, {
   crossrefChipRow,
   openTopic,
+  submitProfileTopic,
   type TopicPiece,
 } from "./main.tsx";
 import Topic, {
@@ -21,9 +22,16 @@ import Topic, {
   extractFidPayloads,
   fidPayload,
   isSafeLinkUrl,
+  saveProfileBody,
   snippet,
+  submitProfileComment,
+  submitProfileLink,
+  type TopicAuthor,
   topicAuthorLabel,
+  type TopicComment,
   topicCorpus,
+  type TopicLink,
+  type TopicLinkKind,
   whenLabel,
 } from "./topic.tsx";
 
@@ -47,6 +55,57 @@ export default pattern(() => {
     createdAt: 1,
     createdByName: "Legacy Person",
     comments: [{ authorName: "Old Agent", body: "old", sentAt: 2 }],
+  });
+
+  // Deterministic bindings for the exact handlers used by Profile-backed UI
+  // controls. Pattern tests do not provide a #profile wish result, so bind the
+  // resolved snapshot values directly here rather than inventing a production
+  // fallback identity.
+  const profileTopics = new Writable<TopicPiece[] | Default<[]>>([]);
+  const profileTitleDraft = new Writable("Profile topic");
+  const profileComments = new Writable<TopicComment[] | Default<[]>>([]);
+  const profileCommentDraft = new Writable("via the profile composer");
+  const profileBody = new Writable<string | Default<"">>("old body");
+  const profileBodyDraft = new Writable("profile-edited body");
+  const profileEditingBody = new Writable(true);
+  const profileBodyUpdatedBy = new Writable<
+    TopicAuthor | Default<{ kind: "person"; name: "" }>
+  >({ kind: "person", name: "" });
+  const profileBodyUpdatedAt = new Writable<number | Default<0>>(0);
+  const profileLinks = new Writable<TopicLink[] | Default<[]>>([]);
+  const profileLinkUrlDraft = new Writable("https://example.com/profile-link");
+  const profileLinkLabelDraft = new Writable("profile link");
+  const profileLinkKindDraft = new Writable<TopicLinkKind>("session");
+
+  const profileSubmitTopic = submitProfileTopic({
+    topics: profileTopics,
+    mentionable: profileTopics,
+    newTitle: profileTitleDraft,
+    profileName: " Ada ",
+    profileAvatar: " 🦊 ",
+  });
+  const profileSubmitComment = submitProfileComment({
+    comments: profileComments,
+    commentDraft: profileCommentDraft,
+    profileName: "Ada",
+    profileAvatar: "🦊",
+  });
+  const profileSaveBody = saveProfileBody({
+    body: profileBody,
+    bodyDraft: profileBodyDraft,
+    editingBody: profileEditingBody,
+    bodyUpdatedBy: profileBodyUpdatedBy,
+    bodyUpdatedAt: profileBodyUpdatedAt,
+    profileName: "Ada",
+    profileAvatar: "🦊",
+  });
+  const profileSubmitLink = submitProfileLink({
+    links: profileLinks,
+    linkUrlDraft: profileLinkUrlDraft,
+    linkLabelDraft: profileLinkLabelDraft,
+    linkKindDraft: profileLinkKindDraft,
+    profileName: "Ada",
+    profileAvatar: "🦊",
   });
 
   // --- actions ---
@@ -117,6 +176,19 @@ export default pattern(() => {
       body: "bumping the first topic",
       agentName: "Sol",
     });
+  });
+
+  const action_submit_profile_topic = action(() => {
+    profileSubmitTopic.send();
+  });
+  const action_submit_profile_comment = action(() => {
+    profileSubmitComment.send();
+  });
+  const action_save_profile_body = action(() => {
+    profileSaveBody.send();
+  });
+  const action_submit_profile_link = action(() => {
+    profileSubmitLink.send();
   });
 
   // --- UI-affordance flows (the same paths the rendered controls drive) ---
@@ -249,6 +321,50 @@ export default pattern(() => {
         legacy.comments?.[0]?.authorName,
       ) === "Old Agent"
   );
+
+  const assert_profile_topic_submitted = computed(() => {
+    const list = profileTopics.get() ?? [];
+    return list.length === 1 &&
+      list[0]?.title === "Profile topic" &&
+      list[0]?.createdBy?.kind === "person" &&
+      list[0]?.createdBy?.name === "Ada" &&
+      list[0]?.createdBy?.avatar === "🦊" &&
+      profileTitleDraft.get() === "";
+  });
+
+  const assert_profile_comment_submitted = computed(() => {
+    const list = profileComments.get() ?? [];
+    return list.length === 1 &&
+      list[0]?.body === "via the profile composer" &&
+      list[0]?.author?.kind === "person" &&
+      list[0]?.author?.name === "Ada" &&
+      list[0]?.author?.avatar === "🦊" &&
+      (list[0]?.sentAt ?? 0) > 0 &&
+      profileCommentDraft.get() === "";
+  });
+
+  const assert_profile_body_saved = computed(() =>
+    profileBody.get() === "profile-edited body" &&
+    profileBodyUpdatedBy.get()?.kind === "person" &&
+    profileBodyUpdatedBy.get()?.name === "Ada" &&
+    profileBodyUpdatedAt.get() > 0 &&
+    profileEditingBody.get() === false
+  );
+
+  const assert_profile_link_submitted = computed(() => {
+    const list = profileLinks.get() ?? [];
+    return list.length === 1 &&
+      list[0]?.kind === "session" &&
+      list[0]?.url === "https://example.com/profile-link" &&
+      list[0]?.label === "profile link" &&
+      list[0]?.addedBy?.kind === "person" &&
+      list[0]?.addedBy?.name === "Ada" &&
+      list[0]?.addedBy?.avatar === "🦊" &&
+      (list[0]?.addedAt ?? 0) > 0 &&
+      profileLinkUrlDraft.get() === "" &&
+      profileLinkLabelDraft.get() === "" &&
+      profileLinkKindDraft.get() === "web";
+  });
 
   // A fresh comment on the FIRST topic makes it the most recently active.
   const assert_pure_helpers = computed(() =>
@@ -451,6 +567,14 @@ export default pattern(() => {
     [UI]: board[UI],
     tests: [
       { assertion: assert_initial },
+      { action: action_submit_profile_topic },
+      { assertion: assert_profile_topic_submitted },
+      { action: action_submit_profile_comment },
+      { assertion: assert_profile_comment_submitted },
+      { action: action_save_profile_body },
+      { assertion: assert_profile_body_saved },
+      { action: action_submit_profile_link },
+      { assertion: assert_profile_link_submitted },
       { action: action_add_blank_topic },
       { assertion: assert_still_empty },
       { action: action_add_unsigned_topic },
@@ -492,8 +616,8 @@ export default pattern(() => {
       { action: action_cancel_edit },
       { assertion: assert_edit_cancelled },
       { action: action_submit_blank_link_draft },
-      // Materialize the direct Topic after its comment and link exist so the
-      // nested row renderers are exercised without putting UI into TopicPiece.
+      // Materialize the direct and legacy Topics without putting UI into the
+      // board's shared TopicPiece projection.
       { render: directTopic[UI] },
       { render: legacy[UI] },
       { assertion: assert_legacy_fields_load },

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -3,9 +3,9 @@
  *
  * Complements multi-user.test.tsx (which covers cross-runtime isolation and
  * merge behavior): this file drives every exposed stream and derived value in
- * one runtime — action guards, authorship fallback ("someone" before a name
- * is set), the unsafe-scheme link rejection, label defaulting, body Edit→Save
- * via setBody, activity-based sorting, the derived crossref graph (edges from
+ * one runtime — action guards, atomic agent signatures, legacy authorship
+ * fallback, the unsafe-scheme link rejection, label defaulting, body updates,
+ * activity-based sorting, the derived crossref graph (edges from
  * fids pasted in bodies, comments, and link URLs; never persisted), and the
  * exported pure helpers.
  */
@@ -22,6 +22,7 @@ import Topic, {
   fidPayload,
   isSafeLinkUrl,
   snippet,
+  topicAuthorLabel,
   topicCorpus,
   whenLabel,
 } from "./topic.tsx";
@@ -39,64 +40,89 @@ export default pattern(() => {
   // Branch pin for the detail derive: a piece with no `mentionable` wired
   // (the pre-rev corpus, until backfilled) derives empty connection sets.
   const lone = Topic({ title: "Lone", createdAt: 1, createdByName: "t" });
+  // Pre-migration fields remain accepted and readable, but new writes below
+  // never produce them.
+  const legacy = Topic({
+    title: "Legacy",
+    createdAt: 1,
+    createdByName: "Legacy Person",
+    comments: [{ authorName: "Old Agent", body: "old", sentAt: 2 }],
+  });
 
   // --- actions ---
 
   const action_add_blank_topic = action(() => {
-    board.addTopic.send({ title: "   " });
+    board.addTopic.send({ title: "   ", agentName: "Sol" });
+  });
+  const action_add_unsigned_topic = action(() => {
+    board.addTopic.send({ title: "Unsigned", agentName: "   " });
   });
   const action_add_first_topic = action(() => {
-    board.addTopic.send({ title: "  First topic  " });
-  });
-  const action_set_name = action(() => {
-    board.setMyName.send({ name: "  Tester  " });
+    board.addTopic.send({ title: "  First topic  ", agentName: "  Sol  " });
   });
   const action_add_second_topic = action(() => {
-    board.addTopic.send({ title: "Second topic" });
+    board.addTopic.send({ title: "Second topic", agentName: "Fable" });
+  });
+  const action_add_third_topic = action(() => {
+    board.addTopic.send({ title: "Composed topic", agentName: "Sol" });
   });
 
   const action_blank_comment = action(() => {
-    board.topics?.[0]?.addComment.send({ body: "   " });
+    board.topics?.[0]?.addComment.send({ body: "   ", agentName: "Sol" });
   });
-  const action_comment_unnamed = action(() => {
-    board.topics?.[0]?.addComment.send({ body: "hello thread" });
+  const action_comment_unsigned = action(() => {
+    board.topics?.[0]?.addComment.send({
+      body: "unsigned",
+      agentName: "   ",
+    });
+  });
+  const action_comment_signed = action(() => {
+    board.topics?.[0]?.addComment.send({
+      body: "hello thread",
+      agentName: "Sol",
+    });
   });
   const action_set_body = action(() => {
-    board.topics?.[0]?.setBody.send({ body: "line one\nline two" });
+    board.topics?.[0]?.setBody.send({
+      body: "line one\nline two",
+      agentName: "Sol",
+    });
   });
   const action_link_unsafe = action(() => {
     board.topics?.[0]?.addLink.send({
       kind: "web",
       url: "javascript:alert(1)",
       label: "evil",
+      agentName: "Sol",
     });
   });
   const action_link_blank = action(() => {
-    board.topics?.[0]?.addLink.send({ kind: "web", url: "   ", label: "x" });
+    board.topics?.[0]?.addLink.send({
+      kind: "web",
+      url: "   ",
+      label: "x",
+      agentName: "Sol",
+    });
   });
   const action_link_valid_unlabeled = action(() => {
     board.topics?.[0]?.addLink.send({
       kind: "pr",
       url: "https://github.com/commontoolsinc/labs/pull/4643",
       label: "  ",
+      agentName: "Sol",
     });
   });
   const action_comment_first_again = action(() => {
-    board.topics?.[0]?.addComment.send({ body: "bumping the first topic" });
+    board.topics?.[0]?.addComment.send({
+      body: "bumping the first topic",
+      agentName: "Sol",
+    });
   });
 
   // --- UI-affordance flows (the same paths the rendered controls drive) ---
 
-  const action_submit_topic_via_composer = action(() => {
-    board.newTitle?.set("Composed topic");
-    board.submitTopic.send();
-  });
   const action_submit_blank_comment_draft = action(() => {
     directTopic.commentDraft.set("   ");
-    directTopic.submitComment.send();
-  });
-  const action_submit_comment_draft = action(() => {
-    directTopic.commentDraft.set("via the composer");
     directTopic.submitComment.send();
   });
   // Edit flows are split across test steps: startEditBody's handler runs in
@@ -109,18 +135,8 @@ export default pattern(() => {
     directTopic.bodyDraft.set("abandoned draft");
     directTopic.cancelEditBody.send();
   });
-  const action_save_edit = action(() => {
-    directTopic.bodyDraft.set("edited body");
-    directTopic.saveBody.send();
-  });
   const action_submit_blank_link_draft = action(() => {
     directTopic.linkUrlDraft.set("   ");
-    directTopic.submitLink.send();
-  });
-  const action_submit_link_draft = action(() => {
-    directTopic.linkUrlDraft.set("https://example.com/design");
-    directTopic.linkLabelDraft.set("design notes");
-    directTopic.linkKindDraft.set("session");
     directTopic.submitLink.send();
   });
   // Bound at pattern-body level (binding inside an action is an illegal
@@ -137,7 +153,6 @@ export default pattern(() => {
 
   const assert_initial = computed(() =>
     board.topicCount === 0 &&
-    board.myName === "" &&
     (board.topics ?? []).length === 0 &&
     (board.mentionable ?? []).length === 0
   );
@@ -145,19 +160,17 @@ export default pattern(() => {
   // Blank titles are rejected by the addTopic guard.
   const assert_still_empty = computed(() => board.topicCount === 0);
 
-  // Topic created before any name is set: authorship falls back to "someone"
-  // (the `(myName.get() ?? "").trim()` guard — cubic P1 on PR #4643).
   const assert_first_topic = computed(() =>
     board.topicCount === 1 &&
     board.topics?.[0]?.title === "First topic" &&
-    board.topics?.[0]?.createdByName === "someone" &&
+    board.topics?.[0]?.createdBy?.kind === "agent" &&
+    board.topics?.[0]?.createdBy?.name === "Sol" &&
+    !board.topics?.[0]?.createdByName &&
     (board.topics?.[0]?.createdAt ?? 0) > 0 &&
     board.topics?.[0]?.commentCount === 0 &&
     board.topics?.[0]?.lastActivityAt === board.topics?.[0]?.createdAt &&
     board.topics?.[0]?.[NAME] === "First topic"
   );
-
-  const assert_named = computed(() => board.myName === "Tester");
 
   const assert_blank_comment_rejected = computed(() =>
     board.topics?.[0]?.commentCount === 0
@@ -165,7 +178,9 @@ export default pattern(() => {
 
   const assert_comment_landed = computed(() =>
     board.topics?.[0]?.commentCount === 1 &&
-    board.topics?.[0]?.comments?.[0]?.authorName === "Tester" &&
+    board.topics?.[0]?.comments?.[0]?.author?.kind === "agent" &&
+    board.topics?.[0]?.comments?.[0]?.author?.name === "Sol" &&
+    !board.topics?.[0]?.comments?.[0]?.authorName &&
     board.topics?.[0]?.comments?.[0]?.body === "hello thread" &&
     (board.topics?.[0]?.comments?.[0]?.sentAt ?? 0) > 0 &&
     (board.topics?.[0]?.lastActivityAt ?? 0) >=
@@ -173,7 +188,10 @@ export default pattern(() => {
   );
 
   const assert_body_set = computed(() =>
-    board.topics?.[0]?.body === "line one\nline two"
+    board.topics?.[0]?.body === "line one\nline two" &&
+    board.topics?.[0]?.bodyUpdatedBy?.kind === "agent" &&
+    board.topics?.[0]?.bodyUpdatedBy?.name === "Sol" &&
+    (board.topics?.[0]?.bodyUpdatedAt ?? 0) > 0
   );
 
   // javascript: and blank URLs are rejected; a valid https link with a blank
@@ -185,32 +203,27 @@ export default pattern(() => {
     (board.topics?.[0]?.links ?? []).length === 1 &&
     board.topics?.[0]?.links?.[0]?.kind === "pr" &&
     board.topics?.[0]?.links?.[0]?.label ===
-      "https://github.com/commontoolsinc/labs/pull/4643"
+      "https://github.com/commontoolsinc/labs/pull/4643" &&
+    board.topics?.[0]?.links?.[0]?.addedBy?.name === "Sol" &&
+    (board.topics?.[0]?.links?.[0]?.addedAt ?? 0) > 0
   );
 
-  // Second topic created after naming: authorship snapshots the name; the
-  // board name computed reflects the count.
   const assert_second_topic = computed(() =>
     board.topicCount === 2 &&
     board.topics?.[1]?.title === "Second topic" &&
-    board.topics?.[1]?.createdByName === "Tester" &&
+    board.topics?.[1]?.createdBy?.kind === "agent" &&
+    board.topics?.[1]?.createdBy?.name === "Fable" &&
     board[NAME] === "Topics (2)"
   );
 
-  const assert_composed_topic = computed(() =>
+  const assert_third_topic = computed(() =>
     board.topicCount === 3 &&
     board.topics?.[2]?.title === "Composed topic" &&
-    board.newTitle?.get() === ""
+    board.topics?.[2]?.createdBy?.name === "Sol"
   );
 
   const assert_blank_draft_rejected = computed(() =>
     directTopic.commentCount === 0
-  );
-
-  const assert_composer_comment = computed(() =>
-    directTopic.commentCount === 1 &&
-    directTopic.comments?.[0]?.body === "via the composer" &&
-    directTopic.commentDraft.get() === ""
   );
 
   // startEditBody copied the current body into the draft and opened the editor.
@@ -224,17 +237,17 @@ export default pattern(() => {
     directTopic.body === "line one\nline two"
   );
 
-  const assert_edit_saved = computed(() =>
-    directTopic.editingBody === false &&
-    directTopic.body === "edited body"
-  );
-
-  const assert_link_draft_flow = computed(() =>
-    (directTopic.links ?? []).length === 1 &&
-    directTopic.links?.[0]?.kind === "session" &&
-    directTopic.links?.[0]?.label === "design notes" &&
-    directTopic.linkUrlDraft.get() === "" &&
-    directTopic.linkKindDraft.get() === "web"
+  const assert_legacy_fields_load = computed(() =>
+    legacy.createdByName === "Legacy Person" &&
+    legacy.createdBy === undefined &&
+    legacy.comments?.[0]?.authorName === "Old Agent" &&
+    legacy.comments?.[0]?.author === undefined &&
+    topicAuthorLabel(legacy.createdBy, legacy.createdByName) ===
+      "Legacy Person" &&
+    topicAuthorLabel(
+        legacy.comments?.[0]?.author,
+        legacy.comments?.[0]?.authorName,
+      ) === "Old Agent"
   );
 
   // A fresh comment on the FIRST topic makes it the most recently active.
@@ -275,6 +288,7 @@ export default pattern(() => {
     const fid = board.crossrefs?.[0]?.fid ?? "";
     board.topics?.[1]?.setBody.send({
       body: `relates to https://estuary.example/topics-dev/${fid} directly`,
+      agentName: "Sol",
     });
   });
   const assert_body_edge = computed(() =>
@@ -323,6 +337,7 @@ export default pattern(() => {
     const enc = (board.crossrefs?.[0]?.fid ?? "").replace(":", "%3A");
     board.topics?.[2]?.addComment.send({
       body: `shared as ?shared-pattern=estuary%2Ftopics-dev%2F${enc}`,
+      agentName: "Sol",
     });
   });
   const assert_comment_edge = computed(() =>
@@ -339,6 +354,7 @@ export default pattern(() => {
         board.crossrefs?.[1]?.fid ?? ""
       }`,
       label: "the second topic",
+      agentName: "Sol",
     });
   });
   const assert_link_edge = computed(() =>
@@ -353,6 +369,7 @@ export default pattern(() => {
     const own = board.crossrefs?.[0]?.fid ?? "";
     board.topics?.[0]?.setBody.send({
       body: `self ${own} and unknown fid1:${"Z".repeat(43)} stay edgeless`,
+      agentName: "Sol",
     });
   });
   const assert_self_unknown_ignored = computed(() =>
@@ -362,7 +379,10 @@ export default pattern(() => {
 
   // Nothing is persisted: retract the prose and the edge is simply gone.
   const action_remove_body_ref = action(() => {
-    board.topics?.[1]?.setBody.send({ body: "no references anymore" });
+    board.topics?.[1]?.setBody.send({
+      body: "no references anymore",
+      agentName: "Sol",
+    });
   });
   const assert_edge_removed = computed(() =>
     (board.crossrefs?.[1]?.refsOut ?? []).length === 0 &&
@@ -433,13 +453,15 @@ export default pattern(() => {
       { assertion: assert_initial },
       { action: action_add_blank_topic },
       { assertion: assert_still_empty },
+      { action: action_add_unsigned_topic },
+      { assertion: assert_still_empty },
       { action: action_add_first_topic },
       { assertion: assert_first_topic },
-      { action: action_set_name },
-      { assertion: assert_named },
       { action: action_blank_comment },
       { assertion: assert_blank_comment_rejected },
-      { action: action_comment_unnamed },
+      { action: action_comment_unsigned },
+      { assertion: assert_blank_comment_rejected },
+      { action: action_comment_signed },
       { assertion: assert_comment_landed },
       { action: action_set_body },
       { assertion: assert_body_set },
@@ -461,25 +483,20 @@ export default pattern(() => {
       { assertion: assert_chip_row_markup },
       { render: board[UI] },
       { action: action_comment_first_again },
-      { action: action_submit_topic_via_composer },
-      { assertion: assert_composed_topic },
+      { action: action_add_third_topic },
+      { assertion: assert_third_topic },
       { action: action_submit_blank_comment_draft },
       { assertion: assert_blank_draft_rejected },
-      { action: action_submit_comment_draft },
-      { assertion: assert_composer_comment },
       { action: action_start_edit },
       { assertion: assert_editing },
       { action: action_cancel_edit },
       { assertion: assert_edit_cancelled },
-      { action: action_start_edit },
-      { action: action_save_edit },
-      { assertion: assert_edit_saved },
       { action: action_submit_blank_link_draft },
-      { action: action_submit_link_draft },
       // Materialize the direct Topic after its comment and link exist so the
       // nested row renderers are exercised without putting UI into TopicPiece.
       { render: directTopic[UI] },
-      { assertion: assert_link_draft_flow },
+      { render: legacy[UI] },
+      { assertion: assert_legacy_fields_load },
       { action: action_open_topic },
       { assertion: assert_pure_helpers },
       { action: action_comment_ref_encoded },


### PR DESCRIPTION
## Summary

- replace the shared `myName` mutation flow with per-mutation structured attribution
- use canonical Profile snapshots for browser-authored topics, comments, links, and body saves
- require CLI/headless mutations to carry `agentName` atomically with their content
- retain `myName`, `createdByName`, and `authorName` only as optional legacy read/render fallbacks
- show body/link authorship and include their timestamps in `lastActivityAt`

## Design boundary

Fabric remains authoritative for the human principal behind the identity key, operation history, and concurrency. This change intentionally adds neither a duplicate activity ledger nor an application-level revision/CAS protocol; Topics should expose gaps in those Fabric guarantees through dogfooding.

This is designed for the short-term model established by the Profiles workstream (including loom#4074): an agent uses its human user's key and supplies its own name as a content-level signature.

## Verification

- `deno task cf check packages/patterns/topics/main.tsx --no-run`
- `deno task cf check packages/patterns/topics/topic.tsx --no-run`
- `deno task cf check packages/patterns/topics/topics.test.tsx --no-run`
- `deno task cf check packages/patterns/topics/multi-user.test.tsx --no-run`
- `deno task cf test packages/patterns/topics/topics.test.tsx` (29 passed)
- `deno task cf test packages/patterns/topics/multi-user.test.tsx` (7 passed)
- focused `deno lint`, `deno fmt --check`, and `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787346620&installation_model_id=428580&pr_number=4917&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4917&signature=422335c586ad98b371b2366575a7418ca32dc201467b911c0f335e0e3756f44e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make agent attribution atomic and profile-native across Topics. Headless streams require `agentName`; browser actions snapshot the viewer’s `#profile`, and the UI shows clear “started by”, “last updated by”, and link authorship while legacy fields render read-only.

- **New Features**
  - Structured `TopicAuthor` on topics (`createdBy`), comments, links (`addedBy`/`addedAt`), and body saves (`bodyUpdatedBy`/`bodyUpdatedAt`).
  - Streams now require an explicit actor: `addTopic`, `addComment`, `addLink`, `setBody` all carry `agentName`; blank values are rejected.
  - Profile UI: “Acting as” badge, controls disabled until a profile exists, avatars in comments, labels via `topicAuthorLabel`, “started by” and “last updated by” shown; links display their author.
  - `lastActivityAt` now includes body saves and link additions.
  - Exports: `TopicAuthor`, `AgentAuthoredEvent`, `AddCommentEvent`, `AddLinkEvent`, `SetBodyEvent`, `topicAuthorFromAgent`, `topicAuthorFromPerson`, `topicAuthorLabel`, `submitProfileTopic`, `submitProfileComment`, `saveProfileBody`, `submitProfileLink`.

- **Migration**
  - Remove `setMyName` and any “commenting as” inputs; `TopicsOutput.myName` is gone.
  - Pass `agentName` with headless calls to `addTopic`, `addComment`, `addLink`, and `setBody`.
  - Prefer `createdBy`/`addedBy`/`bodyUpdatedBy`; render with `topicAuthorLabel`. Legacy fields (`myName`, `createdByName`, `authorName`) remain read-only.
  - Aligns with the Profiles workstream (CT-1878); agent handlers are wish-free (CT-1879).

<sup>Written for commit 036aeeeaaf11fcf981e509237be880ff40499eb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

