### PR TITLE
fix(runner): keep inherited properties out of storage paths

### DIFF
--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -484,6 +484,16 @@ export function createQueryResultProxy<T>(
           };
       }
 
+      // Prototype properties are JavaScript behavior, not persisted child
+      // values. Reflect them from the current container instead of issuing a
+      // storage read for an inherited path such as `constructor` or
+      // `toString`. Storage traversal deliberately considers own properties
+      // only; keeping the same boundary here also avoids recording spurious
+      // reactive dependencies for prototype members.
+      if (!Object.hasOwn(value, prop) && prop in value) {
+        return Reflect.get(value, prop, receiver);
+      }
+
       return createQueryResultProxy(
         runtime,
         proxyTx,

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -195,7 +195,8 @@ export const resolve = (
   while (++at < path.length) {
     const key = path[at];
     if (isRecord(value)) {
-      value = (value as FabricPlainObject)[key];
+      const record = value as FabricPlainObject;
+      value = Object.hasOwn(record, key) ? record[key] : undefined;
     } else {
       // If the value is undefined, the path doesn't exist, but we can still
       // write onto it. Return error with last valid path component.

--- a/packages/runner/test/frozen-proxy-target.test.ts
+++ b/packages/runner/test/frozen-proxy-target.test.ts
@@ -164,6 +164,25 @@ describe("frozen proxy target: proxy wrapping and trap behavior", () => {
     expect(String(proxy.b)).toBe("hello");
   });
 
+  it("reflects inherited prototype members without treating them as stored paths", async () => {
+    const link = writeCell(runtime, tx, "frozen-prototype-members", {
+      value: 1,
+    });
+
+    tx = await commitAndReopen(runtime, tx);
+
+    const proxy = createQueryResultProxy<{ value: number }>(
+      runtime,
+      tx,
+      link,
+      0,
+      false,
+    );
+
+    expect(proxy.constructor).toBe(Object);
+    expect(proxy.toString()).toBe("[object Object]");
+  });
+
   it("resolves nested links multiple levels deep in a frozen tree", async () => {
     // Create a target cell.
     const innerCell = runtime.getCell<{ deep: string }>(

--- a/packages/runner/test/transaction-notfound.test.ts
+++ b/packages/runner/test/transaction-notfound.test.ts
@@ -158,6 +158,23 @@ describe("Transaction NotFound Behavior", () => {
     expect(result.ok?.value).toBeUndefined();
   });
 
+  it("should not read inherited properties as stored document paths", () => {
+    const storage = new MockStorageManager();
+    const replica = storage.open(testSpace).replica as MockReplica;
+    replica.setData("doc:1", "application/json", { age: 30 });
+
+    const tx = storage.edit();
+    const result = tx.read({
+      space: testSpace,
+      id: "doc:1",
+      type: "application/json",
+      path: ["constructor"],
+    });
+
+    expect(result.ok).toBeDefined();
+    expect(result.ok?.value).toBeUndefined();
+  });
+
   it("should return TypeMismatchError when traversing through non-object", () => {
     const storage = new MockStorageManager();
     const replica = storage.open(testSpace).replica as MockReplica;


### PR DESCRIPTION
## Summary

- make attestation path resolution traverse own document properties only
- expose inherited JavaScript prototype members directly through query-result proxies
- add focused storage and proxy regressions

## Root cause

The v2 transaction's root attestation resolver indexed records without an own-property check. A path such as `["constructor"]` therefore resolved `Object.prototype.constructor` as though it were persisted document data. Query-result proxies depended on that accidental behavior to expose prototype members, which also recorded spurious child-path reads.

This change aligns the root resolver with the existing v2 path helpers and keeps prototype behavior at the JavaScript proxy boundary.

## Impact

Inherited properties can no longer enter storage values or reactive dependency paths. Normal calls such as `value.constructor` and `value.toString()` continue to work through query-result proxies.

## Validation

- `deno fmt --check` on all four changed files
- `deno check` on all four changed files
- focused transaction, frozen-proxy, and action-result round-trip tests
- complete runner unit suite: 1,004 passed / 5,386 steps

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787354477&installation_model_id=428580&pr_number=4925&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4925&signature=e434eccd4f78faa789864576ce24c02ef240948c717cc063b97c02ff5bd6fd5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops inherited prototype properties from being stored or traversed as document paths. Storage only traverses own properties; proxies reflect prototype members like `constructor` and `toString()` without storage reads or reactive deps.

- **Bug Fixes**
  - Use `Object.hasOwn` in attestation resolver to ignore inherited keys.
  - Reflect inherited members via `Reflect.get` in query-result proxies to avoid reads/deps.
  - Add tests for prototype access and “not found” path behavior.

<sup>Written for commit 79156b22b9a0556ef2349750dbb35b98f9fe9a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

