### PR TITLE
fix(cli): keep cf view usable after parser failures

### DIFF
--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -263,8 +263,8 @@ export function buildDiffDocument(
         mapping,
         definitions,
         hunks,
-        // A deleted file's new path is /dev/null (absent), so fall back to the
-        // old path; otherwise a removed .md reads as TypeScript.
+        newFileName: file.newPath ?? file.oldPath,
+        oldFileName: file.oldPath ?? file.newPath,
         markdown: isMarkdownPath(file.newPath ?? file.oldPath),
       }));
     }
@@ -347,7 +347,10 @@ interface HunkCtx {
   mapping: FileMapping | undefined;
   definitions: Map<string, Definition[]>;
   hunks: DiffHunkInfo[];
-  /** The file is Markdown, so fragment-parsed lines are coloured as Markdown. */
+  /** Paths whose extensions select the new- and old-side fragment parsers. */
+  newFileName: string | undefined;
+  oldFileName: string | undefined;
+  /** The new-side workspace file is Markdown, so headings form its structure. */
   markdown: boolean;
 }
 
@@ -461,9 +464,9 @@ function buildHunk(hunk: DiffHunk, ctx: HunkCtx): StructureNode {
     newFragment,
     lines,
     rawLines,
-    ctx.markdown,
+    ctx.newFileName,
   );
-  applyFragmentSpans(oldFragment, lines, rawLines, ctx.markdown);
+  applyFragmentSpans(oldFragment, lines, rawLines, ctx.oldFileName);
 
   // --- structure ---------------------------------------------------------
   // Verified hunks remap the workspace file's own nodes (precise ranges, live
