### PR TITLE
fix: prefixItems support across CFC walkers, matchers, and display (CT-1895)

### DIFF
--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema } from "@commonfabric/api";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { schemaToTypeString } from "@commonfabric/runner";
 import { cliCommand } from "./cli-name.ts";
 
 export interface ExecCommandSpec {
@@ -1010,70 +1011,19 @@ export function renderExecHelp(
   return lines.join("\n");
 }
 
-function schemaShapeString(
-  schema: JSONSchema,
-  depth = 0,
-): string {
+function schemaShapeString(schema: JSONSchema): string {
   if (isSchemaLessHandlerInput(schema)) {
     return "void";
   }
-
-  if (depth >= 4) {
-    return "{...}";
-  }
-
-  if (!isSchemaObject(schema)) {
-    return "unknown";
-  }
-
-  if (Array.isArray(schema.enum)) {
-    return schema.enum.map((value) => toCompactDebugString(value)).join(" | ");
-  }
-
-  const unionSchemas = Array.isArray(schema.anyOf)
-    ? schema.anyOf
-    : Array.isArray(schema.oneOf)
-    ? schema.oneOf
-    : null;
-  if (unionSchemas) {
-    return unionSchemas.map((variant) =>
-      schemaShapeString(variant as JSONSchema, depth + 1)
-    ).join(" | ");
-  }
-
-  const type = schemaType(schema);
-  if (type === "string") return "string";
-  if (type === "number" || type === "integer") return "number";
-  if (type === "boolean") return "boolean";
-  if (type === "null") return "null";
-
-  if (type === "array") {
-    // We don't handle tuples here (prefixItems)
-    const items = isSchemaObject(schema)
-      ? schema.items as JSONSchema
-      : undefined;
-    return `${items ? schemaShapeString(items, depth + 1) : "unknown"}[]`;
-  }
-
-  const properties = objectProperties(schema);
-  if (!properties) {
-    return "unknown";
-  }
-
-  const keys = Object.keys(properties).filter((key) => !key.startsWith("$"));
-  if (keys.length === 0) {
-    return "{}";
-  }
-
-  const required = requiredFlags(schema);
-  const lines = keys.map((key) => {
-    const propSchema = properties[key];
-    return `${"  ".repeat(depth + 1)}${key}${required.has(key) ? "" : "?"}: ${
-      schemaShapeString(propSchema, depth + 1)
-    }`;
+  // Same TS-like rendering the runner uses for LLM context; CLI help only adds
+  // the "void" spelling for schema-less handler inputs above. The formatter
+  // resolves $refs against options.defs, not the schema's own $defs, so
+  // thread them through.
+  return schemaToTypeString(schema, {
+    defs: isSchemaObject(schema)
+      ? schema.$defs as Record<string, JSONSchema> | undefined
+      : undefined,
   });
-
-  return `{\n${lines.join("\n")}\n${"  ".repeat(depth)}}`;
 }
 
 function pieceJsonUsageLine(commandPrefix: string): string {

--- a/packages/cli/lib/view/parse.ts
+++ b/packages/cli/lib/view/parse.ts
@@ -1906,13 +1906,17 @@ function fieldType(
   const props = readSchemaProps(o);
   if (props.type === "array") {
     // Tuples (prefixItems) render as TS tuple types; an `items` schema
-    // alongside becomes a rest element
+    // alongside becomes a rest element. An absent (or non-false) `items`
+    // leaves the tail open in JSON Schema, so it renders `...unknown[]` —
+    // only `items: false` closes the tuple (PR #4969 review).
     if (props.prefixItems) {
       const slots = props.prefixItems.elements.map((el) =>
         ts.isObjectLiteralExpression(el) ? fieldType(el).type : "any"
       );
       if (props.items) {
         slots.push(`...${fieldType(props.items).type}[]`);
+      } else if (!props.itemsFalse) {
+        slots.push("...unknown[]");
       }
       return { type: `[${slots.join(", ")}]` };
     }
@@ -1939,6 +1943,8 @@ interface SchemaProps {
   properties?: ts.ObjectLiteralExpression;
   required: string[];
   items?: ts.ObjectLiteralExpression;
+  /** True when the literal spells `items: false` (a closed tuple). */
+  itemsFalse?: boolean;
   prefixItems?: ts.ArrayLiteralExpression;
 }
 
@@ -1957,6 +1963,10 @@ function readSchemaProps(obj: ts.ObjectLiteralExpression): SchemaProps {
       result.properties = p.initializer;
     } else if (key === "items" && ts.isObjectLiteralExpression(p.initializer)) {
       result.items = p.initializer;
+    } else if (
+      key === "items" && p.initializer.kind === ts.SyntaxKind.FalseKeyword
+    ) {
+      result.itemsFalse = true;
     } else if (
       key === "prefixItems" && ts.isArrayLiteralExpression(p.initializer)
     ) {

--- a/packages/cli/lib/view/parse.ts
+++ b/packages/cli/lib/view/parse.ts
@@ -1892,7 +1892,11 @@ function parseSchemaObject(obj: ts.ObjectLiteralExpression): SchemaMeta {
     }
   }
   const rootType = props.type ??
-    (props.items ? "array" : props.properties ? "object" : "any");
+    (props.items || props.prefixItems
+      ? "array"
+      : props.properties
+      ? "object"
+      : "any");
   return { rootType, required: props.required, fields };
 }
 
@@ -1901,6 +1905,17 @@ function fieldType(
 ): { type: string; fields?: readonly SchemaField[] } {
   const props = readSchemaProps(o);
   if (props.type === "array") {
+    // Tuples (prefixItems) render as TS tuple types; an `items` schema
+    // alongside becomes a rest element
+    if (props.prefixItems) {
+      const slots = props.prefixItems.elements.map((el) =>
+        ts.isObjectLiteralExpression(el) ? fieldType(el).type : "any"
+      );
+      if (props.items) {
+        slots.push(`...${fieldType(props.items).type}[]`);
+      }
+      return { type: `[${slots.join(", ")}]` };
+    }
     if (props.items) {
       const it = fieldType(props.items);
       return { type: `${it.type}[]`, fields: it.fields };
@@ -1924,6 +1939,7 @@ interface SchemaProps {
   properties?: ts.ObjectLiteralExpression;
   required: string[];
   items?: ts.ObjectLiteralExpression;
+  prefixItems?: ts.ArrayLiteralExpression;
 }
 
 function readSchemaProps(obj: ts.ObjectLiteralExpression): SchemaProps {
@@ -1941,6 +1957,10 @@ function readSchemaProps(obj: ts.ObjectLiteralExpression): SchemaProps {
       result.properties = p.initializer;
     } else if (key === "items" && ts.isObjectLiteralExpression(p.initializer)) {
       result.items = p.initializer;
+    } else if (
+      key === "prefixItems" && ts.isArrayLiteralExpression(p.initializer)
+    ) {
+      result.prefixItems = p.initializer;
     } else if (
       key === "required" && ts.isArrayLiteralExpression(p.initializer)
     ) {

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -728,6 +728,33 @@ describe("renderExecHelp", () => {
     expect(help).toContain("counts?: Record<string, number>");
   });
 
+  it("threads the schema's own $defs into the input type", () => {
+    const help = renderExecHelp(
+      "/tmp/defs.tool",
+      makeSpec("tool", {
+        type: "object",
+        properties: {
+          user: { $ref: "#/$defs/User" },
+        },
+        $defs: {
+          User: { type: "string" },
+        },
+      } as JSONSchema),
+    );
+    // The small definition inlines through the threaded $defs instead of
+    // rendering "unknown".
+    expect(help).toContain("user?: string");
+  });
+
+  it("renders a boolean input schema as unknown", () => {
+    const help = renderExecHelp(
+      "/tmp/boolean.tool",
+      makeSpec("tool", false as JSONSchema),
+    );
+    expect(help).toContain("Input type:");
+    expect(help).toContain("  unknown");
+  });
+
   it("abbreviates the input type at the depth cap", () => {
     // The shared formatter's default maxDepth (4) matches the cap the CLI's
     // own renderer used before it delegated to schemaToTypeString

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -697,6 +697,72 @@ describe("renderExecHelp", () => {
     expect(help).not.toContain("Input schema:");
   });
 
+  it("renders tuples, const, type arrays, and index signatures in the input type", () => {
+    // CT-1895: tuples used to render as "unknown[]"; const, type arrays, and
+    // index-signature value types were lossy the same way
+    const help = renderExecHelp(
+      "/tmp/shapes.tool",
+      makeSpec("tool", {
+        type: "object",
+        properties: {
+          pair: {
+            type: "array",
+            prefixItems: [{ type: "string" }, { type: "number" }],
+          },
+          rest: {
+            type: "array",
+            prefixItems: [{ type: "string" }],
+            items: { type: "boolean" },
+          },
+          kind: { type: "string", const: "point" },
+          maybe: { type: ["string", "null"] },
+          counts: { type: "object", additionalProperties: { type: "number" } },
+        },
+      } as JSONSchema),
+    );
+
+    expect(help).toContain("pair?: [string, number]");
+    expect(help).toContain("rest?: [string, ...boolean[]]");
+    expect(help).toContain('kind?: "point"');
+    expect(help).toContain("maybe?: string | null");
+    expect(help).toContain("counts?: Record<string, number>");
+  });
+
+  it("abbreviates the input type at the depth cap", () => {
+    // The shared formatter's default maxDepth (4) matches the cap the CLI's
+    // own renderer used before it delegated to schemaToTypeString
+    const help = renderExecHelp(
+      "/tmp/deep.tool",
+      makeSpec("tool", {
+        type: "object", // depth 0
+        properties: {
+          a: {
+            type: "object", // depth 1
+            properties: {
+              b: {
+                type: "object", // depth 2
+                properties: {
+                  c: {
+                    type: "object", // depth 3
+                    properties: {
+                      d: { // depth 4: abbreviated
+                        type: "object",
+                        properties: { e: { type: "string" } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as JSONSchema),
+    );
+
+    expect(help).toContain("d?: {...}");
+    expect(help).not.toContain("e?:");
+  });
+
   it("renders direct mounted-file usage when called via shebang", () => {
     const help = renderExecHelp(
       "./legacyWrite.handler",

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -721,7 +721,7 @@ describe("renderExecHelp", () => {
       } as JSONSchema),
     );
 
-    expect(help).toContain("pair?: [string, number]");
+    expect(help).toContain("pair?: [string, number, ...unknown[]]");
     expect(help).toContain("rest?: [string, ...boolean[]]");
     expect(help).toContain('kind?: "point"');
     expect(help).toContain("maybe?: string | null");

--- a/packages/cli/test/view-parse.test.ts
+++ b/packages/cli/test/view-parse.test.ts
@@ -160,7 +160,7 @@ const __cfLift_1 = lift({
     schema: { fields: readonly { name: string; type: string }[] };
   }).schema;
   const pair = schema.fields.find((f) => f.name === "pair");
-  assertEquals(pair?.type, "[string, number]");
+  assertEquals(pair?.type, "[string, number, ...unknown[]]");
   const rest = schema.fields.find((f) => f.name === "rest");
   assertEquals(rest?.type, "[string, ...boolean[]]");
 });

--- a/packages/cli/test/view-parse.test.ts
+++ b/packages/cli/test/view-parse.test.ts
@@ -140,6 +140,31 @@ Deno.test("parse: structure tree groups by section with builders and schemas", (
   );
 });
 
+Deno.test("parse: tuple (prefixItems) schema fields render as tuple types", () => {
+  // CT-1895: tuples used to summarize as bare "array"
+  const doc = parseDocument(`// transformed: /app.ts
+const __cfLift_1 = lift({
+    type: "object",
+    properties: {
+        pair: { type: "array", prefixItems: [{ type: "string" }, { type: "number" }] },
+        rest: { type: "array", prefixItems: [{ type: "string" }], items: { type: "boolean" } }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema, ({ pair }) => pair);
+`);
+  const schemaNode = doc.flatStructure.find((n) => n.meta?.kind === "schema");
+  assert(schemaNode, "found a schema-meta node");
+  const schema = (schemaNode!.meta as {
+    kind: "schema";
+    schema: { fields: readonly { name: string; type: string }[] };
+  }).schema;
+  const pair = schema.fields.find((f) => f.name === "pair");
+  assertEquals(pair?.type, "[string, number]");
+  const rest = schema.fields.find((f) => f.name === "rest");
+  assertEquals(rest?.type, "[string, ...boolean[]]");
+});
+
 Deno.test("parse: definition index resolves declarations", () => {
   const doc = parseDocument(SAMPLE);
   assert(doc.definitions.has("myPattern"), "myPattern defined");

--- a/packages/cli/test/view-parse.test.ts
+++ b/packages/cli/test/view-parse.test.ts
@@ -165,6 +165,32 @@ const __cfLift_1 = lift({
   assertEquals(rest?.type, "[string, ...boolean[]]");
 });
 
+Deno.test("parse: closed tuples (items: false) and non-object slots", () => {
+  const doc = parseDocument(`// transformed: /app.ts
+const __cfLift_1 = lift({
+    type: "object",
+    properties: {
+        closed: { type: "array", prefixItems: [{ type: "string" }], items: false },
+        loose: { type: "array", prefixItems: [true] }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema, ({ closed }) => closed);
+`);
+  const schemaNode = doc.flatStructure.find((n) => n.meta?.kind === "schema");
+  assert(schemaNode, "found a schema-meta node");
+  const schema = (schemaNode!.meta as {
+    kind: "schema";
+    schema: { fields: readonly { name: string; type: string }[] };
+  }).schema;
+  // items: false closes the tuple — no ...unknown[] tail.
+  const closed = schema.fields.find((f) => f.name === "closed");
+  assertEquals(closed?.type, "[string]");
+  // A non-object-literal slot renders as "any"; the tail stays open.
+  const loose = schema.fields.find((f) => f.name === "loose");
+  assertEquals(loose?.type, "[any, ...unknown[]]");
+});
+
 Deno.test("parse: definition index resolves declarations", () => {
   const doc = parseDocument(SAMPLE);
   assert(doc.definitions.has("myPattern"), "myPattern defined");

--- a/packages/patterns/tools/openapi-extract.test.ts
+++ b/packages/patterns/tools/openapi-extract.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from "@std/assert";
+import { extractAPI } from "./openapi-extract.ts";
+
+Deno.test("extractAPI renders tuple (prefixItems) schemas as tuple types", () => {
+  // CT-1895: tuples used to render as bare "array"
+  const spec = {
+    openapi: "3.1.0",
+    info: { title: "Tuples", version: "1.0.0" },
+    paths: {
+      "/things": {
+        get: {
+          operationId: "listThings",
+          parameters: [{
+            name: "range",
+            in: "query",
+            schema: {
+              type: "array",
+              prefixItems: [{ type: "integer" }, { type: "integer" }],
+            },
+          }],
+          responses: { "200": { description: "ok" } },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Thing: {
+          type: "object",
+          properties: {
+            pair: {
+              type: "array",
+              prefixItems: [{ type: "string" }, { type: "number" }],
+            },
+            rest: {
+              type: "array",
+              prefixItems: [{ type: "string" }],
+              items: { type: "boolean" },
+            },
+            plain: { type: "array", items: { type: "string" } },
+          },
+        },
+      },
+    },
+  };
+
+  const api = extractAPI(spec as Record<string, unknown>);
+
+  const thing = api.models.find((m) => m.name === "Thing");
+  assertEquals(thing?.properties["pair"].type, "[string, number]");
+  assertEquals(thing?.properties["rest"].type, "[string, ...array<boolean>]");
+  assertEquals(thing?.properties["plain"].type, "array<string>");
+
+  const endpoint = api.endpoints.find((e) => e.operationId === "listThings");
+  const range = endpoint?.parameters.find((p) => p.name === "range");
+  assertEquals(range?.type, "[integer, integer]");
+});

--- a/packages/patterns/tools/openapi-extract.test.ts
+++ b/packages/patterns/tools/openapi-extract.test.ts
@@ -46,11 +46,14 @@ Deno.test("extractAPI renders tuple (prefixItems) schemas as tuple types", () =>
   const api = extractAPI(spec as Record<string, unknown>);
 
   const thing = api.models.find((m) => m.name === "Thing");
-  assertEquals(thing?.properties["pair"].type, "[string, number]");
+  assertEquals(
+    thing?.properties["pair"].type,
+    "[string, number, ...array<unknown>]",
+  );
   assertEquals(thing?.properties["rest"].type, "[string, ...array<boolean>]");
   assertEquals(thing?.properties["plain"].type, "array<string>");
 
   const endpoint = api.endpoints.find((e) => e.operationId === "listThings");
   const range = endpoint?.parameters.find((p) => p.name === "range");
-  assertEquals(range?.type, "[integer, integer]");
+  assertEquals(range?.type, "[integer, integer, ...array<unknown>]");
 });

--- a/packages/patterns/tools/openapi-extract.ts
+++ b/packages/patterns/tools/openapi-extract.ts
@@ -154,9 +154,16 @@ function schemaToTypeString(
       const slots = prefixItems.map((slot) =>
         schemaToTypeString(spec, slot, cache)
       );
-      const rest = resolved["items"] as Record<string, unknown> | undefined;
-      if (rest) {
-        slots.push(`...array<${schemaToTypeString(spec, rest, cache)}>`);
+      const rest = resolved["items"];
+      if (rest && typeof rest === "object") {
+        slots.push(
+          `...array<${
+            schemaToTypeString(spec, rest as Record<string, unknown>, cache)
+          }>`,
+        );
+      } else if (rest !== false) {
+        // An absent `items` leaves the tail open (PR #4969 review).
+        slots.push("...array<unknown>");
       }
       return `[${slots.join(", ")}]`;
     }

--- a/packages/patterns/tools/openapi-extract.ts
+++ b/packages/patterns/tools/openapi-extract.ts
@@ -145,6 +145,21 @@ function schemaToTypeString(
   const type = resolved["type"] as string | undefined;
 
   if (type === "array") {
+    // OpenAPI 3.1 tuples; an `items` schema alongside `prefixItems` covers
+    // the remaining positions
+    const prefixItems = resolved["prefixItems"] as
+      | Record<string, unknown>[]
+      | undefined;
+    if (Array.isArray(prefixItems) && prefixItems.length > 0) {
+      const slots = prefixItems.map((slot) =>
+        schemaToTypeString(spec, slot, cache)
+      );
+      const rest = resolved["items"] as Record<string, unknown> | undefined;
+      if (rest) {
+        slots.push(`...array<${schemaToTypeString(spec, rest, cache)}>`);
+      }
+      return `[${slots.join(", ")}]`;
+    }
     const items = resolved["items"] as Record<string, unknown> | undefined;
     if (items) {
       const inner = schemaToTypeString(spec, items, cache);

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -1,5 +1,12 @@
 import { isRecord } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+import {
+  ARRAY_SUBSCHEMA_KEYS,
+  RECORD_SUBSCHEMA_KEYS,
+  SINGLE_SUBSCHEMA_KEYS,
+  UNUSED_RECORD_SUBSCHEMA_KEYS,
+  UNUSED_SINGLE_SUBSCHEMA_KEYS,
+} from "../schema-walk.ts";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import {
@@ -694,29 +701,41 @@ function schemaMayGrantWritableHandles(schema: unknown): boolean {
 }
 
 /**
+ * The subschema-bearing keywords the aligned walk positions against a value:
+ * `properties`/`additionalProperties` for record values, `items`/`prefixItems`
+ * for array values.
+ */
+const MODELED_SCHEMA_KEYWORDS: ReadonlySet<string> = new Set([
+  "properties",
+  "additionalProperties",
+  "items",
+  "prefixItems",
+]);
+
+/**
  * Schema keywords that can route a subschema to a value position through a
  * mechanism the aligned walk does not model. Their presence at a position
  * makes the walk fall back to treating the whole value subtree as writably
- * bound (when a grant may exist below). The walk models only `properties`,
- * `additionalProperties`, and `items`; `$defs`/`definitions` are harmless
- * without a `$ref` (which is listed).
+ * bound (when a grant may exist below).
+ *
+ * Derived from schema-walk's canonical keyword vocabulary (both tiers) so a
+ * keyword added there cannot silently bypass this fail-safe: an omission here
+ * fails OPEN — a grant routed through the missing keyword would be walked
+ * past, and tagging its cell computed silently drops user writes. The ref
+ * keywords are added by hand (they are resolution, not subschema edges, in
+ * schema-walk); `$defs`/`definitions` stay out — dormant without a `$ref`,
+ * which is listed.
  */
 const UNMODELED_SCHEMA_KEYWORDS: readonly string[] = [
   "$ref",
   "$dynamicRef",
-  "allOf",
-  "anyOf",
-  "oneOf",
-  "not",
-  "if",
-  "then",
-  "else",
-  "dependentSchemas",
-  "prefixItems",
-  "contains",
-  "patternProperties",
-  "propertyNames",
-  "contentSchema",
+  ...[
+    ...SINGLE_SUBSCHEMA_KEYS,
+    ...ARRAY_SUBSCHEMA_KEYS,
+    ...RECORD_SUBSCHEMA_KEYS,
+    ...UNUSED_SINGLE_SUBSCHEMA_KEYS,
+    ...UNUSED_RECORD_SUBSCHEMA_KEYS,
+  ].filter((keyword) => !MODELED_SCHEMA_KEYWORDS.has(keyword)),
 ];
 
 /**
@@ -860,12 +879,30 @@ function assignComputedCellKinds(
     else seen.set(target, new Set([schema]));
     if (Array.isArray(target)) {
       const items = schema.items;
-      if (items === undefined) {
+      if ("prefixItems" in schema && !Array.isArray(schema.prefixItems)) {
+        // Malformed prefixItems (not a schema array): a grant could hide in a
+        // shape the slot alignment below would walk past — fail safe.
+        collectAll();
+        return;
+      }
+      const prefixItems = Array.isArray(schema.prefixItems)
+        ? schema.prefixItems
+        : undefined;
+      if (items === undefined && prefixItems === undefined) {
         collectAll(); // Array value under an object-shaped schema: misaligned.
         return;
       }
-      for (const element of target) {
-        collectWritablyBoundRoots(element, items, out, seen);
+      for (let index = 0; index < target.length; index++) {
+        const slotSchema =
+          prefixItems !== undefined && index < prefixItems.length
+            ? prefixItems[index]
+            : items;
+        // An element past the tuple slots with no `items` schema has no
+        // covering subschema — like an undeclared property, no `asCell`
+        // position exists for it, so the handler receives at most a plain,
+        // unwritable value.
+        if (slotSchema === undefined) continue;
+        collectWritablyBoundRoots(target[index], slotSchema, out, seen);
       }
       return;
     }

--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -1,4 +1,9 @@
-import type { FetchBinaryResult, JSONSchema } from "@commonfabric/api";
+import type {
+  FetchBinaryResult,
+  JSONSchema,
+  JSONSchemaObj,
+} from "@commonfabric/api";
+import { isRecord } from "@commonfabric/utils/types";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
@@ -11,6 +16,7 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
 import { validateAgainstSchema } from "../cfc/schema-sanitization.ts";
+import { mapSubschemas } from "../schema-walk.ts";
 import {
   isProtectedToolshedFirstPartyRoute,
   isToolshedApiOrigin,
@@ -163,47 +169,33 @@ const asTypeArray = (type: unknown): string[] =>
  * treats such schemas as closed (a CFC-sanitization rule); fetch
  * verification follows standard JSON Schema semantics, where unknown object
  * properties are allowed unless the schema names `additionalProperties`.
+ *
+ * Exported for unit testing only — not part of the fetch builtin surface.
  */
-function schemaWithOpenObjects(schema: JSONSchema): JSONSchema {
-  if (typeof schema === "boolean") return schema;
-  const result: Record<string, unknown> = { ...schema };
+export function schemaWithOpenObjects(schema: JSONSchema): JSONSchema {
+  if (!isRecord(schema)) return schema;
+  // Default-tier walk plus `$defs`. The never-emitted keywords (`contains`,
+  // `if`/`then`/`else`, ...) are deliberately NOT rewritten — opening objects
+  // under them would make those paths look supported; if one becomes emitted,
+  // it moves to the used tier in schema-walk and this walk picks it up.
+  const mapped = mapSubschemas(
+    schema as JSONSchemaObj,
+    (child) =>
+      // Draft-07 array-form `items`; the 2020-12 tuple form is `prefixItems`,
+      // which mapSubschemas already walks element-wise.
+      Array.isArray(child)
+        ? child.map(schemaWithOpenObjects) as unknown as JSONSchema
+        : schemaWithOpenObjects(child),
+    { includeDefs: true },
+  );
 
-  for (const key of ["not", "additionalProperties"]) {
-    if (typeof result[key] === "object" && result[key] !== null) {
-      result[key] = schemaWithOpenObjects(result[key] as JSONSchema);
-    }
+  const declaresObjectShape = asTypeArray(mapped.type).includes("object") ||
+    mapped.properties !== undefined ||
+    mapped.required !== undefined;
+  if (declaresObjectShape && mapped.additionalProperties === undefined) {
+    return { ...mapped, additionalProperties: true } as JSONSchema;
   }
-  if (Array.isArray(result.items)) {
-    result.items = result.items.map((item) =>
-      schemaWithOpenObjects(item as JSONSchema)
-    );
-  } else if (typeof result.items === "object" && result.items !== null) {
-    result.items = schemaWithOpenObjects(result.items as JSONSchema);
-  }
-  for (const key of ["allOf", "anyOf", "oneOf"]) {
-    if (Array.isArray(result[key])) {
-      result[key] = (result[key] as JSONSchema[]).map((branch) =>
-        schemaWithOpenObjects(branch)
-      );
-    }
-  }
-  for (const key of ["properties", "$defs"]) {
-    if (typeof result[key] === "object" && result[key] !== null) {
-      result[key] = Object.fromEntries(
-        Object.entries(result[key] as Record<string, JSONSchema>).map((
-          [name, child],
-        ) => [name, schemaWithOpenObjects(child)]),
-      );
-    }
-  }
-
-  const declaresObjectShape = asTypeArray(result.type).includes("object") ||
-    result.properties !== undefined ||
-    result.required !== undefined;
-  if (declaresObjectShape && result.additionalProperties === undefined) {
-    result.additionalProperties = true;
-  }
-  return result as JSONSchema;
+  return mapped;
 }
 
 const fetchBinaryKind: FetchKind = {

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -31,6 +31,13 @@ import {
 } from "./llm-schemas.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isBoolean, isObject, isRecord } from "@commonfabric/utils/types";
+import type { JSONSchemaObj } from "../builder/types.ts";
+import {
+  ARRAY_SUBSCHEMA_KEYS,
+  mapSubschemas,
+  RECORD_SUBSCHEMA_KEYS,
+  SINGLE_SUBSCHEMA_KEYS,
+} from "../schema-walk.ts";
 
 // Message schema that mints the `LlmDerived` provenance stamp (Epic D1).
 // Recorded as the schema write-policy input for each model-produced message's
@@ -384,7 +391,7 @@ function simplifySchemaForContext(
   depth: number = 0,
   maxDepth: number = 3,
 ): JSONSchema {
-  if (typeof schema !== "object" || schema === null) {
+  if (!isRecord(schema)) {
     return schema;
   }
 
@@ -407,52 +414,32 @@ function simplifySchemaForContext(
     "asCell",
     "default",
     "required",
-    "additionalProperties",
   ];
 
   // Maximum enum values to preserve (to prevent bloat)
   const MAX_ENUM_VALUES = 10;
 
+  // Shallow pass: filter keys, then let mapSubschemas rewrite the kept
+  // subschema keywords below.
   for (const [key, value] of Object.entries(schemaObj)) {
-    // Skip $defs and $ref - these can be huge with recursive types
-    if (key === "$defs" || key === "$ref") {
-      continue;
-    }
-
-    // Skip $-prefixed keys (like $UI schemas) - these are internal/VDOM
+    // Skip $-prefixed keys: $defs/$ref can be huge with recursive types, and
+    // keys like $UI are internal/VDOM
     if (key.startsWith("$")) {
       continue;
     }
 
-    // Handle properties recursively
-    if (key === "properties" && typeof value === "object" && value !== null) {
-      const simplifiedProps: Record<string, unknown> = {};
-      for (const [propKey, propValue] of Object.entries(value)) {
-        // Skip $-prefixed properties ($UI, $TYPE, etc.) - these are internal/VDOM
-        if (propKey.startsWith("$")) {
-          continue;
-        }
-        if (typeof propValue === "object" && propValue !== null) {
-          simplifiedProps[propKey] = simplifySchemaForContext(
-            propValue as JSONSchema,
-            depth + 1,
-            maxDepth,
-          );
-        } else {
-          simplifiedProps[propKey] = propValue;
-        }
-      }
-      simplified[key] = simplifiedProps;
+    // Keep properties, dropping $-prefixed ones ($UI, $TYPE, etc. are
+    // internal/VDOM); their values are simplified by the walk below
+    if (key === "properties" && isRecord(value)) {
+      simplified[key] = Object.fromEntries(
+        Object.entries(value).filter(([name]) => !name.startsWith("$")),
+      );
       continue;
     }
 
-    // Handle items recursively (for arrays)
-    if (key === "items" && typeof value === "object" && value !== null) {
-      simplified[key] = simplifySchemaForContext(
-        value as JSONSchema,
-        depth + 1,
-        maxDepth,
-      );
+    // Keep the other subschema-bearing keywords for the walk below
+    if (SIMPLIFY_SUBSCHEMA_KEYS.has(key)) {
+      simplified[key] = value;
       continue;
     }
 
@@ -467,33 +454,38 @@ function simplifySchemaForContext(
       continue;
     }
 
-    // Handle anyOf/oneOf/allOf recursively
+    // Preserve semantic markers and other primitive values, but skip complex
+    // objects not handled above
     if (
-      (key === "anyOf" || key === "oneOf" || key === "allOf") &&
-      Array.isArray(value)
+      PRESERVE_KEYS.includes(key) || typeof value !== "object" ||
+      value === null
     ) {
-      simplified[key] = value.map((v) =>
-        typeof v === "object" && v !== null
-          ? simplifySchemaForContext(v as JSONSchema, depth + 1, maxDepth)
-          : v
-      );
-      continue;
-    }
-
-    // Preserve keys from PRESERVE_KEYS list
-    if (PRESERVE_KEYS.includes(key)) {
-      simplified[key] = value;
-      continue;
-    }
-
-    // Preserve other primitive values, but skip complex objects not handled above
-    if (typeof value !== "object" || value === null) {
       simplified[key] = value;
     }
   }
 
-  return simplified as JSONSchema;
+  return mapSubschemas(
+    simplified as JSONSchemaObj,
+    (child) =>
+      // Draft-07 array-form `items`; the 2020-12 tuple form is `prefixItems`,
+      // which mapSubschemas already walks element-wise.
+      Array.isArray(child)
+        ? child.map((element) =>
+          simplifySchemaForContext(element, depth + 1, maxDepth)
+        ) as unknown as JSONSchema
+        : simplifySchemaForContext(child, depth + 1, maxDepth),
+  );
 }
+
+// The subschema-bearing keywords simplifySchemaForContext keeps (and recurses
+// into). The never-emitted tier (`contains`, `if`/`then`/`else`, ...) is
+// deliberately absent: passing those through would make them look supported.
+// `properties` is handled separately to drop $-prefixed names first.
+const SIMPLIFY_SUBSCHEMA_KEYS: ReadonlySet<string> = new Set([
+  ...SINGLE_SUBSCHEMA_KEYS,
+  ...ARRAY_SUBSCHEMA_KEYS,
+  ...RECORD_SUBSCHEMA_KEYS,
+]);
 
 function observationLinkForValue(
   value: unknown,

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2125,14 +2125,25 @@ function toolInputRequiredIntegrityFailure(
       }
     }
   }
-  // Array items: a floor under `items` gates every model-supplied element
-  // (e.g. `recipients: { items: { ifc: { requiredIntegrity } } }`).
-  if (isRecord(schema.items) && Array.isArray(value)) {
+  // Array elements: a tuple slot's floor gates its exact position, and a
+  // floor under `items` gates the positions past the slots (2020-12,
+  // matching the sanitizer's semantics — e.g.
+  // `recipients: { items: { ifc: { requiredIntegrity } } }`). Tuple slots
+  // previously went entirely ungated: this walk never descended
+  // prefixItems.
+  if (Array.isArray(value)) {
+    const prefixItems = Array.isArray(schema.prefixItems)
+      ? schema.prefixItems
+      : undefined;
     for (let index = 0; index < value.length; index++) {
+      const slotSchema = prefixItems !== undefined && index < prefixItems.length
+        ? prefixItems[index]
+        : schema.items;
+      if (!isRecord(slotSchema)) continue;
       const failure = toolInputRequiredIntegrityFailure(
         runtime,
         space,
-        schema.items,
+        slotSchema,
         value[index],
         `${path}[${index}]`,
         trust,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -484,31 +484,47 @@ const cellMethods = new Set<
   "query",
 ]);
 
-/** Parse the explicit column list from `INSERT INTO t (a, b, c) VALUES ...`,
- *  used to map positional `_cf_link` params. Returns undefined when there is no
- *  explicit column list (columnless `INSERT … VALUES (…)`, `UPDATE`, opaque
- *  SQL). The capture must be immediately followed by `VALUES`, so a columnless
- *  insert's VALUES tuple is NOT mistaken for a column list. */
 // The schema for one element of an array schema, suitable for a standalone
 // element cell. The array's items schema is often a `$ref` into the array
 // schema's `$defs`; carry those `$defs` onto the element schema so the reference
 // (and any nested references) still resolve once the element is addressed on its
 // own, detached from the array.
-function elementSchemaFor(
+// The schema covering one element of `arraySchema`. The covering schema is
+// index-determined for tuples — prefixItems[index] when the index is within
+// the slots, `items` past them — so callers that know the element's index
+// should pass it. Without an index (elementById is id-keyed; the element's
+// position is unknown), the element is treated as rest-region: tuple slots
+// are positional and cannot be id-addressed, so `items` covers it, and a
+// pure tuple (no `items`) yields `undefined` — no principled per-element
+// schema exists there (CT-1895 borderline site).
+// Exported for unit testing only.
+export function elementSchemaFor(
   arraySchema: JSONSchema | undefined,
+  index?: number,
 ): JSONSchema | undefined {
   if (!isRecord(arraySchema)) return undefined;
-  const items = arraySchema.items;
-  if (!isRecord(items) || Array.isArray(items)) {
-    return items as JSONSchema | undefined;
+  const prefixItems = Array.isArray(arraySchema.prefixItems)
+    ? arraySchema.prefixItems as JSONSchema[]
+    : undefined;
+  const covering = prefixItems !== undefined && index !== undefined &&
+      index < prefixItems.length
+    ? prefixItems[index]
+    : arraySchema.items;
+  if (!isRecord(covering) || Array.isArray(covering)) {
+    return covering as JSONSchema | undefined;
   }
   const defs = arraySchema.$defs;
-  if (defs && !("$defs" in items)) {
-    return { ...items, $defs: defs } as JSONSchema;
+  if (defs && !("$defs" in covering)) {
+    return { ...covering, $defs: defs } as JSONSchema;
   }
-  return items as JSONSchema;
+  return covering as JSONSchema;
 }
 
+/** Parse the explicit column list from `INSERT INTO t (a, b, c) VALUES ...`,
+ *  used to map positional `_cf_link` params. Returns undefined when there is no
+ *  explicit column list (columnless `INSERT … VALUES (…)`, `UPDATE`, opaque
+ *  SQL). The capture must be immediately followed by `VALUES`, so a columnless
+ *  insert's VALUES tuple is NOT mistaken for a column list. */
 function parseSqliteInsertColumns(sql: string): string[] | undefined {
   const m = sql.match(
     /\binsert\b[\s\S]*?\binto\b\s+[^()]+?\(([^)]*)\)\s*values\b/i,
@@ -1718,6 +1734,11 @@ export class CellImpl<T extends FabricValue>
       },
     );
     const arraySchema = resolveSchema(resolvedLink.schema ?? this.schema);
+    // The element's index is unknown here (id-keyed addressing, and this
+    // method deliberately never reads the array), so a tuple schema's slot
+    // cannot be selected: elementSchemaFor falls back to the rest `items`
+    // schema for prefixItems arrays. A caller that knows the element sits
+    // in a tuple slot can pass the slot schema explicitly via `schema`.
     const elementSchema = schema ?? elementSchemaFor(arraySchema);
     return this.runtime.getCellFromEntityId(
       resolvedLink.space,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1053,28 +1053,51 @@ export const storedSchemaCoversCandidateEnvelope = (
       return false;
     }
     const storedProperties = stored.properties;
-    return Object.entries(candidate.properties).every(([key, child]) =>
-      storedSchemaCoversCandidateEnvelope(
-        storedProperties[key] as JSONSchema | undefined,
-        child as JSONSchema,
+    if (
+      !Object.entries(candidate.properties).every(([key, child]) =>
+        storedSchemaCoversCandidateEnvelope(
+          storedProperties[key] as JSONSchema | undefined,
+          child as JSONSchema,
+        )
       )
-    );
+    ) {
+      return false;
+    }
+    // Rest claims (PR #4969 review): a candidate additionalProperties is a
+    // claim about every undeclared key — an early return here would judge
+    // it "covered" without comparing, dropping it from the merge. No
+    // candidate rest claim means the properties coverage above suffices;
+    // boolean forms must match exactly; a schema-valued claim needs a
+    // covering stored one.
+    const candidateRest = candidate.additionalProperties;
+    if (candidateRest === undefined) {
+      return true;
+    }
+    if (typeof candidateRest === "boolean") {
+      return stored.additionalProperties === candidateRest;
+    }
+    return typeof stored.additionalProperties === "object" &&
+      stored.additionalProperties !== null &&
+      storedSchemaCoversCandidateEnvelope(
+        stored.additionalProperties,
+        candidateRest,
+      );
   }
 
   // Tuple slots: when either side declares prefixItems, coverage requires
   // slot-wise coverage — otherwise the items branch below would judge
   // envelopes "covered" while their tuple slots differ, and the candidate's
-  // slot info would be dropped instead of merged (fail-open). A stored side
-  // with slots the candidate lacks also fails closed: the stored rest
-  // `items` does not speak for the slot positions the candidate's `items`
-  // covers.
+  // slot info would be dropped instead of merged (fail-open). Arities must
+  // be EQUAL (PR #4969 review): with differing arities, one side's rest
+  // `items` claims positions the other covers with slots, and the shared
+  // items branch below cannot compare those — fail closed and merge.
   if (
     candidate.prefixItems !== undefined || stored.prefixItems !== undefined
   ) {
     if (
       !Array.isArray(candidate.prefixItems) ||
       !Array.isArray(stored.prefixItems) ||
-      candidate.prefixItems.length > stored.prefixItems.length
+      candidate.prefixItems.length !== stored.prefixItems.length
     ) {
       return false;
     }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2864,14 +2864,40 @@ const policySchemaMatchesValue = (
       policySchemaMatchesValue(childSchema, value[key], schemaRoot)
     );
   }
-  if (
-    Array.isArray(value) && typeof schema.items === "object" &&
-    schema.items !== null
-  ) {
-    const itemSchema = schema.items;
-    return value.every((item) =>
-      policySchemaMatchesValue(itemSchema, item, schemaRoot)
-    );
+  if (Array.isArray(value)) {
+    // 2020-12 array semantics, mirroring validateAgainstSchema: tuple slots
+    // condition their exact position, `items` conditions the positions past
+    // them. Before prefixItems was handled here, a tuple-shaped condition
+    // fell through to `return true` and vacuously matched any array.
+    const prefixItems = Array.isArray(schema.prefixItems)
+      ? schema.prefixItems
+      : undefined;
+    if (prefixItems !== undefined) {
+      const slots = Math.min(prefixItems.length, value.length);
+      for (let index = 0; index < slots; index++) {
+        if (
+          !policySchemaMatchesValue(
+            prefixItems[index],
+            value[index],
+            schemaRoot,
+          )
+        ) {
+          return false;
+        }
+      }
+    }
+    if (typeof schema.items === "object" && schema.items !== null) {
+      const itemSchema = schema.items;
+      for (
+        let index = prefixItems?.length ?? 0;
+        index < value.length;
+        index++
+      ) {
+        if (!policySchemaMatchesValue(itemSchema, value[index], schemaRoot)) {
+          return false;
+        }
+      }
+    }
   }
   return true;
 };

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1028,7 +1028,9 @@ const schemasEqualIgnoringWriterStamp = (
     stripWriterIdentityStamp(right),
   );
 
-const storedSchemaCoversCandidateEnvelope = (
+// Exported for unit testing of the merge-skip decision. Not part of the
+// public CFC surface.
+export const storedSchemaCoversCandidateEnvelope = (
   stored: JSONSchema | undefined,
   candidate: JSONSchema | undefined,
 ): boolean => {
@@ -1056,6 +1058,36 @@ const storedSchemaCoversCandidateEnvelope = (
         child as JSONSchema,
       )
     );
+  }
+
+  // Tuple slots: when either side declares prefixItems, coverage requires
+  // slot-wise coverage — otherwise the items branch below would judge
+  // envelopes "covered" while their tuple slots differ, and the candidate's
+  // slot info would be dropped instead of merged (fail-open). A stored side
+  // with slots the candidate lacks also fails closed: the stored rest
+  // `items` does not speak for the slot positions the candidate's `items`
+  // covers.
+  if (
+    candidate.prefixItems !== undefined || stored.prefixItems !== undefined
+  ) {
+    if (
+      !Array.isArray(candidate.prefixItems) ||
+      !Array.isArray(stored.prefixItems) ||
+      candidate.prefixItems.length > stored.prefixItems.length
+    ) {
+      return false;
+    }
+    const storedSlots = stored.prefixItems;
+    if (
+      !candidate.prefixItems.every((slot, index) =>
+        storedSchemaCoversCandidateEnvelope(storedSlots[index], slot)
+      )
+    ) {
+      return false;
+    }
+    // Slots covered; the rest `items` (if any) is judged by the shared
+    // branch below. A slots-only candidate reaches the conservative
+    // `return false` (merge) the same way.
   }
 
   if (

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -20,6 +20,7 @@ import type { FabricValue } from "@commonfabric/api";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import { isRecord } from "@commonfabric/utils/types";
 import type { JSONSchema } from "../builder/types.ts";
+import { forEachSubschema } from "../schema-walk.ts";
 import { normalizeCellScope } from "../scope.ts";
 import { ignoreReadForScheduling } from "../scheduler.ts";
 import type {
@@ -2032,28 +2033,11 @@ const walkIfcSchema = (
       });
     }
 
-    if (resolved.properties) {
-      for (const [key, child] of Object.entries(resolved.properties)) {
-        walkIfcSchema(child, [...path, key], entries, childRoot, nextActive);
-      }
-    }
-    const compound = [
-      ...(resolved.anyOf ?? []),
-      ...(resolved.oneOf ?? []),
-      ...(resolved.allOf ?? []),
-    ];
-    for (const child of compound) {
-      walkIfcSchema(child, path, entries, childRoot, nextActive);
-    }
-    if (typeof resolved.items === "object" && resolved.items !== null) {
-      walkIfcSchema(
-        resolved.items,
-        [...path, "*"],
-        entries,
-        childRoot,
-        nextActive,
-      );
-    }
+    // Keyword descent via the shared walk, so the vocabulary cannot silently
+    // drift from schema-walk's (a missed keyword here fails open:
+    // under-tainting). The visitor owns the path rule per keyword — that
+    // part is this walker's semantics, not the walk's.
+    //
     // Record-only `additionalProperties` descends as the same `*` segment
     // arrays get from `items` (template-population §4) — RESTRICTED to
     // record-only objects (no NAMED property). The restriction is
@@ -2068,20 +2052,77 @@ const walkIfcSchema = (
     // all of them; schema helpers routinely emit that wrapper shape, and
     // skipping it would silently drop the declared map label (codex/cubic
     // review on this PR).
-    if (
-      (resolved.properties === undefined ||
-        Object.keys(resolved.properties).length === 0) &&
-      typeof resolved.additionalProperties === "object" &&
-      resolved.additionalProperties !== null
-    ) {
-      walkIfcSchema(
-        resolved.additionalProperties,
-        [...path, "*"],
-        entries,
-        childRoot,
-        nextActive,
-      );
-    }
+    const recordOnly = resolved.properties === undefined ||
+      Object.keys(resolved.properties).length === 0;
+    // `items` is subject to the same limitation as `additionalProperties`:
+    // with `prefixItems` present it covers only the indices PAST the tuple
+    // slots, but a `*` entry matches ANY index — including the slots — so a
+    // mixed tuple-plus-rest schema would over-taint the slot positions.
+    // Expressing "every index except the slots" needs the exclusion
+    // semantics §3.3 forbids, so the mixed case mints no `*` entry for the
+    // rest schema (the slots still mint at their concrete indices below).
+    const tupleFree = !Array.isArray(resolved.prefixItems) ||
+      resolved.prefixItems.length === 0;
+    forEachSubschema(resolved, (child, keyword, key, index) => {
+      switch (keyword) {
+        case "properties":
+          walkIfcSchema(child, [...path, key!], entries, childRoot, nextActive);
+          break;
+        case "anyOf":
+        case "oneOf":
+        case "allOf":
+          walkIfcSchema(child, path, entries, childRoot, nextActive);
+          break;
+        case "items":
+          if (tupleFree) {
+            walkIfcSchema(
+              child,
+              [...path, "*"],
+              entries,
+              childRoot,
+              nextActive,
+            );
+          }
+          break;
+        case "prefixItems":
+          // Tuple slots mint at their concrete index — unlike `items`' `*`
+          // entry, a slot label applies to exactly that position.
+          walkIfcSchema(
+            child,
+            [...path, String(index!)],
+            entries,
+            childRoot,
+            nextActive,
+          );
+          break;
+        case "additionalProperties":
+          if (recordOnly) {
+            walkIfcSchema(
+              child,
+              [...path, "*"],
+              entries,
+              childRoot,
+              nextActive,
+            );
+          }
+          break;
+        case "not":
+          // Negation describes what the value must NOT be. Minting
+          // label/policy entries from it would enforce an author's negated
+          // branch as if it labeled real data — deliberately skipped (unlike
+          // joinSchema, where unioning `not` atoms into the LUB is a safe
+          // over-taint).
+          break;
+        default:
+          // A keyword schema-walk knows but this walker has no path rule
+          // for: descend at the parent's own path — labels join at the
+          // position (over-taint, fail-safe) rather than being silently
+          // dropped (under-taint, fail-open). Give new keywords an explicit
+          // case above.
+          walkIfcSchema(child, path, entries, childRoot, nextActive);
+          break;
+      }
+    });
     return entries;
   }
 };

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2110,15 +2110,17 @@ const walkIfcSchema = (
     // review on this PR).
     const recordOnly = resolved.properties === undefined ||
       Object.keys(resolved.properties).length === 0;
-    // `items` is subject to the same limitation as `additionalProperties`:
-    // with `prefixItems` present it covers only the indices PAST the tuple
-    // slots, but a `*` entry matches ANY index — including the slots — so a
-    // mixed tuple-plus-rest schema would over-taint the slot positions.
-    // Expressing "every index except the slots" needs the exclusion
-    // semantics §3.3 forbids, so the mixed case mints no `*` entry for the
-    // rest schema (the slots still mint at their concrete indices below).
-    const tupleFree = !Array.isArray(resolved.prefixItems) ||
-      resolved.prefixItems.length === 0;
+    // `items` keeps its `*` entry even beside `prefixItems` (PR #4969
+    // review). The `*` matches ANY index — including the tuple slots — so
+    // the mixed tuple-plus-rest shape over-taints the slots with the rest
+    // labels; but the alternative (minting nothing, as additionalProperties
+    // does beside named properties) silently DROPS the tail elements'
+    // declared labels — fail-open, strictly worse than over-taint.
+    // Expressing "every index past the slots" precisely needs a path
+    // grammar beyond `*`; until then the wildcard stays. The record-side
+    // no-mint rule is unchanged: there the `*` entry would misassign
+    // through schemaAtPath's properties-first resolution, a trade that
+    // predates tuple support.
     forEachSubschema(resolved, (child, keyword, key, index) => {
       switch (keyword) {
         case "properties":
@@ -2130,15 +2132,7 @@ const walkIfcSchema = (
           walkIfcSchema(child, path, entries, childRoot, nextActive);
           break;
         case "items":
-          if (tupleFree) {
-            walkIfcSchema(
-              child,
-              [...path, "*"],
-              entries,
-              childRoot,
-              nextActive,
-            );
-          }
+          walkIfcSchema(child, [...path, "*"], entries, childRoot, nextActive);
           break;
         case "prefixItems":
           // Tuple slots mint at their concrete index — unlike `items`' `*`

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -21,6 +21,7 @@ import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import { isRecord } from "@commonfabric/utils/types";
 import type { JSONSchema } from "../builder/types.ts";
 import { forEachSubschema } from "../schema-walk.ts";
+import { arrayMatchesPositionally } from "../schema-match.ts";
 import { normalizeCellScope } from "../scope.ts";
 import { ignoreReadForScheduling } from "../scheduler.ts";
 import type {
@@ -2897,38 +2898,19 @@ const policySchemaMatchesValue = (
     );
   }
   if (Array.isArray(value)) {
-    // 2020-12 array semantics, mirroring validateAgainstSchema: tuple slots
-    // condition their exact position, `items` conditions the positions past
-    // them. Before prefixItems was handled here, a tuple-shaped condition
-    // fell through to `return true` and vacuously matched any array.
-    const prefixItems = Array.isArray(schema.prefixItems)
-      ? schema.prefixItems
-      : undefined;
-    if (prefixItems !== undefined) {
-      const slots = Math.min(prefixItems.length, value.length);
-      for (let index = 0; index < slots; index++) {
-        if (
-          !policySchemaMatchesValue(
-            prefixItems[index],
-            value[index],
-            schemaRoot,
-          )
-        ) {
-          return false;
-        }
-      }
-    }
-    if (typeof schema.items === "object" && schema.items !== null) {
-      const itemSchema = schema.items;
-      for (
-        let index = prefixItems?.length ?? 0;
-        index < value.length;
-        index++
-      ) {
-        if (!policySchemaMatchesValue(itemSchema, value[index], schemaRoot)) {
-          return false;
-        }
-      }
+    // Shared position rule (schema-match.ts): tuple slots condition their
+    // exact position, `items` conditions the positions past them. Before
+    // prefixItems was handled here, a tuple-shaped condition fell through
+    // to `return true` and vacuously matched any array.
+    if (
+      !arrayMatchesPositionally(
+        schema,
+        value,
+        (childSchema, childValue) =>
+          policySchemaMatchesValue(childSchema, childValue, schemaRoot),
+      )
+    ) {
+      return false;
     }
   }
   return true;

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1064,17 +1064,29 @@ export const storedSchemaCoversCandidateEnvelope = (
       return false;
     }
     // Rest claims (PR #4969 review): a candidate additionalProperties is a
-    // claim about every undeclared key — an early return here would judge
-    // it "covered" without comparing, dropping it from the merge. No
-    // candidate rest claim means the properties coverage above suffices;
-    // boolean forms must match exactly; a schema-valued claim needs a
-    // covering stored one.
+    // claim about every key absent from the CANDIDATE's properties — which
+    // includes keys the stored side NAMES. Stored rest does not govern
+    // stored-named keys, so each stored-only named property must itself
+    // cover the candidate rest claim, and the rest claims must cover too.
+    // No candidate rest claim means the properties coverage above suffices;
+    // boolean forms must match exactly.
     const candidateRest = candidate.additionalProperties;
     if (candidateRest === undefined) {
       return true;
     }
     if (typeof candidateRest === "boolean") {
       return stored.additionalProperties === candidateRest;
+    }
+    for (const [key, storedChild] of Object.entries(storedProperties)) {
+      if (Object.hasOwn(candidate.properties, key)) continue;
+      if (
+        !storedSchemaCoversCandidateEnvelope(
+          storedChild as JSONSchema,
+          candidateRest,
+        )
+      ) {
+        return false;
+      }
     }
     return typeof stored.additionalProperties === "object" &&
       stored.additionalProperties !== null &&

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -324,12 +324,21 @@ const assertNoDivergentIfcBranches = (
     }
   }
 
-  for (const [key, value] of Object.entries(object.properties ?? {})) {
-    assertNoDivergentIfcBranches(value, `${path}/${key}`);
-  }
-  if (object.items !== undefined) {
-    assertNoDivergentIfcBranches(object.items, `${path}/*`);
-  }
+  // Recurse over the shared keyword vocabulary so a divergent-ifc shape
+  // cannot hide under a keyword this guard forgot (prefixItems and
+  // additionalProperties previously escaped it). Combinator members are
+  // technically redundant here — a member containing ifc anywhere already
+  // threw via branchContainsIfc above — but descending them is harmless.
+  forEachSubschema(object, (child, keyword, key, index) => {
+    const childPath = keyword === "properties"
+      ? `${path}/${key}`
+      : keyword === "items" || keyword === "additionalProperties"
+      ? `${path}/*`
+      : keyword === "prefixItems"
+      ? `${path}/${index}`
+      : path;
+    assertNoDivergentIfcBranches(child, childPath);
+  });
 };
 
 const mergeRequired = (

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -403,17 +403,46 @@ const mergeSchemaNode = (
     );
   }
 
-  const mergedProperties: Record<string, JSONSchema> = {
-    ...(left.properties ?? {}),
-  };
-  for (const [key, value] of Object.entries(right.properties ?? {})) {
-    mergedProperties[key] = key in mergedProperties
-      ? mergeSchemaNode(
-        mergedProperties[key],
-        value,
-        `${path}/${key}`,
-      )
-      : value;
+  // A side's claim about a named key is its properties[key] where declared,
+  // else its object-valued additionalProperties (the rest claim covering
+  // every undeclared key) — the record twin of the prefixItems/items rule
+  // below. So a key only one side names still merges with the other side's
+  // rest claim rather than winning wholesale.
+  const leftAdditional = typeof left.additionalProperties === "object" &&
+      left.additionalProperties !== null
+    ? left.additionalProperties
+    : undefined;
+  const rightAdditional = typeof right.additionalProperties === "object" &&
+      right.additionalProperties !== null
+    ? right.additionalProperties
+    : undefined;
+  const mergedProperties: Record<string, JSONSchema> = {};
+  for (
+    const key of new Set([
+      ...Object.keys(left.properties ?? {}),
+      ...Object.keys(right.properties ?? {}),
+    ])
+  ) {
+    const leftClaim = left.properties?.[key] ?? leftAdditional;
+    const rightClaim = right.properties?.[key] ?? rightAdditional;
+    mergedProperties[key] = leftClaim !== undefined &&
+        rightClaim !== undefined
+      ? mergeSchemaNode(leftClaim, rightClaim, `${path}/${key}`)
+      : (rightClaim ?? leftClaim)!;
+  }
+
+  // Object-valued rest claims merge like items; boolean forms keep the
+  // spread's right-wins behavior (closed-object union semantics are
+  // CT-1898's question, not this merge's).
+  let mergedAdditionalProperties = left.additionalProperties;
+  if (leftAdditional !== undefined && rightAdditional !== undefined) {
+    mergedAdditionalProperties = mergeSchemaNode(
+      leftAdditional,
+      rightAdditional,
+      `${path}/*`,
+    );
+  } else if (right.additionalProperties !== undefined) {
+    mergedAdditionalProperties = right.additionalProperties;
   }
 
   let mergedItems = left.items;
@@ -421,6 +450,40 @@ const mergeSchemaNode = (
     mergedItems = mergeSchemaNode(left.items, right.items, `${path}/*`);
   } else if (right.items !== undefined) {
     mergedItems = right.items;
+  }
+
+  // Tuple slots merge slot-wise like properties — the `{...left, ...right}`
+  // spread below would otherwise let one side's prefixItems win wholesale,
+  // dropping the other side's slot ifc/defaults. A side's claim about slot
+  // index i is its prefixItems[i] where declared, else its rest `items`
+  // (2020-12: `items` speaks for every index past that side's slots). So a
+  // shorter side's `items` claim merges into the longer side's extra slots,
+  // and a side introducing prefixItems beside an items-only side merges
+  // each slot with that `items` claim rather than winning wholesale.
+  let mergedPrefixItems: JSONSchema[] | undefined;
+  if (left.prefixItems !== undefined || right.prefixItems !== undefined) {
+    const slotClaim = (
+      side: typeof left,
+      index: number,
+    ): JSONSchema | undefined =>
+      side.prefixItems !== undefined && index < side.prefixItems.length
+        ? side.prefixItems[index]
+        : side.items;
+    const length = Math.max(
+      left.prefixItems?.length ?? 0,
+      right.prefixItems?.length ?? 0,
+    );
+    const slots: JSONSchema[] = [];
+    for (let index = 0; index < length; index++) {
+      const leftSlot = slotClaim(left, index);
+      const rightSlot = slotClaim(right, index);
+      slots.push(
+        leftSlot !== undefined && rightSlot !== undefined
+          ? mergeSchemaNode(leftSlot, rightSlot, `${path}/${index}`)
+          : (rightSlot ?? leftSlot)!,
+      );
+    }
+    mergedPrefixItems = slots;
   }
 
   // `$defs` is not merged: `{...left, ...right}` lets a `right` envelope that
@@ -437,6 +500,12 @@ const mergeSchemaNode = (
       ? { properties: mergedProperties }
       : {}),
     ...(mergedItems !== undefined ? { items: mergedItems } : {}),
+    ...(mergedPrefixItems !== undefined
+      ? { prefixItems: mergedPrefixItems }
+      : {}),
+    ...(mergedAdditionalProperties !== undefined
+      ? { additionalProperties: mergedAdditionalProperties }
+      : {}),
     ifc: mergeIfc(left.ifc, right.ifc, path),
     required: mergeRequired(left.required, right.required, mergedProperties),
     default: mergeDefaults(left.default, right.default),

--- a/packages/runner/src/cfc/structured-result.ts
+++ b/packages/runner/src/cfc/structured-result.ts
@@ -259,20 +259,34 @@ const knownPropertyNames = (
 const itemSchemaForIndex = (
   schema: JSONSchema,
   fullSchema: JSONSchema,
+  index: number,
 ): JSONSchema => {
   const resolved = resolveSchemaForValidation(schema, fullSchema);
   const itemSchemas: JSONSchema[] = [];
-  if (
-    isRecord(resolved) &&
-    (typeof resolved.items === "boolean" || isRecord(resolved.items))
-  ) {
-    itemSchemas.push(resolved.items);
-  }
-  if (isRecord(resolved) && Array.isArray(resolved.allOf)) {
-    for (const branch of resolved.allOf) {
-      const item = itemSchemaForIndex(branch, fullSchema);
-      if (item !== true) {
-        itemSchemas.push(item);
+  if (isRecord(resolved)) {
+    // 2020-12 array semantics: a tuple slot governs its exact index; the
+    // uniform `items` schema governs only the indices past the slots.
+    // Collecting only `items` let tuple elements sanitize against an
+    // unconstrained schema, dodging the opaque-link/raw-string gate.
+    const prefixItems = Array.isArray(resolved.prefixItems)
+      ? resolved.prefixItems
+      : undefined;
+    if (prefixItems !== undefined && index < prefixItems.length) {
+      const slot = prefixItems[index];
+      if (typeof slot === "boolean" || isRecord(slot)) {
+        itemSchemas.push(slot);
+      }
+    } else if (
+      typeof resolved.items === "boolean" || isRecord(resolved.items)
+    ) {
+      itemSchemas.push(resolved.items);
+    }
+    if (Array.isArray(resolved.allOf)) {
+      for (const branch of resolved.allOf) {
+        const item = itemSchemaForIndex(branch, fullSchema, index);
+        if (item !== true) {
+          itemSchemas.push(item);
+        }
       }
     }
   }
@@ -305,7 +319,7 @@ const sanitizeValueWithOpaqueLinks = (
     const items = value.map((item, index) => {
       const sanitized = sanitizeValueWithOpaqueLinks(
         item,
-        itemSchemaForIndex(effectiveSchema, fullSchema),
+        itemSchemaForIndex(effectiveSchema, fullSchema, index),
         fullSchema,
         opaqueHandleId,
         [...path, index],

--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -247,11 +247,17 @@ const uiContractsFromSchemaInternal = (
     Array.isArray(resolvedSchema.allOf);
   const hasItems = isRecord(resolvedSchema.items) ||
     typeof resolvedSchema.items === "boolean";
+  // prefixItems counts as children too (PR #4969 review): an unknown-typed
+  // tuple with a contract-bearing $defs entry must not mint that contract
+  // at the array's own path — the slot that references the definition mints
+  // it at its index via the descent below.
+  const hasPrefixItems = Array.isArray(resolvedSchema.prefixItems);
   if (
     contract === undefined &&
     !hasProperties &&
     !hasCompoundSchemas &&
     !hasItems &&
+    !hasPrefixItems &&
     resolvedSchema.type === "unknown" &&
     isRecord(resolvedSchema.$defs)
   ) {

--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -299,17 +299,15 @@ const uiContractsFromSchemaInternal = (
     );
   }
 
-  // `items` mints a `*` entry, subject to the same limitation as the ifc
-  // walker (walkIfcSchema): with prefixItems present, `items` governs only
-  // the indices past the tuple slots, but `pathPatternMatches`' `*` matches
-  // ANY index — so the mixed tuple-plus-rest shape mints no `*` entry, and
-  // the slots mint at their concrete index below.
-  const tupleFree = !Array.isArray(resolvedSchema.prefixItems) ||
-    resolvedSchema.prefixItems.length === 0;
+  // `items` keeps its `*` entry even beside prefixItems, mirroring
+  // walkIfcSchema (PR #4969 review): the `*` over-enforces the rest
+  // contract on tuple slots, but minting nothing would silently drop the
+  // tail elements' declared contract — fail-open, strictly worse. A
+  // precise "past the slots" representation needs a path grammar beyond
+  // `*`.
   if (
-    tupleFree &&
-    (isRecord(resolvedSchema.items) ||
-      typeof resolvedSchema.items === "boolean")
+    isRecord(resolvedSchema.items) ||
+    typeof resolvedSchema.items === "boolean"
   ) {
     entries.push(
       ...uiContractsFromSchemaInternal(

--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -299,8 +299,17 @@ const uiContractsFromSchemaInternal = (
     );
   }
 
+  // `items` mints a `*` entry, subject to the same limitation as the ifc
+  // walker (walkIfcSchema): with prefixItems present, `items` governs only
+  // the indices past the tuple slots, but `pathPatternMatches`' `*` matches
+  // ANY index — so the mixed tuple-plus-rest shape mints no `*` entry, and
+  // the slots mint at their concrete index below.
+  const tupleFree = !Array.isArray(resolvedSchema.prefixItems) ||
+    resolvedSchema.prefixItems.length === 0;
   if (
-    isRecord(resolvedSchema.items) || typeof resolvedSchema.items === "boolean"
+    tupleFree &&
+    (isRecord(resolvedSchema.items) ||
+      typeof resolvedSchema.items === "boolean")
   ) {
     entries.push(
       ...uiContractsFromSchemaInternal(
@@ -310,6 +319,19 @@ const uiContractsFromSchemaInternal = (
         seenRefs,
       ),
     );
+  }
+
+  if (Array.isArray(resolvedSchema.prefixItems)) {
+    for (let index = 0; index < resolvedSchema.prefixItems.length; index++) {
+      entries.push(
+        ...uiContractsFromSchemaInternal(
+          resolvedSchema.prefixItems[index] as JSONSchema,
+          childRoot,
+          [...path, String(index)],
+          seenRefs,
+        ),
+      );
+    }
   }
 
   return entries;

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,4 +1,5 @@
 import { isObject, isRecord } from "@commonfabric/utils/types";
+import { forEachSubschema } from "./schema-walk.ts";
 import {
   fabricFromNativeValue,
   type FabricPlainObject,
@@ -159,6 +160,14 @@ export const schemaIfcOverlapsPath = (
   if (schema === undefined || typeof schema === "boolean") {
     return false;
   }
+  // Keyword descent via the shared walk. This predicate only decides
+  // whether a schema-policy input MIGHT cover the written path — a true
+  // records and evaluates the input — so over-matching errs safe. That is
+  // why `items`/`additionalProperties` keep unconditional `*` segments even
+  // beside prefixItems/properties (unlike walkIfcSchema's minted entries,
+  // where a `*` covering named positions would over-taint them), and why
+  // combinator branches and `not` descend at the same path. Tuple slots
+  // overlap at their concrete index.
   const visit = (
     current: JSONSchema,
     path: readonly string[],
@@ -173,37 +182,16 @@ export const schemaIfcOverlapsPath = (
     ) {
       return true;
     }
-    if (current.type === "object" && isRecord(current.properties)) {
-      for (const [key, child] of Object.entries(current.properties)) {
-        if (visit(child as JSONSchema, [...path, key])) {
-          return true;
-        }
-      }
-    }
-    if (current.type === "array") {
-      // Tuple slots overlap at their concrete index. `items` keeps its
-      // unconditional `*` segment even beside prefixItems: this predicate
-      // only decides whether a schema-policy input MIGHT cover the written
-      // path, so over-matching errs safe (the input is recorded and
-      // evaluated), unlike walkIfcSchema's minted entries where a `*`
-      // covering the slots would over-taint them.
-      if (Array.isArray(current.prefixItems)) {
-        for (let index = 0; index < current.prefixItems.length; index++) {
-          if (
-            visit(
-              current.prefixItems[index] as JSONSchema,
-              [...path, String(index)],
-            )
-          ) {
-            return true;
-          }
-        }
-      }
-      if (current.items !== undefined) {
-        return visit(current.items, [...path, "*"]);
-      }
-    }
-    return false;
+    return forEachSubschema(current, (child, keyword, key, index) => {
+      const childPath = keyword === "properties"
+        ? [...path, key!]
+        : keyword === "prefixItems"
+        ? [...path, String(index!)]
+        : keyword === "items" || keyword === "additionalProperties"
+        ? [...path, "*"]
+        : path;
+      return visit(child, childPath);
+    });
   };
   return visit(schema, basePath);
 };

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -149,7 +149,9 @@ const labelHasValues = (
 const cfcLabelViewHasValues = (view: CfcLabelView | undefined): boolean =>
   view?.entries.some((entry) => labelHasValues(entry.label)) ?? false;
 
-const schemaIfcOverlapsPath = (
+// Exported for unit testing of the overlap predicate. Not part of the
+// public surface.
+export const schemaIfcOverlapsPath = (
   schema: JSONSchema | undefined,
   basePath: readonly string[],
   sourcePath: readonly string[],
@@ -178,8 +180,28 @@ const schemaIfcOverlapsPath = (
         }
       }
     }
-    if (current.type === "array" && current.items !== undefined) {
-      return visit(current.items, [...path, "*"]);
+    if (current.type === "array") {
+      // Tuple slots overlap at their concrete index. `items` keeps its
+      // unconditional `*` segment even beside prefixItems: this predicate
+      // only decides whether a schema-policy input MIGHT cover the written
+      // path, so over-matching errs safe (the input is recorded and
+      // evaluated), unlike walkIfcSchema's minted entries where a `*`
+      // covering the slots would over-taint them.
+      if (Array.isArray(current.prefixItems)) {
+        for (let index = 0; index < current.prefixItems.length; index++) {
+          if (
+            visit(
+              current.prefixItems[index] as JSONSchema,
+              [...path, String(index)],
+            )
+          ) {
+            return true;
+          }
+        }
+      }
+      if (current.items !== undefined) {
+        return visit(current.items, [...path, "*"]);
+      }
     }
     return false;
   };

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3572,8 +3572,22 @@ export class Runner {
         }
       }
 
-      if (Array.isArray(currentValue) && schema.items !== undefined) {
-        for (const item of currentValue) visit(schema.items, item);
+      if (Array.isArray(currentValue)) {
+        // A tuple slot covers its exact index; `items` covers the indices
+        // past the slots (2020-12). prefixItems-only schemas previously
+        // skipped elements entirely.
+        const prefixItems = Array.isArray(schema.prefixItems)
+          ? schema.prefixItems
+          : undefined;
+        for (let index = 0; index < currentValue.length; index++) {
+          const slotSchema =
+            prefixItems !== undefined && index < prefixItems.length
+              ? prefixItems[index]
+              : schema.items;
+          if (slotSchema !== undefined) {
+            visit(slotSchema, currentValue[index]);
+          }
+        }
       }
       if (
         schema.additionalProperties !== undefined &&

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -13,6 +13,7 @@ import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
 import { rendererVDOMSchema } from "./schemas.ts";
+import { forEachSubschema } from "./schema-walk.ts";
 import {
   type CellScope,
   type Frame,
@@ -3435,27 +3436,69 @@ export class Runner {
         return;
       }
 
-      // TODO(danfuzz): This descends live `FabricValue` action inputs via
-      // `Object.entries` with no `FabricSpecialObject` guard, decomposing
-      // `FabricPrimitive` values and walking `FabricInstance` values by internal
-      // slots.
-      if (isRecord(schema.properties) && isRecord(currentValue)) {
-        for (const [key, propertySchema] of Object.entries(schema.properties)) {
-          visit(propertySchema, currentValue[key], [...path, key]);
+      // Keyword descent via the shared walk (a keyword missed here means
+      // asCell markers escaping write tracking — the prefixItems gap,
+      // CT-1895). The value-position keywords align value and path — a
+      // named property or undeclared-key (`additionalProperties`) at its
+      // key, a tuple slot at its index, `items` elements past the slots at
+      // theirs — falling back to the conservative same-value/same-path
+      // visit when value and schema misalign. Combinator branches and
+      // `not` genuinely describe the same position: same value, same path.
+      // `not` is included deliberately: a nested `not` (not-of-not)
+      // re-selects values that DO match the inner subschema, so skipping it
+      // could let an asCell marker escape tracking; over-collection is this
+      // walker's safe direction (mirrors joinSchema's `not` union).
+      //
+      // TODO(danfuzz): The properties/additionalProperties cases descend
+      // live `FabricValue` action inputs with no `FabricSpecialObject`
+      // guard, decomposing `FabricPrimitive` values and walking
+      // `FabricInstance` values by internal slots.
+      forEachSubschema(schema as JSONSchema, (child, keyword, key, index) => {
+        switch (keyword) {
+          case "properties":
+            if (isRecord(currentValue)) {
+              visit(child, currentValue[key!], [...path, key!]);
+            }
+            return;
+          case "prefixItems":
+            visit(
+              child,
+              Array.isArray(currentValue) ? currentValue[index!] : currentValue,
+              [...path, String(index!)],
+            );
+            return;
+          case "items":
+            if (Array.isArray(currentValue)) {
+              // `items` covers the elements past the tuple slots (2020-12).
+              const start = Array.isArray(schema.prefixItems)
+                ? schema.prefixItems.length
+                : 0;
+              for (let i = start; i < currentValue.length; i++) {
+                visit(child, currentValue[i], [...path, String(i)]);
+              }
+            } else {
+              visit(child, currentValue, path);
+            }
+            return;
+          case "additionalProperties":
+            if (isRecord(currentValue) && !Array.isArray(currentValue)) {
+              // Covers only the keys `properties` does not declare.
+              const declaredKeys = isRecord(schema.properties)
+                ? new Set(Object.keys(schema.properties))
+                : undefined;
+              for (const [k, v] of Object.entries(currentValue)) {
+                if (declaredKeys?.has(k)) continue;
+                visit(child, v, [...path, k]);
+              }
+            } else {
+              visit(child, currentValue, path);
+            }
+            return;
+          default:
+            visit(child, currentValue, path);
+            return;
         }
-      }
-
-      for (const key of ["items", "additionalProperties"] as const) {
-        if (schema[key] !== undefined) {
-          visit(schema[key], currentValue, path);
-        }
-      }
-      for (const key of ["anyOf", "oneOf", "allOf"] as const) {
-        const branches = schema[key];
-        if (Array.isArray(branches)) {
-          for (const branch of branches) visit(branch, currentValue, path);
-        }
-      }
+      });
     };
 
     visit(argumentSchema, value, []);

--- a/packages/runner/src/schema-format.ts
+++ b/packages/runner/src/schema-format.ts
@@ -320,9 +320,18 @@ function schemaToTypeStringInner(
     if (indexValueSchema && lines.length > 0) {
       const valueType = schemaToTypeString(indexValueSchema, {
         ...nextOpts,
-        indent: indent + 1,
+        indent: 0,
       });
-      lines.push(`${padding}// other keys: ${valueType}`);
+      // Comment EVERY line: a multiline value type (e.g. an object) would
+      // otherwise escape the comment after its first line and read as outer
+      // object syntax (PR #4969 review).
+      const [first, ...restLines] = valueType.split("\n");
+      lines.push(
+        [
+          `${padding}// other keys: ${first}`,
+          ...restLines.map((line) => `${padding}// ${line}`),
+        ].join("\n"),
+      );
     }
 
     if (lines.length === 0) return "{}";

--- a/packages/runner/src/schema-format.ts
+++ b/packages/runner/src/schema-format.ts
@@ -62,6 +62,23 @@ export interface SchemaFormatOptions {
  * // → "string[]"
  *
  * @example
+ * // Tuples (prefixItems)
+ * schemaToTypeString({
+ *   type: "array",
+ *   prefixItems: [{ type: "string" }, { type: "number" }]
+ * })
+ * // → "[string, number]"
+ *
+ * @example
+ * // An `items` schema alongside `prefixItems` becomes a rest element
+ * schemaToTypeString({
+ *   type: "array",
+ *   prefixItems: [{ type: "string" }],
+ *   items: { type: "number" }
+ * })
+ * // → "[string, ...number[]]"
+ *
+ * @example
  * // Enums as union literals
  * schemaToTypeString({ enum: ["open", "closed"] })
  * // → '"open" | "closed"'
@@ -199,8 +216,19 @@ function schemaToTypeStringInner(
   if (type === "boolean") return "boolean";
   if (type === "null") return "null";
 
-  // Handle arrays
+  // Handle arrays; tuples render as TypeScript tuple types, with a uniform
+  // `items` schema alongside `prefixItems` becoming a rest element
   if (type === "array") {
+    if (Array.isArray(s.prefixItems)) {
+      const slots = (s.prefixItems as JSONSchema[]).map((slot) =>
+        schemaToTypeString(slot, nextOpts)
+      );
+      if (s.items && typeof s.items === "object") {
+        const itemType = schemaToTypeString(s.items as JSONSchema, nextOpts);
+        slots.push(`...${itemType}[]`);
+      }
+      return `[${slots.join(", ")}]`;
+    }
     if (s.items && typeof s.items === "object") {
       const itemType = schemaToTypeString(s.items as JSONSchema, nextOpts);
       return `${itemType}[]`;

--- a/packages/runner/src/schema-format.ts
+++ b/packages/runner/src/schema-format.ts
@@ -84,6 +84,19 @@ export interface SchemaFormatOptions {
  * // → '"open" | "closed"'
  *
  * @example
+ * // const literals and type arrays
+ * schemaToTypeString({ type: "string", const: "x" }) // → '"x"'
+ * schemaToTypeString({ type: ["string", "null"] })   // → "string | null"
+ *
+ * @example
+ * // Index signatures (object-valued additionalProperties)
+ * schemaToTypeString({
+ *   type: "object",
+ *   additionalProperties: { type: "number" }
+ * })
+ * // → "Record<string, number>"
+ *
+ * @example
  * // PatternToolResult schemas (from patternTool())
  * schemaToTypeString({
  *   type: "object",
@@ -160,6 +173,7 @@ function schemaToTypeStringInner(
     } else {
       if (schema.type === "object") return "{...}";
       if (schema.type === "array") return "[...]";
+      if (Array.isArray(schema.type)) return typeArrayToUnion(schema.type);
       return String(schema.type || "unknown");
     }
   }
@@ -189,11 +203,16 @@ function schemaToTypeStringInner(
     }
   }
 
+  // Handle const - show as the literal, matching the enum rendering (the
+  // generator's node path emits `const` where its type path emits a
+  // single-value `enum`)
+  if (s.const !== undefined) {
+    return literalToTypeString(s.const);
+  }
+
   // Handle enum - show as union of literals
   if (Array.isArray(s.enum)) {
-    const values = s.enum.slice(0, 5).map((v) =>
-      typeof v === "string" ? `"${v}"` : String(v)
-    );
+    const values = s.enum.slice(0, 5).map(literalToTypeString);
     if (s.enum.length > 5) values.push("...");
     return values.join(" | ");
   }
@@ -210,6 +229,10 @@ function schemaToTypeStringInner(
 
   // Handle basic types
   const type = s.type;
+
+  // A type array (e.g. from the union formatter's anyOf merge) is a union of
+  // the named types
+  if (Array.isArray(type)) return typeArrayToUnion(type);
 
   if (type === "string") return "string";
   if (type === "number" || type === "integer") return "number";
@@ -239,7 +262,18 @@ function schemaToTypeStringInner(
   // Handle objects
   if (type === "object" || s.properties) {
     const props = s.properties as Record<string, JSONSchema> | undefined;
+    // An index signature (object-valued additionalProperties) carries a value
+    // schema worth showing; a bare `additionalProperties: true` does not
+    const indexValueSchema = typeof s.additionalProperties === "object" &&
+        s.additionalProperties !== null
+      ? s.additionalProperties as JSONSchema
+      : undefined;
     if (!props || Object.keys(props).length === 0) {
+      if (indexValueSchema) {
+        return `Record<string, ${
+          schemaToTypeString(indexValueSchema, nextOpts)
+        }>`;
+      }
       if (s.additionalProperties) return "Record<string, unknown>";
       return "{}";
     }
@@ -262,6 +296,15 @@ function schemaToTypeStringInner(
       lines.push(`${padding}${key}${optional}: ${propType}`);
     }
 
+    // Named properties alongside an index signature keep both, TS-style
+    if (indexValueSchema) {
+      const valueType = schemaToTypeString(indexValueSchema, {
+        ...nextOpts,
+        indent: indent + 1,
+      });
+      lines.push(`${padding}[key: string]: ${valueType}`);
+    }
+
     if (lines.length === 0) return "{}";
 
     const closePadding = "  ".repeat(indent);
@@ -270,6 +313,17 @@ function schemaToTypeStringInner(
 
   // Fallback
   return type ? String(type) : "unknown";
+}
+
+/** Renders a literal value the way TS spells the literal type. */
+function literalToTypeString(value: unknown): string {
+  return typeof value === "string" ? `"${value}"` : String(value);
+}
+
+/** Renders a JSON Schema `type` array as a TS union, e.g. "number | string". */
+function typeArrayToUnion(types: readonly unknown[]): string {
+  const names = types.map((t) => t === "integer" ? "number" : String(t));
+  return [...new Set(names)].join(" | ") || "unknown";
 }
 
 function getWrappedTypeString(

--- a/packages/runner/src/schema-format.ts
+++ b/packages/runner/src/schema-format.ts
@@ -258,7 +258,9 @@ function schemaToTypeStringInner(
       if (s.items && typeof s.items === "object") {
         slots.push(
           `...${
-            restElementType(schemaToTypeString(s.items as JSONSchema, nextOpts))
+            arrayElementType(
+              schemaToTypeString(s.items as JSONSchema, nextOpts),
+            )
           }[]`,
         );
       } else if (s.items !== false) {
@@ -268,7 +270,7 @@ function schemaToTypeStringInner(
     }
     if (s.items && typeof s.items === "object") {
       const itemType = schemaToTypeString(s.items as JSONSchema, nextOpts);
-      return `${itemType}[]`;
+      return `${arrayElementType(itemType)}[]`;
     }
     return "unknown[]";
   }
@@ -310,19 +312,23 @@ function schemaToTypeStringInner(
       lines.push(`${padding}${key}${optional}: ${propType}`);
     }
 
+    // Named properties alongside an index signature: TypeScript cannot
+    // express "every key EXCEPT the named ones" — an inline index signature
+    // conflicts with incompatible named properties, and an intersection
+    // with Record<string, T> wrongly constrains the named keys too. Render
+    // a descriptive comment line instead (PR #4969 review, both rounds).
+    if (indexValueSchema && lines.length > 0) {
+      const valueType = schemaToTypeString(indexValueSchema, {
+        ...nextOpts,
+        indent: indent + 1,
+      });
+      lines.push(`${padding}// other keys: ${valueType}`);
+    }
+
     if (lines.length === 0) return "{}";
 
     const closePadding = "  ".repeat(indent);
-    const objectType = `{\n${lines.join(",\n")}\n${closePadding}}`;
-
-    // Named properties alongside an index signature render as an
-    // intersection: an inline `[key: string]: T` beside a property whose
-    // type is incompatible with T is invalid TypeScript (PR #4969 review).
-    if (indexValueSchema) {
-      const valueType = schemaToTypeString(indexValueSchema, nextOpts);
-      return `${objectType} & Record<string, ${valueType}>`;
-    }
-    return objectType;
+    return `{\n${lines.join(",\n")}\n${closePadding}}`;
   }
 
   // Fallback
@@ -346,12 +352,14 @@ function typeArrayToUnion(types: readonly unknown[]): string {
 }
 
 /**
- * Wraps a rest-element type in parens when needed: `...(number | string)[]`
- * is valid TS, `...number | string[]` means something else entirely
- * (PR #4969 review).
+ * Wraps an array-element type in parens when `[]` would bind tighter than
+ * the type expression: unions (`(number | string)[]`), intersections, and
+ * function types (`((e: T) => void)[]`) all need grouping — the ungrouped
+ * spellings mean something else entirely (PR #4969 review).
  */
-function restElementType(itemType: string): string {
-  return itemType.includes(" | ") || itemType.includes(" & ")
+function arrayElementType(itemType: string): string {
+  return itemType.includes(" | ") || itemType.includes(" & ") ||
+      itemType.includes("=>")
     ? `(${itemType})`
     : itemType;
 }

--- a/packages/runner/src/schema-format.ts
+++ b/packages/runner/src/schema-format.ts
@@ -15,7 +15,7 @@ export interface SchemaFormatOptions {
   defs?: Record<string, JSONSchema>;
   /** Current recursion depth (internal use) */
   depth?: number;
-  /** Maximum recursion depth before abbreviating (default: 3) */
+  /** Maximum recursion depth before abbreviating (default: 4) */
   maxDepth?: number;
   /** Current indentation level (internal use) */
   indent?: number;

--- a/packages/runner/src/schema-format.ts
+++ b/packages/runner/src/schema-format.ts
@@ -67,7 +67,8 @@ export interface SchemaFormatOptions {
  *   type: "array",
  *   prefixItems: [{ type: "string" }, { type: "number" }]
  * })
- * // → "[string, number]"
+ * // → "[string, number, ...unknown[]]" (an absent `items` leaves the tail
+ * // open; only `items: false` closes the tuple)
  *
  * @example
  * // An `items` schema alongside `prefixItems` becomes a rest element
@@ -147,6 +148,11 @@ function schemaToTypeStringInner(
       const defName = match[1];
       const def = defs[defName];
       if (def) {
+        // Ref hops recurse BEFORE the depth cap below, so a ref cycle
+        // (e.g. `$defs: {A: {$ref: "#/$defs/A"}}`) must bail here — at the
+        // cap, fall back to the type name instead of inlining (PR #4969
+        // review: `--help` overflowed the stack on recursive $defs).
+        if (depth >= maxDepth) return defName;
         // For small definitions, inline them; otherwise use the type name
         const defStr = schemaToTypeString(def, { ...nextOpts, indent: 0 });
         if (defStr.length < 50) {
@@ -240,15 +246,23 @@ function schemaToTypeStringInner(
   if (type === "null") return "null";
 
   // Handle arrays; tuples render as TypeScript tuple types, with a uniform
-  // `items` schema alongside `prefixItems` becoming a rest element
+  // `items` schema alongside `prefixItems` becoming a rest element. An
+  // absent (or `true`) `items` beside `prefixItems` leaves the tail OPEN in
+  // JSON Schema, so it renders `...unknown[]` — only `items: false` closes
+  // the tuple (PR #4969 review).
   if (type === "array") {
     if (Array.isArray(s.prefixItems)) {
       const slots = (s.prefixItems as JSONSchema[]).map((slot) =>
         schemaToTypeString(slot, nextOpts)
       );
       if (s.items && typeof s.items === "object") {
-        const itemType = schemaToTypeString(s.items as JSONSchema, nextOpts);
-        slots.push(`...${itemType}[]`);
+        slots.push(
+          `...${
+            restElementType(schemaToTypeString(s.items as JSONSchema, nextOpts))
+          }[]`,
+        );
+      } else if (s.items !== false) {
+        slots.push("...unknown[]");
       }
       return `[${slots.join(", ")}]`;
     }
@@ -296,34 +310,50 @@ function schemaToTypeStringInner(
       lines.push(`${padding}${key}${optional}: ${propType}`);
     }
 
-    // Named properties alongside an index signature keep both, TS-style
-    if (indexValueSchema) {
-      const valueType = schemaToTypeString(indexValueSchema, {
-        ...nextOpts,
-        indent: indent + 1,
-      });
-      lines.push(`${padding}[key: string]: ${valueType}`);
-    }
-
     if (lines.length === 0) return "{}";
 
     const closePadding = "  ".repeat(indent);
-    return `{\n${lines.join(",\n")}\n${closePadding}}`;
+    const objectType = `{\n${lines.join(",\n")}\n${closePadding}}`;
+
+    // Named properties alongside an index signature render as an
+    // intersection: an inline `[key: string]: T` beside a property whose
+    // type is incompatible with T is invalid TypeScript (PR #4969 review).
+    if (indexValueSchema) {
+      const valueType = schemaToTypeString(indexValueSchema, nextOpts);
+      return `${objectType} & Record<string, ${valueType}>`;
+    }
+    return objectType;
   }
 
   // Fallback
   return type ? String(type) : "unknown";
 }
 
-/** Renders a literal value the way TS spells the literal type. */
+/**
+ * Renders a literal value the way TS spells the literal type. JSON
+ * serialization escapes string contents (PR #4969 review: `"a"b"` was
+ * emitted for a legal string constant) and renders object/array literals
+ * as JSON instead of "[object Object]".
+ */
 function literalToTypeString(value: unknown): string {
-  return typeof value === "string" ? `"${value}"` : String(value);
+  return JSON.stringify(value) ?? String(value);
 }
 
 /** Renders a JSON Schema `type` array as a TS union, e.g. "number | string". */
 function typeArrayToUnion(types: readonly unknown[]): string {
   const names = types.map((t) => t === "integer" ? "number" : String(t));
   return [...new Set(names)].join(" | ") || "unknown";
+}
+
+/**
+ * Wraps a rest-element type in parens when needed: `...(number | string)[]`
+ * is valid TS, `...number | string[]` means something else entirely
+ * (PR #4969 review).
+ */
+function restElementType(itemType: string): string {
+  return itemType.includes(" | ") || itemType.includes(" & ")
+    ? `(${itemType})`
+    : itemType;
 }
 
 function getWrappedTypeString(

--- a/packages/runner/src/schema-match.ts
+++ b/packages/runner/src/schema-match.ts
@@ -26,7 +26,10 @@ export const arrayMatchesPositionally = (
       if (!matches(prefixItems[index], value[index])) return false;
     }
   }
-  if (typeof schema.items === "object" && schema.items !== null) {
+  if (schema.items === false) {
+    // A closed tuple: `items: false` forbids any element past the slots.
+    if (value.length > (prefixItems?.length ?? 0)) return false;
+  } else if (typeof schema.items === "object" && schema.items !== null) {
     for (
       let index = prefixItems?.length ?? 0;
       index < value.length;

--- a/packages/runner/src/schema-match.ts
+++ b/packages/runner/src/schema-match.ts
@@ -1,0 +1,39 @@
+/**
+ * Value-aligned array position matching (2020-12 semantics): a tuple slot
+ * (`prefixItems[i]`) governs exactly index i, and the uniform `items` schema
+ * governs only the indices past the slots.
+ *
+ * Shared by the narrow value matchers (`matchesConcreteValue` in schema.ts,
+ * `policySchemaMatchesValue` in cfc/prepare.ts) so the position rule cannot
+ * drift between them again — CT-1895 fixed the same prefixItems fall-through
+ * in each matcher separately; CT-1899 tracks consolidating the matchers
+ * themselves. The `matches` callback owns recursion and ref semantics: the
+ * matchers differ exactly there ($defs threading vs fail-closed policy refs).
+ */
+import type { JSONSchema, JSONSchemaObj } from "./builder/types.ts";
+
+export const arrayMatchesPositionally = (
+  schema: JSONSchemaObj,
+  value: readonly unknown[],
+  matches: (childSchema: JSONSchema, childValue: unknown) => boolean,
+): boolean => {
+  const prefixItems = Array.isArray(schema.prefixItems)
+    ? schema.prefixItems
+    : undefined;
+  if (prefixItems !== undefined) {
+    const slots = Math.min(prefixItems.length, value.length);
+    for (let index = 0; index < slots; index++) {
+      if (!matches(prefixItems[index], value[index])) return false;
+    }
+  }
+  if (typeof schema.items === "object" && schema.items !== null) {
+    for (
+      let index = prefixItems?.length ?? 0;
+      index < value.length;
+      index++
+    ) {
+      if (!matches(schema.items, value[index])) return false;
+    }
+  }
+  return true;
+};

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -841,7 +841,9 @@ export function processDefaultValue(
             "help: either allow items with valid schema, or use empty array default",
         );
       }
-      return covering as JSONSchema;
+      // Thread the array schema's $defs so a $ref slot resolves during
+      // recursive default processing (PR #4969 review).
+      return branchWithParentDefs(resolvedSchema, covering as JSONSchema);
     };
 
     const result = defaultValue.map((item, i) =>

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -23,6 +23,7 @@ import {
 } from "@commonfabric/data-model/schema-utils";
 import { createCell, isCell } from "./cell.ts";
 import { forEachSubschema } from "./schema-walk.ts";
+import { arrayMatchesPositionally } from "./schema-match.ts";
 import { readMaybeLink, resolveLink } from "./link-resolution.ts";
 import { type IExtendedStorageTransaction } from "./storage/interface.ts";
 import { getTransactionForChildCells } from "./storage/extended-storage-transaction.ts";
@@ -292,12 +293,21 @@ const matchesConcreteValue = (
     );
   }
 
-  if (
-    Array.isArray(value) && typeof resolved.items === "object" &&
-    resolved.items !== null
-  ) {
-    const itemSchema = branchWithParentDefs(resolved, resolved.items);
-    return value.every((item) => matchesConcreteValue(itemSchema, item));
+  if (Array.isArray(value)) {
+    // Shared position rule (schema-match.ts): tuple slots match their exact
+    // position, `items` matches only the positions past them. A
+    // prefixItems-only schema previously fell through to `return true`,
+    // letting ANY array match — so the wrong anyOf/oneOf branch could be
+    // selected for tuple values.
+    return arrayMatchesPositionally(
+      resolved,
+      value,
+      (childSchema, childValue) =>
+        matchesConcreteValue(
+          branchWithParentDefs(resolved, childSchema),
+          childValue,
+        ),
+    );
   }
 
   return true;

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -813,28 +813,36 @@ export function processDefaultValue(
     );
   }
 
-  // Handle array type defaults
+  // Handle array type defaults. A tuple slot (prefixItems[i]) covers its
+  // exact index; `items` covers the indices past the slots (2020-12).
+  // prefixItems-only schemas previously skipped this branch entirely, so
+  // tuple defaults went unprocessed.
   if (
     resolvedSchema.type === "array" && Array.isArray(defaultValue) &&
-    resolvedSchema.items
+    (resolvedSchema.items !== undefined ||
+      Array.isArray(resolvedSchema.prefixItems))
   ) {
-    // TODO(@ubik2): Need to handle prefixItems
-    // Handle boolean items values
-    let itemSchema: JSONSchema;
-    if (resolvedSchema.items === true) {
-      // items: true means allow any item type
-      itemSchema = {};
-    } else if ((resolvedSchema.items as any) === false) {
-      // items: false means no additional items allowed (empty arrays only)
-      // For default value processing, we'll treat this as an error
-      throw new Error(
-        "Array schema error: items: false conflicts with non-empty default\n" +
-          "help: either allow items with valid schema, or use empty array default",
-      );
-    } else {
-      // items is a JSONSchema object
-      itemSchema = resolvedSchema.items as JSONSchema;
-    }
+    const prefixItems = Array.isArray(resolvedSchema.prefixItems)
+      ? resolvedSchema.prefixItems
+      : undefined;
+    const schemaForIndex = (i: number): JSONSchema => {
+      const covering = prefixItems !== undefined && i < prefixItems.length
+        ? prefixItems[i]
+        : resolvedSchema.items;
+      // An absent or `true` covering schema allows any item.
+      if (covering === undefined || covering === true) return {};
+      if ((covering as unknown) === false) {
+        // `false` means no value allowed at this position. For default value
+        // processing, we'll treat this as an error. (With prefixItems, an
+        // `items: false` rest schema only conflicts when the default has
+        // elements PAST the tuple slots.)
+        throw new Error(
+          "Array schema error: items: false conflicts with non-empty default\n" +
+            "help: either allow items with valid schema, or use empty array default",
+        );
+      }
+      return covering as JSONSchema;
+    };
 
     const result = defaultValue.map((item, i) =>
       processDefaultValue(
@@ -842,7 +850,7 @@ export function processDefaultValue(
         tx,
         {
           ...link,
-          schema: itemSchema,
+          schema: schemaForIndex(i),
           path: [...link.path, String(i)],
         },
         item,

--- a/packages/runner/test/argument-scheduler-read-links.test.ts
+++ b/packages/runner/test/argument-scheduler-read-links.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Pins the schema/value alignment of the argument scheduler-read collector
+ * (`collectArgumentSchedulerReadLinks`): write-redirect links bound in tuple
+ * (prefixItems) slot positions must be visited like `items`-covered elements
+ * (CT-1895 — prefixItems-only schemas previously skipped array elements
+ * entirely, so links bound in tuple positions escaped scheduler read
+ * tracking).
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { NormalizedFullLink } from "../src/link-utils.ts";
+
+const signer = await Identity.fromPassphrase("argument scheduler read links");
+const space = signer.did();
+
+describe("argument scheduler read links", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const collect = (
+    argumentSchema: unknown,
+    value: unknown,
+    resultCell: unknown,
+  ): NormalizedFullLink[] =>
+    // deno-lint-ignore no-explicit-any
+    (runtime.runner as any).collectArgumentSchedulerReadLinks(
+      argumentSchema,
+      value,
+      resultCell,
+    );
+
+  it("visits tuple (prefixItems) slot elements", () => {
+    const resultCell = runtime.getCell(space, "sched-read-result");
+    const sourceCell = runtime.getCell<number>(space, "sched-read-source");
+    const argumentSchema = {
+      type: "object",
+      properties: {
+        route: {
+          type: "array",
+          prefixItems: [{ type: "number" }],
+        },
+      },
+    };
+    const value = {
+      route: [sourceCell.getAsWriteRedirectLink({ base: resultCell })],
+    };
+
+    const links = collect(argumentSchema, value, resultCell);
+    expect(links.length).toBe(1);
+    expect(links[0].id).toBe(sourceCell.getAsNormalizedFullLink().id);
+  });
+
+  it("visits items-covered elements past the tuple slots", () => {
+    // Parity pin: the rest region keeps its pre-existing items coverage.
+    const resultCell = runtime.getCell(space, "sched-read-rest-result");
+    const sourceCell = runtime.getCell<number>(space, "sched-read-rest-src");
+    const argumentSchema = {
+      type: "object",
+      properties: {
+        route: {
+          type: "array",
+          prefixItems: [{ type: "string" }],
+          items: { type: "number" },
+        },
+      },
+    };
+    const value = {
+      route: ["label", sourceCell.getAsWriteRedirectLink({ base: resultCell })],
+    };
+
+    const links = collect(argumentSchema, value, resultCell);
+    expect(links.length).toBe(1);
+    expect(links[0].id).toBe(sourceCell.getAsNormalizedFullLink().id);
+  });
+});

--- a/packages/runner/test/cell-arrays.test.ts
+++ b/packages/runner/test/cell-arrays.test.ts
@@ -11,7 +11,7 @@ import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { toCell } from "../src/back-to-cell.ts";
-import { type Cell, isCell } from "../src/cell.ts";
+import { type Cell, elementSchemaFor, isCell } from "../src/cell.ts";
 import { JSONSchema } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
@@ -629,5 +629,128 @@ describe("plain-schema array traversal", () => {
       tx,
     );
     expect(invalidObjects.get()).toBeUndefined();
+  });
+});
+
+// CT-1895 (borderline site): the covering schema for a tuple element is
+// index-determined — prefixItems[index] within the slots, `items` past them
+// — so elementSchemaFor takes the index when the caller knows it. Without
+// one (elementById is id-keyed), a tuple schema yields undefined: there is
+// no principled per-element schema to pick, and the schema/$defs loss is
+// the documented cost.
+describe("elementSchemaFor tuple (prefixItems) schemas", () => {
+  const tupleArraySchema = {
+    type: "array",
+    prefixItems: [
+      { $ref: "#/$defs/Point" },
+      { type: "number" },
+    ],
+    items: { type: "string" },
+    $defs: {
+      Point: { type: "object", properties: { x: { type: "number" } } },
+    },
+  } as const satisfies JSONSchema;
+
+  it("picks the slot schema for a covered index, threading $defs", () => {
+    expect(elementSchemaFor(tupleArraySchema, 0)).toEqual({
+      $ref: "#/$defs/Point",
+      $defs: {
+        Point: { type: "object", properties: { x: { type: "number" } } },
+      },
+    });
+    expect(elementSchemaFor(tupleArraySchema, 1)).toEqual({
+      type: "number",
+      $defs: {
+        Point: { type: "object", properties: { x: { type: "number" } } },
+      },
+    });
+  });
+
+  it("picks items past the tuple slots", () => {
+    expect(elementSchemaFor(tupleArraySchema, 2)).toEqual({
+      type: "string",
+      $defs: {
+        Point: { type: "object", properties: { x: { type: "number" } } },
+      },
+    });
+  });
+
+  it("treats an index-less element as rest-region (items)", () => {
+    // elementById is id-keyed: tuple slots are positional and cannot be
+    // id-addressed, so the element falls under `items`.
+    expect(elementSchemaFor(tupleArraySchema)).toEqual({
+      type: "string",
+      $defs: {
+        Point: { type: "object", properties: { x: { type: "number" } } },
+      },
+    });
+  });
+
+  it("yields undefined for a pure tuple (no items) without an index", () => {
+    expect(
+      elementSchemaFor(
+        {
+          type: "array",
+          prefixItems: [{ type: "number" }],
+        } as const satisfies JSONSchema,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("keeps items-only behavior without an index", () => {
+    expect(
+      elementSchemaFor(
+        {
+          type: "array",
+          items: { type: "string" },
+        } as const satisfies JSONSchema,
+      ),
+    ).toEqual({ type: "string" });
+  });
+});
+
+describe("elementById on tuple (prefixItems) arrays", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("falls back to the rest items schema (index unknown by design)", () => {
+    // elementById is id-keyed and deliberately never reads the array, so a
+    // tuple slot cannot be selected; the element carries the rest `items`
+    // schema. Callers that know the element's slot pass its schema
+    // explicitly.
+    const tupleSchema = {
+      type: "array",
+      prefixItems: [
+        { type: "object", properties: { x: { type: "number" } } },
+      ],
+      items: { type: "string" },
+    } as const satisfies JSONSchema;
+
+    const c = runtime.getCell<unknown[]>(
+      space,
+      "tuple-element-by-id",
+      tupleSchema,
+      tx,
+    );
+    c.set([]);
+
+    const el = c.elementById("k");
+    expect(el.schema).toEqual({ type: "string" });
   });
 });

--- a/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
+++ b/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
@@ -760,6 +760,103 @@ describe("CFC trusted agent: tool-input requiredIntegrity (Epic D2)", () => {
     }
   });
 
+  it("passes elements past the slots of a floorless tuple", async () => {
+    // The element past the tuple arity has no covering schema (no `items`),
+    // so no floor position exists for it and the call executes.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    const tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, handler, Writable } = commonfabric;
+    try {
+      const routeInputSchema = {
+        type: "object",
+        properties: {
+          route: {
+            type: "array",
+            prefixItems: [{ type: "string" }],
+          },
+        },
+        required: ["route"],
+        additionalProperties: false,
+      } as const satisfies JSONSchema;
+      const sendRoute = handler<{ route: string[] }, { sent: any }>(
+        routeInputSchema,
+        {
+          type: "object",
+          properties: {
+            sent: {
+              type: "array",
+              items: { type: "string" },
+              asCell: ["cell"],
+            },
+          },
+          required: ["sent"],
+        },
+        ({ route }, { sent }) => {
+          for (const r of route) sent.push(r);
+        },
+      );
+      const resultSchema = {
+        type: "object",
+        properties: {
+          sent: { type: "array", items: { type: "string" } },
+          tools: true,
+        },
+        required: ["sent", "tools"],
+      } as const satisfies JSONSchema;
+      const testPattern = pattern(
+        () => {
+          const sent = Writable.of<string[]>([]);
+          return {
+            sent,
+            tools: {
+              sendRoute: {
+                description: "Send along a route.",
+                inputSchema: routeInputSchema,
+                handler: sendRoute({ sent }),
+              },
+            },
+          };
+        },
+        false,
+        resultSchema,
+      );
+      const resultCell = runtime.getCell(
+        space,
+        "agent-tuple-floorless",
+        resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+      await runtime.idle();
+
+      const catalog = llmToolExecutionHelpers.buildToolCatalog(
+        result.key("tools") as any,
+        false,
+      );
+      await llmToolExecutionHelpers.executeToolCalls(runtime, space, catalog, [{
+        type: "tool-call",
+        toolCallId: "call-tuple-open",
+        toolName: "sendRoute",
+        input: { route: ["a", "b"] },
+      }] as any);
+      await runtime.idle();
+
+      const sent = (await result.key("sent").pull()) as string[] | undefined;
+      expect(sent).toEqual(["a", "b"]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("descends into tuple (prefixItems) slot floors", async () => {
     // CT-1895: the gate never descended prefixItems, so a floor declared on
     // a tuple slot was never enforced — a model-supplied literal in that
@@ -852,7 +949,9 @@ describe("CFC trusted agent: tool-input requiredIntegrity (Epic D2)", () => {
         type: "tool-call",
         toolCallId: "call-tuple",
         toolName: "sendRoute",
-        input: { route: ["evil@x.org", "harmless note"] },
+        // The third element sits past the tuple slots with no `items`
+        // schema — no floor position exists for it (covered continue).
+        input: { route: ["evil@x.org", "harmless note", "extra"] },
       }] as any);
       await runtime.idle();
 

--- a/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
+++ b/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
@@ -759,4 +759,108 @@ describe("CFC trusted agent: tool-input requiredIntegrity (Epic D2)", () => {
       await storageManager.close();
     }
   });
+
+  it("descends into tuple (prefixItems) slot floors", async () => {
+    // CT-1895: the gate never descended prefixItems, so a floor declared on
+    // a tuple slot was never enforced — a model-supplied literal in that
+    // slot executed the tool.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    const tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, handler, Writable } = commonfabric;
+    try {
+      const routeInputSchema = {
+        type: "object",
+        properties: {
+          route: {
+            type: "array",
+            prefixItems: [
+              {
+                type: "string",
+                ifc: { requiredIntegrity: [KERNEL_ATOM] },
+              },
+              { type: "string" },
+            ],
+          },
+        },
+        required: ["route"],
+        additionalProperties: false,
+      } as const satisfies JSONSchema;
+      const sendRoute = handler<{ route: string[] }, { sent: any }>(
+        routeInputSchema,
+        {
+          type: "object",
+          properties: {
+            sent: {
+              type: "array",
+              items: { type: "string" },
+              asCell: ["cell"],
+            },
+          },
+          required: ["sent"],
+        },
+        ({ route }, { sent }) => {
+          for (const r of route) sent.push(r);
+        },
+      );
+      const resultSchema = {
+        type: "object",
+        properties: {
+          sent: { type: "array", items: { type: "string" } },
+          tools: true,
+        },
+        required: ["sent", "tools"],
+      } as const satisfies JSONSchema;
+      const testPattern = pattern(
+        () => {
+          const sent = Writable.of<string[]>([]);
+          return {
+            sent,
+            tools: {
+              sendRoute: {
+                description: "Send along a route.",
+                inputSchema: routeInputSchema,
+                handler: sendRoute({ sent }),
+              },
+            },
+          };
+        },
+        false,
+        resultSchema,
+      );
+      const resultCell = runtime.getCell(
+        space,
+        "agent-tuple-slot-floor",
+        resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+      await runtime.idle();
+
+      const catalog = llmToolExecutionHelpers.buildToolCatalog(
+        result.key("tools") as any,
+        false,
+      );
+      await llmToolExecutionHelpers.executeToolCalls(runtime, space, catalog, [{
+        type: "tool-call",
+        toolCallId: "call-tuple",
+        toolName: "sendRoute",
+        input: { route: ["evil@x.org", "harmless note"] },
+      }] as any);
+      await runtime.idle();
+
+      const sent = (await result.key("sent").pull()) as string[] | undefined;
+      expect((sent ?? []).includes("evil@x.org")).toBe(false);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
 });

--- a/packages/runner/test/cfc-labelmap-components.test.ts
+++ b/packages/runner/test/cfc-labelmap-components.test.ts
@@ -187,4 +187,114 @@ describe("CFC labelMap component origins", () => {
       await storageManager.close();
     }
   });
+
+  it("mints declared entries for tuple (prefixItems) slots at their index", async () => {
+    // CT-1895: walkIfcSchema never descended prefixItems, so an ifc on a
+    // tuple slot minted no labelMap entry — tuple data under-tainted.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const guarded = internSchema(
+        {
+          type: "object",
+          properties: {
+            pair: {
+              type: "array",
+              prefixItems: [
+                { type: "string", ifc: { confidentiality: ["secret"] } },
+                { type: "number" },
+              ],
+            },
+          },
+        } satisfies JSONSchema,
+        true,
+      );
+
+      const tx = runtime.edit();
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-components-tuple-slot",
+        guarded.schema,
+        tx,
+      );
+      cell.set({ pair: ["hush", 7] });
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const persistedId = parseLink(cell.getAsLink()).id!;
+      const entries = replicaEntries(storageManager, persistedId);
+      // The slot label lands at its concrete index, not a `*` wildcard.
+      const slot = entries.find((e) =>
+        e.path.length === 2 && e.path[0] === "pair" && e.path[1] === "0"
+      );
+      expect(slot).toBeDefined();
+      expect(slot!.origin).toBe("declared");
+      expect(slot!.label.confidentiality).toEqual(["secret"]);
+      // The unlabeled slot mints nothing.
+      expect(entries.some((e) => e.path[1] === "1")).toBe(false);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a labeled items rest schema beside prefixItems mints no wildcard entry", async () => {
+    // `items`' `*` entry matches ANY index, including the tuple slots — but
+    // with prefixItems present, `items` covers only the indices past the
+    // slots. Like additionalProperties beside named properties, the mixed
+    // shape mints no `*` entry (exclusion semantics §3.3 forbids expressing
+    // "every index except the slots"); the slots still mint at their index.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const guarded = internSchema(
+        {
+          type: "object",
+          properties: {
+            pair: {
+              type: "array",
+              prefixItems: [
+                { type: "string", ifc: { confidentiality: ["secret"] } },
+              ],
+              items: { type: "number", ifc: { confidentiality: ["rest"] } },
+            },
+          },
+        } satisfies JSONSchema,
+        true,
+      );
+
+      const tx = runtime.edit();
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-components-tuple-rest",
+        guarded.schema,
+        tx,
+      );
+      cell.set({ pair: ["hush", 7] });
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const persistedId = parseLink(cell.getAsLink()).id!;
+      const entries = replicaEntries(storageManager, persistedId);
+      const slot = entries.find((e) =>
+        e.path.length === 2 && e.path[0] === "pair" && e.path[1] === "0"
+      );
+      expect(slot).toBeDefined();
+      expect(slot!.label.confidentiality).toEqual(["secret"]);
+      expect(
+        entries.some((e) => e.path[0] === "pair" && e.path[1] === "*"),
+      ).toBe(false);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
 });

--- a/packages/runner/test/cfc-labelmap-components.test.ts
+++ b/packages/runner/test/cfc-labelmap-components.test.ts
@@ -242,12 +242,11 @@ describe("CFC labelMap component origins", () => {
     }
   });
 
-  it("a labeled items rest schema beside prefixItems mints no wildcard entry", async () => {
-    // `items`' `*` entry matches ANY index, including the tuple slots — but
-    // with prefixItems present, `items` covers only the indices past the
-    // slots. Like additionalProperties beside named properties, the mixed
-    // shape mints no `*` entry (exclusion semantics §3.3 forbids expressing
-    // "every index except the slots"); the slots still mint at their index.
+  it("a labeled items rest schema beside prefixItems keeps its wildcard entry", async () => {
+    // PR #4969 review: dropping the `*` entry for the mixed tuple-plus-rest
+    // shape silently dropped the tail elements' declared labels (fail-open).
+    // The `*` stays — it over-taints the slots with the rest labels, the
+    // fail-safe direction — and the slots still mint at their index.
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
@@ -289,9 +288,11 @@ describe("CFC labelMap component origins", () => {
       );
       expect(slot).toBeDefined();
       expect(slot!.label.confidentiality).toEqual(["secret"]);
-      expect(
-        entries.some((e) => e.path[0] === "pair" && e.path[1] === "*"),
-      ).toBe(false);
+      const wildcard = entries.find((e) =>
+        e.path.length === 2 && e.path[0] === "pair" && e.path[1] === "*"
+      );
+      expect(wildcard).toBeDefined();
+      expect(wildcard!.label.confidentiality).toEqual(["rest"]);
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/cfc-labelmap-components.test.ts
+++ b/packages/runner/test/cfc-labelmap-components.test.ts
@@ -204,6 +204,9 @@ describe("CFC labelMap component origins", () => {
           properties: {
             pair: {
               type: "array",
+              // The negated branch is deliberately NOT minted (its ifc must
+              // not label real data); walking past it is pinned here.
+              not: { type: "string", ifc: { confidentiality: ["negated"] } },
               prefixItems: [
                 { type: "string", ifc: { confidentiality: ["secret"] } },
                 { type: "number" },

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -843,7 +843,24 @@ describe("storedSchemaCoversCandidateEnvelope (merge-skip decision)", () => {
     expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(false);
   });
 
-  it("covers slot-wise when stored slots cover every candidate slot", () => {
+  it("covers slot-wise when arities are equal and slots cover", () => {
+    const stored = {
+      type: "array",
+      prefixItems: [{ type: "string" }, { type: "number" }],
+      items: { type: "number" },
+    } as const;
+    const candidate = {
+      type: "array",
+      prefixItems: [{ type: "string" }, { type: "number" }],
+      items: { type: "number" },
+    } as const;
+    expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(true);
+  });
+
+  it("fails closed on differing tuple arities (PR #4969 review)", () => {
+    // With differing arities, the candidate's `items` claims positions the
+    // stored side covers with slots — the shared items branch cannot
+    // compare those, so coverage must fail closed and merge.
     const stored = {
       type: "array",
       prefixItems: [{ type: "string" }, { type: "number" }],
@@ -853,6 +870,47 @@ describe("storedSchemaCoversCandidateEnvelope (merge-skip decision)", () => {
       type: "array",
       prefixItems: [{ type: "string" }],
       items: { type: "number" },
+    } as const;
+    expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(false);
+  });
+
+  it("does not judge a candidate additionalProperties claim covered via properties alone", () => {
+    // PR #4969 review: the properties branch early-returned without
+    // comparing rest claims, so a candidate map-value claim was dropped
+    // instead of merged.
+    const stored = {
+      type: "object",
+      properties: { a: { type: "string" } },
+    } as const;
+    const candidate = {
+      type: "object",
+      properties: { a: { type: "string" } },
+      additionalProperties: {
+        type: "string",
+        ifc: { confidentiality: ["x"] },
+      },
+    } as const;
+    expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(false);
+  });
+
+  it("covers a candidate additionalProperties claim the stored side carries", () => {
+    // Stored differs (extra declared property) so the deep-equality
+    // shortcut misses and the rest-claim comparison actually runs.
+    const stored = {
+      type: "object",
+      properties: { a: { type: "string" }, b: { type: "number" } },
+      additionalProperties: {
+        type: "string",
+        ifc: { confidentiality: ["x"] },
+      },
+    } as const;
+    const candidate = {
+      type: "object",
+      properties: { a: { type: "string" } },
+      additionalProperties: {
+        type: "string",
+        ifc: { confidentiality: ["x"] },
+      },
     } as const;
     expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(true);
   });

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -306,6 +306,136 @@ describe("mergeCfcSchemaEnvelopes", () => {
     });
   });
 
+  it("merges tuple (prefixItems) slots slot-wise", () => {
+    // CT-1895: the {...left, ...right} spread let one side's prefixItems
+    // win wholesale, dropping the other side's slot ifc/defaults.
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "array",
+      prefixItems: [
+        {
+          type: "string",
+          ifc: { confidentiality: ["secret"] },
+        },
+        { type: "number" },
+      ],
+    }, {
+      type: "array",
+      prefixItems: [
+        { type: "string", default: "cmd" },
+        { type: "number" },
+      ],
+    });
+
+    const slots = (merged as JSONSchemaObj).prefixItems as JSONSchemaObj[];
+    // Slot 0 carries BOTH sides' contributions: the existing ifc and the
+    // candidate default.
+    expect((slots[0].ifc as { confidentiality?: string[] }).confidentiality)
+      .toEqual(["secret"]);
+    expect(slots[0].default).toBe("cmd");
+  });
+
+  it("keeps slots only one side declares", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "array",
+      prefixItems: [{ type: "string", ifc: { confidentiality: ["secret"] } }],
+    }, {
+      type: "array",
+      prefixItems: [{ type: "string" }, { type: "number", default: 3 }],
+    });
+
+    const slots = (merged as JSONSchemaObj).prefixItems as JSONSchemaObj[];
+    expect(slots.length).toBe(2);
+    expect((slots[0].ifc as { confidentiality?: string[] }).confidentiality)
+      .toEqual(["secret"]);
+    expect(slots[1]).toEqual({ type: "number", default: 3 });
+  });
+
+  it("merges a rest items claim into the other side's extra tuple slots", () => {
+    // 2020-12: a side's `items` speaks for every index past its slots — so
+    // its claim about index 1 must land in the longer side's slot 1, not be
+    // silently reinterpreted as "indices >= 2" by the merged arity.
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "array",
+      prefixItems: [{ type: "string" }],
+      items: { type: "number", ifc: { confidentiality: ["x"] } },
+    }, {
+      type: "array",
+      prefixItems: [{ type: "string" }, { type: "number", default: 3 }],
+    });
+
+    const slots = (merged as JSONSchemaObj).prefixItems as JSONSchemaObj[];
+    expect((slots[1].ifc as { confidentiality?: string[] }).confidentiality)
+      .toEqual(["x"]);
+    expect(slots[1].default).toBe(3);
+    // The rest claim itself survives for indices past all slots.
+    const items = (merged as JSONSchemaObj).items as JSONSchemaObj;
+    expect((items.ifc as { confidentiality?: string[] }).confidentiality)
+      .toEqual(["x"]);
+  });
+
+  it("merges an items-only side into a side introducing prefixItems", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "array",
+      items: { type: "number", ifc: { confidentiality: ["x"] } },
+    }, {
+      type: "array",
+      prefixItems: [{ type: "number", default: 1 }],
+    });
+
+    const slots = (merged as JSONSchemaObj).prefixItems as JSONSchemaObj[];
+    expect((slots[0].ifc as { confidentiality?: string[] }).confidentiality)
+      .toEqual(["x"]);
+    expect(slots[0].default).toBe(1);
+  });
+
+  it("merges a rest additionalProperties claim into the other side's named keys", () => {
+    // The record twin of the items/prefixItems rule: an object-valued
+    // additionalProperties speaks for every undeclared key, so its claim
+    // merges into keys only the other side names.
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "object",
+      additionalProperties: {
+        type: "string",
+        ifc: { confidentiality: ["x"] },
+      },
+    }, {
+      type: "object",
+      properties: { name: { type: "string", default: "d" } },
+    });
+
+    const props = (merged as JSONSchemaObj).properties as Record<
+      string,
+      JSONSchemaObj
+    >;
+    expect((props.name.ifc as { confidentiality?: string[] }).confidentiality)
+      .toEqual(["x"]);
+    expect(props.name.default).toBe("d");
+    // The rest claim itself survives for undeclared keys.
+    const additional = (merged as JSONSchemaObj)
+      .additionalProperties as JSONSchemaObj;
+    expect((additional.ifc as { confidentiality?: string[] }).confidentiality)
+      .toEqual(["x"]);
+  });
+
+  it("merges object-valued additionalProperties from both sides", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "object",
+      additionalProperties: {
+        type: "string",
+        ifc: { confidentiality: ["x"] },
+      },
+    }, {
+      type: "object",
+      additionalProperties: { type: "string", default: "d" },
+    });
+
+    const additional = (merged as JSONSchemaObj)
+      .additionalProperties as JSONSchemaObj;
+    expect((additional.ifc as { confidentiality?: string[] }).confidentiality)
+      .toEqual(["x"]);
+    expect(additional.default).toBe("d");
+  });
+
   it("keeps candidate items when only the candidate declares them", () => {
     const merged = mergeCfcSchemaEnvelopes({
       type: "array",

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -558,6 +558,36 @@ describe("mergeCfcSchemaEnvelopes", () => {
     ).toThrow(/divergent oneOf branches/);
   });
 
+  it("rejects divergent ifc branches nested under a tuple slot", () => {
+    // CT-1895: the guard's recursion visited only properties and items, so
+    // a divergent-ifc shape under a prefixItems slot escaped it.
+    const withTupleBranches = {
+      type: "array",
+      prefixItems: [{
+        oneOf: [
+          { type: "string", ifc: { confidentiality: ["secret"] } },
+          { type: "number" },
+        ],
+      }],
+    } as const;
+    expect(() => mergeCfcSchemaEnvelopes(withTupleBranches, withTupleBranches))
+      .toThrow(/divergent oneOf branches/);
+  });
+
+  it("rejects divergent ifc branches nested under additionalProperties", () => {
+    const withMapBranches = {
+      type: "object",
+      additionalProperties: {
+        anyOf: [
+          { type: "string", ifc: { confidentiality: ["secret"] } },
+          { type: "number" },
+        ],
+      },
+    } as const;
+    expect(() => mergeCfcSchemaEnvelopes(withMapBranches, withMapBranches))
+      .toThrow(/divergent anyOf branches/);
+  });
+
   it("allows non-object divergent branches without ifc labels", () => {
     const merged = mergeCfcSchemaEnvelopes({
       anyOf: [true, { type: "string" }],

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -417,6 +417,35 @@ describe("mergeCfcSchemaEnvelopes", () => {
       .toEqual(["x"]);
   });
 
+  it('keeps a property legitimately named "__proto__" through the merge', () => {
+    // Regression pin for a PR #4969 review claim that did NOT reproduce:
+    // in V8/Deno a computed store with a "__proto__" key creates an own
+    // data property (verified by probe), so the merge preserves this valid
+    // JSON key end-to-end. Pinned so an engine or refactor change that
+    // breaks the assumption is caught.
+    const left = {
+      type: "object",
+      properties: JSON.parse(
+        '{"__proto__": {"type": "string", "ifc": {"confidentiality": ["x"]}}}',
+      ),
+    } as JSONSchemaObj;
+    const right = {
+      type: "object",
+      properties: JSON.parse(
+        '{"__proto__": {"type": "string", "default": "d"}}',
+      ),
+    } as JSONSchemaObj;
+
+    const merged = mergeCfcSchemaEnvelopes(left, right) as JSONSchemaObj;
+    const props = merged.properties as Record<string, JSONSchemaObj>;
+    expect(Object.hasOwn(props, "__proto__")).toBe(true);
+    const proto = Object.getOwnPropertyDescriptor(props, "__proto__")!
+      .value as JSONSchemaObj;
+    expect((proto.ifc as { confidentiality?: string[] }).confidentiality)
+      .toEqual(["x"]);
+    expect(proto.default).toBe("d");
+  });
+
   it("merges object-valued additionalProperties from both sides", () => {
     const merged = mergeCfcSchemaEnvelopes({
       type: "object",

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -446,6 +446,18 @@ describe("mergeCfcSchemaEnvelopes", () => {
     expect(proto.default).toBe("d");
   });
 
+  it("keeps the candidate's boolean additionalProperties via the spread", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "object",
+      properties: { a: { type: "string" } },
+    }, {
+      type: "object",
+      properties: { a: { type: "string" } },
+      additionalProperties: true,
+    });
+    expect((merged as JSONSchemaObj).additionalProperties).toBe(true);
+  });
+
   it("merges object-valued additionalProperties from both sides", () => {
     const merged = mergeCfcSchemaEnvelopes({
       type: "object",
@@ -918,6 +930,39 @@ describe("storedSchemaCoversCandidateEnvelope (merge-skip decision)", () => {
         type: "string",
         ifc: { confidentiality: ["x"] },
       },
+    } as const;
+    expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(false);
+  });
+
+  it("boolean rest claims must match exactly for coverage", () => {
+    const stored = {
+      type: "object",
+      properties: { a: { type: "string" }, b: { type: "number" } },
+      additionalProperties: false,
+    } as const;
+    const covered = {
+      type: "object",
+      properties: { a: { type: "string" } },
+      additionalProperties: false,
+    } as const;
+    const open = {
+      type: "object",
+      properties: { a: { type: "string" } },
+      additionalProperties: true,
+    } as const;
+    expect(storedSchemaCoversCandidateEnvelope(stored, covered)).toBe(true);
+    expect(storedSchemaCoversCandidateEnvelope(stored, open)).toBe(false);
+  });
+
+  it("fails closed when only the candidate declares prefixItems", () => {
+    const stored = {
+      type: "array",
+      items: { type: "number" },
+    } as const;
+    const candidate = {
+      type: "array",
+      prefixItems: [{ type: "number" }],
+      items: { type: "number" },
     } as const;
     expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(false);
   });

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -967,9 +967,12 @@ describe("storedSchemaCoversCandidateEnvelope (merge-skip decision)", () => {
     expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(false);
   });
 
-  it("covers a candidate additionalProperties claim the stored side carries", () => {
-    // Stored differs (extra declared property) so the deep-equality
-    // shortcut misses and the rest-claim comparison actually runs.
+  it("stored-only named properties must cover the candidate rest claim", () => {
+    // PR #4969 review round 2: the candidate rest claim governs every key
+    // absent from the CANDIDATE's properties — including stored-NAMED keys.
+    // An unlabeled stored `b` does not cover a confidential rest claim, so
+    // coverage must fail closed and merge (the earlier version of this test
+    // pinned the fail-open behavior).
     const stored = {
       type: "object",
       properties: { a: { type: "string" }, b: { type: "number" } },
@@ -985,6 +988,24 @@ describe("storedSchemaCoversCandidateEnvelope (merge-skip decision)", () => {
         type: "string",
         ifc: { confidentiality: ["x"] },
       },
+    } as const;
+    expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(false);
+  });
+
+  it("covers the rest claim when stored-only named properties carry it too", () => {
+    const restClaim = {
+      type: "string",
+      ifc: { confidentiality: ["x"] },
+    } as const;
+    const stored = {
+      type: "object",
+      properties: { a: { type: "string" }, b: restClaim },
+      additionalProperties: restClaim,
+    } as const;
+    const candidate = {
+      type: "object",
+      properties: { a: { type: "string" } },
+      additionalProperties: restClaim,
     } as const;
     expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(true);
   });

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { JSONSchemaObj } from "../src/builder/types.ts";
 import { mergeCfcSchemaEnvelopes } from "../src/cfc/schema-merge.ts";
+import { storedSchemaCoversCandidateEnvelope } from "../src/cfc/prepare.ts";
 
 describe("mergeCfcSchemaEnvelopes", () => {
   // C5: `observes` is a scalar consumption class, not a set-like claim.
@@ -661,5 +662,65 @@ describe("mergeCfcSchemaEnvelopes", () => {
         approved: { type: "boolean" },
       },
     });
+  });
+});
+
+// CT-1895: the merge-skip decision judged envelopes "covered" via the items
+// branch while their tuple slots differed, dropping the candidate's slot
+// info instead of merging it (fail-open: coverage=true skips the merge).
+describe("storedSchemaCoversCandidateEnvelope (merge-skip decision)", () => {
+  it("differing tuple slots are not judged covered by matching items", () => {
+    const stored = {
+      type: "array",
+      prefixItems: [{ type: "string" }],
+      items: { type: "number" },
+    } as const;
+    const candidate = {
+      type: "array",
+      prefixItems: [{ type: "string", default: "x" }],
+      items: { type: "number" },
+    } as const;
+    expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(false);
+  });
+
+  it("covers slot-wise when stored slots cover every candidate slot", () => {
+    const stored = {
+      type: "array",
+      prefixItems: [{ type: "string" }, { type: "number" }],
+      items: { type: "number" },
+    } as const;
+    const candidate = {
+      type: "array",
+      prefixItems: [{ type: "string" }],
+      items: { type: "number" },
+    } as const;
+    expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(true);
+  });
+
+  it("fails closed when the candidate declares more slots than stored", () => {
+    const stored = {
+      type: "array",
+      prefixItems: [{ type: "string" }],
+      items: { type: "number" },
+    } as const;
+    const candidate = {
+      type: "array",
+      prefixItems: [{ type: "string" }, { type: "number" }],
+      items: { type: "number" },
+    } as const;
+    expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(false);
+  });
+
+  it("stored-only prefixItems fails closed — rest items do not speak for slots", () => {
+    const stored = {
+      type: "array",
+      prefixItems: [{ type: "string" }],
+      items: { type: "number" },
+    } as const;
+    const candidate = {
+      type: "array",
+      items: { type: "number" },
+    } as const;
+    expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(false);
   });
 });

--- a/packages/runner/test/cfc-schema-sanitization.test.ts
+++ b/packages/runner/test/cfc-schema-sanitization.test.ts
@@ -1194,6 +1194,42 @@ describe("schema-based prompt injection sanitization compatibility", () => {
     });
   });
 
+  it("sanitizes tuple (prefixItems) elements against their slot schema", () => {
+    // CT-1895: itemSchemaForIndex collected only `items` (+allOf), so tuple
+    // elements sanitized against an unconstrained schema — a raw string in a
+    // number slot dodged the opaque-link gate.
+    const schema = {
+      type: "object",
+      properties: {
+        pair: {
+          type: "array",
+          prefixItems: [
+            { type: "string", enum: ["label"] },
+            { type: "number" },
+          ],
+        },
+      },
+      required: ["pair"],
+      additionalProperties: false,
+    } as const satisfies JSONSchema;
+
+    const sanitized = validateAndSanitizeSchemaValueWithOpaqueLinks({
+      schema,
+      value: { pair: ["label", "untrusted page text"] },
+      opaqueHandleId: "child-run-1",
+    });
+
+    // Slot 0 pins the string via its enum — kept (schema-inert); slot 1 is
+    // a number slot, so the raw string is linkified rather than passed
+    // through.
+    expect(sanitized).toEqual({
+      value: {
+        pair: ["label", { "@link": "opaque:child-run-1#/pair/1" }],
+      },
+      linkedStringCount: 1,
+    });
+  });
+
   it("preserves caller-provided opaque links when the matching schema branch allows them", () => {
     const opaqueLinkSchema = {
       type: "object",

--- a/packages/runner/test/cfc-schema-sanitization.test.ts
+++ b/packages/runner/test/cfc-schema-sanitization.test.ts
@@ -1230,6 +1230,37 @@ describe("schema-based prompt injection sanitization compatibility", () => {
     });
   });
 
+  it("boolean tuple slots sanitize with boolean semantics", () => {
+    // itemSchemaForIndex pushes boolean slot schemas through combineAllOf: a
+    // `true` slot keeps non-string values as-is (free strings still
+    // linkify — an unconstrained schema does not pin them); a `false` slot
+    // admits nothing, so the raw string there is linkified.
+    const schema = {
+      type: "object",
+      properties: {
+        pair: {
+          type: "array",
+          prefixItems: [true, false],
+        },
+      },
+      required: ["pair"],
+      additionalProperties: false,
+    } as unknown as JSONSchema;
+
+    const sanitized = validateAndSanitizeSchemaValueWithOpaqueLinks({
+      schema,
+      value: { pair: [5, "blocked"] },
+      opaqueHandleId: "child-run-1",
+    });
+
+    expect(sanitized).toEqual({
+      value: {
+        pair: [5, { "@link": "opaque:child-run-1#/pair/1" }],
+      },
+      linkedStringCount: 1,
+    });
+  });
+
   it("preserves caller-provided opaque links when the matching schema branch allows them", () => {
     const opaqueLinkSchema = {
       type: "object",

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -253,6 +253,30 @@ describe("CFC UI contract matching", () => {
     }]);
   });
 
+  it("does not fall back to $defs contracts for unknown-typed tuples", () => {
+    // PR #4969 review: the $defs fallback's no-children guard did not count
+    // prefixItems, so an unknown-typed tuple with one contract-bearing
+    // definition minted that contract at the array's own path — enforced
+    // for every array write instead of just the referencing slot.
+    const contracts = uiContractsFromSchema({
+      type: "unknown",
+      prefixItems: [
+        { $ref: "#/$defs/Action" },
+        { type: "number" },
+      ],
+      $defs: {
+        Action: trustedPatternUiActionSchema,
+      },
+    } as never);
+
+    // Only the referencing slot mints, at its concrete index — no
+    // root-path entry.
+    expect(contracts.map((entry) => entry.path)).toEqual([["0"]]);
+    expect((contracts[0].contract as { action?: string }).action).toBe(
+      "SubmitDirectCommand",
+    );
+  });
+
   it("keeps sibling ifc metadata when resolving local $refs", () => {
     const contracts = uiContractsFromSchema({
       type: "array",

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -231,16 +231,26 @@ describe("CFC UI contract matching", () => {
     }]);
   });
 
-  it("mints no wildcard entry for items beside prefixItems", () => {
-    // Same rule as the ifc walker: a `*` entry matches ANY index including
-    // the tuple slots, but `items` governs only the indices past them.
+  it("keeps the items wildcard entry beside prefixItems", () => {
+    // PR #4969 review: dropping the `*` entry silently dropped the tail
+    // elements' declared contract (fail-open). The `*` stays — it
+    // over-enforces the rest contract on tuple slots, the fail-safe
+    // direction.
     const contracts = uiContractsFromSchema({
       type: "array",
       prefixItems: [{ type: "number" }],
       items: trustedPatternUiActionSchema,
     });
 
-    expect(contracts).toEqual([]);
+    expect(contracts).toEqual([{
+      path: ["*"],
+      contract: {
+        helper: "UiAction",
+        action: "SubmitDirectCommand",
+        trustedPattern: "TrustedDirectCommandSurface",
+        requiredEventIntegrity: ["TrustedDirectCommandSurface"],
+      },
+    }]);
   });
 
   it("keeps sibling ifc metadata when resolving local $refs", () => {

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -209,6 +209,40 @@ describe("CFC UI contract matching", () => {
     ).toBe(true);
   });
 
+  it("collects contracts declared in tuple (prefixItems) slots at their index", () => {
+    // CT-1895: contracts in tuple element schemas were never collected, so
+    // a declared UI contract on a slot went unenforced.
+    const contracts = uiContractsFromSchema({
+      type: "array",
+      prefixItems: [
+        { type: "number" },
+        trustedPatternUiActionSchema,
+      ],
+    });
+
+    expect(contracts).toEqual([{
+      path: ["1"],
+      contract: {
+        helper: "UiAction",
+        action: "SubmitDirectCommand",
+        trustedPattern: "TrustedDirectCommandSurface",
+        requiredEventIntegrity: ["TrustedDirectCommandSurface"],
+      },
+    }]);
+  });
+
+  it("mints no wildcard entry for items beside prefixItems", () => {
+    // Same rule as the ifc walker: a `*` entry matches ANY index including
+    // the tuple slots, but `items` governs only the indices past them.
+    const contracts = uiContractsFromSchema({
+      type: "array",
+      prefixItems: [{ type: "number" }],
+      items: trustedPatternUiActionSchema,
+    });
+
+    expect(contracts).toEqual([]);
+  });
+
   it("keeps sibling ifc metadata when resolving local $refs", () => {
     const contracts = uiContractsFromSchema({
       type: "array",

--- a/packages/runner/test/cfc-wildcard-link-applicability.test.ts
+++ b/packages/runner/test/cfc-wildcard-link-applicability.test.ts
@@ -101,6 +101,22 @@ describe("CFC policy value-conditions on tuple (prefixItems) schemas", () => {
       .toBe(false);
   });
 
+  it("a closed tuple (items: false) rejects extra elements", () => {
+    // PR #4969 review: the shared matcher skipped boolean `items`, so a
+    // closed tuple vacuously accepted arrays with extra elements — the
+    // policy entry applied where its condition excluded the value shape.
+    const schema = {
+      type: "array",
+      prefixItems: [{ const: "cmd" }],
+      items: false,
+    } as const satisfies JSONSchema;
+
+    expect(wildcardPolicyMatchesValue(tx, target, schema, ["cmd"]))
+      .toBe(true);
+    expect(wildcardPolicyMatchesValue(tx, target, schema, ["cmd", "extra"]))
+      .toBe(false);
+  });
+
   it("conditions items only past the tuple slots", () => {
     const schema = {
       type: "array",

--- a/packages/runner/test/cfc-wildcard-link-applicability.test.ts
+++ b/packages/runner/test/cfc-wildcard-link-applicability.test.ts
@@ -74,3 +74,45 @@ describe("CFC wildcard policy applicability on unresolvable links", () => {
       .toBe(false);
   });
 });
+
+// CT-1895: policySchemaMatchesValue validated arrays only against `items`,
+// so a tuple-shaped (prefixItems) value condition vacuously matched ANY
+// array — the policy entry applied where its condition should have excluded
+// it, or vice versa.
+describe("CFC policy value-conditions on tuple (prefixItems) schemas", () => {
+  const space = "did:key:tuple-policy" as const;
+  const target = { space, id: "of:guarded" as const, scope: "space" as const };
+  const tx = {
+    getWriteDetails: () => [],
+    readValueOrThrow: () => undefined,
+  } as unknown as IExtendedStorageTransaction;
+
+  it("conditions each tuple slot instead of vacuously matching", () => {
+    const schema = {
+      type: "array",
+      prefixItems: [{ const: "transfer" }, { type: "number" }],
+    } as const satisfies JSONSchema;
+
+    expect(wildcardPolicyMatchesValue(tx, target, schema, ["transfer", 5]))
+      .toBe(true);
+    expect(wildcardPolicyMatchesValue(tx, target, schema, ["burn", 5]))
+      .toBe(false);
+    expect(wildcardPolicyMatchesValue(tx, target, schema, ["transfer", "x"]))
+      .toBe(false);
+  });
+
+  it("conditions items only past the tuple slots", () => {
+    const schema = {
+      type: "array",
+      prefixItems: [{ const: "cmd" }],
+      items: { type: "number" },
+    } as const satisfies JSONSchema;
+
+    // Slot 0 is a string the `items` schema would reject — it must only
+    // condition the elements past the tuple arity.
+    expect(wildcardPolicyMatchesValue(tx, target, schema, ["cmd", 1, 2]))
+      .toBe(true);
+    expect(wildcardPolicyMatchesValue(tx, target, schema, ["cmd", 1, "x"]))
+      .toBe(false);
+  });
+});

--- a/packages/runner/test/computed-cell-kinds.test.ts
+++ b/packages/runner/test/computed-cell-kinds.test.ts
@@ -557,6 +557,178 @@ describe("computed cell kinds", () => {
       expect(descriptorFor(testPattern, "list")?.kind).toBeUndefined();
     });
 
+    it("grant-free tuple (prefixItems) slots stay computed", () => {
+      // Covered by the provably-handle-free gate (no grant anywhere in the
+      // schema); pins that tuple schemas don't regress that shortcut.
+      const double = lift((x: number) => x * 2);
+      const bump = handler(
+        true as const,
+        {
+          type: "object",
+          properties: {
+            target: {
+              type: "array",
+              prefixItems: [{ type: "number" }, { type: "string" }],
+            },
+          },
+        } as const,
+        (_event, _ctx) => {},
+      );
+      const testPattern = pattern<{ x: number }>(({ x }) => {
+        const doubled = double(x);
+        return { doubled, on: bump({ target: [doubled, "label"] }) };
+      });
+      expect(descriptorFor(testPattern, "doubled")?.kind).toBe("computed");
+    });
+
+    it("a capture in a grant-free tuple slot stays computed beside a granting slot", () => {
+      // CT-1895: prefixItems used to be an unmodeled keyword, so a grant in
+      // ANY slot collected the whole subtree. The aligned walk now proves the
+      // capture in slot 1 unreachable through the slot-0 grant.
+      const double = lift((x: number) => x * 2);
+      const bump = handler(
+        true as const,
+        {
+          type: "object",
+          properties: {
+            target: {
+              type: "array",
+              prefixItems: [
+                { type: "number", asCell: ["cell"] },
+                { type: "number" },
+              ],
+            },
+          },
+        } as const,
+        (_event, _ctx) => {},
+      );
+      const testPattern = pattern<{ x: number }>(({ x }) => {
+        const doubled = double(x);
+        return { doubled, on: bump({ target: [5, doubled] }) };
+      });
+      expect(descriptorFor(testPattern, "doubled")?.kind).toBe("computed");
+    });
+
+    it("a writable grant in a tuple slot disqualifies the capture bound there", () => {
+      const double = lift((x: number) => x * 2);
+      const bump = handler(
+        true as const,
+        {
+          type: "object",
+          properties: {
+            target: {
+              type: "array",
+              prefixItems: [
+                { type: "number", asCell: ["cell"] },
+                { type: "string" },
+              ],
+            },
+          },
+        } as const,
+        (_event, _ctx) => {},
+      );
+      const testPattern = pattern<{ x: number }>(({ x }) => {
+        const doubled = double(x);
+        return { doubled, on: bump({ target: [doubled, "label"] }) };
+      });
+      expect(descriptorFor(testPattern, "doubled")?.kind).toBeUndefined();
+    });
+
+    it("a grant in the items rest schema disqualifies elements past the tuple slots", () => {
+      const double = lift((x: number) => x * 2);
+      const bump = handler(
+        true as const,
+        {
+          type: "object",
+          properties: {
+            target: {
+              type: "array",
+              prefixItems: [{ type: "string" }],
+              items: { type: "number", asCell: ["cell"] },
+            },
+          },
+        } as unknown as JSONSchema,
+        (_event, _ctx) => {},
+      );
+      const testPattern = pattern<{ x: number }>(({ x }) => {
+        const doubled = double(x);
+        return { doubled, on: bump({ target: ["label", doubled] }) };
+      });
+      expect(descriptorFor(testPattern, "doubled")?.kind).toBeUndefined();
+    });
+
+    it("elements past the tuple slots with no items schema have no asCell position", () => {
+      const double = lift((x: number) => x * 2);
+      const bump = handler(
+        true as const,
+        {
+          type: "object",
+          properties: {
+            target: {
+              type: "array",
+              // The grant sits in slot 0, where a plain string is bound; the
+              // capture at index 1 is past the tuple arity with no `items`
+              // schema, so no covering subschema exists for it.
+              prefixItems: [{ type: "string", asCell: ["cell"] }],
+            },
+          },
+        } as const,
+        (_event, _ctx) => {},
+      );
+      const testPattern = pattern<{ x: number }>(({ x }) => {
+        const doubled = double(x);
+        return { doubled, on: bump({ target: ["label", doubled] }) };
+      });
+      expect(descriptorFor(testPattern, "doubled")?.kind).toBe("computed");
+    });
+
+    it("malformed prefixItems (not a schema array) fails closed", () => {
+      const double = lift((x: number) => x * 2);
+      const bump = handler(
+        true as const,
+        {
+          type: "object",
+          properties: {
+            target: {
+              type: "array",
+              prefixItems: { 0: { type: "number", asCell: ["cell"] } },
+            },
+          },
+        } as unknown as JSONSchema,
+        (_event, _ctx) => {},
+      );
+      const testPattern = pattern<{ x: number }>(({ x }) => {
+        const doubled = double(x);
+        return { doubled, on: bump({ target: [doubled] }) };
+      });
+      expect(descriptorFor(testPattern, "doubled")?.kind).toBeUndefined();
+    });
+
+    it("unused-tier keywords (contains) stay in the derived unmodeled list", () => {
+      // Pins that the derivation from schema-walk's vocabulary keeps the
+      // never-emitted tier failing closed.
+      const double = lift((x: number) => x * 2);
+      const bump = handler(
+        true as const,
+        {
+          type: "object",
+          properties: {
+            target: {
+              type: "array",
+              items: { type: "number" },
+              contains: { type: "number", asCell: ["cell"] },
+            },
+          },
+        } as unknown as JSONSchema,
+        (_event, _ctx) => {},
+      );
+      const testPattern = pattern<{ x: number }>(({ x }) => {
+        const doubled = double(x);
+        return { doubled, on: bump({ target: [doubled] }) };
+      });
+      expect(descriptorFor(testPattern, "doubled")?.kind).toBeUndefined();
+    });
+
     it("an array value under an object-shaped subschema fails closed", () => {
       const toList = lift((x: number) => [x]);
       const bump = handler(

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -2170,4 +2170,21 @@ describe("schemaIfcOverlapsPath", () => {
     } as const satisfies JSONSchema;
     expect(schemaIfcOverlapsPath(restSchema, [], ["list", "3"])).toBe(true);
   });
+
+  it("sees labels inside combinator branches (shared-walk descent)", () => {
+    // Gained by the forEachSubschema rework: ifc under an anyOf branch was
+    // previously invisible to the predicate (fail-open).
+    const branchSchema = {
+      type: "object",
+      properties: {
+        field: {
+          anyOf: [
+            { type: "string", ifc: { confidentiality: ["x"] } },
+            { type: "number" },
+          ],
+        },
+      },
+    } as const satisfies JSONSchema;
+    expect(schemaIfcOverlapsPath(branchSchema, [], ["field"])).toBe(true);
+  });
 });

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -8,6 +8,7 @@ import {
   compactChangeSet,
   diffAndUpdate,
   normalizeAndDiff,
+  schemaIfcOverlapsPath,
 } from "../src/data-updating.ts";
 import { Runtime } from "../src/runtime.ts";
 import {
@@ -2129,5 +2130,44 @@ describe("scope-isolation write guard", () => {
       dest.key("item").getAsNormalizedFullLink(),
     );
     expect(isSigilLink(stored)).toBe(true);
+  });
+});
+
+// CT-1895: the overlap predicate deciding whether a schema-policy write
+// input might cover a written path missed ifc labels in tuple slots, so
+// schema-policy inputs for tuple positions were skipped (fail-open).
+describe("schemaIfcOverlapsPath", () => {
+  const tupleSchema = {
+    type: "object",
+    properties: {
+      pair: {
+        type: "array",
+        prefixItems: [
+          { type: "string", ifc: { confidentiality: ["x"] } },
+          { type: "number" },
+        ],
+      },
+    },
+  } as const satisfies JSONSchema;
+
+  it("overlaps a write into a labeled tuple slot", () => {
+    expect(schemaIfcOverlapsPath(tupleSchema, [], ["pair", "0"])).toBe(true);
+  });
+
+  it("does not overlap the unlabeled slot", () => {
+    expect(schemaIfcOverlapsPath(tupleSchema, [], ["pair", "1"])).toBe(false);
+  });
+
+  it("still overlaps items-covered elements via the wildcard", () => {
+    const restSchema = {
+      type: "object",
+      properties: {
+        list: {
+          type: "array",
+          items: { type: "string", ifc: { confidentiality: ["x"] } },
+        },
+      },
+    } as const satisfies JSONSchema;
+    expect(schemaIfcOverlapsPath(restSchema, [], ["list", "3"])).toBe(true);
   });
 });

--- a/packages/runner/test/fetch-builtins.test.ts
+++ b/packages/runner/test/fetch-builtins.test.ts
@@ -7,6 +7,8 @@ import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { setPatternEnvironment } from "../src/env.ts";
+import { schemaWithOpenObjects } from "../src/builtins/fetch.ts";
+import type { JSONSchema } from "@commonfabric/api";
 
 const signer = await Identity.fromPassphrase("test fetch builtins");
 const space = signer.did();
@@ -64,6 +66,12 @@ describe("fetch builtins (fetchBinary / fetchText / fetchJson)", () => {
         return new Response(BINARY_BODY.slice(), {
           status: 200,
           headers: { "Content-Type": "Image/PNG; some=param" },
+        });
+      }
+      if (url.endsWith("/tuple")) {
+        return new Response(JSON.stringify([{ id: "a", extra: 1 }, 42]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
         });
       }
       return new Response(
@@ -245,6 +253,28 @@ describe("fetch builtins (fetchBinary / fetchText / fetchJson)", () => {
     });
   });
 
+  it("fetchJson accepts a tuple (prefixItems) result schema", async () => {
+    // Tuple slots are not validated on this path today: `prefixItems` sits in
+    // the strict-constraints tier and fetch verification runs non-strict. This
+    // pins that a tuple result schema doesn't reject the fetch outright; the
+    // open-objects rewrite of tuple slots is pinned by the
+    // schemaWithOpenObjects unit tests below.
+    const data = await runFetch("fetchJson", {
+      url: "http://mock-test-server.local/tuple",
+      schema: {
+        type: "array",
+        prefixItems: [
+          { type: "object", properties: { id: { type: "string" } } },
+          { type: "number" },
+        ],
+      },
+    }, "fetch-json-tuple-schema-test");
+
+    expect(data.error).toBeUndefined();
+    expect(data.pending).toBe(false);
+    expect(data.result).toEqual([{ id: "a", extra: 1 }, 42]);
+  });
+
   it("clears a prior result when the URL becomes empty", async () => {
     const urlCell = runtime.getCell<string>(
       space,
@@ -297,5 +327,57 @@ describe("fetch builtins (fetchBinary / fetchText / fetchJson)", () => {
     expect(cleared.result).toBeUndefined();
     expect(cleared.pending).toBe(false);
     expect(cleared.error).toBeUndefined();
+  });
+});
+
+describe("schemaWithOpenObjects", () => {
+  it("opens object schemas inside prefixItems slots (CT-1895)", () => {
+    const opened = schemaWithOpenObjects({
+      type: "array",
+      prefixItems: [
+        { type: "object", properties: { id: { type: "string" } } },
+        { type: "number" },
+      ],
+    }) as Record<string, any>;
+
+    expect(opened.prefixItems[0].additionalProperties).toBe(true);
+    expect(opened.prefixItems[1].additionalProperties).toBeUndefined();
+  });
+
+  it("leaves never-emitted keywords untouched", () => {
+    // `contains`/`if`/`then`/`else` are in schema-walk's unused tier — our
+    // schemas never emit them, and rewriting them here would make those paths
+    // look supported. If one becomes emitted it moves to the used tier and
+    // this walk picks it up.
+    const opened = schemaWithOpenObjects({
+      type: "array",
+      contains: { type: "object", properties: { x: { type: "number" } } },
+      if: { type: "object", properties: { kind: { const: "a" } } },
+      then: { type: "object", properties: { a: { type: "string" } } },
+    } as JSONSchema) as Record<string, any>;
+
+    expect(opened.contains.additionalProperties).toBeUndefined();
+    expect(opened.if.additionalProperties).toBeUndefined();
+    expect(opened.then.additionalProperties).toBeUndefined();
+  });
+
+  it("still opens nested objects and leaves non-object shapes alone", () => {
+    const opened = schemaWithOpenObjects({
+      type: "object",
+      properties: {
+        list: {
+          type: "array",
+          items: { type: "object", properties: { y: { type: "string" } } },
+        },
+      },
+      $defs: {
+        Def: { type: "object", properties: { z: { type: "number" } } },
+      },
+    }) as Record<string, any>;
+
+    expect(opened.additionalProperties).toBe(true);
+    expect(opened.properties.list.additionalProperties).toBeUndefined();
+    expect(opened.properties.list.items.additionalProperties).toBe(true);
+    expect(opened.$defs.Def.additionalProperties).toBe(true);
   });
 });

--- a/packages/runner/test/llm-dialog-helpers.test.ts
+++ b/packages/runner/test/llm-dialog-helpers.test.ts
@@ -1106,6 +1106,81 @@ Deno.test("simplifySchemaForContext preserves items schema for arrays", () => {
   assertEquals(result.items?.required, ["id"]);
 });
 
+Deno.test("simplifySchemaForContext preserves and simplifies prefixItems tuple slots", () => {
+  // CT-1895: prefixItems used to be dropped wholesale, leaving the LLM a bare
+  // { type: "array" } for tuple schemas.
+  const schema: any = {
+    type: "array",
+    prefixItems: [
+      { type: "object", properties: { id: { type: "number" } }, $UI: {} },
+      { type: "string", $ref: "#/$defs/Foo" },
+    ],
+  };
+  const result = simplifySchemaForContext(schema) as any;
+  assertEquals(result.prefixItems?.length, 2);
+  assertEquals(result.prefixItems?.[0]?.properties?.id?.type, "number");
+  assertEquals(result.prefixItems?.[0]?.$UI, undefined);
+  assertEquals(result.prefixItems?.[1]?.type, "string");
+  assertEquals(result.prefixItems?.[1]?.$ref, undefined);
+});
+
+Deno.test("simplifySchemaForContext simplifies subschemas under not and additionalProperties", () => {
+  // Both are in the emitted keyword tier: `not` used to be dropped, and an
+  // object-valued additionalProperties used to be copied verbatim ($ref and
+  // all). Both now go through the same simplification as any subschema.
+  const schema: any = {
+    type: "object",
+    not: { type: "string", $ref: "#/$defs/Foo" },
+    additionalProperties: { type: "number", $defs: { X: {} } },
+  };
+  const result = simplifySchemaForContext(schema) as any;
+  assertEquals(result.not?.type, "string");
+  assertEquals(result.not?.$ref, undefined);
+  assertEquals(result.additionalProperties?.type, "number");
+  assertEquals(result.additionalProperties?.$defs, undefined);
+});
+
+Deno.test("simplifySchemaForContext still drops never-emitted keywords", () => {
+  // `contains`/`if`/`then`/`else` are in schema-walk's unused tier — passing
+  // them through would make those paths look supported.
+  const schema: any = {
+    type: "array",
+    contains: { type: "object" },
+    if: { type: "object" },
+    then: { type: "object" },
+  };
+  const result = simplifySchemaForContext(schema) as any;
+  assertEquals(result.contains, undefined);
+  assertEquals(result.if, undefined);
+  assertEquals(result.then, undefined);
+});
+
+Deno.test("simplifySchemaForContext applies the depth cap inside prefixItems", () => {
+  const schema: any = {
+    type: "array", // depth 0
+    prefixItems: [{
+      type: "object", // depth 1
+      properties: {
+        a: {
+          type: "object", // depth 2
+          properties: {
+            b: {
+              type: "object", // depth 3: minimal
+              asCell: ["cell"],
+              properties: { c: { type: "string" } },
+            },
+          },
+        },
+      },
+    }],
+  };
+  const result = simplifySchemaForContext(schema) as any;
+  const capped = result.prefixItems?.[0]?.properties?.a?.properties?.b;
+  assertEquals(capped?.type, "object");
+  assertEquals(capped?.asCell, ["cell"]);
+  assertEquals(capped?.properties, undefined);
+});
+
 Deno.test("simplifySchemaForContext handles Stream with nested detail structure", () => {
   // This is the exact case from the bug report: Stream<{ detail: { value: string }}>
   const schema: any = {

--- a/packages/runner/test/materializer-envelope-collection.test.ts
+++ b/packages/runner/test/materializer-envelope-collection.test.ts
@@ -103,6 +103,115 @@ describe("materializer envelope collection", () => {
     expect(envelopes[0].id).toBe(targetCell.getAsNormalizedFullLink().id);
   });
 
+  it("collects from undeclared keys via an additionalProperties grant", () => {
+    // The rest claim covers only keys `properties` does not declare.
+    const resultCell = runtime.getCell(space, "envelope-map-result");
+    const targetCell = runtime.getCell<number>(space, "envelope-map-target");
+    const declaredCell = runtime.getCell<number>(space, "envelope-map-decl");
+    const argumentSchema = {
+      type: "object",
+      properties: {
+        bag: {
+          type: "object",
+          properties: { declared: { type: "number" } },
+          additionalProperties: { type: "number", asCell: ["cell"] },
+        },
+      },
+    };
+    const inputs = {
+      bag: {
+        declared: declaredCell.getAsWriteRedirectLink({ base: resultCell }),
+        extra: targetCell.getAsWriteRedirectLink({ base: resultCell }),
+      },
+    };
+    const envelopes = collect(argumentSchema, inputs, resultCell, [["bag"]]);
+    expect(envelopes.length).toBe(1);
+    expect(envelopes[0].id).toBe(targetCell.getAsNormalizedFullLink().id);
+  });
+
+  it("collects items-covered elements past the tuple slots at their index", () => {
+    const resultCell = runtime.getCell(space, "envelope-rest-result");
+    const targetCell = runtime.getCell<number>(space, "envelope-rest-target");
+    const argumentSchema = {
+      type: "object",
+      properties: {
+        route: {
+          type: "array",
+          prefixItems: [{ type: "string" }],
+          items: { type: "number", asCell: ["cell"] },
+        },
+      },
+    };
+    const inputs = {
+      route: ["label", targetCell.getAsWriteRedirectLink({ base: resultCell })],
+    };
+    const envelopes = collect(argumentSchema, inputs, resultCell, [["route"]]);
+    expect(envelopes.length).toBe(1);
+    expect(envelopes[0].id).toBe(targetCell.getAsNormalizedFullLink().id);
+  });
+
+  it("falls back conservatively when value and schema misalign", () => {
+    // A non-array value under a tuple/items schema and a non-record value
+    // under an additionalProperties schema take the same-value/same-path
+    // conservative visits.
+    const resultCell = runtime.getCell(space, "envelope-misaligned-result");
+    const targetCell = runtime.getCell<number>(space, "envelope-mis-target");
+    const argumentSchema = {
+      type: "object",
+      properties: {
+        route: {
+          type: "array",
+          prefixItems: [{ type: "number", asCell: ["cell"] }],
+          items: { type: "number" },
+        },
+        bag: {
+          type: "object",
+          additionalProperties: { type: "number", asCell: ["cell"] },
+        },
+      },
+    };
+    const inputs = {
+      // Misaligned: a single link where the schema says array/record.
+      route: targetCell.getAsWriteRedirectLink({ base: resultCell }),
+      bag: targetCell.getAsWriteRedirectLink({ base: resultCell }),
+    };
+    const envelopes = collect(argumentSchema, inputs, resultCell, [
+      ["route"],
+      ["bag"],
+    ]);
+    expect(envelopes.length).toBe(1);
+    expect(envelopes[0].id).toBe(targetCell.getAsNormalizedFullLink().id);
+
+    // Primitive values under rest schemas take the conservative visit and
+    // collect nothing.
+    expect(collect(argumentSchema, { route: 1, bag: 2 }, resultCell, [
+      ["route"],
+      ["bag"],
+    ])).toEqual([]);
+  });
+
+  it("descends combinator branches at the same position", () => {
+    const resultCell = runtime.getCell(space, "envelope-anyof-result");
+    const targetCell = runtime.getCell<number>(space, "envelope-anyof-target");
+    const argumentSchema = {
+      type: "object",
+      properties: {
+        target: {
+          anyOf: [
+            { type: "number" },
+            { type: "number", asCell: ["cell"] },
+          ],
+        },
+      },
+    };
+    const inputs = {
+      target: targetCell.getAsWriteRedirectLink({ base: resultCell }),
+    };
+    const envelopes = collect(argumentSchema, inputs, resultCell, [["target"]]);
+    expect(envelopes.length).toBe(1);
+    expect(envelopes[0].id).toBe(targetCell.getAsNormalizedFullLink().id);
+  });
+
   it("collects cell-branded tuple (prefixItems) slot positions", () => {
     // CT-1895: the walker never descended prefixItems, so asCell/writeonly
     // markers in tuple slots escaped write tracking.

--- a/packages/runner/test/materializer-envelope-collection.test.ts
+++ b/packages/runner/test/materializer-envelope-collection.test.ts
@@ -102,6 +102,28 @@ describe("materializer envelope collection", () => {
     expect(envelopes.length).toBe(1);
     expect(envelopes[0].id).toBe(targetCell.getAsNormalizedFullLink().id);
   });
+
+  it("collects cell-branded tuple (prefixItems) slot positions", () => {
+    // CT-1895: the walker never descended prefixItems, so asCell/writeonly
+    // markers in tuple slots escaped write tracking.
+    const resultCell = runtime.getCell(space, "envelope-tuple-result");
+    const targetCell = runtime.getCell<number>(space, "envelope-tuple-target");
+    const argumentSchema = {
+      type: "object",
+      properties: {
+        route: {
+          type: "array",
+          prefixItems: [{ type: "number", asCell: ["cell"] }],
+        },
+      },
+    };
+    const inputs = {
+      route: [targetCell.getAsWriteRedirectLink({ base: resultCell })],
+    };
+    const envelopes = collect(argumentSchema, inputs, resultCell, [["route"]]);
+    expect(envelopes.length).toBe(1);
+    expect(envelopes[0].id).toBe(targetCell.getAsNormalizedFullLink().id);
+  });
 });
 
 // The branch at the runner's envelope-derivation site: presence of

--- a/packages/runner/test/resolve-schema.test.ts
+++ b/packages/runner/test/resolve-schema.test.ts
@@ -190,6 +190,30 @@ describe("resolveSchema", () => {
       expect(narrowed.ifc).toEqual({ integrity: ["label-branch"] });
     });
 
+    it("a closed tuple (items: false) does not match arrays with extras", () => {
+      // PR #4969 review: boolean `items` was skipped, so a closed-tuple
+      // branch matched arrays with extra elements and could win the union.
+      const schema: JSONSchema = {
+        anyOf: [
+          {
+            type: "array",
+            prefixItems: [{ const: "cmd" }],
+            items: false,
+            ifc: { integrity: ["closed-tuple-branch"] },
+          },
+          {
+            type: "array",
+            ifc: { integrity: ["open-array-branch"] },
+          },
+        ],
+      };
+
+      const narrowed = expectNontrivial(
+        resolveSchemaForValue(schema, ["cmd", "extra"]),
+      );
+      expect(narrowed.ifc).toEqual({ integrity: ["open-array-branch"] });
+    });
+
     it("matches items only past the tuple slots", () => {
       const schema: JSONSchema = {
         anyOf: [

--- a/packages/runner/test/resolve-schema.test.ts
+++ b/packages/runner/test/resolve-schema.test.ts
@@ -163,6 +163,55 @@ describe("resolveSchema", () => {
       expect(narrowed.ifc).toEqual({ integrity: ["string-branch"] });
     });
 
+    it("narrows tuple (prefixItems) branches by slot values", () => {
+      // CT-1895: a prefixItems-only branch matched ANY array (the matcher
+      // fell through to true), so the wrong union branch could be selected
+      // for tuple values.
+      const schema: JSONSchema = {
+        anyOf: [
+          {
+            type: "array",
+            prefixItems: [{ const: "point" }, { type: "number" }],
+            ifc: { integrity: ["point-branch"] },
+          },
+          {
+            type: "array",
+            prefixItems: [{ const: "label" }, { type: "string" }],
+            ifc: { integrity: ["label-branch"] },
+          },
+        ],
+      };
+
+      const narrowed = expectNontrivial(
+        resolveSchemaForValue(schema, ["label", "x"]),
+      );
+
+      expect(narrowed.anyOf).toBe(undefined);
+      expect(narrowed.ifc).toEqual({ integrity: ["label-branch"] });
+    });
+
+    it("matches items only past the tuple slots", () => {
+      const schema: JSONSchema = {
+        anyOf: [
+          {
+            type: "array",
+            // Slot 0 is a string the rest schema would reject; items must
+            // only constrain the elements past the tuple arity.
+            prefixItems: [{ type: "string" }],
+            items: { type: "number" },
+            ifc: { integrity: ["tuple-branch"] },
+          },
+          { type: "string" },
+        ],
+      };
+
+      const narrowed = expectNontrivial(
+        resolveSchemaForValue(schema, ["cmd", 1, 2]),
+      );
+
+      expect(narrowed.ifc).toEqual({ integrity: ["tuple-branch"] });
+    });
+
     it("narrows union branches with nested refs to parent defs", () => {
       const schema: JSONSchema = {
         anyOf: [

--- a/packages/runner/test/schema-defaults.test.ts
+++ b/packages/runner/test/schema-defaults.test.ts
@@ -65,6 +65,42 @@ describe("Schema - Default Values", () => {
       expect(value.age).toBe(30);
     });
 
+    it("processes tuple (prefixItems) defaults against their slot schemas", () => {
+      // CT-1895: prefixItems-only schemas skipped array default processing
+      // entirely, so nested defaults inside tuple elements never resolved.
+      const c = runtime.getCell<{ name: string }>(
+        space,
+        "tuple defaults slot processing 1",
+        undefined,
+        tx,
+      );
+      c.set({ name: "t" });
+
+      const schema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          pair: {
+            type: "array",
+            default: [{}, {}],
+            prefixItems: [
+              {
+                type: "object",
+                properties: { x: { type: "number", default: 1 } },
+              },
+              {
+                type: "object",
+                properties: { y: { type: "number", default: 2 } },
+              },
+            ],
+          },
+        },
+      } as const satisfies JSONSchema;
+
+      const value = c.asSchema(schema).get();
+      expect(value.pair).toEqual([{ x: 1 }, { y: 2 }]);
+    });
+
     it("should resolve defaults when using $ref in property schemas", () => {
       const schema = {
         $defs: {

--- a/packages/runner/test/schema-defaults.test.ts
+++ b/packages/runner/test/schema-defaults.test.ts
@@ -135,6 +135,58 @@ describe("Schema - Default Values", () => {
       expect(value.pair).toEqual([{ x: 1 }]);
     });
 
+    it("allows any value in boolean-true tuple slots", () => {
+      const c = runtime.getCell<{ name: string }>(
+        space,
+        "tuple defaults true slot 1",
+        undefined,
+        tx,
+      );
+      c.set({ name: "t" });
+
+      const schema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          pair: {
+            type: "array",
+            default: [5],
+            prefixItems: [true],
+          },
+        },
+      } as unknown as JSONSchema;
+
+      const value = c.asSchema(schema).get() as { pair?: unknown };
+      expect(value.pair).toEqual([5]);
+    });
+
+    it("rejects default elements past the slots of a closed tuple", () => {
+      const c = runtime.getCell<{ name: string }>(
+        space,
+        "tuple defaults closed 1",
+        undefined,
+        tx,
+      );
+      c.set({ name: "t" });
+
+      const schema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          pair: {
+            type: "array",
+            default: ["a", "b"],
+            prefixItems: [{ type: "string" }],
+            items: false,
+          },
+        },
+      } as unknown as JSONSchema;
+
+      expect(() => c.asSchema(schema).get()).toThrow(
+        /items: false conflicts/,
+      );
+    });
+
     it("should resolve defaults when using $ref in property schemas", () => {
       const schema = {
         $defs: {

--- a/packages/runner/test/schema-defaults.test.ts
+++ b/packages/runner/test/schema-defaults.test.ts
@@ -101,6 +101,40 @@ describe("Schema - Default Values", () => {
       expect(value.pair).toEqual([{ x: 1 }, { y: 2 }]);
     });
 
+    it("resolves $ref tuple slots against the array's $defs", () => {
+      // PR #4969 review: the selected slot schema was passed to recursive
+      // default processing without the array's $defs, so a $ref slot went
+      // unresolved and its nested defaults disappeared.
+      const c = runtime.getCell<{ name: string }>(
+        space,
+        "tuple defaults ref slot 1",
+        undefined,
+        tx,
+      );
+      c.set({ name: "t" });
+
+      const schema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          pair: {
+            type: "array",
+            default: [{}],
+            prefixItems: [{ $ref: "#/$defs/P" }],
+            $defs: {
+              P: {
+                type: "object",
+                properties: { x: { type: "number", default: 1 } },
+              },
+            },
+          },
+        },
+      } as const satisfies JSONSchema;
+
+      const value = c.asSchema(schema).get();
+      expect(value.pair).toEqual([{ x: 1 }]);
+    });
+
     it("should resolve defaults when using $ref in property schemas", () => {
       const schema = {
         $defs: {

--- a/packages/runner/test/schema-format.test.ts
+++ b/packages/runner/test/schema-format.test.ts
@@ -18,6 +18,61 @@ Deno.test("schemaToTypeString converts arrays", () => {
   assertEquals(schemaToTypeString(schema), "string[]");
 });
 
+Deno.test("schemaToTypeString converts type arrays to unions", () => {
+  // The union formatter merges anyOf branches into type arrays; these used to
+  // hit the String(type) fallback and render as "number,string"
+  assertEquals(
+    schemaToTypeString({ type: ["number", "string"] } as any),
+    "number | string",
+  );
+  assertEquals(
+    schemaToTypeString({ type: ["string", "null"] } as any),
+    "string | null",
+  );
+  assertEquals(
+    schemaToTypeString({ type: ["integer", "number"] } as any),
+    "number",
+  );
+});
+
+Deno.test("schemaToTypeString renders const literals like their enum twins", () => {
+  // The generator's node path emits const where its type path emits a
+  // single-value enum; both should render as the TS literal type
+  assertEquals(
+    schemaToTypeString({ type: "string", const: "x" } as any),
+    '"x"',
+  );
+  assertEquals(schemaToTypeString({ type: "number", const: 42 } as any), "42");
+  assertEquals(
+    schemaToTypeString({ type: "string", enum: ["x"] } as any),
+    '"x"',
+  );
+});
+
+Deno.test("schemaToTypeString keeps the index-signature value type", () => {
+  assertEquals(
+    schemaToTypeString({
+      type: "object",
+      additionalProperties: { type: "number" },
+    } as any),
+    "Record<string, number>",
+  );
+  // Named properties alongside an index signature keep both, TS-style
+  assertEquals(
+    schemaToTypeString({
+      type: "object",
+      properties: { a: { type: "string" } },
+      additionalProperties: { type: "number" },
+    } as any),
+    "{\n  a?: string,\n  [key: string]: number\n}",
+  );
+  // Bare additionalProperties: true stays as before
+  assertEquals(
+    schemaToTypeString({ type: "object", additionalProperties: true } as any),
+    "Record<string, unknown>",
+  );
+});
+
 Deno.test("schemaToTypeString converts tuples (prefixItems)", () => {
   // CT-1895: tuples used to render as "unknown[]"
   const schema: any = {

--- a/packages/runner/test/schema-format.test.ts
+++ b/packages/runner/test/schema-format.test.ts
@@ -57,14 +57,18 @@ Deno.test("schemaToTypeString keeps the index-signature value type", () => {
     } as any),
     "Record<string, number>",
   );
-  // Named properties alongside an index signature keep both, TS-style
+  // Named properties alongside an index signature: TS cannot express
+  // "every key except the named ones", so the rest claim renders as a
+  // descriptive comment line (PR #4969 review, both rounds — the inline
+  // index signature was invalid TS, and & Record<string, T> wrongly
+  // constrained the named keys too).
   assertEquals(
     schemaToTypeString({
       type: "object",
       properties: { a: { type: "string" } },
       additionalProperties: { type: "number" },
     } as any),
-    "{\n  a?: string\n} & Record<string, number>",
+    "{\n  a?: string,\n  // other keys: number\n}",
   );
   // Bare additionalProperties: true stays as before
   assertEquals(
@@ -120,18 +124,28 @@ Deno.test("schemaToTypeString parenthesizes union rest elements", () => {
   );
 });
 
-Deno.test("schemaToTypeString parenthesizes intersection rest elements", () => {
+Deno.test("schemaToTypeString parenthesizes function types in array elements", () => {
+  // PR #4969 review round 2: `...({...}) => void[]` and `{...} => void[]`
+  // are invalid/mean something else; function elements need grouping in
+  // both rest and ordinary arrays.
+  const streamItems = {
+    asCell: ["stream"],
+    properties: { value: { type: "string" } },
+  };
   assertEquals(
     schemaToTypeString({
       type: "array",
       prefixItems: [{ type: "string" }],
-      items: {
-        type: "object",
-        properties: { a: { type: "string" } },
-        additionalProperties: { type: "number" },
-      },
+      items: streamItems,
     } as any),
-    "[string, ...({\n  a?: string\n} & Record<string, number>)[]]",
+    "[string, ...(({\n  value?: string\n}) => void)[]]",
+  );
+  assertEquals(
+    schemaToTypeString({
+      type: "array",
+      items: streamItems,
+    } as any),
+    "(({\n  value?: string\n}) => void)[]",
   );
 });
 

--- a/packages/runner/test/schema-format.test.ts
+++ b/packages/runner/test/schema-format.test.ts
@@ -64,7 +64,7 @@ Deno.test("schemaToTypeString keeps the index-signature value type", () => {
       properties: { a: { type: "string" } },
       additionalProperties: { type: "number" },
     } as any),
-    "{\n  a?: string,\n  [key: string]: number\n}",
+    "{\n  a?: string\n} & Record<string, number>",
   );
   // Bare additionalProperties: true stays as before
   assertEquals(
@@ -84,7 +84,7 @@ Deno.test("schemaToTypeString converts tuples (prefixItems)", () => {
   };
   assertEquals(
     schemaToTypeString(schema),
-    "[string, {\n  x?: number\n}]",
+    "[string, {\n  x?: number\n}, ...unknown[]]",
   );
 });
 
@@ -95,6 +95,61 @@ Deno.test("schemaToTypeString renders items alongside prefixItems as a rest elem
     items: { type: "boolean" },
   };
   assertEquals(schemaToTypeString(schema), "[string, number, ...boolean[]]");
+});
+
+Deno.test("schemaToTypeString closes the tuple only for items: false", () => {
+  assertEquals(
+    schemaToTypeString({
+      type: "array",
+      prefixItems: [{ type: "string" }],
+      items: false,
+    } as any),
+    "[string]",
+  );
+});
+
+Deno.test("schemaToTypeString parenthesizes union rest elements", () => {
+  // PR #4969 review: `...number | string[]` means something else entirely.
+  assertEquals(
+    schemaToTypeString({
+      type: "array",
+      prefixItems: [{ type: "string" }],
+      items: { type: ["number", "string"] },
+    } as any),
+    "[string, ...(number | string)[]]",
+  );
+});
+
+Deno.test("schemaToTypeString escapes string literals and renders JSON constants", () => {
+  // PR #4969 review: `"a"b"` was emitted for a legal string constant, and
+  // object/array constants rendered as "[object Object]".
+  assertEquals(
+    schemaToTypeString({ type: "string", const: 'a"b' } as any),
+    '"a\\"b"',
+  );
+  assertEquals(
+    schemaToTypeString({ const: { kind: "point" } } as any),
+    '{"kind":"point"}',
+  );
+  assertEquals(
+    schemaToTypeString({ enum: ["a", ["b"]] } as any),
+    '"a" | ["b"]',
+  );
+});
+
+Deno.test("schemaToTypeString survives recursive $defs", () => {
+  // PR #4969 review: ref hops recursed before the depth cap, so a ref
+  // cycle overflowed the stack (reachable from CLI --help).
+  const defs: any = { A: { $ref: "#/$defs/A" } };
+  assertEquals(schemaToTypeString({ $ref: "#/$defs/A" } as any, { defs }), "A");
+  const mutual: any = {
+    A: { $ref: "#/$defs/B" },
+    B: { $ref: "#/$defs/A" },
+  };
+  assertEquals(
+    schemaToTypeString({ $ref: "#/$defs/A" } as any, { defs: mutual }),
+    "A",
+  );
 });
 
 Deno.test("schemaToTypeString abbreviates tuples at max depth", () => {

--- a/packages/runner/test/schema-format.test.ts
+++ b/packages/runner/test/schema-format.test.ts
@@ -18,6 +18,41 @@ Deno.test("schemaToTypeString converts arrays", () => {
   assertEquals(schemaToTypeString(schema), "string[]");
 });
 
+Deno.test("schemaToTypeString converts tuples (prefixItems)", () => {
+  // CT-1895: tuples used to render as "unknown[]"
+  const schema: any = {
+    type: "array",
+    prefixItems: [
+      { type: "string" },
+      { type: "object", properties: { x: { type: "number" } } },
+    ],
+  };
+  assertEquals(
+    schemaToTypeString(schema),
+    "[string, {\n  x?: number\n}]",
+  );
+});
+
+Deno.test("schemaToTypeString renders items alongside prefixItems as a rest element", () => {
+  const schema: any = {
+    type: "array",
+    prefixItems: [{ type: "string" }, { type: "number" }],
+    items: { type: "boolean" },
+  };
+  assertEquals(schemaToTypeString(schema), "[string, number, ...boolean[]]");
+});
+
+Deno.test("schemaToTypeString abbreviates tuples at max depth", () => {
+  const schema: any = {
+    type: "object",
+    properties: {
+      pair: { type: "array", prefixItems: [{ type: "string" }] },
+    },
+  };
+  const result = schemaToTypeString(schema, { maxDepth: 1 });
+  assert(result.includes("pair?: [...]"));
+});
+
 Deno.test("schemaToTypeString converts objects with properties", () => {
   const schema: any = {
     type: "object",

--- a/packages/runner/test/schema-format.test.ts
+++ b/packages/runner/test/schema-format.test.ts
@@ -70,6 +70,19 @@ Deno.test("schemaToTypeString keeps the index-signature value type", () => {
     } as any),
     "{\n  a?: string,\n  // other keys: number\n}",
   );
+  // A multiline value type stays fully commented — an uncommented
+  // continuation line would read as outer-object syntax.
+  assertEquals(
+    schemaToTypeString({
+      type: "object",
+      properties: { a: { type: "string" } },
+      additionalProperties: {
+        type: "object",
+        properties: { x: { type: "number" } },
+      },
+    } as any),
+    "{\n  a?: string,\n  // other keys: {\n  //   x?: number\n  // }\n}",
+  );
   // Bare additionalProperties: true stays as before
   assertEquals(
     schemaToTypeString({ type: "object", additionalProperties: true } as any),

--- a/packages/runner/test/schema-format.test.ts
+++ b/packages/runner/test/schema-format.test.ts
@@ -120,6 +120,21 @@ Deno.test("schemaToTypeString parenthesizes union rest elements", () => {
   );
 });
 
+Deno.test("schemaToTypeString parenthesizes intersection rest elements", () => {
+  assertEquals(
+    schemaToTypeString({
+      type: "array",
+      prefixItems: [{ type: "string" }],
+      items: {
+        type: "object",
+        properties: { a: { type: "string" } },
+        additionalProperties: { type: "number" },
+      },
+    } as any),
+    "[string, ...({\n  a?: string\n} & Record<string, number>)[]]",
+  );
+});
+
 Deno.test("schemaToTypeString escapes string literals and renders JSON constants", () => {
   // PR #4969 review: `"a"b"` was emitted for a legal string constant, and
   // object/array constants rendered as "[object Object]".
@@ -149,6 +164,13 @@ Deno.test("schemaToTypeString survives recursive $defs", () => {
   assertEquals(
     schemaToTypeString({ $ref: "#/$defs/A" } as any, { defs: mutual }),
     "A",
+  );
+});
+
+Deno.test("schemaToTypeString renders type arrays at the depth cap", () => {
+  assertEquals(
+    schemaToTypeString({ type: ["string", "null"] } as any, { maxDepth: 0 }),
+    "string | null",
   );
 });
 


### PR DESCRIPTION
Works through every site in the CT-1895 audit ("prefixItems ignored by items-only schema walkers"), one commit per site, each pinned by a test verified to bite on the old code. Full runner package suite green: 1023 files, 5441 steps.

Linear-issue: CT-1895

## The bug class

2020-12 tuple schemas (`prefixItems`) were silently ignored by hand-rolled schema walkers that only knew `items`. In CFC code the miss direction is fail-open (under-tainting, unenforced floors, vacuously-matching policy conditions); elsewhere it meant wrong branch selection, unprocessed defaults, escaped write tracking, and `unknown[]` renderings.

## CFC / security-relevant

- **`walkIfcSchema`**: an `ifc` on a tuple slot minted no labelMap entry (under-taint). Slots now mint at their concrete index; keyword descent via `forEachSubschema`; `items`/`additionalProperties` `*` entries are gated (a `*` matches ANY position, and §3.3 forbids the exclusion semantics needed to say "all except the named ones"); `not` skipped (negated branches must not mint policy entries); fail-safe default for future keywords.
- **`policySchemaMatchesValue`**: tuple-shaped policy value conditions vacuously matched any array. Slots now condition their exact position, `items` the positions past them.
- **`storedSchemaCoversCandidateEnvelope`**: envelopes with differing tuple slots were judged "covered" via the items branch, dropping candidate slot claims instead of merging. Slot-wise coverage, fail-closed on shape mismatch.
- **`mergeSchemaNode`**: one side's `prefixItems`/`additionalProperties` won wholesale via spread. Positional and rest claims now merge slot-/key-wise, symmetric for arrays and records (a side's claim about a position is its named slot else its rest claim).
- **`assertNoDivergentIfcBranches`**: divergent-ifc shapes under a tuple slot or `additionalProperties` escaped the guard. Recursion via `forEachSubschema`.
- **`itemSchemaForIndex`** (structured results): tuple elements sanitized against an unconstrained schema — a raw string in a number slot dodged the opaque-link gate. The element index now threads through.
- **`ui-contract`**: contracts declared in tuple slots were never collected/enforced.
- **`toolInputRequiredIntegrityFailure`**: required-integrity floors in tuple slots were never enforced — a model-supplied literal in a floored slot executed the tool (pinned by a new D2 test).

## Runner core

- **`matchesConcreteValue`**: any array matched a prefixItems-only schema → wrong anyOf/oneOf branch for tuple values. Fixed via a new shared position primitive (`schema-match.ts` `arrayMatchesPositionally`) that `policySchemaMatchesValue` also delegates to — the seed of CT-1899's consolidation.
- **`collectWritableCellArgumentLinks`**: asCell/writeonly markers in tuple slots escaped write tracking. Reworked onto `forEachSubschema` with per-position value/path alignment.
- **`collectArgumentSchedulerReadLinks`**: prefixItems-only schemas skipped array elements entirely.
- **`schemaIfcOverlapsPath`**: ifc in tuple slots was invisible to the schema-policy overlap predicate; the `forEachSubschema` follow-up also fixed missed combinator/`additionalProperties`/`not` descent (all widening — this predicate's safe direction).
- **`processDefaultValue`**: resolves the long-standing TODO — tuple defaults process against their slot schemas.
- **`elementSchemaFor`/`elementById`**: slot selection by index in the helper; `elementById` deliberately punts to the rest `items` schema (id-keyed, never reads the array — documented, with an explicit-schema escape hatch).

## Builtins, display, and the walk-vocabulary hardening

- `schemaWithOpenObjects` (fetch) and `simplifySchemaForContext` (llm-dialog) reworked onto `mapSubschemas`. Finding recorded on the ticket: the fetch symptom as written does not reproduce — `prefixItems` validation is strict-tier only, so tuple slots were silently unvalidated rather than spuriously rejected.
- `schemaToTypeString` renders tuples (`[string, ...number[]]`), plus type-array/`const`/index-signature fidelity fixes; CLI exec help now delegates to it; the pager and openapi-extract get idiom-local tuple rendering (both structurally unable to delegate).
- `builder/pattern.ts`: `UNMODELED_SCHEMA_KEYWORDS` is now derived from schema-walk's vocabulary (an omission fails OPEN — silently dropped user writes), and `prefixItems` moved to modeled with precise slot alignment in the computed-kind walk.

## Boundary rule applied throughout

Structural walkers (label minting, guards, stamps, link collection) moved onto `forEachSubschema`/`mapSubschemas` so the keyword vocabulary cannot drift again; value-aligned matchers/validators keep their own keyword dispatch (each keyword carries its own quantifier and value pairing) — their consolidation is CT-1899. The closing-keyword semantics question surfaced along the way is CT-1898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787445816&installation_model_id=428580&pr_number=4969&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4969&signature=137e5e55c34bff2e8c914c0ef8ace5c05f7c5aab1b18a5cfb801de62ac2214f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full JSON Schema 2020‑12 tuple (`prefixItems`) support across walkers, matchers, and type rendering. Fixes CT‑1895 by closing fail‑open gaps (labels, policy conditions, defaults, coverage) and rendering tuples accurately across CLI and OpenAPI.

- **Bug Fixes**
  - CFC labeling and UI contracts: tuple slots mint at their index; `$defs` fallback counts `prefixItems`; `items` keeps its `*` entry beside `prefixItems`; `not` branches skipped; required‑integrity floors apply per slot.
  - Matchers and narrowing: arrays match positionally (slot i governs index i; `items` only past the slots); closed tuples (`items: false`) reject extra elements; shared `arrayMatchesPositionally` used by value and policy matchers.
  - Merging and coverage: coverage requires equal tuple arities, verifies rest claims, and stored‑only named properties must cover the candidate rest claim; schema merge combines slot/rest claims positionally (arrays and records).
  - Collectors and overlap: writable‑cell and scheduler‑read link collectors visit tuple slots; `schemaIfcOverlapsPath` descends tuple slots and combinators via the shared walk.
  - Structured results and defaults: tuple elements sanitize against their slot schema; default processing resolves per slot (or rest) with parent `$defs` threaded so `$ref` slots populate.
  - Display and extraction: `schemaToTypeString` renders tuples and open tails (`[string, ...unknown[]]` unless `items: false`), unions from type arrays, `const` literals, JSON‑escaped string/complex literals; mixed properties + `additionalProperties` render with an “other keys” comment (not a `Record` intersection), and multiline values prefix every line; function types are parenthesized in arrays/rest; union rest elements are parenthesized; ref‑cycle rendering respects the depth cap. CLI exec help delegates to `schemaToTypeString`; pager shows tuple types and detects `items: false`; OpenAPI extract renders tuple/rest (`[string, ...array<T>]`).

- **Refactors**
  - Structural walkers moved to `forEachSubschema`/`mapSubschemas` so the keyword vocabulary stays aligned; tuple slots are now visited consistently across CFC, fetch, and LLM schema passes.
  - Pattern builder: the modeled‑keyword list is derived from the walk vocabulary; `prefixItems` is modeled in the aligned walk so grants/captures align per slot.

<sup>Written for commit 60e17beea1f788bcf3742011b9736a522d6fd615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

