### PR TITLE
cf-harness: recover from bad-cwd / timed-out bash calls at the tool boundary

### DIFF
--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -478,6 +478,95 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "cf-harness integration: a real sandbox path-escape is a tool result, not a run-fatal error",
+  ignore: !INTEGRATION,
+  permissions: { env: true, read: true, run: true, write: true },
+  async fn() {
+    await withHarness(
+      "integration-tool-error-recovery",
+      async (engine) => {
+        const requests: Array<{
+          messages: Array<{ role: string; content: string }>;
+        }> = [];
+        const loop = new CfHarnessPromptLoop({
+          apiKey: "test-key",
+          engine,
+          maxModelTurns: 3,
+          fetchFn: (_input, init) => {
+            const request = JSON.parse(String(init?.body ?? "{}")) as {
+              messages: Array<{ role: string; content: string }>;
+            };
+            requests.push(request);
+            // Turn 1: the model tries to `ls` the container root. cwd "/"
+            // escapes the sandbox roots, so the real DockerRunscSandbox
+            // `resolvePath` throws — the exact D9 scenario that used to kill
+            // the whole run on turn 1.
+            const payload = requests.length === 1
+              ? {
+                choices: [{
+                  index: 0,
+                  message: {
+                    role: "assistant",
+                    content: "",
+                    tool_calls: [{
+                      id: "call-escape",
+                      type: "function",
+                      function: {
+                        name: "bash",
+                        arguments: JSON.stringify({ command: "ls", cwd: "/" }),
+                      },
+                    }],
+                  },
+                }],
+              }
+              : {
+                choices: [{
+                  index: 0,
+                  message: {
+                    role: "assistant",
+                    content: "recovered after the sandbox rejected the path",
+                  },
+                }],
+              };
+            return Promise.resolve(
+              new Response(JSON.stringify(payload), { status: 200 }),
+            );
+          },
+        });
+
+        const result = await loop.runPrompt({
+          model: "gpt-5.4",
+          prompt: "List the container root.",
+        });
+
+        // The run completed instead of dying on the path-escape throw.
+        assertEquals(result.runState.status, "completed");
+        assertEquals(
+          result.finalAssistantText,
+          "recovered after the sandbox rejected the path",
+        );
+        // The model got a second turn: the bash tool converted the real
+        // resolvePath throw into an ordinary failed result carrying a
+        // known-safe message (the model's own cwd), NOT the raw exception.
+        assertEquals(requests.length, 2);
+        const toolMessage = requests[1].messages.at(-1);
+        assertEquals(toolMessage?.role, "tool");
+        assertStringIncludes(
+          toolMessage?.content ?? "",
+          "cwd is outside the sandbox: /",
+        );
+        assertEquals(
+          (toolMessage?.content ?? "").includes("path escapes"),
+          false,
+        );
+      },
+      { cfcEnforcementMode: "observe" },
+    );
+  },
+});
+
+Deno.test({
   name: "cf-harness integration: local Labs deno task cf help runs in sandbox",
   ignore: !CF_CLI_INTEGRATION,
   permissions: { env: true, read: true, run: true, write: true },

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -2358,6 +2358,15 @@ export class CfHarnessPromptLoop {
         ...optionalPolicyEventIndexes(policyEventIndexes),
         errorDetail: toErrorDetail(error),
       });
+      // Reaching this catch means a genuinely fatal tool failure — sandbox
+      // spawn/infra, CFC transport, artifact/run-state persistence, an engine
+      // invariant, or a cancelled run. These are not model-correctable, so the
+      // run stays fatal. RECOVERABLE mistakes (a `cwd` outside the sandbox, a
+      // command timeout) never arrive here: the bash tool converts them into an
+      // ordinary failed BashToolOutput the model reacts to, which flows through
+      // the normal CFC-mediated output path below (see bash.ts). Keeping the
+      // narrowing at the tool boundary is what lets this catch stay run-fatal
+      // without matching error-message strings.
       throw error;
     }
     const modelOutputResult = await this.#modelFacingToolOutput(

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -8,6 +8,7 @@ import {
   normalize,
 } from "@std/path/posix";
 import { DenoProcessRunner, type ProcessRunner } from "./process-runner.ts";
