### PR TITLE
Reorganize cf-harness documentation

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -107,6 +107,8 @@ One line per archived document; each document's header carries the fuller
 
 ### Executed plans and work orders
 
+- [cf-harness implementation plan](packages/cf-harness/docs/IMPLEMENTATION_PLAN.md)
+  — April 2026 package bootstrap plan and implementation checkpoint.
 - [2026-03-17-ct-exec-fuse-callables.md](plans/2026-03-17-ct-exec-fuse-callables.md)
   and [its test plan](plans/2026-03-17-ct-exec-fuse-callables-test-plan.md) —
   `cf exec` and mounted callable files.
@@ -199,6 +201,8 @@ One line per archived document; each document's header carries the fuller
 
 ### Investigations, journals, and working notes
 
+- [cf-harness Loom migration notes](packages/cf-harness/docs/LOOM_MIGRATION_NOTES.md)
+  — April 2026 pre-integration assessment of Loom's Codex batch and interactive paths.
 - [bug3-suggestion-alias-verification-2026-07.md](packages/patterns/bug3-suggestion-alias-verification-2026-07.md)
   — verification that the December 2025 survey's Bug 3 (Counter values
   rendering as raw `$alias` objects when instantiated via `fetchAndRunPattern`)

--- a/docs/history/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/history/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
@@ -1,3 +1,11 @@
+---
+status: historical
+created: 2026-04-17
+archived: 2026-07-22
+reason: "Executed package bootstrap plan; the implementation and product integrations have advanced beyond its staged checkpoint."
+superseded-by: packages/cf-harness/docs/CURRENT_STATE.md
+---
+
 # cf-harness Implementation Plan
 
 This document is the checked-in package-local implementation plan for
@@ -35,7 +43,7 @@ Current Loom migration judgment:
 See also:
 
 - [LOOM_MIGRATION_NOTES.md](LOOM_MIGRATION_NOTES.md)
-- [SKILLS_SUPPORT_SPEC.md](SKILLS_SUPPORT_SPEC.md)
+- [SKILLS_SUPPORT_SPEC.md](../../../../../packages/cf-harness/docs/SKILLS_SUPPORT_SPEC.md)
 
 ## Design Principles
 
@@ -81,15 +89,15 @@ The package already includes:
 
 ### Stage A: Package skeleton and contracts
 
-- package scaffold under [packages/cf-harness](..)
-- package exports and tasks in [deno.jsonc](../deno.jsonc)
+- package scaffold under [packages/cf-harness](../../../../../packages/cf-harness)
+- package exports and tasks in [deno.jsonc](../../../../../packages/cf-harness/deno.jsonc)
 - initial contract surfaces:
-  - [prompt-slot.ts](../src/contracts/prompt-slot.ts)
-  - [run-manifest.ts](../src/contracts/run-manifest.ts)
-  - [observation.ts](../src/contracts/observation.ts)
-  - [policy.ts](../src/contracts/policy.ts)
-  - [transcript.ts](../src/contracts/transcript.ts)
-  - [tool-result.ts](../src/contracts/tool-result.ts)
+  - [prompt-slot.ts](../../../../../packages/cf-harness/src/contracts/prompt-slot.ts)
+  - [run-manifest.ts](../../../../../packages/cf-harness/src/contracts/run-manifest.ts)
+  - [observation.ts](../../../../../packages/cf-harness/src/contracts/observation.ts)
+  - [policy.ts](../../../../../packages/cf-harness/src/contracts/policy.ts)
+  - [transcript.ts](../../../../../packages/cf-harness/src/contracts/transcript.ts)
+  - [tool-result.ts](../../../../../packages/cf-harness/src/contracts/tool-result.ts)
 
 Why this was done first:
 
@@ -97,9 +105,9 @@ Why this was done first:
 
 ### Stage B: Execution core
 
-- sandbox adapter in [src/sandbox](../src/sandbox)
-- engine in [engine.ts](../src/engine.ts)
-- built-in tool implementations in [src/tools](../src/tools)
+- sandbox adapter in [src/sandbox](../../../../../packages/cf-harness/src/sandbox)
+- engine in [engine.ts](../../../../../packages/cf-harness/src/engine.ts)
+- built-in tool implementations in [src/tools](../../../../../packages/cf-harness/src/tools)
 
 Why:
 
@@ -108,9 +116,9 @@ Why:
 
 ### Stage C: Prompt/tool loop
 
-- bounded prompt loop in [prompt-loop.ts](../src/prompt-loop.ts)
+- bounded prompt loop in [prompt-loop.ts](../../../../../packages/cf-harness/src/prompt-loop.ts)
 - OpenAI-compatible client in
-  [openai-client.ts](../src/gateway/openai-client.ts)
+  [openai-client.ts](../../../../../packages/cf-harness/src/gateway/openai-client.ts)
 
 Why:
 
