### PR TITLE
docs: tighten the fabric overview's closing third; define patterns early

### DIFF
--- a/docs/plans/inverting-the-physics-of-trust.md
+++ b/docs/plans/inverting-the-physics-of-trust.md
@@ -36,8 +36,9 @@ matters) is the same ceiling: sensitive data, untrusted input, and
 network access cannot safely coexist under the current rules.
 
 The fabric is a runtime built on the opposite rule: **the software is
-untrusted, and safety attaches to the data.** Three mechanisms enforce
-it, and all three are built. Together they form a distributed, trusted
+untrusted, and safety attaches to the data.** Its unit of untrusted
+code is the pattern: a small, bounded program. Three mechanisms enforce
+the rule — all three built — and they add up to a distributed, trusted
 microkernel for networked software in the AI era.
 
 ## In this repository
@@ -48,7 +49,7 @@ microkernel for networked software in the AI era.
 - the flow-checking machinery
 - the sandboxing
 - a reactive, multiplayer-by-default storage layer with keypair identity
-- roughly two hundred running programs, including a live demonstration
+- roughly two hundred running patterns, including a live demonstration
   of prompt injection being structurally contained
   (`packages/patterns/cfc-agent-prompt-injection-demo/`)
 - an attestation pipeline running on Intel TDX hardware
@@ -96,14 +97,15 @@ bit of a nag, and the reward for satisfying it is code that provably has
 no data races. Humans find such checkers a slog. Language models have
 infinite patience: they are happy to grind against the checker until it
 is satisfied, and whatever they come up with is safe by construction.
-And because programs carry no authority of their own, any program anyone
-has already spent the tokens to make can be safely reused: programs are
-crowd-sourced, cached save points in the latent space of software.
+And because patterns carry no authority of their own, any pattern
+anyone has already spent the tokens to make can be safely reused:
+patterns are crowd-sourced, cached save points in the latent space of
+software.
 
-What makes the check tractable is the compiler: programs are plain
+What makes the check tractable is the compiler: patterns are plain
 TypeScript, and the compiler rewrites every closure to capture only the
 fields it actually reads, so taint is tracked per field rather than per
-program, and the full dataflow graph is known before anything runs. None
+pattern, and the full dataflow graph is known before anything runs. None
 of this is hidden: `cf check <pattern> --show-transformed` prints the
 exact code the runtime executes.
 
@@ -114,8 +116,8 @@ prove, bit for bit, that it is running the open-source runtime, in
 memory its own operator cannot read. Nodes refuse peers that cannot
 prove it, so you can build a trusted fabric out of untrusted nodes: your
 data may flow anywhere that can prove itself, and nowhere else. Identity
-is a keypair, not an account. State accretes at Schelling points, and
-durable Schelling points form where no participant can hold the state
+is a keypair, not an account, so state accretes at Schelling points —
+and the durable ones form where no participant can hold the state
 hostage.
 
 Attestation is existing hardware pointed backward. Confidential
@@ -132,7 +134,7 @@ attestation is only as strong as the ecosystem that checks it
 (independent verifiers, transparency logs, reproducible builds), and
 nobody stands up that ecosystem for one workload; a payments enclave is
 not worth it. A general-purpose runtime that can run anything is a
-different matter: verify the runtime once, and every program that ever
+different matter: verify the runtime once, and every pattern that ever
 runs on it inherits the verification.
 
 ## Four classes of cloud security
@@ -178,8 +180,7 @@ exploded, it invalidated Windows 95's security model, no amount of
 patching a monolithic kernel could make it safe, and the industry moved
 to NT, a kernel with the boundary designed in from the start.
 
-There is also a reason this is buildable now and was not before: two
-ingredients arrived almost at once. Secure enclaves make trust across a
+This is buildable now because two ingredients arrived almost at once. Secure enclaves make trust across a
 network possible. And language models write software for approximately
 free; a new framework used to mean convincing humans to write for an
 empty ecosystem, and now models will happily write for it. The standard
