### PR TITLE
fix(ci): wait for Toolshed before package integration

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -418,6 +418,11 @@ jobs:
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
           ./common-binaries/toolshed --port="$TOOLSHED_PORT" &
 
+      - name: ⏳ Wait for Toolshed to be ready
+        uses: ./.github/actions/wait-for-toolshed
+        with:
+          url: http://localhost:8000
+
       # For Astral
       # https://github.com/lino-levan/astral/blob/f5ef833b2c5bde3783564a6b925073d5d46bb4b8/README.md#no-usable-sandbox-with-user-namespace-cloning-enabled
       - name: 🛡️ Disable AppArmor restriction for browser tests


### PR DESCRIPTION
## What

- gate the package integration matrix on the existing Toolshed `/_health` readiness action
- start runner, runtime-client, and shell package integration tests only after the local Toolshed server is accepting requests

## Why

The package integration job starts Toolshed in the background and immediately advances to test setup. On a cold Blacksmith runner, Toolshed may still be downloading `libsqlite3.so` when the runtime-client suite begins, causing an initial wave of `Could not connect to "http://localhost:8000/"` failures.

This exact race failed the first attempt of main run 29979650105 and the immediately preceding main run 29977357197. Re-running the unchanged commit passed once Toolshed started quickly. Other integration jobs already use the shared `wait-for-toolshed` action; this brings the package matrix in line with them.

## Impact

No product behavior changes. CI waits for a healthy Toolshed process instead of relying on startup timing. A genuine startup failure now reports a focused readiness error after the action's bounded timeout rather than cascading through runtime-client assertions.

## Verification

- `deno fmt --check .github/workflows/deno.yml`
- `git diff --check`
- confirmed `.github/actions/wait-for-toolshed/action.yml` polls `/_health` with a 60-second default timeout
- compared failed and successful attempts of run 29979650105; only the successful attempt reached `Server running` before tests started

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787374167&installation_model_id=428580&pr_number=4935&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4935&signature=b0b515ecf01fbca18c42e3b1c76b6f9ed8e93d2f3e6ff1439aac61af6dc01664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI now waits for the local Toolshed server to report healthy before starting package integration tests. Adds a `./.github/actions/wait-for-toolshed` step (polls `/_health`, 60s default) to prevent startup race failures on cold runners.

<sup>Written for commit 0763cffc7c382c1ea8db3dac2b6e5dae67839c30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

