### PR TITLE
fix(toolshed): nest query schemas under request.query so they document

### DIFF
--- a/packages/toolshed/lib/configure-open-api.test.ts
+++ b/packages/toolshed/lib/configure-open-api.test.ts
@@ -114,6 +114,73 @@ Deno.test("openapi reference", async (t) => {
     );
   });
 
+  // A route that declares its query parameters through the top-level `query`
+  // key instead of `request.query` slips that key past `createRoute`, which
+  // copies it verbatim into the Operation Object and serializes the zod schema's
+  // internals under it. Correctly declared query parameters land in the
+  // Operation's `parameters` array instead. These two routes carry
+  // query parameters and stand for that whole class.
+  await t.step(
+    "query parameters are documented under `parameters`",
+    async () => {
+      const doc = await (await app.request("/doc")).json();
+
+      for (
+        const [path, params] of [
+          ["/api/health/llm", ["verbose", "alert", "models", "forceAlert"]],
+          ["/api/ai/llm/models", ["search", "capability", "task"]],
+        ] as const
+      ) {
+        const operation = doc.paths[path].get;
+        assert(
+          !("query" in operation),
+          `${path} carries a raw \`query\` key: ${
+            JSON.stringify(operation.query)
+          }`,
+        );
+
+        const documented = (operation.parameters ?? [])
+          .filter((p: { in: string }) => p.in === "query")
+          .map((p: { name: string }) => p.name)
+          .sort();
+        assertEquals(
+          documented,
+          [...params].sort(),
+          `${path} does not document its query parameters`,
+        );
+      }
+    },
+  );
+
+  // A zod schema handed to a place the generator does not recognize is copied
+  // into the document verbatim, and serializing it dumps the library's internal
+  // fields — `def`/`_def` (the schema definition), `_zod` and `~standard` (the
+  // instance handles), `_cached` — into the output. None of those are OpenAPI
+  // keys, so finding one anywhere in the document marks a leaked schema.
+  await t.step("the document carries no raw zod internals", async () => {
+    const doc = await (await app.request("/doc")).json();
+
+    const forbidden = new Set(["def", "_def", "_zod", "~standard", "_cached"]);
+    const leaks: string[] = [];
+    const scan = (value: unknown, path: string) => {
+      if (Array.isArray(value)) {
+        value.forEach((item, i) => scan(item, `${path}[${i}]`));
+      } else if (value && typeof value === "object") {
+        for (const [key, child] of Object.entries(value)) {
+          if (forbidden.has(key)) leaks.push(`${path}.${key}`);
+          scan(child, `${path}.${key}`);
+        }
+      }
+    };
+    scan(doc, "$");
+
+    assertEquals(
+      leaks,
+      [],
+      `the document leaks zod internals at: ${leaks.join(", ")}`,
+    );
+  });
+
   // Scalar renders the configuration it is handed into the page without
   // validating it, serializing an unknown key as readily as a known one. The
   // document URL is read back out of the page and fetched, so the two routes

--- a/packages/toolshed/routes/ai/llm/llm.routes.ts
+++ b/packages/toolshed/routes/ai/llm/llm.routes.ts
@@ -175,7 +175,9 @@ export const getModels = createRoute({
   path: "/api/ai/llm/models",
   method: "get",
   tags,
-  query: GetModelsRouteQueryParams,
+  request: {
+    query: GetModelsRouteQueryParams,
+  },
   responses: {
     [HttpStatusCodes.OK]: jsonContent(
       ModelsResponseSchema.openapi({

--- a/packages/toolshed/routes/health/health.routes.ts
+++ b/packages/toolshed/routes/health/health.routes.ts
@@ -59,12 +59,14 @@ export const llm = createRoute({
   path: "/api/health/llm",
   method: "get",
   tags,
-  query: z.object({
-    verbose: z.string().optional(),
-    alert: z.string().optional(),
-    models: z.string().optional(),
-    forceAlert: z.string().optional(),
-  }),
+  request: {
+    query: z.object({
+      verbose: z.string().optional(),
+      alert: z.string().optional(),
+      models: z.string().optional(),
+      forceAlert: z.string().optional(),
+    }),
+  },
   responses: {
     [HttpStatusCodes.OK]: jsonContent(
       LLMHealthResponseSchema,


### PR DESCRIPTION
Two GET routes declared their query parameters through a top-level `query` key handed to `createRoute()`:

- `/api/health/llm` in routes/health/health.routes.ts
- `/api/ai/llm/models` in routes/ai/llm/llm.routes.ts

`@hono/zod-openapi`'s `createRoute` looks for the request schema under `request.query`; it does not recognize a top-level `query`. The unrecognized key is copied verbatim into the OpenAPI Operation Object and serialized, which dumps the zod schema's internal fields (`def`, `shape`, `innerType`, and so on) into `GET /doc` under a bogus `query` key. Two things go wrong: the served document carries a key that is not part of OpenAPI 3.0 and holds library internals, and the query parameters are never documented as `parameters` at all. The mistake predates the zod 4 upgrade, which only changed which internal fields leak (zod 3 spilled `_def`/`~standard`/`_cached` instead).

Nest each route's query schema under `request: { query: ... }`, matching every other toolshed route. The parameters now appear under the Operation's `parameters` array. This also turns on runtime query validation through @hono/zod-validator, whose failures route through `defaultHook` as a 400. Both schemas are made up entirely of optional strings, so no request that previously succeeded can now fail validation, and both handlers keep reading the raw parameters through `c.req.query()`.

Extend the `/doc` regression test, which runs against the real assembled app, with two assertions: a positive check that both routes document their query parameters under `parameters` with no top-level `query` key, and a document-wide scan that fails on any leaked zod-internal key (`def`, `_def`, `_zod`, `~standard`, `_cached`), pinning this whole class of bug.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787421647&installation_model_id=428580&pr_number=4949&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4949&signature=20981009aabaf680d09c12f5dc870e63557e3d727612665b89f7bff66075c8fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAPI docs by nesting GET route query schemas under request.query so parameters render correctly and no zod internals leak into /doc. Also enables runtime query validation without changing successful request behavior.

- **Bug Fixes**
  - Moved query schemas to `request.query` for `/api/health/llm` and `/api/ai/llm/models`
  - OpenAPI now lists query params under `parameters`; removed bogus top-level `query` and leaked internals
  - Enabled runtime query validation via `@hono/zod-validator`; all fields optional, so no new failures
  - Extended `/doc` test to assert parameters are documented and to fail on leaked zod internals (`def`, `_def`, `_zod`, `~standard`, `_cached`)

<sup>Written for commit afb5a4e8d54910a2c0c04b67f0d68e76da71eca2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

