### PR TITLE
docs(cts): TODO to retire pre-moduleIdentity aged-data exceptions (mid-Sept 2026)

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -2602,6 +2602,22 @@ non-exported case reaches provenance through the `__cfReg` registration sink
 — the gap guarded by
 `packages/runner/test/cfc-nonexported-binding-identity.test.ts`.
 
+> **TODO (review after 2026-09-15): retire the pre-`moduleIdentity` aged-data
+> exceptions.** The writeAuthorizedBy path carries several compatibility
+> allowances purely so integrity works over data written before claims were
+> `moduleIdentity`-anchored: the one-leading-segment spelling tolerance in
+> reconciliation (`writerClaimFilesCorrespond`), stamp adoption onto stored
+> *unstamped* claims, the legacy `bundleId` stamp arm, and the unstamped
+> minting path for callers that omit the identity map. Claims born stamped
+> (labs#4871) mean every write now anchors on `moduleIdentity`, so aged
+> claims **self-heal on their next write** — once no pre-anchoring data
+> remains, these exceptions can be deleted and verification tightened to
+> require an exact `moduleIdentity` match. Revisit around mid-September 2026:
+> confirm the aged-data population has drained (or force a rewrite sweep),
+> then remove the tolerance in `writer-claim-correspondence.ts`, the
+> unstamped-adoption branch in `reconcileWriterClaimStamp`, the `bundleId`
+> arm, and this note. (Berni's ask on the labs#4871 review.)
+
 No fixture in `test/fixtures/**` exercises `__cfBindVerifiedBinding` as of
 this writing; the annotation paths are covered by `test/cfc-authoring.test.ts`
 and the runner tests above.


### PR DESCRIPTION
## Why

Follow-up to #4871, per @seefeldb's review ask. The `writeAuthorizedBy` path carries several compatibility allowances that exist purely to keep integrity working over data written **before** claims were `moduleIdentity`-anchored:

- the one-leading-segment spelling tolerance in reconciliation (`writerClaimFilesCorrespond`),
- stamp adoption onto stored **unstamped** claims,
- the legacy `bundleId` stamp arm,
- the unstamped minting path for callers that omit the identity map.

Claims are now **born stamped** (#4871), so every write anchors on `moduleIdentity` and aged claims **self-heal on their next write**. Once the pre-anchoring data population has drained, these exceptions can be deleted and verification tightened to require an exact `moduleIdentity` match — removing a class of subtle, security-adjacent leniency.

## What Changed

A single dated **TODO (review after 2026-09-15)** in the behavior spec's `writeAuthorizedBy` section (`docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md`), naming each exception and the exact removal sites, so this doesn't get forgotten. Docs-only; no code change.

## Test plan

Docs-only; spec-sync test passes. No code blocks added (nothing for `check-docs` to compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only: add a dated TODO in the behavior spec to retire pre-`moduleIdentity` aged-data exceptions in `writeAuthorizedBy` after 2026-09-15 (CT-1886). It lists each exception and where to remove it, so verification can require exact `moduleIdentity` matches once legacy data drains.

<sup>Written for commit 623c7bc8d77f654e87f273b0d5f3097c9a8c7e51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