@@ -189,69 +190,76 @@ infinite software.
 
 ## Resonant by default
 
-Hollow things are things you like, but afterwards you are left feeling
-regret. Resonant things are things you like, and afterwards you feel
-nourished. They are superficially similar but fundamentally different.
-Modern society — modern tech, modern business, modern politics — is
-great at delivering hollow experiences and terrible at delivering
-resonant ones. AI supercharges everything, so it is more important than
+All of this machinery is for one thing: how software feels to live
+with. Hollow things are things you like, but
+afterwards you are left feeling regret. Resonant things are things you
+like, and afterwards you feel nourished. They are superficially similar
+but fundamentally different. Modern society — modern tech, modern
+business, modern politics — is great at delivering hollow experiences
+and terrible at delivering resonant ones; the aggregator equilibrium,
+maximally-used and minimally-liked, is hollowness as a market outcome. AI supercharges everything, so it is more important than
 ever that software become resonant by default. And to do that, you need
 to invert the physics of trust.
 
-[Resonant computing](https://resonantcomputing.org) has five
-principles, and the inversion is what turns each one from aspiration
-into structure:
+[Resonant computing](https://resonantcomputing.org), a manifesto we
+co-authored, names five principles. The inversion gives each one
+teeth:
 
 - **Private.** Policies on data make people the primary stewards of
   their own context, determining how it is used.
-- **Dedicated.** Flow checking proves at compile time that software
-  works exclusively for you — no hidden agendas, no conflicting
-  interests.
-- **Plural.** The attestation mesh and keypair identity mean no single
-  entity controls the digital spaces we inhabit.
-- **Adaptable.** Infinite software, safe by construction: open-ended,
-  able to meet the specific, context-dependent needs of each person.
-- **Prosocial.** A multiplayer substrate where collective signals
-  belong to the people whose data they are — software that helps us
-  become better neighbors, collaborators, and stewards of shared
-  spaces.
+- **Dedicated.** Flow checking proves at compile time that your data
+  serves no interest but yours: every flow out of your context is
+  either policy-permitted or a compile error.
+- **Plural.** No single entity controls the digital spaces we inhabit:
+  identity is a keypair, and the mesh has no center.
+- **Adaptable.** Infinite software, safe by construction — open-ended
+  enough to meet each person's actual needs.
+- **Prosocial.** Multiplayer is the substrate default, and collective
+  signals carry the policies of the people who generated them: no
+  intermediary can own what a group made together.
 
 ## From cells to a city
 
-This is what life did with dangerous chemistry: put it in boundaries.
-The mechanisms above are the membrane, and what they make possible is
-small, bounded programs — policy-checked, provenance-carrying, unable
-to leak what they touch. A single one is unimpressive. But as more
-patterns accumulate, they transmute into something radically different,
-with emergent power that makes the individual programs look puny: a
-general-purpose material that can be shaped into nearly infinite
-variety.
+Life did this with dangerous chemistry: put it in cells. The
+mechanisms above are the membrane, and what they make possible is
+patterns: policy-checked, provenance-carrying, unable to leak what they
+touch. A
+single one is unimpressive: a screenshot of any one running pattern
+looks like almost nothing, the way any single web page looked like
+almost nothing in 1994. The point of the web was never a page; it was
+the emergent whole, the ability to teleport anywhere. The same is true
+here. Because policies survive derivation, patterns compose: any two
+that check can be joined, and the joint result still checks; no trust
+negotiation required. As more patterns accumulate,
+they transmute into something radically different, with emergent power
+that makes the individual patterns look puny: a general-purpose
+material that can be shaped into nearly anything. The patterns are the
+cells; the fabric is the organism.
 
 Infinite software will not be infinite apps; it will be one system that
 does infinite things. The software melts away, and it feels like your
-data coming alive — something that lives with you, holding up the day
-like a tray: light, organized, human-scale, the mundane scaffolding of
-a good life. Alive not like a person, with one face you can talk to,
+data coming alive — something that lives with you. Alive not like a
+person, with one face you can talk to,
 but like a city. A whole city of cognitive labor that works just for
 you.
 
 ## The whole unlock
 
-For forty years we have structurally underproduced software: the
-expense of creating it, and the verticalized world of the same-origin
-paradigm. LLMs have changed the first. We can change the second.
+For forty years we have structurally underproduced software, for two
+reasons: it was expensive to create, and the same-origin paradigm
+verticalized the world. LLMs removed the expense. The paradigm is a
+design choice.
 Personal computing was supposed to make computers personal; instead, it
 made people subordinate to software. This is the way back: a personal
-fabric that everyone can own, woven into a society-scale common fabric
-of intention. If the singularity comes, let it be plural: exuberant,
+fabric that everyone can own, woven into a society-scale common
+fabric. If the singularity comes, let it be plural: exuberant,
 creative, messy — billions of experiments in flourishing, not one
 experiment in species-wide management.
 
-And none of it survives without the inversion. Every property above
-leans on the same rule — the fabric has your intentions woven in,
-structurally guiding what it can and cannot do, not as some hastily
-jury-rigged solution on top. Safety attaches to the data, not the
-software. Inverting the physics of trust is the whole unlock.
+And none of it survives without the inversion. The fabric has your
+intentions woven in, structurally guiding what it can and cannot do —
+not as some hastily jury-rigged solution on top. Inverting the physics
+of trust is the whole unlock.
 
 ## Where things stand
 


### PR DESCRIPTION
## Why

Follow-up to #4939. Review feedback on the landed overview: the closing third introduced the resonant-computing frame too abruptly, two of the five principles claimed more than the mechanisms prove, the emergence argument asserted rather than showed, and "pattern" — the fabric's actual unit of untrusted code — was never defined, leaving the doc saying "programs" throughout.

## What changed

- Define the pattern in the lede ("its unit of untrusted code is the pattern: a small, bounded program") and use the term consistently.
- Bridge into "Resonant by default" and tie hollow/resonant to the aggregator equilibrium established in the lede; note resonant computing as a co-authored manifesto.
- "Dedicated" and "Prosocial" now name their enforcing mechanisms instead of overclaiming (flow checking proves flows, not motives).
- The emergence paragraph shows its mechanism — policies survive derivation, so patterns compose without trust negotiation — with the 1994-web-page analogy: no single pattern is the point; the fabric is.
- Smooth the relocated Schelling sentence; single support metaphor in the city passage.

## Test plan

Docs only; paths unchanged and previously verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787414019&installation_model_id=428580&pr_number=4944&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4944&signature=f76af381ce6e2e2280980ab74a8625209cb460738aea2b5f7fe878ac0931f721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Define “pattern” early as the fabric’s unit of untrusted code and use it consistently. Tighten the closing third to ground “Resonant by default” in mechanisms, tie hollow vs. resonant to the aggregator equilibrium, and show how policies let checked patterns compose (1994 web analogy) so the fabric, not any single pattern, is the point.

- **Refactors**
  - Replace “program” with “pattern” across the doc (including “In this repository”) and clarify the lede.
  - Show composition: policies survive derivation; checked patterns join without trust negotiation.
  - Ground principles: Dedicated = compile-time flow checks (every outward flow is policy-permitted or a compile error); Plural = keypair identity and a mesh with no center; Prosocial = multiplayer substrate with group-owned signals (no intermediary ownership); link to the co-authored resonant-computing manifesto; tighten Adaptable.
  - Smooth connective tissue: Schelling-points sentence (durable where no participant can hold state hostage), enclaves + language models timing, attestation inheritance (“verify runtime once; every pattern inherits”), the final inversion wrap, and the “patterns are the cells; the fabric is the organism” framing.

<sup>Written for commit fe47c44513b684b72523af51c756918c6a9065f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

