### PR TITLE
fix(cli): wait on the tool-result sink instead of a 25ms poll

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -99,6 +99,9 @@ One line per archived document; each document's header carries the fuller
   — the v1 scheduler's mechanisms and their v2 dispositions, June 2026.
 - [PREEXISTING_BUGS.md](packages/patterns/PREEXISTING_BUGS.md) — pattern
   runtime bug survey, December 2025.
+- [piece-timeout-hangs-investigation.md](packages/cli/piece-timeout-hangs-investigation.md)
+  — why the CLI tool-result poll was replaced event-driven and why the
+  piece-start and sync bounds could not be removed at the CLI layer, July 2026.
 
 ### Executed plans and work orders
 

--- a/docs/history/packages/cli/piece-timeout-hangs-investigation.md
+++ b/docs/history/packages/cli/piece-timeout-hangs-investigation.md
@@ -1,0 +1,142 @@
+---
+status: historical
+created: 2026-07-22
+archived: 2026-07-22
+reason: "Investigation of the three CLI piece-library timeouts; records why the tool-result poll was replaced event-driven and why the piece-start and sync bounds could not be removed at the CLI layer."
+---
+
+# CLI piece-library timeouts: which are removable, and why
+
+The CLI's piece library carried three wall-clock waits that the repository's
+engineering principles single out for removal — a poll, and two timeouts that
+bound success:
+
+1. `packages/cli/lib/callable.ts` — the tool-result wait polled the result cell
+   every 25 milliseconds until a 15-second deadline, then threw a generic
+   "timed out waiting for tool result".
+2. `packages/cli/lib/piece.ts` `newPiece` — a 60-second bound races
+   `pieces.create(...)` and rejects with "Piece created but failed to start
+   within 60s".
+3. `packages/cli/lib/utils.ts` `awaitSyncWithTimeout` — a 30-second bound wraps
+   `storageManager.synced()` (used by `loadManager`, `acl.ts`, and `wish.ts`).
+
+This document records what the runtime actually offers as an event-driven
+completion or failure signal for each, so the choice of what to change is
+traceable. The tool-result poll was replaced with an event-driven wait. The
+other two bounds were left in place because the runtime surfaces no signal that
+would let the CLI replace them without reintroducing a silent, diagnostic-free
+hang.
+
+## 1. Tool-result poll — replaced with an event-driven wait
+
+The runtime does offer an authoritative completion signal for a tool run, so
+the poll was removed.
+
+- `runtime.run(tx, pattern, input, resultCell)` returns the result `Cell`
+  (`packages/runner/src/runtime.ts` `run`). The existing code already subscribed
+  to that cell's `sink`, which fires on the value's arrival, including a
+  server-pushed writeback (`sinkHelper` re-subscribes the callback as a
+  scheduler effect, `packages/runner/src/cell.ts`).
+- `runtime.settled()` (`packages/runner/src/runtime.ts`) drains the runtime to
+  full quiescence: scheduler idle, storage synced, and every in-flight async
+  builtin — an LLM call, a fetch — awaited to completion. It is bounded by
+  convergence rounds, not by a wall clock, and it awaits the async work rather
+  than polling for it. It normalizes a failed builtin to "settled", so a broken
+  tool converges rather than hanging.
+
+The wait now commits the run, awaits `settled()`, and takes the sink-captured
+value; if the sink reported nothing it reads the result cell once, and if that
+is still empty it fails loudly — surfacing the pattern's own recorded runtime
+error when there is one, and otherwise reporting that the tool produced no
+result. This also fixes a real defect the 15-second ceiling caused: a
+legitimate but slow tool (an LLM call longer than 15 seconds) was failed even
+though it would have completed.
+
+One residual dependency comes with this. `settled()` awaits every in-flight
+async builtin, so a tool whose network builtin opens a connection that is
+accepted but never answered — no response, no reset — leaves `settled()` waiting
+with no wall-clock ceiling, where the old 15-second poll would have given up.
+This is a liveness gap in the builtins — an LLM or fetch request carries no
+request deadline of its own — not in the callable path, and it is shared by
+every caller of `settled()` in the codebase: the runtime builtins and the CLI
+test runner all trust it to complete. Bounding it belongs with the builtins'
+request handling rather than a wall-clock guard re-added in the CLI, which would
+once again bound success for a legitimately slow tool.
+
+## 2. Piece-start bound — kept; no failure signal exists
+
+`newPiece` → `pieces.create` → `runPersistent` → `startPiece`, which awaits
+`runtime.start(piece)`, then `getResult(piece).pull()`, then `synced()`.
+
+- The hang is in `getResult(piece).pull()`. `Cell.pull()` resolves inside
+  `scheduler.idle().then(...)` (`packages/runner/src/cell.ts`), and `idle()` /
+  `waitForQuiescence` parks the waiter without resolving while a lineage-head or
+  load-parked-head event is outstanding
+  (`packages/runner/src/scheduler/facade.ts`). A piece whose pattern never
+  settles — a node stuck on an input or a load that never lands — leaves `idle()`
+  parked, so `pull()` never resolves. `runtime.start` itself does not hang.
+- A piece whose pattern *throws* does **not** hang: the scheduler catches the
+  throw, marks the action run, `idle()` resolves, and `pull()` returns
+  `undefined` while the error goes only to the error channel
+  (`packages/runner/src/scheduler/run.ts`). That is the "silent error swallowing"
+  half of the bug the bound originally addressed.
+- A dispatched pattern error is not a reliable "start failed" signal. The
+  reactive run path dispatches every non-`RetryImmediately` throw to the error
+  handlers with no transient-versus-terminal classification
+  (`packages/runner/src/scheduler/run.ts`); a transient throw — reading an input
+  that is momentarily `undefined` — is dispatched to the same handlers yet
+  recovers on a later pass. Rejecting the wait on "the first error for this
+  piece" would reject runs that were going to succeed.
+
+So the authoritative signal is success (the result cell's sink firing a defined
+value); there is no authoritative per-piece failure event. On the success path
+the wait is already event-driven — `pull()` resolves when the scheduler
+quiesces. The 60-second bound is the only thing that converts the never-settle
+hang into a message in an interactive CLI. It was kept, and its message now
+carries the runtime error the pattern recorded while starting rather than only
+pointing at the server logs.
+
+## 3. Sync bound — kept; the failure is swallowed or retried forever
+
+`storageManager.synced()` (`packages/runner/src/storage/v2.ts`) awaits its pull
+and commit promises but never inspects their `Result.error`. On an
+authorization failure — for example a client/server EXPERIMENTAL-option
+mismatch — one of two things happens, and neither surfaces a usable signal:
+
+- **Swallowed.** The pull path resolves its promise with an error that
+  `toConnectionError` (`packages/runner/src/storage/v2.ts`) has already flattened
+  from `AuthorizationError` to a generic `ConnectionError`, and `synced()` then
+  discards the `Result.error` entirely. `synced()` resolves and the auth failure
+  vanishes.
+- **Retried forever.** If the failure manifests as a transport close or an auth
+  failure during a reconnect, the memory client enters an unbounded
+  `while (!this.#closed)` reconnect loop that retries on any error with no
+  auth classification (`packages/memory/v2/client.ts` `reconnect`).
+  `ensureConnected()` blocks every request on that loop, so `session.watchAddSync`
+  never returns, the sync promise never settles, and `synced()` hangs.
+
+There is no event-driven signal a `StorageManager` holder can subscribe to for
+this failure: the storage notification union has no error variant, no telemetry
+marker is emitted on the read/connect path, the inspector `PushState`/`PullState`
+auth variants are not fed by the v2 storage manager, and the runtime
+`errorHandlers` are the pattern-execution channel, not the session channel.
+`healthCheck()` only probes `/_health` unauthenticated, so it does not pre-empt
+the mismatch either. The 30-second bound is the only thing that converts the
+hang into the actionable AuthorizationError message it prints today.
+
+### Recommended follow-up (not done here)
+
+Removing the sync bound honestly requires new plumbing in the foundation layer,
+which also removes the retry loop the engineering principles call out:
+
+1. Preserve the `AuthorizationError` name through `toConnectionError` instead of
+   flattening it to `ConnectionError`.
+2. Surface the pull `Result.error` from `synced()` (or a companion status API) so
+   a caller can observe the failure.
+3. Replace the unbounded `reconnect()` retry loop with an auth-classified break
+   (or a session-error callback) so the hang path produces a settled, typed
+   failure.
+
+That change alters reconnection semantics for every memory client — shell,
+toolshed, and the background piece service, not only the CLI — so it belongs in
+its own reviewed change rather than bundled with the CLI cleanup.

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -6,7 +6,6 @@ import {
 import type { ExecCommandSpec } from "./exec-schema.ts";
 
 export const CF_RUNTIME_ERROR_LOG = Symbol.for("cf.cli.runtimeErrorLog");
-const DEFAULT_TOOL_RESULT_TIMEOUT_MS = 15_000;
 
 export interface CliRuntimeErrorRecord {
   message: string;
@@ -50,6 +49,11 @@ export interface CallableRuntimeLike {
   [CF_RUNTIME_ERROR_LOG]?: CliRuntimeErrorRecord[];
   storageManager?: { synced: () => Promise<void> };
   idle: () => Promise<void>;
+  // Drain to full quiescence: scheduler idle, storage synced, and every
+  // in-flight async builtin (an LLM call, a fetch) finished. This is how a tool
+  // whose result arrives asynchronously is awaited without polling or a
+  // deadline. Optional so lightweight test doubles can omit it.
+  settled?: () => Promise<void>;
   edit: () => CallableTransactionLike;
   getCell: (
     space: string,
@@ -90,12 +94,7 @@ export interface CallableResolution {
 }
 
 export interface CallableExecutionDeps {
-  timeoutMs?: number;
   uuid?: () => string;
-  waitForResult?: (
-    resultCell: CallableCellLike,
-    timeoutMs: number,
-  ) => Promise<unknown>;
 }
 
 export interface ExecutedCallable {
@@ -119,7 +118,7 @@ function asExtraParams(value: unknown): Record<string, unknown> {
   return isRecord(value) ? value : {};
 }
 
-function runtimeErrorLog(runtime: unknown): CliRuntimeErrorRecord[] {
+export function runtimeErrorLog(runtime: unknown): CliRuntimeErrorRecord[] {
   if (typeof runtime !== "object" || runtime === null) {
     return [];
   }
@@ -201,24 +200,6 @@ function mergeToolInput(
     ...base,
     ...extraParams,
   };
-}
-
-async function defaultWaitForResult(
-  resultCell: CallableCellLike,
-  timeoutMs: number,
-): Promise<unknown> {
-  if (typeof resultCell.pull !== "function") {
-    throw new Error("Callable result cell cannot be pulled");
-  }
-  const startedAt = Date.now();
-  while (Date.now() - startedAt <= timeoutMs) {
-    const value = await resultCell.pull();
-    if (value !== undefined) {
-      return value;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 25));
-  }
-  throw new Error(`Timed out waiting for tool result after ${timeoutMs}ms`);
 }
 
 export function detectCallableKind(
@@ -336,21 +317,27 @@ export async function executeResolvedCallable(
   const extraParams = asExtraParams(
     resolved.callableCell.key("extraParams").get?.(),
   );
-  const tx = resolved.manager.runtime.edit();
+  const runtime = resolved.manager.runtime;
+  const runtimeErrors = runtimeErrorLog(runtime);
+  const errorCountBefore = runtimeErrors.length;
+  const tx = runtime.edit();
   const resultScope = resolved.callableCell.getAsNormalizedFullLink?.().scope;
-  const resultCell = resolved.manager.runtime.getCell(
+  const resultCell = runtime.getCell(
     resolved.space,
     deps.uuid?.() ?? crypto.randomUUID(),
     pattern?.resultSchema,
     tx,
     resultScope,
   );
-  const running = resolved.manager.runtime.run(
+  const running = runtime.run(
     tx,
     pattern,
     mergeToolInput(input, extraParams),
     resultCell,
   );
+  // Capture the tool's result off its cell's sink. sink() fires immediately with
+  // the current (initially undefined) value and re-fires on every committed
+  // change, including the server-pushed writeback of an async tool's result.
   let sinkValue: unknown;
   let hasSinkValue = false;
   const cancelSink = typeof running?.sink === "function"
@@ -364,24 +351,48 @@ export async function executeResolvedCallable(
 
   let outputValue: unknown;
   try {
-    await resolved.manager.runtime.idle();
-    resolved.manager.runtime.prepareTxForCommit?.(tx);
+    await runtime.idle();
+    runtime.prepareTxForCommit?.(tx);
     if (typeof tx.commit !== "function") {
       throw new Error("Callable runtime transaction is not committable");
     }
     await tx.commit();
-    const waitForResult = deps.waitForResult ?? defaultWaitForResult;
-    const timeoutMs = deps.timeoutMs ?? DEFAULT_TOOL_RESULT_TIMEOUT_MS;
 
-    await resolved.manager.runtime.idle();
-    await resolved.manager.synced();
-    await resolved.manager.runtime.storageManager?.synced();
+    // Drain the tool to a fully settled state — scheduler idle, storage synced,
+    // and every in-flight async builtin finished — so the result is final by the
+    // time we read it. A synchronous tool has already written its result; an
+    // async tool's LLM/fetch call is awaited to completion here, with no poll
+    // interval under it and no deadline over it. `settled()` normalizes a failed
+    // builtin to "settled", so a broken tool converges here rather than hanging.
+    if (typeof runtime.settled === "function") {
+      await runtime.settled();
+    } else {
+      await runtime.idle();
+      await resolved.manager.synced();
+      await runtime.storageManager?.synced();
+    }
+
     if (hasSinkValue) {
       outputValue = sinkValue;
     } else {
-      await waitForResult(resultCell, timeoutMs);
-      await resolved.manager.runtime.storageManager?.synced();
-      outputValue = await waitForResult(resultCell, timeoutMs);
+      // Fully settled with nothing on the sink: read once (a server-pushed value
+      // can land without re-triggering the local effect).
+      outputValue = typeof resultCell.pull === "function"
+        ? await resultCell.pull()
+        : resultCell.get();
+      if (outputValue === undefined) {
+        // The tool ran to a fully settled state without producing a result.
+        // Keep the caller's contract of a defined result or an explicit
+        // failure: surface the runtime error the pattern recorded when there
+        // is one, and otherwise fail loudly rather than emitting nothing.
+        const latestError = runtimeErrors.slice(errorCountBefore).at(-1)
+          ?.message;
+        throw new Error(
+          latestError !== undefined
+            ? `Tool "${resolved.cellKey}" failed: ${latestError}`
+            : `Tool "${resolved.cellKey}" produced no result.`,
+        );
+      }
     }
   } finally {
     cancelSink?.();

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -58,12 +58,7 @@ export interface ExecDependencies {
   stat?: (path: string) => Promise<Deno.FileInfo>;
   readDir?: (path: string) => AsyncIterable<Deno.DirEntry>;
   delay?: (ms: number) => Promise<void>;
-  timeoutMs?: number;
   uuid?: () => string;
-  waitForResult?: (
-    resultCell: CallableCellLike,
-    timeoutMs: number,
-  ) => Promise<unknown>;
   invocationStyle?: "cf" | "direct";
   readJsonInput?: () => Promise<unknown>;
   readTextInput?: () => Promise<string>;

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -57,6 +57,7 @@ import {
   type CliRuntimeErrorRecord,
   detectCallableKind,
   executeResolvedCallable,
+  runtimeErrorLog,
 } from "./callable.ts";
 import { executeCallableCommand } from "./callable-command.ts";
 import {
@@ -1073,7 +1074,16 @@ export async function newPiece(
         entry,
       ),
   );
+  // A piece whose pattern never settles leaves `pieces.create` awaiting a
+  // scheduler `idle()` that never resolves, and the runtime surfaces no
+  // event that a start has definitively failed (a thrown pattern reports its
+  // error and still resolves; a stuck async load reports nothing). This
+  // wall-clock bound is the only thing that turns that hang into a message.
+  // When it fires, report the actual runtime error the pattern recorded while
+  // starting rather than only pointing at the server logs.
   const PIECE_START_TIMEOUT_MS = 60_000;
+  const runtimeErrors = runtimeErrorLog(manager.runtime);
+  const errorCountBefore = runtimeErrors.length;
   const piece = await timeCliPhase("newPiece.create", () => {
     const createPromise = pieces.create(program, {
       repository: entry.repository,
@@ -1082,11 +1092,15 @@ export async function newPiece(
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
+        const recorded = runtimeErrors.slice(errorCountBefore).at(-1)?.message;
+        const detail = recorded !== undefined
+          ? `A runtime error was reported while it started: ${recorded}`
+          : `Check toolshed logs for runtime errors.`;
         reject(
           new Error(
             `Piece created but failed to start within ${
               PIECE_START_TIMEOUT_MS / 1000
-            }s. ` + `Check toolshed logs for runtime errors.`,
+            }s. ${detail}`,
           ),
         );
       }, PIECE_START_TIMEOUT_MS);

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1815,7 +1815,7 @@ describe("mounted callable resolution and execution", () => {
     });
   });
 
-  it("idles before committing mounted tool results and syncs before waiting", async () => {
+  it("settles mounted tool results before reading, without polling", async () => {
     const mountpoint = join(tmpDir, "mount");
     const filePath = await createMountedFile(mountpoint, {
       relativePath: "home/pieces/notes-2/result/search.tool",
@@ -1848,8 +1848,8 @@ describe("mounted callable resolution and execution", () => {
           },
         },
       },
+      toolResult: { echoed: "tea" },
     });
-    const timeouts: number[] = [];
 
     await writeLiveMountState(stateDir, mountpoint);
 
@@ -1861,25 +1861,17 @@ describe("mounted callable resolution and execution", () => {
         loadManager: () => Promise.resolve(harness.manager),
         loadPiece: () => Promise.resolve(harness.piece),
         uuid: () => "tool-result-id",
-        waitForResult: (_cell, timeoutMs) => {
-          harness.tracker.events.push("wait");
-          timeouts.push(timeoutMs);
-          return Promise.resolve({ echoed: "tea" });
-        },
       },
     );
 
-    expect(timeouts).toEqual([15_000, 15_000]);
+    // Commit, then drain to a fully settled state, then read the result cell
+    // once. No poll loop and no deadline: `settled()` awaits the tool's async
+    // work to completion.
     expect(harness.tracker.events).toEqual([
       "run",
       "idle",
       "commit",
-      "idle",
-      "manager.synced",
-      "storage.synced",
-      "wait",
-      "storage.synced",
-      "wait",
+      "settled",
     ]);
     expect(JSON.parse(result.outputText!)).toEqual({ echoed: "tea" });
   });
@@ -1930,22 +1922,99 @@ describe("mounted callable resolution and execution", () => {
         loadManager: () => Promise.resolve(harness.manager),
         loadPiece: () => Promise.resolve(harness.piece),
         uuid: () => "tool-result-id",
-        waitForResult: () => {
-          throw new Error("waitForResult should not be used");
-        },
       },
     );
 
+    // The sink reported the result, so after settling there is no result-cell
+    // read at all — the sink value is authoritative.
     expect(harness.tracker.events).toEqual([
       "run",
       "sink",
       "idle",
       "commit",
-      "idle",
-      "manager.synced",
-      "storage.synced",
+      "settled",
     ]);
     expect(JSON.parse(result.outputText!)).toEqual({ echoed: "from-sink" });
+  });
+
+  it("fails loudly when a mounted tool settles without a result", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const filePath = await createMountedFile(mountpoint, {
+      relativePath: "home/pieces/notes-2/result/search.tool",
+      pieceId: "of:piece-123",
+    });
+    const harness = createExecHarness({
+      callableKind: "tool",
+      cellProp: "result",
+      cellKey: "search",
+      pieceId: "of:piece-123",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+      pattern: {
+        argumentSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+        resultSchema: { type: "object" },
+      },
+      // No toolResult, no sink value, no recorded error: the tool settled
+      // without producing anything.
+    });
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    await expect(
+      executeMountedCallableFile(filePath, ["--query", "tea"], {
+        stateDir,
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        uuid: () => "tool-result-id",
+      }),
+    ).rejects.toThrow('Tool "search" produced no result.');
+  });
+
+  it("surfaces the recorded runtime error when a mounted tool produces no result", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const filePath = await createMountedFile(mountpoint, {
+      relativePath: "home/pieces/notes-2/result/search.tool",
+      pieceId: "of:piece-123",
+    });
+    const harness = createExecHarness({
+      callableKind: "tool",
+      cellProp: "result",
+      cellKey: "search",
+      pieceId: "of:piece-123",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+      pattern: {
+        argumentSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+        resultSchema: { type: "object" },
+      },
+      // The tool run records a runtime error and writes no result.
+      toolRunError: "boom from the tool pattern",
+    });
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    await expect(
+      executeMountedCallableFile(filePath, ["--query", "tea"], {
+        stateDir,
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        uuid: () => "tool-result-id",
+      }),
+    ).rejects.toThrow('Tool "search" failed: boom from the tool pattern');
   });
 
   it("pulls mounted tool result cells before serializing output", async () => {
@@ -2506,6 +2575,7 @@ function createExecHarness(options: {
   toolResultGetValue?: unknown;
   toolResultPullValue?: unknown;
   toolSinkValue?: unknown;
+  toolRunError?: string;
   handlerFailureMessage?: string;
   handlerSendRequiresReceiver?: boolean;
   sparseHandlerCell?: boolean;
@@ -2667,6 +2737,9 @@ function createExecHarness(options: {
       ) => {
         tracker.events.push("run");
         tracker.toolRunInput = input;
+        if (options.toolRunError !== undefined) {
+          runtimeErrors.push({ message: options.toolRunError });
+        }
         state.value = options.toolResult;
         state.getValue = options.toolResultGetValue ?? options.toolResult;
         state.pullValue = options.toolResultPullValue ?? options.toolResult;
@@ -2682,6 +2755,10 @@ function createExecHarness(options: {
       },
       idle: () => {
         tracker.events.push("idle");
+        return Promise.resolve();
+      },
+      settled: () => {
+        tracker.events.push("settled");
         return Promise.resolve();
       },
     },


### PR DESCRIPTION
The CLI's piece callable path waited for a tool's result by polling the result cell every 25 milliseconds until a fixed 15-second deadline, then throwing a generic "timed out waiting for tool result". The poll added dead time under fast tools and, worse, put an upper bound on success: a legitimate but slow tool — an LLM call that runs longer than 15 seconds — was failed even though it would have completed.

Replace the poll with an event-driven wait. After committing the tool run, drain the runtime to a fully settled state with `settled()`, which awaits scheduler quiescence, storage sync, and every in-flight async builtin (an LLM call, a fetch) to completion. This is bounded by convergence rounds, not by a wall clock, so a slow tool is awaited rather than abandoned. The tool's result is captured off its result cell's `sink`, which fires on the value's arrival including a server-pushed writeback; when the sink has not reported a value by the time the runtime settles, the result cell is read once.

Keep the caller's contract of a defined result or an explicit failure: when a tool runs to a fully settled state and still has no result, fail loudly — surfacing the runtime error the pattern recorded during the run when there is one, and otherwise reporting that the tool produced no result — rather than emitting `JSON.stringify(undefined)` and exiting zero. This removes the injected `waitForResult`/`timeoutMs` execution dependencies, which existed only to observe the poll, and updates the mounted-callable tests to assert the settle-then-read sequence and both failure branches.

One residual dependency comes with the switch: `settled()` awaits every in-flight async builtin, so a tool whose network builtin opens a connection that is accepted but never answered can leave the wait pending with no wall-clock ceiling. That is a liveness gap in the builtins' own request handling — shared by every caller of `settled()` in the codebase, which all trust it to complete — not something to paper over with a CLI timeout that would re-bound legitimately slow tools.

The 60-second bound in `newPiece` and the 30-second sync bound in `awaitSyncWithTimeout` are left in place: investigation of the runtime showed both guard genuine hangs for which it surfaces no event-driven failure signal. The piece-start hang is a scheduler `idle()` that never resolves when a pattern never settles — a thrown pattern reports its error and still resolves, a stuck async load reports nothing, and a dispatched pattern error is not reliably terminal — so removing the bound would reintroduce a silent, diagnostic-free hang in an interactive CLI. The sync hang is an authorization failure that the storage layer either swallows (flattened to a generic connection error and then discarded by `synced()`) or retries forever in an unbounded reconnect loop with nothing to subscribe to. Removing that bound safely needs foundation-layer plumbing that changes reconnection semantics for every client, so it is left for its own reviewed change. When the piece-start bound fires it now reports the runtime error recorded while the piece was starting rather than only pointing at the server logs. The full investigation — what signal the runtime offers for each wait — is recorded under docs/history.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787421343&installation_model_id=428580&pr_number=4946&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4946&signature=bb1c621d963fac2e128746f6065d15abae2a40c3c6159a831eb95a633bf6491c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CLI tool-result waiting to an event-driven settle using `runtime.settled()` and the result cell `sink`, replacing the 25ms poll and 15s deadline. Slow tools now finish, fast tools avoid dead time, and we fail clearly if no result is produced.

- **Bug Fixes**
  - Await tool completion via `runtime.settled()` and the result cell’s `sink`; after settle, read once if the sink didn't report. No polling or wall-clock deadline.
  - If a tool settles without a result, throw with the recorded runtime error or “produced no result” (no more empty JSON).
  - Keep the 60s piece-start and 30s sync bounds; piece-start timeout now includes the recorded runtime error.

- **Refactors**
  - Remove `timeoutMs` and `waitForResult` from CLI execution deps; simplify to settle-then-read.
  - Update tests to assert the settle path and both failure branches.
  - Add `docs/history/packages/cli/piece-timeout-hangs-investigation.md`; link from `docs/history/README.md`.

<sup>Written for commit 38c981d9ab022a00d3b869d13d7f0a3f7f9099b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

