### PR TITLE
fix(piece): cold-start setup repair for roots whose identity moved without setup

### DIFF
--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -633,10 +633,20 @@ export class PiecesController<T = unknown> {
       // the lazy updater schedule one redundant check post-start. Benign: the
       // awaited checkAndUpdateDefaultPattern above already reconciled, so the
       // check observes a current identity and no-ops.
+      //
+      // expectedPatternIdentity is the repair precondition, not a formality:
+      // it atomically rejects a repair superseded by a concurrent source
+      // update (the identity is re-asserted inside every setup retry), and it
+      // makes runSynced THROW on a setup-commit failure instead of logging
+      // and continuing — without it this catch never sees commit-level
+      // failures and a dead root would be reported as a successful start.
       try {
         await timePiecesPhase(
           "ensureDefaultPattern.coldStartSetupRepair",
-          () => runtime.runSynced(writableRoot, repairPattern),
+          () =>
+            runtime.runSynced(writableRoot, repairPattern, undefined, {
+              expectedPatternIdentity: ref,
+            }),
         );
       } catch (repairError) {
         pieceUpdateLogger.warn(

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -3,6 +3,7 @@ import {
   entityIdFrom,
   type EnvReader,
   experimentalOptionsFromEnv,
+  getPatternIdentityRef,
   type JSONSchema,
   type MemorySpace,
   type ModuleByteCache,
@@ -578,10 +579,77 @@ export class PiecesController<T = unknown> {
       rootToStart = await this.#manager.getDefaultPattern(false) ?? root;
     }
 
-    await timePiecesPhase(
-      "ensureDefaultPattern.startPiece",
-      () => this.#manager.startPiece(rootToStart, DEFAULT_ROOT_RUN_OPTIONS),
-    );
+    try {
+      await timePiecesPhase(
+        "ensureDefaultPattern.startPiece",
+        () => this.#manager.startPiece(rootToStart, DEFAULT_ROOT_RUN_OPTIONS),
+      );
+    } catch (startError) {
+      // Cold-start setup repair. checkAndUpdateDefaultPattern moves
+      // patternIdentity WITHOUT running the setup phase ("Never calls run()"),
+      // and Runner.start() of a not-running piece instantiates the stored
+      // identity directly — also without setup. A root whose identity moved
+      // while it was not running (the bricked-space heal: no watcher existed
+      // to swap it in place) therefore boots over a doc that never
+      // materialized the pattern's internal cells — handler
+      // `{ "$stream": true }` markers included — and dies at instantiation
+      // ("Handler used as lift", the 2026-07-22 estuary failure). This also
+      // covers docs ALREADY left in that state by an earlier session: their
+      // identity compares current, so no further swap will ever fire.
+      //
+      // run() (setup + start) is the sanctioned repair: with an unchanged
+      // pattern pointer the setup phase is idempotent — it only materializes
+      // missing internal cells and writes no argument (none supplied). Fail
+      // closed: if the repair cannot proceed or fails, surface the ORIGINAL
+      // start error; nothing is torn down or overwritten.
+      const runtime = this.#manager.runtime;
+      const ref = getPatternIdentityRef(rootToStart);
+      if (ref === undefined) throw startError;
+      let pattern;
+      try {
+        pattern = await runtime.patternManager.loadPatternByIdentity(
+          ref.identity,
+          ref.symbol,
+          this.#manager.getSpace(),
+        );
+      } catch {
+        throw startError;
+      }
+      if (pattern === undefined) throw startError;
+      pieceUpdateLogger.warn(
+        "cold-start-setup-repair",
+        () => [
+          "startEnsuredDefaultPattern: start failed; re-running setup for",
+          `${ref.identity}#${ref.symbol}`,
+          startError,
+        ],
+      );
+      const repairPattern = pattern;
+      // Detach any transaction view the resolved root carries: getDefault-
+      // Pattern hands back a cell bound to a read-only tx, and runSynced
+      // would otherwise adopt it for the setup writes.
+      const writableRoot = rootToStart.withTx();
+      // runSynced does not plumb schedulePatternUpdate, so the repair may let
+      // the lazy updater schedule one redundant check post-start. Benign: the
+      // awaited checkAndUpdateDefaultPattern above already reconciled, so the
+      // check observes a current identity and no-ops.
+      try {
+        await timePiecesPhase(
+          "ensureDefaultPattern.coldStartSetupRepair",
+          () => runtime.runSynced(writableRoot, repairPattern),
+        );
+      } catch (repairError) {
+        pieceUpdateLogger.warn(
+          "cold-start-setup-repair-failed",
+          () => [
+            "startEnsuredDefaultPattern: setup repair failed",
+            `${ref.identity}#${ref.symbol}`,
+            repairError,
+          ],
+        );
+        throw startError;
+      }
+    }
     await timePiecesPhase(
       "ensureDefaultPattern.runtime.idle",
       () => this.#manager.runtime.idle(),

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -1209,6 +1209,62 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(afterEvent.key("count").get()).toBe(1);
   });
 
+  it("failed cold-start repair stays fail-closed and leaves the doc healable", async () => {
+    // The repair's own failure contract: when the one-shot setup repair
+    // cannot commit, the ORIGINAL start error must surface (not the repair's),
+    // and the doc must be left exactly as it was — the next boot's repair
+    // attempt still heals it. Driven at the runSynced boundary because the
+    // in-process failure classes (arg validation) are skipped for an
+    // unchanged identity (samePattern), so a commit-layer failure is the
+    // realistic remaining one.
+    await setupHome({ systemPatternAutoUpdate: true });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    const staleRef = getPatternIdentityRef(root)!;
+    await manager.stopPiece(root);
+
+    stub.setSource(SOURCE_V3_HANDLER);
+    const restoreProbe = shadowLoadProbe(staleRef.identity, "undefined");
+    const rt = runtime as unknown as {
+      runSynced: (...args: unknown[]) => Promise<unknown>;
+    };
+    const originalRunSynced = rt.runSynced.bind(runtime);
+    rt.runSynced = () =>
+      Promise.reject(new Error("repair backend unavailable"));
+    let thrown: unknown;
+    try {
+      await controller.ensureDefaultPattern();
+    } catch (error) {
+      thrown = error;
+    } finally {
+      rt.runSynced = originalRunSynced;
+      restoreProbe();
+    }
+    // The original start failure surfaces, not the repair's own error.
+    expect(String(thrown)).toContain("Handler used as lift");
+    expect(String(thrown)).not.toContain("repair backend unavailable");
+
+    // Nothing was torn down or corrupted: with the repair path restored, the
+    // very next boot heals the same doc end-to-end.
+    await controller.ensureDefaultPattern();
+    await runtime.idle();
+    const after = (await manager.getDefaultPattern(false))!;
+    expect(getPatternIdentityRef(after)?.identity).toBe(
+      await identityForSource(SOURCE_V3_HANDLER, {}, HOME_PATTERN_URL),
+    );
+    expect(after.key("count").get()).toBe(0);
+    (after.key("bump") as unknown as { send: (e: unknown) => void }).send({});
+    await runtime.idle();
+    await (after as unknown as { pull: () => Promise<unknown> }).pull();
+    const afterEvent = (await manager.getDefaultPattern(false))!;
+    expect(afterEvent.key("count").get()).toBe(1);
+  });
+
   it("replaces an unloadable stale sourceless space root", async () => {
     // The fallback covers every space's DEFAULT pattern, not just home
     // (widened by the flag owner after a non-home field report): a root

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -1111,6 +1111,102 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(after).toBeDefined();
   });
 
+  it("cold-boot swap: handler-bearing replacement heals a root that was NOT running", async () => {
+    // The real estuary bricked-space shape, which the running-piece test
+    // above cannot see: a bricked root never STARTED (its stored source
+    // fails to load), so there is no patternIdentity watcher when the swap
+    // lands. ensureDefaultPattern reconciles BEFORE start
+    // (startEnsuredDefaultPattern -> checkAndUpdateDefaultPattern), then
+    // cold-starts the piece — and Runner.startCore's initial instantiation
+    // does not run the setup phase, so the incoming pattern's
+    // { "$stream": true } markers were never materialized on the reused doc.
+    await setupHome({ systemPatternAutoUpdate: true });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    const staleRef = getPatternIdentityRef(root)!;
+
+    // The piece is NOT running when the swap lands — the defining difference
+    // from the watcher-path test above.
+    await manager.stopPiece(root);
+
+    stub.setSource(SOURCE_V3_HANDLER);
+    const restore = shadowLoadProbe(staleRef.identity, "undefined");
+    try {
+      // The real boot entry: reconcile-before-start, then cold start.
+      await controller.ensureDefaultPattern();
+    } finally {
+      restore();
+    }
+    await runtime.idle();
+
+    // Re-resolve: the controller's cell is a pre-heal transaction view.
+    const after = (await manager.getDefaultPattern(false))!;
+    expect(getPatternIdentityRef(after)?.identity).toBe(
+      await identityForSource(SOURCE_V3_HANDLER, {}, HOME_PATTERN_URL),
+    );
+    // Functional pin: the pattern body ran its setup (count materialized)…
+    expect(after.key("count").get()).toBe(0);
+    // …and the handler's stream marker actually works end-to-end.
+    (after.key("bump") as unknown as { send: (e: unknown) => void }).send({});
+    await runtime.idle();
+    await (after as unknown as { pull: () => Promise<unknown> }).pull();
+    const afterEvent = (await manager.getDefaultPattern(false))!;
+    expect(afterEvent.key("count").get()).toBe(1);
+  });
+
+  it("cold start heals a doc whose identity already moved without setup", async () => {
+    // The CURRENT durable state of an estuary space bricked by the deployed
+    // build: the 2026-07-22 flow already CAS-wrote patternIdentity to the
+    // official pattern (checkAndUpdateDefaultPattern "Never calls run()"),
+    // but no setup ever committed, so the doc has no internal-cell manifest
+    // entries or stream markers for that pattern. On the next boot the
+    // identity compares current, so no further swap fires — the doc must be
+    // healed at cold start itself.
+    await setupHome({ systemPatternAutoUpdate: true });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    await manager.stopPiece(root);
+
+    stub.setSource(SOURCE_V3_HANDLER);
+    const targetId = await identityForSource(
+      SOURCE_V3_HANDLER,
+      {},
+      HOME_PATTERN_URL,
+    );
+    // Model the already-committed swap: identity points at the CURRENT
+    // official pattern, doc still set up for SOURCE_V1 (marker-less for V3).
+    const { error } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).setMetaRaw("patternIdentity", {
+        identity: targetId,
+        symbol: "default",
+      });
+    });
+    expect(error).toBeUndefined();
+
+    await controller.ensureDefaultPattern();
+    await runtime.idle();
+
+    // Re-resolve: the controller's cell is a pre-heal transaction view.
+    const after = (await manager.getDefaultPattern(false))!;
+    expect(getPatternIdentityRef(after)?.identity).toBe(targetId);
+    expect(after.key("count").get()).toBe(0);
+    (after.key("bump") as unknown as { send: (e: unknown) => void }).send({});
+    await runtime.idle();
+    await (after as unknown as { pull: () => Promise<unknown> }).pull();
+    const afterEvent = (await manager.getDefaultPattern(false))!;
+    expect(afterEvent.key("count").get()).toBe(1);
+  });
+
   it("replaces an unloadable stale sourceless space root", async () => {
     // The fallback covers every space's DEFAULT pattern, not just home
     // (widened by the flag owner after a non-home field report): a root

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -1108,7 +1108,9 @@ describe("checkAndUpdateDefaultPattern", () => {
     // was logged rather than swallowed.
     const after = (await manager.getDefaultPattern(true))!;
     await runtime.idle();
-    expect(after).toBeDefined();
+    // Functional pin, not just existence: the OLD pattern's nodes are still
+    // the ones running — its result reads back — after the refused swap.
+    expect(after.key("marker").get()).toBe("v1");
   });
 
   it("cold-boot swap: handler-bearing replacement heals a root that was NOT running", async () => {

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -1265,6 +1265,93 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(afterEvent.key("count").get()).toBe(1);
   });
 
+  it("repair guards rethrow the original start error when the pattern cannot be resolved", async () => {
+    // The repair's admission guards, driven through the real boot entry.
+    // Cold start of a doc in the already-swapped state whose (current)
+    // identity cannot be loaded: the repair's own load sees the same
+    // outcome, and each guard must surface the ORIGINAL start error.
+    await setupHome({ systemPatternAutoUpdate: true });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    await manager.stopPiece(root);
+    stub.setSource(SOURCE_V3_HANDLER);
+    const targetId = await identityForSource(
+      SOURCE_V3_HANDLER,
+      {},
+      HOME_PATTERN_URL,
+    );
+    const { error } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).setMetaRaw("patternIdentity", {
+        identity: targetId,
+        symbol: "default",
+      });
+    });
+    expect(error).toBeUndefined();
+
+    // Guard: the repair's loadPatternByIdentity resolves undefined.
+    let restore = shadowLoadProbe(targetId, "undefined");
+    let thrown: unknown;
+    try {
+      await controller.ensureDefaultPattern();
+    } catch (e) {
+      thrown = e;
+    } finally {
+      restore();
+    }
+    expect(thrown).toBeDefined();
+
+    // Guard: the repair's loadPatternByIdentity rejects outright.
+    restore = shadowLoadProbe(targetId, "reject");
+    thrown = undefined;
+    try {
+      await controller.ensureDefaultPattern();
+    } catch (e) {
+      thrown = e;
+    } finally {
+      restore();
+    }
+    expect(thrown).toBeDefined();
+
+    // With the probes gone the same doc still heals — the guards left it
+    // untouched.
+    await controller.ensureDefaultPattern();
+    await runtime.idle();
+    const after = (await manager.getDefaultPattern(false))!;
+    expect(after.key("count").get()).toBe(0);
+  });
+
+  it("repair guard rethrows the original start error for a malformed identity ref", async () => {
+    // A root whose patternIdentity meta is present but malformed: start
+    // fails, and the repair cannot even name a pattern to load — the
+    // ref-undefined guard must surface the original start failure.
+    await setupHome({ systemPatternAutoUpdate: true });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    await manager.stopPiece(root);
+    const { error } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).setMetaRaw("patternIdentity", { malformed: true });
+    });
+    expect(error).toBeUndefined();
+
+    let thrown: unknown;
+    try {
+      await controller.ensureDefaultPattern();
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeDefined();
+  });
+
   it("replaces an unloadable stale sourceless space root", async () => {
     // The fallback covers every space's DEFAULT pattern, not just home
     // (widened by the flag owner after a non-home field report): a root


### PR DESCRIPTION
Was stacked on #4900; now rebased onto main after #4900 and #4901 merged — only the two commits here are new. Companion to #4901.

## Why

#4900 correctly fixes the *running-piece* swap path: the `patternIdentity` watcher now runs setup before instantiating. But a bricked space's root was never running — its old source fails to compile — so no watcher exists. The swap is applied pre-start by `checkAndUpdateDefaultPattern` as a bare metadata write, and the subsequent cold start (`startPiece` → `startCore`) instantiates with no `applySetupState`. Result: the exact live-Estuary failure, reproduced byte-for-byte on #4900's branch by the first new test here:

```
Error: Handler used as lift: node's $event input resolves to of:fid1:..., which reads
undefined — the { "$stream": true } marker was never written there.
    at Runner.startCore (runner.ts)        ← initial instantiation, no setup
    at async PiecesController.startEnsuredDefaultPattern
    at async PiecesController.ensureDefaultPattern
```

Worse, any space whose swap **already committed durably** under the deployed July-22 build (identity now compares current, doc still marker-less — the likely current state of the bricked Estuary spaces) never re-enters the swap path at all, so even a fixed swap can't revisit it. Without this repair, those spaces stay bricked after deploying #4900+#4901.

## What changed

One mechanism in `startEnsuredDefaultPattern` covers both cases: if the cold `startPiece` fails, make a single setup-repair attempt — resolve the stored (unchanged) identity via `loadPatternByIdentity`, then `runtime.runSynced(...)` (setup + start). Setup is idempotent here: `materializeDerivedInternalCells` seeds only manifest-missing internal cells (the `$stream` markers included) and never overwrites user data. Fail-closed: if the repair can't proceed or fails, the original start error is rethrown and nothing is torn down. Piece-package only; zero cost on the happy path; the runner and #4900's watcher fix are untouched.

## Test plan

Two new tests in `packages/piece/test/check-update-default-pattern.test.ts`, red/green verified against #4900's head:

1. **Cold pre-start swap:** handler-bearing replacement swapped in while the piece is stopped, driven through the real `ensureDefaultPattern` boot entry; asserts the handler actually fires post-heal (`bump.send({})` → `count === 1`). Red on #4900 alone.
2. **Already-swapped doc:** `patternIdentity` already points at the current pattern, doc never set up — no further swap will fire; cold start itself must heal. Red on #4900 alone.

After the fix: target file 41/41 steps green (including all of #4900's own tests), full `packages/piece` suite 21 passed / 247 steps / 0 failed, `deno check` / `lint` / `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cold-start failures when a piece’s `patternIdentity` changed while stopped. Adds a one-time setup repair on start so bricked spaces boot cleanly and handlers work; enforces a precondition so commit failures surface and concurrent updates are rejected.

- Bug Fixes
  - Add one-time cold-start setup repair in `startEnsuredDefaultPattern`.
  - On start failure, resolve stored identity via `getPatternIdentityRef` + `patternManager.loadPatternByIdentity`, detach any read-only tx with `root.withTx()`, then call `runtime.runSynced(...)` with `expectedPatternIdentity` to materialize missing internal cells (e.g., `$stream` markers), throw on commit failures, and reject if identity changed — without touching user data.
  - Fail-closed: rethrow the original start error if repair can’t run or fails; happy path and watcher-based swap remain unchanged. Logs under `cold-start-setup-repair` and `cold-start-setup-repair-failed`.
  - Tests cover cold pre-start swap, already-swapped docs healed on boot, fail-closed repair (original error surfaces; next boot heals), refused-swap functional pin (`marker === "v1"`), and repair admission guards (malformed identity ref; pattern load undefined/reject) that rethrow the original start error and leave the doc healable.

<sup>Written for commit 80c5bde28be11cd73e579be6078ccec8e81414a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