@@ -119,8 +127,8 @@ Why:
 
 ### Stage D: Persistence and resumability
 
-- artifact store in [artifacts.ts](../src/artifacts.ts)
-- run-state tracking in [run-state.ts](../src/run-state.ts)
+- artifact store in [artifacts.ts](../../../../../packages/cf-harness/src/artifacts.ts)
+- run-state tracking in [run-state.ts](../../../../../packages/cf-harness/src/run-state.ts)
 - retained Loom run manifest artifacts
 - transcript-based resume support in the prompt loop and CLI
 
@@ -131,8 +139,8 @@ Why:
 
 ### Stage E: Operator CLI
 
-- package-local CLI in [cli.ts](../src/cli.ts)
-- entrypoint in [main.ts](../src/main.ts)
+- package-local CLI in [cli.ts](../../../../../packages/cf-harness/src/cli.ts)
+- entrypoint in [main.ts](../../../../../packages/cf-harness/src/main.ts)
 
 Why:
 
@@ -320,7 +328,7 @@ Why:
 
 See the package-local spec:
 
-- [SKILLS_SUPPORT_SPEC.md](SKILLS_SUPPORT_SPEC.md)
+- [SKILLS_SUPPORT_SPEC.md](../../../../../packages/cf-harness/docs/SKILLS_SUPPORT_SPEC.md)
 
 ## Current Verified State
 
@@ -451,14 +459,14 @@ The remaining subagent work is still substantial:
 
 For a new engineer or agent:
 
-1. [README.md](../README.md)
-2. [config.ts](../src/config.ts)
-3. [engine.ts](../src/engine.ts)
-4. [prompt-loop.ts](../src/prompt-loop.ts)
-5. [cli.ts](../src/cli.ts)
-6. [integration/engine.integration.test.ts](../integration/engine.integration.test.ts)
+1. [README.md](../../../../../packages/cf-harness/README.md)
+2. [config.ts](../../../../../packages/cf-harness/src/config.ts)
+3. [engine.ts](../../../../../packages/cf-harness/src/engine.ts)
+4. [prompt-loop.ts](../../../../../packages/cf-harness/src/prompt-loop.ts)
+5. [cli.ts](../../../../../packages/cf-harness/src/cli.ts)
+6. [integration/engine.integration.test.ts](../../../../../packages/cf-harness/integration/engine.integration.test.ts)
 
 For the broader architectural context:
 
-- [runner README](../../runner/README.md)
+- [runner README](../../../../../packages/runner/README.md)
 - `specs/cfc/18-runtime-implementation-profiles.md` in the sibling `specs` repo

--- a/docs/history/packages/cf-harness/docs/LOOM_MIGRATION_NOTES.md
+++ b/docs/history/packages/cf-harness/docs/LOOM_MIGRATION_NOTES.md
@@ -1,3 +1,11 @@
+---
+status: historical
+created: 2026-04-17
+archived: 2026-07-22
+reason: "Pre-integration assessment; Loom now has batch and opt-in interactive cf-harness adapters."
+superseded-by: packages/cf-harness/docs/CURRENT_STATE.md
+---
+
 # Loom Migration Notes
 
 This note captures the current understanding of how Loom uses Codex today and

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -4,10 +4,17 @@
 built as a general Common Fabric agent runtime, with Loom as the first target
 use case.
 
-The package is intentionally early and experimental. It already has a real
-execution core, a bounded prompt/tool loop, persistence, resumability, a thin
-operator CLI, explicit Agent Skills preload, and the first pass of CFC-aware
+The package is experimental but already integrated into Loom and Pattern
+Factory. It has a real execution core, bounded batch and interactive prompt/tool
+loops, durable artifacts and resumability, an operator CLI, explicit Agent
+Skills support, constrained delegation profiles, and CFC-aware mediation and
 deny/recovery shaping.
+
+For a concise status and lifecycle-aware documentation map, start with
+[docs/README.md](docs/README.md) and
+[docs/CURRENT_STATE.md](docs/CURRENT_STATE.md). The package's draft conformance
+claim is in [docs/IMPLEMENTATION_PROFILE.md](docs/IMPLEMENTATION_PROFILE.md);
+remaining work is in [docs/ROADMAP.md](docs/ROADMAP.md).
 
 ## Why This Exists
 
@@ -667,7 +674,11 @@ export CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR="$HOME/.local/share/runsc-cfc
 
 ## Related Docs
 
