### PR TITLE
ci: require one aggregate check for pull requests

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,7 +1,7 @@
 name: Coverage Comment
 
 # Posts the coverage-debt suggestion comment produced by the Coverage Check
-# gate in the Deno Workflow. That gate runs on `pull_request`, where fork PRs
+# gate in the CI workflow. That gate runs on `pull_request`, where fork PRs
 # only get a read-only token, so it cannot comment directly — it uploads the
 # comment as the `coverage-comment` artifact instead. This workflow runs in the
 # base-repo context (trusted, default-branch code) with a write token and posts
@@ -9,7 +9,7 @@ name: Coverage Comment
 
 on:
   workflow_run:
-    workflows: ["Deno Workflow"]
+    workflows: ["CI"]
     types:
       - completed
 

--- a/.github/workflows/dashboard-image.yml
+++ b/.github/workflows/dashboard-image.yml
@@ -1,19 +1,8 @@
-name: Dashboard Image
+name: Dashboard
 
 on:
+  workflow_call:
   push:
-    branches: [main]
-    paths:
-      - "Dockerfile.dashboard"
-      - "packages/dashboard/**"
-      - "scripts/ci-gantt.ts"
-      - "deno.jsonc"
-      - "deno.lock"
-      - ".dockerignore"
-      - ".github/actions/deno-setup/**"
-      - ".github/actions/deno-install/**"
-      - ".github/workflows/dashboard-image.yml"
-  pull_request:
     branches: [main]
     paths:
       - "Dockerfile.dashboard"
@@ -30,7 +19,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: dashboard-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -38,8 +27,8 @@ env:
   SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
-  dashboard_tests:
-    name: Dashboard tests
+  tests:
+    name: Tests
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
@@ -59,8 +48,8 @@ jobs:
         working-directory: packages/dashboard
         run: deno task test
 
-  dashboard_build:
-    name: Dashboard image build
+  build:
+    name: Image build
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
@@ -83,8 +72,8 @@ jobs:
           tags: ${{ env.IMAGE }}:${{ env.SOURCE_SHA }}
 
   publish_authorization:
-    name: Authorize dashboard image publish
-    needs: [dashboard_tests, dashboard_build]
+    name: Authorize publish
+    needs: [tests, build]
     if: ${{ !cancelled() }}
     outputs:
       allowed: ${{ steps.decision.outputs.allowed }}
@@ -95,11 +84,11 @@ jobs:
         id: decision
         env:
           ACTOR_ID: ${{ github.actor_id }}
