### PR TITLE
fix(topics): preserve deployed schema compatibility

### DIFF
--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -37,6 +37,9 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
 - **Wish-free agent handlers.** CLI streams do not depend on profile wishes.
   Blank `agentName` values reject the mutation, and the signature is carried in
   the same event as the content, avoiding shared mutable attribution state.
+  During the deployed-schema migration, omission (distinct from an explicit
+  blank value) remains accepted for old callers; topic/comment attribution then
+  falls back to their hidden legacy `myName`.
 - **Mergeable writes everywhere users collide**: comments, links, and topics are
   `push` appends; concurrent writers all land. The body is a large string
   (whole-value conflict semantics), so body edits go through an explicit
@@ -45,9 +48,12 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   duplicate nor an application-level revision/CAS protocol. If Fabric cannot
   preserve history or safely arbitrate concurrent body writes, this dogfood
   surface should expose the framework gap rather than conceal it mechanically.
-- **Storage compatibility is read-only.** `myName`, `createdByName`, and
-  `authorName` remain optional in accepted schemas so existing boards/topics
-  load and render. New code does not read `myName` or write any legacy field.
+- **Compatibility is temporary but honest.** The previous result contract made
+  `myName`, `createdByName`, and `authorName` observable, and its mutation
+  streams omitted `agentName`. Those surfaces remain deprecated but functional:
+  new structured writes mirror the legacy display strings, while old unsigned
+  topic/comment calls use `myName` and the other streams preserve their prior
+  behavior. New browser and agent callers never depend on them.
 - **`mentionable` is a structural reference, not derived data.** The board
   passes its own topics list at creation; the topic derives its Connections
   read-side from it (SELF + equals to find its own row). Requires the

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -48,8 +48,8 @@ export type {
 
 export interface TopicsInput {
   topics?: Writable<TopicPiece[] | Default<[]>>;
-  /** @deprecated Accepted so boards created before profile-backed authorship
-   * continue to load. New code never reads or writes this field. */
+  /** @deprecated Retained while pre-Profile callers still use the old
+   * `setMyName` + unsigned-event contract. New callers use `agentName`. */
   myName?: PerUser<Writable<string | Default<"">>>;
 }
 
@@ -57,8 +57,10 @@ export interface AddTopicEvent {
   title: string;
   /** The agent making this mutation. The authenticated principal remains the
    * human whose identity key invoked the stream; this is the agent's explicit
-   * content-level signature under that shared principal. */
-  agentName: string;
+   * content-level signature under that shared principal. Optional only so
+   * callers of the previous deployed schema remain valid; new callers must
+   * provide a non-blank name. */
+  agentName?: string;
 }
 
 /** One topic's place in the prose reference graph. Derived at read time from
@@ -95,6 +97,10 @@ export interface TopicsOutput {
    * headless driving, like the chat exemplar's drafts). */
   newTitle?: PerSession<Writable<string>>;
   addTopic: Stream<AddTopicEvent>;
+  /** @deprecated Compatibility view for callers of the previous board. */
+  myName: string;
+  /** @deprecated Compatibility mutation for callers of the previous board. */
+  setMyName: Stream<{ name: string }>;
   /** Submit the footer composer as the current viewer's canonical Profile. */
   submitTopic: Stream<void>;
 }
@@ -111,9 +117,17 @@ export const submitProfileTopic = handler<void, {
   topics: Writable<TopicPiece[] | Default<[]>>;
   mentionable: Writable<TopicPiece[] | Default<[]>>;
   newTitle: Writable<string>;
+  myName: Writable<string | Default<"">>;
   profileName: string;
   profileAvatar: string;
-}>((_, { topics, mentionable, newTitle, profileName, profileAvatar }) => {
+}>((_, {
+  topics,
+  mentionable,
+  newTitle,
+  myName,
+  profileName,
+  profileAvatar,
+}) => {
   const trimmed = (newTitle.get() ?? "").trim();
   const author = topicAuthorFromPerson(profileName, profileAvatar);
   if (!trimmed || !author) return;
@@ -121,13 +135,15 @@ export const submitProfileTopic = handler<void, {
     title: trimmed,
     createdAt: Date.now(),
     createdBy: author,
+    createdByName: topicAuthorLabel(author),
+    myName,
     mentionable,
   });
   topics.push(piece);
   newTitle.set("");
 });
 
-export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
+export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
   const newTitle = new Writable.perSession("");
 
   // Browser authorship comes from the current viewer's canonical Profile.
