### PR TITLE
fix(memory,runner): reject non-finite `increment` amounts

### DIFF
--- a/packages/memory/test/v2-patch-test.ts
+++ b/packages/memory/test/v2-patch-test.ts
@@ -475,6 +475,23 @@ Deno.test("memory v2 increment rejects a zero amount", () => {
   assert(threw, "a zero increment must throw");
 });
 
+// A non-finite `by` is meaningless for a concurrent-sum counter and would set
+// the counter to an absorbing `NaN`/`±Infinity`, so it is rejected alongside a
+// zero amount. (`-0 === 0`, so negative zero is already caught by the zero gate.)
+Deno.test("memory v2 increment rejects a non-finite amount", () => {
+  for (const by of [NaN, Infinity, -Infinity]) {
+    let threw = false;
+    try {
+      applyPatch({ value: { count: 1 } }, [
+        { op: "increment", path: "/value/count", by },
+      ]);
+    } catch {
+      threw = true;
+    }
+    assert(threw, `increment by ${by} must throw`);
+  }
+});
+
 // `remove-by-value` removes every element equal to the given value (by stored
 // value), idempotently, and is a no-op on a missing/non-array target.
 Deno.test("memory v2 remove-by-value removes matching elements", () => {

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -357,9 +357,9 @@ const incrementAtPath = (
   if (path.length === 0) {
     throw new Error("increment requires a non-root path");
   }
-  if (by === 0) {
+  if (!Number.isFinite(by) || by === 0) {
     throw new Error(
-      `increment requires a non-zero amount at ${encodePointer(path)}`,
+      `increment requires a finite non-zero amount at ${encodePointer(path)}`,
     );
   }
   const current = readNumberOrAbsent(root, path);

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1606,8 +1606,7 @@ export class CellImpl<T extends FabricValue>
     if (!Number.isFinite(by) || by === 0) {
       throw new Error(
         "Cell.increment() requires a finite non-zero amount\n" +
-          "help: a zero increment is a no-op; a non-finite amount is not a" +
-          " meaningful increment; drop the call",
+          "help: a zero or non-finite increment is not a meaningful change",
       );
     }
     if (!this.synced) this.sync();

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1603,10 +1603,11 @@ export class CellImpl<T extends FabricValue>
           "help: use in handlers only, ensure cell is typed as number",
       );
     }
-    if (by === 0) {
+    if (!Number.isFinite(by) || by === 0) {
       throw new Error(
-        "Cell.increment() requires a non-zero amount\n" +
-          "help: a zero increment is a no-op; drop the call",
+        "Cell.increment() requires a finite non-zero amount\n" +
+          "help: a zero increment is a no-op; a non-finite amount is not a" +
+          " meaningful increment; drop the call",
       );
     }
     if (!this.synced) this.sync();

--- a/packages/runner/test/array-push-mergeable.test.ts
+++ b/packages/runner/test/array-push-mergeable.test.ts
@@ -556,6 +556,26 @@ describe("mergeable array appends", () => {
       await rt1.dispose();
     }
   });
+
+  // A non-finite amount is not a meaningful increment for a concurrent-sum
+  // counter (it would set the counter to an absorbing `NaN`/`±Infinity`), so it
+  // is rejected before any local write or mergeable-op record.
+  it("increment(non-finite) throws", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    try {
+      const tx = rt1.edit();
+      const cell = rt1.getCell<number>(space, COUNTER_CAUSE, numberSchema, tx);
+      expect(() => cell.increment(NaN)).toThrow();
+      expect(() => cell.increment(Infinity)).toThrow();
+      expect(() => cell.increment(-Infinity)).toThrow();
+      await tx.commit();
+    } finally {
+      await rt1.dispose();
+    }
+  });
 });
 
 // A "keyed collection": a list whose elements are separate entities, each


### PR DESCRIPTION
## What

Both increment enforcement points gated only on `by === 0`, which `NaN`, `Infinity`, and `-Infinity` slip through (`NaN === 0` is `false`):

- `Cell.increment()` — `packages/runner/src/cell.ts` (the client API patterns call)
- `incrementAtPath` — `packages/memory/v2/patch.ts` (the server-side durable backstop)

A non-finite `by` then sets the counter to an absorbing `NaN`/`±Infinity` via `current + by`, which is meaningless for a concurrent-sum counter. `by` is client/user-supplied, so this is genuinely reachable runtime data (not a value the type system normalizes away).

## Change

Both sites now gate on `!Number.isFinite(by) || by === 0` and reword their error messages to "finite non-zero amount". Fixing both keeps local and durable state coherent: without the client-side gate, a `NaN` increment would write `NaN` locally (`diffAndUpdate`) before the server rejected the mergeable op, tearing local vs. durable state.

## Tests

Non-finite rejection coverage added next to the existing zero-amount tests on each side:

- `packages/memory/test/v2-patch-test.ts`
- `packages/runner/test/array-push-mergeable.test.ts`

Both were guard-verified: reverting the gate to `by === 0` makes the new tests fail. Full memory package suite green (425 passed).

## Context

Residual Item 3 from the `===`/`Object.is` non-finite audit arc (the reachable, user-data-facing tail). The handoff pointed only at `patch.ts`; the client-side `Cell.increment()` had the identical blind spot, so both are fixed here for an end-to-end coherent gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReWzAvFTdc97zMG38o2uRR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject non-finite increment amounts (`NaN`, `Infinity`, `-Infinity`) to prevent invalid counter states and keep client and server state in sync.

- **Bug Fixes**
  - Validate `Cell.increment()` and `incrementAtPath` for a finite, non-zero `by` and update errors to say “finite non-zero amount”; keep the `Cell.increment()` help text to one line to avoid adding a source line (`packages/runner/src/cell.ts`, `packages/memory/v2/patch.ts`).
  - Add tests covering non-finite rejections (`packages/memory/test/v2-patch-test.ts`, `packages/runner/test/array-push-mergeable.test.ts`).

<sup>Written for commit fbb0f9ec0634ef17521927f3bc10b80eb10c22f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