-          BUILD_RESULT: ${{ needs.dashboard_build.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
           PUSH_BRANCH: ${{ vars.PUSH_BRANCH }}
           PUBLISHER_ACTOR_IDS: ${{ vars.DASHBOARD_PUBLISHER_ACTOR_IDS }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
-          TEST_RESULT: ${{ needs.dashboard_tests.result }}
+          TEST_RESULT: ${{ needs.tests.result }}
         shell: bash
         run: |
           allowed=false
@@ -122,9 +111,9 @@ jobs:
           echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
 
   publish:
-    name: Publish dashboard image
-    needs: [dashboard_tests, dashboard_build, publish_authorization]
-    if: ${{ needs.publish_authorization.outputs.allowed == 'true' }}
+    name: Publish image
+    needs: [tests, build, publish_authorization]
+    if: ${{ !cancelled() && needs.publish_authorization.outputs.allowed == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     permissions:
@@ -243,3 +232,48 @@ jobs:
             echo "- Tag: \`${IMAGE}:${SOURCE_SHA}\`"
             echo "- Digest: \`${IMAGE}@${DIGEST}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  status:
+    name: Status
+    needs:
+      - tests
+      - build
+      - publish_authorization
+      - publish
+    if: ${{ always() }}
+    permissions: {}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: 🔎 Verify dashboard jobs
+        env:
+          AUTHORIZATION_RESULT: ${{ needs.publish_authorization.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          PUBLISH_ALLOWED: ${{ needs.publish_authorization.outputs.allowed }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          TEST_RESULT: ${{ needs.tests.result }}
+        shell: bash
+        run: |
+          failures=()
+
+          [[ "$TEST_RESULT" == "success" ]] ||
+            failures+=("tests: ${TEST_RESULT}")
+          [[ "$BUILD_RESULT" == "success" ]] ||
+            failures+=("build: ${BUILD_RESULT}")
+          [[ "$AUTHORIZATION_RESULT" == "success" ]] ||
+            failures+=("publish_authorization: ${AUTHORIZATION_RESULT}")
+
+          if [[ "$PUBLISH_ALLOWED" == "true" ]]; then
+            [[ "$PUBLISH_RESULT" == "success" ]] ||
+              failures+=("publish: ${PUBLISH_RESULT}")
+          elif [[ "$PUBLISH_ALLOWED" == "false" ]]; then
+            [[ "$PUBLISH_RESULT" == "skipped" ]] ||
+              failures+=("publish: ${PUBLISH_RESULT}")
+          else
+            failures+=("publish_authorization output: ${PUBLISH_ALLOWED:-missing}")
+          fi
+
+          if (( ${#failures[@]} > 0 )); then
+            printf 'Unsuccessful dashboard jobs:\n'
+            printf '%s\n' "${failures[@]}"
+            exit 1
+          fi

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,4 +1,4 @@
-name: Deno Workflow
+name: CI
 
 on:
   push:
@@ -20,6 +20,14 @@ jobs:
   # ---------------------------------------------------------------------------
   # Tier 0 – These jobs all start immediately with no dependencies
   # ---------------------------------------------------------------------------
+  dashboard:
+    name: "Dashboard"
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/dashboard-image.yml
+    permissions:
+      contents: read
+      id-token: write
+
   check:
     name: "Check"
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -974,6 +982,43 @@ jobs:
           path: perf-metrics.json
           retention-days: 90
           if-no-files-found: ignore
+
+  status:
+    name: "Status"
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs:
+      - dashboard
+      - check
+      - cfcheck
+      - test
+      - runner-test
+      - build-toolshed
+      - build-bg-piece-service
+      - build-cf
+      - generated-patterns-integration-test
+      - package-integration-test
+      - cli-integration-test
+      - pattern-integration-test
+      - pattern-reload-integration-test
+      - pattern-unit-test
+      - coverage-check
+    permissions: {}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: 🔎 Verify pull request jobs
+        env:
+          JOB_RESULTS: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r '
+            to_entries[]
+            | select(.value.result != "success")
+            | "\(.key): \(.value.result)"
+          ' <<< "$JOB_RESULTS")
+
+          if [[ -n "$failures" ]]; then
+            printf 'Unsuccessful pull request jobs:\n%s\n' "$failures"
+            exit 1
+          fi
 
   attest-binaries:
     name: "Attest and Upload Binaries"

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -18,6 +18,31 @@ same rough band. As a default, stop when:
 At that point, keep the timing instrumentation and wait for a concrete trigger
 instead of continuing to split jobs proactively.
 
+## Required Pull Request Checks
+
+Configure merge protection to require `Status`. The GitHub web interface shows
+that check as `CI / Status`, joining the workflow's name to the job's name, but
+merge protection stores and matches the job's name on its own.
+
+`Status` runs after every pull request validation job in `deno.yml`. It runs
+after failed and skipped dependencies. It fails unless every dependency
+succeeded. Add each new pull request validation job to its `needs` list. Its
+dependencies include the reusable Dashboard workflow.
+
+The Dashboard workflow's internal `Status` job waits for the dashboard tests,
+image build, publish authorization, and any authorized publish. The reusable
+workflow reports that result to the CI workflow's `Status`. GitHub names a
+check from a called workflow by joining the calling job's name to the called
+job's name, so that one is called `Dashboard / Status` and does not collide
+with the check to require. Do not require it separately in merge protection.
+
+Keep pull request path filters out of workflows that provide required checks.
+GitHub leaves a required check pending when a path filter prevents its workflow
+from starting.
+
+Require checks from other GitHub Apps separately. A GitHub Actions job cannot
+depend on a check produced by another app.
+
 ## Revisit Triggers
 
 Revisit CI wall-time optimization when at least one of these holds across

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -643,10 +643,14 @@ its embedded tsnet).
 
 **Build, push, deploy**
 
-`.github/workflows/dashboard-image.yml` runs only when the dashboard image,
+On pull requests, the CI workflow calls
+`.github/workflows/dashboard-image.yml` as a reusable workflow. Every pull
+request runs the dashboard tests and an amd64 image build without cloud
+credentials. The internal `Status` job verifies the dashboard workflow, and the
+CI workflow's required `Status` job waits for that result. Main-branch pushes
+start the Dashboard workflow directly only when the dashboard image,
 dashboard package, Gantt drill-down, Deno dependency metadata, or the workflow
-itself changes. Pull requests always run the dashboard tests and an amd64 image
-build without cloud credentials.
+itself changes.
 
 For organization-member pull requests, a passing dashboard test and image build
 publish the source commit as `dev-dashboard:<full-sha>`. A controlled rerun may

--- a/packages/patterns/integration/home-rehydration-churn.test.ts
+++ b/packages/patterns/integration/home-rehydration-churn.test.ts
@@ -26,7 +26,7 @@ const TRUSTED_PROFILE_CREATE_ACTION = "CreateProfile";
 // greppable.
 //
 // To pull the distribution from the most recent 100 CI runs (this test runs in
-// the "Deno Workflow" / deno.yml `package-integration-test` job; PRs land on
+// the "CI" / deno.yml `package-integration-test` job; PRs land on
 // commontoolsinc/labs — adjust -R for a fork). Requires the `gh` CLI:
 //
 //   gh run list -R commontoolsinc/labs --workflow deno.yml --limit 100 \

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -1,0 +1,218 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+
+function jobBlock(workflow: string, jobId: string): string {
+  const jobsStart = workflow.indexOf("jobs:\n");
+  assert(jobsStart >= 0, "workflow jobs section not found");
+
+  const header = `  ${jobId}:\n`;
+  const start = workflow.indexOf(header, jobsStart);
+  assert(start >= 0, `${jobId} job not found`);
+
+  const bodyStart = start + header.length;
+  const nextJobOffset = workflow.slice(bodyStart).search(
+    /^ {2}[A-Za-z_][A-Za-z0-9_-]*:\n/m,
+  );
+  const end = nextJobOffset < 0 ? workflow.length : bodyStart + nextJobOffset;
+  return workflow.slice(start, end);
+}
+
+function jobIds(workflow: string): string[] {
+  const jobsStart = workflow.indexOf("jobs:\n");
+  assert(jobsStart >= 0, "workflow jobs section not found");
+  return [
+    ...workflow.slice(jobsStart).matchAll(
+      /^ {2}([A-Za-z_][A-Za-z0-9_-]*):\n/gm,
+    ),
+  ].map((match) => match[1]);
+}
+
+function neededJobIds(job: string): string[] {
+  const marker = "\n    needs:\n";
+  const needsStart = job.indexOf(marker);
+  assert(needsStart >= 0, "job needs list not found");
+
+  const needsBody = job.slice(needsStart + marker.length);
+  const nextProperty = needsBody.search(/^ {4}[A-Za-z_][A-Za-z0-9_-]*:/m);
+  const needs = nextProperty < 0 ? needsBody : needsBody.slice(0, nextProperty);
+  return [...needs.matchAll(/^ {6}- ([A-Za-z_][A-Za-z0-9_-]*)$/gm)].map(
+    (match) => match[1],
+  );
+}
+
+async function workflow(name: string): Promise<string> {
+  return await Deno.readTextFile(
+    new URL(`../.github/workflows/${name}`, import.meta.url),
+  );
+}
+
+function workflowTriggers(contents: string): string {
+  const triggerEnd = contents.indexOf("\npermissions:");
+  if (triggerEnd >= 0) return contents.slice(0, triggerEnd);
+
+  const concurrencyStart = contents.indexOf("\nconcurrency:");
+  assert(concurrencyStart >= 0, "workflow trigger section not found");
+  return contents.slice(0, concurrencyStart);
+}
+
+Deno.test("Status waits for every pull request validation job", async () => {
+  const contents = await workflow("deno.yml");
+  const gate = jobBlock(contents, "status");
+  const pushOnlyJobs = new Set([
+    "attest-binaries",
+    "deploy-toolshed",
+    "deploy-rapids",
+    "deploy-shell-staging",
+  ]);
+  const expected = jobIds(contents).filter((jobId) =>
+    jobId !== "status" && !pushOnlyJobs.has(jobId)
+  ).sort();
+
+  assertEquals(neededJobIds(gate).sort(), expected);
+  assertStringIncludes(contents, "name: CI\n");
+  assertStringIncludes(gate, 'name: "Status"');
+  assertStringIncludes(
+    gate,
+    "if: ${{ always() && github.event_name == 'pull_request' }}",
+  );
+  assertStringIncludes(gate, "JOB_RESULTS: ${{ toJSON(needs) }}");
+  assertStringIncludes(gate, 'select(.value.result != "success")');
+  assertStringIncludes(gate, "permissions: {}");
+});
+
+Deno.test("Status calls reusable dashboard validation", async () => {
+  const deno = await workflow("deno.yml");
+  const dashboard = await workflow("dashboard-image.yml");
+  const caller = jobBlock(deno, "dashboard");
+
+  assertStringIncludes(caller, 'name: "Dashboard"');
+  assertStringIncludes(
+    caller,
+    "if: ${{ github.event_name == 'pull_request' }}",
+  );
+  assertStringIncludes(
+    caller,
+    "uses: ./.github/workflows/dashboard-image.yml",
+  );
+  assertStringIncludes(
+    caller,
+    "permissions:\n      contents: read\n      id-token: write",
+  );
+  assertStringIncludes(
+    dashboard,
+    "\npermissions:\n  contents: read\n\nconcurrency:\n",
+  );
+  assertEquals(
+    neededJobIds(jobBlock(deno, "status")).includes("dashboard"),
+    true,
+  );
+
+  const denoTriggers = workflowTriggers(deno);
+  assertStringIncludes(denoTriggers, "  pull_request:\n");
+  assertEquals(denoTriggers.includes("\n    paths:"), false);
+
+  const dashboardTriggers = workflowTriggers(dashboard);
+  assertStringIncludes(dashboardTriggers, "  workflow_call:\n");
+  assertStringIncludes(
+    dashboardTriggers,
+    "  push:\n    branches: [main]\n    paths:\n",
+  );
+  assertEquals(dashboardTriggers.includes("  pull_request:\n"), false);
+  assertStringIncludes(
+    dashboard,
+    "group: dashboard-${{ github.event.pull_request.number || github.ref }}",
+  );
+});
+
+Deno.test("Coverage Comment follows the CI workflow by name", async () => {
+  const deno = await workflow("deno.yml");
+  const comment = await workflow("coverage-comment.yml");
+  const name = deno.match(/^name: (.+)$/m);
+  assert(name, "workflow name not found");
+
+  assertStringIncludes(comment, `    workflows: ["${name[1]}"]\n`);
+});
+
+Deno.test("Dashboard Status verifies every reusable workflow job", async () => {
+  const contents = await workflow("dashboard-image.yml");
+  assertStringIncludes(contents, "name: Dashboard\n");
+  assertEquals(jobIds(contents).includes("dashboard_scope"), false);
+
+  const gate = jobBlock(contents, "status");
+  const expected = jobIds(contents).filter((jobId) => jobId !== "status")
+    .sort();
+  assertEquals(neededJobIds(gate).sort(), expected);
+  for (const jobId of expected) {
+    assertStringIncludes(gate, `needs.${jobId}.result`);
+  }
+  assertStringIncludes(gate, "name: Status");
+  assertStringIncludes(gate, "if: ${{ always() }}");
+  assertStringIncludes(
+    gate,
+    "needs.publish_authorization.outputs.allowed",
+  );
+  assertStringIncludes(gate, 'TEST_RESULT" == "success"');
+  assertStringIncludes(gate, 'BUILD_RESULT" == "success"');
+  assertStringIncludes(gate, 'AUTHORIZATION_RESULT" == "success"');
+  assertStringIncludes(gate, 'PUBLISH_ALLOWED" == "true"');
+  assertStringIncludes(gate, 'PUBLISH_ALLOWED" == "false"');
+  assertStringIncludes(gate, "permissions: {}");
+});
+
+Deno.test("called dashboard validation always runs", async () => {
+  const contents = await workflow("dashboard-image.yml");
+
+  for (const jobId of ["tests", "build"]) {
+    const validation = jobBlock(contents, jobId);
+    assertEquals(validation.includes("\n    needs:"), false);
+    assertEquals(validation.includes("\n    if:"), false);
+  }
+
+  const authorization = jobBlock(contents, "publish_authorization");
+  assertStringIncludes(
+    authorization,
+    "needs: [tests, build]",
+  );
+  assertStringIncludes(authorization, "if: ${{ !cancelled() }}");
+  assertStringIncludes(authorization, "ACTOR_ID: ${{ github.actor_id }}");
+  assertStringIncludes(
+    authorization,
+    'if [[ ",${PUBLISHER_ACTOR_IDS}," == *",${ACTOR_ID},"* ]]; then',
+  );
+  assertStringIncludes(
+    authorization,
+    'if [[ "$BUILD_RESULT" == "success" ]]; then',
+  );
+  assertStringIncludes(
+    authorization,
+    'elif [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$member" == "true" ]]; then',
+  );
+  assertStringIncludes(
+    authorization,
+    'if [[ "$TEST_RESULT" == "success" || ("$PUSH_BRANCH" == "true" && "$RUN_ATTEMPT" -gt 1) ]]; then',
+  );
+
+  const publish = jobBlock(contents, "publish");
+  assertStringIncludes(
+    publish,
+    "needs: [tests, build, publish_authorization]",
+  );
+  assertStringIncludes(
+    publish,
+    "!cancelled() && needs.publish_authorization.outputs.allowed == 'true'",
+  );
+  assertStringIncludes(
+    publish,
+    "permissions:\n      contents: read\n      id-token: write",
+  );
+
+  for (
+    const jobId of [
+      "tests",
+      "build",
+      "publish_authorization",
+      "status",
+    ]
+  ) {
+    assertEquals(jobBlock(contents, jobId).includes("id-token: write"), false);
+  }
+});

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -3,7 +3,7 @@
 /**
  * PR Coverage Check
  *
- * Runs as part of PR CI after all test jobs complete. Joins the coverage
+ * Runs as a PR CI job after all test jobs complete. Joins the coverage
  * profiles every test job uploaded and gates the PR on coverage debt: for each
  * source group the PR changed, the count of uncovered lines must not rise above
  * the latest non-cold `main` run's count, unless the PR description accepts the


### PR DESCRIPTION
GitHub merge protection consumes named check runs rather than a workflow-wide result. The Deno and dashboard workflows did not expose one stable result that covered every pull request validation job, so protection could miss new jobs or require multiple independently maintained checks.

Add an always-run PR CI job that waits for every pull request job and rejects every conclusion other than success. Run the dashboard tests and amd64 image build on every pull request, retain Dashboard CI as the reusable workflow's internal verifier, and call that workflow from Deno so its result reaches PR CI. Preserve the path-filtered main-branch image run, publication authorization, controlled rerun behavior, and publish-only OIDC access. Use a dashboard-specific concurrency namespace so the called workflow cannot cancel its caller.

Add workflow regression tests that keep aggregate dependencies complete and protect trigger scope, permission boundaries, publication policy, and skipped-job handling. Document PR CI as the only check that merge protection needs to require.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make PRs require one named check, `CI / Status`, that aggregates every PR job (including the reusable `Dashboard`) and fails unless all succeed. This gives branch protection a single, stable check to require.

- **New Features**
  - Renamed the main workflow to `CI` and the aggregate job to `Status`; Coverage Comment now follows `CI`.
  - Added a `status` job in `deno.yml` that waits on all PR jobs via `toJSON(needs)` + `jq` and fails on any non-success; calls the reusable `Dashboard` workflow on PRs.
  - Converted `dashboard-image.yml` into a reusable `Dashboard` workflow with its own `Status`; removed PR trigger, added `workflow_call`, renamed jobs, gated publish with `!cancelled()` and auth output, switched concurrency to `dashboard-...`, and kept main-branch path-filtered publish with publish-only OIDC.
  - Added workflow regression tests and docs to lock dependencies, triggers, permissions, publication policy, and skipped-job handling; updated `CI_PERFORMANCE.md`, dashboard README, coverage-check comment, and a test note.

- **Migration**
  - In branch protection, require only `Status` (shown as `CI / Status`). Do not require `Dashboard / Status`.
  - Keep path filters out of workflows that provide required checks. Require checks from other GitHub Apps separately.

<sup>Written for commit 63cb96bcf05b5c79ee8eb6aa829d0a004bdd213e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