@@ -146,12 +162,17 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
 
   const addTopic = action(({ title, agentName }: AddTopicEvent) => {
     const trimmed = (title ?? "").trim();
-    const author = topicAuthorFromAgent(agentName);
-    if (!trimmed || !author) return;
+    const author = topicAuthorFromAgent(agentName ?? "");
+    if (!trimmed || (agentName !== undefined && !author)) return;
+    const legacyName = author
+      ? topicAuthorLabel(author)
+      : (myName.get() ?? "").trim() || "someone";
     const piece = Topic({
       title: trimmed,
       createdAt: Date.now(),
       createdBy: author,
+      createdByName: legacyName,
+      myName,
       // The board's own list, so the detail page can derive its connections
       // and the editor has a mention universe (backfilled as a one-time
       // link-bind on pieces created before this input existed).
@@ -162,13 +183,20 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
     newTitle.set("");
   });
 
+  const setMyName = action(({ name }: { name: string }) => {
+    myName.set((name ?? "").trim());
+  });
+
   const submitTopic = submitProfileTopic({
     topics,
     mentionable: topics,
     newTitle,
+    myName,
     profileName,
     profileAvatar,
   });
+
+  const myNameView = computed(() => myName.get() ?? "");
 
   const topicCount = computed(() => asArray(topics.get()).length);
 
@@ -331,6 +359,8 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
     crossrefs,
     newTitle,
     addTopic,
+    myName: myNameView,
+    setMyName,
     submitTopic,
   };
 });

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -33,8 +33,9 @@ export interface TopicAuthor {
 
 export interface AgentAuthoredEvent {
   /** Explicit content-level signature for an agent using its human user's
-   * identity key. Blank names are rejected with the mutation. */
-  agentName: string;
+   * identity key. Optional only so callers of the previous deployed schema
+   * remain valid; new callers must provide a non-blank name. */
+  agentName?: string;
 }
 
 export interface AddCommentEvent extends AgentAuthoredEvent {
@@ -57,9 +58,9 @@ export interface TopicComment {
    * array elements have stable entity identity; future editing addresses
    * elements by reference (`equals()`), not by a synthetic key. */
   author?: TopicAuthor;
-  /** @deprecated Read-only fallback for comments written before structured
-   * authorship. New mutations never write this field. */
-  authorName?: string | Default<"">;
+  /** @deprecated Compatibility shadow for consumers of the previous result
+   * schema. New callers must use `author`; the pattern mirrors this field. */
+  authorName: string | Default<"">;
   body: string | Default<"">;
   sentAt: number | Default<0>;
 }
@@ -69,7 +70,7 @@ export interface TopicLink {
   url: string | Default<"">;
   label: string | Default<"">;
   addedBy?: TopicAuthor;
-  addedAt?: number | Default<0>;
+  addedAt?: number;
 }
 
 export interface TopicInput {
@@ -81,11 +82,10 @@ export interface TopicInput {
   links?: Writable<TopicLink[] | Default<[]>>;
   createdAt?: number | Default<0>;
   createdBy?: TopicAuthor;
-  /** @deprecated Read-only fallback for topics written before structured
-   * authorship. New mutations never write this field. */
+  /** @deprecated Compatibility shadow for the previous result contract. */
   createdByName?: string | Default<"">;
-  /** @deprecated Accepted so pre-migration topic inputs continue to load. New
-   * code never reads or writes this per-user free-text identity field. */
+  /** @deprecated Retained only for callers of the previous unsigned mutation
+   * streams. New callers use Profile authorship or an atomic `agentName`. */
   myName?: PerUser<Writable<string | Default<"">>>;
   bodyUpdatedBy?: Writable<
     TopicAuthor | Default<{ kind: "person"; name: "" }>
@@ -119,8 +119,9 @@ export interface TopicPiece {
   links: TopicLink[];
   createdAt: number;
   createdBy?: TopicAuthor;
-  /** @deprecated Read-only fallback for pre-migration stored topics. */
-  createdByName?: string;
+  /** @deprecated Compatibility shadow for consumers of the previous result
+   * schema. New callers must use `createdBy`; the pattern mirrors this field. */
+  createdByName: string;
   bodyUpdatedBy?: TopicAuthor;
   bodyUpdatedAt?: number;
   commentCount: number;
@@ -393,6 +394,7 @@ export const submitProfileComment = handler<void, {
   if (!text.trim() || !author) return;
   comments.push({
     author,
+    authorName: topicAuthorLabel(author),
     body: text.trim(),
     sentAt: Date.now(),
   });
@@ -478,6 +480,7 @@ export default pattern<TopicInput, TopicOutput>(
       createdAt,
       createdBy,
       createdByName,
+      myName,
       bodyUpdatedBy,
       bodyUpdatedAt,
       mentionable,
@@ -510,11 +513,15 @@ export default pattern<TopicInput, TopicOutput>(
 
     const addComment = action(({ body: text, agentName }: AddCommentEvent) => {
       const trimmed = (text ?? "").trim();
-      const author = topicAuthorFromAgent(agentName);
-      if (!trimmed || !author) return;
+      const author = topicAuthorFromAgent(agentName ?? "");
+      if (!trimmed || (agentName !== undefined && !author)) return;
+      const legacyName = author
+        ? topicAuthorLabel(author)
+        : (myName.get() ?? "").trim() || "someone";
       // Mergeable append: concurrent comments from different users all land.
       comments.push({
         author,
+        authorName: legacyName,
         body: trimmed,
         sentAt: Date.now(),
       });
@@ -523,8 +530,11 @@ export default pattern<TopicInput, TopicOutput>(
     const addLink = action(
       ({ kind, url, label, agentName }: AddLinkEvent) => {
         const trimmedUrl = (url ?? "").trim();
-        const author = topicAuthorFromAgent(agentName);
-        if (!trimmedUrl || !isSafeLinkUrl(trimmedUrl) || !author) return;
+        const author = topicAuthorFromAgent(agentName ?? "");
+        if (
+          !trimmedUrl || !isSafeLinkUrl(trimmedUrl) ||
+          (agentName !== undefined && !author)
+        ) return;
         links.push({
           kind: kind ?? "web",
           url: trimmedUrl,
@@ -536,11 +546,13 @@ export default pattern<TopicInput, TopicOutput>(
     );
 
     const setBody = action(({ body: text, agentName }: SetBodyEvent) => {
-      const author = topicAuthorFromAgent(agentName);
-      if (!author) return;
+      const author = topicAuthorFromAgent(agentName ?? "");
+      if (agentName !== undefined && !author) return;
       body.set(text ?? "");
-      bodyUpdatedBy.set(author);
-      bodyUpdatedAt.set(Date.now());
+      if (author) {
+        bodyUpdatedBy.set(author);
+        bodyUpdatedAt.set(Date.now());
+      }
     });
 
     // --- UI-side actions (close over session drafts) ---

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -4,8 +4,8 @@
  * Complements multi-user.test.tsx (which covers cross-runtime isolation and
  * merge behavior): this file drives every exposed stream and derived value in
  * one runtime — action guards, atomic agent signatures, legacy authorship
- * fallback, the unsafe-scheme link rejection, label defaulting, body updates,
- * activity-based sorting, the derived crossref graph (edges from
+ * fallback/shadow fields, the unsafe-scheme link rejection, label defaulting,
+ * body updates, activity-based sorting, the derived crossref graph (edges from
  * fids pasted in bodies, comments, and link URLs; never persisted), and the
  * exported pure helpers.
  */
@@ -48,8 +48,7 @@ export default pattern(() => {
   // Branch pin for the detail derive: a piece with no `mentionable` wired
   // (the pre-rev corpus, until backfilled) derives empty connection sets.
   const lone = Topic({ title: "Lone", createdAt: 1, createdByName: "t" });
-  // Pre-migration fields remain accepted and readable, but new writes below
-  // never produce them.
+  // Pre-migration fields remain accepted and readable.
   const legacy = Topic({
     title: "Legacy",
     createdAt: 1,
@@ -63,6 +62,7 @@ export default pattern(() => {
   // fallback identity.
   const profileTopics = new Writable<TopicPiece[] | Default<[]>>([]);
   const profileTitleDraft = new Writable("Profile topic");
+  const profileLegacyName = new Writable<string | Default<"">>("");
   const profileComments = new Writable<TopicComment[] | Default<[]>>([]);
   const profileCommentDraft = new Writable("via the profile composer");
   const profileBody = new Writable<string | Default<"">>("old body");
@@ -92,6 +92,7 @@ export default pattern(() => {
     topics: profileTopics,
     mentionable: profileTopics,
     newTitle: profileTitleDraft,
+    myName: profileLegacyName,
     profileName: " Ada ",
     profileAvatar: " 🦊 ",
   });
@@ -135,6 +136,33 @@ export default pattern(() => {
   });
   const action_add_third_topic = action(() => {
     board.addTopic.send({ title: "Composed topic", agentName: "Sol" });
+  });
+
+  // The previous deployed event shapes remain operational while callers
+  // migrate. They use the hidden legacy name cell; new callers always send an
+  // atomic `agentName` instead.
+  const legacyBoard = Topics({});
+  const action_set_legacy_name = action(() => {
+    legacyBoard.setMyName.send({ name: " Legacy User " });
+  });
+  const action_add_legacy_topic = action(() => {
+    legacyBoard.addTopic.send({ title: "Legacy-shaped topic" });
+  });
+  const action_comment_legacy_topic = action(() => {
+    legacyBoard.topics?.[0]?.addComment.send({ body: "legacy comment" });
+  });
+  const action_link_legacy_topic = action(() => {
+    legacyBoard.topics?.[0]?.addLink.send({
+      kind: "web",
+      url: "https://example.com/legacy",
+      label: "legacy link",
+    });
+  });
+  const action_update_legacy_topic_body = action(() => {
+    legacyBoard.topics?.[0]?.setBody.send({ body: "legacy body" });
+  });
+  const action_reject_explicit_blank_legacy_agent = action(() => {
+    legacyBoard.addTopic.send({ title: "must not land", agentName: " " });
   });
 
   const action_blank_comment = action(() => {
@@ -251,7 +279,7 @@ export default pattern(() => {
     board.topics?.[0]?.title === "First topic" &&
     board.topics?.[0]?.createdBy?.kind === "agent" &&
     board.topics?.[0]?.createdBy?.name === "Sol" &&
-    !board.topics?.[0]?.createdByName &&
+    board.topics?.[0]?.createdByName === "Sol (agent)" &&
     (board.topics?.[0]?.createdAt ?? 0) > 0 &&
     board.topics?.[0]?.commentCount === 0 &&
     board.topics?.[0]?.lastActivityAt === board.topics?.[0]?.createdAt &&
@@ -266,7 +294,7 @@ export default pattern(() => {
     board.topics?.[0]?.commentCount === 1 &&
     board.topics?.[0]?.comments?.[0]?.author?.kind === "agent" &&
     board.topics?.[0]?.comments?.[0]?.author?.name === "Sol" &&
-    !board.topics?.[0]?.comments?.[0]?.authorName &&
+    board.topics?.[0]?.comments?.[0]?.authorName === "Sol (agent)" &&
     board.topics?.[0]?.comments?.[0]?.body === "hello thread" &&
     (board.topics?.[0]?.comments?.[0]?.sentAt ?? 0) > 0 &&
     (board.topics?.[0]?.lastActivityAt ?? 0) >=
@@ -336,6 +364,35 @@ export default pattern(() => {
       ) === "Old Agent"
   );
 
+  const assert_legacy_name_set = computed(() =>
+    legacyBoard.myName === "Legacy User"
+  );
+
+  const assert_legacy_topic_created = computed(() =>
+    legacyBoard.topicCount === 1 &&
+    legacyBoard.topics?.[0]?.title === "Legacy-shaped topic" &&
+    legacyBoard.topics?.[0]?.createdBy === undefined &&
+    legacyBoard.topics?.[0]?.createdByName === "Legacy User"
+  );
+
+  const assert_legacy_comment_landed = computed(() =>
+    legacyBoard.topics?.[0]?.comments?.[0]?.author === undefined &&
+    legacyBoard.topics?.[0]?.comments?.[0]?.authorName === "Legacy User" &&
+    legacyBoard.topics?.[0]?.comments?.[0]?.body === "legacy comment"
+  );
+
+  const assert_legacy_link_landed = computed(() =>
+    legacyBoard.topics?.[0]?.links?.[0]?.addedBy === undefined &&
+    legacyBoard.topics?.[0]?.links?.[0]?.label === "legacy link"
+  );
+
+  const assert_legacy_body_landed = computed(() =>
+    legacyBoard.topicCount === 1 &&
+    legacyBoard.topics?.[0]?.body === "legacy body" &&
+    (legacyBoard.topics?.[0]?.bodyUpdatedBy?.name ?? "") === "" &&
+    (legacyBoard.topics?.[0]?.bodyUpdatedAt ?? 0) === 0
+  );
+
   const assert_profile_topic_submitted = computed(() => {
     const list = profileTopics.get() ?? [];
     return list.length === 1 &&
@@ -343,6 +400,7 @@ export default pattern(() => {
       list[0]?.createdBy?.kind === "person" &&
       list[0]?.createdBy?.name === "Ada" &&
       list[0]?.createdBy?.avatar === "🦊" &&
+      list[0]?.createdByName === "Ada" &&
       profileTitleDraft.get() === "";
   });
 
@@ -353,6 +411,7 @@ export default pattern(() => {
       list[0]?.author?.kind === "person" &&
       list[0]?.author?.name === "Ada" &&
       list[0]?.author?.avatar === "🦊" &&
+      list[0]?.authorName === "Ada" &&
       (list[0]?.sentAt ?? 0) > 0 &&
       profileCommentDraft.get() === "";
   });
@@ -589,6 +648,18 @@ export default pattern(() => {
       { assertion: assert_profile_body_saved },
       { action: action_submit_profile_link },
       { assertion: assert_profile_link_submitted },
+      { action: action_set_legacy_name },
+      { assertion: assert_legacy_name_set },
+      { action: action_add_legacy_topic },
+      { assertion: assert_legacy_topic_created },
+      { action: action_comment_legacy_topic },
+      { assertion: assert_legacy_comment_landed },
+      { action: action_link_legacy_topic },
+      { assertion: assert_legacy_link_landed },
+      { action: action_update_legacy_topic_body },
+      { assertion: assert_legacy_body_landed },
+      { action: action_reject_explicit_blank_legacy_agent },
+      { assertion: assert_legacy_body_landed },
       // Render the Profile-authored rows after their mutations land, then the
       // edit state whose Save control is disabled until #profile resolves.
       { render: profileTopic[UI] },

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -42,8 +42,9 @@ decorate titles or link labels, or add manual signature lines to bodies and
 comments. If your stable agent name is unclear, ask before writing.
 
 Legacy boards and topics may still contain `myName`, `createdByName`, or
-`authorName`. Treat them as read-only compatibility fields: never set or copy
-them into new mutations.
+`authorName`. The pattern temporarily mirrors those fields for consumers of the
+previous deployed schema. Treat them as output-only compatibility details: never
+set or copy them into agent mutations.
 
 ## Reading Topics
 


### PR DESCRIPTION
## Summary

- preserve the deprecated `myName` / `setMyName`, `createdByName`, and `authorName` contracts while callers migrate
- keep old unsigned event shapes operational, while explicit blank `agentName` values still reject and all new agent calls remain atomically signed
- mirror structured Profile/agent authorship into legacy display strings for old consumers
- remove the new `addedAt` default that cannot evolve safely beneath the existing link-array constraint
- document the temporary compatibility window in the Topics README and Estuary skill

## Why

The first careful production `cf piece setsrc` attempt for the Estuary Topics board was rejected atomically by the schema-compatibility gate. The Profile-native pattern merged in #4917 had removed or optionalized fields promised by the live result schema, made `agentName` newly required in stream arguments, and added a descendant default under the retained `links` contract.

No production state changed. This follow-up makes the new source genuinely backward compatible rather than bypassing the gate with `--dangerously-allow-incompatible-schema`.

## Impact

New browser behavior remains Profile-native, and new CLI/agent mutations still carry `agentName` in the same event. The restored surfaces are deprecated migration shims only: old callers continue to work, while new callers do not depend on shared mutable attribution.

## Validation

- compiled the exact source downloaded from the live Estuary board and representative live Topic, then proved both candidate schemas with `assertPatternSchemasBackwardCompatible`
  - `board: backward compatible`
  - `topic: backward compatible`
- `deno task cf check packages/patterns/topics/main.tsx packages/patterns/topics/topic.tsx packages/patterns/topics/topics.test.tsx --no-run --root packages/patterns/topics`
- `deno task cf test packages/patterns/topics/topics.test.tsx` — 39 passed
- `deno task cf test packages/patterns/topics/multi-user.test.tsx` — 7 passed
- `deno lint` on changed TS/TSX files
- `deno fmt` on all changed files
- `deno task check-skill-facts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787463725&installation_model_id=428580&pr_number=4973&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4973&signature=f17234ff11c4ff48f4aafa405e58ba84fd4f6b0e74394a765d125533419b8c6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves backward compatibility with the deployed Topics schema so existing boards, topics, and callers keep working while the new Profile/agent-signed flows remain unchanged. Supports CT-1878 migration by keeping old schema surfaces operational during the transition.

- **Bug Fixes**
  - Restored deprecated `myName`, `createdByName`, and `authorName` surfaces; mirrored structured authorship into these legacy fields.
  - Made `agentName` optional only for legacy callers; explicit blank still rejects; new callers must send a non-blank name.
  - Kept unsigned legacy topic/comment/link/body mutations working via hidden `myName`; added board `myName` view and `setMyName` action for compatibility.
  - Removed the `addedAt` default under `links` to avoid breaking the existing link-array constraint.
  - Updated docs in `packages/patterns/topics/README.md` and `skills/topics/SKILL.md`, and expanded tests to cover legacy paths and signing guards.

<sup>Written for commit b1f3c0ac9dc1101333879bc66b4151ca1799915a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