+import { SandboxPathEscapeError } from "./errors.ts";
 import type {
   DockerNetworkMode,
   DockerRunscAdditionalMount,
@@ -635,7 +636,10 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
       const rootLabel = this.config.additionalMounts.length === 0
         ? "workspace root"
         : "allowed sandbox roots";
-      throw new Error(`path escapes ${rootLabel}: ${path}`);
+      throw new SandboxPathEscapeError(
+        path,
+        `path escapes ${rootLabel}: ${path}`,
+      );
     }
     return normalized;
   }

--- a/packages/cf-harness/src/sandbox/errors.ts
+++ b/packages/cf-harness/src/sandbox/errors.ts
@@ -1,0 +1,21 @@
+/**
+ * A tool asked a sandbox to resolve a path that escapes its allowed roots.
+ *
+ * Why a dedicated type: this is the ONE `resolvePath` failure a tool may treat
+ * as RECOVERABLE — the model passed a bad path and can retry with a valid one,
+ * so the bash tool surfaces it as a failed result instead of letting it become
+ * a run-fatal throw (see tools/bash.ts). `SandboxRuntime.resolvePath` is an
+ * injected interface whose contract does not otherwise restrict its failures,
+ * so tools must narrow by THIS TYPE — never by matching the message string, and
+ * never by catching every `resolvePath` throw (a corrupt-runtime or invariant
+ * failure must stay fatal).
+ */
+export class SandboxPathEscapeError extends Error {
+  readonly attemptedPath: string;
+
+  constructor(attemptedPath: string, message?: string) {
+    super(message ?? `path escapes allowed sandbox roots: ${attemptedPath}`);
+    this.name = "SandboxPathEscapeError";
+    this.attemptedPath = attemptedPath;
+  }
+}

--- a/packages/cf-harness/src/tools/bash.ts
+++ b/packages/cf-harness/src/tools/bash.ts
@@ -11,7 +11,29 @@ import {
   cwdMarkerForOutput,
   extractFinalWorkingDirectory,
 } from "./shell-cwd.ts";
+import { ProcessTimeoutError } from "../sandbox/process-runner.ts";
+import { SandboxPathEscapeError } from "../sandbox/errors.ts";
 import type { HarnessToolDefinition } from "./types.ts";
