### PR TITLE
patterns: drop stale explicit LLM model pins so calls use the runtime…

### DIFF
--- a/docs/common/capabilities/llm.md
+++ b/docs/common/capabilities/llm.md
@@ -40,7 +40,6 @@ interface ProductIdea {
 const idea = generateObject<ProductIdea>({
   prompt: userInput,
   system: "Generate a product idea.",
-  model: "anthropic:claude-sonnet-4-5",
 });
 
 // Response: { result: ProductIdea, error: string, pending: boolean }
@@ -79,6 +78,30 @@ const summaries = articles.map((article) => ({
   </div>
 ))}
 ```
+
+### Selecting a Model
+
+`model` is optional on `generateText`, `generateObject`, and `llmDialog`. Omit
+it and the runtime fills in a default. Prefer omitting it over naming a specific
+model version, which stops working on any deployment that no longer offers that
+exact version.
+
+The default an omitted `model` resolves to depends on the call. `generateText`
+and `llmDialog` use the `"default"` alias, which is the deployment's current
+default model. `generateObject` uses a separate default chosen for structured
+output. To pin any call to the deployment's default model explicitly — for
+instance to keep a `generateObject` call on the same model as the rest of a
+pattern — pass `model: "default"`.
+
+Hardcode a specific model only when the call needs that model's particular
+capability — for example a cheaper, faster model for a high-volume map, or a
+model chosen for a vision task.
+
+**TODO:** A call should be able to request a model by capability rather than by
+name — asking for a capability such as "vision", "high-effort", or "low-cost"
+and letting the deployment resolve the best available model that has it. That
+would remove the remaining reason to name a specific model, so a capability need
+would no longer force a version pin that goes stale.
 
 ### Valid Model Names
 

--- a/packages/patterns/deep-research.tsx
+++ b/packages/patterns/deep-research.tsx
@@ -93,7 +93,6 @@ When done, call presentResult with your structured findings.`,
       searchWeb: patternTool(searchWeb),
       readWebpage: patternTool(readWebpage),
     },
-    model: "anthropic:claude-sonnet-4-5",
     context: computed(() => context ?? {}),
     resultSchema: toSchema<ResearchResult>(),
   });

--- a/packages/patterns/examples/write-and-run.tsx
+++ b/packages/patterns/examples/write-and-run.tsx
@@ -87,7 +87,6 @@ Generate ONLY the TypeScript code, no explanations or markdown.`;
   const generated = generateText({
     system: systemPrompt,
     prompt,
-    model: "anthropic:claude-sonnet-4-5",
   });
 
   const processedResult = computed(() => {

--- a/packages/patterns/experimental/email-task-engine.tsx
+++ b/packages/patterns/experimental/email-task-engine.tsx
@@ -589,7 +589,6 @@ Consider:
 Respond with the most appropriate action.`;
       }),
       schema: SUGGESTION_SCHEMA,
-      model: "anthropic:claude-sonnet-4-5",
     });
 
     // Return the cells directly without wrapping in computed;

--- a/packages/patterns/factory-outputs/lot-watch/main.tsx
+++ b/packages/patterns/factory-outputs/lot-watch/main.tsx
@@ -592,7 +592,6 @@ export default pattern<LotWatchInput, LotWatchOutput>(
           },
         },
       },
-      model: "anthropic:claude-sonnet-4-5",
     });
 
     // ---- Actions ----

--- a/packages/patterns/gideon-tests/test-generateobject-error-handling.tsx
+++ b/packages/patterns/gideon-tests/test-generateobject-error-handling.tsx
@@ -44,7 +44,6 @@ export default pattern<Input, Input>(({ userInput }) => {
     prompt: userInput,
     system:
       "Generate a creative product idea based on the user's input. Be concise.",
-    model: "anthropic:claude-sonnet-4-5",
   });
 
   // Error message as string for display

