### PR TITLE
docs(now-wish): stop presenting bare #now as reactive time

### DIFF
--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -46,7 +46,7 @@ Allowed inside patterns:
 | `.get()` on computed or lift result | Access directly; only `Writable` uses `.get()` |
 | `items.filter(...)` inline in JSX | Wrap in `computed()` outside JSX |
 | `items.sort(...)` inline in JSX | Wrap in `computed()` outside JSX |
-| `Date.now()`/`new Date()` or `Math.random()` in a `computed()` or `lift()`, or at pattern-body level | These built-ins throw a `TimeCapabilityError` outside a handler; read them in `action()`/`handler()`, or use the `#now` wish for reactive time |
+| `Date.now()`/`new Date()` or `Math.random()` in a `computed()` or `lift()`, or at pattern-body level | These built-ins throw a `TimeCapabilityError` outside a handler; read them in `action()`/`handler()`, or use the interval `#now/N` wish for reactive time (bare `#now` is a frozen one-shot) |
 | `Date.now()`/`new Date()` or `Math.random()` inside a re-running computation (`computed()` or `lift()`) without clear intent | Move the snapshot into `action()`, `handler()`, or one-time initialization |
 | nested computed with outer-scope reactive vars | Pre-compute with lift or an outer computed |
 | `lift()` closing over reactive deps | Pass dependencies as explicit parameters |

--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -205,8 +205,11 @@ are:
     `TimeCapabilityError`, because an ambient clock/entropy read there would
     break idempotency. Inside a handler the clock is coarsened to one-second
     resolution.
-  - for a live clock a `computed()` can react to, read the `#now` wish
-    (`wish({ query: "#now" })` or `#now/N`) instead
+  - for a live clock a `computed()` can react to, read the interval `#now`
+    wish (`wish({ query: "#now/N" })`, N in seconds) instead. The bare `#now`
+    wish is not a clock: it durably captures the piece's first-ever load time
+    and never advances — right for a created-at stamp, wrong for anything
+    that must track the current time
 
 Locale-sensitive formatting works, with pinned defaults:
 

--- a/docs/common/concepts/action.md
+++ b/docs/common/concepts/action.md
@@ -79,7 +79,8 @@ one-off IDs.
   These built-ins are gated by the sandbox: allowed inside an action or handler
   (the clock is coarsened to one-second resolution), and they throw a
   `TimeCapabilityError` in a lift/computed or at pattern-body level. For
-  reactive time in a computed, read the `#now` wish.
+  reactive time in a computed, read the interval `#now/N` wish (bare `#now` is
+  a frozen first-load capture, not a clock).
 - Prefer capturing time/random snapshots in the action itself rather than
   inside a `computed()` that may re-run many times.
 

