### PR TITLE
test(schema-generator): treat Fabric primitives as leaves in golden normalization

### DIFF
--- a/packages/schema-generator/test/fixtures-runner.test.ts
+++ b/packages/schema-generator/test/fixtures-runner.test.ts
@@ -14,9 +14,11 @@ import {
   valueFromJson,
 } from "@commonfabric/data-model/codec-json";
 import {
+  FabricPrimitive,
   type FabricValue,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { createSchemaTransformerV2 } from "../src/plugin.ts";
 import {
   batchTypeCheckFixtures,
@@ -218,7 +220,18 @@ function normalizeArrayOrdering(obj: unknown): unknown {
   if (Array.isArray(obj)) {
     return obj.map(normalizeArrayOrdering);
   }
-  if (obj && typeof obj === "object") {
+  // A `FabricPrimitive` (`FabricBytes` and the like) has no enumerable own
+  // properties, so `Object.entries` would flatten it to `{}` and hide whatever
+  // it carried -- and then `valueEqual`, which this feeds, would compare two
+  // different primitives as equal. Treat it as a leaf.
+  //
+  // TODO(danfuzz): A `FabricInstance` (the other `FabricSpecialObject`
+  // subclass) is NOT a leaf -- it wraps nested `FabricValue`s -- but there is
+  // no faithful `Object.entries` descent for it either, so it still flattens to
+  // `{}` here. Handle it when the golden path needs to carry one.
+  if (
+    obj !== null && typeof obj === "object" && !(obj instanceof FabricPrimitive)
+  ) {
     const entries = Object.entries(obj as Record<string, unknown>)
       .map(([key, value]) => {
         if (key === "required" && Array.isArray(value)) {
@@ -275,4 +288,53 @@ Deno.test("plain JSON would lose exactly those values", () => {
   assertEquals(roundTrip(Infinity), null);
   assertEquals(roundTrip(-Infinity), null);
   assertThrows(() => JSON.stringify({ v: 1n }), TypeError);
+});
+
+Deno.test("golden compare keeps Fabric special objects distinct, not flattened to {}", () => {
+  // Both normalizers walk objects by key. A Fabric special object has no
+  // enumerable own properties, so walking it flattens it to `{}` -- and then
+  // `valueEqual` sees only `{}` on each side and calls two different values
+  // equal. That is exactly the silent agreement this whole harness exists to
+  // rule out, so it has to hold for special objects too, not only for the
+  // special numbers that motivated the format.
+  //
+  // The generator does not mint a `FabricBytes` default today, so the
+  // post-`normalizeSchema` shape is built directly and driven through the same
+  // encode -> decode -> normalize -> `valueEqual` path the fixture runner uses.
+  const schemaWithBytes = (bytes: number[]) =>
+    ({
+      type: "object",
+      properties: { blob: { type: "string" } },
+      default: { blob: new FabricBytes(new Uint8Array(bytes)) },
+    }) as unknown as Record<string, unknown>;
+
+  // "Expected" side: as a golden would be read back and normalized.
+  const throughGolden = (normalized: Record<string, unknown>) =>
+    normalizeArrayOrdering(
+      decodeGolden(encodeGolden(normalized)),
+    ) as FabricValue;
+
+  // "Actual" side: as the runner normalizes fresh output.
+  const actual = normalizeArrayOrdering(
+    normalizeSchema(schemaWithBytes([1, 2, 3])),
+  ) as FabricValue;
+
+  // Same bytes still compare equal after the full round trip.
+  expect(
+    valueEqual(
+      actual,
+      throughGolden(normalizeSchema(schemaWithBytes([1, 2, 3]))),
+    ),
+  )
+    .toBe(true);
+
+  // Different bytes are still seen as different. This is the assertion that
+  // fails if either normalizer flattens the `FabricBytes` to `{}`.
+  expect(
+    valueEqual(
+      actual,
+      throughGolden(normalizeSchema(schemaWithBytes([4, 5, 6]))),
+    ),
+  )
+    .toBe(false);
 });

--- a/packages/schema-generator/test/utils.ts
+++ b/packages/schema-generator/test/utils.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import { StaticCacheFS } from "@commonfabric/static";
 import { isRecord } from "@commonfabric/utils/types";
+import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 import type { JSONSchemaObj } from "@commonfabric/api";
 
 // Cache for TypeScript library definitions
@@ -474,7 +475,16 @@ function deepCanonicalize(node: unknown): unknown {
   if (Array.isArray(node)) {
     return node.map(deepCanonicalize);
   }
-  if (!isRecord(node)) return node;
+  // A `FabricPrimitive` (`FabricBytes` and the like) keeps its state in private
+  // fields with no enumerable own properties, so walking it with
+  // `Object.entries` would silently flatten it to `{}`. It is a leaf here.
+  //
+  // TODO(danfuzz): The other `FabricSpecialObject` subclass, `FabricInstance`,
+  // is NOT a leaf -- it holds nested `FabricValue`s that this walk ought to
+  // descend into. There is no faithful way to do that through `Object.entries`
+  // either, so a `FabricInstance` still flattens to `{}` here. Handling it is
+  // left for when the golden path needs to carry one.
+  if (!isRecord(node) || node instanceof FabricPrimitive) return node;
 
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(node)) {


### PR DESCRIPTION
Harness hardening for #4904, off `main`. No behavior change outside tests; the
merged schema fix is not affected.

## Why

#4904 gave the golden format a lossless codec, aiming at "every `FabricValue`."
The normalization around it is not lossless yet. `deepCanonicalize()`
(`test/utils.ts`) and `normalizeArrayOrdering()` (`test/fixtures-runner.test.ts`)
both walk every non-null object with `Object.entries`. A `FabricPrimitive` —
`FabricBytes`, and its siblings — keeps its state in private fields with **no
enumerable own properties**, so both walks flatten one to `{}`. The compare then
feeds that to `valueEqual`, which sees `{}` on each side and calls two different
primitives equal:

1. an actual special-object value is reduced to `{}` by `normalizeSchema()`;
2. the golden decodes to the correct primitive;
3. `normalizeArrayOrdering()` reduces the decoded value to `{}`;
4. `valueEqual({}, {})` passes.

That is the silent-agreement failure this harness exists to prevent, recreated
one subclass short of its goal. The existing round-trip test does not catch it
because it calls `encodeGolden` / `decodeGolden` directly and bypasses both
normalizers. (Reported by @mathpirate on #4904.)

The special *numbers* that motivated the format, and the coming bigint, decode
to JS primitives — not special objects — so nothing merged is affected. This is
the future-proofing tail.

## What

Both walks stop at a `FabricPrimitive` and treat it as a leaf, so `valueEqual`
compares it by content instead of comparing two `{}`s. The discriminator is
`instanceof FabricPrimitive` — the sanctioned check (`interface.ts` blesses
`instanceof FabricSpecialObject` for "any special object"; here the narrower
subclass is what's wanted).

A regression drives a `FabricBytes` default through the **full**
encode → decode → normalize → compare path — not the codec round trip the
existing test covers — asserting that matching bytes still compare equal and
differing bytes still compare unequal. It was run against the un-hardened walks
and observed to fail (both sides flattened to `{}`, wrongly equal).

## Scope: `FabricInstance` deliberately left

`FabricInstance` — the other `FabricSpecialObject` subclass — is **not** treated
as a leaf. It wraps nested `FabricValue`s that a faithful walk would descend
into, and `Object.entries` cannot do that either, so it still flattens here. A
`TODO(danfuzz)` in each walk records the gap; the golden path carries no
`FabricInstance` today, and handling it properly is its own task.

## Testing

- schema-generator suite green (`37 passed`, +1 for the regression); a full
  `UPDATE_GOLDENS=1` run leaves the tree clean — **zero fixture churn**.
- `./tasks/check.sh` clean; `deno fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4s5BjnzfVbJS6VVydhZPR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787354325&installation_model_id=428580&pr_number=4924&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4924&signature=663c6ed82a1f57c6345451eef916c81d246987a6551a4c25893fecc32144f528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the schema-generator golden compare by treating `FabricPrimitive` values as leaves during normalization to prevent them from flattening to `{}` and comparing equal by mistake. Test-only change; no runtime behavior impact.

- **Bug Fixes**
  - Updated `deepCanonicalize()` and `normalizeArrayOrdering()` to stop at `FabricPrimitive` (`FabricBytes`, etc.), so `valueEqual` compares by content instead of `{}`.
  - Kept `FabricInstance` as non-leaf with a TODO; it wraps nested `FabricValue`s and isn’t carried on the golden path today.

- **Testing**
  - Added a regression that runs a `FabricBytes` default through encode -> decode -> normalize -> compare; identical bytes are equal, different bytes are not.
  - No fixture churn (`UPDATE_GOLDENS=1` clean).

<sup>Written for commit 0c99783446006d444a1b86ee16482146fd959fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

