### PR TITLE
fix(patterns): waitForDisabled resolves controls with no inner button

### DIFF
--- a/packages/patterns/integration/cf-checkbox.test.ts
+++ b/packages/patterns/integration/cf-checkbox.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./pieces-controller.ts";
 import {
   clickCfButtonAndWaitForText,
+  waitForDisabled,
   waitForText,
 } from "./cfc-browser-helpers.ts";
 
@@ -96,5 +97,80 @@ testComponents.forEach(({ name, file }) => {
         "⚠ Feature is disabled",
       );
     });
+  });
+});
+
+// `waitForDisabled` resolves a control's disabled state from an inner <button>
+// when one exists. A cf-checkbox has no inner button — its shadow root holds an
+// <input type="checkbox"> — and expresses disabled through the host's attribute
+// and `aria-disabled`. This exercises the helper against that control so the
+// fallback keeps resolving both readings instead of hanging until timeout.
+describe("cf-checkbox waitForDisabled fallback integration test", () => {
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
+
+  let pieceId: string;
+  let identity: Identity;
+  let cc: PiecesController;
+
+  beforeAll(async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+    cc = await initializePiecesController({
+      spaceName: SPACE_NAME,
+      apiUrl: new URL(API_URL),
+      identity,
+    });
+    const piece = await cc.create(
+      await Deno.readTextFile(
+        join(
+          import.meta.dirname!,
+          "fixtures",
+          "cf-checkbox-disabled.tsx",
+        ),
+      ),
+      { start: false },
+    );
+    pieceId = piece.id;
+    await cc.acl().set(ANYONE_USER, "WRITE");
+  });
+
+  afterAll(async () => {
+    if (cc) await cc.dispose();
+  });
+
+  it("resolves both the enabled and disabled readings of a control with no inner button", async () => {
+    const page = shell.page();
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: {
+        spaceName: SPACE_NAME,
+        pieceId,
+      },
+      identity,
+    });
+    await page.waitForSelector("#probe-checkbox", { strategy: "pierce" });
+
+    // The checkbox starts enabled; the helper must read the host fallback and
+    // resolve the false reading rather than time out looking for a button.
+    await waitForText(page, "#checkbox-disabled-status", "Checkbox enabled");
+    await waitForDisabled(page, "#probe-checkbox", false);
+
+    // Toggle to disabled; the helper resolves the true reading.
+    await clickCfButtonAndWaitForText(
+      page,
+      "#toggle-disabled",
+      "#checkbox-disabled-status",
+      "Checkbox disabled",
+    );
+    await waitForDisabled(page, "#probe-checkbox", true);
+
+    // Toggle back to enabled; the helper resolves the false reading again.
+    await clickCfButtonAndWaitForText(
+      page,
+      "#toggle-disabled",
+      "#checkbox-disabled-status",
+      "Checkbox enabled",
+    );
+    await waitForDisabled(page, "#probe-checkbox", false);
   });
 });

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -34,7 +34,14 @@ const textAbsent = (
     probe.deepText(element).includes(text)
   );
 
