### PR TITLE
test(shell): replace disposal sleeps in piece.test.ts with real waits

### DIFF
--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -350,9 +350,13 @@ describe("shell piece tests", () => {
       }
       throw error;
     } finally {
+      // Both disposals are awaited to completion: disposeRuntime() awaits the
+      // browser runtime's teardown (worker Dispose round trip and transport
+      // close), and cc.dispose() awaits the in-process runtime's. The keyfile
+      // is only ever read by the already-exited `cf piece new` subprocess, so
+      // nothing outstanding touches it once those return.
       await shell.disposeRuntime();
       await cc?.dispose();
-      await new Promise((resolve) => setTimeout(resolve, 100));
       await Deno.remove(identityPath).catch(() => {});
     }
   });
@@ -439,21 +443,50 @@ describe("shell piece tests", () => {
       // RootView swap while those consumers are still active. Proactive
       // cancellation must tear them all down without recording a console error
       // — the harness afterEach fails the test on any (no allowlist).
+      //
+      // The RootView task disposes the previous RuntimeInternals fire-and-forget
+      // and drops the promise, so there is nothing to await after the swap. Wrap
+      // dispose() before triggering logout to hold onto the exact promise the
+      // swap starts; awaiting it below settles all disposal-raced async work
+      // (the abort's synchronous consumer teardowns, the worker Dispose round
+      // trip, and the transport close) on a real completion instead of a timer.
       await shell.page().evaluate(async () => {
+        const rootView = document.querySelector("x-root-view") as
+          | { _rt?: { value?: { dispose(): Promise<void> } } }
+          | null;
+        const internals = rootView?._rt?.value;
+        if (!internals) {
+          throw new Error(
+            "Runtime internals not available to observe disposal",
+          );
+        }
+        const global = globalThis as unknown as {
+          __ctRuntimeDisposed?: Promise<void>;
+        };
+        global.__ctRuntimeDisposed = undefined;
+        const disposeInternals = internals.dispose.bind(internals);
+        internals.dispose = () => {
+          global.__ctRuntimeDisposed = disposeInternals();
+          return global.__ctRuntimeDisposed;
+        };
         await globalThis.app.apply({
           type: "set-identity",
           identity: undefined,
         });
       });
+      // The swap clears the global only after it has called the wrapped
+      // dispose(), so once the runtime is gone the disposal promise is stashed.
       await waitForCondition(
         shell.page(),
         () => !globalThis.commonfabric?.rt,
       );
-      // Let any disposal-raced async work settle before afterEach inspects the
-      // recorded console errors.
-      await shell.page().evaluate(() =>
-        new Promise((resolve) => setTimeout(resolve, 250))
-      );
+      // Await the disposal the swap started, so all disposal-raced async work
+      // has settled before afterEach inspects the recorded console errors.
+      await shell.page().evaluate(async () => {
+        await (globalThis as unknown as {
+          __ctRuntimeDisposed?: Promise<void>;
+        }).__ctRuntimeDisposed;
+      });
     } finally {
       await Deno.remove(identityPath).catch(() => {});
     }


### PR DESCRIPTION
The piece integration suite carried two fixed setTimeout delays around runtime disposal. Both are flaky by construction: a fixed sleep both puts a floor under the test's runtime and can under-wait on a slow machine, so the thing it guards can complete after the deadline has already passed.

The first test's finally block slept 100ms between disposing the runtimes and removing the identity keyfile. Both disposals there are already awaited to completion: shell.disposeRuntime() awaits the browser runtime's teardown (the worker Dispose round trip and the transport close), and cc.dispose() awaits the in-process runtime's. The keyfile is only ever read by the already-exited `cf piece new` subprocess, and PiecesController.initialize is handed the identity object rather than the path, so nothing outstanding touches the file once those awaits return. The sleep guarded nothing and is removed.

The logout-teardown test slept 250ms after logout to let disposal-raced async work settle before the afterEach console-error check. The RootView runtime task disposes the previous RuntimeInternals fire-and-forget on logout and drops the promise, so there was no completion to await and the test fell back to a timer. It now wraps that RuntimeInternals.dispose() before triggering logout to hold onto the exact promise the swap starts, then awaits it once the swap has cleared the runtime global. Awaiting the dispose promise settles the whole teardown chain — the abort's synchronous consumer teardowns, the worker Dispose round trip, and the transport close — on a real completion signal. The connection marks itself dead the instant disposal begins and drops any late worker console/error notification from there on, so the awaited barrier is strictly stronger than the timer it replaces: it can neither under-wait a slow worker nor race the console-error check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787351838&installation_model_id=428580&pr_number=4919&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4919&signature=0b6e7561d77b396ffb2c66395b62d4e9cd01fff756dd0a059c6d57a0dbe62775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced fixed `setTimeout` sleeps in `packages/shell/integration/piece.test.ts` with real disposal awaits to remove flakiness and avoid slow-machine under-waits.

- **Bug Fixes**
  - Removed the 100ms sleep after `shell.disposeRuntime()`/`cc.dispose()`; safely deletes the identity key file once disposals complete.
  - During logout, wrapped `RuntimeInternals.dispose()` to capture and await its promise after the runtime swap; replaces the 250ms timer and avoids races with the afterEach console-error check.

<sup>Written for commit 342a28039635fcecbff17f5f454f24d80811ad11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

