### PR TITLE
fix(patterns): reject non-finite user data (expense handler + extractor compare)

### DIFF
--- a/packages/patterns/budget-tracker/expense-form.tsx
+++ b/packages/patterns/budget-tracker/expense-form.tsx
@@ -47,7 +47,8 @@ const addExpenseHandler = handler<
   { description: string; amount: number; category?: string; date?: string },
   { expenses: Writable<Expense[]> }
 >(({ description, amount, category, date }, { expenses }) => {
-  if (!description?.trim() || typeof amount !== "number" || amount <= 0) {
+  // `NaN` passes `amount <= 0` (`NaN <= 0` is false), so gate finiteness too.
+  if (!description?.trim() || !Number.isFinite(amount) || amount <= 0) {
     return;
   }
   expenses.push({

--- a/packages/patterns/record/extraction/extractor-module.tsx
+++ b/packages/patterns/record/extraction/extractor-module.tsx
@@ -26,6 +26,7 @@ import {
   pattern,
   toCompactDebugString,
   UI,
+  valueEqual,
   Writable,
 } from "commonfabric";
 import {
@@ -737,8 +738,8 @@ function buildPreview(
     const entry = subPieces.find((e) => e?.type === moduleType);
     const currentValue = entry ? getCurrentValue(entry, fieldName) : undefined;
 
-    // Skip if value hasn't changed
-    if (JSON.stringify(currentValue) === JSON.stringify(extractedValue)) {
+    // Skip if value hasn't changed.
+    if (valueEqual(currentValue, extractedValue)) {
       continue;
     }
 

--- a/packages/patterns/test/source-coverage/commonfabric-stub.test.ts
+++ b/packages/patterns/test/source-coverage/commonfabric-stub.test.ts
@@ -354,6 +354,11 @@ export function equals(left: unknown, right: unknown): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
+export function valueEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
 export function toIndentedDebugString(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }


### PR DESCRIPTION
## What

Two patterns-side sites let non-finite user data slip through. Both handle client/user-supplied runtime data — a handler argument, a stored/extracted field value — so they're genuinely reachable.

### Item 5 — `budget-tracker/expense-form.tsx` programmatic NaN ingress

The `addExpenseHandler` guard was `typeof amount !== "number" || amount <= 0`, which `NaN` passes (`NaN <= 0` is `false`), admitting a `NaN` amount into pattern data. Changed to `!Number.isFinite(amount)`, which rejects non-numbers, `NaN`, and `±Infinity` in one check. The UI-button path already guarded against `NaN`; this closes the programmatic ingress.

### Item 4 — `record/extraction/extractor-module.tsx` stringify skip-gate

The "skip if unchanged" check was `JSON.stringify(currentValue) === JSON.stringify(extractedValue)`. `JSON.stringify` conflates `NaN`/`±Infinity` (all `"null"`) and `-0`/`0`, and is sensitive to object key order, so on stored/extracted values it can wrongly skip a real change or wrongly not-skip. Uses `valueEqual` instead — the `Object.is`-leading, content-hash comparison exposed to the pattern environment in #4970. Also adds `valueEqual` to the source-coverage `commonfabric-stub` (mirroring its `equals`), which the `pattern-source-coverage` harness compiles this changed module against.

## Context

Residual **Items 4 and 5** from the `===`/`Object.is` non-finite audit arc — the reachable, user-data-facing tail. (Item 3, the memory/runner `increment` gate → #4964; the `valueEqual` pattern-env hookup that Item 4 depends on → #4970.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReWzAvFTdc97zMG38o2uRR
