### PR TITLE
docs(identity): stop prescribing the implicit-trust key for normal local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ dist/
 .cf-harness-artifacts/
 claude-research.key
 *.key
+# Backup keys the tailscale share script rotates aside (e.g. cf.key.implicit-trust.bak)
+cf.key.*
 # Exported PKCS8/PEM identity keys (e.g. cf.pem) — never commit private keys
 *.pem
 .passphrase

--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -80,17 +80,26 @@ server. See `docs/development/EXPERIMENTAL_OPTIONS.md` for all available flags.
 - `packages/shell/local-dev-shell.log`
 - `packages/toolshed/local-dev-toolshed.log`
 
-**CLI identity for local dev:** The local toolshed uses an identity derived from
-the passphrase `"implicit trust"`. To create a key matching the local server (so
-the CLI can act as its operator/admin):
+**CLI identity for local dev:** For normal development — deploying pieces,
+pattern work, anything acting as *you* — mint a unique key:
+```bash
+mkdir -p .cf
+deno run -A packages/cli/mod.ts id new > .cf/shared-dev.key
+export CF_IDENTITY="$PWD/.cf/shared-dev.key"
+```
+The local toolshed itself runs as the identity derived from the passphrase
+`"implicit trust"`. Derive that key only when the CLI must act as the server's
+operator/admin (`add-admin-piece`, the background piece service, deploying
+system home patterns):
 ```bash
 deno run -A packages/cli/mod.ts id derive "implicit trust" > claude.key
-export CF_IDENTITY=./claude.key
 ```
-This is a shared, publicly-derivable key — every developer who derives it gets
-the same DID. Use it only against your own localhost. For a personal identity, or
-any shared/remote server, use `id new` instead (see
-[`SHARED_IDENTITY.md`](./SHARED_IDENTITY.md)).
+It is a shared, publicly-derivable key — every developer who derives it gets
+the same DID. Never use it against a server other people use, and don't deploy
+your own work as it even locally: it collapses you into the server principal
+(and into one identity for user counting — see
+[`active-user-counting.md`](./active-user-counting.md)). Full policy:
+[`SHARED_IDENTITY.md`](./SHARED_IDENTITY.md).
 
 For workflows that touch `PerUser`, `PerSession`, favorites, or home-space
 state, use one shared identity in both browser and CLI. The browser login screen

--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -93,6 +93,7 @@ operator/admin (`add-admin-piece`, the background piece service, deploying
 system home patterns):
 ```bash
 deno run -A packages/cli/mod.ts id derive "implicit trust" > claude.key
+export CF_IDENTITY="$PWD/claude.key"
 ```
 It is a shared, publicly-derivable key — every developer who derives it gets
 the same DID. Never use it against a server other people use, and don't deploy

--- a/docs/development/debugging/cli-debugging.md
+++ b/docs/development/debugging/cli-debugging.md
@@ -86,19 +86,19 @@ deno task cf check \
 
 ```bash
 # 1. What's the full state?
-deno task cf piece inspect --piece <piece-id> -i claude.key -a URL -s space
+deno task cf piece inspect --piece <piece-id> -i .cf/shared-dev.key -a URL -s space
 
 # 2. What are the inputs?
-deno task cf piece get --piece <piece-id> /input -i claude.key -a URL -s space
+deno task cf piece get --piece <piece-id> /input -i .cf/shared-dev.key -a URL -s space
 
 # 3. What's a specific computed value?
-deno task cf piece get --piece <piece-id> myComputedField -i claude.key -a URL -s space
+deno task cf piece get --piece <piece-id> myComputedField -i .cf/shared-dev.key -a URL -s space
 
 # 4. Set known input, trigger recompute, verify output
 echo '{"items":[{"title":"test","done":false}]}' | \
-  deno task cf piece set --piece <piece-id> /input -i claude.key -a URL -s space
-deno task cf piece step --piece <piece-id> -i claude.key -a URL -s space
-deno task cf piece get --piece <piece-id> itemCount -i claude.key -a URL -s space
+  deno task cf piece set --piece <piece-id> /input -i .cf/shared-dev.key -a URL -s space
+deno task cf piece step --piece <piece-id> -i .cf/shared-dev.key -a URL -s space
+deno task cf piece get --piece <piece-id> itemCount -i .cf/shared-dev.key -a URL -s space
 ```
 
 ## Common CLI Debugging Patterns