@@ -647,12 +650,12 @@ function applyFragmentSpans(
   fragment: { diffLine: number; code: string }[],
   lines: MutableLine[],
   rawLines: string[],
-  markdown: boolean,
+  fileName: string | undefined,
 ): Document | null {
   if (fragment.length === 0) return null;
   const parsed = parseDocument(
     fragment.map((f) => f.code).join("\n"),
-    markdown ? "fragment.md" : undefined,
+    fileName,
   );
   for (let i = 0; i < fragment.length; i++) {
     const { diffLine } = fragment[i];

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -31,7 +31,6 @@ import {
   sameCommit,
 } from "./commitmsg.ts";
 import { highlightDocument, type Highlighter, parseDocument } from "./parse.ts";
-import { highlightMarkdownLines, isMarkdownPath } from "./markdown.ts";
 import type {
   EditableSource,
   EditPolicy,
@@ -980,8 +979,11 @@ export function createDiffHighlighter(
   seed?: readonly Line[],
 ): Highlighter {
   let text = initialText;
-  let lines: Line[] =
-    (seed ?? initialText.split("\n").map((l) => diffLineRender(l))).slice();
+  const initialRaw = initialText.split("\n");
+  let lines: Line[] = (seed ??
+    initialRaw.map((line, index) =>
+      diffLineRender(line, diffFileNameAt(initialRaw, index))
+    )).slice();
   return {
     get lines() {
       return lines;
@@ -1001,7 +1003,7 @@ export function createDiffHighlighter(
         s++;
       }
       const recoloured = newRaw.slice(p, newRaw.length - s).map((l, i) =>
-        diffLineRender(l, isMarkdownDiffLine(newRaw, p + i))
+        diffLineRender(l, diffFileNameAt(newRaw, p + i))
       );
       lines = lines.slice(0, p).concat(
         recoloured,
@@ -1064,7 +1066,7 @@ function editableStart(
  * diff document builder paints a line, so a live edit re-colours correctly
  * without rebuilding the whole diff.
  */
-function diffLineRender(lineText: string, markdown = false): Line {
+function diffLineRender(lineText: string, fileName?: string): Line {
   if (lineText.length === 0) return { text: "", spans: [] };
   // A hunk header carries its own colour and its counts change when an edit
   // grows or shrinks the hunk, so colour it the way the full parse does rather
@@ -1083,9 +1085,7 @@ function diffLineRender(lineText: string, markdown = false): Line {
     : "whitespace";
   const spans: Span[] = [{ col: 0, text: marker, cls }];
   const code = lineText.slice(1);
-  const content = markdown
-    ? highlightMarkdownLines(code)[0]?.spans
-    : highlightDocument(code)[0]?.spans;
+  const content = highlightDocument(code, fileName)[0]?.spans;
   for (const s of content ?? []) {
     spans.push({ ...s, col: s.col + 1 });
   }
@@ -1093,15 +1093,41 @@ function diffLineRender(lineText: string, markdown = false): Line {
   return bg ? { text: lineText, spans, bg } : { text: lineText, spans };
 }
 
-/** Whether the diff line at `lineIdx` belongs to a Markdown file, by scanning
- * back to the nearest `+++ ` / `diff --git` header. */
-function isMarkdownDiffLine(rawLines: string[], lineIdx: number): boolean {
+/** The old- or new-side file containing `lineIdx`, found from the nearest diff
+ * header. Removed lines use the old path; additions and context use the new
+ * path. */
+function diffFileNameAt(
+  rawLines: string[],
+  lineIdx: number,
+): string | undefined {
+  const oldSide = rawLines[lineIdx]?.startsWith("-") ?? false;
+  let fallback: string | undefined;
   for (let i = Math.min(lineIdx, rawLines.length - 1); i >= 0; i--) {
     const l = rawLines[i];
-    if (l.startsWith("+++ ")) return isMarkdownPath(l.slice(4).split("\t")[0]);
-    if (l.startsWith("diff --git ")) return isMarkdownPath(l);
+    if (l.startsWith("+++ ")) {
+      const path = parserFileName(l.slice(4).split("\t")[0]);
+      if (path !== "/dev/null") {
+        if (!oldSide) return path;
+        fallback ??= path;
+      }
+    }
+    if (l.startsWith("--- ")) {
+      const path = parserFileName(l.slice(4).split("\t")[0]);
+      if (path !== "/dev/null") {
+        if (oldSide) return path;
+        fallback ??= path;
+      }
+    }
+    if (l.startsWith("diff --git ")) {
+      const file = parseDiff(l.replace(/\r$/, ""))?.files[0];
+      return (oldSide ? file?.oldPath : file?.newPath) ?? fallback;
+    }
   }
-  return false;
+  return fallback;
+}
+
+function parserFileName(value: string): string {
+  return value.replace(/\r$/, "").replace(/"$/, "");
 }
 
 export const _internal = {

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -980,9 +980,10 @@ export function createDiffHighlighter(
 ): Highlighter {
   let text = initialText;
   const initialRaw = initialText.split("\n");
+  const initialModel = seed ? null : parseDiff(initialText);
   let lines: Line[] = (seed ??
     initialRaw.map((line, index) =>
-      diffLineRender(line, diffFileNameAt(initialRaw, index))
+      diffLineRender(line, diffFileNameAt(initialRaw, index, initialModel))
     )).slice();
   return {
     get lines() {
@@ -1002,8 +1003,9 @@ export function createDiffHighlighter(
       ) {
         s++;
       }
+      const model = parseDiff(next);
       const recoloured = newRaw.slice(p, newRaw.length - s).map((l, i) =>
-        diffLineRender(l, diffFileNameAt(newRaw, p + i))
+        diffLineRender(l, diffFileNameAt(newRaw, p + i, model))
       );
       lines = lines.slice(0, p).concat(
         recoloured,
@@ -1099,10 +1101,12 @@ function diffLineRender(lineText: string, fileName?: string): Line {
 function diffFileNameAt(
   rawLines: string[],
   lineIdx: number,
+  model: DiffModel | null,
 ): string | undefined {
-  const oldSide = rawLines[lineIdx]?.startsWith("-") ?? false;
+  const oldSide = model?.lines[lineIdx]?.kind === "del";
   let fallback: string | undefined;
   for (let i = Math.min(lineIdx, rawLines.length - 1); i >= 0; i--) {
+    if (model?.lines[i]?.kind !== "meta") continue;
     const l = rawLines[i];
     if (l.startsWith("+++ ")) {
       const path = parserFileName(l.slice(4).split("\t")[0]);

--- a/packages/cli/lib/view/mod.ts
+++ b/packages/cli/lib/view/mod.ts
@@ -126,7 +126,7 @@ export function buildView(
       editSource: diffSource(ws, edit, cache, realGit(safeCwd())),
     };
   }
-  const doc = parseDocument(text, file ?? "transformed.ts");
+  const doc = parseDocument(text, file ?? "transformed.tsx");
   return {
     doc,
     semantics: () =>

--- a/packages/cli/lib/view/parse.ts
+++ b/packages/cli/lib/view/parse.ts
@@ -4,10 +4,9 @@
  *
  * Parsing reuses `npm:typescript` — the exact parser the ts-transformers and
  * js-compiler packages run — so token boundaries, block extents, closures and
- * type positions match what the compiler sees. Nothing here type-checks; it is
- * a pure syntactic pass (`ts.createSourceFile`), which is robust against the
- * concatenated multi-file blobs that `--show-transformed` emits (duplicate
- * declarations across sections are fine for a parser).
+ * type positions match what the compiler sees. Nothing here type-checks. The
+ * filename selects TypeScript or TSX syntax. A parser failure returns verbatim
+ * plain text so the pager remains usable.
  *
  * Three products come out of one parse:
  *   1. Per-line coloured {@link Span}s (full-fidelity: every character is
@@ -40,6 +39,7 @@ import {
 import { isBuilderName, isCallName, isSyntheticName } from "./vocab.ts";
 
 const SK = ts.SyntaxKind;
+const DEFAULT_FILE_NAME = "transformed.tsx";
 
 const STORAGE_KEYWORDS = new Set<ts.SyntaxKind>([
   SK.ConstKeyword,
@@ -141,18 +141,20 @@ interface GlobalSpan {
   bracketDepth?: number;
 }
 
-/** Parse `text` into the document model. `fileName` only affects diagnostics. */
+/** Parse `text` into the document model. */
 export function parseDocument(
   text: string,
-  fileName = "transformed.ts",
+  fileName = DEFAULT_FILE_NAME,
 ): Document {
-  // A Markdown file is coloured as Markdown, not parsed as TypeScript.
-  if (isMarkdownPath(fileName)) return markdownDocument(text);
-  // Parse as TSX: transformed pattern output keeps its JSX (`<cf-vstack>`,
-  // `<p>…</p>`), and in plain-TS mode the parser reads `<` as a comparison and
-  // shreds every statement from the first tag onward. The transformer emits
-  // `as` casts, never `<T>` prefix casts, so TSX has no ambiguity to lose on
-  // the non-JSX sections.
+  try {
+    if (isMarkdownPath(fileName)) return markdownDocument(text);
+    return parseTypeScriptDocument(text, fileName);
+  } catch {
+    return plainDocument(text);
+  }
+}
+
+function parseTypeScriptDocument(text: string, fileName: string): Document {
   const sf = parseSourceFile(text, fileName);
   const lineStarts = computeLineStarts(text);
   const lineOf = (offset: number) => lineIndexOf(lineStarts, offset);
@@ -200,31 +202,59 @@ export function parseDocument(
  */
 export function highlightDocument(
   text: string,
-  fileName = "transformed.ts",
+  fileName = DEFAULT_FILE_NAME,
 ): Line[] {
-  if (isMarkdownPath(fileName)) return highlightMarkdownLines(text);
-  const sf = parseSourceFile(text, fileName);
-  const lineStarts = computeLineStarts(text);
-  return highlightFromSourceFile(
-    sf,
-    text,
-    lineStarts,
-    collectSchemaObjects(sf),
-  );
+  try {
+    if (isMarkdownPath(fileName)) return highlightMarkdownLines(text);
+    const sf = parseSourceFile(text, fileName);
+    const lineStarts = computeLineStarts(text);
+    return highlightFromSourceFile(
+      sf,
+      text,
+      lineStarts,
+      collectSchemaObjects(sf),
+    );
+  } catch {
+    return plainLines(text);
+  }
 }
 
 function parseSourceFile(text: string, fileName: string): ts.SourceFile {
-  // Parse as TSX: transformed pattern output keeps its JSX, and in plain-TS mode
-  // the parser reads `<` as a comparison and shreds every statement from the
-  // first tag onward. The transformer emits `as` casts, never `<T>` prefix
-  // casts, so TSX has no ambiguity to lose on the non-JSX sections.
   return ts.createSourceFile(
     fileName,
     text,
     ts.ScriptTarget.Latest,
     /* setParentNodes */ true,
-    ts.ScriptKind.TSX,
+    scriptKindFor(fileName),
   );
+}
+
+function scriptKindFor(fileName: string): ts.ScriptKind {
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (/\.[cm]?ts$/.test(lower)) return ts.ScriptKind.TS;
+  // Inputs without a TypeScript extension can still be transformed output
+  // containing JSX.
+  return ts.ScriptKind.TSX;
+}
+
+function plainLines(text: string): Line[] {
+  return text.split("\n").map((line) => ({
+    text: line,
+    spans: line.length === 0
+      ? []
+      : [{ col: 0, text: line, cls: "plain" as const }],
+  }));
+}
+
+function plainDocument(text: string): Document {
+  return {
+    text,
+    lines: plainLines(text),
+    structure: [],
+    flatStructure: [],
+    definitions: new Map(),
+  };
 }
 
 function highlightFromSourceFile(
@@ -256,10 +286,54 @@ export interface Highlighter {
  * top-level statement boundary is at bracket depth zero and outside any
  * multi-line token (comment, template), so a bounded rebuild from there is
  * identical to a full parse of the whole document.
+ *
+ * A parsing or highlighting failure returns exact plain-text lines. The next
+ * edit builds a fresh parser and restores syntax highlighting when it succeeds.
  */
 export function createHighlighter(
   initial: string,
-  fileName = "transformed.ts",
+  fileName = DEFAULT_FILE_NAME,
+): Highlighter {
+  let text = initial;
+  let highlighter = tryCreateTypeScriptHighlighter(initial, fileName);
+  let lines: readonly Line[] = highlighter?.lines ?? plainLines(initial);
+
+  return {
+    get lines() {
+      return lines;
+    },
+    update(next: string): readonly Line[] {
+      if (next === text) return lines;
+      text = next;
+      if (highlighter) {
+        try {
+          lines = highlighter.update(next);
+          return lines;
+        } catch {
+          highlighter = undefined;
+        }
+      }
+      highlighter = tryCreateTypeScriptHighlighter(next, fileName);
+      lines = highlighter?.lines ?? plainLines(next);
+      return lines;
+    },
+  };
+}
+
+function tryCreateTypeScriptHighlighter(
+  initial: string,
+  fileName: string,
+): Highlighter | undefined {
+  try {
+    return createTypeScriptHighlighter(initial, fileName);
+  } catch {
+    return undefined;
+  }
+}
+
+function createTypeScriptHighlighter(
+  initial: string,
+  fileName: string,
 ): Highlighter {
   let sf = parseSourceFile(initial, fileName);
   let text = initial;

--- a/packages/cli/lib/view/semantics.ts
+++ b/packages/cli/lib/view/semantics.ts
@@ -84,7 +84,7 @@ export function createSemantics(
 ): Semantics | null {
   let sections: SectionFile[];
   try {
-    sections = splitSections(text, options.fileName ?? "transformed.ts");
+    sections = splitSections(text, options.fileName ?? "transformed.tsx");
   } catch {
     return null;
   }

--- a/packages/cli/test/view-diff.test.ts
+++ b/packages/cli/test/view-diff.test.ts
@@ -271,6 +271,41 @@ Deno.test("diff doc: missing workspace file still highlights and structures via 
   assert(hunk.label.includes("(no workspace file)"), `label: ${hunk.label}`);
 });
 
+Deno.test("diff doc: fragment parsing follows the file extension", () => {
+  const diff = `diff --git a/generic.ts b/generic.ts
+--- a/generic.ts
++++ b/generic.ts
+@@ -0,0 +1 @@
++const identity = <T>(value: T): T => value;
+`;
+  const model = parseDiff(diff)!;
+  const { doc } = buildDiffDocument(diff, model, NO_WS);
+  const parameter = doc.lines[4].spans.find((span) => span.text === "value");
+  assertEquals(
+    parameter?.cls,
+    "parameter",
+    "a .ts fragment uses TypeScript rather than TSX",
+  );
+});
+
+Deno.test("diff doc: renamed fragments use each side's extension", () => {
+  const diff = `diff --git a/generic.ts b/generic.tsx
+--- a/generic.ts
++++ b/generic.tsx
+@@ -1 +1 @@
+-const identity = <T>(value: T): T => value;
++const view = <div>ready</div>;
+`;
+  const model = parseDiff(diff)!;
+  const { doc } = buildDiffDocument(diff, model, NO_WS);
+  const oldParameter = doc.lines[4].spans.find((span) => span.text === "value");
+  assertEquals(
+    oldParameter?.cls,
+    "parameter",
+    "the removed .ts line uses the old TypeScript path",
+  );
+});
+
 Deno.test("diff doc: a drifted workspace line unmaps the whole hunk", () => {
   const { root, ws, done } = tempWorkspace();
   try {

--- a/packages/cli/test/view-diffedit-cov.test.ts
+++ b/packages/cli/test/view-diffedit-cov.test.ts
@@ -551,6 +551,45 @@ Deno.test("diffedit cov: the highlighter recolours a Markdown body line via the 
   assertEquals(out[bodyIdx].spans[0].cls, "diffAdd");
 });
 
+Deno.test("diffedit cov: a CRLF .ts header selects TypeScript for edited lines", () => {
+  const diff = [
+    "diff --git a/generic.ts b/generic.ts\r",
+    "--- a/generic.ts\r",
+    "+++ b/generic.ts\r",
+    "@@ -0,0 +1 @@\r",
+    "+const identity = <T>(value: T): T => value;\r",
+    "",
+  ].join("\n");
+  const highlighter = createDiffHighlighter(diff);
+  const raw = diff.split("\n");
+  raw[4] = raw[4].replace("value;", "value ;");
+  const line = highlighter.update(raw.join("\n"))[4];
+  assertEquals(
+    line.spans.find((span) => span.text === "value" && span.cls === "parameter")
+      ?.cls,
+    "parameter",
+  );
+});
+
+Deno.test("diffedit cov: renamed removed lines use the old extension", () => {
+  const diff = `diff --git a/generic.ts b/generic.tsx
+--- a/generic.ts
++++ b/generic.tsx
+@@ -1 +1 @@
+-const identity = <T>(value: T): T => value;
++const view = <div>ready</div>;
+`;
+  const highlighter = createDiffHighlighter(diff);
+  const raw = diff.split("\n");
+  raw[4] = raw[4].replace("value;", "value ;");
+  const line = highlighter.update(raw.join("\n"))[4];
+  assertEquals(
+    line.spans.find((span) => span.text === "value" && span.cls === "parameter")
+      ?.cls,
+    "parameter",
+  );
+});
+
 Deno.test("diffedit cov: the highlighter scans past a missing +++ to the diff --git Markdown header", () => {
   // No `+++ ` line at all (a truncated header), so the backward scan from the
   // edited body line reaches the `diff --git ...md` header instead.

--- a/packages/cli/test/view-diffedit-cov.test.ts
+++ b/packages/cli/test/view-diffedit-cov.test.ts
@@ -590,6 +590,30 @@ Deno.test("diffedit cov: renamed removed lines use the old extension", () => {
   );
 });
 
+Deno.test("diffedit cov: source lines resembling file headers keep the diff path", () => {
+  const diff = `diff --git a/generic.ts b/generic.ts
+--- a/generic.ts
++++ b/generic.ts
+@@ -1 +1 @@
+--- oldValue; const before = <T>(input: T): T => input;
++++ newValue; const after = <T>(input: T): T => input;
+`;
+  const highlighter = createDiffHighlighter(diff);
+  const raw = diff.split("\n");
+  raw[4] = raw[4].replace("oldValue", "previousValue");
+  raw[5] = raw[5].replace("newValue", "nextValue");
+  const lines = highlighter.update(raw.join("\n"));
+  for (const index of [4, 5]) {
+    assertEquals(
+      lines[index].spans.find((span) =>
+        span.text === "input" && span.cls === "parameter"
+      )?.cls,
+      "parameter",
+      `line ${index + 1} uses the .ts parser`,
+    );
+  }
+});
+
 Deno.test("diffedit cov: the highlighter scans past a missing +++ to the diff --git Markdown header", () => {
   // No `+++ ` line at all (a truncated header), so the backward scan from the
   // edited body line reaches the `diff --git ...md` header instead.

--- a/packages/cli/test/view-helpers.ts
+++ b/packages/cli/test/view-helpers.ts
@@ -69,6 +69,21 @@ interface Bar {
 }
 `;
 
+/** Valid TypeScript that triggers a compiler crash when parsed as TSX. The
+ * generic arrow enters JSX recovery. The later private member produces a
+ * malformed private identifier. */
+export const TS_PARSER_REGRESSION =
+  `export const identity = <T>(value: T): T => {
+  return value;
+};
+class Tx {
+  #floor = 0;
+  set(mode: number): void {
+    if (mode < this.#floor) {}
+  }
+}
+`;
+
 /** Encode a string to bytes for the key decoder. */
 export function bytes(s: string): Uint8Array {
   return new TextEncoder().encode(s);

--- a/packages/cli/test/view-highlighter.test.ts
+++ b/packages/cli/test/view-highlighter.test.ts
@@ -11,7 +11,7 @@
 import { assert, assertEquals } from "@std/assert";
 import { createHighlighter, highlightDocument } from "../lib/view/parse.ts";
 import type { Line } from "../lib/view/model.ts";
-import { SAMPLE } from "./view-helpers.ts";
+import { SAMPLE, TS_PARSER_REGRESSION } from "./view-helpers.ts";
 
 /** The index of the first line that differs in text or spans, or -1. Spans are
  * compared on every field the renderer reads. */
@@ -136,5 +136,48 @@ Deno.test("highlighter: an edit re-baselines correctly across a multi-line comme
     firstDiff(hl.update(closed), highlightDocument(closed, "m.ts")),
     -1,
     "closing the comment restores the lines below",
+  );
+});
+
+Deno.test("highlighter: parser failures fall back and later edits recover", () => {
+  const valid = "const view = <div>ready</div>;\n";
+
+  const highlighter = createHighlighter(valid, "fixture.tsx");
+  assertEquals(
+    firstDiff(
+      highlighter.update(TS_PARSER_REGRESSION),
+      highlightDocument(TS_PARSER_REGRESSION, "fixture.tsx"),
+    ),
+    -1,
+    "an incremental parse failure uses the full-parse fallback",
+  );
+  assertEquals(
+    firstDiff(
+      highlighter.update(valid),
+      highlightDocument(valid, "fixture.tsx"),
+    ),
+    -1,
+    "a later valid edit restores syntax highlighting",
+  );
+
+  const failedInitially = createHighlighter(
+    TS_PARSER_REGRESSION,
+    "fixture.tsx",
+  );
+  assertEquals(
+    firstDiff(
+      failedInitially.lines,
+      highlightDocument(TS_PARSER_REGRESSION, "fixture.tsx"),
+    ),
+    -1,
+    "an initial parse failure uses the full-parse fallback",
+  );
+  assertEquals(
+    firstDiff(
+      failedInitially.update(valid),
+      highlightDocument(valid, "fixture.tsx"),
+    ),
+    -1,
+    "an initially failed highlighter recovers",
   );
 });

--- a/packages/cli/test/view-parse.test.ts
+++ b/packages/cli/test/view-parse.test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals } from "@std/assert";
 import ts from "typescript";
-import { parseDocument, SAMPLE } from "./view-helpers.ts";
+import { parseDocument, SAMPLE, TS_PARSER_REGRESSION } from "./view-helpers.ts";
 import { highlightDocument } from "../lib/view/parse.ts";
 import type { Document, TokenClass } from "../lib/view/model.ts";
 
@@ -264,6 +264,40 @@ export default pattern((_) => {
       n.kind === "statement" && n.label.includes("cf-vstack")
     ),
     "no JSX fragment leaked as a statement node",
+  );
+});
+
+Deno.test("parse: .ts files use the TypeScript parser", () => {
+  const doc = parseDocument(TS_PARSER_REGRESSION, "fixture.ts");
+  assert(
+    doc.flatStructure.some((node) =>
+      node.kind === "closure" && node.name === "identity"
+    ),
+    "the generic arrow function is parsed as TypeScript",
+  );
+  assert(
+    classesOf(doc, "value").has("parameter"),
+    "the generic arrow function parameter is classified",
+  );
+});
+
+Deno.test("parse: a parser failure falls back to verbatim plain text", () => {
+  const doc = parseDocument(TS_PARSER_REGRESSION, "fixture.tsx");
+  assertEquals(doc.flatStructure, []);
+  assertEquals(doc.definitions.size, 0);
+  assertEquals(
+    doc.lines.map((line) => line.text).join("\n"),
+    TS_PARSER_REGRESSION,
+  );
+  for (const line of doc.lines) {
+    assertEquals(
+      line.spans,
+      line.text.length === 0 ? [] : [{ col: 0, text: line.text, cls: "plain" }],
+    );
+  }
+  assertEquals(
+    highlightDocument(TS_PARSER_REGRESSION, "fixture.tsx"),
+    doc.lines,
   );
 });
 


### PR DESCRIPTION
The pager parsed every source file as TSX. Valid TypeScript generic arrows could send the compiler into JSX error recovery, and later AST classification could terminate the pager.

Select TypeScript or TSX from the real source or diff path. Preserve TSX for transformed piped input. Wrap full document parsing, single-pass highlighting, and incremental highlighting so a failure renders exact plain text. Rebuild the incremental parser after later edits so syntax coloring recovers.

Diff fragments and edited lines now retain their side-specific filenames, including CRLF headers and extension-changing renames.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787349162&installation_model_id=428580&pr_number=4918&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4918&signature=fc85e36690bb74506c2149a78bede486ebd436bf858cc503d21fdc32cb689d89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the cf view usable when the TypeScript/TSX parser fails, and fix diff coloring by selecting the right language from real file paths for fragments and live edits.

- **Bug Fixes**
  - Infer TS vs TSX from the actual source or diff path; default to `.tsx` for transformed/piped input. Prevents parsing generic arrows in `.ts` as JSX.
  - Make `parseDocument`, `highlightDocument`, and the incremental highlighter fail-safe: render exact plain text on errors, then rebuild on later edits to restore syntax colors.
  - In diffs, use side-specific filenames for fragments and edited lines; handle `/dev/null`, CRLF headers, quotes, and extension-changing renames so Markdown/TypeScript/TSX are colored correctly.
  - Parse the diff once per pass and only accept path candidates from parsed metadata; choose old vs new side from the line kind and ignore body lines that look like `+++`/`---` headers.

<sup>Written for commit 99fd9bfb179839f26deb97bc54dd7d826d418cef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

