### PR TITLE
spike(storage): concurrent watch-refresh (default-off) — parallelize watch acquisition

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -43,6 +43,7 @@ was last checked against the code.
 | [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection) | `RuntimeOptions.cfcLabelMetadataProtection` | `off` | Bernhard Seefeld (#4638) | `observe` (divergence counting) first, then `enforce` | implemented, staged rollout |
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237) | keep as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative or neutral |
 | [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
+| [`experimentalConcurrentWatchRefresh`](#experimentalconcurrentwatchrefresh) | `IRemoteStorageProviderSettings` (runner mirrors it onto the session via `setConcurrentWatchRefresh()`) | off | Ben Follington (#4937) | graduate to always-on after live measurement, or remove if superseded | implemented behind the flag, off by default, not yet measured over real latency |
 | [`cfcRenderCeiling`](#cfcrenderceiling) | `commonfabric.cfcRenderCeiling()` in the browser (localStorage) | off | Bernhard Seefeld (#4550) | graduate once exchange resolution lands | implemented, off by default, dogfood only |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning) | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache` | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts | Ian Hickson | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked | implemented, on by default for FUSE-T, soak-validated |
 
@@ -601,6 +602,36 @@ the per-epic implementation notes).
 >   keeps its write gate failing closed. It was added by Bernhard Seefeld in
 >   "server-side commit-time row-label re-derivation (Epic E4, Phase 3.c)"
 >   (#4552). It is permanent.
+
+### `experimentalConcurrentWatchRefresh`
+
+- **Toggle via.** `experimentalConcurrentWatchRefresh` on
+  `IRemoteStorageProviderSettings`
+  ([`packages/runner/src/storage/interface.ts`](../../packages/runner/src/storage/interface.ts)),
+  passed through `StorageManager` settings. The runner mirrors it onto each
+  memory session via `SpaceSession.setConcurrentWatchRefresh()`
+  ([`packages/memory/v2/client.ts`](../../packages/memory/v2/client.ts)) —
+  per-session, not a process global.
+- **Added by.** Ben Follington (#4937).
+- **Purpose.** By default watch acquisition is strict single-flight per space: a
+  guard holds every watch refresh after the first until the prior response
+  lands, so traversal-driven pulls discovered a tick apart serialize into
+  one-round-trip-each frames even when nothing depends on the prior response. On
+  a high-RTT link this dominates cold-load wall-clock. With the flag on,
+  refreshes overlap up to a bounded window (`CONCURRENT_WATCH_REFRESH_WINDOW`,
+  currently 8) in `storage/v2.ts`, and the memory client issues the whole
+  watch-mutation family (`watch.set` + `watch.add`) in an ordered issue phase so
+  wire order is preserved and application stays ordered. Same-tick microtask
+  coalescing is unchanged.
+- **Current default and planned end state.** Off by default. It is a spike
+  pending live measurement on a real (estuary-latency) load; the window size is
+  a tuning value. End state is either graduation to always-on with a settled
+  window, or removal if the render-side fix (initial-render descent) makes the
+  waterfall shallow enough that concurrency no longer pays.
+- **Status.** Implemented behind the flag, off by default; not yet measured
+  end-to-end over real latency.
+- **Path to removal.** Graduate to always-on once measured safe and beneficial,
+  or remove if superseded by reducing the round-trip count at the source.
 
 ---
 

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -628,8 +628,8 @@ the per-epic implementation notes).
   a tuning value. End state is either graduation to always-on with a settled
   window, or removal if the render-side fix (initial-render descent) makes the
   waterfall shallow enough that concurrency no longer pays.
-- **Status.** Implemented behind the flag, off by default; not yet measured
-  end-to-end over real latency.
+- **Status on 2026-07-24.** Implemented behind the flag, off by default; not yet
+  measured end-to-end over real latency.
 - **Path to removal.** Graduate to always-on once measured safe and beneficial,
   or remove if superseded by reducing the round-trip count at the source.
 

--- a/packages/memory/test/v2-concurrent-watch-refresh-test.ts
+++ b/packages/memory/test/v2-concurrent-watch-refresh-test.ts
@@ -1,0 +1,146 @@
+/**
+ * Memory-client guarantees for `concurrentWatchRefresh` (set by the runner from
+ * the `experimentalConcurrentWatchRefresh` storage setting):
+ *
+ *  1. Wire order across the whole watch-mutation family is preserved — an eager
+ *     `watch.add` never overtakes an earlier `watch.set` (the bug the ordered
+ *     issue phase fixes).
+ *  2. Overlapping watch.adds through the REAL server all resolve, and later
+ *     mutations on every watched root are delivered.
+ *
+ * Event-driven (no wall-clock sleeps): a deterministic microtask drain settles
+ * the loopback pipeline.
+ */
+import { assertEquals } from "@std/assert";
+import { connect, loopback, type Transport } from "../v2/client.ts";
+import { Server } from "../v2/server.ts";
+import type { EntitySnapshot, WatchSpec } from "../v2.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
+
+async function drainMicrotasks(turns = 50): Promise<void> {
+  for (let i = 0; i < turns; i++) await Promise.resolve();
+}
+
+/** loopback transport that records the type of each client->server message. */
+function recordingLoopback(server: Server, wire: string[]): Transport {
+  const inner = loopback(server);
+  return {
+    send(payload: string) {
+      if (payload.includes('"session.watch.set"')) wire.push("watch.set");
+      else if (payload.includes('"session.watch.add"')) wire.push("watch.add");
+      return inner.send(payload);
+    },
+    close: () => inner.close(),
+    setReceiver: (r) => inner.setReceiver(r),
+    setCloseReceiver: (r) => inner.setCloseReceiver?.(r),
+  };
+}
+
+const rootSpec = (id: string): WatchSpec => ({
+  id,
+  kind: "graph",
+  query: { roots: [{ id, selector: { path: [], schema: false } }] },
+});
+
+Deno.test("concurrent refresh preserves wire order: watch.add never overtakes watch.set", async () => {
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://concurrent-refresh-order"),
+    subscriptionRefreshDelayMs: 0,
+  });
+  const wire: string[] = [];
+  const client = await connect({ transport: recordingLoopback(server, wire) });
+  const space = "did:key:z6Mk-concurrent-refresh-order";
+  const session = await client.mount(space, {}, testSessionOpenAuthFactory);
+  session.setConcurrentWatchRefresh(true);
+  try {
+    // set then add issued in the SAME turn. Under the old eager-add spike the
+    // add reached the wire first; the ordered issue phase must keep [set, add].
+    const set = session.watchSetSync([]);
+    const add = session.watchAddSync([]);
+    await Promise.all([set, add]);
+    assertEquals(wire, ["watch.set", "watch.add"], "wire order preserved");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("concurrent refresh: overlapping watch.adds resolve and later mutations deliver", async () => {
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://concurrent-refresh-loopback"),
+    subscriptionRefreshDelayMs: 0,
+  });
+  const writerClient = await connect({ transport: loopback(server) });
+  const watcherClient = await connect({ transport: loopback(server) });
+  const space = "did:key:z6Mk-concurrent-refresh-loopback";
+  const writer = await writerClient.mount(
+    space,
+    {},
+    testSessionOpenAuthFactory,
+  );
+  const watcher = await watcherClient.mount(
+    space,
+    {},
+    testSessionOpenAuthFactory,
+  );
+  watcher.setConcurrentWatchRefresh(true);
+
+  const ids = Array.from({ length: 5 }, (_, i) => `of:loop-${i}`);
+  try {
+    let seq = 0;
+    for (const id of ids) {
+      await writer.transact({
+        localSeq: ++seq,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id, value: { value: { n: 0 } } }],
+      });
+    }
+
+    // Overlapping watch.adds through the real server (issued without awaiting
+    // between calls). All must resolve.
+    const results = await Promise.all(
+      ids.map((id) => watcher.watchAddSync([rootSpec(id)])),
+    );
+    assertEquals(results.length, ids.length);
+    const view = results[results.length - 1].view;
+    const nOf = (id: string) =>
+      (view.entities.find((e: EntitySnapshot) => e.id === id)?.document as
+        | { value?: { n?: number } }
+        | undefined)?.value?.n;
+    for (const id of ids) assertEquals(nOf(id), 0, `initial value for ${id}`);
+
+    // Later mutations on EVERY watched root are delivered after the concurrent
+    // acquisition — so a watch set that accidentally retained only one
+    // acquisition cannot pass. Effects are pushed asynchronously through the
+    // loopback; consume the subscription until all roots reach n=1.
+    const updates = view.subscribe();
+    const pending = new Set(ids);
+    for (const id of ids) {
+      await writer.transact({
+        localSeq: ++seq,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id, value: { value: { n: 1 } } }],
+      });
+    }
+    while (pending.size > 0) {
+      const next = await updates.next();
+      assertEquals(next.done, false, "subscription must keep delivering");
+      for (const e of next.value.entities as EntitySnapshot[]) {
+        const n = (e.document as { value?: { n?: number } } | undefined)
+          ?.value?.n;
+        if (n === 1) pending.delete(e.id);
+      }
+    }
+    // Reaching here means every watched root's update was delivered.
+    await drainMicrotasks();
+  } finally {
+    await writerClient.close();
+    await watcherClient.close();
+    await server.close();
+  }
+});

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -34,16 +34,6 @@ import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { expandServerMessageSchemas } from "./sync-schema-table.ts";
 import { containsReservedSchemaRefSubstring } from "./sync-schema-ref.ts";
 
