### PR TITLE
fix(runner,patterns): scope CFC additive-required-default to durable data (estuary home heal) — proposal + partial

### DIFF
--- a/docs/development/proposals/cfc-additive-required-durable-data-scope.md
+++ b/docs/development/proposals/cfc-additive-required-durable-data-scope.md
@@ -1,0 +1,72 @@
+# Scope CFC's additive-required-default rule to durable document data
+
+*CFC refuses to materialize a newer pattern over an older stored document when the new schema adds a required field with no default. That guard is meant to protect real document data from vanishing — but it currently fires on fields that hold no document data at all (handler streams, framework projection keys), which makes evolving a system pattern silently brick every older-vintage stored doc. Scope the invariant to durable data.*
+
+**Status:** proposed · needs sign-off from the CFC invariant owners (**@seefeldb**, **@mathpirate**) before the rule change lands · **Updated:** 2026-07-23
+
+Grew out of the live Estuary "home space is bricked" incident. Sits behind the deployed heal chain: #4900 / #4926 (cold-start setup repair) and #4933 (data-field defaults). This is the next — and we believe more general — layer.
+
+---
+
+## Why
+
+Estuary home spaces are bricked for existing users but **fine for a fresh identity**. That asymmetry is the whole tell: a brand-new home materializes cleanly, but an *existing* home root — a stored document written by some older vintage of `home.tsx` — fails when the current `home.tsx` is materialized over it during the cold-start setup repair.
+
+The failure is CFC enforcement rejecting the setup commit:
+
+```
+CFC enforcement rejected commit: relevant transaction was not prepared:
+required field <name> needs a default to preserve old documents
+(cfc-relevant-transaction-not-prepared)
+```
+
+thrown from `mergeRequired` in `packages/runner/src/cfc/schema-merge.ts`. The rule: when merging a candidate (new) schema over a stored (old) one, **any field that is required in the candidate, absent-and-not-required in the stored doc, and carries no `default`** is rejected — because an old document that predates the field would have no value for it and the merge cannot synthesize one.
+
+That rule is correct *for durable document data*. The bug is that it applies to **every** required field, including fields that hold no preservable data:
+
+- **Handler streams** (`asCell: ["stream"]`) — a stream is a runtime-materialized capability marker, not stored data. Pattern setup re-creates every stream on each run, so an old doc that lacks one has nothing to preserve and there is no meaningful default a `Stream<…>` could ever declare. A handler-rich pattern like `home.tsx` therefore **cannot** be healed field-by-field: give every data field a `Default<>` and the guard just advances to the first handler stream, which by construction can't have one.
+- **Framework projection keys** (`$NAME` / `$UI`) — same category: injected by the runtime, not document data.
+
+Because the check fails on the *first* offending field and every user's home is a different vintage, this presents as a **moving target**: favorites for one stored doc, `defaultProfile` for another, a handler stream for a third. It is not one bug with one field — it is an **over-broad invariant that makes any system-pattern evolution brick every older stored document**, one field at a time, until the rule is scoped correctly.
+
+## The two defects
+
+This incident exposed two distinct mechanisms that both produce "additive required field with no default." A complete fix names both.
+
+1. **The invariant over-applies to non-data fields.** Streams and framework keys are required in the emitted schema but hold no preservable document data. The additive-required-default guard should not consider them. *(This proposal's core change.)*
+
+2. **Authors cannot tell which fields are "required" from the type.** `defaultProfile: TrustedDefaultProfile` where `TrustedDefaultProfile = PickerProfileLink<…> | undefined` was emitted **required** — because the schema-generator derives `required` from the absence of a `?` optional marker (`schema-generator.ts`: `if (!member.questionToken) required.push(propName)`), *not* from `| undefined` in the value type. So a field the author intended as optional silently became required-with-no-default and bricked the vintages that lacked it. Fix at the author site (`defaultProfile?`), and consider having the schema-generator treat a `| undefined` value type as optional so this class can't recur silently.
+
+## Proposed change
+
+Scope `mergeRequired`'s additive-required-default requirement to **durable document data**:
+
+- Exempt stream slots (`asCell: ["stream"]`) — a stream has no old value to preserve and no default it could carry. *(Implemented in the accompanying PR: an `isStreamSlot` guard that `continue`s past the default check.)*
+- Optionally extend the same exemption to the framework projection keys (`NAME` / `UI` from `builder/types.ts`). Deferred in the PR as a deliberate scope boundary — a *real* home always carries them, so only a fully-degenerate synthetic doc trips them — but it belongs in the same conceptual bucket and the owners should decide whether to include it.
+- Keep the negative case intact: an additive-required **plain data** field without a default still throws (verified in the PR's unit pin).
+
+The emitted schemas do not change; only the merge-time invariant is scoped. It does not touch authorization: the additive-required-default rule is a *data-preservation* check, not a `writeAuthorizedBy`/`ifc` check, so exempting non-data fields removes no authorization guarantee. (Validated against the CFC/writer/profile safety suite — see PR.)
+
+## Does anyone have to recreate their space?
+
+For every failure mode we have observed: **no.** The fields that fail are all *new* — absent from the old doc — so there is no data conflict and nothing to discard. The heal mechanism already exists (#4926's cold-start repair re-runs setup in place), and setup's data-seeding is guarded (`materializeDerivedInternalCells`: fills only manifest-missing cells with `currentValue === undefined`) so it never overwrites a user's existing favorites/profiles. Once the invariant is scoped correctly, materialization over an old vintage succeeds and the home heals **in place, on next load, with no recreation and no data loss** — for everyone, regardless of version.
+
+The only thing that would force a recreate is a genuinely *incompatible* stored state — real data that cannot map to the current schema, or a corrupted doc. We have **zero evidence** of that; everything observed is the healable "missing new field" kind.
+
+## This is not proven complete — the acceptance criterion
+
+We have peeled four "last" layers in this incident (compile → `$stream` marker → CFC additive-required → …). We should not declare this the final one by reasoning alone. Two specific gaps:
+
+- One vintage's exact throw (`favorites`, on the incident reporter's own home) **could not be reproduced locally** — current `home.tsx` over a synthetic pre-favorites doc defaults favorites cleanly and advances to `defaultProfile`. So there is at least one mechanism we do not yet understand for that specific stored doc (candidate for a production-compile / durable-compile-cache / `eagerSourceAnnotation=false` difference — needs the actual stored schema to see).
+- The additive-required check is only *one* CFC invariant; others, or other setup steps, could reject some vintage we have not loaded.
+
+**Acceptance criterion:** a **population test** — take a corpus of real stored home-root schemas across vintages and materialize current `home.tsx` over each with CFC enforcement *on*, and enumerate which heal. That converts "are we chasing a moving target?" from a guess into a measured list, and is the signal that the scoped rule is *sufficient* rather than merely the next layer. This proposal should not be considered done until that test is green across the corpus.
+
+## The testing gap that let this through
+
+The cold-start repair harness (`packages/piece/test/check-update-default-pattern.test.ts`) runs with `cfcEnforcementMode: "disabled"`. That is why #4926 and #4933 passed their tests but failed in production against the enforcing runtime — the tests never exercised the layer that rejects the commit. The accompanying PR adds the first repro that runs enforcement **on** (`packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts`); the harness gap itself should be closed so future setup-over-old-doc changes are validated against enforcement by default.
+
+## What's landed / in flight
+
+- **Deployed to Estuary** (`67abf6131`): #4900, #4926, #4933.
+- **This PR** (draft, for review): the `isStreamSlot` exemption in `mergeRequired`, `defaultProfile?` at the author site, and the enforcement-on regression test. A concrete, validated *partial* — it fixes the stream and `defaultProfile` classes, but is explicitly **not** claimed to be the complete heal until the population test above is run.

--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -72,7 +72,7 @@ export type HomeOutput = {
   // surface; it only lets an old doc merge. defaultProfile needs none: it is
   // already `… | undefined`, hence not required.
   profiles: Default<TrustedProfileList, []>;
-  defaultProfile: TrustedDefaultProfile;
+  defaultProfile?: TrustedDefaultProfile;
   mru: Default<TrustedProfileMru, []>;
   createProfile: Stream<CreateProfileEvent>;
   addFavorite: Stream<{

--- a/packages/patterns/system/home.vintage-defaults.test.ts
+++ b/packages/patterns/system/home.vintage-defaults.test.ts
@@ -58,8 +58,16 @@ describe("estuary vintage-tolerance: home data fields carry defaults", () => {
     expect(home).toContain("mru: Default<TrustedProfileMru, []>");
   });
 
-  it("defaultProfile stays bare — already optional (| undefined), not required", () => {
-    expect(home).toContain("defaultProfile: TrustedDefaultProfile;");
+  // #4933 left defaultProfile as `defaultProfile: TrustedDefaultProfile;`
+  // believing its `… | undefined` value type made it non-required. It does
+  // NOT: the schema-generator decides `required` from the presence of a `?`
+  // optional marker (schema-generator.ts `if (!member.questionToken)`), not
+  // from the value type — so the bare spelling emitted defaultProfile as
+  // required-with-no-default and the cold-start repair threw on it, one layer
+  // past the six data fields above. The `?` is the fix that makes it genuinely
+  // optional (dropped from `required`), so no default is needed.
+  it("defaultProfile is optional (?) — the value-type-only assumption was wrong", () => {
+    expect(home).toContain("defaultProfile?: TrustedDefaultProfile;");
   });
 
   it("Default is imported (the spellings above are inert without it)", () => {

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -332,6 +332,13 @@ const assertNoDivergentIfcBranches = (
   }
 };
 
+// A stream slot (`asCell: ["stream"]`) is a runtime-materialized capability
+// marker, not stored document data — see the additive-required exemption in
+// `mergeRequired`.
+const isStreamSlot = (schema: JSONSchema | undefined): boolean =>
+  isRecord(schema) && Array.isArray(schema.asCell) &&
+  schema.asCell.includes("stream");
+
 const mergeRequired = (
   existing: readonly string[] | undefined,
   candidate: readonly string[] | undefined,
@@ -346,6 +353,21 @@ const mergeRequired = (
       continue;
     }
     const property = mergedProperties[name];
+    // A newly-required field must carry a default so an old document that
+    // predates the field can still be read (the default synthesizes the
+    // missing value). This guard is about PRESERVABLE DOCUMENT DATA, so it
+    // does not apply to a stream slot: `asCell: ["stream"]` is a
+    // runtime-materialized capability marker, not stored data. Pattern setup
+    // re-materializes every stream marker on each run, so an old doc that
+    // lacks one has no value to preserve and there is no meaningful default a
+    // `Stream<…>` field could declare. Without this exemption, materializing a
+    // handler-rich pattern (e.g. home.tsx) over a doc that predates its
+    // handlers fails additive-required — the estuary cold-start-setup-repair
+    // cascade, where each defaulted DATA field just unmasked the next
+    // required-no-default handler.
+    if (isStreamSlot(property)) {
+      continue;
+    }
     if (!isRecord(property) || property.default === undefined) {
       throw new Error(
         `required field ${name} needs a default to preserve old documents`,

--- a/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
+++ b/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
@@ -1,0 +1,199 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { mergeCfcSchemaEnvelopes } from "../src/cfc/schema-merge.ts";
+import { NAME, UI } from "../src/builder/types.ts";
+import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
+
+// Why: reproduces the live Estuary "home stays bricked" incident's next layer.
+// The cold-start-setup-repair materializes the real home pattern over a home
+// root doc that predates some of home's fields, and CFC schema-merge's
+// additive-required guard ("required field <name> needs a default to preserve
+// old documents") refuses the setup commit. #4933 defaulted the six DATA
+// fields (favorites/journal/spaces/defaultAppUrl/profiles/mru), but that only
+// advanced the rejection to the next required-no-default field: `defaultProfile`
+// (genuinely `… | undefined`, so it should be optional) and then the six
+// exported handler streams — which cannot carry a meaningful `Default<>` and
+// so cannot be healed the #4933 way.
+//
+// These tests run with CFC enforcement ON (the runtime default,
+// "enforce-explicit"); the piece cold-start harness runs with enforcement
+// disabled, which is why #4926/#4933's tests were blind to this layer.
+
+const alice = await Identity.fromPassphrase(
+  "cfc-additive-default-preserves-old-doc-alice",
+);
+
+const OWNER_WRITER = "system.legacy-home";
+
+const ownerProtectedString = (ownerDid: string): JSONSchema => ({
+  type: "string",
+  ifc: {
+    ownerPrincipal: ownerDid,
+    addIntegrity: [{ kind: "represents-principal", subject: ownerDid }],
+    writeAuthorizedBy: [OWNER_WRITER],
+  },
+});
+
+// A realistic pre-favorites home root: it once ran a home setup, so it carries
+// the primordial framework projection keys ($NAME/$UI) and an owner-protected
+// field (so the root is cfc-relevant / has stored CFC metadata), but it
+// predates favorites and the handlers that shipped with it — exactly the
+// vintage whose repair throws additive-required.
+const legacyHomeSchema = (ownerDid: string): JSONSchema => ({
+  type: "object",
+  properties: {
+    [NAME]: { type: "string" },
+    [UI]: { type: "unknown" },
+    owner: ownerProtectedString(ownerDid),
+  },
+  required: [NAME, UI, "owner"],
+});
+
+const compileHomePattern = async (
+  runtime: Runtime,
+  space: ReturnType<typeof alice.did>,
+) => {
+  const repoRoot = new URL("../../..", import.meta.url).pathname.replace(
+    /\/$/,
+    "",
+  );
+  const sourcePath = new URL(
+    "../../patterns/system/home.tsx",
+    import.meta.url,
+  ).pathname;
+  const program = await runtime.harness.resolve(
+    new FileSystemProgramResolver(sourcePath, repoRoot),
+  );
+  return await runtime.patternManager.compilePattern(program, { space });
+};
+
+describe("CFC additive-required default preserves old documents", () => {
+  // Tight pin on the guard itself: a newly-required STREAM slot must not need
+  // a default (a stream carries no preservable document value), while a plain
+  // newly-required data field still must. This isolates the schema-merge fix
+  // from the full home compile.
+  it("exempts an additive-required stream slot from the default requirement", () => {
+    const stored: JSONSchema = {
+      type: "object",
+      properties: { owner: { type: "string" } },
+      required: ["owner"],
+    };
+    const candidate: JSONSchema = {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        // A handler stream slot, exactly as the schema-generator emits home's
+        // exported handlers.
+        addFavorite: {
+          type: "object",
+          properties: {},
+          asCell: ["stream"],
+        },
+      },
+      required: ["owner", "addFavorite"],
+    };
+    // Before the fix this threw: "required field addFavorite needs a default".
+    const merged = mergeCfcSchemaEnvelopes(stored, candidate) as JSONSchemaObj;
+    expect(merged.required).toContain("addFavorite");
+  });
+
+  it("still rejects an additive-required plain data field without a default", () => {
+    const stored: JSONSchema = {
+      type: "object",
+      properties: { owner: { type: "string" } },
+      required: ["owner"],
+    };
+    const candidate: JSONSchema = {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        title: { type: "string" },
+      },
+      required: ["owner", "title"],
+    };
+    expect(() => mergeCfcSchemaEnvelopes(stored, candidate)).toThrow(
+      /required field title needs a default/,
+    );
+  });
+
+  // Faithful end-to-end: run the real home pattern's setup over a realistic
+  // old home root, with enforcement ON. Before the fix, the setup commit is
+  // rejected (defaultProfile, then the handler streams). After the fix it
+  // commits and the home heals.
+  it("materializes the real home pattern over a pre-favorites root under enforcement", async () => {
+    const storageManager = StorageManager.emulate({ as: alice });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+    const space = alice.did();
+    const ROOT = "legacy-home-root";
+    try {
+      // 1. Seed the "old" home root doc (with stored CFC metadata) lacking
+      //    favorites and the handlers.
+      {
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-explicit");
+        tx.setCfcTrustSnapshot({
+          id: `trust-${space}`,
+          actingPrincipal: space,
+        });
+        tx.setCfcImplementationIdentity({
+          kind: "builtin",
+          builtinId: OWNER_WRITER,
+        });
+        const cell = runtime.getCell(
+          space,
+          ROOT,
+          legacyHomeSchema(space),
+          tx,
+        );
+        cell.set({
+          [NAME]: "Legacy Home (pre-setup)",
+          [UI]: null,
+          owner: "alice",
+        });
+        const target = cell.getAsNormalizedFullLink();
+        tx.recordCfcWritePolicyInput({
+          kind: "trusted-event",
+          target: {
+            space: target.space,
+            scope: target.scope,
+            id: target.id,
+            path: ["owner"],
+          },
+          eventId: "seed-owner",
+          provenance: { origin: "dom", trusted: true },
+        });
+        tx.prepareCfc();
+        const res = await tx.commit();
+        expect(res.ok).toBeDefined();
+      }
+
+      // 2. Materialize the real home pattern over the SAME root cell
+      //    (enforce-explicit is the runtime default).
+      const homePattern = await compileHomePattern(runtime, space);
+      const resultCell = runtime.getCell(space, ROOT);
+      const home = await runtime.runSynced(resultCell, homePattern, {});
+      await home.pull();
+      await runtime.idle();
+
+      // Discriminator: the setup projection only overwrites the root's $NAME
+      // with the pattern's "Home" if its commit actually LANDED. When the
+      // additive-required guard rejects the commit, the transaction aborts and
+      // the seeded legacy name survives — so this assertion fails exactly when
+      // the setup was refused (the reproduced bricked-home behavior).
+      expect(home.key(NAME).get()).toBe("Home");
+      // And favorites materialized to its defaulted empty list.
+      const favorites = home.key("favorites");
+      expect(favorites.get() ?? []).toEqual([]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
> **Draft / for review — a proposal + a validated partial fix, not a merge-and-forget.** The invariant change needs sign-off from the CFC owners (@seefeldb, @mathpirate) before it lands.

## Why

Estuary home spaces are bricked for existing users but **fine for a fresh identity** — the tell that this is a schema-**evolution** problem over a heterogeneous population of old stored docs, not a single bug. When #4926's cold-start setup repair materializes current `home.tsx` over an older-vintage home root, CFC's `mergeRequired` rejects the commit: `required field <name> needs a default to preserve old documents` (`cfc-relevant-transaction-not-prepared`).

That guard protects durable document data. But it fires on **every** required field — including fields that hold no document data: **handler streams** (`asCell:["stream"]`, runtime-materialized capabilities re-created on every setup) and framework projection keys. A handler-rich pattern therefore **can't be healed field-by-field** — default every data field and the guard just advances to the first stream, which by construction can't carry one. Because it fails on the *first* offending field and every home is a different vintage, it presents as a **moving target** (favorites here, `defaultProfile` there, a stream elsewhere): an over-broad invariant that bricks any system-pattern evolution over old docs.

**Full rationale — the two defects, the recreate/no-recreate analysis, the population-test acceptance criterion, and the testing gap — is in the proposal doc in this PR:** `docs/development/proposals/cfc-additive-required-durable-data-scope.md`. Please read that; the summary below is the short version.

## What changed

- **`runner/cfc/schema-merge.ts`** — `mergeRequired` exempts stream slots from the additive-required-default requirement. A stream has no old value to preserve and no meaningful default. Plain data fields without a default still throw (negative case pinned). Emitted schemas unchanged; **no authorization guarantee touched** — this is a data-preservation check, not `writeAuthorizedBy`/`ifc`.
- **`patterns/system/home.tsx`** — `defaultProfile?`. It was emitted required-with-no-default because the schema-generator keys `required` off the `?` token, **not** the `| undefined` value type — a second, distinct source of the same symptom.
- **`runner/test/cfc-additive-default-preserves-old-doc.test.ts`** — the **first repro with CFC enforcement ON**, closing the gap that let #4926/#4933 pass (their harness runs `cfcEnforcementMode: "disabled"`).

## ⚠️ This is NOT the complete heal

Fixes the stream + `defaultProfile` classes. Explicitly **not** proven to heal every vintage:
- The incident reporter's exact `favorites` throw **could not be reproduced locally** — a synthetic pre-favorites doc defaults favorites cleanly. At least one vintage-specific mechanism remains unexplained (candidate: production-compile / durable-compile-cache / `eagerSourceAnnotation=false`; needs the real stored schema to diagnose).
- Additive-required is one CFC invariant; others may reject other vintages.

**Acceptance = the population test** (proposal §): materialize current `home.tsx` over a corpus of real stored home-root schemas with enforcement on, enumerate which heal. Don't treat this as done until that's green.

## Does anyone have to recreate their space?

For every failure mode observed: **no** — the failing fields are all *new* (absent from the old doc), so no data conflict, nothing to discard; the heal is in-place on next load, no data loss. Only a genuinely incompatible/corrupted stored state would force a recreate, and we have zero evidence of that. (Detail in the proposal.)

## Test plan

- Enforcement-on repro: 3 steps green (fails without the fix).
- CFC/writer/profile safety suite: 61 steps green.
- `deno check` / `fmt` / `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
