### PR TITLE
fix(cf-code-editor): route remote title-change pill rewrites through …

### DIFF
--- a/packages/patterns/integration/cf-code-editor.test.ts
+++ b/packages/patterns/integration/cf-code-editor.test.ts
@@ -1238,6 +1238,167 @@ describe("cf-code-editor cursor stability", () => {
   });
 });
 
+describe("cf-code-editor backlink title sync", () => {
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
+
+  let identity: Identity;
+  let cc: PiecesController;
+  let piece: PieceController;
+  let sinkCancel: (() => void) | undefined;
+  // The piece's committed content value, tracked by the result-cell sink below,
+  // and a one-shot waiter the sink resolves when the value reaches a target.
+  let latestContent: string | undefined;
+  let contentWaiter: { target: string; deferred: Deferred } | undefined;
+
+  // Resolve once the committed content equals `target`. A browser-side value-
+  // cell write reaches this controller asynchronously, so read the value
+  // through this waiter rather than a bare get(), which can still return the
+  // pre-write value.
+  const awaitCellContent = (target: string): Promise<void> => {
+    if (latestContent === target) return Promise.resolve();
+    const deferred = defer();
+    contentWaiter = { target, deferred };
+    return deferred.promise;
+  };
+
+  beforeAll(async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+    cc = await initializePiecesController({
+      spaceName: SPACE_NAME,
+      apiUrl: new URL(API_URL),
+      identity,
+    });
+    piece = await cc.create(
+      await Deno.readTextFile(
+        join(import.meta.dirname!, "..", "examples", "cf-code-editor-cell.tsx"),
+      ),
+      { start: true },
+    );
+
+    await cc.acl().set(ANYONE_USER, "WRITE");
+
+    // Keep the piece reactive (pull mode) and track its committed content, so a
+    // browser-side write to the value cell is observed here.
+    const resultCell = cc.manager().getResult(piece.getCell());
+    sinkCancel = resultCell.sink((value) => {
+      latestContent = (value as { content?: string } | undefined)?.content;
+      if (contentWaiter && latestContent === contentWaiter.target) {
+        contentWaiter.deferred.resolve();
+        contentWaiter = undefined;
+      }
+    });
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: SPACE_NAME, pieceId: piece.id },
+      identity,
+    });
+    await waitForCondition(shell.page(), editorReady);
+  });
+
+  afterAll(async () => {
+    sinkCancel?.();
+    if (cc) await cc.dispose();
+  });
+
+  // The linked piece's real title is not synced to the editor's runtime in
+  // these tests: the editor's mentionable projection carries only NAME, so a
+  // cross-document linked piece's title only reaches the editor inside the full
+  // default-app. The remote rename is instead delivered by invoking the
+  // editor's own _handleExternalTitleChange with a stand-in piece cell whose
+  // title and NAME are the renamed values, exactly what a real title
+  // subscription would call.
+
+  it("preserves a remote title change over a pending local edit in the debounce window", async () => {
+    const page = shell.page();
+    const pieceId = "backlink-debounce-piece";
+    const pill = `[[📝 Target (${pieceId})]]`;
+    const renamedPill = `[[📝 New Target (${pieceId})]]`;
+
+    // A very long debounce parks the typed edit so nothing commits on its own
+    // timer; the test controls when it flushes (via blur).
+    await configureTiming(page, { strategy: "debounce", delay: 100000 });
+
+    await piece.result.set(pill, ["content"]);
+    await waitForEditorContent(page, pill);
+
+    // Begin a local edit: append a character after the pill. Its Cell write
+    // stays parked in the debounce window — nothing commits yet.
+    await focusEditor(page);
+    await setCursorPosition(page, pill.length);
+    await page.keyboard.type("X");
+    await waitForEditorContent(page, `${pill}X`);
+
+    // The linked piece is renamed while the local edit is pending.
+    assert(
+      await invokeExternalTitleChange(
+        page,
+        pieceId,
+        "New Target",
+        "📝 New Target",
+      ),
+      "editor did not expose _handleExternalTitleChange",
+    );
+
+    // Flush any pending debounced write by blurring, then let it reach storage.
+    await blurEditor(page);
+    await waitForRuntimeSynced(page);
+    await awaitViewSettled(page);
+
+    // The editor and the committed cell converge on one value. Wait for the
+    // committed cell to catch up to the editor's document, then assert that
+    // value carries BOTH the remote title change and the pending local edit.
+    // The rewrite must merge with the pending edit; otherwise the flushed
+    // keystroke buffer commits last and reverts the title to `📝 Target`.
+    const editorContent = await getEditorContent(page);
+    await awaitCellContent(editorContent);
+    assertEquals(
+      editorContent,
+      `${renamedPill}X`,
+      "Debounced write overwrote the remote title change with a stale buffer",
+    );
+  });
+
+  it("persists a remote title change under the blur strategy without user interaction", async () => {
+    const page = shell.page();
+    const pieceId = "backlink-blur-piece";
+    const pill = `[[📝 Target (${pieceId})]]`;
+    const renamedPill = `[[📝 New Target (${pieceId})]]`;
+
+    // Under the blur strategy a user edit commits only on blur. A remote title
+    // change is not user input: it must persist even though the editor is never
+    // focused or blurred in this test.
+    await configureTiming(page, { strategy: "blur" });
+
+    await piece.result.set(pill, ["content"]);
+    await waitForEditorContent(page, pill);
+
+    // Deliver the remote rename with no focus, typing, or blur.
+    assert(
+      await invokeExternalTitleChange(
+        page,
+        pieceId,
+        "New Target",
+        "📝 New Target",
+      ),
+      "editor did not expose _handleExternalTitleChange",
+    );
+    await waitForRuntimeSynced(page);
+
+    // The rewrite must reach the committed cell on its own. Without the flush it
+    // would sit in controller state awaiting a focus/blur cycle that never
+    // comes, and this wait would never resolve.
+    await awaitCellContent(renamedPill);
+    const editorContent = await getEditorContent(page);
+    assertEquals(
+      editorContent,
+      renamedPill,
+      "Editor should show the renamed pill under the blur strategy",
+    );
+  });
+});
+
 /**
  * Get current cursor position in the cf-code-editor
  */