@@ -132,10 +132,10 @@ When iterating on fixes, always use `setsrc` instead of `new`:
 
 ```bash
 # Make a fix to your pattern, then:
-deno task cf piece setsrc --piece <piece-id> pattern.tsx -i claude.key -a URL -s space
+deno task cf piece setsrc --piece <piece-id> pattern.tsx -i .cf/shared-dev.key -a URL -s space
 
 # Test again
-deno task cf piece get --piece <piece-id> brokenField -i claude.key -a URL -s space
+deno task cf piece get --piece <piece-id> brokenField -i .cf/shared-dev.key -a URL -s space
 ```
 
 This keeps you working with the same piece instance, preserving any test data you've set up.

--- a/docs/development/debugging/cli-debugging.md
+++ b/docs/development/debugging/cli-debugging.md
@@ -86,19 +86,19 @@ deno task cf check \
 
 ```bash
 # 1. What's the full state?
-deno task cf piece inspect --piece <piece-id> -i .cf/shared-dev.key -a URL -s space
+deno task cf piece inspect --piece <piece-id> -i "$CF_IDENTITY" -a URL -s space
 
 # 2. What are the inputs?
-deno task cf piece get --piece <piece-id> /input -i .cf/shared-dev.key -a URL -s space
+deno task cf piece get --piece <piece-id> /input -i "$CF_IDENTITY" -a URL -s space
 
 # 3. What's a specific computed value?
-deno task cf piece get --piece <piece-id> myComputedField -i .cf/shared-dev.key -a URL -s space
+deno task cf piece get --piece <piece-id> myComputedField -i "$CF_IDENTITY" -a URL -s space
 
 # 4. Set known input, trigger recompute, verify output
 echo '{"items":[{"title":"test","done":false}]}' | \
-  deno task cf piece set --piece <piece-id> /input -i .cf/shared-dev.key -a URL -s space
-deno task cf piece step --piece <piece-id> -i .cf/shared-dev.key -a URL -s space
-deno task cf piece get --piece <piece-id> itemCount -i .cf/shared-dev.key -a URL -s space
+  deno task cf piece set --piece <piece-id> /input -i "$CF_IDENTITY" -a URL -s space
+deno task cf piece step --piece <piece-id> -i "$CF_IDENTITY" -a URL -s space
+deno task cf piece get --piece <piece-id> itemCount -i "$CF_IDENTITY" -a URL -s space
 ```
 
 ## Common CLI Debugging Patterns
@@ -132,10 +132,10 @@ When iterating on fixes, always use `setsrc` instead of `new`:
 
 ```bash
 # Make a fix to your pattern, then:
-deno task cf piece setsrc --piece <piece-id> pattern.tsx -i .cf/shared-dev.key -a URL -s space
+deno task cf piece setsrc --piece <piece-id> pattern.tsx -i "$CF_IDENTITY" -a URL -s space
 
 # Test again
-deno task cf piece get --piece <piece-id> brokenField -i .cf/shared-dev.key -a URL -s space
+deno task cf piece get --piece <piece-id> brokenField -i "$CF_IDENTITY" -a URL -s space
 ```
 
 This keeps you working with the same piece instance, preserving any test data you've set up.

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -67,14 +67,20 @@ SPACE=team-lunch
 
 **Identity key:**
 
-- **Local dev** — the local toolshed trusts the identity derived from the
-  passphrase `"implicit trust"`. Mint a matching key (use `deno run`, **not**
-  `deno task`, when redirecting — the task wrapper prints ANSI preamble that
-  pollutes the file):
+- **Local dev** — mint your own unique key (use `deno run`, **not** `deno task`,
+  when redirecting — the task wrapper prints ANSI preamble that pollutes the
+  file):
   ```bash
-  deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
-  chmod 600 cf.key
+  mkdir -p .cf
+  deno run -A packages/cli/mod.ts id new > .cf/shared-dev.key
+  chmod 600 .cf/shared-dev.key
   ```
+  The local toolshed accepts any identity; import the same key in the browser
+  (`Import CLI Key` on the login screen) when the CLI and browser should act as
+  one user. Do NOT derive the shared `"implicit trust"` passphrase for deploys —
+  that fixed, publicly-derivable DID is reserved for acting as the local
+  server's own operator identity, and it collapses you into the server
+  principal. See `docs/development/SHARED_IDENTITY.md`.
 - **Prod** — deploy with your own identity, or mint a fresh one
   (`deno run -A packages/cli/mod.ts id new > prod.key`) and share that key with
   whoever should be able to update the piece. Whoever deployed owns it; the

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -74,6 +74,7 @@ SPACE=team-lunch
   mkdir -p .cf
   deno run -A packages/cli/mod.ts id new > .cf/shared-dev.key
   chmod 600 .cf/shared-dev.key