--- a/packages/patterns/gideon-tests/test-llm-dumb-map-generateobject.tsx
+++ b/packages/patterns/gideon-tests/test-llm-dumb-map-generateobject.tsx
@@ -90,7 +90,6 @@ export default pattern<Input>(({ items }) => {
       system:
         "Analyze the sentiment of the following text. Return positive, neutral, or negative sentiment with confidence 0-1 and relevant keywords.",
       prompt: item.content,
-      model: "anthropic:claude-sonnet-4-5",
     }),
   }));
 

--- a/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
+++ b/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
@@ -1389,7 +1389,6 @@ When you're done searching, STOP calling tools and produce your final structured
       system: fullSystemPrompt,
       prompt: agentPrompt,
       tools: allTools,
-      model: "anthropic:claude-sonnet-4-5",
       schema: computed(() => {
         const schema = resultSchema;
         if (schema && Object.keys(schema).length > 0) {

--- a/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
+++ b/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
@@ -648,7 +648,6 @@ export default pattern<Input, Output>(
     });
 
     const aiResponse = generateObject<AIResponseSuggestion>({
-      model: "anthropic:claude-sonnet-4-5",
       system: RESPONSE_SYSTEM_PROMPT,
       prompt: currentExpandedPrompt,
     });

--- a/packages/patterns/google/core/gmail-extractor.tsx
+++ b/packages/patterns/google/core/gmail-extractor.tsx
@@ -126,9 +126,9 @@ export interface GmailExtractorInput {
   /** Maximum number of emails to fetch */
   limit?: number | Default<100>;
 
-  // Note: model parameter removed - hardcoded to fix HTTP 400 errors
-  // when passing variables through building block input.
-  // Use hardcoded "anthropic:claude-sonnet-4-5" instead.
+  // Note: no model parameter is exposed here - passing a model as a variable
+  // through the building block input caused HTTP 400 errors. The generateObject
+  // call below omits model and uses the runtime default instead.
 
   /** Optional linked auth (overrides wish() default) */
   overrideAuth?: GoogleAuthCell;
@@ -463,7 +463,6 @@ const GmailExtractor = pattern<GmailExtractorInput, GmailExtractorOutput>(
           return interpolateTemplate(template, email);
         }) as any,
         schema: extractionSchema as JSONSchema,
-        model: "anthropic:claude-sonnet-4-5",
       });
 
       return {

--- a/packages/patterns/google/extractors/email-style-extractor.tsx
+++ b/packages/patterns/google/extractors/email-style-extractor.tsx
@@ -240,7 +240,6 @@ Extract the writing style patterns from these emails.`;
       schema: STYLE_SCHEMA,
       system:
         "You are an expert linguist analyzing email writing patterns. Extract consistent style patterns across all provided emails. Be specific and use examples from the actual text.",
-      model: "anthropic:claude-sonnet-4-5",
     });
 
     // Auto-save LLM result to persistent Writable

--- a/packages/patterns/google/extractors/expect-response-followup.tsx
+++ b/packages/patterns/google/extractors/expect-response-followup.tsx
@@ -815,7 +815,6 @@ ${threadSummary}
 Write only the email body, no subject line or greeting line (the greeting will be auto-added):`;
     }) as any,
     system: draftSystemPrompt,
-    model: "anthropic:claude-sonnet-4-5",
   });
 
   // Auto-save LLM draft to drafts Writable when generation completes

--- a/packages/patterns/google/extractors/usps-informed-delivery.tsx
+++ b/packages/patterns/google/extractors/usps-informed-delivery.tsx
@@ -322,7 +322,6 @@ If you cannot read the image clearly, make your best guess based on what you can
       ];
     }) as any,
     schema: MAIL_ANALYSIS_SCHEMA,
-    model: "anthropic:claude-sonnet-4-5",
   });
 
   return {

--- a/packages/patterns/record/extraction/extractor-module.tsx
+++ b/packages/patterns/record/extraction/extractor-module.tsx
@@ -1782,7 +1782,6 @@ export const ExtractorModule = pattern<
         ocr: generateText({
           system: OCR_SYSTEM_PROMPT,
           prompt: prompt as any,
-          model: "anthropic:claude-sonnet-4-5",
         }),
       };
     });