@@ -1322,6 +1483,106 @@ async function focusEditor(page: Page): Promise<void> {
       }
     })()
   `);
+}
+
+/**
+ * Blur the CodeMirror editor, flushing any pending debounced Cell write.
+ */
+async function blurEditor(page: Page): Promise<void> {
+  await page.evaluate(`
+    (() => {
+      function findCfCodeEditor(root) {
+        if (!root) return null;
+        const editor = root.querySelector?.('cf-code-editor');
+        if (editor) return editor;
+        const allElements = root.querySelectorAll?.('*') || [];
+        for (const el of allElements) {
+          if (el.shadowRoot) {
+            const found = findCfCodeEditor(el.shadowRoot);
+            if (found) return found;
+          }
+        }
+        return null;
+      }
+
+      const cfEditor = findCfCodeEditor(document);
+      if (cfEditor && cfEditor._editorView) {
+        cfEditor._editorView.contentDOM.blur();
+      }
+    })()
+  `);
+}
+
+/**
+ * Set the editor's input-timing strategy (and optional delay) at runtime.
+ */
+async function configureTiming(
+  page: Page,
+  options: { strategy: string; delay?: number },
+): Promise<void> {
+  await page.evaluate(`
+    ((options) => {
+      function findCfCodeEditor(root) {
+        if (!root) return null;
+        const editor = root.querySelector?.('cf-code-editor');
+        if (editor) return editor;
+        const allElements = root.querySelectorAll?.('*') || [];
+        for (const el of allElements) {
+          if (el.shadowRoot) {
+            const found = findCfCodeEditor(el.shadowRoot);
+            if (found) return found;
+          }
+        }
+        return null;
+      }
+
+      const cfEditor = findCfCodeEditor(document);
+      if (cfEditor && cfEditor._cellController) {
+        cfEditor._cellController.updateTimingOptions(options);
+      }
+    })(${JSON.stringify(options)})
+  `);
+}
+
+/**
+ * Invoke the editor's remote-title-change handler with a stand-in piece cell:
+ * key('title') returns the raw title and any other key (the NAME symbol)
+ * returns the display name, exactly what a real piece-title subscription
+ * delivers. Returns false if the handler is not exposed.
+ */
+async function invokeExternalTitleChange(
+  page: Page,
+  pieceId: string,
+  title: string,
+  name: string,
+): Promise<boolean> {
+  return await page.evaluate(`
+    ((id, title, name) => {
+      function findCfCodeEditor(root) {
+        if (!root) return null;
+        const editor = root.querySelector?.('cf-code-editor');
+        if (editor) return editor;
+        const allElements = root.querySelectorAll?.('*') || [];
+        for (const el of allElements) {
+          if (el.shadowRoot) {
+            const found = findCfCodeEditor(el.shadowRoot);
+            if (found) return found;
+          }
+        }
+        return null;
+      }
+
+      const ed = findCfCodeEditor(document);
+      if (!ed || typeof ed._handleExternalTitleChange !== 'function') return false;
+      const renamed = {
+        key: (k) => ({ get: () => k === 'title' ? title : name }),
+      };
+      ed._handleExternalTitleChange(id, renamed);
+      return true;
+    })(${JSON.stringify(pieceId)}, ${JSON.stringify(title)}, ${
+    JSON.stringify(name)
+  })
+  `) as boolean;
 }
 
 /**

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -1735,11 +1735,16 @@ export class CFCodeEditor extends BaseElement {
       annotations: CFCodeEditor._cellSyncAnnotation.of(true),
     });
 
-    // Update Cell value IMMEDIATELY (bypass debounce) so Cell sync doesn't revert
+    // Record the rewrite as a local edit through the CellController so it merges
+    // with any pending debounced edit and the controller's pending-edit view
+    // stays consistent with the document. Then flush: this is a remote change,
+    // not user input, so it must persist without waiting on the input-timing
+    // strategy — the blur strategy would otherwise hold it until the next
+    // focus/blur cycle, and a rewrite that arrives while the editor is
+    // unfocused would never be written.
     const newDocValue = this._editorView.state.doc.toString();
-    if (isCellHandle(this.value)) {
-      this.value.set(newDocValue);
-    }
+    this.setValue(newDocValue);
+    this._cellController.flush();
   }
 
   /**


### PR DESCRIPTION
…the CellController

When a linked piece's title changes remotely, the editor rewrites the backlink pill text in the document and then has to persist the new document. It did this by writing the document straight to the bound value cell with a raw set(), bypassing the CellController that mediates every other edit.

That raw write is incoherent with the CellController's pending-local-edit tracking. The pill rewrite reaches the document through a cell-sync-annotated dispatch, which makes the editor's update listener skip its usual setValue call. So while the user is mid-typing — inside the debounce window, with a pending local edit still holding the pre-rename keystroke buffer — the rewrite never updates that buffer. Two failures follow:

- Lost update. The pending debounced write later fires with the stale pre-rename buffer and overwrites the title rewrite the raw set() just committed. The typed edit survives; the remote title change is reverted.
- Tracking divergence. The raw set() updates none of the controller's state, so a delivery of the new value is classified against the stale pending edit and suppressed, and the editor's own cell-sync handler repaints the stale buffer back over the rewritten pill.

Record the rewrite through the component's setValue instead of a raw cell set(). The rewrite becomes a local edit, so it merges with any pending edit and both commit through the same debounced write. The controller's pending-edit view stays consistent with the document, so no stale delivery is misclassified and no repaint reverts the pill. With no pending edit the rewrite commits on the next debounce tick rather than immediately; the pill text is derived from the piece's name, so it re-syncs on the next load regardless.

Add an integration test that pins the merged outcome: a backlink pill in the document, a pending local edit inside the debounce window, and a remote title change. The committed content must carry both the new title and the pending edit. A cross-document linked piece's title is not synced to the editor's runtime outside the full default-app, so the rename is delivered by invoking the same handler a real title subscription would, with a stand-in piece cell.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787358196&installation_model_id=428580&pr_number=4930&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4930&signature=9ae0d778791e298f0fac3637bfc3d597d4077c27d04dfb5b7498ec23becaaa72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `cf-code-editor` where a remote backlink title rename could be reverted by a pending debounced local edit. The rewrite now goes through `setValue` and is flushed via the `CellController`, so it merges with in‑flight edits and persists immediately, including under the `blur` strategy.

- **Bug Fixes**
  - Route pill rewrite through component `setValue` (not raw cell `set()`), merging with any pending debounced edit.
  - Flush the `CellController` after the rewrite so the remote change persists without focus/blur, regardless of timing strategy.
  - Integration tests cover debounce‑merge and blur‑no‑interaction paths using `cf-code-editor-cell`, setting timing at runtime, and invoking `_handleExternalTitleChange` with a stand‑in piece cell.

<sup>Written for commit f6b44463d78eaf208016801edc30a385e2183462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

