### PR TITLE
feat(dashboard): add Blacksmith to CI spend

### DIFF
--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -4,7 +4,8 @@
 # out to scripts/ci-gantt.ts, so the repo source must be in the image (modeled on
 # Dockerfile.toolshed). Every backend is reached over its REST API — the GitHub
 # tiles with GH_TOKEN, the cloud-spend tile via BigQuery using the workload's own
-# service account (Workload Identity) — so no cloud CLI is installed.
+# service account (Workload Identity), and the Blacksmith CI-spend source through
+# read-only requests made with an API token — so no cloud CLI is installed.
 #
 # The GKE nodes are linux/amd64, so the image is pinned to that platform. Build
 # it on any host — an Apple-Silicon Mac emulates amd64 through QEMU:

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -51,7 +51,9 @@ a gray placeholder labelled with its id in its registered position until its
 first collection completes, so slow collectors do not leave holes in the board.
 A later ticker pass skips a tile or shared workflow fetch that is still
 updating. It starts every other due collection, so pending work does not pause
-the rest of the dashboard.
+the rest of the dashboard. A collection that remains active for one minute
+turns its tile gray with "refresh still pending" while retaining its last value
+and visuals. Its completed view replaces that pending state.
 A tile whose `collect()` throws is desaturated to a gray "unknown" — it keeps
 its last-known value and shows a short reason (e.g. "source unreachable"), with
 the full error in the server log — so one unreachable source never blanks or

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -49,6 +49,9 @@ results uniformly, mounts any drill-down routes a tile declares, and pushes new
 tile markup as each independent collection completes. Every registered tile has
 a gray placeholder labelled with its id in its registered position until its
 first collection completes, so slow collectors do not leave holes in the board.
+A later ticker pass skips a tile or shared workflow fetch that is still
+updating. It starts every other due collection, so pending work does not pause
+the rest of the dashboard.
 A tile whose `collect()` throws is desaturated to a gray "unknown" — it keeps
 its last-known value and shows a short reason (e.g. "source unreachable"), with
 the full error in the server log — so one unreachable source never blanks or

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -32,6 +32,7 @@ dashboard/
   types.ts      the interface: Tile, TileView, Status, Ctx, Route
   config.ts     port, repo, tunable status thresholds
   lib.ts        shared helpers (github, memo, escapeHtml, sparkline, strip, …)
+  blacksmith.ts authenticated read client for Blacksmith billing data
   ctx.ts        shared, memoized data sources handed to every tile (ctx.runs)
   favicon.ts    runtime status priority and access to generated PNG favicon copies
   favicon-png.generated.ts  generated runtime PNG favicon copies
@@ -170,7 +171,7 @@ surveillance tool.
 | common.tools | synthetic HTTP check of the public site | `COMMON_TOOLS_URL` (optional; defaults to `https://common.tools`) |
 | prod errors | SigNoz trace error rate for one service (errored spans / all spans): last-12h headline, with a per-hour sparkline over the retained trace history (~2 weeks) and the last-12h slice that feeds the headline highlighted. Scoped to `PROD_SERVICE` — the same SigNoz holds staging and one-off perf runs, whose rates are not production's. Gray (not red) when SigNoz is unreachable. Pops out to the SigNoz logs explorer | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `SIGNOZ_UI_URL` for the pop-out |
 | cloud spend | BigQuery billing export, via the REST API | `GCP_BILLING_TABLE` (+ Workload Identity, or `GCP_SA_KEY` locally), optional `GCP_DAILY_BUDGET` |
-| ci spend | GitHub Actions billing, projected to month-end (USD), with a 45-day daily-spend sparkline. Month-to-date sits in the header (the `aside` slot); the sub shows the GitHub-configured budget when there is one; the span the sparkline covers is in its bottom-left corner (the `duration` slot) | `GH_TOKEN` (with org billing read); optional `GH_BILLING_ORG` |
+| ci spend | GitHub Actions and Blacksmith billing, projected to month-end in USD. Each configured source gets a line in the shared 45-day chart and an MTD label. The header shows combined MTD spend. A source that cannot be read shows `$???`, while the headline remains a lower bound from the sources that did respond | either or both of `GH_TOKEN` (with org billing read) and `BLACKSMITH_API_TOKEN`; optional `GH_BILLING_ORG`, `BLACKSMITH_ORG`, `CI_MONTHLY_BUDGET` |
 | benchmark | a runtime benchmark's ~45-day trend, from the `benchmarks.yml` deno-bench artifacts on main | `GH_TOKEN`; optional `BENCH_METRIC` |
 | performance history → `/bench?view=runtime` | runtime benchmark trends, labs or loom CI duration history, and a detailed CI run Gantt. Historical views support windows from 1 through 45 days, date axes, and duration sorting. CI includes end-to-end workflow time, every job, and slowest-shard group lines | `GH_TOKEN` |
 | model spend | OpenAI + Anthropic + OpenRouter usage APIs. Headline is the projected full-month spend (extrapolated from the recent daily rate, spilling into last month when this month is under two weeks old), summed across providers. OpenAI and Anthropic (which expose per-day cost) are charted as one line each over ~45 days, dimmed except for the current-month slice that feeds the headline, with each line's MTD in the right gutter; OpenRouter (monthly total only, abbreviated "OR") is folded into the totals. The subtitle is the bullet-separated key (`OpenAI • Anthropic • OR $0`); the combined MTD sits in the header (the `aside` slot); the span the chart covers is in its bottom-left corner (the `duration` slot). A provider we can't read shows `$???` and drops the tile to gray, but the rest still chart and total | any of `OPENAI_ADMIN_KEY`, `ANTHROPIC_ADMIN_KEY`, `OPENROUTER_KEY`; optional `MODEL_MONTHLY_BUDGET` |
@@ -221,6 +222,30 @@ select only `commontoolsinc/labs`, and grant Actions/Contents read without any
 organization permissions. Classic PATs also work (use `read:org` for GitHub
 users and `admin:org` for ci spend). If the org requires approval for
 fine-grained tokens, yours stays pending until an owner approves it.
