### PR TITLE
feat(memory): classify transaction telemetry

### DIFF
--- a/packages/memory/test/commit-telemetry.test.ts
+++ b/packages/memory/test/commit-telemetry.test.ts
@@ -106,6 +106,15 @@ describe("commit-telemetry", () => {
       schedulerObservationCount: 1,
       sqliteOperationCount: 1,
     });
+
+    expect(classifyCommitTelemetry(
+      commit([sqliteOperation], { schedulerObservation }),
+    )).toEqual({
+      kind: "mixed",
+      entityCount: 0,
+      schedulerObservationCount: 1,
+      sqliteOperationCount: 1,
+    });
   });
 
   it("returns `precondition` for precondition-only requests", () => {

--- a/packages/memory/test/commit-telemetry.test.ts
+++ b/packages/memory/test/commit-telemetry.test.ts
@@ -1,0 +1,141 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import type {
+  ClientCommit,
+  Operation,
+  SchedulerActionObservation,
+} from "../v2.ts";
+import { classifyCommitTelemetry } from "../v2/commit-telemetry.ts";
+
+const commit = (
+  operations: Operation[] = [],
+  extra: Partial<ClientCommit> = {},
+): ClientCommit => ({
+  localSeq: 1,
+  reads: { confirmed: [], pending: [] },
+  operations,
+  ...extra,
+});
+
+const semanticOperation: Operation = {
+  op: "set",
+  id: "of:telemetry-test",
+  value: { value: "hello" },
+};
+
+const sqliteOperation: Operation = {
+  op: "sqlite",
+  db: { id: "of:telemetry-db" },
+  sql: "CREATE TABLE example (value TEXT)",
+};
+
+const schedulerObservation: SchedulerActionObservation = {
+  version: 1,
+  branch: "",
+  pieceId: "of:telemetry-piece",
+  processGeneration: 0,
+  actionId: "telemetry-action",
+  actionKind: "computation",
+  implementationFingerprint: "impl:telemetry",
+  runtimeFingerprint: "runtime:telemetry",
+  observedAtSeq: 0,
+  transactionKind: "action-run",
+  reads: [],
+  shallowReads: [],
+  actualChangedWrites: [],
+  currentKnownWrites: [],
+  materializerWriteEnvelopes: [],
+  status: "success",
+};
+
+describe("commit-telemetry", () => {
+  it("returns `semantic` for non-SQLite entity operations", () => {
+    expect(classifyCommitTelemetry(commit([semanticOperation]))).toEqual({
+      kind: "semantic",
+      entityCount: 1,
+      schedulerObservationCount: 0,
+      sqliteOperationCount: 0,
+    });
+  });
+
+  it("returns `scheduler_observation` for scheduler-only requests", () => {
+    expect(
+      classifyCommitTelemetry(commit([], { schedulerObservation })),
+    ).toEqual({
+      kind: "scheduler_observation",
+      entityCount: 0,
+      schedulerObservationCount: 1,
+      sqliteOperationCount: 0,
+    });
+
+    expect(classifyCommitTelemetry(commit([], {
+      schedulerObservationBatch: [{
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        schedulerObservation,
+      }, {
+        localSeq: 3,
+        reads: { confirmed: [], pending: [] },
+        schedulerObservation,
+      }],
+    }))).toEqual({
+      kind: "scheduler_observation",
+      entityCount: 0,
+      schedulerObservationCount: 2,
+      sqliteOperationCount: 0,
+    });
+  });
+
+  it("returns `sqlite` for SQLite-only requests", () => {
+    expect(classifyCommitTelemetry(commit([sqliteOperation]))).toEqual({
+      kind: "sqlite",
+      entityCount: 0,
+      schedulerObservationCount: 0,
+      sqliteOperationCount: 1,
+    });
+  });
+
+  it("returns `mixed` when several operation classes are present", () => {
+    expect(classifyCommitTelemetry(
+      commit([semanticOperation, sqliteOperation], {
+        schedulerObservation,
+      }),
+    )).toEqual({
+      kind: "mixed",
+      entityCount: 1,
+      schedulerObservationCount: 1,
+      sqliteOperationCount: 1,
+    });
+  });
+
+  it("returns `precondition` for precondition-only requests", () => {
+    expect(classifyCommitTelemetry(commit([], {
+      preconditions: [{ kind: "entity-absent", id: "of:missing" }],
+    }))).toEqual({
+      kind: "precondition",
+      entityCount: 0,
+      schedulerObservationCount: 0,
+      sqliteOperationCount: 0,
+    });
+  });
+
+  it("uses preconditions only as a fallback category", () => {
+    expect(classifyCommitTelemetry(commit([semanticOperation], {
+      preconditions: [{ kind: "entity-absent", id: "of:missing" }],
+    }))).toEqual({
+      kind: "semantic",
+      entityCount: 1,
+      schedulerObservationCount: 0,
+      sqliteOperationCount: 0,
+    });
+  });
+
+  it("returns `empty` for requests without classifiable content", () => {
+    expect(classifyCommitTelemetry(commit())).toEqual({
+      kind: "empty",
+      entityCount: 0,
+      schedulerObservationCount: 0,
+      sqliteOperationCount: 0,
+    });
+  });
+});

--- a/packages/memory/test/v2-commit-telemetry-test.ts
+++ b/packages/memory/test/v2-commit-telemetry-test.ts
@@ -1,0 +1,112 @@
+import { assertEquals } from "@std/assert";
+import type { ClientCommit, Operation } from "../v2.ts";
+import { classifyCommitTelemetry } from "../v2/commit-telemetry.ts";
+
+const commit = (
+  operations: Operation[] = [],
+  extra: Partial<ClientCommit> = {},
+): ClientCommit => ({
+  localSeq: 1,
+  reads: { confirmed: [], pending: [] },
+  operations,
+  ...extra,
+});
+
+const semanticOperation: Operation = {
+  op: "set",
+  id: "of:telemetry-test",
+  value: { value: "hello" },
+};
+
+const sqliteOperation: Operation = {
+  op: "sqlite",
+  db: { id: "of:telemetry-db" },
+  sql: "CREATE TABLE example (value TEXT)",
+};
+
+Deno.test("classifies semantic memory transactions", () => {
+  assertEquals(classifyCommitTelemetry(commit([semanticOperation])), {
+    kind: "semantic",
+    entityCount: 1,
+    schedulerObservationCount: 0,
+    sqliteOperationCount: 0,
+  });
+});
+
+Deno.test("classifies scheduler-observation-only memory transactions", () => {
+  assertEquals(
+    classifyCommitTelemetry(commit([], { schedulerObservation: {} })),
+    {
+      kind: "scheduler_observation",
+      entityCount: 0,
+      schedulerObservationCount: 1,
+      sqliteOperationCount: 0,
+    },
+  );
+
+  assertEquals(
+    classifyCommitTelemetry(commit([], {
+      schedulerObservationBatch: [
+        {
+          localSeq: 2,
+          reads: { confirmed: [], pending: [] },
+          schedulerObservation: {},
+        },
+        {
+          localSeq: 3,
+          reads: { confirmed: [], pending: [] },
+          schedulerObservation: {},
+        },
+      ],
+    })),
+    {
+      kind: "scheduler_observation",
+      entityCount: 0,
+      schedulerObservationCount: 2,
+      sqliteOperationCount: 0,
+    },
+  );
+});
+
+Deno.test("classifies SQLite-only and mixed memory transactions", () => {
+  assertEquals(classifyCommitTelemetry(commit([sqliteOperation])), {
+    kind: "sqlite",
+    entityCount: 0,
+    schedulerObservationCount: 0,
+    sqliteOperationCount: 1,
+  });
+
+  assertEquals(
+    classifyCommitTelemetry(
+      commit([semanticOperation, sqliteOperation], {
+        schedulerObservation: {},
+      }),
+    ),
+    {
+      kind: "mixed",
+      entityCount: 1,
+      schedulerObservationCount: 1,
+      sqliteOperationCount: 1,
+    },
+  );
+});
+
+Deno.test("classifies precondition-only and invalid empty requests", () => {
+  assertEquals(
+    classifyCommitTelemetry(commit([], {
+      preconditions: [{ kind: "entity-absent", id: "of:missing" }],
+    })),
+    {
+      kind: "precondition",
+      entityCount: 0,
+      schedulerObservationCount: 0,
+      sqliteOperationCount: 0,
+    },
+  );
+  assertEquals(classifyCommitTelemetry(commit()), {
+    kind: "empty",
+    entityCount: 0,
+    schedulerObservationCount: 0,
+    sqliteOperationCount: 0,
+  });
+});

--- a/packages/memory/v2/commit-telemetry.ts
+++ b/packages/memory/v2/commit-telemetry.ts
@@ -1,0 +1,57 @@
+import type { ClientCommit } from "../v2.ts";
+
+/** Stable categories used to separate memory transaction traffic in telemetry. */
+export type CommitTelemetryKind =
+  | "semantic"
+  | "scheduler_observation"
+  | "sqlite"
+  | "mixed"
+  | "precondition"
+  | "empty";
+
+export interface CommitTelemetryClassification {
+  kind: CommitTelemetryKind;
+  entityCount: number;
+  schedulerObservationCount: number;
+  sqliteOperationCount: number;
+}
+
+/**
+ * Classify the requested commit without changing validation or persistence.
+ *
+ * This deliberately describes the wire request, so rejected/conflicting
+ * attempts carry the same dimensions as successful attempts. `entityCount`
+ * retains the existing meaning: non-SQLite entity operations.
+ */
+export const classifyCommitTelemetry = (
+  commit: ClientCommit,
+): CommitTelemetryClassification => {
+  const entityCount =
+    commit.operations.filter((operation) => operation.op !== "sqlite").length;
+  const sqliteOperationCount = commit.operations.length - entityCount;
+  const schedulerObservationCount =
+    (commit.schedulerObservation === undefined ? 0 : 1) +
+    (commit.schedulerObservationBatch?.length ?? 0);
+  const componentCount = Number(entityCount > 0) +
+    Number(sqliteOperationCount > 0) +
+    Number(schedulerObservationCount > 0);
+
+  const kind: CommitTelemetryKind = componentCount > 1
+    ? "mixed"
+    : entityCount > 0
+    ? "semantic"
+    : schedulerObservationCount > 0
+    ? "scheduler_observation"
+    : sqliteOperationCount > 0
+    ? "sqlite"
+    : (commit.preconditions?.length ?? 0) > 0
+    ? "precondition"
+    : "empty";
+
+  return {
+    kind,
+    entityCount,
+    schedulerObservationCount,
+    sqliteOperationCount,
+  };
+};

--- a/packages/memory/v2/commit-telemetry.ts
+++ b/packages/memory/v2/commit-telemetry.ts
@@ -1,0 +1,58 @@
+import type { ClientCommit } from "../v2.ts";
+
+/** Stable categories used to separate memory transaction traffic in telemetry. */
+export type CommitTelemetryKind =
+  | "semantic"
+  | "scheduler_observation"
+  | "sqlite"
+  | "mixed"
+  | "precondition"
+  | "empty";
+
+/** Counts and category attached to a `memory.transact` span. */
+export interface CommitTelemetryClassification {
+  kind: CommitTelemetryKind;
+  entityCount: number;
+  schedulerObservationCount: number;
+  sqliteOperationCount: number;
+}
+
+/**
+ * Classify the requested commit without changing validation or persistence.
+ *
+ * This deliberately describes the wire request, so rejected/conflicting
+ * attempts carry the same dimensions as successful attempts. `entityCount`
+ * retains the existing meaning: non-SQLite entity operations.
+ */
+export const classifyCommitTelemetry = (
+  commit: ClientCommit,
+): CommitTelemetryClassification => {
+  const entityCount =
+    commit.operations.filter((operation) => operation.op !== "sqlite").length;
+  const sqliteOperationCount = commit.operations.length - entityCount;
+  const schedulerObservationCount =
+    (commit.schedulerObservation === undefined ? 0 : 1) +
+    (commit.schedulerObservationBatch?.length ?? 0);
+  const componentCount = Number(entityCount > 0) +
+    Number(sqliteOperationCount > 0) +
+    Number(schedulerObservationCount > 0);
+
+  const kind: CommitTelemetryKind = componentCount > 1
+    ? "mixed"
+    : entityCount > 0
+    ? "semantic"
+    : schedulerObservationCount > 0
+    ? "scheduler_observation"
+    : sqliteOperationCount > 0
+    ? "sqlite"
+    : (commit.preconditions?.length ?? 0) > 0
+    ? "precondition"
+    : "empty";
+
+  return {
+    kind,
+    entityCount,
+    schedulerObservationCount,
+    sqliteOperationCount,
+  };
+};

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -47,6 +47,7 @@ import {
   type WatchSpec,
   type WireMemoryProtocolFlags,
 } from "../v2.ts";
+import { classifyCommitTelemetry } from "./commit-telemetry.ts";
 import * as Engine from "./engine.ts";
 import {
   ANYONE_USER,
@@ -1967,6 +1968,20 @@ export class Server {
         if (message.commit.localSeq !== undefined) {
           span.setAttribute("commit.local_seq", message.commit.localSeq);
         }
+        // Classify the request before any await or validation so conflicts and
+        // rejected attempts remain visible in the same dashboard breakdowns as
+        // successful transactions. `entity.count` keeps its existing meaning.
+        const commitTelemetry = classifyCommitTelemetry(message.commit);
+        span.setAttribute("commit.kind", commitTelemetry.kind);
+        span.setAttribute("entity.count", commitTelemetry.entityCount);
+        span.setAttribute(
+          "scheduler.observation.count",
+          commitTelemetry.schedulerObservationCount,
+        );
+        span.setAttribute(
+          "sqlite.operation.count",
+          commitTelemetry.sqliteOperationCount,
+        );
         try {
           const engine = await this.openEngine(message.space);
           // The session may be revoked or replaced while openEngine awaits.
@@ -2119,12 +2134,6 @@ export class Server {
             },
           );
           span.setAttribute("commit.seq", commit.seq);
-          span.setAttribute(
-            "entity.count",
-            message.commit.operations.filter((operation) =>
-              operation.op !== "sqlite"
-            ).length,
-          );
           return {
             type: "response",
             requestId: message.requestId,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2137,26 +2137,11 @@ export class Server {
   private async decideTransaction(
     message: TransactRequest,
   ): Promise<TransactDecision> {
-    const session = this.#sessions.get(message.space, message.sessionId);
-    if (session === null) {
-      return {
-        response: respondTypedError<Engine.AppliedCommit>(
-          message.requestId,
-          toError("SessionError", "Unknown session for space"),
-        ),
-      };
-    }
     let postCommit: (() => Promise<void>) | undefined;
     const response = await tracer.startActiveSpan(
       "memory.transact",
       async (span): Promise<ResponseMessage<Engine.AppliedCommit>> => {
         span.setAttribute("space.did", message.space);
-        if (
-          session.principal !== undefined &&
-          session.principal !== ANYONE_USER
-        ) {
-          span.setAttribute("user.did", session.principal);
-        }
         if (message.requestId !== undefined) {
           span.setAttribute("request.id", message.requestId);
         }
@@ -2188,6 +2173,20 @@ export class Server {
           "sqlite.operation.count",
           commitTelemetry.sqliteOperationCount,
         );
+        const session = this.#sessions.get(message.space, message.sessionId);
+        if (session === null) {
+          span.end();
+          return respondTypedError<Engine.AppliedCommit>(
+            message.requestId,
+            toError("SessionError", "Unknown session for space"),
+          );
+        }
+        if (
+          session.principal !== undefined &&
+          session.principal !== ANYONE_USER
+        ) {
+          span.setAttribute("user.did", session.principal);
+        }
         try {
           const engine = await this.openEngine(message.space);
           // The session may be revoked or replaced while openEngine awaits.

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -54,6 +54,7 @@ import {
   type WatchSpec,
   type WireMemoryProtocolFlags,
 } from "../v2.ts";
+import { classifyCommitTelemetry } from "./commit-telemetry.ts";
 import * as Engine from "./engine.ts";
 import {
   ANYONE_USER,
@@ -2173,6 +2174,20 @@ export class Server {
         if (message.commit.localSeq !== undefined) {
           span.setAttribute("commit.local_seq", message.commit.localSeq);
         }
+        // Classify the request before any await or validation so conflicts and
+        // rejected attempts remain visible in the same dashboard breakdowns as
+        // successful transactions. `entity.count` keeps its existing meaning.
+        const commitTelemetry = classifyCommitTelemetry(message.commit);
+        span.setAttribute("commit.kind", commitTelemetry.kind);
+        span.setAttribute("entity.count", commitTelemetry.entityCount);
+        span.setAttribute(
+          "scheduler.observation.count",
+          commitTelemetry.schedulerObservationCount,
+        );
+        span.setAttribute(
+          "sqlite.operation.count",
+          commitTelemetry.sqliteOperationCount,
+        );
         try {
           const engine = await this.openEngine(message.space);
           // The session may be revoked or replaced while openEngine awaits.
@@ -2353,12 +2368,6 @@ export class Server {
             );
           }
           span.setAttribute("commit.seq", commit.seq);
-          span.setAttribute(
-            "entity.count",
-            message.commit.operations.filter((operation) =>
-              operation.op !== "sqlite"
-            ).length,
-          );
           // The verdict is published before this work begins, while the
           // per-space lock continues to exclude document fan-out.
           postCommit = () =>


### PR DESCRIPTION
## Summary

- classify every `memory.transact` request as `semantic`, `scheduler_observation`, `sqlite`, `mixed`, `precondition`, or `empty`
- add `scheduler.observation.count` and `sqlite.operation.count` span attributes
- retain `entity.count` for non-SQLite entity operations
- stamp the classification before validation so conflicts and rejected attempts remain attributable
- cover single/batched scheduler observations and mixed payloads with focused tests

## Why

A high volume of `memory.transact` spans can currently look like application writes even when the commits only persist scheduler observations. `entity.count = 0` is a useful approximation, but it also includes SQLite-only, precondition-only, and invalid empty requests.

An explicit source-level classification lets the Estuary SigNoz dashboard distinguish semantic entity writes from scheduler bookkeeping without pattern-specific heuristics.

## Dashboard follow-up

The companion infra PR will depend on these attributes and split semantic versus scheduler-only traffic, with per-user/session, latency, and conflict panels.

## Validation

- `deno fmt --check`
- `deno lint`
- `deno task --cwd packages/memory test`
  - 495 passed, 0 failed
- `deno task check`
- `deno task check-no-waitfor`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787354034&installation_model_id=428580&pr_number=4923&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4923&signature=d6cfc19359de46375c148093cdb24df80affcf06692c79672a8082458a9a031d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies every `memory.transact` request and adds span attributes so dashboards can separate semantic writes from scheduler/SQLite traffic and see precise counts. Improves attribution by stamping classification before validation, including for conflicts and rejected attempts.

- **New Features**
  - Classify commits as: `semantic`, `scheduler_observation`, `sqlite`, `mixed`, `precondition`, or `empty`.
  - Add span attributes: `commit.kind`, `entity.count` (non-SQLite operations), `scheduler.observation.count`, `sqlite.operation.count`.
  - Stamp classification before validation to keep rejected/conflicting attempts visible in telemetry.
  - Add focused tests for scheduler single/batch, SQLite-only, mixed, precondition-only, and empty requests.

<sup>Written for commit 00cf2ac1626d4797c8ed623ae1ca1f022103117d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->