### PR TITLE
perf(schema-generator): deep-freeze each schema as it is formatted

### DIFF
--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -285,7 +285,12 @@ export class CommonFabricFormatter implements TypeFormatter {
               ? { not: true, default: defaultValue }
               : { default: defaultValue }) as JSONSchemaObjMutable;
           }
-          (valueSchema as Record<string, unknown>).default = defaultValue;
+          // Rebuild rather than mutate: `valueSchema` is a formatted
+          // sub-schema and is deep-frozen.
+          return {
+            ...(valueSchema as Record<string, unknown>),
+            default: defaultValue,
+          } as JSONSchemaObjMutable;
         }
       }
 
@@ -957,7 +962,12 @@ export class CommonFabricFormatter implements TypeFormatter {
           ? { not: true, default: defaultValue }
           : { default: defaultValue }) as JSONSchemaObjMutable;
       }
-      (valueSchema as any).default = defaultValue;
+      // Rebuild rather than mutate: `valueSchema` is a formatted sub-schema and
+      // is deep-frozen.
+      return {
+        ...(valueSchema as Record<string, unknown>),
+        default: defaultValue,
+      } as JSONSchemaObjMutable;
     }
 
     return valueSchema;

--- a/packages/schema-generator/src/formatters/intersection-formatter.ts
+++ b/packages/schema-generator/src/formatters/intersection-formatter.ts
@@ -194,8 +194,12 @@ export class IntersectionFormatter implements TypeFormatter {
                 const priorComment = typeof existing.$comment === "string"
                   ? existing.$comment as string
                   : undefined;
-                (existing as Record<string, unknown>).$comment = priorComment ??
-                  DOC_CONFLICT_COMMENT;
+                // `existing` is a formatted property schema and is deep-frozen;
+                // store an updated copy rather than mutating it.
+                mergedProps[key] = {
+                  ...(existing as Record<string, unknown>),
+                  $comment: priorComment ?? DOC_CONFLICT_COMMENT,
+                } as JSONSchemaObjMutable;
                 logger.warn(
                   "schema-gen",
                   () => `Intersection doc conflict for '${key}'; using first`,
@@ -270,8 +274,16 @@ export class IntersectionFormatter implements TypeFormatter {
       missingSources: string[];
     },
   ): JSONSchemaObjMutable {
-    const { schema, docTexts, documentedSources, missingSources } = data;
-    if (!isRecord(schema)) return schema;
+    const {
+      schema: originalSchema,
+      docTexts,
+      documentedSources,
+      missingSources,
+    } = data;
+    if (!isRecord(originalSchema)) return originalSchema;
+    // `originalSchema` is a formatted schema and is deep-frozen; the doc
+    // attachments below mutate, so work on a mutable shallow copy.
+    const schema = { ...originalSchema } as JSONSchemaObjMutable;
 
     const uniqueDocTexts = docTexts.filter((doc, index, arr) =>
       arr.indexOf(doc) === index

--- a/packages/schema-generator/src/formatters/object-formatter.ts
+++ b/packages/schema-generator/src/formatters/object-formatter.ts
@@ -294,7 +294,7 @@ export class ObjectFormatter implements TypeFormatter {
       }
 
       // Delegate to the main generator (specific formatters handle wrappers/defaults)
-      const generated = this.schemaGenerator.formatChildType(
+      let generated = this.schemaGenerator.formatChildType(
         resolvedPropType,
         context,
         propTypeNode,
@@ -302,6 +302,9 @@ export class ObjectFormatter implements TypeFormatter {
       // Attach property description from JSDoc (if any)
       const { text, all } = extractDocFromSymbolAndDecls(prop, checker);
       if (text && isRecord(generated)) {
+        // `generated` is a formatted sub-schema and is deep-frozen; attach to a
+        // mutable shallow copy.
+        generated = { ...generated };
         const conflicts = all.filter((s) => s && s !== text);
         (generated as Record<string, unknown>).description = text;
         attachDocTags(generated as Record<string, unknown>, text);
@@ -336,7 +339,7 @@ export class ObjectFormatter implements TypeFormatter {
     const numberIndex = checker.getIndexTypeOfType(type, ts.IndexKind.Number);
     const chosenIndex = stringIndex ?? numberIndex;
     if (chosenIndex) {
-      const apSchema = this.schemaGenerator.formatChildType(
+      let apSchema = this.schemaGenerator.formatChildType(
         chosenIndex,
         context,
         undefined,
@@ -359,6 +362,8 @@ export class ObjectFormatter implements TypeFormatter {
         }
       }
       if (foundDocs.length > 0 && isRecord(apSchema)) {
+        // Frozen sub-schema; attach to a mutable shallow copy.
+        apSchema = { ...apSchema };
         (apSchema as Record<string, unknown>).description = foundDocs[0]!;
         attachDocTags(apSchema as Record<string, unknown>, foundDocs[0]!);
         if (foundDocs.length > 1) {

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 import { isRecord } from "@commonfabric/utils/types";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 
 import type {
   JSONSchemaMutable,
@@ -431,7 +432,13 @@ export class SchemaGenerator implements ISchemaGenerator {
     // Try to find a formatter that supports this type
     for (const formatter of this.formatters) {
       if (formatter.supportsType(type, context)) {
-        const result = formatter.formatType(type, context);
+        // Deep-freeze each formatted (sub)schema as it is produced. Generation
+        // is bottom-up, so a nested schema is frozen before any enclosing
+        // formatter composes or deduplicates it; the value model's hash cache
+        // is keyed on deep-frozen identity, so a frozen subtree is hashed once
+        // and then reused wherever it recurs. `deepFreeze` short-circuits on
+        // already-frozen input, so the bottom-up sweep stays cheap.
+        const result = deepFreeze(formatter.formatType(type, context));
 
         // If this is a named type (all-named policy), store in definitions.
         // We already computed namedKey above with wrapper checks, so reuse it.
@@ -666,16 +673,23 @@ export class SchemaGenerator implements ISchemaGenerator {
     type: ts.Type,
     context: GenerationContext,
   ): JSONSchemaMutable {
-    if (typeof schema !== "object") return schema;
+    if (typeof schema !== "object" || !isRecord(schema)) return schema;
 
     const docInfo = extractDocFromType(type, context.typeChecker);
-    if (docInfo.firstDoc && isRecord(schema) && !("description" in schema)) {
-      (schema as Record<string, unknown>).description = docInfo.firstDoc;
+    const addDescription = !!docInfo.firstDoc && !("description" in schema);
+    // `attachDocTags` runs whenever a string description is present -- either
+    // one we are about to add, or one already there.
+    if (!addDescription && typeof schema.description !== "string") {
+      return schema;
     }
-    if (isRecord(schema) && typeof schema.description === "string") {
-      attachDocTags(schema as Record<string, unknown>, schema.description);
+    // `schema` is a formatted schema and is deep-frozen; attach to a mutable
+    // shallow copy.
+    const out = { ...schema } as Record<string, unknown>;
+    if (addDescription) out.description = docInfo.firstDoc;
+    if (typeof out.description === "string") {
+      attachDocTags(out, out.description);
     }
-    return schema;
+    return out as JSONSchemaMutable;
   }
 
   /**

--- a/packages/schema-generator/test/frozen-output.test.ts
+++ b/packages/schema-generator/test/frozen-output.test.ts
@@ -1,0 +1,45 @@
+import { expect } from "@std/expect";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+
+import { createSchemaTransformerV2 } from "../src/plugin.ts";
+import { getTypeFromCode } from "./utils.ts";
+
+// The generator deep-freezes each schema as it is formatted, so a generated
+// schema -- and every subtree within it -- is immutable. This is what lets the
+// value model's frozen-object hash cache reuse a subtree's hash across the
+// repeated hashing that schema deduplication does, instead of recomputing it.
+
+async function generate(code: string, typeName = "S") {
+  const { type, checker } = await getTypeFromCode(code, typeName);
+  return createSchemaTransformerV2().generateSchema(type, checker);
+}
+
+Deno.test("generated schema is deep-frozen", async () => {
+  const schema = await generate(`
+    interface S {
+      a: string;
+      b: number;
+      c: { nested: boolean; items: string[] };
+    }
+  `);
+  expect(isDeepFrozen(schema)).toBe(true);
+});
+
+Deno.test("a generated default (a nested value) is frozen too", async () => {
+  const schema = await generate(`
+    import { Default } from "commonfabric";
+    interface S {
+      x: Default<{ a: number; b: number }, { a: 1; b: 2 }>;
+    }
+  `);
+  expect(isDeepFrozen(schema)).toBe(true);
+});
+
+Deno.test("a generated union schema is deep-frozen", async () => {
+  const schema = await generate(`
+    interface S {
+      u: { kind: "a"; n: number } | { kind: "b"; s: string };
+    }
+  `);
+  expect(isDeepFrozen(schema)).toBe(true);
+});


### PR DESCRIPTION
Pre-PR for the `dedupeByValueEqual` content-hash work on #4942. Deep-freezes
generated schemas early so the value model's frozen-object hash cache can reuse
subtree hashes during schema deduplication. Behavior-neutral; lands before
#4942.

## Why

`hashStringOf`'s object-hash cache is a `WeakMap` keyed on deep-frozen identity
— a frozen subtree is hashed once and reused by identity thereafter. Schema
generation currently freezes nothing, so its schemas are mutable, and every
schema hashed during dedup (and its nested content, when an enclosing schema is
hashed at an outer step) is re-hashed from scratch. Freezing subtrees as they
are produced turns that repeat hashing into cache hits.

The perf payoff is realized once #4942's hash-based `dedupeByValueEqual` lands
on top; this PR is the foundation, and freezing generated schemas is sound
hygiene on its own.

## What

- Each schema is deep-frozen the moment its formatter produces it, at the one
  choke point every (sub)schema flows through (`SchemaGenerator.formatType`,
  the recursive dispatch). Bottom-up generation means a nested schema is frozen
  before any enclosing formatter composes or deduplicates it. `deepFreeze`
  short-circuits already-frozen input, so the sweep stays cheap.

- Freezing forces the generator to stop mutating already-produced schemas. A
  handful of sites attached JSDoc metadata (`description`, `#tags`, `$comment`)
  or a `Default<>` value to a formatted **child** in place; each now attaches to
  a mutable shallow copy — same resulting object, different identity. The
  `normalizeSchemaForComparison` / `mergeSchemaGroup` builders that assemble a
  fresh local object were not touched.

## Behavior-neutral

Every schema-generator and ts-transformers golden is **byte-identical**,
verified by regenerating both with `UPDATE_GOLDENS=1` — zero churn.

## Performance — measured, and the payoff does not materialize

A direct A/B (best-of-3, same harness/machine, one moderately complex type,
2000 warmed `generateSchema` calls):

| state | µs/gen | vs main |
| --- | ---: | ---: |
| main (no freeze, `JSON.stringify` dedup) | 163.5 | — |
| freeze alone (this PR) | 173.4 | +6% |
| hash-dedup alone (#4942) | 177.4 | +8.5% |
| freeze + hash-dedup (stacked) | 186.0 | **+14%** |

The stacked case is **slower than either piece alone** — the freeze cost and the
hash-dedup cost simply add. If the frozen-subtree hash cache were paying off, the
stack would be *faster* than hash-dedup-alone; it is the opposite.

Why the cache does not help here: it is keyed on object *identity*, and
single-pass schema generation does not re-hash the same object. A generation-time
schema is hashed at most once (by the dedup), then walked once by `createSchemaAst`
to emit as an AST literal, then discarded — there is no in-process schema-reuse for
the cache to hit. (`packages/schema-generator/src` does no hashing of its own; the
runtime re-parses the emitted source into fresh objects, never the frozen ones.)
And `hashStringOf` (a content hash) is inherently pricier per call than a native
`JSON.stringify` for small schemas.

In absolute terms these are ~10–22µs deltas on `generateSchema`, itself well under
1% of real compile time, below the CI perf-check's wall-time noise floor. But the
measured direction is a small net **cost** with no realized benefit in this path,
so this PR's premise (freeze to speed the dedup) does not hold. See the discussion
thread for disposition.

## Testing

- schema-generator `47 passed`, ts-transformers `1105 passed`,
  `./tasks/check.sh` clean.
- New `frozen-output.test.ts` asserts a generated schema, a nested default, and
  a union schema are each `isDeepFrozen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4s5BjnzfVbJS6VVydhZPR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787426562&installation_model_id=428580&pr_number=4954&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4954&signature=f775386b46bb98f433f59850e4b756efdb3ef1bfa4bef78aaa1c203ec25e6506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deep-freeze each generated schema at format time to enable hash-cache reuse during deduplication and prep for hash-based `dedupeByValueEqual` (#4942). Output is unchanged; added tests assert schemas are deep-frozen.

- **Refactors**
  - Freeze every (sub)schema in `SchemaGenerator.formatType` via `deepFreeze` from `@commonfabric/data-model/deep-freeze`.
  - Stop mutating formatted children; clone before adding `description`, doc tags, `$comment`, or `default`.
  - Updated `common-fabric-formatter`, `intersection-formatter`, and `object-formatter`.
  - New `frozen-output.test.ts` verifies root, nested default, and union schemas are deep-frozen.

- **Performance**
  - Enables hash cache hits (keyed by deep-frozen identity) during schema dedup; forms the base for #4942’s content-hash dedupe.

<sup>Written for commit e86f62dbc85d80d091379b48237071a8783113e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



