### PR TITLE
Enable computed cell IDs by default

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -20,7 +20,7 @@ in the same change.
 > flags](#appendix-a-removed-and-never-shipped-flags) rather than deleting the
 > record, so the history stays discoverable.
 
-**Last reviewed:** 2026-07-15. Each flag's section carries the date its status
+**Last reviewed:** 2026-07-23. Each flag's section carries the date its status
 was last checked against the code.
 
 ## Summary table
@@ -32,7 +32,7 @@ was last checked against the code.
 | [`commitPreconditions`](#commitpreconditions) | `RuntimeOptions.experimental` only (mapped `null` — programmatic rollback override — in the canonical env registry) | on | Bernhard Seefeld (#4090) | fold into base scheduler semantics, then delete flag | implemented, on by default |
 | [`eagerSourceAnnotation`](#eagersourceannotation) | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` env, or `RuntimeOptions.experimental` | off in production, on in shell dev builds | gideon (#4458) | permanent debug toggle, not slated for removal | implemented |
 | [`systemPatternAutoUpdate`](#systempatternautoupdate) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental` | on in the shell (same-toolshed system sources, including all roots); off server-side | Bernhard Seefeld (#4611; shell default-on #4619) | graduate to always-on, then delete flag | implemented, on in the shell |
-| [`computedCellIds`](#computedcellids) | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental` | off | Robin McCollum (in development) | graduate to always-on with the computed-cell write-conflict policy | in development on robin/feat-computed-cell-identity-p2 (redesigned: `computed:` URI scheme) |
+| [`computedCellIds`](#computedcellids) | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental` | on | Robin McCollum (#4659) | graduate to unconditional behavior, then delete flag | implemented, on by default |
 | [`cfcEnforcementMode`](#cfcenforcementmode) | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse) | `enforce-explicit` | Bernhard Seefeld (#3263) | tighten default toward `enforce-strict` | active; ladder is permanent |
 | [`cfcFlowLabels`](#cfcflowlabels) | `RuntimeOptions.cfcFlowLabels` | `off` | Bernhard Seefeld (#4011) | move toward `persist` | implemented, staged rollout |
 | [`cfcWriteFloor`](#cfcwritefloor) | `RuntimeOptions.cfcWriteFloor` | `off` | Bernhard Seefeld (#4479) | move toward `enforce` | implemented, staged rollout |
@@ -59,9 +59,9 @@ B](#appendix-b-related-toggles-that-are-not-experimental-flags).
 These flags make up the `ExperimentalOptions` interface in
 [`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). They
 are passed as `new Runtime({ experimental: { ... } })`. Each flag defaults to
-`undefined`, which means "take the built-in default". `commitPreconditions`
-defaults on; the other flags in this category default off unless their section
-says otherwise.
+`undefined`, which means "take the built-in default". `commitPreconditions` and
+`computedCellIds` default on; the other flags in this category default off
+unless their section says otherwise.
 
 The mapping from environment variable to flag is defined once, canonically, as
 `EXPERIMENTAL_ENV_VARS` in
@@ -276,7 +276,7 @@ propagate](#how-flags-propagate).
 - **Toggle via.** `EXPERIMENTAL_COMPUTED_CELL_IDS` environment variable
   (through the canonical env registry) or
   `RuntimeOptions.experimental.computedCellIds`.
-- **Added by.** Robin McCollum, on the computed-cell-identity branch (spec:
+- **Added by.** Robin McCollum, in #4659 (spec:
   [`docs/specs/computed-cell-identity.md`](../specs/computed-cell-identity.md)).
 - **Purpose.** Mints kind-schemed entity ids (`computed:fid1:<hash>`, the
   `computed:` URI scheme replacing `of:`) for derived internal cells. The
@@ -288,19 +288,19 @@ propagate](#how-flags-propagate).
   reference. The flag gates minting only; readers accept both id forms
   unconditionally, so it can flip either way without a migration — but see the
   version-skew note below.
-- **Current default and planned end state.** Off by default. Graduates to
-  always-on together with the computed-cell write-conflict policy (ack-and-drop
-  for stale all-computed commits), then the flag is deleted. The flag is the
-  rollout gate for version skew: clients predating the `computed:` scheme
-  throw on such ids arriving via sync, so it must not graduate until every
-  syncing client carries the readers (old servers are safe — an unknown
-  scheme parses as no kind and stays strict).
-- **Status on 2026-07-15.** In development on
-  `robin/feat-computed-cell-identity-p2`: phase 1 (kind-schemed minting,
-  redesigned from a retired kind-in-hash-tag format that never shipped)
-  implemented behind the flag. Phase 2 (ack-and-drop of stale all-computed
-  commits) is split into its own follow-up PR with its own flag, so this
-  branch changes no conflict semantics.
+- **Current default and planned end state.** On by default. An explicit
+  `false` remains a rollback override for version skew while the flag soaks;
+  clients predating the `computed:` scheme throw on such ids arriving via sync
+  (old servers are safe — an unknown scheme parses as no kind and stays
+  strict). Once the rollout is stable, make minting unconditional and delete
+  the flag. The computed-cell write-conflict policy (ack-and-drop for stale
+  all-computed commits) remains a separately gated follow-up.
+- **Status on 2026-07-23.** Kind-schemed minting landed in #4659 and is on by
+  default. Readers accept both schemes unconditionally, and explicit `false`
+  retains the legacy `of:` minting behavior as a temporary rollback path.
+- **Path to removal.** Confirm all syncing clients carry `computed:`-aware
+  readers and the default-on rollout has soaked; then remove the environment
+  mapping, runtime option, builder guard, and legacy rollback tests.
 
 ---
 

--- a/docs/specs/computed-cell-identity.md
+++ b/docs/specs/computed-cell-identity.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Phase 1 (minting) implemented behind `EXPERIMENTAL_COMPUTED_CELL_IDS`
-(default off) on this branch; redesigned in July 2026 — this document
-describes the redesigned form. Computed ids are now `computed:fid1:<hash>`:
+Phase 1 (minting) is implemented behind `EXPERIMENTAL_COMPUTED_CELL_IDS` and
+defaults on; an explicit `false` remains a temporary rollback override.
+Redesigned in July 2026, computed ids are now `computed:fid1:<hash>`:
 the kind rides the URI scheme, the `FabricHash` format tag stays `fid1`, and
 the earlier kind-in-hash-tag format is retired without back-compat readers
 (the flag never shipped, so no such ids exist). The classifier polarity
@@ -397,9 +397,10 @@ action re-run, and the second commit.
 
 ### Version-skew rollout
 
-New-form ids are a data-compatibility event, so `EXPERIMENTAL_COMPUTED_CELL_IDS`
-(default off) gates MINTING only; readers in this codebase accept both forms
-unconditionally. The skew hazard is one-directional:
+New-form ids are a data-compatibility event, so
+`EXPERIMENTAL_COMPUTED_CELL_IDS` gates MINTING only and defaults on; readers in
+this codebase accept both forms unconditionally. An explicit `false` remains a
+rollback override for version skew. The skew hazard is one-directional:
 
 - **Old clients are the hard constraint.** A client predating the scheme
   THROWS in `fromURI` on a `computed:` id arriving via sync (`Invalid
@@ -546,7 +547,7 @@ this proposal onto persistent-scheduler-state:
   race of two current computed commits is first-wins; unknown-scheme ids
   stay strict.
 - Integration: two-client scenario where both recompute the same node —
-  assert convergence with zero conflict-driven action re-runs; flag-on
+  assert convergence with zero conflict-driven action re-runs; default-on
   instantiation syncs a manifest-linked `computed:fid1:` id through storage
   and reads it back (no special routing below the URI layer); `cf inspect`
   shows the computed value and the drop bookkeeping.

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -208,7 +208,8 @@ export interface ExperimentalOptions {
   /**
    * Mint computed-scheme entity ids (`computed:fid1:<hash>`) for derived
    * internal cells classified as replayable by the builder. Gates minting
-   * only; readers accept both forms unconditionally. See
+   * only; readers accept both forms unconditionally. Defaults to on; pass
+   * `false` as a temporary rollback override. See
    * `docs/specs/computed-cell-identity.md`.
    */
   computedCellIds?: boolean | undefined;
@@ -901,8 +902,8 @@ export class Runtime {
 
     // Unlike ambient flags, computedCellIds is consumed from this Runtime's
     // builder frame. Normalize its local default after override logging so an
-    // omitted option does not appear as an explicit `false` override.
-    this.experimental.computedCellIds ??= false;
+    // omitted option does not appear as an explicit `true` override.
+    this.experimental.computedCellIds ??= true;
 
     // Propagate experimental flags to their ambient control points, then read
     // back the effective state so `experimental.*` reflects what is actually in

--- a/packages/runner/test/computed-cell-kinds.test.ts
+++ b/packages/runner/test/computed-cell-kinds.test.ts
@@ -43,7 +43,6 @@ describe("computed cell kinds", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      experimental: { computedCellIds: true },
     });
     frame = pushFrame({
       space,
@@ -330,12 +329,14 @@ describe("computed cell kinds", () => {
     });
 
     it("mints nothing when the flag is off", async () => {
-      // Replace the flag-on runtime from beforeEach with a default one.
+      // Replace the default-on runtime from beforeEach with an explicit
+      // rollback override.
       popFrame(frame);
       await runtime.dispose();
       runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager,
+        experimental: { computedCellIds: false },
       });
       frame = pushFrame({
         space,
@@ -379,7 +380,7 @@ describe("computed cell kinds", () => {
         await otherStorageManager.close();
       }
 
-      // The original flag-on runtime remains the active frame. Constructing
+      // The original default-on runtime remains the active frame. Constructing
       // and disposing the flag-off runtime above must not change its behavior.
       const double = lift((x: number) => x * 2);
       const flagOnPattern = pattern<{ x: number }>(({ x }) => ({

--- a/packages/runner/test/computed-id-e2e.test.ts
+++ b/packages/runner/test/computed-id-e2e.test.ts
@@ -1,6 +1,6 @@
 /**
  * End-to-end storage test for computed-cell id minting
- * (docs/specs/computed-cell-identity.md): a flag-on pattern instantiation
+ * (docs/specs/computed-cell-identity.md): a default-on pattern instantiation
  * mints a derived internal cell under the `computed:` URI scheme, and the
  * doc flows through the real memory-v2 server (emulated storage manager)
  * with no special routing.
@@ -20,7 +20,7 @@ import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { testSessionOpenAuthFactory } from "./memory-v2-test-utils.ts";
 
 /**
- * End-to-end proof that a flag-on pattern instantiation mints a derived
+ * End-to-end proof that a default-on pattern instantiation mints a derived
  * internal cell with a `computed:fid1:` id and that the doc flows through
  * storage WITHOUT any special routing: it commits, syncs to the memory-v2
  * server, and reads back through a completely independent session exactly
@@ -29,7 +29,7 @@ import { testSessionOpenAuthFactory } from "./memory-v2-test-utils.ts";
 const e2eSigner = await Identity.fromPassphrase("computed-id-e2e");
 const e2eSpace = e2eSigner.did();
 
-describe("computed-cell id end-to-end (flag-on instantiation)", () => {
+describe("computed-cell id end-to-end (default-on instantiation)", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let remoteClient: MemoryV2Client.Client;
@@ -40,7 +40,6 @@ describe("computed-cell id end-to-end (flag-on instantiation)", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      experimental: { computedCellIds: true },
     });
     const candidate = storageManager as unknown as {
       server?: () => MemoryV2Server;

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -37,6 +37,7 @@ describe("ExperimentalOptions", () => {
         experimental: {
           modernCellRep: false,
           commitPreconditions: false,
+          computedCellIds: false,
         },
       });
       expect(runtime.experimental).toEqual({
@@ -65,7 +66,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: true,
         persistentSchedulerState: false,
         commitPreconditions: true,
-        computedCellIds: false,
+        computedCellIds: true,
         eagerSourceAnnotation: false,
       });
       await runtime.dispose();
@@ -83,7 +84,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: true,
-        computedCellIds: false,
+        computedCellIds: true,
         // Read back from the ambient flag (a test seam that deliberately does
         // NOT reset on dispose — see ExperimentalOptions.eagerSourceAnnotation).
         eagerSourceAnnotation: false,

--- a/packages/runner/test/pattern.test.ts
+++ b/packages/runner/test/pattern.test.ts
@@ -83,6 +83,7 @@ describe("pattern", () => {
     expect(doublePattern.derivedInternalCells).toEqual([
       {
         partialCause: "double",
+        kind: "computed",
       },
       {
         partialCause: "x",
@@ -102,9 +103,11 @@ describe("pattern", () => {
     expect(testPattern.derivedInternalCells).toEqual([
       {
         partialCause: { $generated: 0 },
+        kind: "computed",
       },
       {
         partialCause: "doubled",
+        kind: "computed",
       },
     ]);
     expect(testPattern.nodes[0].outputs).toMatchObject({
@@ -140,6 +143,7 @@ describe("pattern", () => {
       {
         partialCause: "isSelected",
         schema: { type: "boolean" },
+        kind: "computed",
       },
       {
         partialCause: {
@@ -147,6 +151,7 @@ describe("pattern", () => {
           $generated: 0,
         },
         schema: { type: "boolean" },
+        kind: "computed",
       },
     ]);
   });


### PR DESCRIPTION
## Summary

- enable `computedCellIds` by default while retaining explicit `false` as a rollback override
- update default-sensitive builder, option-resolution, and storage end-to-end coverage
- update the experimental flag registry and computed-cell identity spec for the new rollout posture

## Impact

Derived internal cells classified as replayable now mint `computed:fid1:` IDs unless a runtime or environment override explicitly disables the flag. Readers continue to accept both `computed:` and legacy `of:` IDs, and this change does not enable the separately gated computed-cell conflict policy.

## Validation

- `deno test -A packages/runner/test/pattern.test.ts packages/runner/test/experimental-options.test.ts packages/runner/test/computed-cell-kinds.test.ts packages/runner/test/computed-id-e2e.test.ts` (70 steps passed)
- full `packages/runner` unit suite exercised 1,012 passing tests and identified three stale default-value assertions in `pattern.test.ts`; those assertions were updated and the affected suite reran green
- `deno fmt` on all changed TypeScript and Markdown files
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787428719&installation_model_id=428580&pr_number=4956&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4956&signature=ec94fda58ca08fa49affb5c4d7f7bacb6842382cd49d2c2473e0ac330c6a43d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `computedCellIds` by default so derived internal cells mint `computed:fid1:` IDs. Readers accept both `computed:` and legacy `of:` IDs; you can roll back with an explicit `false`.

- **Migration**
  - To disable, set `EXPERIMENTAL_COMPUTED_CELL_IDS=false` or use `new Runtime({ experimental: { computedCellIds: false } })`.
  - Update any old clients that don’t understand `computed:` IDs; they will throw on sync. Keep the flag off in those environments until clients are updated.
  - No storage migration needed; this gates minting only.

<sup>Written for commit 932d427b163494e588e4833518e25a065badc269. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