+  export CF_IDENTITY="$PWD/.cf/shared-dev.key"   # replaces the ./your-identity.key placeholder above
   ```
   The local toolshed accepts any identity; import the same key in the browser
   (`Import CLI Key` on the login screen) when the CLI and browser should act as

--- a/scripts/share-pattern-via-tailscale.sh
+++ b/scripts/share-pattern-via-tailscale.sh
@@ -124,7 +124,10 @@ wait_http "http://localhost:$SHELL_PORT/" shell || exit 1
 
 # ---------- identity + deploy ----------
 cd "$REPO_ROOT"
-[ -f cf.key ] || deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
+# Deploy as a unique per-user key, NOT the shared "implicit trust" operator key:
+# this piece is your work, and the toolshed accepts any identity. The reuse
+# guard keeps an existing cf.key working. See docs/development/SHARED_IDENTITY.md.
+[ -f cf.key ] || { deno run -A packages/cli/mod.ts id new > cf.key; chmod 600 cf.key; }
 echo "Deploying $(basename "$PATTERN_ABS")..."
 DEPLOY_OUT="$(deno task cf piece new "$PATTERN_ABS" -i cf.key -a "http://localhost:$TOOLSHED_PORT" -s "$SPACE" 2>&1)"
 PIECE_ID="$(printf '%s' "$DEPLOY_OUT" | grep -oE 'fid[0-9]+:[A-Za-z0-9_-]+' | head -1)"

--- a/scripts/share-pattern-via-tailscale.sh
+++ b/scripts/share-pattern-via-tailscale.sh
@@ -123,11 +123,45 @@ wait_http "http://localhost:$TOOLSHED_PORT/_health" toolshed || exit 1
 wait_http "http://localhost:$SHELL_PORT/" shell || exit 1
 
 # ---------- identity + deploy ----------
-cd "$REPO_ROOT"
-# Deploy as a unique per-user key, NOT the shared "implicit trust" operator key:
-# this piece is your work, and the toolshed accepts any identity. The reuse
-# guard keeps an existing cf.key working. See docs/development/SHARED_IDENTITY.md.
-[ -f cf.key ] || { deno run -A packages/cli/mod.ts id new > cf.key; chmod 600 cf.key; }
+cd "$REPO_ROOT" || exit 1   # cf.key is minted/resolved relative to here
+
+# Deploy as a unique per-user key, NOT the shared "implicit trust" operator key.
+# This piece is your work, and the toolshed accepts any identity; deploying as
+# the operator key collapses you into the local server principal (and into one
+# identity for user counting). See docs/development/SHARED_IDENTITY.md.
+cf_cli() { deno run -A packages/cli/mod.ts "$@"; }
+
+# Mint via a temp file and move into place only on success — a failed keygen
+# must never leave an empty/partial cf.key that the guard below would then trust.
+mint_key() {
+  local tmp
+  tmp="$(mktemp)" || { echo "mktemp failed" >&2; exit 1; }
+  if cf_cli id new > "$tmp" && [ -s "$tmp" ]; then
+    chmod 600 "$tmp"; mv "$tmp" cf.key
+  else
+    rm -f "$tmp"; echo "failed to mint deploy identity" >&2; exit 1
+  fi
+}
+
+if [ ! -f cf.key ]; then
+  echo "Minting a unique deploy identity (cf.key)..."
+  mint_key
+else
+  # Older versions of this script derived the shared "implicit trust" key into
+  # cf.key. Keeping such a key would silently keep deploying (and, via the
+  # tailnet URL, acting) as the server operator. Detect it by DID and re-mint.
+  existing_did="$(cf_cli id did cf.key 2>/dev/null || true)"
+  implicit_tmp="$(mktemp)" || { echo "mktemp failed" >&2; exit 1; }
+  cf_cli id derive "implicit trust" > "$implicit_tmp" 2>/dev/null
+  implicit_did="$(cf_cli id did "$implicit_tmp" 2>/dev/null || true)"
+  rm -f "$implicit_tmp"
+  if [ -n "$existing_did" ] && [ "$existing_did" = "$implicit_did" ]; then
+    echo "  cf.key is the shared \"implicit trust\" operator key — re-minting a unique one" >&2
+    echo "  (previous key backed up to cf.key.implicit-trust.bak)" >&2
+    mv cf.key cf.key.implicit-trust.bak
+    mint_key
+  fi
+fi
 echo "Deploying $(basename "$PATTERN_ABS")..."
 DEPLOY_OUT="$(deno task cf piece new "$PATTERN_ABS" -i cf.key -a "http://localhost:$TOOLSHED_PORT" -s "$SPACE" 2>&1)"
 PIECE_ID="$(printf '%s' "$DEPLOY_OUT" | grep -oE 'fid[0-9]+:[A-Za-z0-9_-]+' | head -1)"


### PR DESCRIPTION
## Summary

An audit of every guidance surface mentioning `implicit trust` / `id derive` (25 files; docs, skills, tutorials, scripts, service READMEs), prompted by the lunch-poll deploy doc steering a routine local deploy onto the shared operator key.

**Policy** ([SHARED_IDENTITY.md](../blob/main/docs/development/SHARED_IDENTITY.md)): `id derive "implicit trust"` produces a fixed, publicly-derivable DID reserved for deliberately acting as the local dev server's own operator identity; normal pattern dev — even on localhost — uses a unique `id new` key (`.cf/shared-dev.key`, browser-importable).

**Already aligned** (no change): CONFIGURATION.md (operator-scoped with warning), both tutorials (06/10), background-piece-service docs (the sanctioned operator case), skills/cf + skills/topics, dashboard README, active-user-counting.md.

**Fixed:**
- `packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md` — flatly instructed deriving implicit trust for local deploys, no operator framing, no warning. Now: `id new` recipe, browser Import CLI Key note, explicit do-not-derive warning with the policy pointer.
- `docs/development/LOCAL_DEV_SERVERS.md` — accurate content but inverted emphasis: the operator derive led a generic "CLI identity for local dev" section (the likely source the stale deploy doc copied). Now leads with the unique-key recipe; the implicit-trust derive is scoped to its operator cases, with the user-counting impact noted.

## Follow-up completed (execution)

The script change this PR originally deferred is now included:

- `scripts/share-pattern-via-tailscale.sh` mints a unique `id new` deploy key instead of deriving `"implicit trust"`. Because a `cf.key` left by the old version of the script *is* the shared operator key, the guard doesn't just skip on `[ -f cf.key ]`: it resolves the key's DID (`cf id did`) and, if it matches the derived implicit-trust DID, backs the key up to `cf.key.implicit-trust.bak` and re-mints a unique one (mirroring loom's `setup.sh` guard). Fresh/unique keys are left untouched; keys are minted via temp-file-then-move so a failed keygen can't leave a poisoned 0-byte `cf.key`.
- Reconciled two stray operator-key references the audit had left: `docs/development/LOCAL_DEV_SERVERS.md` (operator recipe re-exports `CF_IDENTITY`) and `docs/development/debugging/cli-debugging.md` (everyday `-i claude.key` -> `-i .cf/shared-dev.key`).

## Validation

- **Guard behavior** (the substantive change) — exercised against the real `cf` CLI in three states: no `cf.key` -> mints unique; `cf.key` == implicit-trust DID -> detected, backed up, re-minted to a new DID; `cf.key` already unique -> left unchanged (idempotent).
- **Local deploy** — `cf piece new` deploys against a local toolshed with an `id new` key (confirms the toolshed accepts a unique identity; not a full tailnet round-trip).
- `bash -n` clean; no new `shellcheck` findings in the changed region.
- Docs gates note: `deno task check-docs` type-checks only TS/TSX blocks, and `docs/development/LOCAL_DEV_SERVERS.md` + `cli-debugging.md` are `deno fmt`-excluded ("No target files found"). Those gates cover the original docs edits, not the bash/markdown changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787459006&installation_model_id=428580&pr_number=4971&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4971&signature=f402107c090407fb9ad9a819647714315b8b3ece7f2764026d9f7e141e8027af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default local dev now uses a unique `id new` key; `id derive "implicit trust"` is reserved for operator‑only actions.

Docs: updated local dev, lunch‑poll, and debugging pages to export `CF_IDENTITY`, use it in CLI examples, and note the browser “Import CLI Key” flow. Tooling: `scripts/share-pattern-via-tailscale.sh` now mints a unique key, backs up an existing implicit‑trust `cf.key` to `cf.key.implicit-trust.bak`, mints via a temp file for safety, and `.gitignore` ignores `cf.key.*` backups.

<sup>Written for commit 99a5602c6e5c0db54100e05f27cb6ed46f6eaf05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

