### PR TITLE
refactor(schema-generator): compare schema/default values with valueEqual, not JSON.stringify

### DIFF
--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -9,6 +9,7 @@ import {
 } from "../typescript/cell-brand.ts";
 import { isDefaultAliasSymbol } from "../typescript/property-optionality.ts";
 import { numberFromExpression } from "../typescript/numeric-expression.ts";
+import { dedupeByValueEqual } from "../value-equality.ts";
 import type {
   AsCellEntry,
   JSONSchemaMutable,
@@ -2086,16 +2087,10 @@ export class CommonFabricFormatter implements TypeFormatter {
     } else if (schemas.length === 1) {
       return schemas[0]!;
     } else {
-      // Deduplicate identical schemas
-      const seen = new Set<string>();
-      const unique: JSONSchemaMutable[] = [];
-      for (const schema of schemas) {
-        const key = JSON.stringify(schema);
-        if (!seen.has(key)) {
-          seen.add(key);
-          unique.push(schema);
-        }
-      }
+      // Deduplicate identical schemas. `valueEqual` (Object.is at leaves) is
+      // the honest comparison: a `JSON.stringify` dedup key collides distinct
+      // values (`-0`/`0`, `NaN`/`Infinity`) and is key-order sensitive.
+      const unique = dedupeByValueEqual(schemas);
 
       if (unique.length === 1) {
         return unique[0]!;

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -16,10 +16,7 @@ import {
   TypeWithInternals,
 } from "../type-utils.ts";
 import { isRecord } from "@commonfabric/utils/types";
-import {
-  type FabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { dedupeByValueEqual } from "../value-equality.ts";
 
 // Simple primitive schemas only have these keys (possibly just one)
@@ -1050,11 +1047,8 @@ export class UnionFormatter implements TypeFormatter {
       // so we don't need to add it to the list, and we can just return.
       return false;
     }
-    if (
-      anyOf.some((option) =>
-        valueEqual(option as FabricValue, cur as FabricValue)
-      )
-    ) {
+    const curHash = hashStringOf(cur);
+    if (anyOf.some((option) => hashStringOf(option) === curHash)) {
       return false;
     }
     // See if we can merge into one of the anyOf options

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -16,6 +16,11 @@ import {
   TypeWithInternals,
 } from "../type-utils.ts";
 import { isRecord } from "@commonfabric/utils/types";
+import {
+  type FabricValue,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
+import { dedupeByValueEqual } from "../value-equality.ts";
 
 // Simple primitive schemas only have these keys (possibly just one)
 const PRIMITIVE_SCHEMA_KEY_SET = new Set(["type", "enum"]);
@@ -1045,8 +1050,11 @@ export class UnionFormatter implements TypeFormatter {
       // so we don't need to add it to the list, and we can just return.
       return false;
     }
-    const curStr = JSON.stringify(cur);
-    if (anyOf.some((option) => JSON.stringify(option) === curStr)) {
+    if (
+      anyOf.some((option) =>
+        valueEqual(option as FabricValue, cur as FabricValue)
+      )
+    ) {
       return false;
     }
     // See if we can merge into one of the anyOf options
@@ -1065,15 +1073,18 @@ export class UnionFormatter implements TypeFormatter {
       isRecord(cur) && Array.isArray(cur.enum) && isRecord(matchingType) &&
       Array.isArray(matchingType.enum)
     ) {
-      // Add our enum values to their enum values, and keep the same type
-      const mergedEnum = new Set([
+      // Add our enum values to their enum values, and keep the same type.
+      // Dedupe by `valueEqual` rather than a `Set`: a `Set` uses SameValueZero,
+      // which would collapse `-0` and `0` into one enum member, where the value
+      // model keeps them distinct.
+      const mergedEnum = dedupeByValueEqual([
         ...matchingType.enum,
         ...cur.enum,
       ]);
       // Special case for boolean with all options
       if (
-        cur.type === "boolean" && mergedEnum.has(true) &&
-        mergedEnum.has(false)
+        cur.type === "boolean" && mergedEnum.includes(true) &&
+        mergedEnum.includes(false)
       ) {
         // this collapse may allow us to combine with other options that have only a type,
         // but I'm not doing that currently.
@@ -1082,7 +1093,7 @@ export class UnionFormatter implements TypeFormatter {
       } else {
         anyOf[matchingTypeIdx] = {
           ...matchingType,
-          enum: [...mergedEnum].toSorted(),
+          enum: mergedEnum.toSorted(),
         };
       }
     } else if (isRecord(matchingType)) {

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -1,9 +1,6 @@
 import ts from "typescript";
 
-import {
-  type FabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import type { JSONSchemaMutable } from "@commonfabric/api";
 import { NativeTypeFormatter } from "./formatters/native-type-formatter.ts";
 import { getPropertyNameText } from "./typescript/property-name.ts";
@@ -1045,10 +1042,10 @@ export function extractDefaultValueFromBrandedMembers(
     if (agreed === undefined) {
       agreed = extracted;
     } else if (
-      !valueEqual(agreed.value as FabricValue, extracted.value as FabricValue)
+      hashStringOf(agreed.value) !== hashStringOf(extracted.value)
     ) {
       // Genuine disagreement between two branded members is ambiguous; bail.
-      // `valueEqual` (Object.is at leaves) is the honest comparison here: a
+      // The canonical content hash is the honest comparison here: a
       // `JSON.stringify` round-trip would call `-0` and `0` equal, and both
       // `NaN` and `Infinity` equal (each renders `null`), and would spuriously
       // disagree on equal objects written in a different key order.

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -1,5 +1,9 @@
 import ts from "typescript";
 
+import {
+  type FabricValue,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
 import type { JSONSchemaMutable } from "@commonfabric/api";
 import { NativeTypeFormatter } from "./formatters/native-type-formatter.ts";
 import { getPropertyNameText } from "./typescript/property-name.ts";
@@ -1041,8 +1045,13 @@ export function extractDefaultValueFromBrandedMembers(
     if (agreed === undefined) {
       agreed = extracted;
     } else if (
-      JSON.stringify(agreed.value) !== JSON.stringify(extracted.value)
+      !valueEqual(agreed.value as FabricValue, extracted.value as FabricValue)
     ) {
+      // Genuine disagreement between two branded members is ambiguous; bail.
+      // `valueEqual` (Object.is at leaves) is the honest comparison here: a
+      // `JSON.stringify` round-trip would call `-0` and `0` equal, and both
+      // `NaN` and `Infinity` equal (each renders `null`), and would spuriously
+      // disagree on equal objects written in a different key order.
       return undefined;
     }
   }

--- a/packages/schema-generator/src/value-equality.ts
+++ b/packages/schema-generator/src/value-equality.ts
@@ -9,8 +9,15 @@ import { hashStringOf } from "@commonfabric/data-model/value-hash";
  * pairwise comparison: the hash IS the value model's identity — `valueEqual`'s
  * own object path compares `hashStringOf(a) === hashStringOf(b)` — so grouping
  * by hash string in a `Set` yields the same result as O(N²) pairwise
- * `valueEqual`, in one pass. Each item is hashed exactly once; for a deep-frozen
- * item that hash is cached, so it is effectively free.
+ * `valueEqual`, hashing each item just once within this call instead.
+ *
+ * That "once" is per call, not per generation: these schemas are still mutable
+ * when deduped, and `value-hash`'s object-hash cache is keyed on deep-frozen
+ * identity, so each hash is computed fresh, and content nested in an item is
+ * hashed again whenever an enclosing schema is hashed at an outer step. That is
+ * inherent to hashing a mutable tree and is immaterial at the sizes here (a
+ * union's members, an enum's values); if these values were deep-frozen the
+ * cache would remove the repeat work.
  *
  * This is the honest comparison for schema and enum values, where a
  * `JSON.stringify` key or a `Set` of the values is not: stringify renders `NaN`

--- a/packages/schema-generator/src/value-equality.ts
+++ b/packages/schema-generator/src/value-equality.ts
@@ -1,0 +1,28 @@
+import {
+  type FabricValue,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
+
+/**
+ * Deduplicate `items` by `valueEqual` — the value model's own equality, which
+ * leads with `Object.is` at primitive leaves. Keeps the first of each equal
+ * group, in order.
+ *
+ * This is the honest comparison for schema and enum values, where a
+ * `JSON.stringify` key or a `Set` is not: stringify renders `NaN` and
+ * `±Infinity` as `null` and drops the sign of `-0` (so distinct values collide),
+ * and is sensitive to object key order (so equal values with different insertion
+ * order do NOT collide when they should); a `Set` uses SameValueZero, which
+ * conflates `-0` with `0`. `valueEqual` distinguishes `-0` from `0`, treats
+ * `NaN` as equal to itself, and does not depend on key order.
+ */
+export function dedupeByValueEqual<T>(items: readonly T[]): T[] {
+  const out: T[] = [];
+  for (const item of items) {
+    const isDuplicate = out.some((kept) =>
+      valueEqual(kept as FabricValue, item as FabricValue)
+    );
+    if (!isDuplicate) out.push(item);
+  }
+  return out;
+}

--- a/packages/schema-generator/src/value-equality.ts
+++ b/packages/schema-generator/src/value-equality.ts
@@ -1,28 +1,36 @@
-import {
-  type FabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 /**
- * Deduplicate `items` by `valueEqual` — the value model's own equality, which
- * leads with `Object.is` at primitive leaves. Keeps the first of each equal
+ * Deduplicate `items` by value-model equality, keeping the first of each equal
  * group, in order.
  *
+ * Equality is decided by canonical content hash (`hashStringOf`) rather than
+ * pairwise comparison: the hash IS the value model's identity — `valueEqual`'s
+ * own object path compares `hashStringOf(a) === hashStringOf(b)` — so grouping
+ * by hash string in a `Set` yields the same result as O(N²) pairwise
+ * `valueEqual`, in one pass. Each item is hashed exactly once; for a deep-frozen
+ * item that hash is cached, so it is effectively free.
+ *
  * This is the honest comparison for schema and enum values, where a
- * `JSON.stringify` key or a `Set` is not: stringify renders `NaN` and
- * `±Infinity` as `null` and drops the sign of `-0` (so distinct values collide),
- * and is sensitive to object key order (so equal values with different insertion
- * order do NOT collide when they should); a `Set` uses SameValueZero, which
- * conflates `-0` with `0`. `valueEqual` distinguishes `-0` from `0`, treats
- * `NaN` as equal to itself, and does not depend on key order.
+ * `JSON.stringify` key or a `Set` of the values is not: stringify renders `NaN`
+ * and `±Infinity` as `null` and drops the sign of `-0` (distinct values
+ * collide), and is key-order sensitive (equal values do not collide); a `Set`
+ * uses SameValueZero, which conflates `-0` with `0`. The content hash makes the
+ * value model's distinctions -- `-0` ≠ `0`, `NaN` = `NaN`, key-order-independent
+ * -- exactly.
  */
-export function dedupeByValueEqual<T>(items: readonly T[]): T[] {
+export function dedupeByValueEqual<T extends FabricValue>(
+  items: readonly T[],
+): T[] {
+  const seen = new Set<string>();
   const out: T[] = [];
   for (const item of items) {
-    const isDuplicate = out.some((kept) =>
-      valueEqual(kept as FabricValue, item as FabricValue)
-    );
-    if (!isDuplicate) out.push(item);
+    const hash = hashStringOf(item);
+    if (!seen.has(hash)) {
+      seen.add(hash);
+      out.push(item);
+    }
   }
   return out;
 }

--- a/packages/schema-generator/test/value-equality.test.ts
+++ b/packages/schema-generator/test/value-equality.test.ts
@@ -1,0 +1,72 @@
+import { assertEquals } from "@std/assert";
+
+import { dedupeByValueEqual } from "../src/value-equality.ts";
+
+// These pin the distinctions the schema formatters need but that their previous
+// `JSON.stringify` / `Set` comparisons could not make. The formatter call sites
+// take their values from the type system, which cannot express `-0` / `NaN` /
+// `±Infinity`, so the conflations are unreachable through a real pattern today.
+// `dedupeByValueEqual` is exercised directly here instead, the same way
+// `valueEqual` itself is pinned against `Object.is`: feed it the edge values and
+// assert the honest result, so the guarantee holds if the schema system ever
+// does route such values through these paths.
+
+Deno.test("dedupeByValueEqual: keeps -0 and 0 as distinct values", () => {
+  // A `Set` (SameValueZero) or a `JSON.stringify` key ("0" for both) would
+  // collapse these into one. The value model keeps them apart.
+  assertEquals(dedupeByValueEqual([0, -0]), [0, -0]);
+});
+
+Deno.test("dedupeByValueEqual: treats NaN as equal to itself", () => {
+  assertEquals(dedupeByValueEqual([NaN, NaN]).length, 1);
+});
+
+Deno.test("dedupeByValueEqual: keeps NaN, Infinity, and null distinct", () => {
+  // `JSON.stringify` renders all three as `null`, so a stringify key would
+  // merge them; each is its own value.
+  const deduped = dedupeByValueEqual([NaN, Infinity, -Infinity, null]);
+  assertEquals(deduped.length, 4);
+});
+
+Deno.test("dedupeByValueEqual: is not sensitive to object key order", () => {
+  // `JSON.stringify` would emit different text for these and keep both; they are
+  // the same value.
+  const deduped = dedupeByValueEqual([{ a: 1, b: 2 }, { b: 2, a: 1 }]);
+  assertEquals(deduped, [{ a: 1, b: 2 }]);
+});
+
+Deno.test("dedupeByValueEqual: keeps schemas that differ only by a -0 default", () => {
+  // The `maybeWrapInAnyOf` / anyOf-dedup case: two number schemas whose only
+  // difference is a signed-zero default. A stringify key ("...0...") would drop
+  // one; both survive.
+  const a = { type: "number", default: -0 };
+  const b = { type: "number", default: 0 };
+  assertEquals(dedupeByValueEqual([a, b]), [a, b]);
+});
+
+Deno.test("dedupeByValueEqual: collapses genuinely equal schemas", () => {
+  // The dedup still does its job for real duplicates, including equal ones
+  // written in different key order.
+  const deduped = dedupeByValueEqual([
+    { type: "number", default: 5 },
+    { default: 5, type: "number" },
+    { type: "string" },
+  ]);
+  assertEquals(deduped, [{ type: "number", default: 5 }, { type: "string" }]);
+});
+
+// An executable statement of why the previous comparisons were wrong, so that
+// if these ever start passing the refactor is no longer load-bearing and can be
+// revisited.
+Deno.test("contrast: JSON.stringify and Set conflate what dedupeByValueEqual separates", () => {
+  // JSON.stringify collides the values the value model distinguishes...
+  assertEquals(JSON.stringify(-0), JSON.stringify(0)); // both "0"
+  assertEquals(JSON.stringify(NaN), JSON.stringify(null)); // both "null"
+  assertEquals(JSON.stringify(Infinity), JSON.stringify(null)); // both "null"
+  assertEquals(
+    JSON.stringify({ a: 1, b: 2 }) === JSON.stringify({ b: 2, a: 1 }),
+    false, // ...and splits equal values by key order
+  );
+  // ...and a Set merges -0 with 0 (SameValueZero).
+  assertEquals([...new Set([0, -0])].length, 1);
+});


### PR DESCRIPTION
Item 2 of the `===`/`Object.is` audit follow-ups (the "latent stringify-conflation" sites), now that #4887 landed. Off `main`.

## Finding first: these were not actually reachable

The handoff notes flagged four sites as conflations that #4887 would "activate."
Investigating on current `main`, that does not hold: every one takes its value
from the **type system**, which normalizes `-0` to `0` and cannot express `NaN`
or `±Infinity` at all. A probe confirms a `-0` object default emits correctly
and is never conflated. So this is a **robustness / hygiene** change, not a bug
fix, and it is behavior-neutral — every existing schema-generator and
ts-transformers golden is unchanged.

It is still worth doing: the comparisons are the fragile `JSON.stringify` /
`Set` pattern this whole audit has been retiring, and moving to value-model
equality aligns the schema system with the direction of fully embracing
`FabricValue` (@danfuzz's steer). Equality is decided by canonical content hash
(`hashStringOf` — the value model's own identity) via a shared
`dedupeByValueEqual`.

This is for correctness and alignment, **not** speed. A companion change to
deep-freeze generated schemas (so the hash cache could be reused) was built and
measured, found to be a net cost with no in-process schema-reuse to exploit, and
dropped; the content-hash comparison itself is a negligible cost over the
`JSON.stringify` it replaces (a few µs on `generateSchema`, far under 1% of
compile).

## What the old comparisons got wrong

- `JSON.stringify`: `NaN` and `±Infinity` → `null`, `-0` → `0` (distinct values
  collide), and key-order sensitive (equal values wrongly kept apart).
- `Set`: SameValueZero merges `-0` with `0`.

## Sites (now content-hash equality, via a shared `dedupeByValueEqual`)

| site | was |
| --- | --- |
| `type-utils.ts` default-agreement across branded members | `JSON.stringify(a) !== JSON.stringify(b)` |
| `union-formatter.ts` anyOf-option dedup | `JSON.stringify(option) === JSON.stringify(cur)` |
| `union-formatter.ts` enum-value merge | `new Set([...])` |
| `common-fabric-formatter.ts` `maybeWrapInAnyOf` dedup | `Set<string>` of `JSON.stringify(schema)` |

**Left as-is:** `mergeIdenticalSchemas`. Its `normalizeSchemaForComparison`
strips `enum` to its base type and never copies `default`, so no weird value
reaches its `JSON.stringify` grouping key, and it builds the key in fixed order.
Noted in the code.

The runner already validates enum membership with `Object.is`-leaved equality
(`deepEqual` in `runner/src/schema.ts`), so keeping `-0` and `0` distinct on the
generation side is consistent with how they'd be matched.

## Testing

Because the conflations cannot be driven through a real pattern, correctness is
pinned where it can be — on the pure `dedupeByValueEqual` helper, the same way
`valueEqual` itself was pinned against `Object.is`:

- `-0` and `0` kept distinct; `NaN` equal to itself; `NaN` / `Infinity` /
  `-Infinity` / `null` all distinct; key-reordered objects collapse; schemas
  differing only by a `-0` default both kept; genuine duplicates still collapse.
- A contrast test states what `JSON.stringify` and `Set` do to the same inputs.
- Confirmed to **fail** against a `JSON.stringify` implementation of the helper
  (5 of 7).

schema-generator `54 passed`, ts-transformers `1105 passed`, `./tasks/check.sh`
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4s5BjnzfVbJS6VVydhZPR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787410154&installation_model_id=428580&pr_number=4942&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4942&signature=39d0f090aba6a2eb80b73179aa12ea54c14a8c5e4f938e255ff9130b2b9b963e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Perf baseline overrides (CI noise, not this PR)

This change touches only `packages/schema-generator` (compile-time, ~µs per
`generateSchema`), so it cannot affect these pattern-unit subtest timings. Two
consecutive perf-check runs flagged different unrelated metrics (a runner-test
shard, then these two pattern-unit test files), each a small absolute time
swinging ~2× — CI machine variance, not a regression here. Accepting the current
run's timings as the baseline per the project process:

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/airtable/core/util/airtable-auth-manager.test.tsx = 5s
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/cfc-group-chat-demo/main.test.tsx = 12s
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/cfc-group-chat-demo/multi-user.test.tsx = 11s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched schema/default equality to content-hash (`hashStringOf`) instead of `JSON.stringify`/`Set` to prevent value conflation and make dedupe O(N). No behavior change; aligns with the `FabricValue` model.

- **Refactors**
  - Added `dedupeByValueEqual` (groups by `hashStringOf` from `@commonfabric/data-model/value-hash`, `T extends FabricValue`) for stable, order-insensitive dedup; dropped casts at call sites.
  - Updated comparisons in `common-fabric-formatter.ts` (schema dedup), `union-formatter.ts` (anyOf dedup via `hashStringOf`; enum merge via `dedupeByValueEqual`), and `type-utils.ts` (branded-member default agreement via `hashStringOf`).
  - Kept `mergeIdenticalSchemas` on its safe `JSON.stringify` key.
  - Clarified helper docs: inputs are mutable, so hashes are recomputed per call; single-pass Set still gives O(N) behavior.

<sup>Written for commit f5faba69f1c97ed668b99abff9fc7fbe180223c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




