### PR TITLE
feat(lunch-poll): retain canonical profile links

### DIFF
--- a/packages/patterns/integration/lunch-poll-vote.test.ts
+++ b/packages/patterns/integration/lunch-poll-vote.test.ts
@@ -166,8 +166,12 @@ describe("lunch poll: two users vote on a shared option", () => {
           ]),
       );
 
-      // Host joins first -> becomes host/admin. The roster chip carrying the
-      // host's name appears once the join lands.
+      // Host joins first -> becomes host/admin. Fresh identities carry no
+      // shared profile, so the join card opens on the profile create/pick
+      // surface; "Continue as guest" reveals the typed-name input this test
+      // drives. The roster chip carrying the host's name appears once the join
+      // lands.
+      await clickCfButton(hostPage, "#lp-guest-button");
       await timer.run(
         "host name filled",
         () => fillCfInput(hostPage, "#lp-join-name", HOST),
@@ -178,9 +182,11 @@ describe("lunch poll: two users vote on a shared option", () => {
         () => waitForText(hostPage, "body", HOST),
       );
 
-      // Guest joins second. The board shows a participant count, not a full
-      // roster, so the host's join landing is observed as "2 joined" (and the
-      // guest's own page shows its name plus "hosted by Alice").
+      // Guest joins second via the same guest path. The board shows a
+      // participant count, not a full roster, so the host's join landing is
+      // observed as "2 joined" (and the guest's own page shows its name plus
+      // "hosted by Alice").
+      await clickCfButton(guestPage, "#lp-guest-button");
       await fillCfInput(guestPage, "#lp-join-name", GUEST);
       await clickCfButton(guestPage, "#lp-join-button");
       await timer.run(

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -19,9 +19,10 @@ addressed by `(space, causal-cell-id)` — not to "the pattern" in the abstract.
 So "share the state" = "everyone points at the same piece"; "copy the state" =
 "move that piece's values into a new piece." It all lives in **`PerSpace` input
 cells**, shared by everyone in the space: `question`, `options`, `votes`,
-`users`, `adminName`, and **`visits`** (the "Recently eaten" log + embedded vote
-snapshots that feed "Lunch stats"). Plus **`myName`**, which is **`PerUser`**
-(keyed by your DID).
+`users`, `participantProfiles` (the object-wrapped directory of live canonical
+profile links for profile-backed joiners), `adminName`, and **`visits`** (the
+"Recently eaten" log + embedded vote snapshots that feed "Lunch stats"). Plus
+**`myName`**, which is **`PerUser`** (keyed by your DID).
 
 All of these survive an in-place `setsrc` (Option A) and — because `visits` is
 now an ordinary `PerSpace` cell — can all be copied to another piece via the CLI
@@ -132,7 +133,7 @@ MINE=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
 
 # 2. Copy each PerSpace field from the canonical piece into yours.
 #    `--input` reads/writes the input cell where these live.
-for field in question users options votes adminName visits; do
+for field in question users options votes participantProfiles adminName visits; do
   deno task cf piece get --piece "$PIECE" -s "$SPACE" "$field" --input -q \
     | deno task cf piece set --piece "$MINE" -s "$SPACE" "$field" --input -q
 done

--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -65,97 +65,81 @@ const COLLIDING_INITIAL_USERS: User[] = [
     name: "Daffodil",
     avatar: "",
     color: "#2f6f4e",
-    joinedAt: 1,
   },
   {
     name: "Dragonfly",
     avatar: "",
     color: "#c2573a",
-    joinedAt: 2,
   },
   {
     name: "Dan",
     avatar: "",
     color: "#3b4a6b",
-    joinedAt: 3,
   },
   {
     name: "Dana",
     avatar: "",
     color: "#a33b35",
-    joinedAt: 4,
   },
   {
     name: "dan",
     avatar: "",
     color: "#b27722",
-    joinedAt: 5,
   },
   {
     name: "A",
     avatar: "",
     color: "#7c3aed",
-    joinedAt: 6,
   },
   {
     name: "a",
     avatar: "",
     color: "#2f6f4e",
-    joinedAt: 7,
   },
   {
     name: "A1",
     avatar: "",
     color: "#c2573a",
-    joinedAt: 8,
   },
   {
     name: "Bob Smith",
     avatar: "",
     color: "#3b4a6b",
-    joinedAt: 9,
   },
   {
     name: "Bob  Smith",
     avatar: "",
     color: "#a33b35",
-    joinedAt: 10,
   },
   {
     name: "👩🏽‍💻Alice",
     avatar: "",
     color: "#7c3aed",
-    joinedAt: 11,
   },
   {
     name: "👩🏽‍💻Bob",
     avatar: "",
     color: "#2f6f4e",
-    joinedAt: 12,
   },
   {
     name: "🇺🇸Alice",
     avatar: "",
     color: "#c2573a",
-    joinedAt: 13,
   },
   {
     name: "🇺🇸Bob",
     avatar: "",
     color: "#3b4a6b",
-    joinedAt: 14,
   },
   {
     name: "e\u0301Alice",
     avatar: "",
     color: "#a33b35",
-    joinedAt: 15,
   },
   {
     name: "e\u0301Bob",
     avatar: "",
     color: "#b27722",
-    joinedAt: 16,
   },
 ];
 
@@ -300,6 +284,16 @@ export default pattern(() => {
       },
     ],
   });
+
+  // Profile-first join + the header strip/viewer-chip rendering from stored
+  // profile cells are verified at the browser/integration tier (the
+  // scrabble/battleship precedent), not here: a pattern-body `#profile` wish
+  // has no resolving environment in a unit test, and an unset optional cell
+  // input reads as a truthy proxy — so there is no honest way to inject a
+  // resolvable viewer profile cell at this tier. The join LOGIC (name
+  // snapshot, equals()-keyed dedup, directory write) is covered by
+  // participant-identity-card.test.tsx, which injects those values into the
+  // card directly.
 
   // === Actions ===
 

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -9,10 +9,11 @@
  * Identity follows the scrabble idiom:
  * - `users` is a per-space directory of joined participants.
  * - Each viewer's `myName` is per-user; it is set once on join and treated as
