### PR TITLE
fix(dashboard): preserve CI verdicts during reruns

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -178,6 +178,11 @@ surveillance tool.
 | dau | distinct identities active per UTC day on one named service, counted from the `user.did` attribute on the `memory.transact` and `memory.subscriber.sync` spans in SigNoz. The headline is the last day that ran to the end (today is still filling, and a part-day always reads as a drop); the sparkline is the retained history. Gray while the named service has no such spans — which is the resting state until a deployment's tracing is switched on. It counts keypairs rather than people; see [dau](#dau) below | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `DAU_EXCLUDE_DIDS`, `SIGNOZ_UI_URL` |
 | github users | organization members plus outside collaborators, with each roster's size charted over about two months. The headline counts unique users across both rosters | `GH_TOKEN` (with org Members read) |
 
+The **labs ci** and **loom ci** headlines use the most recent completed
+workflow attempt. While GitHub reruns a workflow, the prior attempt's conclusion
+remains visible and the tile marks the activity as **build rerunning**. A new
+workflow run still appears as **next build running**.
+
 ## Credentials
 
 Every tile that reads a private source is gated on its own env var(s) and grays

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -13,8 +13,15 @@ import {
   start,
   tick,
 } from "./server.ts";
-import { LOOM_CI_WORKFLOW, LOOM_REPO, PORT } from "./config.ts";
+import {
+  CI_WORKFLOW,
+  LOOM_CI_WORKFLOW,
+  LOOM_REPO,
+  PORT,
+  REPO,
+} from "./config.ts";
 import { TILES } from "./registry.ts";
+import { labsCi } from "./tiles/main-build.ts";
 import type { Ctx, Run, RunSource, Tile, TileView } from "./types.ts";
 
 const req = (path: string) => new Request(`http://localhost${path}`);
@@ -377,6 +384,47 @@ Deno.test("each run source publishes its dependent tiles as one batch", async ()
     loom.resolve([]);
     await refresh;
   }