+
+// Two RECOVERABLE tool errors the model itself can fix: it passed a `cwd`
+// outside the sandbox, or its command overran the time budget. Like the
+// curl-denied branch below, bash surfaces each as an ordinary failed
+// BashToolOutput the model reacts to on its next turn — it does NOT throw.
+// A throw here would propagate into `CfHarnessEngine.invokeBuiltinTool`, which
+// terminalizes the whole run as `failed`/`tool_error` and persists that state
+// (engine.ts) — killing an agent for a mistake it could simply correct. This
+// was defect D9 in the loom fuse-fabric-access arc and the topics-board topic
+// "cf-harness: tool-call failures are run-fatal (path escape, 20s timeout)".
+// Only host-safe, self-authored detail is echoed: the model's own `cwd` string
+// (already in the transcript) and the numeric timeout — never the raw
+// exception text, which can carry host paths or runtime config, and never the
+// resolved sandbox path. Genuinely fatal failures (docker spawn/infra, CFC
+// transport, persistence, invariants) are left to throw and stay run-fatal.
+export const BASH_CWD_OUTSIDE_SANDBOX_PREFIX = "cwd is outside the sandbox";
+export const BASH_CWD_OUTSIDE_SANDBOX_EXIT_CODE = 1;
+// 124 is the conventional shell exit code for a timed-out command (GNU coreutils
+// `timeout`), which agents already recognize.
+export const BASH_TIMEOUT_EXIT_CODE = 124;
 
 export interface BashToolInput {
   command: string;
@@ -76,9 +98,31 @@ export const bashTool: HarnessToolDefinition<BashToolInput, BashToolOutput> = {
   descriptor: bashToolDescriptor,
   async invoke(context, input) {
     const outputId = context.nextOutputId("bash");
-    const commandCwd = input.cwd !== undefined
-      ? context.resolvePath(input.cwd)
-      : context.currentDir;
+    let commandCwd: string;
+    try {
+      commandCwd = input.cwd !== undefined
+        ? context.resolvePath(input.cwd)
+        : context.currentDir;
+    } catch (error) {
+      // Only a genuine path-escape is recoverable. `context.resolvePath`
+      // delegates to an injected SandboxRuntime whose contract does not
+      // otherwise restrict its failures, so narrow by TYPE: a corrupt-runtime
+      // or invariant failure must stay run-fatal, not masquerade as a bad cwd.
+      if (!(error instanceof SandboxPathEscapeError)) {
+        throw error;
+      }
+      // Recoverable: keep the run alive, leave the working directory unchanged,
+      // and hand the model a known-safe message built from its own `cwd` —
+      // never the raw exception (may carry the sandbox root label) or the
+      // resolved path.
+      return {
+        outputId,
+        stdout: "",
+        stderr: `${BASH_CWD_OUTSIDE_SANDBOX_PREFIX}: ${input.cwd ?? ""}`,
+        exitCode: BASH_CWD_OUTSIDE_SANDBOX_EXIT_CODE,
+        cwd: context.currentDir,
+      };
+    }
     const curlPolicy = validateBashCurlCommand(input.command);
     if (!curlPolicy.allowed) {
       context.setCurrentDir(commandCwd);
@@ -97,24 +141,50 @@ export const bashTool: HarnessToolDefinition<BashToolInput, BashToolOutput> = {
       input.command,
       cwdMarker,
     );
-    const result = await context.sandbox.runShell({
-      command,
+    // Build the CFC invocation context BEFORE the timeout-catching try. It
+    // updates and persists run state; if it fails (including with a
+    // ProcessTimeoutError of its own), that is a setup/persistence failure that
+    // must stay run-fatal, not be misreported as a command timeout below —
+    // `runShell` has not even been called yet.
+    const cfcInvocationContext = await context.createCfcInvocationContext({
+      toolId: "bash",
+      toolOutputId: outputId,
+      operation: "shell",
       cwd: commandCwd,
-      timeoutMs: input.timeoutMs,
-      cfcInvocationContext: await context.createCfcInvocationContext({
-        toolId: "bash",
-        toolOutputId: outputId,
-        operation: "shell",
-        cwd: commandCwd,
-        command,
-        ...(input.cfcInputLabels !== undefined
-          ? { cfcInputLabels: input.cfcInputLabels }
-          : {}),
-        cfcInputLabelPaths: input.cwd !== undefined
-          ? [["command"], ["cwd"]]
-          : [["command"]],
-      }),
+      command,
+      ...(input.cfcInputLabels !== undefined
+        ? { cfcInputLabels: input.cfcInputLabels }
+        : {}),
+      cfcInputLabelPaths: input.cwd !== undefined
+        ? [["command"], ["cwd"]]
+        : [["command"]],
     });
+    let result: Awaited<ReturnType<typeof context.sandbox.runShell>>;
+    try {
+      result = await context.sandbox.runShell({
+        command,
+        cwd: commandCwd,
+        timeoutMs: input.timeoutMs,
+        cfcInvocationContext,
+      });
+    } catch (error) {
+      if (error instanceof ProcessTimeoutError) {
+        // Recoverable: the model's command overran its time budget. The command
+        // still ran in `commandCwd`, so adopt it as the working directory, and
+        // report only the numeric timeout — no host detail from the exception.
+        context.setCurrentDir(commandCwd);
+        return {
+          outputId,
+          stdout: "",
+          stderr: `command timed out after ${error.timeoutMs}ms`,
+          exitCode: BASH_TIMEOUT_EXIT_CODE,
+          cwd: commandCwd,
+        };
+      }
+      // Anything else from runShell — docker spawn/infra, CFC transport — is not
+      // something the model can fix. Let it propagate and stay run-fatal.
+      throw error;
+    }
     const mayTrustCwdMarker = context.cfcEnforcementMode === "disabled" ||
       context.cfcEnforcementMode === "observe";
     const cwdSourceStdout = mayTrustCwdMarker

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -13,6 +13,8 @@ import type { HarnessArtifactStore } from "../src/artifacts.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+import { ProcessTimeoutError } from "../src/sandbox/process-runner.ts";
+import { SandboxPathEscapeError } from "../src/sandbox/errors.ts";
 import { createHarnessImageAttachment } from "../src/image-attachments.ts";
 import { discoverHarnessSkills } from "../src/skills/registry.ts";
 import {
@@ -852,6 +854,154 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
       }),
     },
   );
+});
+
+// A sandbox whose resolvePath throws for anything outside /workspace, so we can
+// drive the bash tool's cwd-escape branch through the whole loop.
+class CwdEscapeSandboxRuntime extends FakeSandboxRuntime {
+  override resolvePath(path: string, cwd?: string): string {
+    if (!this.isPathWithinWorkspace(path)) {
+      // Mirrors docker-runsc.ts: the typed escape whose message carries a host
+      // root label that must NOT reach the model.
+      throw new SandboxPathEscapeError(
+        path,
+        `path escapes allowed sandbox roots: ${path}`,
+      );
+    }
+    return super.resolvePath(path, cwd);
+  }
+}
+
+// Two scripted turns: the model calls bash once, then (after seeing the tool
+// result) produces the given final text. Used by the recovery tests below.
+const twoTurnBashFetch = (
+  fetchCalls: RequestInit[],
+  bashArgs: Record<string, unknown>,
+  finalText: string,
+): typeof fetch =>
+(_input, init) => {
+  fetchCalls.push(init ?? {});
+  const payload = fetchCalls.length === 1
+    ? {
+      choices: [{
+        index: 0,
+        message: {
+          role: "assistant",
+          content: "",
+          tool_calls: [{
+            id: "call-1",
+            type: "function",
+            function: { name: "bash", arguments: JSON.stringify(bashArgs) },
+          }],
+        },
+      }],
+    }
+    : {
+      choices: [{
+        index: 0,
+        message: { role: "assistant", content: finalText },
+      }],
+    };
+  return Promise.resolve(
+    new Response(JSON.stringify(payload), { status: 200 }),
+  );
+};
+
+Deno.test("CfHarnessPromptLoop: a command timeout is a recoverable bash result, not a fatal run", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      // runShell raises the real timeout type for the model's command — the
+      // class that used to kill the whole run on turn 1.
+      sandboxRuntime: new FakeSandboxRuntime(
+        [],
+        new ProcessTimeoutError("bash -lc 'sleep 40'", 20_000),
+      ),
+      runId: "run-tool-timeout",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "disabled",
+    }),
+    fetchFn: twoTurnBashFetch(
+      fetchCalls,
+      { command: "sleep 40" },
+      "The command timed out; I'll run something shorter.",
+    ),
+  });
+
+  const result = await loop.runPrompt({ prompt: "Wait for a while." });
+
+  // The run completed, and the model got a second turn to react.
+  assertEquals(result.runState.status, "completed");
+  assertEquals(fetchCalls.length, 2);
+  const toolMessage = result.transcript.find((message) =>
+    message.role === "tool"
+  );
+  assert(toolMessage !== undefined);
+  // The model sees a bash result carrying a KNOWN-SAFE message we authored...
+  assertStringIncludes(toolMessage.content, "command timed out after 20000ms");
+  assertStringIncludes(toolMessage.content, "124");
+  // ...and NOT the raw exception text (`ProcessTimeoutError.message` is
+  // "process timed out after ..."), so no exception internals leak to the model.
+  assertEquals(toolMessage.content.includes("process timed out after"), false);
+});
+
+Deno.test("CfHarnessPromptLoop: a cwd outside the sandbox is a recoverable bash result, not a fatal run", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new CwdEscapeSandboxRuntime(),
+      runId: "run-tool-cwd-escape",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "disabled",
+    }),
+    fetchFn: twoTurnBashFetch(
+      fetchCalls,
+      { command: "ls", cwd: "/etc" },
+      "That path is off-limits; I'll stay under /workspace.",
+    ),
+  });
+
+  const result = await loop.runPrompt({ prompt: "List /etc." });
+
+  assertEquals(result.runState.status, "completed");
+  assertEquals(fetchCalls.length, 2);
+  const toolMessage = result.transcript.find((message) =>
+    message.role === "tool"
+  );
+  assert(toolMessage !== undefined);
+  // Echoes the model's own cwd with a safe message, never the raw resolvePath
+  // exception (which carries the sandbox root label).
+  assertStringIncludes(toolMessage.content, "cwd is outside the sandbox: /etc");
+  assertEquals(toolMessage.content.includes("path escapes"), false);
+});
+
+Deno.test("CfHarnessPromptLoop: a non-recoverable tool failure stays fatal and never reaches the model", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const engine = new CfHarnessEngine({
+    // A generic runShell failure (docker/infra) carrying host detail. This is
+    // NOT model-correctable: it must stay run-fatal, and its text must never
+    // become a model-facing tool result.
+    sandboxRuntime: new FakeSandboxRuntime(
+      [],
+      new Error("docker daemon unreachable at /Users/ben/.secret/socket"),
+    ),
+    runId: "run-tool-fatal",
+    model: "gpt-5.4",
+    cfcEnforcementMode: "disabled",
+  });
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine,
+    fetchFn: twoTurnBashFetch(fetchCalls, { command: "ls" }, "unreachable"),
+  });
+
+  await assertRejects(() => loop.runPrompt({ prompt: "List files." }));
+  // The run is terminal-failed, and the model never got a second turn — the
+  // host detail could not have leaked into a model-facing tool result.
+  assertEquals(engine.getRunState().status, "failed");
+  assertEquals(fetchCalls.length, 1);
 });
 
 Deno.test("CfHarnessPromptLoop forwards abort signals to gateway requests", async () => {

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -15,7 +15,14 @@ import type { HarnessBrowserAccessLease } from "../src/contracts/browser-access.
 import { BROWSER_SUBAGENT_ALLOWED_SKILL_SCRIPTS } from "../src/contracts/subagent.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import { discoverHarnessSkills } from "../src/skills/registry.ts";
-import { bashTool } from "../src/tools/bash.ts";
+import {
+  BASH_CWD_OUTSIDE_SANDBOX_EXIT_CODE,
+  BASH_CWD_OUTSIDE_SANDBOX_PREFIX,
+  BASH_TIMEOUT_EXIT_CODE,
+  bashTool,
+} from "../src/tools/bash.ts";
+import { ProcessTimeoutError } from "../src/sandbox/process-runner.ts";
+import { SandboxPathEscapeError } from "../src/sandbox/errors.ts";
 import { bashNoSandboxTool } from "../src/tools/bash-no-sandbox.ts";
 import { editFileTool } from "../src/tools/edit-file.ts";
 import { readFileTool } from "../src/tools/read-file.ts";
@@ -393,6 +400,89 @@ Deno.test("bash tool executes the command through the sandbox shell runtime", as
     ].join("\n").length,
   );
   assertEquals(context.currentDir, "/workspace/repo");
+});
+
+// --- recoverable vs fatal tool-boundary narrowing (D9 / cf-review) ----------
+
+Deno.test("bash tool: a SandboxPathEscapeError on cwd is a recoverable result, not a throw", async () => {
+  class PathEscapeSandbox extends FakeSandboxRuntime {
+    override resolvePath(path: string, cwd = this.defaultWorkingDirectory()) {
+      if (!this.isPathWithinWorkspace(path)) {
+        throw new SandboxPathEscapeError(
+          path,
+          `path escapes workspace root: ${path}`,
+        );
+      }
+      return super.resolvePath(path, cwd);
+    }
+  }
+  const sandbox = new PathEscapeSandbox();
+  const context = createContext(sandbox);
+  const output = await bashTool.invoke(context, { command: "ls", cwd: "/etc" });
+
+  assertEquals(output.exitCode, BASH_CWD_OUTSIDE_SANDBOX_EXIT_CODE);
+  assertStringIncludes(
+    output.stderr,
+    `${BASH_CWD_OUTSIDE_SANDBOX_PREFIX}: /etc`,
+  );
+  // The raw escape message (carrying the sandbox root label) never leaks.
+  assertEquals(output.stderr.includes("path escapes"), false);
+  // The command never ran and the working directory is unchanged.
+  assertEquals(sandbox.calls.length, 0);
+  assertEquals(output.cwd, "/workspace");
+});
+
+Deno.test("bash tool: a non-escape resolvePath failure stays fatal (rethrows)", async () => {
+  class CorruptResolveSandbox extends FakeSandboxRuntime {
+    override resolvePath(): string {
+      // NOT a path escape — a corrupt-runtime/invariant failure that must not
+      // be laundered into a recoverable "cwd outside sandbox" result.
+      throw new Error("sandbox runtime invariant violated: /Users/ben/.secret");
+    }
+  }
+  const context = createContext(new CorruptResolveSandbox());
+  await assertRejects(
+    () => bashTool.invoke(context, { command: "ls", cwd: "repo" }),
+    Error,
+    "sandbox runtime invariant violated",
+  );
+});
+
+Deno.test("bash tool: a ProcessTimeoutError from runShell is a recoverable result", async () => {
+  class TimeoutRunShellSandbox extends FakeSandboxRuntime {
+    override runShell(): Promise<SandboxCommandResult> {
+      return Promise.reject(
+        new ProcessTimeoutError("bash -lc 'sleep 40'", 20_000),
+      );
+    }
+  }
+  const context = createContext(new TimeoutRunShellSandbox());
+  const output = await bashTool.invoke(context, {
+    command: "sleep 40",
+    timeoutMs: 20_000,
+  });
+
+  assertEquals(output.exitCode, BASH_TIMEOUT_EXIT_CODE);
+  assertStringIncludes(output.stderr, "command timed out after 20000ms");
+  // Never the raw exception text ("process timed out after ...: <command>").
+  assertEquals(output.stderr.includes("process timed out after"), false);
+});
+
+Deno.test("bash tool: a ProcessTimeoutError during CFC-context setup stays fatal", async () => {
+  const sandbox = new FakeSandboxRuntime();
+  const context = createContext(sandbox);
+  // The invocation context is built (and run state persisted) BEFORE runShell.
+  // A timeout raised there is a persistence failure, not a command timeout, and
+  // must stay run-fatal rather than be misreported as a recoverable timeout.
+  context.createCfcInvocationContext = () => {
+    throw new ProcessTimeoutError("persist-run-state", 5);
+  };
+  await assertRejects(
+    () => bashTool.invoke(context, { command: "ls" }),
+    ProcessTimeoutError,
+  );
+  // runShell was never reached.
+  assertEquals(sandbox.calls.length, 0);
 });
 
 Deno.test("bash tool preserves currentDir inside a configured Fabric mount", async () => {


### PR DESCRIPTION
## Why

A single failing tool call used to kill the **entire** agent run. When a model's `bash` call sets a `cwd` outside the sandbox, `resolvePath` throws; when a command exceeds the time budget, `runShell` throws `ProcessTimeoutError`. Either propagated into `CfHarnessEngine.invokeBuiltinTool`'s catch, which marks the run `failed`/`tool_error` and **persists** it before rethrowing.

The practical effect: a model that orients by running `ls /` (a natural first move in a container) killed its own run on turn 1, and an agent told to wait-and-retry that slept in a command tripped the time budget and died the same way. Hit repeatedly running stock agents against a fabric mount in the loom `fuse-fabric-access` arc (defect **D9**) and filed on the public topics board as *"cf-harness: tool-call failures are run-fatal (path escape, 20s timeout)"*.

A bad `cwd` and an overrun command are things the **model can correct** — not reasons to tear down the whole run.

## What changed

Fix at the **tool boundary**, mirroring the bash tool's existing curl-denied branch: `bashTool.invoke` converts these two recoverable conditions into an ordinary failed `BashToolOutput` (nonzero exit + a known-safe `stderr`) the model reacts to on its next turn, instead of throwing. Only self-authored, host-safe detail is echoed — the model's own `cwd` string (already in the transcript) and the numeric timeout — **never** the raw exception or the resolved path. The output flows the normal `#modelFacingToolOutput` path, so **CFC enforce-mode mediation still applies**, and the run is **never** terminalized for these.

The narrowing is by **type** and by **minimal try-scope**, never by error-message matching:

- **cwd escape** → a new typed `SandboxPathEscapeError` (`sandbox/errors.ts`) thrown by `DockerRunscSandbox.resolvePath`; the bash tool catches **only that type**. `SandboxRuntime.resolvePath` is an injected interface whose contract doesn't otherwise restrict its failures, so a corrupt-runtime / invariant failure **rethrows and stays run-fatal**. → `exit 1`, `stderr: "cwd is outside the sandbox: <cwd>"`.
- **timeout** → `catch (e) if (e instanceof ProcessTimeoutError)` around **only** the `runShell` await. The CFC invocation context (which persists run state) is built **before** the try, so a `ProcessTimeoutError` raised during that persistence stays fatal instead of masquerading as a command timeout. → `exit 124`, `stderr: "command timed out after <n>ms"`.

Errors that **throw** still fail the run: the prompt loop's tool catch is unchanged (rethrows), so non-escape `resolvePath` failures, `runShell` throws other than `ProcessTimeoutError`, CFC-context persistence failures, and engine invariants all remain run-fatal.

### Out of scope (pre-existing) — tracked in CT-1912

Round-3 review surfaced that some *pre-command* sandbox failures — docker `create` nonzero, missing container ID, and CFC-sidecar write failure — are **returned** by `DockerRunscSandbox.run()` as a `SandboxCommandResult` (exit 125), not thrown, so they reach the model as a bash result and the sidecar path embeds a raw host transport path. This PR **does not touch those paths** (its only `docker-runsc.ts` change is the typed `resolvePath` throw) and does not change how bash forwards a returned nonzero result — the behavior is pre-existing (since #4018). Making infra/CFC-transport setup failures fatal + redacting the host path is filed as **[CT-1912](https://linear.app/common-tools/issue/CT-1912)**.

### Review history

Tool-boundary redesign of an original broad prompt-loop catch, across three `/cf-review` rounds: R1 flagged the broad catch swallowed setup/persistence/invariant errors and sent raw `error.message` unmediated → moved to the tool boundary; R2 flagged two narrowing gaps → typed `SandboxPathEscapeError` + hoisted CFC setup; R3 confirmed both resolved and no leakage in the recoverable messages, and surfaced the pre-existing infra hole above (CT-1912).

Exit-code: unchanged — a recovered run exiting 0 matches existing behavior for a nonzero `bash` result.

## Test plan

- **`tools-execution.test.ts`** (bash boundary): a typed path-escape and a `runShell` timeout each become recoverable results (safe message only, raw exception **absent**); a **non-escape** resolvePath failure and a `ProcessTimeoutError` **during CFC setup** each stay **fatal** (rethrow).
- **`prompt-loop.test.ts`**: the same two recoveries end-to-end through the loop; a generic `runShell` failure stays fatal and never reaches the model.
- **`engine.integration.test.ts`** (`CF_HARNESS_INTEGRATION=1`): the full loop over the **real `runsc-cfc` sandbox** — a genuine `resolvePath` throw for `cwd:"/"` recovers to completion. **Verified live: `ok (935ms)`.**
- Full `packages/cf-harness/test/` suite: **507 passed, 0 failed**. `deno fmt --check` + `deno lint` clean; touched source type-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)