--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -114,8 +114,9 @@ Reading the ambient clock or entropy inside a `computed()` — `Date.now()`,
 no-argument `new Date()`, or `Math.random()` — throws a `TimeCapabilityError`:
 those are reactive inputs that would themselves break the idempotency this
 section is about. Capture a timestamp inside a handler (where `Date.now()` is
-allowed, coarsened to one-second resolution), or read the reactive `#now` wish
-for a value that updates on its own.
+allowed, coarsened to one-second resolution), or read the interval `#now/N`
+wish for a value that updates on its own (the bare `#now` wish is a durable
+one-shot — the piece's first-ever load time — and never updates).
 
 The scheduler re-runs computations when their dependencies change. If a computation modifies a cell it depends on, it triggers itself. With idempotent operations, the second run produces no change, so the system settles.
 

--- a/docs/common/concepts/handler.md
+++ b/docs/common/concepts/handler.md
@@ -101,7 +101,8 @@ instead of hiding it in module-scoped mutable variables.
   timestamp or random ID. Inside a handler these built-ins are allowed (the
   clock is coarsened to one-second resolution); in a lift/computed or at
   pattern-body level they throw a `TimeCapabilityError`. For reactive time in a
-  computed, read the `#now` wish.
+  computed, read the interval `#now/N` wish (bare `#now` is a frozen
+  first-load capture, not a clock).
 - Timers are not part of the authored surface and do not compile, so drive
   timed work through the scheduler rather than reaching for `setTimeout()` or
   `setInterval()` in handler code.

--- a/docs/common/conventions/wish.md
+++ b/docs/common/conventions/wish.md
@@ -237,7 +237,7 @@ The `scope` parameter can redirect or fan the others out across other spaces.
 | `#suggestions`      | Suggestion history of the current space                 |
 | `#summaryIndex`     | Summary index of the current space                      |
 | `#knowledgeGraph`   | Knowledge graph of the current space                    |
-| `#now`              | Current timestamp (one-shot, 1s resolution)             |
+| `#now`              | Piece's first-ever load time, durable — never advances  |
 | `#now/N`            | Reactive timestamp, every N seconds (N must be 1-86400) |
 | `#favorites`        | User's favorites list (home space)                      |
 | `#favorites/<term>` | First favorite matching `<term>` (legacy search)        |
@@ -258,7 +258,9 @@ routed to the suggestion picker.
 
 ```tsx
 // Shown inside a pattern body.
-// One-shot: captures the time once at first load, never updates.
+// One-shot: durably captures the piece's FIRST-EVER load time — a reload, or
+// any other runtime opening the same piece, reads the original capture. It
+// never updates; use it for created-at stamps, never as a clock.
 const createdAt = wish<number>({ query: "#now" });
 
 // Reactive: updates every 60 seconds, re-triggering downstream computed()s.

--- a/docs/common/conventions/wish.md
+++ b/docs/common/conventions/wish.md
@@ -272,6 +272,17 @@ const timeAgo = computed(() => {
 });
 ```
 
+For a one-off timestamp of the **triggering event** — not the piece's first
+load, and not a reactive tick — call `Date.now()` / `new Date()` directly
+**inside a handler or action**. There the sandbox exposes the event's own
+instant, frozen for the whole handler cascade and coarsened to one-second
+resolution; it is not a live wall-clock read (shaped/delayed delivery can make
+it lag real time). The three sit on a spectrum: `#now` is the piece's first-load
+instant, the handler clock is the current event's instant (a single frozen
+reading), and `#now/N` is a reading that keeps refreshing. Reach for `#now` only
+for a created-at stamp; use the handler clock to stamp an event, or `#now/N` for
+a value that must track the current time.
+
 ### Periodic work: polling a data source on a `#now/N` tick
 
 `#now/N` is also how a pattern does periodic *work* — "check this feed every five

