### PR TITLE
fix(data-model): handle runtimes without Error.isError

### DIFF
--- a/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
+++ b/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
@@ -752,6 +752,11 @@ Notes:
   `packages/runner/src/sandbox/error-taming.ts`. The phase call reveals
   `globalThis.hardenIntrinsics`, which the runtime deletes afterwards so the
   host realm's global surface matches the one-call form.
+- An engine that does not provide `Error.isError` before lockdown has no
+  intrinsic to restore. Native error classification falls back to
+  `instanceof Error` there. This recognizes SES errors because the repaired
+  constructors share the host error prototype hierarchy. General
+  cross-realm error recognition requires the native method.
 - `overrideTaming: "severe"` remains the compatibility default.
 - `localeTaming: "unsafe"` is load-bearing only together with the pre-lockdown
   vetted shim in `packages/runner/src/sandbox/locale-taming.ts`, which replaces

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -44,6 +44,20 @@ export const NATIVE_TAGS = Object.freeze(
 export type NativeTag = typeof NATIVE_TAGS[keyof typeof NATIVE_TAGS];
 
 /**
+ * Checks whether a value is a native `Error`.
+ *
+ * `Error.isError()` recognizes errors from other realms when the engine
+ * provides it. Engines without it fall back to `instanceof`, which recognizes
+ * errors that share the current realm's prototype hierarchy.
+ */
+export function isNativeError(value: unknown): value is Error {
+  const isError = (Error as { isError?: (value: unknown) => boolean }).isError;
+  return typeof isError === "function"
+    ? isError(value)
+    : value instanceof Error;
+}
+
+/**
  * Maps a constructor to its native-instance tag. Returns the tag string if
  * the constructor is a recognized type (JS builtins or system-defined
  * special primitives), or `null` otherwise.
@@ -123,10 +137,9 @@ export function tagFromNativeClass(
  *
  * Dispatches via the value's constructor (O(1) switch in `tagFromNativeClass`,
  * which matches `Error` subclasses via `prototype instanceof Error`). Falls
- * back to `Error.isError()` and `Array.isArray()` for values whose constructor
- * is unreachable -- a severed prototype, or another realm -- since the internal
- * slot survives where a constructor lookup does not, and to a prototype check
- * for null-prototype objects.
+ * back to native error detection and `Array.isArray()` for values whose
+ * constructor is unreachable -- a severed prototype, or another realm -- and
+ * to a prototype check for null-prototype objects.
  *
  * For tags that have pass-through handling (`Object`, `Array`) or no dedicated
  * handler (`null`), a per-instance `hasToJSON()` check upgrades the tag to
@@ -160,9 +173,8 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
     // `Error`s with no reachable constructor -- e.g. one whose prototype has
     // been severed, or one from another realm. An ordinary subclass (including
     // `DOMException`) never gets here: `tagFromNativeClass()` matches it via
-    // `prototype instanceof Error`. The internal slot survives either way,
-    // which is what `Error.isError()` reads.
-    if (Error.isError(value)) return NATIVE_TAGS.Error;
+    // `prototype instanceof Error`.
+    if (isNativeError(value)) return NATIVE_TAGS.Error;
 
     // `FabricInstance` values (object-like protocol types).
     if (value instanceof FabricInstance) return NATIVE_TAGS.FabricInstance;

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import {
+  isNativeError,
   NATIVE_TAGS,
   tagFromNativeClass,
   tagFromNativeValue,
@@ -97,6 +98,28 @@ describe("native-type-tags", () => {
     it("returns `Object` tag for null-prototype objects (no constructor)", () => {
       const obj = Object.create(null);
       expect(tagFromNativeValue(obj)).toBe(NATIVE_TAGS.Object);
+    });
+
+    it("classifies values when `Error.isError` is unavailable", () => {
+      const descriptor = Object.getOwnPropertyDescriptor(Error, "isError");
+      Object.defineProperty(Error, "isError", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      try {
+        expect(isNativeError(new Error("test"))).toBe(true);
+        expect(tagFromNativeValue(Object.create(null))).toBe(
+          NATIVE_TAGS.Object,
+        );
+      } finally {
+        if (descriptor) {
+          Object.defineProperty(Error, "isError", descriptor);
+        } else {
+          delete (Error as { isError?: unknown }).isError;
+        }
+      }
     });
 
     it("returns `HasToJSON` tag for plain objects with `toJSON()`", () => {

--- a/packages/runner/src/sandbox/error-taming.ts
+++ b/packages/runner/src/sandbox/error-taming.ts
@@ -38,7 +38,8 @@
 /**
  * The real `Error.isError`, captured before lockdown can replace the
  * constructor holding it. `undefined` on a runtime that predates the method,
- * in which case there is nothing to restore and nothing to fake.
+ * in which case there is nothing to restore. Error classification falls back
+ * to the shared prototype hierarchy on those runtimes.
  */
 const FERAL_IS_ERROR: unknown = (Error as { isError?: unknown }).isError;
 

--- a/packages/runner/src/sandbox/result-normalization.ts
+++ b/packages/runner/src/sandbox/result-normalization.ts
@@ -8,6 +8,7 @@ import {
   FabricEpochNsec,
   FabricRegExp,
 } from "@commonfabric/data-model/fabric-primitives";
+import { isNativeError } from "@commonfabric/data-model/native-type-tags";
 
 import { isReactive } from "../builder/types.ts";
 import { isCellLink } from "../link-utils.ts";
@@ -33,7 +34,6 @@ const regexpFlagsGetter = Object.getOwnPropertyDescriptor(
   RegExp.prototype,
   "flags",
 )!.get!;
-const errorIsError = Error.isError;
 
 const hasToJSON = (value: object): boolean =>
   "toJSON" in value &&
@@ -110,7 +110,7 @@ function normalizeSandboxNativeLeaf(value: unknown): unknown {
     return new FabricBytes(new Uint8Array(value as Uint8Array));
   }
 
-  if (errorIsError(value)) {
+  if (isNativeError(value)) {
     return FabricError.fromNativeError(value as Error);
   }
 
@@ -144,7 +144,7 @@ function formatActionResultError(
   const actionStr = actionName ? `\n  in action: ${actionName}` : "";
   const hint = hintForActionResult(value);
   const hintStr = hint ? ` ${hint}` : "";
-  const causeIsError = errorIsError(cause) || cause instanceof Error;
+  const causeIsError = isNativeError(cause);
   const causeStr = causeIsError ? `\n${(cause as Error).message}` : "";
   return new Error(
     `Action returned a ${typeNameForActionResult(value)}${pathStr}.` +

--- a/packages/runner/test/action-result-validation.test.ts
+++ b/packages/runner/test/action-result-validation.test.ts
@@ -36,6 +36,34 @@ describe("normalizeSandboxResult", () => {
     expect((value.error as FabricError).type).toBe("TypeError");
   });
 
+  it("canonicalizes errors when `Error.isError` is unavailable", async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Error, "isError");
+    Object.defineProperty(Error, "isError", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    try {
+      const {
+        normalizeSandboxResult: normalizeWithoutNativeErrorCheck,
+      } = await import(
+        "../src/sandbox/result-normalization.ts?error-is-error-unavailable"
+      );
+      const normalized = normalizeWithoutNativeErrorCheck(
+        new TypeError("fabric"),
+      );
+      expect(normalized.value).toBeInstanceOf(FabricError);
+      expect((normalized.value as FabricError).type).toBe("TypeError");
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(Error, "isError", descriptor);
+      } else {
+        delete (Error as { isError?: unknown }).isError;
+      }
+    }
+  });
+
   it("preserves opaque leaves while normalizing their siblings", () => {
     const reactive = { [isReactiveMarker]: true };
     const cellLink = linkRefFrom({ id: "of:test" });

--- a/packages/runner/test/error-taming.test.ts
+++ b/packages/runner/test/error-taming.test.ts
@@ -58,11 +58,10 @@ describe("Error.isError under SES lockdown", () => {
     });
 
     it("installs nothing when handed a non-function", () => {
-      // How a runtime without `Error.isError` declines. Every runtime we run
-      // on has it, but an older browser would not, and there the shim must
-      // define nothing rather than define the property as `undefined` — which
-      // fails SES's `isError: fn` permit and gets stripped back out with an
-      // unpermitted-intrinsic report on every lockdown.
+      // How a runtime without `Error.isError` declines. The pinned browser
+      // integration runtime takes this path. The shim defines nothing because
+      // an `undefined` property fails SES's `isError: fn` permit and gets
+      // stripped back out with an unpermitted-intrinsic report.
       //
       // `null` rather than the `undefined` a real such runtime would supply:
       // an explicit `undefined` argument re-triggers the parameter default and


### PR DESCRIPTION
Some supported browser engines do not provide Error.isError. Native value classification and sandbox result normalization called the method unconditionally. Ordinary constructor-less objects or errors could therefore abort conversion with a TypeError.

Add a shared error detector that uses the native method when available and falls back to the shared Error prototype hierarchy. Use it across data model conversion and the sandbox result boundary.

Add deterministic tests that remove the method and exercise both object classification and error normalization. Document the cross-realm limitation of the fallback.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787432216&installation_model_id=428580&pr_number=4957&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4957&signature=c9a2a8b38ab10d03078701aa4f82f82036b4b17850b55c7d6f7bf027b7b5baa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix error classification on runtimes without `Error.isError` by adding a shared fallback. Prevents TypeError crashes in native value tagging and sandbox result normalization; errors now canonicalize to `FabricError`.

- **Bug Fixes**
  - Added `isNativeError` that uses native `Error.isError` when present, else `instanceof Error`.
  - Wired into `tagFromNativeValue` and sandbox result normalization (incl. action error causes) to detect errors reliably.
  - Added tests that remove `Error.isError`; updated SES docs on fallback limits and that no intrinsic is restored when missing.

<sup>Written for commit 28a3c5aa1f3fbcc91cc976d061a9dc8ae45de224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

