### PR TITLE
fix(lunch-poll): tick the poll's clock (#now/300) instead of freezing at first load

### DIFF
--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -162,13 +162,15 @@ const COLLIDING_INITIAL_USERS: User[] = [
 export default pattern(() => {
   const poll = CozyPoll({});
 
-  // Reference times derive from the one-shot `#now` wish (the pattern body
-  // cannot read the ambient clock — mirrors how the pattern under test gets
-  // its own "today"): "yesterday" for the seeded stale vote, and the day key
-  // the pattern is expected to filter to. Both read as unresolved
-  // (undefined / "") until `#now` resolves; the dependent assertions guard
-  // that window and the harness re-evaluates them once the wish lands.
-  const nowCell = wish<number>({ query: "#now" });
+  // Reference times derive from the interval `#now/300` wish — the same
+  // shared ticking clock the pattern under test runs on (the pattern body
+  // cannot read the ambient clock; the bare one-shot `#now` would freeze at
+  // first capture, which is exactly what the poll must not do): "yesterday"
+  // for the seeded stale vote, and the day key the pattern is expected to
+  // filter to. Both read as unresolved (undefined / "") until the wish
+  // resolves; the dependent assertions guard that window and the harness
+  // re-evaluates them once the wish lands.
+  const nowCell = wish<number>({ query: "#now/300" });
   const staleCastAt = computed(() =>
     nowCell.result == null ? undefined : nowCell.result - 86_400_000
   );
@@ -536,7 +538,7 @@ export default pattern(() => {
 
   // === Current-day vote filter ===
 
-  // The header renders the session's date, and `todayDate` exposes the local
+  // The header renders the current date, and `todayDate` exposes the local
   // day key the votes are filtered to. The `todayKey !== ""` guard holds the
   // assertion false until this pattern's `#now` wish resolves.
   const assert_today_header_renders = computed(() =>

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -45,13 +45,16 @@
  * and the UI (tallies, swatches, per-option highlights, header count, logVisit
  * snapshots) only shows votes cast on the current day. Older votes stay stored
  * but hidden — the (voter, option) vote key means a re-cast overwrites the same
- * entity, so they don't accumulate. "Today" is the one-shot `#now` wish
- * (`loadedAt`, resolved in every viewing runtime; null — shown as an empty
- * vote view — until it resolves), overridden by a per-session cell the vote
- * handlers refresh so a tab
- * left open across midnight snaps forward on the next interaction. The day
- * boundary is the runtime's local timezone (the viewer's, in the browser); two
- * viewers in different timezones can see different vote sets around midnight.
+ * entity, so they don't accumulate. "Today" is the interval `#now/300` wish
+ * (`nowTick`): the runtime's shared per-space clock, coarsened to five
+ * minutes, written immediately on subscribe (and refreshed on reload), then
+ * advanced on aligned boundaries — so an open tab rolls to the new day at
+ * midnight on its own. It reads null until the wish resolves (shown as an
+ * empty vote view and a placeholder date) and stays null on pre-#4740
+ * runtimes, where the vote and visit handlers no-op rather than read an
+ * ambient clock the runtime may not provide. The day boundary is the
+ * runtime's local timezone (the viewer's, in the browser); two viewers in
+ * different timezones can see different vote sets around midnight.
  */
 
 import {
@@ -205,9 +208,6 @@ type VotesCell = Writable<Vote[] | Default<[]>>;
 type UsersCell = Writable<User[] | Default<[]>>;
 type NameCell = Writable<string | Default<"">>;
 type HistoryCell = Writable<HistoryEntry[] | Default<[]>>;
-// The session's "today" (ms epoch) — see the current-day filter note in the
-// file header.
-type TodayCell = Writable<number>;
 
 const POLL_THEME = {
   fontFamily:
@@ -450,7 +450,7 @@ export const dayKeyOf = (ms: number): string => {
   }`;
 };
 
-// Header label for the session's "today" ("Thursday, Jul 10"). Formatted from
+// Header label for the current day ("Thursday, Jul 10"). Formatted from
 // the name tables, not toLocaleDateString: SES localeTaming ("safe") aliases
 // toLocale* methods to their non-locale forms, so option-driven locale
 // formatting is unreliable under lockdown.
@@ -474,8 +474,8 @@ const newHistoryId = (
   );
 
 // Parse a "YYYY-MM-DD" draft (from the host's date input) into a timestamp,
-// anchored to local midnight. Blank or unparseable → the caller's explicit
-// deterministic `#now` snapshot.
+// anchored to local midnight. Blank or unparseable → the caller's current
+// `#now/300` tick, i.e. today.
 const parseVisitDate = (
   draft: string | undefined,
   fallbackNow: number,
@@ -577,16 +577,17 @@ const removeOption = handler<RemoveOptionEvent, {
 const castVote = handler<CastVoteEvent, {
   votes: VotesCell;
   myName: NameCell;
-  today: TodayCell;
-  loadedAt: number | null;
-}>(({ optionId, voteType }, { votes, myName, today, loadedAt }) => {
+  nowTick: number | null;
+}>(({ optionId, voteType }, { votes, myName, nowTick }) => {
   const me = trimmedName(myName.get());
   if (!me) return;
-  // Use the session's deterministic `#now` snapshot. This keeps the deployed
-  // source compatible with Loom runtimes from before handler-scoped Date.now().
-  const now = loadedAt;
+  // Stamp with the shared `#now/300` tick — fresh to five minutes, all a
+  // day-granularity stamp needs, and it keeps the deployed source compatible
+  // with Loom runtimes from before handler-scoped Date.now(). Null until the
+  // wish resolves (and always on pre-#4740 runtimes, which also show no
+  // votes): voting no-ops rather than reading an ambient clock.
+  const now = nowTick;
   if (!now) return;
-  today.set(now);
   // My vote for this option has a deterministic address, so this reads and
   // edits just that one vote — never the whole list. Clicking the current
   // color toggles the vote off; any other color sets it.
@@ -653,8 +654,7 @@ const logVisit = handler<LogVisitEvent, {
   myName: NameCell;
   adminName: NameCell;
   visitDate: NameCell;
-  today: TodayCell;
-  loadedAt: number | null;
+  nowTick: number | null;
 }>(
   (
     { optionId, title, wentAt },
@@ -666,8 +666,7 @@ const logVisit = handler<LogVisitEvent, {
       myName,
       adminName,
       visitDate,
-      today,
-      loadedAt,
+      nowTick,
     },
   ) => {
     const me = trimmedName(myName.get());
@@ -679,7 +678,7 @@ const logVisit = handler<LogVisitEvent, {
       place = opt ? trimmedName(opt.title) : "";
     }
     if (!place) return;
-    const fallbackNow = today.get() || loadedAt || 0;
+    const fallbackNow = nowTick || 0;
     const when = typeof wentAt === "number"
       ? wentAt
       : parseVisitDate(visitDate.get(), fallbackNow);
@@ -698,13 +697,11 @@ const logVisit = handler<LogVisitEvent, {
     // option title (options can be removed later; the title is the record).
     // Only today's votes are "current opinion": stale votes are hidden from
     // the UI, so they stay out of the snapshot too. Same day source as the
-    // UI's `todaysVotes` (`today` override, else the `#now` load snapshot) —
-    // the snapshot must capture what the host is looking at, not the wall
-    // clock's day, or a tab crossing midnight logs an empty new-day snapshot
-    // of a board still showing yesterday's votes. While `#now` is still
-    // resolving (no override, null `loadedAt`) the board shows no votes, so
-    // the snapshot stays empty for that window too.
-    const nowRef = today.get() || loadedAt;
+    // UI's `todaysVotes` (the shared `#now/300` tick), so the snapshot
+    // captures exactly what the host is looking at, by construction. While
+    // the wish is still unresolved (null `nowTick`) the board shows no votes,
+    // so the snapshot stays empty for that window too.
+    const nowRef = nowTick;
     const nowDay = nowRef ? dayKeyOf(nowRef) : null;
     const titleById = new Map(options.get().map((o) => [o.id, o.title]));
     const voteSnapshot: VoteSnapshot[] = [];
@@ -873,8 +870,8 @@ export interface CozyPollOutput {
   userCount: number;
   optionCount: number;
   voteCount: number;
-  // The session's current local day ("YYYY-MM-DD") that votes are filtered
-  // to; "" until the `#now` wish resolves.
+  // The current local day ("YYYY-MM-DD") that votes are filtered to; ""
+  // until the `#now/300` wish resolves.
   todayDate: string;
   // Votes cast on the current day — the only votes the UI shows and tallies.
   todaysVotes: readonly Vote[];
@@ -932,23 +929,21 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // Host's backdate field for "we went here" — a "YYYY-MM-DD" draft, blank
     // means today. Per-session like the other form drafts.
     const visitDate = Writable.perSession.of<string>("");
-    // "Now" at load — the one-shot `#now` wish, resolved in EVERY viewing
-    // runtime (pattern bodies run per session; the calendar idiom). This, not
-    // the cell below, is what makes "today" defined for a session that hasn't
-    // interacted yet: a scoped cell's `.of()` initial is seeded only into the
-    // piece-creating session's partition, and every other session reads
-    // undefined from it (see docs/development/debugging/gotchas/
-    // scoped-cell-pitfalls.md #5). The body cannot read the ambient clock, so
-    // `loadedAt` reads null until the wish resolves; every downstream read
-    // guards that load window (an empty vote view and a placeholder date).
-    const loadedAtWish = wish<number>({ query: "#now" });
-    const loadedAt = computed(() => loadedAtWish.result ?? null);
-    // Handler-refreshed override (ms epoch) so a tab left open across
-    // midnight snaps forward on the next vote interaction. 0 = "this session
-    // hasn't interacted"; every read falls back to `loadedAt`. The initial is
-    // a stable literal on purpose — a computed initial would embed a
-    // different schema default per runtime and churn the built graph.
-    const today = Writable.perSession.of<number>(0);
+    // The clock the poll runs on — the interval `#now/300` wish: the
+    // runtime's shared per-space tick, coarsened to five minutes, written
+    // immediately on subscribe (and refreshed on reload), then advanced on
+    // aligned boundaries by a runner-owned timer (builtins/wish.ts). Five
+    // minutes is plenty for day-granularity stamps and keeps tick writes
+    // negligible. Deliberately NOT the bare one-shot `#now`: that wish
+    // durably captures the piece's FIRST-EVER load time and never advances
+    // again, which would freeze the current-day filter (and every new
+    // `castAt`) at the poll's birth day. The body cannot read the ambient
+    // clock, so `nowTick` reads null until the wish resolves — and forever on
+    // pre-#4740 runtimes, which lack `#now` — and every downstream read
+    // guards that window (an empty vote view, a placeholder date, and vote /
+    // visit handlers that no-op).
+    const nowTickWish = wish<number>({ query: "#now/300" });
+    const nowTick = computed(() => nowTickWish.result ?? null);
     // Two-step confirmation for destructive actions. Stores the optionId
     // pending remove-confirm (null or undefined = nothing pending). Same idiom as
     // parking-coordinator's `removePersonConfirmTarget`.
@@ -974,7 +969,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       myName,
       adminName,
     });
-    const boundCastVote = castVote({ votes, myName, today, loadedAt });
+    const boundCastVote = castVote({ votes, myName, nowTick });
     const boundSetOptionImage = setOptionImage({ options, myName, adminName });
     const boundClearMyVote = clearMyVote({ votes, myName });
     const boundResetVotes = resetVotes({ votes, myName, adminName });
@@ -986,8 +981,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       myName,
       adminName,
       visitDate,
-      today,
-      loadedAt,
+      nowTick,
     });
     const boundRemoveHistoryEntry = removeHistoryEntry({
       visits,
@@ -1002,22 +996,16 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const userCount = users.length;
     const optionCount = options.length;
     const voteCount = votes.length;
-    // Current-day filter: the UI only shows votes cast on this session's
-    // "today" (local calendar day). Derived at top level so every remote
-    // voter's vote entity resolves (same reason `ranked` is computed here,
-    // not per-option — see the swatch comment below).
-    // `|| loadedAt` (not ??) covers both the unwritten cross-session read
-    // (undefined) and the seeded 0. The combined value is null while `#now`
-    // is still resolving; for that window the day key reads "" and the
-    // current-day vote set is empty.
-    const todayKey = computed(() => {
-      const ref = today.get() || loadedAt;
-      return ref ? dayKeyOf(ref) : "";
-    });
+    // Current-day filter: the UI only shows votes cast on the current day
+    // (local calendar), per the shared tick. Derived at top level so every
+    // remote voter's vote entity resolves (same reason `ranked` is computed
+    // here, not per-option — see the swatch comment below). While `#now/300`
+    // is still resolving the day key reads "" and the current-day vote set is
+    // empty.
+    const todayKey = computed(() => (nowTick ? dayKeyOf(nowTick) : ""));
     const todaysVotes = computed(() => {
-      const ref = today.get() || loadedAt;
-      if (!ref) return EMPTY_VOTES;
-      const key = dayKeyOf(ref);
+      if (!nowTick) return EMPTY_VOTES;
+      const key = dayKeyOf(nowTick);
       return votes.filter((v) =>
         typeof v.castAt === "number" && dayKeyOf(v.castAt) === key
       );
@@ -1105,8 +1093,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                     const u = userCount ?? 0;
                     const o = optionCount ?? 0;
                     const v = todayVoteCount ?? 0;
-                    const todayRef = today.get() || loadedAt;
-                    const todayLabel = todayRef ? dayLabelOf(todayRef) : "…";
+                    const todayLabel = nowTick ? dayLabelOf(nowTick) : "…";
                     const admin = trimmedName(adminName);
                     const viewer = me;
                     const amAdmin = isAdmin;


### PR DESCRIPTION
## Summary

- switch the poll's time source from the one-shot `#now` wish to the interval `#now/300` wish — a shared per-space clock that ticks on aligned five-minute boundaries
- remove the per-session `today` override cell, whose only purpose was to let handler clock reads un-stale a frozen view; every day read now derives from the one ticking source
- mirror the switch in the test suite's reference clock so its "same clock as the pattern under test" premise stays true

## Why

Follow-up to #4922, which replaced handler `Date.now()` reads with the `#now` wish for pre-#4740 Loom compatibility. That PR's model of the primitive was wrong: bare `#now` is not a per-session load snapshot. It is a **durable, first-write-wins capture keyed by the wish node's cause** — the runner deliberately re-reads the first-ever captured time on every re-instantiation, in every runtime, forever (`builtins/wish.ts`, one-shot `#now` block).

Routed through handlers, that froze the poll's clock at the piece's birth day:

- every new `castAt` is stamped with the birth timestamp, so the current-day filter compares birth-day to birth-day and **votes never age out again** — the daily-reset feature (#4661) is dead the day after deploy
- the header date shows the birth date forever
- blank-date visit logs all collapse onto the birth timestamp, degrading the `wentAt` sort and `MAX_HISTORY` trim

The interval `#now/300` wish has none of these problems and the same compatibility envelope:

- **current runtimes**: the tick is initialized immediately on subscribe, refreshed on reload, and advanced by a runner-owned timer — so the day filter, header date, and vote stamps track real time, and an open tab rolls to the new day at midnight on its own (something even the pre-#4922 code only did on the next interaction)
- **pre-#4740 runtimes**: `#now/300` is unrecognized exactly like `#now` is — the wish stays unresolved, `nowTick` reads null, and the existing guards keep their behavior (empty vote view, placeholder date, vote/log handlers no-op; explicit-date visit logging still works)

Five-minute coarsening is plenty for day-granularity stamps and keeps tick writes negligible (one shared cell per space; concurrent tabs' writes are idempotent, first commit wins).

With a ticking source the per-session `today` cell could only ever pin a session *behind* the shared clock (it stores the tick at last interaction), so it is removed rather than kept as dead weight — the `today.get() || loadedAt` fallback dance and its scoped-cell-pitfall caveats dissolve with it.

## Test posture

The ticking contract itself is pinned at the runner level (`wish.test.ts`: `#now/5` coarsening, `#now/1` ticking, `#now/0` rejection, `#now/60`, `#now/86400`). Pattern tests pin the wiring: a handler-cast vote lands in `todaysVotes`, `todayDate` agrees with an independently-wished reference clock, and a seeded previous-day vote stays hidden. Frozen-vs-ticking is not distinguishable at pattern-test granularity — a fresh instantiation always captures a fresh one-shot — which is why #4922's regression was invisible to CI; the runner tests are the honest home for that distinction.

## Coordination

#4928 (canonical profile links) touches overlapping regions of `main.tsx`; whichever lands second needs a small mechanical rebase. `joinedAt: 0` and the silent no-op of voting on pre-#4740 runtimes are deliberately unchanged here.

## Validation

- `deno task cf check packages/patterns/lunch-poll/main.tsx --no-run` — clean, no diagnostics
- `deno task cf test packages/patterns/lunch-poll/ --root packages/patterns` — 74 passed, 0 failed
- `deno fmt --check` / `deno lint` on both touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787440000&installation_model_id=428580&pr_number=4959&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4959&signature=7f58c252508e766efd7e39562d3ead04c4b31ad1b569f018c1319940f9744f89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the lunch poll clock freezing by switching from one-shot `#now` to the shared five-minute tick `#now/300`, so the header date, daily filter, and timestamps track real time. Removes the per-session `today` override and updates tests to use the same ticking clock.

- **Bug Fixes**
  - Votes now age out at midnight; header date updates without interaction.
  - Visit logs record correct `wentAt` and trim order.
  - Pre-#4740 runtimes degrade safely: unresolved wish → empty view/placeholder, vote/log handlers no-op.

- **Refactors**
  - Replaced `#now` with `#now/300`; removed `today` cell and `loadedAt` fallback paths; handlers stamp with `nowTick`.
  - Test suite mirrors the tick (`#now/300`) for reference time reads.

<sup>Written for commit 30fd9ea39f6d20e3fc3b0a4d81adb2c4e8c824c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