+
+### `BLACKSMITH_API_TOKEN`
+
+Powers the Blacksmith share of **ci spend**. Use the bearer token accepted by
+the Blacksmith CLI. The CLI's documented
+[`blacksmith auth login`](https://docs.blacksmith.sh/blacksmith-testbox/cli#blacksmith-auth-login)
+flow opens a browser and saves the returned token under
+`~/.blacksmith/credentials`. The CLI also accepts
+`blacksmith auth login --api-token <token>` as a non-interactive way to save an
+existing token to that file. The flag does not create or register a token with
+Blacksmith.
+
+The dashboard does not read the CLI credentials file. Complete the browser
+login on a trusted workstation, then copy the saved token into the deployment's
+secret manager as `BLACKSMITH_API_TOKEN`. Do not run the CLI login command in
+the dashboard container. Set `BLACKSMITH_ORG` when it differs from
+`GH_BILLING_ORG` or the owner in `DASHBOARD_REPO`. The account needs
+organization billing access. Blacksmith
+[maps billing access to organization admins](https://docs.blacksmith.sh/blacksmith-administration/permissions).
+
+The collector sends the token as `Authorization: Bearer` to
+`https://backend.blacksmith.sh`. It makes read-only `GET` requests and does not
+store or rotate the token. `BLACKSMITH_API_URL` overrides the backend URL in the
+same way as the CLI, primarily for local testing.
 
 ### `SIGNOZ_URL` + `SIGNOZ_API_KEY`
 
@@ -330,6 +355,9 @@ it.
 | env var | tile | purpose |
 |---|---|---|
 | `GH_BILLING_ORG` | ci spend | org login for billing (default: the org from `DASHBOARD_REPO` — `commontoolsinc`). |
+| `BLACKSMITH_ORG` | ci spend | Blacksmith organization login. Defaults to `GH_BILLING_ORG`, then the owner from `DASHBOARD_REPO`. |
+| `BLACKSMITH_API_URL` | ci spend | Blacksmith backend URL. Defaults to `https://backend.blacksmith.sh`. |
+| `CI_MONTHLY_BUDGET` | ci spend | combined monthly USD budget across GitHub and Blacksmith. Without it, a single provider uses its configured budget. Two providers use the sum when both have a configured budget. |
 | `MODEL_MONTHLY_BUDGET` | model spend | combined monthly USD budget across providers. |
 | `GCP_SA_KEY` | cloud spend | a service-account key JSON (the whole file, as the value) for local development; in GKE, Workload Identity supplies the token and this is unset. |
 | `GCP_DAILY_BUDGET` | cloud spend | daily USD budget. |
@@ -376,17 +404,20 @@ Notes:
   read. A second token would not reduce exposure because the process would hold
   both, so there is just one. With Actions read alone, those two tiles gray out
   and the other GitHub tiles still work.
-- **`ci spend`** shows the org's **projected** full-month Actions spend —
-  extrapolated from the billable daily rate over a trailing window of at least two
-  weeks (spilling into last month's daily data early in the month), or the whole
-  month-to-date when that's longer, so a couple of noisy early-month days don't
-  dominate. It's measured against the Actions **budget configured in GitHub**
-  (Settings → Billing → Budgets), which the tile reads automatically via the
-  budgets API. The spend is billable USD **net of discounts**, so the included-usage
-  allowance is already deducted; the sub-line shows the actual month-to-date. GitHub's
-  billing data is per-day (and per-SKU, per-repo) — no finer. If GitHub has no
-  Actions budget set, the tile shows the projection without a budget comparison.
-  (Classic-plan orgs fall back to minutes vs the included allowance.)
+- **`ci spend`** shows the **projected** full-month total across GitHub Actions
+  and Blacksmith. Each source is projected from its own recent daily rate. The
+  rate uses at least two weeks and reaches into last month early in a month.
+  GitHub contributes net Actions spend after discounts and included usage.
+  Blacksmith's current invoice amount supplies its month-to-date total. Daily
+  runner cost and sticky-disk storage cost supply its history and projection.
+  The storage range total is assigned to days in proportion to the reported
+  daily cache footprint. `CI_MONTHLY_BUDGET` overrides provider budgets. A
+  single provider otherwise uses its own configured budget. With both providers,
+  their budgets are added only when both exist. Blacksmith's budget is its
+  monthly spending-alert threshold. A failed configured source turns the tile
+  gray and shows `$???` for that source. The values from responding sources
+  remain as a lower bound. A GitHub classic-plan setup still falls back to
+  minutes when Blacksmith is not configured.
 - **`benchmark`** trends one `deno bench` measurement over ~45 days. The
   `benchmarks.yml` job on main runs `deno bench --json` over the runner, cache,
   and deep-equal benchmarks and uploads the report as a `bench-results` artifact
@@ -525,11 +556,16 @@ Env knobs for the dev loop:
 - `GH_TOKEN` (or `GITHUB_TOKEN`) — required for the GitHub tiles. CI spend also
   needs Administration read. GitHub users also needs Members read. Without the
   token, those tiles stay gray.
+- `BLACKSMITH_API_TOKEN` — enables the Blacksmith share of CI spend. Use
+  `BLACKSMITH_ORG` when its organization differs from the GitHub billing
+  organization.
 - `DASHBOARD_PORT` — run several instances at once (e.g. one per branch) without clashing.
 - `DASHBOARD_REPO` — point the CI tiles at any repo. Its owner selects the
   organization for GitHub users.
 - `PROD_URL` — point the production tile at a local server (`http://localhost:8000/`) instead of prod. It checks `/_health` on that origin.
-- The other credential envs (see **Credentials** above — `SIGNOZ_*`, `GCP_*`, `OPENAI_ADMIN_KEY`/`ANTHROPIC_ADMIN_KEY`/`OPENROUTER_KEY`, `DISCORD_*`) — set one to develop that gated tile against its real backend.
+- The other credential envs (see **Credentials** above — `SIGNOZ_*`, `GCP_*`,
+  `OPENAI_ADMIN_KEY`/`ANTHROPIC_ADMIN_KEY`/`OPENROUTER_KEY`, `DISCORD_*`) — set
+  one to develop that gated tile against its real backend.
 
 It never crashes on a missing credential: the GitHub tiles need `GH_TOKEN` and
 the other private-source tiles each need their own env var, and any tile whose
@@ -634,13 +670,14 @@ container already exists from `tofu apply`), uncomment the ExternalSecret in
 `make apply-dev-dashboard-stage`. So you can deploy green and light tiles up one
 at a time.
 
-Every backend is reached over its REST API, so the image carries no cloud CLI.
-The GitHub tiles use `GH_TOKEN`; the cloud-spend tile queries BigQuery as the
-pod's own service account through Workload Identity — the infra repo's
+Every backend is reached over HTTP, so the image carries no cloud CLI. The
+GitHub tiles use `GH_TOKEN`. The Blacksmith share of CI spend uses
+`BLACKSMITH_API_TOKEN`. The cloud-spend tile queries BigQuery as the pod's
+own service account through Workload Identity. The infra repo's
 `tofu/gke/dashboard.tf` provisions that account, the Workload Identity binding,
-and its BigQuery Job User + Data Viewer grants, so no key is stored in the
-cluster. Lighting the tile up is then just setting `GCP_BILLING_TABLE` (and
-`dashboard_billing_dataset` for the export dataset).
+and its BigQuery Job User and Data Viewer grants. Lighting the cloud-spend tile
+up is then just setting `GCP_BILLING_TABLE` and
+`dashboard_billing_dataset` for the export dataset.
 
 ## Design notes
 

--- a/packages/dashboard/blacksmith.test.ts
+++ b/packages/dashboard/blacksmith.test.ts
@@ -1,0 +1,127 @@
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { BlacksmithClient, blacksmithRoutes } from "./blacksmith.ts";
+
+function environment(values: Record<string, string>) {
+  return (name: string): string | undefined => values[name];
+}
+
+Deno.test("Blacksmith client: an unset token leaves the source disabled", () => {
+  assertEquals(BlacksmithClient.fromEnvironment(environment({})), null);
+  assertEquals(
+    BlacksmithClient.fromEnvironment(
+      environment({ BLACKSMITH_API_TOKEN: "  " }),
+    ),
+    null,
+  );
+});
+
+Deno.test("Blacksmith client: invalid backend URLs are rejected before a request", () => {
+  for (
+    const value of [
+      "not-a-url",
+      "http://backend.blacksmith.sh",
+      "ftp://localhost",
+      "ws://localhost",
+    ]
+  ) {
+    try {
+      BlacksmithClient.fromEnvironment(
+        environment({
+          BLACKSMITH_API_TOKEN: "blacksmith-token",
+          BLACKSMITH_API_URL: value,
+        }),
+      );
+      throw new Error("expected invalid API URL to be rejected");
+    } catch (error) {
+      assertStringIncludes((error as Error).message, "BLACKSMITH_API_URL");
+    }
+  }
+});
+
+Deno.test("Blacksmith client: authenticated reads use the CLI bearer token", async () => {
+  const realFetch = globalThis.fetch;
+  const requests: Array<{ url: string; headers: Headers }> = [];
+  globalThis.fetch = (input, init) => {
+    requests.push({
+      url: input instanceof Request ? input.url : String(input),
+      headers: new Headers(init?.headers),
+    });
+    return Promise.resolve(
+      Response.json({ ok: true }),
+    );
+  };
+  try {
+    const client = BlacksmithClient.fromEnvironment(
+      environment({ BLACKSMITH_API_TOKEN: "  blacksmith-token  " }),
+    );
+    assertEquals(await client?.get("billing"), { ok: true });
+    assertEquals(
+      requests[0].url,
+      "https://backend.blacksmith.sh/api/billing",
+    );
+    assertEquals(
+      requests[0].headers.get("authorization"),
+      "Bearer blacksmith-token",
+    );
+    assertEquals(requests[0].headers.has("cookie"), false);
+    assertEquals(requests[0].headers.has("origin"), false);
+
+    const local = BlacksmithClient.fromEnvironment(
+      environment({
+        BLACKSMITH_API_TOKEN: "local-token",
+        BLACKSMITH_API_URL: "http://localhost:9000/root/",
+      }),
+    );
+    assertEquals(await local?.get("invoice"), { ok: true });
+    assertEquals(
+      requests[1].url,
+      "http://localhost:9000/root/api/invoice",
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+Deno.test("Blacksmith client: rejected tokens and failed reads have bounded errors", async () => {
+  const realFetch = globalThis.fetch;
+  const client = BlacksmithClient.fromEnvironment(
+    environment({ BLACKSMITH_API_TOKEN: "blacksmith-token" }),
+  )!;
+  try {
+    for (const status of [401, 403]) {
+      globalThis.fetch = () => Promise.resolve(new Response(null, { status }));
+      await assertRejects(
+        () => client.get("billing"),
+        Error,
+        "API token rejected",
+      );
+    }
+
+    globalThis.fetch = () =>
+      Promise.resolve(new Response(null, { status: 503 }));
+    await assertRejects(
+      () => client.get("billing"),
+      Error,
+      "HTTP 503",
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+Deno.test("Blacksmith routes encode the organization and UTC range", () => {
+  const start = new Date("2026-01-01T00:00:00.000Z");
+  const end = new Date("2026-01-31T23:59:59.999Z");
+  const route = blacksmithRoutes.daily("acme/tools", start, end);
+  assertStringIncludes(route, "user/github/orgs/acme%2Ftools/metrics/daily?");
+  assertStringIncludes(route, "start_date=2026-01-01T00%3A00%3A00.000Z");
+  assertStringIncludes(route, "end_date=2026-01-31T23%3A59%3A59.999Z");
+  assertEquals(
+    blacksmithRoutes.invoiceAmount("acme/tools"),
+    "user/github/orgs/acme%2Ftools/metrics/invoice-amount",
+  );
+  assertEquals(
+    blacksmithRoutes.spendingThreshold("acme/tools"),
+    "user/github/orgs/acme%2Ftools/email-alert-threshold",
+  );
+});

--- a/packages/dashboard/blacksmith.ts
+++ b/packages/dashboard/blacksmith.ts
@@ -1,0 +1,77 @@
+type Environment = (name: string) => string | undefined;
+
+const DEFAULT_API_URL = "https://backend.blacksmith.sh";
+
+function apiURL(value: string | undefined): string {
+  const raw = value?.trim() || DEFAULT_API_URL;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("BLACKSMITH_API_URL is not a valid URL");
+  }
+  const localHTTP = parsed.protocol === "http:" &&
+    parsed.hostname === "localhost";
+  if (parsed.protocol !== "https:" && !localHTTP) {
+    throw new Error("BLACKSMITH_API_URL must use HTTPS");
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+export class BlacksmithClient {
+  private constructor(
+    private readonly token: string,
+    private readonly baseURL: string,
+  ) {}
+
+  static fromEnvironment(env: Environment): BlacksmithClient | null {
+    const token = env("BLACKSMITH_API_TOKEN")?.trim();
+    if (!token) return null;
+    return new BlacksmithClient(token, apiURL(env("BLACKSMITH_API_URL")));
+  }
+
+  async get<T>(path: string): Promise<T> {
+    const response = await fetch(
+      `${this.baseURL}/api/${path.replace(/^\/+/, "")}`,
+      {
+        headers: {
+          accept: "application/json, text/plain, */*",
+          authorization: `Bearer ${this.token}`,
+        },
+      },
+    );
+    if (response.status === 401 || response.status === 403) {
+      throw new Error("Blacksmith API token rejected");
+    }
+    if (!response.ok) {
+      throw new Error(`Blacksmith billing failed: HTTP ${response.status}`);
+    }
+    return await response.json() as T;
+  }
+}
+
+const orgPath = (org: string) => `user/github/orgs/${encodeURIComponent(org)}`;
+
+function rangeQuery(start: Date, end: Date): string {
+  const query = new URLSearchParams({
+    start_date: start.toISOString(),
+    end_date: end.toISOString(),
+  });
+  return query.toString();
+}
+
+export const blacksmithRoutes = {
+  daily: (org: string, start: Date, end: Date) =>
+    `${orgPath(org)}/metrics/daily?${rangeQuery(start, end)}`,
+  stickyDaily: (org: string, start: Date, end: Date) =>
+    `${orgPath(org)}/metrics/docker/daily-by-type?${rangeQuery(start, end)}`,
+  stickyTotal: (org: string, start: Date, end: Date) =>
+    `${orgPath(org)}/metrics/docker/sticky-disk/total?${
+      rangeQuery(start, end)
+    }`,
+  invoiceAmount: (org: string) => `${orgPath(org)}/metrics/invoice-amount`,
+  spendingThreshold: (org: string) => `${orgPath(org)}/email-alert-threshold`,
+};

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -3,7 +3,12 @@
 // binds a port or reaches a source; the tiles are stand-ins with a canned
 // collect(), registered under the ids the real registry uses so their views
 // reach the page.
-import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import {
   broadcast,
   clients,
@@ -497,6 +502,81 @@ Deno.test("overlapping ticks skip an updating run source and refresh another sou
     await first;
   }
   assertEquals(slowCollections, 1);
+});
+
+Deno.test("an unexpected standalone collection failure releases the tile for its next refresh", async () => {
+  let collections = 0;
+  const unreadable: TileView = {
+    label: "unreadable standalone view",
+    get status(): TileView["status"] {
+      throw new Error("standalone view cannot be copied");
+    },
+  };
+  const tile: Tile = {
+    id: "standalone-cleanup-probe",
+    intervalMs: 0,
+    collect(_ctx, publish): Promise<TileView> {
+      collections++;
+      if (collections === 1) {
+        publish?.(unreadable);
+        throw new Error("standalone collection failed");
+      }
+      return Promise.resolve({
+        label: "recovered standalone view",
+        status: "good",
+      });
+    },
+  };
+
+  await assertRejects(
+    () => tick([tile]),
+    Error,
+    "standalone view cannot be copied",
+  );
+  await tick([tile]);
+  assertEquals(collections, 2, "the failed update no longer keeps the tile active");
+});
+
+Deno.test("an unexpected source collection failure releases its source and tiles", async () => {
+  const source = { repo: "test/source-cleanup", workflow: "ci.yml" };
+  let fetches = 0;
+  let collections = 0;
+  const unreadable: TileView = {
+    label: "unreadable source view",
+    get status(): TileView["status"] {
+      throw new Error("source view cannot be copied");
+    },
+  };
+  const sourceCtx: Ctx = {
+    runs: () => Promise.resolve([]),
+    runsFor: () => {
+      fetches++;
+      return Promise.resolve([]);
+    },
+    env: () => undefined,
+  };
+  const tile: Tile = {
+    id: "source-cleanup-probe",
+    intervalMs: 0,
+    runSources: [source],
+    collect(_ctx, publish): Promise<TileView> {
+      collections++;
+      if (collections === 1) {
+        publish?.(unreadable);
+        throw new Error("source collection failed");
+      }
+      return Promise.resolve({ label: "recovered source view", status: "good" });
+    },
+  };
+
+  await assertRejects(
+    () => tick([tile], sourceCtx),
+    Error,
+    "source view cannot be copied",
+  );
+  await tick([tile], sourceCtx);
+  assertEquals(fetches, 2, "the failed update no longer keeps the source active");
+  assertEquals(collections, 2, "the failed update no longer keeps the tile active");
 });
 
 Deno.test("a multi-source tile stays active until every source update completes", async () => {

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -235,6 +235,64 @@ Deno.test("per-collector updates keep a red handoff's incident age", async () =>
   assertEquals(faviconRedSinceInPage(), "null");
 });
 
+Deno.test("simultaneous collector completions keep a red handoff's incident age", async () => {
+  const realNow = Date.now;
+  const startedAt = realNow() + 1_000;
+  let now = startedAt;
+  Date.now = () => now;
+  const modelGood: TileView = {
+    label: "simultaneous model spend",
+    status: "good",
+    value: "passing",
+  };
+  const modelBad: TileView = {
+    label: "simultaneous model spend",
+    status: "bad",
+    value: "failed",
+  };
+  const gcpGood: TileView = {
+    label: "simultaneous gcp spend",
+    status: "good",
+    value: "passing",
+  };
+  const gcpBad: TileView = {
+    label: "simultaneous gcp spend",
+    status: "bad",
+    value: "failed",
+  };
+  const model = deferred<TileView>();
+  const gcp = deferred<TileView>();
+  let handoff: Promise<void> | undefined;
+  try {
+    await tick([
+      fake("model-spend", () => modelBad),
+      fake("gcp-spend", () => gcpGood),
+    ]);
+    const redSince = faviconRedSinceInPage();
+    assertEquals(redSince, String(startedAt));
+
+    now = startedAt + 1_000;
+    handoff = tick([
+      fake("model-spend", () => model.promise),
+      fake("gcp-spend", () => gcp.promise),
+    ]);
+    model.resolve(modelGood);
+    gcp.resolve(gcpBad);
+    await handoff;
+
+    assertEquals(faviconRedSinceInPage(), redSince);
+  } finally {
+    model.resolve(modelGood);
+    gcp.resolve(gcpGood);
+    await handoff;
+    await tick([
+      fake("model-spend", () => modelGood),
+      fake("gcp-spend", () => gcpGood),
+    ]);
+    Date.now = realNow;
+  }
+});
+
 Deno.test("a tile stays wide through failures and keeps its last good view", async () => {
   await tick([fake("recent-runs", () => {
     throw new Error("HTTP 404: Not Found");
@@ -275,17 +333,132 @@ Deno.test("the ticker leaves a tile alone until its interval has elapsed", async
   assertEquals((await (await handle(req("/healthz"))).json()).at, at, "and nothing is reported as changed");
 });
 
-Deno.test("a tick that is still running makes the next tick a no-op", async () => {
-  let release = (_: TileView) => {};
-  const slow = tick([fake("labs-ci", () => new Promise<TileView>((r) => release = r))]);
-  let collects = 0;
-  await tick([fake("loom-ci", () => {
-    collects++;
-    return { label: "loom ci", status: "good", value: "passing" };
-  })]);
-  assertEquals(collects, 0, "the overlapping tick collected nothing");
-  release({ label: "labs ci", status: "good", value: "passing" });
-  await slow;
+Deno.test("overlapping ticks skip a tile already updating and collect other due tiles", async () => {
+  const slow = deferred<TileView>();
+  let duplicateCollects = 0;
+  let otherCollects = 0;
+  const first = tick([fake("overlap-slow", () => slow.promise)]);
+
+  await tick([
+    fake("overlap-slow", () => {
+      duplicateCollects++;
+      return { label: "duplicate", status: "good" };
+    }),
+    fake("overlap-fast", () => {
+      otherCollects++;
+      return { label: "fast", status: "good" };
+    }),
+  ]);
+
+  assertEquals(duplicateCollects, 0, "the updating tile is not collected twice");
+  assertEquals(otherCollects, 1, "another due tile is still collected");
+  slow.resolve({ label: "slow", status: "good" });
+  await first;
+});
+
+Deno.test("overlapping ticks skip an updating run source and refresh another source", async () => {
+  const slowSource = { repo: "test/overlap-slow", workflow: "ci.yml" };
+  const fastSource = { repo: "test/overlap-fast", workflow: "ci.yml" };
+  const slowRuns = deferred<Run[]>();
+  let slowFetches = 0;
+  let fastFetches = 0;
+  let slowCollections = 0;
+  let fastCollections = 0;
+  const sourceCtx: Ctx = {
+    runs: () => slowRuns.promise,
+    runsFor: (repo) => {
+      if (repo === slowSource.repo) {
+        slowFetches++;
+        return slowRuns.promise;
+      }
+      fastFetches++;
+      return Promise.resolve([]);
+    },
+    env: () => undefined,
+  };
+  const slowTile: Tile = {
+    id: "overlap-source-slow",
+    intervalMs: 0,
+    runSources: [slowSource],
+    collect: () => {
+      slowCollections++;
+      return Promise.resolve({ label: "slow source", status: "good" });
+    },
+  };
+  const fastTile: Tile = {
+    id: "overlap-source-fast",
+    intervalMs: 0,
+    runSources: [fastSource],
+    collect: () => {
+      fastCollections++;
+      return Promise.resolve({ label: "fast source", status: "good" });
+    },
+  };
+  const first = tick([slowTile], sourceCtx);
+
+  try {
+    await tick([slowTile, fastTile], sourceCtx);
+    assertEquals(slowFetches, 1, "the updating source is not fetched twice");
+    assertEquals(slowCollections, 0, "the slow source has not completed");
+    assertEquals(fastFetches, 1, "another due source is fetched");
+    assertEquals(fastCollections, 1, "another source's tile is collected");
+  } finally {
+    slowRuns.resolve([]);
+    await first;
+  }
+  assertEquals(slowCollections, 1);
+});
+
+Deno.test("a multi-source tile stays active until every source update completes", async () => {
+  const slowSource = { repo: "test/multi-source-slow", workflow: "ci.yml" };
+  const fastSource = { repo: "test/multi-source-fast", workflow: "ci.yml" };
+  const slowRuns = deferred<Run[]>();
+  let slowFetches = 0;
+  let fastFetches = 0;
+  let collections = 0;
+  const sourceCtx: Ctx = {
+    runs: () => slowRuns.promise,
+    runsFor: (repo) => {
+      if (repo === slowSource.repo) {
+        slowFetches++;
+        return slowRuns.promise;
+      }
+      fastFetches++;
+      return Promise.resolve([]);
+    },
+    env: () => undefined,
+  };
+  const tile: Tile = {
+    id: "overlap-multi-source",
+    intervalMs: 0,
+    runSources: [slowSource, fastSource],
+    collect: () => {
+      collections++;
+      return Promise.resolve({ label: "multi source", status: "good" });
+    },
+  };
+  let published = () => {};
+  const firstPublication = new Promise<void>((resolve) => published = resolve);
+  const client = {
+    enqueue() {
+      published();
+    },
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+  clients.add(client);
+  const first = tick([tile], sourceCtx);
+
+  try {
+    await firstPublication;
+    assertEquals(collections, 1, "the ready source collected the tile");
+    await tick([tile], sourceCtx);
+    assertEquals(slowFetches, 1, "the pending source was not fetched again");
+    assertEquals(fastFetches, 1, "the completed source still skips the active tile");
+  } finally {
+    clients.delete(client);
+    slowRuns.resolve([]);
+    await first;
+  }
+  assertEquals(collections, 2, "the pending source completes its original collection");
 });
 
 Deno.test("each completed collection is published while slower tiles are still running", async () => {
@@ -704,13 +877,10 @@ Deno.test("routes: a tile's drill-down path wins over the page; anything else is
   assertEquals((await (await handle(req("/healthz"))).json()).ok, true);
 });
 
-Deno.test("start: serves the handler on the configured port and keeps collecting", async () => {
-  // A tick in flight makes start()'s own first tick a no-op, so this reaches no source.
-  let release = (_: TileView) => {};
-  const inflight = tick([fake("labs-ci", () => new Promise<TileView>((r) => release = r))]);
-
+Deno.test("start: serves the handler on the configured port and keeps collecting", () => {
   const served: { opts: Deno.ServeTcpOptions; handler: unknown }[] = [];
   const logged: string[] = [];
+  let collections = 0;
   const log = console.log;
   console.log = (m: string) => logged.push(m);
   let timer = 0;
@@ -719,7 +889,9 @@ Deno.test("start: serves the handler on the configured port and keeps collecting
       served.push({ opts, handler });
       opts.onListen?.({ transport: "tcp", hostname: "localhost", port: PORT });
       return undefined;
-    }) as unknown as typeof Deno.serve).timer;
+    }) as unknown as typeof Deno.serve, () => {
+      collections++;
+    }).timer;
   } finally {
     clearInterval(timer);
     console.log = log;
@@ -729,7 +901,5 @@ Deno.test("start: serves the handler on the configured port and keeps collecting
   assertEquals(served[0].handler, handle, "every request goes through the one handler");
   assertStringIncludes(logged[0], `http://localhost:${PORT}`);
   assertStringIncludes(logged[0], `${TILES.length} tiles registered`);
-
-  release({ label: "labs ci", status: "good", value: "passing" });
-  await inflight;
+  assertEquals(collections, 1, "startup collects immediately");
 });

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -333,6 +333,96 @@ Deno.test("the ticker leaves a tile alone until its interval has elapsed", async
   assertEquals((await (await handle(req("/healthz"))).json()).at, at, "and nothing is reported as changed");
 });
 
+Deno.test("an update still running after one minute stays gray until it completes", async () => {
+  const realNow = Date.now;
+  const startedAt = realNow() + 10_000;
+  let now = startedAt;
+  Date.now = () => now;
+  const lastView: TileView = {
+    label: "pending model spend",
+    status: "good",
+    value: "last value",
+    sub: "last detail",
+    extra: "<span>last chart</span>",
+  };
+  const finalView: TileView = {
+    label: "pending model spend",
+    status: "good",
+    value: "fresh value",
+    sub: "fresh detail",
+    extra: "<span>fresh chart</span>",
+  };
+  const final = deferred<TileView>();
+  let publishIntermediate = (_view: TileView) => {};
+  const tile: Tile = {
+    id: "model-spend",
+    intervalMs: 0,
+    async collect(_ctx, publish) {
+      publishIntermediate = publish ?? publishIntermediate;
+      return await final.promise;
+    },
+  };
+  const messages: string[] = [];
+  const client = {
+    enqueue(value: Uint8Array) {
+      messages.push(dec.decode(value));
+    },
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+  let collection: Promise<void> | undefined;
+  try {
+    await tick([fake("model-spend", () => lastView)]);
+    now++;
+    collection = tick([tile]);
+    clients.add(client);
+
+    now += 59_999;
+    await tick([tile]);
+    assert(tileHtml("pending model spend").startsWith(`good" data-tile-id="model-spend">`));
+    assertEquals(messages.length, 0);
+
+    now++;
+    await tick([tile]);
+    const stale = tileHtml("pending model spend");
+    assert(stale.startsWith(`unknown" data-tile-id="model-spend">`));
+    assertStringIncludes(stale, "last value");
+    assertStringIncludes(stale, "refresh still pending");
+    assertStringIncludes(stale, "last chart");
+    assertEquals(messages.length, 1, "the stale transition is published");
+
+    now += 15_000;
+    await tick([tile]);
+    assertEquals(messages.length, 1, "later ticks do not repeat the stale transition");
+
+    publishIntermediate({
+      label: "pending model spend",
+      status: "good",
+      value: "new cached value",
+      sub: "new cached detail",
+      extra: "<span>new cached chart</span>",
+    });
+    const intermediate = tileHtml("pending model spend");
+    assert(intermediate.startsWith(`unknown" data-tile-id="model-spend">`));
+    assertStringIncludes(intermediate, "new cached value");
+    assertStringIncludes(intermediate, "refresh still pending");
+    assertStringIncludes(intermediate, "new cached chart");
+
+    final.resolve(finalView);
+    await collection;
+    const fresh = tileHtml("pending model spend");
+    assert(fresh.startsWith(`good" data-tile-id="model-spend">`));
+    assertStringIncludes(fresh, "fresh value");
+    assertStringIncludes(fresh, "fresh detail");
+  } finally {
+    clients.delete(client);
+    final.resolve(finalView);
+    try {
+      await collection;
+    } finally {
+      Date.now = realNow;
+    }
+  }
+});
+
 Deno.test("overlapping ticks skip a tile already updating and collect other due tiles", async () => {
   const slow = deferred<TileView>();
   let duplicateCollects = 0;
@@ -410,9 +500,13 @@ Deno.test("overlapping ticks skip an updating run source and refresh another sou
 });
 
 Deno.test("a multi-source tile stays active until every source update completes", async () => {
+  const realNow = Date.now;
+  let now = realNow() + 20_000;
+  Date.now = () => now;
   const slowSource = { repo: "test/multi-source-slow", workflow: "ci.yml" };
   const fastSource = { repo: "test/multi-source-fast", workflow: "ci.yml" };
   const slowRuns = deferred<Run[]>();
+  const fastRuns = deferred<Run[]>();
   let slowFetches = 0;
   let fastFetches = 0;
   let collections = 0;
@@ -424,41 +518,73 @@ Deno.test("a multi-source tile stays active until every source update completes"
         return slowRuns.promise;
       }
       fastFetches++;
-      return Promise.resolve([]);
+      return fastRuns.promise;
     },
     env: () => undefined,
   };
   const tile: Tile = {
-    id: "overlap-multi-source",
+    id: "recent-runs",
     intervalMs: 0,
     runSources: [slowSource, fastSource],
     collect: () => {
       collections++;
-      return Promise.resolve({ label: "multi source", status: "good" });
+      return Promise.resolve({
+        label: "multi source",
+        status: "good",
+        value: "fresh source value",
+      });
     },
   };
-  let published = () => {};
-  const firstPublication = new Promise<void>((resolve) => published = resolve);
-  const client = {
-    enqueue() {
-      published();
-    },
-  } as unknown as ReadableStreamDefaultController<Uint8Array>;
-  clients.add(client);
-  const first = tick([tile], sourceCtx);
+  let first: Promise<void> | undefined;
+  let client: ReadableStreamDefaultController<Uint8Array> | undefined;
 
   try {
+    await tick([fake("recent-runs", () => ({
+      label: "multi source",
+      status: "good",
+      value: "last source value",
+    }))]);
+    now++;
+    first = tick([tile], sourceCtx);
+
+    now += 60_000;
+    await tick([tile], sourceCtx);
+    const stale = tileHtml("multi source");
+    assert(stale.startsWith(`unknown wide" data-tile-id="recent-runs">`));
+    assertStringIncludes(stale, "last source value");
+    assertStringIncludes(stale, "refresh still pending");
+
+    let published = () => {};
+    const firstPublication = new Promise<void>((resolve) => published = resolve);
+    client = {
+      enqueue() {
+        published();
+      },
+    } as unknown as ReadableStreamDefaultController<Uint8Array>;
+    clients.add(client);
+    fastRuns.resolve([]);
     await firstPublication;
     assertEquals(collections, 1, "the ready source collected the tile");
+    const partiallyComplete = tileHtml("multi source");
+    assert(partiallyComplete.startsWith(`unknown wide" data-tile-id="recent-runs">`));
+    assertStringIncludes(partiallyComplete, "fresh source value");
+    assertStringIncludes(partiallyComplete, "refresh still pending");
+
     await tick([tile], sourceCtx);
     assertEquals(slowFetches, 1, "the pending source was not fetched again");
     assertEquals(fastFetches, 1, "the completed source still skips the active tile");
   } finally {
-    clients.delete(client);
+    if (client) clients.delete(client);
     slowRuns.resolve([]);
-    await first;
+    fastRuns.resolve([]);
+    try {
+      await first;
+    } finally {
+      Date.now = realNow;
+    }
   }
   assertEquals(collections, 2, "the pending source completes its original collection");
+  assert(tileHtml("multi source").startsWith(`good wide" data-tile-id="recent-runs">`));
 });
 
 Deno.test("each completed collection is published while slower tiles are still running", async () => {
@@ -553,6 +679,8 @@ Deno.test("each run source publishes its dependent tiles as one batch", async ()
 });
 
 Deno.test("a ready source publishes while an older combined collection is still running", async () => {
+  const realNow = Date.now;
+  let now = realNow() + 30_000;
   const labsSource = { repo: "test/labs-independent", workflow: "ci.yml" };
   const loomSource = { repo: "test/loom-independent", workflow: "ci.yml" };
   const labs = deferred<Run[]>();
@@ -590,7 +718,6 @@ Deno.test("a ready source publishes while an older combined collection is still 
     sourceTile("loom-ci", "independent loom", [loomSource]),
     combined,
   ];
-
   const messages: string[] = [];
   let published = (_message: string) => {};
   const nextMessage = () => new Promise<string>((resolve) => published = resolve);
@@ -601,17 +728,30 @@ Deno.test("a ready source publishes while an older combined collection is still 
       published(message);
     },
   } as unknown as ReadableStreamDefaultController<Uint8Array>;
-  clients.add(client);
-  const refresh = tick(tiles, sourceCtx);
+  let refresh: Promise<void> | undefined;
+  Date.now = () => now;
   try {
+    await tick([fake("recent-runs", () => ({
+      label: "independent recent",
+      status: "good",
+      value: "prior combined",
+    }))]);
+    clients.add(client);
+    refresh = tick(tiles, sourceCtx);
     labs.resolve([sourceRun(4, "labs ready")]);
     await oldCollectionStarted;
+
+    now += 60_000;
+    await tick(tiles, sourceCtx);
+    assertStringIncludes(tileHtml("independent recent"), "refresh still pending");
+    messages.length = 0;
 
     const loomUpdate = nextMessage();
     loom.resolve([sourceRun(5, "loom ready")]);
     const first = updateFromEvent(await loomUpdate);
     assertStringIncludes(first.gridHtml, "independent loom");
     assertStringIncludes(first.wideHtml, "labs ready, loom ready");
+    assertStringIncludes(first.wideHtml, `unknown wide" data-tile-id="recent-runs">`);
     assert(!first.gridHtml.includes("independent labs"));
     publishOld({ label: "independent recent", status: "bad", value: "older cached merge" });
     assertEquals(messages.length, 1);
@@ -622,6 +762,7 @@ Deno.test("a ready source publishes while an older combined collection is still 
     const second = updateFromEvent(await labsUpdate);
     assertStringIncludes(second.gridHtml, "independent labs");
     assertStringIncludes(second.wideHtml, "labs ready, loom ready");
+    assertStringIncludes(second.wideHtml, `good wide" data-tile-id="recent-runs">`);
     assertEquals(messages.length, 2);
     await refresh;
   } finally {
@@ -629,7 +770,11 @@ Deno.test("a ready source publishes while an older combined collection is still 
     labs.resolve([]);
     loom.resolve([]);
     oldCollection.resolve(undefined);
-    await refresh;
+    try {
+      await refresh;
+    } finally {
+      Date.now = realNow;
+    }
   }
 });
 

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -18,6 +18,7 @@
 //   DISCORD_BOT_TOKEN, DISCORD_GUILD_ID   online-by-role tile
 //   GH_TOKEN                          GitHub tiles; org Members read also powers
 //                                     the organization-users tile
+//   BLACKSMITH_API_TOKEN              Blacksmith share of the ci-spend tile
 
 import { CI_WORKFLOW, PORT, REPO } from "./config.ts";
 import { TILES } from "./registry.ts";

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -35,7 +35,12 @@ const lastRun = new Map<string, number>();
 const runSnapshots = new Map<string, Run[]>();
 const runSourceErrors = new Map<string, string>();
 const lastSourceTileRun = new Map<string, number>();
-const activeTileUpdates = new Map<string, number>();
+interface ActiveTileUpdate {
+  count: number;
+  startedAt: number;
+  stale: boolean;
+}
+const activeTileUpdates = new Map<string, ActiveTileUpdate>();
 const activeRunSourceUpdates = new Set<string>();
 let lastChange = 0;
 let faviconRedSince: number | null = null;
@@ -52,7 +57,7 @@ function updateFaviconRedSince(now: number, recoveryIsSettled = true): void {
   const status = faviconStatus(
     TILES.flatMap((tile) => {
       const view = views.get(tile.id);
-      return view ? [view.status] : [];
+      return view ? [activeTileView(tile, view).status] : [];
     }),
   );
   if (status === "bad" || recoveryIsSettled) {
@@ -75,10 +80,13 @@ function dashboardUpdate(currentViews: ReadonlyMap<string, TileView> = views): D
   const wide: string[] = [];
   const statuses: TileView["status"][] = [];
   for (const t of TILES) {
-    const v = currentViews.get(t.id) ?? {
-      label: t.id,
-      status: "unknown" as const,
-    };
+    const v = activeTileView(
+      t,
+      currentViews.get(t.id) ?? {
+        label: t.id,
+        status: "unknown" as const,
+      },
+    );
     statuses.push(v.status);
     (t.wide ? wide : grid).push(renderTile(v, t.id, t.wide));
   }
@@ -117,18 +125,50 @@ export const broadcast = (update: DashboardUpdate) => {
 const runSourceKey = (source: RunSource): string => `${source.repo} ${source.workflow}`;
 const runSourceTileKey = (source: RunSource, tile: Tile): string => `${runSourceKey(source)} ${tile.id}`;
 
-function beginTileUpdate(tile: Tile): void {
-  activeTileUpdates.set(tile.id, (activeTileUpdates.get(tile.id) ?? 0) + 1);
+function beginTileUpdate(tile: Tile, startedAt: number): void {
+  const active = activeTileUpdates.get(tile.id);
+  if (active) {
+    active.count++;
+  } else {
+    activeTileUpdates.set(tile.id, {
+      count: 1,
+      startedAt,
+      stale: false,
+    });
+  }
 }
 
 function finishTileUpdate(tile: Tile): void {
-  const remaining = (activeTileUpdates.get(tile.id) ?? 1) - 1;
-  if (remaining === 0) activeTileUpdates.delete(tile.id);
-  else activeTileUpdates.set(tile.id, remaining);
+  const active = activeTileUpdates.get(tile.id);
+  if (!active || active.count === 1) activeTileUpdates.delete(tile.id);
+  else active.count--;
 }
 
 function allUpdatesSettled(): boolean {
   return activeTileUpdates.size === 0 && activeRunSourceUpdates.size === 0;
+}
+
+const STALE_UPDATE_MS = 60_000;
+const STALE_UPDATE_SUB = "refresh still pending";
+
+function activeTileView(tile: Tile, view: TileView): TileView {
+  return activeTileUpdates.get(tile.id)?.stale
+    ? { ...view, status: "unknown", sub: STALE_UPDATE_SUB }
+    : view;
+}
+
+function grayStaleTileUpdates(now: number): void {
+  let changed = false;
+  for (const active of activeTileUpdates.values()) {
+    if (active.stale || now - active.startedAt < STALE_UPDATE_MS) continue;
+    active.stale = true;
+    changed = true;
+  }
+  if (changed) {
+    lastChange = now;
+    updateFaviconRedSince(now, false);
+    broadcast(dashboardUpdate());
+  }
 }
 
 interface RunSourceGroup {
@@ -235,6 +275,7 @@ function publishIntermediateView(tile: Tile, view: TileView): void {
 const TICK_MS = 15_000;
 export async function tick(tiles: Tile[] = TILES, sourceCtx: Ctx = ctx) {
   const now = Date.now();
+  grayStaleTileUpdates(now);
   const sourceGroups = groupRunSources(tiles);
   const sourceTiles = new Set(sourceGroups.flatMap((group) => group.tiles));
   const activeAtTickStart = new Set(activeTileUpdates.keys());
@@ -253,10 +294,10 @@ export async function tick(tiles: Tile[] = TILES, sourceCtx: Ctx = ctx) {
   });
   if (!dueTiles.length && !dueSources.length) return;
 
-  for (const tile of dueTiles) beginTileUpdate(tile);
+  for (const tile of dueTiles) beginTileUpdate(tile, now);
   for (const group of dueSources) {
     activeRunSourceUpdates.add(runSourceKey(group.source));
-    for (const tile of group.tiles) beginTileUpdate(tile);
+    for (const tile of group.tiles) beginTileUpdate(tile, now);
   }
 
   const refreshTile = async (tile: Tile) => {

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -35,6 +35,8 @@ const lastRun = new Map<string, number>();
 const runSnapshots = new Map<string, Run[]>();
 const runSourceErrors = new Map<string, string>();
 const lastSourceTileRun = new Map<string, number>();
+const activeTileUpdates = new Map<string, number>();
+const activeRunSourceUpdates = new Set<string>();
 let lastChange = 0;
 let faviconRedSince: number | null = null;
 
@@ -114,6 +116,20 @@ export const broadcast = (update: DashboardUpdate) => {
 
 const runSourceKey = (source: RunSource): string => `${source.repo} ${source.workflow}`;
 const runSourceTileKey = (source: RunSource, tile: Tile): string => `${runSourceKey(source)} ${tile.id}`;
+
+function beginTileUpdate(tile: Tile): void {
+  activeTileUpdates.set(tile.id, (activeTileUpdates.get(tile.id) ?? 0) + 1);
+}
+
+function finishTileUpdate(tile: Tile): void {
+  const remaining = (activeTileUpdates.get(tile.id) ?? 1) - 1;
+  if (remaining === 0) activeTileUpdates.delete(tile.id);
+  else activeTileUpdates.set(tile.id, remaining);
+}
+
+function allUpdatesSettled(): boolean {
+  return activeTileUpdates.size === 0 && activeRunSourceUpdates.size === 0;
+}
 
 interface RunSourceGroup {
   source: RunSource;
@@ -215,38 +231,57 @@ function publishIntermediateView(tile: Tile, view: TileView): void {
 }
 
 // One ticker collects every tile that is due (respecting each tile's interval).
-// A reentrancy guard stops a slow tick from overlapping the next one.
+// Later ticks skip work that is still running and collect the other due tiles.
 const TICK_MS = 15_000;
-let ticking = false;
 export async function tick(tiles: Tile[] = TILES, sourceCtx: Ctx = ctx) {
-  if (ticking) return;
-  ticking = true;
-  try {
-    const now = Date.now();
-    const sourceGroups = groupRunSources(tiles);
-    const sourceTiles = new Set(sourceGroups.flatMap((group) => group.tiles));
-    const dueTiles = tiles.filter((tile) =>
-      !sourceTiles.has(tile) && now - (lastRun.get(tile.id) ?? 0) >= tile.intervalMs
+  const now = Date.now();
+  const sourceGroups = groupRunSources(tiles);
+  const sourceTiles = new Set(sourceGroups.flatMap((group) => group.tiles));
+  const activeAtTickStart = new Set(activeTileUpdates.keys());
+  const dueTiles = tiles.filter((tile) =>
+    !sourceTiles.has(tile) &&
+    !activeAtTickStart.has(tile.id) &&
+    now - (lastRun.get(tile.id) ?? 0) >= tile.intervalMs
+  );
+  const dueSources = sourceGroups.flatMap((group) => {
+    if (activeRunSourceUpdates.has(runSourceKey(group.source))) return [];
+    const due = group.tiles.filter((tile) =>
+      !activeAtTickStart.has(tile.id) &&
+      now - (lastSourceTileRun.get(runSourceTileKey(group.source, tile)) ?? 0) >= tile.intervalMs
     );
-    const dueSources = sourceGroups.flatMap((group) => {
-      const due = group.tiles.filter((tile) =>
-        now - (lastSourceTileRun.get(runSourceTileKey(group.source, tile)) ?? 0) >= tile.intervalMs
+    return due.length ? [{ source: group.source, tiles: due }] : [];
+  });
+  if (!dueTiles.length && !dueSources.length) return;
+
+  for (const tile of dueTiles) beginTileUpdate(tile);
+  for (const group of dueSources) {
+    activeRunSourceUpdates.add(runSourceKey(group.source));
+    for (const tile of group.tiles) beginTileUpdate(tile);
+  }
+
+  const refreshTile = async (tile: Tile) => {
+    let released = false;
+    try {
+      const view = await collectView(
+        tile,
+        sourceCtx,
+        (intermediate) => publishIntermediateView(tile, intermediate),
       );
-      return due.length ? [{ source: group.source, tiles: due }] : [];
-    });
-    if (!dueTiles.length && !dueSources.length) return;
+      finishTileUpdate(tile);
+      released = true;
+      publishViews([{ tile, view }], allUpdatesSettled());
+    } finally {
+      if (!released) finishTileUpdate(tile);
+    }
+  };
 
-    let remaining = dueTiles.length + dueSources.length;
-    const publish = (collected: { tile: Tile; view: TileView }[]) => {
-      remaining--;
-      publishViews(collected, remaining === 0);
-    };
-
-    // Source fetches and dependent collections run independently. Each tile
-    // retains the completed view with the highest snapshot revision.
-    let sourceRevision = 0;
-    const publishedTileRevision = new Map<string, number>();
-    const refreshSource = async (group: RunSourceGroup) => {
+  // Source fetches and dependent collections run independently. Each tile
+  // retains the completed view with the highest snapshot revision.
+  let sourceRevision = 0;
+  const publishedTileRevision = new Map<string, number>();
+  const refreshSource = async (group: RunSourceGroup) => {
+    let released = false;
+    try {
       let runs: Run[] | undefined;
       let error: string | undefined;
       try {
@@ -294,25 +329,22 @@ export async function tick(tiles: Tile[] = TILES, sourceCtx: Ctx = ctx) {
       for (const tile of group.tiles) {
         lastSourceTileRun.set(runSourceTileKey(group.source, tile), completedAt);
       }
-      publish(current);
-    };
+      activeRunSourceUpdates.delete(runSourceKey(group.source));
+      for (const tile of group.tiles) finishTileUpdate(tile);
+      released = true;
+      publishViews(current, allUpdatesSettled());
+    } finally {
+      if (!released) {
+        activeRunSourceUpdates.delete(runSourceKey(group.source));
+        for (const tile of group.tiles) finishTileUpdate(tile);
+      }
+    }
+  };
 
-    await Promise.all([
-      ...dueTiles.map(async (tile) =>
-        publish([{
-          tile,
-          view: await collectView(
-            tile,
-            sourceCtx,
-            (intermediate) => publishIntermediateView(tile, intermediate),
-          ),
-        }])
-      ),
-      ...dueSources.map(refreshSource),
-    ]);
-  } finally {
-    ticking = false;
-  }
+  await Promise.all([
+    ...dueTiles.map(refreshTile),
+    ...dueSources.map(refreshSource),
+  ]);
 }
 
 // Collect drill-down routes declared by tiles.
@@ -374,9 +406,12 @@ export async function handle(req: Request): Promise<Response> {
 
 // The side effects: collect once, keep collecting, and serve. Running the file
 // starts them; importing it does not.
-export function start(serve: typeof Deno.serve = Deno.serve) {
-  tick();
-  const timer = setInterval(tick, TICK_MS);
+export function start(
+  serve: typeof Deno.serve = Deno.serve,
+  collect: () => void | Promise<void> = tick,
+) {
+  collect();
+  const timer = setInterval(collect, TICK_MS);
   const server = serve({
     port: PORT,
     onListen: () => console.log(`\n  Fabric wall LIVE:  http://localhost:${PORT}\n  ${TILES.length} tiles registered.\n`),

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -1,11 +1,10 @@
-// ci spend tests. The tile is a pure collect(ctx) -> TileView over GitHub's org
-// billing APIs, so the two things it reads from outside are pinned here: the clock
-// (it asks for the months around today, and rates the month against how much of it
-// has passed) and fetch (canned usage reports and budgets, shaped as the live API
-// returns them).
+// ci spend tests. The tile is a pure collect(ctx) -> TileView over GitHub and
+// Blacksmith billing data. The tests pin the clock and provide fixed responses
+// for both sources.
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Ctx, TileView } from "../types.ts";
 import { REPO } from "../config.ts";
+import { blacksmithRoutes } from "../blacksmith.ts";
 import { githubCiSpend } from "./github-ci-spend.ts";
 
 const ORG = "acme";
@@ -31,13 +30,92 @@ const item = (date: string, netAmount: number, product = "actions") => ({
 });
 
 // A run of days in one month, each spending the same amount.
-const days = (year: number, month: number, from: number, to: number, amount: number) =>
-  Array.from({ length: to - from + 1 }, (_, i) => item(`${year}-${pad(month)}-${pad(from + i)}`, amount));
+const days = (
+  year: number,
+  month: number,
+  from: number,
+  to: number,
+  amount: number,
+) =>
+  Array.from(
+    { length: to - from + 1 },
+    (_, i) => item(`${year}-${pad(month)}-${pad(from + i)}`, amount),
+  );
 
 const usagePath = (year: number, month: number, org = ORG) =>
   `organizations/${org}/settings/billing/usage?year=${year}&month=${month}`;
-const budgetsPath = (org = ORG) => `organizations/${org}/settings/billing/budgets`;
+const budgetsPath = (org = ORG) =>
+  `organizations/${org}/settings/billing/budgets`;
 const classicPath = (org = ORG) => `orgs/${org}/settings/billing/actions`;
+
+const blacksmithDay = (date: string, cost: unknown) => ({
+  date,
+  jobs: 1,
+  cost,
+  minutes: 1,
+});
+
+function blacksmithRouteSet(
+  now: string,
+  dailyMetrics: unknown[],
+  footprint: {
+    dockerfile: unknown[];
+    stickydisk: unknown[];
+  } = { dockerfile: [], stickydisk: [] },
+  storageByMonth: Record<string, number> = {},
+  org = ORG,
+  billing: { invoice?: unknown; threshold?: unknown } = {},
+): Record<string, unknown> {
+  const observed = new Date(now);
+  const today = Date.UTC(
+    observed.getUTCFullYear(),
+    observed.getUTCMonth(),
+    observed.getUTCDate(),
+  );
+  const end = new Date(today - 1);
+  const start = new Date(today - 45 * D);
+  const routes: Record<string, unknown> = {
+    [`api/${blacksmithRoutes.daily(org, start, end)}`]: {
+      daily_metrics: dailyMetrics,
+    },
+    [`api/${blacksmithRoutes.stickyDaily(org, start, end)}`]: footprint,
+  };
+  let cursor = new Date(start);
+  while (cursor <= end) {
+    const nextMonth = Date.UTC(
+      cursor.getUTCFullYear(),
+      cursor.getUTCMonth() + 1,
+      1,
+    );
+    const segmentEnd = new Date(Math.min(end.getTime(), nextMonth - 1));
+    const month = cursor.toISOString().slice(0, 7);
+    routes[`api/${blacksmithRoutes.stickyTotal(org, cursor, segmentEnd)}`] = {
+      total_cost: storageByMonth[month] ?? 0,
+      total_gb_hours: 0,
+    };
+    cursor = new Date(nextMonth);
+  }
+  const month = observed.toISOString().slice(0, 7);
+  const measuredMtd = dailyMetrics.reduce<number>((sum, entry) => {
+    if (!entry || typeof entry !== "object") return sum;
+    const metric = entry as Record<string, unknown>;
+    return typeof metric.date === "string" && metric.date.startsWith(month) &&
+        Number.isFinite(Number(metric.cost))
+      ? sum + Number(metric.cost)
+      : sum;
+  }, storageByMonth[month] ?? 0);
+  routes[`api/${blacksmithRoutes.invoiceAmount(org)}`] = "invoice" in billing
+    ? billing.invoice
+    : measuredMtd;
+  routes[`api/${blacksmithRoutes.spendingThreshold(org)}`] =
+    "threshold" in billing ? billing.threshold : null;
+  return routes;
+}
+
+const BLACKSMITH_ENV = {
+  BLACKSMITH_API_TOKEN: "blacksmith-token",
+  BLACKSMITH_ORG: ORG,
+};
 
 function ctx(env: Record<string, string>): Ctx {
   return {
@@ -68,11 +146,17 @@ async function view(
   globalThis.fetch = (input: URL | Request | string) => {
     const url = new URL(input instanceof Request ? input.url : String(input));
     const key = url.pathname.slice(1) + url.search;
-    if (!(key in routes)) return Promise.resolve(new Response(null, { status: 404 }));
+    if (!(key in routes)) {
+      return Promise.resolve(new Response(null, { status: 404 }));
+    }
     const body = routes[key];
     if (body instanceof Error) return Promise.reject(body);
+    if (body instanceof Response) return Promise.resolve(body);
     return Promise.resolve(
-      new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } }),
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
     );
   };
   try {
@@ -89,6 +173,7 @@ Deno.test("ci spend: without a token the tile is gray and names what it needs", 
   assertEquals(v.value, "—");
   assertStringIncludes(v.sub ?? "", "GH_TOKEN");
   assertStringIncludes(v.sub ?? "", "org billing read"); // the extra right this tile needs
+  assertStringIncludes(v.sub ?? "", "BLACKSMITH_API_TOKEN");
 });
 
 Deno.test("ci spend: projects the month from the settled daily rate, against the GitHub budget", async () => {
@@ -117,9 +202,13 @@ Deno.test("ci spend: projects the month from the settled daily rate, against the
   assertEquals(v.value, "~$310/mo");
   assertEquals(v.aside, '<span class="hmtd">$180 MTD</span>');
   // The Actions budget, not the Copilot one that shares the response.
-  assertEquals(v.sub, "$2700 budget");
+  assertEquals(v.sub, undefined);
+  assertStringIncludes(v.extra ?? "", "Budget $2700");
   assertEquals(v.status, "good"); // $310 of a $2700 budget
-  assertEquals(v.href, "https://github.com/organizations/acme/settings/billing");
+  assertEquals(
+    v.href,
+    "https://github.com/organizations/acme/settings/billing",
+  );
   assertEquals(v.hint, "billing ↗");
   assertStringIncludes(v.extra ?? "", "<polyline");
   // The line ends on the last day with a figure (the 10th), not on today: billing
@@ -131,37 +220,56 @@ Deno.test("ci spend: projects the month from the settled daily rate, against the
 Deno.test("ci spend: a 200 without a usageItems array grays out rather than reading as $0", async () => {
   // A permission-filtered view answers 200 with no usable report. Nothing was
   // measured, so nothing may be claimed — least of all a green "$0/mo".
-  for (const body of [{}, { usageItems: null }, { usageItems: { message: "not visible" } }]) {
-    const v = await view("2026-01-20T09:00:00Z", { [usagePath(2026, 1)]: body });
+  for (
+    const body of [{}, { usageItems: null }, {
+      usageItems: { message: "not visible" },
+    }]
+  ) {
+    const v = await view("2026-01-20T09:00:00Z", {
+      [usagePath(2026, 1)]: body,
+    });
     assertEquals(v.status, "unknown");
     assertEquals(v.value, "—");
     assertEquals(v.sub, "billing usage unavailable");
-    assertEquals(v.href, "https://github.com/organizations/acme/settings/billing"); // still drills through
+    assertEquals(
+      v.href,
+      "https://github.com/organizations/acme/settings/billing",
+    ); // still drills through
   }
 });
 
 Deno.test("ci spend: no Actions budget in GitHub -> the projection stands, uncompared", async () => {
   const usage = { usageItems: days(2026, 1, 1, 10, 18) };
   // The org has no budgets endpoint response at all.
-  const none = await view("2026-01-20T09:00:00Z", { [usagePath(2026, 1)]: usage });
+  const none = await view("2026-01-20T09:00:00Z", {
+    [usagePath(2026, 1)]: usage,
+  });
   assertEquals(none.value, "~$310/mo");
   assertEquals(none.sub, undefined);
+  assertStringIncludes(none.extra ?? "", "Budget $???");
   assertEquals(none.status, "good"); // an absent budget never alarms
   // The org budgets Actions' neighbours but not Actions.
   const other = await view("2026-01-20T09:00:00Z", {
     [usagePath(2026, 1)]: usage,
-    [budgetsPath()]: { budgets: [{ budget_product_sku: "copilot", budget_amount: 5 }] },
+    [budgetsPath()]: {
+      budgets: [{ budget_product_sku: "copilot", budget_amount: 5 }],
+    },
   });
   assertEquals(other.sub, undefined);
+  assertStringIncludes(other.extra ?? "", "Budget $???");
   assertEquals(other.status, "good");
 });
 
 Deno.test("ci spend: a projection over budget goes amber, and well over goes red", async () => {
-  const spend = (perDay: number) => ({ usageItems: days(2026, 1, 1, 10, perDay) });
+  const spend = (perDay: number) => ({
+    usageItems: days(2026, 1, 1, 10, perDay),
+  });
   const at = (perDay: number, budget: number) =>
     view("2026-01-20T09:00:00Z", {
       [usagePath(2026, 1)]: spend(perDay),
-      [budgetsPath()]: { budgets: [{ budget_product_sku: "actions", budget_amount: budget }] },
+      [budgetsPath()]: {
+        budgets: [{ budget_product_sku: "actions", budget_amount: budget }],
+      },
     });
   // $18/day over the 10 days that spent -> $180 rated over 18 settled days -> $310.
   assertEquals((await at(18, 400)).status, "good"); // under budget
@@ -197,21 +305,39 @@ Deno.test("ci spend: a prior month we can't read shortens the chart, it doesn't 
   assertEquals(v.duration, 10 * D); // January 1st to 10th only
 });
 
+Deno.test("ci spend: an unavailable prior month is not zero-spend history", async () => {
+  const v = await view("2026-01-03T09:00:00Z", {
+    [usagePath(2026, 1)]: { usageItems: days(2026, 1, 1, 2, 20) },
+    [budgetsPath()]: {
+      budgets: [{ budget_product_sku: "actions", budget_amount: 400 }],
+    },
+  });
+  assertEquals(v.value, "~$620/mo");
+  assertEquals(v.aside, '<span class="hmtd">$40 MTD</span>');
+  assertEquals(v.status, "bad");
+  assertEquals(v.duration, 2 * D);
+});
+
 Deno.test("ci spend: one day of data is not a chart, but it is still a projection", async () => {
   const v = await view("2026-01-20T09:00:00Z", {
     [usagePath(2026, 1)]: { usageItems: [item("2026-01-01", 180)] },
   });
   assertEquals(v.value, "~$310/mo");
-  assertEquals(v.extra, ""); // a single point draws no line
+  assertStringIncludes(v.extra ?? "", "GitHub $180");
+  assertEquals(v.extra?.includes("<polyline"), false); // a single point draws no line
   assertEquals(v.duration, 0);
 });
 
 Deno.test("ci spend: a row whose date is unreadable leaves the chart out", async () => {
   const v = await view("2026-01-20T09:00:00Z", {
-    [usagePath(2026, 1)]: { usageItems: [item("2026-01-01", 180), item("", 0)] },
+    [usagePath(2026, 1)]: {
+      usageItems: [item("2026-01-01", 180), item("", 20)],
+    },
   });
-  assertEquals(v.value, "~$310/mo");
-  assertEquals(v.extra, "");
+  assertEquals(v.value, "~$344/mo");
+  assertEquals(v.aside, '<span class="hmtd">$200 MTD</span>');
+  assertStringIncludes(v.extra ?? "", "GitHub $200");
+  assertEquals(v.extra?.includes("<polyline"), false);
   assertEquals(v.duration, 0);
 });
 
@@ -220,7 +346,11 @@ Deno.test("ci spend: the classic plan falls back to minutes against the included
   // endpoint answers in minutes.
   const classic = (used: number, included: number, paid: number) =>
     view("2026-01-20T09:00:00Z", {
-      [classicPath()]: { total_minutes_used: used, included_minutes: included, total_paid_minutes_used: paid },
+      [classicPath()]: {
+        total_minutes_used: used,
+        included_minutes: included,
+        total_paid_minutes_used: paid,
+      },
     });
   const easy = await classic(1000, 3000, 0);
   assertEquals(easy.status, "good");
@@ -237,12 +367,314 @@ Deno.test("ci spend: the classic plan falls back to minutes against the included
 
 Deno.test("ci spend: both billing endpoints unreachable -> gray with a calm reason", async () => {
   const v = await view("2026-01-20T09:00:00Z", {
-    [classicPath()]: new TypeError("error sending request for url (https://api.github.com/orgs/acme/…)"),
+    [classicPath()]: new TypeError(
+      "error sending request for url (https://api.github.com/orgs/acme/…)",
+    ),
   });
   assertEquals(v.status, "unknown"); // never a false green, never a red
   assertEquals(v.value, "—");
   assertEquals(v.sub, "source unreachable"); // the phrase, not the stack
-  assertEquals(v.href, "https://github.com/organizations/acme/settings/billing");
+  assertEquals(
+    v.href,
+    "https://github.com/organizations/acme/settings/billing",
+  );
+  assertStringIncludes(
+    v.extra ?? "",
+    '<span class="swatch" style="background:#58a6ff"></span> GitHub $??? • Budget $???',
+  );
+});
+
+Deno.test("ci spend: every failed provider retains the combined middle line", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const routes = blacksmithRouteSet(now, []);
+  const dailyPath = Object.keys(routes).find((path) =>
+    path.includes("/metrics/daily?")
+  )!;
+  routes[dailyPath] = new Response(null, { status: 401 });
+
+  const result = await view(now, routes, {
+    GH_TOKEN: "gh_pat_x",
+    GH_BILLING_ORG: ORG,
+    ...BLACKSMITH_ENV,
+    CI_MONTHLY_BUDGET: "500",
+  });
+  assertEquals(result.status, "unknown");
+  assertEquals(result.value, "—");
+  assertStringIncludes(
+    result.extra ?? "",
+    '<p class="sub"><span class="swatch" style="background:#58a6ff"></span> GitHub $??? • <span class="swatch" style="background:#f59e0b"></span> Blacksmith $??? • Budget $500</p>',
+  );
+});
+
+Deno.test("ci spend: Blacksmith invoice, runner, storage, and threshold form one provider", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const compute = Array.from(
+    { length: 10 },
+    (_, index) => blacksmithDay(`2026-01-${pad(index + 1)}`, 10),
+  );
+  const routes = blacksmithRouteSet(
+    now,
+    compute,
+    {
+      dockerfile: [
+        { date: "2026-01-01", value: 1 },
+        { date: "2026-01-02", value: 3 },
+      ],
+      stickydisk: [],
+    },
+    { "2026-01": 40 },
+    ORG,
+    {
+      invoice: { amount: 150, currency: "USD" },
+      threshold: 230,
+    },
+  );
+  const v = await view(now, routes, BLACKSMITH_ENV);
+
+  assertEquals(v.value, "~$245/mo");
+  assertEquals(v.aside, '<span class="hmtd">$150 MTD</span>');
+  assertEquals(v.sub, undefined);
+  assertEquals(v.status, "warn");
+  assertEquals(v.href, "https://app.blacksmith.sh/");
+  assertStringIncludes(v.extra ?? "", "Blacksmith");
+  assertStringIncludes(v.extra ?? "", "$150");
+  assertStringIncludes(v.extra ?? "", "Budget $230");
+  assertStringIncludes(v.extra ?? "", "<polyline");
+  assertEquals(v.duration, 10 * D);
+});
+
+Deno.test("ci spend: malformed Blacksmith costs never read as a green zero", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const malformedDaily = blacksmithRouteSet(now, [
+    blacksmithDay("2026-01-01", null),
+  ]);
+  const negativeDaily = blacksmithRouteSet(now, [
+    blacksmithDay("2026-01-01", -1),
+  ]);
+  const malformedTotal = blacksmithRouteSet(now, [
+    blacksmithDay("2026-01-01", 1),
+  ]);
+  const totalPath = Object.keys(malformedTotal).find((path) =>
+    path.includes("/sticky-disk/total?")
+  )!;
+  malformedTotal[totalPath] = { total_cost: null };
+  const negativeTotal = blacksmithRouteSet(now, [
+    blacksmithDay("2026-01-01", 1),
+  ]);
+  const negativeTotalPath = Object.keys(negativeTotal).find((path) =>
+    path.includes("/sticky-disk/total?")
+  )!;
+  negativeTotal[negativeTotalPath] = { total_cost: -1 };
+
+  for (
+    const routes of [
+      malformedDaily,
+      negativeDaily,
+      malformedTotal,
+      negativeTotal,
+    ]
+  ) {
+    const v = await view(now, routes, BLACKSMITH_ENV);
+    assertEquals(v.status, "unknown");
+    assertEquals(v.value, "—");
+  }
+});
+
+Deno.test("ci spend: Blacksmith token errors say how to restore the source", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const expiredRoutes = blacksmithRouteSet(now, []);
+  const dailyPath = Object.keys(expiredRoutes).find((path) =>
+    path.includes("/metrics/daily?")
+  )!;
+  expiredRoutes[dailyPath] = new Response(null, { status: 401 });
+
+  const rejected = await view(now, expiredRoutes, BLACKSMITH_ENV);
+  assertEquals(rejected.status, "unknown");
+  assertEquals(rejected.sub, "check BLACKSMITH_API_TOKEN");
+
+  const invalid = await view(now, {}, {
+    BLACKSMITH_API_TOKEN: "blacksmith-token",
+    BLACKSMITH_API_URL: "not-a-url",
+  });
+  assertEquals(invalid.status, "unknown");
+  assertEquals(invalid.sub, "check BLACKSMITH_API_URL");
+});
+
+Deno.test("ci spend: current Blacksmith billing endpoint failures are not hidden", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  for (
+    const route of [
+      blacksmithRoutes.invoiceAmount(ORG),
+      blacksmithRoutes.spendingThreshold(ORG),
+    ]
+  ) {
+    const routes = blacksmithRouteSet(now, [
+      blacksmithDay("2026-01-01", 10),
+    ]);
+    routes[`api/${route}`] = new Response(null, { status: 503 });
+
+    const result = await view(now, routes, BLACKSMITH_ENV);
+    assertEquals(result.status, "unknown");
+    assertEquals(result.value, "—");
+  }
+});
+
+Deno.test("ci spend: a combined budget avoids the unused Blacksmith threshold", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const routes = blacksmithRouteSet(now, [
+    blacksmithDay("2026-01-01", 10),
+  ]);
+  routes[`api/${blacksmithRoutes.spendingThreshold(ORG)}`] = new Response(
+    null,
+    {
+      status: 503,
+    },
+  );
+
+  const result = await view(now, routes, {
+    ...BLACKSMITH_ENV,
+    CI_MONTHLY_BUDGET: "100",
+  });
+  assertEquals(result.status, "good");
+  assertEquals(result.value, "~$16/mo");
+  assertEquals(result.sub, undefined);
+  assertStringIncludes(result.extra ?? "", "Budget $100");
+});
+
+Deno.test("ci spend: GitHub and Blacksmith share totals, chart, and combined budget", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const blacksmith = blacksmithRouteSet(
+    now,
+    Array.from(
+      { length: 10 },
+      (_, index) => blacksmithDay(`2026-01-${pad(index + 1)}`, 5),
+    ),
+  );
+  const v = await view(
+    now,
+    {
+      [usagePath(2026, 1)]: { usageItems: days(2026, 1, 1, 10, 18) },
+      [budgetsPath()]: {
+        budgets: [
+          { budget_product_sku: "actions", budget_amount: 1 },
+        ],
+      },
+      ...blacksmith,
+    },
+    {
+      GH_TOKEN: "gh_pat_x",
+      GH_BILLING_ORG: ORG,
+      ...BLACKSMITH_ENV,
+      CI_MONTHLY_BUDGET: "350",
+    },
+  );
+
+  assertEquals(v.value, "~$392/mo");
+  assertEquals(v.aside, '<span class="hmtd">$230 MTD</span>');
+  assertEquals(v.sub, undefined);
+  assertEquals(v.status, "warn");
+  assertEquals(v.href, undefined);
+  assertStringIncludes(
+    v.extra ?? "",
+    '<p class="sub"><span class="swatch" style="background:#58a6ff"></span> GitHub • <span class="swatch" style="background:#f59e0b"></span> Blacksmith • Budget $350</p>',
+  );
+  assertStringIncludes(v.extra ?? "", "$180");
+  assertStringIncludes(v.extra ?? "", "$50");
+});
+
+Deno.test("ci spend: provider budgets combine when no explicit budget is set", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const blacksmith = blacksmithRouteSet(
+    now,
+    Array.from(
+      { length: 10 },
+      (_, index) => blacksmithDay(`2026-01-${pad(index + 1)}`, 5),
+    ),
+    undefined,
+    undefined,
+    ORG,
+    { threshold: 100 },
+  );
+  const v = await view(
+    now,
+    {
+      [usagePath(2026, 1)]: { usageItems: days(2026, 1, 1, 10, 18) },
+      [budgetsPath()]: {
+        budgets: [{ budget_product_sku: "actions", budget_amount: 300 }],
+      },
+      ...blacksmith,
+    },
+    {
+      GH_TOKEN: "gh_pat_x",
+      GH_BILLING_ORG: ORG,
+      ...BLACKSMITH_ENV,
+    },
+  );
+
+  assertEquals(v.value, "~$392/mo");
+  assertEquals(v.sub, undefined);
+  assertStringIncludes(v.extra ?? "", "Budget $400");
+  assertEquals(v.status, "good");
+});
+
+Deno.test("ci spend: a partial provider budget is not treated as the combined budget", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const blacksmith = blacksmithRouteSet(
+    now,
+    [blacksmithDay("2026-01-01", 50)],
+    undefined,
+    undefined,
+    ORG,
+    { threshold: 1 },
+  );
+  const v = await view(
+    now,
+    {
+      [usagePath(2026, 1)]: { usageItems: days(2026, 1, 1, 10, 18) },
+      ...blacksmith,
+    },
+    {
+      GH_TOKEN: "gh_pat_x",
+      GH_BILLING_ORG: ORG,
+      ...BLACKSMITH_ENV,
+    },
+  );
+
+  assertEquals(v.sub, undefined);
+  assertStringIncludes(v.extra ?? "", "Budget $???");
+  assertEquals(v.status, "good");
+});
+
+Deno.test("ci spend: one failed configured source leaves a gray lower bound", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const blacksmith = blacksmithRouteSet(now, []);
+  const dailyPath = Object.keys(blacksmith).find((path) =>
+    path.includes("/metrics/daily?")
+  )!;
+  blacksmith[dailyPath] = new Response(null, { status: 401 });
+  const v = await view(
+    now,
+    {
+      [usagePath(2026, 1)]: { usageItems: days(2026, 1, 1, 10, 18) },
+      ...blacksmith,
+    },
+    {
+      GH_TOKEN: "gh_pat_x",
+      GH_BILLING_ORG: ORG,
+      ...BLACKSMITH_ENV,
+      CI_MONTHLY_BUDGET: "1",
+    },
+  );
+
+  assertEquals(v.value, "≥$310/mo");
+  assertEquals(v.aside, '<span class="hmtd">$180 MTD</span>');
+  assertEquals(v.status, "unknown");
+  assertStringIncludes(
+    v.extra ?? "",
+    '<span class="swatch" style="background:#f59e0b"></span> Blacksmith $???',
+  );
+  assertStringIncludes(v.extra ?? "", "GitHub");
+  assertStringIncludes(v.extra ?? "", "Budget $1");
 });
 
 Deno.test("ci spend: GITHUB_TOKEN works, and the org defaults to the CI tiles' repo owner", async () => {
@@ -253,6 +685,9 @@ Deno.test("ci spend: GITHUB_TOKEN works, and the org defaults to the CI tiles' r
     { GITHUB_TOKEN: "gh_pat_x" },
   );
   assertEquals(v.value, "~$310/mo");
-  assertEquals(v.href, `https://github.com/organizations/${org}/settings/billing`);
+  assertEquals(
+    v.href,
+    `https://github.com/organizations/${org}/settings/billing`,
+  );
   assert(org.length > 0);
 });

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -5,7 +5,10 @@ import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Ctx, TileView } from "../types.ts";
 import { REPO } from "../config.ts";
 import { blacksmithRoutes } from "../blacksmith.ts";
-import { githubCiSpend } from "./github-ci-spend.ts";
+import {
+  githubCiSpend,
+  projectMonthly,
+} from "./github-ci-spend.ts";
 
 const ORG = "acme";
 const D = 86_400_000;
@@ -117,6 +120,10 @@ const BLACKSMITH_ENV = {
   BLACKSMITH_ORG: ORG,
 };
 
+class RejectedRoute {
+  constructor(readonly reason: unknown) {}
+}
+
 function ctx(env: Record<string, string>): Ctx {
   return {
     runs: () => Promise.resolve([]),
@@ -150,6 +157,7 @@ async function view(
       return Promise.resolve(new Response(null, { status: 404 }));
     }
     const body = routes[key];
+    if (body instanceof RejectedRoute) return Promise.reject(body.reason);
     if (body instanceof Error) return Promise.reject(body);
     if (body instanceof Response) return Promise.resolve(body);
     return Promise.resolve(
@@ -174,6 +182,10 @@ Deno.test("ci spend: without a token the tile is gray and names what it needs", 
   assertStringIncludes(v.sub ?? "", "GH_TOKEN");
   assertStringIncludes(v.sub ?? "", "org billing read"); // the extra right this tile needs
   assertStringIncludes(v.sub ?? "", "BLACKSMITH_API_TOKEN");
+});
+
+Deno.test("ci spend: a projection with no observed rate window preserves the measured total", () => {
+  assertEquals(projectMonthly(37, 0, 31, []), 37);
 });
 
 Deno.test("ci spend: projects the month from the settled daily rate, against the GitHub budget", async () => {
@@ -480,6 +492,121 @@ Deno.test("ci spend: malformed Blacksmith costs never read as a green zero", asy
   }
 });
 
+Deno.test("ci spend: malformed Blacksmith daily and storage payloads are unavailable", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const cases: Array<{
+    name: string;
+    routeFragment: string;
+    response: unknown;
+  }> = [
+    {
+      name: "daily metrics are not an array",
+      routeFragment: "/metrics/daily?",
+      response: { daily_metrics: null },
+    },
+    {
+      name: "storage collections are not arrays",
+      routeFragment: "/metrics/docker/daily-by-type?",
+      response: { dockerfile: {}, stickydisk: [] },
+    },
+    {
+      name: "a daily date is not text",
+      routeFragment: "/metrics/daily?",
+      response: {
+        daily_metrics: [{ date: 42, jobs: 1, cost: 1, minutes: 1 }],
+      },
+    },
+    {
+      name: "a daily date is not a calendar day",
+      routeFragment: "/metrics/daily?",
+      response: {
+        daily_metrics: [blacksmithDay("2026-99-99", 1)],
+      },
+    },
+    {
+      name: "a storage measurement is blank",
+      routeFragment: "/metrics/docker/daily-by-type?",
+      response: {
+        dockerfile: [{ date: "2026-01-01", value: " " }],
+        stickydisk: [],
+      },
+    },
+  ];
+
+  for (const malformed of cases) {
+    const routes = blacksmithRouteSet(now, [
+      blacksmithDay("2026-01-01", 1),
+    ]);
+    const path = Object.keys(routes).find((candidate) =>
+      candidate.includes(malformed.routeFragment)
+    );
+    assert(path, malformed.name);
+    routes[path] = malformed.response;
+
+    const result = await view(now, routes, BLACKSMITH_ENV);
+    assertEquals(result.status, "unknown", malformed.name);
+    assertEquals(result.value, "—", malformed.name);
+    assertEquals(result.sub, "temporarily unavailable", malformed.name);
+  }
+});
+
+Deno.test("ci spend: malformed Blacksmith invoice and threshold payloads are unavailable", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const cases: Array<{
+    name: string;
+    billing: { invoice?: unknown; threshold?: unknown };
+  }> = [
+    {
+      name: "invoice currency is not USD",
+      billing: { invoice: { amount: 10, currency: "EUR" } },
+    },
+    {
+      name: "invoice amount is negative",
+      billing: { invoice: { amount: -1, currency: "USD" } },
+    },
+    {
+      name: "threshold object has no supported field",
+      billing: { threshold: {} },
+    },
+    {
+      name: "threshold is negative",
+      billing: { threshold: { threshold: -1 } },
+    },
+  ];
+
+  for (const malformed of cases) {
+    const routes = blacksmithRouteSet(
+      now,
+      [blacksmithDay("2026-01-01", 10)],
+      undefined,
+      undefined,
+      ORG,
+      malformed.billing,
+    );
+    const result = await view(now, routes, BLACKSMITH_ENV);
+    assertEquals(result.status, "unknown", malformed.name);
+    assertEquals(result.value, "—", malformed.name);
+    assertEquals(result.sub, "temporarily unavailable", malformed.name);
+  }
+});
+
+Deno.test("ci spend: a null threshold field is an unknown provider budget", async () => {
+  const now = "2026-01-20T09:00:00Z";
+  const routes = blacksmithRouteSet(
+    now,
+    [blacksmithDay("2026-01-01", 10)],
+    undefined,
+    undefined,
+    ORG,
+    { threshold: { threshold: null } },
+  );
+
+  const result = await view(now, routes, BLACKSMITH_ENV);
+  assertEquals(result.status, "good");
+  assertEquals(result.value, "~$16/mo");
+  assertStringIncludes(result.extra ?? "", "Budget $???");
+});
+
 Deno.test("ci spend: Blacksmith token errors say how to restore the source", async () => {
   const now = "2026-01-20T09:00:00Z";
   const expiredRoutes = blacksmithRouteSet(now, []);
@@ -498,6 +625,36 @@ Deno.test("ci spend: Blacksmith token errors say how to restore the source", asy
   });
   assertEquals(invalid.status, "unknown");
   assertEquals(invalid.sub, "check BLACKSMITH_API_URL");
+});
+
+Deno.test("ci spend: a source that rejects without an Error remains unavailable", async () => {
+  const rejected = new RejectedRoute("billing stopped");
+  const result = await view("2026-01-20T09:00:00Z", {
+    [usagePath(2026, 1)]: rejected,
+    [classicPath()]: rejected,
+  });
+
+  assertEquals(result.status, "unknown");
+  assertEquals(result.value, "—");
+  assertEquals(result.sub, "CI spend unavailable");
+});
+
+Deno.test("ci spend: a Blacksmith token removed during collection is unavailable", async () => {
+  let tokenReads = 0;
+  const result = await githubCiSpend.collect({
+    runs: () => Promise.resolve([]),
+    runsFor: () => Promise.resolve([]),
+    env: (name) => {
+      if (name !== "BLACKSMITH_API_TOKEN") return undefined;
+      tokenReads++;
+      return tokenReads === 1 ? "blacksmith-token" : undefined;
+    },
+  });
+
+  assertEquals(tokenReads, 2);
+  assertEquals(result.status, "unknown");
+  assertEquals(result.value, "—");
+  assertEquals(result.sub, "temporarily unavailable");
 });
 
 Deno.test("ci spend: current Blacksmith billing endpoint failures are not hidden", async () => {

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -455,6 +455,45 @@ Deno.test("ci spend: Blacksmith invoice, runner, storage, and threshold form one
   assertEquals(v.duration, 10 * D);
 });
 
+Deno.test("ci spend: a Blacksmith invoice without daily history still supplies MTD and forecast totals", async () => {
+  const at = (now: string) =>
+    view(
+      now,
+      blacksmithRouteSet(
+        now,
+        [],
+        undefined,
+        undefined,
+        ORG,
+        {
+          invoice: { amount: 150, currency: "USD" },
+          threshold: 300,
+        },
+      ),
+      BLACKSMITH_ENV,
+    );
+
+  const early = await at("2026-01-10T09:00:00Z");
+  assertEquals(early.value, "~$332/mo");
+  assertEquals(early.aside, '<span class="hmtd">$150 MTD</span>');
+  assertEquals(early.sub, undefined);
+  assertEquals(early.status, "warn");
+  assertEquals(
+    early.extra,
+    '<p class="sub"><span class="swatch" style="background:#f59e0b"></span> Blacksmith $150 • Budget $300</p>',
+  );
+  assertEquals(early.duration, 0);
+  assertEquals(early.href, "https://app.blacksmith.sh/");
+  assertEquals(early.hint, "billing ↗");
+
+  const ongoing = await at("2026-01-20T09:00:00Z");
+  assertEquals(ongoing.value, "~$245/mo");
+  assertEquals(ongoing.aside, '<span class="hmtd">$150 MTD</span>');
+  assertEquals(ongoing.status, "good");
+  assertEquals(ongoing.extra, early.extra);
+  assertEquals(ongoing.duration, 0);
+});
+
 Deno.test("ci spend: malformed Blacksmith costs never read as a green zero", async () => {
   const now = "2026-01-20T09:00:00Z";
   const malformedDaily = blacksmithRouteSet(now, [

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -1,98 +1,124 @@
-// ci spend: the org's GitHub Actions spend for the month, extrapolated to a
-// projected full-month total, against the Actions budget configured in GitHub. The
-// billable spend (net of discounts — so the included-usage allowance is already
-// deducted) and its per-day breakdown come from the enhanced billing platform's
-// usage report; a classic-plan fallback shows minutes vs the included allowance.
+// ci spend: month-to-date CI cost across GitHub Actions and Blacksmith,
+// projected to a full-month total. Each configured source contributes one line
+// to a shared 45-day daily-spend chart. The line labels show each source's
+// month-to-date spend and the header shows the combined month-to-date total.
 //
-// The projection's daily rate is measured over a trailing window of at least two
-// weeks — or the whole month-to-date if that is longer — so a couple of noisy
-// early-month days don't dominate. When this month has under two weeks of data,
-// the window spills into the tail of last month's daily spend. Uses GH_TOKEN,
-// which for this tile must also carry org billing read (an org owner or billing
-// manager) on top of the Actions read the other GitHub tiles use.
+// GitHub's enhanced billing report supplies daily net Actions spend. Blacksmith
+// supplies an invoice total, daily runner cost, and a range total for sticky-disk
+// storage. The invoice is the month-to-date source of truth. The daily endpoints
+// supply the projection and chart, with storage assigned to days in proportion
+// to the daily cache footprint. A configured source that cannot be read shows
+// "$???" and makes the combined projection a lower bound.
 import type { Status, Tile, TileView } from "../types.ts";
-import { budgetStatus, friendlyError, github, SPARK_FADE, sparkline, usd } from "../lib.ts";
+import {
+  budgetStatus,
+  friendlyError,
+  github,
+  multiSparkline,
+  readBudget,
+  SPARK_FADE,
+  usd,
+} from "../lib.ts";
 import { REPO } from "../config.ts";
+import { BlacksmithClient, blacksmithRoutes } from "../blacksmith.ts";
 
 interface UsageItem {
   date: string;
   product: string;
   netAmount: number;
 }
+
 interface Budget {
   budget_product_sku?: string;
   budget_amount?: number;
 }
+
 interface ActionsBilling {
   total_minutes_used: number;
   total_paid_minutes_used: number;
   included_minutes: number;
 }
 
-// The usage report labels the product "actions" (lowercase) and splits it across
-// SKUs (runner minutes, storage) and repos; match case-insensitively.
+interface DailySpend {
+  byDay: Map<string, number>;
+  mtd: number;
+  projected: number;
+}
+
+interface GitHubDollarSpend extends DailySpend {
+  kind: "dollars";
+  budget: number;
+}
+
+interface BlacksmithSpend extends DailySpend {
+  budget: number;
+}
+
+interface GitHubMinuteSpend {
+  kind: "minutes";
+  used: number;
+  included: number;
+  paid: number;
+}
+
+type GitHubSpend = GitHubDollarSpend | GitHubMinuteSpend;
+
+interface BlacksmithDailyResponse {
+  daily_metrics?: Array<{
+    date?: unknown;
+    cost?: unknown;
+  }>;
+}
+
+interface BlacksmithStickyDailyResponse {
+  dockerfile?: Array<{ date?: unknown; value?: unknown }>;
+  stickydisk?: Array<{ date?: unknown; value?: unknown }>;
+}
+
+interface BlacksmithStickyTotalResponse {
+  total_cost?: unknown;
+}
+
 const actionsOf = (report: { usageItems?: UsageItem[] }): UsageItem[] =>
-  (report.usageItems ?? []).filter((i) => String(i.product).toLowerCase() === "actions");
-const sumNet = (items: UsageItem[]): number => items.reduce((s, i) => s + (Number(i.netAmount) || 0), 0);
-const byDayOf = (items: UsageItem[]): Map<string, number> => {
-  const byDay = new Map<string, number>();
-  for (const i of items) {
-    const day = i.date.slice(0, 10);
-    byDay.set(day, (byDay.get(day) ?? 0) + (Number(i.netAmount) || 0));
-  }
-  return byDay;
-};
-// Billable spend for every calendar day of one month. The usage report carries a row
-// only for a day that had usage, so a day it omits is a day that spent nothing, and a
-// rate measured over the month has to count it.
-const monthSeries = (items: UsageItem[], year: number, month0: number): number[] =>
-  calendarMonth(byDayOf(items), year, month0);
+  (report.usageItems ?? []).filter((item) =>
+    String(item.product).toLowerCase() === "actions"
+  );
 
-const usagePath = (org: string, y: number, m: number) =>
-  `organizations/${org}/settings/billing/usage?year=${y}&month=${m}`;
+const usagePath = (org: string, year: number, month: number) =>
+  `organizations/${org}/settings/billing/usage?year=${year}&month=${month}`;
 
-// How late a source settles a day's billing. GitHub's usage report runs a day or two
-// behind. The provider cost APIs return a zero bucket for the day in progress.
 export const GITHUB_LAG_DAYS = 2;
 export const PROVIDER_LAG_DAYS = 1;
+export const MIN_WINDOW_DAYS = 14;
+const SPARK_DAYS = 45;
+const DAY_MS = 86_400_000;
+const GITHUB_COLOR = "#58a6ff";
+const BLACKSMITH_COLOR = "#f59e0b";
 
-// The leading days of a month whose spend is known, given how many days have passed
-// since that month began and how late the source settles.
-//
-// A day is known once it carries a figure, and failing that once the source has had
-// `lagDays` to settle it. Both halves are needed. Counting only the days that carried
-// spend stalls the window the moment spend stops, so a month that spends nothing after
-// the 14th goes on rating itself over 14 days until the month ends, and a fortnight
-// whose spend all landed on the 2nd is rated over two days. Counting every day that
-// has passed instead divides by days whose figures have not arrived, dragging the rate
-// toward zero. A zero day inside the window is left alone either way: that is a day
-// which really did spend nothing, and it belongs in the rate.
-//
-// For last month, `elapsedDays` counts from that month's own first day, so it includes
-// however much of this month has gone by. Exported for unit testing.
-export function settled(daily: number[], elapsedDays: number, lagDays: number): number[] {
+export function settled(
+  daily: number[],
+  elapsedDays: number,
+  lagDays: number,
+): number[] {
   let withData = daily.length;
   while (withData > 0 && daily[withData - 1] === 0) withData--;
   const known = Math.max(withData, elapsedDays - lagDays);
   return daily.slice(0, Math.max(0, Math.min(daily.length, known)));
 }
 
-// Daily values for every calendar day of one month, chronological and indexed from the
-// 1st, with the days a source has no entry for filled in as zero. Exported for the
-// model-spend tile, whose per-provider maps are keyed the same way.
-export function calendarMonth(byDay: Map<string, number>, year: number, month0: number): number[] {
+export function calendarMonth(
+  byDay: Map<string, number>,
+  year: number,
+  month0: number,
+): number[] {
   const days = new Date(Date.UTC(year, month0 + 1, 0)).getUTCDate();
   const prefix = `${year}-${String(month0 + 1).padStart(2, "0")}-`;
-  return Array.from({ length: days }, (_, i) => byDay.get(prefix + String(i + 1).padStart(2, "0")) ?? 0);
+  return Array.from(
+    { length: days },
+    (_, index) => byDay.get(prefix + String(index + 1).padStart(2, "0")) ?? 0,
+  );
 }
 
-// Project a full-month total from a daily rate measured over a window of at least
-// two weeks — or the whole month-to-date if that is longer. When this month has
-// fewer than two weeks of data, the window fills from the tail of last month's
-// daily spend. Exported for unit testing.
-export const MIN_WINDOW_DAYS = 14;
-// How many trailing calendar days the daily-spend sparkline aims to cover.
-const SPARK_DAYS = 45;
 export function projectMonthly(
   mtd: number,
   coveredThis: number,
@@ -102,44 +128,478 @@ export function projectMonthly(
   const needFromLast = Math.max(0, MIN_WINDOW_DAYS - coveredThis);
   const tail = needFromLast > 0 ? lastMonthDaily.slice(-needFromLast) : [];
   const windowDays = coveredThis + tail.length;
-  if (windowDays <= 0) return mtd; // no data anywhere
-  const windowSpend = mtd + tail.reduce((s, d) => s + d, 0);
+  if (windowDays <= 0) return mtd;
+  const windowSpend = mtd + tail.reduce((sum, daily) => sum + daily, 0);
   return (windowSpend / windowDays) * daysInMonth;
 }
 
-// A sparkline of the last up-to-SPARK_DAYS calendar days of daily billable spend,
-// in-range gaps filled with 0, the current month's tail drawn brighter in the
-// same gradient style as the other tiles. The bottom-right corner shows the span
-// it covers (e.g. "45 days"). Ends on the last day with data (billing lags a day
-// or two, so this avoids a fake trailing dip to zero).
-function dailySparkline(
-  byDay: Map<string, number>,
-  year: number,
-  month0: number,
-  status: Status,
-): { chart: string; spanMs: number } {
-  const keys = [...byDay.keys()].sort();
-  if (keys.length < 2) return { chart: "", spanMs: 0 };
-  const ms = (k: string) => Date.parse(`${k}T00:00:00Z`);
-  const end = ms(keys[keys.length - 1]);
-  const start = Math.max(ms(keys[0]), end - (SPARK_DAYS - 1) * 86_400_000);
-  const monthStart = Date.UTC(year, month0, 1);
-  const series: number[] = [];
-  let current = 0;
-  for (let t = start; t <= end; t += 86_400_000) {
-    series.push(byDay.get(new Date(t).toISOString().slice(0, 10)) ?? 0);
-    if (t >= monthStart) current++;
+function dayKey(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const day = value.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return null;
+  const parsed = Date.parse(`${day}T00:00:00Z`);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString().slice(0, 10) === day ? day : null;
+}
+
+function finiteNumber(value: unknown): number | null {
+  if (typeof value !== "number" && typeof value !== "string") return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function addDaily(
+  target: Map<string, number>,
+  day: string,
+  amount: number,
+): void {
+  if (amount === 0) return;
+  target.set(day, (target.get(day) ?? 0) + amount);
+}
+
+function addGitHubDays(
+  target: Map<string, number>,
+  items: UsageItem[],
+): void {
+  for (const item of items) {
+    const day = dayKey(item.date);
+    if (!day) continue;
+    addDaily(target, day, Number(item.netAmount) || 0);
   }
-  if (series.length < 2) return { chart: "", spanMs: 0 };
-  // Mark the slice the projection rates: this month, reaching back to
-  // MIN_WINDOW_DAYS when the month is younger than that, since projectMonthly
-  // borrows that many days from last month's tail. Both count calendar days from
-  // the start of the month, so the mark tracks the window up to the unsettled days
-  // at the end, which the projection leaves out and the line still draws.
-  const windowDays = Math.min(series.length, Math.max(current, MIN_WINDOW_DAYS));
-  const highlight = { count: windowDays, color: "#c7ccd4" };
-  // The inclusive day span the line covers, for the tile's duration slot.
-  return { chart: sparkline(series, "#727882", highlight, SPARK_FADE[status]), spanMs: end - start + 86_400_000 };
+}
+
+function summarizeDaily(
+  byDay: Map<string, number>,
+  now: Date,
+  lagDays: number,
+  measuredMtd?: number,
+  priorMonthDaily?: number[],
+): Omit<DailySpend, "byDay"> {
+  const year = now.getUTCFullYear();
+  const month0 = now.getUTCMonth();
+  const dayOfMonth = now.getUTCDate();
+  const thisMonth = calendarMonth(byDay, year, month0);
+  const dailyMtd = thisMonth.reduce((sum, amount) => sum + amount, 0);
+  const mtd = measuredMtd ?? dailyMtd;
+  const coveredThis = settled(thisMonth, dayOfMonth, lagDays).length;
+  const previousMonth = month0 === 0 ? 11 : month0 - 1;
+  const previousYear = month0 === 0 ? year - 1 : year;
+  const previous = calendarMonth(byDay, previousYear, previousMonth);
+  const lastMonthDaily = priorMonthDaily ??
+    settled(
+      previous,
+      previous.length + dayOfMonth,
+      lagDays,
+    );
+  const daysInMonth = new Date(Date.UTC(year, month0 + 1, 0)).getUTCDate();
+  return {
+    mtd,
+    projected: projectMonthly(
+      mtd,
+      coveredThis,
+      daysInMonth,
+      lastMonthDaily,
+    ),
+  };
+}
+
+class GitHubUsageShapeError extends Error {}
+
+async function githubDollarSpend(
+  token: string,
+  org: string,
+  now: Date,
+): Promise<GitHubDollarSpend> {
+  const year = now.getUTCFullYear();
+  const month0 = now.getUTCMonth();
+  const dayOfMonth = now.getUTCDate();
+  const report = await github<{ usageItems?: UsageItem[] }>(
+    usagePath(org, year, month0 + 1),
+    token,
+  );
+  if (!Array.isArray(report.usageItems)) {
+    throw new GitHubUsageShapeError("billing usage unavailable");
+  }
+
+  const current = actionsOf(report);
+  const mtd = current.reduce(
+    (sum, item) => sum + (Number(item.netAmount) || 0),
+    0,
+  );
+  const byDay = new Map<string, number>();
+  addGitHubDays(byDay, current);
+  let priorMonthDaily: number[] = [];
+  let immediatePrior = true;
+  let remaining = SPARK_DAYS - dayOfMonth;
+  let previousYear = year;
+  let previousMonth = month0;
+  while (remaining > 0) {
+    previousMonth--;
+    if (previousMonth < 0) {
+      previousMonth = 11;
+      previousYear--;
+    }
+    try {
+      const previous = await github<{ usageItems?: UsageItem[] }>(
+        usagePath(org, previousYear, previousMonth + 1),
+        token,
+      );
+      if (Array.isArray(previous.usageItems)) {
+        const previousItems = actionsOf(previous);
+        addGitHubDays(byDay, previousItems);
+        if (immediatePrior) {
+          const previousSeries = calendarMonth(
+            byDay,
+            previousYear,
+            previousMonth,
+          );
+          priorMonthDaily = settled(
+            previousSeries,
+            previousSeries.length + dayOfMonth,
+            GITHUB_LAG_DAYS,
+          );
+        }
+      }
+    } catch {
+      // A missing prior month shortens the chart and leaves current billing usable.
+    }
+    remaining -= new Date(
+      Date.UTC(previousYear, previousMonth + 1, 0),
+    ).getUTCDate();
+    immediatePrior = false;
+  }
+
+  let budget = NaN;
+  try {
+    const response = await github<{ budgets?: Budget[] }>(
+      `organizations/${org}/settings/billing/budgets`,
+      token,
+    );
+    const actions = (response.budgets ?? []).find((entry) =>
+      String(entry.budget_product_sku).toLowerCase() === "actions"
+    );
+    if (actions && Number.isFinite(Number(actions.budget_amount))) {
+      budget = Number(actions.budget_amount);
+    }
+  } catch {
+    // An unset GitHub budget leaves the spend projection uncompared.
+  }
+
+  return {
+    kind: "dollars",
+    byDay,
+    ...summarizeDaily(
+      byDay,
+      now,
+      GITHUB_LAG_DAYS,
+      mtd,
+      priorMonthDaily,
+    ),
+    budget,
+  };
+}
+
+async function githubSpend(
+  token: string,
+  org: string,
+  now: Date,
+): Promise<GitHubSpend> {
+  try {
+    return await githubDollarSpend(token, org, now);
+  } catch (error) {
+    if (error instanceof GitHubUsageShapeError) throw error;
+    const billing = await github<ActionsBilling>(
+      `orgs/${org}/settings/billing/actions`,
+      token,
+    );
+    return {
+      kind: "minutes",
+      used: Number(billing.total_minutes_used) || 0,
+      included: Number(billing.included_minutes) || 0,
+      paid: Number(billing.total_paid_minutes_used) || 0,
+    };
+  }
+}
+
+function parseBlacksmithDaily(
+  response: BlacksmithDailyResponse,
+): Map<string, number> {
+  if (!Array.isArray(response.daily_metrics)) {
+    throw new Error("Blacksmith daily costs have an unexpected shape");
+  }
+  const byDay = new Map<string, number>();
+  for (const entry of response.daily_metrics) {
+    const day = dayKey(entry.date);
+    const cost = finiteNumber(entry.cost);
+    if (!day || cost === null || cost < 0) {
+      throw new Error("Blacksmith daily costs have an unexpected shape");
+    }
+    addDaily(byDay, day, cost);
+  }
+  return byDay;
+}
+
+function parseBlacksmithFootprint(
+  response: BlacksmithStickyDailyResponse,
+): Map<string, number> {
+  if (
+    !Array.isArray(response.dockerfile) || !Array.isArray(response.stickydisk)
+  ) {
+    throw new Error("Blacksmith storage usage has an unexpected shape");
+  }
+  const byDay = new Map<string, number>();
+  for (const entries of [response.dockerfile, response.stickydisk]) {
+    for (const entry of entries) {
+      const day = dayKey(entry.date);
+      const bytes = finiteNumber(entry.value);
+      if (!day || bytes === null || bytes < 0) {
+        throw new Error("Blacksmith storage usage has an unexpected shape");
+      }
+      addDaily(byDay, day, bytes);
+    }
+  }
+  return byDay;
+}
+
+function parseBlacksmithInvoice(response: unknown): number {
+  let amount: unknown = response;
+  if (response && typeof response === "object") {
+    const invoice = response as Record<string, unknown>;
+    if (
+      "currency" in invoice &&
+      (typeof invoice.currency !== "string" ||
+        invoice.currency.toUpperCase() !== "USD")
+    ) {
+      throw new Error("Blacksmith invoice amount has an unexpected shape");
+    }
+    amount = invoice.amount;
+  }
+  const parsed = finiteNumber(amount);
+  if (parsed === null || parsed < 0) {
+    throw new Error("Blacksmith invoice amount has an unexpected shape");
+  }
+  return parsed;
+}
+
+function parseBlacksmithBudget(response: unknown): number {
+  if (response === null || response === undefined) return NaN;
+  let threshold: unknown = response;
+  if (typeof response === "object") {
+    const settings = response as Record<string, unknown>;
+    if (!("threshold" in settings) && !("email_alert_threshold" in settings)) {
+      throw new Error("Blacksmith spending threshold has an unexpected shape");
+    }
+    threshold = settings.threshold ?? settings.email_alert_threshold;
+  }
+  if (threshold === null || threshold === undefined) return NaN;
+  const parsed = finiteNumber(threshold);
+  if (parsed === null || parsed < 0) {
+    throw new Error("Blacksmith spending threshold has an unexpected shape");
+  }
+  return parsed;
+}
+
+function calendarDays(start: Date, end: Date): string[] {
+  const days: string[] = [];
+  const first = Date.UTC(
+    start.getUTCFullYear(),
+    start.getUTCMonth(),
+    start.getUTCDate(),
+  );
+  const last = Date.UTC(
+    end.getUTCFullYear(),
+    end.getUTCMonth(),
+    end.getUTCDate(),
+  );
+  for (let time = first; time <= last; time += DAY_MS) {
+    days.push(new Date(time).toISOString().slice(0, 10));
+  }
+  return days;
+}
+
+function monthSegments(start: Date, end: Date): Array<{
+  start: Date;
+  end: Date;
+}> {
+  const segments: Array<{ start: Date; end: Date }> = [];
+  let cursor = new Date(start);
+  while (cursor <= end) {
+    const nextMonth = Date.UTC(
+      cursor.getUTCFullYear(),
+      cursor.getUTCMonth() + 1,
+      1,
+    );
+    const segmentEnd = new Date(Math.min(end.getTime(), nextMonth - 1));
+    segments.push({ start: new Date(cursor), end: segmentEnd });
+    cursor = new Date(nextMonth);
+  }
+  return segments;
+}
+
+function addAllocatedStorage(
+  target: Map<string, number>,
+  footprint: Map<string, number>,
+  start: Date,
+  end: Date,
+  totalCost: number,
+): void {
+  const days = calendarDays(start, end);
+  if (days.length === 0 || totalCost === 0) return;
+  const totalWeight = days.reduce(
+    (sum, day) => sum + (footprint.get(day) ?? 0),
+    0,
+  );
+  for (const day of days) {
+    const share = totalWeight > 0
+      ? (footprint.get(day) ?? 0) / totalWeight
+      : 1 / days.length;
+    addDaily(target, day, totalCost * share);
+  }
+}
+
+async function blacksmithSpend(
+  client: BlacksmithClient,
+  org: string,
+  now: Date,
+  readProviderBudget: boolean,
+): Promise<BlacksmithSpend> {
+  const today = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+  );
+  const end = new Date(today - 1);
+  const start = new Date(today - SPARK_DAYS * DAY_MS);
+  const segments = monthSegments(start, end);
+  const [daily, stickyDaily, stickyTotals, invoice, threshold] = await Promise
+    .all([
+      client.get<BlacksmithDailyResponse>(
+        blacksmithRoutes.daily(org, start, end),
+      ),
+      client.get<BlacksmithStickyDailyResponse>(
+        blacksmithRoutes.stickyDaily(org, start, end),
+      ),
+      Promise.all(
+        segments.map((segment) =>
+          client.get<BlacksmithStickyTotalResponse>(
+            blacksmithRoutes.stickyTotal(org, segment.start, segment.end),
+          )
+        ),
+      ),
+      client.get<unknown>(blacksmithRoutes.invoiceAmount(org)),
+      readProviderBudget
+        ? client.get<unknown>(blacksmithRoutes.spendingThreshold(org))
+        : Promise.resolve(undefined),
+    ]);
+  const compute = parseBlacksmithDaily(daily);
+  const footprint = parseBlacksmithFootprint(stickyDaily);
+  for (const [index, response] of stickyTotals.entries()) {
+    const totalCost = finiteNumber(response.total_cost);
+    if (totalCost === null || totalCost < 0) {
+      throw new Error("Blacksmith storage cost has an unexpected shape");
+    }
+    const segment = segments[index];
+    addAllocatedStorage(
+      compute,
+      footprint,
+      segment.start,
+      segment.end,
+      totalCost,
+    );
+  }
+  const measuredMtd = parseBlacksmithInvoice(invoice);
+  return {
+    byDay: compute,
+    ...summarizeDaily(
+      compute,
+      now,
+      PROVIDER_LAG_DAYS,
+      measuredMtd,
+    ),
+    budget: parseBlacksmithBudget(threshold),
+  };
+}
+
+function spendChart(
+  sources: Array<{
+    spend: DailySpend | null;
+    color: string;
+  }>,
+  now: Date,
+  status: Status,
+): { chart: string; duration: number } {
+  const allDays = new Set<string>();
+  for (const source of sources) {
+    if (source.spend) {
+      for (const day of source.spend.byDay.keys()) allDays.add(day);
+    }
+  }
+  if (allDays.size < 2) return { chart: "", duration: 0 };
+  const sorted = [...allDays].sort();
+  const timeOf = (day: string) => Date.parse(`${day}T00:00:00Z`);
+  const end = timeOf(sorted[sorted.length - 1]);
+  const start = Math.max(timeOf(sorted[0]), end - (SPARK_DAYS - 1) * DAY_MS);
+  const grid: string[] = [];
+  for (let time = start; time <= end; time += DAY_MS) {
+    grid.push(new Date(time).toISOString().slice(0, 10));
+  }
+  const lines = sources.flatMap((source) =>
+    source.spend
+      ? [{
+        vals: grid.map((day) => source.spend!.byDay.get(day) ?? 0),
+        color: source.color,
+        label: usd(source.spend.mtd),
+      }]
+      : []
+  );
+  const monthStart = `${now.getUTCFullYear()}-${
+    String(now.getUTCMonth() + 1).padStart(2, "0")
+  }-01`;
+  const currentDays = grid.filter((day) => day >= monthStart).length;
+  const windowDays = Math.min(
+    grid.length,
+    Math.max(currentDays, MIN_WINDOW_DAYS),
+  );
+  return {
+    chart: multiSparkline(lines, {
+      fadeFrom: SPARK_FADE[status],
+      highlight: { count: windowDays },
+    }),
+    duration: end - start + DAY_MS,
+  };
+}
+
+function minutesView(
+  org: string,
+  spend: GitHubMinuteSpend,
+): TileView {
+  const fraction = spend.included > 0 ? spend.used / spend.included : 0;
+  const status: Status = spend.paid > 0 || fraction >= 1
+    ? "bad"
+    : fraction >= 0.8
+    ? "warn"
+    : "good";
+  return {
+    label: "ci spend",
+    status,
+    value: `${spend.paid} paid min`,
+    sub: `${spend.used} / ${spend.included} min · MTD`,
+    href: `https://github.com/organizations/${org}/settings/billing`,
+    hint: "billing ↗",
+  };
+}
+
+function unavailableMessage(error: unknown): string {
+  if (error instanceof GitHubUsageShapeError) return error.message;
+  if (!(error instanceof Error)) return "CI spend unavailable";
+  if (error.message === "Blacksmith API token rejected") {
+    return "check BLACKSMITH_API_TOKEN";
+  }
+  if (error.message.includes("BLACKSMITH_API_URL")) {
+    return "check BLACKSMITH_API_URL";
+  }
+  return friendlyError(error.message);
 }
 
 export const githubCiSpend: Tile = {
@@ -148,113 +608,161 @@ export const githubCiSpend: Tile = {
   async collect(ctx): Promise<TileView> {
     const label = "ci spend";
     const token = ctx.env("GH_TOKEN") ?? ctx.env("GITHUB_TOKEN");
-    if (!token) {
-      return { label, status: "unknown", value: "—", sub: "set GH_TOKEN (needs org billing read)" };
-    }
-    const org = ctx.env("GH_BILLING_ORG") ?? REPO.split("/")[0];
-    // The whole tile drills through to this org's GitHub billing settings.
-    const drill = {
-      href: `https://github.com/organizations/${org}/settings/billing`,
-      hint: "billing ↗",
-    };
-    const now = new Date();
-    const year = now.getUTCFullYear();
-    const month0 = now.getUTCMonth();
-    const dayOfMonth = now.getUTCDate();
-
-    try {
-      const report = await github<{ usageItems?: UsageItem[] }>(usagePath(org, year, month0 + 1), token);
-      // A 200 without a well-formed usageItems array (e.g. a permission-filtered
-      // view) must not read as a real $0 — gray out instead.
-      if (!Array.isArray(report.usageItems)) {
-        return { ...drill, label, status: "unknown", value: "—", sub: "billing usage unavailable" };
-      }
-      const items = actionsOf(report);
-      const mtd = sumNet(items);
-      // The days of this month whose billing has settled. The projection divides by
-      // these, so a quiet weekend counts and the days still to settle do not. Every
-      // day carrying spend is settled by construction, so the month-to-date total is
-      // the spend over exactly these days and stays the numerator.
-      const coveredThis = settled(monthSeries(items, year, month0), dayOfMonth, GITHUB_LAG_DAYS).length;
-      const daysInMonth = new Date(Date.UTC(year, month0 + 1, 0)).getUTCDate();
-
-      // Daily billable spend keyed by calendar day, across this month plus enough
-      // prior months to fill the ~45-day sparkline. The immediate prior month's
-      // daily series also feeds the projection when this month is under two weeks
-      // old.
-      const byDay = new Map<string, number>();
-      const addDays = (its: UsageItem[]) => {
-        for (const i of its) {
-          const d = i.date.slice(0, 10);
-          byDay.set(d, (byDay.get(d) ?? 0) + (Number(i.netAmount) || 0));
-        }
-      };
-      addDays(items);
-      let lastMonthDaily: number[] = [];
-      let remaining = SPARK_DAYS - now.getUTCDate(); // days needed before this month
-      let py = year, pm = month0; // step back month by month
-      let firstPrior = true;
-      while (remaining > 0) {
-        pm -= 1;
-        if (pm < 0) {
-          pm = 11;
-          py -= 1;
-        }
-        try {
-          const prev = await github<{ usageItems?: UsageItem[] }>(usagePath(org, py, pm + 1), token);
-          const its = actionsOf(prev);
-          addDays(its);
-          // Settled like this month: early in a month the borrowed tail is the part
-          // most likely not to have settled, and taking those days as real zeros
-          // would rate the whole window near zero. Its days have had this month's
-          // elapsed days on top of their own to settle.
-          if (firstPrior) {
-            const prev = monthSeries(its, py, pm);
-            lastMonthDaily = settled(prev, prev.length + dayOfMonth, GITHUB_LAG_DAYS);
-          }
-        } catch { /* a prior month is unavailable — the window just covers less */ }
-        remaining -= new Date(Date.UTC(py, pm + 1, 0)).getUTCDate();
-        firstPrior = false;
-      }
-      const projected = projectMonthly(mtd, coveredThis, daysInMonth, lastMonthDaily);
-
-      // The org's Actions budget is configured in GitHub (Settings -> Billing ->
-      // Budgets) and read here; it is the only source for the budget.
-      let budget = NaN;
-      try {
-        const b = await github<{ budgets?: Budget[] }>(`organizations/${org}/settings/billing/budgets`, token);
-        const actions = (b.budgets ?? []).find((x) => String(x.budget_product_sku).toLowerCase() === "actions");
-        if (actions && Number.isFinite(Number(actions.budget_amount))) budget = Number(actions.budget_amount);
-      } catch { /* no GitHub budget available; leave it unset */ }
-
-      const status = budgetStatus(projected, budget);
-      const spark = dailySparkline(byDay, year, month0, status);
+    const blacksmithToken = ctx.env("BLACKSMITH_API_TOKEN")?.trim();
+    if (!token && !blacksmithToken) {
       return {
-        ...drill,
         label,
-        status,
-        value: `~${usd(projected)}/mo`,
-        // MTD in the header aside; the budget (when GitHub has one) in the sub; the
-        // span the sparkline covers goes to the tile's duration slot.
-        aside: `<span class="hmtd">${usd(mtd)} MTD</span>`,
-        sub: Number.isFinite(budget) ? `${usd(budget)} budget` : undefined,
-        extra: spark.chart,
-        duration: spark.spanMs,
+        status: "unknown",
+        value: "—",
+        sub: "set GH_TOKEN (needs org billing read) / BLACKSMITH_API_TOKEN",
       };
-    } catch {
-      // Classic endpoint (minutes, no dollars) for orgs not on the enhanced platform.
-      try {
-        const b = await github<ActionsBilling>(`orgs/${org}/settings/billing/actions`, token);
-        const used = Number(b.total_minutes_used) || 0;
-        const included = Number(b.included_minutes) || 0;
-        const paid = Number(b.total_paid_minutes_used) || 0;
-        const frac = included > 0 ? used / included : 0;
-        const status: Status = paid > 0 || frac >= 1 ? "bad" : frac >= 0.8 ? "warn" : "good";
-        return { ...drill, label, status, value: `${paid} paid min`, sub: `${used} / ${included} min · MTD` };
-      } catch (classicErr) {
-        const msg = classicErr instanceof Error ? classicErr.message : String(classicErr);
-        return { ...drill, label, status: "unknown", value: "—", sub: friendlyError(msg) };
-      }
     }
+
+    const githubOrg = ctx.env("GH_BILLING_ORG") ?? REPO.split("/")[0];
+    const combinedBudgetRaw = ctx.env("CI_MONTHLY_BUDGET");
+    const hasCombinedBudget = combinedBudgetRaw !== undefined &&
+      combinedBudgetRaw.trim() !== "";
+    const now = new Date();
+    const [githubResult, blacksmithResult] = await Promise.all([
+      token
+        ? githubSpend(token, githubOrg, now).catch((error) => ({ error }))
+        : Promise.resolve(null),
+      blacksmithToken
+        ? (async () => {
+          const client = BlacksmithClient.fromEnvironment(ctx.env);
+          if (!client) throw new Error("Blacksmith API token unavailable");
+          const org = ctx.env("BLACKSMITH_ORG") ??
+            ctx.env("GH_BILLING_ORG") ?? REPO.split("/")[0];
+          return await blacksmithSpend(client, org, now, !hasCombinedBudget);
+        })().catch((error) => ({ error }))
+        : Promise.resolve(null),
+    ]);
+
+    const githubError = githubResult && "error" in githubResult
+      ? githubResult.error
+      : null;
+    const blacksmithError = blacksmithResult && "error" in blacksmithResult
+      ? blacksmithResult.error
+      : null;
+    const githubValue = githubResult && !("error" in githubResult)
+      ? githubResult
+      : null;
+    const blacksmithValue = blacksmithResult && !("error" in blacksmithResult)
+      ? blacksmithResult
+      : null;
+
+    if (
+      githubValue?.kind === "minutes" && !blacksmithToken &&
+      !blacksmithError
+    ) {
+      return minutesView(githubOrg, githubValue);
+    }
+
+    const githubDollars = githubValue?.kind === "dollars" ? githubValue : null;
+    const present = [githubDollars, blacksmithValue].filter(
+      (spend): spend is GitHubDollarSpend | BlacksmithSpend => spend !== null,
+    );
+    const combinedBudget = readBudget(combinedBudgetRaw);
+    const githubBudget = githubDollars?.budget ?? NaN;
+    const blacksmithBudget = blacksmithValue?.budget ?? NaN;
+    const providerBudget = token && blacksmithToken
+      ? Number.isFinite(githubBudget) && Number.isFinite(blacksmithBudget)
+        ? githubBudget + blacksmithBudget
+        : NaN
+      : token
+      ? githubBudget
+      : blacksmithBudget;
+    const budget = hasCombinedBudget ? combinedBudget : providerBudget;
+    const swatch = (color: string) =>
+      `<span class="swatch" style="background:${color}"></span>`;
+    const legendItem = (
+      configured: boolean,
+      spend: DailySpend | null,
+      name: string,
+      color: string,
+      charted: boolean,
+    ): string[] => {
+      if (!configured) return [];
+      if (!spend) return [`${swatch(color)} ${name} $???`];
+      const amount = charted ? "" : ` ${usd(spend.mtd)}`;
+      return [`${swatch(color)} ${name}${amount}`];
+    };
+    const legend = (charted: boolean): string =>
+      `<p class="sub">${
+        [
+          ...legendItem(
+            Boolean(token),
+            githubDollars,
+            "GitHub",
+            GITHUB_COLOR,
+            charted,
+          ),
+          ...legendItem(
+            Boolean(blacksmithToken),
+            blacksmithValue,
+            "Blacksmith",
+            BLACKSMITH_COLOR,
+            charted,
+          ),
+          `Budget ${Number.isFinite(budget) ? usd(budget) : "$???"}`,
+        ].join(" • ")
+      }</p>`;
+    if (present.length === 0) {
+      const error = githubError ?? blacksmithError;
+      return {
+        ...(token && !blacksmithToken
+          ? {
+            href:
+              `https://github.com/organizations/${githubOrg}/settings/billing`,
+            hint: "billing ↗",
+          }
+          : {}),
+        label,
+        status: "unknown",
+        value: "—",
+        sub: unavailableMessage(error),
+        extra: legend(false),
+      };
+    }
+
+    const complete = !(
+      (token && !githubDollars) ||
+      (blacksmithToken && !blacksmithValue)
+    );
+    const totalMtd = present.reduce((sum, spend) => sum + spend.mtd, 0);
+    const totalProjected = present.reduce(
+      (sum, spend) => sum + spend.projected,
+      0,
+    );
+    const status: Status = complete
+      ? budgetStatus(totalProjected, budget)
+      : "unknown";
+    const chart = spendChart(
+      [
+        { spend: githubDollars, color: GITHUB_COLOR },
+        { spend: blacksmithValue, color: BLACKSMITH_COLOR },
+      ],
+      now,
+      status,
+    );
+
+    const drill = token && !blacksmithToken
+      ? {
+        href: `https://github.com/organizations/${githubOrg}/settings/billing`,
+        hint: "billing ↗",
+      }
+      : !token && blacksmithToken
+      ? { href: "https://app.blacksmith.sh/", hint: "billing ↗" }
+      : {};
+
+    return {
+      ...drill,
+      label,
+      status,
+      value: `${complete ? "~" : "≥"}${usd(totalProjected)}/mo`,
+      aside: `<span class="hmtd">${usd(totalMtd)} MTD</span>`,
+      extra: `${legend(Boolean(chart.chart))}${chart.chart}`,
+      duration: chart.duration,
+    };
   },
 };


### PR DESCRIPTION
The CI spend tile reported only GitHub Actions billing, so moving workloads to Blacksmith made the dashboard understate both current and projected CI cost.

Add a Blacksmith client authenticated by the long-lived bearer token accepted by the CLI. Use the invoice amount for authoritative month-to-date spend, daily runner and sticky-disk metrics for history and projection, and the spending-alert threshold for the provider budget. Required billing reads fail closed, while an explicit combined CI budget avoids the unused provider-threshold request.

Combine GitHub and Blacksmith in one projection, month-to-date header, chart, and colored provider-and-budget legend. Omit unconfigured providers, retain unknown markers for failed configured sources or budgets, and preserve the combined line even when every provider is unavailable.

Preserve the GitHub collector semantics while sharing the projection machinery: unavailable prior-month history shortens the early-month rate window instead of becoming zero spend, and current Actions rows remain in month-to-date totals even when an invalid date keeps them out of the chart.

Document the deployment secret and CLI credential behavior, remove browser-session rotation and caching, and cover authentication, route construction, storage allocation, budget selection, incomplete history, partial failures, and rendered legend states.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787424131&installation_model_id=428580&pr_number=4953&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4953&signature=c3c1c12100a1e7fafc8ce7ffe1d14deb18371a7a5cf63a613e6cf9b21305f507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Blacksmith to the CI spend tile and combines it with GitHub Actions into one projection, shared 45‑day chart, and legend. Updates the scheduler to skip only already‑running work, keep publish order on simultaneous completions, and gray stalled updates after one minute.

- **New Features**
  - Combined GitHub + Blacksmith CI spend with a shared 45‑day chart and colored legend; per‑provider MTD labels; combined MTD in the header.
  - Blacksmith client authenticated via `BLACKSMITH_API_TOKEN`; supports `BLACKSMITH_ORG` and `BLACKSMITH_API_URL`. Handles invoice‑only months and links to billing.
  - Budgeting: `CI_MONTHLY_BUDGET` overrides; else use provider budgets (GitHub Actions budget; Blacksmith spending‑alert threshold). Sum only when both exist.
  - Failure handling: omit unconfigured providers; show `$???` for failed ones; keep a gray lower‑bound combined value and preserve the line even if all providers fail.
  - GitHub semantics kept: prior‑month gaps shorten the early‑month window; classic plan still falls back to minutes.

- **Migration**
  - Set `BLACKSMITH_API_TOKEN` (from the CLI bearer token). Optional: `BLACKSMITH_ORG`, `BLACKSMITH_API_URL`, `CI_MONTHLY_BUDGET`.
  - Ensure `GH_TOKEN` has org billing read for GitHub spend.

<sup>Written for commit a7a0a22d500eaa047b5d2fb3676c34dad7d54695. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