--- a/packages/patterns/self-improving-classifier.tsx
+++ b/packages/patterns/self-improving-classifier.tsx
@@ -1724,7 +1724,6 @@ Respond with:
 - classification: true for YES, false for NO
 - confidence: a number between 0 and 1 indicating your confidence
 - reasoning: a brief explanation of why you classified it this way`,
-      model: "anthropic:claude-sonnet-4-5",
     });
 
     // When LLM result arrives, compute the classification result
@@ -1972,7 +1971,6 @@ Each suggestion should have:
 - pattern: a regex pattern (without delimiters)
 - predicts: true for YES, false for NO
 - reasoning: why this pattern indicates the classification`,
-      model: "anthropic:claude-sonnet-4-5",
     });
 
     // Derive visible suggestions from LLM result, filtered by dismissed indices

--- a/packages/patterns/store-mapper.tsx
+++ b/packages/patterns/store-mapper.tsx
@@ -363,7 +363,6 @@ export default pattern<Input, Output>(
             },
           },
         },
-        model: "anthropic:claude-sonnet-4-5",
       });
 
       return {

--- a/packages/patterns/system/home-ben.tsx
+++ b/packages/patterns/system/home-ben.tsx
@@ -237,7 +237,6 @@ Write in past tense, personal style. Focus on:
     }),
     system:
       "You analyze user activity and content to understand their interests. The piece content is provided in the context. Look at the actual data/content, not just titles. Extract meaningful insights about what they care about, work on, or are interested in.",