-- [IMPLEMENTATION_PLAN.md](docs/IMPLEMENTATION_PLAN.md)
-- [LOOM_MIGRATION_NOTES.md](docs/LOOM_MIGRATION_NOTES.md)
+- [cf-harness documentation map](docs/README.md)
+- [current implementation state](docs/CURRENT_STATE.md)
+- [Agent Harness implementation profile](docs/IMPLEMENTATION_PROFILE.md)
+- [roadmap](docs/ROADMAP.md)
+- [skills support design and contract](docs/SKILLS_SUPPORT_SPEC.md)
 - [runner README](../runner/README.md)
+- `specs/agent-harness/` in the sibling `specs` repo
 - `specs/cfc/18-runtime-implementation-profiles.md` in the sibling `specs` repo

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -1,0 +1,121 @@
+# cf-harness Current State
+
+Status: current implementation reference\
+Last verified: 2026-07-22
+
+`cf-harness` is an experimental but product-integrated Common Fabric agent
+runtime. Loom is its first product adapter and Pattern Factory is its first
+multi-phase orchestration adapter.
+
+## Architecture
+
+The runtime has four main boundaries:
+
+1. The caller supplies prompt-slot roles, model and gateway configuration,
+   tools, child profiles, mounts, resource bounds, skills, policy mode, and
+   optional structured-result schemas.
+2. The prompt loop performs bounded OpenAI-compatible model turns and invokes
+   only the configured tool/profile surface.
+3. Tool execution uses Docker with a configurable runtime, normally `runsc-cfc`.
+   The browser child is the exceptional host-adjacent profile and is constrained
+   to a leased local CDP endpoint and a narrow command policy.
+4. The artifact store records run state, transcript, reports, capability and
+   policy snapshots, tool outputs, child references, skills provenance, and
+   optional product run manifests.
+
+The Common Fabric runner or another trusted mediator owns authoritative CFC
+meaning. The harness transports prompt-slot and invocation evidence, applies the
+selected exposure/side-effect policy, and records its decisions. It does not ask
+the model to make policy decisions.
+
+## Supported surfaces
+
+The current package provides:
+
+- batch CLI execution with bounded model turns and optional streamed events;
+- machine-readable capability discovery with `--describe-capabilities`;
+- workspace, Fabric, and explicit host mounts with path containment;
+- sandboxed shell, file, image, web-fetch, skills, edit/write, and delegation
+  tools;
+- one child at a time through `default`, `browser`, `web_fetch`, and
+  `web_search` profiles;
+- schema-validated, sanitized child returns with raw child evidence retained
+  outside the ordinary parent return channel;
+- image inputs and structured top-level batch results;
+- explicit skill preload, indexed supporting-resource reads, and exact
+  allowlisted Deno/Bash skill scripts;
+- transcript-based resume and durable run artifacts;
+- interactive NDJSON stdio sessions with optional SQLite session, turn, event,
+  replay, cancellation, and restore state;
+- CFC modes `disabled`, `observe`, `enforce-explicit`, and `enforce-strict`,
+  plus prompt-slot, invocation-context, policy-event, and model-influence
+  evidence.
+
+Run the capability probe instead of copying this list into adapters:
+
+```bash
+deno task run -- --describe-capabilities
+```
+
+## Product integrations
+
+### Loom
+
+Loom's batch adapter dynamically probes capabilities, constructs a run manifest,
+creates a narrow temporary workspace, supplies explicit mounts and skills,
+requests structured capture results, and retains reviewable run artifacts.
+Autonomous wish dispatch currently routes through `cf-harness` when Loom's Page
+authority prerequisites are considered available.
+
+Loom also has an opt-in adapter for the interactive NDJSON protocol. It is not
+the default interactive harness, and browser automation is not yet wired into
+that interactive product path.
+
+Loom currently forces autonomous `cf-harness` runs to `observe` mode while
+trusted `runsc-cfc` observation metadata is not wired through every local tool
+path. This is a product-integration deviation, not the package default.
+
+### Pattern Factory
+
+Pattern Factory runs each supported phase as a separate batch invocation. The
+launcher owns phase ordering, validation, bounded critic/manual-test repair
+passes, and finalization; `cf-harness` owns the phase-local model/tool loop and
+evidence. All default Pattern Factory phase profiles currently use CFC `observe`
+mode.
+
+## Known limitations
+
+- End-to-end runner-owned CFC mediation is incomplete in the current product
+  integrations; enforcing modes therefore cannot yet replace their `observe`
+  bridges.
+- Capability discovery does not prove that Docker, `runsc-cfc`, a browser lease,
+  or another external dependency is healthy. Callers must perform dependency
+  preflight for workflows that require them.
+- Package-default sandbox networking is a provisional bridge-oriented posture,
+  not the final destination policy model. Product adapters may narrow it.
+- Delegation is serial: only one child runs at a time.
+- Model-driven dynamic skill activation is not implemented. Skills are
+  explicitly preloaded by the caller; child skills are profile-controlled.
+- Resume is transcript-oriented and does not recover an arbitrary partially
+  executed tool or orchestration state machine.
+- Raw operator artifacts use filesystem paths. Parent-visible child returns are
+  sanitized, but a future opaque artifact-handle layer would further reduce path
+  and placement coupling.
+
+## Verification
+
+Package behavior is covered by the unit suite:
+
+```bash
+deno task test
+```
+
+Real sandbox/CFC paths are separately environment-gated:
+
+```bash
+deno task test:integration
+```
+
+Product adapters maintain their own contract and cancellation tests; package
+tests alone are not evidence that Docker, Browser Access, or a live product
+instance is healthy.