+});
+
+Deno.test("a new source snapshot keeps the prior CI verdict during a rerun", async () => {
+  const failure = {
+    ...sourceRun(81, "failed build"),
+    conclusion: "failure",
+  };
+  const olderSuccess = sourceRun(82, "older passing build");
+  let runs = [failure, olderSuccess];
+  const sourceCtx: Ctx = {
+    runs: () => Promise.resolve(runs),
+    runsFor: (repo, workflow) => {
+      assertEquals(repo, REPO);
+      assertEquals(workflow, CI_WORKFLOW);
+      return Promise.resolve(runs);
+    },
+    env: () => undefined,
+  };
+  const tile = { ...labsCi, intervalMs: 0 };
+
+  await tick([tile], sourceCtx);
+  assertStringIncludes(
+    page(),
+    `<a class="tile bad link" data-tile-id="labs-ci"`,
+  );
+
+  runs = [{
+    ...failure,
+    status: "in_progress",
+    conclusion: null,
+    run_attempt: 2,
+    display_title: "rerun failed build",
+  }, olderSuccess];
+  await tick([tile], sourceCtx);
+  const rerunning = page();
+  assertStringIncludes(
+    rerunning,
+    `<a class="tile bad link" data-tile-id="labs-ci"`,
+  );
+  assertStringIncludes(rerunning, "failure");
+  assertStringIncludes(rerunning, "build rerunning");
 });
 
 Deno.test("a ready source publishes while an older combined collection is still running", async () => {

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -41,9 +41,11 @@ function ctx(
   };
 }
 
+let nextRunId = 1;
+
 function run(over: Partial<Run>): Run {
   return {
-    id: 1,
+    id: nextRunId++,
     status: "completed",
     conclusion: "success",
     run_attempt: 1,

--- a/packages/dashboard/tiles/main-build.test.ts
+++ b/packages/dashboard/tiles/main-build.test.ts
@@ -1,6 +1,10 @@
 // The main-build tile's streak: how long the tip conclusion has held on main.
 // Canned runs, no network. See tiles.test.ts for the rest of this tile's contract.
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import { LOOM_REPO, REPO } from "../config.ts";
 import type { Ctx, Run } from "../types.ts";
 import { labsCi, loomCi } from "./main-build.ts";
@@ -249,6 +253,43 @@ Deno.test("labs ci: an observed failure survives a rerun without another API res
   );
 });
 
+Deno.test("labs ci: a malformed required attempt is rejected", async () => {
+  const id = 60;
+  const active = run({
+    id,
+    status: "in_progress",
+    conclusion: null,
+    run_attempt: 2,
+    head_sha: "latest",
+    run_started_at: ago(5),
+  });
+  const malformed = run({
+    id,
+    status: "completed",
+    conclusion: null,
+    run_attempt: 1,
+    head_sha: "latest",
+    run_started_at: ago(30),
+  });
+  const olderSuccess = run({
+    id: 160,
+    conclusion: "success",
+    head_sha: "older",
+    run_started_at: ago(90),
+  });
+
+  await withGithubAttempt(malformed, async (urls) => {
+    await assertRejects(
+      () => labsCi.collect(ctx([active, olderSuccess])),
+      Error,
+      `GitHub run ${id} attempt 1 did not include a completed conclusion`,
+    );
+    assertEquals(urls, [
+      `https://api.github.com/repos/${REPO}/actions/runs/${id}/attempts/1`,
+    ]);
+  });
+});
+
 Deno.test("labs ci: a repeated failure keeps the streak from the prior attempt", async () => {
   const id = 52;
   const firstAttempt = run({
@@ -356,6 +397,38 @@ Deno.test("labs ci: a cold completed rerun backfills its prior result", async ()
       `https://api.github.com/repos/${REPO}/actions/runs/57/attempts/1`,
     ]);
   });
+});
+
+Deno.test("labs ci: an unavailable optional attempt preserves the known verdict", async () => {
+  const id = 61;
+  const secondAttempt = run({
+    id,
+    conclusion: "success",
+    run_attempt: 2,
+    head_sha: "latest",
+    run_started_at: ago(5),
+  });
+  const olderFailure = run({
+    id: 161,
+    conclusion: "failure",
+    head_sha: "older",
+    run_started_at: ago(90),
+  });
+
+  await withGithubAttempt(
+    new Error("attempt endpoint unavailable"),
+    async (urls) => {
+      const view = await labsCi.collect(
+        ctx([secondAttempt, olderFailure]),
+      );
+      assertEquals(view.status, "good");
+      assertEquals(view.value, "passing");
+      assertEquals(view.sub, "green for 5m");
+      assertEquals(urls, [
+        `https://api.github.com/repos/${REPO}/actions/runs/${id}/attempts/1`,
+      ]);
+    },
+  );
 });
 
 Deno.test("labs ci: a missed attempt breaks the cached streak", async () => {

--- a/packages/dashboard/tiles/main-build.test.ts
+++ b/packages/dashboard/tiles/main-build.test.ts
@@ -1,8 +1,9 @@
 // The main-build tile's streak: how long the tip conclusion has held on main.
 // Canned runs, no network. See tiles.test.ts for the rest of this tile's contract.
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { LOOM_REPO, REPO } from "../config.ts";
 import type { Ctx, Run } from "../types.ts";
-import { labsCi } from "./main-build.ts";
+import { labsCi, loomCi } from "./main-build.ts";
 
 function ctx(runs: Run[]): Ctx {
   return {
@@ -12,9 +13,11 @@ function ctx(runs: Run[]): Ctx {
   };
 }
 
+let nextRunId = 1;
+
 function run(over: Partial<Run>): Run {
   return {
-    id: 1,
+    id: nextRunId++,
     status: "completed",
     conclusion: "success",
     run_attempt: 1,
@@ -31,6 +34,420 @@ function run(over: Partial<Run>): Run {
 
 // Runs arrive newest-first, and the tile ages the streak off Date.now().
 const ago = (mins: number) => new Date(Date.now() - mins * 60_000).toISOString();
+
+async function withGithubAttempt(
+  response: Run | Error | ((url: string) => Run | Error),
+  body: (urls: string[]) => Promise<void>,
+): Promise<void> {
+  const urls: string[] = [];
+  const realFetch = globalThis.fetch;
+  const realToken = Deno.env.get("GH_TOKEN");
+  Deno.env.set("GH_TOKEN", "test-token");
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const url = input instanceof Request ? input.url : String(input);
+    urls.push(url);
+    const attempt = typeof response === "function"
+      ? response(url)
+      : response;
+    return attempt instanceof Error
+      ? Promise.reject(attempt)
+      : Promise.resolve(Response.json(attempt));
+  }) as typeof fetch;
+  try {
+    await body(urls);
+  } finally {
+    globalThis.fetch = realFetch;
+    if (realToken === undefined) Deno.env.delete("GH_TOKEN");
+    else Deno.env.set("GH_TOKEN", realToken);
+  }
+}
+
+Deno.test("labs and loom ci: an active rerun retains its last completed failure", async () => {
+  const cases = [
+    { tile: labsCi, repo: REPO, id: 41 },
+    { tile: loomCi, repo: LOOM_REPO, id: 42 },
+  ];
+  for (const { tile, repo, id } of cases) {
+    const active = run({
+      id,
+      status: "in_progress",
+      conclusion: null,
+      run_attempt: 2,
+      head_sha: "latest",
+      display_title: "retry the failed build",
+      run_started_at: ago(5),
+    });
+    const failure = run({
+      id,
+      conclusion: "failure",
+      run_attempt: 1,
+      head_sha: "latest",
+      run_started_at: ago(30),
+    });
+    const olderSuccess = run({
+      id: id + 100,
+      conclusion: "success",
+      head_sha: "older",
+      run_started_at: ago(90),
+    });
+
+    await withGithubAttempt(failure, async (urls) => {
+      const first = await tile.collect(ctx([active, olderSuccess]));
+      const second = await tile.collect(ctx([active, olderSuccess]));
+      assertEquals(first.status, "bad");
+      assertEquals(first.value, "failure");
+      assertStringIncludes(first.extra ?? "", "build rerunning");
+      assertEquals(second.status, "bad");
+      assertEquals(urls, [
+        `https://api.github.com/repos/${repo}/actions/runs/${id}/attempts/1`,
+      ]);
+    });
+  }
+});
+
+Deno.test("labs ci: an active rerun retains a success over an older failure", async () => {
+  const id = 43;
+  const active = run({
+    id,
+    status: "in_progress",
+    conclusion: null,
+    run_attempt: 2,
+    head_sha: "latest",
+    display_title: "verify the passing build",
+    run_started_at: ago(5),
+  });
+  const success = run({
+    id,
+    conclusion: "success",
+    run_attempt: 1,
+    head_sha: "latest",
+    run_started_at: ago(30),
+  });
+  const olderFailure = run({
+    id: 143,
+    conclusion: "failure",
+    head_sha: "older",
+    run_started_at: ago(90),
+  });
+
+  await withGithubAttempt(success, async () => {
+    const view = await labsCi.collect(ctx([active, olderFailure]));
+    assertEquals(view.status, "good");
+    assertEquals(view.value, "passing");
+    assertStringIncludes(view.extra ?? "", "build rerunning");
+  });
+});
+
+Deno.test("labs ci: a newer build does not hide the completed attempt of an older rerun", async () => {
+  const cases = [
+    {
+      runId: 44,
+      newRunId: 45,
+      conclusion: "failure",
+      olderConclusion: "success",
+      status: "bad",
+      value: "failure",
+    },
+    {
+      runId: 46,
+      newRunId: 47,
+      conclusion: "success",
+      olderConclusion: "failure",
+      status: "good",
+      value: "passing",
+    },
+  ] as const;
+
+  for (
+    const {
+      runId,
+      newRunId,
+      conclusion,
+      olderConclusion,
+      status,
+      value,
+    } of cases
+  ) {
+    const newBuild = run({
+      id: newRunId,
+      status: "in_progress",
+      conclusion: null,
+      run_attempt: 1,
+      run_started_at: ago(2),
+    });
+    const activeRerun = run({
+      id: runId,
+      status: "in_progress",
+      conclusion: null,
+      run_attempt: 2,
+      run_started_at: ago(5),
+    });
+    const completedAttempt = run({
+      id: runId,
+      conclusion,
+      run_attempt: 1,
+      run_started_at: ago(30),
+    });
+    const older = run({
+      id: runId + 100,
+      conclusion: olderConclusion,
+      run_started_at: ago(90),
+    });
+
+    await withGithubAttempt(completedAttempt, async (urls) => {
+      const view = await labsCi.collect(
+        ctx([newBuild, activeRerun, older]),
+      );
+      assertEquals(view.status, status);
+      assertEquals(view.value, value);
+      assertStringIncludes(view.extra ?? "", "next build running");
+      assertEquals(urls, [
+        `https://api.github.com/repos/${REPO}/actions/runs/${runId}/attempts/1`,
+      ]);
+    });
+  }
+});
+
+Deno.test("labs ci: an observed failure survives a rerun without another API result", async () => {
+  const id = 51;
+  const failure = run({
+    id,
+    conclusion: "failure",
+    run_attempt: 1,
+    head_sha: "latest",
+    run_started_at: ago(30),
+  });
+  const olderSuccess = run({
+    id: 151,
+    conclusion: "success",
+    head_sha: "older",
+    run_started_at: ago(90),
+  });
+  assertEquals(
+    (await labsCi.collect(ctx([failure, olderSuccess]))).status,
+    "bad",
+  );
+
+  await withGithubAttempt(
+    new Error("attempt endpoint unavailable"),
+    async (urls) => {
+      const active = run({
+        id,
+        status: "in_progress",
+        conclusion: null,
+        run_attempt: 2,
+        head_sha: "latest",
+        display_title: "retry the failed build",
+        run_started_at: ago(5),
+      });
+      const view = await labsCi.collect(ctx([active, olderSuccess]));
+      assertEquals(view.status, "bad");
+      assertEquals(view.value, "failure");
+      assertStringIncludes(view.extra ?? "", "build rerunning");
+      assertEquals(urls, []);
+    },
+  );
+});
+
+Deno.test("labs ci: a repeated failure keeps the streak from the prior attempt", async () => {
+  const id = 52;
+  const firstAttempt = run({
+    id,
+    conclusion: "failure",
+    run_attempt: 1,
+    head_sha: "latest",
+    run_started_at: ago(30),
+  });
+  const olderSuccess = run({
+    id: 152,
+    conclusion: "success",
+    head_sha: "older",
+    run_started_at: ago(90),
+  });
+  assertEquals(
+    (await labsCi.collect(ctx([firstAttempt, olderSuccess]))).sub,
+    "failure for 30m",
+  );
+
+  const secondAttempt = run({
+    id,
+    conclusion: "failure",
+    run_attempt: 2,
+    head_sha: "latest",
+    run_started_at: ago(5),
+  });
+  const view = await labsCi.collect(ctx([secondAttempt, olderSuccess]));
+  assertEquals(view.status, "bad");
+  assertEquals(view.sub, "failure for 30m");
+});
+
+Deno.test("labs ci: a new build preserves the prior run's attempt history", async () => {
+  const id = 55;
+  const firstAttempt = run({
+    id,
+    conclusion: "failure",
+    run_attempt: 1,
+    head_sha: "previous",
+    run_started_at: ago(60),
+  });
+  const olderSuccess = run({
+    id: 155,
+    conclusion: "success",
+    head_sha: "older",
+    run_started_at: ago(120),
+  });
+  await labsCi.collect(ctx([firstAttempt, olderSuccess]));
+
+  const secondAttempt = run({
+    id,
+    conclusion: "failure",
+    run_attempt: 2,
+    head_sha: "previous",
+    run_started_at: ago(30),
+  });
+  assertEquals(
+    (await labsCi.collect(ctx([secondAttempt, olderSuccess]))).sub,
+    "failure for 1h 0m",
+  );
+
+  const newBuild = run({
+    id: 56,
+    status: "in_progress",
+    conclusion: null,
+    run_attempt: 1,
+    head_sha: "latest",
+    run_started_at: ago(5),
+  });
+  const view = await labsCi.collect(
+    ctx([newBuild, secondAttempt, olderSuccess]),
+  );
+  assertEquals(view.status, "bad");
+  assertEquals(view.sub, "failure for 1h 0m");
+  assertStringIncludes(view.extra ?? "", "next build running");
+});
+
+Deno.test("labs ci: a cold completed rerun backfills its prior result", async () => {
+  const secondAttempt = run({
+    id: 57,
+    conclusion: "success",
+    run_attempt: 2,
+    head_sha: "latest",
+    run_started_at: ago(5),
+  });
+  const firstAttempt = run({
+    id: 57,
+    conclusion: "failure",
+    run_attempt: 1,
+    head_sha: "latest",
+    run_started_at: ago(30),
+  });
+  const olderSuccess = run({
+    id: 157,
+    conclusion: "success",
+    head_sha: "older",
+    run_started_at: ago(90),
+  });
+
+  await withGithubAttempt(firstAttempt, async (urls) => {
+    const view = await labsCi.collect(ctx([secondAttempt, olderSuccess]));
+    assertEquals(view.status, "good");
+    assertEquals(view.sub, "green for 5m");
+    assertEquals(urls, [
+      `https://api.github.com/repos/${REPO}/actions/runs/57/attempts/1`,
+    ]);
+  });
+});
+
+Deno.test("labs ci: a missed attempt breaks the cached streak", async () => {
+  const id = 58;
+  const firstAttempt = run({
+    id,
+    conclusion: "success",
+    run_attempt: 1,
+    head_sha: "latest",
+    run_started_at: ago(90),
+  });
+  const olderFailure = run({
+    id: 158,
+    conclusion: "failure",
+    head_sha: "older",
+    run_started_at: ago(180),
+  });
+  assertEquals(
+    (await labsCi.collect(ctx([firstAttempt, olderFailure]))).sub,
+    "green for 1h 30m",
+  );
+
+  const thirdAttempt = run({
+    id,
+    conclusion: "success",
+    run_attempt: 3,
+    head_sha: "latest",
+    run_started_at: ago(5),
+  });
+  const secondAttempt = run({
+    id,
+    conclusion: "failure",
+    run_attempt: 2,
+    head_sha: "latest",
+    run_started_at: ago(30),
+  });
+  await withGithubAttempt(secondAttempt, async (urls) => {
+    const view = await labsCi.collect(ctx([thirdAttempt, olderFailure]));
+    assertEquals(view.status, "good");
+    assertEquals(view.sub, "green for 5m");
+    assertEquals(urls, [
+      `https://api.github.com/repos/${REPO}/actions/runs/${id}/attempts/2`,
+    ]);
+  });
+});
+
+Deno.test("labs ci: a cold third attempt reconstructs its completed failure streak", async () => {
+  const id = 59;
+  const active = run({
+    id,
+    status: "in_progress",
+    conclusion: null,
+    run_attempt: 3,
+    head_sha: "latest",
+    run_started_at: ago(5),
+  });
+  const secondAttempt = run({
+    id,
+    conclusion: "failure",
+    run_attempt: 2,
+    head_sha: "latest",
+    run_started_at: ago(30),
+  });
+  const firstAttempt = run({
+    id,
+    conclusion: "failure",
+    run_attempt: 1,
+    head_sha: "latest",
+    run_started_at: ago(60),
+  });
+  const olderSuccess = run({
+    id: 159,
+    conclusion: "success",
+    head_sha: "older",
+    run_started_at: ago(120),
+  });
+
+  await withGithubAttempt(
+    (url) => url.endsWith("/attempts/2") ? secondAttempt : firstAttempt,
+    async (urls) => {
+      const view = await labsCi.collect(ctx([active, olderSuccess]));
+      assertEquals(view.status, "bad");
+      assertEquals(view.value, "failure");
+      assertEquals(view.sub, "failure for 1h 0m");
+      assertStringIncludes(view.extra ?? "", "build rerunning");
+      assertEquals(urls, [
+        `https://api.github.com/repos/${REPO}/actions/runs/${id}/attempts/2`,
+        `https://api.github.com/repos/${REPO}/actions/runs/${id}/attempts/1`,
+      ]);
+    },
+  );
+});
 
 Deno.test("labs ci streak: measured from the flip, not from the oldest run in the window", async () => {
   const runs = [

--- a/packages/dashboard/tiles/main-build.test.ts
+++ b/packages/dashboard/tiles/main-build.test.ts
@@ -253,41 +253,53 @@ Deno.test("labs ci: an observed failure survives a rerun without another API res
   );
 });
 
-Deno.test("labs ci: a malformed required attempt is rejected", async () => {
-  const id = 60;
-  const active = run({
-    id,
-    status: "in_progress",
-    conclusion: null,
-    run_attempt: 2,
-    head_sha: "latest",
-    run_started_at: ago(5),
-  });
-  const malformed = run({
-    id,
-    status: "completed",
-    conclusion: null,
-    run_attempt: 1,
-    head_sha: "latest",
-    run_started_at: ago(30),
-  });
-  const olderSuccess = run({
-    id: 160,
-    conclusion: "success",
-    head_sha: "older",
-    run_started_at: ago(90),
-  });
+Deno.test("labs ci: a malformed required attempt is rejected", async (t) => {
+  const cases: { name: string; overrides: Partial<Run> }[] = [
+    { name: "wrong run id", overrides: { id: 999 } },
+    { name: "wrong attempt", overrides: { run_attempt: 2 } },
+    { name: "unfinished status", overrides: { status: "in_progress" } },
+    { name: "missing conclusion", overrides: { conclusion: null } },
+  ];
 
-  await withGithubAttempt(malformed, async (urls) => {
-    await assertRejects(
-      () => labsCi.collect(ctx([active, olderSuccess])),
-      Error,
-      `GitHub run ${id} attempt 1 did not include a completed conclusion`,
-    );
-    assertEquals(urls, [
-      `https://api.github.com/repos/${REPO}/actions/runs/${id}/attempts/1`,
-    ]);
-  });
+  for (const [index, { name, overrides }] of cases.entries()) {
+    await t.step(name, async () => {
+      const id = 600 + index;
+      const active = run({
+        id,
+        status: "in_progress",
+        conclusion: null,
+        run_attempt: 2,
+        head_sha: "latest",
+        run_started_at: ago(5),
+      });
+      const malformed = run({
+        id,
+        status: "completed",
+        conclusion: "success",
+        run_attempt: 1,
+        head_sha: "latest",
+        run_started_at: ago(30),
+        ...overrides,
+      });
+      const olderSuccess = run({
+        id: 1600 + index,
+        conclusion: "success",
+        head_sha: "older",
+        run_started_at: ago(90),
+      });
+
+      await withGithubAttempt(malformed, async (urls) => {
+        await assertRejects(
+          () => labsCi.collect(ctx([active, olderSuccess])),
+          Error,
+          `GitHub run ${id} attempt 1 did not include a completed conclusion`,
+        );
+        assertEquals(urls, [
+          `https://api.github.com/repos/${REPO}/actions/runs/${id}/attempts/1`,
+        ]);
+      });
+    });
+  }
 });
 
 Deno.test("labs ci: a repeated failure keeps the streak from the prior attempt", async () => {
@@ -408,9 +420,9 @@ Deno.test("labs ci: an unavailable optional attempt preserves the known verdict"
     head_sha: "latest",
     run_started_at: ago(5),
   });
-  const olderFailure = run({
+  const olderSuccess = run({
     id: 161,
-    conclusion: "failure",
+    conclusion: "success",
     head_sha: "older",
     run_started_at: ago(90),
   });
@@ -419,7 +431,7 @@ Deno.test("labs ci: an unavailable optional attempt preserves the known verdict"
     new Error("attempt endpoint unavailable"),
     async (urls) => {
       const view = await labsCi.collect(
-        ctx([secondAttempt, olderFailure]),
+        ctx([secondAttempt, olderSuccess]),
       );
       assertEquals(view.status, "good");
       assertEquals(view.value, "passing");

--- a/packages/dashboard/tiles/main-build.ts
+++ b/packages/dashboard/tiles/main-build.ts
@@ -1,20 +1,97 @@
-// ci build: the last COMPLETED run on main drives the status (good/bad), or
-// unknown before the first completed run is known. A newer in-flight run is a
-// minor secondary facet. Drills through to the main commit history. One factory
+// ci build: the last completed attempt on main drives the status (good/bad), or
+// unknown before the first completed attempt is known. A newer in-flight run is
+// a minor secondary facet. Drills through to the main commit history. One factory
 // builds both the labs and loom instances against their own repo + workflow.
-import { runSource, type Status, type Tile, type TileView } from "../types.ts";
-import { escapeHtml, humanDur } from "../lib.ts";
+import {
+  runSource,
+  type Run,
+  type Status,
+  type Tile,
+  type TileView,
+} from "../types.ts";
+import { escapeHtml, github, humanDur } from "../lib.ts";
 import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "../config.ts";
 
 function makeBuildTile(opts: { id: string; label: string; repo: string; workflow: string }): Tile {
   const commitsUrl = `https://github.com/${opts.repo}/commits/main`;
+  const completedAttemptCache = new Map<number, Map<number, Run>>();
+
+  function attemptsFor(run: Run): Map<number, Run> {
+    let attempts = completedAttemptCache.get(run.id);
+    if (!attempts) {
+      attempts = new Map();
+      completedAttemptCache.set(run.id, attempts);
+    }
+    return attempts;
+  }
+
+  async function completedAttempt(run: Run, attempt: number): Promise<Run> {
+    const attempts = attemptsFor(run);
+    const cached = attempts.get(attempt);
+    if (cached) return cached;
+    const completed = await github<Run>(
+      `repos/${opts.repo}/actions/runs/${run.id}/attempts/${attempt}`,
+    );
+    if (
+      completed.id !== run.id ||
+      completed.run_attempt !== attempt ||
+      completed.status !== "completed" ||
+      !completed.conclusion
+    ) {
+      throw new Error(
+        `GitHub run ${run.id} attempt ${attempt} did not include a completed conclusion`,
+      );
+    }
+    attempts.set(attempt, completed);
+    return completed;
+  }
+
+  async function completedHistory(runs: Run[]): Promise<Run[]> {
+    const visibleRunIds = new Set(runs.map((run) => run.id));
+    for (const runId of completedAttemptCache.keys()) {
+      if (!visibleRunIds.has(runId)) completedAttemptCache.delete(runId);
+    }
+    for (const run of runs) {
+      if (run.status === "completed" && run.conclusion) {
+        attemptsFor(run).set(run.run_attempt, run);
+      }
+    }
+
+    const completed: Run[] = [];
+    let headConclusion: string | undefined;
+    history:
+    for (const run of runs) {
+      let attempt = run.status === "completed" && run.conclusion
+        ? run.run_attempt
+        : run.run_attempt - 1;
+      while (attempt >= 1) {
+        let prior: Run;
+        try {
+          prior = await completedAttempt(run, attempt);
+        } catch (error) {
+          if (completed.length === 0) throw error;
+          break history;
+        }
+        completed.push(prior);
+        if (headConclusion === undefined) {
+          headConclusion = prior.conclusion!;
+        } else if (prior.conclusion !== headConclusion) {
+          break history;
+        }
+        attempt--;
+      }
+    }
+    return completed;
+  }
+
   return {
     id: opts.id,
     intervalMs: 30_000,
     runSources: [runSource(opts.repo, opts.workflow)],
     async collect(ctx): Promise<TileView> {
       const runs = await ctx.runsFor(opts.repo, opts.workflow);
-      const completed = runs.filter((r) => r.status === "completed" && r.conclusion);
+      const latest = runs[0];
+      const completed = await completedHistory(runs);
       const lastDone = completed[0];
       const conclusion = lastDone?.conclusion ?? "";
       const s: Status = conclusion === "" ? "unknown" : conclusion === "success" ? "good" : "bad";
@@ -22,7 +99,7 @@ function makeBuildTile(opts: { id: string; label: string; repo: string; workflow
       let streak = "";
       if (lastDone) {
         const head = lastDone.conclusion;
-        let flipAt = completed[completed.length - 1].run_started_at;
+        let flipAt = lastDone.run_started_at;
         for (const r of completed) {
           if (r.conclusion !== head) break;
           flipAt = r.run_started_at;
@@ -30,9 +107,11 @@ function makeBuildTile(opts: { id: string; label: string; repo: string; workflow
         streak = `${head === "success" ? "green" : head} for ${humanDur(Date.now() - Date.parse(flipAt))}`;
       }
 
-      const latest = runs[0];
+      const runningLabel = latest?.run_attempt > 1
+        ? "build rerunning"
+        : "next build running";
       const running = latest && latest.status !== "completed"
-        ? `<span class="running" title="${escapeHtml((latest.display_title ?? "").slice(0, 90))}"><span class="rdot"></span>next build running</span>`
+        ? `<span class="running" title="${escapeHtml((latest.display_title ?? "").slice(0, 90))}"><span class="rdot"></span>${runningLabel}</span>`
         : "";
 
       return {


### PR DESCRIPTION
GitHub replaces a workflow run's completed attempt with its active rerun in workflow-run snapshots. The dashboard then skipped that verdict and inherited an older workflow's result, which could turn a failed tile green or a passing tile red until the rerun finished. Overlapping main builds made the same problem possible beyond the first snapshot row.\n\nKeep completed attempts for every workflow run in the current source snapshot. Walk runs from newest to oldest, resolve the exact prior attempt for active reruns, and backfill attempt history until the conclusion changes. This keeps the headline and streak tied to the newest completed verdict across active reruns, cold starts, missed attempts, and overlapping builds while pruning runs that leave the snapshot.\n\nLabel active reruns as 'build rerunning' while first attempts remain 'next build running'. Document the behavior and cover both CI repositories, symmetric verdicts, source-snapshot replacement, cache retention and eviction, attempt gaps, and third-attempt cold starts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787428357&installation_model_id=428580&pr_number=4955&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4955&signature=e7b164a672e4c0c539429f00c60ea26635957a9ad9f72ac497fef9d5f94f54a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps CI tiles stable during reruns by showing the last completed attempt’s verdict. Applies to both labs and loom CI, with clear “build rerunning” vs “next build running” labels.

- **Bug Fixes**
  - Backfill completed attempts per run via the GitHub Attempts API and keep that verdict during reruns and overlapping builds.
  - Validate required attempt responses; reject malformed data. When older attempt history is unavailable, keep the known verdict and stop the streak at that boundary.
  - Seed and prune a per-run attempt cache as snapshots change; handle cold starts, repeated failures, and third-attempt reruns.
  - README documents the behavior; tests cover both CI repos, snapshot replacement, overlapping runs, error paths, and streak retention.

<sup>Written for commit 00be53897e7042051e2c3417aaaffa1a6a66a8a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

