### PR TITLE
fix(runner): drop wrong-base fallback in collectResumeOwnedCells (CT-1897)

### DIFF
--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -393,7 +393,7 @@ function sendValueToBindingInner<T>(
  *
  * @param cfc - The ContextualFlowControl object, which we need to get the schema at sub-paths
  * @param binding - The binding to unwrap.
- * @param argumentCellLink - The link to the argument cell
+ * @param argumentCellLink - The link to the argument cell or undefined if not available.
  * @param resultCell - The result cell used to resolve result aliases
  * @param options - Optional configuration.
  * @param options.targetSchema - Schema for the binding being produced. Source
@@ -404,7 +404,7 @@ function sendValueToBindingInner<T>(
 export function unwrapOneLevelAndBindtoDoc<T, U>(
   cfc: ContextualFlowControl,
   binding: T,
-  argumentCellLink: NormalizedFullLink,
+  argumentCellLink: NormalizedFullLink | undefined,
   resultCell: AnyCell<unknown>,
   options?: UnwrapOneLevelOptions,
 ): T {
@@ -465,13 +465,16 @@ export function unwrapOneLevelAndBindtoDoc<T, U>(
         );
       } else {
         // Resolve the special values for "argument" and "result".
+        if (alias.cell !== "argument" && alias.cell !== "result") {
+          throw new Error("Invalid pseudo-alias cell: " + alias.cell);
+        }
         const link = alias.cell === "argument"
           ? argumentCellLink
-          : alias.cell === "result"
-          ? resultCellLink
-          : undefined;
+          : resultCellLink;
         if (link === undefined) {
-          throw new Error("Invalid pseudo-alias cell: " + alias.cell);
+          throw new Error(
+            "Cannot bind argument alias: no argument cell link available",
+          );
         }
         const path = alias.path;
         // we might have a schema in the alias, but if not, we may have one

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -464,10 +464,8 @@ export function unwrapOneLevelAndBindtoDoc<T, U>(
           { includeSchema: true, overwrite: "redirect" },
         );
       } else {
-        // Resolve the special values for "argument" and "result".
-        if (alias.cell !== "argument" && alias.cell !== "result") {
-          throw new Error("Invalid pseudo-alias cell: " + alias.cell);
-        }
+        // Resolve the special values for "argument" and "result" — the only
+        // `cell` values isAliasBinding admits.
         const link = alias.cell === "argument"
           ? argumentCellLink
           : resultCellLink;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2697,8 +2697,10 @@ export class Runner {
     // findAllWriteRedirectCells itself only walks sigil links. Without the
     // argument meta link the bindings cannot be bound, so the node walk is
     // skipped — the pre-sync is best-effort, and binding against a substitute
-    // document would pre-sync the wrong cells (see CT-1897 for the same
-    // defaulting bug in collectResumeOwnedCells).
+    // document would pre-sync the wrong cells (CT-1897). Skipping wholesale is
+    // right here because node inputs nearly always alias the argument doc;
+    // collectResumeOwnedCells instead passes the possibly-missing link through
+    // and skips per-node, since sub-pattern outputs rarely alias it.
     const argumentMetaLink = getMetaLink(resultCell, "argument");
     if (argumentMetaLink === undefined) {
       // Instrumentation for how often the meta link is missing here (fresh
@@ -2899,6 +2901,15 @@ export class Runner {
       out.push(getDerivedInternalCell(resultCell, descriptor));
     }
 
+    // May be undefined: this walk runs before setup writes the meta on fresh
+    // first runs, and child result cells are not synced yet on a cold-cache
+    // resume. That is fine for binding — unwrapOneLevelAndBindtoDoc only needs
+    // the argument link when an output actually aliases the argument doc, and
+    // throws otherwise. Substituting a different document instead would derive
+    // the wrong `resultFor` identity and pre-sync the wrong owned-cell subtree
+    // (CT-1897).
+    const argumentLink = getMetaLink(resultCell, "argument");
+
     for (const node of pattern.nodes) {
       const module = node.module;
       if (module.type !== "pattern" || !isPattern(module.implementation)) {
@@ -2916,16 +2927,14 @@ export class Runner {
       // resolved spot yields the same `resultFor` identity the child's setup
       // mints; the unresolved head of a multi-hop binding would be a different
       // cell, pre-syncing the wrong owned-cell subtree.
-      const argumentLink = getMetaLink(resultCell, "argument") ??
-        resultCell.getAsNormalizedFullLink();
-      const unwrappedOutputs = unwrapOneLevelAndBindtoDoc(
-        this.runtime.cfc,
-        node.outputs,
-        argumentLink,
-        resultCell,
-      );
       let spotLink: NormalizedFullLink | undefined;
       try {
+        const unwrappedOutputs = unwrapOneLevelAndBindtoDoc(
+          this.runtime.cfc,
+          node.outputs,
+          argumentLink,
+          resultCell,
+        );
         spotLink = firstResolvedOutputRedirect(
           this.runtime,
           tx,
@@ -2933,11 +2942,12 @@ export class Runner {
           resultCell,
         );
       } catch (error) {
-        // A node shape that cannot be resolved contributes nothing rather than
-        // breaking the resume walk; log it so a resume that silently skips its
-        // owned-cell pre-sync is diagnosable.
+        // A node whose outputs cannot be bound (e.g. they alias the argument
+        // doc while the argument link is unavailable) or resolved contributes
+        // nothing rather than breaking the resume walk; log it so a resume
+        // that silently skips its owned-cell pre-sync is diagnosable.
         logger.warn("resume-owned-cells", () => [
-          "skipping a sub-pattern node whose output redirect did not resolve",
+          "skipping a sub-pattern node whose outputs did not bind or resolve",
           error,
         ]);
         continue;

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -362,6 +362,52 @@ describe("pattern-binding", () => {
       ).toBe(true);
     });
 
+    it("binds result aliases without an argument link", () => {
+      // collectResumeOwnedCells passes an undefined argument link when the
+      // argument meta is not yet written (fresh run) or not yet synced (cold
+      // resume); bindings that never touch the argument must still unwrap.
+      const binding = {
+        y: { $alias: { cell: "result", path: ["b"] } },
+        z: 3,
+      };
+      const resultCell = runtime.getCell<{ b: number }>(
+        space,
+        "no argument link result cell",
+        undefined,
+        tx,
+      );
+      const result = unwrapOneLevelAndBindtoDoc(
+        runtime.cfc,
+        binding,
+        undefined,
+        resultCell,
+      );
+      expect(
+        areLinksSame(result.y, resultCell.key("b").getAsWriteRedirectLink()),
+      ).toBe(true);
+      expect(result.z).toBe(3);
+    });
+
+    it("throws when an argument alias binds without an argument link", () => {
+      const binding = {
+        y: { $alias: { cell: "argument", path: ["b"] } },
+      };
+      const resultCell = runtime.getCell<{ b: number }>(
+        space,
+        "missing argument link result cell",
+        undefined,
+        tx,
+      );
+      expect(() =>
+        unwrapOneLevelAndBindtoDoc(
+          runtime.cfc,
+          binding,
+          undefined,
+          resultCell,
+        )
+      ).toThrow("Cannot bind argument alias: no argument cell link available");
+    });
+
     it("uses the argument link schema when converting aliases", () => {
       const profileSchema = {
         type: "object",


### PR DESCRIPTION
## Summary

`collectResumeOwnedCells` defaulted a missing argument meta link to the result cell's own link before binding sub-pattern node outputs. Binding against that substitute document resolves the wrong output spot, derives the wrong `resultFor` identity, and pre-syncs the wrong owned-cell subtree — silently losing the pre-sync for the real child on exactly the cold-resume path the walk exists for. This is the same defaulting bug the node pre-sync in `syncCellsForRunningPatternInner` was already fixed for (CT-1897); this site kept the substitute.

## How often the fallback fired

Instrumentation across the suites showed it fires routinely:
- Every fresh `runSynced` of a pattern with sub-pattern nodes hits it at every nesting level, because the pre-setup sync at `runner.ts` runs before setup writes the argument meta (observed at depths 1–4 via `home-add-favorite.test.ts`, 15 hits per unit-suite run).
- Cold-cache resumes can hit it at depth ≥ 1, because child result cells are not synced before the walk and `getMetaLink` is a synchronous local read.

## Fix

Handle it one level down: pass the possibly-undefined meta link straight to `unwrapOneLevelAndBindtoDoc`, which already accepts `undefined` and only needs the link when an output actually aliases the argument doc. Nodes that do alias it throw and are skipped per-node by the existing catch — with a distinct "Cannot bind argument alias: no argument cell link available" error replacing the misleading "Invalid pseudo-alias cell" for this case. The common case — sub-pattern outputs that never touch the argument — keeps its pre-sync.

Instrumented counts with the fix in place: all 15 missing-link unwraps in the unit suite bind successfully; the throw fired **zero** times across the unit and runner-integration suites. It is a purely defensive guard for argument-aliased outputs, which don't occur in the current corpus.

## Testing

- Full runner unit suite: 1006 passed, 0 failed
- `runner` integration suite (local servers): passed
- `patterns-reload` integration suite (resume-focused): passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787365372&installation_model_id=428580&pr_number=4934&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4934&signature=5c75673e8d315f6d44c45969e2a5ec306a5e12c66386ed24e5dc6d39bfd3f4a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the resume-owned-cells walk using a wrong fallback base when the argument meta link is missing, preventing incorrect `resultFor` identities and lost pre-syncs. Implements CT-1897 by skipping only nodes that truly require the missing link.

- **Bug Fixes**
  - In `collectResumeOwnedCells`, removed the fallback that substituted the result cell’s link; pass the possibly-missing argument link to `unwrapOneLevelAndBindtoDoc` so only argument-aliased nodes are skipped and others pre-sync normally.
  - `unwrapOneLevelAndBindtoDoc` throws a clear "Cannot bind argument alias: no argument cell link available" only when an output aliases the argument doc; updated logging to "skipping a sub-pattern node whose outputs did not bind or resolve".

- **Refactors**
  - Deleted unreachable "Invalid pseudo-alias cell" branch in `unwrapOneLevelAndBindtoDoc`; added tests to pin result-alias/constant behavior and the missing-argument-link throw.

<sup>Written for commit cda11ab81c52561ebc7a00394d1026480c3d4d54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