--- a/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
@@ -1,0 +1,108 @@
+# cf-harness Implementation Profile
+
+Status: draft conformance statement\
+Profile date: 2026-07-22
+
+This document describes `@commonfabric/cf-harness` against the draft Common
+Fabric
+[Agent Harness specifications](https://github.com/commontoolsinc/specs/tree/main/agent-harness).
+It is deliberately more conservative than the feature list: protocol presence
+does not imply full conformance or external dependency health.
+
+## Claimed classes
+
+| Class         | Status                                                     | Evidence boundary                                                                                                                                                                                      |
+| ------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Core batch    | implemented; provisional conformance                       | Package unit tests cover configuration, lifecycle, tools, containment, artifacts, resume, and diagnostics. Real Docker/runtime behavior requires integration tests.                                    |
+| Delegation    | implemented; experimental                                  | Unit tests cover profiles, fresh child context, retained child artifacts, and sanitized/structured return handling. Only serial single-child orchestration is supported.                               |
+| Interactive   | implemented; experimental                                  | NDJSON v1 and SQLite-backed sessions/turns/events/replay are covered by package and Loom adapter tests. The protocol is not yet declared stable.                                                       |
+| CFC transport | partial; reduced assurance in current product integrations | Prompt-slot, invocation-context, model-influence, mediation, and deny/recovery behavior are tested. Loom and Pattern Factory still select `observe` because trusted mediation is not wired end to end. |
+
+## Capability discovery
+
+The machine-readable probe is:
+
+```bash
+deno task run -- --describe-capabilities
+```
+
+It reports CLI fields, repeatable fields, parent and built-in tools, child
+profiles, native model tools, and optional features. Adapters should use this
+probe to handle vendor skew.
+
+The probe does not health-check Docker, the selected Docker runtime, Browser
+Access, a model gateway, or configured mount sources. This is a known deviation
+from `AH-CAP-4` when a caller treats advertised capability as readiness. The
+retirement condition is a caller-visible dependency preflight contract that
+checks every dependency required by the selected run profile before the first
+model turn.
+
+## Trust and execution profile
+
+- Model gateway: OpenAI-compatible chat completions, with optional native model
+  tools declared separately.
+- Execution substrate: Docker; normally the sibling gVisor `runsc-cfc` runtime,
+  with configurable image and runtime.
+- CFC authority: Common Fabric runner/runtime evidence and trusted sandbox
+  sidecars. Harness-local policy logic is conservative transport/enforcement,
+  not the source of label meaning.
+- Host execution: unavailable to parent runs. The browser child profile exposes
+  only a constrained host command/script policy bound to an explicit local CDP
+  lease.
+- Network: explicit in configuration but still provisional. Sandboxed `bash`
+  applies a direct-`curl` destination guard; `web_fetch` and web child profiles
+  have their own bounded request policies.
+- Artifacts: retained under an explicit artifact root and reserved from normal
+  workspace discovery when the roots overlap.
+
+## Parent and child surfaces
+
+Current selectable parent tools are `bash`, `read_file`, `view_image`,
+`web_fetch`, `read_skill_resource`, `run_skill_script`, `edit_file`,
+`write_file`, and `delegate_task`. Individual runs receive only their configured
+subset; `web_fetch` and `run_skill_script` are not in the ordinary default
+surface. `bash-no-sandbox` exists only as a built-in used by authorized child
+profiles and cannot be selected as a parent CLI tool.
+
+Current child profiles are `default`, `browser`, `web_fetch`, and `web_search`.
+Each profile supplies an exact tool/network/skill policy. Parent skills and
+authority do not transfer implicitly.
+
+## Lifecycle and evidence
+
+Runs have stable identifiers and persist run-state, transcript, report,
+capability, policy, tool, skill, and child evidence. Signal handling
+terminalizes the active run. Product wrappers that create additional process
+groups are responsible for forwarding cancellation and reaping the complete
+owned group; Loom's batch wrapper implements and tests that integration
+boundary.
+
+Resume preserves recorded transcript/run configuration and rejects unsupported
+new inputs such as image or skill changes. It is not a general recovery system
+for an in-flight external side effect.
+
+## CFC deviations and retirement conditions
+
+1. **Product `observe` bridges.** Loom and Pattern Factory select `observe` for
+   workflows whose sandbox output does not yet carry trusted mediation metadata
+   end to end. Owners: the respective product adapters plus the cf-harness/CFC
+   integration. Retirement: real sidecar evidence is present for every exposed
+   observation and enforcing-mode adapter suites pass without opaque-output
+   regressions.
+2. **Provisional network policy.** Package-default bridge networking and the
+   shell `curl` guard are integration mechanisms, not a complete destination
+   capability system. Retirement: network authority is represented and enforced
+   as an explicit profile across sandbox and dedicated web tools.
+3. **Filesystem artifact references.** Operator reports may expose raw artifact
+   paths. Retirement: parent/model channels use opaque handles with an explicit
+   release/readback step while operator tooling retains resolvable provenance.
+
+## Test evidence
+
+- `deno task test` — package contract suite.
+- `deno task test:integration` — environment-gated real `runsc-cfc` paths.
+- Loom `tests/harness/` and dispatch tests — capability skew, commands,
+  cancellation, mounts, structured results, interactive translation, and run
+  review.
+- Pattern Factory launcher tests and phase smokes — phase ownership, validation,
+  repair routing, skills, browser leases, and finalization.

--- a/packages/cf-harness/docs/README.md
+++ b/packages/cf-harness/docs/README.md
@@ -1,0 +1,37 @@
+# cf-harness Documentation
+
+This directory contains live documentation for the current `cf-harness`
+implementation. The repository-wide lifecycle rules in
+[`../../../docs/README.md`](../../../docs/README.md) apply here: current
+reference and intended designs stay live; completed plans and point-in-time
+migration notes live under `docs/history/` at the repository root.
+
+## Start here
+
+- [Package README](../README.md) — operator entry point, commands, and detailed
+  feature reference.
+- [CURRENT_STATE.md](CURRENT_STATE.md) — concise current architecture,
+  integrations, and known gaps.
+- [IMPLEMENTATION_PROFILE.md](IMPLEMENTATION_PROFILE.md) — conformance statement
+  against the cross-repository Agent Harness specification.
+- [ROADMAP.md](ROADMAP.md) — remaining work only; shipped milestones are not
+  repeated as a plan.
+- [SKILLS_SUPPORT_SPEC.md](SKILLS_SUPPORT_SPEC.md) — live
+  implementation-specific skills contract and future dynamic-activation design.
+
+## Normative boundary
+
+The implementation-independent runtime and CFC contracts live in the sibling
+`specs` repository under `agent-harness/`. This package owns exact CLI flags,
+tools, profiles, schemas, defaults, artifacts, and deviations. Loom and Pattern
+Factory own their adapter and rollout behavior.
+
+## Historical records
+
+- [`IMPLEMENTATION_PLAN.md`](../../../docs/history/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md)
+  — the April 2026 package bootstrap plan and checkpoint.
+- [`LOOM_MIGRATION_NOTES.md`](../../../docs/history/packages/cf-harness/docs/LOOM_MIGRATION_NOTES.md)
+  — the April 2026 pre-integration assessment of Loom's Codex paths.
+
+Historical documents are useful background, not descriptions of the current
+system.

--- a/packages/cf-harness/docs/ROADMAP.md
+++ b/packages/cf-harness/docs/ROADMAP.md
@@ -1,0 +1,62 @@
+# cf-harness Roadmap
+
+Status: live, non-normative\
+Last reviewed: 2026-07-22
+
+This document lists remaining work. Shipped milestones belong in
+[CURRENT_STATE.md](CURRENT_STATE.md), tests, and history rather than in a
+permanently growing implementation plan.
+
+## 1. Complete the CFC transport boundary
+
+- Carry trusted observation metadata from `runsc-cfc`/runner mediation through
+  every tool path used by Loom and Pattern Factory.
+- Exercise `enforce-explicit` in product adapter tests without losing ordinary
+  tool observations.
+- Remove the product `observe` bridges only after those suites prove the full
+  path and retained run evidence explains every release/denial.
+- Keep prompt-slot evidence, model-context influence, invocation inputs, and
+  side-effect authorization distinct.
+
+## 2. Make dependency readiness contractual
+
+- Add a preflight surface for Docker daemon, selected runtime, sandbox image,
+  model gateway, mounts, Browser Access lease, and trusted CFC sidecar paths.
+- Let product adapters reject a run before its first model turn when a required
+  dependency is unavailable.
+- Keep capability discovery deterministic and side-effect free; report health
+  separately rather than overloading capability presence.
+
+## 3. Stabilize the interactive protocol
+
+- Version and document the NDJSON request/response/event schemas as a supported
+  compatibility surface.
+- Finish product-level browser support and define any allowed turn concurrency.
+- Expand crash/reconnect and cancellation integration tests before making the
+  Loom adapter generally available.
+
+## 4. Tighten delegation and artifacts
+
+- Replace parent/model-facing raw artifact paths with opaque handles and an
+  explicit release/readback mechanism.
+- Decide whether parallel children are a product requirement; if so, specify
+  scheduling, budget, cancellation, event ordering, and context isolation before
+  implementing them.
+- Extend resume only where external side-effect replay semantics can be made
+  explicit and testable.
+
+## 5. Evolve skills only from concrete needs
+
+- Keep explicit caller preload and profile-scoped child skills as the stable
+  path.
+- Add model-driven `load_skill` activation only when a product needs it and the
+  catalog, policy, digest, resume, and subagent semantics are agreed.
+- Do not add remote/global skill installation before provenance and trust policy
+  are explicit.
+
+## Exit discipline
+
+When a roadmap item ships, update the current reference and conformance profile,
+add test evidence, and remove it from this file. If a proposed direction is
+abandoned or superseded, preserve the decision as a historical record instead of
+leaving a stale “next step” in live documentation.

--- a/packages/cf-harness/docs/SKILLS_SUPPORT_SPEC.md
+++ b/packages/cf-harness/docs/SKILLS_SUPPORT_SPEC.md
@@ -1,19 +1,20 @@
-# cf-harness Skills Support Spec
+# cf-harness Skills Support Design and Contract
 
 Date: 2026-04-30
 
+Status: live implementation-specific contract; future sections are non-normative
+
 ## Purpose
 
-Add first-class Agent Skills support to `cf-harness` so Common Fabric product
+Define first-class Agent Skills support in `cf-harness` so Common Fabric product
 workflows can supply durable, task-specific operating knowledge without stuffing
 large documentation bundles into every prompt.
 
 The near-term motivating case is Pattern Factory. Its Claude and Codex paths
 depend heavily on repo-local skills such as `pattern-dev`, `pattern-implement`,
 `pattern-ui`, `pattern-test`, `pattern-critic`, `agent-browser`, and `cf`. The
-current `cf-harness` Pattern Factory build smoke does not have comparable skill
-support, so it lacks the implementation guidance that existing runtimes use to
-reach acceptable quality.
+`cf-harness` now supplies those skills to Pattern Factory through explicit,
+phase-owned preload and profile-scoped child policy.
 
 This spec defines a supported path for skill discovery, activation, provenance,
 and CFC-aware handling in `cf-harness`.
@@ -38,11 +39,10 @@ and `description`, then point to canonical repo docs. Examples:
   `docs/common/ai/pattern-testing-guide.md`.
 - `skills/cf/SKILL.md` provides current CLI command guidance.
 
-`cf-harness` now uses `skillsRoot?: string` in `src/config.ts` for explicit
-skill preload. The CLI, prompt loop, and artifact store persist the discovered
-registry and activation artifacts. The registry is also being extended to
-snapshot supporting resources that are actually present in the configured skill
-directories at run start.
+`cf-harness` uses `skillsRoot?: string` in `src/config.ts` for explicit skill
+preload. The CLI, prompt loop, and artifact store persist the discovered
+registry and activation artifacts. The registry snapshots supporting resources
+that are present in the configured skill directories at run start.
 
 ## External Models Reviewed
 
@@ -107,7 +107,7 @@ metadata and container path. See
 - Managing user-global skill directories outside an explicitly configured root.
 - Running skill scripts automatically or without an exact operator allowlist.
 - Treating `allowed-tools` as a permission grant.
-- Full Pattern Factory fulfillment in the same slice.
+- Defining Pattern Factory's general orchestration or fulfillment contract.
 - Implementing a broad filesystem discovery tool as a prerequisite.
 
 ## Skill Compatibility Contract
@@ -147,8 +147,8 @@ Validation should be lenient where that improves compatibility:
 
 ## Supporting Resource Index
 
-Supporting resources should be discovered automatically from the filesystem at
-runtime. Normal skills should not need a hand-authored resource manifest.
+Supporting resources are discovered automatically from the filesystem at
+runtime. Normal skills do not need a hand-authored resource manifest.
 
 At run start, `cf-harness` should snapshot every accepted skill directory and
 record a resource index inside `skill-registry.json`. This index is bounded by
@@ -175,7 +175,7 @@ Each resource record should include:
 - diagnostics
 - for `scripts/**`: executable bit, shebang when present, and inferred runtime
 
-Resource discovery must:
+Resource discovery:
 
 - skip the root `SKILL.md`
 - sort paths deterministically
@@ -316,13 +316,13 @@ before model exposure.
 
 ## CLI and Config Surface
 
-Use the existing config field:
+The current config field is:
 
 ```ts
 skillsRoot?: string;
 ```
 
-Add CLI flags:
+The current CLI flags are:
 
 ```text
 --skills-root <path>      Skill root containing <name>/SKILL.md
@@ -331,7 +331,7 @@ Add CLI flags:
 --no-skill-catalog        Disable automatic skill catalog disclosure
 ```
 
-Recommended v1 behavior:
+Current v1 behavior:
 
 - If `--skills-root` is absent, skills are disabled.
 - `--skills-root` must resolve within `--workspace` unless a future trusted
@@ -348,15 +348,12 @@ Recommended v1 behavior:
 Do not auto-discover user-global skill roots in the first slice. That keeps the
 trust boundary simple and avoids host-specific behavior in batch/product runs.
 
-## First Implementation Slice
+## Explicit Preload
 
-The first slice should implement explicit skill preloading, not fully dynamic
-model-driven activation.
-
-Status: implemented for package CLI runs. The harness now scans an explicitly
-configured `--skills-root`, accepts repeatable `--skill` preload names, injects
-the selected `SKILL.md` files as configured context before the task prompt, and
-persists `skill-registry.json` and `skill-activations.json`.
+Status: implemented. The harness scans an explicitly configured `--skills-root`,
+accepts repeatable `--skill` preload names, injects the selected `SKILL.md`
+files as configured context before the task prompt, and persists
+`skill-registry.json` and `skill-activations.json`.
 
 This is enough for Pattern Factory to invoke `cf-harness` with phase-relevant
 skills:
@@ -605,24 +602,24 @@ receive additional raw context through the return channel.
 
 ## Pattern Factory Wiring
 
-Pattern Factory should not depend on model-driven skill selection in the first
-slice. Its launcher already knows the phase, so it can pass explicit skills.
+Pattern Factory does not depend on model-driven skill selection. Its launcher
+knows the phase and passes exact skills.
 
-Recommended initial mapping:
+The default mapping is:
 
-| Phase         | Explicit skills                                                                |
-| ------------- | ------------------------------------------------------------------------------ |
-| `spec`        | none initially, possibly future `pattern-dev` if specs need framework concepts |
-| `ux_design`   | none initially, or future design-specific skill if one is created              |
-| `ui_design`   | `pattern-ui`                                                                   |
-| `build`       | `pattern-dev`, `pattern-implement`, `cf`                                       |
-| `critic`      | `pattern-critic`                                                               |
-| `manual_test` | `pattern-test`, `agent-browser`, `cf`                                          |
+| Phase         | Explicit skills                                                                                                             |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `spec`        | none                                                                                                                        |
+| `ux_design`   | none                                                                                                                        |
+| `ui_design`   | `pattern-ui`, `lit-component`                                                                                               |
+| `build`       | `pattern-dev`, `pattern-schema`, `pattern-implement`, `pattern-test`, `pattern-debug`, `pattern-ui`, `cf`, `pattern-deploy` |
+| `critic`      | `pattern-critic`, `pattern-dev`, `pattern-test`, `pattern-debug`, `pattern-ui`                                              |
+| `manual_test` | `agent-browser`, `cf`, `pattern-deploy`, `pattern-debug`, `pattern-test`                                                    |
+| `grade`       | none                                                                                                                        |
+| `summarize`   | none                                                                                                                        |
 
-The build phase is the immediate beneficiary. It should receive `pattern-dev`,
-`pattern-implement`, and likely `cf`, while still keeping parent tools narrow.
-The skill text can point the model to exact docs; the harness can provide
-`read_file` and `write_file` without granting broad `bash`.
+The launcher keeps phase tools separate from skill content. Loading a skill does
+not grant `bash`, file writes, browser access, or script execution.
 
 For Pattern Factory's symlinked layout, prefer passing the canonical labs root:
 
@@ -638,73 +635,36 @@ The harness should expose sandbox paths in injected text, for example:
 
 This avoids ambiguity between host paths and sandbox paths.
 
-## Implementation Plan
+## Delivery Status
 
-### Slice 1: Explicit Skill Preload
-
-- Add `src/skills/registry.ts` for scanning, frontmatter parsing, validation,
-  and digesting.
-- Add `src/contracts/skill.ts` for registry and activation artifacts.
-- Add CLI flags `--skills-root`, `--skill`, and `--no-skill-catalog`.
-- Thread `skillsRoot` and explicit skills through config and prompt loop setup.
-- Inject explicit skill context blocks before the task prompt.
-- Persist `skill-registry.json` and `skill-activations.json`.
-- Add unit tests for parsing, traversal, symlink containment, duplicates, and
-  CLI parsing.
-
-### Slice 2: Pattern Factory Build Wiring
-
-- Pass `--skills-root` and explicit build skills from Pattern Factory's
-  `cf-harness` build phase.
-- Keep parent tool allowance at `read_file write_file`.
-- Re-run a local build smoke and compare output quality against the previous
-  no-skills attempt.
-
-### Slice 3: Dynamic `load_skill` Tool
-
-- Register `load_skill` only when a valid skill catalog exists.
-- Put available skills in the tool description or system catalog.
-- Return full `SKILL.md` content and supporting file lists on demand.
-- Add activation dedupe and transcript/resume behavior.
-
-### Slice 4: Subagent Skill Policy
-
-- Add optional `skills` to `delegate_task`.
-- Add profile-level allowed skill patterns.
-- Record child skill activations in child artifacts.
-- Keep parent return channel summary-only.
-
-### Slice 5: Richer Policy
-
-- Interpret `allowed-tools` as an optional narrowing rule.
-- Add user-level or organization-level skill roots if product needs them.
-- Add remote skill bundle installation only after trust and provenance policy is
-  explicit.
+| Capability                                                                          | Status                                                     |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Explicit skill root, discovery, preload, registry, activation, and resume artifacts | implemented                                                |
+| Indexed supporting-resource reads                                                   | implemented                                                |
+| Exact allowlisted sandbox Deno/Bash skill scripts                                   | implemented                                                |
+| Profile-scoped host skill scripts for the leased browser child                      | implemented                                                |
+| Pattern Factory phase-specific skills                                               | implemented                                                |
+| Explicit child-profile skill policy and summary-only parent return                  | implemented                                                |
+| Model-driven dynamic `load_skill` activation                                        | not implemented; future design above                       |
+| User/global/remote skill installation                                               | not planned without a product requirement and trust design |
 
 ## Open Questions
 
 - Should `--skills-root` accept multiple roots now, or stay singular until a
   concrete product need appears?
-- Should explicit `--skill` preload include raw frontmatter, or strip
-  frontmatter after parsing? Raw full-file loading is simpler and preserves
-  compatibility metadata; stripped body is cleaner.
 - In batch resume, should skill digest drift fail closed by default? This spec
   recommends yes, but operator mode might prefer a warning.
-- Should `allowed-tools` be enforced as a narrowing rule in slice 1, or left
-  advisory until dynamic activation exists?
-- Should Pattern Factory's `ui_design` phase receive `pattern-ui` immediately,
-  or wait until build quality is recovered first?
+- What stable policy vocabulary should govern model-driven catalog visibility
+  before a `load_skill` tool is added?
+- If multiple roots are ever supported, how should precedence, duplicate names,
+  and trust tiers be represented in artifacts?
 
-## Recommendation
+## Current Direction
 
-Pause further Pattern Factory build orchestration until `cf-harness` can preload
-explicit skills.
-
-Implement Slice 1 in `labs` first. Then wire only the Pattern Factory build
-phase to pass explicit skills and repeat the local smoke. This should improve
-build output quality without expanding the parent tool surface or committing to
-full model-driven skill discovery before the core provenance and CFC semantics
-are in place.
+Keep explicit caller preload as the stable product path. Add dynamic
+model-driven activation only in response to a concrete workflow that cannot
+select skills at the adapter boundary, and only after catalog visibility,
+provenance, resume, and child-policy semantics are specified and tested.
 
 [agent-skills-spec]: https://agentskills.io/specification
 [agent-skills-client]: https://agentskills.io/client-implementation/adding-skills-support


### PR DESCRIPTION
## Why

cf-harness documentation mixed current behavior, aspirational design, and completed migration plans in one directory. That made it hard to tell what was authoritative and made renewed implementation work riskier than it needed to be.

## What changed

- add a documentation index with explicit current, normative, roadmap, and historical categories
- capture the current implementation state and an implementation conformance profile
- move superseded implementation and Loom migration plans into the labs history tree
- rewrite the skills support document around the behavior that is implemented today
- update the package README and history index to point to the new structure

This is a documentation-only change; it does not alter cf-harness behavior.

## Documentation series

- [specs #17 — shared agent harness specification](https://github.com/commontoolsinc/specs/pull/17)
- [labs #4929 — cf-harness documentation lifecycle](https://github.com/commontoolsinc/labs/pull/4929)
- [loom #4266 — current cf-harness integration](https://github.com/commontoolsinc/loom/pull/4266)
- [pattern-factory #55 — adapter documentation](https://github.com/commontoolsinc/pattern-factory/pull/55)

## Validation

- `deno task check-docs` — all 518 checked code blocks passed
- local Markdown link-target audit
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787357779&installation_model_id=428580&pr_number=4929&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4929&signature=69fcb594de0044588f6ba79dece140a0c9f23f53aeeba7fa06d12bbbd56862dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->