--- a/packages/patterns/examples/reactive-now.tsx
+++ b/packages/patterns/examples/reactive-now.tsx
@@ -17,7 +17,9 @@ import {
 //    reactive code: `Date.now()` / `new Date()` throw in a lift, a computed, or
 //    the pattern body (a live clock read would make the computation
 //    non-idempotent). The replacement is the `#now` wish:
-//      wish({ query: "#now" })     one snapshot, captured when it first resolves
+//      wish({ query: "#now" })     one durable snapshot — the piece's
+//                                  FIRST-EVER load; reloads and other
+//                                  runtimes read the original capture
 //      wish({ query: "#now/N" })   a fresh snapshot every N seconds
 //    Both are coarse (one second) and grid-aligned, and read `null` until the
 //    wish resolves — so guard for that load window. `new Date(ms)` with an
@@ -62,7 +64,7 @@ const setTyped = handler<{ value: string }, { typed: Writable<string> }>(
 export interface ReactiveNowOutput {
   [NAME]: string;
   [UI]: VNode;
-  /** The one-shot load time, "HH:MM:SS" (or "…" before #now resolves). */
+  /** The piece's first-load time, "HH:MM:SS" (or "…" before #now resolves). */
   loadedAt: string;
   /** The ticking current time, "HH:MM:SS" (or "…"). */
   now: string;
@@ -85,7 +87,8 @@ export interface ReactiveNowOutput {
 }
 
 export const ReactiveNow = pattern<void, ReactiveNowOutput>(() => {
-  // One-shot: resolves once, then holds — a stable "when this instance loaded".
+  // One-shot: resolves once, then holds durably — "when this piece FIRST
+  // loaded", shared by every later reload and runtime (not per-session).
   const loadedAtCell = wish<number>({ query: "#now" });
   // Ticking: a fresh coarse timestamp every second.
   const nowCell = wish<number>({ query: "#now/1" });

--- a/packages/patterns/examples/reactive-now.tsx
+++ b/packages/patterns/examples/reactive-now.tsx
@@ -24,6 +24,12 @@ import {
 //    Both are coarse (one second) and grid-aligned, and read `null` until the
 //    wish resolves — so guard for that load window. `new Date(ms)` with an
 //    explicit argument is deterministic and is NOT gated.
+//    For a one-off timestamp of the TRIGGERING EVENT, `Date.now()` / `new Date()`
+//    are allowed directly inside a handler/action — no wish needed. That is the
+//    event's own instant, frozen for the whole handler cascade and coarsened to
+//    one second; it is NOT a live wall-clock read (shaped/delayed delivery can
+//    make it lag real time). Use it to stamp the event; use `#now/N` when the
+//    value must keep refreshing reactively.
 //
 // 2. Receiving input — delivery shaping (W3 events, plan-B cell flips). Input
 //    reaches a pattern two ways, and both are shaped by the same token bucket: the

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -1188,13 +1188,13 @@ formatting.
 ## `examples/reactive-now.tsx`
 
 Example pattern demonstrating both pattern-facing surfaces of the timing
-side-channel mitigations. Reading time: a one-shot `#now` snapshot (load time),
-a ticking `#now/1` clock (current time), and a `#now`-derived "N seconds ago"
-elapsed label — a worked reference for migrating clock reads off the forbidden
-body-level `Date.now()` onto `#now`. Receiving input: a "Tap" button and a
-`$value` text box, so a live browser can watch the token-bucket delivery shaping
-— bursts are realtime, only sustained mashing/typing is throttled, and nothing
-is dropped.
+side-channel mitigations. Reading time: a one-shot `#now` snapshot (the piece's
+first-ever load, durable), a ticking `#now/1` clock (current time), and a
+`#now`-derived "N seconds ago" elapsed label — a worked reference for migrating
+clock reads off the forbidden body-level `Date.now()` onto `#now`. Receiving
+input: a "Tap" button and a `$value` text box, so a live browser can watch the
+token-bucket delivery shaping — bursts are realtime, only sustained
+mashing/typing is throttled, and nothing is dropped.
 
 **Keywords:** now, wish, time, elapsed, relative-time, reactive,
 capability-gate, timing, delivery-shaping, token-bucket, input

--- a/packages/runner/src/builder/safe-builtins.ts
+++ b/packages/runner/src/builder/safe-builtins.ts
@@ -42,9 +42,11 @@ export function sandboxDateNow(): number {
   throw new TimeCapabilityError(
     "The ambient clock (Date.now() / new Date()) is not available in this " +
       "context. Read it inside a handler (it reports the triggering event's " +
-      "time, coarsened to one second), or for reactive display read the #now " +
-      'clock (wish({ query: "#now" }) or #now/N). Formatting a known timestamp ' +
-      "with new Date(ms) is unaffected.",
+      "time, coarsened to one second), or for a live clock read the interval " +
+      '#now wish (wish({ query: "#now/N" }), N in seconds). The bare "#now" ' +
+      "wish is not a clock — it durably captures the piece's first-ever load " +
+      "time and never advances (use it for created-at stamps). Formatting a " +
+      "known timestamp with new Date(ms) is unaffected.",
   );
 }
 

--- a/skills/cf-review/SKILL.md
+++ b/skills/cf-review/SKILL.md
@@ -111,8 +111,9 @@ A confirmed bug or regression is Blocking. Watch especially for:
   timers in a lift, computed, or pattern body. These built-ins are gated by the
   sandbox: allowed only inside a handler (the clock coarsened to one-second
   resolution) and throwing a `TimeCapabilityError` elsewhere. Reading the clock
-  reactively in a computed is the `#now` wish. A read that survives into a
-  re-running computation is a bug regardless.
+  reactively in a computed is the interval `#now/N` wish — flag bare `#now` used
+  as a clock: it durably freezes at the piece's first-ever load. A read that
+  survives into a re-running computation is a bug regardless.
 - **Time-based waits _(any code)_** — `sleep` / `setTimeout` used to "wait for"
   a result instead of awaiting the actual event or signal. Almost never
   justified (animations aside) and a prime source of CI flakiness: what takes X

--- a/skills/fuse-agent/SKILL.md
+++ b/skills/fuse-agent/SKILL.md
@@ -180,8 +180,9 @@ const id = `${now.toString(36)}-${Math.random().toString(36).slice(2, 11)}`;
 const timestamp = new Date(now).toISOString();
 ```
 
-For reactive time in a computed, read the live clock with the `#now` wish rather
-than calling `Date.now()`.
+For reactive time in a computed, read the live clock with the interval `#now/N`
+wish rather than calling `Date.now()` (bare `#now` is a frozen first-load
+capture, not a clock).
 
 If a handler fails with messages like:
 


### PR DESCRIPTION
## Summary

Follow-up to #4959. Every guidance surface that tells authors how to read time reactively presented bare `#now` as the answer — with `#now` listed first or alone: the `TimeCapabilityError` message itself, `pattern-development-guide.md`, `pattern-critique-guide.md`, the `computed`/`action`/`handler` concept docs, the `wish.md` target table, the `reactive-now.tsx` worked example's comments, and the `cf-review` / `fuse-agent` skills.

Bare `#now` is not reactive: it durably captures the piece's **first-ever** load time (keyed by the wish node's cause — every later reload, session, and runtime reads the original capture) and never advances. The runtime's own error message steered pattern authors into exactly the trap #4922 fell into, where the lunch poll's current-day filter froze at the poll's birth day.

This change says it plainly at all eleven sites: **reactive/live time is the interval `#now/N` wish; bare `#now` is a durable first-load capture — right for created-at stamps, wrong for clocks.** The `cf-review` skill now also asks reviewers to flag bare `#now` used as a clock.

## Notes

- Text-only: no behavior changes. The `TimeCapabilityError` string is not pinned by any test (checked).
- `wish.md`'s example already used `createdAt` for the one-shot — the correct idiom — so only its comments sharpened.
- `packages/patterns/factory-outputs/lot-watch/DESIGN.md` mentions a future "`#now`-driven purge" generically; left alone (it makes no claim about bare-`#now` semantics).

## Validation

- `deno task check-docs` — all 518 code blocks pass
- `deno task check-skill-facts` — OK
- `deno task cf check packages/patterns/examples/reactive-now.tsx --no-run` — clean
- `deno check packages/runner/src/builder/safe-builtins.ts` + `deno fmt --check` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies time semantics across docs, examples, skills, and the `TimeCapabilityError` message: bare `#now` is a durable first-load timestamp (shared across reloads/runtimes); `#now/N` is the reactive clock; the handler/action clock is a one-off event timestamp (the triggering event’s instant, frozen for the cascade and coarsened to 1s), not a live wall clock. Text-only updates; no behavior changes.

- **Migration**
  - Replace `#now` used as a clock with `#now/N` (N=1–86400 seconds).
  - For a one-off event timestamp, call `Date.now()` / `new Date()` in a handler or action — the event’s instant, frozen for the cascade and coarsened to 1s (not a live wall clock).
  - Keep `#now` only for created-at timestamps.

<sup>Written for commit 2e1bcddacf72defe3c14d420cc829660ca2a4989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