- *   immutable thereafter. The join name/avatar come from the viewer's shared
- *   profile (`wish({ query: "#profile" })` — its built-in UI covers profile
- *   create/pick); programmatic callers can still pass an explicit name in the
- *   `joinAs` event.
+ *   immutable thereafter. A profile-backed join stores the viewer's live
+ *   `wish({ query: "#profile" })` cell in the object-wrapped
+ *   `participantProfiles` directory, while keeping a name/avatar snapshot in
+ *   the legacy name-keyed poll state. A guest may instead type a string; guest
+ *   entries deliberately have no canonical profile link.
  * - The first joiner's name is captured into `adminName` (per-space). They can
  *   add/remove options and reset votes. `isAdmin` is derived, not stored.
  * - Open host takeover: any joined participant can `claimHost`, transferring
@@ -32,9 +33,10 @@
  * denormalized, so the snapshot survives the option being removed. The
  * "📊 Lunch stats" card derives per-place visit + green/yellow/red tallies from
  * those embedded snapshots via a plain `computed` (the `tallyOptions` idiom).
- * Live voting stays on the in-cell `votes` array. Each entry — and each embedded
- * vote — carries a frozen name snapshot plus a live `Cell<User>` profile link
- * (the shared-profile-roster live-link idiom).
+ * Live voting stays on the in-cell `votes` array. Each history entry — and each
+ * embedded vote — carries a frozen name plus a same-space `Cell<User>` roster
+ * link. Canonical cross-space profile identity lives separately in
+ * `participantProfiles` so legacy stored Lunch Poll arguments remain valid.
  *
  * History was briefly backed by the SQLite builtin (#4144/#4145, to dogfood it),
  * but that brought a deployed-piece "invalid database handle" failure plus a
@@ -81,8 +83,53 @@ export interface User {
   /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
   avatar?: string;
   color: string;
-  joinedAt: number;
 }
+
+/**
+ * The minimal profile shape a roster needs: the stable identity cell for
+ * `<cf-profile-badge>` binding and `equals()` dedup. Deliberately just
+ * `{ name?, avatar? }`, matching the shared-profile-rosters spec's
+ * `ParticipantProfileCell` — a richer wish schema (bio / externalLinks /
+ * verifiedIdentities Cell[]) makes the cross-space `#profile` result fail to
+ * resolve, so the badge falls back to "Unknown profile". The display NAME is
+ * never read off this cell; it comes from the `#profileName` string wish and
+ * is snapshotted at join.
+ */
+export interface LunchProfile {
+  readonly name?: string;
+  readonly avatar?: string;
+}
+
+/** Stable identity for a profile-backed participant. */
+export type LunchProfileCell = Cell<LunchProfile>;
+
+export interface ParticipantProfileLink {
+  /** Immutable Lunch Poll name used by the current name-keyed vote schema. */
+  readonly name: string;
+  /** Live canonical profile cell; compare it by identity with `equals()`. */
+  readonly profile: LunchProfileCell;
+}
+
+/**
+ * Live profile links use an object-wrapped directory. Nested cross-space cells
+ * inside Lunch Poll's legacy bare `users` array do not preserve strong handler
+ * schemas, so the compatibility-safe profile index remains separate.
+ */
+export interface ParticipantProfileDirectory {
+  readonly participants: ParticipantProfileLink[] | Default<[]>;
+}
+
+export const DEFAULT_PARTICIPANT_PROFILES = {
+  participants: [] as ParticipantProfileLink[],
+} satisfies ParticipantProfileDirectory;
+
+export type ParticipantProfileDirectoryValue =
+  | ParticipantProfileDirectory
+  | Default<typeof DEFAULT_PARTICIPANT_PROFILES>;
+
+export type ParticipantProfileDirectoryCell = Writable<
+  ParticipantProfileDirectoryValue
+>;
 
 export interface Option {
   id: string;
@@ -146,8 +193,8 @@ export type ResetVotesEvent = Record<PropertyKey, never>;
  * A snapshot of one person's vote at the moment a visit was logged, embedded in
  * the visit's `votes` list. `optionTitle` is denormalized (options can be
  * removed later; the title is the meaningful record). `voter` is a frozen name
- * snapshot; `voterLink` is a live `Cell<User>` link to that voter's profile
- * (null if the voter is no longer in the directory).
+ * snapshot; `voterLink` is a live `Cell<User>` link to that voter's Lunch Poll
+ * roster entry (null if the voter is no longer in the directory).
  */
 export interface VoteSnapshot {
   voter: string;
@@ -160,8 +207,9 @@ export interface VoteSnapshot {
  * A place the group actually ate, logged by the host — one entry in the
  * `PerSpace<HistoryEntry[]>` visit log. `loggedByName` is a frozen name snapshot
  * (what the "Recently eaten" card renders); `loggedBy` is a live `Cell<User>`
- * link to the logging host's profile (null if absent). `votes` embeds the vote
- * snapshot taken at log time, so per-place stats survive an option's removal.
+ * link to the logging host's Lunch Poll roster entry (null if absent). `votes`
+ * embeds the vote snapshot taken at log time, so per-place stats survive an
+ * option's removal.
  */
 export interface HistoryEntry {
   id: string;
@@ -261,11 +309,20 @@ const unusedId = (
   return id;
 };
 
+// Guard against live options AND every optionId still referenced by a vote:
+// without the vote sweep, a remove→re-add of the same (name, title) would mint
+// the removed option's id again and adopt any stray votes that merged in after
+// the removal cascade's read.
 const newOptionId = (
   options: readonly Option[],
+  votes: readonly Vote[],
   addedByName: string,
   title: string,
-): string => unusedId("o", [addedByName, title], options.map((o) => o.id));
+): string =>
+  unusedId("o", [addedByName, title], [
+    ...options.map((o) => o.id),
+    ...votes.map((v) => v.optionId),
+  ]);
 
 // The deterministic key a vote is addressed by: a voter's vote for one option.
 // castVote, clearMyVote, and the removeOption cascade all derive the same key,
@@ -504,10 +561,11 @@ const visitLabel = (wentAt: number): string => {
 
 const addOption = handler<AddOptionEvent, {
   options: OptionsCell;
+  votes: VotesCell;
   myName: NameCell;
   adminName: NameCell;
   optionDraft: NameCell;
-}>(({ title }, { options, myName, adminName, optionDraft }) => {
+}>(({ title }, { options, votes, myName, adminName, optionDraft }) => {
   const me = trimmedName(myName.get());
   const admin = trimmedName(adminName.get());
   if (!me || me !== admin) return;
@@ -515,8 +573,9 @@ const addOption = handler<AddOptionEvent, {
   if (!trimmed) return;
   // Address the option by its id so later edits and removal reach it without a
   // positional index. addUnique merges concurrent adds (distinct ids) and is
-  // idempotent on the id.
-  const id = newOptionId(options.get(), me, trimmed);
+  // idempotent on the id. The votes read joins the id-freshness guard into
+  // this transaction's conflict set — a concurrent cast retries the add.
+  const id = newOptionId(options.get(), votes.get(), me, trimmed);
   const option = options.elementById(id);
   option.set({
     id,
@@ -684,9 +743,9 @@ const logVisit = handler<LogVisitEvent, {
       : parseVisitDate(visitDate.get(), fallbackNow);
     if (!when) return;
 
-    // Resolve a name → that user's live Cell<User> in the directory, for the
-    // `*Link` live-profile links (the shared-profile-roster idiom). users.key(i)
-    // is a stable cell that round-trips through the array as a link.
+    // Resolve a name → that user's same-space Cell<User> roster entry.
+    // Canonical cross-space identity is held by `participantProfiles`; these
+    // historical links remain unchanged for stored-value compatibility.
     const us = users.get();
     const cellForName = (name: string): Cell<User> | null => {
       const idx = us.findIndex((u) => u.name === name);
@@ -847,6 +906,8 @@ export interface CozyPollInput {
   options?: PerSpace<Option[] | Default<[]>>;
   votes?: PerSpace<Vote[] | Default<[]>>;
   users?: PerSpace<User[] | Default<[]>>;
+  /** Canonical live profile links for profile-backed users; guests are absent. */
+  participantProfiles?: PerSpace<ParticipantProfileDirectoryValue>;
   adminName?: PerSpace<string | Default<"">>;
   myName?: PerUser<string | Default<"">>;
   // Durable "we went here" log; each entry embeds its own vote snapshot. Capped
@@ -865,6 +926,7 @@ export interface CozyPollOutput {
   // only `todaysVotes` — see the current-day filter note in the file header.
   votes: readonly Vote[];
   users: readonly User[];
+  participantProfiles: readonly ParticipantProfileLink[];
   adminName: string;
   myName: string;
   userCount: number;
@@ -909,6 +971,7 @@ export interface CozyPollOutput {
 const EMPTY_OPTIONS: Option[] = [];
 const EMPTY_VOTES: Vote[] = [];
 const EMPTY_USERS: User[] = [];
+const EMPTY_PARTICIPANT_PROFILE_LINKS: ParticipantProfileLink[] = [];
 
 export default pattern<CozyPollInput, CozyPollOutput>(
   (
@@ -917,6 +980,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       options,
       votes,
       users,
+      participantProfiles,
       adminName,
       myName,
       visits,
@@ -952,13 +1016,46 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     >(null);
     const resetConfirmPending = Writable.perSession.of<boolean>(false);
     const clearHistoryConfirmPending = Writable.perSession.of<boolean>(false);
+    // Resolve the viewer's shared profile at the TOP LEVEL, per the
+    // shared-profile-rosters spec (docs/specs/shared-profile-rosters.md): the
+    // `#profile` cell is the stable identity (badge + `equals()` dedup), and
+    // `#profileName` / `#profileAvatar` are the display strings. Simple schema
+    // on purpose — a rich schema fails to resolve the cross-space result. The
+    // injected `profile` input (tests) overrides the wish cell. These pass
+    // DOWN into the identity card; the card no longer wishes for itself, so
+    // resolution happens in this piece's top-level context where it works.
+    const profileWish = wish<LunchProfile>({ query: "#profile" });
+    const profileNameWish = wish<string>({ query: "#profileName" });
+    const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
+    // Bind the badge/identity to the wish result DIRECTLY (the demo idiom). Do
+    // NOT reintroduce a `profile ?? …` injection override: an unset optional
+    // cell input is a truthy proxy at pattern-build time, so `??` returns that
+    // broken proxy instead of the real result and every badge falls back to
+    // "Unknown profile". Profile-backed rendering is verified at the browser
+    // tier (the scrabble/battleship precedent), not via a pattern-body cell
+    // injection.
+    const viewerProfileCell = profileWish.result;
+    const viewerProfileName = computed(() =>
+      trimmedName(profileNameWish.result ?? "")
+    );
+    const viewerProfileAvatar = computed(() =>
+      (profileAvatarWish.result ?? "").trim()
+    );
+    // This pattern renders identity only from the STORED directory entries, so
+    // a later profile switch cannot orphan the joined identity.
     const participantIdentity = ParticipantIdentityCard({
       users,
       myName,
       adminName,
+      participantProfiles,
+      profile: viewerProfileCell,
+      profileName: viewerProfileName,
+      profileAvatar: viewerProfileAvatar,
+      profileSetupUI: profileWish[UI],
     });
     const boundAddOption = addOption({
       options,
+      votes,
       myName,
       adminName,
       optionDraft,
@@ -1041,6 +1138,31 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const me = participantIdentity.me;
     const isJoined = participantIdentity.isJoined;
     const isAdmin = participantIdentity.isAdmin;
+    // Normalize the Default<>-wrapped directory once: downstream maps need
+    // one concrete element type, not the raw schema union.
+    const participantLinks = computed((): readonly ParticipantProfileLink[] =>
+      participantProfiles.participants ?? EMPTY_PARTICIPANT_PROFILE_LINKS
+    );
+    // The viewer's stored canonical profile link(s) — the STORED entry (not
+    // the live `#profile` wish) is the rendered identity source, so switching
+    // the active profile after joining keeps the joined badge. An array of
+    // 0-or-1 entries: the header chip renders it with a plain static map,
+    // which keeps the `$profile` binding free of conditionals.
+    const viewerLinks = computed((): readonly ParticipantProfileLink[] => {
+      const viewerName = participantIdentity.me;
+      if (!viewerName) return EMPTY_PARTICIPANT_PROFILE_LINKS;
+      return participantLinks.filter((entry) => entry.name === viewerName);
+    });
+    const viewerHasStoredProfile = computed(() => viewerLinks.length > 0);
+    // Guests (typed-name joins) have no directory entry; the participants
+    // strip renders them as plain name chips next to the profile badges.
+    const guestUsers = computed(() => {
+      const linked = new Set(participantLinks.map((entry) => entry.name));
+      return users.filter((u) => !linked.has(u.name));
+    });
+    // Hoisted booleans for the JSX ternaries below (the file's reset-confirm
+    // idiom): conditions in JSX stay bare computed refs.
+    const hasParticipants = computed(() => users.length > 0);
     // Hoist a boolean cell for the reset-confirm JSX ternary so TS doesn't
     // narrow `resetConfirmPending` itself and lose the `.set` method in
     // the false branch.
@@ -1120,12 +1242,69 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                       </div>
                     );
                   })}
+                  {hasParticipants
+                    ? (
+                      <div
+                        data-participants-strip
+                        style={{
+                          marginTop: "8px",
+                          display: "flex",
+                          alignItems: "center",
+                          flexWrap: "wrap",
+                          gap: "6px",
+                        }}
+                      >
+                        {
+                          /* Every profile-backed participant renders from
+                            their STORED live cell (the canonical-roster
+                            idiom, multi-user-patterns.md#presenting-identity);
+                            guests keep plain name chips. Static maps on
+                            purpose — `$profile` bindings cannot live inside
+                            the tally computed below. These badges navigate;
+                            only the viewer's own chip is noNavigate. */
+                        }
+                        {participantLinks.map((entry) => (
+                          <cf-profile-badge
+                            variant="chip"
+                            size="sm"
+                            $profile={entry.profile}
+                            data-participant-badge={entry.name}
+                          />
+                        ))}
+                        {guestUsers.map((u) => (
+                          <span
+                            data-participant-guest={u.name}
+                            title={u.name}
+                            style={{
+                              display: "inline-flex",
+                              alignItems: "center",
+                              padding: "2px 8px",
+                              borderRadius: "9999px",
+                              background: "#f3f4f6",
+                              border: "1px solid #e5e7eb",
+                              fontSize: "11px",
+                              fontWeight: 600,
+                              color: "#374151",
+                              whiteSpace: "nowrap",
+                            }}
+                          >
+                            {u.name}
+                          </span>
+                        ))}
+                      </div>
+                    )
+                    : null}
                 </div>
-                {computed(() => {
-                  const viewer = me;
-                  if (viewer === "") return null;
-                  const amAdmin = isAdmin;
-                  return (
+                {
+                  /* Static JSX only in this cluster: the viewer badge carries
+                    a `$profile` binding, and a `$`-binding inside an authored
+                    `computed(() => …)` VNode is materialized by the lift and
+                    blanks the whole render (pattern-critique-guide §5). JSX
+                    ternaries compile to static-branch `ifElse`, the safe
+                    conditional shape at a `$`-binding position. */
+                }
+                {isJoined
+                  ? (
                     <div
                       style={{
                         display: "flex",
@@ -1133,7 +1312,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                         alignItems: "center",
                       }}
                     >
-                      {amAdmin
+                      {isAdmin
                         ? (
                           <span
                             style={{
@@ -1154,30 +1333,48 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                           </span>
                         )
                         : null}
-                      <span
-                        title={viewer}
-                        style={{
-                          display: "inline-flex",
-                          alignItems: "center",
-                          gap: "6px",
-                          padding: "4px 10px",
-                          borderRadius: "9999px",
-                          background: "#f3f4f6",
-                          border: "1px solid #e5e7eb",
-                          fontSize: "12px",
-                          fontWeight: 600,
-                          color: "#374151",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        <span style={{ fontSize: "10px", color: "#10b981" }}>
-                          ●
+                      {
+                        /* The viewer's chip binds the STORED directory entry
+                          (never the live `#profile` wish), so a profile
+                          switch after joining keeps the joined identity.
+                          `viewerLinks` is pre-filtered to 0-or-1 entries, so
+                          this map stays conditional-free at the binding. */
+                      }
+                      {viewerLinks.map((entry) => (
+                        <cf-profile-badge
+                          variant="chip"
+                          size="sm"
+                          $profile={entry.profile}
+                          noNavigate
+                          data-viewer-badge
+                        />
+                      ))}
+                      {viewerHasStoredProfile ? null : (
+                        <span
+                          title={me}
+                          style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: "6px",
+                            padding: "4px 10px",
+                            borderRadius: "9999px",
+                            background: "#f3f4f6",
+                            border: "1px solid #e5e7eb",
+                            fontSize: "12px",
+                            fontWeight: 600,
+                            color: "#374151",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          <span style={{ fontSize: "10px", color: "#10b981" }}>
+                            ●
+                          </span>
+                          {me}
                         </span>
-                        {viewer}
-                      </span>
+                      )}
                     </div>
-                  );
-                })}
+                  )
+                  : null}
               </div>
             </div>
 
@@ -1189,6 +1386,31 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                   margin: "0 auto",
                 }}
               >
+                {
+                  /* Always-on live self-badge, at the TOP LEVEL co-located with
+                    the `#profile` wish — the profile-roster-live-demo idiom. A
+                    `<cf-profile-badge>` rendered here keeps the viewer's profile
+                    pattern running in this runtime, which is what materializes
+                    the cross-space profile so EVERY badge (this one, the header
+                    viewer chip, and the participants strip's stored-cell badges)
+                    resolves instead of falling back to "Unknown profile", and it
+                    reliably primes the `#profileName` string the join label and
+                    roster snapshot read. A badge rendered inside the identity
+                    sub-pattern does NOT achieve this — it must be top-level.
+                    Static JSX position: the `$profile` binding must not sit
+                    inside an authored `computed(() => …)` VNode. */
+                }
+                <div
+                  data-viewer-self-badge
+                  style={{ marginBottom: "12px" }}
+                >
+                  <cf-profile-badge
+                    variant="chip"
+                    size="sm"
+                    $profile={viewerProfileCell}
+                    noNavigate
+                  />
+                </div>
                 {participantIdentity[UI]}
 
                 {/* Top choice — only when there are votes */}
@@ -1790,6 +2012,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       options: computed(() => options ?? EMPTY_OPTIONS),
       votes: computed(() => votes ?? EMPTY_VOTES),
       users: computed(() => users ?? EMPTY_USERS),
+      participantProfiles: participantLinks,
       adminName: computed(() => trimmedName(adminName)),
       myName: participantIdentity.me,
       userCount,

--- a/packages/patterns/lunch-poll/participant-identity-card.test.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.test.tsx
@@ -1,6 +1,19 @@
-import { action, assert, Default, pattern, UI, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  Default,
+  equals,
+  pattern,
+  UI,
+  Writable,
+} from "commonfabric";
 import ParticipantIdentityCard from "./participant-identity-card.tsx";
-import type { User } from "./main.tsx";
+import {
+  DEFAULT_PARTICIPANT_PROFILES,
+  type LunchProfile,
+  type ParticipantProfileDirectoryValue,
+  type User,
+} from "./main.tsx";
 import {
   findNode,
   hasText,
@@ -25,10 +38,46 @@ export default pattern(() => {
   const users = new Writable<User[] | Default<[]>>([]);
   const myName = new Writable<string | Default<"">>("");
   const adminName = new Writable<string | Default<"">>("");
+  const participantProfiles = Writable.of<ParticipantProfileDirectoryValue>(
+    DEFAULT_PARTICIPANT_PROFILES,
+  );
+  // No profile resolved: name/avatar are empty strings (as the parent's
+  // top-level wishes read before resolving), so the card shows the setup path.
   const participantIdentity = ParticipantIdentityCard({
     users,
     myName,
     adminName,
+    participantProfiles,
+    profileName: "",
+    profileAvatar: "",
+  });
+
+  // The profile-backed path is injected explicitly so lane-2 tests exercise
+  // what the parent passes down from its top-level wishes: the identity CELL
+  // (`profile`) plus the resolved display strings (`profileName`/`avatar`).
+  // The name is a live cell so the toggle test can update it; the display
+  // name is never read off `aliceProfile` — only used as badge/`equals()`
+  // identity — so that cell only needs the minimal `{ name, avatar }` shape.
+  const profileUsers = new Writable<User[] | Default<[]>>([]);
+  const profileMyName = new Writable<string | Default<"">>("");
+  const profileAdminName = new Writable<string | Default<"">>("");
+  const profileDirectory = Writable.of<ParticipantProfileDirectoryValue>(
+    DEFAULT_PARTICIPANT_PROFILES,
+  );
+  const aliceProfile = Writable.of<LunchProfile>({
+    name: "Profile Alice",
+    avatar: "alice.png",
+  });
+  const profileNameCell = new Writable<string | Default<"">>("Profile Alice");
+  const profileAvatarCell = new Writable<string | Default<"">>("alice.png");
+  const profileIdentity = ParticipantIdentityCard({
+    users: profileUsers,
+    myName: profileMyName,
+    adminName: profileAdminName,
+    participantProfiles: profileDirectory,
+    profile: aliceProfile,
+    profileName: profileNameCell,
+    profileAvatar: profileAvatarCell,
   });
 
   // Profile-first UI fires `joinAs.send({})` (no name) for the "Join as <name>"
@@ -42,6 +91,40 @@ export default pattern(() => {
     participantIdentity.joinAs.send({ name: "Alex" });
   });
 
+  const action_join_with_profile = action(() => {
+    profileIdentity.joinAs.send({});
+  });
+
+  const action_use_different_name = action(() => {
+    const button = findByProp(
+      profileIdentity[UI],
+      "aria-label",
+      "Use a different name",
+    );
+    const onClick = propsOf(button)?.onClick;
+    if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+      (onClick as { send: (event: Record<string, never>) => void }).send({});
+    }
+  });
+
+  const action_cancel_different_name = action(() => {
+    const button = findByProp(
+      profileIdentity[UI],
+      "aria-label",
+      "Back to profile join",
+    );
+    const onClick = propsOf(button)?.onClick;
+    if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+      (onClick as { send: (event: Record<string, never>) => void }).send({});
+    }
+  });
+
+  // The viewer renames their profile after joining: the parent's #profileName
+  // wish would re-resolve, so the display string the card reflects changes.
+  const action_update_canonical_profile = action(() => {
+    profileNameCell.set("Alice Updated");
+  });
+
   const action_try_rejoin_as_alex_two = action(() => {
     participantIdentity.joinAs.send({ name: "Alex Two" });
   });
@@ -51,7 +134,6 @@ export default pattern(() => {
       name: "Blair",
       avatar: "",
       color: "#c2573a",
-      joinedAt: 1,
     });
     myName.set("Blair");
   });
@@ -68,25 +150,33 @@ export default pattern(() => {
   );
 
   // With no profile resolved and nobody joined, the join surface shows the
-  // manual-name fallback: the text input and Join button render, the "First to
-  // join becomes the host." hint shows, and neither profile-first control (the
-  // "Use a different name" toggle nor the "Cancel" escape hatch) is present.
-  // Walking the tree materializes showManualEntry, hasProfile, and joinHint.
-  const assert_manual_fallback_renders = assert(() => {
+  // profile-setup branch: the wish's built-in [UI] slot plus the explicit
+  // "Continue as guest" button. The typed-name input is NOT present — the
+  // guest path never appears automatically (it needs the explicit toggle).
+  // Walking the tree materializes showProfileSetup, hasProfile, and joinHint.
+  const assert_guest_setup_renders = assert(() => {
     const ui = participantIdentity[UI];
+    const guestButton = findByProp(ui, "id", "lp-guest-button");
     const input = findByProp(ui, "id", "lp-join-name");
-    const joinButton = findByProp(ui, "id", "lp-join-button");
-    const useDifferentName = findByProp(
-      ui,
-      "aria-label",
-      "Use a different name",
-    );
-    const cancel = findByProp(ui, "aria-label", "Use my profile name instead");
-    return input !== undefined &&
-      joinButton !== undefined &&
-      useDifferentName === undefined &&
-      cancel === undefined &&
+    const setupSlot = findByProp(ui, "data-profile-setup", true);
+    return guestButton !== undefined &&
+      input === undefined &&
+      setupSlot !== undefined &&
       hasText(ui, "First to join becomes the host.");
+  });
+
+  const assert_profile_first_renders = assert(() => {
+    const ui = profileIdentity[UI];
+    return hasText(ui, "Join as Profile Alice") &&
+      findByProp(ui, "data-profile-identity", "canonical") !== undefined &&
+      findByProp(ui, "aria-label", "Use a different name") !== undefined;
+  });
+
+  const assert_profile_manual_entry_renders = assert(() => {
+    const ui = profileIdentity[UI];
+    return findByProp(ui, "id", "lp-join-name") !== undefined &&
+      findByProp(ui, "aria-label", "Back to profile join") !== undefined &&
+      findByProp(ui, "data-profile-identity", "canonical") === undefined;
   });
 
   const assert_empty_send_noop = assert(() =>
@@ -99,12 +189,34 @@ export default pattern(() => {
     const currentUsers = users.get();
     return currentUsers.length === 1 &&
       currentUsers[0]?.name === "Alex" &&
-      currentUsers[0]?.joinedAt === 0 &&
       myName.get() === "Alex" &&
       adminName.get() === "Alex" &&
+      participantProfiles.get().participants.length === 0 &&
       participantIdentity.me === "Alex" &&
       participantIdentity.isJoined === true &&
       participantIdentity.isAdmin === true;
+  });
+
+  const assert_joined_with_profile = assert(() => {
+    const currentUsers = profileUsers.get();
+    const links = profileDirectory.get().participants;
+    return currentUsers.length === 1 &&
+      currentUsers[0]?.name === "Profile Alice" &&
+      currentUsers[0]?.avatar === "alice.png" &&
+      profileMyName.get() === "Profile Alice" &&
+      profileAdminName.get() === "Profile Alice" &&
+      links.length === 1 &&
+      links[0]?.name === "Profile Alice" &&
+      equals(links[0]?.profile, aliceProfile) &&
+      profileIdentity.isJoined === true &&
+      profileIdentity.isAdmin === true;
+  });
+
+  const assert_profile_link_stays_live = assert(() => {
+    const currentUsers = profileUsers.get();
+    return currentUsers[0]?.name === "Profile Alice" &&
+      currentUsers[0]?.avatar === "alice.png" &&
+      profileIdentity.profileName === "Alice Updated";
   });
 
   const assert_rejoin_noop = assert(() => {
@@ -131,9 +243,18 @@ export default pattern(() => {
   return {
     tests: [
       { assertion: assert_initial },
-      { assertion: assert_manual_fallback_renders },
+      { assertion: assert_guest_setup_renders },
+      { assertion: assert_profile_first_renders },
+      { action: action_use_different_name },
+      { assertion: assert_profile_manual_entry_renders },
+      { action: action_cancel_different_name },
+      { assertion: assert_profile_first_renders },
       { action: action_join_empty },
       { assertion: assert_empty_send_noop },
+      { action: action_join_with_profile },
+      { assertion: assert_joined_with_profile },
+      { action: action_update_canonical_profile },
+      { assertion: assert_profile_link_stays_live },
       { action: action_join_as_alex },
       { assertion: assert_joined_as_alex },
       { action: action_try_rejoin_as_alex_two },

--- a/packages/patterns/lunch-poll/participant-identity-card.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.tsx
@@ -1,16 +1,22 @@
 import {
   computed,
   Default,
+  equals,
   handler,
   NAME,
   pattern,
   type Stream,
   UI,
   type VNode,
-  wish,
   Writable,
 } from "commonfabric";
-import type { ClaimHostEvent, JoinEvent, User } from "./main.tsx";
+import type {
+  ClaimHostEvent,
+  JoinEvent,
+  LunchProfileCell,
+  ParticipantProfileDirectoryCell,
+  User,
+} from "./main.tsx";
 
 /** Parent-owned roster cell shared by all viewers. */
 export type ParticipantIdentityUsersCell = Writable<User[] | Default<[]>>;
@@ -35,6 +41,12 @@ const joinAs = handler<JoinEvent, {
   myName: ParticipantIdentityNameCell;
   adminName: ParticipantIdentityNameCell;
   joinName: ParticipantIdentityNameCell;
+  participantProfiles: ParticipantProfileDirectoryCell;
+  profile: LunchProfileCell | undefined;
+  // The display strings arrive pre-resolved (from `#profileName` /
+  // `#profileAvatar`, or the injected profile object) — field reads off the
+  // live `#profile` result are NOT a reliable display source; the dedicated
+  // string wishes are (the battleship-lobby idiom, multi-user-patterns.md).
   profileName: string;
   profileAvatar: string;
 }>(
@@ -45,6 +57,8 @@ const joinAs = handler<JoinEvent, {
       myName,
       adminName,
       joinName,
+      participantProfiles,
+      profile,
       profileName,
       profileAvatar,
     },
@@ -60,14 +74,20 @@ const joinAs = handler<JoinEvent, {
       name: trimmed,
       avatar: override ? "" : (profileAvatar ?? "").trim(),
       color: colorForIndex(existing.length),
-      // Ordering comes from the shared roster itself; avoid ambient time so
-      // this action also works in pre-#4740 secure Loom runtimes.
-      joinedAt: 0,
     };
     // A duplicate name must reject the second join rather than silently make
     // two sessions the same participant. Keep the admission read and write the
     // resulting roster as one conflict-safe read-modify-write transaction.
     users.set([...existing, user]);
+    if (!override && profile) {
+      const currentLinks = participantProfiles.get().participants ?? [];
+      if (!currentLinks.some((entry) => equals(entry.profile, profile))) {
+        participantProfiles.key("participants").set([
+          ...currentLinks,
+          { name: trimmed, profile },
+        ]);
+      }
+    }
     myName.set(trimmed);
     if (trimmedName(adminName.get()) === "") {
       adminName.set(trimmed);
@@ -95,12 +115,14 @@ const claimHost = handler<ClaimHostEvent, {
  * and `isAdmin`) are intended for downstream sub-patterns such as per-option
  * cards.
  *
- * Joining is profile-first: when `#profileName` resolves, the surface offers a
- * one-click "Join as <name>" (carrying the profile name and avatar) with a
- * "Use a different name" escape hatch. The manual name input is the FALLBACK,
- * shown by default only when no profile resolves. This keeps the shared profile
- * — not a hand-typed name — the primary identity, so avatars aren't dropped and
- * viewers aren't asked to retype who they already are.
+ * Joining is profile-first. The parent resolves the viewer's `#profile` at
+ * top level (per docs/specs/shared-profile-rosters.md) and passes the cell,
+ * display name, and the wish's create/pick surface in. When a profile
+ * resolves, the card offers a one-click "Join as <name>" and retains the live
+ * cell in the shared profile directory. When it doesn't, the card renders the
+ * passed create/pick surface — the typed-name guest path never appears
+ * automatically; "Continue as guest" is an explicit choice, and guest entries
+ * store only the entered string.
  */
 
 /**
@@ -119,6 +141,34 @@ export interface ParticipantIdentityCardInput {
 
   /** Shared admin name cell. */
   adminName: ParticipantIdentityNameCell;
+
+  /** Object-wrapped directory of live canonical profile links. */
+  participantProfiles: ParticipantProfileDirectoryCell;
+
+  /**
+   * The viewer's resolved `#profile` cell, from the parent's top-level wish
+   * (or an injected cell in tests). Used only as the badge/`equals()` identity
+   * — never read for its name; the display name arrives as `profileName`.
+   * Undefined until it resolves (or when the viewer has no profile).
+   */
+  profile?: LunchProfileCell;
+
+  /**
+   * The viewer's resolved display name, from the parent's top-level
+   * `#profileName` wish (or injected in tests). "" until it resolves; the join
+   * card gates on this being non-empty and snapshots it into the roster.
+   */
+  profileName: string;
+
+  /** The viewer's resolved avatar, from the parent's `#profileAvatar` wish. */
+  profileAvatar: string;
+
+  /**
+   * The `#profile` wish's built-in create/pick surface (`profileWish[UI]`),
+   * rendered by the parent's top-level wish and passed down so the card shows
+   * it in the no-profile state. Omitted in tests without a wish environment.
+   */
+  profileSetupUI?: VNode;
 }
 
 /**
@@ -144,6 +194,9 @@ export interface ParticipantIdentityCardOutput {
   /** Whether the current viewer currently owns admin actions. */
   isAdmin: boolean;
 
+  /** Current canonical profile display name, or empty for a guest/no profile. */
+  profileName: string;
+
   /** Bound stream that joins the current viewer and claims admin if first. */
   joinAs: Stream<JoinEvent>;
 
@@ -155,35 +208,57 @@ export default pattern<
   ParticipantIdentityCardInput,
   ParticipantIdentityCardOutput
 >(
-  ({ users, myName, adminName }) => {
+  (
+    {
+      users,
+      myName,
+      adminName,
+      participantProfiles,
+      profile,
+      profileName,
+      profileAvatar,
+      profileSetupUI,
+    },
+  ) => {
     const joinName = Writable.perSession.of<string>("");
-    const profileNameWish = wish<string>({ query: "#profileName" });
-    const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
-
-    const profileName = computed(() => profileNameWish.result ?? "");
-    const profileAvatar = computed(() => profileAvatarWish.result ?? "");
+    // The parent resolves the viewer's profile at top level (per
+    // docs/specs/shared-profile-rosters.md) and passes the results in:
+    // `profile` is the identity cell (badge + `equals()` dedup), `profileName`
+    // / `profileAvatar` are the display strings. The card never reads the name
+    // off the cell — the cross-space `#profileName` value is the source, and
+    // it is snapshotted into the roster on join.
+    const canonicalProfileName = computed(() => trimmedName(profileName));
+    const canonicalProfileAvatar = computed(() => (profileAvatar ?? "").trim());
     const boundJoin = joinAs({
       users,
       myName,
       adminName,
       joinName,
-      profileName,
-      profileAvatar,
+      participantProfiles,
+      profile,
+      profileName: canonicalProfileName,
+      profileAvatar: canonicalProfileAvatar,
     });
     const boundClaimHost = claimHost({ myName, adminName });
 
-    // The join name/avatar default to the viewer's shared profile; the manual
-    // input is only a fallback for when no profile resolves (or the viewer
-    // deliberately wants a one-off name). `useCustomName` reveals that input
-    // even when a profile IS present.
+    // Joining is profile-first, and the typed-name path is never automatic:
+    // with no resolved profile the card renders the wish's create/pick UI,
+    // and "Continue as guest" is an explicit secondary action. `useCustomName`
+    // also lets a profile-holder deliberately join under a one-off name.
     const useCustomName = Writable.perSession.of<boolean>(false);
-    const profileDisplayName = computed(() =>
-      trimmedName(profileNameWish.result ?? "")
+    // Gate on the resolved profile NAME. `#profileName` is a cross-space
+    // computed value: the profile's `initialNameApplied` lift lives in its own
+    // inSpace child space and only materializes once a `$profile` badge starts
+    // the profile pattern in this runtime (the raw `#profile` result is a
+    // pending proxy, not a usable truthiness signal). The badge in the setup
+    // branch below is what does that priming, so the empty-name window is a
+    // brief transient, not a deadlock — see its comment.
+    const hasProfile = computed(() => canonicalProfileName !== "");
+    const showProfileJoin = computed(() => hasProfile && !useCustomName.get());
+    const showProfileSetup = computed(() =>
+      !hasProfile && !useCustomName.get()
     );
-    const hasProfile = computed(() => profileDisplayName !== "");
-    const showManualEntry = computed(() =>
-      profileDisplayName === "" || useCustomName.get()
-    );
+    const showManualEntry = computed(() => useCustomName.get());
 
     const me = computed(() => trimmedName(myName.get()));
     const isJoined = computed(() => trimmedName(myName.get()) !== "");
@@ -236,6 +311,75 @@ export default pattern<
               >
                 {joinHint}
               </div>
+              {showProfileJoin
+                ? (
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: "8px",
+                      alignItems: "center",
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <div
+                      data-profile-identity="canonical"
+                      style={{ display: "inline-flex", alignItems: "center" }}
+                    >
+                      <cf-profile-badge
+                        $profile={profile}
+                        size="sm"
+                        noNavigate
+                      />
+                    </div>
+                    <cf-button
+                      id="lp-join-button"
+                      variant="primary"
+                      aria-label="Join the poll with your profile name"
+                      onClick={() => boundJoin.send({})}
+                    >
+                      Join as {canonicalProfileName}
+                    </cf-button>
+                    <cf-button
+                      variant="ghost"
+                      size="sm"
+                      aria-label="Use a different name"
+                      onClick={() => useCustomName.set(true)}
+                    >
+                      Use a different name
+                    </cf-button>
+                  </div>
+                )
+                : null}
+              {showProfileSetup
+                ? (
+                  <div
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: "8px",
+                    }}
+                  >
+                    {
+                      /* Built-in profile create/pick surface, resolved by the
+                        parent's top-level `#profile` wish and passed in. The
+                        typed-name path never appears automatically — guests
+                        opt in below. */
+                    }
+                    <div data-profile-setup>{profileSetupUI}</div>
+                    <div>
+                      <cf-button
+                        id="lp-guest-button"
+                        variant="ghost"
+                        size="sm"
+                        aria-label="Continue as guest with a typed name"
+                        onClick={() => useCustomName.set(true)}
+                      >
+                        Continue as guest
+                      </cf-button>
+                    </div>
+                  </div>
+                )
+                : null}
               {showManualEntry
                 ? (
                   <div
@@ -261,50 +405,20 @@ export default pattern<
                     >
                       Join
                     </cf-button>
-                    {hasProfile
-                      ? (
-                        <cf-button
-                          variant="ghost"
-                          size="sm"
-                          aria-label="Use my profile name instead"
-                          onClick={() => {
-                            useCustomName.set(false);
-                            joinName.set("");
-                          }}
-                        >
-                          Cancel
-                        </cf-button>
-                      )
-                      : null}
-                  </div>
-                )
-                : (
-                  <div
-                    style={{
-                      display: "flex",
-                      gap: "8px",
-                      alignItems: "center",
-                      flexWrap: "wrap",
-                    }}
-                  >
-                    <cf-button
-                      id="lp-join-button"
-                      variant="primary"
-                      aria-label="Join the poll with your profile name"
-                      onClick={() => boundJoin.send({})}
-                    >
-                      Join as {profileDisplayName}
-                    </cf-button>
                     <cf-button
                       variant="ghost"
                       size="sm"
-                      aria-label="Use a different name"
-                      onClick={() => useCustomName.set(true)}
+                      aria-label="Back to profile join"
+                      onClick={() => {
+                        useCustomName.set(false);
+                        joinName.set("");
+                      }}
                     >
-                      Use a different name
+                      Back
                     </cf-button>
                   </div>
-                )}
+                )
+                : null}
             </div>
           )}
 
@@ -342,6 +456,7 @@ export default pattern<
       me,
       isJoined,
       isAdmin,
+      profileName: canonicalProfileName,
       joinAs: boundJoin,
       claimHost: boundClaimHost,
     };


### PR DESCRIPTION
## Why

Lunch Poll currently treats `#profileName` and `#profileAvatar` as frozen strings. That makes a profile-backed participant indistinguishable from a guest and prevents Loom from rendering or following the user's canonical profile as it changes.

The poll also has an important compatibility constraint: today's deployed piece uses a bare, name-keyed `users` array, and guests must still be able to join with a typed string.

## What

- Resolve the current viewer's live `#profile` cell in the parent pattern.
- Add an optional, object-wrapped `participantProfiles` directory for canonical cross-space profile links, separate from the legacy bare `users` array.
- On a profile-backed join, retain that live cell and snapshot the current name/avatar into the existing name-keyed poll state.
- Keep "Use a different name" as a true guest path; guest joins store only the entered string and no profile link.
- Render the canonical badge for profile-backed viewers while retaining the existing string chip for guests.
- Expose the profile directory to consumers and cover profile-first UI, guest fallback, persisted cell identity, and live profile updates in the focused test pattern.

## Compatibility and rollout

This is stacked on #4922 so it includes the secure-runtime and candidate-schema compatibility fixes. The new profile directory is optional and does not rewrite the existing `users`, votes, admin, or history schemas.

Loom #4074 enables the native profile experience, but it does not itself set `fabric_default_host: hosted`. A separate Loom Route A/default-host migration is still required before local Looms resolve `#profile` from Estuary by default. Until then, users without a resolved profile continue through the typed guest-name path.

Existing guest roster entries are intentionally not mutated in the background. New joins use the canonical cell whenever Loom resolves one; an explicit migration/re-link affordance can be added later if old guest entries need upgrading.

## Tests

- `deno task cf check packages/patterns/lunch-poll/main.tsx --no-run`
- `deno task cf check packages/patterns/lunch-poll/participant-identity-card.test.tsx --no-run`
- `deno lint packages/patterns/lunch-poll/main.tsx packages/patterns/lunch-poll/participant-identity-card.tsx packages/patterns/lunch-poll/participant-identity-card.test.tsx`
- Lunch Poll directory tests: 66 sandbox-safe assertions passed; the multi-user test requires loopback access.
- `deno task cf test packages/patterns/lunch-poll/multi-user.test.tsx --root packages/patterns --timeout 15000`: 11 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains canonical profile identity by storing each profile-backed viewer’s live `#profile` cell in `participantProfiles` and rendering all badges from those stored links. Makes join profile‑first via top‑level `#profile` wishes and an always‑on self‑badge, with an explicit “Continue as guest” path; fixes join deadlocks and “Unknown profile”.

- **New Features**
  - Added `participantProfiles` with `participants: [{ name, profile }]` (dedup with `equals()`); exposed on output; participants strip and header chip render badges from STORED links; guests show as chips.
  - Resolved `#profile`/`#profileName`/`#profileAvatar` at the top level and passed `profile`/`profileName`/`profileAvatar`/`profileSetupUI` into `ParticipantIdentityCard`; profile-backed joins write the live cell; the card exposes `profileName`.

- **Bug Fixes**
  - Bound badges to STORED links in static JSX and added a top‑level self‑badge to prime profile resolution, keeping identity stable across profile switches and preventing blanking.
  - Made option ids vote‑aware and removed `joinedAt`; updated docs (`DEPLOY-AND-SHARE.md`) to include `participantProfiles` and integration tests to click `#lp-guest-button` for the typed‑name path.

<sup>Written for commit 7fafd327d54a9869e28602dd6601f5a47bcd5079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