-    model: "anthropic:claude-sonnet-4-5",
     // Pass the subject cell as context - system will serialize it properly
     context: computed(() => {
       const entry = pendingEntry;

--- a/packages/patterns/system/knowledge-graph.tsx
+++ b/packages/patterns/system/knowledge-graph.tsx
@@ -259,7 +259,6 @@ Use exact piece names from the piece list above for fromName/toName/pieceNames.`
         edges: allEdgesFromBase,
       }),
     },
-    model: "anthropic:claude-sonnet-4-5" as const,
     builtinTools: false,
     resultSchema: toSchema<GraphAnnotations>(),
   };

--- a/packages/patterns/system/quick-capture.tsx
+++ b/packages/patterns/system/quick-capture.tsx
@@ -193,7 +193,6 @@ ${profileSection}`;
       system: systemPrompt,
       messages,
       tools: llmTools,
-      model: "anthropic:claude-sonnet-4-5" as const,
       builtinTools: false,
     };
 

--- a/packages/patterns/system/suggestion.tsx
+++ b/packages/patterns/system/suggestion.tsx
@@ -202,7 +202,6 @@ Use the user context above to personalize your suggestions when relevant.`;
           "Ask the user a clarifying question. Options are optional — if provided (2-4 strings), they appear as quick-select buttons alongside a free-text input. If omitted, only a text input is shown. After calling, STOP and wait for the user's answer. Input: { question: string, options?: string[] }",
       },
     },
-    model: "anthropic:claude-sonnet-4-5",
     context,
     resultSchema: toSchema<{ cell: SuggestionResultCell }>(),
     queue: "suggestions",

--- a/packages/toolshed/routes/ai/llm/llm.routes.ts
+++ b/packages/toolshed/routes/ai/llm/llm.routes.ts
@@ -70,7 +70,7 @@ export const LLMRequestSchema = toZod<LLMRequest>().with({
   messages: z.array(MessageSchema) as any, // Trust our BuiltInLLMMessage = CoreMessage alignment
   system: z.string().optional(),
   model: z.string().openapi({
-    example: "claude-sonnet-4-5",
+    example: "default",
   }),
   maxTokens: z.number().optional(),
   stop: z.string().optional(),
@@ -215,7 +215,7 @@ export const generateText = createRoute({
         "application/json": {
           schema: LLMRequestSchema.openapi({
             example: {
-              model: "anthropic:claude-sonnet-4-5",
+              model: "default",
               system: "You are a pirate, make sure you talk like one.",
               stream: false,
               cache: true,


### PR DESCRIPTION
… default

Many patterns hardcoded `model: "anthropic:claude-sonnet-4-5"` on their generateText, generateObject, and llmDialog calls. That names a specific model version. A deployment that no longer offers that exact version rejects the request with "Unknown model", so the pin turns into a live failure wherever the pinned version is absent, even though an equivalent current model is available.

The pattern-facing LLM builtins already make the model optional and fill in a default when it is omitted. Dropping an unjustified pin therefore lets the call follow the runtime's default model instead of naming a version a given deployment may not have.

For each pin, the choice of that specific model had no stated or implied justification, so the whole `model` field is dropped from the call. What the omitted field resolves to depends on the builtin:

- generateText and llmDialog send `model ?? DEFAULT_MODEL_NAME`, and `DEFAULT_MODEL_NAME` is the alias "default", which the toolshed resolves at request time to the deployment's current default model.
- generateObject sends `model ?? DEFAULT_GENERATE_OBJECT_MODELS`, a separate default chosen for structured output. That is a different model from the "default" alias, but it is still a runtime default rather than a version named in the pattern, which is the property this change is after. The lot-watch plate reader's image input still works because that default is image-capable.

A call that specifically needs the deployment's default model on generateObject can pass `model: "default"` explicitly; none of these calls did, so they simply omit it.

Pins that carry a reason are left untouched: models picked for cost and latency (the haiku calls in high-volume maps, suggestable helpers, and rollups), an OCR call annotated as using a vision model, the user-facing model pickers whose whole purpose is selecting a model, the prompt-injection demo's deliberately chosen gateway model, the grounded-search model selected for its search grounding capability, and the standalone importer tool that calls the Anthropic Messages API directly (where a model name is required and there is no default alias).

Documentation is updated alongside the code so it stays honest:

- The Gmail extractor's comment explaining why its model is not a pattern input named the old version; it now says the call omits model and uses the runtime default.
- The `/api/ai/llm` route's request examples were boilerplate that happened to pin a version; they now show the "default" alias. That endpoint requires a model, so the field cannot simply be dropped there.
- The LLM capability guide dropped the pinned model from its generateObject example and gained a "Selecting a Model" note: omit `model`, and prefer that over naming a version. The note records the wrinkle that generateText and llmDialog fall back to the "default" alias while generateObject falls back to its own structured-output default, and that `model: "default"` is how to get the deployment default explicitly. It also carries a TODO to let a call select a model by capability (vision, high-effort, low-cost) instead of by name, which would remove the remaining reason to pin a version.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787423230&installation_model_id=428580&pr_number=4952&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4952&signature=1d8692fa8fa5833cb38e04972b7ba4ec9c6a97102a28781f98bccb8d968c6faf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove hardcoded LLM model pins so `generateText`, `generateObject`, and `llmDialog` use runtime defaults instead of a specific version. This prevents "Unknown model" errors and keeps patterns compatible across deployments.

- **Refactors**
  - Dropped `model: "anthropic:claude-sonnet-4-5"` so the runtime selects a default.
  - Defaults: `generateText`/`llmDialog` use `"default"`; `generateObject` uses its structured-output default (image-capable).
  - Kept intentional pins only where needed: cost/latency paths, user model pickers, prompt-injection gateway, grounded search, Anthropic Messages API importer.
  - Docs/examples updated: LLM guide adds “Selecting a Model”; `/api/ai/llm` request schema and examples now use `"default"`; Gmail extractor comment notes defaulting.

- **Migration**
  - No changes needed for existing patterns.
  - To force the deployment default on `generateObject`, set `model: "default"`.
  - `/api/ai/llm` still requires `model`; use `"default"` unless a specific model is needed.

<sup>Written for commit 9e930ebddb5854c35ae6bbf5a14ac198c3dba988. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