-const buttonDisabledIs = (
+// Resolve a control's disabled state and compare it to `disabled`. An inner
+// <button> is authoritative when present: its `.disabled` DOM property is the
+// control's real state. Without one, fall back to the host — a native form
+// control exposes `.disabled`, and a custom element like cf-checkbox reflects
+// `disabled` to an attribute and also sets `aria-disabled`. A control that is
+// neither disabled nor carries the attribute resolves to enabled, so
+// `waitForDisabled(el, false)` satisfies immediately instead of hanging.
+const disabledIs = (
   probe: ProbeApi,
   selector: string,
   disabled: boolean,
@@ -44,9 +51,20 @@ const buttonDisabledIs = (
   const button = element instanceof HTMLButtonElement
     ? element
     : element.shadowRoot?.querySelector("button");
-  return button instanceof HTMLButtonElement
-    ? button.disabled === disabled
-    : false;
+  let resolved: boolean;
+  if (button instanceof HTMLButtonElement) {
+    resolved = button.disabled;
+  } else if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLSelectElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    resolved = element.disabled;
+  } else {
+    resolved = element.hasAttribute("disabled") ||
+      element.getAttribute("aria-disabled") === "true";
+  }
+  return resolved === disabled;
 };
 
 const runtimeIdle = async (): Promise<boolean> => {
@@ -587,7 +605,7 @@ export async function waitForDisabled(
   disabled: boolean,
 ) {
   try {
-    await waitForCondition(page, buttonDisabledIs, {
+    await waitForCondition(page, disabledIs, {
       args: [selector, disabled],
     });
   } catch (cause) {
@@ -1623,14 +1641,29 @@ async function readDisabledProbe(
     collect(document, matches);
     const element = matches[0];
     if (!element) return { selector: targetSelector, disabled: undefined };
+    // Resolve disabled the same way `disabledIs` does, so the diagnostic reports
+    // the state the wait was actually testing: an inner <button> when present,
+    // else the host's own `.disabled` (native controls) or its `disabled` /
+    // `aria-disabled` attributes (custom elements like cf-checkbox).
     const button = element instanceof HTMLButtonElement
       ? element
       : element.shadowRoot?.querySelector("button");
+    let disabled: boolean;
+    if (button instanceof HTMLButtonElement) {
+      disabled = button.disabled;
+    } else if (
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLSelectElement ||
+      element instanceof HTMLTextAreaElement
+    ) {
+      disabled = element.disabled;
+    } else {
+      disabled = element.hasAttribute("disabled") ||
+        element.getAttribute("aria-disabled") === "true";
+    }
     return {
       selector: element.tagName.toLowerCase(),
-      disabled: button instanceof HTMLButtonElement
-        ? button.disabled
-        : undefined,
+      disabled,
     };
   }, { args: [selector] });
 }

--- a/packages/patterns/integration/fixtures/cf-checkbox-disabled.tsx
+++ b/packages/patterns/integration/fixtures/cf-checkbox-disabled.tsx
@@ -1,0 +1,54 @@
+import {
+  type Default,
+  handler,
+  ifElse,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+// Fixture for the `waitForDisabled` browser helper. A cf-checkbox renders an
+// <input type="checkbox"> in its shadow root and no <button>, so it exercises
+// the helper's fallback to the host's `disabled` / `aria-disabled` state. Its
+// disabled state is driven by a cell that a button toggles, letting a test
+// observe the helper resolve both the enabled and the disabled reading.
+interface Input {
+  controlDisabled: Writable<boolean | Default<false>>;
+}
+
+interface Output {
+  [NAME]: string;
+  [UI]: VNode;
+  controlDisabled: boolean;
+}
+
+const toggleDisabled = handler<unknown, { controlDisabled: Writable<boolean> }>(
+  (_event, { controlDisabled }) => controlDisabled.set(!controlDisabled.get()),
+);
+
+const CfCheckboxDisabled = pattern<Input, Output>(({ controlDisabled }) => {
+  return {
+    [NAME]: "cf-checkbox-disabled",
+    [UI]: (
+      <cf-vstack gap="2" style="padding: 2rem;">
+        <cf-checkbox id="probe-checkbox" disabled={controlDisabled}>
+          Probe checkbox
+        </cf-checkbox>
+        <p id="checkbox-disabled-status">
+          {ifElse(controlDisabled, "Checkbox disabled", "Checkbox enabled")}
+        </p>
+        <cf-button
+          id="toggle-disabled"
+          onClick={toggleDisabled({ controlDisabled })}
+        >
+          Toggle disabled
+        </cf-button>
+      </cf-vstack>
+    ),
+    controlDisabled,
+  };
+});
+
+export default CfCheckboxDisabled;


### PR DESCRIPTION
The waitForDisabled integration helper resolved a control's disabled state by finding an inner <button> in the element's shadow root and reading its `.disabled` property. When the target has no inner button — a cf-checkbox renders an <input type="checkbox"> and no button, and some controls express disabled only through an aria-disabled attribute on the host — the predicate found no button and returned false unconditionally. Because the predicate could never become true, both waitForDisabled(el, false) and waitForDisabled(el, true) waited out the timeout and threw a misleading "timed out" error instead of reading the control's real state. No present caller hit this, so it was a latent trap for the first test written against a checkbox or aria-disabled control.

Resolve the disabled state from the best available signal and compare it once to the requested value. An inner <button> stays authoritative when present, so existing button-backed callers are unchanged. Without one, fall back to the host: a native <input>/<select>/<textarea> exposes a `.disabled` DOM property, and a custom element such as cf-checkbox reflects `disabled` to an attribute and also sets aria-disabled. A control that is neither disabled nor carries the attribute now resolves to enabled, so waitForDisabled(el, false) satisfies immediately rather than hanging. The readDisabledProbe diagnostic resolves the state the same way, so a genuine timeout reports the real reading rather than "unknown".

Add an integration fixture that renders a cf-checkbox whose disabled state a button toggles, and a test that drives waitForDisabled through both the enabled and disabled readings, covering the no-inner-button fallback. The test times out against the old button-only predicate and passes with the fallback in place.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787421434&installation_model_id=428580&pr_number=4947&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4947&signature=97cbb8aa6175bd8075d97c9108a83d0304fd3eb2f800391208ed8ccf18de0b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `waitForDisabled` to correctly read disabled state when a control has no inner button (e.g. `cf-checkbox`, native inputs, or hosts using `aria-disabled`), preventing hangs and improving error messages.

- **Bug Fixes**
  - Prefer inner `button.disabled`; else use host `.disabled` or `disabled`/`aria-disabled`.
  - Align `readDisabledProbe` with the same logic for accurate timeout diagnostics.
  - Add `cf-checkbox-disabled` fixture and an integration test covering enabled/disabled without an inner button.

<sup>Written for commit 0843c89782e6f7bfaf7bb8407128a228d454d7b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

