### PR TITLE
refactor(patterns): drop the redundant scrollIntoView from three more…

### DIFF
--- a/packages/patterns/integration/home-profile.test.ts
+++ b/packages/patterns/integration/home-profile.test.ts
@@ -235,10 +235,6 @@ async function clickProfileLink(page: any, name: string) {
         if (!(chip?.textContent ?? "").includes(targetName)) continue;
         const clickTarget = chip?.shadowRoot?.querySelector("button") ?? chip ??
           element;
-        (clickTarget as HTMLElement).scrollIntoView({
-          block: "center",
-          inline: "center",
-        });
         clickTarget.setAttribute("data-profile-link-click", targetToken);
         return true;
       }

--- a/packages/patterns/integration/note-button-helpers.ts
+++ b/packages/patterns/integration/note-button-helpers.ts
@@ -13,22 +13,22 @@ import { settleView } from "./cfc-browser-helpers.ts";
 const NOTE_BUTTON_CLICK_TARGET_ATTR = "data-cfc-note-button-target";
 
 // Serialized into the page by waitForCondition: find the first rendered
-// button/link whose text or title matches, scroll it into view, and stamp its
-// inner click target with `token`. "Rendered" means laid out and not
-// display:none/visibility:hidden — the same elements the innerText scan the
-// poll used could see — and is viewport-independent, so a match below the fold
-// is scrolled in rather than skipped. Returns false until a match exists, so
+// button/link whose text or title matches and stamp its inner click target with
+// `token`. "Rendered" means laid out and not display:none/visibility:hidden —
+// the same elements the innerText scan the poll used could see — and is
+// viewport-independent, so a match below the fold is still tagged: the click
+// scrolls the element into view itself. Returns false until a match exists, so
 // the wait re-checks on the next DOM mutation instead of the caller retrying a
 // bare find-and-click loop. Self-contained — it closes over nothing in this
 // module — so it can be serialized and run in the page.
-const markNoteButton = async (
+const markNoteButton = (
   probe: ProbeApi,
   selector: string,
   match: "includes" | "exact" | "title",
   needle: string,
   token: string,
   attr: string,
-): Promise<boolean> => {
+): boolean => {
   const target = probe.collect(selector).find((element) => {
     if (!probe.isRendered(element)) return false;
     if (match === "title") return element.getAttribute("title") === needle;
@@ -36,10 +36,6 @@ const markNoteButton = async (
     return match === "exact" ? text === needle : text.includes(needle);
   }) as HTMLElement | undefined;
   if (!target) return false;
-  target.scrollIntoView({ block: "center", inline: "center" });
-  await new Promise((resolve) =>
-    requestAnimationFrame(() => requestAnimationFrame(resolve))
-  );
   const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
     | HTMLElement
     | null) ?? target;

--- a/packages/patterns/integration/profile-embed.test.ts
+++ b/packages/patterns/integration/profile-embed.test.ts
@@ -295,7 +295,6 @@ async function markCfButtonByText(page: Page, label: string, token: string) {
       const clickTarget = (host.shadowRoot?.querySelector("[data-cf-button]") as
         | HTMLElement
         | null) ?? host;
-      clickTarget.scrollIntoView({ block: "center", inline: "center" });
       clickTarget.setAttribute("data-cfc-mark", targetToken);
       return true;
     }


### PR DESCRIPTION
… cfc test helpers

The change that removed the redundant scrollIntoView from the four click/fill predicates in cfc-browser-helpers.ts (#4913) left three sibling helpers in the same integration suite carrying the same now-inert scroll, for the same reason: each tags a control that a later ElementHandle.click() scrolls into view on its own — astral runs DOM.scrollIntoViewIfNeeded before it computes click coordinates — so the helper's own scroll changes neither whether the control is tagged nor whether the click lands.

markNoteButton in note-button-helpers.ts is the exact fifth sibling of the four: a waitForCondition predicate that gates on the viewport-independent isRendered, scrolls, awaits two animation frames, then tags a click target. waitForCondition re-runs a predicate on every DOM mutation, and the shell sets html { scroll-behavior: smooth }, so on a churning page it re-issued a smooth scroll and restarted the animation on each re-entry — wasted work that never changed the outcome. That frame wait was its only await, so the predicate becomes plain synchronous.

clickProfileLink in home-profile.test.ts and markCfButtonByText in profile-embed.test.ts are one-shot page.evaluate markers that scroll a click target and then tag it. They run once, so there is no re-entry churn, but the scroll is redundant all the same: the trusted click that follows scrolls the element into view.

Two related sites are deliberately left alone. The explicit scrollIntoView helper in cfc-group-chat-demo.test.ts is an author-chosen step rather than a tag-then-click predicate, and the presentation-mode fill path (typeIntoCfInput) moves a real cursor to box coordinates and legitimately needs the element on-screen.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787421517&installation_model_id=428580&pr_number=4948&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4948&signature=6012d3f9614e2f4a2c079970a89e3fcfc6aebb153424456d03bdde591a2bab23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant scrollIntoView calls from three CFC test helpers. Clicks already scroll targets into view, so this drops no-ops and reduces flake on churning pages.

- **Refactors**
  - In `note-button-helpers.ts`, `markNoteButton` no longer scrolls or waits; it’s now a synchronous predicate that only tags the click target.
  - In `home-profile.test.ts` and `profile-embed.test.ts`, removed one-off `scrollIntoView` before tagging; rely on the trusted click to scroll.
  - Behavior unchanged: same elements are tagged and clicks still land; fewer reflows and smoother runs.

<sup>Written for commit adbd60568719143361929847de79bcb9599fafc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

