### PR TITLE
fix(piece): let a source update preserve retained links — verified against committed state

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2059,6 +2059,11 @@
           "npm:@opentelemetry/api@^1.9.1"
         ]
       },
+      "packages/piece": {
+        "dependencies": [
+          "jsr:@db/sqlite@0.13.0"
+        ]
+      },
       "packages/runner": {
         "dependencies": [
           "npm:@opentelemetry/api@^1.9.1",

--- a/packages/piece/deno.jsonc
+++ b/packages/piece/deno.jsonc
@@ -1,5 +1,10 @@
 {
   "name": "@commonfabric/piece",
+  "imports": {
+    // Test-only: the setsrc retained-capability-link test seeds a real
+    // on-disk sqlite file so the disk-source registry is exercised for real.
+    "@db/sqlite": "jsr:@db/sqlite@0.13.0"
+  },
   "tasks": {
     // --no-check: this package is type-checked by `deno task check` (tasks/check.sh).
     "test": "deno test --no-check --allow-env --allow-ffi --allow-read --allow-write"

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -2,6 +2,7 @@ import {
   Cell,
   type CellPath,
   ContextualFlowControl,
+  deepEqual,
   extractDefaultValues,
   formatFabricRef,
   getMetaLink,
@@ -1431,6 +1432,38 @@ function withoutMissingFlag(
   return contract;
 }
 
+/**
+ * Whether a supplied SERIALIZED link is identical to the value already
+ * durably committed at its path under `baseCell`.
+ *
+ * This is what lets a restore flow (`linksPreservedVerbatim`) treat a
+ * serialized link as a preserved direct handle without taking the caller's
+ * word for any individual link: writing back bytes that are already committed
+ * grants nothing that was not already granted. Anything else arriving under
+ * the flag — a fresh link minted from the incoming pattern's schema
+ * `default`s, a caller-mutated envelope — fails the comparison and falls
+ * through to the rebuild rules, exactly as if the flag were unset.
+ *
+ * The comparison must run against COMMITTED state, not the transaction's
+ * staged view: the caller that sets the flag validates after
+ * `applySetupState` has already staged the argument write, so a staged-side
+ * read would compare the supplied links against themselves and always pass.
+ * `withTx()` with no transaction detaches the read.
+ */
+function linkMatchesCommittedState(
+  suppliedLink: SuppliedLink,
+  baseCell: Cell<unknown>,
+  basePath: readonly (string | number)[],
+): boolean {
+  if (suppliedLink.value === undefined) return false;
+  const committedRoot = baseCell.withTx().getRaw();
+  const committed = getValueAtPath(committedRoot, [
+    ...basePath,
+    ...suppliedLink.path,
+  ]);
+  return deepEqual(committed, suppliedLink.value);
+}
+
 /** @internal Exported for focused durable-link contract tests. */
 export function assertSuppliedLinkSchemasCompatible(
   links: readonly SuppliedLink[],
@@ -1463,8 +1496,16 @@ export function assertSuppliedLinkSchemasCompatible(
      * to say. `setPattern` is the case that has one: `applySetupState` carries
      * the argument over from `previousArgumentCell.getRaw()`, so every
      * retained link survives byte for byte by construction and there is no
-     * rebuild for the ordinary-alias rules below to police. Left unset (every
-     * other flow), those rules apply exactly as before.
+     * rebuild for the ordinary-alias rules below to police.
+     *
+     * The declaration is scoped, not trusted: a serialized link only counts
+     * as preserved when it is identical to the value already durably
+     * committed at its path ({@link linkMatchesCommittedState}) — restoring
+     * committed bytes grants nothing new. Any link that fails that comparison
+     * (one minted from the incoming pattern's schema `default`s, a mutated
+     * envelope, a lying caller) is validated by the rebuild rules below
+     * exactly as if this option were unset. Left unset (every other flow),
+     * those rules apply to every serialized link, as before.
      */
     linksPreservedVerbatim?: boolean;
   } = {},
@@ -1563,8 +1604,9 @@ export function assertSuppliedLinkSchemasCompatible(
       }
     }
     // Does the original envelope survive? Two independent ways to know it
-    // does: the caller declared it for every link it supplied, or this value
-    // is a live Cell the caller demonstrably holds.
+    // does: this value is a live Cell the caller demonstrably holds, or the
+    // caller declared a preserving write plan AND this link is identical to
+    // what is already committed at its path.
     //
     // These answer different questions and must not be conflated. `isCell` is
     // PROVENANCE — a live Cell is a capability the caller possesses, whereas a
@@ -1579,8 +1621,18 @@ export function assertSuppliedLinkSchemasCompatible(
     // holds serialized links, which are never `isCell()`, so the restore was
     // always judged to be exposing the capability as an ordinary alias — a
     // laundering that the caller was not in fact performing.
+    //
+    // The declared plan is verified per link, not trusted: only bytes already
+    // durably committed at this path count as "preserved" (see
+    // `linkMatchesCommittedState`). In the one flow that sets the flag, the
+    // staged argument is the previous argument merged with the INCOMING
+    // pattern's schema defaults — a link-shaped default would be brand-new,
+    // pattern-authored bytes riding the same restore, and it falls through to
+    // the rebuild rules here.
     const preservesDirectHandle = targetOuter !== undefined &&
-      (options.linksPreservedVerbatim === true || isCell(suppliedLink.value));
+      (isCell(suppliedLink.value) ||
+        (options.linksPreservedVerbatim === true &&
+          linkMatchesCommittedState(suppliedLink, baseCell, basePath)));
     if (preservesDirectHandle) preservedDirectHandles.add(suppliedLink);
 
     let sourceContracts: PathSchemaContract[];
@@ -1681,11 +1733,15 @@ export function assertSuppliedLinkSchemasCompatible(
       // is caller-written bytes. The rebuild branch checks it below ("link
       // carries a non-durable Cell wrapper"); this branch could previously
       // skip it because `isCell` was the only way in, and a live Cell has no
-      // separate envelope to forge. A caller declaring it preserves serialized
-      // links verbatim reopens that gap, so re-assert it here: a carried
-      // wrapper has to match the source's own durable contract, never widen
-      // it. (Loom's injected links carry none — `PieceManager.link` serializes
-      // with `KeepAsCell.OnlyStream` — so the real restore case is unaffected.)
+      // separate envelope to forge. A serialized link only reaches here when
+      // it is identical to already-committed state, but committed does not
+      // mean vetted — raw write paths (`PieceManager.link`) commit links
+      // without ever running this validator — so re-assert it: a carried
+      // wrapper's `asCell` STACK (kind and scope, per `asCellShapesMatch`;
+      // payload schemas are proved separately against the durable contracts)
+      // has to match every durable contract of the source. (Loom's injected
+      // links carry no envelope — `PieceManager.link` serializes with
+      // `KeepAsCell.OnlyStream` — so the real restore case is unaffected.)
       if (!isCell(suppliedLink.value)) {
         const carried = ContextualFlowControl.getAsCellValues(link.schema);
         if (carried.length > 0) {
@@ -1695,9 +1751,15 @@ export function assertSuppliedLinkSchemasCompatible(
               [{ schema: link.schema, root: link.schema }],
               [],
             )[0]?.schema;
-          const matchesDurableContract = sourceContracts.some((contract) =>
-            asCellShapesMatch(carriedSchema, contract.schema)
-          );
+          // `.every`, not `.some`: the durable contracts are a conjunction,
+          // so a wrapper the source did not declare in ALL of them was never
+          // uniformly granted. Contracts that disagree about the wrapper
+          // stack reject every carried envelope — that state is already
+          // refused at the outer level below.
+          const matchesDurableContract = sourceContracts.length > 0 &&
+            sourceContracts.every((contract) =>
+              asCellShapesMatch(carriedSchema, contract.schema)
+            );
           if (!matchesDurableContract) {
             throw new Error(
               `input link at ${displayPath} schema is not compatible: link carries a non-durable Cell wrapper`,
@@ -2797,7 +2859,12 @@ export class PieceController<T = unknown> {
                 priorArgumentSchema: previousPattern.argumentSchema,
                 // `applySetupState` rewrites the argument from `getRaw()`, so
                 // every retained link's envelope is written back unchanged and
-                // nothing here is rebuilt as an alias.
+                // nothing here is rebuilt as an alias. The validator verifies
+                // that per link against committed state rather than taking
+                // this declaration on trust — anything the setup staged that
+                // is NOT already committed (e.g. a link-shaped schema
+                // default from the incoming pattern) still faces the full
+                // rebuild rules.
                 linksPreservedVerbatim: true,
               },
             ),

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -1431,6 +1431,37 @@ function withoutMissingFlag(
   return contract;
 }
 
+/**
+ * The capability a source declares at its outermost level, when that kind is
+ * a true capability rather than an ordinary `cell`/`stream` and every contract
+ * agrees on it.
+ *
+ * Used only to decide whether an already-durable link may be restored as-is.
+ * Returns undefined for anything ambiguous — disagreeing contracts, a
+ * localization issue, an ordinary value — so the caller falls through to the
+ * full validation below, which reports each of those in its own words rather
+ * than having them silently swallowed here.
+ */
+function restorableCapabilityKind(
+  contracts: readonly PathSchemaContract[],
+): CellKind | undefined {
+  const localized = contracts.map((contract) =>
+    localizeOuterCellContract(contract)
+  );
+  if (localized.some((entry) => entry.issue !== undefined)) return undefined;
+  const outers = localized.flatMap((entry) =>
+    entry.outer === undefined ? [] : [entry.outer]
+  );
+  const outer = outers[0];
+  if (outer === undefined) return undefined;
+  if (!outers.every((other) => outerCellShapesMatch(outer, other))) {
+    return undefined;
+  }
+  return outer.kind === "cell" || outer.kind === "stream"
+    ? undefined
+    : outer.kind;
+}
+
 /** @internal Exported for focused durable-link contract tests. */
 export function assertSuppliedLinkSchemasCompatible(
   links: readonly SuppliedLink[],
@@ -1548,12 +1579,9 @@ export function assertSuppliedLinkSchemasCompatible(
         );
       }
     }
-    const preservesDirectHandle = targetOuter !== undefined &&
-      isCell(suppliedLink.value);
-    if (preservesDirectHandle) preservedDirectHandles.add(suppliedLink);
-
     let sourceContracts: PathSchemaContract[];
     let rawSourceContracts: PathSchemaContract[];
+    let preservesDirectHandle = false;
     try {
       rawSourceContracts = durableSource.schemas.flatMap((source) =>
         linkPathContracts(
@@ -1562,6 +1590,29 @@ export function assertSuppliedLinkSchemasCompatible(
           { trackSourcePresence: true, preserveMissingFlag: true },
         )
       );
+      // Whether the ORIGINAL link value survives verbatim — keeping whatever
+      // capability it carries — or is rebuilt below as a plain alias.
+      //
+      // A live Cell handed in by a caller qualifies outright. So does a link
+      // being RESTORED over an unchanged capability declaration: `setPattern`
+      // re-applies the piece's retained links from `argumentCell.getRaw()`,
+      // and raw storage holds SERIALIZED links, which are never `isCell()`.
+      // Keying only on `isCell` therefore made every capability-kind input
+      // permanently un-updatable — the restore was always judged to be
+      // exposing the capability as an ordinary alias, even when the incoming
+      // pattern declared that exact capability at that exact path. Preserving
+      // a capability into a destination that asks for the same capability is
+      // not exposure; it is the identity case.
+      //
+      // Deliberately narrow: ordinary `cell`/`stream` sources keep their
+      // existing sanitize-and-rebuild path untouched, so this only reaches
+      // true capabilities (e.g. an injected `sqlite` handle).
+      const restoredCapability = restorableCapabilityKind(rawSourceContracts);
+      preservesDirectHandle = targetOuter !== undefined &&
+        (isCell(suppliedLink.value) ||
+          restoredCapability === targetOuter.kind);
+      if (preservesDirectHandle) preservedDirectHandles.add(suppliedLink);
+
       sourceContracts = durableSource.schemas.flatMap((source) => {
         const root = preservesDirectHandle
           ? source.root

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -1455,7 +1455,9 @@ function linkMatchesCommittedState(
   baseCell: Cell<unknown>,
   basePath: readonly (string | number)[],
 ): boolean {
-  if (suppliedLink.value === undefined) return false;
+  // No undefined guard needed: `parseLinkOrThrow` has already rejected any
+  // supplied value that is not a real link record, so `suppliedLink.value`
+  // can never equal an absent committed slot here.
   const committedRoot = baseCell.withTx().getRaw();
   const committed = getValueAtPath(committedRoot, [
     ...basePath,

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -1431,37 +1431,6 @@ function withoutMissingFlag(
   return contract;
 }
 
-/**
- * The capability a source declares at its outermost level, when that kind is
- * a true capability rather than an ordinary `cell`/`stream` and every contract
- * agrees on it.
- *
- * Used only to decide whether an already-durable link may be restored as-is.
- * Returns undefined for anything ambiguous — disagreeing contracts, a
- * localization issue, an ordinary value — so the caller falls through to the
- * full validation below, which reports each of those in its own words rather
- * than having them silently swallowed here.
- */
-function restorableCapabilityKind(
-  contracts: readonly PathSchemaContract[],
-): CellKind | undefined {
-  const localized = contracts.map((contract) =>
-    localizeOuterCellContract(contract)
-  );
-  if (localized.some((entry) => entry.issue !== undefined)) return undefined;
-  const outers = localized.flatMap((entry) =>
-    entry.outer === undefined ? [] : [entry.outer]
-  );
-  const outer = outers[0];
-  if (outer === undefined) return undefined;
-  if (!outers.every((other) => outerCellShapesMatch(outer, other))) {
-    return undefined;
-  }
-  return outer.kind === "cell" || outer.kind === "stream"
-    ? undefined
-    : outer.kind;
-}
-
 /** @internal Exported for focused durable-link contract tests. */
 export function assertSuppliedLinkSchemasCompatible(
   links: readonly SuppliedLink[],
@@ -1484,6 +1453,20 @@ export function assertSuppliedLinkSchemasCompatible(
      * so a fresh link to an arbitrary contract-less document is still refused.
      */
     priorArgumentSchema?: JSONSchema;
+    /**
+     * The caller writes each supplied link's ORIGINAL envelope back, rather
+     * than rebuilding it from a materialized read.
+     *
+     * This is a statement about the caller's WRITE PLAN, not about its
+     * authority — authority is `isCell` below, which is real evidence that the
+     * caller held a live handle. Only the caller knows its own plan, so it has
+     * to say. `setPattern` is the case that has one: `applySetupState` carries
+     * the argument over from `previousArgumentCell.getRaw()`, so every
+     * retained link survives byte for byte by construction and there is no
+     * rebuild for the ordinary-alias rules below to police. Left unset (every
+     * other flow), those rules apply exactly as before.
+     */
+    linksPreservedVerbatim?: boolean;
   } = {},
 ): Set<SuppliedLink> {
   const preservedDirectHandles = new Set<SuppliedLink>();
@@ -1579,9 +1562,29 @@ export function assertSuppliedLinkSchemasCompatible(
         );
       }
     }
+    // Does the original envelope survive? Two independent ways to know it
+    // does: the caller declared it for every link it supplied, or this value
+    // is a live Cell the caller demonstrably holds.
+    //
+    // These answer different questions and must not be conflated. `isCell` is
+    // PROVENANCE — a live Cell is a capability the caller possesses, whereas a
+    // serialized sigil link is just bytes it wrote. The rules below are about
+    // the WRITE PLAN: every one of them polices a rebuild that is about to
+    // happen. Inferring the plan from the provenance is sound wherever the
+    // caller actually rebuilds, and false at `setPattern`, which rebuilds
+    // nothing — it discards this function's return value and lets
+    // `applySetupState` carry the argument over from `getRaw()`. That is why
+    // an injected capability input (Loom's `db: SqliteDb`, `asCell:
+    // ["sqlite"]`) could never be carried across a source update: raw storage
+    // holds serialized links, which are never `isCell()`, so the restore was
+    // always judged to be exposing the capability as an ordinary alias — a
+    // laundering that the caller was not in fact performing.
+    const preservesDirectHandle = targetOuter !== undefined &&
+      (options.linksPreservedVerbatim === true || isCell(suppliedLink.value));
+    if (preservesDirectHandle) preservedDirectHandles.add(suppliedLink);
+
     let sourceContracts: PathSchemaContract[];
     let rawSourceContracts: PathSchemaContract[];
-    let preservesDirectHandle = false;
     try {
       rawSourceContracts = durableSource.schemas.flatMap((source) =>
         linkPathContracts(
@@ -1590,29 +1593,6 @@ export function assertSuppliedLinkSchemasCompatible(
           { trackSourcePresence: true, preserveMissingFlag: true },
         )
       );
-      // Whether the ORIGINAL link value survives verbatim — keeping whatever
-      // capability it carries — or is rebuilt below as a plain alias.
-      //
-      // A live Cell handed in by a caller qualifies outright. So does a link
-      // being RESTORED over an unchanged capability declaration: `setPattern`
-      // re-applies the piece's retained links from `argumentCell.getRaw()`,
-      // and raw storage holds SERIALIZED links, which are never `isCell()`.
-      // Keying only on `isCell` therefore made every capability-kind input
-      // permanently un-updatable — the restore was always judged to be
-      // exposing the capability as an ordinary alias, even when the incoming
-      // pattern declared that exact capability at that exact path. Preserving
-      // a capability into a destination that asks for the same capability is
-      // not exposure; it is the identity case.
-      //
-      // Deliberately narrow: ordinary `cell`/`stream` sources keep their
-      // existing sanitize-and-rebuild path untouched, so this only reaches
-      // true capabilities (e.g. an injected `sqlite` handle).
-      const restoredCapability = restorableCapabilityKind(rawSourceContracts);
-      preservesDirectHandle = targetOuter !== undefined &&
-        (isCell(suppliedLink.value) ||
-          restoredCapability === targetOuter.kind);
-      if (preservesDirectHandle) preservedDirectHandles.add(suppliedLink);
-
       sourceContracts = durableSource.schemas.flatMap((source) => {
         const root = preservesDirectHandle
           ? source.root
@@ -1697,6 +1677,34 @@ export function assertSuppliedLinkSchemasCompatible(
     }
 
     if (preservesDirectHandle) {
+      // A SERIALIZED link carries its own `schema` envelope, and that envelope
+      // is caller-written bytes. The rebuild branch checks it below ("link
+      // carries a non-durable Cell wrapper"); this branch could previously
+      // skip it because `isCell` was the only way in, and a live Cell has no
+      // separate envelope to forge. A caller declaring it preserves serialized
+      // links verbatim reopens that gap, so re-assert it here: a carried
+      // wrapper has to match the source's own durable contract, never widen
+      // it. (Loom's injected links carry none — `PieceManager.link` serializes
+      // with `KeepAsCell.OnlyStream` — so the real restore case is unaffected.)
+      if (!isCell(suppliedLink.value)) {
+        const carried = ContextualFlowControl.getAsCellValues(link.schema);
+        if (carried.length > 0) {
+          const carriedSchema = link.schema === undefined
+            ? undefined
+            : linkPathContracts(
+              [{ schema: link.schema, root: link.schema }],
+              [],
+            )[0]?.schema;
+          const matchesDurableContract = sourceContracts.some((contract) =>
+            asCellShapesMatch(carriedSchema, contract.schema)
+          );
+          if (!matchesDurableContract) {
+            throw new Error(
+              `input link at ${displayPath} schema is not compatible: link carries a non-durable Cell wrapper`,
+            );
+          }
+        }
+      }
       const localizedSources = sourceContracts.map((contract) =>
         localizeOuterCellContract(contract)
       );
@@ -2785,7 +2793,13 @@ export class PieceController<T = unknown> {
               argumentSchema,
               argumentCell,
               this.#manager,
-              { priorArgumentSchema: previousPattern.argumentSchema },
+              {
+                priorArgumentSchema: previousPattern.argumentSchema,
+                // `applySetupState` rewrites the argument from `getRaw()`, so
+                // every retained link's envelope is written back unchanged and
+                // nothing here is rebuilt as an alias.
+                linksPreservedVerbatim: true,
+              },
             ),
         repository: options?.repository,
       }) as Cell<T>;

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -4,6 +4,7 @@ import { createSession, Identity } from "@commonfabric/identity";
 import {
   getPatternIdentityRef,
   getPatternRepository,
+  isCell,
   isLink,
   type JSONSchema,
   KeepAsCell,
@@ -1058,20 +1059,20 @@ describe("piece pull materialization", () => {
     ).toThrow(/projection alias reconciliation requires a transaction/);
   });
 
-  it("restores a capability link whose destination declares the same kind", async () => {
+  it("restores retained links whose destination declares an outer capability", async () => {
     // A source update (`PieceController.setPattern`, i.e. `cf piece setsrc`)
     // re-applies the piece's retained links from `argumentCell.getRaw()`.
     // Raw storage holds SERIALIZED links, never live Cells, so every link on
-    // that path fails `isCell()` — which is what `preservesDirectHandle`
-    // keys off. A capability-kind input was therefore always judged to be
-    // "exposed as an ordinary alias", even when the incoming pattern
-    // declares that exact capability at that exact path.
+    // that path fails `isCell()` — which is what `preservesDirectHandle` used
+    // to key off, alone. Every retained link into an `asCell`-declaring slot
+    // was therefore rejected: capability kinds as "exposed as an ordinary
+    // alias", ordinary `Cell<T>` slots as "asCell changed". Same cause, three
+    // error messages.
     //
     // The practical effect: a piece holding an injected `SqliteDb` input
     // (Loom's native connector panels — `db: SqliteDb`, which compiles to
     // `asCell: ["sqlite"]`) could never have its source updated in place.
-    // Restoring a link into a destination that declares the SAME capability
-    // preserves the capability; it does not expose it as a plain alias.
+    // `setPattern` rebuilds nothing, so there was no aliasing to police.
     const sqliteDb: JSONSchema = {
       type: "object",
       properties: {
@@ -1108,9 +1109,49 @@ describe("piece pull materialization", () => {
     });
 
     const raw = base.getRaw() as { db: unknown };
-    // Guard the premise: the restore path really does see a serialized link.
+    // Guard the premise: the restore path really does see a SERIALIZED link,
+    // so this cannot silently decay into the already-covered live-Cell case.
+    // `isLink` is not enough — it accepts a live Cell too.
     expect(isLink(raw.db)).toBe(true);
+    expect(isCell(raw.db)).toBe(false);
 
+    const restore = (destination: JSONSchema) =>
+      assertSuppliedLinkSchemasCompatible(
+        [{ path: ["db"], value: raw.db }],
+        destination,
+        base,
+        manager,
+        {
+          priorArgumentSchema: argumentSchema,
+          linksPreservedVerbatim: true,
+        },
+      );
+
+    expect(() => restore(argumentSchema)).not.toThrow();
+
+    // Same kind, narrowed payload the source already satisfies.
+    expect(() =>
+      restore({
+        type: "object",
+        properties: {
+          db: { ...sqliteDb, description: "renamed in the new source" },
+        },
+        required: ["db"],
+      })
+    ).not.toThrow();
+
+    // Laundering is still refused: the capability may not become a plain
+    // alias just because the caller preserves envelopes.
+    expect(() =>
+      restore({
+        type: "object",
+        properties: { db: { type: "object", asCell: ["cell"] } },
+        required: ["db"],
+      })
+    ).toThrow(/cannot be exposed as cell/);
+
+    // And a caller that does NOT preserve envelopes is unaffected — the
+    // ordinary-alias rule still applies to every other entry point.
     expect(() =>
       assertSuppliedLinkSchemasCompatible(
         [{ path: ["db"], value: raw.db }],
@@ -1118,6 +1159,117 @@ describe("piece pull materialization", () => {
         base,
         manager,
         { priorArgumentSchema: argumentSchema },
+      )
+    ).toThrow(/sqlite capability cannot be exposed as an ordinary alias/);
+  });
+
+  it("refuses a preserved link whose carried wrapper widens its contract", async () => {
+    // The envelope on a SERIALIZED link is caller-written bytes. Declaring
+    // that links are preserved verbatim must not become a way to smuggle a
+    // forged `asCell` past the check the rebuild branch performs.
+    const readonlyNum: JSONSchema = { type: "number", asCell: ["readonly"] };
+    const argumentSchema: JSONSchema = {
+      type: "object",
+      properties: { v: readonlyNum },
+      required: ["v"],
+    };
+
+    const producer = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: { type: "object", properties: {} },
+        resultSchema: {
+          type: "object",
+          properties: { v: { type: "number" } },
+          required: ["v"],
+        },
+        result: { v: 1 },
+        nodes: [],
+      }),
+      {},
+      undefined,
+      { start: true },
+    );
+    await runtime.editWithRetry((tx) => {
+      producer.withTx(tx).setMetaRaw("schema", argumentSchema);
+    });
+
+    const base = runtime.getCell(
+      manager.getSpace(),
+      "forged-wrapper-argument-" + crypto.randomUUID(),
+    );
+    await runtime.editWithRetry((tx) => {
+      base.withTx(tx).set({ v: producer.key("v") });
+    });
+
+    const raw = base.getRaw() as { v: Record<string, never> };
+    const forged = JSON.parse(JSON.stringify(raw.v));
+    const envelope = forged["/"]?.["link@1"];
+    // Guard the premise: we really are forging a wire envelope.
+    expect(envelope).toBeDefined();
+    envelope.schema = { type: "number", asCell: ["cell"] };
+
+    expect(() =>
+      assertSuppliedLinkSchemasCompatible(
+        [{ path: ["v"], value: forged }],
+        argumentSchema,
+        base,
+        manager,
+        {
+          priorArgumentSchema: argumentSchema,
+          linksPreservedVerbatim: true,
+        },
+      )
+    ).toThrow(/non-durable Cell wrapper/);
+  });
+
+  it("restores a retained ordinary Cell link across a source update", async () => {
+    // The same defect with a different error message (`asCell changed`), which
+    // is why fixing only the capability wording would have left the class
+    // half-broken: ANY `asCell`-declaring input slot was un-restorable.
+    const counter: JSONSchema = { type: "number", asCell: ["cell"] };
+    const argumentSchema: JSONSchema = {
+      type: "object",
+      properties: { count: counter },
+      required: ["count"],
+    };
+
+    const producer = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: { type: "object", properties: {} },
+        resultSchema: {
+          type: "object",
+          properties: { count: { type: "number" } },
+          required: ["count"],
+        },
+        result: { count: 3 },
+        nodes: [],
+      }),
+      {},
+      undefined,
+      { start: true },
+    );
+
+    const base = runtime.getCell(
+      manager.getSpace(),
+      "ordinary-cell-argument-" + crypto.randomUUID(),
+    );
+    await runtime.editWithRetry((tx) => {
+      base.withTx(tx).set({ count: producer.key("count") });
+    });
+
+    const raw = base.getRaw() as { count: unknown };
+    expect(isCell(raw.count)).toBe(false);
+
+    expect(() =>
+      assertSuppliedLinkSchemasCompatible(
+        [{ path: ["count"], value: raw.count }],
+        argumentSchema,
+        base,
+        manager,
+        {
+          priorArgumentSchema: argumentSchema,
+          linksPreservedVerbatim: true,
+        },
       )
     ).not.toThrow();
   });

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1161,12 +1161,42 @@ describe("piece pull materialization", () => {
         { priorArgumentSchema: argumentSchema },
       )
     ).toThrow(/sqlite capability cannot be exposed as an ordinary alias/);
+
+    // And the declaration is scoped by committed state, not taken on trust:
+    // the same serialized link supplied at a path where it is NOT already
+    // committed is a fresh link riding the restore — the staged argument on
+    // a source update is the previous argument merged with the INCOMING
+    // pattern's schema defaults, so link-shaped defaults arrive exactly this
+    // way — and it faces the rebuild rules despite the flag: the identical
+    // bytes that restore fine at `db` are refused at `db2`.
+    const twoSlotSchema: JSONSchema = {
+      type: "object",
+      properties: { db: sqliteDb, db2: sqliteDb },
+      required: ["db"],
+    };
+    expect(() =>
+      assertSuppliedLinkSchemasCompatible(
+        [{ path: ["db2"], value: raw.db }],
+        twoSlotSchema,
+        base,
+        manager,
+        {
+          priorArgumentSchema: twoSlotSchema,
+          linksPreservedVerbatim: true,
+        },
+      )
+    ).toThrow(/sqlite capability cannot be exposed as an ordinary alias/);
   });
 
   it("refuses a preserved link whose carried wrapper widens its contract", async () => {
     // The envelope on a SERIALIZED link is caller-written bytes. Declaring
     // that links are preserved verbatim must not become a way to smuggle a
-    // forged `asCell` past the check the rebuild branch performs.
+    // forged `asCell` past the check the rebuild branch performs. Two layers
+    // refuse it: a forged envelope that was never committed loses preserve
+    // status outright (it is not the committed bytes at its path) and faces
+    // the rebuild rules; and even a COMMITTED forged envelope — raw write
+    // paths like `PieceManager.link` commit links without ever running this
+    // validator — is caught by the preserve branch's own wrapper check.
     const readonlyNum: JSONSchema = { type: "number", asCell: ["readonly"] };
     const argumentSchema: JSONSchema = {
       type: "object",
@@ -1208,7 +1238,7 @@ describe("piece pull materialization", () => {
     expect(envelope).toBeDefined();
     envelope.schema = { type: "number", asCell: ["cell"] };
 
-    expect(() =>
+    const supplyForged = () =>
       assertSuppliedLinkSchemasCompatible(
         [{ path: ["v"], value: forged }],
         argumentSchema,
@@ -1218,8 +1248,20 @@ describe("piece pull materialization", () => {
           priorArgumentSchema: argumentSchema,
           linksPreservedVerbatim: true,
         },
-      )
-    ).toThrow(/non-durable Cell wrapper/);
+      );
+
+    // Layer 1: never committed — the forgery is not the committed bytes at
+    // its path, so the flag does not apply and the rebuild rules refuse the
+    // capability slot outright.
+    expect(supplyForged).toThrow(/cannot be exposed as an ordinary alias/);
+
+    // Layer 2: commit the forgery raw (as an unvalidated write path would),
+    // making it identical to committed state — the preserve branch's own
+    // wrapper check still refuses the non-durable envelope.
+    await runtime.editWithRetry((tx) => {
+      base.withTx(tx).key("v").setRawUntyped(forged);
+    });
+    expect(supplyForged).toThrow(/non-durable Cell wrapper/);
   });
 
   it("restores a retained ordinary Cell link across a source update", async () => {

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1058,6 +1058,70 @@ describe("piece pull materialization", () => {
     ).toThrow(/projection alias reconciliation requires a transaction/);
   });
 
+  it("restores a capability link whose destination declares the same kind", async () => {
+    // A source update (`PieceController.setPattern`, i.e. `cf piece setsrc`)
+    // re-applies the piece's retained links from `argumentCell.getRaw()`.
+    // Raw storage holds SERIALIZED links, never live Cells, so every link on
+    // that path fails `isCell()` — which is what `preservesDirectHandle`
+    // keys off. A capability-kind input was therefore always judged to be
+    // "exposed as an ordinary alias", even when the incoming pattern
+    // declares that exact capability at that exact path.
+    //
+    // The practical effect: a piece holding an injected `SqliteDb` input
+    // (Loom's native connector panels — `db: SqliteDb`, which compiles to
+    // `asCell: ["sqlite"]`) could never have its source updated in place.
+    // Restoring a link into a destination that declares the SAME capability
+    // preserves the capability; it does not expose it as a plain alias.
+    const sqliteDb: JSONSchema = {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        tables: { type: "object" },
+        rev: { type: "number" },
+      },
+      asCell: ["sqlite"],
+    };
+    const argumentSchema: JSONSchema = {
+      type: "object",
+      properties: { db: sqliteDb },
+      required: ["db"],
+    };
+
+    // The injected handle: seeded directly at a deterministic id, so it
+    // carries no producer-owned metadata — exactly how a disk-source handle
+    // is created (`linkSqliteDiskSource`). `durableSourceContract` finds
+    // nothing, so validation falls back to the prior argument contract.
+    const handle = runtime.getCell(
+      manager.getSpace(),
+      "sqlite-handle-" + crypto.randomUUID(),
+    );
+    await runtime.editWithRetry((tx) => {
+      handle.withTx(tx).set({ id: "handle-1", tables: {}, rev: 0 });
+    });
+
+    const base = runtime.getCell(
+      manager.getSpace(),
+      "sqlite-panel-argument-" + crypto.randomUUID(),
+    );
+    await runtime.editWithRetry((tx) => {
+      base.withTx(tx).set({ db: handle });
+    });
+
+    const raw = base.getRaw() as { db: unknown };
+    // Guard the premise: the restore path really does see a serialized link.
+    expect(isLink(raw.db)).toBe(true);
+
+    expect(() =>
+      assertSuppliedLinkSchemasCompatible(
+        [{ path: ["db"], value: raw.db }],
+        argumentSchema,
+        base,
+        manager,
+        { priorArgumentSchema: argumentSchema },
+      )
+    ).not.toThrow();
+  });
+
   it("fails closed for ambiguous producer and destination Cell contracts", async () => {
     const ordinarySourceSchema: JSONSchema = {
       type: "object",

--- a/packages/piece/test/setsrc-retained-capability-link.test.ts
+++ b/packages/piece/test/setsrc-retained-capability-link.test.ts
@@ -1,0 +1,302 @@
+/**
+ * TEMPORARY end-to-end verification (tmp-e2e-*): `cf piece setsrc` over a
+ * piece holding a LIVE, LINKED injected SQLite capability input.
+ *
+ * Everything here is real except the network hop: the emulated StorageManager
+ * is a loopback client against a real MemoryV2Server, so
+ * `registerSqliteDiskSource` + `sqliteQuery` hit the server's real disk-source
+ * registry and really attach the on-disk file read-only.
+ *
+ * Shape mirrors Loom's sqlite-injection reconciler:
+ *   deriveDiskHandleId(space, realPath) -> seed handle cell at that id ->
+ *   provider.registerSqliteDiskSource(handleId, path) ->
+ *   manager.link(handleId, [], pieceId, ["db"])
+ * then `PieceController.setPattern(<different program>)`, which is exactly
+ * what `cf piece setsrc` drives.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import {
+  createRef,
+  entityIdFrom,
+  isLink,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+// The piece package's import map has no `@db/sqlite` entry (and this scratch
+// file must not edit the tracked deno.jsonc), so pin the same JSR version the
+// rest of the workspace pins.
+import { Database } from "@db/sqlite";
+import { PieceManager } from "../src/manager.ts";
+import { PieceController } from "../src/ops/piece-controller.ts";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("tmp-e2e-setsrc-sqlite");
+
+/** Byte-for-byte the derivation in packages/cli/lib/sqlite-source.ts. */
+function deriveDiskHandleId(space: string, absPath: string): string {
+  return createRef({ disk: { path: absPath } }, {
+    space,
+    scheme: "sqlite",
+  }).taggedHashString;
+}
+
+function seedDiskDb(path: string): void {
+  const seed = new Database(path);
+  seed.exec("CREATE TABLE lookup (k TEXT, v TEXT)");
+  seed.exec(
+    "INSERT INTO lookup (k, v) VALUES ('a', '1'), ('b', '2'), ('c', '3')",
+  );
+  seed.close();
+}
+
+/**
+ * A genuinely different program per version: different NAME, different
+ * `version` literal, and a different LIMIT so the query itself changes (the
+ * read-through assertion can then tell v1 from v2 by row COUNT, not just by a
+ * string the pattern echoes).
+ */
+function panelProgram(version: string, limit: number): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        "/// <cts-enable />",
+        "import { NAME, pattern, type SqliteDb } from 'commonfabric';",
+        "interface Row { k: string; v: string; }",
+        "interface In { db: SqliteDb; }",
+        "interface Out {",
+        "  [NAME]: string;",
+        "  version: string;",
+        "  rows: { pending: boolean; result?: Row[]; error?: unknown };",
+        "}",
+        "const Panel = pattern<In, Out>(({ db }) => {",
+        `  const rows = db.query<Row>("SELECT k, v FROM lookup ORDER BY k LIMIT ${limit}");`,
+        "  return {",
+        `    [NAME]: ${JSON.stringify("panel-" + version)},`,
+        `    version: ${JSON.stringify(version)},`,
+        "    rows,",
+        "  };",
+        "});",
+        "export default Panel;",
+      ].join("\n"),
+    }],
+  };
+}
+
+describe("setsrc over a retained injected sqlite capability link", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+  let diskPath: string;
+
+  beforeEach(async () => {
+    diskPath = Deno.makeTempFileSync({ suffix: ".sqlite" });
+    seedDiskDb(diskPath);
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://localhost:9999"),
+      storageManager,
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "tmp-e2e-setsrc-" + crypto.randomUUID(),
+    });
+    manager = new PieceManager(session, runtime);
+    await manager.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    try {
+      Deno.removeSync(diskPath);
+    } catch { /* ignore */ }
+  });
+
+  it("updates the source and keeps reading through the capability", async () => {
+    const space = manager.getSpace();
+    const realPath = Deno.realPathSync(diskPath);
+
+    // 1. Deploy the piece from v1 (LIMIT 2). No `db` argument yet — the
+    //    reconciler links it in afterwards, exactly as Loom does.
+    const v1 = await runtime.patternManager.compilePattern(
+      panelProgram("v1", 2),
+      { space },
+    );
+    const piece = await manager.runPersistent(
+      v1,
+      {},
+      "tmp-e2e-setsrc-piece-" + crypto.randomUUID(),
+      { start: true },
+    );
+    const pieceId = entityRefToString(piece.entityId);
+
+    // 2. Seed the handle cell at the deterministic id + register the on-disk
+    //    source with the server (sqlite-injection.ts steps 1 and 2).
+    const handleId = deriveDiskHandleId(space, realPath);
+    const handle = runtime.getCellFromEntityId(
+      space,
+      entityIdFrom(handleId),
+      [],
+      undefined,
+    );
+    const seedRes = await runtime.editWithRetry((tx) => {
+      handle.withTx(tx).set({ id: handleId, tables: {}, rev: 0 });
+    });
+    if (seedRes.error) throw seedRes.error;
+    const provider = runtime.storageManager.open(space);
+    expect(typeof provider.registerSqliteDiskSource).toBe("function");
+    await provider.registerSqliteDiskSource!(handleId, realPath);
+
+    // 3. Link the handle into the piece's `db` input (sqlite-injection.ts
+    //    step 3: `pieceManager.link(handleId, [], pieceId, [dbField])`).
+    await manager.link(handleId, [], pieceId, ["db"]);
+    await runtime.idle();
+    await manager.synced();
+
+    const result = manager.getResult(piece);
+    const cancel = result.sink(() => {});
+    try {
+      const rowsOf = (): { k: string; v: string }[] | undefined => {
+        const raw = result.key("rows").key("result").get() as
+          | { k: string; v: string }[]
+          | undefined;
+        return raw;
+      };
+      const waitFor = async (
+        desc: string,
+        pred: () => boolean,
+        ms = 20_000,
+      ) => {
+        const deadline = Date.now() + ms;
+        let last: unknown;
+        while (Date.now() < deadline) {
+          await runtime.idle();
+          await runtime.storageManager.synced();
+          try {
+            if (pred()) return;
+          } catch (e) {
+            last = e;
+          }
+          await new Promise((r) => setTimeout(r, 25));
+        }
+        throw new Error(
+          `timeout waiting for ${desc}` + (last ? ` (last: ${last})` : "") +
+            ` — rows=${JSON.stringify(rowsOf())} version=${
+              JSON.stringify(result.key("version").get())
+            } error=${JSON.stringify(result.key("rows").key("error").get())}`,
+        );
+      };
+
+      // 4. PRE-CHECK: the capability really is live — the query returns the
+      //    on-disk rows through the injected handle, windowed by v1's LIMIT 2.
+      await waitFor(
+        "v1 to read 2 rows through the injected source",
+        () => (rowsOf()?.length ?? -1) === 2,
+      );
+      expect(rowsOf()).toEqual([{ k: "a", v: "1" }, { k: "b", v: "2" }]);
+      expect(result.key("version").get()).toBe("v1");
+
+      // The `db` argument really is a SERIALIZED link in raw storage (the
+      // premise of the bug: the restore path never sees a live Cell).
+      const rawArgument = () =>
+        manager.getArgument(piece)!.getRaw() as { db?: unknown };
+      const rawArgumentBefore = rawArgument();
+      expect(isLink(rawArgumentBefore.db)).toBe(true);
+
+      // 5. THE ACT UNDER TEST: `cf piece setsrc` with a CHANGED program.
+      const controller = new PieceController(manager, piece);
+      await controller.setPattern(panelProgram("v2", 3));
+      await runtime.idle();
+      await manager.synced();
+
+      // 6. The link survived, and still points at the SAME handle.
+      const rawArgumentAfter = rawArgument();
+      expect(isLink(rawArgumentAfter.db)).toBe(true);
+      expect(JSON.stringify(rawArgumentAfter.db)).toBe(
+        JSON.stringify(rawArgumentBefore.db),
+      );
+
+      // 7. And it is not merely preserved-but-dead: the NEW program reads
+      //    through the capability and gets the on-disk rows back, now
+      //    windowed by v2's LIMIT 3.
+      await waitFor(
+        "v2 to read 3 rows through the same injected source",
+        () => result.key("version").get() === "v2" &&
+          (rowsOf()?.length ?? -1) === 3,
+      );
+      expect(rowsOf()).toEqual([
+        { k: "a", v: "1" },
+        { k: "b", v: "2" },
+        { k: "c", v: "3" },
+      ]);
+      // 8. Loom's reconciler retries setsrc on every pass, so a SECOND
+      //    consecutive update over the (now once-restored) link must work too.
+      await controller.setPattern(panelProgram("v3", 1));
+      await runtime.idle();
+      await manager.synced();
+      const rawArgumentThird = rawArgument();
+      expect(JSON.stringify(rawArgumentThird.db)).toBe(
+        JSON.stringify(rawArgumentBefore.db),
+      );
+      await waitFor(
+        "v3 to read 1 row through the same injected source",
+        () => result.key("version").get() === "v3" &&
+          (rowsOf()?.length ?? -1) === 1,
+      );
+      expect(rowsOf()).toEqual([{ k: "a", v: "1" }]);
+
+      console.log(
+        "SETSRC_E2E_OK version=" + result.key("version").get() +
+          " rows=" + JSON.stringify(rowsOf()),
+      );
+    } finally {
+      cancel();
+    }
+
+    // 9. Cold reload: a FRESH runtime over the same (already-registered)
+    //    storage must load the updated piece and still read through the
+    //    retained link — i.e. the durable state setsrc left behind is
+    //    coherent, not just the in-memory one.
+    const freshSession = await createSession({
+      identity: signer,
+      spaceName: manager.getSpaceName()!,
+    });
+    const freshRuntime = new Runtime({
+      apiUrl: new URL("http://localhost:9999"),
+      storageManager,
+    });
+    const freshManager = new PieceManager(freshSession, freshRuntime);
+    try {
+      await freshManager.synced();
+      const freshPieces = new PiecesController(freshManager);
+      const freshPiece = await freshPieces.get(pieceId, true);
+      const freshResult = freshManager.getResult(freshPiece.getCell());
+      const stop = freshResult.sink(() => {});
+      try {
+        const deadline = Date.now() + 20_000;
+        let rows: unknown;
+        while (Date.now() < deadline) {
+          await freshRuntime.idle();
+          await freshRuntime.storageManager.synced();
+          rows = freshResult.key("rows").key("result").get();
+          if (Array.isArray(rows) && rows.length === 1) break;
+          await new Promise((r) => setTimeout(r, 25));
+        }
+        expect(freshResult.key("version").get()).toBe("v3");
+        expect(rows).toEqual([{ k: "a", v: "1" }]);
+        console.log("SETSRC_E2E_RELOAD_OK rows=" + JSON.stringify(rows));
+      } finally {
+        stop();
+      }
+    } finally {
+      await freshRuntime.dispose();
+    }
+  });
+});

--- a/packages/piece/test/setsrc-retained-capability-link.test.ts
+++ b/packages/piece/test/setsrc-retained-capability-link.test.ts
@@ -1,6 +1,14 @@
 /**
- * TEMPORARY end-to-end verification (tmp-e2e-*): `cf piece setsrc` over a
- * piece holding a LIVE, LINKED injected SQLite capability input.
+ * End-to-end: `cf piece setsrc` over a piece holding a LIVE, LINKED injected
+ * SQLite capability input.
+ *
+ * Regression coverage for the restore path rejecting every retained link into
+ * an `asCell`-declaring input slot ("sqlite capability cannot be exposed as an
+ * ordinary alias"): raw storage holds SERIALIZED links, which are never
+ * `isCell()`, so a piece with a linked capability input could be deployed but
+ * never source-updated again. The fix is the `linksPreservedVerbatim` option
+ * on `assertSuppliedLinkSchemasCompatible`, set at the `setPattern` call site;
+ * removing it there fails this test with exactly that error.
  *
  * Everything here is real except the network hop: the emulated StorageManager
  * is a loopback client against a real MemoryV2Server, so
@@ -19,6 +27,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
 import {
+  type Cell,
   createRef,
   entityIdFrom,
   isLink,
@@ -27,15 +36,22 @@ import {
 } from "@commonfabric/runner";
 import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-// The piece package's import map has no `@db/sqlite` entry (and this scratch
-// file must not edit the tracked deno.jsonc), so pin the same JSR version the
-// rest of the workspace pins.
+// Test-only dependency; pinned in this package's deno.jsonc (see the comment
+// on the entry there).
 import { Database } from "@db/sqlite";
 import { PieceManager } from "../src/manager.ts";
 import { PieceController } from "../src/ops/piece-controller.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 
-const signer = await Identity.fromPassphrase("tmp-e2e-setsrc-sqlite");
+const signer = await Identity.fromPassphrase("setsrc-e2e-sqlite");
+
+type Row = { k: string; v: string };
+
+/** The result shape every version of the test pattern below produces. */
+interface PanelResult {
+  version: string;
+  rows: { pending: boolean; result?: Row[]; error?: unknown };
+}
 
 /** Byte-for-byte the derivation in packages/cli/lib/sqlite-source.ts. */
 function deriveDiskHandleId(space: string, absPath: string): string {
@@ -58,7 +74,7 @@ function seedDiskDb(path: string): void {
  * A genuinely different program per version: different NAME, different
  * `version` literal, and a different LIMIT so the query itself changes (the
  * read-through assertion can then tell v1 from v2 by row COUNT, not just by a
- * string the pattern echoes).
+ * string the pattern echoes). Produces {@link PanelResult}.
  */
 function panelProgram(version: string, limit: number): RuntimeProgram {
   return {
@@ -105,7 +121,7 @@ describe("setsrc over a retained injected sqlite capability link", () => {
     });
     const session = await createSession({
       identity: signer,
-      spaceName: "tmp-e2e-setsrc-" + crypto.randomUUID(),
+      spaceName: "setsrc-e2e-" + crypto.randomUUID(),
     });
     manager = new PieceManager(session, runtime);
     await manager.synced();
@@ -132,7 +148,7 @@ describe("setsrc over a retained injected sqlite capability link", () => {
     const piece = await manager.runPersistent(
       v1,
       {},
-      "tmp-e2e-setsrc-piece-" + crypto.randomUUID(),
+      "setsrc-e2e-piece-" + crypto.randomUUID(),
       { start: true },
     );
     const pieceId = entityRefToString(piece.entityId);
@@ -160,15 +176,10 @@ describe("setsrc over a retained injected sqlite capability link", () => {
     await runtime.idle();
     await manager.synced();
 
-    const result = manager.getResult(piece);
+    const result = manager.getResult(piece) as Cell<PanelResult>;
     const cancel = result.sink(() => {});
     try {
-      const rowsOf = (): { k: string; v: string }[] | undefined => {
-        const raw = result.key("rows").key("result").get() as
-          | { k: string; v: string }[]
-          | undefined;
-        return raw;
-      };
+      const rowsOf = () => result.key("rows").key("result").get();
       const waitFor = async (
         desc: string,
         pred: () => boolean,
@@ -251,11 +262,6 @@ describe("setsrc over a retained injected sqlite capability link", () => {
           (rowsOf()?.length ?? -1) === 1,
       );
       expect(rowsOf()).toEqual([{ k: "a", v: "1" }]);
-
-      console.log(
-        "SETSRC_E2E_OK version=" + result.key("version").get() +
-          " rows=" + JSON.stringify(rowsOf()),
-      );
     } finally {
       cancel();
     }
@@ -277,7 +283,9 @@ describe("setsrc over a retained injected sqlite capability link", () => {
       await freshManager.synced();
       const freshPieces = new PiecesController(freshManager);
       const freshPiece = await freshPieces.get(pieceId, true);
-      const freshResult = freshManager.getResult(freshPiece.getCell());
+      const freshResult = freshManager.getResult(
+        freshPiece.getCell(),
+      ) as Cell<PanelResult>;
       const stop = freshResult.sink(() => {});
       try {
         const deadline = Date.now() + 20_000;
@@ -291,7 +299,6 @@ describe("setsrc over a retained injected sqlite capability link", () => {
         }
         expect(freshResult.key("version").get()).toBe("v3");
         expect(rows).toEqual([{ k: "a", v: "1" }]);
-        console.log("SETSRC_E2E_RELOAD_OK rows=" + JSON.stringify(rows));
       } finally {
         stop();
       }

--- a/packages/piece/test/setsrc-retained-capability-link.test.ts
+++ b/packages/piece/test/setsrc-retained-capability-link.test.ts
@@ -239,7 +239,8 @@ describe("setsrc over a retained injected sqlite capability link", () => {
       //    windowed by v2's LIMIT 3.
       await waitFor(
         "v2 to read 3 rows through the same injected source",
-        () => result.key("version").get() === "v2" &&
+        () =>
+          result.key("version").get() === "v2" &&
           (rowsOf()?.length ?? -1) === 3,
       );
       expect(rowsOf()).toEqual([
@@ -258,7 +259,8 @@ describe("setsrc over a retained injected sqlite capability link", () => {
       );
       await waitFor(
         "v3 to read 1 row through the same injected source",
-        () => result.key("version").get() === "v3" &&
+        () =>
+          result.key("version").get() === "v3" &&
           (rowsOf()?.length ?? -1) === 1,
       );
       expect(rowsOf()).toEqual([{ k: "a", v: "1" }]);


### PR DESCRIPTION

## Why

A Loom user's `loom setup --defaults` failed with `setsrc failed … input link
at db schema is not compatible: sqlite capability cannot be exposed as an
ordinary alias` for the Signal native panel, and the failure retried on every
instance preparation.

The cause is not sqlite-specific, or even capability-specific:
`PieceController.setPattern` (what `cf piece setsrc` drives) validates
retained argument links from `argumentCell.getRaw()`, and raw storage holds
SERIALIZED sigil links — which never pass `isCell()` (an `instanceof` check).
`preservesDirectHandle` keyed on exactly that, so **every** retained link
into an `asCell`-declaring input slot failed a source update: capability
kinds as "cannot be exposed as an ordinary alias", ordinary `Cell<T>` slots
as "asCell changed". Only unwrapped value slots passed, which is why this
went unnoticed. Any piece with a linked capability input (Loom's connector
panels: `db: SqliteDb` → `asCell: ["sqlite"]`) could be deployed once but
never source-updated again.

The guard conflated three questions: **provenance** (did the caller hold a
live handle — `isCell`), the **write plan** (will the envelope be written
back, or rebuilt from a materialized read — what the `!preservesDirectHandle`
rules actually police), and **capability policy** (`cellCapabilityCanNarrow`).
The write plan was inferred from provenance. That inference is sound wherever
the caller rebuilds, and false at `setPattern`, which rebuilds nothing:
`validateArgumentLinks` discards the returned set and `applySetupState`
carries the argument over from `previousArgumentCell.getRaw()` byte for byte.
The guard was vetoing an update, not confining a capability.

## What changed

- `assertSuppliedLinkSchemasCompatible` gains a `linksPreservedVerbatim`
  option, set at exactly one call site (`setPattern`). The other four call
  sites are byte-identical in behavior.
- The declaration is **verified per link, not trusted**: a serialized link
  only counts as preserved when it is identical to the value already durably
  committed at its path (`linkMatchesCommittedState`, a tx-detached read —
  the staged view would compare the links against themselves). Restoring
  committed bytes grants nothing that was not already granted; anything else
  (a link-shaped schema `default` from the incoming pattern, a mutated
  envelope, a lying future caller) falls through to the rebuild rules exactly
  as if the option were unset.
- Capability policy is untouched and still enforced on the preserve branch:
  `cellCapabilityCanNarrow`, bidirectional contract-subset proofs for
  writable kinds, and the forged-wrapper check — now against **every**
  durable contract (`.some` → `.every`, with an explicit empty-set guard
  since `.every([])` is vacuously true where `.some` failed closed).

## Test plan

- `packages/piece/test/setsrc-retained-capability-link.test.ts` — e2e over a
  real on-disk sqlite file and the server's real disk-source registry,
  mirroring Loom's injection sequence: seed handle → `registerSqliteDiskSource`
  → `manager.link` → two consecutive `setPattern`s → cold reload. Asserts the
  link survives byte-identical AND the new program still reads rows through
  the capability. Removing `linksPreservedVerbatim` from the call site fails
  it with the exact reported error (verified).
- Unit coverage in `pull-materialization.test.ts`: serialized-link restore
  for capability and ordinary-Cell slots (with `isCell(raw) === false`
  premise guards), laundering still refused, non-preserving callers
  unaffected, the committed-state scope (identical bytes restore at their
  committed path, are refused at any other), and both forged-envelope layers
  (never-committed forgery dies on the rebuild rules; a committed forgery —
  raw write paths commit links without this validator — dies on the preserve
  branch's own wrapper check).
- Full piece suite 22 passed / 247 steps; CFC sqlite capability integration
  (`sqlite-read-clearance-multi-runtime`, `sqlite-db-owner-multi-runtime`);
  CLI suite 109 passed; `deno task check` clean.

## Notes for review

- Envelope-carrying **stream** links at setsrc move from the rebuild regime
  (forward subset) to the preserve regime (reverse subset), so a source
  update that *widens* a stream event payload now fails link validation where
  it previously passed. This matches the long-standing live-Cell preserve
  semantics (reverse subset is the sound direction for send-capable handles),
  and links serialized without envelopes (`PieceManager.link`,
  `KeepAsCell.OnlyStream`) are unaffected — they failed the old regime too.
  Flagging it because it is a behavior flip for that population.
- `asCellShapesMatch` compares the wrapper stack (kind/scope), not payload
  schemas — payloads are proved separately against the durable contracts.
  The forged-wrapper comment now says exactly that; parity with the rebuild
  branch's existing use of the same helper.
- `PieceManager.link` still commits links with a bare `setRawUntyped` and no
  contract validation — the first check a daemon-made link ever meets is a
  later setsrc, which is why this presented as "deployed fine, can never be
  updated." Separate arc; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Source updates now preserve retained input links by treating serialized links as preserved handles when they match committed state. This fixes capability inputs (like `SqliteDb`) wrongly flagged as “exposed as an ordinary alias” and includes minor formatting via deno fmt.

- **Bug Fixes**
  - Added `linksPreservedVerbatim` to `assertSuppliedLinkSchemasCompatible`; set only by `setPattern`.
  - Verified each serialized link against committed bytes with `linkMatchesCommittedState`; non-matching links fall back to rebuild rules.
  - Enforced carried wrapper stacks against all durable contracts (uses `.every` with an empty-set guard) to block forged envelopes.
  - Fixed rejection of retained capability and ordinary `asCell` links on source update; pieces with injected `SqliteDb` can now be updated.
  - Note: preserved stream links now validate with reverse subset; widening event payloads may fail.
  - Removed an unreachable guard in `linkMatchesCommittedState`.

- **Tests**
  - Added e2e `setsrc-retained-capability-link.test.ts` using real disk-source registry and test-only `@db/sqlite`; asserts byte-identical preservation, reads across consecutive updates, and cold reload.
  - Added unit coverage for serialized-link restore, non-preserving callers, committed-path scoping, and forged wrapper checks.

<sup>Written for commit 68af0640d2db6fcaa747a974173ffc76535b5f8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

