### PR TITLE
feat(runner,api): expose `valueEqual` to the pattern environment

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2963,6 +2963,14 @@ export type EqualsFunction = (
 ) => boolean;
 
 /**
+ * Deep structural equality for two values, intended for `FabricValue`-shaped
+ * data. Compares primitives with `Object.is` (so `NaN` equals `NaN` and `-0`
+ * is distinct from `0`). Unlike `equals`, it compares values directly and does
+ * not resolve cells or links.
+ */
+export type ValueEqualFunction = (a: unknown, b: unknown) => boolean;
+
+/**
  * Multi-user pattern test descriptor (`cf test`). Export it as the test
  * file's default export to run each participant pattern in its own isolated
  * runtime (own identity) against one shared space. The optional `setup`
@@ -3027,6 +3035,7 @@ export declare const createNodeFactory: CreateNodeFactoryFunction;
 /** @deprecated Use Cell.of(defaultValue?) instead */
 export declare const cell: CellTypeConstructor<AsCell>["of"];
 export declare const equals: EqualsFunction;
+export declare const valueEqual: ValueEqualFunction;
 export declare const byRef: ByRefFunction;
 export function getPatternEnvironment(): PatternEnvironment {
   const location = globalThis.location;

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -82,6 +82,7 @@ import { isTrustedPattern, setPatternProgram } from "./pattern-metadata.ts";
 import {
   FabricInstance,
   FabricPrimitive,
+  valueEqual,
 } from "@commonfabric/data-model/fabric-value";
 import {
   FabricEpochDays,
@@ -296,6 +297,9 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     // Debug stringifiers (helpers exposed for pattern code)
     toCompactDebugString,
     toIndentedDebugString,
+
+    // Value comparison helper exposed for pattern code
+    valueEqual,
   } as BuilderFunctionsAndConstants & {
     __cfHelpers?: BuilderFunctionsAndConstants;
   };

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -454,6 +454,9 @@ export interface BuilderFunctionsAndConstants {
     typeof import("@commonfabric/data-model/value-debug").toCompactDebugString;
   toIndentedDebugString:
     typeof import("@commonfabric/data-model/value-debug").toIndentedDebugString;
+
+  // Value comparison
+  valueEqual: typeof import("@commonfabric/data-model/fabric-value").valueEqual;
 }
 
 // Runtime interface needed by createCell

--- a/packages/runner/test/builder-value-equal.test.ts
+++ b/packages/runner/test/builder-value-equal.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createBuilder } from "../src/builder/factory.ts";
+
+// `valueEqual` is exposed to pattern code through the `commonfabric` builder
+// surface (declared in `api/index.ts`, bound in `builder/factory.ts`). These
+// tests pin that it is present and is the real `data-model` `valueEqual` — the
+// `Object.is`-leading, content-hash comparison — rather than a stand-in.
+describe("commonfabric valueEqual builtin", () => {
+  const { valueEqual } = createBuilder().commonfabric;
+
+  it("is exposed as a function on the pattern surface", () => {
+    expect(typeof valueEqual).toBe("function");
+  });
+
+  it("compares primitives with Object.is semantics", () => {
+    expect(valueEqual(NaN, NaN)).toBe(true);
+    expect(valueEqual(-0, 0)).toBe(false);
+    expect(valueEqual(1, 1)).toBe(true);
+    expect(valueEqual(1, "1")).toBe(false);
+  });
+
+  it("compares objects by content, independent of key order", () => {
+    expect(valueEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+    expect(valueEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(valueEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(valueEqual([1, 2], [1, 2, 3])).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Makes the runtime's `valueEqual` — the `data-model`-aware, `Object.is`-leading, content-hash equality — available to pattern code through the `commonfabric` surface.

## Why

Pattern modules run in the sandbox and can only import the `commonfabric` barrel plus their own relative files. The `js-compiler` resolver rejects `@commonfabric/data-model/fabric-value` (confirmed empirically), and it can't be re-exported through the `api` barrel either, since `api` may not depend on `data-model`. So a pattern needing a `FabricValue`-aware equality had no honest option short of duplicating core comparison machinery.

## Change

Exposes `valueEqual` exactly as `toCompactDebugString`/`toIndentedDebugString` are exposed:

- `api/index.ts` — declare the `ValueEqualFunction` type and `export declare const valueEqual`.
- `runner/src/builder/types.ts` — type the field on `BuilderFunctionsAndConstants` as `typeof import("@commonfabric/data-model/fabric-value").valueEqual`.
- `runner/src/builder/factory.ts` — import the data-model implementation and bind it into the `commonfabric` object.

The pattern-facing signature takes `unknown` args — patterns routinely hold `unknown`-typed stored reads and LLM output, and this matches the permissive boundary already used by `equals` and `toCompactDebugString` (avoids forcing `as FabricValue` casts at every call site). The runtime binding is the real, strictly-typed `valueEqual`.

## Tests

`runner/test/builder-value-equal.test.ts` pins that `valueEqual` is present on the pattern surface and is the real implementation: `NaN` equals `NaN`, `-0` distinct from `0`, and objects compared by content independent of key order.

## Context

Pure hookup, split out as its own PR. The first consumer — the record extractor's `JSON.stringify` skip-gate (Item 4 of the `===`/`Object.is` non-finite audit arc) — lands separately in #4966 once this merges. (Item 3 → #4964; Item 5 → #4966.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReWzAvFTdc97zMG38o2uRR
