### PR TITLE
feat(patterns): add privacy-safe Topics workload diagnostics

### DIFF
--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -143,6 +143,7 @@ export function setWorkerStateForTesting(
       [string, Cell<{ bgUpdater: Stream<unknown> }>]
     >;
     streamValidator?: typeof isStream;
+    detachOtelBridge?: (() => void) | null;
   },
 ): void {
   if ("initialized" in state) initialized = state.initialized ?? false;
@@ -159,6 +160,9 @@ export function setWorkerStateForTesting(
   }
   if ("streamValidator" in state) {
     streamValidator = state.streamValidator ?? isStream;
+  }
+  if ("detachOtelBridge" in state) {
+    detachOtelBridge = state.detachOtelBridge ?? null;
   }
 }
 
@@ -244,30 +248,34 @@ export async function cleanup(): Promise<void> {
   currentSession = null;
   manager = null;
 
-  // Ensure storage is synced before cleanup
-  if (runtime) {
-    await runtime.storageManager.synced();
-    await runtime.dispose();
-    runtime = null;
-  }
-
-  // Detach the OTel bridge only after the runtime is fully torn down, so the
-  // final sync/dispose telemetry (storage completions, subscription removals)
-  // is still observed; detaching closes any spans left in flight.
-  if (detachOtelBridge) {
-    detachOtelBridge();
-    detachOtelBridge = null;
-  }
-
-  // Flush buffered spans/metrics before the controller terminates this worker;
-  // fail-open — telemetry teardown must never block cleanup.
   try {
-    await shutdownOpenTelemetry();
-  } catch (error) {
-    console.error("Failed to shut down OpenTelemetry:", error);
-  }
+    if (runtime) {
+      try {
+        await runtime.storageManager.synced();
+      } finally {
+        await runtime.dispose();
+      }
+    }
+  } finally {
+    runtime = null;
 
-  initialized = false;
+    // Detach only after runtime teardown so final sync/dispose telemetry is
+    // observed. The finally block also closes spans when teardown rejects.
+    if (detachOtelBridge) {
+      detachOtelBridge();
+      detachOtelBridge = null;
+    }
+
+    // Flush before the controller terminates this worker. Telemetry teardown
+    // remains fail-open and must not replace a runtime cleanup failure.
+    try {
+      await shutdownOpenTelemetry();
+    } catch (error) {
+      console.error("Failed to shut down OpenTelemetry:", error);
+    }
+
+    initialized = false;
+  }
 }
 
 export async function runPiece(data: RunData): Promise<void> {

--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -183,30 +183,34 @@ export async function initialize(
     errorHandlers: [errorHandler],
   }));
   // Each worker is its own isolate: the provider main.ts registers doesn't
-  // exist here, so initialize OTel in-worker (idempotent, fail-open) or the
-  // bridge below would attach to no-op instruments.
+  // exist here, so initialize OTel in-worker when export is enabled. Setup is
+  // idempotent and fail-open; a failed setup leaves the API instruments no-op.
   await initOpenTelemetry();
 
-  // Bridge the runtime's existing telemetry stream to OpenTelemetry. This is a
-  // second, passive consumer of the same event bus the debug tooling uses; it
-  // emits no-op instruments unless a provider is registered (see otel.ts).
-  detachOtelBridge = attachRuntimeTelemetryOtelBridge(runtime.telemetry, {
-    tracer: getTracer(),
-    meter: getMeter(),
-    attributes: {
-      "ct.runtime": "bg-piece",
-      "space.did": spaceId,
-      "user.did": identity.did(),
-    },
-    // Metric datapoints don't inherit resource attributes in SigNoz, so stamp
-    // the scoping labels explicitly (metrics only — on spans these live on the
-    // resource, and duplicating them as span attributes makes the bare key
-    // ambiguous in queries).
-    metricAttributes: {
-      "service.name": env.OTEL_SERVICE_NAME,
-      "deployment.environment": env.ENV,
-    },
-  });
+  // Do not attach a no-op bridge when OTel is disabled: attaching retains the
+  // runtime's detailed event-commit telemetry until cleanup. Enabled workers
+  // retain the bridge and detach it during cleanup after runtime disposal.
+  if (env.OTEL_ENABLED) {
+    detachOtelBridge = attachRuntimeTelemetryOtelBridge(runtime.telemetry, {
+      tracer: getTracer(),
+      meter: getMeter(),
+      attributes: {
+        "ct.runtime": "bg-piece",
+      },
+      spanAttributes: {
+        "space.did": spaceId,
+        "user.did": identity.did(),
+      },
+      // Metric datapoints don't inherit resource attributes in SigNoz, so stamp
+      // the scoping labels explicitly (metrics only — on spans these live on the
+      // resource, and duplicating them as span attributes makes the bare key
+      // ambiguous in queries).
+      metricAttributes: {
+        "service.name": env.OTEL_SERVICE_NAME,
+        "deployment.environment": env.ENV,
+      },
+    });
+  }
 
   manager = new PieceManager(currentSession, runtime);
   await manager.ready;

--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -17,6 +17,7 @@ import { env } from "./env.ts";
 import {
   getMeter,
   getTracer,
+  getTracerProvider,
   initOpenTelemetry,
   shutdownOpenTelemetry,
 } from "./otel.ts";
@@ -47,6 +48,34 @@ let runtime: Runtime | null = null;
 let detachOtelBridge: (() => void) | null = null;
 const loadedPieces = new Map<string, Cell<{ bgUpdater: Stream<unknown> }>>();
 let streamValidator = isStream;
+
+/** Attach detailed runtime telemetry only after the canonical OTel init succeeds. */
+export function attachOtelBridgeWhenInitialized(
+  telemetry: Runtime["telemetry"],
+  spaceDid: DID,
+  userDid: DID,
+): (() => void) | null {
+  if (getTracerProvider() === undefined) return null;
+  return attachRuntimeTelemetryOtelBridge(telemetry, {
+    tracer: getTracer(),
+    meter: getMeter(),
+    attributes: {
+      "ct.runtime": "bg-piece",
+    },
+    spanAttributes: {
+      "space.did": spaceDid,
+      "user.did": userDid,
+    },
+    // Metric datapoints don't inherit resource attributes in SigNoz, so stamp
+    // the scoping labels explicitly (metrics only — on spans these live on the
+    // resource, and duplicating them as span attributes makes the bare key
+    // ambiguous in queries).
+    metricAttributes: {
+      "service.name": env.OTEL_SERVICE_NAME,
+      "deployment.environment": env.ENV,
+    },
+  });
+}
 
 export function recordLatestError(e: ErrorWithContext): void {
   latestError = e;
@@ -190,27 +219,11 @@ export async function initialize(
   // Do not attach a no-op bridge when OTel is disabled: attaching retains the
   // runtime's detailed event-commit telemetry until cleanup. Enabled workers
   // retain the bridge and detach it during cleanup after runtime disposal.
-  if (env.OTEL_ENABLED) {
-    detachOtelBridge = attachRuntimeTelemetryOtelBridge(runtime.telemetry, {
-      tracer: getTracer(),
-      meter: getMeter(),
-      attributes: {
-        "ct.runtime": "bg-piece",
-      },
-      spanAttributes: {
-        "space.did": spaceId,
-        "user.did": identity.did(),
-      },
-      // Metric datapoints don't inherit resource attributes in SigNoz, so stamp
-      // the scoping labels explicitly (metrics only — on spans these live on the
-      // resource, and duplicating them as span attributes makes the bare key
-      // ambiguous in queries).
-      metricAttributes: {
-        "service.name": env.OTEL_SERVICE_NAME,
-        "deployment.environment": env.ENV,
-      },
-    });
-  }
+  detachOtelBridge = attachOtelBridgeWhenInitialized(
+    runtime.telemetry,
+    spaceId,
+    identity.did(),
+  );
 
   manager = new PieceManager(currentSession, runtime);
   await manager.ready;

--- a/packages/background-piece-service/test/otel.test.ts
+++ b/packages/background-piece-service/test/otel.test.ts
@@ -10,6 +10,9 @@ import {
   type OtelConfig,
   shutdownOpenTelemetry,
 } from "../src/otel.ts";
+import { attachOtelBridgeWhenInitialized } from "../src/worker.ts";
+import { RuntimeTelemetry } from "@commonfabric/runner";
+import { Identity } from "@commonfabric/identity";
 
 const cfg = (enabled: boolean): OtelConfig => ({
   OTEL_ENABLED: enabled,
@@ -19,6 +22,36 @@ const cfg = (enabled: boolean): OtelConfig => ({
 });
 
 describe("OpenTelemetry setup", () => {
+  it(
+    "only attaches the worker telemetry bridge after telemetry initialization",
+    { sanitizeOps: false, sanitizeResources: false },
+    async () => {
+      const telemetry = new RuntimeTelemetry();
+      const identity = await Identity.fromPassphrase("bg-piece-otel-bridge");
+      assertEquals(
+        attachOtelBridgeWhenInitialized(
+          telemetry,
+          identity.did(),
+          identity.did(),
+        ),
+        null,
+      );
+
+      await initOpenTelemetry(cfg(true));
+      try {
+        const detach = attachOtelBridgeWhenInitialized(
+          telemetry,
+          identity.did(),
+          identity.did(),
+        );
+        assert(detach !== null, "enabled telemetry should attach the bridge");
+        detach();
+      } finally {
+        await shutdownOpenTelemetry();
+      }
+    },
+  );
+
   it("exposes a no-op tracer and no provider before init", () => {
     assertEquals(getTracerProvider(), undefined);
     const tracer = getTracer();

--- a/packages/background-piece-service/test/worker-module-subprocess.ts
+++ b/packages/background-piece-service/test/worker-module-subprocess.ts
@@ -7,6 +7,7 @@ import {
 } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import {
+  attachOtelBridgeWhenInitialized,
   executeWorkerRequest,
   formatConsoleMessage,
   handleWorkerMessage,
@@ -19,6 +20,7 @@ import {
   workerConsoleContext,
 } from "../src/worker.ts";
 import { WorkerIPCMessageType } from "../src/worker-ipc.ts";
+import { RuntimeTelemetry } from "@commonfabric/runner";
 
 const TEST_DID = "did:key:z6Mktestspace";
 const OTHER_DID = "did:key:z6Mkotherspace";
@@ -26,6 +28,19 @@ const PIECE_ID = `fid1:${"a".repeat(54)}`;
 
 try {
   resetWorkerStateForTesting();
+
+  // No provider is registered in this subprocess, which is the same state the
+  // fail-open OTel initializer leaves after setup failure.
+  const telemetry = new RuntimeTelemetry();
+  assertEquals(
+    attachOtelBridgeWhenInitialized(
+      telemetry,
+      TEST_DID as never,
+      TEST_DID as never,
+    ),
+    null,
+  );
+  assertEquals(telemetry.detailedEventCommitTelemetryEnabled, false);
 
   assertEquals(workerConsoleContext(undefined), "Worker(NO_SPACE)");
   assertEquals(workerConsoleContext(TEST_DID as never), `Worker(${TEST_DID})`);

--- a/packages/background-piece-service/test/worker-module-subprocess.ts
+++ b/packages/background-piece-service/test/worker-module-subprocess.ts
@@ -8,6 +8,7 @@ import {
 import { Identity } from "@commonfabric/identity";
 import {
   attachOtelBridgeWhenInitialized,
+  cleanup,
   executeWorkerRequest,
   formatConsoleMessage,
   handleWorkerMessage,
@@ -280,6 +281,39 @@ try {
     `runtime failed @ ${TEST_DID}:${PIECE_ID} running pattern`,
   );
   assertEquals(state.sends.length, 2);
+
+  let detachCalls = 0;
+  setWorkerStateForTesting({
+    initialized: true,
+    runtime: null,
+    detachOtelBridge: () => {
+      detachCalls++;
+    },
+  });
+  await cleanup();
+  await cleanup();
+  assertEquals(detachCalls, 1);
+
+  let disposeCalls = 0;
+  setWorkerStateForTesting({
+    initialized: true,
+    runtime: {
+      storageManager: {
+        synced: () => Promise.reject(new Error("sync failed")),
+      },
+      dispose: () => {
+        disposeCalls++;
+        return Promise.resolve();
+      },
+    } as never,
+    detachOtelBridge: () => {
+      detachCalls++;
+    },
+  });
+  await assertRejects(() => cleanup(), Error, "sync failed");
+  await cleanup();
+  assertEquals(disposeCalls, 1);
+  assertEquals(detachCalls, 2);
 } finally {
   resetWorkerStateForTesting();
 }

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -6,13 +6,13 @@ import { NameSchema } from "@commonfabric/runner/schemas";
 import {
   CellHandle,
   FavoritesManager,
+  HostRuntimeTelemetryMarker,
   JSONValue,
   PageHandle,
   Program,
   RuntimeClient,
   RuntimeClientEvents,
   RuntimeClientOptions,
-  RuntimeTelemetryMarkerResult,
 } from "@commonfabric/runtime-client";
 import { WebWorkerRuntimeTransport } from "@commonfabric/runtime-client/transports/web-worker";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -109,7 +109,7 @@ export type RuntimeInternalsCallbacks = {
  * embedder owns SDK setup and passes the sink in. Absent = zero added work.
  */
 export interface RuntimeTelemetrySink {
-  handleMarker(marker: RuntimeTelemetryMarkerResult): void;
+  handleMarker(marker: HostRuntimeTelemetryMarker): void;
   shutdown(): void | Promise<void>;
 }
 
@@ -306,7 +306,7 @@ export class RuntimeInternals extends EventTarget {
     { promise: Promise<PageHandle<NameSchema>>; started: boolean }
   > = new Map();
   // TODO(runtime-worker-refactor)
-  #telemetryMarkers: RuntimeTelemetryMarkerResult[] = [];
+  #telemetryMarkers: HostRuntimeTelemetryMarker[] = [];
   // Optional OTel sink (browser telemetry enabled). Inert when undefined.
   #telemetrySink?: RuntimeTelemetrySink;
 
@@ -330,7 +330,7 @@ export class RuntimeInternals extends EventTarget {
     return this.#client;
   }
 
-  telemetry(): RuntimeTelemetryMarkerResult[] {
+  telemetry(): HostRuntimeTelemetryMarker[] {
     return this.#telemetryMarkers;
   }
 
@@ -614,7 +614,7 @@ export class RuntimeInternals extends EventTarget {
     console.error("[RuntimeClient Error]", event);
   };
 
-  #onTelemetry = (marker: RuntimeTelemetryMarkerResult) => {
+  #onTelemetry = (marker: HostRuntimeTelemetryMarker) => {
     this.#telemetryMarkers.push(marker);
     this.dispatchEvent(new CustomEvent("telemetryupdate"));
     // Additionally translate the marker into OTel spans/metrics when a sink is

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -4,6 +4,7 @@ import { Database } from "@db/sqlite";
 import {
   type AppliedCommit,
   applyCommit as applyCommitEngine,
+  applyCommitWithOutcome as applyCommitWithOutcomeEngine,
   close,
   createBranch,
   type Engine,
@@ -47,6 +48,15 @@ const DIRECT_TEST_SCOPE_CONTEXT = {
 
 const applyCommit: typeof applyCommitEngine = (engine, options) =>
   applyCommitEngine(engine, {
+    ...options,
+    principal: options.principal ?? DIRECT_TEST_SCOPE_CONTEXT.principal,
+  });
+
+const applyCommitWithOutcome: typeof applyCommitWithOutcomeEngine = (
+  engine,
+  options,
+) =>
+  applyCommitWithOutcomeEngine(engine, {
     ...options,
     principal: options.principal ?? DIRECT_TEST_SCOPE_CONTEXT.principal,
   });
@@ -555,6 +565,61 @@ Deno.test("memory v2 accepts observation-only commits without semantic revisions
       `SELECT count(*) AS count FROM scheduler_observation`,
     ).get() as { count: number };
     assertEquals(observationRows.count, 1);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 apply outcomes distinguish first application from replay", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    const semantic = {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set" as const,
+        id: "of:outcome-semantic",
+        value: { value: true },
+      }],
+    };
+    const observationOnly = {
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [],
+      schedulerObservation: observationForAction("outcome:single"),
+    };
+    const batch = {
+      localSeq: 3,
+      reads: { confirmed: [], pending: [] },
+      operations: [],
+      schedulerObservationBatch: [
+        {
+          localSeq: 4,
+          reads: { confirmed: [], pending: [] },
+          schedulerObservation: observationForAction("outcome:batch:one"),
+        },
+        {
+          localSeq: 5,
+          reads: { confirmed: [], pending: [] },
+          schedulerObservation: observationForAction("outcome:batch:two"),
+        },
+      ],
+    };
+
+    for (const commit of [semantic, observationOnly, batch]) {
+      const first = applyCommitWithOutcome(engine, {
+        sessionId: "session:apply-outcome",
+        commit,
+      });
+      const replay = applyCommitWithOutcome(engine, {
+        sessionId: "session:apply-outcome",
+        commit,
+      });
+      assertEquals(first.replayed, false);
+      assertEquals(replay.replayed, true);
+    }
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -583,6 +583,7 @@ Deno.test("memory v2 apply outcomes distinguish first application from replay", 
         id: "of:outcome-semantic",
         value: { value: true },
       }],
+      schedulerObservation: observationForAction("outcome:semantic"),
     };
     const observationOnly = {
       localSeq: 2,
@@ -624,6 +625,9 @@ Deno.test("memory v2 apply outcomes distinguish first application from replay", 
     }
 
     const [semanticOutcome, observationOutcome, batchOutcome] = outcomes;
+    const semanticObservationResult = semanticOutcome?.first.commit
+      .schedulerObservationResults?.[0];
+    assertExists(semanticObservationResult?.schedulerObservationId);
     assertEquals(semanticOutcome?.first.commit, {
       seq: 1,
       branch: "",
@@ -637,18 +641,26 @@ Deno.test("memory v2 apply outcomes distinguish first application from replay", 
         op: "set",
         document: { value: true },
       }],
+      schedulerObservationId: semanticObservationResult.schedulerObservationId,
+      schedulerObservationResults: [semanticObservationResult],
     });
-    assertEquals(semanticOutcome?.replay.commit.revisions, [{
-      id: "of:outcome-semantic",
-      scope: "space",
-      scopeKey: "space",
-      branch: "",
+    assertEquals(semanticOutcome?.replay.commit, {
       seq: 1,
-      opIndex: 0,
-      commitSeq: 1,
-      op: "set",
-      document: { value: true },
-    }]);
+      branch: "",
+      revisions: [{
+        id: "of:outcome-semantic",
+        scope: "space",
+        scopeKey: "space",
+        branch: "",
+        seq: 1,
+        opIndex: 0,
+        commitSeq: 1,
+        op: "set",
+        document: { value: true },
+      }],
+      schedulerObservationId: semanticObservationResult.schedulerObservationId,
+      schedulerObservationResults: [semanticObservationResult],
+    });
 
     const observationResult = observationOutcome?.first.commit
       .schedulerObservationResults?.[0];
@@ -686,8 +698,8 @@ Deno.test("memory v2 apply outcomes distinguish first application from replay", 
       batchOutcome?.replay.commit.schedulerObservationResults,
       batchResults,
     );
-    assertEquals(countRows(engine, "scheduler_observation"), 3);
-    assertEquals(countRows(engine, "scheduler_observation_replay"), 3);
+    assertEquals(countRows(engine, "scheduler_observation"), 4);
+    assertEquals(countRows(engine, "scheduler_observation_replay"), 4);
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -608,6 +608,7 @@ Deno.test("memory v2 apply outcomes distinguish first application from replay", 
       ],
     };
 
+    const outcomes = [];
     for (const commit of [semantic, observationOnly, batch]) {
       const first = applyCommitWithOutcome(engine, {
         sessionId: "session:apply-outcome",
@@ -619,7 +620,74 @@ Deno.test("memory v2 apply outcomes distinguish first application from replay", 
       });
       assertEquals(first.replayed, false);
       assertEquals(replay.replayed, true);
+      outcomes.push({ first, replay });
     }
+
+    const [semanticOutcome, observationOutcome, batchOutcome] = outcomes;
+    assertEquals(semanticOutcome?.first.commit, {
+      seq: 1,
+      branch: "",
+      revisions: [{
+        id: "of:outcome-semantic",
+        scopeKey: "space",
+        branch: "",
+        seq: 1,
+        opIndex: 0,
+        commitSeq: 1,
+        op: "set",
+        document: { value: true },
+      }],
+    });
+    assertEquals(semanticOutcome?.replay.commit.revisions, [{
+      id: "of:outcome-semantic",
+      scope: "space",
+      scopeKey: "space",
+      branch: "",
+      seq: 1,
+      opIndex: 0,
+      commitSeq: 1,
+      op: "set",
+      document: { value: true },
+    }]);
+
+    const observationResult = observationOutcome?.first.commit
+      .schedulerObservationResults?.[0];
+    assertEquals(observationResult?.localSeq, observationOnly.localSeq);
+    assertEquals(observationResult?.status, "kept");
+    assertExists(observationResult?.schedulerObservationId);
+    assertEquals(
+      observationOutcome?.replay.commit.schedulerObservationResults,
+      [observationResult],
+    );
+
+    const batchResults = batchOutcome?.first.commit.schedulerObservationResults;
+    assertEquals(
+      batchResults?.map(({ localSeq, status, schedulerObservationId }) => ({
+        localSeq,
+        status,
+        schedulerObservationId,
+      })),
+      [
+        {
+          localSeq: 4,
+          status: "kept",
+          schedulerObservationId: batchResults?.[0]?.schedulerObservationId,
+        },
+        {
+          localSeq: 5,
+          status: "kept",
+          schedulerObservationId: batchResults?.[1]?.schedulerObservationId,
+        },
+      ],
+    );
+    assertExists(batchResults?.[0]?.schedulerObservationId);
+    assertExists(batchResults?.[1]?.schedulerObservationId);
+    assertEquals(
+      batchOutcome?.replay.commit.schedulerObservationResults,
+      batchResults,
+    );
+    assertEquals(countRows(engine, "scheduler_observation"), 3);
+    assertEquals(countRows(engine, "scheduler_observation_replay"), 3);
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -1489,6 +1489,34 @@ Deno.test("memory v2 server telemetry accounts for unknown-session attempts", as
   }
 });
 
+Deno.test("memory v2 server telemetry preserves malformed transact ingress errors", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-telemetry-malformed-transact",
+    0,
+    true,
+  );
+  try {
+    const response = await server.transact({
+      type: "transact",
+      requestId: "malformed",
+      space: "did:key:z6Mk-memory-v2-server-telemetry-malformed-transact",
+      sessionId: "session:unknown",
+      commit: { reads: null, operations: null },
+    } as never);
+    assertEquals(response, {
+      type: "response",
+      requestId: "malformed",
+      error: {
+        name: "SessionError",
+        message: "Unknown session for space",
+      },
+    });
+    assertEquals(server.commitTelemetry().transactCount, 1);
+  } finally {
+    await server.close();
+  }
+});
+
 Deno.test("memory v2 server telemetry accounts for transacts rejected by a connection session gate", async () => {
   const server = createServer(
     "memory://memory-v2-server-telemetry-connection-session",

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -141,6 +141,52 @@ Deno.test("memory v2 server stateless respond does not issue hello.ok", async ()
   }
 });
 
+Deno.test("memory v2 diagnostics wait for an active receive", async () => {
+  const authorizationStarted = Promise.withResolvers<void>();
+  const releaseAuthorization = Promise.withResolvers<string>();
+  const server = new Server({
+    store: new URL("memory://memory-v2-server-receive-fence"),
+    subscriptionRefreshDelayMs: 0,
+    authorizeSessionOpen() {
+      authorizationStarted.resolve();
+      return releaseAuthorization.promise;
+    },
+    sessionOpenAuth: { audience: TEST_AUDIENCE },
+  });
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(messages);
+    const receive = connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open",
+      space: "did:key:z6Mk-memory-v2-server-receive-fence",
+      session: {},
+      invocation: authInvocation(sessionOpen),
+    }));
+    await authorizationStarted.promise;
+
+    let waitComplete = false;
+    const wait = server.waitForDiagnosticsReceives().then(() => {
+      waitComplete = true;
+    });
+    await Promise.resolve();
+    const completedBeforeAuthorization = waitComplete;
+
+    releaseAuthorization.resolve("did:key:z6Mk-memory-v2-server-principal");
+    await Promise.all([receive, wait]);
+    assertEquals(completedBeforeAuthorization, false);
+    assertEquals(
+      assertResponse<unknown>(shiftMessage(messages)).requestId,
+      "open",
+    );
+  } finally {
+    releaseAuthorization.resolve("did:key:z6Mk-memory-v2-server-principal");
+    await server.close();
+  }
+});
+
 Deno.test("memory v2 server parser ignores transact invocation and authorization payloads", () => {
   assertEquals(
     parseClientMessage(encodeMemoryBoundary({
@@ -1392,6 +1438,11 @@ Deno.test("memory v2 server rejects telemetry snapshots when disabled", async ()
       Error,
       "commit telemetry is disabled",
     );
+    assertThrows(
+      () => server.diagnosticsActivityGeneration(),
+      Error,
+      "commit telemetry is disabled",
+    );
   } finally {
     await server.close();
   }
@@ -1415,11 +1466,48 @@ Deno.test("memory v2 server aggregate diagnostics bypass exported spans", async 
       diagnosticsTracer: recordingTracer(aggregateSpanNames),
     },
   );
+  const aggregateMessages: ServerMessage[] = [];
+  const aggregateConnection = aggregate.connect((message) =>
+    aggregateMessages.push(message)
+  );
+  const aggregateSpace = "did:key:z6Mk-private-aggregate-span";
 
   try {
+    await aggregateConnection.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(aggregateMessages);
+    await aggregateConnection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-aggregate",
+      space: aggregateSpace,
+      session: {},
+      invocation: authInvocation(sessionOpen),
+    }));
+    const sessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(aggregateMessages),
+    ).ok!.sessionId;
+    await aggregateConnection.receive(encodeMemoryBoundary({
+      type: "transact",
+      requestId: "aggregate-transaction",
+      space: aggregateSpace,
+      sessionId,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:aggregate-span",
+          value: { value: true },
+        }],
+      },
+    }));
+    assertEquals(
+      assertResponse<unknown>(shiftMessage(aggregateMessages)).requestId,
+      "aggregate-transaction",
+    );
+
     await Promise.all([
       ordinary.flushSessions(["did:key:z6Mk-ordinary-span"]),
-      aggregate.flushSessions(["did:key:z6Mk-private-aggregate-span"]),
+      aggregate.flushSessions([aggregateSpace]),
     ]);
 
     assertEquals(ordinarySpanNames, ["memory.fanout"]);
@@ -1439,9 +1527,12 @@ Deno.test("memory v2 server telemetry accounts for unknown-session attempts", as
     localSeq: 1,
     reads: { confirmed: [], pending: [] },
     operations: [{
-      op: "set",
+      op: "patch",
       id: "of:telemetry-unknown-session",
-      value: { value: { ignored: true } },
+      patches: [
+        { op: "replace", path: "/source/private", value: "ignored" },
+        { op: "replace", path: "/private", value: "ignored" },
+      ],
     }],
   };
 
@@ -1475,9 +1566,9 @@ Deno.test("memory v2 server telemetry accounts for unknown-session attempts", as
         max: encodedByteLength(commit.operations[0]),
       },
       newlyPersistedRevisions: { total: 0, max: 0 },
-      operationsByType: { set: 1, patch: 0, delete: 0, sqlite: 0 },
+      operationsByType: { set: 0, patch: 1, delete: 0, sqlite: 0 },
       receivedPatchOperationsByType: {
-        replace: 0,
+        replace: 2,
         add: 0,
         remove: 0,
         move: 0,
@@ -1498,7 +1589,7 @@ Deno.test("memory v2 server telemetry accounts for unknown-session attempts", as
         "remove-by-value": 0,
         increment: 0,
       },
-      patchesByPathShape: {},
+      patchesByPathShape: { metadata: 1, other: 1 },
       rejectedByName: { SessionError: 1 },
     });
   } finally {
@@ -1513,22 +1604,38 @@ Deno.test("memory v2 server telemetry preserves malformed transact ingress error
     true,
   );
   try {
-    const response = await server.transact({
+    const nonRecordResponse = await server.transact({
       type: "transact",
-      requestId: "malformed",
+      requestId: "non-record",
       space: "did:key:z6Mk-memory-v2-server-telemetry-malformed-transact",
       sessionId: "session:unknown",
-      commit: { reads: null, operations: null },
+      commit: null,
     } as never);
-    assertEquals(response, {
+    assertEquals(nonRecordResponse, {
       type: "response",
-      requestId: "malformed",
+      requestId: "non-record",
       error: {
         name: "SessionError",
         message: "Unknown session for space",
       },
     });
-    assertEquals(server.commitTelemetry().transactCount, 1);
+
+    const circularCommit: Record<string, unknown> = {
+      reads: { confirmed: [] },
+      operations: [],
+    };
+    circularCommit.self = circularCommit;
+    const circularResponse = await server.transact({
+      type: "transact",
+      requestId: "circular",
+      space: "did:key:z6Mk-memory-v2-server-telemetry-malformed-transact",
+      sessionId: "session:unknown",
+      commit: circularCommit,
+    } as never);
+    assertEquals(circularResponse.error?.name, "SessionError");
+    const telemetry = server.commitTelemetry();
+    assertEquals(telemetry.transactCount, 2);
+    assertEquals(telemetry.receivedCommitBytes, { total: 0, max: 0 });
   } finally {
     await server.close();
   }
@@ -2981,6 +3088,64 @@ Deno.test("memory v2 diagnostics flush falls back to a regular refresh without t
     await server.flushDiagnosticsSessions();
     await effectSent.promise;
     assertEquals(assertEffect(shiftMessage(messages)).effect.toSeq, 1);
+    assertEquals(messages, []);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 diagnostics skip waiting for an acknowledged effect", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-diagnostics-already-acknowledged",
+    0,
+    true,
+  );
+  const messages: ServerMessage[] = [];
+  const effectSent = Promise.withResolvers<void>();
+  const connection = server.connect((message) => {
+    messages.push(message);
+    if (message.type === "session/effect") effectSent.resolve();
+  });
+  const space =
+    "did:key:z6Mk-memory-v2-server-diagnostics-already-acknowledged";
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(messages);
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open",
+      space,
+      session: {},
+      invocation: authInvocation(sessionOpen),
+    }));
+    const sessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(messages),
+    ).ok!.sessionId;
+    server.syncSessionForConnection = () =>
+      Promise.resolve({
+        type: "session/effect",
+        space,
+        sessionId,
+        effect: {
+          type: "sync",
+          fromSeq: 0,
+          toSeq: 0,
+          upserts: [],
+          removes: [],
+        },
+      });
+    server.markSpaceDirty(space);
+
+    let flushComplete = false;
+    const flush = server.flushDiagnosticsSessions().then(() => {
+      flushComplete = true;
+    });
+    await effectSent.promise;
+    await tick();
+    assertEquals(flushComplete, true);
+    await flush;
+    assertEquals(assertEffect(shiftMessage(messages)).effect.toSeq, 0);
     assertEquals(messages, []);
   } finally {
     await server.close();

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -1,8 +1,10 @@
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals, assertExists, assertThrows } from "@std/assert";
 import { FakeTime } from "@std/testing/time";
+import { INVALID_SPAN_CONTEXT, trace, type Tracer } from "@opentelemetry/api";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { parseClientMessage, Server, SessionRegistry } from "../v2/server.ts";
 import {
+  type ClientCommit,
   decodeMemoryBoundary,
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
@@ -14,6 +16,7 @@ import {
   type SessionEffectMessage,
   type SessionOpenAuthMetadata,
   type SessionSync,
+  toDocumentPath,
 } from "../v2.ts";
 import { createGraphFixture } from "./v2-graph.fixture.ts";
 
@@ -64,7 +67,15 @@ const assertEffect = (
   return message as SessionEffectMessage & { effect: SessionSync };
 };
 
-const createServer = (store: string, refreshDelayMs = 0) =>
+const createServer = (
+  store: string,
+  refreshDelayMs = 0,
+  commitTelemetry = false,
+  diagnosticsOptions: {
+    aggregateOnlyDiagnostics?: boolean;
+    diagnosticsTracer?: Tracer;
+  } = {},
+) =>
   new Server({
     store: new URL(store),
     subscriptionRefreshDelayMs: refreshDelayMs,
@@ -78,7 +89,25 @@ const createServer = (store: string, refreshDelayMs = 0) =>
     sessionOpenAuth: {
       audience: TEST_AUDIENCE,
     },
+    commitTelemetry,
+    ...diagnosticsOptions,
   });
+
+const recordingTracer = (names: string[]): Tracer =>
+  ({
+    startActiveSpan(name: string, ...args: unknown[]) {
+      const callback = args.at(-1);
+      if (typeof callback !== "function") {
+        throw new Error("recording tracer requires a span callback");
+      }
+      names.push(name);
+      return callback(trace.wrapSpanContext(INVALID_SPAN_CONTEXT));
+    },
+  }) as unknown as Tracer;
+
+const encodedByteLength = (
+  value: Parameters<typeof encodeMemoryBoundary>[0],
+): number => new TextEncoder().encode(encodeMemoryBoundary(value)).byteLength;
 
 Deno.test("memory v2 server stateless respond does not issue hello.ok", async () => {
   const server = createServer("memory://memory-v2-server-stateless-respond");
@@ -1121,6 +1150,504 @@ Deno.test("memory v2 server opens sessions, commits documents, and answers graph
           },
         },
       }],
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 server commit telemetry records received transact aggregates", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-commit-telemetry",
+    0,
+    true,
+  );
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  const space = "did:key:z6Mk-memory-v2-server-commit-telemetry";
+  const initialCommit = {
+    localSeq: 1,
+    reads: { confirmed: [], pending: [] },
+    operations: [{
+      op: "set",
+      id: "of:doc:1",
+      value: { value: { version: 1, links: [] } },
+    }],
+  };
+  const conflictingRead = { id: "of:doc:1", path: [], seq: 0 };
+  const patchCommit = {
+    localSeq: 2,
+    reads: { confirmed: [], pending: [] },
+    operations: [{
+      op: "patch",
+      id: "of:doc:1",
+      patches: [
+        { op: "replace", path: "/value", value: { version: 2, links: [] } },
+        {
+          op: "add",
+          path: "/value/did:key:z6MkTelemetrySecret/content-shaped-key",
+          value: true,
+        },
+        {
+          op: "append",
+          path: "/value/links",
+          values: ["private-link-value"],
+        },
+      ],
+    }],
+  };
+  const conflictingCommit = {
+    localSeq: 3,
+    reads: { confirmed: [conflictingRead], pending: [] },
+    operations: [{
+      op: "set",
+      id: "of:doc:1",
+      value: { value: { version: 2 } },
+    }],
+  };
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(messages);
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-telemetry",
+      space,
+      session: {},
+      invocation: authInvocation(sessionOpen),
+    }));
+    const opened = assertResponse<{ sessionId: string }>(
+      shiftMessage(messages),
+    );
+    const sessionId = opened.ok!.sessionId;
+
+    for (
+      const [requestId, commit] of [
+        ["tx-1", initialCommit],
+        ["tx-replay", initialCommit],
+        ["tx-patch", patchCommit],
+        ["tx-patch-replay", patchCommit],
+        ["tx-conflict", conflictingCommit],
+      ] as const
+    ) {
+      await connection.receive(encodeMemoryBoundary({
+        type: "transact",
+        requestId,
+        space,
+        sessionId,
+        commit,
+      }));
+      shiftMessage(messages);
+    }
+
+    const initialCommitBytes = encodedByteLength(initialCommit);
+    const conflictingCommitBytes = encodedByteLength(conflictingCommit);
+    const patchCommitBytes = encodedByteLength(patchCommit);
+    const initialOperationBytes = encodedByteLength(
+      initialCommit.operations[0],
+    );
+    const conflictingOperationBytes = encodedByteLength(
+      conflictingCommit.operations[0],
+    );
+    const patchOperationBytes = encodedByteLength(patchCommit.operations[0]);
+    const emptyConfirmedReadsBytes = encodedByteLength(
+      initialCommit.reads.confirmed,
+    );
+    const conflictingConfirmedReadsBytes = encodedByteLength(
+      conflictingCommit.reads.confirmed,
+    );
+    const telemetry = server.commitTelemetry();
+    assertEquals(telemetry, {
+      transactCount: 5,
+      acceptedCount: 4,
+      rejectedCount: 1,
+      conflictCount: 1,
+      replayCount: 2,
+      receivedCommitBytes: {
+        total: initialCommitBytes * 2 + patchCommitBytes * 2 +
+          conflictingCommitBytes,
+        max: Math.max(
+          initialCommitBytes,
+          patchCommitBytes,
+          conflictingCommitBytes,
+        ),
+      },
+      confirmedReadEntries: { total: 1, max: 1 },
+      confirmedReadBytes: {
+        total: emptyConfirmedReadsBytes * 4 + conflictingConfirmedReadsBytes,
+        max: Math.max(emptyConfirmedReadsBytes, conflictingConfirmedReadsBytes),
+      },
+      operationEntries: { total: 5, max: 1 },
+      operationBytes: {
+        total: initialOperationBytes * 2 + patchOperationBytes * 2 +
+          conflictingOperationBytes,
+        max: Math.max(
+          initialOperationBytes,
+          patchOperationBytes,
+          conflictingOperationBytes,
+        ),
+      },
+      newlyPersistedRevisions: { total: 2, max: 1 },
+      operationsByType: { set: 3, patch: 2, delete: 0, sqlite: 0 },
+      receivedPatchOperationsByType: {
+        replace: 2,
+        add: 2,
+        remove: 0,
+        move: 0,
+        splice: 0,
+        append: 2,
+        "add-unique": 0,
+        "remove-by-value": 0,
+        increment: 0,
+      },
+      newlyAppliedPatchOperationsByType: {
+        replace: 1,
+        add: 1,
+        remove: 0,
+        move: 0,
+        splice: 0,
+        append: 1,
+        "add-unique": 0,
+        "remove-by-value": 0,
+        increment: 0,
+      },
+      patchesByPathShape: { "value-root": 2, "value/*/*": 2, "value/*": 2 },
+      rejectedByName: { ConflictError: 1 },
+    });
+    const serializedTelemetry = encodeMemoryBoundary(telemetry);
+    assertEquals(
+      serializedTelemetry.includes("did:key:z6MkTelemetrySecret"),
+      false,
+    );
+    assertEquals(serializedTelemetry.includes("content-shaped-key"), false);
+    assertEquals(serializedTelemetry.includes("private-link-value"), false);
+    telemetry.operationsByType.set = 999;
+    telemetry.receivedPatchOperationsByType.append = 999;
+    telemetry.newlyAppliedPatchOperationsByType.append = 999;
+    telemetry.patchesByPathShape["value-root"] = 999;
+    assertEquals(server.commitTelemetry(), {
+      transactCount: 0,
+      acceptedCount: 0,
+      rejectedCount: 0,
+      conflictCount: 0,
+      replayCount: 0,
+      receivedCommitBytes: { total: 0, max: 0 },
+      confirmedReadEntries: { total: 0, max: 0 },
+      confirmedReadBytes: { total: 0, max: 0 },
+      operationEntries: { total: 0, max: 0 },
+      operationBytes: { total: 0, max: 0 },
+      newlyPersistedRevisions: { total: 0, max: 0 },
+      operationsByType: { set: 0, patch: 0, delete: 0, sqlite: 0 },
+      receivedPatchOperationsByType: {
+        replace: 0,
+        add: 0,
+        remove: 0,
+        move: 0,
+        splice: 0,
+        append: 0,
+        "add-unique": 0,
+        "remove-by-value": 0,
+        increment: 0,
+      },
+      newlyAppliedPatchOperationsByType: {
+        replace: 0,
+        add: 0,
+        remove: 0,
+        move: 0,
+        splice: 0,
+        append: 0,
+        "add-unique": 0,
+        "remove-by-value": 0,
+        increment: 0,
+      },
+      patchesByPathShape: {},
+      rejectedByName: {},
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 server rejects telemetry snapshots when disabled", async () => {
+  const server = createServer("memory://memory-v2-server-telemetry-disabled");
+  try {
+    assertThrows(
+      () => server.commitTelemetry(),
+      Error,
+      "commit telemetry is disabled",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 server aggregate diagnostics bypass exported spans", async () => {
+  const ordinarySpanNames: string[] = [];
+  const ordinary = createServer(
+    "memory://memory-v2-server-ordinary-spans",
+    0,
+    false,
+    { diagnosticsTracer: recordingTracer(ordinarySpanNames) },
+  );
+  const aggregateSpanNames: string[] = [];
+  const aggregate = createServer(
+    "memory://memory-v2-server-aggregate-spans",
+    0,
+    true,
+    {
+      aggregateOnlyDiagnostics: true,
+      diagnosticsTracer: recordingTracer(aggregateSpanNames),
+    },
+  );
+
+  try {
+    await Promise.all([
+      ordinary.flushSessions(["did:key:z6Mk-ordinary-span"]),
+      aggregate.flushSessions(["did:key:z6Mk-private-aggregate-span"]),
+    ]);
+
+    assertEquals(ordinarySpanNames, ["memory.fanout"]);
+    assertEquals(aggregateSpanNames, []);
+  } finally {
+    await Promise.all([ordinary.close(), aggregate.close()]);
+  }
+});
+
+Deno.test("memory v2 server telemetry accounts for unknown-session attempts", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-telemetry-unknown-session",
+    0,
+    true,
+  );
+  const commit: ClientCommit = {
+    localSeq: 1,
+    reads: { confirmed: [], pending: [] },
+    operations: [{
+      op: "set",
+      id: "of:telemetry-unknown-session",
+      value: { value: { ignored: true } },
+    }],
+  };
+
+  try {
+    const response = await server.transact({
+      type: "transact",
+      requestId: "unknown-session",
+      space: "did:key:z6Mk-memory-v2-server-telemetry-unknown-session",
+      sessionId: "session:unknown",
+      commit,
+    });
+    assertEquals(response.error?.name, "SessionError");
+    assertEquals(server.commitTelemetry(), {
+      transactCount: 1,
+      acceptedCount: 0,
+      rejectedCount: 1,
+      conflictCount: 0,
+      replayCount: 0,
+      receivedCommitBytes: {
+        total: encodedByteLength(commit),
+        max: encodedByteLength(commit),
+      },
+      confirmedReadEntries: { total: 0, max: 0 },
+      confirmedReadBytes: {
+        total: encodedByteLength(commit.reads.confirmed),
+        max: encodedByteLength(commit.reads.confirmed),
+      },
+      operationEntries: { total: 1, max: 1 },
+      operationBytes: {
+        total: encodedByteLength(commit.operations[0]),
+        max: encodedByteLength(commit.operations[0]),
+      },
+      newlyPersistedRevisions: { total: 0, max: 0 },
+      operationsByType: { set: 1, patch: 0, delete: 0, sqlite: 0 },
+      receivedPatchOperationsByType: {
+        replace: 0,
+        add: 0,
+        remove: 0,
+        move: 0,
+        splice: 0,
+        append: 0,
+        "add-unique": 0,
+        "remove-by-value": 0,
+        increment: 0,
+      },
+      newlyAppliedPatchOperationsByType: {
+        replace: 0,
+        add: 0,
+        remove: 0,
+        move: 0,
+        splice: 0,
+        append: 0,
+        "add-unique": 0,
+        "remove-by-value": 0,
+        increment: 0,
+      },
+      patchesByPathShape: {},
+      rejectedByName: { SessionError: 1 },
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 server telemetry accounts for transacts rejected by a connection session gate", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-telemetry-connection-session",
+    0,
+    true,
+  );
+  const firstMessages: ServerMessage[] = [];
+  const secondMessages: ServerMessage[] = [];
+  const firstConnection = server.connect((message) =>
+    firstMessages.push(message)
+  );
+  const secondConnection = server.connect((message) =>
+    secondMessages.push(message)
+  );
+  const space = "did:key:z6Mk-memory-v2-server-telemetry-connection-session";
+  const commit: ClientCommit = {
+    localSeq: 1,
+    reads: {
+      confirmed: [{
+        id: "of:telemetry-connection-session",
+        path: toDocumentPath([]),
+        seq: 0,
+      }],
+      pending: [],
+    },
+    operations: [{
+      op: "patch",
+      id: "of:telemetry-connection-session",
+      patches: [
+        { op: "replace", path: "/value", value: { ignored: true } },
+        { op: "append", path: "/value/items", values: ["ignored"] },
+      ],
+    }],
+  };
+
+  try {
+    await firstConnection.receive(encodeMemoryBoundary(HELLO));
+    const firstSessionOpen = expectHelloOk(firstMessages);
+    await firstConnection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-first",
+      space,
+      session: { sessionId: "session:first" },
+      invocation: authInvocation(firstSessionOpen),
+    }));
+    assertEquals(
+      assertResponse<{ sessionId: string }>(shiftMessage(firstMessages)).ok
+        ?.sessionId,
+      "session:first",
+    );
+
+    await secondConnection.receive(encodeMemoryBoundary(HELLO));
+    expectHelloOk(secondMessages);
+    await secondConnection.receive(encodeMemoryBoundary({
+      type: "transact",
+      requestId: "rejected-connection-transaction",
+      space,
+      sessionId: "session:first",
+      commit,
+    }));
+
+    assertEquals(shiftMessage(secondMessages), {
+      type: "response",
+      requestId: "rejected-connection-transaction",
+      error: {
+        name: "SessionError",
+        message: "Session is not open on this connection",
+      },
+    });
+    assertEquals(
+      await server.readDocument(space, "of:telemetry-connection-session"),
+      null,
+    );
+    assertEquals(server.diagnosticsActivityGeneration(), 1);
+    assertEquals(server.commitTelemetry(), {
+      transactCount: 1,
+      acceptedCount: 0,
+      rejectedCount: 1,
+      conflictCount: 0,
+      replayCount: 0,
+      receivedCommitBytes: {
+        total: encodedByteLength(commit),
+        max: encodedByteLength(commit),
+      },
+      confirmedReadEntries: { total: 1, max: 1 },
+      confirmedReadBytes: {
+        total: encodedByteLength(commit.reads.confirmed),
+        max: encodedByteLength(commit.reads.confirmed),
+      },
+      operationEntries: { total: 1, max: 1 },
+      operationBytes: {
+        total: encodedByteLength(commit.operations[0]),
+        max: encodedByteLength(commit.operations[0]),
+      },
+      newlyPersistedRevisions: { total: 0, max: 0 },
+      operationsByType: { set: 0, patch: 1, delete: 0, sqlite: 0 },
+      receivedPatchOperationsByType: {
+        replace: 1,
+        add: 0,
+        remove: 0,
+        move: 0,
+        splice: 0,
+        append: 1,
+        "add-unique": 0,
+        "remove-by-value": 0,
+        increment: 0,
+      },
+      newlyAppliedPatchOperationsByType: {
+        replace: 0,
+        add: 0,
+        remove: 0,
+        move: 0,
+        splice: 0,
+        append: 0,
+        "add-unique": 0,
+        "remove-by-value": 0,
+        increment: 0,
+      },
+      patchesByPathShape: { "value-root": 1, "value/*": 1 },
+      rejectedByName: { SessionError: 1 },
+    });
+    assertEquals(server.diagnosticsActivityGeneration(), 1);
+    assertEquals(server.commitTelemetry(), {
+      transactCount: 0,
+      acceptedCount: 0,
+      rejectedCount: 0,
+      conflictCount: 0,
+      replayCount: 0,
+      receivedCommitBytes: { total: 0, max: 0 },
+      confirmedReadEntries: { total: 0, max: 0 },
+      confirmedReadBytes: { total: 0, max: 0 },
+      operationEntries: { total: 0, max: 0 },
+      operationBytes: { total: 0, max: 0 },
+      newlyPersistedRevisions: { total: 0, max: 0 },
+      operationsByType: { set: 0, patch: 0, delete: 0, sqlite: 0 },
+      receivedPatchOperationsByType: {
+        replace: 0,
+        add: 0,
+        remove: 0,
+        move: 0,
+        splice: 0,
+        append: 0,
+        "add-unique": 0,
+        "remove-by-value": 0,
+        increment: 0,
+      },
+      newlyAppliedPatchOperationsByType: {
+        replace: 0,
+        add: 0,
+        remove: 0,
+        move: 0,
+        splice: 0,
+        append: 0,
+        "add-unique": 0,
+        "remove-by-value": 0,
+        increment: 0,
+      },
+      patchesByPathShape: {},
+      rejectedByName: {},
     });
   } finally {
     await server.close();
@@ -2225,12 +2752,20 @@ Deno.test("memory v2 server watch set replacement emits removes for entities tha
   }
 });
 
-Deno.test("memory v2 server does not echo same-session operation docs through watches", async () => {
-  const server = createServer("memory://memory-v2-server-suppress-own-watch");
+Deno.test("memory v2 server records emitted watch effects for diagnostics", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-suppress-own-watch",
+    0,
+    true,
+  );
   const writerMessages: ServerMessage[] = [];
   const observerMessages: ServerMessage[] = [];
   const writer = server.connect((message) => writerMessages.push(message));
-  const observer = server.connect((message) => observerMessages.push(message));
+  const observerEffectSent = Promise.withResolvers<void>();
+  const observer = server.connect((message) => {
+    observerMessages.push(message);
+    if (message.type === "session/effect") observerEffectSent.resolve();
+  });
   const space = "did:key:z6Mk-memory-v2-suppress-own-watch";
 
   try {
@@ -2290,6 +2825,7 @@ Deno.test("memory v2 server does not echo same-session operation docs through wa
       shiftMessage(messages);
     }
 
+    const generationBeforeTransaction = server.diagnosticsActivityGeneration();
     await writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "writer-tx",
@@ -2308,9 +2844,17 @@ Deno.test("memory v2 server does not echo same-session operation docs through wa
     const committed = assertResponse<any>(shiftMessage(writerMessages));
     assertEquals(committed.requestId, "writer-tx");
     assertEquals(committed.ok?.seq, 1);
+    assertEquals(
+      server.diagnosticsActivityGeneration(),
+      generationBeforeTransaction + 1,
+    );
 
-    await server.flushSessions([space]);
+    let flushComplete = false;
+    const flush = server.flushDiagnosticsSessions().then(() => {
+      flushComplete = true;
+    });
 
+    await observerEffectSent.promise;
     assertEquals(writerMessages, []);
     const observerEffect = assertEffect(shiftMessage(observerMessages));
     assertEquals(observerEffect.effect.upserts, [{
@@ -2324,8 +2868,228 @@ Deno.test("memory v2 server does not echo same-session operation docs through wa
     }]);
     assertEquals(observerEffect.effect.removes, []);
     assertEquals(observerMessages, []);
+    await Promise.resolve();
+    assertEquals(flushComplete, false);
+
+    await observer.receive(encodeMemoryBoundary({
+      type: "session.ack",
+      requestId: "observer-ack",
+      space,
+      sessionId: observerSessionId,
+      seenSeq: observerEffect.effect.toSeq,
+    }));
+    assertEquals(
+      assertResponse<unknown>(shiftMessage(observerMessages)).requestId,
+      "observer-ack",
+    );
+    await flush;
+    assertEquals(flushComplete, true);
+    assertEquals(
+      server.diagnosticsActivityGeneration(),
+      generationBeforeTransaction + 2,
+    );
   } finally {
     await server.close();
+  }
+});
+
+Deno.test("memory v2 diagnostics flush completes without emitted effects", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-diagnostics-no-effect",
+    0,
+    true,
+  );
+  try {
+    await server.flushDiagnosticsSessions();
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 diagnostics flush releases an effect waiter when its connection closes", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-diagnostics-closed-session",
+    0,
+    true,
+  );
+  const messages: ServerMessage[] = [];
+  const effectSent = Promise.withResolvers<void>();
+  const connection = server.connect((message) => {
+    messages.push(message);
+    if (message.type === "session/effect") effectSent.resolve();
+  });
+  const space = "did:key:z6Mk-memory-v2-server-diagnostics-closed-session";
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(messages);
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open",
+      space,
+      session: {},
+      invocation: authInvocation(sessionOpen),
+    }));
+    const sessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(messages),
+    ).ok!.sessionId;
+    server.syncSessionForConnection = () =>
+      Promise.resolve({
+        type: "session/effect",
+        space,
+        sessionId,
+        effect: {
+          type: "sync",
+          fromSeq: 0,
+          toSeq: 1,
+          upserts: [],
+          removes: [],
+        },
+      });
+    server.markSpaceDirty(space);
+
+    const flush = server.flushDiagnosticsSessions();
+    await effectSent.promise;
+    const effect = assertEffect(shiftMessage(messages));
+    assertEquals(effect.effect.toSeq, 1);
+    connection.close();
+    await flush;
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 diagnostics flush serializes overlapping effect fences", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-diagnostics-overlapping-flushes",
+    0,
+    true,
+  );
+  const messages: ServerMessage[] = [];
+  const effectSent = Promise.withResolvers<void>();
+  const connection = server.connect((message) => {
+    messages.push(message);
+    if (message.type === "session/effect") effectSent.resolve();
+  });
+  const space = "did:key:z6Mk-memory-v2-server-diagnostics-overlapping-flushes";
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(messages);
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open",
+      space,
+      session: {},
+      invocation: authInvocation(sessionOpen),
+    }));
+    const sessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(messages),
+    ).ok!.sessionId;
+    server.syncSessionForConnection = () =>
+      Promise.resolve({
+        type: "session/effect",
+        space,
+        sessionId,
+        effect: {
+          type: "sync",
+          fromSeq: 0,
+          toSeq: 1,
+          upserts: [],
+          removes: [],
+        },
+      });
+    server.markSpaceDirty(space);
+
+    let firstResolved = false;
+    let secondResolved = false;
+    const first = server.flushDiagnosticsSessions().then(() => {
+      firstResolved = true;
+    });
+    await effectSent.promise;
+    const second = server.flushDiagnosticsSessions().then(() => {
+      secondResolved = true;
+    });
+    await Promise.resolve();
+    assertEquals(firstResolved, false);
+    assertEquals(secondResolved, false);
+
+    const effect = assertEffect(shiftMessage(messages));
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.ack",
+      requestId: "ack",
+      space,
+      sessionId,
+      seenSeq: effect.effect.toSeq,
+    }));
+    shiftMessage(messages);
+    await Promise.all([first, second]);
+    assertEquals(firstResolved, true);
+    assertEquals(secondResolved, true);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 server close releases an outstanding diagnostics flush", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-diagnostics-close-flush",
+    0,
+    true,
+  );
+  const messages: ServerMessage[] = [];
+  const effectSent = Promise.withResolvers<void>();
+  const connection = server.connect((message) => {
+    messages.push(message);
+    if (message.type === "session/effect") effectSent.resolve();
+  });
+  const space = "did:key:z6Mk-memory-v2-server-diagnostics-close-flush";
+  let closed = false;
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(messages);
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open",
+      space,
+      session: {},
+      invocation: authInvocation(sessionOpen),
+    }));
+    const sessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(messages),
+    ).ok!.sessionId;
+    server.syncSessionForConnection = () =>
+      Promise.resolve({
+        type: "session/effect",
+        space,
+        sessionId,
+        effect: {
+          type: "sync",
+          fromSeq: 0,
+          toSeq: 1,
+          upserts: [],
+          removes: [],
+        },
+      });
+    server.markSpaceDirty(space);
+
+    let flushResolved = false;
+    const flush = server.flushDiagnosticsSessions().then(() => {
+      flushResolved = true;
+    });
+    await effectSent.promise;
+    await Promise.resolve();
+    assertEquals(flushResolved, false);
+
+    const close = server.close().then(() => {
+      closed = true;
+    });
+    await Promise.all([flush, close]);
+    assertEquals(flushResolved, true);
+    assertEquals(closed, true);
+  } finally {
+    if (!closed) await server.close();
   }
 });
 

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -187,6 +187,59 @@ Deno.test("memory v2 diagnostics wait for an active receive", async () => {
   }
 });
 
+Deno.test("memory v2 diagnostics flush stops when the server closes", async () => {
+  const authorizationStarted = Promise.withResolvers<void>();
+  const releaseAuthorization = Promise.withResolvers<string>();
+  const server = new Server({
+    store: new URL("memory://memory-v2-server-close-receive-fence"),
+    subscriptionRefreshDelayMs: 0,
+    authorizeSessionOpen() {
+      authorizationStarted.resolve();
+      return releaseAuthorization.promise;
+    },
+    sessionOpenAuth: { audience: TEST_AUDIENCE },
+  });
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  let receive: Promise<void> | undefined;
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(messages);
+    receive = connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open",
+      space: "did:key:z6Mk-memory-v2-server-close-receive-fence",
+      session: {},
+      invocation: authInvocation(sessionOpen),
+    }));
+    await authorizationStarted.promise;
+
+    const waitStarted = Promise.withResolvers<void>();
+    const waitForDiagnosticsReceives = server.waitForDiagnosticsReceives.bind(
+      server,
+    );
+    server.waitForDiagnosticsReceives = () => {
+      waitStarted.resolve();
+      return waitForDiagnosticsReceives();
+    };
+    let flushComplete = false;
+    const flush = server.flushDiagnosticsSessions().then(() => {
+      flushComplete = true;
+    });
+    await waitStarted.promise;
+    assertEquals(flushComplete, false);
+
+    const close = server.close();
+    releaseAuthorization.resolve("did:key:z6Mk-memory-v2-server-principal");
+    await Promise.all([receive, flush, close]);
+    assertEquals(flushComplete, true);
+  } finally {
+    releaseAuthorization.resolve("did:key:z6Mk-memory-v2-server-principal");
+    await server.close();
+    if (receive) await receive;
+  }
+});
+
 Deno.test("memory v2 server parser ignores transact invocation and authorization payloads", () => {
   assertEquals(
     parseClientMessage(encodeMemoryBoundary({

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -19,6 +19,7 @@ import {
   toDocumentPath,
 } from "../v2.ts";
 import { createGraphFixture } from "./v2-graph.fixture.ts";
+import { StandaloneMemoryServer } from "../v2/standalone.ts";
 
 const HELLO_FLAGS = getMemoryProtocolFlags();
 const HELLO = {
@@ -27,6 +28,22 @@ const HELLO = {
   flags: HELLO_FLAGS,
 } as const;
 const TEST_AUDIENCE = "did:key:z6Mk-memory-v2-server-test-audience";
+
+Deno.test("standalone memory exposes aggregate diagnostic controls", async () => {
+  const server = StandaloneMemoryServer.start({
+    commitTelemetry: true,
+    aggregateOnlyDiagnostics: true,
+  });
+  try {
+    await server.flushSessions();
+    await server.flushDiagnosticsSessions();
+    await server.waitForDiagnosticsReceives();
+    assertEquals(server.diagnosticsActivityGeneration(), 0);
+    assertEquals(server.commitTelemetry().transactCount, 0);
+  } finally {
+    await server.close();
+  }
+});
 
 const tick = async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -2938,14 +2938,50 @@ Deno.test("memory v2 server records emitted watch effects for diagnostics", asyn
   }
 });
 
-Deno.test("memory v2 diagnostics flush completes without emitted effects", async () => {
+Deno.test("memory v2 diagnostics flush falls back to a regular refresh without telemetry", async () => {
   const server = createServer(
-    "memory://memory-v2-server-diagnostics-no-effect",
-    0,
-    true,
+    "memory://memory-v2-server-diagnostics-telemetry-disabled",
   );
+  const messages: ServerMessage[] = [];
+  const effectSent = Promise.withResolvers<void>();
+  const connection = server.connect((message) => {
+    messages.push(message);
+    if (message.type === "session/effect") effectSent.resolve();
+  });
+  const space = "did:key:z6Mk-memory-v2-server-diagnostics-telemetry-disabled";
+
   try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(messages);
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open",
+      space,
+      session: {},
+      invocation: authInvocation(sessionOpen),
+    }));
+    const sessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(messages),
+    ).ok!.sessionId;
+    server.syncSessionForConnection = () =>
+      Promise.resolve({
+        type: "session/effect",
+        space,
+        sessionId,
+        effect: {
+          type: "sync",
+          fromSeq: 0,
+          toSeq: 1,
+          upserts: [],
+          removes: [],
+        },
+      });
+    server.markSpaceDirty(space);
+
     await server.flushDiagnosticsSessions();
+    await effectSent.promise;
+    assertEquals(assertEffect(shiftMessage(messages)).effect.toSeq, 1);
+    assertEquals(messages, []);
   } finally {
     await server.close();
   }
@@ -3133,6 +3169,7 @@ Deno.test("memory v2 server close releases an outstanding diagnostics flush", as
     await Promise.all([flush, close]);
     assertEquals(flushResolved, true);
     assertEquals(closed, true);
+    await server.flushDiagnosticsSessions();
   } finally {
     if (!closed) await server.close();
   }

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -881,26 +881,31 @@ Deno.test("findSyncSchemaRef ignores inherited object properties", () => {
   const inheritedValue = {
     $alias: { id: "of:polluted", path: [], schema: "schema-ref@2:fid1:evil" },
   };
-  Object.defineProperty(Object.prototype, inheritedKey, {
-    value: inheritedValue,
-    enumerable: true,
-    configurable: true,
+  const inherited = { [inheritedKey]: inheritedValue };
+  let prototypeRead = false;
+  const doc = new Proxy({ value: { plain: "doc" } }, {
+    getPrototypeOf() {
+      if (!prototypeRead) {
+        prototypeRead = true;
+        return Object.prototype;
+      }
+      return inherited;
+    },
+    get(target, key, receiver) {
+      return key === inheritedKey
+        ? inheritedValue
+        : Reflect.get(target, key, receiver);
+    },
   });
-  try {
-    // The traversal must only follow own properties: an enumerable inherited
-    // key carrying an alias payload must not surface as a reserved reference.
-    const doc = {
-      value: { plain: "doc" },
-    };
-    assertEquals(findSyncSchemaRef(doc), undefined);
-    // Sanity: the same shape as an own property is found.
-    assertEquals(
-      findSyncSchemaRef({ nested: inheritedValue }),
-      "schema-ref@2:fid1:evil",
-    );
-  } finally {
-    Reflect.deleteProperty(Object.prototype, inheritedKey);
-  }
+  // The first prototype read passes the plain-object gate; subsequent reads
+  // expose the test-local inherited key to the traversal's `for...in` loop.
+  assertEquals(Reflect.get(doc, inheritedKey), inheritedValue);
+  assertEquals(findSyncSchemaRef(doc), undefined);
+  // Sanity: the same shape as an own property is found.
+  assertEquals(
+    findSyncSchemaRef({ nested: inheritedValue }),
+    "schema-ref@2:fid1:evil",
+  );
 });
 
 Deno.test("sync schema table compression preserves own __proto__ keys", () => {

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -877,24 +877,30 @@ Deno.test("memory server negotiates schema-table v2 sync frames per connection",
 });
 
 Deno.test("findSyncSchemaRef ignores inherited object properties", () => {
-  // The traversal must only follow own properties: an enumerable INHERITED
-  // key carrying a link-payload shape must not surface as a reserved
-  // reference. Built on a custom prototype so the test never touches
-  // Object.prototype.
-  const pollutedProto = {
-    polluted: {
-      $alias: { id: "of:polluted", path: [], schema: "schema-ref@2:fid1:evil" },
-    },
+  const inheritedKey = "__cf_sync_schema_ref_pollution__";
+  const inheritedValue = {
+    $alias: { id: "of:polluted", path: [], schema: "schema-ref@2:fid1:evil" },
   };
-  const doc = Object.assign(Object.create(pollutedProto), {
-    value: { plain: "doc" },
-  }) as Record<string, unknown>;
-  assertEquals(findSyncSchemaRef(doc), undefined);
-  // Sanity: the same shape as an OWN property is found.
-  assertEquals(
-    findSyncSchemaRef({ nested: pollutedProto.polluted }),
-    "schema-ref@2:fid1:evil",
-  );
+  Object.defineProperty(Object.prototype, inheritedKey, {
+    value: inheritedValue,
+    enumerable: true,
+    configurable: true,
+  });
+  try {
+    // The traversal must only follow own properties: an enumerable inherited
+    // key carrying an alias payload must not surface as a reserved reference.
+    const doc = {
+      value: { plain: "doc" },
+    };
+    assertEquals(findSyncSchemaRef(doc), undefined);
+    // Sanity: the same shape as an own property is found.
+    assertEquals(
+      findSyncSchemaRef({ nested: inheritedValue }),
+      "schema-ref@2:fid1:evil",
+    );
+  } finally {
+    Reflect.deleteProperty(Object.prototype, inheritedKey);
+  }
 });
 
 Deno.test("sync schema table compression preserves own __proto__ keys", () => {

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -861,6 +861,12 @@ export interface AppliedCommit {
   schedulerDirtiedReaders?: SchedulerReaderIndexEntry[];
 }
 
+/** Internal apply outcome. Kept separate from the wire-facing AppliedCommit. */
+export interface AppliedCommitOutcome {
+  commit: AppliedCommit;
+  replayed: boolean;
+}
+
 export type SchedulerActionKind =
   | "computation"
   | "effect"
@@ -2377,6 +2383,13 @@ export const applyCommit = (
   engine: Engine,
   options: ApplyCommitOptions,
 ): AppliedCommit => {
+  return applyCommitWithOutcome(engine, options).commit;
+};
+
+export const applyCommitWithOutcome = (
+  engine: Engine,
+  options: ApplyCommitOptions,
+): AppliedCommitOutcome => {
   return engine.database.transaction(applyCommitTransaction).immediate(
     engine,
     options,
@@ -4892,7 +4905,7 @@ const applyCommitTransaction = (
     commit,
     sqliteAttachments,
   }: ApplyCommitOptions,
-): AppliedCommit => {
+): AppliedCommitOutcome => {
   const sessionKey = resolveCommitSessionKey(sessionId, principal);
   const schedulerObservation = commit
     .schedulerObservation as SchedulerActionObservation | undefined;
@@ -4953,15 +4966,18 @@ const applyCommitTransaction = (
       )
       : undefined;
     return {
-      seq: existing.seq,
-      branch: existing.branch,
-      revisions: selectCommitRevisions(engine, existing.seq),
-      ...(observationResult?.schedulerObservationId !== undefined
-        ? { schedulerObservationId: observationResult.schedulerObservationId }
-        : {}),
-      ...(observationResult
-        ? { schedulerObservationResults: [observationResult] }
-        : {}),
+      replayed: true,
+      commit: {
+        seq: existing.seq,
+        branch: existing.branch,
+        revisions: selectCommitRevisions(engine, existing.seq),
+        ...(observationResult?.schedulerObservationId !== undefined
+          ? { schedulerObservationId: observationResult.schedulerObservationId }
+          : {}),
+        ...(observationResult
+          ? { schedulerObservationResults: [observationResult] }
+          : {}),
+      },
     };
   }
 
@@ -5099,23 +5115,26 @@ const applyCommitTransaction = (
     : undefined;
 
   return {
-    seq,
-    branch,
-    revisions,
-    ...(schedulerObservationResult
-      ? {
-        schedulerObservationId: schedulerObservationResult.observationId,
-        schedulerObservationResults: [{
-          localSeq: commit.localSeq,
-          status: "kept" as const,
+    replayed: false,
+    commit: {
+      seq,
+      branch,
+      revisions,
+      ...(schedulerObservationResult
+        ? {
           schedulerObservationId: schedulerObservationResult.observationId,
-          executionContextKey: schedulerObservationResult.executionContextKey,
-        }],
-      }
-      : {}),
-    ...(schedulerDirtiedReaders && schedulerDirtiedReaders.length > 0
-      ? { schedulerDirtiedReaders }
-      : {}),
+          schedulerObservationResults: [{
+            localSeq: commit.localSeq,
+            status: "kept" as const,
+            schedulerObservationId: schedulerObservationResult.observationId,
+            executionContextKey: schedulerObservationResult.executionContextKey,
+          }],
+        }
+        : {}),
+      ...(schedulerDirtiedReaders && schedulerDirtiedReaders.length > 0
+        ? { schedulerDirtiedReaders }
+        : {}),
+    },
   };
 };
 
@@ -5667,7 +5686,7 @@ const applySchedulerObservationOnlyCommit = (
     reads: ClientCommit["reads"];
     schedulerObservation: SchedulerActionObservation;
   },
-): AppliedCommit => {
+): AppliedCommitOutcome => {
   const observedAtSeq = headSeq(engine, branch);
   const replayPayload = schedulerObservationReplayPayload({
     branch,
@@ -5691,13 +5710,16 @@ const applySchedulerObservationOnlyCommit = (
       existingReplay,
     );
     return {
-      seq: existingReplay.observed_at_seq,
-      branch,
-      revisions: [],
-      ...(replayed.schedulerObservationId !== undefined
-        ? { schedulerObservationId: replayed.schedulerObservationId }
-        : {}),
-      schedulerObservationResults: [replayed],
+      replayed: true,
+      commit: {
+        seq: existingReplay.observed_at_seq,
+        branch,
+        revisions: [],
+        ...(replayed.schedulerObservationId !== undefined
+          ? { schedulerObservationId: replayed.schedulerObservationId }
+          : {}),
+        schedulerObservationResults: [replayed],
+      },
     };
   }
 
@@ -5719,14 +5741,17 @@ const applySchedulerObservationOnlyCommit = (
       payload: replayPayload,
     });
     return {
-      seq: observedAtSeq,
-      branch,
-      revisions: [],
-      schedulerObservationResults: [{
-        localSeq,
-        status: "dropped",
-        reason: dropReason,
-      }],
+      replayed: false,
+      commit: {
+        seq: observedAtSeq,
+        branch,
+        revisions: [],
+        schedulerObservationResults: [{
+          localSeq,
+          status: "dropped",
+          reason: dropReason,
+        }],
+      },
     };
   }
 
@@ -5747,16 +5772,19 @@ const applySchedulerObservationOnlyCommit = (
     observation: schedulerObservation,
   });
   return {
-    seq: observedAtSeq,
-    branch,
-    revisions: [],
-    schedulerObservationId: observationResult.observationId,
-    schedulerObservationResults: [{
-      localSeq,
-      status: "kept",
+    replayed: false,
+    commit: {
+      seq: observedAtSeq,
+      branch,
+      revisions: [],
       schedulerObservationId: observationResult.observationId,
-      executionContextKey: observationResult.executionContextKey,
-    }],
+      schedulerObservationResults: [{
+        localSeq,
+        status: "kept",
+        schedulerObservationId: observationResult.observationId,
+        executionContextKey: observationResult.executionContextKey,
+      }],
+    },
   };
 };
 
@@ -5777,10 +5805,11 @@ const applySchedulerObservationBatchCommit = (
     branch: BranchName;
     batch: NonNullable<ClientCommit["schedulerObservationBatch"]>;
   },
-): AppliedCommit => {
+): AppliedCommitOutcome => {
   const results: AppliedSchedulerObservationResult[] = [];
+  let replayed = true;
   for (const item of batch) {
-    const result = applySchedulerObservationOnlyCommit(engine, {
+    const outcome = applySchedulerObservationOnlyCommit(engine, {
       sessionId,
       sessionKey,
       space,
@@ -5791,14 +5820,18 @@ const applySchedulerObservationBatchCommit = (
       schedulerObservation: item
         .schedulerObservation as SchedulerActionObservation,
     });
-    results.push(result.schedulerObservationResults![0]);
+    replayed &&= outcome.replayed;
+    results.push(outcome.commit.schedulerObservationResults![0]);
   }
 
   return {
-    seq: headSeq(engine, branch),
-    branch,
-    revisions: [],
-    schedulerObservationResults: results,
+    replayed,
+    commit: {
+      seq: headSeq(engine, branch),
+      branch,
+      revisions: [],
+      schedulerObservationResults: results,
+    },
   };
 };
 

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -16,6 +16,7 @@ import {
   type HelloMessage,
   type Operation,
   parseMemoryProtocolFlags,
+  type PatchOp,
   type ResponseMessage,
   type SchedulerActionSnapshotQuery,
   type SchedulerExecutionContextKey,
@@ -98,7 +99,13 @@ import {
 } from "./server-sync.ts";
 import { SessionRegistry, type SessionState } from "./session-registry.ts";
 import { authorizationError } from "./session-open-auth.ts";
-import { SpanStatusCode, trace } from "@opentelemetry/api";
+import {
+  INVALID_SPAN_CONTEXT,
+  type Span,
+  SpanStatusCode,
+  trace,
+  type Tracer,
+} from "@opentelemetry/api";
 
 export { SessionRegistry } from "./session-registry.ts";
 
@@ -251,6 +258,211 @@ const toPreconditionFailedError = (
 
 export type MemoryAclMode = "off" | "observe" | "enforce";
 
+/**
+ * Aggregate, content-free telemetry for received transact attempts. Commit
+ * payload metrics describe the parsed request before authorization or
+ * capability filtering; outcomes describe the server's final disposition.
+ */
+export interface CommitTelemetrySnapshot {
+  transactCount: number;
+  acceptedCount: number;
+  rejectedCount: number;
+  conflictCount: number;
+  replayCount: number;
+  receivedCommitBytes: { total: number; max: number };
+  confirmedReadEntries: { total: number; max: number };
+  confirmedReadBytes: { total: number; max: number };
+  operationEntries: { total: number; max: number };
+  operationBytes: { total: number; max: number };
+  newlyPersistedRevisions: { total: number; max: number };
+  operationsByType: Record<Operation["op"], number>;
+  /** Patch kinds in received requests, including rejected and replayed requests. */
+  receivedPatchOperationsByType: PatchOperationKindCounts;
+  /** Patch kinds newly applied by non-replayed commits only. */
+  newlyAppliedPatchOperationsByType: PatchOperationKindCounts;
+  patchesByPathShape: Record<string, number>;
+  rejectedByName: Record<string, number>;
+}
+
+type CommitTelemetryCounter = { total: number; max: number };
+
+type PatchOperationKindCounts = Record<PatchOp["op"], number>;
+
+const emptyPatchOperationKindCounts = (): PatchOperationKindCounts => ({
+  replace: 0,
+  add: 0,
+  remove: 0,
+  move: 0,
+  splice: 0,
+  append: 0,
+  "add-unique": 0,
+  "remove-by-value": 0,
+  increment: 0,
+});
+
+const emptyCommitTelemetryCounter = (): CommitTelemetryCounter => ({
+  total: 0,
+  max: 0,
+});
+
+const emptyCommitTelemetrySnapshot = (): CommitTelemetrySnapshot => ({
+  transactCount: 0,
+  acceptedCount: 0,
+  rejectedCount: 0,
+  conflictCount: 0,
+  replayCount: 0,
+  receivedCommitBytes: emptyCommitTelemetryCounter(),
+  confirmedReadEntries: emptyCommitTelemetryCounter(),
+  confirmedReadBytes: emptyCommitTelemetryCounter(),
+  operationEntries: emptyCommitTelemetryCounter(),
+  operationBytes: emptyCommitTelemetryCounter(),
+  newlyPersistedRevisions: emptyCommitTelemetryCounter(),
+  operationsByType: { set: 0, patch: 0, delete: 0, sqlite: 0 },
+  receivedPatchOperationsByType: emptyPatchOperationKindCounts(),
+  newlyAppliedPatchOperationsByType: emptyPatchOperationKindCounts(),
+  patchesByPathShape: {},
+  rejectedByName: {},
+});
+
+const addCommitTelemetryCounter = (
+  counter: CommitTelemetryCounter,
+  value: number,
+): void => {
+  counter.total += value;
+  counter.max = Math.max(counter.max, value);
+};
+
+const incrementCommitTelemetryMap = (
+  map: Record<string, number>,
+  key: string,
+): void => {
+  map[key] = (map[key] ?? 0) + 1;
+};
+
+const patchPathShape = (path: string): string => {
+  if (path === "/value") return "value-root";
+  if (path.startsWith("/value/")) {
+    const segments = path.slice("/value/".length).split("/");
+    return `value/${
+      segments.map((segment) => /^\d+$/.test(segment) ? "#" : "*").join("/")
+    }`;
+  }
+  // Entity-document metadata has a small fixed surface; all other roots are
+  // deliberately collapsed so arbitrary keys never enter telemetry.
+  return path === "" || path === "/source" || path.startsWith("/source/")
+    ? "metadata"
+    : "other";
+};
+
+let commitTelemetryTextEncoder: TextEncoder | undefined;
+
+class CommitTelemetry {
+  #snapshot = emptyCommitTelemetrySnapshot();
+
+  recordTransactAttempt(): void {
+    this.#snapshot.transactCount += 1;
+  }
+
+  recordReceivedCommit(commit: ClientCommit): void {
+    const encodedByteLength = (
+      value: Parameters<typeof encodeMemoryBoundary>[0],
+    ): number =>
+      (commitTelemetryTextEncoder ??= new TextEncoder()).encode(
+        encodeMemoryBoundary(value),
+      ).byteLength;
+    const confirmedReads = commit.reads.confirmed;
+    const operations = commit.operations;
+    const confirmedReadBytes = encodedByteLength(confirmedReads);
+    const operationBytes = operations.reduce(
+      (total, operation) => total + encodedByteLength(operation),
+      0,
+    );
+
+    addCommitTelemetryCounter(
+      this.#snapshot.receivedCommitBytes,
+      encodedByteLength(commit),
+    );
+    addCommitTelemetryCounter(
+      this.#snapshot.confirmedReadEntries,
+      confirmedReads.length,
+    );
+    addCommitTelemetryCounter(
+      this.#snapshot.confirmedReadBytes,
+      confirmedReadBytes,
+    );
+    addCommitTelemetryCounter(
+      this.#snapshot.operationEntries,
+      operations.length,
+    );
+    addCommitTelemetryCounter(this.#snapshot.operationBytes, operationBytes);
+    for (const operation of operations) {
+      this.#snapshot.operationsByType[operation.op] += 1;
+      if (operation.op === "patch") {
+        for (const patch of operation.patches) {
+          this.#snapshot.receivedPatchOperationsByType[patch.op] += 1;
+          this.#recordPatchPath(patch);
+        }
+      }
+    }
+  }
+
+  #recordPatchPath(patch: PatchOp): void {
+    incrementCommitTelemetryMap(
+      this.#snapshot.patchesByPathShape,
+      patchPathShape(patch.path),
+    );
+  }
+
+  recordAccepted(
+    applied: Engine.AppliedCommitOutcome,
+  ): void {
+    this.#snapshot.acceptedCount += 1;
+    if (applied.replayed) {
+      this.#snapshot.replayCount += 1;
+    } else {
+      for (const revision of applied.commit.revisions) {
+        for (const patch of revision.patches ?? []) {
+          this.#snapshot.newlyAppliedPatchOperationsByType[patch.op] += 1;
+        }
+      }
+    }
+    addCommitTelemetryCounter(
+      this.#snapshot.newlyPersistedRevisions,
+      applied.replayed ? 0 : applied.commit.revisions.length,
+    );
+  }
+
+  recordRejected(name: string): void {
+    this.#snapshot.rejectedCount += 1;
+    if (name === "ConflictError") this.#snapshot.conflictCount += 1;
+    this.#snapshot.rejectedByName[name] =
+      (this.#snapshot.rejectedByName[name] ?? 0) + 1;
+  }
+
+  snapshotAndReset(): CommitTelemetrySnapshot {
+    const snapshot: CommitTelemetrySnapshot = {
+      ...this.#snapshot,
+      receivedCommitBytes: { ...this.#snapshot.receivedCommitBytes },
+      confirmedReadEntries: { ...this.#snapshot.confirmedReadEntries },
+      confirmedReadBytes: { ...this.#snapshot.confirmedReadBytes },
+      operationEntries: { ...this.#snapshot.operationEntries },
+      operationBytes: { ...this.#snapshot.operationBytes },
+      newlyPersistedRevisions: { ...this.#snapshot.newlyPersistedRevisions },
+      operationsByType: { ...this.#snapshot.operationsByType },
+      receivedPatchOperationsByType: {
+        ...this.#snapshot.receivedPatchOperationsByType,
+      },
+      newlyAppliedPatchOperationsByType: {
+        ...this.#snapshot.newlyAppliedPatchOperationsByType,
+      },
+      patchesByPathShape: { ...this.#snapshot.patchesByPathShape },
+      rejectedByName: { ...this.#snapshot.rejectedByName },
+    };
+    this.#snapshot = emptyCommitTelemetrySnapshot();
+    return snapshot;
+  }
+}
+
 type AclState =
   | { kind: "missing" }
   | { kind: "invalid" }
@@ -355,6 +567,17 @@ type DirtyOrigin = {
   seq: number;
 };
 
+type DiagnosticsEffectAck = {
+  promise: Promise<void>;
+  cancel: () => void;
+};
+
+type DiagnosticsEffectAckWaiter = {
+  connectionId: string;
+  targetSeq: number;
+  resolve: () => void;
+};
+
 class Connection {
   #ready = false;
   #closed = false;
@@ -378,6 +601,9 @@ class Connection {
   ) {}
 
   private send(message: ServerMessage): void {
+    if (message.type === "session/effect") {
+      this.server.recordDiagnosticsOutgoingMessage();
+    }
     this.sendRaw(
       this.#syncSchemaTable ? compressServerMessageSchemas(message) : message,
     );
@@ -436,6 +662,7 @@ class Connection {
     if (!this.#sessions.delete(key) || this.#closed) {
       return;
     }
+    this.server.cancelDiagnosticsEffectAcks(this.id, space, sessionId);
     this.send({
       type: "session/revoked",
       space,
@@ -520,6 +747,13 @@ class Connection {
     return this.#pendingReceives > 0;
   }
 
+  async waitForReceiveQueueToSettle(): Promise<void> {
+    while (this.#pendingReceives > 0) {
+      this.#receiveIdle ??= Promise.withResolvers<void>();
+      await this.#receiveIdle.promise;
+    }
+  }
+
   async waitForReceiveQueueToDrain(deadlineMs: number): Promise<boolean> {
     while (this.#pendingReceives > 0) {
       const remainingMs = deadlineMs - Date.now();
@@ -549,18 +783,21 @@ class Connection {
     requestId: string,
     space: string,
     sessionId: string,
+    rejectedResponse?: () => ServerMessage,
   ): boolean {
     if (this.hasSession(space, sessionId)) {
       return true;
     }
-    this.send({
-      type: "response",
-      requestId,
-      error: toError(
-        "SessionError",
-        "Session is not open on this connection",
-      ),
-    });
+    this.send(
+      rejectedResponse?.() ?? {
+        type: "response",
+        requestId,
+        error: toError(
+          "SessionError",
+          "Session is not open on this connection",
+        ),
+      },
+    );
     return false;
   }
 
@@ -632,6 +869,14 @@ class Connection {
             parsed.requestId,
             parsed.space,
             parsed.sessionId,
+            () =>
+              this.server.rejectTransact(
+                parsed,
+                toError(
+                  "SessionError",
+                  "Session is not open on this connection",
+                ),
+              ),
           )
         ) {
           return;
@@ -811,6 +1056,7 @@ class Connection {
         continue;
       }
       if (effect !== null) {
+        this.server.recordDiagnosticsSessionEffect(this.id, effect);
         this.send(effect);
       }
     }
@@ -821,6 +1067,7 @@ class Connection {
       return;
     }
     this.#closed = true;
+    this.server.cancelDiagnosticsEffectAcks(this.id);
     for (const { space, sessionId } of this.#sessions.values()) {
       this.server.detachSession(space, sessionId, this.id);
     }
@@ -863,6 +1110,17 @@ export class Server {
   // re-ensures (additive migration) with no hash-collision risk.
   #ensuredSchemas = new Map<string, true>();
   #ensuredSchemasMax = 4096;
+  #commitTelemetry?: CommitTelemetry;
+  #diagnosticsActivityGeneration = 0;
+  #diagnosticsEffectAcks?: DiagnosticsEffectAck[];
+  #diagnosticsEffectAckWaiters?: Map<
+    string,
+    Set<DiagnosticsEffectAckWaiter>
+  >;
+  #diagnosticsFlushQueue: Promise<void> = Promise.resolve();
+  #closeSignal = Promise.withResolvers<void>();
+  #closed = false;
+  #tracer: Tracer;
 
   #recordSchemaEnsured(key: string): void {
     this.#ensuredSchemas.set(key, true);
@@ -922,10 +1180,184 @@ export class Server {
         mode: MemoryAclMode;
         serviceDids?: readonly string[];
       };
+      /** Enable aggregate received-commit telemetry for synthetic workloads. */
+      commitTelemetry?: boolean;
+      /** Suppress identifier-bearing logs and spans for aggregate diagnostics. */
+      aggregateOnlyDiagnostics?: boolean;
+      /** Override the OTel tracer, primarily for isolated verification. */
+      diagnosticsTracer?: Tracer;
     },
   ) {
     this.#sessions = options.sessions ?? new SessionRegistry();
     this.#store = options.store;
+    this.#tracer = options.diagnosticsTracer ?? tracer;
+    if (options.commitTelemetry) {
+      this.#commitTelemetry = new CommitTelemetry();
+    }
+  }
+
+  #warn(...args: unknown[]): void {
+    if (!this.options.aggregateOnlyDiagnostics) console.warn(...args);
+  }
+
+  #withSpan<T>(name: string, callback: (span: Span) => T): T {
+    if (this.options.aggregateOnlyDiagnostics) {
+      return callback(trace.wrapSpanContext(INVALID_SPAN_CONTEXT));
+    }
+    return this.#tracer.startActiveSpan(name, callback);
+  }
+
+  #withRootSpan<T>(name: string, callback: (span: Span) => T): T {
+    if (this.options.aggregateOnlyDiagnostics) {
+      return callback(trace.wrapSpanContext(INVALID_SPAN_CONTEXT));
+    }
+    return this.#tracer.startActiveSpan(name, { root: true }, callback);
+  }
+
+  /** Returns and resets aggregate transact telemetry when collection is enabled. */
+  commitTelemetry(): CommitTelemetrySnapshot {
+    if (this.#commitTelemetry === undefined) {
+      throw new Error("commit telemetry is disabled");
+    }
+    return this.#commitTelemetry.snapshotAndReset();
+  }
+
+  #recordReceivedTransact(message: TransactRequest): void {
+    const telemetry = this.#commitTelemetry;
+    if (telemetry === undefined) {
+      return;
+    }
+    this.#diagnosticsActivityGeneration++;
+    telemetry.recordTransactAttempt();
+    telemetry.recordReceivedCommit(message.commit);
+  }
+
+  /** Records a parsed transact rejected before it reaches the apply boundary. */
+  rejectTransact(
+    message: TransactRequest,
+    error: V2Error,
+  ): ResponseMessage<Engine.AppliedCommit> {
+    this.#recordReceivedTransact(message);
+    this.#commitTelemetry?.recordRejected(error.name);
+    return respondTypedError<Engine.AppliedCommit>(message.requestId, error);
+  }
+
+  /** Monotonic local-diagnostics activity counter; unavailable when disabled. */
+  diagnosticsActivityGeneration(): number {
+    if (this.#commitTelemetry === undefined) {
+      throw new Error("commit telemetry is disabled");
+    }
+    return this.#diagnosticsActivityGeneration;
+  }
+
+  /** Records a content-free emitted session effect for local diagnostics only. */
+  recordDiagnosticsOutgoingMessage(): void {
+    if (this.#commitTelemetry !== undefined) {
+      this.#diagnosticsActivityGeneration++;
+    }
+  }
+
+  recordDiagnosticsSessionEffect(
+    connectionId: string,
+    effect: SessionEffectMessage,
+  ): void {
+    if (
+      this.#closed ||
+      this.#commitTelemetry === undefined ||
+      this.#diagnosticsEffectAcks === undefined
+    ) {
+      return;
+    }
+    this.#diagnosticsEffectAcks.push(
+      this.waitForDiagnosticsEffectAck(connectionId, effect),
+    );
+  }
+
+  private waitForDiagnosticsEffectAck(
+    connectionId: string,
+    effect: SessionEffectMessage,
+  ): DiagnosticsEffectAck {
+    const key = sessionKey(effect.space, effect.sessionId);
+    const targetSeq = effect.effect.toSeq;
+    let waiter: DiagnosticsEffectAckWaiter | undefined;
+    const cancel = () => {
+      if (waiter === undefined) return;
+      const waiters = this.#diagnosticsEffectAckWaiters?.get(key);
+      waiters?.delete(waiter);
+      if (waiters?.size === 0) {
+        this.#diagnosticsEffectAckWaiters?.delete(key);
+      }
+      waiter.resolve();
+      waiter = undefined;
+    };
+    const session = this.#sessions.get(effect.space, effect.sessionId);
+    if (session === null || session.seenSeq >= targetSeq) {
+      return { promise: Promise.resolve(), cancel };
+    }
+    const deferred = Promise.withResolvers<void>();
+    waiter = { connectionId, targetSeq, resolve: deferred.resolve };
+    let waiters = this.#diagnosticsEffectAckWaiters?.get(key);
+    if (waiters === undefined) {
+      waiters = new Set();
+      (this.#diagnosticsEffectAckWaiters ??= new Map()).set(key, waiters);
+    }
+    waiters.add(waiter);
+    // The check after registration closes the acknowledgment race: an ack may
+    // update seenSeq between the initial check and creating this waiter.
+    if (
+      (this.#sessions.get(effect.space, effect.sessionId)?.seenSeq ?? 0) >=
+        targetSeq
+    ) {
+      cancel();
+    }
+    return { promise: deferred.promise, cancel };
+  }
+
+  private resolveDiagnosticsEffectAcks(
+    space: string,
+    sessionId: string,
+    seenSeq: number,
+  ): void {
+    const key = sessionKey(space, sessionId);
+    const waiters = this.#diagnosticsEffectAckWaiters?.get(key);
+    if (waiters === undefined) return;
+    for (const waiter of [...waiters]) {
+      if (seenSeq >= waiter.targetSeq) {
+        waiters.delete(waiter);
+        waiter.resolve();
+      }
+    }
+    if (waiters.size === 0) {
+      this.#diagnosticsEffectAckWaiters?.delete(key);
+    }
+  }
+
+  cancelDiagnosticsEffectAcks(
+    connectionId: string,
+    space?: string,
+    sessionId?: string,
+  ): void {
+    for (const [key, waiters] of this.#diagnosticsEffectAckWaiters ?? []) {
+      if (space !== undefined && key !== sessionKey(space, sessionId!)) {
+        continue;
+      }
+      for (const waiter of [...waiters]) {
+        if (waiter.connectionId === connectionId) {
+          waiters.delete(waiter);
+          waiter.resolve();
+        }
+      }
+      if (waiters.size === 0) {
+        this.#diagnosticsEffectAckWaiters?.delete(key);
+      }
+    }
+  }
+
+  private cancelAllDiagnosticsEffectAcks(): void {
+    for (const waiters of this.#diagnosticsEffectAckWaiters?.values() ?? []) {
+      for (const waiter of waiters) waiter.resolve();
+    }
+    this.#diagnosticsEffectAckWaiters?.clear();
   }
 
   nowSeconds(): number {
@@ -1054,7 +1486,7 @@ export class Server {
     }
     if (this.#aclMode() === "observe") {
       this.aclStats.wouldDeny += 1;
-      console.warn(
+      this.#warn(
         `[memory-acl] would deny ${requirement} on ${space} for ` +
           `${principalLabel} (capability: ${capability ?? "none"})`,
       );
@@ -1193,6 +1625,13 @@ export class Server {
       // Drop the de-authorized session from the registry: the refresh loop
       // iterates registered sessions, so removal stops all further watch
       // pushes, and its next message fails closed (Unknown session).
+      if (session.ownerConnectionId !== null) {
+        this.cancelDiagnosticsEffectAcks(
+          session.ownerConnectionId,
+          space,
+          session.id,
+        );
+      }
       this.#sessions.remove(space, session.id);
       if (session.id === writerSessionId) {
         // The writer's own session — it just removed its own access. Removal
@@ -1247,6 +1686,11 @@ export class Server {
   }
 
   async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#closeSignal.resolve();
+    this.cancelAllDiagnosticsEffectAcks();
+    await this.#diagnosticsFlushQueue;
     this.cancelScheduledRefresh();
     await this.#refreshing;
     for (const engine of this.#engines.values()) {
@@ -1662,7 +2106,7 @@ export class Server {
       if (wantColumns && !(await ensureColumnOriginAvailable())) {
         // The reason names a filesystem path, and this error reaches the query
         // caller, so it goes to the log and the caller gets the bare fact.
-        console.warn(
+        this.#warn(
           `[memory-sqlite] column-origin symbols could not be bound: ` +
             `${columnOriginUnavailableReason()}`,
         );
@@ -1909,6 +2353,11 @@ export class Server {
         toError("SessionError", "Unknown session for space"),
       );
     }
+    this.resolveDiagnosticsEffectAcks(
+      message.space,
+      message.sessionId,
+      session.seenSeq,
+    );
     try {
       const engine = await this.openEngine(message.space);
       return {
@@ -1932,15 +2381,18 @@ export class Server {
   transact(
     message: TransactRequest,
   ): Promise<ResponseMessage<Engine.AppliedCommit>> {
+    this.#recordReceivedTransact(message);
+    const telemetry = this.#commitTelemetry;
     const session = this.#sessions.get(message.space, message.sessionId);
     if (session === null) {
+      telemetry?.recordRejected("SessionError");
       return Promise.resolve(respondTypedError<Engine.AppliedCommit>(
         message.requestId,
         toError("SessionError", "Unknown session for space"),
       ));
     }
 
-    return tracer.startActiveSpan(
+    return this.#withSpan(
       "memory.transact",
       async (span): Promise<ResponseMessage<Engine.AppliedCommit>> => {
         span.setAttribute("space.did", message.space);
@@ -1967,6 +2419,7 @@ export class Server {
         if (message.commit.localSeq !== undefined) {
           span.setAttribute("commit.local_seq", message.commit.localSeq);
         }
+        let commitWasApplied = false;
         try {
           const engine = await this.openEngine(message.space);
           // The session may be revoked or replaced while openEngine awaits.
@@ -1975,6 +2428,7 @@ export class Server {
           if (
             this.#sessions.get(message.space, message.sessionId) !== session
           ) {
+            telemetry?.recordRejected("SessionError");
             return respondTypedError<Engine.AppliedCommit>(
               message.requestId,
               toError("SessionError", "Unknown or replaced session for space"),
@@ -1987,6 +2441,7 @@ export class Server {
             message.commit,
           );
           if (invalid) {
+            telemetry?.recordRejected(invalid.name);
             return respondTypedError<Engine.AppliedCommit>(
               message.requestId,
               invalid,
@@ -2004,6 +2459,7 @@ export class Server {
             aclTouched ? "OWNER" : "WRITE",
           );
           if (deny) {
+            telemetry?.recordRejected(deny.name);
             return respondTypedError<Engine.AppliedCommit>(
               message.requestId,
               deny,
@@ -2058,19 +2514,26 @@ export class Server {
             commitPayload.operations,
             { principal: session.principal, sessionId: message.sessionId },
           );
-          let commit: Engine.AppliedCommit;
+          let outcome: Engine.AppliedCommitOutcome;
           try {
-            commit = tracer.startActiveSpan(
+            outcome = this.#withSpan(
               "memory.commit.persist",
               (persistSpan) => {
                 try {
-                  return Engine.applyCommit(engine, {
+                  const applied = Engine.applyCommitWithOutcome(engine, {
                     sessionId: message.sessionId,
                     space: message.space,
                     principal: session.principal,
                     commit: commitPayload,
                     sqliteAttachments,
                   });
+                  // The engine transaction has committed at this point. Cleanup
+                  // and post-commit effects cannot turn this into a rejection.
+                  commitWasApplied = true;
+                  if (telemetry !== undefined) {
+                    telemetry.recordAccepted(applied);
+                  }
+                  return applied;
                 } finally {
                   persistSpan.end();
                 }
@@ -2087,6 +2550,7 @@ export class Server {
               detachDatabase(engine.database, alias);
             }
           }
+          const commit = outcome.commit;
           if (aclTouched) {
             this.#invalidateAclCapabilities(message.space);
             // Pass the writing session so it isn't sent the terminal revocation
@@ -2168,6 +2632,9 @@ export class Server {
           );
           if (retryAfterSeq !== undefined) {
             responseError.retryAfterSeq = retryAfterSeq;
+          }
+          if (!commitWasApplied) {
+            telemetry?.recordRejected(responseError.name);
           }
           span.recordException(
             error instanceof Error ? error : new Error(messageText),
@@ -2686,7 +3153,7 @@ export class Server {
     if (session === null) {
       return Promise.resolve(null);
     }
-    return tracer.startActiveSpan(
+    return this.#withSpan(
       "memory.subscriber.sync",
       async (span): Promise<SessionEffectMessage | null> => {
         span.setAttribute("space.did", space);
@@ -2782,7 +3249,7 @@ export class Server {
             const updates = new Map<string, SessionCacheEntry>();
 
             for (const graph of session.graphs.values()) {
-              const refreshed = tracer.startActiveSpan(
+              const refreshed = this.#withSpan(
                 "memory.watch.refresh",
                 (watchSpan) => {
                   watchSpan.setAttribute("space.did", space);
@@ -2980,7 +3447,7 @@ export class Server {
         sync.observations = observations;
       }
     } catch (error) {
-      console.warn(
+      this.#warn(
         "attachAdoptionObservations failed; sync pushed without observations",
         error,
       );
@@ -3068,6 +3535,53 @@ export class Server {
       }
     });
     await this.#refreshing;
+  }
+
+  /**
+   * Flush local diagnostic sessions only after every already-started client
+   * frame has reached the server. This is event-driven and intentionally has
+   * no deadline because the diagnostics barrier needs a true fixed point.
+   */
+  async #flushDiagnosticsSessions(): Promise<void> {
+    if (this.#closed) return;
+    await Promise.race([
+      this.waitForDiagnosticsReceives(),
+      this.#closeSignal.promise,
+    ]);
+    if (this.#closed) return;
+    if (this.#commitTelemetry === undefined) {
+      await this.flushSessions();
+      return;
+    }
+    const effects: DiagnosticsEffectAck[] = [];
+    this.#diagnosticsEffectAcks = effects;
+    try {
+      await this.flushSessions();
+      await Promise.all(effects.map((effect) => effect.promise));
+    } finally {
+      for (const effect of effects) effect.cancel();
+      if (this.#diagnosticsEffectAcks === effects) {
+        this.#diagnosticsEffectAcks = undefined;
+      }
+    }
+  }
+
+  async flushDiagnosticsSessions(): Promise<void> {
+    const flush = this.#diagnosticsFlushQueue.then(
+      () => this.#flushDiagnosticsSessions(),
+      () => this.#flushDiagnosticsSessions(),
+    );
+    this.#diagnosticsFlushQueue = flush.catch(() => undefined);
+    await flush;
+  }
+
+  /** Await server receipt of client frames already started by diagnostics. */
+  async waitForDiagnosticsReceives(): Promise<void> {
+    await Promise.all(
+      [...this.#connections.values()].map((connection) =>
+        connection.waitForReceiveQueueToSettle()
+      ),
+    );
   }
 
   private scheduleRefresh(): void {
@@ -3168,9 +3682,8 @@ export class Server {
         // context manager propagates the active context into timer callbacks,
         // so without it this span could parent under whichever memory.transact
         // happened to schedule the refresh.
-        await tracer.startActiveSpan(
+        await this.#withRootSpan(
           "memory.fanout",
-          { root: true },
           async (span) => {
             span.setAttribute("space.did", space);
             span.setAttribute("subscriber.count", this.#connections.size);
@@ -3334,7 +3847,7 @@ export class Server {
         );
       }
     } catch (error) {
-      console.warn(
+      this.#warn(
         "Post-commit scheduler state update failed after semantic commit:",
         error,
       );

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -363,15 +363,28 @@ class CommitTelemetry {
     this.#snapshot.transactCount += 1;
   }
 
-  recordReceivedCommit(commit: ClientCommit): void {
+  recordReceivedCommit(commit: unknown): void {
+    if (!isRecord(commit)) return;
     const encodedByteLength = (
       value: Parameters<typeof encodeMemoryBoundary>[0],
-    ): number =>
-      (commitTelemetryTextEncoder ??= new TextEncoder()).encode(
-        encodeMemoryBoundary(value),
-      ).byteLength;
-    const confirmedReads = commit.reads.confirmed;
-    const operations = commit.operations;
+    ): number => {
+      try {
+        return (commitTelemetryTextEncoder ??= new TextEncoder()).encode(
+          encodeMemoryBoundary(value),
+        ).byteLength;
+      } catch {
+        // Telemetry is observational; malformed ingress must reach the normal
+        // protocol validator and typed-error path unchanged.
+        return 0;
+      }
+    };
+    const reads = isRecord(commit.reads) ? commit.reads : undefined;
+    const confirmedReads = Array.isArray(reads?.confirmed)
+      ? reads.confirmed
+      : [];
+    const operations = Array.isArray(commit.operations)
+      ? commit.operations.filter(isRecord)
+      : [];
     const confirmedReadBytes = encodedByteLength(confirmedReads);
     const operationBytes = operations.reduce(
       (total, operation) => total + encodedByteLength(operation),
@@ -396,20 +409,34 @@ class CommitTelemetry {
     );
     addCommitTelemetryCounter(this.#snapshot.operationBytes, operationBytes);
     for (const operation of operations) {
-      this.#snapshot.operationsByType[operation.op] += 1;
-      if (operation.op === "patch") {
+      if (
+        operation.op === "set" || operation.op === "patch" ||
+        operation.op === "delete" || operation.op === "sqlite"
+      ) {
+        this.#snapshot.operationsByType[operation.op] += 1;
+      }
+      if (operation.op === "patch" && Array.isArray(operation.patches)) {
         for (const patch of operation.patches) {
-          this.#snapshot.receivedPatchOperationsByType[patch.op] += 1;
-          this.#recordPatchPath(patch);
+          if (
+            isRecord(patch) && typeof patch.path === "string" &&
+            (patch.op === "replace" || patch.op === "add" ||
+              patch.op === "remove" || patch.op === "move" ||
+              patch.op === "splice" || patch.op === "append" ||
+              patch.op === "add-unique" || patch.op === "remove-by-value" ||
+              patch.op === "increment")
+          ) {
+            this.#snapshot.receivedPatchOperationsByType[patch.op] += 1;
+            this.#recordPatchPath(patch.path);
+          }
         }
       }
     }
   }
 
-  #recordPatchPath(patch: PatchOp): void {
+  #recordPatchPath(path: string): void {
     incrementCommitTelemetryMap(
       this.#snapshot.patchesByPathShape,
-      patchPathShape(patch.path),
+      patchPathShape(path),
     );
   }
 

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -51,6 +51,10 @@ export class StandaloneMemoryServer {
         mode: MemoryServer.MemoryAclMode;
         serviceDids?: readonly string[];
       };
+      /** Enable aggregate received-commit telemetry for synthetic workloads. */
+      commitTelemetry?: boolean;
+      /** Do not emit payload-bearing local debug logs. */
+      aggregateOnlyDiagnostics?: boolean;
     } = {},
   ): StandaloneMemoryServer {
     const memory = new MemoryServer.Server({
@@ -59,6 +63,8 @@ export class StandaloneMemoryServer {
         audience: standaloneMemoryAudience,
       },
       acl: options.acl,
+      commitTelemetry: options.commitTelemetry,
+      aggregateOnlyDiagnostics: options.aggregateOnlyDiagnostics,
     });
     const http = Deno.serve({
       hostname: "127.0.0.1",
@@ -75,7 +81,8 @@ export class StandaloneMemoryServer {
           socket.send(encodeMemoryBoundary(message));
         }
       });
-      const debugWrites = Deno.env.get("CF_DEBUG_MEMORY_WRITES") === "1";
+      const debugWrites = !options.aggregateOnlyDiagnostics &&
+        Deno.env.get("CF_DEBUG_MEMORY_WRITES") === "1";
       socket.addEventListener("message", (event) => {
         if (typeof event.data !== "string") {
           socket.close(1003, "memory websocket expects text frames");
@@ -102,6 +109,27 @@ export class StandaloneMemoryServer {
   async close(): Promise<void> {
     await this.#http.shutdown();
     await this.#memory.close();
+  }
+
+  /** Returns and resets aggregate transact telemetry when collection is enabled. */
+  commitTelemetry(): MemoryServer.CommitTelemetrySnapshot {
+    return this.#memory.commitTelemetry();
+  }
+
+  async flushSessions(): Promise<void> {
+    await this.#memory.flushSessions();
+  }
+
+  async flushDiagnosticsSessions(): Promise<void> {
+    await this.#memory.flushDiagnosticsSessions();
+  }
+
+  async waitForDiagnosticsReceives(): Promise<void> {
+    await this.#memory.waitForDiagnosticsReceives();
+  }
+
+  diagnosticsActivityGeneration(): number {
+    return this.#memory.diagnosticsActivityGeneration();
   }
 }
 

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -207,6 +207,8 @@ PerUser, mergeable, backlinks, crossrefs, references, graph
 ```ts
 interface TopicsInput {
   topics?: Writable<TopicPiece[] | Default<[]>>;
+  /** @deprecated Read-only compatibility for pre-profile boards. */
+  myName?: PerUser<Writable<string | Default<"">>>;
 }
 // TopicInput additionally takes mentionable?: Writable<TopicPiece[]> — the
 // board's own list, wired at creation, for detail-page Connections.
@@ -220,7 +222,9 @@ interface TopicsOutput {
   mentionable: TopicPiece[];
   topicCount: number;
   crossrefs: TopicCrossref[]; // { fid, topic, refsOut, referencedBy }
+  newTitle?: PerSession<Writable<string>>;
   addTopic: Stream<{ title: string; agentName: string }>;
+  submitTopic: Stream<void>; // profile-authored browser composer
 }
 ```
 

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -195,7 +195,7 @@ thread, typed links out. Deliberately minimal — no statuses, labels, or
 assignees. The board derives the corpus's prose reference graph (topic fids
 pasted in bodies/comments/link URLs → navigable crossref chips, never
 persisted). Demonstrates: reading-list-style piece-in-list composition,
-`PerUser` display-name on a shared piece, mergeable comment appends,
+profile-native authorship on a shared piece, mergeable comment appends,
 session-scoped drafts, read-side derived backlinks over sibling pieces
 (`resolveAsCell().entityId` for piece identity), `multiUserTest` coverage.
 
@@ -207,7 +207,6 @@ PerUser, mergeable, backlinks, crossrefs, references, graph
 ```ts
 interface TopicsInput {
   topics?: Writable<TopicPiece[] | Default<[]>>;
-  myName?: PerUser<Writable<string | Default<"">>>;
 }
 // TopicInput additionally takes mentionable?: Writable<TopicPiece[]> — the
 // board's own list, wired at creation, for detail-page Connections.
@@ -221,9 +220,7 @@ interface TopicsOutput {
   mentionable: TopicPiece[];
   topicCount: number;
   crossrefs: TopicCrossref[]; // { fid, topic, refsOut, referencedBy }
-  myName: string;
-  addTopic: Stream<{ title: string }>;
-  setMyName: Stream<{ name: string }>;
+  addTopic: Stream<{ title: string; agentName: string }>;
 }
 ```
 

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -98,6 +98,8 @@ export interface MultiRuntimeHarnessOptions {
   diagnostics?: boolean;
   /** Keep Topics diagnostic data in workers; parent receives fixed aggregates only. */
   aggregateOnlyDiagnostics?: boolean;
+  /** Seed each worker identity's home space with a minimal profile for Topics. */
+  bootstrapProfile?: boolean;
   sessions: (string | MultiRuntimeSessionSpec)[];
   spaceName?: string;
   /**
@@ -665,6 +667,8 @@ export class MultiRuntimeHarness {
           apiUrl,
           diagnostics: options.diagnostics === true,
           aggregateOnlyDiagnostics: options.aggregateOnlyDiagnostics === true,
+          bootstrapProfile: options.aggregateOnlyDiagnostics === true ||
+            options.bootstrapProfile === true,
           diagnosticMutationsEnabled: options.diagnostics === true &&
             !options.apiUrl,
           ...(normalized.wsDelayMs !== undefined
@@ -702,6 +706,8 @@ export class MultiRuntimeHarness {
         apiUrl,
         diagnostics: options.diagnostics === true,
         aggregateOnlyDiagnostics: options.aggregateOnlyDiagnostics === true,
+        bootstrapProfile: options.aggregateOnlyDiagnostics === true ||
+          options.bootstrapProfile === true,
         aggregateBootstrapCreator: bootstrapChannel !== undefined,
         ...(bootstrapChannel
           ? {

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -22,10 +22,18 @@
 
 import { Identity } from "@commonfabric/identity";
 import { StandaloneMemoryServer } from "@commonfabric/memory/v2/standalone";
+import type { CommitTelemetrySnapshot } from "@commonfabric/memory/v2/server";
 import { setPersistentSchedulerStateConfig } from "@commonfabric/memory/v2";
 import { experimentalOptionsFromEnv } from "@commonfabric/runner";
 import type {
   RuntimeDiagnosticsSnapshot,
+  RuntimeDiagnosticsSummary,
+  RuntimeTelemetrySnapshot,
+  TopicsDiagnosticsChurnTotals,
+  TopicsDiagnosticsCrossrefValidation,
+  TopicsDiagnosticsNoopOutcome,
+  TopicsDiagnosticsOperationOutcome,
+  TopicsDiagnosticsSummary,
   TrustedUiDescriptor,
   WorkerRequest,
   WorkerResponse,
@@ -50,7 +58,17 @@ function propagateExperimentalEnvToServerRealm(): void {
 }
 
 export type { TrustedUiDescriptor };
+export type { RuntimeDiagnosticsSummary };
 export type { RuntimeDiagnosticsSnapshot };
+export type { RuntimeTelemetrySnapshot };
+export type { CommitTelemetrySnapshot };
+export type {
+  TopicsDiagnosticsChurnTotals,
+  TopicsDiagnosticsCrossrefValidation,
+  TopicsDiagnosticsNoopOutcome,
+  TopicsDiagnosticsOperationOutcome,
+  TopicsDiagnosticsSummary,
+};
 
 export interface MultiRuntimeSessionSpec {
   /** Label used in error messages and as the identity passphrase seed. */
@@ -78,6 +96,8 @@ export interface MultiRuntimeHarnessOptions {
   input?: Record<string, unknown>;
   /** Enable scheduler graph/stats/action diagnostics for this harness run. */
   diagnostics?: boolean;
+  /** Keep Topics diagnostic data in workers; parent receives fixed aggregates only. */
+  aggregateOnlyDiagnostics?: boolean;
   sessions: (string | MultiRuntimeSessionSpec)[];
   spaceName?: string;
   /**
@@ -90,6 +110,31 @@ export interface MultiRuntimeHarnessOptions {
 const DEFAULT_TIMEOUT_MS = 30_000;
 const RPC_TIMEOUT_MS = 120_000;
 
+function hasExactKeys(
+  value: unknown,
+  expected: readonly string[],
+): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const keys = Object.keys(value).sort();
+  return keys.length === expected.length &&
+    keys.every((key, index) => key === expected[index]);
+}
+
+function assertAggregateBootstrapResponse(
+  value: unknown,
+  kind: "empty" | "ready" | "success",
+): void {
+  const valid = kind === "empty"
+    ? hasExactKeys(value, [])
+    : kind === "ready"
+    ? hasExactKeys(value, ["ok", "ready"]) && value.ok === true &&
+      value.ready === true
+    : hasExactKeys(value, ["ok"]) && value.ok === true;
+  if (!valid) throw new Error("operation-failed");
+}
+
 class WorkerClient {
   #worker: Worker;
   #nextId = 1;
@@ -97,6 +142,7 @@ class WorkerClient {
     number,
     { resolve: (value: unknown) => void; reject: (error: Error) => void }
   >();
+  #aggregateOnlyDiagnostics = false;
   readonly label: string;
 
   constructor(label: string) {
@@ -111,19 +157,32 @@ class WorkerClient {
       this.#pending.delete(event.data.id);
       if ("error" in event.data) {
         pending.reject(
-          new Error(`[${this.label}] ${event.data.error}`),
+          new Error(
+            this.#aggregateOnlyDiagnostics
+              ? "operation-failed"
+              : `[${this.label}] ${event.data.error}`,
+          ),
         );
       } else {
         pending.resolve(event.data.ok);
       }
     };
     this.#worker.onerror = (event) => {
-      const error = new Error(`[${this.label}] worker error: ${event.message}`);
+      if (this.#aggregateOnlyDiagnostics) event.preventDefault();
+      const error = new Error(
+        this.#aggregateOnlyDiagnostics
+          ? "operation-failed"
+          : `[${this.label}] worker error: ${event.message}`,
+      );
       for (const pending of this.#pending.values()) {
         pending.reject(error);
       }
       this.#pending.clear();
     };
+  }
+
+  setAggregateOnlyDiagnostics(value: boolean): void {
+    this.#aggregateOnlyDiagnostics = value;
   }
 
   call(cmd: string, args: Record<string, unknown> = {}): Promise<unknown> {
@@ -134,7 +193,9 @@ class WorkerClient {
         this.#pending.delete(id);
         reject(
           new Error(
-            `[${this.label}] ${cmd} timed out after ${RPC_TIMEOUT_MS}ms`,
+            this.#aggregateOnlyDiagnostics
+              ? "operation-failed"
+              : `[${this.label}] ${cmd} timed out after ${RPC_TIMEOUT_MS}ms`,
           ),
         );
       }, RPC_TIMEOUT_MS);
@@ -155,7 +216,13 @@ class WorkerClient {
   terminate(): void {
     this.#worker.terminate();
     for (const pending of this.#pending.values()) {
-      pending.reject(new Error(`[${this.label}] worker terminated`));
+      pending.reject(
+        new Error(
+          this.#aggregateOnlyDiagnostics
+            ? "operation-failed"
+            : `[${this.label}] worker terminated`,
+        ),
+      );
     }
     this.#pending.clear();
   }
@@ -165,11 +232,18 @@ export class MultiRuntimeSession {
   readonly label: string;
   readonly identity: Identity;
   #client: WorkerClient;
+  #diagnosticMutationsEnabled: boolean;
 
-  constructor(label: string, identity: Identity, client: WorkerClient) {
+  constructor(
+    label: string,
+    identity: Identity,
+    client: WorkerClient,
+    diagnosticMutationsEnabled: boolean,
+  ) {
     this.label = label;
     this.identity = identity;
     this.#client = client;
+    this.#diagnosticMutationsEnabled = diagnosticMutationsEnabled;
   }
 
   /**
@@ -178,13 +252,13 @@ export class MultiRuntimeSession {
    * surface (required for trusted-action handlers).
    */
   async send(
-    handler: string,
+    target: string | (string | number)[],
     event: unknown = {},
     trustedUi?: TrustedUiDescriptor,
     opts: { idle?: boolean } = {},
   ): Promise<void> {
     await this.#client.call("send", {
-      handler,
+      target,
       event,
       trustedUi,
       idle: opts.idle,
@@ -211,6 +285,40 @@ export class MultiRuntimeSession {
   }
 
   /**
+   * Diagnostic-only operation for a result field that resolves directly to
+   * `['value', stringKey]` in its containing storage document. It preserves
+   * that document's sibling fields and replaces only `stringKey` with raw
+   * array data through a single low-level write at `['value']`, intentionally
+   * producing a whole-root memory patch rather than `Cell.set`'s nested diff.
+   * It is not a general-purpose mutation API.
+   */
+  async prepareContainingDocumentValueRoot(
+    path: (string | number)[],
+    value: readonly unknown[],
+    opts: { idle?: boolean } = {},
+  ): Promise<void> {
+    this.#assertDiagnosticMutationsEnabled();
+    await this.#client.call("prepareContainingDocumentValueRoot", {
+      path,
+      value,
+      idle: opts.idle,
+    });
+  }
+
+  /** Commit exactly one previously prepared diagnostic root replacement. */
+  async commitPreparedContainingDocumentValueRoot(): Promise<
+    { ok: boolean; error?: { name?: string; message?: string } }
+  > {
+    this.#assertDiagnosticMutationsEnabled();
+    return await this.#client.call(
+      "commitPreparedContainingDocumentValueRoot",
+    ) as {
+      ok: boolean;
+      error?: { name?: string; message?: string };
+    };
+  }
+
+  /**
    * Append `value` to the array cell reached by `path`, exactly like a
    * `CellHandle.push`: read-modify-write that keeps its read as a compare-and-set
    * precondition (the `handleCellPush` path), so a concurrent push conflicts
@@ -228,9 +336,19 @@ export class MultiRuntimeSession {
     }) as { ok: boolean; error?: { name?: string; message?: string } };
   }
 
-  /** Read a value from the piece result, pulling fresh state first. */
-  async read(path: (string | number)[] = []): Promise<unknown> {
-    return await this.#client.call("read", { path });
+  /**
+   * Read a value from the piece result, pulling fresh state first. `omitKeys`
+   * removes named object fields during transfer when a derived graph would be
+   * recursive or unnecessarily large.
+   */
+  async read(
+    path: (string | number)[] = [],
+    opts: { omitKeys?: readonly string[] } = {},
+  ): Promise<unknown> {
+    return await this.#client.call("read", {
+      path,
+      omitKeys: opts.omitKeys,
+    });
   }
 
   /** Read the RAW stored value at `path` (links resolved to the target cell,
@@ -276,16 +394,186 @@ export class MultiRuntimeSession {
     await this.#client.call("idle");
   }
 
+  async settled(): Promise<void> {
+    await this.#client.call("settled");
+  }
+
+  async delayedFramesDrained(): Promise<void> {
+    await this.#client.call("delayedFramesDrained");
+  }
+
   /** Capture scheduler graph, settle stats history, and action run trace. */
-  async diagnostics(): Promise<RuntimeDiagnosticsSnapshot> {
-    return await this.#client.call("diagnostics") as RuntimeDiagnosticsSnapshot;
+  async diagnostics(
+    opts: { idle?: boolean } = {},
+  ): Promise<RuntimeDiagnosticsSnapshot> {
+    return await this.#client.call(
+      "diagnostics",
+      opts,
+    ) as RuntimeDiagnosticsSnapshot;
+  }
+
+  /** Capture content-free scheduler aggregates inside the worker. */
+  async diagnosticsSummary(
+    opts: { idle?: boolean } = {},
+  ): Promise<RuntimeDiagnosticsSummary> {
+    return await this.#client.call(
+      "diagnosticsSummary",
+      opts,
+    ) as RuntimeDiagnosticsSummary;
+  }
+
+  async diagnosticsActivityGeneration(): Promise<number> {
+    return (await this.#client.call(
+      "diagnosticsActivityGeneration",
+    ) as { generation: number }).generation;
+  }
+
+  /** Aggregate-only Topics diagnostics; no pattern values or links cross IPC. */
+  async topicsDiagnosticsSummary(): Promise<TopicsDiagnosticsSummary> {
+    return await this.#client.call(
+      "topicsDiagnosticsSummary",
+    ) as TopicsDiagnosticsSummary;
+  }
+
+  async topicsDiagnosticsChurn(
+    opts: { idle?: boolean } = {},
+  ): Promise<TopicsDiagnosticsChurnTotals> {
+    return await this.#client.call(
+      "topicsDiagnosticsChurn",
+      opts,
+    ) as TopicsDiagnosticsChurnTotals;
+  }
+
+  async topicsDiagnosticsSend(
+    target: string | (string | number)[],
+    event: unknown = {},
+    opts: { idle?: boolean } = {},
+  ): Promise<TopicsDiagnosticsOperationOutcome> {
+    return await this.#client.call("topicsDiagnosticsSend", {
+      target,
+      event,
+      idle: opts.idle,
+    }) as TopicsDiagnosticsOperationOutcome;
+  }
+
+  async topicsDiagnosticsSet(
+    path: (string | number)[],
+    value: unknown,
+    opts: { idle?: boolean } = {},
+  ): Promise<TopicsDiagnosticsOperationOutcome> {
+    return await this.#client.call("topicsDiagnosticsSet", {
+      path,
+      value,
+      idle: opts.idle,
+    }) as TopicsDiagnosticsOperationOutcome;
+  }
+
+  async topicsDiagnosticsNoop(
+    topicIndex: number,
+    opts: { idle?: boolean } = {},
+  ): Promise<TopicsDiagnosticsNoopOutcome> {
+    return await this.#client.call("topicsDiagnosticsNoop", {
+      topicIndex,
+      idle: opts.idle,
+    }) as TopicsDiagnosticsNoopOutcome;
+  }
+
+  async topicsDiagnosticsPrepareReversedRoot(
+    opts: { idle?: boolean } = {},
+  ): Promise<TopicsDiagnosticsOperationOutcome> {
+    this.#assertDiagnosticMutationsEnabled();
+    return await this.#client.call("topicsDiagnosticsPrepareReversedRoot", {
+      idle: opts.idle,
+    }) as TopicsDiagnosticsOperationOutcome;
+  }
+
+  async topicsDiagnosticsCommitPreparedRoot(): Promise<
+    TopicsDiagnosticsOperationOutcome
+  > {
+    this.#assertDiagnosticMutationsEnabled();
+    return await this.#client.call(
+      "topicsDiagnosticsCommitPreparedRoot",
+    ) as TopicsDiagnosticsOperationOutcome;
+  }
+
+  async topicsDiagnosticsCreateCrossref(
+    sourceIndex: number,
+    targetIndex: number,
+    opts: { idle?: boolean } = {},
+  ): Promise<TopicsDiagnosticsOperationOutcome> {
+    return await this.#client.call("topicsDiagnosticsCreateCrossref", {
+      sourceIndex,
+      targetIndex,
+      idle: opts.idle,
+    }) as TopicsDiagnosticsOperationOutcome;
+  }
+
+  async topicsDiagnosticsValidateCrossrefs(
+    topicCount: number,
+  ): Promise<TopicsDiagnosticsCrossrefValidation> {
+    return await this.#client.call("topicsDiagnosticsValidateCrossrefs", {
+      topicCount,
+    }) as TopicsDiagnosticsCrossrefValidation;
+  }
+
+  async topicsDiagnosticsConvergenceBegin(
+    channel: string,
+    participants: number,
+  ): Promise<
+    { ok: true; ready: true } | { ok: false; error: "operation-failed" }
+  > {
+    return await this.#client.call("topicsDiagnosticsConvergenceBegin", {
+      channel,
+      participants,
+    }) as { ok: true; ready: true } | { ok: false; error: "operation-failed" };
+  }
+
+  async topicsDiagnosticsConvergencePublish(channel: string): Promise<
+    { ok: true } | { ok: false; error: "operation-failed" }
+  > {
+    return await this.#client.call("topicsDiagnosticsConvergencePublish", {
+      channel,
+    }) as { ok: true } | { ok: false; error: "operation-failed" };
+  }
+
+  async topicsDiagnosticsConvergenceFinish(): Promise<
+    | {
+      ok: true;
+      converged: boolean;
+      summary: { topics: number[]; comments: number[]; links: number[] };
+    }
+    | { ok: false; error: "operation-failed" }
+  > {
+    return await this.#client.call("topicsDiagnosticsConvergenceFinish") as
+      | {
+        ok: true;
+        converged: boolean;
+        summary: { topics: number[]; comments: number[]; links: number[] };
+      }
+      | { ok: false; error: "operation-failed" };
+  }
+
+  async topicsDiagnosticsConvergenceCancel(): Promise<
+    { ok: true } | { ok: false; error: "operation-failed" }
+  > {
+    return await this.#client.call("topicsDiagnosticsConvergenceCancel") as {
+      ok: true;
+    } | { ok: false; error: "operation-failed" };
+  }
+
+  /**
+   * Atomically collect and reset local scheduler telemetry since the previous
+   * snapshot. Available only when the harness was created with diagnostics.
+   */
+  async telemetry(): Promise<RuntimeTelemetrySnapshot> {
+    return await this.#client.call("telemetry") as RuntimeTelemetrySnapshot;
   }
 
   /** Per-logger message counts (logger name -> key -> {total,...}). */
-  async loggerCounts(): Promise<
+  async loggerCounts(opts: { idle?: boolean } = {}): Promise<
     Record<string, Record<string, { total: number }>> & { total: number }
   > {
-    return await this.#client.call("loggerCounts") as
+    return await this.#client.call("loggerCounts", opts) as
       & Record<
         string,
         Record<string, { total: number }>
@@ -305,21 +593,35 @@ export class MultiRuntimeSession {
   client(): WorkerClient {
     return this.#client;
   }
+
+  #assertDiagnosticMutationsEnabled(): void {
+    if (!this.#diagnosticMutationsEnabled) {
+      throw new Error(
+        "containing-document root replacement requires a local diagnostics harness",
+      );
+    }
+  }
 }
 
 export class MultiRuntimeHarness {
   readonly sessions: MultiRuntimeSession[];
   readonly pieceId: string;
   #server?: StandaloneMemoryServer;
+  #diagnosticsEnabled: boolean;
+  #aggregateOnlyDiagnostics: boolean;
 
   private constructor(
     sessions: MultiRuntimeSession[],
     pieceId: string,
     server?: StandaloneMemoryServer,
+    diagnosticsEnabled = false,
+    aggregateOnlyDiagnostics = false,
   ) {
     this.sessions = sessions;
     this.pieceId = pieceId;
     this.#server = server;
+    this.#diagnosticsEnabled = diagnosticsEnabled;
+    this.#aggregateOnlyDiagnostics = aggregateOnlyDiagnostics;
   }
 
   static async create(
@@ -330,7 +632,10 @@ export class MultiRuntimeHarness {
     }
     propagateExperimentalEnvToServerRealm();
     const spaceName = options.spaceName ?? crypto.randomUUID();
-    const server = options.apiUrl ? undefined : StandaloneMemoryServer.start();
+    const server = options.apiUrl ? undefined : StandaloneMemoryServer.start({
+      commitTelemetry: options.diagnostics === true,
+      aggregateOnlyDiagnostics: options.aggregateOnlyDiagnostics === true,
+    });
     const apiUrl = (options.apiUrl ?? server!.url).href;
 
     const sessions: MultiRuntimeSession[] = [];
@@ -346,17 +651,31 @@ export class MultiRuntimeHarness {
             { implementation: "noble" },
           );
         const client = new WorkerClient(normalized.label);
-        await client.call("init", {
+        client.setAggregateOnlyDiagnostics(
+          options.aggregateOnlyDiagnostics === true,
+        );
+        const initialized = await client.call("init", {
           rawIdentity: identity.serialize(),
           spaceName,
           apiUrl,
           diagnostics: options.diagnostics === true,
+          aggregateOnlyDiagnostics: options.aggregateOnlyDiagnostics === true,
+          diagnosticMutationsEnabled: options.diagnostics === true &&
+            !options.apiUrl,
           ...(normalized.wsDelayMs !== undefined
             ? { wsDelayMs: normalized.wsDelayMs }
             : {}),
         });
+        if (options.aggregateOnlyDiagnostics) {
+          assertAggregateBootstrapResponse(initialized, "empty");
+        }
         sessions.push(
-          new MultiRuntimeSession(normalized.label, identity, client),
+          new MultiRuntimeSession(
+            normalized.label,
+            identity,
+            client,
+            options.diagnostics === true && !options.apiUrl,
+          ),
         );
       }
 
@@ -365,27 +684,82 @@ export class MultiRuntimeHarness {
       // client loads the pattern through a verified load (required for
       // trusted-action CFC writes), and no session holds special in-memory
       // compile state.
+      const bootstrapChannel = options.aggregateOnlyDiagnostics
+        ? `topics-bootstrap-${crypto.randomUUID()}`
+        : undefined;
       bootstrap = new WorkerClient("bootstrap");
-      await bootstrap.call("init", {
+      bootstrap.setAggregateOnlyDiagnostics(
+        options.aggregateOnlyDiagnostics === true,
+      );
+      const bootstrapInitialized = await bootstrap.call("init", {
         rawIdentity: sessions[0].identity.serialize(),
         spaceName,
         apiUrl,
         diagnostics: options.diagnostics === true,
+        aggregateOnlyDiagnostics: options.aggregateOnlyDiagnostics === true,
+        aggregateBootstrapCreator: bootstrapChannel !== undefined,
+        ...(bootstrapChannel
+          ? {
+            aggregateBootstrapChannel: bootstrapChannel,
+            aggregateBootstrapParticipants: sessions.length,
+          }
+          : {}),
+        diagnosticMutationsEnabled: false,
       });
-      const { pieceId } = await bootstrap.call("createPiece", {
+      if (options.aggregateOnlyDiagnostics) {
+        assertAggregateBootstrapResponse(bootstrapInitialized, "empty");
+      }
+      if (bootstrapChannel) {
+        const prepared = await Promise.all(
+          sessions.map((session) =>
+            session.client().call("topicsDiagnosticsPrepareBootstrap", {
+              channel: bootstrapChannel,
+            })
+          ),
+        );
+        for (const response of prepared) {
+          assertAggregateBootstrapResponse(response, "ready");
+        }
+      }
+      const created = await bootstrap.call("createPiece", {
         programPath: options.programPath,
         rootPath: options.rootPath,
         input: options.input,
       }) as { pieceId: string };
-      await bootstrap.call("dispose");
+      if (bootstrapChannel) {
+        assertAggregateBootstrapResponse(created, "success");
+      }
+      const bootstrapDisposed = await bootstrap.call("dispose");
+      if (bootstrapChannel) {
+        assertAggregateBootstrapResponse(bootstrapDisposed, "success");
+      }
       bootstrap.terminate();
       bootstrap = undefined;
 
-      for (const session of sessions) {
-        await session.client().call("openPiece", { pieceId });
+      if (bootstrapChannel) {
+        const finished = await Promise.all(
+          sessions.map((session) =>
+            session.client().call("topicsDiagnosticsFinishBootstrap")
+          ),
+        );
+        for (const response of finished) {
+          assertAggregateBootstrapResponse(response, "success");
+        }
+      } else {
+        for (const session of sessions) {
+          await session.client().call("openPiece", {
+            pieceId: created.pieceId,
+          });
+        }
       }
 
-      return new MultiRuntimeHarness(sessions, pieceId, server);
+      return new MultiRuntimeHarness(
+        sessions,
+        bootstrapChannel ? "aggregate-only" : created.pieceId,
+        server,
+        options.diagnostics === true && !options.apiUrl,
+        options.aggregateOnlyDiagnostics === true,
+      );
     } catch (error) {
       bootstrap?.terminate();
       for (const session of sessions) {
@@ -402,6 +776,67 @@ export class MultiRuntimeHarness {
       throw new Error(`No session labeled "${label}"`);
     }
     return session;
+  }
+
+  /**
+   * Atomically collect and reset canonical memory transact telemetry. This is
+   * available only for local diagnostic harnesses: a remote toolshed cannot
+   * provide an equivalent server-side snapshot.
+   */
+  memoryTelemetry(): CommitTelemetrySnapshot {
+    if (!this.#server || !this.#diagnosticsEnabled) {
+      throw new Error(
+        "memoryTelemetry() is unavailable when MultiRuntimeHarness uses apiUrl",
+      );
+    }
+    return this.#server.commitTelemetry();
+  }
+
+  /** Event-driven local diagnostic quiescence barrier; ordinary tests use settle(). */
+  async diagnosticsBarrier(): Promise<void> {
+    if (!this.#server || !this.#diagnosticsEnabled) {
+      throw new Error(
+        "diagnosticsBarrier() requires a local diagnostics harness",
+      );
+    }
+    while (true) {
+      const generationBeforeCycle = this.#server
+        .diagnosticsActivityGeneration();
+      const workerGenerationsBeforeCycle = await Promise.all(
+        this.sessions.map((session) => session.diagnosticsActivityGeneration()),
+      );
+      await Promise.all(
+        this.sessions.map((session) => session.delayedFramesDrained()),
+      );
+      await Promise.all(this.sessions.map((session) => session.settled()));
+      await Promise.all(this.sessions.map((session) => session.idle()));
+      await Promise.all(
+        this.sessions.map((session) => session.delayedFramesDrained()),
+      );
+      await Promise.all(this.sessions.map((session) => session.settled()));
+      await Promise.all(
+        this.sessions.map((session) => session.delayedFramesDrained()),
+      );
+      await this.#server.flushDiagnosticsSessions();
+      await Promise.all(this.sessions.map((session) => session.idle()));
+      await Promise.all(this.sessions.map((session) => session.settled()));
+      await Promise.all(
+        this.sessions.map((session) => session.delayedFramesDrained()),
+      );
+      await this.#server.waitForDiagnosticsReceives();
+      const workerGenerationsAfterCycle = await Promise.all(
+        this.sessions.map((session) => session.diagnosticsActivityGeneration()),
+      );
+      if (
+        generationBeforeCycle ===
+          this.#server.diagnosticsActivityGeneration() &&
+        workerGenerationsBeforeCycle.every((generation, index) =>
+          generation === workerGenerationsAfterCycle[index]
+        )
+      ) {
+        return;
+      }
+    }
   }
 
   /** Let all runtimes finish local work and exchange pending sync traffic. */
@@ -441,7 +876,9 @@ export class MultiRuntimeHarness {
   async dispose(): Promise<void> {
     for (const session of this.sessions) {
       await session.disposeSession().catch((error) => {
-        console.warn(`Failed to dispose session "${session.label}":`, error);
+        if (!this.#aggregateOnlyDiagnostics) {
+          console.warn(`Failed to dispose session "${session.label}":`, error);
+        }
       });
     }
     await this.#server?.close();

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -630,6 +630,11 @@ export class MultiRuntimeHarness {
     if (options.sessions.length === 0) {
       throw new Error("MultiRuntimeHarness needs at least one session");
     }
+    if (options.aggregateOnlyDiagnostics && options.apiUrl) {
+      throw new Error(
+        "aggregate-only diagnostics require the local in-process memory server",
+      );
+    }
     propagateExperimentalEnvToServerRealm();
     const spaceName = options.spaceName ?? crypto.randomUUID();
     const server = options.apiUrl ? undefined : StandaloneMemoryServer.start({

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -12,14 +12,12 @@ import type {
   SchedulerGraphSnapshot,
 } from "@commonfabric/runner";
 import {
-  areLinksSame,
   classifyTelemetryWriteCounts,
   markRendererInputTx,
   markUiInputBlindWriteTx,
   setBlindStructuralTarget,
   unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
-import type { NormalizedFullLink } from "@commonfabric/runner/shared";
 import { markRendererTrustedEvent } from "@commonfabric/runner/cfc";
 import { Identity, type KeyPairRaw } from "@commonfabric/identity";
 import {
@@ -1534,57 +1532,54 @@ const handlers: Record<
           validatedSources: 0,
         } satisfies TopicsDiagnosticsCrossrefValidation;
       }
-      await syncResultTopology();
-      const target = topicsCell(["topics", 0]).resolveAsCell();
-      await target.sync();
+      await idle();
+      const target = await syncResultTopology(["crossrefs", 0, "topic"]);
       await target.pull();
-      const targetLink = target.getAsNormalizedFullLink();
-      const sourceLinks: NormalizedFullLink[] = [];
+      const sources: Cell<any>[] = [];
+      let validatedSources = 0;
       for (let index = 1; index < topicCount; index++) {
-        const refsOut = topicsCell(["topics", index, "crossrefs", "refsOut"]);
-        await refsOut.sync();
+        const refsOut = await syncResultTopology([
+          "crossrefs",
+          index,
+          "refsOut",
+        ]);
         const values = await refsOut.pull();
         if (!Array.isArray(values) || values.length !== 1) {
           return { ok: false, validatedSources: index - 1 };
         }
         const referenced = refsOut.key(0).resolveAsCell();
-        await referenced.sync();
         await referenced.pull();
-        if (!areLinksSame(referenced.getAsNormalizedFullLink(), targetLink)) {
+        if (!referenced.equals(target)) {
           return { ok: false, validatedSources: index - 1 };
         }
-        const source = topicsCell(["topics", index]).resolveAsCell();
-        await source.sync();
+        const source = await syncResultTopology([
+          "crossrefs",
+          index,
+          "topic",
+        ]);
         await source.pull();
-        sourceLinks.push(source.getAsNormalizedFullLink());
+        sources.push(source);
+        validatedSources++;
       }
-      const referencedBy = topicsCell([
-        "topics",
-        0,
+      const referencedBy = await syncResultTopology([
         "crossrefs",
+        0,
         "referencedBy",
       ]);
-      await referencedBy.sync();
       const backlinks = await referencedBy.pull();
       if (!Array.isArray(backlinks) || backlinks.length !== topicCount - 1) {
-        return { ok: false, validatedSources: sourceLinks.length };
+        return { ok: false, validatedSources };
       }
       for (const [index] of backlinks.entries()) {
         const backlink = referencedBy.key(index).resolveAsCell();
-        await backlink.sync();
         await backlink.pull();
-        if (
-          !areLinksSame(
-            backlink.getAsNormalizedFullLink(),
-            sourceLinks[index],
-          )
-        ) {
-          return { ok: false, validatedSources: sourceLinks.length };
+        if (!backlink.equals(sources[index])) {
+          return { ok: false, validatedSources };
         }
       }
       return {
         ok: true,
-        validatedSources: sourceLinks.length,
+        validatedSources,
       } satisfies TopicsDiagnosticsCrossrefValidation;
     } catch {
       return {

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -6,13 +6,20 @@
  * main thread orchestrates via a tiny request/response protocol.
  */
 
-import type { Cell } from "@commonfabric/runner";
-import type { SchedulerGraphSnapshot } from "@commonfabric/runner";
+import type {
+  Cell,
+  RuntimeTelemetryMarker,
+  SchedulerGraphSnapshot,
+} from "@commonfabric/runner";
 import {
+  areLinksSame,
+  classifyTelemetryWriteCounts,
+  markRendererInputTx,
   markUiInputBlindWriteTx,
   setBlindStructuralTarget,
   unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
+import type { NormalizedFullLink } from "@commonfabric/runner/shared";
 import { markRendererTrustedEvent } from "@commonfabric/runner/cfc";
 import { Identity, type KeyPairRaw } from "@commonfabric/identity";
 import {
@@ -22,6 +29,8 @@ import {
 } from "./pieces-controller.ts";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import { writePathShape } from "./telemetry-path-shape.ts";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 export interface WorkerRequest {
   id: number;
@@ -46,10 +55,313 @@ export interface RuntimeDiagnosticsSnapshot {
   actionRunTrace: unknown[];
 }
 
+/** Content-free scheduler aggregates suitable for cross-worker diagnostics. */
+export interface RuntimeDiagnosticsSummary {
+  nodeCount: number;
+  edgeCount: number;
+  dirtyNodeCount: number;
+  pendingNodeCount: number;
+  settleHistoryEntryCount: number;
+  maxTrailingSettleDurationMs: number;
+}
+
+/** Counter-only local scheduler telemetry; no pattern values are retained. */
+export interface RuntimeTelemetrySnapshot {
+  invocationCount: number;
+  /** Distinct event IDs observed only inside the worker, never returned. */
+  distinctInvokedEventCount: number;
+  distinctSuccessfulEventCount: number;
+  distinctDroppedEventCount: number;
+  droppedEventsByReason: Record<
+    "piece-load" | "lineage" | "preflight" | "load-gate",
+    number
+  >;
+  permanentRejectionsByReason: Record<
+    "origin-committed" | "receipt-exists",
+    number
+  >;
+  /** Scheduler event commit markers observed. */
+  commitMarkerCount: number;
+  /** Direct UI-style set/push commits recorded by this harness worker. */
+  directCommitCount: number;
+  successfulCommitCount: number;
+  failedAttemptCount: number;
+  terminalFailureCount: number;
+  retryMarkerCount: number;
+  maxRetryAttempt: number;
+  readCount: number;
+  writeCount: number;
+  changedWriteCount: number;
+  writesTruncatedCount: number;
+  writesByPathShape: Record<string, number>;
+}
+
+/** Aggregate-only Topics state used for private cross-worker convergence checks. */
+export type TopicsDiagnosticsSummary =
+  | {
+    ok: true;
+    topics: number;
+    comments: number;
+    links: number;
+  }
+  | { ok: false; error: "operation-failed" };
+
+/** Fixed outcome returned by Topics-only mutation commands. */
+export interface TopicsDiagnosticsOperationOutcome {
+  ok: boolean;
+  error?: "operation-failed";
+}
+
+export interface TopicsDiagnosticsNoopOutcome
+  extends TopicsDiagnosticsOperationOutcome {
+  submitted: number;
+  directAccepted: number;
+  directRejected: number;
+}
+
+export interface TopicsDiagnosticsCrossrefValidation {
+  ok: boolean;
+  validatedSources: number;
+}
+
+/** Fixed storage-churn counters used by aggregate-only Topics diagnostics. */
+export interface TopicsDiagnosticsChurnTotals {
+  commitConflicts: number;
+  commitPreempted: number;
+  commitHeldRevert: number;
+  commitHeldSent: number;
+  commitReverts: number;
+  commitRejected: number;
+}
+
+class LocalRuntimeTelemetry {
+  #snapshot: RuntimeTelemetrySnapshot = LocalRuntimeTelemetry.empty();
+  #invokedEventIds = new Set<string>();
+  #successfulEventIds = new Set<string>();
+  #droppedEventIds = new Set<string>();
+
+  static empty(): RuntimeTelemetrySnapshot {
+    return {
+      invocationCount: 0,
+      distinctInvokedEventCount: 0,
+      distinctSuccessfulEventCount: 0,
+      distinctDroppedEventCount: 0,
+      droppedEventsByReason: {
+        "piece-load": 0,
+        lineage: 0,
+        preflight: 0,
+        "load-gate": 0,
+      },
+      permanentRejectionsByReason: {
+        "origin-committed": 0,
+        "receipt-exists": 0,
+      },
+      commitMarkerCount: 0,
+      directCommitCount: 0,
+      successfulCommitCount: 0,
+      failedAttemptCount: 0,
+      terminalFailureCount: 0,
+      retryMarkerCount: 0,
+      maxRetryAttempt: 0,
+      readCount: 0,
+      writeCount: 0,
+      changedWriteCount: 0,
+      writesTruncatedCount: 0,
+      writesByPathShape: {},
+    };
+  }
+
+  record(marker: RuntimeTelemetryMarker): void {
+    if (marker.type === "scheduler.invocation") {
+      this.#snapshot.invocationCount++;
+      this.#invokedEventIds.add(marker.eventId);
+      this.#snapshot.distinctInvokedEventCount = this.#invokedEventIds.size;
+      return;
+    }
+    if (marker.type === "scheduler.event.drop") {
+      this.#droppedEventIds.add(marker.eventId);
+      this.#snapshot.distinctDroppedEventCount = this.#droppedEventIds.size;
+      this.#snapshot.droppedEventsByReason[marker.reason]++;
+      return;
+    }
+    if (marker.type !== "scheduler.event.commit") return;
+
+    this.#snapshot.commitMarkerCount++;
+    this.#recordCommit({
+      readCount: marker.readCount,
+      writeCount: marker.writeCount,
+      changedWriteCount: marker.changedWriteCount,
+      writes: marker.writes.map(markerPath),
+      failed: marker.error !== undefined,
+    });
+    if (marker.writesTruncated) this.#snapshot.writesTruncatedCount++;
+    if (marker.error === undefined) {
+      this.#successfulEventIds.add(marker.eventId);
+      this.#snapshot.distinctSuccessfulEventCount =
+        this.#successfulEventIds.size;
+    }
+    if (marker.permanentRejection !== undefined) {
+      this.#snapshot.permanentRejectionsByReason[marker.permanentRejection]++;
+    }
+    if (marker.terminal) this.#snapshot.terminalFailureCount++;
+    if (marker.backoffMs !== undefined && marker.retryAttempt !== undefined) {
+      this.#snapshot.retryMarkerCount++;
+      this.#snapshot.maxRetryAttempt = Math.max(
+        this.#snapshot.maxRetryAttempt,
+        marker.retryAttempt,
+      );
+    }
+  }
+
+  recordDirectCommit(
+    summary: {
+      readCount: number;
+      writeCount: number;
+      changedWriteCount: number;
+      writes: readonly string[];
+      failed: boolean;
+    },
+  ): void {
+    this.#snapshot.directCommitCount++;
+    this.#recordCommit(summary);
+  }
+
+  #recordCommit(summary: {
+    readCount: number;
+    writeCount: number;
+    changedWriteCount: number;
+    writes: readonly string[];
+    failed: boolean;
+  }): void {
+    this.#snapshot.readCount += summary.readCount;
+    this.#snapshot.writeCount += summary.writeCount;
+    this.#snapshot.changedWriteCount += summary.changedWriteCount;
+    if (summary.failed) this.#snapshot.failedAttemptCount++;
+    else this.#snapshot.successfulCommitCount++;
+    for (const path of summary.writes) {
+      const shape = writePathShape(path);
+      this.#snapshot.writesByPathShape[shape] =
+        (this.#snapshot.writesByPathShape[shape] ?? 0) + 1;
+    }
+  }
+
+  snapshotAndReset(): RuntimeTelemetrySnapshot {
+    const snapshot = {
+      ...this.#snapshot,
+      writesByPathShape: { ...this.#snapshot.writesByPathShape },
+      droppedEventsByReason: { ...this.#snapshot.droppedEventsByReason },
+      permanentRejectionsByReason: {
+        ...this.#snapshot.permanentRejectionsByReason,
+      },
+    };
+    this.#snapshot = LocalRuntimeTelemetry.empty();
+    this.#invokedEventIds.clear();
+    this.#successfulEventIds.clear();
+    this.#droppedEventIds.clear();
+    return snapshot;
+  }
+}
+
 let cc: PiecesController | undefined;
 let piece: PieceController | undefined;
 let resultSchema: unknown;
 let resultSinkCancel: (() => void) | undefined;
+let telemetry: LocalRuntimeTelemetry | undefined;
+let telemetryListener: ((event: Event) => void) | undefined;
+let releaseDetailedEventCommitTelemetry: (() => void) | undefined;
+let diagnosticsEnabled = false;
+let aggregateOnlyDiagnostics = false;
+let aggregateBootstrapCreator = false;
+let aggregateBootstrapChannel: string | undefined;
+let aggregateBootstrapParticipants = 0;
+let diagnosticMutationsEnabled = false;
+let diagnosticsActivityGeneration = 0;
+let pendingContainingDocumentRootCommit: (() => Promise<unknown>) | undefined;
+let delayedFrameCount = 0;
+let delayedFrameDrainers: (() => void)[] = [];
+let bootstrapChannel: BroadcastChannel | undefined;
+let bootstrapPieceId: string | undefined;
+let bootstrapReady: (() => void) | undefined;
+let convergenceChannel: BroadcastChannel | undefined;
+let convergenceExpected = 0;
+let convergenceEntries: {
+  token: string;
+  topics: number;
+  comments: number;
+  links: number;
+}[] = [];
+let convergenceReady: (() => void) | undefined;
+let convergencePublishChannels: BroadcastChannel[] = [];
+let privateTopicsEqualityToken: string | undefined;
+let restoreAggregateConsole: (() => void) | undefined;
+
+function suppressAggregateConsole(): void {
+  if (restoreAggregateConsole) return;
+  const debug = console.debug;
+  const error = console.error;
+  const info = console.info;
+  const log = console.log;
+  const warn = console.warn;
+  console.debug = () => {};
+  console.error = () => {};
+  console.info = () => {};
+  console.log = () => {};
+  console.warn = () => {};
+  restoreAggregateConsole = () => {
+    console.debug = debug;
+    console.error = error;
+    console.info = info;
+    console.log = log;
+    console.warn = warn;
+    restoreAggregateConsole = undefined;
+  };
+}
+
+const fixedSuccess = () => ({ ok: true } as const);
+const fixedFailure = () => ({ ok: false, error: "operation-failed" } as const);
+
+function closeTopicsChannels(): void {
+  bootstrapChannel?.close();
+  bootstrapChannel = undefined;
+  bootstrapPieceId = undefined;
+  bootstrapReady?.();
+  bootstrapReady = undefined;
+  convergenceChannel?.close();
+  convergenceChannel = undefined;
+  convergenceExpected = 0;
+  convergenceEntries = [];
+  for (const channel of convergencePublishChannels) channel.close();
+  convergencePublishChannels = [];
+  convergenceReady?.();
+  convergenceReady = undefined;
+}
+
+function beginDelayedFrame(): () => void {
+  delayedFrameCount++;
+  return () => {
+    delayedFrameCount--;
+    if (delayedFrameCount === 0) {
+      for (const resolve of delayedFrameDrainers) resolve();
+      delayedFrameDrainers = [];
+    }
+  };
+}
+
+async function awaitDelayedFramesDrained(): Promise<void> {
+  if (delayedFrameCount === 0) return;
+  await new Promise<void>((resolve) => delayedFrameDrainers.push(resolve));
+}
+
+function trailingSettleDuration(history: unknown): number {
+  if (!Array.isArray(history)) return 0;
+  return history.slice(-5).reduce((maximum, entry) => {
+    const stats = isRecord(entry) && isRecord(entry.stats) ? entry.stats : {};
+    const duration = stats.totalDurationMs;
+    return typeof duration === "number" && Number.isFinite(duration)
+      ? Math.max(maximum, duration)
+      : maximum;
+  }, 0);
+}
 
 function controller(): PiecesController {
   if (!cc) throw new Error("worker not initialized");
@@ -59,6 +371,65 @@ function controller(): PiecesController {
 function currentPiece(): PieceController {
   if (!piece) throw new Error("no piece attached");
   return piece;
+}
+
+function normalizePath(
+  value: unknown,
+  description: string,
+  allowEmpty = false,
+): (string | number)[] {
+  if (!Array.isArray(value) || (!allowEmpty && value.length === 0)) {
+    throw new Error(
+      `${description} must be ${allowEmpty ? "a" : "a non-empty"} ` +
+        "(string | number)[] path",
+    );
+  }
+  const path: (string | number)[] = [];
+  for (const segment of value) {
+    if (typeof segment === "string" && segment.length > 0) {
+      path.push(segment);
+      continue;
+    }
+    if (
+      typeof segment === "number" && Number.isInteger(segment) && segment >= 0
+    ) {
+      path.push(segment);
+      continue;
+    }
+    throw new Error(
+      `${description} contains an invalid path segment: ${
+        JSON.stringify(segment)
+      }`,
+    );
+  }
+  return path;
+}
+
+function normalizeSendTarget(value: unknown): (string | number)[] {
+  if (typeof value === "string" && value.length > 0) return [value];
+  return normalizePath(value, "send target");
+}
+
+function normalizeOmitKeys(value: unknown): string[] {
+  if (value === undefined) return [];
+  if (
+    !Array.isArray(value) ||
+    value.some((key) => typeof key !== "string" || key.length === 0)
+  ) {
+    throw new Error("read omitKeys must be a string[] of non-empty keys");
+  }
+  return [...new Set(value)];
+}
+
+function displayPath(path: readonly (string | number)[]): string {
+  return path.map((segment) => JSON.stringify(segment)).join(".");
+}
+
+function markerPath(address: string): string {
+  // Commit markers identify addresses as space/entity/path. Keep only the
+  // structural path for workload attribution; diagnostics must not retain IDs.
+  const segments = address.split("/");
+  return segments.slice(2).join("/") || "$root";
 }
 
 // Read through the pattern's declared result schema, like the UI does —
@@ -71,6 +442,10 @@ function result(): Cell<any> {
 async function idle(): Promise<void> {
   await controller().manager().runtime.idle();
   await controller().manager().synced();
+}
+
+async function settled(): Promise<void> {
+  await controller().manager().runtime.settled();
 }
 
 async function attachPiece(next: PieceController): Promise<void> {
@@ -86,9 +461,14 @@ async function attachPiece(next: PieceController): Promise<void> {
  * Make `value` postMessage-safe: keep JSON data, drop functions/cells,
  * stringify bigints (JSON.stringify throws on them).
  */
-function sanitizeForTransfer(value: unknown): unknown {
+function sanitizeForTransfer(
+  value: unknown,
+  omitKeys: readonly string[] = [],
+): unknown {
   if (value === undefined) return undefined;
+  const omitted = new Set(omitKeys);
   return JSON.parse(JSON.stringify(value, (_key, entry) => {
+    if (omitted.has(_key)) return undefined;
     if (typeof entry === "function") return undefined;
     if (typeof entry === "bigint") return entry.toString();
     return entry;
@@ -151,15 +531,25 @@ function installWsDelay(delayMs: number): void {
           fn.call(ws, ev);
         }
       };
-      setTimeout(deliver, delayMs);
+      const done = beginDelayedFrame();
+      setTimeout(() => {
+        try {
+          deliver();
+        } finally {
+          done();
+        }
+      }, delayMs);
     });
     const nativeSend = ws.send.bind(ws);
     ws.send = (data: Parameters<WebSocket["send"]>[0]) => {
+      const done = beginDelayedFrame();
       setTimeout(() => {
         try {
           nativeSend(data);
         } catch {
           // Socket closed while the frame was in flight; same as a network drop.
+        } finally {
+          done();
         }
       }, delayMs);
     };
@@ -199,6 +589,8 @@ async function maybeAttachOtelBridge(identity: Identity): Promise<void> {
     meter: metrics.getMeter("ct-runner-bridge"),
     attributes: {
       "ct.runtime": "harness",
+    },
+    spanAttributes: {
       "space.did": manager.getSpace(),
       "user.did": identity.did(),
     },
@@ -206,11 +598,187 @@ async function maybeAttachOtelBridge(identity: Identity): Promise<void> {
   runtime.scheduler.setEventPreflightTelemetryEnabled(true);
 }
 
+function topicsCell(path: readonly (string | number)[] = []): Cell<any> {
+  let cell = result();
+  for (const segment of path) cell = cell.key(segment as never) as Cell<any>;
+  return cell;
+}
+
+async function syncResultTopology(
+  path: readonly (string | number)[] = [],
+): Promise<Cell<any>> {
+  let cell = result();
+  await cell.sync();
+  await cell.pull();
+  for (const segment of path) {
+    cell = cell.key(segment as never).resolveAsCell();
+    await cell.sync();
+    await cell.pull();
+  }
+  return cell;
+}
+
+const asTopicsRecordArray = (value: unknown): Record<string, unknown>[] =>
+  Array.isArray(value) ? value.filter(isRecord) : [];
+
+const asTopicsNumber = (value: unknown): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : 0;
+
+interface TopicsContentProjection {
+  title: string;
+  body: string;
+  createdAt: number;
+  createdByName: string;
+  comments: { authorName: string; body: string; sentAt: number }[];
+  links: { kind: string; url: string; label: string }[];
+}
+
+function topicsContentProjection(
+  values: Record<string, unknown>,
+): TopicsContentProjection {
+  return {
+    title: typeof values.title === "string" ? values.title : "",
+    body: typeof values.body === "string" ? values.body : "",
+    createdAt: asTopicsNumber(values.createdAt),
+    createdByName: typeof values.createdByName === "string"
+      ? values.createdByName
+      : "",
+    comments: asTopicsRecordArray(values.comments).map((comment) => ({
+      authorName: typeof comment.authorName === "string"
+        ? comment.authorName
+        : "",
+      body: typeof comment.body === "string" ? comment.body : "",
+      sentAt: asTopicsNumber(comment.sentAt),
+    })),
+    links: asTopicsRecordArray(values.links).map((link) => ({
+      kind: typeof link.kind === "string" ? link.kind : "",
+      url: typeof link.url === "string" ? link.url : "",
+      label: typeof link.label === "string" ? link.label : "",
+    })),
+  };
+}
+
+async function topicsDiagnosticsSummary(): Promise<TopicsDiagnosticsSummary> {
+  await syncResultTopology();
+  const topics = topicsCell(["topics"]);
+  await topics.sync();
+  const pulledTopics = await topics.pull();
+  const entries = Array.isArray(pulledTopics) ? pulledTopics : [];
+  type SharedTopicsProjection = TopicsContentProjection & {
+    link: { id: string; space: string; scope: string; path: string[] };
+  };
+  const projection: (SharedTopicsProjection | null)[] = [];
+  for (const [index, entry] of entries.entries()) {
+    if (!isRecord(entry)) {
+      projection.push(null);
+      continue;
+    }
+    const topic = topics.key(index) as Cell<any>;
+    await topic.sync();
+    await topic.pull();
+    const link = topic.resolveAsCell().getAsNormalizedFullLink();
+    projection.push({
+      ...topicsContentProjection(entry),
+      link: {
+        id: link.id,
+        space: link.space,
+        scope: link.scope,
+        path: [...link.path],
+      },
+    });
+  }
+  privateTopicsEqualityToken = hashStringOf(projection);
+  const present = projection.filter((topic): topic is SharedTopicsProjection =>
+    topic !== null
+  );
+  return {
+    ok: true,
+    topics: present.length,
+    comments: present.reduce(
+      (total, topic) => total + topic.comments.length,
+      0,
+    ),
+    links: present.reduce((total, topic) => total + topic.links.length, 0),
+  };
+}
+
+async function privateTopicsConvergence(): Promise<
+  { token: string; topics: number; comments: number; links: number }
+> {
+  const summary = await topicsDiagnosticsSummary();
+  if (!summary.ok) throw new Error("operation-failed");
+  if (!privateTopicsEqualityToken) throw new Error("operation-failed");
+  return {
+    token: privateTopicsEqualityToken,
+    topics: summary.topics,
+    comments: summary.comments,
+    links: summary.links,
+  };
+}
+
+const topicsOperationFailure = (): TopicsDiagnosticsOperationOutcome => ({
+  ok: false,
+  error: "operation-failed",
+});
+
+function preparedAggregateBootstrap():
+  | { channel: string; participants: number }
+  | undefined {
+  if (
+    !aggregateBootstrapCreator || aggregateBootstrapChannel === undefined ||
+    aggregateBootstrapParticipants < 1
+  ) {
+    return undefined;
+  }
+  return {
+    channel: aggregateBootstrapChannel,
+    participants: aggregateBootstrapParticipants,
+  };
+}
+
 const handlers: Record<
   string,
   (args: Record<string, unknown>) => Promise<unknown>
 > = {
-  async init({ rawIdentity, spaceName, apiUrl, diagnostics, wsDelayMs }) {
+  async init({
+    rawIdentity,
+    spaceName,
+    apiUrl,
+    diagnostics,
+    aggregateOnlyDiagnostics: aggregateOnly,
+    aggregateBootstrapCreator: bootstrapCreator,
+    aggregateBootstrapChannel: creatorChannel,
+    aggregateBootstrapParticipants: creatorParticipants,
+    diagnosticMutationsEnabled: enableDiagnosticMutations,
+    wsDelayMs,
+  }) {
+    if (cc) {
+      if (aggregateOnlyDiagnostics || aggregateOnly === true) {
+        return fixedFailure();
+      }
+      throw new Error("worker already initialized");
+    }
+    const aggregate = aggregateOnly === true;
+    const creator = aggregate && bootstrapCreator === true;
+    if (
+      creator &&
+      (typeof creatorChannel !== "string" || creatorChannel.length === 0 ||
+        typeof creatorParticipants !== "number" ||
+        !Number.isSafeInteger(creatorParticipants) ||
+        creatorParticipants < 1)
+    ) {
+      return fixedFailure();
+    }
+    aggregateOnlyDiagnostics = aggregateOnly === true;
+    aggregateBootstrapCreator = creator;
+    aggregateBootstrapChannel = creator && typeof creatorChannel === "string"
+      ? creatorChannel
+      : undefined;
+    aggregateBootstrapParticipants = creator &&
+        typeof creatorParticipants === "number"
+      ? creatorParticipants
+      : 0;
+    if (aggregateOnlyDiagnostics) suppressAggregateConsole();
     const identity = await Identity.deserialize(rawIdentity as KeyPairRaw);
     if (typeof wsDelayMs === "number") installWsDelay(wsDelayMs);
     cc = await initializePiecesController({
@@ -218,16 +786,41 @@ const handlers: Record<
       identity,
       spaceName: spaceName as string,
     });
-    if (diagnostics === true) {
-      const scheduler = controller().manager().runtime.scheduler;
+    diagnosticsEnabled = diagnostics === true;
+    diagnosticMutationsEnabled = enableDiagnosticMutations === true;
+    diagnosticsActivityGeneration = 0;
+    if (diagnosticsEnabled) {
+      const runtime = controller().manager().runtime;
+      const scheduler = runtime.scheduler;
       scheduler.enableSettleStats();
       scheduler.setActionRunTraceEnabled(true);
+      releaseDetailedEventCommitTelemetry = runtime.telemetry
+        .retainDetailedEventCommitTelemetry();
+      telemetry = new LocalRuntimeTelemetry();
+      telemetryListener = (event: Event) => {
+        const marker =
+          (event as CustomEvent<{ marker: RuntimeTelemetryMarker }>)
+            .detail.marker;
+        telemetry?.record(marker);
+        diagnosticsActivityGeneration++;
+      };
+      runtime.telemetry.addEventListener("telemetry", telemetryListener);
     }
-    await maybeAttachOtelBridge(identity);
-    return { did: identity.did() };
+    if (!aggregateOnlyDiagnostics) await maybeAttachOtelBridge(identity);
+    return {};
   },
 
-  async createPiece({ programPath, rootPath, input }) {
+  async createPiece({
+    programPath,
+    rootPath,
+    input,
+  }) {
+    const aggregateBootstrap = aggregateOnlyDiagnostics
+      ? preparedAggregateBootstrap()
+      : undefined;
+    if (aggregateOnlyDiagnostics && aggregateBootstrap === undefined) {
+      return fixedFailure();
+    }
     const program = await controller().manager().runtime.harness.resolve(
       new FileSystemProgramResolver(
         programPath as string,
@@ -240,6 +833,21 @@ const handlers: Record<
     });
     await attachPiece(created);
     await idle();
+    if (aggregateBootstrap) {
+      const broadcast = new BroadcastChannel(aggregateBootstrap.channel);
+      let acknowledgements = 0;
+      await new Promise<void>((resolve) => {
+        broadcast.onmessage = (event: MessageEvent<unknown>) => {
+          if (isRecord(event.data) && event.data.bootstrapAck === true) {
+            acknowledgements++;
+            if (acknowledgements === aggregateBootstrap.participants) resolve();
+          }
+        };
+        broadcast.postMessage({ pieceId: created.id });
+      });
+      broadcast.close();
+      return fixedSuccess();
+    }
     return { pieceId: created.id };
   },
 
@@ -249,7 +857,7 @@ const handlers: Record<
     return {};
   },
 
-  async send({ handler, event, trustedUi, idle: doIdle }) {
+  async send({ target, event, trustedUi, idle: doIdle }) {
     const trusted = trustedUi as TrustedUiDescriptor | undefined;
     let eventValue: unknown = event ?? {};
     if (trusted) {
@@ -271,14 +879,20 @@ const handlers: Record<
       };
       markRendererTrustedEvent(eventValue);
     }
-    const target = result();
+    const targetPath = normalizeSendTarget(target);
+    let stream = result();
+    for (const segment of targetPath) {
+      stream = stream.key(segment as never);
+    }
     const { error } = await controller().manager().runtime.editWithRetry(
       (tx) => {
-        target.key(handler as never).withTx(tx).send(eventValue as never);
+        stream.withTx(tx).send(eventValue as never);
       },
     );
     if (error) {
-      throw new Error(`send "${handler}" failed: ${error.message}`);
+      throw new Error(
+        `send ${displayPath(targetPath)} failed: ${error.message}`,
+      );
     }
     // `idle: false` returns as soon as the event is queued, leaving the action
     // run + commit in flight — lets a test stack several sends into a deep
@@ -288,9 +902,177 @@ const handlers: Record<
     return {};
   },
 
+  async topicsDiagnosticsSummary() {
+    try {
+      return await topicsDiagnosticsSummary();
+    } catch {
+      return topicsOperationFailure();
+    }
+  },
+
+  topicsDiagnosticsPrepareBootstrap({ channel }) {
+    try {
+      if (!aggregateOnlyDiagnostics || typeof channel !== "string") {
+        return Promise.resolve(fixedFailure());
+      }
+      bootstrapChannel?.close();
+      bootstrapPieceId = undefined;
+      bootstrapChannel = new BroadcastChannel(channel);
+      bootstrapChannel.onmessage = (event: MessageEvent<unknown>) => {
+        if (isRecord(event.data) && typeof event.data.pieceId === "string") {
+          bootstrapPieceId = event.data.pieceId;
+          bootstrapChannel?.postMessage({ bootstrapAck: true });
+          bootstrapReady?.();
+          bootstrapReady = undefined;
+        }
+      };
+      return Promise.resolve({ ok: true, ready: true });
+    } catch {
+      return Promise.resolve(fixedFailure());
+    }
+  },
+
+  async topicsDiagnosticsFinishBootstrap() {
+    try {
+      if (!aggregateOnlyDiagnostics || !bootstrapChannel) return fixedFailure();
+      if (!bootstrapPieceId) {
+        await new Promise<void>((resolve) => bootstrapReady = resolve);
+      }
+      if (!bootstrapPieceId) return fixedFailure();
+      await attachPiece(await controller().get(bootstrapPieceId, true));
+      await idle();
+      bootstrapChannel.close();
+      bootstrapChannel = undefined;
+      bootstrapPieceId = undefined;
+      return fixedSuccess();
+    } catch {
+      return fixedFailure();
+    }
+  },
+
+  topicsDiagnosticsConvergenceBegin({ channel, participants }) {
+    try {
+      if (
+        !aggregateOnlyDiagnostics || typeof channel !== "string" ||
+        typeof participants !== "number" ||
+        !Number.isSafeInteger(participants) || participants < 1 ||
+        convergenceChannel
+      ) return Promise.resolve(fixedFailure());
+      convergenceExpected = participants;
+      convergenceEntries = [];
+      convergenceChannel = new BroadcastChannel(channel);
+      convergenceChannel.onmessage = (event: MessageEvent<unknown>) => {
+        const value = event.data;
+        if (
+          !isRecord(value) || typeof value.token !== "string" ||
+          typeof value.receipt !== "string" ||
+          typeof value.topics !== "number" ||
+          typeof value.comments !== "number" ||
+          typeof value.links !== "number"
+        ) return;
+        convergenceEntries.push({
+          token: value.token,
+          topics: value.topics,
+          comments: value.comments,
+          links: value.links,
+        });
+        convergenceChannel?.postMessage({ ack: value.receipt });
+        if (convergenceEntries.length === convergenceExpected) {
+          convergenceReady?.();
+          convergenceReady = undefined;
+        }
+      };
+      return Promise.resolve({ ok: true, ready: true });
+    } catch {
+      return Promise.resolve(fixedFailure());
+    }
+  },
+
+  async topicsDiagnosticsConvergencePublish({ channel }) {
+    try {
+      if (!aggregateOnlyDiagnostics || typeof channel !== "string") {
+        return fixedFailure();
+      }
+      const entry = await privateTopicsConvergence();
+      if (convergenceChannel) {
+        convergenceEntries.push(entry);
+        if (convergenceEntries.length === convergenceExpected) {
+          convergenceReady?.();
+          convergenceReady = undefined;
+        }
+        return fixedSuccess();
+      }
+      const broadcast = new BroadcastChannel(channel);
+      const receipt = crypto.randomUUID();
+      convergencePublishChannels.push(broadcast);
+      await new Promise<void>((resolve) => {
+        broadcast.onmessage = (event: MessageEvent<unknown>) => {
+          if (isRecord(event.data) && event.data.ack === receipt) resolve();
+        };
+        broadcast.postMessage({ ...entry, receipt });
+      });
+      broadcast.close();
+      convergencePublishChannels = convergencePublishChannels.filter((item) =>
+        item !== broadcast
+      );
+      return fixedSuccess();
+    } catch {
+      return fixedFailure();
+    }
+  },
+
+  topicsDiagnosticsConvergenceFinish() {
+    try {
+      if (!convergenceChannel) return Promise.resolve(fixedFailure());
+      if (convergenceEntries.length !== convergenceExpected) {
+        return Promise.resolve(fixedFailure());
+      }
+      const reference = convergenceEntries[0].token;
+      const result = {
+        ok: true as const,
+        converged: convergenceEntries.every((entry) =>
+          entry.token === reference
+        ),
+        summary: {
+          topics: convergenceEntries.map((entry) => entry.topics),
+          comments: convergenceEntries.map((entry) => entry.comments),
+          links: convergenceEntries.map((entry) => entry.links),
+        },
+      };
+      convergenceChannel.close();
+      convergenceChannel = undefined;
+      convergenceExpected = 0;
+      convergenceEntries = [];
+      for (const channel of convergencePublishChannels) channel.close();
+      convergencePublishChannels = [];
+      return Promise.resolve(result);
+    } catch {
+      return Promise.resolve(fixedFailure());
+    }
+  },
+
+  topicsDiagnosticsConvergenceCancel() {
+    try {
+      closeTopicsChannels();
+      return Promise.resolve(fixedSuccess());
+    } catch {
+      return Promise.resolve(fixedFailure());
+    }
+  },
+
+  async topicsDiagnosticsSend({ target, event, idle }) {
+    try {
+      await syncResultTopology();
+      await handlers.send({ target, event, idle });
+      return { ok: true } satisfies TopicsDiagnosticsOperationOutcome;
+    } catch {
+      return topicsOperationFailure();
+    }
+  },
+
   // Faithful mirror of RuntimeProcessor.handleCellSet — the path a UI binding
   // takes for a plain `set`: ONE fresh edit tx, a single un-retried commit,
-  // marked as a blind leaf write. The blind-vs-CAS choice is by METHOD, not value
+  // marked as renderer input plus a blind leaf write. The blind-vs-CAS choice is by METHOD, not value
   // shape: a `set` is ALWAYS blind (last-write-wins); read-modify-write goes
   // through `push` (below), which keeps compare-and-set. We await the commit so
   // the test can observe the outcome (a conflict surfaces as a Result error).
@@ -300,9 +1082,12 @@ const handlers: Record<
     const runtime = controller().manager().runtime;
     const tx = runtime.edit();
     let cell = result();
-    for (const segment of (path ?? []) as (string | number)[]) {
+    for (const segment of normalizePath(path ?? [], "set path", true)) {
       cell = cell.key(segment as never) as Cell<any>;
     }
+    // Match RuntimeProcessor.handleCellSet: a blind `$value` write carries
+    // renderer-input provenance so scheduler wake shaping remains faithful.
+    markRendererInputTx(tx);
     markUiInputBlindWriteTx(tx);
     // Mirror handleCellSet: thread the cell's PARENT address as the structural
     // existence/shape precondition for the blind write.
@@ -316,9 +1101,19 @@ const handlers: Record<
     cell.withTx(tx).set(value as never);
     unmarkUiInputBlindWriteTx(tx);
     runtime.prepareTxForCommit(tx);
+    const log = tx.getReactivityLog?.();
+    const writeCounts = log
+      ? classifyTelemetryWriteCounts(log.writes, log.attemptedWrites ?? [])
+      : { writeCount: 0, changedWriteCount: 0 };
     const res = await tx.commit() as {
       error?: { name?: string; message?: string };
     };
+    telemetry?.recordDirectCommit({
+      readCount: log ? log.reads.length + log.shallowReads.length : 0,
+      ...writeCounts,
+      writes: log?.writes.map((write) => write.path.join("/")) ?? [],
+      failed: res?.error !== undefined,
+    });
     if (doIdle !== false) await idle();
     return sanitizeForTransfer({
       ok: !res?.error,
@@ -326,6 +1121,209 @@ const handlers: Record<
         ? { name: res.error.name, message: res.error.message }
         : undefined,
     });
+  },
+
+  async topicsDiagnosticsSet({ path, value, idle }) {
+    try {
+      await syncResultTopology();
+      const outcome = await handlers.set({ path, value, idle }) as {
+        ok: boolean;
+      };
+      return outcome.ok
+        ? { ok: true } satisfies TopicsDiagnosticsOperationOutcome
+        : topicsOperationFailure();
+    } catch {
+      return topicsOperationFailure();
+    }
+  },
+
+  async topicsDiagnosticsNoop({ topicIndex, idle }) {
+    try {
+      if (
+        typeof topicIndex !== "number" ||
+        !Number.isSafeInteger(topicIndex) ||
+        topicIndex < 0
+      ) {
+        return {
+          ...topicsOperationFailure(),
+          submitted: 0,
+          directAccepted: 0,
+          directRejected: 0,
+        } satisfies TopicsDiagnosticsNoopOutcome;
+      }
+      await syncResultTopology();
+      const title = topicsCell(["topics", topicIndex, "title"]);
+      const body = topicsCell(["topics", topicIndex, "body"]);
+      await Promise.all([title.sync(), body.sync()]);
+      const [titleValue, bodyValue] = await Promise.all([
+        title.pull(),
+        body.pull(),
+      ]);
+      const setOutcome = await handlers.topicsDiagnosticsSet({
+        path: ["topics", topicIndex, "title"],
+        value: titleValue,
+        idle,
+      }) as TopicsDiagnosticsOperationOutcome;
+      const sendOutcome = await handlers.topicsDiagnosticsSend({
+        target: ["topics", topicIndex, "setBody"],
+        event: { body: bodyValue },
+        idle,
+      }) as TopicsDiagnosticsOperationOutcome;
+      const ok = setOutcome.ok && sendOutcome.ok;
+      return {
+        ...(ok ? { ok: true } : topicsOperationFailure()),
+        submitted: 2,
+        directAccepted: setOutcome.ok ? 1 : 0,
+        directRejected: setOutcome.ok ? 0 : 1,
+      } satisfies TopicsDiagnosticsNoopOutcome;
+    } catch {
+      return {
+        ...topicsOperationFailure(),
+        submitted: 0,
+        directAccepted: 0,
+        directRejected: 0,
+      } satisfies TopicsDiagnosticsNoopOutcome;
+    }
+  },
+
+  /**
+   * Diagnostic-only whole-document replacement for one direct child of a
+   * result document's `value` record. Unlike `set`, this deliberately writes
+   * `['value']` through the transaction API, producing one root patch rather
+   * than a recursive cell diff.
+   */
+  async prepareContainingDocumentValueRoot({ path, value, idle: doIdle }) {
+    if (!diagnosticMutationsEnabled) {
+      throw new Error(
+        "containing-document root replacement requires a local diagnostics harness",
+      );
+    }
+    if (pendingContainingDocumentRootCommit !== undefined) {
+      throw new Error(
+        "containing-document root replacement is already prepared",
+      );
+    }
+    if (!Array.isArray(value)) {
+      throw new Error(
+        "containing-document root replacement value must be an array",
+      );
+    }
+    const target = result();
+    await target.pull();
+    let cell = target;
+    for (
+      const segment of normalizePath(
+        path ?? [],
+        "containing-document root replacement path",
+      )
+    ) {
+      cell = cell.key(segment as never) as Cell<any>;
+    }
+    const runtime = controller().manager().runtime;
+    const tx = runtime.edit();
+    const link = cell.withTx(tx).resolveAsCell().getAsNormalizedFullLink();
+    // Normalized cell links are value-relative. Convert to the canonical
+    // document-memory path before enforcing the direct-child constraint.
+    const resolvedPath = ["value", ...link.path];
+    if (
+      resolvedPath.length !== 2 || resolvedPath[0] !== "value" ||
+      typeof resolvedPath[1] !== "string"
+    ) {
+      throw new Error(
+        "containing-document root replacement requires a direct string-key child of value",
+      );
+    }
+
+    const address = {
+      space: link.space,
+      id: link.id,
+      scope: link.scope,
+      type: "application/json" as const,
+      path: ["value"],
+    };
+    const containingValue = tx.readOrThrow(address);
+    if (!isRecord(containingValue)) {
+      throw new Error(
+        "containing-document root replacement requires value to be a record",
+      );
+    }
+    tx.writeOrThrow(address, {
+      ...containingValue,
+      [resolvedPath[1]]: value,
+    });
+    pendingContainingDocumentRootCommit = async () => {
+      runtime.prepareTxForCommit(tx);
+      const log = tx.getReactivityLog?.();
+      const writeCounts = log
+        ? classifyTelemetryWriteCounts(log.writes, log.attemptedWrites ?? [])
+        : { writeCount: 0, changedWriteCount: 0 };
+      const res = await tx.commit() as {
+        error?: { name?: string; message?: string };
+      };
+      telemetry?.recordDirectCommit({
+        readCount: log ? log.reads.length + log.shallowReads.length : 0,
+        ...writeCounts,
+        writes: log?.writes.map((write) => write.path.join("/")) ?? [],
+        failed: res?.error !== undefined,
+      });
+      if (doIdle !== false) await idle();
+      return sanitizeForTransfer({
+        ok: !res?.error,
+        error: res?.error
+          ? { name: res.error.name, message: res.error.message }
+          : undefined,
+      });
+    };
+    return {};
+  },
+
+  async commitPreparedContainingDocumentValueRoot() {
+    if (!diagnosticMutationsEnabled) {
+      throw new Error(
+        "containing-document root replacement requires a local diagnostics harness",
+      );
+    }
+    const commit = pendingContainingDocumentRootCommit;
+    if (commit === undefined) {
+      throw new Error("no containing-document root replacement is prepared");
+    }
+    pendingContainingDocumentRootCommit = undefined;
+    return await commit();
+  },
+
+  async topicsDiagnosticsPrepareReversedRoot({ idle }) {
+    try {
+      await syncResultTopology();
+      const topics = topicsCell(["topics"]).resolveAsCell();
+      await topics.sync();
+      await topics.pull();
+      const rawTopics = topics.getRaw();
+      if (!Array.isArray(rawTopics) || rawTopics.length < 2) {
+        return topicsOperationFailure();
+      }
+      await handlers.prepareContainingDocumentValueRoot({
+        path: ["topics"],
+        value: [...rawTopics].reverse(),
+        idle,
+      });
+      return { ok: true } satisfies TopicsDiagnosticsOperationOutcome;
+    } catch {
+      return topicsOperationFailure();
+    }
+  },
+
+  async topicsDiagnosticsCommitPreparedRoot() {
+    try {
+      const outcome = await handlers
+        .commitPreparedContainingDocumentValueRoot({}) as {
+          ok: boolean;
+        };
+      return outcome.ok
+        ? { ok: true } satisfies TopicsDiagnosticsOperationOutcome
+        : topicsOperationFailure();
+    } catch {
+      return topicsOperationFailure();
+    }
   },
 
   // Faithful mirror of RuntimeProcessor.handleCellPush / CellHandle.push: a
@@ -337,7 +1335,7 @@ const handlers: Record<
   async push({ path, value, idle: doIdle }) {
     const runtime = controller().manager().runtime;
     let cell = result();
-    for (const segment of (path ?? []) as (string | number)[]) {
+    for (const segment of normalizePath(path ?? [], "push path", true)) {
       cell = cell.key(segment as never) as Cell<any>;
     }
     const currentRaw = cell.get();
@@ -345,9 +1343,19 @@ const handlers: Record<
     const tx = runtime.edit();
     cell.withTx(tx).set([...current, value] as never);
     runtime.prepareTxForCommit(tx);
+    const log = tx.getReactivityLog?.();
+    const writeCounts = log
+      ? classifyTelemetryWriteCounts(log.writes, log.attemptedWrites ?? [])
+      : { writeCount: 0, changedWriteCount: 0 };
     const res = await tx.commit() as {
       error?: { name?: string; message?: string };
     };
+    telemetry?.recordDirectCommit({
+      readCount: log ? log.reads.length + log.shallowReads.length : 0,
+      ...writeCounts,
+      writes: log?.writes.map((write) => write.path.join("/")) ?? [],
+      failed: res?.error !== undefined,
+    });
     if (doIdle !== false) await idle();
     return sanitizeForTransfer({
       ok: !res?.error,
@@ -357,14 +1365,14 @@ const handlers: Record<
     });
   },
 
-  async read({ path }) {
-    const target = result();
-    await target.pull();
-    let cell = target;
-    for (const segment of (path ?? []) as (string | number)[]) {
-      cell = cell.key(segment as never);
-    }
-    return sanitizeForTransfer(cell.get());
+  async read({ path, omitKeys }) {
+    const normalizedPath = normalizePath(path ?? [], "read path", true);
+    const cell = await syncResultTopology(normalizedPath);
+    const value = await cell.pull();
+    return sanitizeForTransfer(
+      value,
+      normalizeOmitKeys(omitKeys),
+    );
   },
 
   /**
@@ -374,13 +1382,12 @@ const handlers: Record<
    * `requestHash`. Nested links in the raw value stay sigils.
    */
   async readRaw({ path }) {
-    const target = result();
-    await target.pull();
-    let cell = target;
-    for (const segment of (path ?? []) as (string | number)[]) {
-      cell = cell.key(segment as never);
-    }
-    return sanitizeForTransfer(cell.resolveAsCell().getRaw());
+    const normalizedPath = normalizePath(path ?? [], "readRaw path", true);
+    const cell = await syncResultTopology(normalizedPath);
+    const resolved = cell.resolveAsCell();
+    await resolved.sync();
+    await resolved.pull();
+    return sanitizeForTransfer(resolved.getRaw());
   },
 
   /**
@@ -389,13 +1396,11 @@ const handlers: Record<
    * assert the storage addressing (e.g. scope) of pattern state.
    */
   async link({ path }) {
-    const target = result();
-    await target.pull();
-    let cell = target;
-    for (const segment of (path ?? []) as (string | number)[]) {
-      cell = cell.key(segment as never);
-    }
+    const normalizedPath = normalizePath(path ?? [], "link path", true);
+    const cell = await syncResultTopology(normalizedPath);
     const resolved = cell.resolveAsCell();
+    await resolved.sync();
+    await resolved.pull();
     const link = resolved.getAsNormalizedFullLink();
     return sanitizeForTransfer({
       id: link.id,
@@ -403,6 +1408,104 @@ const handlers: Record<
       scope: link.scope,
       path: link.path,
     });
+  },
+
+  async topicsDiagnosticsCreateCrossref({ sourceIndex, targetIndex, idle }) {
+    try {
+      if (
+        typeof sourceIndex !== "number" ||
+        !Number.isSafeInteger(sourceIndex) || sourceIndex < 0 ||
+        typeof targetIndex !== "number" ||
+        !Number.isSafeInteger(targetIndex) || targetIndex < 0
+      ) return topicsOperationFailure();
+      await syncResultTopology();
+      const target = topicsCell(["topics", targetIndex]).resolveAsCell();
+      await target.sync();
+      await target.pull();
+      const fid = /fid1:[A-Za-z0-9_-]+/.exec(
+        target.getAsNormalizedFullLink().id,
+      )?.[0];
+      if (!fid) return topicsOperationFailure();
+      return await handlers.topicsDiagnosticsSend({
+        target: ["topics", sourceIndex, "setBody"],
+        event: { body: `Reference ${fid}` },
+        idle,
+      }) as TopicsDiagnosticsOperationOutcome;
+    } catch {
+      return topicsOperationFailure();
+    }
+  },
+
+  async topicsDiagnosticsValidateCrossrefs({ topicCount }) {
+    try {
+      if (
+        typeof topicCount !== "number" ||
+        !Number.isSafeInteger(topicCount) ||
+        topicCount < 2
+      ) {
+        return {
+          ok: false,
+          validatedSources: 0,
+        } satisfies TopicsDiagnosticsCrossrefValidation;
+      }
+      await syncResultTopology();
+      const target = topicsCell(["topics", 0]).resolveAsCell();
+      await target.sync();
+      await target.pull();
+      const targetLink = target.getAsNormalizedFullLink();
+      const sourceLinks: NormalizedFullLink[] = [];
+      for (let index = 1; index < topicCount; index++) {
+        const refsOut = topicsCell(["topics", index, "crossrefs", "refsOut"]);
+        await refsOut.sync();
+        const values = await refsOut.pull();
+        if (!Array.isArray(values) || values.length !== 1) {
+          return { ok: false, validatedSources: index - 1 };
+        }
+        const referenced = refsOut.key(0).resolveAsCell();
+        await referenced.sync();
+        await referenced.pull();
+        if (!areLinksSame(referenced.getAsNormalizedFullLink(), targetLink)) {
+          return { ok: false, validatedSources: index - 1 };
+        }
+        const source = topicsCell(["topics", index]).resolveAsCell();
+        await source.sync();
+        await source.pull();
+        sourceLinks.push(source.getAsNormalizedFullLink());
+      }
+      const referencedBy = topicsCell([
+        "topics",
+        0,
+        "crossrefs",
+        "referencedBy",
+      ]);
+      await referencedBy.sync();
+      const backlinks = await referencedBy.pull();
+      if (!Array.isArray(backlinks) || backlinks.length !== topicCount - 1) {
+        return { ok: false, validatedSources: sourceLinks.length };
+      }
+      for (const [index] of backlinks.entries()) {
+        const backlink = referencedBy.key(index).resolveAsCell();
+        await backlink.sync();
+        await backlink.pull();
+        if (
+          !areLinksSame(
+            backlink.getAsNormalizedFullLink(),
+            sourceLinks[index],
+          )
+        ) {
+          return { ok: false, validatedSources: sourceLinks.length };
+        }
+      }
+      return {
+        ok: true,
+        validatedSources: sourceLinks.length,
+      } satisfies TopicsDiagnosticsCrossrefValidation;
+    } catch {
+      return {
+        ok: false,
+        validatedSources: 0,
+      } satisfies TopicsDiagnosticsCrossrefValidation;
+    }
   },
 
   // Raw replica read: a storage-transaction read at an explicit address,
@@ -432,8 +1535,18 @@ const handlers: Record<
     return {};
   },
 
-  async diagnostics() {
-    await idle();
+  async settled() {
+    await settled();
+    return {};
+  },
+
+  async delayedFramesDrained() {
+    await awaitDelayedFramesDrained();
+    return {};
+  },
+
+  async diagnostics({ idle: doIdle } = {}) {
+    if (doIdle !== false) await idle();
     const scheduler = controller().manager().runtime.scheduler;
     return sanitizeForTransfer(
       {
@@ -444,31 +1557,127 @@ const handlers: Record<
     );
   },
 
-  async loggerCounts() {
-    await idle();
+  async diagnosticsSummary({ idle: doIdle } = {}) {
+    if (doIdle !== false) await idle();
+    const scheduler = controller().manager().runtime.scheduler;
+    const graph = scheduler.getGraphSnapshot();
+    const settleStatsHistory = scheduler.getSettleStatsHistory();
+    return {
+      nodeCount: graph.nodes.length,
+      edgeCount: graph.edges.length,
+      dirtyNodeCount: graph.nodes.filter((node) => node.isDirty).length,
+      pendingNodeCount: graph.nodes.filter((node) => node.isPending).length,
+      settleHistoryEntryCount: settleStatsHistory.length,
+      maxTrailingSettleDurationMs: trailingSettleDuration(settleStatsHistory),
+    } satisfies RuntimeDiagnosticsSummary;
+  },
+
+  async topicsDiagnosticsChurn({ idle: doIdle } = {}) {
+    if (doIdle !== false) await idle();
+    const storage = getLoggerCountsBreakdown()["storage.v2"] ?? {};
+    return {
+      commitConflicts: storage["commit-conflict"]?.total ?? 0,
+      commitPreempted: storage["commit-preempted"]?.total ?? 0,
+      commitHeldRevert: storage["commit-held-revert"]?.total ?? 0,
+      commitHeldSent: storage["commit-held-sent"]?.total ?? 0,
+      commitReverts: storage["commit-revert"]?.total ?? 0,
+      commitRejected: storage["commit-rejected"]?.total ?? 0,
+    } satisfies TopicsDiagnosticsChurnTotals;
+  },
+
+  diagnosticsActivityGeneration() {
+    return Promise.resolve({ generation: diagnosticsActivityGeneration });
+  },
+
+  telemetry() {
+    if (!telemetry) {
+      throw new Error("runtime telemetry requires diagnostics: true");
+    }
+    return Promise.resolve(sanitizeForTransfer(telemetry.snapshotAndReset()));
+  },
+
+  async loggerCounts({ idle: doIdle } = {}) {
+    if (doIdle !== false) await idle();
     return getLoggerCountsBreakdown();
   },
 
   async dispose() {
-    resultSinkCancel?.();
-    resultSinkCancel = undefined;
-    piece = undefined;
-    if (cc) {
-      await cc.dispose();
-      cc = undefined;
+    const aggregate = aggregateOnlyDiagnostics;
+    try {
+      pendingContainingDocumentRootCommit = undefined;
+      closeTopicsChannels();
+      resultSinkCancel?.();
+      resultSinkCancel = undefined;
+      if (telemetryListener && cc) {
+        cc.manager().runtime.telemetry.removeEventListener(
+          "telemetry",
+          telemetryListener,
+        );
+      }
+      telemetryListener = undefined;
+      releaseDetailedEventCommitTelemetry?.();
+      releaseDetailedEventCommitTelemetry = undefined;
+      telemetry = undefined;
+      piece = undefined;
+      if (cc) {
+        await cc.dispose();
+        cc = undefined;
+      }
+      return aggregate ? fixedSuccess() : {};
+    } catch {
+      return aggregate ? fixedFailure() : {};
+    } finally {
+      diagnosticsEnabled = false;
+      aggregateOnlyDiagnostics = false;
+      aggregateBootstrapCreator = false;
+      aggregateBootstrapChannel = undefined;
+      aggregateBootstrapParticipants = 0;
+      diagnosticMutationsEnabled = false;
+      diagnosticsActivityGeneration = 0;
+      if (!aggregate) restoreAggregateConsole?.();
     }
-    return {};
   },
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 
+const aggregateOnlyCommands = new Set([
+  "init",
+  "createPiece",
+  "idle",
+  "settled",
+  "delayedFramesDrained",
+  "diagnosticsSummary",
+  "diagnosticsActivityGeneration",
+  "telemetry",
+  "dispose",
+  "topicsDiagnosticsChurn",
+  "topicsDiagnosticsSummary",
+  "topicsDiagnosticsPrepareBootstrap",
+  "topicsDiagnosticsFinishBootstrap",
+  "topicsDiagnosticsConvergenceBegin",
+  "topicsDiagnosticsConvergencePublish",
+  "topicsDiagnosticsConvergenceFinish",
+  "topicsDiagnosticsConvergenceCancel",
+  "topicsDiagnosticsSend",
+  "topicsDiagnosticsSet",
+  "topicsDiagnosticsNoop",
+  "topicsDiagnosticsPrepareReversedRoot",
+  "topicsDiagnosticsCommitPreparedRoot",
+  "topicsDiagnosticsCreateCrossref",
+  "topicsDiagnosticsValidateCrossrefs",
+]);
+
 self.onmessage = (event: MessageEvent<WorkerRequest>) => {
   const { id, cmd, args } = event.data;
   const handler = handlers[cmd];
   const respond = (response: WorkerResponse) =>
     (self as unknown as Worker).postMessage(response);
+  if (aggregateOnlyDiagnostics && !aggregateOnlyCommands.has(cmd)) {
+    respond({ id, error: "operation-failed" });
+    return;
+  }
   if (!handler) {
     respond({ id, error: `unknown command "${cmd}"` });
     return;
@@ -478,7 +1687,9 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
     (error: unknown) =>
       respond({
         id,
-        error: error instanceof Error
+        error: aggregateOnlyDiagnostics
+          ? "operation-failed"
+          : error instanceof Error
           ? `${error.message}\n${error.stack ?? ""}`
           : String(error),
       }),

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -677,13 +677,21 @@ interface TopicsContentProjection {
   createdAt: number;
   createdBy?: TopicsAuthorProjection;
   createdByName: string;
+  bodyUpdatedBy?: TopicsAuthorProjection;
+  bodyUpdatedAt: number;
   comments: {
     author?: TopicsAuthorProjection;
     authorName: string;
     body: string;
     sentAt: number;
   }[];
-  links: { kind: string; url: string; label: string }[];
+  links: {
+    kind: string;
+    url: string;
+    label: string;
+    addedBy?: TopicsAuthorProjection;
+    addedAt: number;
+  }[];
 }
 
 interface TopicsAuthorProjection {
@@ -714,6 +722,8 @@ function topicsContentProjection(
     createdByName: typeof values.createdByName === "string"
       ? values.createdByName
       : "",
+    bodyUpdatedBy: topicsAuthorProjection(values.bodyUpdatedBy),
+    bodyUpdatedAt: asTopicsNumber(values.bodyUpdatedAt),
     comments: asTopicsRecordArray(values.comments).map((comment) => ({
       author: topicsAuthorProjection(comment.author),
       authorName: typeof comment.authorName === "string"
@@ -726,6 +736,8 @@ function topicsContentProjection(
       kind: typeof link.kind === "string" ? link.kind : "",
       url: typeof link.url === "string" ? link.url : "",
       label: typeof link.label === "string" ? link.label : "",
+      addedBy: topicsAuthorProjection(link.addedBy),
+      addedAt: asTopicsNumber(link.addedAt),
     })),
   };
 }

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -295,6 +295,53 @@ let convergencePublishChannels: BroadcastChannel[] = [];
 let privateTopicsEqualityToken: string | undefined;
 let restoreAggregateConsole: (() => void) | undefined;
 
+async function seedDeterministicProfile(): Promise<void> {
+  const runtime = controller().manager().runtime;
+  const userDid = runtime.userIdentityDID;
+  const profileDid = (await Identity.fromPassphrase(
+    `topics-diagnostics-profile:${userDid}`,
+    { implementation: "noble" },
+  )).did();
+  const profileDefaultId = "topics-diagnostics-profile-default";
+
+  const profileTx = runtime.edit();
+  const profileDefault = runtime.getCell<unknown>(
+    profileDid,
+    profileDefaultId,
+    undefined,
+    profileTx,
+  );
+  profileDefault.set({
+    name: "Topics Diagnostics",
+    initialNameApplied: "Topics Diagnostics",
+    avatar: "",
+    bio: "",
+    elements: [],
+  });
+  runtime.getSpaceCell(profileDid, undefined, profileTx).key("defaultPattern")
+    .set(profileDefault);
+  await profileTx.commit();
+  await runtime.idle();
+
+  const homeTx = runtime.edit();
+  const homeDefault = runtime.getCell<unknown>(
+    userDid,
+    "topics-diagnostics-home-default",
+    undefined,
+    homeTx,
+  );
+  const profileLink = runtime.getCell<unknown>(
+    profileDid,
+    profileDefaultId,
+    undefined,
+    homeTx,
+  );
+  homeDefault.key("profiles").set([profileLink]);
+  runtime.getHomeSpaceCell(homeTx).key("defaultPattern").set(homeDefault);
+  await homeTx.commit();
+  await runtime.idle();
+}
+
 function suppressAggregateConsole(): void {
   if (restoreAggregateConsole) return;
   const debug = console.debug;
@@ -628,9 +675,32 @@ interface TopicsContentProjection {
   title: string;
   body: string;
   createdAt: number;
+  createdBy?: TopicsAuthorProjection;
   createdByName: string;
-  comments: { authorName: string; body: string; sentAt: number }[];
+  comments: {
+    author?: TopicsAuthorProjection;
+    authorName: string;
+    body: string;
+    sentAt: number;
+  }[];
   links: { kind: string; url: string; label: string }[];
+}
+
+interface TopicsAuthorProjection {
+  kind: string;
+  name: string;
+  avatar: string;
+}
+
+function topicsAuthorProjection(
+  value: unknown,
+): TopicsAuthorProjection | undefined {
+  if (!isRecord(value)) return undefined;
+  return {
+    kind: typeof value.kind === "string" ? value.kind : "",
+    name: typeof value.name === "string" ? value.name : "",
+    avatar: typeof value.avatar === "string" ? value.avatar : "",
+  };
 }
 
 function topicsContentProjection(
@@ -640,10 +710,12 @@ function topicsContentProjection(
     title: typeof values.title === "string" ? values.title : "",
     body: typeof values.body === "string" ? values.body : "",
     createdAt: asTopicsNumber(values.createdAt),
+    createdBy: topicsAuthorProjection(values.createdBy),
     createdByName: typeof values.createdByName === "string"
       ? values.createdByName
       : "",
     comments: asTopicsRecordArray(values.comments).map((comment) => ({
+      author: topicsAuthorProjection(comment.author),
       authorName: typeof comment.authorName === "string"
         ? comment.authorName
         : "",
@@ -750,6 +822,7 @@ const handlers: Record<
     aggregateBootstrapChannel: creatorChannel,
     aggregateBootstrapParticipants: creatorParticipants,
     diagnosticMutationsEnabled: enableDiagnosticMutations,
+    bootstrapProfile,
     wsDelayMs,
   }) {
     if (cc) {
@@ -789,6 +862,7 @@ const handlers: Record<
     diagnosticsEnabled = diagnostics === true;
     diagnosticMutationsEnabled = enableDiagnosticMutations === true;
     diagnosticsActivityGeneration = 0;
+    if (bootstrapProfile === true) await seedDeterministicProfile();
     if (diagnosticsEnabled) {
       const runtime = controller().manager().runtime;
       const scheduler = runtime.scheduler;
@@ -1166,7 +1240,7 @@ const handlers: Record<
       }) as TopicsDiagnosticsOperationOutcome;
       const sendOutcome = await handlers.topicsDiagnosticsSend({
         target: ["topics", topicIndex, "setBody"],
-        event: { body: bodyValue },
+        event: { body: bodyValue, agentName: "Topics Diagnostics" },
         idle,
       }) as TopicsDiagnosticsOperationOutcome;
       const ok = setOutcome.ok && sendOutcome.ok;
@@ -1428,7 +1502,7 @@ const handlers: Record<
       if (!fid) return topicsOperationFailure();
       return await handlers.topicsDiagnosticsSend({
         target: ["topics", sourceIndex, "setBody"],
-        event: { body: `Reference ${fid}` },
+        event: { body: `Reference ${fid}`, agentName: "Topics Diagnostics" },
         idle,
       }) as TopicsDiagnosticsOperationOutcome;
     } catch {

--- a/packages/patterns/integration/telemetry-path-shape.ts
+++ b/packages/patterns/integration/telemetry-path-shape.ts
@@ -1,0 +1,11 @@
+/** Redacts structural write paths to a fixed, content-free vocabulary. */
+export function writePathShape(path: string): string {
+  const segments = path.split("/").filter((segment) => segment.length > 0);
+  if (segments.length === 0) return "$root";
+  return segments.map((segment) => {
+    if (segment === "value") return "value";
+    if (segment === "metadata") return "metadata";
+    if (/^\d+$/.test(segment)) return "#";
+    return "*";
+  }).join("/");
+}

--- a/packages/patterns/integration/topics-diagnose-scripted.test.ts
+++ b/packages/patterns/integration/topics-diagnose-scripted.test.ts
@@ -1,0 +1,791 @@
+import { assertEquals } from "@std/assert";
+import type {
+  CommitTelemetrySnapshot,
+  MultiRuntimeHarnessOptions,
+  RuntimeDiagnosticsSummary,
+  RuntimeTelemetrySnapshot,
+  TopicsDiagnosticsChurnTotals,
+  TopicsDiagnosticsCrossrefValidation,
+  TopicsDiagnosticsNoopOutcome,
+  TopicsDiagnosticsOperationOutcome,
+  TopicsDiagnosticsSummary,
+} from "./multi-runtime-harness.ts";
+import {
+  createTopicsDiagnosticsHarness,
+  runTopicsDiagnostics,
+  runTopicsDiagnosticsCli,
+  type TopicsDiagnosticsCase,
+  type TopicsDiagnosticsConfig,
+  TopicsDiagnosticsError,
+  type TopicsDiagnosticsErrorCode,
+  type TopicsDiagnosticsHarness,
+  type TopicsDiagnosticsReport,
+  type TopicsDiagnosticsSession,
+} from "../tools/topics-diagnose.ts";
+
+interface Script {
+  cardinalityFailure?: boolean;
+  concurrentFailure?: boolean;
+  convergence?: "begin" | "publish" | "finish" | "different";
+  crossrefFailure?: boolean;
+  noopFailure?: boolean;
+  root?: "prepare-failure" | "same-outcomes" | "invalid-telemetry";
+  sequentialFailure?: boolean;
+  setFailure?: boolean;
+  telemetryFailure?: boolean;
+  unexpectedFailure?: boolean;
+}
+
+const telemetry = (successfulEvents = 0): RuntimeTelemetrySnapshot => ({
+  invocationCount: successfulEvents,
+  distinctInvokedEventCount: successfulEvents,
+  distinctSuccessfulEventCount: successfulEvents,
+  distinctDroppedEventCount: 0,
+  droppedEventsByReason: {
+    "piece-load": 0,
+    lineage: 0,
+    preflight: 0,
+    "load-gate": 0,
+  },
+  permanentRejectionsByReason: { "origin-committed": 0, "receipt-exists": 0 },
+  commitMarkerCount: successfulEvents,
+  directCommitCount: 0,
+  successfulCommitCount: successfulEvents,
+  failedAttemptCount: 0,
+  terminalFailureCount: 0,
+  retryMarkerCount: 0,
+  maxRetryAttempt: 0,
+  readCount: 0,
+  writeCount: successfulEvents,
+  changedWriteCount: successfulEvents,
+  writesTruncatedCount: 0,
+  writesByPathShape: successfulEvents === 0
+    ? {}
+    : { "value/field": successfulEvents },
+});
+
+const memoryTelemetry = (script: Script): CommitTelemetrySnapshot => ({
+  transactCount: 0,
+  acceptedCount: 0,
+  rejectedCount: 0,
+  conflictCount: script.root === "invalid-telemetry" ? 0 : 1,
+  replayCount: 0,
+  receivedCommitBytes: { total: 0, max: 0 },
+  confirmedReadEntries: { total: 0, max: 0 },
+  confirmedReadBytes: { total: 0, max: 0 },
+  operationEntries: { total: 0, max: 0 },
+  operationBytes: { total: 0, max: 0 },
+  newlyPersistedRevisions: { total: 0, max: 0 },
+  operationsByType: { set: 0, patch: 0, delete: 0, sqlite: 0 },
+  receivedPatchOperationsByType: {
+    replace: 0,
+    add: 0,
+    remove: 0,
+    move: 0,
+    splice: 0,
+    append: 0,
+    "add-unique": 0,
+    "remove-by-value": 0,
+    increment: 0,
+  },
+  newlyAppliedPatchOperationsByType: {
+    replace: 0,
+    add: 0,
+    remove: 0,
+    move: 0,
+    splice: 0,
+    append: 0,
+    "add-unique": 0,
+    "remove-by-value": 0,
+    increment: 0,
+  },
+  patchesByPathShape: {
+    "value-root": script.root === "invalid-telemetry" ? 0 : 2,
+  },
+  rejectedByName: {},
+});
+
+class ScriptedHarness implements TopicsDiagnosticsHarness {
+  readonly sessions: readonly TopicsDiagnosticsSession[];
+  readonly crossrefs: [number, number][] = [];
+  #comments = 0;
+  #commitCount = 0;
+  #links = 0;
+  #queuedEvents = 0;
+  #topics = 0;
+  cancelCalls = 0;
+  disposeCalls = 0;
+  readonly sensitiveInputs: string[] = [];
+
+  constructor(
+    readonly topicCount: number,
+    sessionCount: number,
+    readonly script: Script = {},
+  ) {
+    this.sessions = Array.from(
+      { length: sessionCount },
+      () => new ScriptedSession(this),
+    );
+  }
+
+  async diagnosticsBarrier(): Promise<void> {
+    await Promise.resolve();
+    if (this.script.unexpectedFailure) {
+      throw new Error("private runtime failure");
+    }
+  }
+
+  memoryTelemetry(): CommitTelemetrySnapshot {
+    return memoryTelemetry(this.script);
+  }
+
+  async dispose(): Promise<void> {
+    await Promise.resolve();
+    this.disposeCalls++;
+  }
+
+  counts(): { topics: number; comments: number; links: number } {
+    return {
+      topics: this.#topics,
+      comments: this.#comments,
+      links: this.#links,
+    };
+  }
+
+  summary(): TopicsDiagnosticsSummary {
+    const counts = this.counts();
+    return this.script.cardinalityFailure
+      ? {
+        ok: true,
+        topics: counts.topics + 1,
+        comments: counts.comments,
+        links: counts.links,
+      }
+      : {
+        ok: true,
+        ...counts,
+      };
+  }
+
+  enqueue(): void {
+    this.#queuedEvents++;
+  }
+
+  nextTelemetry(): RuntimeTelemetrySnapshot {
+    const snapshot = telemetry(
+      this.#queuedEvents + (this.script.telemetryFailure ? 1 : 0),
+    );
+    this.#queuedEvents = 0;
+    return snapshot;
+  }
+
+  addTopic(): TopicsDiagnosticsOperationOutcome {
+    if (this.script.sequentialFailure && this.#topics === 0) {
+      return { ok: false };
+    }
+    if (this.script.concurrentFailure) return { ok: false };
+    this.#topics++;
+    this.enqueue();
+    return { ok: true };
+  }
+
+  addComment(): TopicsDiagnosticsOperationOutcome {
+    if (this.script.concurrentFailure) return { ok: false };
+    this.#comments++;
+    this.enqueue();
+    return { ok: true };
+  }
+
+  addLink(): TopicsDiagnosticsOperationOutcome {
+    if (this.script.concurrentFailure) return { ok: false };
+    this.#links++;
+    this.enqueue();
+    return { ok: true };
+  }
+
+  prepare(): TopicsDiagnosticsOperationOutcome {
+    return { ok: this.script.root !== "prepare-failure" };
+  }
+
+  commit(): TopicsDiagnosticsOperationOutcome {
+    const ok = this.script.root === "same-outcomes" ||
+      this.#commitCount++ % 2 === 0;
+    return { ok };
+  }
+
+  churn(): TopicsDiagnosticsChurnTotals {
+    const rootConflictOccurred = this.#commitCount > 0;
+    return {
+      commitConflicts: rootConflictOccurred ? 1 : 0,
+      commitPreempted: 0,
+      commitHeldRevert: 0,
+      commitHeldSent: 0,
+      commitReverts: rootConflictOccurred ? 1 : 0,
+      commitRejected: 0,
+    };
+  }
+}
+
+class ScriptedSession implements TopicsDiagnosticsSession {
+  constructor(readonly harness: ScriptedHarness) {}
+
+  async diagnosticsSummary(): Promise<RuntimeDiagnosticsSummary> {
+    await Promise.resolve();
+    return {
+      nodeCount: 0,
+      edgeCount: 0,
+      dirtyNodeCount: 0,
+      pendingNodeCount: 0,
+      settleHistoryEntryCount: 0,
+      maxTrailingSettleDurationMs: 0,
+    };
+  }
+
+  async telemetry(): Promise<RuntimeTelemetrySnapshot> {
+    await Promise.resolve();
+    return this.harness.nextTelemetry();
+  }
+
+  async topicsDiagnosticsSummary(): Promise<TopicsDiagnosticsSummary> {
+    await Promise.resolve();
+    return this.harness.summary();
+  }
+
+  async topicsDiagnosticsChurn(): Promise<TopicsDiagnosticsChurnTotals> {
+    await Promise.resolve();
+    return this.harness.churn();
+  }
+
+  async topicsDiagnosticsSend(
+    ...[target, input]: Parameters<
+      TopicsDiagnosticsSession["topicsDiagnosticsSend"]
+    >
+  ): Promise<TopicsDiagnosticsOperationOutcome> {
+    await Promise.resolve();
+    if (input !== undefined) {
+      this.harness.sensitiveInputs.push(JSON.stringify(input));
+    }
+    if (target === "addTopic") return this.harness.addTopic();
+    if (Array.isArray(target) && target.at(-1) === "addComment") {
+      return this.harness.addComment();
+    }
+    if (Array.isArray(target) && target.at(-1) === "addLink") {
+      return this.harness.addLink();
+    }
+    if (this.harness.script.concurrentFailure) return { ok: false };
+    this.harness.enqueue();
+    return { ok: true };
+  }
+
+  async topicsDiagnosticsSet(
+    ...[_path, value]: Parameters<
+      TopicsDiagnosticsSession["topicsDiagnosticsSet"]
+    >
+  ): Promise<TopicsDiagnosticsOperationOutcome> {
+    await Promise.resolve();
+    this.harness.sensitiveInputs.push(JSON.stringify(value));
+    return { ok: !this.harness.script.setFailure };
+  }
+
+  async topicsDiagnosticsNoop(): Promise<TopicsDiagnosticsNoopOutcome> {
+    await Promise.resolve();
+    const ok = !this.harness.script.noopFailure;
+    if (ok) this.harness.enqueue();
+    return {
+      ok,
+      submitted: 1,
+      directAccepted: ok ? 1 : 0,
+      directRejected: ok ? 0 : 1,
+    };
+  }
+
+  async topicsDiagnosticsPrepareReversedRoot(): Promise<
+    TopicsDiagnosticsOperationOutcome
+  > {
+    await Promise.resolve();
+    return this.harness.prepare();
+  }
+
+  async topicsDiagnosticsCommitPreparedRoot(): Promise<
+    TopicsDiagnosticsOperationOutcome
+  > {
+    await Promise.resolve();
+    return this.harness.commit();
+  }
+
+  async topicsDiagnosticsCreateCrossref(
+    sourceIndex: number,
+    targetIndex: number,
+  ): Promise<TopicsDiagnosticsOperationOutcome> {
+    await Promise.resolve();
+    this.harness.crossrefs.push([sourceIndex, targetIndex]);
+    if (this.harness.script.concurrentFailure) return { ok: false };
+    this.harness.enqueue();
+    return { ok: true };
+  }
+
+  async topicsDiagnosticsValidateCrossrefs(): Promise<
+    TopicsDiagnosticsCrossrefValidation
+  > {
+    await Promise.resolve();
+    return {
+      ok: !this.harness.script.crossrefFailure,
+      validatedSources: this.harness.crossrefs.length,
+    };
+  }
+
+  async topicsDiagnosticsConvergenceBegin(): Promise<
+    { ok: true; ready: true } | { ok: false; error: "operation-failed" }
+  > {
+    await Promise.resolve();
+    return this.harness.script.convergence === "begin"
+      ? { ok: false, error: "operation-failed" }
+      : { ok: true, ready: true };
+  }
+
+  async topicsDiagnosticsConvergencePublish(): Promise<
+    { ok: true } | { ok: false; error: "operation-failed" }
+  > {
+    await Promise.resolve();
+    return this.harness.script.convergence === "publish"
+      ? { ok: false, error: "operation-failed" }
+      : { ok: true };
+  }
+
+  async topicsDiagnosticsConvergenceFinish(): Promise<
+    | {
+      ok: true;
+      converged: boolean;
+      summary: { topics: number[]; comments: number[]; links: number[] };
+    }
+    | { ok: false; error: "operation-failed" }
+  > {
+    await Promise.resolve();
+    if (this.harness.script.convergence === "finish") {
+      return { ok: false, error: "operation-failed" };
+    }
+    const summary = this.harness.counts();
+    return {
+      ok: true,
+      converged: this.harness.script.convergence !== "different",
+      summary: {
+        topics: Array(this.harness.sessions.length).fill(summary.topics),
+        comments: Array(this.harness.sessions.length).fill(
+          summary.comments,
+        ),
+        links: Array(this.harness.sessions.length).fill(summary.links),
+      },
+    };
+  }
+
+  async topicsDiagnosticsConvergenceCancel(): Promise<{ ok: true }> {
+    await Promise.resolve();
+    this.harness.cancelCalls++;
+    return { ok: true };
+  }
+}
+
+interface HarnessExpectation {
+  config: TopicsDiagnosticsConfig;
+  caseConfig: TopicsDiagnosticsCase;
+  sessionCount: number;
+}
+
+function factory(
+  script: Script = {},
+  expectation?: HarnessExpectation,
+): {
+  createHarness: (
+    config: TopicsDiagnosticsConfig,
+    caseConfig: TopicsDiagnosticsCase,
+  ) => Promise<TopicsDiagnosticsHarness>;
+  harnesses: ScriptedHarness[];
+} {
+  const harnesses: ScriptedHarness[] = [];
+  return {
+    harnesses,
+    createHarness: async (config, caseConfig) => {
+      await Promise.resolve();
+      if (expectation !== undefined) {
+        assertEquals(config, expectation.config);
+        assertEquals(caseConfig, expectation.caseConfig);
+        assertEquals(
+          caseConfig.users * config.sessionsPerUser,
+          expectation.sessionCount,
+        );
+      }
+      const harness = new ScriptedHarness(
+        caseConfig.topics,
+        caseConfig.users * config.sessionsPerUser,
+        script,
+      );
+      if (expectation !== undefined) {
+        assertEquals(harness.topicCount, expectation.caseConfig.topics);
+        assertEquals(harness.sessions.length, expectation.sessionCount);
+      }
+      harnesses.push(harness);
+      return harness;
+    },
+  };
+}
+
+async function assertFailure(
+  args: readonly string[],
+  script: Script,
+  expected: TopicsDiagnosticsErrorCode,
+  expectedCancelCalls = 0,
+): Promise<void> {
+  const dependency = factory(script);
+  const report = await runTopicsDiagnostics(args, dependency);
+  const [result] = report.results;
+  if (result === undefined || result.ok) throw new Error("expected failure");
+  assertEquals(result.error, expected);
+  assertEquals(dependency.harnesses.length, 1);
+  assertEquals(dependency.harnesses[0]?.cancelCalls, expectedCancelCalls);
+  assertEquals(dependency.harnesses[0]?.disposeCalls, 1);
+}
+
+Deno.test("Topics diagnostics constructs production harness options without private report data", async () => {
+  const config: TopicsDiagnosticsConfig = {
+    profile: "matrix",
+    program: "topics/main.tsx",
+    topicCounts: [3],
+    userCounts: [2],
+    rounds: 1,
+    typingSteps: 1,
+    sessionsPerUser: 2,
+    wsDelayMs: 7,
+    scenarios: ["noops"],
+  };
+  const scripted = new ScriptedHarness(3, 4);
+  let options: MultiRuntimeHarnessOptions | undefined;
+  let nextId = 0;
+  const harness = await createTopicsDiagnosticsHarness(
+    config,
+    { topics: 3, users: 2 },
+    {
+      randomUUID: () => `id-${++nextId}`,
+      createRuntimeHarness: (value) => {
+        options = value;
+        return Promise.resolve(scripted);
+      },
+    },
+  );
+  if (harness !== scripted || options === undefined) {
+    throw new Error("expected injected runtime harness");
+  }
+  assertEquals(options.programPath.endsWith("/topics/main.tsx"), true);
+  assertEquals(options.diagnostics, true);
+  assertEquals(options.aggregateOnlyDiagnostics, true);
+  assertEquals(options.spaceName, "topics-diagnostics-id-3");
+  const sessionOptions = options.sessions.map((session) => {
+    if (typeof session === "string") {
+      throw new Error("expected configured diagnostic session");
+    }
+    return { label: session.label, wsDelayMs: session.wsDelayMs };
+  });
+  assertEquals(sessionOptions, [
+    { label: "user-1-session-1", wsDelayMs: 7 },
+    { label: "user-1-session-2", wsDelayMs: 7 },
+    { label: "user-2-session-1", wsDelayMs: 7 },
+    { label: "user-2-session-2", wsDelayMs: 7 },
+  ]);
+});
+
+Deno.test("Topics diagnostics CLI prints reports and maps failures to safe exits", async () => {
+  const success: TopicsDiagnosticsReport = {
+    kind: "topics-workload-diagnostics",
+    config: {
+      profile: "matrix",
+      topicCounts: [1],
+      userCounts: [1],
+      rounds: 1,
+      typingSteps: 1,
+      sessionsPerUser: 1,
+      wsDelayMs: 0,
+      scenarios: ["noops"],
+    },
+    elapsedMs: 1,
+    results: [],
+  };
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const exits: number[] = [];
+  const dependencies = {
+    log: (message: string) => logs.push(message),
+    error: (message: string) => errors.push(message),
+    exit: (code: number) => exits.push(code),
+  };
+
+  await runTopicsDiagnosticsCli([], {
+    ...dependencies,
+    run: () => Promise.resolve(success),
+  });
+  assertEquals(JSON.parse(logs[0]), success);
+  assertEquals(errors, []);
+  assertEquals(exits, []);
+
+  await runTopicsDiagnosticsCli([], {
+    ...dependencies,
+    run: () =>
+      Promise.resolve({
+        ...success,
+        results: [{
+          ok: false,
+          case: { topics: 1, users: 1 },
+          error: "phase-operation-failed",
+        }],
+      }),
+  });
+  assertEquals(exits, [1]);
+
+  await runTopicsDiagnosticsCli([], {
+    ...dependencies,
+    run: () =>
+      Promise.reject(new TopicsDiagnosticsError("invalid-configuration")),
+  });
+  assertEquals(errors, ["invalid-configuration"]);
+  assertEquals(exits, [1, 1]);
+});
+
+Deno.test("Topics diagnostics orchestrates all ordinary phases and row-local crossrefs", async () => {
+  const dependency = factory({}, {
+    config: {
+      profile: "matrix",
+      program: "topics/main.tsx",
+      topicCounts: [3],
+      userCounts: [2],
+      rounds: 1,
+      typingSteps: 1,
+      sessionsPerUser: 2,
+      wsDelayMs: 0,
+      scenarios: [
+        "create-topics",
+        "noops",
+        "titles",
+        "comments",
+        "links",
+        "bodies",
+        "crossrefs",
+      ],
+    },
+    caseConfig: { topics: 3, users: 2 },
+    sessionCount: 4,
+  });
+  const report = await runTopicsDiagnostics([
+    "--quick",
+    "--topics=3",
+    "--users=2",
+    "--rounds=1",
+    "--typing-steps=1",
+    "--sessions-per-user=2",
+    "--scenario=create-topics,noops,titles,comments,links,bodies,crossrefs",
+  ], dependency);
+  const [result] = report.results;
+  if (result === undefined || !result.ok) throw new Error("expected success");
+  assertEquals(result.result.phases.map((phase) => phase.phase), [
+    "concurrent-topic-creation",
+    "repeated-noop-writes",
+    "live-title-typing",
+    "concurrent-comments",
+    "concurrent-links",
+    "concurrent-body-saves",
+    "cross-reference-fanout",
+  ]);
+  const [harness] = dependency.harnesses;
+  if (harness === undefined) throw new Error("expected scripted harness");
+  assertEquals(harness.crossrefs, [[1, 0], [2, 0]]);
+  assertEquals(result.result.convergence, {
+    converged: true,
+    summary: {
+      topics: [3, 3, 3, 3],
+      comments: [4, 4, 4, 4],
+      links: [4, 4, 4, 4],
+    },
+  });
+  assertEquals(result.result.phases.map((phase) => phase.telemetry), [
+    telemetry(3),
+    telemetry(3),
+    telemetry(),
+    telemetry(4),
+    telemetry(4),
+    telemetry(4),
+    telemetry(2),
+  ]);
+  assertEquals(result.result.phases[1].derivedTelemetry, {
+    attemptedWritesPerSubmittedOperation: 1,
+    changedWritesPerSubmittedOperation: 1,
+    elidedNoopCandidateWrites: 0,
+  });
+  assertEquals(harness.cancelCalls, 1);
+  assertEquals(harness.disposeCalls, 1);
+  const serializedReport = JSON.stringify(report);
+  for (
+    const sensitiveFragment of [
+      "diagnostic-",
+      "Topics Diagnostics",
+      "https://",
+      "did:",
+    ]
+  ) {
+    assertEquals(serializedReport.includes(sensitiveFragment), false);
+  }
+  for (const sensitiveInput of harness.sensitiveInputs) {
+    assertEquals(serializedReport.includes(sensitiveInput), false);
+  }
+});
+
+Deno.test("Topics diagnostics reports successful conflict metrics and disposes its convergence channel", async () => {
+  const dependency = factory({}, {
+    config: {
+      profile: "conflicts",
+      program: "topics/main.tsx",
+      topicCounts: [2],
+      userCounts: [1],
+      rounds: 1,
+      typingSteps: 2,
+      sessionsPerUser: 2,
+      wsDelayMs: 10,
+      scenarios: ["root-oscillation"],
+    },
+    caseConfig: { topics: 2, users: 1 },
+    sessionCount: 2,
+  });
+  const report = await runTopicsDiagnostics([
+    "--profile=conflicts",
+    "--users=1",
+    "--rounds=1",
+  ], dependency);
+  const [result] = report.results;
+  if (result === undefined || !result.ok) throw new Error("expected success");
+  assertEquals(result.result.phases.map((phase) => phase.phase), [
+    "setup-topics",
+    "alternating-whole-root-oscillation",
+  ]);
+  const oscillation = result.result.phases[1];
+  if (oscillation === undefined) throw new Error("expected conflict phase");
+  assertEquals(oscillation.operations, {
+    submitted: 4,
+    directAccepted: 2,
+    directRejected: 2,
+  });
+  assertEquals(oscillation.memoryTelemetry.conflictCount, 1);
+  assertEquals(oscillation.churn, {
+    commitConflicts: 2,
+    commitPreempted: 0,
+    commitHeldRevert: 0,
+    commitHeldSent: 0,
+    commitReverts: 2,
+    commitRejected: 0,
+  });
+  assertEquals(oscillation.rootOscillation, {
+    distinctStateCount: 2,
+    targetWriteCount: 2,
+    twoStepEligibleCount: 0,
+    twoStepRepeatCount: 0,
+    twoStepRepeatRatio: null,
+  });
+  const [harness] = dependency.harnesses;
+  if (harness === undefined) throw new Error("expected scripted harness");
+  assertEquals(harness.cancelCalls, 1);
+  assertEquals(harness.disposeCalls, 1);
+});
+
+Deno.test("Topics diagnostics reports phase operation and verification failures safely", async () => {
+  await assertFailure(
+    ["--quick", "--topics=2", "--users=1", "--scenario=noops"],
+    { sequentialFailure: true },
+    "phase-operation-failed",
+  );
+  await assertFailure(
+    ["--quick", "--topics=2", "--users=2", "--scenario=create-topics"],
+    { concurrentFailure: true },
+    "phase-operation-failed",
+  );
+  await assertFailure(
+    ["--quick", "--topics=2", "--users=1", "--scenario=titles"],
+    { setFailure: true },
+    "phase-operation-failed",
+  );
+  await assertFailure(
+    ["--quick", "--topics=2", "--users=1", "--scenario=noops"],
+    { noopFailure: true },
+    "phase-operation-failed",
+  );
+  await assertFailure(
+    ["--quick", "--topics=2", "--users=1", "--scenario=noops"],
+    { telemetryFailure: true },
+    "phase-operation-failed",
+  );
+  await assertFailure(
+    ["--quick", "--topics=2", "--users=1", "--scenario=comments"],
+    { cardinalityFailure: true },
+    "phase-verification-failed",
+  );
+  await assertFailure(
+    ["--quick", "--topics=3", "--users=1", "--scenario=crossrefs"],
+    { crossrefFailure: true },
+    "phase-verification-failed",
+  );
+});
+
+Deno.test("Topics diagnostics reports root and convergence failures safely", async () => {
+  for (
+    const root of [
+      "prepare-failure",
+      "same-outcomes",
+      "invalid-telemetry",
+    ] as const
+  ) {
+    await assertFailure(
+      ["--profile=conflicts", "--rounds=1"],
+      { root },
+      root === "same-outcomes" || root === "invalid-telemetry"
+        ? "root-oscillation-failed"
+        : "phase-operation-failed",
+    );
+  }
+  for (
+    const convergence of ["begin", "publish", "finish", "different"] as const
+  ) {
+    await assertFailure(
+      ["--quick", "--topics=1", "--users=1", "--scenario=noops"],
+      { convergence },
+      "convergence-failed",
+      convergence === "begin" ? 0 : 1,
+    );
+  }
+});
+
+Deno.test("Topics diagnostics classifies harness and per-case failures safely", async () => {
+  const initialization = await runTopicsDiagnostics(["--quick"], {
+    createHarness: () => Promise.reject(new Error("private initialization")),
+  });
+  assertEquals(initialization.results[0], {
+    ok: false,
+    case: { topics: 2, users: 2 },
+    error: "harness-initialization-failed",
+  });
+
+  const dependency = factory();
+  const report = await runTopicsDiagnostics([
+    "--quick",
+    "--cases=1x1,2x1",
+    "--scenario=noops",
+  ], {
+    createHarness: (_config, caseConfig) => {
+      if (caseConfig.topics === 1) {
+        return Promise.resolve(
+          new ScriptedHarness(1, 1, {
+            unexpectedFailure: true,
+          }),
+        );
+      }
+      return dependency.createHarness(_config, caseConfig);
+    },
+  });
+  assertEquals(report.results.map((result) => result.ok), [false, true]);
+  const [failed] = report.results;
+  if (failed === undefined || failed.ok) throw new Error("expected failure");
+  assertEquals(failed.error, "unknown-error");
+});

--- a/packages/patterns/integration/topics-diagnose-scripted.test.ts
+++ b/packages/patterns/integration/topics-diagnose-scripted.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import type {
   CommitTelemetrySnapshot,
   MultiRuntimeHarnessOptions,
@@ -546,6 +546,14 @@ Deno.test("Topics diagnostics CLI prints reports and maps failures to safe exits
   });
   assertEquals(errors, ["invalid-configuration"]);
   assertEquals(exits, [1, 1]);
+});
+
+Deno.test("Topics diagnostics maps invalid arguments to a safe error", async () => {
+  await assertRejects(
+    () => runTopicsDiagnostics(["--unsupported"]),
+    TopicsDiagnosticsError,
+    "invalid-configuration",
+  );
 });
 
 Deno.test("Topics diagnostics orchestrates all ordinary phases and row-local crossrefs", async () => {

--- a/packages/patterns/integration/topics-diagnose.test.ts
+++ b/packages/patterns/integration/topics-diagnose.test.ts
@@ -71,6 +71,87 @@ Deno.test("Topics diagnostics classifies invalid CLI configuration", async () =>
   assertEquals(reportSafeErrorCode(error), "invalid-configuration");
 });
 
+Deno.test("Topics diagnostics runs aggregate-only matrix phases", async () => {
+  const report = await runTopicsDiagnostics([
+    "--quick",
+    "--topics=2",
+    "--users=2",
+    "--sessions-per-user=1",
+    "--rounds=1",
+    "--typing-steps=1",
+    "--scenario=create-topics,noops,titles,comments,links,bodies,crossrefs",
+    "--cases=2x2,3x2",
+  ]);
+
+  assertEquals(report.kind, "topics-workload-diagnostics");
+  assertEquals(report.results.length, 2);
+  for (const [index, result] of report.results.entries()) {
+    if (!result.ok) throw new Error(`diagnostics failed: ${result.error}`);
+    const topicCount = index + 2;
+    assertEquals(result.result.case, { topics: topicCount, users: 2 });
+    assertEquals(result.result.convergence.converged, true);
+    assertEquals(
+      result.result.phases.map((phase) => phase.phase),
+      [
+        "concurrent-topic-creation",
+        "repeated-noop-writes",
+        "live-title-typing",
+        "concurrent-comments",
+        "concurrent-links",
+        "concurrent-body-saves",
+        "cross-reference-fanout",
+      ],
+    );
+    assertEquals(result.result.convergence.summary, {
+      topics: [topicCount, topicCount],
+      comments: [2, 2],
+      links: [2, 2],
+    });
+    for (const phase of result.result.phases) {
+      assertEquals(phase.telemetry.distinctDroppedEventCount, 0);
+      assertEquals(phase.telemetry.terminalFailureCount, 0);
+      assertEquals(phase.graph.postSettleMaxPendingAcrossSessions, 0);
+      assertEquals(phase.derivedTelemetry.elidedNoopCandidateWrites >= 0, true);
+      const serialized = JSON.stringify(phase);
+      assertEquals(serialized.includes("diagnostic-"), false);
+      assertEquals(serialized.includes("did:"), false);
+      assertEquals(serialized.includes("https://"), false);
+    }
+  }
+  const serializedReport = JSON.stringify(report);
+  assertEquals(serializedReport.includes("diagnostic-"), false);
+  assertEquals(serializedReport.includes("did:"), false);
+  assertEquals(serializedReport.includes("https://"), false);
+});
+
+Deno.test("Topics diagnostics runs aggregate-only conflict phase", async () => {
+  const report = await runTopicsDiagnostics([
+    "--profile=conflicts",
+    "--quick",
+    "--rounds=1",
+  ]);
+
+  const [result] = report.results;
+  if (!result.ok) throw new Error(`diagnostics failed: ${result.error}`);
+  assertEquals(
+    result.result.phases.map((phase) => phase.phase),
+    [
+      "setup-topics",
+      "alternating-whole-root-oscillation",
+    ],
+  );
+  assertEquals(result.result.convergence.converged, true);
+  const oscillation = result.result.phases[1];
+  assertEquals(oscillation.rootOscillation?.targetWriteCount, 2);
+  assertEquals(oscillation.memoryTelemetry.conflictCount > 0, true);
+  for (const phase of result.result.phases) {
+    const serialized = JSON.stringify(phase);
+    assertEquals(serialized.includes("diagnostic-"), false);
+    assertEquals(serialized.includes("did:"), false);
+    assertEquals(serialized.includes("https://"), false);
+  }
+});
+
 Deno.test("Topics diagnostics reduces content-free runtime summaries", () => {
   const summaries = [
     {

--- a/packages/patterns/integration/topics-diagnose.test.ts
+++ b/packages/patterns/integration/topics-diagnose.test.ts
@@ -1,213 +1,28 @@
-import { assertEquals, assertRejects, assertThrows } from "@std/assert";
-import { MultiRuntimeHarness } from "../integration/multi-runtime-harness.ts";
-import {
-  casesFromArgs,
-  configFromArgs,
-  deriveTelemetry,
-  rootOscillationMetadata,
-  writePathShape,
-} from "./topics-diagnose-config.ts";
+import { assertEquals, assertRejects } from "@std/assert";
+import { MultiRuntimeHarness } from "./multi-runtime-harness.ts";
 import {
   graphSummary,
   reportSafeErrorCode,
   runTopicsDiagnostics,
   settleSummary,
   TopicsDiagnosticsError,
-} from "./topics-diagnose.ts";
+} from "../tools/topics-diagnose.ts";
 
-Deno.test("Topics diagnostics validates explicit matrix arguments", () => {
-  const config = configFromArgs([
-    "--topics=2,4",
-    "--users=1,3",
-    "--rounds=2",
-    "--typing-steps=3",
-    "--sessions-per-user=2",
-    "--ws-delay-ms=5",
-    "--scenario=comments,bodies",
-  ]);
-  assertEquals(config.topicCounts, [2, 4]);
-  assertEquals(config.userCounts, [1, 3]);
-  assertEquals(config.scenarios, ["comments", "bodies"]);
-  assertEquals(casesFromArgs(["--cases=2x1,4x3"], config), [
-    { topics: 2, users: 1 },
-    { topics: 4, users: 3 },
-  ]);
-  assertThrows(() => configFromArgs(["--topics="]));
-  assertThrows(() => configFromArgs(["--users=0"]));
-  assertThrows(() => configFromArgs(["--scenario=unknown"]));
-  assertThrows(() => casesFromArgs(["--cases=2by3"], config));
-});
+// Covered by tools/topics-diagnose-config.test.ts.
 
-Deno.test("Topics diagnostics requires two topics for crossrefs only", () => {
-  const crossrefs = configFromArgs(["--scenario=crossrefs"]);
-  assertThrows(() => casesFromArgs(["--cases=1x1"], crossrefs));
-  const generatedCrossrefs = configFromArgs([
-    "--topics=1",
-    "--users=1",
-    "--scenario=crossrefs",
-  ]);
-  assertThrows(() => casesFromArgs([], generatedCrossrefs));
-  const comments = configFromArgs(["--scenario=comments"]);
-  assertEquals(casesFromArgs(["--cases=1x1"], comments), [{
-    topics: 1,
-    users: 1,
-  }]);
-});
+// Covered by tools/topics-diagnose-config.test.ts.
 
-Deno.test("Topics diagnostics applies conflicts profile defaults before explicit overrides", () => {
-  const conflicts = configFromArgs(["--profile=conflicts"]);
-  assertEquals(conflicts, {
-    profile: "conflicts",
-    program: "topics/main.tsx",
-    topicCounts: [2],
-    userCounts: [2],
-    rounds: 4,
-    typingSteps: 2,
-    sessionsPerUser: 2,
-    wsDelayMs: 10,
-    scenarios: ["root-oscillation"],
-  });
-  assertEquals(configFromArgs(["--profile=conflicts", "--quick"]).rounds, 2);
+// Covered by tools/topics-diagnose-config.test.ts.
 
-  const overridden = configFromArgs([
-    "--profile=conflicts",
-    "--topics=3",
-    "--users=4",
-    "--rounds=7",
-    "--typing-steps=6",
-    "--sessions-per-user=1",
-    "--ws-delay-ms=0",
-    "--scenario=comments",
-  ]);
-  assertEquals(overridden.topicCounts, [3]);
-  assertEquals(overridden.userCounts, [4]);
-  assertEquals(overridden.rounds, 7);
-  assertEquals(overridden.typingSteps, 6);
-  assertEquals(overridden.sessionsPerUser, 1);
-  assertEquals(overridden.wsDelayMs, 0);
-  assertEquals(overridden.scenarios, ["comments"]);
-  assertThrows(() => configFromArgs(["--profile=missing"]));
-});
+// Covered by tools/topics-diagnose-config.test.ts.
 
-Deno.test("Topics diagnostics keeps root oscillation opt-in for matrix runs", () => {
-  assertEquals(configFromArgs(["--quick"]).scenarios, [
-    "names",
-    "create-topics",
-    "noops",
-    "titles",
-    "comments",
-    "links",
-    "bodies",
-    "crossrefs",
-  ]);
-  assertEquals(
-    configFromArgs(["--quick", "--scenario=all"]).scenarios.at(-1),
-    "root-oscillation",
-  );
-});
+// Covered by tools/topics-diagnose-config.test.ts.
 
-Deno.test("Topics diagnostics validates root oscillation topology", () => {
-  const oneTopic = configFromArgs([
-    "--profile=conflicts",
-    "--topics=1",
-  ]);
-  assertThrows(() => casesFromArgs([], oneTopic));
-  const oneSession = configFromArgs([
-    "--profile=conflicts",
-    "--users=1",
-    "--sessions-per-user=1",
-  ]);
-  assertThrows(() => casesFromArgs([], oneSession));
-  const zeroRounds = configFromArgs([
-    "--profile=conflicts",
-    "--rounds=0",
-  ]);
-  assertThrows(() => casesFromArgs([], zeroRounds));
-  const oneRound = configFromArgs([
-    "--profile=conflicts",
-    "--rounds=1",
-  ]);
-  assertEquals(casesFromArgs([], oneRound), [{ topics: 2, users: 2 }]);
-});
+// Covered by tools/topics-diagnose-config.test.ts.
 
-Deno.test("Topics diagnostics derives write amplification ratios without negatives", () => {
-  const telemetry = {
-    invocationCount: 2,
-    distinctInvokedEventCount: 2,
-    distinctSuccessfulEventCount: 1,
-    distinctDroppedEventCount: 1,
-    droppedEventsByReason: {
-      "piece-load": 0,
-      lineage: 1,
-      preflight: 0,
-      "load-gate": 0,
-    },
-    permanentRejectionsByReason: {
-      "origin-committed": 0,
-      "receipt-exists": 1,
-    },
-    commitMarkerCount: 3,
-    directCommitCount: 0,
-    successfulCommitCount: 2,
-    failedAttemptCount: 1,
-    terminalFailureCount: 0,
-    retryMarkerCount: 1,
-    maxRetryAttempt: 2,
-    readCount: 4,
-    writeCount: 5,
-    changedWriteCount: 3,
-    writesTruncatedCount: 0,
-    writesByPathShape: { "value/*": 3 },
-  };
-  assertEquals(deriveTelemetry(telemetry, 2), {
-    changedWritesPerSubmittedOperation: 1.5,
-    attemptedWritesPerSubmittedOperation: 2.5,
-    elidedNoopCandidateWrites: 2,
-  });
-  assertEquals(deriveTelemetry({ ...telemetry, changedWriteCount: 8 }, 0), {
-    changedWritesPerSubmittedOperation: 0,
-    attemptedWritesPerSubmittedOperation: 0,
-    elidedNoopCandidateWrites: 0,
-  });
-});
+// Covered by tools/topics-diagnose-config.test.ts.
 
-Deno.test("Topics diagnostics redacts write path keys", () => {
-  const shape = writePathShape("value/did:key:private/topic-content/17");
-  assertEquals(shape, "value/*/*/#");
-  assertEquals(shape.includes("did:key"), false);
-  assertEquals(shape.includes("content"), false);
-});
-
-Deno.test("Topics diagnostics reports bounded root oscillation repeat metadata", () => {
-  assertEquals(rootOscillationMetadata([]), {
-    distinctStateCount: 0,
-    targetWriteCount: 0,
-    twoStepEligibleCount: 0,
-    twoStepRepeatCount: 0,
-    twoStepRepeatRatio: null,
-  });
-  assertEquals(rootOscillationMetadata([0]), {
-    distinctStateCount: 1,
-    targetWriteCount: 1,
-    twoStepEligibleCount: 0,
-    twoStepRepeatCount: 0,
-    twoStepRepeatRatio: null,
-  });
-  assertEquals(rootOscillationMetadata([0, 1]), {
-    distinctStateCount: 2,
-    targetWriteCount: 2,
-    twoStepEligibleCount: 0,
-    twoStepRepeatCount: 0,
-    twoStepRepeatRatio: null,
-  });
-  assertEquals(rootOscillationMetadata([0, 1, 0, 1]), {
-    distinctStateCount: 2,
-    targetWriteCount: 4,
-    twoStepEligibleCount: 2,
-    twoStepRepeatCount: 2,
-    twoStepRepeatRatio: 1,
-  });
-});
+// Covered by tools/topics-diagnose-config.test.ts.
 
 Deno.test("Topics diagnostics maps report errors to fixed safe codes", () => {
   assertEquals(
@@ -487,4 +302,19 @@ Deno.test("Topics diagnostics RPC responses are aggregate-only", async () => {
   } finally {
     await harness.dispose();
   }
+});
+
+Deno.test("aggregate-only diagnostics reject remote storage before worker creation", async () => {
+  await assertRejects(
+    () =>
+      MultiRuntimeHarness.create({
+        programPath: new URL("../topics/main.tsx", import.meta.url).pathname,
+        rootPath: new URL("..", import.meta.url).pathname,
+        aggregateOnlyDiagnostics: true,
+        apiUrl: new URL("https://example.invalid/"),
+        sessions: ["remote-rejected"],
+      }),
+    Error,
+    "aggregate-only diagnostics require the local in-process memory server",
+  );
 });

--- a/packages/patterns/integration/topics-diagnose.test.ts
+++ b/packages/patterns/integration/topics-diagnose.test.ts
@@ -1,4 +1,6 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { join, resolve } from "@std/path";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import { MultiRuntimeHarness } from "./multi-runtime-harness.ts";
 import {
   graphSummary,
@@ -7,6 +9,15 @@ import {
   settleSummary,
   TopicsDiagnosticsError,
 } from "../tools/topics-diagnose.ts";
+
+const REPO_ROOT = join(import.meta.dirname!, "..", "..", "..");
+const TOPICS_DIAGNOSE = join(
+  REPO_ROOT,
+  "packages",
+  "patterns",
+  "tools",
+  "topics-diagnose.ts",
+);
 
 // Covered by tools/topics-diagnose-config.test.ts.
 
@@ -69,6 +80,31 @@ Deno.test("Topics diagnostics classifies invalid CLI configuration", async () =>
     error = caught;
   }
   assertEquals(reportSafeErrorCode(error), "invalid-configuration");
+});
+
+Deno.test("Topics diagnostics CLI rejects invalid arguments", async () => {
+  const coverageDir = Deno.env.get("DENO_COVERAGE_DIR");
+  const output = await runDenoCommandWithTemporaryLock({
+    root: REPO_ROOT,
+    env: coverageDir ? { DENO_COVERAGE_DIR: resolve(coverageDir) } : undefined,
+    args: (lockPath) => [
+      "run",
+      "--config",
+      join(REPO_ROOT, "deno.jsonc"),
+      "--lock",
+      lockPath,
+      "--frozen=true",
+      "--allow-all",
+      TOPICS_DIAGNOSE,
+      "--unsupported",
+    ],
+  });
+
+  assertEquals(output.code, 1);
+  assertStringIncludes(
+    new TextDecoder().decode(output.stderr),
+    "invalid-configuration",
+  );
 });
 
 Deno.test("Topics diagnostics reduces content-free runtime summaries", () => {

--- a/packages/patterns/integration/topics-diagnose.test.ts
+++ b/packages/patterns/integration/topics-diagnose.test.ts
@@ -138,15 +138,21 @@ Deno.test("Topics diagnostics RPC responses are aggregate-only", async () => {
     assertEquals(harness.pieceId, "aggregate-only");
     const [first, second] = harness.sessions;
     const adds = await Promise.all([
-      first.topicsDiagnosticsSend("addTopic", { title: "diagnostic-topic-1" }),
-      second.topicsDiagnosticsSend("addTopic", { title: "diagnostic-topic-2" }),
+      first.topicsDiagnosticsSend("addTopic", {
+        title: "diagnostic-topic-1",
+        agentName: "Diagnostics A",
+      }),
+      second.topicsDiagnosticsSend("addTopic", {
+        title: "diagnostic-topic-2",
+        agentName: "Diagnostics B",
+      }),
     ]);
     await harness.diagnosticsBarrier();
     const summary = await first.topicsDiagnosticsSummary();
     await Promise.all(harness.sessions.map((session) => session.telemetry()));
     const sameValueOutcome = await first.topicsDiagnosticsSend(
       ["topics", 0, "setBody"],
-      { body: "" },
+      { body: "", agentName: "Diagnostics A" },
       { idle: false },
     );
     await harness.diagnosticsBarrier();

--- a/packages/patterns/integration/topics-diagnose.test.ts
+++ b/packages/patterns/integration/topics-diagnose.test.ts
@@ -71,87 +71,6 @@ Deno.test("Topics diagnostics classifies invalid CLI configuration", async () =>
   assertEquals(reportSafeErrorCode(error), "invalid-configuration");
 });
 
-Deno.test("Topics diagnostics runs aggregate-only matrix phases", async () => {
-  const report = await runTopicsDiagnostics([
-    "--quick",
-    "--topics=2",
-    "--users=2",
-    "--sessions-per-user=1",
-    "--rounds=1",
-    "--typing-steps=1",
-    "--scenario=create-topics,noops,titles,comments,links,bodies,crossrefs",
-    "--cases=2x2,3x2",
-  ]);
-
-  assertEquals(report.kind, "topics-workload-diagnostics");
-  assertEquals(report.results.length, 2);
-  for (const [index, result] of report.results.entries()) {
-    if (!result.ok) throw new Error(`diagnostics failed: ${result.error}`);
-    const topicCount = index + 2;
-    assertEquals(result.result.case, { topics: topicCount, users: 2 });
-    assertEquals(result.result.convergence.converged, true);
-    assertEquals(
-      result.result.phases.map((phase) => phase.phase),
-      [
-        "concurrent-topic-creation",
-        "repeated-noop-writes",
-        "live-title-typing",
-        "concurrent-comments",
-        "concurrent-links",
-        "concurrent-body-saves",
-        "cross-reference-fanout",
-      ],
-    );
-    assertEquals(result.result.convergence.summary, {
-      topics: [topicCount, topicCount],
-      comments: [2, 2],
-      links: [2, 2],
-    });
-    for (const phase of result.result.phases) {
-      assertEquals(phase.telemetry.distinctDroppedEventCount, 0);
-      assertEquals(phase.telemetry.terminalFailureCount, 0);
-      assertEquals(phase.graph.postSettleMaxPendingAcrossSessions, 0);
-      assertEquals(phase.derivedTelemetry.elidedNoopCandidateWrites >= 0, true);
-      const serialized = JSON.stringify(phase);
-      assertEquals(serialized.includes("diagnostic-"), false);
-      assertEquals(serialized.includes("did:"), false);
-      assertEquals(serialized.includes("https://"), false);
-    }
-  }
-  const serializedReport = JSON.stringify(report);
-  assertEquals(serializedReport.includes("diagnostic-"), false);
-  assertEquals(serializedReport.includes("did:"), false);
-  assertEquals(serializedReport.includes("https://"), false);
-});
-
-Deno.test("Topics diagnostics runs aggregate-only conflict phase", async () => {
-  const report = await runTopicsDiagnostics([
-    "--profile=conflicts",
-    "--quick",
-    "--rounds=1",
-  ]);
-
-  const [result] = report.results;
-  if (!result.ok) throw new Error(`diagnostics failed: ${result.error}`);
-  assertEquals(
-    result.result.phases.map((phase) => phase.phase),
-    [
-      "setup-topics",
-      "alternating-whole-root-oscillation",
-    ],
-  );
-  assertEquals(result.result.convergence.converged, true);
-  const oscillation = result.result.phases[1];
-  assertEquals(oscillation.rootOscillation?.targetWriteCount, 2);
-  assertEquals(oscillation.memoryTelemetry.conflictCount > 0, true);
-  for (const phase of result.result.phases) {
-    const serialized = JSON.stringify(phase);
-    assertEquals(serialized.includes("diagnostic-"), false);
-    assertEquals(serialized.includes("did:"), false);
-    assertEquals(serialized.includes("https://"), false);
-  }
-});
-
 Deno.test("Topics diagnostics reduces content-free runtime summaries", () => {
   const summaries = [
     {
@@ -335,6 +254,12 @@ Deno.test("Topics diagnostics RPC responses are aggregate-only", async () => {
     assertEquals(Object.keys(convergenceReady).sort(), ["ok", "ready"]);
     assertEquals(Object.keys(finish).sort(), ["converged", "ok", "summary"]);
     if (!finish.ok) throw new Error("convergence unexpectedly failed");
+    assertEquals(finish.converged, true);
+    assertEquals(finish.summary, {
+      topics: [2, 2],
+      comments: [0, 0],
+      links: [0, 0],
+    });
     assertEquals(Object.keys(finish.summary).sort(), [
       "comments",
       "links",

--- a/packages/patterns/integration/topics-nested-send.test.ts
+++ b/packages/patterns/integration/topics-nested-send.test.ts
@@ -1,0 +1,268 @@
+import { assert, assertEquals } from "@std/assert";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { isSigilLink } from "@commonfabric/runner/shared";
+import {
+  MultiRuntimeHarness,
+  type MultiRuntimeSession,
+} from "./multi-runtime-harness.ts";
+
+const PROGRAM_PATH = join(import.meta.dirname!, "..", "topics", "main.tsx");
+const ROOT_PATH = join(import.meta.dirname!, "..");
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+async function firstTopic(session: MultiRuntimeSession): Promise<
+  Record<string, unknown>
+> {
+  const topics = await session.read(["topics"]);
+  assert(Array.isArray(topics), "Topics result must expose an array");
+  const topic = topics[0];
+  assert(isRecord(topic), "Topics result must expose the first topic");
+  return topic;
+}
+
+describe("Topics nested stream dispatch across isolated runtimes", () => {
+  let harness: MultiRuntimeHarness;
+  let alice: MultiRuntimeSession;
+  let bob: MultiRuntimeSession;
+
+  beforeAll(async () => {
+    harness = await MultiRuntimeHarness.create({
+      programPath: PROGRAM_PATH,
+      rootPath: ROOT_PATH,
+      diagnostics: true,
+      sessions: ["alice", "bob"],
+    });
+    alice = harness.session("alice");
+    bob = harness.session("bob");
+  });
+
+  afterAll(async () => {
+    await harness?.dispose();
+  });
+
+  it("dispatches a Topic child handler by path and propagates its result", async () => {
+    await alice.send("addTopic", { title: "Nested handler topic" });
+    await harness.diagnosticsBarrier();
+    await bob.telemetry();
+
+    await bob.send(["topics", 0, "addComment"], {
+      body: "A nested stream invocation",
+    });
+
+    await harness.diagnosticsBarrier();
+    const propagatedComments = (await firstTopic(alice)).comments;
+    assert(Array.isArray(propagatedComments));
+    assert(isRecord(propagatedComments[0]));
+    assertEquals(
+      propagatedComments[0].body,
+      "A nested stream invocation",
+    );
+
+    const telemetry = await bob.telemetry();
+    assert(telemetry.invocationCount >= 1);
+    assert(telemetry.distinctInvokedEventCount >= 1);
+    assert(telemetry.distinctSuccessfulEventCount >= 1);
+    assertEquals(telemetry.distinctDroppedEventCount, 0);
+    assert(telemetry.commitMarkerCount >= 1);
+    assert(telemetry.writeCount >= telemetry.changedWriteCount);
+    assertEquals(JSON.stringify(telemetry).includes("eventId"), false);
+    assertEquals(JSON.stringify(telemetry).includes("evt:"), false);
+
+    await bob.telemetry();
+    const title = await bob.read(["topics", 0, "title"]);
+    const outcome = await bob.set(["topics", 0, "title"], title);
+    assert(outcome.ok);
+    const directTelemetry = await bob.telemetry();
+    assertEquals(directTelemetry.distinctInvokedEventCount, 0);
+    assertEquals(directTelemetry.distinctSuccessfulEventCount, 0);
+    assertEquals(directTelemetry.distinctDroppedEventCount, 0);
+    assertEquals(directTelemetry.droppedEventsByReason, {
+      "piece-load": 0,
+      lineage: 0,
+      preflight: 0,
+      "load-gate": 0,
+    });
+    assertEquals(directTelemetry.directCommitCount, 1);
+    assertEquals(directTelemetry.changedWriteCount, 0);
+    assert(directTelemetry.writeCount >= 1);
+
+    const topic = await firstTopic(alice);
+    const comments = topic.comments;
+    assert(Array.isArray(comments));
+    assert(isRecord(comments[0]));
+    assertEquals(comments[0].body, "A nested stream invocation");
+  });
+
+  it("waits for queued nested handler commits at the diagnostics barrier", async () => {
+    const coldHarness = await MultiRuntimeHarness.create({
+      programPath: PROGRAM_PATH,
+      rootPath: ROOT_PATH,
+      diagnostics: true,
+      sessions: [
+        { label: "cold-alice", wsDelayMs: 0 },
+        { label: "cold-bob", wsDelayMs: 0 },
+      ],
+    });
+    const coldAlice = coldHarness.session("cold-alice");
+    const coldBob = coldHarness.session("cold-bob");
+    try {
+      await Promise.all([
+        coldAlice.send(
+          "addTopic",
+          { title: "Cold nested handler topic A" },
+          undefined,
+          { idle: false },
+        ),
+        coldBob.send(
+          "addTopic",
+          { title: "Cold nested handler topic B" },
+          undefined,
+          { idle: false },
+        ),
+      ]);
+      await coldHarness.diagnosticsBarrier();
+      await Promise.all([coldAlice.telemetry(), coldBob.telemetry()]);
+      coldHarness.memoryTelemetry();
+
+      await Promise.all([
+        coldAlice.send(
+          ["topics", 0, "addLink"],
+          {
+            kind: "web",
+            url: "https://example.invalid/diagnostic/alice",
+            label: "Alice diagnostic link",
+          },
+          undefined,
+          { idle: false },
+        ),
+        coldBob.send(
+          ["topics", 1, "addLink"],
+          {
+            kind: "web",
+            url: "https://example.invalid/diagnostic/bob",
+            label: "Bob diagnostic link",
+          },
+          undefined,
+          { idle: false },
+        ),
+      ]);
+
+      await coldHarness.diagnosticsBarrier();
+
+      const eventTelemetry = await Promise.all([
+        coldAlice.telemetry(),
+        coldBob.telemetry(),
+      ]);
+      const memoryTelemetry = coldHarness.memoryTelemetry();
+      const total = (key: keyof typeof eventTelemetry[number]): number =>
+        eventTelemetry.reduce((sum, entry) => {
+          const value = entry[key];
+          return sum + (typeof value === "number" ? value : 0);
+        }, 0);
+      const outcomeSummary = {
+        invoked: total("distinctInvokedEventCount"),
+        successful: total("distinctSuccessfulEventCount"),
+        dropped: total("distinctDroppedEventCount"),
+        receivedAppends: memoryTelemetry.receivedPatchOperationsByType.append,
+        appliedAppends:
+          memoryTelemetry.newlyAppliedPatchOperationsByType.append,
+      };
+      assertEquals(outcomeSummary, {
+        invoked: 2,
+        successful: 2,
+        dropped: 0,
+        receivedAppends: 2,
+        appliedAppends: 2,
+      });
+
+      for (const session of [coldAlice, coldBob]) {
+        let rawLinkCount = 0;
+        let projectedLinkCount = 0;
+        for (const topicIndex of [0, 1]) {
+          const rawLinks = await session.readRaw([
+            "topics",
+            topicIndex,
+            "links",
+          ]);
+          assert(Array.isArray(rawLinks));
+          assertEquals(rawLinks.length, 1);
+          rawLinkCount += rawLinks.length;
+
+          const links = await session.read(["topics", topicIndex, "links"]);
+          assert(Array.isArray(links));
+          assertEquals(links.length, 1);
+          projectedLinkCount += links.length;
+        }
+        assertEquals(rawLinkCount, 2);
+        assertEquals(projectedLinkCount, 2);
+      }
+    } finally {
+      await coldHarness.dispose();
+    }
+  });
+
+  it("preserves raw Topic links through a containing-document root reorder", async () => {
+    await alice.send("addTopic", { title: "First linked topic" });
+    await alice.send("addTopic", { title: "Second linked topic" });
+    await harness.diagnosticsBarrier();
+
+    const rawTopics = await alice.readRaw(["topics"]);
+    assert(Array.isArray(rawTopics));
+    assert(rawTopics.length >= 2);
+    assert(
+      rawTopics.every(isSigilLink),
+      "Raw Topics entries must remain Fabric link sigils",
+    );
+    const reordered = [rawTopics[1], rawTopics[0], ...rawTopics.slice(2)];
+
+    await harness.diagnosticsBarrier();
+    const before = await Promise.all(
+      [alice, bob].map((session) => session.loggerCounts({ idle: false })),
+    );
+    harness.memoryTelemetry();
+    await Promise.all(
+      [alice, bob].map((session) =>
+        session.prepareContainingDocumentValueRoot(
+          ["topics"],
+          reordered,
+          { idle: false },
+        )
+      ),
+    );
+    const outcomes = await Promise.all(
+      [alice, bob].map((session) =>
+        session.commitPreparedContainingDocumentValueRoot()
+      ),
+    );
+    assert(outcomes.some((outcome) => outcome.ok));
+    assert(outcomes.some((outcome) => !outcome.ok));
+    await harness.diagnosticsBarrier();
+
+    assertEquals(await alice.readRaw(["topics"]), reordered);
+    const topics = await alice.read(["topics"]);
+    assert(Array.isArray(topics));
+    assert(isRecord(topics[0]));
+    assert(isRecord(topics[1]));
+    const telemetry = harness.memoryTelemetry();
+    assert(telemetry.acceptedCount >= 1);
+    assert(telemetry.conflictCount >= 1);
+    assert(telemetry.receivedCommitBytes.total > 0);
+    assert(telemetry.newlyPersistedRevisions.total > 0);
+    assert((telemetry.patchesByPathShape["value-root"] ?? 0) >= 1);
+    const after = await Promise.all(
+      [alice, bob].map((session) => session.loggerCounts({ idle: false })),
+    );
+    const counterDelta = (name: string): number =>
+      after.reduce(
+        (total, entry, index) =>
+          total + (entry["storage.v2"]?.[name]?.total ?? 0) -
+          (before[index]["storage.v2"]?.[name]?.total ?? 0),
+        0,
+      );
+    assert(counterDelta("commit-conflict") > 0);
+    assert(counterDelta("commit-revert") > 0);
+  });
+});

--- a/packages/patterns/integration/topics-nested-send.test.ts
+++ b/packages/patterns/integration/topics-nested-send.test.ts
@@ -33,6 +33,7 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
       programPath: PROGRAM_PATH,
       rootPath: ROOT_PATH,
       diagnostics: true,
+      bootstrapProfile: true,
       sessions: ["alice", "bob"],
     });
     alice = harness.session("alice");
@@ -44,12 +45,16 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
   });
 
   it("dispatches a Topic child handler by path and propagates its result", async () => {
-    await alice.send("addTopic", { title: "Nested handler topic" });
+    await alice.send("addTopic", {
+      title: "Nested handler topic",
+      agentName: "Alice",
+    });
     await harness.diagnosticsBarrier();
     await bob.telemetry();
 
     await bob.send(["topics", 0, "addComment"], {
       body: "A nested stream invocation",
+      agentName: "Bob",
     });
 
     await harness.diagnosticsBarrier();
@@ -101,6 +106,7 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
       programPath: PROGRAM_PATH,
       rootPath: ROOT_PATH,
       diagnostics: true,
+      bootstrapProfile: true,
       sessions: [
         { label: "cold-alice", wsDelayMs: 0 },
         { label: "cold-bob", wsDelayMs: 0 },
@@ -112,13 +118,13 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
       await Promise.all([
         coldAlice.send(
           "addTopic",
-          { title: "Cold nested handler topic A" },
+          { title: "Cold nested handler topic A", agentName: "Cold Alice" },
           undefined,
           { idle: false },
         ),
         coldBob.send(
           "addTopic",
-          { title: "Cold nested handler topic B" },
+          { title: "Cold nested handler topic B", agentName: "Cold Bob" },
           undefined,
           { idle: false },
         ),
@@ -134,6 +140,7 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
             kind: "web",
             url: "https://example.invalid/diagnostic/alice",
             label: "Alice diagnostic link",
+            agentName: "Cold Alice",
           },
           undefined,
           { idle: false },
@@ -144,6 +151,7 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
             kind: "web",
             url: "https://example.invalid/diagnostic/bob",
             label: "Bob diagnostic link",
+            agentName: "Cold Bob",
           },
           undefined,
           { idle: false },
@@ -205,8 +213,14 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
   });
 
   it("preserves raw Topic links through a containing-document root reorder", async () => {
-    await alice.send("addTopic", { title: "First linked topic" });
-    await alice.send("addTopic", { title: "Second linked topic" });
+    await alice.send("addTopic", {
+      title: "First linked topic",
+      agentName: "Alice",
+    });
+    await alice.send("addTopic", {
+      title: "Second linked topic",
+      agentName: "Alice",
+    });
     await harness.diagnosticsBarrier();
 
     const rawTopics = await alice.readRaw(["topics"]);

--- a/packages/patterns/integration/topics-nested-send.test.ts
+++ b/packages/patterns/integration/topics-nested-send.test.ts
@@ -44,11 +44,27 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
     await harness?.dispose();
   });
 
-  it("dispatches a Topic child handler by path and propagates its result", async () => {
-    await alice.send("addTopic", {
-      title: "Nested handler topic",
-      agentName: "Alice",
-    });
+  it("dispatches nested handlers, drains queued commits, and preserves links through a root conflict", async () => {
+    await Promise.all([
+      alice.send(
+        "addTopic",
+        {
+          title: "Nested handler topic",
+          agentName: "Alice",
+        },
+        undefined,
+        { idle: false },
+      ),
+      bob.send(
+        "addTopic",
+        {
+          title: "Linked topic",
+          agentName: "Bob",
+        },
+        undefined,
+        { idle: false },
+      ),
+    ]);
     await harness.diagnosticsBarrier();
     await bob.telemetry();
 
@@ -57,7 +73,44 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
       agentName: "Bob",
     });
 
+    const handlerTelemetry = await bob.telemetry();
+    assert(handlerTelemetry.invocationCount >= 1);
+    assert(handlerTelemetry.distinctInvokedEventCount >= 1);
+    assert(handlerTelemetry.distinctSuccessfulEventCount >= 1);
+    assertEquals(handlerTelemetry.distinctDroppedEventCount, 0);
+    assert(handlerTelemetry.commitMarkerCount >= 1);
+    assert(handlerTelemetry.writeCount >= handlerTelemetry.changedWriteCount);
+    assertEquals(JSON.stringify(handlerTelemetry).includes("eventId"), false);
+    assertEquals(JSON.stringify(handlerTelemetry).includes("evt:"), false);
+
+    await Promise.all([alice.telemetry(), bob.telemetry()]);
+    harness.memoryTelemetry();
+    await Promise.all([
+      alice.send(
+        ["topics", 0, "addLink"],
+        {
+          kind: "web",
+          url: "https://example.invalid/diagnostic/alice",
+          label: "Alice diagnostic link",
+          agentName: "Alice",
+        },
+        undefined,
+        { idle: false },
+      ),
+      bob.send(
+        ["topics", 1, "addLink"],
+        {
+          kind: "web",
+          url: "https://example.invalid/diagnostic/bob",
+          label: "Bob diagnostic link",
+          agentName: "Bob",
+        },
+        undefined,
+        { idle: false },
+      ),
+    ]);
     await harness.diagnosticsBarrier();
+
     const propagatedComments = (await firstTopic(alice)).comments;
     assert(Array.isArray(propagatedComments));
     assert(isRecord(propagatedComments[0]));
@@ -66,15 +119,47 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
       "A nested stream invocation",
     );
 
-    const telemetry = await bob.telemetry();
-    assert(telemetry.invocationCount >= 1);
-    assert(telemetry.distinctInvokedEventCount >= 1);
-    assert(telemetry.distinctSuccessfulEventCount >= 1);
-    assertEquals(telemetry.distinctDroppedEventCount, 0);
-    assert(telemetry.commitMarkerCount >= 1);
-    assert(telemetry.writeCount >= telemetry.changedWriteCount);
-    assertEquals(JSON.stringify(telemetry).includes("eventId"), false);
-    assertEquals(JSON.stringify(telemetry).includes("evt:"), false);
+    const eventTelemetry = await Promise.all([
+      alice.telemetry(),
+      bob.telemetry(),
+    ]);
+    const memoryTelemetry = harness.memoryTelemetry();
+    const total = (key: keyof typeof eventTelemetry[number]): number =>
+      eventTelemetry.reduce((sum, entry) => {
+        const value = entry[key];
+        return sum + (typeof value === "number" ? value : 0);
+      }, 0);
+    assertEquals({
+      invoked: total("distinctInvokedEventCount"),
+      successful: total("distinctSuccessfulEventCount"),
+      dropped: total("distinctDroppedEventCount"),
+      receivedAppends: memoryTelemetry.receivedPatchOperationsByType.append,
+      appliedAppends: memoryTelemetry.newlyAppliedPatchOperationsByType.append,
+    }, {
+      invoked: 2,
+      successful: 2,
+      dropped: 0,
+      receivedAppends: 2,
+      appliedAppends: 2,
+    });
+
+    for (const session of [alice, bob]) {
+      let rawLinkCount = 0;
+      let projectedLinkCount = 0;
+      for (const topicIndex of [0, 1]) {
+        const rawLinks = await session.readRaw(["topics", topicIndex, "links"]);
+        assert(Array.isArray(rawLinks));
+        assertEquals(rawLinks.length, 1);
+        rawLinkCount += rawLinks.length;
+
+        const links = await session.read(["topics", topicIndex, "links"]);
+        assert(Array.isArray(links));
+        assertEquals(links.length, 1);
+        projectedLinkCount += links.length;
+      }
+      assertEquals(rawLinkCount, 2);
+      assertEquals(projectedLinkCount, 2);
+    }
 
     await bob.telemetry();
     const title = await bob.read(["topics", 0, "title"]);
@@ -99,129 +184,6 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
     assert(Array.isArray(comments));
     assert(isRecord(comments[0]));
     assertEquals(comments[0].body, "A nested stream invocation");
-  });
-
-  it("waits for queued nested handler commits at the diagnostics barrier", async () => {
-    const coldHarness = await MultiRuntimeHarness.create({
-      programPath: PROGRAM_PATH,
-      rootPath: ROOT_PATH,
-      diagnostics: true,
-      bootstrapProfile: true,
-      sessions: [
-        { label: "cold-alice", wsDelayMs: 0 },
-        { label: "cold-bob", wsDelayMs: 0 },
-      ],
-    });
-    const coldAlice = coldHarness.session("cold-alice");
-    const coldBob = coldHarness.session("cold-bob");
-    try {
-      await Promise.all([
-        coldAlice.send(
-          "addTopic",
-          { title: "Cold nested handler topic A", agentName: "Cold Alice" },
-          undefined,
-          { idle: false },
-        ),
-        coldBob.send(
-          "addTopic",
-          { title: "Cold nested handler topic B", agentName: "Cold Bob" },
-          undefined,
-          { idle: false },
-        ),
-      ]);
-      await coldHarness.diagnosticsBarrier();
-      await Promise.all([coldAlice.telemetry(), coldBob.telemetry()]);
-      coldHarness.memoryTelemetry();
-
-      await Promise.all([
-        coldAlice.send(
-          ["topics", 0, "addLink"],
-          {
-            kind: "web",
-            url: "https://example.invalid/diagnostic/alice",
-            label: "Alice diagnostic link",
-            agentName: "Cold Alice",
-          },
-          undefined,
-          { idle: false },
-        ),
-        coldBob.send(
-          ["topics", 1, "addLink"],
-          {
-            kind: "web",
-            url: "https://example.invalid/diagnostic/bob",
-            label: "Bob diagnostic link",
-            agentName: "Cold Bob",
-          },
-          undefined,
-          { idle: false },
-        ),
-      ]);
-
-      await coldHarness.diagnosticsBarrier();
-
-      const eventTelemetry = await Promise.all([
-        coldAlice.telemetry(),
-        coldBob.telemetry(),
-      ]);
-      const memoryTelemetry = coldHarness.memoryTelemetry();
-      const total = (key: keyof typeof eventTelemetry[number]): number =>
-        eventTelemetry.reduce((sum, entry) => {
-          const value = entry[key];
-          return sum + (typeof value === "number" ? value : 0);
-        }, 0);
-      const outcomeSummary = {
-        invoked: total("distinctInvokedEventCount"),
-        successful: total("distinctSuccessfulEventCount"),
-        dropped: total("distinctDroppedEventCount"),
-        receivedAppends: memoryTelemetry.receivedPatchOperationsByType.append,
-        appliedAppends:
-          memoryTelemetry.newlyAppliedPatchOperationsByType.append,
-      };
-      assertEquals(outcomeSummary, {
-        invoked: 2,
-        successful: 2,
-        dropped: 0,
-        receivedAppends: 2,
-        appliedAppends: 2,
-      });
-
-      for (const session of [coldAlice, coldBob]) {
-        let rawLinkCount = 0;
-        let projectedLinkCount = 0;
-        for (const topicIndex of [0, 1]) {
-          const rawLinks = await session.readRaw([
-            "topics",
-            topicIndex,
-            "links",
-          ]);
-          assert(Array.isArray(rawLinks));
-          assertEquals(rawLinks.length, 1);
-          rawLinkCount += rawLinks.length;
-
-          const links = await session.read(["topics", topicIndex, "links"]);
-          assert(Array.isArray(links));
-          assertEquals(links.length, 1);
-          projectedLinkCount += links.length;
-        }
-        assertEquals(rawLinkCount, 2);
-        assertEquals(projectedLinkCount, 2);
-      }
-    } finally {
-      await coldHarness.dispose();
-    }
-  });
-
-  it("preserves raw Topic links through a containing-document root reorder", async () => {
-    await alice.send("addTopic", {
-      title: "First linked topic",
-      agentName: "Alice",
-    });
-    await alice.send("addTopic", {
-      title: "Second linked topic",
-      agentName: "Alice",
-    });
-    await harness.diagnosticsBarrier();
 
     const rawTopics = await alice.readRaw(["topics"]);
     assert(Array.isArray(rawTopics));
@@ -232,7 +194,6 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
     );
     const reordered = [rawTopics[1], rawTopics[0], ...rawTopics.slice(2)];
 
-    await harness.diagnosticsBarrier();
     const before = await Promise.all(
       [alice, bob].map((session) => session.loggerCounts({ idle: false })),
     );
@@ -251,8 +212,8 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
         session.commitPreparedContainingDocumentValueRoot()
       ),
     );
-    assert(outcomes.some((outcome) => outcome.ok));
-    assert(outcomes.some((outcome) => !outcome.ok));
+    assertEquals(outcomes.filter((outcome) => outcome.ok).length, 1);
+    assertEquals(outcomes.filter((outcome) => !outcome.ok).length, 1);
     await harness.diagnosticsBarrier();
 
     assertEquals(await alice.readRaw(["topics"]), reordered);
@@ -260,12 +221,12 @@ describe("Topics nested stream dispatch across isolated runtimes", () => {
     assert(Array.isArray(topics));
     assert(isRecord(topics[0]));
     assert(isRecord(topics[1]));
-    const telemetry = harness.memoryTelemetry();
-    assert(telemetry.acceptedCount >= 1);
-    assert(telemetry.conflictCount >= 1);
-    assert(telemetry.receivedCommitBytes.total > 0);
-    assert(telemetry.newlyPersistedRevisions.total > 0);
-    assert((telemetry.patchesByPathShape["value-root"] ?? 0) >= 1);
+    const rootMemoryTelemetry = harness.memoryTelemetry();
+    assert(rootMemoryTelemetry.acceptedCount >= 1);
+    assert(rootMemoryTelemetry.conflictCount >= 1);
+    assert(rootMemoryTelemetry.receivedCommitBytes.total > 0);
+    assert(rootMemoryTelemetry.newlyPersistedRevisions.total > 0);
+    assert((rootMemoryTelemetry.patchesByPathShape["value-root"] ?? 0) >= 1);
     const after = await Promise.all(
       [alice, bob].map((session) => session.loggerCounts({ idle: false })),
     );

--- a/packages/patterns/tools/topics-diagnose-config.test.ts
+++ b/packages/patterns/tools/topics-diagnose-config.test.ts
@@ -59,7 +59,6 @@ Deno.test("Topics diagnostics applies profile and quick defaults", () => {
   });
   assertEquals(configFromArgs(["--profile=conflicts", "--quick"]).rounds, 2);
   assertEquals(configFromArgs(["--quick"]).scenarios, [
-    "names",
     "create-topics",
     "noops",
     "titles",

--- a/packages/patterns/tools/topics-diagnose-config.test.ts
+++ b/packages/patterns/tools/topics-diagnose-config.test.ts
@@ -1,0 +1,137 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  casesFromArgs,
+  configFromArgs,
+  deriveTelemetry,
+  rootOscillationMetadata,
+  writePathShape,
+} from "./topics-diagnose-config.ts";
+
+Deno.test("Topics diagnostics validates explicit matrix arguments", () => {
+  const config = configFromArgs([
+    "--topics=2,4",
+    "--users=1,3",
+    "--rounds=2",
+    "--typing-steps=3",
+    "--sessions-per-user=2",
+    "--ws-delay-ms=5",
+    "--scenario=comments,bodies",
+  ]);
+  assertEquals(config.topicCounts, [2, 4]);
+  assertEquals(config.userCounts, [1, 3]);
+  assertEquals(config.scenarios, ["comments", "bodies"]);
+  assertEquals(casesFromArgs(["--cases=2x1,4x3"], config), [
+    { topics: 2, users: 1 },
+    { topics: 4, users: 3 },
+  ]);
+  assertThrows(() => configFromArgs(["--topics="]));
+  assertThrows(() => configFromArgs(["--users=0"]));
+  assertThrows(() => configFromArgs(["--scenario=unknown"]));
+  assertThrows(() => casesFromArgs(["--cases=2by3"], config));
+});
+
+Deno.test("Topics diagnostics rejects malformed and unsupported CLI tokens", () => {
+  for (
+    const args of [
+      ["--quick=true"],
+      ["--topics", "1"],
+      ["--quick", "--quick"],
+      ["--unknown=value"],
+      ["stray"],
+    ]
+  ) {
+    assertThrows(() => configFromArgs(args));
+  }
+});
+
+Deno.test("Topics diagnostics applies profile and quick defaults", () => {
+  const conflicts = configFromArgs(["--profile=conflicts"]);
+  assertEquals(conflicts, {
+    profile: "conflicts",
+    program: "topics/main.tsx",
+    topicCounts: [2],
+    userCounts: [2],
+    rounds: 4,
+    typingSteps: 2,
+    sessionsPerUser: 2,
+    wsDelayMs: 10,
+    scenarios: ["root-oscillation"],
+  });
+  assertEquals(configFromArgs(["--profile=conflicts", "--quick"]).rounds, 2);
+  assertEquals(configFromArgs(["--quick"]).scenarios, [
+    "names",
+    "create-topics",
+    "noops",
+    "titles",
+    "comments",
+    "links",
+    "bodies",
+    "crossrefs",
+  ]);
+  assertEquals(
+    configFromArgs(["--quick", "--scenario=all"]).scenarios.at(-1),
+    "root-oscillation",
+  );
+});
+
+Deno.test("Topics diagnostics validates root oscillation topology", () => {
+  assertThrows(() =>
+    casesFromArgs([], configFromArgs(["--profile=conflicts", "--topics=1"]))
+  );
+  assertThrows(() =>
+    casesFromArgs(
+      [],
+      configFromArgs([
+        "--profile=conflicts",
+        "--users=1",
+        "--sessions-per-user=1",
+      ]),
+    )
+  );
+  assertThrows(() =>
+    casesFromArgs([], configFromArgs(["--profile=conflicts", "--rounds=0"]))
+  );
+  assertEquals(
+    casesFromArgs([], configFromArgs(["--profile=conflicts", "--rounds=1"])),
+    [{ topics: 2, users: 2 }],
+  );
+});
+
+Deno.test("Topics diagnostics derives content-free telemetry summaries", () => {
+  const telemetry = {
+    invocationCount: 2,
+    distinctInvokedEventCount: 2,
+    distinctSuccessfulEventCount: 1,
+    distinctDroppedEventCount: 1,
+    droppedEventsByReason: {
+      "piece-load": 0,
+      lineage: 1,
+      preflight: 0,
+      "load-gate": 0,
+    },
+    permanentRejectionsByReason: { "origin-committed": 0, "receipt-exists": 1 },
+    commitMarkerCount: 3,
+    directCommitCount: 0,
+    successfulCommitCount: 2,
+    failedAttemptCount: 1,
+    terminalFailureCount: 0,
+    retryMarkerCount: 1,
+    maxRetryAttempt: 2,
+    readCount: 4,
+    writeCount: 5,
+    changedWriteCount: 3,
+    writesTruncatedCount: 0,
+    writesByPathShape: { "value/*": 3 },
+  };
+  assertEquals(deriveTelemetry(telemetry, 2), {
+    changedWritesPerSubmittedOperation: 1.5,
+    attemptedWritesPerSubmittedOperation: 2.5,
+    elidedNoopCandidateWrites: 2,
+  });
+  assertEquals(
+    writePathShape("value/did:key:private/topic-content/17"),
+    "value/*/*/#",
+  );
+  assertEquals(rootOscillationMetadata([0, 1, 0, 1]).twoStepRepeatRatio, 1);
+  assertEquals(rootOscillationMetadata([0]).twoStepRepeatRatio, null);
+});

--- a/packages/patterns/tools/topics-diagnose-config.test.ts
+++ b/packages/patterns/tools/topics-diagnose-config.test.ts
@@ -42,6 +42,13 @@ Deno.test("Topics diagnostics rejects malformed and unsupported CLI tokens", () 
   ) {
     assertThrows(() => configFromArgs(args));
   }
+  assertThrows(() => configFromArgs(["--rounds=1", "--rounds=2"]));
+  assertThrows(() => configFromArgs(["--rounds=1.5"]));
+  assertThrows(() => configFromArgs(["--scenario="]));
+  assertThrows(() => configFromArgs(["--scenario=all,comments"]));
+  assertThrows(() => configFromArgs(["--profile=unknown"]));
+  assertThrows(() => configFromArgs(["--program="]));
+  assertThrows(() => casesFromArgs(["--cases="], configFromArgs(["--quick"])));
 });
 
 Deno.test("Topics diagnostics applies profile and quick defaults", () => {
@@ -133,4 +140,71 @@ Deno.test("Topics diagnostics derives content-free telemetry summaries", () => {
   );
   assertEquals(rootOscillationMetadata([0, 1, 0, 1]).twoStepRepeatRatio, 1);
   assertEquals(rootOscillationMetadata([0]).twoStepRepeatRatio, null);
+});
+
+Deno.test("Topics diagnostics reduces sparse telemetry and only reports path shapes", () => {
+  const config = configFromArgs([
+    "--quick",
+    "--program=topics/main.tsx",
+    "--scenario=comments,comments",
+    "--rounds=0",
+    "--typing-steps=0",
+    "--ws-delay-ms=0",
+  ]);
+  assertEquals(config.scenarios, ["comments"]);
+  assertEquals(casesFromArgs(["--cases=2x1,2x1"], config), [
+    { topics: 2, users: 1 },
+    { topics: 2, users: 1 },
+  ]);
+  assertEquals(
+    deriveTelemetry({
+      invocationCount: 0,
+      distinctInvokedEventCount: 0,
+      distinctSuccessfulEventCount: 0,
+      distinctDroppedEventCount: 0,
+      droppedEventsByReason: {
+        "piece-load": 0,
+        lineage: 0,
+        preflight: 0,
+        "load-gate": 0,
+      },
+      permanentRejectionsByReason: {
+        "origin-committed": 0,
+        "receipt-exists": 0,
+      },
+      commitMarkerCount: 0,
+      directCommitCount: 0,
+      successfulCommitCount: 0,
+      failedAttemptCount: 0,
+      terminalFailureCount: 0,
+      retryMarkerCount: 0,
+      maxRetryAttempt: 0,
+      readCount: 0,
+      writeCount: 1,
+      changedWriteCount: 3,
+      writesTruncatedCount: 0,
+      writesByPathShape: {},
+    }, 0),
+    {
+      changedWritesPerSubmittedOperation: 0,
+      attemptedWritesPerSubmittedOperation: 0,
+      elidedNoopCandidateWrites: 0,
+    },
+  );
+  assertEquals(writePathShape("value/actual-topic/12"), "value/*/#");
+  assertEquals(writePathShape("value/actual-topic/private-key"), "value/*/*");
+  assertEquals(rootOscillationMetadata([]), {
+    distinctStateCount: 0,
+    targetWriteCount: 0,
+    twoStepEligibleCount: 0,
+    twoStepRepeatCount: 0,
+    twoStepRepeatRatio: null,
+  });
+  assertEquals(rootOscillationMetadata([0, 1, 1]), {
+    distinctStateCount: 2,
+    targetWriteCount: 3,
+    twoStepEligibleCount: 1,
+    twoStepRepeatCount: 0,
+    twoStepRepeatRatio: 0,
+  });
 });

--- a/packages/patterns/tools/topics-diagnose-config.ts
+++ b/packages/patterns/tools/topics-diagnose-config.ts
@@ -1,5 +1,4 @@
 export const ALL_TOPICS_SCENARIOS = [
-  "names",
   "create-topics",
   "noops",
   "titles",

--- a/packages/patterns/tools/topics-diagnose-config.ts
+++ b/packages/patterns/tools/topics-diagnose-config.ts
@@ -82,6 +82,34 @@ export interface RootOscillationMetadata {
 
 export { writePathShape } from "../integration/telemetry-path-shape.ts";
 
+const VALUE_OPTIONS = new Set([
+  "profile",
+  "program",
+  "topics",
+  "users",
+  "rounds",
+  "typing-steps",
+  "sessions-per-user",
+  "ws-delay-ms",
+  "scenario",
+  "cases",
+]);
+
+/** Reject unknown, positional, malformed, and repeated bare CLI tokens. */
+function validateArgs(args: readonly string[]): void {
+  let quickCount = 0;
+  for (const arg of args) {
+    if (arg === "--quick") {
+      quickCount++;
+      continue;
+    }
+    const match = /^--([a-z-]+)=(.*)$/.exec(arg);
+    if (match !== null && VALUE_OPTIONS.has(match[1])) continue;
+    throw new Error(`unsupported diagnostics argument: ${arg}`);
+  }
+  if (quickCount > 1) throw new Error("--quick may be provided once");
+}
+
 function explicitArg(
   args: readonly string[],
   name: string,
@@ -161,6 +189,7 @@ function profileFromArgs(args: readonly string[]): TopicsDiagnosticsProfile {
 export function configFromArgs(
   args: readonly string[],
 ): TopicsDiagnosticsConfig {
+  validateArgs(args);
   const quick = args.includes("--quick");
   const profile = profileFromArgs(args);
   const conflicts = profile === "conflicts";
@@ -211,6 +240,7 @@ export function casesFromArgs(
   args: readonly string[],
   config: TopicsDiagnosticsConfig,
 ): TopicsDiagnosticsCase[] {
+  validateArgs(args);
   const raw = explicitArg(args, "cases");
   const cases = raw === undefined
     ? config.topicCounts.flatMap((topics) =>

--- a/packages/patterns/tools/topics-diagnose-config.ts
+++ b/packages/patterns/tools/topics-diagnose-config.ts
@@ -1,0 +1,299 @@
+export const ALL_TOPICS_SCENARIOS = [
+  "names",
+  "create-topics",
+  "noops",
+  "titles",
+  "comments",
+  "links",
+  "bodies",
+  "crossrefs",
+  "root-oscillation",
+] as const;
+
+export type TopicsScenario = typeof ALL_TOPICS_SCENARIOS[number];
+
+const MATRIX_TOPICS_SCENARIOS = ALL_TOPICS_SCENARIOS.filter(
+  (scenario) => scenario !== "root-oscillation",
+);
+
+export const TOPICS_DIAGNOSTICS_PROFILES = ["matrix", "conflicts"] as const;
+
+export type TopicsDiagnosticsProfile =
+  typeof TOPICS_DIAGNOSTICS_PROFILES[number];
+
+export interface TopicsDiagnosticsConfig {
+  profile: TopicsDiagnosticsProfile;
+  program: string;
+  topicCounts: readonly number[];
+  userCounts: readonly number[];
+  rounds: number;
+  typingSteps: number;
+  sessionsPerUser: number;
+  wsDelayMs: number;
+  scenarios: readonly TopicsScenario[];
+}
+
+export interface TopicsDiagnosticsCase {
+  topics: number;
+  users: number;
+}
+
+/** The counter-only shape supplied by MultiRuntimeSession telemetry snapshots. */
+export interface RuntimeTelemetrySnapshot {
+  invocationCount: number;
+  distinctInvokedEventCount: number;
+  distinctSuccessfulEventCount: number;
+  distinctDroppedEventCount: number;
+  droppedEventsByReason: Record<
+    "piece-load" | "lineage" | "preflight" | "load-gate",
+    number
+  >;
+  permanentRejectionsByReason: Record<
+    "origin-committed" | "receipt-exists",
+    number
+  >;
+  commitMarkerCount: number;
+  directCommitCount: number;
+  successfulCommitCount: number;
+  failedAttemptCount: number;
+  terminalFailureCount: number;
+  retryMarkerCount: number;
+  maxRetryAttempt: number;
+  readCount: number;
+  writeCount: number;
+  changedWriteCount: number;
+  writesTruncatedCount: number;
+  writesByPathShape: Record<string, number>;
+}
+
+export interface DerivedTelemetry {
+  changedWritesPerSubmittedOperation: number;
+  attemptedWritesPerSubmittedOperation: number;
+  elidedNoopCandidateWrites: number;
+}
+
+export interface RootOscillationMetadata {
+  distinctStateCount: number;
+  targetWriteCount: number;
+  twoStepEligibleCount: number;
+  twoStepRepeatCount: number;
+  twoStepRepeatRatio: number | null;
+}
+
+export { writePathShape } from "../integration/telemetry-path-shape.ts";
+
+function explicitArg(
+  args: readonly string[],
+  name: string,
+): string | undefined {
+  const prefix = `--${name}=`;
+  const matches = args.filter((arg) => arg.startsWith(prefix));
+  if (matches.length > 1) throw new Error(`--${name} may be provided once`);
+  return matches[0]?.slice(prefix.length);
+}
+
+function nonNegativeInteger(value: string, name: string, minimum = 0): number {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`--${name} must be an integer >= ${minimum}; got ${value}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(`--${name} must be an integer >= ${minimum}; got ${value}`);
+  }
+  return parsed;
+}
+
+function numberList(
+  args: readonly string[],
+  name: string,
+  fallback: readonly number[],
+  minimum: number,
+): number[] {
+  const raw = explicitArg(args, name);
+  if (raw === undefined) return [...fallback];
+  if (raw.trim() === "") throw new Error(`--${name} must not be empty`);
+  return raw.split(",").map((value) =>
+    nonNegativeInteger(value.trim(), name, minimum)
+  );
+}
+
+function isTopicsScenario(value: string): value is TopicsScenario {
+  return ALL_TOPICS_SCENARIOS.some((scenario) => scenario === value);
+}
+
+function scenarioList(
+  args: readonly string[],
+  fallback: readonly TopicsScenario[],
+): TopicsScenario[] {
+  const raw = explicitArg(args, "scenario");
+  if (raw === undefined) return [...fallback];
+  if (raw === "all") return [...ALL_TOPICS_SCENARIOS];
+  if (raw.trim() === "") throw new Error("--scenario must not be empty");
+  const names = raw.split(",").map((entry) => entry.trim());
+  if (names.includes("all")) {
+    throw new Error("--scenario=all cannot be combined with named scenarios");
+  }
+  const unknown = names.find((name) => !isTopicsScenario(name));
+  if (unknown) {
+    throw new Error(
+      `unknown scenario "${unknown}"; choose ${
+        ALL_TOPICS_SCENARIOS.join(", ")
+      }, or all`,
+    );
+  }
+  return [...new Set(names.filter(isTopicsScenario))];
+}
+
+function profileFromArgs(args: readonly string[]): TopicsDiagnosticsProfile {
+  const profile = explicitArg(args, "profile") ?? "matrix";
+  if (
+    !TOPICS_DIAGNOSTICS_PROFILES.some((candidate) => candidate === profile)
+  ) {
+    throw new Error(
+      `unknown profile "${profile}"; choose ${
+        TOPICS_DIAGNOSTICS_PROFILES.join(", ")
+      }`,
+    );
+  }
+  return profile as TopicsDiagnosticsProfile;
+}
+
+export function configFromArgs(
+  args: readonly string[],
+): TopicsDiagnosticsConfig {
+  const quick = args.includes("--quick");
+  const profile = profileFromArgs(args);
+  const conflicts = profile === "conflicts";
+  const program = explicitArg(args, "program") ?? "topics/main.tsx";
+  if (program.trim() === "") throw new Error("--program must not be empty");
+  return {
+    profile,
+    program,
+    topicCounts: numberList(
+      args,
+      "topics",
+      conflicts || quick ? [2] : [2, 8],
+      1,
+    ),
+    userCounts: numberList(
+      args,
+      "users",
+      conflicts || quick ? [2] : [2, 4],
+      1,
+    ),
+    rounds: nonNegativeInteger(
+      explicitArg(args, "rounds") ??
+        String(conflicts ? (quick ? 2 : 4) : quick ? 1 : 3),
+      "rounds",
+    ),
+    typingSteps: nonNegativeInteger(
+      explicitArg(args, "typing-steps") ??
+        String(conflicts ? 2 : quick ? 2 : 5),
+      "typing-steps",
+    ),
+    sessionsPerUser: nonNegativeInteger(
+      explicitArg(args, "sessions-per-user") ?? String(conflicts ? 2 : 1),
+      "sessions-per-user",
+      1,
+    ),
+    wsDelayMs: nonNegativeInteger(
+      explicitArg(args, "ws-delay-ms") ?? String(conflicts ? 10 : 0),
+      "ws-delay-ms",
+    ),
+    scenarios: scenarioList(
+      args,
+      conflicts ? ["root-oscillation"] : MATRIX_TOPICS_SCENARIOS,
+    ),
+  };
+}
+
+export function casesFromArgs(
+  args: readonly string[],
+  config: TopicsDiagnosticsConfig,
+): TopicsDiagnosticsCase[] {
+  const raw = explicitArg(args, "cases");
+  const cases = raw === undefined
+    ? config.topicCounts.flatMap((topics) =>
+      config.userCounts.map((users) => ({ topics, users }))
+    )
+    : raw.split(",").map((entry) => {
+      if (raw.trim() === "") throw new Error("--cases must not be empty");
+      const source = entry.trim();
+      const match = /^(\d+)x(\d+)$/.exec(source);
+      if (!match) {
+        throw new Error(`--cases entries must be TOPICSxUSERS; got ${source}`);
+      }
+      return {
+        topics: nonNegativeInteger(match[1], "cases topics", 1),
+        users: nonNegativeInteger(match[2], "cases users", 1),
+      };
+    });
+  if (
+    config.scenarios.includes("crossrefs") ||
+    config.scenarios.includes("root-oscillation")
+  ) {
+    const invalid = cases.find((entry) => entry.topics < 2);
+    if (invalid) {
+      throw new Error(
+        `${
+          config.scenarios.includes("root-oscillation")
+            ? "root-oscillation"
+            : "crossrefs"
+        } requires at least 2 topics; got ${invalid.topics}x${invalid.users}`,
+      );
+    }
+  }
+  if (config.scenarios.includes("root-oscillation")) {
+    if (config.rounds < 1) {
+      throw new Error("root-oscillation requires --rounds >= 1");
+    }
+    const invalid = cases.find((entry) =>
+      entry.users * config.sessionsPerUser < 2
+    );
+    if (invalid) {
+      throw new Error(
+        `root-oscillation requires at least 2 total sessions; got ${invalid.topics}x${invalid.users} with ${config.sessionsPerUser} sessions per user`,
+      );
+    }
+  }
+  return cases;
+}
+
+export function deriveTelemetry(
+  telemetry: RuntimeTelemetrySnapshot,
+  submittedOperations: number,
+): DerivedTelemetry {
+  return {
+    changedWritesPerSubmittedOperation: submittedOperations === 0
+      ? 0
+      : telemetry.changedWriteCount / submittedOperations,
+    attemptedWritesPerSubmittedOperation: submittedOperations === 0
+      ? 0
+      : telemetry.writeCount / submittedOperations,
+    elidedNoopCandidateWrites: Math.max(
+      0,
+      telemetry.writeCount - telemetry.changedWriteCount,
+    ),
+  };
+}
+
+/** Content-free repeat statistics for intended whole-root state transitions. */
+export function rootOscillationMetadata(
+  attemptedStates: readonly number[],
+): RootOscillationMetadata {
+  const twoStepAttemptCount = Math.max(0, attemptedStates.length - 2);
+  const twoStepRepeatCount = attemptedStates.reduce(
+    (count, state, index) =>
+      index >= 2 && state === attemptedStates[index - 2] ? count + 1 : count,
+    0,
+  );
+  return {
+    distinctStateCount: new Set(attemptedStates).size,
+    targetWriteCount: attemptedStates.length,
+    twoStepEligibleCount: twoStepAttemptCount,
+    twoStepRepeatCount,
+    twoStepRepeatRatio: twoStepAttemptCount === 0
+      ? null
+      : twoStepRepeatCount / twoStepAttemptCount,
+  };
+}

--- a/packages/patterns/tools/topics-diagnose.test.ts
+++ b/packages/patterns/tools/topics-diagnose.test.ts
@@ -1,0 +1,490 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { MultiRuntimeHarness } from "../integration/multi-runtime-harness.ts";
+import {
+  casesFromArgs,
+  configFromArgs,
+  deriveTelemetry,
+  rootOscillationMetadata,
+  writePathShape,
+} from "./topics-diagnose-config.ts";
+import {
+  graphSummary,
+  reportSafeErrorCode,
+  runTopicsDiagnostics,
+  settleSummary,
+  TopicsDiagnosticsError,
+} from "./topics-diagnose.ts";
+
+Deno.test("Topics diagnostics validates explicit matrix arguments", () => {
+  const config = configFromArgs([
+    "--topics=2,4",
+    "--users=1,3",
+    "--rounds=2",
+    "--typing-steps=3",
+    "--sessions-per-user=2",
+    "--ws-delay-ms=5",
+    "--scenario=comments,bodies",
+  ]);
+  assertEquals(config.topicCounts, [2, 4]);
+  assertEquals(config.userCounts, [1, 3]);
+  assertEquals(config.scenarios, ["comments", "bodies"]);
+  assertEquals(casesFromArgs(["--cases=2x1,4x3"], config), [
+    { topics: 2, users: 1 },
+    { topics: 4, users: 3 },
+  ]);
+  assertThrows(() => configFromArgs(["--topics="]));
+  assertThrows(() => configFromArgs(["--users=0"]));
+  assertThrows(() => configFromArgs(["--scenario=unknown"]));
+  assertThrows(() => casesFromArgs(["--cases=2by3"], config));
+});
+
+Deno.test("Topics diagnostics requires two topics for crossrefs only", () => {
+  const crossrefs = configFromArgs(["--scenario=crossrefs"]);
+  assertThrows(() => casesFromArgs(["--cases=1x1"], crossrefs));
+  const generatedCrossrefs = configFromArgs([
+    "--topics=1",
+    "--users=1",
+    "--scenario=crossrefs",
+  ]);
+  assertThrows(() => casesFromArgs([], generatedCrossrefs));
+  const comments = configFromArgs(["--scenario=comments"]);
+  assertEquals(casesFromArgs(["--cases=1x1"], comments), [{
+    topics: 1,
+    users: 1,
+  }]);
+});
+
+Deno.test("Topics diagnostics applies conflicts profile defaults before explicit overrides", () => {
+  const conflicts = configFromArgs(["--profile=conflicts"]);
+  assertEquals(conflicts, {
+    profile: "conflicts",
+    program: "topics/main.tsx",
+    topicCounts: [2],
+    userCounts: [2],
+    rounds: 4,
+    typingSteps: 2,
+    sessionsPerUser: 2,
+    wsDelayMs: 10,
+    scenarios: ["root-oscillation"],
+  });
+  assertEquals(configFromArgs(["--profile=conflicts", "--quick"]).rounds, 2);
+
+  const overridden = configFromArgs([
+    "--profile=conflicts",
+    "--topics=3",
+    "--users=4",
+    "--rounds=7",
+    "--typing-steps=6",
+    "--sessions-per-user=1",
+    "--ws-delay-ms=0",
+    "--scenario=comments",
+  ]);
+  assertEquals(overridden.topicCounts, [3]);
+  assertEquals(overridden.userCounts, [4]);
+  assertEquals(overridden.rounds, 7);
+  assertEquals(overridden.typingSteps, 6);
+  assertEquals(overridden.sessionsPerUser, 1);
+  assertEquals(overridden.wsDelayMs, 0);
+  assertEquals(overridden.scenarios, ["comments"]);
+  assertThrows(() => configFromArgs(["--profile=missing"]));
+});
+
+Deno.test("Topics diagnostics keeps root oscillation opt-in for matrix runs", () => {
+  assertEquals(configFromArgs(["--quick"]).scenarios, [
+    "names",
+    "create-topics",
+    "noops",
+    "titles",
+    "comments",
+    "links",
+    "bodies",
+    "crossrefs",
+  ]);
+  assertEquals(
+    configFromArgs(["--quick", "--scenario=all"]).scenarios.at(-1),
+    "root-oscillation",
+  );
+});
+
+Deno.test("Topics diagnostics validates root oscillation topology", () => {
+  const oneTopic = configFromArgs([
+    "--profile=conflicts",
+    "--topics=1",
+  ]);
+  assertThrows(() => casesFromArgs([], oneTopic));
+  const oneSession = configFromArgs([
+    "--profile=conflicts",
+    "--users=1",
+    "--sessions-per-user=1",
+  ]);
+  assertThrows(() => casesFromArgs([], oneSession));
+  const zeroRounds = configFromArgs([
+    "--profile=conflicts",
+    "--rounds=0",
+  ]);
+  assertThrows(() => casesFromArgs([], zeroRounds));
+  const oneRound = configFromArgs([
+    "--profile=conflicts",
+    "--rounds=1",
+  ]);
+  assertEquals(casesFromArgs([], oneRound), [{ topics: 2, users: 2 }]);
+});
+
+Deno.test("Topics diagnostics derives write amplification ratios without negatives", () => {
+  const telemetry = {
+    invocationCount: 2,
+    distinctInvokedEventCount: 2,
+    distinctSuccessfulEventCount: 1,
+    distinctDroppedEventCount: 1,
+    droppedEventsByReason: {
+      "piece-load": 0,
+      lineage: 1,
+      preflight: 0,
+      "load-gate": 0,
+    },
+    permanentRejectionsByReason: {
+      "origin-committed": 0,
+      "receipt-exists": 1,
+    },
+    commitMarkerCount: 3,
+    directCommitCount: 0,
+    successfulCommitCount: 2,
+    failedAttemptCount: 1,
+    terminalFailureCount: 0,
+    retryMarkerCount: 1,
+    maxRetryAttempt: 2,
+    readCount: 4,
+    writeCount: 5,
+    changedWriteCount: 3,
+    writesTruncatedCount: 0,
+    writesByPathShape: { "value/*": 3 },
+  };
+  assertEquals(deriveTelemetry(telemetry, 2), {
+    changedWritesPerSubmittedOperation: 1.5,
+    attemptedWritesPerSubmittedOperation: 2.5,
+    elidedNoopCandidateWrites: 2,
+  });
+  assertEquals(deriveTelemetry({ ...telemetry, changedWriteCount: 8 }, 0), {
+    changedWritesPerSubmittedOperation: 0,
+    attemptedWritesPerSubmittedOperation: 0,
+    elidedNoopCandidateWrites: 0,
+  });
+});
+
+Deno.test("Topics diagnostics redacts write path keys", () => {
+  const shape = writePathShape("value/did:key:private/topic-content/17");
+  assertEquals(shape, "value/*/*/#");
+  assertEquals(shape.includes("did:key"), false);
+  assertEquals(shape.includes("content"), false);
+});
+
+Deno.test("Topics diagnostics reports bounded root oscillation repeat metadata", () => {
+  assertEquals(rootOscillationMetadata([]), {
+    distinctStateCount: 0,
+    targetWriteCount: 0,
+    twoStepEligibleCount: 0,
+    twoStepRepeatCount: 0,
+    twoStepRepeatRatio: null,
+  });
+  assertEquals(rootOscillationMetadata([0]), {
+    distinctStateCount: 1,
+    targetWriteCount: 1,
+    twoStepEligibleCount: 0,
+    twoStepRepeatCount: 0,
+    twoStepRepeatRatio: null,
+  });
+  assertEquals(rootOscillationMetadata([0, 1]), {
+    distinctStateCount: 2,
+    targetWriteCount: 2,
+    twoStepEligibleCount: 0,
+    twoStepRepeatCount: 0,
+    twoStepRepeatRatio: null,
+  });
+  assertEquals(rootOscillationMetadata([0, 1, 0, 1]), {
+    distinctStateCount: 2,
+    targetWriteCount: 4,
+    twoStepEligibleCount: 2,
+    twoStepRepeatCount: 2,
+    twoStepRepeatRatio: 1,
+  });
+});
+
+Deno.test("Topics diagnostics maps report errors to fixed safe codes", () => {
+  assertEquals(
+    reportSafeErrorCode(
+      new TopicsDiagnosticsError("invalid-configuration"),
+    ),
+    "invalid-configuration",
+  );
+  assertEquals(
+    reportSafeErrorCode(
+      new TopicsDiagnosticsError("harness-initialization-failed"),
+    ),
+    "harness-initialization-failed",
+  );
+  assertEquals(
+    reportSafeErrorCode(
+      new TopicsDiagnosticsError("phase-verification-failed"),
+    ),
+    "phase-verification-failed",
+  );
+  assertEquals(
+    reportSafeErrorCode(new TopicsDiagnosticsError("phase-operation-failed")),
+    "phase-operation-failed",
+  );
+  assertEquals(
+    reportSafeErrorCode(new TopicsDiagnosticsError("convergence-failed")),
+    "convergence-failed",
+  );
+  assertEquals(
+    reportSafeErrorCode(new Error("https://example.invalid/private?id=123")),
+    "unknown-error",
+  );
+  assertEquals(
+    reportSafeErrorCode({ message: "user-supplied input" }),
+    "unknown-error",
+  );
+});
+
+Deno.test("Topics diagnostics classifies invalid CLI configuration", async () => {
+  let error: unknown;
+  try {
+    await runTopicsDiagnostics(["--topics=0"]);
+  } catch (caught) {
+    error = caught;
+  }
+  assertEquals(reportSafeErrorCode(error), "invalid-configuration");
+});
+
+Deno.test("Topics diagnostics reduces content-free runtime summaries", () => {
+  const summaries = [
+    {
+      nodeCount: 3,
+      edgeCount: 2,
+      dirtyNodeCount: 1,
+      pendingNodeCount: 0,
+      settleHistoryEntryCount: 7,
+      maxTrailingSettleDurationMs: 4,
+    },
+    {
+      nodeCount: 5,
+      edgeCount: 1,
+      dirtyNodeCount: 0,
+      pendingNodeCount: 2,
+      settleHistoryEntryCount: 9,
+      maxTrailingSettleDurationMs: 6,
+    },
+  ];
+  assertEquals(graphSummary(summaries), {
+    postSettleMaxNodesAcrossSessions: 5,
+    postSettleMaxEdgesAcrossSessions: 2,
+    postSettleMaxDirtyAcrossSessions: 1,
+    postSettleMaxPendingAcrossSessions: 2,
+  });
+  assertEquals(settleSummary(summaries), {
+    trailingCumulativeHistoryEntries: 16,
+    maxTrailingSettleMs: 6,
+  });
+});
+
+function assertTopicsDiagnosticsIpcShape(value: unknown): void {
+  const forbiddenKey =
+    /(?:did|fid|url|content|body|title|token|fingerprint|hash|piece.?id|(?:^|_)id|message|stack)/i;
+  const forbiddenValue =
+    /(?:did:|fid1:|https?:\/\/|diagnostic-(?:topic|title|body|comment|link))/i;
+  if (typeof value === "string") {
+    if (forbiddenValue.test(value)) throw new Error("unsafe diagnostic value");
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach(assertTopicsDiagnosticsIpcShape);
+    return;
+  }
+  if (value !== null && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      if (forbiddenKey.test(key)) {
+        throw new Error(`unsafe diagnostic key: ${key}`);
+      }
+      assertTopicsDiagnosticsIpcShape(entry);
+    }
+  }
+}
+
+Deno.test("Topics diagnostics RPC responses are aggregate-only", async () => {
+  const rootPath = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+  const harness = await MultiRuntimeHarness.create({
+    programPath: new URL("../topics/main.tsx", import.meta.url).pathname,
+    rootPath,
+    diagnostics: true,
+    aggregateOnlyDiagnostics: true,
+    sessions: ["topics-diagnostics-ipc-a", "topics-diagnostics-ipc-b"],
+  });
+  try {
+    assertEquals(harness.pieceId, "aggregate-only");
+    const [first, second] = harness.sessions;
+    const adds = await Promise.all([
+      first.topicsDiagnosticsSend("addTopic", { title: "diagnostic-topic-1" }),
+      second.topicsDiagnosticsSend("addTopic", { title: "diagnostic-topic-2" }),
+    ]);
+    await harness.diagnosticsBarrier();
+    const summary = await first.topicsDiagnosticsSummary();
+    await Promise.all(harness.sessions.map((session) => session.telemetry()));
+    const sameValueOutcome = await first.topicsDiagnosticsSend(
+      ["topics", 0, "setBody"],
+      { body: "" },
+      { idle: false },
+    );
+    await harness.diagnosticsBarrier();
+    const sameValueTelemetry = await Promise.all(
+      harness.sessions.map((session) => session.telemetry()),
+    );
+    const attemptedSameValueWrites = sameValueTelemetry.reduce(
+      (total, entry) => total + entry.writeCount,
+      0,
+    );
+    const changedSameValueWrites = sameValueTelemetry.reduce(
+      (total, entry) => total + entry.changedWriteCount,
+      0,
+    );
+    assertEquals(attemptedSameValueWrites > changedSameValueWrites, true);
+    const set = await first.topicsDiagnosticsSet(
+      ["topics", 0, "title"],
+      "diagnostic-title",
+    );
+    const noop = await first.topicsDiagnosticsNoop(0);
+    const churn = await first.topicsDiagnosticsChurn();
+    const crossref = await first.topicsDiagnosticsCreateCrossref(1, 0);
+    await harness.diagnosticsBarrier();
+    const crossrefValidation = await first.topicsDiagnosticsValidateCrossrefs(
+      2,
+    );
+    const prepares = await Promise.all(
+      harness.sessions.map((session) =>
+        session.topicsDiagnosticsPrepareReversedRoot({ idle: false })
+      ),
+    );
+    const commits = await Promise.all(
+      harness.sessions.map((session) =>
+        session.topicsDiagnosticsCommitPreparedRoot()
+      ),
+    );
+    const convergenceChannel = `topics-test-${crypto.randomUUID()}`;
+    const convergenceReady = await first.topicsDiagnosticsConvergenceBegin(
+      convergenceChannel,
+      2,
+    );
+    const publish = await Promise.all(
+      harness.sessions.map((session) =>
+        session.topicsDiagnosticsConvergencePublish(convergenceChannel)
+      ),
+    );
+    assertEquals(publish, [{ ok: true }, { ok: true }]);
+    const finish = await first.topicsDiagnosticsConvergenceFinish();
+    const cancel = await first.topicsDiagnosticsConvergenceCancel();
+    const responses = {
+      adds,
+      summary,
+      sameValueOutcome,
+      sameValueTelemetry,
+      set,
+      noop,
+      churn,
+      crossref,
+      crossrefValidation,
+      prepares,
+      commits,
+      convergenceReady,
+      publish,
+      finish,
+      cancel,
+    };
+    assertEquals(Object.keys(summary).sort(), [
+      "comments",
+      "links",
+      "ok",
+      "topics",
+    ]);
+    assertEquals(Object.keys(noop).sort(), [
+      "directAccepted",
+      "directRejected",
+      "ok",
+      "submitted",
+    ]);
+    assertEquals(Object.keys(crossrefValidation).sort(), [
+      "ok",
+      "validatedSources",
+    ]);
+    for (
+      const outcome of [
+        ...adds,
+        sameValueOutcome,
+        set,
+        crossref,
+        ...prepares,
+        ...commits,
+      ]
+    ) {
+      assertEquals(
+        Object.keys(outcome).sort(),
+        outcome.ok ? ["ok"] : ["error", "ok"],
+      );
+      assertEquals(outcome.ok || outcome.error === "operation-failed", true);
+    }
+    assertEquals(Object.keys(convergenceReady).sort(), ["ok", "ready"]);
+    assertEquals(Object.keys(finish).sort(), ["converged", "ok", "summary"]);
+    if (!finish.ok) throw new Error("convergence unexpectedly failed");
+    assertEquals(Object.keys(finish.summary).sort(), [
+      "comments",
+      "links",
+      "topics",
+    ]);
+    assertEquals(Object.keys(cancel).sort(), ["ok"]);
+    assertTopicsDiagnosticsIpcShape(responses);
+    const createWithoutPrivateBootstrap = await first.client().call(
+      "createPiece",
+    );
+    assertEquals(createWithoutPrivateBootstrap, {
+      ok: false,
+      error: "operation-failed",
+    });
+    assertTopicsDiagnosticsIpcShape(createWithoutPrivateBootstrap);
+    const reinitializeAsBootstrap = await first.client().call("init", {
+      aggregateOnlyDiagnostics: true,
+      aggregateBootstrapCreator: true,
+      aggregateBootstrapChannel: `topics-test-${crypto.randomUUID()}`,
+      aggregateBootstrapParticipants: 1,
+    });
+    assertEquals(reinitializeAsBootstrap, {
+      ok: false,
+      error: "operation-failed",
+    });
+    const createWithCallerChannel = await first.client().call("createPiece", {
+      programPath: new URL("../topics/main.tsx", import.meta.url).pathname,
+      rootPath,
+      bootstrapChannel: `topics-test-${crypto.randomUUID()}`,
+      bootstrapParticipants: 1,
+    });
+    assertEquals(createWithCallerChannel, {
+      ok: false,
+      error: "operation-failed",
+    });
+    assertTopicsDiagnosticsIpcShape({
+      reinitializeAsBootstrap,
+      createWithCallerChannel,
+    });
+    for (
+      const forbiddenCall of [
+        () => first.read(),
+        () => first.readRaw(),
+        () => first.rawRead({ id: "private", space: "private" }),
+        () => first.link(),
+        () => first.diagnostics(),
+        () => first.loggerCounts(),
+      ]
+    ) {
+      await assertRejects(forbiddenCall, Error, "operation-failed");
+    }
+  } finally {
+    await harness.dispose();
+  }
+});

--- a/packages/patterns/tools/topics-diagnose.ts
+++ b/packages/patterns/tools/topics-diagnose.ts
@@ -113,6 +113,52 @@ export const TOPICS_DIAGNOSTICS_ERROR_CODES = [
 export type TopicsDiagnosticsErrorCode =
   typeof TOPICS_DIAGNOSTICS_ERROR_CODES[number];
 
+/** The aggregate-only session operations used by the diagnostics orchestrator. */
+export type TopicsDiagnosticsSession = Pick<
+  MultiRuntimeSession,
+  | "diagnosticsSummary"
+  | "telemetry"
+  | "topicsDiagnosticsSummary"
+  | "topicsDiagnosticsChurn"
+  | "topicsDiagnosticsSend"
+  | "topicsDiagnosticsSet"
+  | "topicsDiagnosticsNoop"
+  | "topicsDiagnosticsPrepareReversedRoot"
+  | "topicsDiagnosticsCommitPreparedRoot"
+  | "topicsDiagnosticsCreateCrossref"
+  | "topicsDiagnosticsValidateCrossrefs"
+  | "topicsDiagnosticsConvergenceBegin"
+  | "topicsDiagnosticsConvergencePublish"
+  | "topicsDiagnosticsConvergenceFinish"
+  | "topicsDiagnosticsConvergenceCancel"
+>;
+
+/** Narrow harness surface required to run Topics diagnostic cases. */
+export type TopicsDiagnosticsHarness =
+  & Pick<
+    MultiRuntimeHarness,
+    "diagnosticsBarrier" | "memoryTelemetry" | "dispose"
+  >
+  & {
+    sessions: readonly TopicsDiagnosticsSession[];
+  };
+
+/** Optional orchestration seam for fast diagnostics tests. */
+export interface TopicsDiagnosticsDependencies {
+  createHarness?: (
+    config: TopicsDiagnosticsConfig,
+    caseConfig: TopicsDiagnosticsCase,
+  ) => Promise<TopicsDiagnosticsHarness>;
+}
+
+/** Testable dependencies for constructing the production runtime harness. */
+export interface TopicsDiagnosticsHarnessFactoryDependencies {
+  createRuntimeHarness?: (
+    options: Parameters<typeof MultiRuntimeHarness.create>[0],
+  ) => Promise<TopicsDiagnosticsHarness>;
+  randomUUID?: () => string;
+}
+
 export class TopicsDiagnosticsError extends Error {
   constructor(
     readonly code: TopicsDiagnosticsErrorCode,
@@ -211,7 +257,7 @@ const emptyTelemetry = (): RuntimeTelemetrySnapshot => ({
 });
 
 async function collectChurn(
-  sessions: readonly MultiRuntimeSession[],
+  sessions: readonly TopicsDiagnosticsSession[],
   opts: { idle?: boolean } = {},
 ): Promise<ChurnTotals> {
   const counts = await Promise.all(
@@ -287,7 +333,7 @@ export function settleSummary(
 
 async function phase(
   name: string,
-  harness: MultiRuntimeHarness,
+  harness: TopicsDiagnosticsHarness,
   operation: () => Promise<PhaseExecution>,
   verifyAfterSettle?: () => Promise<void>,
 ): Promise<PhaseReport> {
@@ -341,15 +387,18 @@ async function phase(
   };
 }
 
-async function createHarness(
+export async function createTopicsDiagnosticsHarness(
   config: TopicsDiagnosticsConfig,
   caseConfig: TopicsDiagnosticsCase,
-): Promise<MultiRuntimeHarness> {
+  dependencies: TopicsDiagnosticsHarnessFactoryDependencies = {},
+): Promise<TopicsDiagnosticsHarness> {
   const identities = await Promise.all(Array.from(
     { length: caseConfig.users },
     (_entry, index) =>
       Identity.fromPassphrase(
-        `topics-diagnose-${crypto.randomUUID()}-user-${index + 1}`,
+        `topics-diagnose-${
+          dependencies.randomUUID?.() ?? crypto.randomUUID()
+        }-user-${index + 1}`,
         { implementation: "noble" },
       ),
   ));
@@ -360,14 +409,19 @@ async function createHarness(
       ...(config.wsDelayMs > 0 ? { wsDelayMs: config.wsDelayMs } : {}),
     }))
   );
-  return await MultiRuntimeHarness.create({
+  const options: Parameters<typeof MultiRuntimeHarness.create>[0] = {
     programPath: join(ROOT_PATH, config.program),
     rootPath: ROOT_PATH,
     diagnostics: true,
     aggregateOnlyDiagnostics: true,
     sessions,
-    spaceName: `topics-diagnostics-${crypto.randomUUID()}`,
-  });
+    spaceName: `topics-diagnostics-${
+      dependencies.randomUUID?.() ?? crypto.randomUUID()
+    }`,
+  };
+  return await (dependencies.createRuntimeHarness
+    ? dependencies.createRuntimeHarness(options)
+    : MultiRuntimeHarness.create(options));
 }
 
 async function setOutcomes(
@@ -404,7 +458,7 @@ const submitted = (count: number): PhaseExecution => ({
 });
 
 async function assertSharedCardinality(
-  session: MultiRuntimeSession,
+  session: TopicsDiagnosticsSession,
   expected: { topics: number; comments: number; links: number },
 ): Promise<void> {
   const actual = await session.topicsDiagnosticsSummary();
@@ -419,7 +473,7 @@ async function assertSharedCardinality(
 }
 
 async function collectConvergence(
-  sessions: readonly MultiRuntimeSession[],
+  sessions: readonly TopicsDiagnosticsSession[],
 ): Promise<ConvergenceReport> {
   const coordinator = sessions[0];
   const channel = `topics-convergence-${crypto.randomUUID()}`;
@@ -448,10 +502,13 @@ async function collectConvergence(
 async function runCase(
   config: TopicsDiagnosticsConfig,
   caseConfig: TopicsDiagnosticsCase,
+  createHarnessForCase: NonNullable<
+    TopicsDiagnosticsDependencies["createHarness"]
+  >,
 ): Promise<CaseReport> {
-  let harness: MultiRuntimeHarness;
+  let harness: TopicsDiagnosticsHarness;
   try {
-    harness = await createHarness(config, caseConfig);
+    harness = await createHarnessForCase(config, caseConfig);
   } catch {
     throw new TopicsDiagnosticsError("harness-initialization-failed");
   }
@@ -746,7 +803,7 @@ async function runCase(
   }
 }
 
-export async function runTopicsDiagnostics(args: readonly string[]): Promise<{
+export interface TopicsDiagnosticsReport {
   kind: string;
   config: TopicsDiagnosticsReportConfig;
   elapsedMs: number;
@@ -755,7 +812,12 @@ export async function runTopicsDiagnostics(args: readonly string[]): Promise<{
     case: TopicsDiagnosticsCase;
     error: TopicsDiagnosticsErrorCode;
   })[];
-}> {
+}
+
+export async function runTopicsDiagnostics(
+  args: readonly string[],
+  dependencies: TopicsDiagnosticsDependencies = {},
+): Promise<TopicsDiagnosticsReport> {
   let config: TopicsDiagnosticsConfig;
   let cases: TopicsDiagnosticsCase[];
   try {
@@ -765,6 +827,8 @@ export async function runTopicsDiagnostics(args: readonly string[]): Promise<{
     throw new TopicsDiagnosticsError("invalid-configuration");
   }
   const startedAt = performance.now();
+  const createHarnessForCase = dependencies.createHarness ??
+    createTopicsDiagnosticsHarness;
   const results: ({ ok: true; result: CaseReport } | {
     ok: false;
     case: TopicsDiagnosticsCase;
@@ -775,7 +839,10 @@ export async function runTopicsDiagnostics(args: readonly string[]): Promise<{
       `[topics diagnose] ${caseConfig.topics} topics x ${caseConfig.users} users`,
     );
     try {
-      results.push({ ok: true, result: await runCase(config, caseConfig) });
+      results.push({
+        ok: true,
+        result: await runCase(config, caseConfig, createHarnessForCase),
+      });
     } catch (error) {
       results.push({
         ok: false,
@@ -801,13 +868,31 @@ export async function runTopicsDiagnostics(args: readonly string[]): Promise<{
   };
 }
 
-if (import.meta.main) {
+export interface TopicsDiagnosticsCliDependencies {
+  error?: (message: string) => void;
+  exit?: (code: number) => void;
+  log?: (message: string) => void;
+  run?: (args: readonly string[]) => Promise<TopicsDiagnosticsReport>;
+}
+
+export async function runTopicsDiagnosticsCli(
+  args: readonly string[],
+  dependencies: TopicsDiagnosticsCliDependencies = {},
+): Promise<void> {
+  const exit = dependencies.exit ?? Deno.exit;
+  const run = dependencies.run ?? runTopicsDiagnostics;
+  let report: TopicsDiagnosticsReport;
   try {
-    const report = await runTopicsDiagnostics(Deno.args);
-    console.log(JSON.stringify(report, null, 2));
-    if (report.results.some((result) => !result.ok)) Deno.exit(1);
+    report = await run(args);
   } catch (error) {
-    console.error(reportSafeErrorCode(error));
-    Deno.exit(1);
+    (dependencies.error ?? console.error)(reportSafeErrorCode(error));
+    exit(1);
+    return;
   }
+  (dependencies.log ?? console.log)(JSON.stringify(report, null, 2));
+  if (report.results.some((result) => !result.ok)) exit(1);
+}
+
+if (import.meta.main) {
+  await runTopicsDiagnosticsCli(Deno.args);
 }

--- a/packages/patterns/tools/topics-diagnose.ts
+++ b/packages/patterns/tools/topics-diagnose.ts
@@ -460,25 +460,6 @@ async function runCase(
   const selected = new Set(config.scenarios);
   const representative = sessions[0];
   try {
-    if (selected.has("names")) {
-      phases.push(
-        await phase("display-name-handler-updates", harness, async () => {
-          const operations = sessions.flatMap((session, index) =>
-            Array.from(
-              { length: config.typingSteps },
-              (_entry, step) =>
-                session.topicsDiagnosticsSend(
-                  "setMyName",
-                  { name: `diagnostic-user-${index + 1}-${step + 1}` },
-                  { idle: false },
-                ),
-            )
-          );
-          return await submittedOutcomes(operations);
-        }),
-      );
-    }
-
     const concurrentCreation = selected.has("create-topics");
     const createName = concurrentCreation
       ? "concurrent-topic-creation"
@@ -491,6 +472,7 @@ async function runCase(
               "addTopic",
               {
                 title: `diagnostic-topic-${index + 1}`,
+                agentName: "Topics Diagnostics",
               },
             );
             if (!outcome.ok) {
@@ -504,7 +486,10 @@ async function runCase(
           (_entry, index) =>
             sessions[index % sessions.length].topicsDiagnosticsSend(
               "addTopic",
-              { title: `diagnostic-topic-${index + 1}` },
+              {
+                title: `diagnostic-topic-${index + 1}`,
+                agentName: "Topics Diagnostics",
+              },
               { idle: false },
             ),
         );
@@ -574,6 +559,7 @@ async function runCase(
                   "addComment",
                 ], {
                   body: `diagnostic-comment-${index + 1}-${round + 1}`,
+                  agentName: "Topics Diagnostics",
                 }, { idle: false }),
             )
           );
@@ -604,6 +590,7 @@ async function runCase(
                     round + 1
                   }`,
                   label: "diagnostic-link",
+                  agentName: "Topics Diagnostics",
                 }, { idle: false }),
             )
           );
@@ -632,6 +619,7 @@ async function runCase(
                   "setBody",
                 ], {
                   body: `diagnostic-body-${index + 1}-${round + 1}`,
+                  agentName: "Topics Diagnostics",
                 }, { idle: false }),
             )
           );

--- a/packages/patterns/tools/topics-diagnose.ts
+++ b/packages/patterns/tools/topics-diagnose.ts
@@ -893,6 +893,4 @@ export async function runTopicsDiagnosticsCli(
   if (report.results.some((result) => !result.ok)) exit(1);
 }
 
-if (import.meta.main) {
-  await runTopicsDiagnosticsCli(Deno.args);
-}
+if (import.meta.main) await runTopicsDiagnosticsCli(Deno.args);

--- a/packages/patterns/tools/topics-diagnose.ts
+++ b/packages/patterns/tools/topics-diagnose.ts
@@ -1,0 +1,825 @@
+import { Identity } from "@commonfabric/identity";
+import { join } from "@std/path";
+import {
+  type CommitTelemetrySnapshot,
+  MultiRuntimeHarness,
+  type MultiRuntimeSession,
+  type RuntimeDiagnosticsSummary,
+  type TopicsDiagnosticsOperationOutcome,
+} from "../integration/multi-runtime-harness.ts";
+import {
+  casesFromArgs,
+  configFromArgs,
+  type DerivedTelemetry,
+  deriveTelemetry,
+  type RootOscillationMetadata,
+  rootOscillationMetadata,
+  type RuntimeTelemetrySnapshot,
+  type TopicsDiagnosticsCase,
+  type TopicsDiagnosticsConfig,
+} from "./topics-diagnose-config.ts";
+
+export {
+  ALL_TOPICS_SCENARIOS,
+  casesFromArgs,
+  configFromArgs,
+  type DerivedTelemetry,
+  deriveTelemetry,
+  type RootOscillationMetadata,
+  rootOscillationMetadata,
+  type RuntimeTelemetrySnapshot,
+  type TopicsDiagnosticsCase,
+  type TopicsDiagnosticsConfig,
+  type TopicsDiagnosticsProfile,
+  type TopicsScenario,
+} from "./topics-diagnose-config.ts";
+
+const ROOT_PATH = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+
+interface ChurnTotals {
+  commitConflicts: number;
+  commitPreempted: number;
+  commitHeldRevert: number;
+  commitHeldSent: number;
+  commitReverts: number;
+  commitRejected: number;
+}
+
+interface PhaseReport {
+  phase: string;
+  elapsedMs: number;
+  operations: PhaseOperations;
+  telemetry: RuntimeTelemetrySnapshot;
+  derivedTelemetry: DerivedTelemetry;
+  memoryTelemetry: CommitTelemetrySnapshot;
+  rootOscillation?: RootOscillationMetadata;
+  graph: {
+    postSettleMaxNodesAcrossSessions: number;
+    postSettleMaxEdgesAcrossSessions: number;
+    postSettleMaxDirtyAcrossSessions: number;
+    postSettleMaxPendingAcrossSessions: number;
+  };
+  settle: {
+    trailingCumulativeHistoryEntries: number;
+    maxTrailingSettleMs: number;
+  };
+  churn: ChurnTotals;
+}
+
+interface PhaseOperations {
+  submitted: number;
+  directAccepted: number;
+  directRejected: number;
+}
+
+interface PhaseExecution extends PhaseOperations {
+  /** Internal only: queued events which must reach a final successful commit. */
+  expectedQueuedEventCount: number;
+  rootOscillation?: RootOscillationMetadata;
+}
+
+export interface ConvergenceReport {
+  converged: boolean;
+  summary: { topics: number[]; comments: number[]; links: number[] };
+}
+
+export interface CaseReport {
+  case: TopicsDiagnosticsCase;
+  phases: PhaseReport[];
+  convergence: ConvergenceReport;
+}
+
+export interface TopicsDiagnosticsReportConfig {
+  profile: TopicsDiagnosticsConfig["profile"];
+  topicCounts: readonly number[];
+  userCounts: readonly number[];
+  rounds: number;
+  typingSteps: number;
+  sessionsPerUser: number;
+  wsDelayMs: number;
+  scenarios: readonly TopicsDiagnosticsConfig["scenarios"][number][];
+}
+
+export const TOPICS_DIAGNOSTICS_ERROR_CODES = [
+  "invalid-configuration",
+  "harness-initialization-failed",
+  "phase-operation-failed",
+  "phase-verification-failed",
+  "root-oscillation-failed",
+  "convergence-failed",
+  "unknown-error",
+] as const;
+
+export type TopicsDiagnosticsErrorCode =
+  typeof TOPICS_DIAGNOSTICS_ERROR_CODES[number];
+
+export class TopicsDiagnosticsError extends Error {
+  constructor(
+    readonly code: TopicsDiagnosticsErrorCode,
+  ) {
+    super(code);
+  }
+}
+
+/** Maps arbitrary failures to report-safe fixed diagnostic categories. */
+export function reportSafeErrorCode(
+  error: unknown,
+): TopicsDiagnosticsErrorCode {
+  return error instanceof TopicsDiagnosticsError ? error.code : "unknown-error";
+}
+
+function addTelemetry(
+  total: RuntimeTelemetrySnapshot,
+  next: RuntimeTelemetrySnapshot,
+): RuntimeTelemetrySnapshot {
+  const writesByPathShape = { ...total.writesByPathShape };
+  for (const [path, count] of Object.entries(next.writesByPathShape)) {
+    writesByPathShape[path] = (writesByPathShape[path] ?? 0) + count;
+  }
+  const droppedEventsByReason = {
+    "piece-load": total.droppedEventsByReason["piece-load"] +
+      next.droppedEventsByReason["piece-load"],
+    lineage: total.droppedEventsByReason.lineage +
+      next.droppedEventsByReason.lineage,
+    preflight: total.droppedEventsByReason.preflight +
+      next.droppedEventsByReason.preflight,
+    "load-gate": total.droppedEventsByReason["load-gate"] +
+      next.droppedEventsByReason["load-gate"],
+  };
+  const permanentRejectionsByReason = {
+    "origin-committed": total.permanentRejectionsByReason[
+      "origin-committed"
+    ] + next.permanentRejectionsByReason["origin-committed"],
+    "receipt-exists": total.permanentRejectionsByReason["receipt-exists"] +
+      next.permanentRejectionsByReason["receipt-exists"],
+  };
+  return {
+    invocationCount: total.invocationCount + next.invocationCount,
+    distinctInvokedEventCount: total.distinctInvokedEventCount +
+      next.distinctInvokedEventCount,
+    distinctSuccessfulEventCount: total.distinctSuccessfulEventCount +
+      next.distinctSuccessfulEventCount,
+    distinctDroppedEventCount: total.distinctDroppedEventCount +
+      next.distinctDroppedEventCount,
+    droppedEventsByReason,
+    permanentRejectionsByReason,
+    commitMarkerCount: total.commitMarkerCount + next.commitMarkerCount,
+    directCommitCount: total.directCommitCount + next.directCommitCount,
+    successfulCommitCount: total.successfulCommitCount +
+      next.successfulCommitCount,
+    failedAttemptCount: total.failedAttemptCount + next.failedAttemptCount,
+    terminalFailureCount: total.terminalFailureCount +
+      next.terminalFailureCount,
+    retryMarkerCount: total.retryMarkerCount + next.retryMarkerCount,
+    maxRetryAttempt: Math.max(total.maxRetryAttempt, next.maxRetryAttempt),
+    readCount: total.readCount + next.readCount,
+    writeCount: total.writeCount + next.writeCount,
+    changedWriteCount: total.changedWriteCount + next.changedWriteCount,
+    writesTruncatedCount: total.writesTruncatedCount +
+      next.writesTruncatedCount,
+    writesByPathShape,
+  };
+}
+
+const emptyTelemetry = (): RuntimeTelemetrySnapshot => ({
+  invocationCount: 0,
+  distinctInvokedEventCount: 0,
+  distinctSuccessfulEventCount: 0,
+  distinctDroppedEventCount: 0,
+  droppedEventsByReason: {
+    "piece-load": 0,
+    lineage: 0,
+    preflight: 0,
+    "load-gate": 0,
+  },
+  permanentRejectionsByReason: {
+    "origin-committed": 0,
+    "receipt-exists": 0,
+  },
+  commitMarkerCount: 0,
+  directCommitCount: 0,
+  successfulCommitCount: 0,
+  failedAttemptCount: 0,
+  terminalFailureCount: 0,
+  retryMarkerCount: 0,
+  maxRetryAttempt: 0,
+  readCount: 0,
+  writeCount: 0,
+  changedWriteCount: 0,
+  writesTruncatedCount: 0,
+  writesByPathShape: {},
+});
+
+async function collectChurn(
+  sessions: readonly MultiRuntimeSession[],
+  opts: { idle?: boolean } = {},
+): Promise<ChurnTotals> {
+  const counts = await Promise.all(
+    sessions.map((session) => session.topicsDiagnosticsChurn(opts)),
+  );
+  return counts.reduce<ChurnTotals>((total, entry) => {
+    return {
+      commitConflicts: total.commitConflicts + entry.commitConflicts,
+      commitPreempted: total.commitPreempted + entry.commitPreempted,
+      commitHeldRevert: total.commitHeldRevert + entry.commitHeldRevert,
+      commitHeldSent: total.commitHeldSent + entry.commitHeldSent,
+      commitReverts: total.commitReverts + entry.commitReverts,
+      commitRejected: total.commitRejected + entry.commitRejected,
+    };
+  }, {
+    commitConflicts: 0,
+    commitPreempted: 0,
+    commitHeldRevert: 0,
+    commitHeldSent: 0,
+    commitReverts: 0,
+    commitRejected: 0,
+  });
+}
+
+function subtractChurn(after: ChurnTotals, before: ChurnTotals): ChurnTotals {
+  return {
+    commitConflicts: after.commitConflicts - before.commitConflicts,
+    commitPreempted: after.commitPreempted - before.commitPreempted,
+    commitHeldRevert: after.commitHeldRevert - before.commitHeldRevert,
+    commitHeldSent: after.commitHeldSent - before.commitHeldSent,
+    commitReverts: after.commitReverts - before.commitReverts,
+    commitRejected: after.commitRejected - before.commitRejected,
+  };
+}
+
+export function graphSummary(
+  diagnostics: readonly RuntimeDiagnosticsSummary[],
+): PhaseReport["graph"] {
+  return {
+    postSettleMaxNodesAcrossSessions: Math.max(
+      0,
+      ...diagnostics.map((entry) => entry.nodeCount),
+    ),
+    postSettleMaxEdgesAcrossSessions: Math.max(
+      0,
+      ...diagnostics.map((entry) => entry.edgeCount),
+    ),
+    postSettleMaxDirtyAcrossSessions: Math.max(
+      0,
+      ...diagnostics.map((entry) => entry.dirtyNodeCount),
+    ),
+    postSettleMaxPendingAcrossSessions: Math.max(
+      0,
+      ...diagnostics.map((entry) => entry.pendingNodeCount),
+    ),
+  };
+}
+
+export function settleSummary(
+  diagnostics: readonly RuntimeDiagnosticsSummary[],
+): PhaseReport["settle"] {
+  return {
+    trailingCumulativeHistoryEntries: diagnostics.reduce(
+      (total, entry) => total + entry.settleHistoryEntryCount,
+      0,
+    ),
+    maxTrailingSettleMs: Math.max(
+      0,
+      ...diagnostics.map((entry) => entry.maxTrailingSettleDurationMs),
+    ),
+  };
+}
+
+async function phase(
+  name: string,
+  harness: MultiRuntimeHarness,
+  operation: () => Promise<PhaseExecution>,
+  verifyAfterSettle?: () => Promise<void>,
+): Promise<PhaseReport> {
+  await harness.diagnosticsBarrier();
+  const churnBefore = await collectChurn(harness.sessions, { idle: false });
+  await Promise.all(harness.sessions.map((session) => session.telemetry()));
+  harness.memoryTelemetry();
+  const startedAt = performance.now();
+  const operations = await operation();
+  await harness.diagnosticsBarrier();
+  try {
+    await verifyAfterSettle?.();
+  } catch {
+    throw new TopicsDiagnosticsError("phase-verification-failed");
+  }
+  await harness.diagnosticsBarrier();
+  const [snapshots, diagnostics, churnAfter] = await Promise.all([
+    Promise.all(harness.sessions.map((session) => session.telemetry())),
+    Promise.all(
+      harness.sessions.map((session) =>
+        session.diagnosticsSummary({ idle: false })
+      ),
+    ),
+    collectChurn(harness.sessions, { idle: false }),
+  ]);
+  const telemetry = snapshots.reduce(addTelemetry, emptyTelemetry());
+  if (
+    telemetry.distinctSuccessfulEventCount !==
+      operations.expectedQueuedEventCount ||
+    telemetry.distinctDroppedEventCount !== 0 ||
+    telemetry.terminalFailureCount !== 0
+  ) {
+    throw new TopicsDiagnosticsError("phase-operation-failed");
+  }
+  const {
+    rootOscillation,
+    expectedQueuedEventCount: _expected,
+    ...phaseOperations
+  } = operations;
+  return {
+    phase: name,
+    elapsedMs: performance.now() - startedAt,
+    operations: phaseOperations,
+    telemetry,
+    derivedTelemetry: deriveTelemetry(telemetry, phaseOperations.submitted),
+    memoryTelemetry: harness.memoryTelemetry(),
+    ...(rootOscillation === undefined ? {} : { rootOscillation }),
+    graph: graphSummary(diagnostics),
+    settle: settleSummary(diagnostics),
+    churn: subtractChurn(churnAfter, churnBefore),
+  };
+}
+
+async function createHarness(
+  config: TopicsDiagnosticsConfig,
+  caseConfig: TopicsDiagnosticsCase,
+): Promise<MultiRuntimeHarness> {
+  const identities = await Promise.all(Array.from(
+    { length: caseConfig.users },
+    (_entry, index) =>
+      Identity.fromPassphrase(
+        `topics-diagnose-${crypto.randomUUID()}-user-${index + 1}`,
+        { implementation: "noble" },
+      ),
+  ));
+  const sessions = identities.flatMap((identity, userIndex) =>
+    Array.from({ length: config.sessionsPerUser }, (_entry, sessionIndex) => ({
+      label: `user-${userIndex + 1}-session-${sessionIndex + 1}`,
+      identity,
+      ...(config.wsDelayMs > 0 ? { wsDelayMs: config.wsDelayMs } : {}),
+    }))
+  );
+  return await MultiRuntimeHarness.create({
+    programPath: join(ROOT_PATH, config.program),
+    rootPath: ROOT_PATH,
+    diagnostics: true,
+    aggregateOnlyDiagnostics: true,
+    sessions,
+    spaceName: `topics-diagnostics-${crypto.randomUUID()}`,
+  });
+}
+
+async function setOutcomes(
+  operations: readonly Promise<TopicsDiagnosticsOperationOutcome>[],
+): Promise<PhaseExecution> {
+  const outcomes = await Promise.all(operations);
+  if (outcomes.some((outcome) => !outcome.ok)) {
+    throw new TopicsDiagnosticsError("phase-operation-failed");
+  }
+  const directAccepted = outcomes.filter((outcome) => outcome.ok).length;
+  return {
+    submitted: outcomes.length,
+    directAccepted,
+    directRejected: outcomes.length - directAccepted,
+    expectedQueuedEventCount: 0,
+  };
+}
+
+async function submittedOutcomes(
+  operations: readonly Promise<TopicsDiagnosticsOperationOutcome>[],
+): Promise<PhaseExecution> {
+  const outcomes = await Promise.all(operations);
+  if (outcomes.some((outcome) => !outcome.ok)) {
+    throw new TopicsDiagnosticsError("phase-operation-failed");
+  }
+  return submitted(outcomes.length);
+}
+
+const submitted = (count: number): PhaseExecution => ({
+  submitted: count,
+  directAccepted: 0,
+  directRejected: 0,
+  expectedQueuedEventCount: count,
+});
+
+async function assertSharedCardinality(
+  session: MultiRuntimeSession,
+  expected: { topics: number; comments: number; links: number },
+): Promise<void> {
+  const actual = await session.topicsDiagnosticsSummary();
+  if (
+    !actual.ok ||
+    actual.topics !== expected.topics ||
+    actual.comments !== expected.comments ||
+    actual.links !== expected.links
+  ) {
+    throw new TopicsDiagnosticsError("phase-verification-failed");
+  }
+}
+
+async function collectConvergence(
+  sessions: readonly MultiRuntimeSession[],
+): Promise<ConvergenceReport> {
+  const coordinator = sessions[0];
+  const channel = `topics-convergence-${crypto.randomUUID()}`;
+  const ready = await coordinator.topicsDiagnosticsConvergenceBegin(
+    channel,
+    sessions.length,
+  );
+  if (!ready.ok) throw new TopicsDiagnosticsError("convergence-failed");
+  try {
+    const publishes = await Promise.all(
+      sessions.map((session) =>
+        session.topicsDiagnosticsConvergencePublish(channel)
+      ),
+    );
+    if (publishes.some((outcome) => !outcome.ok)) {
+      throw new TopicsDiagnosticsError("convergence-failed");
+    }
+    const result = await coordinator.topicsDiagnosticsConvergenceFinish();
+    if (!result.ok) throw new TopicsDiagnosticsError("convergence-failed");
+    return { converged: result.converged, summary: result.summary };
+  } finally {
+    await coordinator.topicsDiagnosticsConvergenceCancel();
+  }
+}
+
+async function runCase(
+  config: TopicsDiagnosticsConfig,
+  caseConfig: TopicsDiagnosticsCase,
+): Promise<CaseReport> {
+  let harness: MultiRuntimeHarness;
+  try {
+    harness = await createHarness(config, caseConfig);
+  } catch {
+    throw new TopicsDiagnosticsError("harness-initialization-failed");
+  }
+  const sessions = harness.sessions;
+  const phases: PhaseReport[] = [];
+  const selected = new Set(config.scenarios);
+  const representative = sessions[0];
+  try {
+    if (selected.has("names")) {
+      phases.push(
+        await phase("display-name-handler-updates", harness, async () => {
+          const operations = sessions.flatMap((session, index) =>
+            Array.from(
+              { length: config.typingSteps },
+              (_entry, step) =>
+                session.topicsDiagnosticsSend(
+                  "setMyName",
+                  { name: `diagnostic-user-${index + 1}-${step + 1}` },
+                  { idle: false },
+                ),
+            )
+          );
+          return await submittedOutcomes(operations);
+        }),
+      );
+    }
+
+    const concurrentCreation = selected.has("create-topics");
+    const createName = concurrentCreation
+      ? "concurrent-topic-creation"
+      : "setup-topics";
+    phases.push(
+      await phase(createName, harness, async () => {
+        if (!concurrentCreation) {
+          for (let index = 0; index < caseConfig.topics; index++) {
+            const outcome = await representative.topicsDiagnosticsSend(
+              "addTopic",
+              {
+                title: `diagnostic-topic-${index + 1}`,
+              },
+            );
+            if (!outcome.ok) {
+              throw new TopicsDiagnosticsError("phase-operation-failed");
+            }
+          }
+          return submitted(caseConfig.topics);
+        }
+        const operations = Array.from(
+          { length: caseConfig.topics },
+          (_entry, index) =>
+            sessions[index % sessions.length].topicsDiagnosticsSend(
+              "addTopic",
+              { title: `diagnostic-topic-${index + 1}` },
+              { idle: false },
+            ),
+        );
+        return await submittedOutcomes(operations);
+      }, async () => {
+        await assertSharedCardinality(representative, {
+          topics: caseConfig.topics,
+          comments: 0,
+          links: 0,
+        });
+      }),
+    );
+
+    if (selected.has("noops")) {
+      phases.push(
+        await phase("repeated-noop-writes", harness, async () => {
+          const outcomes = await Promise.all(Array.from(
+            { length: caseConfig.topics },
+            (_entry, index) =>
+              sessions[index % sessions.length]
+                .topicsDiagnosticsNoop(index, { idle: false }),
+          ));
+          if (outcomes.some((outcome) => !outcome.ok)) {
+            throw new TopicsDiagnosticsError("phase-operation-failed");
+          }
+          const totals = outcomes.reduce<PhaseOperations>((total, outcome) => ({
+            submitted: total.submitted + outcome.submitted,
+            directAccepted: total.directAccepted + outcome.directAccepted,
+            directRejected: total.directRejected + outcome.directRejected,
+          }), { submitted: 0, directAccepted: 0, directRejected: 0 });
+          return { ...totals, expectedQueuedEventCount: outcomes.length };
+        }),
+      );
+    }
+
+    if (selected.has("titles")) {
+      phases.push(
+        await phase("live-title-typing", harness, async () => {
+          const operations = Array.from(
+            { length: caseConfig.topics },
+            (_entry, topicIndex) =>
+              Array.from(
+                { length: config.typingSteps },
+                (_ignored, step) =>
+                  sessions[(topicIndex + step) % sessions.length]
+                    .topicsDiagnosticsSet(
+                      ["topics", topicIndex, "title"],
+                      `diagnostic-title-${topicIndex + 1}-${step + 1}`,
+                      { idle: false },
+                    ),
+              ),
+          ).flat();
+          return await setOutcomes(operations);
+        }),
+      );
+    }
+    if (selected.has("comments")) {
+      phases.push(
+        await phase("concurrent-comments", harness, async () => {
+          const operations = sessions.flatMap((session, index) =>
+            Array.from(
+              { length: config.rounds },
+              (_entry, round) =>
+                session.topicsDiagnosticsSend([
+                  "topics",
+                  (index + round) % caseConfig.topics,
+                  "addComment",
+                ], {
+                  body: `diagnostic-comment-${index + 1}-${round + 1}`,
+                }, { idle: false }),
+            )
+          );
+          return await submittedOutcomes(operations);
+        }, async () => {
+          await assertSharedCardinality(representative, {
+            topics: caseConfig.topics,
+            comments: sessions.length * config.rounds,
+            links: 0,
+          });
+        }),
+      );
+    }
+    if (selected.has("links")) {
+      phases.push(
+        await phase("concurrent-links", harness, async () => {
+          const operations = sessions.flatMap((session, index) =>
+            Array.from(
+              { length: config.rounds },
+              (_entry, round) =>
+                session.topicsDiagnosticsSend([
+                  "topics",
+                  (index + round) % caseConfig.topics,
+                  "addLink",
+                ], {
+                  kind: "web",
+                  url: `https://example.invalid/diagnostic/${index + 1}/${
+                    round + 1
+                  }`,
+                  label: "diagnostic-link",
+                }, { idle: false }),
+            )
+          );
+          return await submittedOutcomes(operations);
+        }, async () => {
+          await assertSharedCardinality(representative, {
+            topics: caseConfig.topics,
+            comments: selected.has("comments")
+              ? sessions.length * config.rounds
+              : 0,
+            links: sessions.length * config.rounds,
+          });
+        }),
+      );
+    }
+    if (selected.has("bodies")) {
+      phases.push(
+        await phase("concurrent-body-saves", harness, async () => {
+          const operations = sessions.flatMap((session, index) =>
+            Array.from(
+              { length: config.rounds },
+              (_entry, round) =>
+                session.topicsDiagnosticsSend([
+                  "topics",
+                  (index + round) % caseConfig.topics,
+                  "setBody",
+                ], {
+                  body: `diagnostic-body-${index + 1}-${round + 1}`,
+                }, { idle: false }),
+            )
+          );
+          return await submittedOutcomes(operations);
+        }),
+      );
+    }
+    if (selected.has("root-oscillation")) {
+      const oscillationPhase = await phase(
+        "alternating-whole-root-oscillation",
+        harness,
+        async () => {
+          const attemptedStates: number[] = [];
+          const outcomes: TopicsDiagnosticsOperationOutcome[] = [];
+          for (let round = 0; round < config.rounds; round++) {
+            for (const state of [1, 0]) {
+              attemptedStates.push(state);
+              const writers = sessions.slice(0, 2);
+              const preparations = await Promise.all(
+                writers.map((session) =>
+                  session.topicsDiagnosticsPrepareReversedRoot({ idle: false })
+                ),
+              );
+              if (preparations.some((outcome) => !outcome.ok)) {
+                throw new TopicsDiagnosticsError("phase-operation-failed");
+              }
+              const pairOutcomes = await Promise.all(
+                writers.map((session) =>
+                  session.topicsDiagnosticsCommitPreparedRoot()
+                ),
+              );
+              if (
+                !pairOutcomes.some((outcome) => outcome.ok) ||
+                !pairOutcomes.some((outcome) => !outcome.ok)
+              ) {
+                throw new TopicsDiagnosticsError("root-oscillation-failed");
+              }
+              outcomes.push(...pairOutcomes);
+              await harness.diagnosticsBarrier();
+            }
+          }
+          const directAccepted = outcomes.filter((outcome) =>
+            outcome.ok
+          ).length;
+          return {
+            submitted: outcomes.length,
+            directAccepted,
+            directRejected: outcomes.length - directAccepted,
+            expectedQueuedEventCount: 0,
+            rootOscillation: rootOscillationMetadata(attemptedStates),
+          };
+        },
+        async () => {
+          await Promise.all(
+            sessions.map((session) =>
+              assertSharedCardinality(session, {
+                topics: caseConfig.topics,
+                comments: selected.has("comments")
+                  ? sessions.length * config.rounds
+                  : 0,
+                links: selected.has("links")
+                  ? sessions.length * config.rounds
+                  : 0,
+              })
+            ),
+          );
+        },
+      );
+      const rootPatchCount =
+        oscillationPhase.memoryTelemetry.patchesByPathShape["value-root"] ?? 0;
+      if (
+        oscillationPhase.operations.directAccepted < config.rounds * 2 ||
+        oscillationPhase.operations.directRejected === 0 ||
+        rootPatchCount < config.rounds * 2 ||
+        oscillationPhase.memoryTelemetry.conflictCount === 0 ||
+        oscillationPhase.churn.commitConflicts === 0 ||
+        oscillationPhase.churn.commitReverts === 0 ||
+        ((oscillationPhase.rootOscillation?.twoStepEligibleCount ?? 0) > 0 &&
+          oscillationPhase.rootOscillation?.twoStepRepeatRatio !== 1)
+      ) {
+        throw new TopicsDiagnosticsError("root-oscillation-failed");
+      }
+      phases.push(oscillationPhase);
+    }
+    if (selected.has("crossrefs")) {
+      phases.push(
+        await phase("cross-reference-fanout", harness, async () => {
+          const operations = Array.from(
+            { length: caseConfig.topics - 1 },
+            (_entry, index) => {
+              const sourceIndex = index + 1;
+              return sessions[index % sessions.length]
+                .topicsDiagnosticsCreateCrossref(sourceIndex, 0, {
+                  idle: false,
+                });
+            },
+          );
+          return await submittedOutcomes(operations);
+        }, async () => {
+          const validation = await Promise.all(
+            sessions.map((session) =>
+              session.topicsDiagnosticsValidateCrossrefs(caseConfig.topics)
+            ),
+          );
+          if (validation.some((outcome) => !outcome.ok)) {
+            throw new TopicsDiagnosticsError("phase-verification-failed");
+          }
+        }),
+      );
+    }
+
+    await harness.diagnosticsBarrier();
+    const convergence = await collectConvergence(sessions);
+    if (!convergence.converged) {
+      throw new TopicsDiagnosticsError("convergence-failed");
+    }
+    return {
+      case: caseConfig,
+      phases,
+      convergence,
+    };
+  } finally {
+    await harness.dispose();
+  }
+}
+
+export async function runTopicsDiagnostics(args: readonly string[]): Promise<{
+  kind: string;
+  config: TopicsDiagnosticsReportConfig;
+  elapsedMs: number;
+  results: readonly ({ ok: true; result: CaseReport } | {
+    ok: false;
+    case: TopicsDiagnosticsCase;
+    error: TopicsDiagnosticsErrorCode;
+  })[];
+}> {
+  let config: TopicsDiagnosticsConfig;
+  let cases: TopicsDiagnosticsCase[];
+  try {
+    config = configFromArgs(args);
+    cases = casesFromArgs(args, config);
+  } catch {
+    throw new TopicsDiagnosticsError("invalid-configuration");
+  }
+  const startedAt = performance.now();
+  const results: ({ ok: true; result: CaseReport } | {
+    ok: false;
+    case: TopicsDiagnosticsCase;
+    error: TopicsDiagnosticsErrorCode;
+  })[] = [];
+  for (const caseConfig of cases) {
+    console.error(
+      `[topics diagnose] ${caseConfig.topics} topics x ${caseConfig.users} users`,
+    );
+    try {
+      results.push({ ok: true, result: await runCase(config, caseConfig) });
+    } catch (error) {
+      results.push({
+        ok: false,
+        case: caseConfig,
+        error: reportSafeErrorCode(error),
+      });
+    }
+  }
+  return {
+    kind: "topics-workload-diagnostics",
+    config: {
+      profile: config.profile,
+      topicCounts: config.topicCounts,
+      userCounts: config.userCounts,
+      rounds: config.rounds,
+      typingSteps: config.typingSteps,
+      sessionsPerUser: config.sessionsPerUser,
+      wsDelayMs: config.wsDelayMs,
+      scenarios: config.scenarios,
+    },
+    elapsedMs: performance.now() - startedAt,
+    results,
+  };
+}
+
+if (import.meta.main) {
+  try {
+    const report = await runTopicsDiagnostics(Deno.args);
+    console.log(JSON.stringify(report, null, 2));
+    if (report.results.some((result) => !result.ok)) Deno.exit(1);
+  } catch (error) {
+    console.error(reportSafeErrorCode(error));
+    Deno.exit(1);
+  }
+}

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -119,7 +119,9 @@ Supported scenarios are `names`, `create-topics`, `noops`, `titles`, `comments`,
 the original scenarios; `--scenario=all` adds root oscillation.
 `--profile=conflicts` is intentionally small and deterministic: 2 topics, 2
 users, 2 sessions per user, a 10ms WebSocket frame delay, 4 rounds, and only
-`root-oscillation`; `--quick` keeps that topology but uses 2 rounds. Every
+`root-oscillation`; `--profile=conflicts --quick` keeps that topology but uses 2
+rounds. Standalone `--quick` instead selects the small matrix: 2 topics, 2
+users, 1 round, 2 typing steps, and the ordinary matrix scenarios. Every
 explicit dimension or `--scenario` overrides profile defaults.
 `root-oscillation` has each worker read the stored topics link array locally,
 preserve those links, and prepare the reversed whole-root value between two

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -107,16 +107,16 @@ deno run --frozen -A packages/patterns/tools/topics-diagnose.ts --profile=confli
 # Explicit matrix and a focused scenario subset.
 deno run --frozen -A packages/patterns/tools/topics-diagnose.ts \
   --cases=2x2,8x4 --rounds=3 --typing-steps=5 \
-  --scenario=names,comments,bodies
+  --scenario=comments,bodies
 
 # Two sessions per identity with deliberate storage-frame delay.
 deno run --frozen -A packages/patterns/tools/topics-diagnose.ts \
   --topics=4 --users=2 --sessions-per-user=2 --ws-delay-ms=10
 ```
 
-Supported scenarios are `names`, `create-topics`, `noops`, `titles`, `comments`,
-`links`, `bodies`, `crossrefs`, and `root-oscillation`. The matrix default keeps
-the original scenarios; `--scenario=all` adds root oscillation.
+Supported scenarios are `create-topics`, `noops`, `titles`, `comments`, `links`,
+`bodies`, `crossrefs`, and `root-oscillation`. The matrix default keeps the
+original scenarios; `--scenario=all` adds root oscillation.
 `--profile=conflicts` is intentionally small and deterministic: 2 topics, 2
 users, 2 sessions per user, a 10ms WebSocket frame delay, 4 rounds, and only
 `root-oscillation`; `--profile=conflicts --quick` keeps that topology but uses 2
@@ -129,18 +129,16 @@ sessions. Its diagnostic-only harness operation replaces the containing
 document's `value` record (preserving siblings), so canonical memory telemetry
 records a literal `/value` patch rather than nested `/value/topics/*` diffs. It
 requires at least two topics and two total sessions. The `noops` phase repeats
-each topic's current title and body so write elision is measured directly.
-`names` sends `setMyName` handler traffic: Topics does not expose the writable
-UI-bound display-name input as an output. When `create-topics` is not selected,
-setup creates the seed topics serially so focused profiles begin from a known
-baseline. Each target is prepared from the same confirmed root in two sessions
-then committed concurrently; the accepted root write and stale conflict/revert
-are both observed before the next target. Phase snapshots use an event-driven
-drain of delayed frames, worker synchronization, and server refreshes before
-counter reset or collection. `--program`, `--topics`, `--users`, `--rounds`,
-`--typing-steps`, `--sessions-per-user`, `--ws-delay-ms`, and
-`--cases=TOPICSxUSERS` are also available; invalid explicit values fail instead
-of falling back.
+each topic's current title and body so write elision is measured directly. When
+`create-topics` is not selected, setup creates the seed topics serially so
+focused profiles begin from a known baseline. Each target is prepared from the
+same confirmed root in two sessions then committed concurrently; the accepted
+root write and stale conflict/revert are both observed before the next target.
+Phase snapshots use an event-driven drain of delayed frames, worker
+synchronization, and server refreshes before counter reset or collection.
+`--program`, `--topics`, `--users`, `--rounds`, `--typing-steps`,
+`--sessions-per-user`, `--ws-delay-ms`, and `--cases=TOPICSxUSERS` are also
+available; invalid explicit values fail instead of falling back.
 
 Each phase reports logical submitted operations plus direct set/push accepted
 and rejected outcomes; queued stream sends are submitted, not accepted. It also
@@ -182,12 +180,14 @@ contender. `twoStepEligibleCount` is `max(0, target writes - 2)`. It contains no
 links, IDs, values, or fingerprints. When no two-step comparison is eligible,
 its ratio is `null`; a one-round conflict profile remains valid and still
 measures accepted root writes and stale conflicts. Final convergence reports
-only a boolean equality result and per-session cardinality arrays; private
-comparison data and the user-supplied program path are never serialized. Failed
-cases use only fixed diagnostic error codes, never exception messages or input
-content: `invalid-configuration`, `harness-initialization-failed`,
-`phase-verification-failed`, `phase-operation-failed`,
-`root-oscillation-failed`, `convergence-failed`, or `unknown-error`.
+only a boolean equality result and per-session cardinality arrays; the private
+equality token includes durable topic, comment, link, and structured author
+snapshots, but neither that data nor the user-supplied program path is
+serialized. Failed cases use only fixed diagnostic error codes, never exception
+messages or input content: `invalid-configuration`,
+`harness-initialization-failed`, `phase-verification-failed`,
+`phase-operation-failed`, `root-oscillation-failed`, `convergence-failed`, or
+`unknown-error`.
 
 Canonical byte definitions and the oscillation sequence shape are stable local
 diagnostic signals. Their totals, accepted/rejected outcomes, conflict counts,

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -84,3 +84,122 @@ cf piece call --piece <topic> addLink \
 Every agent-authored mutation carries `agentName`; there is no preceding “set
 current name” call. Fabric's operation history retains the authenticated human
 principal, while the stored snapshot disambiguates which agent acted.
+
+Do **not** run `cf piece step` from a fresh CLI replica: a replica with a
+partial view persists deriveds computed from that partial view. Writes commit
+fine on their own; renderers derive for themselves. Verify writes via a renderer
+or post-materialization fid reads.
+
+## Local workload diagnostics
+
+`topics-diagnose.ts` runs the board in worker-isolated local runtimes sharing an
+in-process memory server. It creates a fresh space per matrix case, drives real
+root and nested Topic streams, and emits one pretty JSON report on stdout;
+progress goes to stderr. Local runs require no collector.
+
+```bash
+# Small smoke matrix (two users, two topics).
+deno run --frozen -A packages/patterns/tools/topics-diagnose.ts --quick
+
+# Focused two-state whole-root conflict/storage profile.
+deno run --frozen -A packages/patterns/tools/topics-diagnose.ts --profile=conflicts
+
+# Explicit matrix and a focused scenario subset.
+deno run --frozen -A packages/patterns/tools/topics-diagnose.ts \
+  --cases=2x2,8x4 --rounds=3 --typing-steps=5 \
+  --scenario=names,comments,bodies
+
+# Two sessions per identity with deliberate storage-frame delay.
+deno run --frozen -A packages/patterns/tools/topics-diagnose.ts \
+  --topics=4 --users=2 --sessions-per-user=2 --ws-delay-ms=10
+```
+
+Supported scenarios are `names`, `create-topics`, `noops`, `titles`, `comments`,
+`links`, `bodies`, `crossrefs`, and `root-oscillation`. The matrix default keeps
+the original scenarios; `--scenario=all` adds root oscillation.
+`--profile=conflicts` is intentionally small and deterministic: 2 topics, 2
+users, 2 sessions per user, a 10ms WebSocket frame delay, 4 rounds, and only
+`root-oscillation`; `--quick` keeps that topology but uses 2 rounds. Every
+explicit dimension or `--scenario` overrides profile defaults.
+`root-oscillation` has each worker read the stored topics link array locally,
+preserve those links, and prepare the reversed whole-root value between two
+sessions. Its diagnostic-only harness operation replaces the containing
+document's `value` record (preserving siblings), so canonical memory telemetry
+records a literal `/value` patch rather than nested `/value/topics/*` diffs. It
+requires at least two topics and two total sessions. The `noops` phase repeats
+each topic's current title and body so write elision is measured directly.
+`names` sends `setMyName` handler traffic: Topics does not expose the writable
+UI-bound display-name input as an output. When `create-topics` is not selected,
+setup creates the seed topics serially so focused profiles begin from a known
+baseline. Each target is prepared from the same confirmed root in two sessions
+then committed concurrently; the accepted root write and stale conflict/revert
+are both observed before the next target. Phase snapshots use an event-driven
+drain of delayed frames, worker synchronization, and server refreshes before
+counter reset or collection. `--program`, `--topics`, `--users`, `--rounds`,
+`--typing-steps`, `--sessions-per-user`, `--ws-delay-ms`, and
+`--cases=TOPICSxUSERS` are also available; invalid explicit values fail instead
+of falling back.
+
+Each phase reports logical submitted operations plus direct set/push accepted
+and rejected outcomes; queued stream sends are submitted, not accepted. It also
+reports scheduler invocations, scheduler commit markers, direct UI-style
+commits, retries, read/write/changed-write totals, truncated-write markers,
+distinct invoked/successful/dropped event counts, fixed drop and permanent
+rejection reason maps, and changed writes grouped by structural marker path. The
+worker correlates event IDs only in private sets; JSON reports contain no event
+IDs, handler IDs, paths, content, DIDs, or URLs beyond the fixed path shapes
+described below. `changedWriteCount` includes locally applied/speculative paths
+from failed or retried attempts; `writesByPathShape` contains only fixed
+structural shapes (`value`, `*`, `#`, `metadata`, `other`, `$root`), never IDs
+or field/content keys. Derived ratios show changed and attempted writes per
+submitted operation; `elided` is `writeCount - changedWriteCount` clamped at
+zero, so it is a candidate signal, not proof of a product-level no-op. Graph
+samples are post-settle cross-session maxima and settle samples are trailing
+cumulative history, not per-phase peaks. Workload inputs and control paths may
+cross into workers, but Topics diagnostic responses contain only numeric
+aggregates, booleans, fixed outcomes, and structural metadata. Equality tokens
+and bootstrap piece IDs travel only between workers over a fresh private
+BroadcastChannel; workers aggregate their scheduler graph and settle data into
+numeric counts and durations before transfer, so no scheduler nodes, edges,
+histories, action traces, or pattern values cross IPC for Topics diagnostics.
+They and storage-conflict churn are local runtime observations; compare them
+across the same machine/configuration, not as stable production benchmarks. Each
+local diagnostic phase also includes `memoryTelemetry`, a snapshot reset at the
+phase boundary from the canonical memory server: transact/accepted/rejected
+counts, conflict and replay counts, total/max received commit bytes, confirmed
+read entries/bytes, operation entries/bytes, newly persisted revisions, and
+rejections grouped by error name. It also reports fixed-vocabulary patch-op
+counts for received requests and newly applied non-replay revisions (including
+`append`); these counts contain no patch values, paths, or IDs. Canonical patch
+paths use the same privacy rule; a whole document `value` replacement is
+reported as `value-root`. `rootOscillation` is content-free metadata: the number
+of intended distinct states, target writes, and two-step eligible/repeat
+count/ratio. `targetWriteCount` counts one intended accepted state per competing
+transaction pair; the phase's `operations.submitted` also includes each stale
+contender. `twoStepEligibleCount` is `max(0, target writes - 2)`. It contains no
+links, IDs, values, or fingerprints. When no two-step comparison is eligible,
+its ratio is `null`; a one-round conflict profile remains valid and still
+measures accepted root writes and stale conflicts. Final convergence reports
+only a boolean equality result and per-session cardinality arrays; private
+comparison data and the user-supplied program path are never serialized. Failed
+cases use only fixed diagnostic error codes, never exception messages or input
+content: `invalid-configuration`, `harness-initialization-failed`,
+`phase-verification-failed`, `phase-operation-failed`,
+`root-oscillation-failed`, `convergence-failed`, or `unknown-error`.
+
+Canonical byte definitions and the oscillation sequence shape are stable local
+diagnostic signals. Their totals, accepted/rejected outcomes, conflict counts,
+scheduler churn, graph/settle samples, and timing remain observational: they can
+vary by runtime scheduling and should not be compared as exact production
+benchmarks.
+
+### Telemetry privacy
+
+Topics diagnostics use aggregate-only workers. They do not attach the runtime
+OTel bridge and suppress worker error output, so identifier-bearing worker spans
+and scheduler error payloads cannot escape through the diagnostic process. The
+local memory server also uses non-recording spans and suppresses free-form
+warnings in this mode. Aggregate workers reject generic read, raw-read, link,
+detailed-diagnostics, and logger-map RPCs; only lifecycle controls and the
+fixed-shape Topics commands are available. The report retains only numeric
+aggregates and fixed categories.

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -202,6 +202,8 @@ OTel bridge and suppress worker error output, so identifier-bearing worker spans
 and scheduler error payloads cannot escape through the diagnostic process. The
 local memory server also uses non-recording spans and suppresses free-form
 warnings in this mode. Aggregate workers reject generic read, raw-read, link,
-detailed-diagnostics, and logger-map RPCs; only lifecycle controls and the
-fixed-shape Topics commands are available. The report retains only numeric
-aggregates and fixed categories.
+detailed-diagnostics, and logger-map RPCs. They allow lifecycle controls, the
+fixed-shape Topics commands, and the sanitized `diagnosticsSummary`,
+`diagnosticsActivityGeneration`, `telemetry`, and `topicsDiagnosticsChurn`
+aggregate commands. Those responses and the report retain only numeric
+aggregates, booleans, and fixed categories.

--- a/packages/runner/src/ensure-piece-running.ts
+++ b/packages/runner/src/ensure-piece-running.ts
@@ -35,11 +35,11 @@ function cellTraversalKey(cell: Cell<any>): string {
   return JSON.stringify([space, id, path]);
 }
 
-function followResultCellChain(
+async function followResultCellChain(
   runtime: Runtime,
   rootCell: Cell<any>,
   tx: IExtendedStorageTransaction,
-): Cell<any> | undefined {
+): Promise<Cell<any> | undefined> {
   let currentCell = rootCell;
   const visited = new Set<string>();
   let depth = 0;
@@ -54,6 +54,7 @@ function followResultCellChain(
     }
     visited.add(key);
 
+    await currentCell.sync();
     const resultLink = getMetaLink(currentCell, "result");
     if (resultLink === undefined) return currentCell;
 
@@ -110,11 +111,12 @@ export async function ensurePieceRunning(
 
       // If this is an internal/argument/derived cell, find the result cell that
       // owns the chain.
-      const resultCell = followResultCellChain(runtime, rootCell, tx);
+      const resultCell = await followResultCellChain(runtime, rootCell, tx);
       if (resultCell === undefined) return false;
 
       // If rootCell is a result cell, it will carry a `{ identity, symbol }`
       // pattern pointer.
+      await resultCell.sync();
       const identityRef = readPatternIdentity(resultCell);
       if (!identityRef) {
         logger.debug("ensure-piece", () => [

--- a/packages/runner/src/ensure-piece-running.ts
+++ b/packages/runner/src/ensure-piece-running.ts
@@ -114,9 +114,8 @@ export async function ensurePieceRunning(
       const resultCell = await followResultCellChain(runtime, rootCell, tx);
       if (resultCell === undefined) return false;
 
-      // If rootCell is a result cell, it will carry a `{ identity, symbol }`
-      // pattern pointer.
-      await resultCell.sync();
+      // followResultCellChain synchronizes every cell before returning it, so
+      // the terminal result cell's pattern pointer is already current here.
       const identityRef = readPatternIdentity(resultCell);
       if (!identityRef) {
         logger.debug("ensure-piece", () => [

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -102,6 +102,7 @@ export {
   setBlindStructuralTarget,
   unmarkUiInputBlindWriteTx,
 } from "./storage/reactivity-log.ts";
+export { classifyTelemetryWriteCounts } from "./scheduler/reactivity.ts";
 export { resolveLink } from "./link-resolution.ts";
 export {
   areLinksSame,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -209,10 +209,13 @@ export {
 } from "./cfc.ts";
 export type { Mutable } from "@commonfabric/utils/types";
 export {
+  type HostRuntimeTelemetryMarker,
+  type HostSchedulerEventPreflightStats,
   RuntimeTelemetry,
   RuntimeTelemetryEvent,
   type RuntimeTelemetryMarker,
   type RuntimeTelemetryMarkerResult,
+  type SchedulerEventPreflightStats,
   type SchedulerGraphEdge,
   type SchedulerGraphNode,
   type SchedulerGraphSnapshot,

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -25,6 +25,7 @@ import {
 } from "./backpressure.ts";
 import type {
   SchedulerActionInfo,
+  SchedulerEventDropReason,
   SchedulerEventPreflightStats,
 } from "../telemetry.ts";
 import { MAX_EVENT_BACKLOG_PER_STREAM } from "./constants.ts";
@@ -35,6 +36,7 @@ import type { OriginStatus } from "./lineage.ts";
 import type { NodeRegistry } from "./node-record.ts";
 import { RetryImmediately } from "./retry-immediately.ts";
 import {
+  eventCommitTelemetryWriteCounts,
   hasAnnotatedWrites,
   trustedEventWriteCandidatesFromTransaction,
   txToReactivityLog,
@@ -130,11 +132,18 @@ export interface SchedulerEventQueueState {
 function notifyEventDropped(
   state: Pick<SchedulerEventQueueState, "runtime">,
   args: {
+    readonly id: string;
     readonly eventLink: NormalizedFullLink;
     readonly onCommit?: QueuedEvent["onCommit"];
   },
+  dropReason: SchedulerEventDropReason,
   reason: string,
 ): void {
+  state.runtime.telemetry.submit({
+    type: "scheduler.event.drop",
+    eventId: args.id,
+    reason: dropReason,
+  });
   logger.warn("scheduler", reason, { eventLink: args.eventLink });
   if (!args.onCommit) return;
   const tx = state.runtime.edit();
@@ -161,6 +170,7 @@ export function dropQueuedEvent(
     & Pick<SchedulerEventQueueState, "runtime" | "eventQueue">
     & Partial<Pick<SchedulerEventQueueState, "releaseLineageEvent">>,
   event: QueuedEvent,
+  dropReason: SchedulerEventDropReason,
   reason: string,
 ): void {
   const index = state.eventQueue.indexOf(event);
@@ -170,7 +180,7 @@ export function dropQueuedEvent(
   }
   if (event.finalOutcomeNotified) return;
   event.finalOutcomeNotified = true;
-  notifyEventDropped(state, event, reason);
+  notifyEventDropped(state, event, dropReason, reason);
 }
 
 function findEventHandler(
@@ -369,6 +379,7 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
           dropQueuedEvent(
             state,
             queuedEvent,
+            "piece-load",
             started
               ? `Event dropped: no handler registered for ${args.eventLink.id} after starting its piece`
               : `Event dropped: no handler registered for ${args.eventLink.id} and its piece could not be started`,
@@ -378,6 +389,7 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
         dropQueuedEvent(
           state,
           queuedEvent,
+          "piece-load",
           `Event dropped: starting the piece for ${args.eventLink.id} failed: ${
             error instanceof Error ? error.message : String(error)
           }`,
@@ -396,7 +408,8 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
     // instantiate). Trying again won't change this, so settle the event now.
     notifyEventDropped(
       state,
-      args,
+      { ...args, id },
+      "load-gate",
       `Event dropped: no handler registered for ${args.eventLink.id} ` +
         `after starting its piece`,
     );
@@ -483,7 +496,11 @@ export interface SchedulerEventExecutionState {
     originTx: IExtendedStorageTransaction,
     event: QueuedEvent,
   ) => void;
-  readonly dropEvent: (event: QueuedEvent, reason: string) => void;
+  readonly dropEvent: (
+    event: QueuedEvent,
+    dropReason: SchedulerEventDropReason,
+    reason: string,
+  ) => void;
   readonly recordLineageEvent: (
     originTx: IExtendedStorageTransaction,
     event: QueuedEvent,
@@ -524,7 +541,11 @@ export function preflightQueuedEventDependencies(state: {
   readonly getNextDebounceRunTime: (action: Action) => number | undefined;
   readonly getNextEligibleRunTime: (action: Action) => number | undefined;
   readonly scheduleWake: (notBefore: number) => void;
-  readonly dropEvent: (event: QueuedEvent, reason: string) => void;
+  readonly dropEvent: (
+    event: QueuedEvent,
+    dropReason: SchedulerEventDropReason,
+    reason: string,
+  ) => void;
 }, queuedEvent: QueuedEvent): EventDependencyPreflightResult {
   const { handler, event: eventValue } = queuedEvent;
   const preflightStats = createEventPreflightTraceContext();
@@ -558,6 +579,7 @@ export function preflightQueuedEventDependencies(state: {
     // await it hanging.
     state.dropEvent(
       queuedEvent,
+      "preflight",
       `Event dropped: populateDependencies threw during dependency ` +
         `preflight for ${queuedEvent.eventLink.id}`,
     );
@@ -720,6 +742,7 @@ export async function processPullQueuedEventDuringExecute(
     if (originStatus === "failed") {
       state.dropEvent(
         queuedEvent,
+        "lineage",
         `Event dropped: lineage origin failed before ${queuedEvent.id} dispatched`,
       );
       logger.debug("scheduler-lineage", () => [
@@ -788,7 +811,8 @@ export async function processPullQueuedEventDuringExecute(
       getNextDebounceRunTime: (dep) => state.getNextDebounceRunTime(dep),
       getNextEligibleRunTime: (dep) => state.getNextEligibleRunTime(dep),
       scheduleWake: (notBefore) => state.scheduleWake(notBefore),
-      dropEvent: (event, reason) => state.dropEvent(event, reason),
+      dropEvent: (event, dropReason, reason) =>
+        state.dropEvent(event, dropReason, reason),
     }, queuedEvent);
     shouldSkipEvent = preflight.shouldSkipEvent;
 
@@ -894,6 +918,7 @@ export async function dispatchQueuedEvent(state: {
 
   state.runtime.telemetry.submit({
     type: "scheduler.invocation",
+    eventId: queuedEvent.id,
     handlerId,
     handlerInfo: state.getActionTelemetryInfo(handler),
   });
@@ -1066,10 +1091,17 @@ export async function dispatchQueuedEvent(state: {
     }
 
     state.runtime.prepareTxForCommit(tx);
+    const detailedEventCommitTelemetry =
+      state.runtime.telemetry.detailedEventCommitTelemetryEnabled;
     const log = txToReactivityLog(tx);
-    const telemetryWrites = log.writes
-      .slice(0, EVENT_COMMIT_TELEMETRY_WRITE_LIMIT)
-      .map(formatEventCommitAddress);
+    const writeCounts = detailedEventCommitTelemetry
+      ? eventCommitTelemetryWriteCounts(tx, log.writes)
+      : { writeCount: log.writes.length, changedWriteCount: log.writes.length };
+    const telemetryWrites = detailedEventCommitTelemetry
+      ? log.writes
+        .slice(0, EVENT_COMMIT_TELEMETRY_WRITE_LIMIT)
+        .map(formatEventCommitAddress)
+      : [];
     // Do not await event commits here. commit() applies the transaction
     // locally before returning, and the scheduler must let later client work
     // continue against that speculative state while server confirmation is in
@@ -1098,13 +1130,15 @@ export async function dispatchQueuedEvent(state: {
 
       state.runtime.telemetry.submit({
         type: "scheduler.event.commit",
+        eventId: queuedEvent.id,
         handlerId,
         handlerInfo: state.getActionTelemetryInfo(handler),
         readCount: log.reads.length + log.shallowReads.length,
-        writeCount: log.writes.length,
-        changedWriteCount: log.writes.length,
+        writeCount: writeCounts.writeCount,
+        changedWriteCount: writeCounts.changedWriteCount,
         writes: telemetryWrites,
-        ...(log.writes.length > EVENT_COMMIT_TELEMETRY_WRITE_LIMIT
+        ...(detailedEventCommitTelemetry &&
+            log.writes.length > EVENT_COMMIT_TELEMETRY_WRITE_LIMIT
           ? { writesTruncated: true }
           : {}),
         ...(result.error ? { error: result.error.message } : {}),

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -414,7 +414,8 @@ export class Scheduler {
   private eventQueue: QueuedEvent[] = [];
   private eventHandlers: [NormalizedFullLink, EventHandler][] = [];
   readonly lineage = new SpeculationLineage({
-    dropQueuedEvent: (event, reason) => this.dropEvent(event, reason),
+    dropQueuedEvent: (event, reason) =>
+      this.dropEvent(event, "lineage", reason),
     queueExecution: () => this.queueExecution(),
     onError: (error) => logger.error("lineage", () => [error]),
   });
@@ -2477,8 +2478,8 @@ export class Scheduler {
       releaseLineageEvent: (originTx, queuedEvent) => {
         this.lineage.release(originTx, queuedEvent);
       },
-      dropEvent: (queuedEvent, reason) => {
-        this.dropEvent(queuedEvent, reason);
+      dropEvent: (queuedEvent, dropReason, reason) => {
+        this.dropEvent(queuedEvent, dropReason, reason);
       },
       recordLineageEvent: (originTx, queuedEvent) => {
         this.lineage.recordEvent(originTx, queuedEvent);
@@ -2760,12 +2761,17 @@ export class Scheduler {
     const detail = error instanceof Error ? error.message : String(error);
     this.dropEvent(
       event,
+      "load-gate",
       `Event dropped: required replica load failed before dispatch (${detail})`,
     );
     this.queueExecution();
   }
 
-  private dropEvent(event: QueuedEvent, reason: string): void {
+  private dropEvent(
+    event: QueuedEvent,
+    dropReason: import("../telemetry.ts").SchedulerEventDropReason,
+    reason: string,
+  ): void {
     if (this.headEventLoadPark?.eventId === event.id) {
       this.headEventLoadPark = null;
     }
@@ -2781,6 +2787,7 @@ export class Scheduler {
         },
       },
       event,
+      dropReason,
       reason,
     );
   }

--- a/packages/runner/src/scheduler/reactivity.ts
+++ b/packages/runner/src/scheduler/reactivity.ts
@@ -137,6 +137,87 @@ export function txToReactivityLog(
   return toSchedulerReactivityLog(txToTransactionReactivityLog(tx));
 }
 
+/**
+ * Counts event-commit write targets for telemetry without widening the
+ * scheduler's dependency ReactivityLog. Changed writes are transaction writes;
+ * attempted targets that do not overlap a changed write are no-op candidates.
+ */
+export function eventCommitTelemetryWriteCounts(
+  tx: IExtendedStorageTransaction,
+  changedWrites: readonly IMemorySpaceAddress[],
+): { writeCount: number; changedWriteCount: number } {
+  return classifyTelemetryWriteCounts(
+    changedWrites,
+    txToTransactionReactivityLog(tx).attemptedWrites ?? [],
+  );
+}
+
+export function classifyTelemetryWriteCounts(
+  changedWrites: readonly IMemorySpaceAddress[],
+  attemptedWrites: readonly IMemorySpaceAddress[],
+): { writeCount: number; changedWriteCount: number } {
+  const attemptedTargets = new Map<string, IMemorySpaceAddress>();
+  for (const address of attemptedWrites) {
+    attemptedTargets.set(normalizedAddressKey(address), address);
+  }
+  const changedByDocument = new Map<
+    string,
+    ChangedPathNode
+  >();
+  for (const changed of changedWrites) {
+    const documentKey = normalizedDocumentKey(changed);
+    const root = changedByDocument.get(documentKey) ?? changedPathNode();
+    let node = root;
+    for (const segment of changed.path) {
+      const child = node.children.get(segment) ?? changedPathNode();
+      node.children.set(segment, child);
+      node = child;
+    }
+    node.terminal = true;
+    changedByDocument.set(documentKey, root);
+  }
+  const noOpCandidates = [...attemptedTargets.values()].filter((attempted) => {
+    let node = changedByDocument.get(normalizedDocumentKey(attempted));
+    if (!node) return true;
+    if (node.terminal) return false;
+    for (const segment of attempted.path) {
+      node = node.children.get(segment);
+      if (!node) return true;
+      if (node.terminal) return false;
+    }
+    // The attempted path is a prefix of at least one changed path.
+    return node.children.size === 0;
+  });
+  return {
+    changedWriteCount: changedWrites.length,
+    writeCount: changedWrites.length + noOpCandidates.length,
+  };
+}
+
+interface ChangedPathNode {
+  terminal: boolean;
+  children: Map<string, ChangedPathNode>;
+}
+
+function changedPathNode(): ChangedPathNode {
+  return { terminal: false, children: new Map() };
+}
+
+function normalizedAddressKey(address: IMemorySpaceAddress): string {
+  return JSON.stringify([
+    normalizedDocumentKey(address),
+    address.path,
+  ]);
+}
+
+function normalizedDocumentKey(address: IMemorySpaceAddress): string {
+  return JSON.stringify([
+    address.space,
+    normalizeCellScope(address.scope),
+    address.id,
+  ]);
+}
+
 function txToTransactionReactivityLog(
   tx: IExtendedStorageTransaction,
 ): TransactionReactivityLog {

--- a/packages/runner/src/scheduler/reactivity.ts
+++ b/packages/runner/src/scheduler/reactivity.ts
@@ -8,6 +8,7 @@ import { normalizeCellScope } from "../scope.ts";
 import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
+  IStorageTransaction,
   TransactionReactivityLog,
 } from "../storage/interface.ts";
 import { reactivityLogFromActivities } from "../storage/reactivity-log.ts";
@@ -143,7 +144,7 @@ export function txToReactivityLog(
  * attempted targets that do not overlap a changed write are no-op candidates.
  */
 export function eventCommitTelemetryWriteCounts(
-  tx: IExtendedStorageTransaction,
+  tx: IStorageTransaction | IExtendedStorageTransaction,
   changedWrites: readonly IMemorySpaceAddress[],
 ): { writeCount: number; changedWriteCount: number } {
   return classifyTelemetryWriteCounts(
@@ -219,7 +220,7 @@ function normalizedDocumentKey(address: IMemorySpaceAddress): string {
 }
 
 function txToTransactionReactivityLog(
-  tx: IExtendedStorageTransaction,
+  tx: IStorageTransaction | IExtendedStorageTransaction,
 ): TransactionReactivityLog {
   const direct = getDirectTransactionReactivityLog(tx);
   if (direct) {

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -41,7 +41,7 @@ export { type Cancel, useCancelGroup } from "./cancel.ts";
 export type {
   CycleReport,
   HostRuntimeTelemetryMarker,
-  HostSchedulerActionInfo,
+  HostSchedulerEventPreflightStats,
   NonIdempotentReport,
   RuntimeTelemetry,
   RuntimeTelemetryEvent,

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -40,10 +40,13 @@ export {
 export { type Cancel, useCancelGroup } from "./cancel.ts";
 export type {
   CycleReport,
+  HostRuntimeTelemetryMarker,
+  HostSchedulerActionInfo,
   NonIdempotentReport,
   RuntimeTelemetry,
   RuntimeTelemetryEvent,
   RuntimeTelemetryMarkerResult,
+  SchedulerActionInfo,
   SchedulerDiagnosisResult,
   SchedulerGraphEdge,
   SchedulerGraphNode,

--- a/packages/runner/src/telemetry-otel-bridge.ts
+++ b/packages/runner/src/telemetry-otel-bridge.ts
@@ -1,10 +1,10 @@
-// OpenTelemetry bridge for the runtime's existing telemetry stream.
+// OpenTelemetry bridge for runtime telemetry at two privacy levels.
 //
-// This does NOT add a parallel instrumentation layer. It subscribes to the
-// SAME `RuntimeTelemetry` event bus that the debug tooling consumes (see
-// telemetry.ts / runtime-client) and translates each `RuntimeTelemetryMarker`
-// into OpenTelemetry spans and metrics. The debug tooling keeps working
-// unchanged; OTel is just a second consumer of one event stream.
+// Worker/server callers feed detailed RuntimeTelemetry markers from the
+// RuntimeTelemetry EventTarget. Browser hosts feed HostRuntimeTelemetryMarker,
+// the aggregate-only projection received over the worker-to-host boundary.
+// Detailed markers can supply diagnostic span attributes; host markers produce
+// only metrics available from their safe aggregate fields.
 //
 // It depends ONLY on `@opentelemetry/api` (interface-only, side-effect free), so
 // importing it never pulls the OTel SDK into a bundle and never forces
@@ -12,10 +12,10 @@
 // owns its SDK provider setup and passes a Tracer + Meter in. When no provider
 // is registered the API returns no-op instruments, so the bridge is inert.
 //
-// Reuse across runtimes: the worker/server side exposes an EventTarget
-// (`runtime.telemetry`); the main thread / browser receives the same markers via
-// `runtime-client.on("telemetry", ...)`. Both feed `handleMarker()`, so one
-// translation table serves all three execution contexts.
+// Reuse across runtimes: the worker/server side exposes `runtime.telemetry`,
+// while the browser host receives its sanitized projection through
+// `runtime-client.on("telemetry", ...)`. `handleMarker()` selects the detailed
+// or aggregate translator without widening the worker-to-host payload.
 
 import {
   type Attributes,
@@ -28,6 +28,7 @@ import type {
   HostRuntimeTelemetryMarker,
   RuntimeTelemetry,
   RuntimeTelemetryEvent,
+  RuntimeTelemetryMarkerResult,
 } from "./telemetry.ts";
 
 export interface OtelBridgeOptions {
@@ -66,8 +67,10 @@ export interface OtelBridgeOptions {
 }
 
 export interface RuntimeTelemetryOtelBridge {
-  /** Translate a single marker into spans/metrics. Safe to call for any type. */
-  handleMarker(marker: HostRuntimeTelemetryMarker): void;
+  /** Translate a detailed runtime or aggregate-safe host marker into telemetry. */
+  handleMarker(
+    marker: HostRuntimeTelemetryMarker | RuntimeTelemetryMarkerResult,
+  ): void;
   /** Close any spans still open (e.g. storage ops without a completion). */
   shutdown(): void;
 }
@@ -98,9 +101,8 @@ export function attachRuntimeTelemetryOtelBridge(
 }
 
 /**
- * Create a bridge whose `handleMarker` can be wired to any marker source —
- * an EventTarget listener (worker/server) or `runtime-client.on("telemetry")`
- * (main thread / browser).
+ * Create a bridge for detailed EventTarget markers (worker/server) and
+ * aggregate-safe `runtime-client.on("telemetry")` markers (browser host).
  */
 export function createRuntimeTelemetryOtelBridge(
   options: OtelBridgeOptions,
@@ -272,7 +274,7 @@ export function createRuntimeTelemetryOtelBridge(
     }
   };
 
-  const handleMarker = (marker: HostRuntimeTelemetryMarker): void => {
+  const handleRuntimeMarker = (marker: RuntimeTelemetryMarkerResult): void => {
     switch (marker.type) {
       case "scheduler.run":
         runs.add(
@@ -443,12 +445,140 @@ export function createRuntimeTelemetryOtelBridge(
     }
   };
 
+  const handleHostMarker = (marker: HostRuntimeTelemetryMarker): void => {
+    switch (marker.type) {
+      case "scheduler.run":
+        runs.add(1, mattrs({ "ct.error": !marker.ok }));
+        break;
+      case "scheduler.run.complete":
+        actionDuration.record(
+          marker.durationMs,
+          mattrs({ "ct.error": !marker.ok }),
+        );
+        break;
+      case "scheduler.settle":
+        settleDuration.record(marker.durationMs, mattrs());
+        settleIterations.record(marker.iterations, mattrs());
+        break;
+      case "scheduler.invocation":
+        invocations.add(1, mattrs());
+        break;
+      case "cell.update":
+        cellUpdates.add(1, mattrs());
+        break;
+      case "scheduler.event.commit": {
+        const attributes = mattrs({
+          "ct.commit.terminal": marker.terminal ?? "none",
+          "ct.error": !marker.ok,
+        });
+        commits.add(1, attributes);
+        commitWrites.record(marker.writeCount, attributes);
+        commitChangedWrites.record(marker.changedWriteCount, attributes);
+        commitNoopCandidates.record(
+          Math.max(0, marker.writeCount - marker.changedWriteCount),
+          attributes,
+        );
+        commitReads.record(marker.readCount, attributes);
+        if (marker.backoffMs !== undefined) commitRetries.add(1, attributes);
+        break;
+      }
+      case "scheduler.event.preflight": {
+        const total = marker.populateMs + marker.txToLogMs +
+          marker.depCommitMs + marker.collectMs + marker.scheduleMs;
+        const attributes = mattrs();
+        preflightPhase.populate.record(marker.populateMs, attributes);
+        preflightPhase.txToLog.record(marker.txToLogMs, attributes);
+        preflightPhase.depCommit.record(marker.depCommitMs, attributes);
+        preflightPhase.collect.record(marker.collectMs, attributes);
+        preflightPhase.schedule.record(marker.scheduleMs, attributes);
+        preflightPhase.total.record(total, attributes);
+        preflightDirtyDeps.record(marker.dirtyDependencyCount, attributes);
+        break;
+      }
+      case "scheduler.non-settling":
+        busyRatio.record(marker.busyRatio, mattrs());
+        nonSettling.add(1, mattrs());
+        break;
+      case "storage.connection.update":
+        storageConnection.add(
+          1,
+          mattrs({
+            "ct.connection.status": marker.status,
+            "ct.connection.attempt": marker.attempt,
+          }),
+        );
+        break;
+      case "storage.subscription.add":
+        subscriptions.add(1, mattrs());
+        break;
+      case "storage.subscription.remove":
+        subscriptions.add(-1, mattrs());
+        break;
+      case "scheduler.event.drop":
+      case "storage.push.start":
+      case "storage.push.complete":
+      case "storage.push.error":
+      case "storage.pull.start":
+      case "storage.pull.complete":
+      case "storage.pull.error":
+      case "scheduler.graph.snapshot":
+      case "scheduler.subscribe":
+      case "scheduler.dependencies.update":
+        break;
+    }
+  };
+
+  const handleMarker = (
+    marker: HostRuntimeTelemetryMarker | RuntimeTelemetryMarkerResult,
+  ): void => {
+    if (isHostRuntimeTelemetryMarker(marker)) {
+      handleHostMarker(marker);
+      return;
+    }
+    handleRuntimeMarker(marker);
+  };
+
   const shutdown = () => {
     for (const { span } of openOps.values()) span.end();
     openOps.clear();
   };
 
   return { handleMarker, shutdown };
+}
+
+function isHostRuntimeTelemetryMarker(
+  marker: HostRuntimeTelemetryMarker | RuntimeTelemetryMarkerResult,
+): marker is HostRuntimeTelemetryMarker {
+  switch (marker.type) {
+    case "scheduler.run":
+    case "scheduler.run.complete":
+    case "scheduler.invocation":
+    case "scheduler.event.commit":
+    case "scheduler.event.preflight":
+    case "storage.push.start":
+    case "storage.push.complete":
+    case "storage.push.error":
+    case "storage.pull.start":
+    case "storage.pull.complete":
+    case "storage.pull.error":
+    case "storage.connection.update":
+    case "storage.subscription.add":
+    case "storage.subscription.remove":
+      return "ok" in marker;
+    case "scheduler.graph.snapshot":
+      return "nodeCount" in marker;
+    case "scheduler.dependencies.update":
+      return "readCount" in marker;
+    case "cell.update":
+      return !("change" in marker);
+    case "scheduler.event.drop":
+      return !("eventId" in marker);
+    case "scheduler.subscribe":
+      return !("actionId" in marker);
+    case "scheduler.settle":
+    case "scheduler.non-settling":
+      return true;
+  }
 }
 
 function nowMs(): number {

--- a/packages/runner/src/telemetry-otel-bridge.ts
+++ b/packages/runner/src/telemetry-otel-bridge.ts
@@ -25,9 +25,9 @@ import {
   type Tracer,
 } from "@opentelemetry/api";
 import type {
+  HostRuntimeTelemetryMarker,
   RuntimeTelemetry,
   RuntimeTelemetryEvent,
-  RuntimeTelemetryMarkerResult,
 } from "./telemetry.ts";
 
 export interface OtelBridgeOptions {
@@ -67,7 +67,7 @@ export interface OtelBridgeOptions {
 
 export interface RuntimeTelemetryOtelBridge {
   /** Translate a single marker into spans/metrics. Safe to call for any type. */
-  handleMarker(marker: RuntimeTelemetryMarkerResult): void;
+  handleMarker(marker: HostRuntimeTelemetryMarker): void;
   /** Close any spans still open (e.g. storage ops without a completion). */
   shutdown(): void;
 }
@@ -272,7 +272,7 @@ export function createRuntimeTelemetryOtelBridge(
     }
   };
 
-  const handleMarker = (marker: RuntimeTelemetryMarkerResult): void => {
+  const handleMarker = (marker: HostRuntimeTelemetryMarker): void => {
     switch (marker.type) {
       case "scheduler.run":
         runs.add(

--- a/packages/runner/src/telemetry-otel-bridge.ts
+++ b/packages/runner/src/telemetry-otel-bridge.ts
@@ -25,6 +25,7 @@ import {
   type Tracer,
 } from "@opentelemetry/api";
 import type {
+  RuntimeTelemetry,
   RuntimeTelemetryEvent,
   RuntimeTelemetryMarkerResult,
 } from "./telemetry.ts";
@@ -35,10 +36,15 @@ export interface OtelBridgeOptions {
   /**
    * Attributes stamped on every emitted span and metric — the dimensions the
    * markers themselves don't carry. Set here once at attach time from the host's
-   * session/identity, e.g.:
-   *   { "user.did": principal, "space.did": space, "ct.runtime": "bg-piece" }
+   * host context, e.g. `{ "ct.runtime": "bg-piece" }`. Put high-cardinality
+   * identity dimensions in `spanAttributes` instead.
    */
   attributes?: Attributes;
+  /**
+   * Attributes stamped on SPANS ONLY, merged over `attributes`. Use for trace
+   * pivots such as identities that would create excessive metric cardinality.
+   */
+  spanAttributes?: Attributes;
   /**
    * Attributes stamped on METRICS ONLY, merged over `attributes`. Backends
    * don't map OTel resource attributes onto metric datapoint labels, so pass
@@ -72,10 +78,14 @@ export interface RuntimeTelemetryOtelBridge {
  * in-flight spans.
  */
 export function attachRuntimeTelemetryOtelBridge(
-  telemetry: EventTarget,
+  telemetry:
+    & EventTarget
+    & Partial<Pick<RuntimeTelemetry, "retainDetailedEventCommitTelemetry">>,
   options: OtelBridgeOptions,
 ): () => void {
   const bridge = createRuntimeTelemetryOtelBridge(options);
+  const releaseDetailedEventCommitTelemetry = telemetry
+    .retainDetailedEventCommitTelemetry?.();
   const listener = (event: Event) => {
     bridge.handleMarker((event as RuntimeTelemetryEvent).marker);
   };
@@ -83,6 +93,7 @@ export function attachRuntimeTelemetryOtelBridge(
   return () => {
     telemetry.removeEventListener("telemetry", listener);
     bridge.shutdown();
+    releaseDetailedEventCommitTelemetry?.();
   };
 }
 
@@ -97,9 +108,12 @@ export function createRuntimeTelemetryOtelBridge(
   const { tracer, meter } = options;
   const actionRunSpanThresholdMs = options.actionRunSpanThresholdMs ?? 10;
   const base = options.attributes ?? {};
+  const spanBase = options.spanAttributes
+    ? { ...base, ...options.spanAttributes }
+    : base;
   const attrs = (extra?: Attributes): Attributes =>
-    extra ? { ...base, ...extra } : base;
-  // Metric datapoints get the extra scoping labels; spans keep `base` only.
+    extra ? { ...spanBase, ...extra } : spanBase;
+  // Metric datapoints get metric-only labels; spans keep span-only labels.
   const mbase = options.metricAttributes
     ? { ...base, ...options.metricAttributes }
     : base;
@@ -126,6 +140,16 @@ export function createRuntimeTelemetryOtelBridge(
     "ct.scheduler.commit.changed_writes",
     { description: "Changed writes per commit" },
   );
+  const commitWrites = meter.createHistogram("ct.scheduler.commit.writes", {
+    description: "Changed writes plus classified no-op candidates per commit",
+  });
+  const commitNoopCandidates = meter.createHistogram(
+    "ct.scheduler.commit.noop_candidate_writes",
+    { description: "Deduplicated non-overlapping no-op candidates per commit" },
+  );
+  const commitReads = meter.createHistogram("ct.scheduler.commit.reads", {
+    description: "Scheduler dependency reads per commit",
+  });
   // Per-phase preflight timings — the scheduler's own breakdown of where an
   // event's cost goes. These are the multi-user hot-path signals.
   const preflightPhase = {
@@ -294,26 +318,39 @@ export function createRuntimeTelemetryOtelBridge(
         settleIterations.record(marker.iterations, mattrs());
         break;
       case "scheduler.invocation":
+        // eventId is intentionally internal correlation state. Do not attach it
+        // to OTel attributes or spans.
         invocations.add(1, mattrs(patternAttrs(marker.handlerInfo)));
         break;
       case "cell.update":
         cellUpdates.add(1, mattrs());
         break;
       case "scheduler.event.commit": {
-        commits.add(
-          1,
-          mattrs({
-            ...patternAttrs(marker.handlerInfo),
-            "ct.commit.terminal": marker.terminal ?? "none",
-            "ct.error": !!marker.error,
-          }),
+        // eventId is intentionally internal correlation state. Do not attach it
+        // to OTel attributes or spans.
+        const commitAttributes = {
+          ...patternAttrs(marker.handlerInfo),
+          "ct.commit.terminal": marker.terminal ?? "none",
+          "ct.error": !!marker.error,
+        };
+        const metricAttributes = mattrs(commitAttributes);
+        commits.add(1, metricAttributes);
+        commitWrites.record(marker.writeCount, metricAttributes);
+        commitChangedWrites.record(marker.changedWriteCount, metricAttributes);
+        commitNoopCandidates.record(
+          Math.max(0, marker.writeCount - marker.changedWriteCount),
+          metricAttributes,
         );
-        commitChangedWrites.record(marker.changedWriteCount, mattrs());
-        if (marker.retryAttempt && marker.retryAttempt > 1) {
-          commitRetries.add(1, mattrs(patternAttrs(marker.handlerInfo)));
+        commitReads.record(marker.readCount, metricAttributes);
+        if (marker.backoffMs !== undefined) {
+          commitRetries.add(1, metricAttributes);
         }
         break;
       }
+      case "scheduler.event.drop":
+        // Local diagnostics correlate these internally; OTel deliberately gets
+        // neither event IDs nor a new event-level cardinality dimension.
+        break;
       case "scheduler.event.preflight": {
         const total = marker.populateMs + marker.txToLogMs +
           marker.depCommitMs +

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -69,6 +69,14 @@ export interface SchedulerActionInfo {
   writes?: string[];
 }
 
+/** Content-free action metadata safe to transfer to a runtime host. */
+export interface HostSchedulerActionInfo {
+  patternName?: string;
+  moduleName?: string;
+  readCount?: number;
+  writeCount?: number;
+}
+
 export interface SchedulerEventPreflightStats {
   visitCount: number;
   dirtyInputCount: number;
@@ -302,6 +310,29 @@ export type RuntimeTelemetryMarker = {
 export type RuntimeTelemetryMarkerResult = RuntimeTelemetryMarker & {
   timeStamp: number;
 };
+
+type WithoutInternalTelemetryDetails<Marker extends { type: string }> =
+  Marker["type"] extends
+    | "scheduler.invocation"
+    | "scheduler.event.drop" ? Omit<Marker, "eventId">
+    : Marker["type"] extends "scheduler.event.commit"
+      ? Omit<Marker, "eventId" | "writes" | "writesTruncated">
+    : Marker;
+
+type WithHostSchedulerActionInfo<Marker> = Marker extends {
+  actionInfo?: SchedulerActionInfo;
+} ? Omit<Marker, "actionInfo"> & { actionInfo?: HostSchedulerActionInfo }
+  : Marker extends { handlerInfo?: SchedulerActionInfo }
+    ? Omit<Marker, "handlerInfo"> & { handlerInfo?: HostSchedulerActionInfo }
+  : Marker;
+
+/** Telemetry marker safe to transfer from a runtime worker to its host. */
+export type HostRuntimeTelemetryMarker = RuntimeTelemetryMarkerResult extends
+  infer Marker
+  ? Marker extends { type: string }
+    ? WithHostSchedulerActionInfo<WithoutInternalTelemetryDetails<Marker>>
+  : never
+  : never;
 
 export class RuntimeTelemetryEvent
   extends CustomEvent<{ marker: RuntimeTelemetryMarker }> {

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -101,6 +101,13 @@ export interface SchedulerEventPreflightActionSummary {
   writeCount: number;
 }
 
+/** Fixed, content-free reasons an event can be dropped before dispatch. */
+export type SchedulerEventDropReason =
+  | "piece-load"
+  | "lineage"
+  | "preflight"
+  | "load-gate";
+
 // ============================================================
 // Diagnosis types for non-settling / non-idempotent detection
 // ============================================================
@@ -169,16 +176,24 @@ export type RuntimeTelemetryMarker = {
   error?: string;
 } | {
   type: "scheduler.invocation";
+  /** Internal-only correlation key. Never export this as an OTel attribute. */
+  eventId: string;
   handlerId: string;
   handlerInfo?: SchedulerActionInfo;
   error?: string;
 } | {
   type: "scheduler.event.commit";
+  /** Internal-only correlation key. Never export this as an OTel attribute. */
+  eventId: string;
   handlerId: string;
   handlerInfo?: SchedulerActionInfo;
+  /** Scheduler dependency reads performed by this commit attempt. */
   readCount: number;
+  /** Changed writes plus deduplicated non-overlapping no-op candidate targets. */
   writeCount: number;
+  /** Paths locally changed by this attempt, including speculative failed retries. */
   changedWriteCount: number;
+  /** Capped structural addresses for changed writes only. */
   writes: string[];
   writesTruncated?: boolean;
   error?: string;
@@ -194,6 +209,12 @@ export type RuntimeTelemetryMarker = {
    * deterministic server-side commit-rule refusal (never retried).
    */
   terminal?: "permanent" | "convergence" | "rule";
+} | {
+  /** A final pre-dispatch outcome, categorized without event content. */
+  type: "scheduler.event.drop";
+  /** Internal-only correlation key. Never export this as an OTel attribute. */
+  eventId: string;
+  reason: SchedulerEventDropReason;
 } | {
   type: "scheduler.event.preflight";
   handlerId: string;
@@ -298,6 +319,7 @@ export class RuntimeTelemetryEvent
 
 export class RuntimeTelemetry extends EventTarget {
   #storageTelemetry: StorageTelemetry;
+  #detailedEventCommitTelemetryLeases = 0;
 
   constructor() {
     super();
@@ -306,6 +328,26 @@ export class RuntimeTelemetry extends EventTarget {
 
   submit(marker: RuntimeTelemetryMarker) {
     this.dispatchEvent(new RuntimeTelemetryEvent(marker));
+  }
+
+  /** Whether a consumer has requested detailed event-commit telemetry. */
+  get detailedEventCommitTelemetryEnabled(): boolean {
+    return this.#detailedEventCommitTelemetryLeases > 0;
+  }
+
+  /**
+   * Request detailed event-commit telemetry until the returned release function
+   * is called. Releases are idempotent so independent consumers cannot disable
+   * each other's demand.
+   */
+  retainDetailedEventCommitTelemetry(): () => void {
+    this.#detailedEventCommitTelemetryLeases++;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.#detailedEventCommitTelemetryLeases--;
+    };
   }
 
   processInspectorCommand(command: Inspector.BroadcastCommand) {

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -69,14 +69,6 @@ export interface SchedulerActionInfo {
   writes?: string[];
 }
 
-/** Content-free action metadata safe to transfer to a runtime host. */
-export interface HostSchedulerActionInfo {
-  patternName?: string;
-  moduleName?: string;
-  readCount?: number;
-  writeCount?: number;
-}
-
 export interface SchedulerEventPreflightStats {
   visitCount: number;
   dirtyInputCount: number;
@@ -107,6 +99,24 @@ export interface SchedulerEventPreflightActionSummary {
   readCount: number;
   shallowReadCount: number;
   writeCount: number;
+}
+
+/** Aggregate-only preflight statistics safe to transfer to a runtime host. */
+export interface HostSchedulerEventPreflightStats {
+  visitCount: number;
+  dirtyInputCount: number;
+  resultTrueCount: number;
+  workSetAddCount: number;
+  reverseDependencyActionCount: number;
+  reverseDependencyEdgeCount: number;
+  logReadCount: number;
+  logShallowReadCount: number;
+  writerCandidateCount: number;
+  writerOverlapCount: number;
+  directWriterCount: number;
+  hotActionCount: number;
+  hotFanoutActionCount: number;
+  rootDirectWriterCount: number;
 }
 
 /** Fixed, content-free reasons an event can be dropped before dispatch. */
@@ -311,28 +321,96 @@ export type RuntimeTelemetryMarkerResult = RuntimeTelemetryMarker & {
   timeStamp: number;
 };
 
-type WithoutInternalTelemetryDetails<Marker extends { type: string }> =
-  Marker["type"] extends
-    | "scheduler.invocation"
-    | "scheduler.event.drop" ? Omit<Marker, "eventId">
-    : Marker["type"] extends "scheduler.event.commit"
-      ? Omit<Marker, "eventId" | "writes" | "writesTruncated">
-    : Marker;
-
-type WithHostSchedulerActionInfo<Marker> = Marker extends {
-  actionInfo?: SchedulerActionInfo;
-} ? Omit<Marker, "actionInfo"> & { actionInfo?: HostSchedulerActionInfo }
-  : Marker extends { handlerInfo?: SchedulerActionInfo }
-    ? Omit<Marker, "handlerInfo"> & { handlerInfo?: HostSchedulerActionInfo }
-  : Marker;
-
 /** Telemetry marker safe to transfer from a runtime worker to its host. */
-export type HostRuntimeTelemetryMarker = RuntimeTelemetryMarkerResult extends
-  infer Marker
-  ? Marker extends { type: string }
-    ? WithHostSchedulerActionInfo<WithoutInternalTelemetryDetails<Marker>>
-  : never
-  : never;
+export type HostRuntimeTelemetryMarker =
+  | { type: "scheduler.run"; timeStamp: number; ok: boolean }
+  | {
+    type: "scheduler.run.complete";
+    timeStamp: number;
+    durationMs: number;
+    ok: boolean;
+  }
+  | {
+    type: "scheduler.settle";
+    timeStamp: number;
+    durationMs: number;
+    iterations: number;
+    settledEarly: boolean;
+    seedCount: number;
+    workSetSize: number;
+  }
+  | { type: "cell.update"; timeStamp: number }
+  | { type: "scheduler.invocation"; timeStamp: number; ok: boolean }
+  | {
+    type: "scheduler.event.commit";
+    timeStamp: number;
+    readCount: number;
+    writeCount: number;
+    changedWriteCount: number;
+    ok: boolean;
+    permanentRejection?: "origin-committed" | "receipt-exists";
+    retryAttempt?: number;
+    backoffMs?: number;
+    terminal?: "permanent" | "convergence" | "rule";
+  }
+  | {
+    type: "scheduler.event.drop";
+    timeStamp: number;
+    reason: SchedulerEventDropReason;
+  }
+  | {
+    type: "scheduler.event.preflight";
+    timeStamp: number;
+    readCount: number;
+    shallowReadCount: number;
+    dirtySizeBefore: number;
+    pendingSizeBefore: number;
+    dirtyDependencyCount: number;
+    hasDirtyDependencies: boolean;
+    skipped: boolean;
+    populateMs: number;
+    txToLogMs: number;
+    depCommitMs: number;
+    collectMs: number;
+    scheduleMs: number;
+    stats: HostSchedulerEventPreflightStats;
+    ok: boolean;
+  }
+  | { type: "storage.push.start"; timeStamp: number; ok: boolean }
+  | { type: "storage.push.complete"; timeStamp: number; ok: boolean }
+  | { type: "storage.push.error"; timeStamp: number; ok: false }
+  | { type: "storage.pull.start"; timeStamp: number; ok: boolean }
+  | { type: "storage.pull.complete"; timeStamp: number; ok: boolean }
+  | { type: "storage.pull.error"; timeStamp: number; ok: false }
+  | {
+    type: "storage.connection.update";
+    timeStamp: number;
+    status: "pending" | "ok" | "error";
+    attempt: number;
+    ok: boolean;
+  }
+  | { type: "storage.subscription.add"; timeStamp: number; ok: boolean }
+  | { type: "storage.subscription.remove"; timeStamp: number; ok: boolean }
+  | {
+    type: "scheduler.graph.snapshot";
+    timeStamp: number;
+    nodeCount: number;
+    edgeCount: number;
+  }
+  | { type: "scheduler.subscribe"; timeStamp: number; isEffect: boolean }
+  | {
+    type: "scheduler.dependencies.update";
+    timeStamp: number;
+    readCount: number;
+    writeCount: number;
+  }
+  | {
+    type: "scheduler.non-settling";
+    timeStamp: number;
+    busyTime: number;
+    windowDuration: number;
+    busyRatio: number;
+  };
 
 export class RuntimeTelemetryEvent
   extends CustomEvent<{ marker: RuntimeTelemetryMarker }> {

--- a/packages/runner/test/ensure-piece-running.test.ts
+++ b/packages/runner/test/ensure-piece-running.test.ts
@@ -1,14 +1,48 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { type Pattern } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
 import { ensurePieceRunning } from "../src/ensure-piece-running.ts";
 import { trustPattern } from "./support/trusted-builder.ts";
 import { getDerivedInternalCell, getMetaCell } from "../src/link-utils.ts";
 import { setResultCell } from "../src/result-utils.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+
+  private sharedServer!: MemoryV2Server.Server;
+
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -796,5 +830,115 @@ describe("queueEvent with auto-start", () => {
     expect(resultCell.getAsQueryResult()).toMatchObject({
       doubled: 12,
     });
+  });
+
+  it("starts a piece for a queued nested event on a fresh replica", async () => {
+    const server = newSharedServer();
+    const writerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const writerRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: writerStorage,
+    });
+    const readerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const readerRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: readerStorage,
+    });
+    let handlerRunCount = 0;
+    const receivedEvents: unknown[] = [];
+
+    try {
+      const pattern: Pattern = {
+        argumentSchema: { type: "object" },
+        resultSchema: {
+          type: "object",
+          properties: { events: { type: "object" } },
+        },
+        derivedInternalCells: [{
+          partialCause: "events",
+          schema: { default: { $stream: true } },
+        }],
+        result: {
+          events: { $alias: { partialCause: "events", path: [] } },
+        },
+        nodes: [{
+          module: {
+            type: "javascript",
+            wrapper: "handler",
+            implementation: (event: unknown) => {
+              handlerRunCount++;
+              receivedEvents.push(event);
+            },
+          },
+          inputs: {
+            $event: { $alias: { partialCause: "events", path: [] } },
+          },
+          outputs: {},
+        }],
+      };
+      const patternIdentity = {
+        identity: "test-ensure-piece-cold-nested-event",
+        symbol: "default",
+      };
+      writerRuntime.patternManager.associatePatternIdentity(
+        trustPattern(writerRuntime, pattern),
+        patternIdentity,
+      );
+      readerRuntime.patternManager.associatePatternIdentity(
+        trustPattern(readerRuntime, pattern),
+        patternIdentity,
+      );
+
+      const tx = writerRuntime.edit();
+      const resultCell = writerRuntime.getCell(
+        space,
+        "cold-nested-event-result",
+        undefined,
+        tx,
+      );
+      const intermediateCell = writerRuntime.getCell(
+        space,
+        "cold-nested-event-intermediate",
+        undefined,
+        tx,
+      );
+      const eventsCell = getDerivedInternalCell(resultCell, {
+        partialCause: "events",
+      }, tx);
+      const argumentCell = getMetaCell(resultCell, "argument", tx);
+
+      resultCell.setRaw({
+        events: eventsCell.getAsWriteRedirectLink(),
+      });
+      resultCell.setMetaRaw("patternIdentity", patternIdentity);
+      resultCell.setMetaRaw("argument", argumentCell.getAsWriteRedirectLink());
+      argumentCell.set({});
+      intermediateCell.setRaw({});
+      eventsCell.setRaw({ $stream: true });
+      setResultCell(eventsCell, intermediateCell);
+      setResultCell(intermediateCell, resultCell);
+
+      await tx.commit();
+      await writerStorage.synced();
+
+      readerRuntime.scheduler.queueEvent(
+        eventsCell.getAsNormalizedFullLink(),
+        { type: "click", x: 42 },
+      );
+      await readerRuntime.settled();
+
+      expect(handlerRunCount).toBe(1);
+      expect(receivedEvents).toEqual([{ type: "click", x: 42 }]);
+    } finally {
+      await readerRuntime.dispose();
+      await readerStorage.close();
+      await writerRuntime.dispose();
+      await writerStorage.close();
+      await server.close();
+    }
   });
 });

--- a/packages/runner/test/scheduler-event-identity.test.ts
+++ b/packages/runner/test/scheduler-event-identity.test.ts
@@ -139,13 +139,17 @@ describe("scheduler event identity", () => {
     const backgroundTasks = new Set<Promise<unknown>>();
     let callbackCount = 0;
     let callbackStatus: string | undefined;
+    const markers: unknown[] = [];
     const droppedTx = {
       abort: () => {},
       status: () => ({ status: "error" }),
     } as unknown as IExtendedStorageTransaction;
 
     queueSchedulerEvent({
-      runtime: { edit: () => droppedTx } as unknown as Runtime,
+      runtime: {
+        edit: () => droppedTx,
+        telemetry: { submit: (marker: unknown) => markers.push(marker) },
+      } as unknown as Runtime,
       eventHandlers: [],
       eventQueue,
       backgroundTasks,
@@ -163,11 +167,17 @@ describe("scheduler event identity", () => {
         callbackStatus = commitTx.status().status;
       },
     });
+    const eventId = eventQueue[0]?.id;
 
     await Promise.all([...backgroundTasks]);
     expect(eventQueue).toEqual([]);
     expect(callbackCount).toBe(1);
     expect(callbackStatus).toBe("error");
+    expect(markers).toEqual([{
+      type: "scheduler.event.drop",
+      eventId,
+      reason: "piece-load",
+    }]);
   });
 
   it("does not resurrect an event dropped while its handler is loading", async () => {
@@ -179,8 +189,12 @@ describe("scheduler event identity", () => {
       abort: () => {},
       status: () => ({ status: "error" }),
     } as unknown as IExtendedStorageTransaction;
+    const markers: unknown[] = [];
     const state = {
-      runtime: { edit: () => droppedTx } as unknown as Runtime,
+      runtime: {
+        edit: () => droppedTx,
+        telemetry: { submit: (marker: unknown) => markers.push(marker) },
+      } as unknown as Runtime,
       eventHandlers: [],
       eventQueue,
       backgroundTasks,
@@ -200,13 +214,23 @@ describe("scheduler event identity", () => {
     const queued = eventQueue[0];
     expect(queued.handlerLoadPending).toBe(true);
 
-    dropQueuedEvent(state, queued, "lineage failed while loading");
-    dropQueuedEvent(state, queued, "duplicate terminal notification");
+    dropQueuedEvent(state, queued, "lineage", "lineage failed while loading");
+    dropQueuedEvent(
+      state,
+      queued,
+      "lineage",
+      "duplicate terminal notification",
+    );
     pieceLoad.resolve(true);
     await Promise.all([...backgroundTasks]);
 
     expect(eventQueue).toEqual([]);
     expect(callbackCount).toBe(1);
     expect(queued.handlerLoadPending).toBe(true);
+    expect(markers).toEqual([{
+      type: "scheduler.event.drop",
+      eventId: queued.id,
+      reason: "lineage",
+    }]);
   });
 });

--- a/packages/runner/test/scheduler-events.test.ts
+++ b/packages/runner/test/scheduler-events.test.ts
@@ -447,6 +447,8 @@ describe("event handling", () => {
     await tx.commit();
 
     const commitMarkers: RuntimeTelemetryMarker[] = [];
+    const releaseDetailedEventCommitTelemetry = runtime.telemetry
+      .retainDetailedEventCommitTelemetry();
     const listener = (event: Event) => {
       const marker = (event as CustomEvent<{
         marker: RuntimeTelemetryMarker;
@@ -475,11 +477,122 @@ describe("event handling", () => {
       expect(marker?.type).toBe("scheduler.event.commit");
       if (marker?.type === "scheduler.event.commit") {
         expect(marker.writeCount).toBe(40);
+        expect(marker.changedWriteCount).toBe(40);
         expect(marker.writes.length).toBe(25);
         expect(marker.writesTruncated).toBe(true);
       }
     } finally {
       runtime.telemetry.removeEventListener("telemetry", listener);
+      releaseDetailedEventCommitTelemetry();
+    }
+  });
+
+  it("should skip no-op candidate classification without detailed event commit telemetry", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "should report same-value event sets as no-op candidates event",
+      undefined,
+      tx,
+    );
+    const targetCell = runtime.getCell<number>(
+      space,
+      "should report same-value event sets as no-op candidates target",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    targetCell.set(1);
+    await tx.commit();
+
+    const commitMarkers: RuntimeTelemetryMarker[] = [];
+    const listener = (event: Event) => {
+      const marker = (event as CustomEvent<{
+        marker: RuntimeTelemetryMarker;
+      }>).detail.marker;
+      if (marker.type === "scheduler.event.commit") {
+        commitMarkers.push(marker);
+      }
+    };
+    runtime.telemetry.addEventListener("telemetry", listener);
+
+    try {
+      const eventHandler: EventHandler = (handlerTx) => {
+        targetCell.withTx(handlerTx).set(1);
+      };
+      runtime.scheduler.addEventHandler(
+        eventHandler,
+        eventCell.getAsNormalizedFullLink(),
+      );
+
+      runtime.scheduler.queueEvent(eventCell.getAsNormalizedFullLink(), 1);
+      await waitForSchedulerCondition(runtime, () => commitMarkers.length > 0);
+
+      const marker = commitMarkers.at(-1);
+      expect(marker?.type).toBe("scheduler.event.commit");
+      if (marker?.type === "scheduler.event.commit") {
+        // No lease means the scheduler does not inspect attempted writes or
+        // build path keys. The marker retains cheap compatibility fields.
+        expect(marker.writeCount).toBe(0);
+        expect(marker.changedWriteCount).toBe(0);
+        expect(marker.writes).toEqual([]);
+      }
+    } finally {
+      runtime.telemetry.removeEventListener("telemetry", listener);
+    }
+  });
+
+  it("should report same-value event sets as no-op candidates when detailed telemetry is retained", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "detailed no-op candidate event",
+      undefined,
+      tx,
+    );
+    const targetCell = runtime.getCell<number>(
+      space,
+      "detailed no-op candidate target",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    targetCell.set(1);
+    await tx.commit();
+
+    const commitMarkers: RuntimeTelemetryMarker[] = [];
+    const listener = (event: Event) => {
+      const marker = (event as CustomEvent<{
+        marker: RuntimeTelemetryMarker;
+      }>).detail.marker;
+      if (marker.type === "scheduler.event.commit") {
+        commitMarkers.push(marker);
+      }
+    };
+    const releaseDetailedEventCommitTelemetry = runtime.telemetry
+      .retainDetailedEventCommitTelemetry();
+    runtime.telemetry.addEventListener("telemetry", listener);
+
+    try {
+      const eventHandler: EventHandler = (handlerTx) => {
+        targetCell.withTx(handlerTx).set(1);
+      };
+      runtime.scheduler.addEventHandler(
+        eventHandler,
+        eventCell.getAsNormalizedFullLink(),
+      );
+
+      runtime.scheduler.queueEvent(eventCell.getAsNormalizedFullLink(), 1);
+      await waitForSchedulerCondition(runtime, () => commitMarkers.length > 0);
+
+      const marker = commitMarkers.at(-1);
+      expect(marker?.type).toBe("scheduler.event.commit");
+      if (marker?.type === "scheduler.event.commit") {
+        expect(marker.writeCount).toBe(1);
+        expect(marker.changedWriteCount).toBe(0);
+        expect(marker.writes).toEqual([]);
+      }
+    } finally {
+      runtime.telemetry.removeEventListener("telemetry", listener);
+      releaseDetailedEventCommitTelemetry();
     }
   });
 

--- a/packages/runner/test/scheduler-reactivity.test.ts
+++ b/packages/runner/test/scheduler-reactivity.test.ts
@@ -1,11 +1,19 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type {
+  Activity,
   IMemorySpaceAddress,
+  ITransactionJournal,
   MemorySpace,
   URI,
 } from "../src/storage/interface.ts";
-import { classifyTelemetryWriteCounts } from "../src/scheduler/reactivity.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+import {
+  classifyTelemetryWriteCounts,
+  eventCommitTelemetryWriteCounts,
+} from "../src/scheduler/reactivity.ts";
+import { markReadAsAttemptedWrite } from "../src/storage/reactivity-log.ts";
+import { ManagedStorageTransaction } from "../src/traverse.ts";
 
 const space = "did:key:telemetry" as MemorySpace;
 
@@ -19,6 +27,44 @@ function address(path: string[]): IMemorySpaceAddress {
 }
 
 describe("event commit telemetry write counts", () => {
+  it("counts an attempted no-op write through the transaction wrapper", () => {
+    const attempted = address(["value", "title"]);
+    const activity: Activity[] = [{
+      read: { ...attempted, meta: markReadAsAttemptedWrite },
+    }];
+    const journal: ITransactionJournal = {
+      activity: () => activity,
+      history: () => [],
+      novelty: () => [],
+    };
+    const tx = new ExtendedStorageTransaction(
+      new ManagedStorageTransaction({ load: () => null }, journal),
+    );
+
+    expect(eventCommitTelemetryWriteCounts(tx, [])).toEqual({
+      changedWriteCount: 0,
+      writeCount: 1,
+    });
+  });
+
+  it("derives attempted writes from a transaction journal fallback", () => {
+    const attempted = address(["value", "title"]);
+    const activity: Activity[] = [{
+      read: { ...attempted, meta: markReadAsAttemptedWrite },
+    }];
+    const journal: ITransactionJournal = {
+      activity: () => activity,
+      history: () => [],
+      novelty: () => [],
+    };
+    const tx = new ManagedStorageTransaction({ load: () => null }, journal);
+
+    expect(eventCommitTelemetryWriteCounts(tx, [])).toEqual({
+      changedWriteCount: 0,
+      writeCount: 1,
+    });
+  });
+
   it("counts an exact same-value leaf set as one no-op candidate", () => {
     expect(
       classifyTelemetryWriteCounts([], [

--- a/packages/runner/test/scheduler-reactivity.test.ts
+++ b/packages/runner/test/scheduler-reactivity.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type {
+  IMemorySpaceAddress,
+  MemorySpace,
+  URI,
+} from "../src/storage/interface.ts";
+import { classifyTelemetryWriteCounts } from "../src/scheduler/reactivity.ts";
+
+const space = "did:key:telemetry" as MemorySpace;
+
+function address(path: string[]): IMemorySpaceAddress {
+  return {
+    space,
+    scope: "space",
+    id: "of:fid1:telemetry" as URI,
+    path,
+  };
+}
+
+describe("event commit telemetry write counts", () => {
+  it("counts an exact same-value leaf set as one no-op candidate", () => {
+    expect(
+      classifyTelemetryWriteCounts([], [
+        address(["value", "title"]),
+      ]),
+    )
+      .toEqual({ changedWriteCount: 0, writeCount: 1 });
+  });
+
+  it("counts an ordinary changed scalar without a no-op candidate", () => {
+    expect(classifyTelemetryWriteCounts(
+      [address(["value", "title"])],
+      [address(["value", "title"])],
+    )).toEqual({ changedWriteCount: 1, writeCount: 1 });
+  });
+
+  it("does not classify a parent attempt overlapping a changed child as no-op", () => {
+    expect(classifyTelemetryWriteCounts(
+      [address(["value", "topic", "title"])],
+      [address(["value", "topic"])],
+    )).toEqual({ changedWriteCount: 1, writeCount: 1 });
+  });
+
+  it("deduplicates identical attempted targets", () => {
+    expect(classifyTelemetryWriteCounts([], [
+      address(["value", "title"]),
+      address(["value", "title"]),
+    ])).toEqual({ changedWriteCount: 0, writeCount: 1 });
+  });
+
+  it("classifies large disjoint write sets without pairwise comparisons", () => {
+    const changed = Array.from(
+      { length: 1000 },
+      (_entry, index) => address(["changed", String(index)]),
+    );
+    const attempted = Array.from(
+      { length: 1000 },
+      (_entry, index) => address(["attempted", String(index)]),
+    );
+    expect(classifyTelemetryWriteCounts(changed, attempted)).toEqual({
+      changedWriteCount: 1000,
+      writeCount: 2000,
+    });
+  });
+
+  it("classifies deeply nested paths without rebuilding every prefix", () => {
+    const common = Array.from({ length: 5_000 }, (_, index) => `p${index}`);
+    expect(classifyTelemetryWriteCounts(
+      [address([...common, "changed"])],
+      [address([...common, "attempted"])],
+    )).toEqual({ changedWriteCount: 1, writeCount: 2 });
+    expect(classifyTelemetryWriteCounts(
+      [address([...common, "changed"])],
+      [address(common)],
+    )).toEqual({ changedWriteCount: 1, writeCount: 1 });
+  });
+});

--- a/packages/runner/test/telemetry-otel-bridge.test.ts
+++ b/packages/runner/test/telemetry-otel-bridge.test.ts
@@ -13,6 +13,7 @@ import {
   createRuntimeTelemetryOtelBridge,
 } from "../src/telemetry-otel-bridge.ts";
 import {
+  type HostRuntimeTelemetryMarker,
   RuntimeTelemetry,
   RuntimeTelemetryEvent,
   type RuntimeTelemetryMarkerResult,
@@ -301,6 +302,161 @@ describe("createRuntimeTelemetryOtelBridge", () => {
     bridge.handleMarker(marker({ type: "scheduler.dependencies.update" }));
     bridge.handleMarker(marker({ type: "scheduler.graph.snapshot" }));
     bridge.handleMarker(marker({ type: "scheduler.subscribe" }));
+    expect(meterCalls).toHaveLength(0);
+    expect(spans).toHaveLength(0);
+  });
+
+  it("records aggregate host markers without creating detailed spans", () => {
+    const stats = {
+      visitCount: 1,
+      dirtyInputCount: 2,
+      resultTrueCount: 3,
+      workSetAddCount: 4,
+      reverseDependencyActionCount: 5,
+      reverseDependencyEdgeCount: 6,
+      logReadCount: 7,
+      logShallowReadCount: 8,
+      writerCandidateCount: 9,
+      writerOverlapCount: 10,
+      directWriterCount: 11,
+      hotActionCount: 12,
+      hotFanoutActionCount: 13,
+      rootDirectWriterCount: 14,
+    };
+    const markers = [
+      { type: "scheduler.run", timeStamp: 1, ok: false },
+      { type: "cell.update", timeStamp: 1 },
+      { type: "scheduler.invocation", timeStamp: 1, ok: false },
+      {
+        type: "scheduler.run.complete",
+        timeStamp: 1,
+        durationMs: 20,
+        ok: false,
+      },
+      {
+        type: "scheduler.settle",
+        timeStamp: 1,
+        durationMs: 21,
+        iterations: 2,
+        settledEarly: false,
+        seedCount: 3,
+        workSetSize: 4,
+      },
+      {
+        type: "scheduler.event.commit",
+        timeStamp: 1,
+        readCount: 5,
+        writeCount: 6,
+        changedWriteCount: 4,
+        ok: false,
+        backoffMs: 7,
+        terminal: "rule",
+      },
+      {
+        type: "scheduler.event.preflight",
+        timeStamp: 1,
+        readCount: 1,
+        shallowReadCount: 2,
+        dirtySizeBefore: 3,
+        pendingSizeBefore: 4,
+        dirtyDependencyCount: 5,
+        hasDirtyDependencies: true,
+        skipped: false,
+        populateMs: 6,
+        txToLogMs: 7,
+        depCommitMs: 8,
+        collectMs: 9,
+        scheduleMs: 10,
+        stats,
+        ok: false,
+      },
+      {
+        type: "scheduler.non-settling",
+        timeStamp: 1,
+        busyTime: 2,
+        windowDuration: 3,
+        busyRatio: 0.75,
+      },
+      {
+        type: "storage.connection.update",
+        timeStamp: 1,
+        status: "error",
+        attempt: 2,
+        ok: false,
+      },
+      { type: "storage.subscription.add", timeStamp: 1, ok: false },
+      { type: "storage.subscription.remove", timeStamp: 1, ok: false },
+    ] satisfies HostRuntimeTelemetryMarker[];
+
+    for (const hostMarker of markers) bridge.handleMarker(hostMarker);
+
+    expect(meterCalls.map((call) => call.instrument)).toEqual([
+      "ct.scheduler.runs",
+      "ct.cell.updates",
+      "ct.scheduler.invocations",
+      "ct.scheduler.action.duration_ms",
+      "ct.scheduler.settle.duration_ms",
+      "ct.scheduler.settle.iterations",
+      "ct.scheduler.commits",
+      "ct.scheduler.commit.writes",
+      "ct.scheduler.commit.changed_writes",
+      "ct.scheduler.commit.noop_candidate_writes",
+      "ct.scheduler.commit.reads",
+      "ct.scheduler.commit.retries",
+      "ct.scheduler.preflight.populate_ms",
+      "ct.scheduler.preflight.tx_to_log_ms",
+      "ct.scheduler.preflight.dep_commit_ms",
+      "ct.scheduler.preflight.collect_ms",
+      "ct.scheduler.preflight.schedule_ms",
+      "ct.scheduler.preflight.total_ms",
+      "ct.scheduler.preflight.dirty_dependency_count",
+      "ct.scheduler.busy_ratio",
+      "ct.scheduler.non_settling.events",
+      "ct.storage.connection.updates",
+      "ct.storage.subscriptions",
+      "ct.storage.subscriptions",
+    ]);
+    expect(meterCalls[0].attributes).toEqual({ "ct.error": true });
+    expect(meterCalls[3].attributes).toEqual({ "ct.error": true });
+    expect(meterCalls[6].attributes).toEqual({
+      "ct.commit.terminal": "rule",
+      "ct.error": true,
+    });
+    expect(meterCalls[16].value).toBe(10);
+    expect(meterCalls[17].value).toBe(40);
+    expect(meterCalls[21].attributes).toEqual({
+      "ct.connection.status": "error",
+      "ct.connection.attempt": 2,
+    });
+    expect(spans).toHaveLength(0);
+  });
+
+  it("ignores host-only marker types across every discriminator family", () => {
+    const ignored = [
+      { type: "scheduler.event.drop", timeStamp: 1, reason: "preflight" },
+      {
+        type: "scheduler.graph.snapshot",
+        timeStamp: 1,
+        nodeCount: 2,
+        edgeCount: 3,
+      },
+      { type: "scheduler.subscribe", timeStamp: 1, isEffect: true },
+      {
+        type: "scheduler.dependencies.update",
+        timeStamp: 1,
+        readCount: 2,
+        writeCount: 3,
+      },
+      { type: "storage.push.start", timeStamp: 1, ok: false },
+      { type: "storage.push.complete", timeStamp: 1, ok: false },
+      { type: "storage.push.error", timeStamp: 1, ok: false },
+      { type: "storage.pull.start", timeStamp: 1, ok: false },
+      { type: "storage.pull.complete", timeStamp: 1, ok: false },
+      { type: "storage.pull.error", timeStamp: 1, ok: false },
+    ] satisfies HostRuntimeTelemetryMarker[];
+
+    for (const hostMarker of ignored) bridge.handleMarker(hostMarker);
+
     expect(meterCalls).toHaveLength(0);
     expect(spans).toHaveLength(0);
   });

--- a/packages/runner/test/telemetry-otel-bridge.test.ts
+++ b/packages/runner/test/telemetry-otel-bridge.test.ts
@@ -13,6 +13,7 @@ import {
   createRuntimeTelemetryOtelBridge,
 } from "../src/telemetry-otel-bridge.ts";
 import {
+  RuntimeTelemetry,
   RuntimeTelemetryEvent,
   type RuntimeTelemetryMarkerResult,
 } from "../src/telemetry.ts";
@@ -102,6 +103,7 @@ describe("createRuntimeTelemetryOtelBridge", () => {
   const setup = (options: {
     attributes?: Attributes;
     metricAttributes?: Attributes;
+    spanAttributes?: Attributes;
   } = {}) => {
     const m = makeRecordingMeter();
     const t = makeRecordingTracer();
@@ -133,30 +135,52 @@ describe("createRuntimeTelemetryOtelBridge", () => {
     }]);
   });
 
-  it("counts commits, changed writes, and retries only when retrying", () => {
+  it("records commit amplification and counts every scheduled retry", () => {
     bridge.handleMarker(marker({
       type: "scheduler.event.commit",
+      eventId: "evt:private:0:of:stream",
+      readCount: 6,
+      writeCount: 7,
       changedWriteCount: 4,
       retryAttempt: 1,
+      backoffMs: 1,
     }));
     expect(meterCalls.map((c) => c.instrument)).toEqual([
       "ct.scheduler.commits",
+      "ct.scheduler.commit.writes",
       "ct.scheduler.commit.changed_writes",
+      "ct.scheduler.commit.noop_candidate_writes",
+      "ct.scheduler.commit.reads",
+      "ct.scheduler.commit.retries",
     ]);
+    expect(meterCalls[1].value).toBe(7);
+    expect(meterCalls[2].value).toBe(4);
+    expect(meterCalls[3].value).toBe(3);
+    expect(meterCalls[4].value).toBe(6);
+    for (const call of meterCalls) {
+      expect(call.attributes?.eventId).toBeUndefined();
+      expect(call.attributes?.["ct.event_id"]).toBeUndefined();
+    }
 
     meterCalls.length = 0;
     bridge.handleMarker(marker({
       type: "scheduler.event.commit",
+      readCount: 1,
+      writeCount: 2,
       changedWriteCount: 2,
       retryAttempt: 3,
-      terminal: "completed",
+      terminal: "convergence",
     }));
     expect(meterCalls.map((c) => c.instrument)).toEqual([
       "ct.scheduler.commits",
+      "ct.scheduler.commit.writes",
       "ct.scheduler.commit.changed_writes",
-      "ct.scheduler.commit.retries",
+      "ct.scheduler.commit.noop_candidate_writes",
+      "ct.scheduler.commit.reads",
     ]);
-    expect(meterCalls[0].attributes?.["ct.commit.terminal"]).toBe("completed");
+    expect(meterCalls[0].attributes?.["ct.commit.terminal"]).toBe(
+      "convergence",
+    );
   });
 
   it("records every preflight phase and a retroactive span", () => {
@@ -314,6 +338,40 @@ describe("createRuntimeTelemetryOtelBridge", () => {
     expect(spans[0].attributes["user.did"]).toBe("did:key:alice");
   });
 
+  it("stamps span-only attributes on spans but never metrics", () => {
+    setup({
+      attributes: { "ct.runtime": "harness" },
+      spanAttributes: { "user.did": "did:key:alice" },
+    });
+    bridge.handleMarker(marker({ type: "cell.update" }));
+    bridge.handleMarker(marker({
+      id: "op-span-only",
+      type: "storage.push.start",
+      operation: "send",
+    }));
+    expect(meterCalls[0].attributes).toEqual({ "ct.runtime": "harness" });
+    expect(spans[0].attributes).toEqual({
+      "ct.runtime": "harness",
+      "user.did": "did:key:alice",
+      "ct.storage.kind": "push",
+      "ct.storage.operation": "send",
+    });
+  });
+
+  it("attributes every commit histogram with pattern attribution", () => {
+    bridge.handleMarker(marker({
+      type: "scheduler.event.commit",
+      readCount: 2,
+      writeCount: 3,
+      changedWriteCount: 1,
+      handlerInfo: { patternName: "topics", moduleName: "topic" },
+    }));
+    for (const call of meterCalls) {
+      expect(call.attributes?.["ct.pattern"]).toBe("topics");
+      expect(call.attributes?.["ct.module"]).toBe("topic");
+    }
+  });
+
   it("closes in-flight storage spans on shutdown", () => {
     bridge.handleMarker(marker({
       id: "op-5",
@@ -454,6 +512,26 @@ describe("scheduler.run.complete / scheduler.settle / storage join keys", () => 
 });
 
 describe("attachRuntimeTelemetryOtelBridge", () => {
+  it("retains detailed event commit telemetry until detached", () => {
+    const m = makeRecordingMeter();
+    const t = makeRecordingTracer();
+    const telemetry = new RuntimeTelemetry();
+    const retainedElsewhere = telemetry.retainDetailedEventCommitTelemetry();
+
+    const detach = attachRuntimeTelemetryOtelBridge(telemetry, {
+      tracer: t.tracer,
+      meter: m.meter,
+    });
+    expect(telemetry.detailedEventCommitTelemetryEnabled).toBe(true);
+
+    retainedElsewhere();
+    expect(telemetry.detailedEventCommitTelemetryEnabled).toBe(true);
+    detach();
+    expect(telemetry.detailedEventCommitTelemetryEnabled).toBe(false);
+    detach();
+    expect(telemetry.detailedEventCommitTelemetryEnabled).toBe(false);
+  });
+
   it("feeds telemetry events through the bridge until detached", () => {
     const m = makeRecordingMeter();
     const t = makeRecordingTracer();

--- a/packages/runner/test/telemetry-otel-bridge.test.ts
+++ b/packages/runner/test/telemetry-otel-bridge.test.ts
@@ -461,6 +461,17 @@ describe("createRuntimeTelemetryOtelBridge", () => {
     expect(spans).toHaveLength(0);
   });
 
+  it("ignores detailed event drops with private event IDs", () => {
+    bridge.handleMarker(marker({
+      type: "scheduler.event.drop",
+      eventId: "evt:private:0:of:stream",
+      reason: "preflight",
+    }));
+
+    expect(meterCalls).toHaveLength(0);
+    expect(spans).toHaveLength(0);
+  });
+
   it("stamps base attributes on spans and metrics alike", () => {
     setup({ attributes: { "user.did": "did:key:alice" } });
     bridge.handleMarker(marker({ type: "cell.update" }));

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -17,7 +17,12 @@ import {
 } from "./runtime-processor.ts";
 import { atomsOutsideCeiling } from "@commonfabric/runner/cfc";
 import { cfcAtom } from "@commonfabric/api/cfc";
-import { type RuntimeFetch, runtimePresets } from "@commonfabric/runner";
+import {
+  type HostRuntimeTelemetryMarker,
+  type RuntimeFetch,
+  runtimePresets,
+  type RuntimeTelemetryMarkerResult,
+} from "@commonfabric/runner";
 import {
   type CellRef,
   type CfcLabelView,
@@ -31,10 +36,11 @@ import {
   getCell,
   mapCellRefsToSigilLinks,
 } from "./utils.ts";
-import { Runtime } from "@commonfabric/runner";
+import { Runtime, RuntimeTelemetry } from "@commonfabric/runner";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import * as V2Storage from "../../runner/src/storage/v2.ts";
 import { parseLink } from "../../runner/src/link-utils.ts";
+import type { URI } from "../../runner/src/storage/interface.ts";
 
 const cfcSigner = await Identity.fromPassphrase(
   "runtime-processor-cfc-label-tests",
@@ -843,141 +849,536 @@ describe("sanitizeForPostMessage", () => {
 });
 
 describe("telemetryMarkerForHost", () => {
-  it("keeps event correlations and detailed writes inside the runtime worker", () => {
-    const marker = telemetryMarkerForHost({
-      type: "scheduler.event.commit",
-      eventId: "evt:did:key:private",
-      handlerId: "handler:private",
-      readCount: 2,
-      writeCount: 3,
-      changedWriteCount: 1,
-      writes: ["value/did:key:private/title"],
-      writesTruncated: true,
-      handlerInfo: {
-        patternName: "Topics",
-        reads: ["did:key:private/of:fid1:private/title"],
-        writes: ["did:key:private/of:fid1:private/description"],
-      },
-      timeStamp: 1,
-    });
-
-    expect(marker).toEqual({
-      type: "scheduler.event.commit",
-      handlerId: "handler:private",
-      readCount: 2,
-      writeCount: 3,
-      changedWriteCount: 1,
-      handlerInfo: {
-        patternName: "Topics",
-        readCount: 1,
-        writeCount: 1,
-      },
-      timeStamp: 1,
-    });
-    expect(JSON.stringify(marker)).not.toContain("evt:");
-    expect(JSON.stringify(marker)).not.toContain("value/did:");
-    expect(JSON.stringify(marker)).not.toContain("of:fid1:");
-  });
-
-  it("summarizes nested action metadata for every host-facing marker", () => {
-    const actionInfo = {
-      moduleName: "topics.tsx",
-      reads: ["did:key:private/of:fid1:private/title"],
-      writes: [
-        "did:key:private/of:fid1:private/title",
-        "did:key:private/of:fid1:private/description",
-      ],
-    };
-
-    expect(telemetryMarkerForHost({
-      type: "scheduler.run.complete",
-      actionId: "action",
-      actionInfo,
-      durationMs: 1,
-      timeStamp: 1,
-    })).toEqual({
-      type: "scheduler.run.complete",
-      actionId: "action",
-      actionInfo: {
-        moduleName: "topics.tsx",
-        readCount: 1,
-        writeCount: 2,
-      },
-      durationMs: 1,
-      timeStamp: 1,
-    });
-
-    const invocation = telemetryMarkerForHost({
-      type: "scheduler.invocation",
-      eventId: "evt:private",
-      handlerId: "handler",
-      handlerInfo: actionInfo,
-      timeStamp: 1,
-    });
-    expect(invocation).toEqual({
-      type: "scheduler.invocation",
-      handlerId: "handler",
-      handlerInfo: {
-        moduleName: "topics.tsx",
-        readCount: 1,
-        writeCount: 2,
-      },
-      timeStamp: 1,
-    });
-    expect(JSON.stringify(invocation)).not.toContain("did:key:");
-
-    const preflight = telemetryMarkerForHost({
-      type: "scheduler.event.preflight",
-      handlerId: "handler",
-      handlerInfo: actionInfo,
+  const privateSentinel =
+    "private did:example:secret fid1:secret https://private.example/path error /private/path Topics preview";
+  const timeStamp = 1;
+  const actionInfo = {
+    patternName: privateSentinel,
+    moduleName: privateSentinel,
+    reads: [privateSentinel],
+    writes: [privateSentinel],
+  };
+  const stats = {
+    visitCount: 1,
+    dirtyInputCount: 2,
+    resultTrueCount: 3,
+    workSetAddCount: 4,
+    reverseDependencyActionCount: 5,
+    reverseDependencyEdgeCount: 6,
+    logReadCount: 7,
+    logShallowReadCount: 8,
+    writerCandidateCount: 9,
+    writerOverlapCount: 10,
+    directWriterCount: 11,
+    hotActions: [{
+      actionId: privateSentinel,
+      actionType: "effect" as const,
+      visitCount: 1,
+      dirtyInputCount: 1,
+      resultTrueCount: 1,
+      reverseDependencyEdgeCount: 1,
+      maxDirectWriterCount: 1,
+      dirty: true,
+      pending: true,
       readCount: 1,
-      shallowReadCount: 0,
-      dirtySizeBefore: 0,
-      pendingSizeBefore: 0,
-      dirtyDependencyCount: 0,
-      hasDirtyDependencies: false,
-      skipped: false,
-      populateMs: 0,
-      txToLogMs: 0,
-      depCommitMs: 0,
-      collectMs: 0,
-      scheduleMs: 0,
-      stats: {
-        visitCount: 0,
-        dirtyInputCount: 0,
-        resultTrueCount: 0,
-        workSetAddCount: 0,
-        reverseDependencyActionCount: 0,
-        reverseDependencyEdgeCount: 0,
-        logReadCount: 0,
-        logShallowReadCount: 0,
-        writerCandidateCount: 0,
-        writerOverlapCount: 0,
-        directWriterCount: 0,
+      shallowReadCount: 1,
+      writeCount: 1,
+    }],
+    hotFanoutActions: [{
+      actionId: privateSentinel,
+      actionType: "computation" as const,
+      visitCount: 1,
+      dirtyInputCount: 1,
+      resultTrueCount: 1,
+      reverseDependencyEdgeCount: 1,
+      maxDirectWriterCount: 1,
+      dirty: true,
+      pending: true,
+      readCount: 1,
+      shallowReadCount: 1,
+      writeCount: 1,
+    }],
+    rootDirectWriters: [{
+      actionId: privateSentinel,
+      actionType: "unknown" as const,
+      visitCount: 1,
+      dirtyInputCount: 1,
+      resultTrueCount: 1,
+      reverseDependencyEdgeCount: 1,
+      maxDirectWriterCount: 1,
+      dirty: true,
+      pending: true,
+      readCount: 1,
+      shallowReadCount: 1,
+      writeCount: 1,
+    }],
+  };
+  const aggregateStats = {
+    visitCount: 1,
+    dirtyInputCount: 2,
+    resultTrueCount: 3,
+    workSetAddCount: 4,
+    reverseDependencyActionCount: 5,
+    reverseDependencyEdgeCount: 6,
+    logReadCount: 7,
+    logShallowReadCount: 8,
+    writerCandidateCount: 9,
+    writerOverlapCount: 10,
+    directWriterCount: 11,
+    hotActionCount: 1,
+    hotFanoutActionCount: 1,
+    rootDirectWriterCount: 1,
+  };
+
+  it("projects every runtime marker to an exact aggregate-safe host shape", () => {
+    const cases = [
+      {
+        input: {
+          type: "scheduler.run",
+          actionId: privateSentinel,
+          actionInfo,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: { type: "scheduler.run", timeStamp, ok: false },
       },
-      timeStamp: 1,
-    });
-    if (preflight.type !== "scheduler.event.preflight") {
-      throw new Error("Expected a scheduler.event.preflight marker");
+      {
+        input: {
+          type: "scheduler.run.complete",
+          actionId: privateSentinel,
+          actionInfo,
+          durationMs: 2,
+          timeStamp,
+        },
+        output: {
+          type: "scheduler.run.complete",
+          timeStamp,
+          durationMs: 2,
+          ok: true,
+        },
+      },
+      {
+        input: {
+          type: "scheduler.settle",
+          durationMs: 2,
+          iterations: 3,
+          settledEarly: true,
+          seedCount: 4,
+          workSetSize: 5,
+          timeStamp,
+        },
+        output: {
+          type: "scheduler.settle",
+          timeStamp,
+          durationMs: 2,
+          iterations: 3,
+          settledEarly: true,
+          seedCount: 4,
+          workSetSize: 5,
+        },
+      },
+      {
+        input: {
+          type: "cell.update",
+          change: {
+            address: { id: privateSentinel as URI, path: [privateSentinel] },
+            before: privateSentinel,
+            after: privateSentinel,
+          },
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: { type: "cell.update", timeStamp },
+      },
+      {
+        input: {
+          type: "scheduler.invocation",
+          eventId: privateSentinel,
+          handlerId: privateSentinel,
+          handlerInfo: actionInfo,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: { type: "scheduler.invocation", timeStamp, ok: false },
+      },
+      {
+        input: {
+          type: "scheduler.event.commit",
+          eventId: privateSentinel,
+          handlerId: privateSentinel,
+          handlerInfo: actionInfo,
+          readCount: 2,
+          writeCount: 3,
+          changedWriteCount: 1,
+          writes: [privateSentinel],
+          writesTruncated: true,
+          error: privateSentinel,
+          permanentRejection: "receipt-exists" as const,
+          retryAttempt: 4,
+          backoffMs: 5,
+          terminal: "rule" as const,
+          timeStamp,
+        },
+        output: {
+          type: "scheduler.event.commit",
+          timeStamp,
+          readCount: 2,
+          writeCount: 3,
+          changedWriteCount: 1,
+          ok: false,
+          permanentRejection: "receipt-exists" as const,
+          retryAttempt: 4,
+          backoffMs: 5,
+          terminal: "rule" as const,
+        },
+      },
+      {
+        input: {
+          type: "scheduler.event.drop",
+          eventId: privateSentinel,
+          reason: "preflight" as const,
+          timeStamp,
+        },
+        output: {
+          type: "scheduler.event.drop",
+          timeStamp,
+          reason: "preflight" as const,
+        },
+      },
+      {
+        input: {
+          type: "scheduler.event.preflight",
+          handlerId: privateSentinel,
+          handlerInfo: actionInfo,
+          readCount: 1,
+          shallowReadCount: 2,
+          dirtySizeBefore: 3,
+          pendingSizeBefore: 4,
+          dirtyDependencyCount: 5,
+          hasDirtyDependencies: true,
+          skipped: false,
+          populateMs: 6,
+          txToLogMs: 7,
+          depCommitMs: 8,
+          collectMs: 9,
+          scheduleMs: 10,
+          stats,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: {
+          type: "scheduler.event.preflight",
+          timeStamp,
+          readCount: 1,
+          shallowReadCount: 2,
+          dirtySizeBefore: 3,
+          pendingSizeBefore: 4,
+          dirtyDependencyCount: 5,
+          hasDirtyDependencies: true,
+          skipped: false,
+          populateMs: 6,
+          txToLogMs: 7,
+          depCommitMs: 8,
+          collectMs: 9,
+          scheduleMs: 10,
+          stats: aggregateStats,
+          ok: false,
+        },
+      },
+      {
+        input: {
+          type: "storage.push.start",
+          id: privateSentinel,
+          operation: privateSentinel,
+          localSeq: 1,
+          spaceDid: privateSentinel,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: { type: "storage.push.start", timeStamp, ok: false },
+      },
+      {
+        input: {
+          type: "storage.push.complete",
+          id: privateSentinel,
+          sessionId: privateSentinel,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: { type: "storage.push.complete", timeStamp, ok: false },
+      },
+      {
+        input: {
+          type: "storage.push.error",
+          id: privateSentinel,
+          sessionId: privateSentinel,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: { type: "storage.push.error", timeStamp, ok: false as const },
+      },
+      {
+        input: {
+          type: "storage.pull.start",
+          id: privateSentinel,
+          operation: privateSentinel,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: { type: "storage.pull.start", timeStamp, ok: false },
+      },
+      {
+        input: {
+          type: "storage.pull.complete",
+          id: privateSentinel,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: { type: "storage.pull.complete", timeStamp, ok: false },
+      },
+      {
+        input: {
+          type: "storage.pull.error",
+          id: privateSentinel,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: { type: "storage.pull.error", timeStamp, ok: false as const },
+      },
+      {
+        input: {
+          type: "storage.connection.update",
+          status: "error" as const,
+          attempt: 2,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: {
+          type: "storage.connection.update",
+          timeStamp,
+          status: "error" as const,
+          attempt: 2,
+          ok: false,
+        },
+      },
+      {
+        input: {
+          type: "storage.subscription.add",
+          id: privateSentinel,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: { type: "storage.subscription.add", timeStamp, ok: false },
+      },
+      {
+        input: {
+          type: "storage.subscription.remove",
+          id: privateSentinel,
+          error: privateSentinel,
+          timeStamp,
+        },
+        output: { type: "storage.subscription.remove", timeStamp, ok: false },
+      },
+      {
+        input: {
+          type: "scheduler.graph.snapshot",
+          graph: {
+            nodes: [{
+              id: privateSentinel,
+              type: "effect" as const,
+              isDirty: true,
+              isPending: true,
+              preview: privateSentinel,
+              reads: [privateSentinel],
+              writes: [privateSentinel],
+              patternIdentity: {
+                identity: privateSentinel,
+                symbol: privateSentinel,
+              },
+            }],
+            edges: [{
+              from: privateSentinel,
+              to: privateSentinel,
+              cells: [privateSentinel],
+            }],
+            timestamp: 0,
+          },
+          timeStamp,
+        },
+        output: {
+          type: "scheduler.graph.snapshot",
+          timeStamp,
+          nodeCount: 1,
+          edgeCount: 1,
+        },
+      },
+      {
+        input: {
+          type: "scheduler.subscribe",
+          actionId: privateSentinel,
+          isEffect: true,
+          timeStamp,
+        },
+        output: { type: "scheduler.subscribe", timeStamp, isEffect: true },
+      },
+      {
+        input: {
+          type: "scheduler.dependencies.update",
+          actionId: privateSentinel,
+          reads: [privateSentinel],
+          writes: [privateSentinel, privateSentinel],
+          timeStamp,
+        },
+        output: {
+          type: "scheduler.dependencies.update",
+          timeStamp,
+          readCount: 1,
+          writeCount: 2,
+        },
+      },
+      {
+        input: {
+          type: "scheduler.non-settling",
+          busyTime: 2,
+          windowDuration: 3,
+          busyRatio: 4,
+          timeStamp,
+        },
+        output: {
+          type: "scheduler.non-settling",
+          timeStamp,
+          busyTime: 2,
+          windowDuration: 3,
+          busyRatio: 4,
+        },
+      },
+    ] satisfies readonly {
+      input: RuntimeTelemetryMarkerResult;
+      output: HostRuntimeTelemetryMarker;
+    }[];
+
+    for (const { input, output } of cases) {
+      const marker = telemetryMarkerForHost(input);
+      expect(marker).toEqual(output);
+      const serialized = JSON.stringify(marker);
+      for (
+        const forbidden of [
+          privateSentinel,
+          "did:",
+          "fid1:",
+          "https://",
+          "/private/path",
+          "Topics",
+          "preview",
+        ]
+      ) {
+        expect(serialized).not.toContain(forbidden);
+      }
     }
-    expect(preflight.handlerInfo).toEqual({
-      moduleName: "topics.tsx",
-      readCount: 1,
-      writeCount: 2,
+  });
+});
+
+describe("RuntimeProcessor telemetry lifecycle", () => {
+  const createTelemetryProcessor = () => {
+    const schedulerCalls: boolean[] = [];
+    let retains = 0;
+    let releases = 0;
+    let disposals = 0;
+    let synchronizations = 0;
+    let removals = 0;
+    const telemetry = new RuntimeTelemetry();
+    const retain = telemetry.retainDetailedEventCommitTelemetry.bind(telemetry);
+    telemetry.retainDetailedEventCommitTelemetry = () => {
+      retains++;
+      const release = retain();
+      return () => {
+        releases++;
+        release();
+      };
+    };
+    const runtime = {
+      scheduler: {
+        setEventPreflightTelemetryEnabled(enabled: boolean) {
+          schedulerCalls.push(enabled);
+        },
+      },
+      storageManager: {
+        synced: () => {
+          synchronizations++;
+          return Promise.resolve();
+        },
+      },
+      dispose: () => {
+        disposals++;
+        return Promise.resolve();
+      },
+    } as unknown as Runtime;
+    const remove = telemetry.removeEventListener.bind(telemetry);
+    telemetry.removeEventListener = (type, listener, options) => {
+      removals++;
+      remove(type, listener, options);
+    };
+    const processor = Reflect.construct(RuntimeProcessor, [
+      runtime,
+      {},
+      {},
+      "did:key:z6MkTelemetryTest",
+      cfcSigner,
+      telemetry,
+    ]) as RuntimeProcessor;
+    return {
+      processor,
+      schedulerCalls,
+      counts: () => ({
+        retains,
+        releases,
+        disposals,
+        synchronizations,
+        removals,
+      }),
+    };
+  };
+
+  it("retains and releases detailed event telemetry exactly once", () => {
+    const { processor, schedulerCalls, counts } = createTelemetryProcessor();
+    processor.setTelemetryEnabled({
+      type: RequestType.SetTelemetryEnabled,
+      enabled: true,
     });
-    expect(JSON.stringify(preflight)).not.toContain("did:key:");
+    processor.setTelemetryEnabled({
+      type: RequestType.SetTelemetryEnabled,
+      enabled: true,
+    });
+    expect(schedulerCalls).toEqual([true]);
+    expect(counts()).toMatchObject({ retains: 1, releases: 0 });
+
+    processor.setTelemetryEnabled({
+      type: RequestType.SetTelemetryEnabled,
+      enabled: false,
+    });
+    processor.setTelemetryEnabled({
+      type: RequestType.SetTelemetryEnabled,
+      enabled: false,
+    });
+    expect(schedulerCalls).toEqual([true, false]);
+    expect(counts()).toMatchObject({ retains: 1, releases: 1 });
   });
 
-  it("keeps only aggregate drop details when crossing the worker boundary", () => {
-    expect(telemetryMarkerForHost({
-      type: "scheduler.event.drop",
-      eventId: "evt:private",
-      reason: "preflight",
-      timeStamp: 1,
-    })).toEqual({
-      type: "scheduler.event.drop",
-      reason: "preflight",
-      timeStamp: 1,
+  it("releases detailed telemetry during disposal", async () => {
+    const { processor, counts } = createTelemetryProcessor();
+    processor.setTelemetryEnabled({
+      type: RequestType.SetTelemetryEnabled,
+      enabled: true,
+    });
+    const disposal = processor.dispose();
+    expect(processor.dispose()).toBe(disposal);
+    await disposal;
+    expect(counts()).toMatchObject({
+      retains: 1,
+      releases: 1,
+      removals: 1,
+      synchronizations: 1,
+      disposals: 1,
     });
   });
 });

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -13,6 +13,7 @@ import {
   RuntimeProcessor,
   sanitizeForPostMessage,
   shouldReconcileHomeRoot,
+  telemetryMarkerForHost,
 } from "./runtime-processor.ts";
 import { atomsOutsideCeiling } from "@commonfabric/runner/cfc";
 import { cfcAtom } from "@commonfabric/api/cfc";
@@ -837,6 +838,146 @@ describe("sanitizeForPostMessage", () => {
           handler: "[Function]",
         },
       });
+    });
+  });
+});
+
+describe("telemetryMarkerForHost", () => {
+  it("keeps event correlations and detailed writes inside the runtime worker", () => {
+    const marker = telemetryMarkerForHost({
+      type: "scheduler.event.commit",
+      eventId: "evt:did:key:private",
+      handlerId: "handler:private",
+      readCount: 2,
+      writeCount: 3,
+      changedWriteCount: 1,
+      writes: ["value/did:key:private/title"],
+      writesTruncated: true,
+      handlerInfo: {
+        patternName: "Topics",
+        reads: ["did:key:private/of:fid1:private/title"],
+        writes: ["did:key:private/of:fid1:private/description"],
+      },
+      timeStamp: 1,
+    });
+
+    expect(marker).toEqual({
+      type: "scheduler.event.commit",
+      handlerId: "handler:private",
+      readCount: 2,
+      writeCount: 3,
+      changedWriteCount: 1,
+      handlerInfo: {
+        patternName: "Topics",
+        readCount: 1,
+        writeCount: 1,
+      },
+      timeStamp: 1,
+    });
+    expect(JSON.stringify(marker)).not.toContain("evt:");
+    expect(JSON.stringify(marker)).not.toContain("value/did:");
+    expect(JSON.stringify(marker)).not.toContain("of:fid1:");
+  });
+
+  it("summarizes nested action metadata for every host-facing marker", () => {
+    const actionInfo = {
+      moduleName: "topics.tsx",
+      reads: ["did:key:private/of:fid1:private/title"],
+      writes: [
+        "did:key:private/of:fid1:private/title",
+        "did:key:private/of:fid1:private/description",
+      ],
+    };
+
+    expect(telemetryMarkerForHost({
+      type: "scheduler.run.complete",
+      actionId: "action",
+      actionInfo,
+      durationMs: 1,
+      timeStamp: 1,
+    })).toEqual({
+      type: "scheduler.run.complete",
+      actionId: "action",
+      actionInfo: {
+        moduleName: "topics.tsx",
+        readCount: 1,
+        writeCount: 2,
+      },
+      durationMs: 1,
+      timeStamp: 1,
+    });
+
+    const invocation = telemetryMarkerForHost({
+      type: "scheduler.invocation",
+      eventId: "evt:private",
+      handlerId: "handler",
+      handlerInfo: actionInfo,
+      timeStamp: 1,
+    });
+    expect(invocation).toEqual({
+      type: "scheduler.invocation",
+      handlerId: "handler",
+      handlerInfo: {
+        moduleName: "topics.tsx",
+        readCount: 1,
+        writeCount: 2,
+      },
+      timeStamp: 1,
+    });
+    expect(JSON.stringify(invocation)).not.toContain("did:key:");
+
+    const preflight = telemetryMarkerForHost({
+      type: "scheduler.event.preflight",
+      handlerId: "handler",
+      handlerInfo: actionInfo,
+      readCount: 1,
+      shallowReadCount: 0,
+      dirtySizeBefore: 0,
+      pendingSizeBefore: 0,
+      dirtyDependencyCount: 0,
+      hasDirtyDependencies: false,
+      skipped: false,
+      populateMs: 0,
+      txToLogMs: 0,
+      depCommitMs: 0,
+      collectMs: 0,
+      scheduleMs: 0,
+      stats: {
+        visitCount: 0,
+        dirtyInputCount: 0,
+        resultTrueCount: 0,
+        workSetAddCount: 0,
+        reverseDependencyActionCount: 0,
+        reverseDependencyEdgeCount: 0,
+        logReadCount: 0,
+        logShallowReadCount: 0,
+        writerCandidateCount: 0,
+        writerOverlapCount: 0,
+        directWriterCount: 0,
+      },
+      timeStamp: 1,
+    });
+    if (preflight.type !== "scheduler.event.preflight") {
+      throw new Error("Expected a scheduler.event.preflight marker");
+    }
+    expect(preflight.handlerInfo).toEqual({
+      moduleName: "topics.tsx",
+      readCount: 1,
+      writeCount: 2,
+    });
+    expect(JSON.stringify(preflight)).not.toContain("did:key:");
+  });
+
+  it("keeps only aggregate drop details when crossing the worker boundary", () => {
+    expect(telemetryMarkerForHost({
+      type: "scheduler.event.drop",
+      eventId: "evt:private",
+      reason: "preflight",
+      timeStamp: 1,
+    })).toEqual({
+      type: "scheduler.event.drop",
+      reason: "preflight",
+      timeStamp: 1,
     });
   });
 });

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -451,6 +451,7 @@ export class RuntimeProcessor {
   private subscriptions = new Map<string, Cancel>();
   private telemetry: RuntimeTelemetry;
   #telemetryEnabled = false;
+  #releaseDetailedEventCommitTelemetry: (() => void) | undefined;
 
   // VDOM mounts: mountId -> { reconciler, cancel }
   private vdomMounts = new Map<
@@ -728,6 +729,8 @@ export class RuntimeProcessor {
     this._isDisposed = true;
     this.disposingPromise = (async () => {
       this.telemetry.removeEventListener("telemetry", this.#onTelemetry);
+      this.#releaseDetailedEventCommitTelemetry?.();
+      this.#releaseDetailedEventCommitTelemetry = undefined;
       try {
         this.#siteTableCancel?.();
         this.#siteTableCancel = undefined;
@@ -1344,8 +1347,16 @@ export class RuntimeProcessor {
   }
 
   setTelemetryEnabled(request: SetTelemetryEnabledRequest): void {
+    if (request.enabled === this.#telemetryEnabled) return;
     this.#telemetryEnabled = request.enabled;
     this.runtime.scheduler.setEventPreflightTelemetryEnabled(request.enabled);
+    if (request.enabled) {
+      this.#releaseDetailedEventCommitTelemetry = this.telemetry
+        .retainDetailedEventCommitTelemetry();
+    } else {
+      this.#releaseDetailedEventCommitTelemetry?.();
+      this.#releaseDetailedEventCommitTelemetry = undefined;
+    }
   }
 
   resetLoggerBaselines(_: any): void {

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -35,12 +35,11 @@ import {
   type SigilLink,
   unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
-import type { RuntimeTelemetryMarkerResult } from "@commonfabric/runner";
-import {
-  type HostSchedulerActionInfo,
-  linkRefPayload,
-  type SchedulerActionInfo,
-} from "@commonfabric/runner/shared";
+import type {
+  RuntimeTelemetryMarkerResult,
+  SchedulerEventPreflightStats,
+} from "@commonfabric/runner";
+import { linkRefPayload } from "@commonfabric/runner/shared";
 import {
   cfcLabelViewForCell,
   createRenderConfidentialityResolver,
@@ -183,66 +182,159 @@ export function telemetryMarkerForHost(
 ): HostRuntimeTelemetryMarker {
   switch (marker.type) {
     case "scheduler.run":
-    case "scheduler.run.complete": {
-      const { actionInfo, ...safe } = marker;
       return {
-        ...safe,
-        ...(actionInfo
-          ? { actionInfo: telemetryActionInfoForHost(actionInfo) }
-          : {}),
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        ok: marker.error === undefined,
       };
-    }
-    case "scheduler.invocation": {
-      const { eventId: _eventId, handlerInfo, ...safe } = marker;
+    case "scheduler.run.complete":
       return {
-        ...safe,
-        ...(handlerInfo
-          ? { handlerInfo: telemetryActionInfoForHost(handlerInfo) }
-          : {}),
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        durationMs: marker.durationMs,
+        ok: marker.error === undefined,
       };
-    }
-    case "scheduler.event.drop": {
-      const { eventId: _eventId, ...safe } = marker;
-      return safe;
-    }
-    case "scheduler.event.commit": {
-      const {
-        eventId: _eventId,
-        writes: _writes,
-        writesTruncated: _writesTruncated,
-        handlerInfo,
-        ...safe
-      } = marker;
+    case "scheduler.settle":
       return {
-        ...safe,
-        ...(handlerInfo
-          ? { handlerInfo: telemetryActionInfoForHost(handlerInfo) }
-          : {}),
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        durationMs: marker.durationMs,
+        iterations: marker.iterations,
+        settledEarly: marker.settledEarly,
+        seedCount: marker.seedCount,
+        workSetSize: marker.workSetSize,
       };
-    }
+    case "cell.update":
+      return { type: marker.type, timeStamp: marker.timeStamp };
+    case "scheduler.invocation":
+      return {
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        ok: marker.error === undefined,
+      };
+    case "scheduler.event.commit":
+      return {
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        readCount: marker.readCount,
+        writeCount: marker.writeCount,
+        changedWriteCount: marker.changedWriteCount,
+        ok: marker.error === undefined,
+        ...(marker.permanentRejection === undefined
+          ? {}
+          : { permanentRejection: marker.permanentRejection }),
+        ...(marker.retryAttempt === undefined
+          ? {}
+          : { retryAttempt: marker.retryAttempt }),
+        ...(marker.backoffMs === undefined
+          ? {}
+          : { backoffMs: marker.backoffMs }),
+        ...(marker.terminal === undefined ? {} : { terminal: marker.terminal }),
+      };
+    case "scheduler.event.drop":
+      return {
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        reason: marker.reason,
+      };
     case "scheduler.event.preflight": {
-      const { handlerInfo, ...safe } = marker;
       return {
-        ...safe,
-        ...(handlerInfo
-          ? { handlerInfo: telemetryActionInfoForHost(handlerInfo) }
-          : {}),
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        readCount: marker.readCount,
+        shallowReadCount: marker.shallowReadCount,
+        dirtySizeBefore: marker.dirtySizeBefore,
+        pendingSizeBefore: marker.pendingSizeBefore,
+        dirtyDependencyCount: marker.dirtyDependencyCount,
+        hasDirtyDependencies: marker.hasDirtyDependencies,
+        skipped: marker.skipped,
+        populateMs: marker.populateMs,
+        txToLogMs: marker.txToLogMs,
+        depCommitMs: marker.depCommitMs,
+        collectMs: marker.collectMs,
+        scheduleMs: marker.scheduleMs,
+        stats: telemetryPreflightStatsForHost(marker.stats),
+        ok: marker.error === undefined,
       };
     }
-    default:
-      return marker;
+    case "storage.push.start":
+    case "storage.push.complete":
+    case "storage.pull.start":
+    case "storage.pull.complete":
+    case "storage.subscription.add":
+    case "storage.subscription.remove":
+      return {
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        ok: marker.error === undefined,
+      };
+    case "storage.push.error":
+    case "storage.pull.error":
+      return { type: marker.type, timeStamp: marker.timeStamp, ok: false };
+    case "storage.connection.update":
+      return {
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        status: marker.status,
+        attempt: marker.attempt,
+        ok: marker.error === undefined,
+      };
+    case "scheduler.graph.snapshot":
+      return {
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        nodeCount: marker.graph.nodes.length,
+        edgeCount: marker.graph.edges.length,
+      };
+    case "scheduler.subscribe":
+      return {
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        isEffect: marker.isEffect,
+      };
+    case "scheduler.dependencies.update":
+      return {
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        readCount: marker.reads.length,
+        writeCount: marker.writes.length,
+      };
+    case "scheduler.non-settling":
+      return {
+        type: marker.type,
+        timeStamp: marker.timeStamp,
+        busyTime: marker.busyTime,
+        windowDuration: marker.windowDuration,
+        busyRatio: marker.busyRatio,
+      };
   }
+
+  return assertNeverTelemetryMarker(marker);
 }
 
-function telemetryActionInfoForHost(
-  info: SchedulerActionInfo,
-): HostSchedulerActionInfo {
-  const { reads, writes, ...safe } = info;
+function telemetryPreflightStatsForHost(
+  stats: SchedulerEventPreflightStats,
+) {
   return {
-    ...safe,
-    ...(reads ? { readCount: reads.length } : {}),
-    ...(writes ? { writeCount: writes.length } : {}),
+    visitCount: stats.visitCount,
+    dirtyInputCount: stats.dirtyInputCount,
+    resultTrueCount: stats.resultTrueCount,
+    workSetAddCount: stats.workSetAddCount,
+    reverseDependencyActionCount: stats.reverseDependencyActionCount,
+    reverseDependencyEdgeCount: stats.reverseDependencyEdgeCount,
+    logReadCount: stats.logReadCount,
+    logShallowReadCount: stats.logShallowReadCount,
+    writerCandidateCount: stats.writerCandidateCount,
+    writerOverlapCount: stats.writerOverlapCount,
+    directWriterCount: stats.directWriterCount,
+    hotActionCount: stats.hotActions?.length ?? 0,
+    hotFanoutActionCount: stats.hotFanoutActions?.length ?? 0,
+    rootDirectWriterCount: stats.rootDirectWriters?.length ?? 0,
   };
+}
+
+function assertNeverTelemetryMarker(marker: never): never {
+  throw new Error(`Unhandled runtime telemetry marker: ${marker}`);
 }
 
 /**

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -35,7 +35,12 @@ import {
   type SigilLink,
   unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
-import { linkRefPayload } from "@commonfabric/runner/shared";
+import type { RuntimeTelemetryMarkerResult } from "@commonfabric/runner";
+import {
+  type HostSchedulerActionInfo,
+  linkRefPayload,
+  type SchedulerActionInfo,
+} from "@commonfabric/runner/shared";
 import {
   cfcLabelViewForCell,
   createRenderConfidentialityResolver,
@@ -152,7 +157,7 @@ import {
   type RenderDeclassificationPolicy,
   WorkerReconciler,
 } from "@commonfabric/html/worker";
-import type { VDomOp } from "../protocol/types.ts";
+import type { HostRuntimeTelemetryMarker, VDomOp } from "../protocol/types.ts";
 import type { JSONValue, RuntimeOptions } from "@commonfabric/runner";
 import {
   postContextualRuntimeError,
@@ -168,6 +173,77 @@ const cfcLabelLogger = getLogger("runtime-client.cfc-label", {
   enabled: true,
   level: "error",
 });
+
+/**
+ * Keep event correlation and detailed write addresses in the worker. The host
+ * needs aggregate counts and fixed categories, not identifier-bearing joins.
+ */
+export function telemetryMarkerForHost(
+  marker: RuntimeTelemetryMarkerResult,
+): HostRuntimeTelemetryMarker {
+  switch (marker.type) {
+    case "scheduler.run":
+    case "scheduler.run.complete": {
+      const { actionInfo, ...safe } = marker;
+      return {
+        ...safe,
+        ...(actionInfo
+          ? { actionInfo: telemetryActionInfoForHost(actionInfo) }
+          : {}),
+      };
+    }
+    case "scheduler.invocation": {
+      const { eventId: _eventId, handlerInfo, ...safe } = marker;
+      return {
+        ...safe,
+        ...(handlerInfo
+          ? { handlerInfo: telemetryActionInfoForHost(handlerInfo) }
+          : {}),
+      };
+    }
+    case "scheduler.event.drop": {
+      const { eventId: _eventId, ...safe } = marker;
+      return safe;
+    }
+    case "scheduler.event.commit": {
+      const {
+        eventId: _eventId,
+        writes: _writes,
+        writesTruncated: _writesTruncated,
+        handlerInfo,
+        ...safe
+      } = marker;
+      return {
+        ...safe,
+        ...(handlerInfo
+          ? { handlerInfo: telemetryActionInfoForHost(handlerInfo) }
+          : {}),
+      };
+    }
+    case "scheduler.event.preflight": {
+      const { handlerInfo, ...safe } = marker;
+      return {
+        ...safe,
+        ...(handlerInfo
+          ? { handlerInfo: telemetryActionInfoForHost(handlerInfo) }
+          : {}),
+      };
+    }
+    default:
+      return marker;
+  }
+}
+
+function telemetryActionInfoForHost(
+  info: SchedulerActionInfo,
+): HostSchedulerActionInfo {
+  const { reads, writes, ...safe } = info;
+  return {
+    ...safe,
+    ...(reads ? { readCount: reads.length } : {}),
+    ...(writes ? { writeCount: writes.length } : {}),
+  };
+}
 
 /**
  * PageId intake: accepts both the bare tagged hash (`fid1:<hash>`, the
@@ -1383,7 +1459,7 @@ export class RuntimeProcessor {
     const marker = (event as RuntimeTelemetryEvent).marker;
     self.postMessage({
       type: NotificationType.Telemetry,
-      marker,
+      marker: telemetryMarkerForHost(marker),
     });
   };
 

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -1,5 +1,6 @@
 import type {
   ActionRunTraceEntry,
+  HostRuntimeTelemetryMarker,
   JSONSchema,
   JSONValue,
   NormalizedFullLink,
@@ -16,11 +17,10 @@ import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { CfcLabelView } from "@commonfabric/runner/cfc/label-view-core";
 import type { DID, KeyPairRaw } from "@commonfabric/identity";
 import { type Program } from "@commonfabric/js-compiler/interface";
-import { RuntimeTelemetryMarkerResult } from "@commonfabric/runtime-client";
 import type { MetaField } from "@commonfabric/api";
 export type { JSONSchema, JSONValue, Program };
 
-export type { CfcLabelView };
+export type { CfcLabelView, HostRuntimeTelemetryMarker };
 
 export type MessageId = number;
 
@@ -875,7 +875,7 @@ export interface ErrorNotification {
 
 export interface TelemetryNotification {
   type: NotificationType.Telemetry;
-  marker: RuntimeTelemetryMarkerResult;
+  marker: HostRuntimeTelemetryMarker;
 }
 
 /**

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -10,7 +10,6 @@ import type {
   ActionRunTraceEntry,
   JSONSchema,
   PatternCoverageData,
-  RuntimeTelemetryMarkerResult,
   SchedulerDiagnosisResult,
   SchedulerGraphSnapshot,
   SettleStats,
@@ -63,7 +62,7 @@ export type RuntimeClientEvents = {
   console: [ConsoleNotification];
   navigaterequest: [{ cell: CellHandle }];
   error: [ErrorNotification];
-  telemetry: [RuntimeTelemetryMarkerResult];
+  telemetry: [TelemetryNotification["marker"]];
   pendingwriteschange: [{ pending: boolean }];
 };
 

--- a/packages/shell/src/lib/debugger-controller.ts
+++ b/packages/shell/src/lib/debugger-controller.ts
@@ -275,14 +275,6 @@ export class DebuggerController implements ReactiveController {
         this.telemetryMarkers = allMarkers.slice(-MAX_TELEMETRY_EVENTS);
         this.updateVersion++;
 
-        // Check for graph snapshot events in recent markers
-        const latestMarker = allMarkers[allMarkers.length - 1];
-        if (latestMarker?.type === "scheduler.graph.snapshot") {
-          this.processGraphSnapshot(
-            (latestMarker as { graph: SchedulerGraphSnapshot }).graph,
-          );
-        }
-
         // NOTE: Auto-refresh disabled - was causing infinite loop
         // (telemetry -> UI update -> sink -> telemetry)
         // Use manual refresh button instead

--- a/packages/shell/src/lib/debugger-controller.ts
+++ b/packages/shell/src/lib/debugger-controller.ts
@@ -3,9 +3,9 @@ import type { RuntimeInternals } from "./runtime.ts";
 import type {
   CellHandle,
   CellRef,
+  HostRuntimeTelemetryMarker,
   LoggerFlagsData,
   PatternSourceInfo,
-  RuntimeTelemetryMarkerResult,
   SchedulerDiagnosisResult,
   SchedulerGraphEdge,
   SchedulerGraphSnapshot,
@@ -59,7 +59,7 @@ export class DebuggerController implements ReactiveController {
   private runtime?: RuntimeInternals;
   private visible = false;
   private telemetryEnabled = false; // Manual telemetry on/off
-  private telemetryMarkers: RuntimeTelemetryMarkerResult[] = [];
+  private telemetryMarkers: HostRuntimeTelemetryMarker[] = [];
   private updateVersion = 0;
   private watchedCells = new Map<string, WatchedCell>();
 
@@ -176,7 +176,7 @@ export class DebuggerController implements ReactiveController {
   /**
    * Get the current telemetry markers
    */
-  getTelemetryMarkers(): RuntimeTelemetryMarkerResult[] {
+  getTelemetryMarkers(): HostRuntimeTelemetryMarker[] {
     return this.telemetryMarkers;
   }
 

--- a/packages/shell/src/lib/otel.ts
+++ b/packages/shell/src/lib/otel.ts
@@ -9,7 +9,7 @@
 //
 // Only type-only imports appear at the top; they are erased at build time and
 // never pull the OTel packages into the default bundle.
-import type { RuntimeTelemetryMarkerResult } from "@commonfabric/runtime-client";
+import type { HostRuntimeTelemetryMarker } from "@commonfabric/runtime-client";
 
 // localStorage key that gates telemetry — the same flag the debugger controller
 // toggles (packages/shell/src/lib/debugger-controller.ts).
@@ -32,7 +32,7 @@ export interface InitBrowserOtelOptions {
  */
 export interface BrowserTelemetry {
   /** Feed one RuntimeTelemetry marker into the OTel bridge. */
-  handleMarker(marker: RuntimeTelemetryMarkerResult): void;
+  handleMarker(marker: HostRuntimeTelemetryMarker): void;
   /**
    * Update the space.did stamped on subsequent spans. The runtime (and this
    * sink) lives across space navigations, so the host must keep this current.

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -2,8 +2,8 @@ import { css, html, LitElement, TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
 import { ResizableDrawerController } from "../lib/resizable-drawer-controller.ts";
 import type {
+  HostRuntimeTelemetryMarker,
   LoggerMetadata,
-  RuntimeTelemetryMarkerResult,
   TimingStats,
 } from "@commonfabric/runtime-client";
 import { isRecord } from "@commonfabric/utils/types";
@@ -832,7 +832,7 @@ export class XDebuggerView extends LitElement {
   accessor visible = false;
 
   @property({ attribute: false })
-  accessor telemetryMarkers: RuntimeTelemetryMarkerResult[] = [];
+  accessor telemetryMarkers: HostRuntimeTelemetryMarker[] = [];
 
   @property({ attribute: false })
   accessor debuggerController: DebuggerController | undefined = undefined;
@@ -894,7 +894,7 @@ export class XDebuggerView extends LitElement {
   private accessor isPaused = false;
 
   @state()
-  private accessor pausedMarkers: RuntimeTelemetryMarkerResult[] = [];
+  private accessor pausedMarkers: HostRuntimeTelemetryMarker[] = [];
 
   @state()
   private accessor tooltipData: {
@@ -1100,7 +1100,7 @@ export class XDebuggerView extends LitElement {
     this.fullHeightEvents = newSet;
   }
 
-  private async copyJson(data: RuntimeTelemetryMarkerResult) {
+  private async copyJson(data: HostRuntimeTelemetryMarker) {
     try {
       const jsonString = JSON.stringify(data, null, 2);
       await navigator.clipboard.writeText(jsonString);
@@ -1116,7 +1116,7 @@ export class XDebuggerView extends LitElement {
     }`;
   }
 
-  private getEventIcon(marker: RuntimeTelemetryMarkerResult): string {
+  private getEventIcon(marker: HostRuntimeTelemetryMarker): string {
     const type = marker.type;
 
     // Try to find a matching topic
@@ -1132,7 +1132,7 @@ export class XDebuggerView extends LitElement {
     return "📊";
   }
 
-  private getEventColor(marker: RuntimeTelemetryMarkerResult): string {
+  private getEventColor(marker: HostRuntimeTelemetryMarker): string {
     const type = marker.type;
 
     // Try to find a matching topic
@@ -1148,7 +1148,7 @@ export class XDebuggerView extends LitElement {
     return "#64748b";
   }
 
-  private matchesActiveTopics(marker: RuntimeTelemetryMarkerResult): boolean {
+  private matchesActiveTopics(marker: HostRuntimeTelemetryMarker): boolean {
     if (this.activeSubtopics.size === 0) return false;
 
     const type = marker.type;
@@ -1168,7 +1168,7 @@ export class XDebuggerView extends LitElement {
     return false;
   }
 
-  private matchesSearch(marker: RuntimeTelemetryMarkerResult): boolean {
+  private matchesSearch(marker: HostRuntimeTelemetryMarker): boolean {
     if (!this.searchText) return true;
 
     const searchLower = this.searchText.toLowerCase();
@@ -1177,7 +1177,7 @@ export class XDebuggerView extends LitElement {
     return markerStr.includes(searchLower);
   }
 
-  private getFilteredEvents(): RuntimeTelemetryMarkerResult[] {
+  private getFilteredEvents(): HostRuntimeTelemetryMarker[] {
     const markers = this.isPaused ? this.pausedMarkers : this.telemetryMarkers;
 
     return markers.filter((marker) =>
@@ -1186,7 +1186,7 @@ export class XDebuggerView extends LitElement {
   }
 
   private renderEventDetails(
-    marker: RuntimeTelemetryMarkerResult,
+    marker: HostRuntimeTelemetryMarker,
   ): TemplateResult[] {
     const details = [];
 
@@ -1237,21 +1237,21 @@ export class XDebuggerView extends LitElement {
             </div>
           `);
         }
-        if (Array.isArray(info.reads) && info.reads.length > 0) {
+        if (typeof info.readCount === "number" && info.readCount > 0) {
           details.push(html`
             <div class="event-detail">
               <span class="event-detail-label">reads:</span>
-              <span class="event-detail-value">${info.reads
-                .length} dependencies</span>
+              <span class="event-detail-value">${info
+                .readCount} dependencies</span>
             </div>
           `);
         }
-        if (Array.isArray(info.writes) && info.writes.length > 0) {
+        if (typeof info.writeCount === "number" && info.writeCount > 0) {
           details.push(html`
             <div class="event-detail">
               <span class="event-detail-label">writes:</span>
-              <span class="event-detail-value">${info.writes
-                .length} outputs</span>
+              <span class="event-detail-value">${info
+                .writeCount} outputs</span>
             </div>
           `);
         }

--- a/tasks/select-pattern-integration-files.ts
+++ b/tasks/select-pattern-integration-files.ts
@@ -28,6 +28,7 @@ export const FOUR_SHARD_ASSIGNMENTS: Readonly<Record<string, number>> = {
   "cf-code-editor.test.ts": 1,
   "home-profile-reload-durability.test.ts": 1,
   "sqlite-db-owner-multi-runtime.test.ts": 1,
+  "topics-diagnose-scripted.test.ts": 1,
 
   // shard 2
   "cfc-group-chat-demo-two-browsers.test.ts": 2,


### PR DESCRIPTION
## Summary

Add deterministic, content-free diagnostics for stressing the Topics pattern across isolated runtimes. The new `topics-diagnose` command measures event execution, scheduler settling, storage transactions, conflicts, write amplification, graph shape, and convergence without exporting document values, raw links, entity identifiers, or caller-selected bootstrap identities.

## Why

Topics has enough nested cells, cross-references, concurrent users, and replicated sessions to expose scheduler and memory behavior that unit-level timings cannot explain. Before this change, a workload could appear slow or flaky without a reliable way to separate useful commits from retries, no-op amplification, storage conflicts, delayed frames, or unsettled graph work. Polling for visible state also made multi-runtime tests timing-sensitive and could declare success before queued nested handler commits had drained.

This PR creates an event-driven measurement path so performance investigations can compare deterministic counters first and treat wall-clock timing as secondary, noisy evidence.

## What changed

### Structured runtime telemetry

- Add a typed runtime telemetry sink and extend the OpenTelemetry bridge with scheduler-run, event-commit, retry, storage, and settling measurements.
- Keep detailed write samples lease-controlled so normal runtimes do not pay for no-op classification unless a diagnostics consumer explicitly retains it.
- Preserve telemetry bridge leases in runtime clients and background workers for the full runtime lifetime.

### Deterministic synchronization

- Add scheduler diagnostic barriers that wait for queued work, in-flight event commits, delayed frames, storage acknowledgement, server refresh, and nested-cell topology synchronization.
- Correlate queued events with stable event IDs and commit outcomes.
- Synchronize every nested result-cell hop before dispatching an event on a cold replica.
- Preserve Fabric sigils in raw reads by using `pull()` as the synchronization fence and `getRaw()` as the value source.

### Canonical memory diagnostics

- Report aggregate transaction counts, accepted/rejected outcomes, conflicts, replays, byte and operation totals, patch-operation types, redacted path shapes, and scheduler state.
- Add an event-driven diagnostics flush fence for queued receive and watch-refresh work.
- Keep the aggregate snapshot path separate from exported spans.

### Hardened multi-runtime harness

- Expose only an aggregate diagnostics RPC allowlist; generic read, raw-read, link, logger, and diagnostics commands are rejected in aggregate mode.
- Keep worker-local immutable bootstrap creator state so callers cannot select a BroadcastChannel piece identity.
- Aggregate content-free telemetry across runtime workers and validate final convergence.
- Add regressions for cold nested dispatch, delayed commit draining, and raw Topic-link preservation through root reordering.

### Topics workload CLI

- Add configurable matrix runs plus `--quick` and deterministic `--profile=conflicts` presets.
- Exercise topic setup, comment and cross-reference workloads, typing, and bounded root oscillation.
- Emit one JSON report with per-phase operation counts, runtime and memory aggregates, write-amplification ratios, graph/settling state, oscillation metadata, and convergence.
- Document invocation, interpretation, and the privacy contract in `packages/patterns/topics/README.md`.

## Privacy and safety contract

Diagnostic reports contain bounded counts, timings, fixed error codes, patch kinds, and redacted path-shape buckets only. They do not contain document values, comments, raw links, entity IDs, DIDs, session IDs, user IDs, event IDs, transaction IDs, stack traces, or arbitrary error text. Aggregate workers reject general-purpose inspection RPCs rather than relying only on report redaction.

## Validation

Run with the repository-pinned Deno 2.8.1:

- `deno task check`
- `deno fmt --check`
- 8 runner test suites / 67 steps across telemetry, event identity, scheduler events, barriers, and nested piece startup
- 87 memory tests across scheduler state and server transaction diagnostics
- 13 Topics diagnostics tests / 3 integration steps
- `deno run --frozen -A packages/patterns/tools/topics-diagnose.ts --profile=conflicts`
  - 16 submitted / 8 accepted / 8 rejected
  - two-step repeat ratio 1
  - converged
- `deno run --frozen -A packages/patterns/tools/topics-diagnose.ts --profile=conflicts --rounds=1`
  - 4 submitted / 2 accepted / 2 rejected
  - two-step repeat ratio null
  - converged
- LSP diagnostics: zero errors in every modified TypeScript file
- `git diff --check`

## Investigation scope

The workload is suitable for matched steady-state contention comparisons. It does not perform a pattern-version upgrade, so it can detect deterministic steady-state regressions around an upgrade-related change but cannot by itself prove or disprove claims specifically about old/new generated-cell overlap during an upgrade. The matched comparison against #4916 is reported separately with that limitation made explicit.

## Performance baseline

This PR intentionally adds two multi-runtime integration suites: the nested-send suite adds about 135 seconds to shard 2, and the aggregate-only diagnostics RPC test adds about 67 seconds to shard 1. These narrow baselines use clean attempt 3 values; broader attempt 2 runner noise is not accepted.

NEW_PERF_BASELINE: job: Pattern Integration Tests (2/4) = 255s
NEW_PERF_BASELINE: step: patterns integration = 224s
NEW_PERF_BASELINE: job: Pattern Integration Tests = 255s
NEW_PERF_BASELINE: job: Pattern Integration Tests (1/4) = 217s

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787421993&installation_model_id=428580&pr_number=4950&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4950&signature=ab62be02baf5abc7ea68f3e2128fafa29c4df2f293222baf035991013587ed87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a privacy-safe Topics workload diagnostics CLI and structured runtime/memory telemetry to measure scheduler, storage, and convergence deterministically across isolated runtimes. Hosts now receive aggregate-only telemetry; event IDs and write paths stay inside the worker.

- **New Features**
  - `topics-diagnose` CLI: matrix runs, `--quick`, `--profile=conflicts`, real nested streams, one JSON report.
  - Structured runtime telemetry: commit amplification (reads/writes vs changed writes), retries, drop reasons; opt-in detailed samples via lease; upgraded `@opentelemetry` bridge with separate `attributes`, `spanAttributes`, and metric attributes; host markers (`HostRuntimeTelemetryMarker`) emit metrics only and include preflight stats.
  - Deterministic sync: scheduler/storage barriers for queued work, in‑flight commits, delayed frames, server refresh, and nested‑cell topology; cold replica sync; flush fences for receive/watch refresh.
  - Memory server diagnostics: aggregate, content‑free commit telemetry (transactions, outcomes, conflicts, replays, patch kinds, redacted path shapes); `commitTelemetry` and `aggregateOnlyDiagnostics` options; hardened multi‑runtime harness with an RPC allowlist and convergence checks.
  - Docs: usage and the privacy contract in `packages/patterns/topics/README.md`.

- **Bug Fixes**
  - Enforce host‑only aggregate telemetry: define host‑safe markers; redact worker details in `@commonfabric/runtime-client` before postMessage; `@commonfabric/lib-shell` and the shell consume host markers and keep graph detail off host telemetry; OTel bridge preserves metrics for host‑safe markers.
  - Attach the OTel bridge in the background piece service only after initialization; fail‑open returns `null`; guarantee bridge cleanup on shutdown.
  - Preserve malformed transaction errors in memory v2 diagnostics and distinguish first‑apply from replay.
  - Validate Topics diagnostics CLI arguments and materialized crossrefs; move workload tests to integration.
  - Synchronize nested piece result‑cell chains before dispatch and avoid redundant re‑syncs.
  - Tests: isolate inherited‑property pollution coverage for schema‑ref traversal; consolidate Topics diagnostics scenarios for faster, clearer runs.

<sup>Written for commit b9ee8cba686c5211f5c0f78df074c8cc4a14538d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