-// EXPERIMENT toggle (default off): when true, `watchAddSync` fires its network
-// request outside the serialized watch-mutation chain so multiple watch.add
-// round trips overlap on the wire. Module-level so it can be flipped for
-// measurement without threading a setting through the runner; a real rollout
-// would gate this off the storage settings flag instead.
-export let __concurrentWatchRefresh = false;
-export function __setConcurrentWatchRefresh(value: boolean): void {
-  __concurrentWatchRefresh = value;
-}
-
 export interface Transport {
   send(payload: string): Promise<void>;
   close(): Promise<void>;
@@ -480,7 +470,20 @@ export class SpaceSession {
   #ackScheduled = false;
   #ackFlushing = false;
   #background = new Set<Promise<void>>();
-  #watchMutation: Promise<void> = Promise.resolve();
+  // Watch-mutation ordering. `#watchApply` serializes the APPLICATION of watch
+  // responses (the `#watchSpecs` / `#watchView` mutations) in call order.
+  // `#watchIssue` serializes REQUEST ISSUE in call order and, in concurrent
+  // mode, advances as soon as a request has been *sent* (not answered), so
+  // multiple watch round trips overlap on the wire while application stays
+  // ordered. In single-flight mode `#watchIssue` is unused and each mutation's
+  // request+apply run together on `#watchApply` (byte-identical to the pre-
+  // concurrency behavior).
+  #watchApply: Promise<void> = Promise.resolve();
+  #watchIssue: Promise<void> = Promise.resolve();
+  // Per-session (default off): allow watch-refresh round trips to overlap.
+  // Set by the runner from the `experimentalConcurrentWatchRefresh` storage
+  // setting; see docs/development/EXPERIMENTAL_OPTIONS.md. NOT a process global.
+  #concurrentWatchRefresh = false;
   #closed = false;
   #closeError: Error | null = null;
   #readyOnConnection = true;
@@ -644,27 +647,30 @@ export class SpaceSession {
 
   async watchSetSync(watches: WatchSpec[]): Promise<WatchMutationResult> {
     this.#assertOpen();
-    return await this.runWatchMutation(async () => {
-      const result = await this.client.request<WatchSetResult>({
-        type: "session.watch.set",
-        requestId: crypto.randomUUID(),
-        space: this.space,
-        sessionId: this.#sessionId,
-        watches,
-      });
-      this.noteResult(result.serverSeq);
-      this.#watchSpecs = watches;
-      if (this.#watchView === null) {
-        this.#watchView = WatchView.fromSync(result.sync);
-      } else {
-        this.#watchView.applySync(result.sync, false);
-      }
-      this.scheduleAck(result.serverSeq);
-      return {
-        view: this.#watchView,
-        sync: result.sync,
-      };
-    });
+    return await this.runWatchMutation(
+      () =>
+        this.client.request<WatchSetResult>({
+          type: "session.watch.set",
+          requestId: crypto.randomUUID(),
+          space: this.space,
+          sessionId: this.#sessionId,
+          watches,
+        }),
+      (result) => {
+        this.noteResult(result.serverSeq);
+        this.#watchSpecs = watches;
+        if (this.#watchView === null) {
+          this.#watchView = WatchView.fromSync(result.sync);
+        } else {
+          this.#watchView.applySync(result.sync, false);
+        }
+        this.scheduleAck(result.serverSeq);
+        return {
+          view: this.#watchView,
+          sync: result.sync,
+        };
+      },
+    );
   }
 
   async watchAdd(watches: WatchSpec[]): Promise<WatchView> {
@@ -679,41 +685,34 @@ export class SpaceSession {
 
   async watchAddSync(watches: WatchSpec[]): Promise<WatchMutationResult> {
     this.#assertOpen();
-    const sendRequest = () =>
-      this.client.request<WatchAddResult>({
-        type: "session.watch.add",
-        requestId: crypto.randomUUID(),
-        space: this.space,
-        sessionId: this.#sessionId,
-        watches,
-      });
-    // EXPERIMENT (concurrent watch refresh): fire the network request BEFORE
-    // entering the serialized mutation chain, so multiple watch.add round trips
-    // overlap on the wire. The chain still serializes the VIEW application
-    // (`#watchSpecs` / `#watchView.applySync`) in request-issue order, so
-    // ordering guarantees are preserved — only the request/response wait is
-    // lifted out of the critical section. Default path (flag off) is unchanged:
-    // request and apply both run inside the serialized section.
-    const eager = __concurrentWatchRefresh ? sendRequest() : undefined;
-    return await this.runWatchMutation(async () => {
-      const result = await (eager ?? sendRequest());
-      this.noteResult(result.serverSeq);
-      this.#watchSpecs = [
-        ...new Map(
-          [...this.#watchSpecs, ...watches].map((watch) => [watch.id, watch]),
-        ).values(),
-      ];
-      if (this.#watchView === null) {
-        this.#watchView = WatchView.fromSync(result.sync);
-      } else {
-        this.#watchView.applySync(result.sync, false);
-      }
-      this.scheduleAck(result.serverSeq);
-      return {
-        view: this.#watchView,
-        sync: result.sync,
-      };
-    });
+    return await this.runWatchMutation(
+      () =>
+        this.client.request<WatchAddResult>({
+          type: "session.watch.add",
+          requestId: crypto.randomUUID(),
+          space: this.space,
+          sessionId: this.#sessionId,
+          watches,
+        }),
+      (result) => {
+        this.noteResult(result.serverSeq);
+        this.#watchSpecs = [
+          ...new Map(
+            [...this.#watchSpecs, ...watches].map((watch) => [watch.id, watch]),
+          ).values(),
+        ];
+        if (this.#watchView === null) {
+          this.#watchView = WatchView.fromSync(result.sync);
+        } else {
+          this.#watchView.applySync(result.sync, false);
+        }
+        this.scheduleAck(result.serverSeq);
+        return {
+          view: this.#watchView,
+          sync: result.sync,
+        };
+      },
+    );
   }
 
   async ack(seenSeq: number): Promise<void> {
@@ -932,11 +931,66 @@ export class SpaceSession {
     }
   }
 
-  private async runWatchMutation<T>(work: () => Promise<T>): Promise<T> {
+  /**
+   * Enable/disable concurrent watch refresh for THIS session (default off).
+   * Set by the runner from the `experimentalConcurrentWatchRefresh` storage
+   * setting. Per-session by design — no process global — so one storage
+   * manager's choice never leaks to another client in the same process.
+   */
+  setConcurrentWatchRefresh(enabled: boolean): void {
+    this.#concurrentWatchRefresh = enabled;
+  }
+
+  /**
+   * Serialize a watch mutation (`watch.set` / `watch.add`). `send` issues the
+   * request; `apply` mutates the session view (`#watchSpecs` / `#watchView`)
+   * from the response. Splitting them lets concurrent mode overlap the request
+   * round trips while keeping application ordered.
+   */
+  private async runWatchMutation<R, T>(
+    send: () => Promise<R>,
+    apply: (result: R) => T,
+  ): Promise<T> {
     this.#assertOpen();
-    const previous = this.#watchMutation;
-    const current = previous.catch(() => undefined).then(work);
-    this.#watchMutation = current.then(() => undefined, () => undefined);
+    if (!this.#concurrentWatchRefresh) {
+      // Single-flight (default): send + apply run together, chained on the
+      // prior mutation's completion. Nothing is issued until the previous
+      // mutation fully resolves. Structurally identical to the pre-concurrency
+      // path (a single `work` closure chained on the mutation promise, then
+      // `await`-ed) so its microtask timing — which some downstream ordering
+      // depends on — is unchanged.
+      const previous = this.#watchApply;
+      const current = previous.catch(() => undefined).then(async () =>
+        apply(await send())
+      );
+      this.#watchApply = current.then(() => undefined, () => undefined);
+      return await current;
+    }
+    // Concurrent: preserve wire order across the WHOLE watch-mutation family
+    // (set + add) by issuing requests in call order, while applying responses
+    // in that same order.
+    //  - `#watchIssue` advances as soon as `send()` has been CALLED (its frame
+    //    scheduled ahead of the next mutation's), so an earlier `watch.set` can
+    //    never be overtaken on the wire by a later `watch.add`.
+    //  - the apply step waits for [prior apply, this response], so `#watchSpecs`
+    //    / `#watchView` mutate in call order regardless of which response lands
+    //    first.
+    let response!: Promise<R>;
+    const issued = this.#watchIssue.catch(() => undefined).then(() => {
+      response = send();
+      // Attach a rejection handler immediately: a later request may reject
+      // while an earlier mutation is still pending, which would otherwise
+      // surface as an unhandled rejection even though the caller-facing
+      // apply-chain promise below has its own catch.
+      response.catch(() => undefined);
+    });
+    this.#watchIssue = issued.then(() => undefined, () => undefined);
+
+    const current = Promise.all([
+      this.#watchApply.catch(() => undefined),
+      issued,
+    ]).then(() => response).then((result) => apply(result));
+    this.#watchApply = current.then(() => undefined, () => undefined);
     return await current;
   }
 

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -34,6 +34,16 @@ import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { expandServerMessageSchemas } from "./sync-schema-table.ts";
 import { containsReservedSchemaRefSubstring } from "./sync-schema-ref.ts";
 
+// EXPERIMENT toggle (default off): when true, `watchAddSync` fires its network
+// request outside the serialized watch-mutation chain so multiple watch.add
+// round trips overlap on the wire. Module-level so it can be flipped for
+// measurement without threading a setting through the runner; a real rollout
+// would gate this off the storage settings flag instead.
+export let __concurrentWatchRefresh = false;
+export function __setConcurrentWatchRefresh(value: boolean): void {
+  __concurrentWatchRefresh = value;
+}
+
 export interface Transport {
   send(payload: string): Promise<void>;
   close(): Promise<void>;
@@ -669,14 +679,24 @@ export class SpaceSession {
 
   async watchAddSync(watches: WatchSpec[]): Promise<WatchMutationResult> {
     this.#assertOpen();
-    return await this.runWatchMutation(async () => {
-      const result = await this.client.request<WatchAddResult>({
+    const sendRequest = () =>
+      this.client.request<WatchAddResult>({
         type: "session.watch.add",
         requestId: crypto.randomUUID(),
         space: this.space,
         sessionId: this.#sessionId,
         watches,
       });
+    // EXPERIMENT (concurrent watch refresh): fire the network request BEFORE
+    // entering the serialized mutation chain, so multiple watch.add round trips
+    // overlap on the wire. The chain still serializes the VIEW application
+    // (`#watchSpecs` / `#watchView.applySync`) in request-issue order, so
+    // ordering guarantees are preserved — only the request/response wait is
+    // lifted out of the critical section. Default path (flag off) is unchanged:
+    // request and apply both run inside the serialized section.
+    const eager = __concurrentWatchRefresh ? sendRequest() : undefined;
+    return await this.runWatchMutation(async () => {
+      const result = await (eager ?? sendRequest());
       this.noteResult(result.serverSeq);
       this.#watchSpecs = [
         ...new Map(

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -320,13 +320,15 @@ export interface IRemoteStorageProviderSettings {
 
   /**
    * EXPERIMENTAL (default off): allow more than one watch-refresh round trip
-   * to be in flight per space at once. Today a single-flight guard
-   * (`#watchRefreshFlushing`) holds every refresh after the first until the
-   * prior response lands, so traversal-driven pulls discovered a tick apart —
-   * even with no data dependency between them — serialize into one-RTT-each
-   * frames instead of fanning out. With this on, a batch flushes as soon as it
-   * is scheduled; same-tick microtask coalescing is unchanged. Off preserves
-   * the exact current behavior.
+   * to be in flight per space at once, up to a bounded window
+   * (`CONCURRENT_WATCH_REFRESH_WINDOW`). By default watch acquisition is strict
+   * single-flight, so traversal-driven pulls discovered a tick apart — even
+   * with no data dependency between them — serialize into one-RTT-each frames
+   * instead of fanning out. With this on, refreshes overlap up to the window
+   * and the memory client issues the watch-mutation family (set + add) in an
+   * ordered issue phase so wire order is preserved. Same-tick microtask
+   * coalescing is unchanged. Off preserves the exact current behavior. See
+   * docs/development/EXPERIMENTAL_OPTIONS.md.
    */
   experimentalConcurrentWatchRefresh?: boolean;
 }

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -317,6 +317,18 @@ export interface IRemoteStorageProviderSettings {
    * abort.
    */
   connectionTimeout: number;
+
+  /**
+   * EXPERIMENTAL (default off): allow more than one watch-refresh round trip
+   * to be in flight per space at once. Today a single-flight guard
+   * (`#watchRefreshFlushing`) holds every refresh after the first until the
+   * prior response lands, so traversal-driven pulls discovered a tick apart —
+   * even with no data dependency between them — serialize into one-RTT-each
+   * frames instead of fanning out. With this on, a batch flushes as soon as it
+   * is scheduled; same-tick microtask coalescing is unchanged. Off preserves
+   * the exact current behavior.
+   */
+  experimentalConcurrentWatchRefresh?: boolean;
 }
 
 export interface LocalStorageOptions {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1691,11 +1691,14 @@ class SpaceReplica implements ISpaceReplica {
   #queuedWatchRefreshScheduled = false;
   #watchRefreshFlushing = false;
 
+  #settings: IRemoteStorageProviderSettings;
+
   constructor(options: ProviderOptions) {
     this.#space = options.space;
     this.#subscription = options.subscription;
     this.#createSession = options.createSession;
     this.#getTelemetry = options.getTelemetry ?? (() => undefined);
+    this.#settings = options.settings;
   }
 
   did(): MemorySpace {
@@ -2284,17 +2287,28 @@ class SpaceReplica implements ISpaceReplica {
   }
 
   private scheduleWatchRefreshFlush(): void {
+    // EXPERIMENTAL: when concurrent refresh is enabled, the single-flight
+    // `#watchRefreshFlushing` gate is ignored so a batch flushes as soon as it
+    // is scheduled, even while a prior refresh is still awaiting its response.
+    // Same-tick coalescing (via `#queuedWatchRefreshScheduled` + the merge in
+    // `enqueueWatchRefresh`) is unchanged; only the cross-RTT serialization is
+    // lifted.
+    const singleFlight = this.#settings.experimentalConcurrentWatchRefresh !==
+      true;
     if (
       this.#queuedWatchRefresh === null ||
       this.#queuedWatchRefreshScheduled ||
-      this.#watchRefreshFlushing
+      (singleFlight && this.#watchRefreshFlushing)
     ) {
       return;
     }
     this.#queuedWatchRefreshScheduled = true;
     queueMicrotask(() => {
       this.#queuedWatchRefreshScheduled = false;
-      if (this.#watchRefreshFlushing || this.#queuedWatchRefresh === null) {
+      if (
+        (singleFlight && this.#watchRefreshFlushing) ||
+        this.#queuedWatchRefresh === null
+      ) {
         return;
       }
       const batch = this.#queuedWatchRefresh;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -575,6 +575,15 @@ export const defaultSettings: IRemoteStorageProviderSettings = {
   connectionTimeout: 30_000,
 };
 
+/**
+ * Max concurrent watch-refresh round trips per space when
+ * `experimentalConcurrentWatchRefresh` is on. Bounds how many requests a
+ * traversal-discovered wave may have outstanding at once — high enough to hide
+ * per-request latency behind a deep waterfall, low enough to keep the server's
+ * receive queue and the client's outstanding-request set bounded.
+ */
+const CONCURRENT_WATCH_REFRESH_WINDOW = 8;
+
 const comparePath = (left: readonly string[], right: readonly string[]) => {
   if (left.length !== right.length) {
     return left.length - right.length;
@@ -1689,7 +1698,11 @@ class SpaceReplica implements ISpaceReplica {
   #staleFloor = new Map<string, number>();
   #queuedWatchRefresh: WatchRefreshBatch | null = null;
   #queuedWatchRefreshScheduled = false;
-  #watchRefreshFlushing = false;
+  // Number of watch-refresh round trips currently awaiting a response. Capped
+  // at `#maxWatchRefreshInFlight()` (1 = single-flight; the concurrent window
+  // otherwise) so a large incrementally-discovered wave cannot put an unbounded
+  // number of requests on the wire.
+  #watchRefreshInFlight = 0;
 
   #settings: IRemoteStorageProviderSettings;
 
@@ -2212,6 +2225,14 @@ class SpaceReplica implements ISpaceReplica {
   ): Promise<Result<Unit, PullError>> {
     try {
       const { session } = await this.sessionHandle();
+      // Per-session (no global): mirror the storage setting onto the session so
+      // its watch-mutation family (set + add) uses the ordered-issue concurrent
+      // path. Idempotent; cheap to re-assert each refresh. Optional-chained so
+      // lightweight session doubles in tests (which never opt into concurrency)
+      // are unaffected.
+      session.setConcurrentWatchRefresh?.(
+        this.#settings.experimentalConcurrentWatchRefresh === true,
+      );
       const rawEntries = [...entries];
       const watchEntries = compactWatchEntries(rawEntries);
       if (watchEntries.length === 0) {
@@ -2286,19 +2307,27 @@ class SpaceReplica implements ISpaceReplica {
     return batch.pending.promise;
   }
 
+  /**
+   * Max watch-refresh round trips allowed in flight at once. 1 preserves the
+   * historical strict single-flight behavior; with
+   * `experimentalConcurrentWatchRefresh` on, refreshes overlap up to a bounded
+   * window so traversal-discovered waves fan out WITHOUT an unbounded number of
+   * outstanding requests (backpressure).
+   */
+  #maxWatchRefreshInFlight(): number {
+    return this.#settings.experimentalConcurrentWatchRefresh === true
+      ? CONCURRENT_WATCH_REFRESH_WINDOW
+      : 1;
+  }
+
   private scheduleWatchRefreshFlush(): void {
-    // EXPERIMENTAL: when concurrent refresh is enabled, the single-flight
-    // `#watchRefreshFlushing` gate is ignored so a batch flushes as soon as it
-    // is scheduled, even while a prior refresh is still awaiting its response.
-    // Same-tick coalescing (via `#queuedWatchRefreshScheduled` + the merge in
-    // `enqueueWatchRefresh`) is unchanged; only the cross-RTT serialization is
-    // lifted.
-    const singleFlight = this.#settings.experimentalConcurrentWatchRefresh !==
-      true;
+    // Flush the queued batch when a slot is free. Same-tick coalescing (via
+    // `#queuedWatchRefreshScheduled` + the merge in `enqueueWatchRefresh`) is
+    // unchanged; the window bounds cross-RTT concurrency (1 = single-flight).
     if (
       this.#queuedWatchRefresh === null ||
       this.#queuedWatchRefreshScheduled ||
-      (singleFlight && this.#watchRefreshFlushing)
+      this.#watchRefreshInFlight >= this.#maxWatchRefreshInFlight()
     ) {
       return;
     }
@@ -2306,15 +2335,19 @@ class SpaceReplica implements ISpaceReplica {
     queueMicrotask(() => {
       this.#queuedWatchRefreshScheduled = false;
       if (
-        (singleFlight && this.#watchRefreshFlushing) ||
-        this.#queuedWatchRefresh === null
+        this.#queuedWatchRefresh === null ||
+        this.#watchRefreshInFlight >= this.#maxWatchRefreshInFlight()
       ) {
         return;
       }
       const batch = this.#queuedWatchRefresh;
       this.#queuedWatchRefresh = null;
-      this.#watchRefreshFlushing = true;
+      this.#watchRefreshInFlight += 1;
       void this.flushWatchRefreshBatch(batch);
+      // If the window admits more and another batch has already coalesced,
+      // schedule it now; otherwise the flush's `finally` re-schedules as slots
+      // free.
+      this.scheduleWatchRefreshFlush();
     });
   }
 
@@ -2328,7 +2361,7 @@ class SpaceReplica implements ISpaceReplica {
     } catch (error) {
       batch.pending.resolve({ error: toConnectionError(error) });
     } finally {
-      this.#watchRefreshFlushing = false;
+      this.#watchRefreshInFlight -= 1;
       this.scheduleWatchRefreshFlush();
     }
   }

--- a/packages/runner/test/memory-v2-concurrent-watch-refresh.test.ts
+++ b/packages/runner/test/memory-v2-concurrent-watch-refresh.test.ts
@@ -1,0 +1,212 @@
+/**
+ * EXPERIMENT: does lifting the single-flight `#watchRefreshFlushing` guard let
+ * watch-refresh round trips overlap?
+ *
+ * Measured motivation: in mobile-Loom HAR captures, per-space watch acquisition
+ * is strict single-flight — 0 overlapping requests within a space across 154
+ * round trips — so traversal-driven pulls discovered a tick apart serialize
+ * into one-RTT-each frames. This pins the current behavior and the behavior
+ * under `experimentalConcurrentWatchRefresh`.
+ *
+ * The transport holds every `watch.add` response open and signals on receipt,
+ * so the test can observe how many refreshes are in flight at once.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import type { URI } from "@commonfabric/memory/interface";
+import {
+  type EntityDocument,
+  type SessionSync,
+  type SessionSyncUpsert,
+} from "@commonfabric/memory/v2";
+import type { IStorageProviderWithReplica } from "../src/storage/interface.ts";
+import { defaultSettings } from "../src/storage/v2.ts";
+import { __setConcurrentWatchRefresh } from "@commonfabric/memory/v2/client";
+import {
+  ScriptedSessionTransport,
+  type ScriptedTransportMessage,
+  SingleSessionFactory,
+  TestStorageManager,
+} from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("memory-v2-concurrent-refresh");
+const space = signer.did();
+
+type TestProvider = IStorageProviderWithReplica & {
+  get(uri: URI): EntityDocument | undefined;
+  sync(
+    uri: URI,
+    selector?: { path: string[]; schema: unknown },
+  ): Promise<unknown>;
+};
+
+const doc = (
+  id: URI,
+  seq: number,
+  value: SessionSyncUpsert["doc"],
+): SessionSyncUpsert => ({ branch: "", id, seq, doc: value });
+
+const fullSync = (
+  toSeq: number,
+  upserts: SessionSyncUpsert[],
+): SessionSync => ({ type: "sync", fromSeq: 0, toSeq, upserts, removes: [] });
+
+/**
+ * Holds every `watch.add` response open. Records how many are in flight
+ * simultaneously (the whole point of the measurement) and lets the test
+ * release them explicitly.
+ */
+class HoldingTransport extends ScriptedSessionTransport {
+  watchAddCount = 0;
+  inFlight = 0;
+  maxConcurrent = 0;
+  rootCounts: number[] = [];
+  #held: Array<() => void> = [];
+  #sentSignals = new Map<number, ReturnType<typeof Promise.withResolvers<void>>>();
+
+  constructor() {
+    super({
+      name: "concurrent-refresh",
+      sessionId: "session:concurrent-refresh",
+      space,
+    });
+  }
+
+  /** Resolves when the Nth `watch.add` has been received. */
+  sent(n: number): Promise<void> {
+    let d = this.#sentSignals.get(n);
+    if (!d) {
+      d = Promise.withResolvers<void>();
+      this.#sentSignals.set(n, d);
+    }
+    return d.promise;
+  }
+
+  releaseAll(): void {
+    const held = this.#held;
+    this.#held = [];
+    for (const respond of held) respond();
+  }
+
+  protected override ackServerSeq(): number {
+    return 100;
+  }
+
+  protected override handle(message: ScriptedTransportMessage): void {
+    if (message.type !== "session.watch.add") {
+      throw new Error(`Unhandled scripted message: ${message.type}`);
+    }
+    this.watchAddCount += 1;
+    this.inFlight += 1;
+    this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);
+    const roots = message.watches?.flatMap((w) =>
+      w.query?.roots?.map((r) => r.id as URI) ?? []
+    ) ?? [];
+    this.rootCounts.push(roots.length);
+
+    (this.#sentSignals.get(this.watchAddCount) ??
+      (() => {
+        const d = Promise.withResolvers<void>();
+        this.#sentSignals.set(this.watchAddCount, d);
+        return d;
+      })()).resolve();
+
+    this.#held.push(() => {
+      this.inFlight -= 1;
+      this.respond({
+        type: "response",
+        requestId: message.requestId!,
+        ok: {
+          serverSeq: roots.length,
+          sync: fullSync(
+            roots.length,
+            roots.map((id, i) => doc(id, i + 1, { value: { label: id } })),
+          ),
+        },
+      });
+    });
+  }
+}
+
+function makeProvider(concurrent: boolean) {
+  // Both serialization layers must lift together: the SpaceReplica flush guard
+  // (settings flag) AND the client session's runWatchMutation chain (this
+  // toggle). Lifting only one leaves the other serializing.
+  __setConcurrentWatchRefresh(concurrent);
+  const transport = new HoldingTransport();
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL(`memory://concurrent-refresh-${concurrent}`),
+    settings: {
+      ...defaultSettings,
+      experimentalConcurrentWatchRefresh: concurrent,
+    },
+  }, new SingleSessionFactory(transport));
+  return { transport, storageManager,
+    provider: storageManager.open(space) as TestProvider };
+}
+
+/**
+ * Issue N pulls one microtask-wave apart (each after the previous refresh has
+ * been *sent* but not answered), simulating traversal that discovers the next
+ * cell only after the prior request goes out.
+ */
+async function drive(provider: TestProvider, transport: HoldingTransport, n: number) {
+  const pulls: Promise<unknown>[] = [];
+  for (let i = 0; i < n; i++) {
+    const uri = `of:concurrent-${i}-${crypto.randomUUID()}` as unknown as URI;
+    pulls.push(provider.sync(uri, { path: [], schema: false }));
+    // Wait until this pull's refresh has actually been sent before issuing the
+    // next, so they are genuinely discovered a wave apart (not same-tick
+    // coalesced). Under the single-flight guard the send blocks until release,
+    // so bound the wait so the guarded run doesn't hang.
+    await Promise.race([
+      transport.sent(i + 1),
+      new Promise((r) => setTimeout(r, 25)),
+    ]);
+  }
+  return pulls;
+}
+
+Deno.test("single-flight by default: watch refreshes do NOT overlap", async () => {
+  const { transport, storageManager, provider } = makeProvider(false);
+  try {
+    const pulls = drive(provider, transport, 4);
+    // Give the guarded pipeline time to send whatever it will while held.
+    await new Promise((r) => setTimeout(r, 60));
+    assertEquals(transport.maxConcurrent, 1, "guard should serialize to 1");
+    assertEquals(transport.watchAddCount, 1, "only the first refresh is sent");
+    transport.releaseAll();
+    // As each response lands the next flush drains; keep releasing.
+    for (let i = 0; i < 6; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+      transport.releaseAll();
+    }
+    await Promise.all(await pulls);
+    assertEquals(transport.maxConcurrent, 1, "never more than 1 in flight");
+  } finally {
+    await storageManager.close();
+  }
+});
+
+Deno.test("experimentalConcurrentWatchRefresh: refreshes overlap", async () => {
+  const { transport, storageManager, provider } = makeProvider(true);
+  try {
+    const pulls = drive(provider, transport, 4);
+    await new Promise((r) => setTimeout(r, 60));
+    assert(
+      transport.maxConcurrent >= 2,
+      `expected overlapping refreshes, got maxConcurrent=${transport.maxConcurrent}`,
+    );
+    transport.releaseAll();
+    await new Promise((r) => setTimeout(r, 20));
+    transport.releaseAll();
+    await Promise.all(await pulls);
+    console.log(
+      `[concurrent] watchAdds=${transport.watchAddCount} ` +
+        `maxConcurrent=${transport.maxConcurrent} rootCounts=${transport.rootCounts}`,
+    );
+  } finally {
+    await storageManager.close();
+  }
+});

--- a/packages/runner/test/memory-v2-concurrent-watch-refresh.test.ts
+++ b/packages/runner/test/memory-v2-concurrent-watch-refresh.test.ts
@@ -1,15 +1,14 @@
 /**
- * EXPERIMENT: does lifting the single-flight `#watchRefreshFlushing` guard let
- * watch-refresh round trips overlap?
+ * `experimentalConcurrentWatchRefresh` at the RUNNER storage layer: watch-
+ * refresh round trips may overlap up to a bounded window instead of the default
+ * strict single-flight. (The memory-client ordering guarantees — wire order
+ * across the set/add family and ordered delivery through the real server — are
+ * covered in packages/memory/test/v2-concurrent-watch-refresh-test.ts, where
+ * the in-package server/loopback helpers are available.)
  *
- * Measured motivation: in mobile-Loom HAR captures, per-space watch acquisition
- * is strict single-flight — 0 overlapping requests within a space across 154
- * round trips — so traversal-driven pulls discovered a tick apart serialize
- * into one-RTT-each frames. This pins the current behavior and the behavior
- * under `experimentalConcurrentWatchRefresh`.
- *
- * The transport holds every `watch.add` response open and signals on receipt,
- * so the test can observe how many refreshes are in flight at once.
+ * Everything here is event-driven (no wall-clock sleeps): progress is awaited
+ * on transport signals, and the "nothing more happens" assertions use a
+ * deterministic microtask drain, not a timer.
  */
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
@@ -21,7 +20,6 @@ import {
 } from "@commonfabric/memory/v2";
 import type { IStorageProviderWithReplica } from "../src/storage/interface.ts";
 import { defaultSettings } from "../src/storage/v2.ts";
-import { __setConcurrentWatchRefresh } from "@commonfabric/memory/v2/client";
 import {
   ScriptedSessionTransport,
   type ScriptedTransportMessage,
@@ -31,6 +29,10 @@ import {
 
 const signer = await Identity.fromPassphrase("memory-v2-concurrent-refresh");
 const space = signer.did();
+
+// CONCURRENT_WATCH_REFRESH_WINDOW in storage/v2.ts. Kept in sync by assertion:
+// the concurrency test proves the observed max equals this.
+const WINDOW = 8;
 
 type TestProvider = IStorageProviderWithReplica & {
   get(uri: URI): EntityDocument | undefined;
@@ -49,20 +51,34 @@ const doc = (
 const fullSync = (
   toSeq: number,
   upserts: SessionSyncUpsert[],
-): SessionSync => ({ type: "sync", fromSeq: 0, toSeq, upserts, removes: [] });
+): SessionSync => ({
+  type: "sync",
+  fromSeq: 0,
+  toSeq,
+  upserts,
+  removes: [],
+});
+
+/** Flush pending microtasks deterministically (no timers). */
+async function drainMicrotasks(turns = 50): Promise<void> {
+  for (let i = 0; i < turns; i++) await Promise.resolve();
+}
 
 /**
- * Holds every `watch.add` response open. Records how many are in flight
- * simultaneously (the whole point of the measurement) and lets the test
- * release them explicitly.
+ * Holds every watch.add response open. Records how many are in flight at once
+ * (the whole point), signals on the Nth request, and releases held responses
+ * on demand. Event-driven: `receivedAtLeast(n)` resolves exactly when the Nth
+ * request lands.
  */
 class HoldingTransport extends ScriptedSessionTransport {
   watchAddCount = 0;
   inFlight = 0;
   maxConcurrent = 0;
-  rootCounts: number[] = [];
   #held: Array<() => void> = [];
-  #sentSignals = new Map<number, ReturnType<typeof Promise.withResolvers<void>>>();
+  #receivedWaiters = new Map<
+    number,
+    ReturnType<typeof Promise.withResolvers<void>>
+  >();
 
   constructor() {
     super({
@@ -72,12 +88,12 @@ class HoldingTransport extends ScriptedSessionTransport {
     });
   }
 
-  /** Resolves when the Nth `watch.add` has been received. */
-  sent(n: number): Promise<void> {
-    let d = this.#sentSignals.get(n);
+  receivedAtLeast(n: number): Promise<void> {
+    if (this.watchAddCount >= n) return Promise.resolve();
+    let d = this.#receivedWaiters.get(n);
     if (!d) {
       d = Promise.withResolvers<void>();
-      this.#sentSignals.set(n, d);
+      this.#receivedWaiters.set(n, d);
     }
     return d.promise;
   }
@@ -99,17 +115,17 @@ class HoldingTransport extends ScriptedSessionTransport {
     this.watchAddCount += 1;
     this.inFlight += 1;
     this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);
-    const roots = message.watches?.flatMap((w) =>
-      w.query?.roots?.map((r) => r.id as URI) ?? []
-    ) ?? [];
-    this.rootCounts.push(roots.length);
+    const roots =
+      message.watches?.flatMap((w) =>
+        w.query?.roots?.map((r) => r.id as URI) ?? []
+      ) ?? [];
 
-    (this.#sentSignals.get(this.watchAddCount) ??
-      (() => {
-        const d = Promise.withResolvers<void>();
-        this.#sentSignals.set(this.watchAddCount, d);
-        return d;
-      })()).resolve();
+    for (const [n, waiter] of this.#receivedWaiters) {
+      if (this.watchAddCount >= n) {
+        waiter.resolve();
+        this.#receivedWaiters.delete(n);
+      }
+    }
 
     this.#held.push(() => {
       this.inFlight -= 1;
@@ -129,10 +145,6 @@ class HoldingTransport extends ScriptedSessionTransport {
 }
 
 function makeProvider(concurrent: boolean) {
-  // Both serialization layers must lift together: the SpaceReplica flush guard
-  // (settings flag) AND the client session's runWatchMutation chain (this
-  // toggle). Lifting only one leaves the other serializing.
-  __setConcurrentWatchRefresh(concurrent);
   const transport = new HoldingTransport();
   const storageManager = TestStorageManager.create({
     as: signer,
@@ -142,69 +154,92 @@ function makeProvider(concurrent: boolean) {
       experimentalConcurrentWatchRefresh: concurrent,
     },
   }, new SingleSessionFactory(transport));
-  return { transport, storageManager,
-    provider: storageManager.open(space) as TestProvider };
+  return {
+    transport,
+    storageManager,
+    provider: storageManager.open(space) as TestProvider,
+  };
 }
 
-/**
- * Issue N pulls one microtask-wave apart (each after the previous refresh has
- * been *sent* but not answered), simulating traversal that discovers the next
- * cell only after the prior request goes out.
- */
-async function drive(provider: TestProvider, transport: HoldingTransport, n: number) {
-  const pulls: Promise<unknown>[] = [];
-  for (let i = 0; i < n; i++) {
-    const uri = `of:concurrent-${i}-${crypto.randomUUID()}` as unknown as URI;
-    pulls.push(provider.sync(uri, { path: [], schema: false }));
-    // Wait until this pull's refresh has actually been sent before issuing the
-    // next, so they are genuinely discovered a wave apart (not same-tick
-    // coalesced). Under the single-flight guard the send blocks until release,
-    // so bound the wait so the guarded run doesn't hang.
-    await Promise.race([
-      transport.sent(i + 1),
-      new Promise((r) => setTimeout(r, 25)),
-    ]);
+const uri = (tag: string) =>
+  `of:${tag}-${crypto.randomUUID()}` as unknown as URI;
+
+/** Release held responses until every pull settles. Signal-driven: after each
+ * release, wait for either all pulls to settle or the next batch to be sent
+ * (a freed slot flushing more work) — never a fixed iteration/time budget. */
+async function drainAllPulls(
+  transport: HoldingTransport,
+  pulls: Promise<unknown>[],
+): Promise<void> {
+  const all = Promise.all(pulls);
+  let done = false;
+  void all.then(() => (done = true));
+  while (!done) {
+    const nextSent = transport.receivedAtLeast(transport.watchAddCount + 1);
+    transport.releaseAll();
+    // Releasing frees window slots, which may flush the next coalesced batch
+    // (its watch.add arrives) — or all pulls settle. Await whichever happens.
+    await Promise.race([all, nextSent]);
   }
-  return pulls;
+  await all;
 }
 
-Deno.test("single-flight by default: watch refreshes do NOT overlap", async () => {
+Deno.test("single-flight by default: watch refreshes never overlap", async () => {
   const { transport, storageManager, provider } = makeProvider(false);
   try {
-    const pulls = drive(provider, transport, 4);
-    // Give the guarded pipeline time to send whatever it will while held.
-    await new Promise((r) => setTimeout(r, 60));
-    assertEquals(transport.maxConcurrent, 1, "guard should serialize to 1");
-    assertEquals(transport.watchAddCount, 1, "only the first refresh is sent");
-    transport.releaseAll();
-    // As each response lands the next flush drains; keep releasing.
-    for (let i = 0; i < 6; i++) {
-      await new Promise((r) => setTimeout(r, 10));
-      transport.releaseAll();
-    }
-    await Promise.all(await pulls);
+    const pulls: Promise<unknown>[] = [];
+    // First pull's refresh is sent and held.
+    pulls.push(provider.sync(uri("sf-a"), { path: [], schema: false }));
+    await transport.receivedAtLeast(1);
+    // A second pull discovered a wave later (after the first was sent) must NOT
+    // be sent while the first is still in flight — that is single-flight.
+    pulls.push(provider.sync(uri("sf-b"), { path: [], schema: false }));
+    await drainMicrotasks();
+    assertEquals(transport.watchAddCount, 1, "second refresh is not sent yet");
     assertEquals(transport.maxConcurrent, 1, "never more than 1 in flight");
+
+    await drainAllPulls(transport, pulls);
+    assertEquals(
+      transport.maxConcurrent,
+      1,
+      "still never more than 1 in flight",
+    );
+    assertEquals(transport.watchAddCount, 2, "both refreshes eventually sent");
   } finally {
     await storageManager.close();
   }
 });
 
-Deno.test("experimentalConcurrentWatchRefresh: refreshes overlap", async () => {
+Deno.test("concurrent refresh overlaps up to the bounded window", async () => {
   const { transport, storageManager, provider } = makeProvider(true);
   try {
-    const pulls = drive(provider, transport, 4);
-    await new Promise((r) => setTimeout(r, 60));
-    assert(
-      transport.maxConcurrent >= 2,
-      `expected overlapping refreshes, got maxConcurrent=${transport.maxConcurrent}`,
+    const pulls: Promise<unknown>[] = [];
+    // Issue pulls one wave apart (each after the prior was SENT) so each is its
+    // own frame. The first WINDOW stay in flight together.
+    for (let i = 1; i <= WINDOW; i++) {
+      pulls.push(provider.sync(uri(`win-${i}`), { path: [], schema: false }));
+      await transport.receivedAtLeast(i);
+    }
+    assertEquals(
+      transport.maxConcurrent,
+      WINDOW,
+      "concurrency reaches exactly the window",
     );
-    transport.releaseAll();
-    await new Promise((r) => setTimeout(r, 20));
-    transport.releaseAll();
-    await Promise.all(await pulls);
-    console.log(
-      `[concurrent] watchAdds=${transport.watchAddCount} ` +
-        `maxConcurrent=${transport.maxConcurrent} rootCounts=${transport.rootCounts}`,
+    assertEquals(transport.watchAddCount, WINDOW, "window is full");
+
+    // One more while the window is full: issued but held back (not sent).
+    pulls.push(provider.sync(uri("win-extra"), { path: [], schema: false }));
+    await drainMicrotasks();
+    assertEquals(
+      transport.watchAddCount,
+      WINDOW,
+      "the over-window pull is not sent until a slot frees",
+    );
+
+    await drainAllPulls(transport, pulls);
+    assert(
+      transport.maxConcurrent === WINDOW,
+      `bounded at the window, saw ${transport.maxConcurrent}`,
     );
   } finally {
     await storageManager.close();


### PR DESCRIPTION
## Why

Investigating mobile-Loom cold-load performance, we found that per-space watch
acquisition is **strict single-flight**: 0 overlapping `session.watch.add`
requests within a space across 154 round trips in two independent HAR captures.
Because traversal discovers cells incrementally, this turns into a long tail of
one-root-per-round-trip frames (roots/frame: min 1, **p50 1**), each paying a
full RTT. On estuary (~188 ms RTT floor) that dominates cold-load wall-clock —
the round-trip *count*, not payload size, is the bottleneck (responses are
~302 B median; the data itself is already loaded by a handful of root-closure
reads). This adds a default-off flag to overlap those refreshes.

## What changed

The serialization lived in **two layers**, and the one that's easy to spot from
the code isn't the binding one:

1. **`SpaceReplica` flush guard** (`runner/src/storage/v2.ts`) — one refresh
   flush per space, the next scheduled in the prior's `finally`. Now a **bounded
   in-flight window** (`CONCURRENT_WATCH_REFRESH_WINDOW = 8`) instead of a
   single-flight boolean: over-window batches stay coalesced and flush as slots
   free. With the flag off the window is 1, i.e. the original single-flight.
2. **`SpaceSession.runWatchMutation`** (`memory/v2/client.ts`) — the binding
   constraint; it chained every watch mutation's request *and* apply onto the
   previous one. Reworked into an **ordered issue phase** + **ordered apply
   phase**: the whole watch-mutation family (`watch.set` + `watch.add`) issues
   in request-issue order so wire order is preserved (`watch.add` never
   overtakes an earlier `watch.set`) and view application stays ordered, while
   the request/response wait no longer serializes. Eager requests get an
   immediate rejection handler.

Wiring is **per session, not a process global**: the runner mirrors the
`experimentalConcurrentWatchRefresh` storage setting onto each memory session
via `SpaceSession.setConcurrentWatchRefresh()` (optional-chained so test session
doubles are unaffected). Registered in `docs/development/EXPERIMENTAL_OPTIONS.md`.

Files:

- **`storage/interface.ts`** — `experimentalConcurrentWatchRefresh` storage setting.
- **`storage/v2.ts`** — bounded-window flush; single-flight when off.
- **`memory/v2/client.ts`** — ordered issue/apply split behind the per-session flag.

### Flag-off is behavior-identical

The default (flag-off) path is byte-for-byte the old behavior, including
microtask timing: `runWatchMutation` stays `async` and returns `await current`
in both branches. That boundary matters — an earlier version dropped the `await`
and a one-tick shift reordered schema interning during commit, breaking CFC
canonicalization idempotence in three suites. Preserved deliberately; don't
simplify it away.

## Status

Off by default, pending live measurement over real (estuary-latency) load; the
window size (8) is a tuning value. End state is graduation to always-on once
measured safe and beneficial, or removal if a render-side fix makes the
waterfall shallow enough that concurrency no longer pays.

## Test plan

```
deno test -A packages/runner/test/memory-v2-concurrent-watch-refresh.test.ts
deno test -A packages/memory/test/v2-concurrent-watch-refresh-test.ts
```

- **Runner** — `single-flight by default` caps concurrency at 1; with the flag
  on, concurrency reaches **exactly the window (8)** and over-window pulls stay
  queued until a slot frees. Event-driven (transport signals, no wall-clock
  sleeps).
- **Memory** (real server via loopback) — set-then-add preserves wire order
  `[watch.set, watch.add]`; overlapping `watch.add`s all resolve and later
  mutations on **every** watched root are delivered.
- **Regression** — the previously-flagged CFC idempotence suites
  (`cfc-persist-split`, `cfc-template-metadata-population`,
  `cfc-template-population`) and the related runner/memory watch suites all pass
  with the flag off. CI green, merge state clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787375879&installation_model_id=428580&pr_number=4937&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4937&signature=10402cad233ae78ef433f86c1c7252b70511578b28462453779242d896dee536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an experimental, default-off concurrent watch-refresh with a bounded in-flight window (8) to parallelize per-space watch acquisition while keeping wire and apply order stable. With the flag off, behavior remains strict single-flight.

- **New Features**
  - Added `experimentalConcurrentWatchRefresh` in `IRemoteStorageProviderSettings`; runner mirrors it per session via `SpaceSession.setConcurrentWatchRefresh()` (not global).
  - Storage enforces a bounded window (`CONCURRENT_WATCH_REFRESH_WINDOW=8`): coalesces when full and flushes as slots free; single-flight is window=1.
  - Memory client routes both `watch.set` and `watch.add` through ordered issue and ordered apply phases to preserve `[set → add]` wire order and serialize view application; adds immediate rejection handlers; flag-off path unchanged.
  - Documented in `docs/development/EXPERIMENTAL_OPTIONS.md`, including a dated status line (“Status on 2026-07-24”).

- **Tests**
  - Runner tests: default caps at 1; with the flag on, concurrency reaches exactly the window and pending batches stay queued until a slot frees.
  - Memory tests: `[watch.set, watch.add]` wire order is preserved; overlapping `watch.add`s resolve and later mutations on all watched roots are delivered.

<sup>Written for commit 3ccd1b2014eaa41eda83b31a2a0be45800f17ed0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

