### PR TITLE
feat(shell): dogfood toggle to enable concurrent watch refresh (#4937 follow-up)

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -611,8 +611,15 @@ the per-epic implementation notes).
   passed through `StorageManager` settings. The runner mirrors it onto each
   memory session via `SpaceSession.setConcurrentWatchRefresh()`
   ([`packages/memory/v2/client.ts`](../../packages/memory/v2/client.ts)) —
-  per-session, not a process global.
-- **Added by.** Ben Follington (#4937).
+  per-session, not a process global. In the **shell** it is a per-browser-profile
+  dogfood toggle: run `commonfabric.concurrentWatchRefresh(true)` in the console
+  and reload. The flag crosses the worker IPC in `InitializationData` and is
+  fixed at `StorageManager.open` time, so — like the render ceiling — it takes
+  effect on the next runtime (reload), not live. Threaded shell → worker via
+  `runtimeHostFlags()`
+  ([`packages/shell/src/lib/host-toggles.ts`](../../packages/shell/src/lib/host-toggles.ts))
+  → `RuntimeInternals.create` → `runtime-processor.ts`'s storage settings.
+- **Added by.** Ben Follington (#4937; shell dogfood toggle in a follow-up PR).
 - **Purpose.** By default watch acquisition is strict single-flight per space: a
   guard holds every watch refresh after the first until the prior response
   lands, so traversal-driven pulls discovered a tick apart serialize into

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -43,7 +43,7 @@ was last checked against the code.
 | [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection) | `RuntimeOptions.cfcLabelMetadataProtection` | `off` | Bernhard Seefeld (#4638) | `observe` (divergence counting) first, then `enforce` | implemented, staged rollout |
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237) | keep as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative or neutral |
 | [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
-| [`experimentalConcurrentWatchRefresh`](#experimentalconcurrentwatchrefresh) | `IRemoteStorageProviderSettings` (runner mirrors it onto the session via `setConcurrentWatchRefresh()`) | off | Ben Follington (#4937) | graduate to always-on after live measurement, or remove if superseded | implemented behind the flag, off by default, not yet measured over real latency |
+| [`experimentalConcurrentWatchRefresh`](#experimentalconcurrentwatchrefresh) | `IRemoteStorageProviderSettings`; in the shell, the `commonfabric.concurrentWatchRefresh()` console command (localStorage, per browser profile) | off | Ben Follington (#4937; shell toggle #4974) | graduate to always-on after live measurement, or remove if superseded | implemented behind the flag, off by default, not yet measured over real latency |
 | [`cfcRenderCeiling`](#cfcrenderceiling) | `commonfabric.cfcRenderCeiling()` in the browser (localStorage) | off | Bernhard Seefeld (#4550) | graduate once exchange resolution lands | implemented, off by default, dogfood only |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning) | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache` | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts | Ian Hickson | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked | implemented, on by default for FUSE-T, soak-validated |
 
@@ -619,7 +619,7 @@ the per-epic implementation notes).
   `runtimeHostFlags()`
   ([`packages/shell/src/lib/host-toggles.ts`](../../packages/shell/src/lib/host-toggles.ts))
   → `RuntimeInternals.create` → `runtime-processor.ts`'s storage settings.
-- **Added by.** Ben Follington (#4937; shell dogfood toggle in a follow-up PR).
+- **Added by.** Ben Follington (#4937; shell dogfood toggle #4974).
 - **Purpose.** By default watch acquisition is strict single-flight per space: a
   guard holds every watch refresh after the first until the prior response
   lands, so traversal-driven pulls discovered a tick apart serialize into

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -157,6 +157,13 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
    */
   patternCoverage?: boolean;
   /**
+   * When true, the worker's remote storage overlaps watch-refresh round trips
+   * up to a bounded window instead of strict single-flight
+   * (`experimentalConcurrentWatchRefresh`). Dogfood flag, default off; fixed at
+   * StorageManager.open time so it takes effect on the next runtime (reload).
+   */
+  concurrentWatchRefresh?: boolean;
+  /**
    * Override the runtime worker URL. By default, deployed builds use the
    * immutable `/builds/<clientVersion>/` asset namespace while local builds
    * fall back to `/scripts/worker-runtime.js`.
@@ -244,6 +251,7 @@ export function createRuntimeClientOptions({
   trustSnapshot,
   forwardWorkerConsole,
   patternCoverage,
+  concurrentWatchRefresh,
 }: {
   session: Session;
   apiUrl: URL;
@@ -255,6 +263,7 @@ export function createRuntimeClientOptions({
   trustSnapshot?: RuntimeTrustSnapshot | null;
   forwardWorkerConsole?: boolean;
   patternCoverage?: boolean;
+  concurrentWatchRefresh?: boolean;
 }) {
   const resolvedTrustSnapshot = trustSnapshot === undefined
     ? {
@@ -284,6 +293,7 @@ export function createRuntimeClientOptions({
     trustSnapshot: resolvedTrustSnapshot,
     forwardWorkerConsole,
     patternCoverage,
+    concurrentWatchRefresh,
   };
 }
 
@@ -650,6 +660,7 @@ export class RuntimeInternals extends EventTarget {
     clientVersion,
     forwardWorkerConsole,
     patternCoverage,
+    concurrentWatchRefresh,
     getBuildHash = fetchBuildHash,
     workerUrl,
     navigate,
@@ -708,6 +719,7 @@ export class RuntimeInternals extends EventTarget {
         trustSnapshot,
         forwardWorkerConsole,
         patternCoverage,
+        concurrentWatchRefresh,
       }),
     );
 

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -469,6 +469,7 @@ describe("RuntimeInternals", () => {
   describe("create() forwards host flags to the worker", () => {
     type CapturedInitData = {
       forwardWorkerConsole?: boolean;
+      concurrentWatchRefresh?: boolean;
       renderDeclassificationPolicy?: string;
       renderConfidentialityCeiling?: {
         atoms?: unknown[];
@@ -476,7 +477,7 @@ describe("RuntimeInternals", () => {
       };
     };
 
-    it("includes forwardWorkerConsole and the render ceiling in the Initialize request", async () => {
+    it("includes forwardWorkerConsole, concurrentWatchRefresh, and the render ceiling in the Initialize request", async () => {
       const { RuntimeInternals, defaultRenderConfidentialityCeiling } =
         await import("@commonfabric/lib-shell");
       const { Identity } = await import("@commonfabric/identity");
@@ -520,6 +521,7 @@ describe("RuntimeInternals", () => {
             workerUrl: new URL("http://shell.test/scripts/worker-runtime.js"),
             getBuildHash: () => Promise.resolve(undefined),
             forwardWorkerConsole: true,
+            concurrentWatchRefresh: true,
             cfcRenderCeiling: true,
           }),
         ).rejects.toThrow("stub init failure");
@@ -529,6 +531,9 @@ describe("RuntimeInternals", () => {
 
       expect(initRequests).toHaveLength(1);
       expect(initRequests[0].data.forwardWorkerConsole).toBe(true);
+      // The dogfood storage toggle rides the same InitializationData path; the
+      // worker maps it into StorageManager.open's experimentalConcurrentWatchRefresh.
+      expect(initRequests[0].data.concurrentWatchRefresh).toBe(true);
       // Epic H3a: the ceiling crosses the worker IPC as InitializationData —
       // exactly the fields the worker-side reconciler consumes.
       expect(initRequests[0].data.renderDeclassificationPolicy).toBe("deny");

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -47,7 +47,10 @@ import {
   stripSigilCfcLabelViews,
 } from "@commonfabric/runner/cfc";
 import { NameSchema, rendererVDOMSchema } from "@commonfabric/runner/schemas";
-import { StorageManager } from "../../runner/src/storage/cache.ts";
+import {
+  defaultSettings,
+  StorageManager,
+} from "../../runner/src/storage/cache.ts";
 import {
   getMetaLink,
   KeepAsCell,
@@ -516,6 +519,14 @@ export class RuntimeProcessor {
       spaceIdentity: spaceIdentity,
       memoryHost: apiUrlObj,
       spaceHostMap: data.spaceHostMap,
+      // Host dogfood toggle (commonfabric.concurrentWatchRefresh): overlap
+      // watch-refresh round trips up to a bounded window. Off unless the host
+      // set it; the default is strict single-flight.
+      settings: {
+        ...defaultSettings,
+        experimentalConcurrentWatchRefresh:
+          data.concurrentWatchRefresh === true,
+      },
     });
 
     // Mirror the durability barrier to the page: `pending` is true while any

--- a/packages/runtime-client/client/initialize-init-data.test.ts
+++ b/packages/runtime-client/client/initialize-init-data.test.ts
@@ -59,6 +59,35 @@ describe("RuntimeClient.initialize InitializationData wiring", () => {
       .data.data;
     expect(data.patternCoverage).toBe(true);
   });
+
+  it("forwards concurrentWatchRefresh into the worker InitializationData", async () => {
+    // Same silent-drop hazard as patternCoverage: the flag is set on
+    // RuntimeClientOptions but the hand-built InitializationData literal must
+    // copy it, or the worker opens storage with the default single-flight
+    // settings and the dogfood toggle has no effect.
+    const identity = await Identity.fromPassphrase(
+      "init-data concurrent-watch-refresh test",
+    );
+    const transport = new CapturingTransport();
+
+    await RuntimeClient.initialize(transport, {
+      apiUrl: new URL("http://toolshed.test"),
+      identity,
+      spaceDid: identity.did(),
+      experimental: {},
+      concurrentWatchRefresh: true,
+    });
+
+    const init = transport.sent.find(
+      (m): m is IPCClientMessage =>
+        "msgId" in m && m.data?.type === RequestType.Initialize,
+    );
+    expect(init).toBeDefined();
+    const data =
+      (init as { data: { data: { concurrentWatchRefresh?: boolean } } })
+        .data.data;
+    expect(data.concurrentWatchRefresh).toBe(true);
+  });
 });
 
 describe("RuntimeClient notification wiring", () => {

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -210,6 +210,13 @@ export interface InitializationData {
   // pulls at teardown via GetPatternCoverage. Test/CI only (the coverage shell
   // build sets it); off by default. See docs/development/COVERAGE.md.
   patternCoverage?: boolean;
+  // When true, the worker's remote storage overlaps watch-refresh round trips
+  // up to a bounded window instead of the default strict single-flight
+  // (`experimentalConcurrentWatchRefresh`, docs/development/EXPERIMENTAL_OPTIONS.md).
+  // Fixed at StorageManager.open time, so like the render ceiling it takes
+  // effect on the next runtime (reload), not live. Off by default; the shell
+  // dogfood toggle `commonfabric.concurrentWatchRefresh()` sets it.
+  concurrentWatchRefresh?: boolean;
 }
 
 export interface InitializeRequest extends BaseRequest {

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -143,6 +143,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
       trustSnapshot: options.trustSnapshot,
       forwardWorkerConsole: options.forwardWorkerConsole,
       patternCoverage: options.patternCoverage,
+      concurrentWatchRefresh: options.concurrentWatchRefresh,
     });
     return new RuntimeClient(initialized, options);
   }

--- a/packages/shell/src/globals.ts
+++ b/packages/shell/src/globals.ts
@@ -31,6 +31,7 @@ declare global {
       includeCurrentValue?: boolean;
     }) => Promise<unknown>;
     forwardWorkerConsole?: (enabled?: boolean) => void;
+    concurrentWatchRefresh?: (enabled?: boolean) => void;
     [key: string]: unknown;
   };
 }

--- a/packages/shell/src/globals.ts
+++ b/packages/shell/src/globals.ts
@@ -31,7 +31,6 @@ declare global {
       includeCurrentValue?: boolean;
     }) => Promise<unknown>;
     forwardWorkerConsole?: (enabled?: boolean) => void;
-    concurrentWatchRefresh?: (enabled?: boolean) => void;
     [key: string]: unknown;
   };
 }

--- a/packages/shell/src/lib/concurrent-watch-refresh.ts
+++ b/packages/shell/src/lib/concurrent-watch-refresh.ts
@@ -1,0 +1,76 @@
+/**
+ * Dogfood toggle for `experimentalConcurrentWatchRefresh` (the storage flag
+ * added in #4937, docs/development/EXPERIMENTAL_OPTIONS.md). When enabled, the
+ * worker's remote storage overlaps watch-refresh round trips up to a bounded
+ * window instead of the default strict single-flight, so traversal-driven pulls
+ * discovered a tick apart no longer serialize into one-RTT-each frames. On a
+ * high-RTT link (estuary) that serialization dominates cold-load wall-clock;
+ * this flag is how we measure the win in production.
+ *
+ * Default OFF — a storage-protocol posture change, enabled deliberately per
+ * browser profile. The setting is fixed at StorageManager.open time and crosses
+ * the worker IPC in InitializationData, so — like the render ceiling and unlike
+ * worker-console forwarding — there is no live apply: flipping the flag takes
+ * effect on the next runtime (reload or re-login).
+ *
+ * Catalogued in docs/development/EXPERIMENTAL_OPTIONS.md
+ * (experimentalConcurrentWatchRefresh).
+ */
+
+const STORAGE_KEY = "concurrentWatchRefresh";
+
+type CommonfabricGlobal = typeof globalThis & {
+  commonfabric?:
+    & { concurrentWatchRefresh?: (enabled?: boolean) => void }
+    & Record<string, unknown>;
+};
+
+/** Whether concurrent watch refresh is enabled for this browser profile. */
+export function isConcurrentWatchRefreshEnabled(): boolean {
+  try {
+    return globalThis.localStorage?.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function setConcurrentWatchRefresh(enabled: boolean): void {
+  try {
+    if (enabled) {
+      globalThis.localStorage.setItem(STORAGE_KEY, "true");
+    } else {
+      globalThis.localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch (error) {
+    console.error(
+      "[concurrent-watch-refresh] Could not persist the setting:",
+      error,
+    );
+    return;
+  }
+  console.info(
+    `[concurrent-watch-refresh] Concurrent watch refresh ${
+      enabled ? "enabled" : "disabled"
+    }. Takes effect on the next runtime (reload).`,
+  );
+}
+
+/**
+ * Install `commonfabric.concurrentWatchRefresh(enabled?)`. Run once at boot,
+ * before any runtime exists. Prints a hint only while the flag is ON so its
+ * presence is discoverable from the console; the default-off state stays silent.
+ */
+export function setupConcurrentWatchRefreshToggle(): void {
+  const global = globalThis as CommonfabricGlobal;
+  const cf = (global.commonfabric ??= {});
+  cf.concurrentWatchRefresh = (enabled = true) =>
+    setConcurrentWatchRefresh(enabled);
+
+  if (isConcurrentWatchRefreshEnabled()) {
+    console.info(
+      "[concurrent-watch-refresh] Concurrent watch refresh is ON — watch " +
+        "acquisition overlaps up to a bounded window. Disable with " +
+        "commonfabric.concurrentWatchRefresh(false).",
+    );
+  }
+}

--- a/packages/shell/src/lib/host-toggles.ts
+++ b/packages/shell/src/lib/host-toggles.ts
@@ -15,6 +15,10 @@ import {
   isCfcRenderCeilingEnabled,
   setupCfcRenderCeilingToggle,
 } from "./render-ceiling.ts";
+import {
+  isConcurrentWatchRefreshEnabled,
+  setupConcurrentWatchRefreshToggle,
+} from "./concurrent-watch-refresh.ts";
 
 /**
  * Install every `commonfabric.*` host-toggle console command. Run once at
@@ -24,6 +28,7 @@ import {
 export function setupHostToggles(): void {
   setupWorkerConsoleToggle();
   setupCfcRenderCeilingToggle();
+  setupConcurrentWatchRefreshToggle();
 }
 
 /**
@@ -49,10 +54,12 @@ export function runtimeHostFlags(): {
   forwardWorkerConsole: boolean;
   cfcRenderCeiling: boolean;
   patternCoverage: boolean;
+  concurrentWatchRefresh: boolean;
 } {
   return {
     forwardWorkerConsole: isWorkerConsoleForwardingEnabled(),
     cfcRenderCeiling: isCfcRenderCeilingEnabled(),
     patternCoverage: isPatternCoverageEnabled(),
+    concurrentWatchRefresh: isConcurrentWatchRefreshEnabled(),
   };
 }

--- a/packages/shell/test/concurrent-watch-refresh.test.ts
+++ b/packages/shell/test/concurrent-watch-refresh.test.ts
@@ -4,8 +4,9 @@ import {
   isConcurrentWatchRefreshEnabled,
   setupConcurrentWatchRefreshToggle,
 } from "../src/lib/concurrent-watch-refresh.ts";
-// Load the ambient-globals module so its declaration of
-// `commonfabric.concurrentWatchRefresh` is exercised alongside the toggle.
+// Load the ambient-globals module so the `commonfabric` global is typed for
+// the cast below (the command rides its `[key: string]: unknown` index
+// signature, matching how cfcRenderCeiling is typed).
 import "../src/globals.ts";
 
 const STORAGE_KEY = "concurrentWatchRefresh";

--- a/packages/shell/test/concurrent-watch-refresh.test.ts
+++ b/packages/shell/test/concurrent-watch-refresh.test.ts
@@ -1,0 +1,185 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  isConcurrentWatchRefreshEnabled,
+  setupConcurrentWatchRefreshToggle,
+} from "../src/lib/concurrent-watch-refresh.ts";
+// Load the ambient-globals module so its declaration of
+// `commonfabric.concurrentWatchRefresh` is exercised alongside the toggle.
+import "../src/globals.ts";
+
+const STORAGE_KEY = "concurrentWatchRefresh";
+
+class FakeStorage {
+  map = new Map<string, string>();
+  throwOnRead = false;
+  throwOnWrite = false;
+  getItem(key: string): string | null {
+    if (this.throwOnRead) throw new Error("read blocked");
+    return this.map.has(key) ? this.map.get(key)! : null;
+  }
+  setItem(key: string, value: string): void {
+    if (this.throwOnWrite) throw new Error("write blocked");
+    this.map.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+}
+
+interface Harness {
+  storage: FakeStorage;
+  info: string[];
+  errors: string[];
+  restore: () => void;
+}
+
+function setup(): Harness {
+  const storage = new FakeStorage();
+  const info: string[] = [];
+  const errors: string[] = [];
+
+  const storageDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage",
+  );
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+
+  const cfGlobal = globalThis as {
+    commonfabric?: { concurrentWatchRefresh?: unknown };
+  };
+  const originalCommonfabric = cfGlobal.commonfabric;
+  cfGlobal.commonfabric = {};
+
+  const realInfo = console.info;
+  const realError = console.error;
+  console.info = (...args: unknown[]) => info.push(args.join(" "));
+  console.error = (...args: unknown[]) => errors.push(args.join(" "));
+
+  return {
+    storage,
+    info,
+    errors,
+    restore: () => {
+      console.info = realInfo;
+      console.error = realError;
+      if (storageDescriptor) {
+        Object.defineProperty(globalThis, "localStorage", storageDescriptor);
+      } else {
+        delete (globalThis as { localStorage?: unknown }).localStorage;
+      }
+      if (originalCommonfabric === undefined) {
+        delete (globalThis as { commonfabric?: unknown }).commonfabric;
+      } else {
+        cfGlobal.commonfabric = originalCommonfabric;
+      }
+    },
+  };
+}
+
+function command(): (enabled?: boolean) => void {
+  const cf = (globalThis as {
+    commonfabric?: { concurrentWatchRefresh?: (enabled?: boolean) => void };
+  }).commonfabric;
+  if (!cf?.concurrentWatchRefresh) {
+    throw new Error("concurrentWatchRefresh was not installed");
+  }
+  return cf.concurrentWatchRefresh;
+}
+
+describe("isConcurrentWatchRefreshEnabled", () => {
+  it('is false when the key is absent and true when set to "true"', () => {
+    const h = setup();
+    try {
+      expect(isConcurrentWatchRefreshEnabled()).toBe(false);
+      h.storage.map.set(STORAGE_KEY, "true");
+      expect(isConcurrentWatchRefreshEnabled()).toBe(true);
+      h.storage.map.set(STORAGE_KEY, "yes");
+      expect(isConcurrentWatchRefreshEnabled()).toBe(false);
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("is false when reading localStorage throws", () => {
+    const h = setup();
+    try {
+      h.storage.throwOnRead = true;
+      expect(isConcurrentWatchRefreshEnabled()).toBe(false);
+    } finally {
+      h.restore();
+    }
+  });
+});
+
+describe("setupConcurrentWatchRefreshToggle", () => {
+  it("installs the command and stays silent while disabled (default posture)", () => {
+    const h = setup();
+    try {
+      setupConcurrentWatchRefreshToggle();
+      expect(typeof command()).toBe("function");
+      expect(h.info).toEqual([]);
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("prints the ON hint when already enabled", () => {
+    const h = setup();
+    try {
+      h.storage.map.set(STORAGE_KEY, "true");
+      setupConcurrentWatchRefreshToggle();
+      expect(h.info.join("\n")).toContain("is ON");
+    } finally {
+      h.restore();
+    }
+  });
+});
+
+describe("commonfabric.concurrentWatchRefresh", () => {
+  it("persists and notes the reload requirement when enabling", () => {
+    const h = setup();
+    try {
+      setupConcurrentWatchRefreshToggle();
+      command()(); // default argument enables
+      expect(h.storage.map.get(STORAGE_KEY)).toBe("true");
+      // The storage setting is fixed at StorageManager.open — the toggle
+      // cannot live-apply, so the confirmation must say when it takes effect.
+      expect(h.info.join("\n")).toContain("enabled");
+      expect(h.info.join("\n")).toContain("next runtime");
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("clears the key when disabling", () => {
+    const h = setup();
+    try {
+      h.storage.map.set(STORAGE_KEY, "true");
+      setupConcurrentWatchRefreshToggle();
+      command()(false);
+      expect(h.storage.map.has(STORAGE_KEY)).toBe(false);
+      expect(h.info.join("\n")).toContain("disabled");
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("logs and bails out when persistence fails", () => {
+    const h = setup();
+    try {
+      setupConcurrentWatchRefreshToggle();
+      h.storage.throwOnWrite = true;
+      command()(true);
+      expect(h.errors.join("\n")).toContain("Could not persist");
+      // The "enabled"/"disabled" confirmation is not logged on failure.
+      expect(h.info.join("\n")).not.toContain("enabled");
+    } finally {
+      h.restore();
+    }
+  });
+});

--- a/packages/shell/test/host-toggles.test.ts
+++ b/packages/shell/test/host-toggles.test.ts
@@ -71,6 +71,7 @@ describe("setupHostToggles", () => {
       }).commonfabric;
       expect(typeof cf?.forwardWorkerConsole).toBe("function");
       expect(typeof cf?.cfcRenderCeiling).toBe("function");
+      expect(typeof cf?.concurrentWatchRefresh).toBe("function");
     } finally {
       h.restore();
     }
@@ -112,6 +113,7 @@ describe("runtimeHostFlags", () => {
         forwardWorkerConsole: false,
         cfcRenderCeiling: false,
         patternCoverage: false,
+        concurrentWatchRefresh: false,
       });
     } finally {
       h.restore();
@@ -126,18 +128,28 @@ describe("runtimeHostFlags", () => {
         forwardWorkerConsole: true,
         cfcRenderCeiling: false,
         patternCoverage: false,
+        concurrentWatchRefresh: false,
       });
       h.storage.map.set("cfcRenderCeiling", "true");
       expect(runtimeHostFlags()).toEqual({
         forwardWorkerConsole: true,
         cfcRenderCeiling: true,
         patternCoverage: false,
+        concurrentWatchRefresh: false,
       });
       h.storage.map.set("patternCoverage", "true");
       expect(runtimeHostFlags()).toEqual({
         forwardWorkerConsole: true,
         cfcRenderCeiling: true,
         patternCoverage: true,
+        concurrentWatchRefresh: false,
+      });
+      h.storage.map.set("concurrentWatchRefresh", "true");
+      expect(runtimeHostFlags()).toEqual({
+        forwardWorkerConsole: true,
+        cfcRenderCeiling: true,
+        patternCoverage: true,
+        concurrentWatchRefresh: true,
       });
     } finally {
       h.restore();


### PR DESCRIPTION
## Why

[#4937](https://github.com/commontoolsinc/labs/pull/4937) landed `experimentalConcurrentWatchRefresh` **default-off** and documented it as "pending live measurement on a real (estuary-latency) load" — but it wired **no way to turn it on** in a deployed build. The browser worker always opens storage with `defaultSettings` (`runtime-processor.ts`), and unlike `cfcRenderCeiling` the flag was never added to the shell's host-toggle seam. So the flag whose entire purpose is a production A/B had no switch: deploying it to estuary would profile byte-identical to the baseline HAR.

This adds the missing enable path so we can actually measure the win.

## What Changed

A per-browser-profile dogfood toggle, following the exact `cfcRenderCeiling` pattern:

- **`commonfabric.concurrentWatchRefresh(enabled?)`** console command, localStorage-backed (`packages/shell/src/lib/concurrent-watch-refresh.ts`), registered in `host-toggles.ts`.
- Threaded shell → worker: `runtimeHostFlags()` → `RuntimeInternals.create` → `createRuntimeClientOptions` → `RuntimeClient.initialize` → `InitializationData` → `runtime-processor`'s `StorageManager.open({ settings: { ...defaultSettings, experimentalConcurrentWatchRefresh } })`.

Like the render ceiling, the setting is fixed at `StorageManager.open` time (crosses the worker IPC in `InitializationData`), so it **takes effect on the next runtime (reload)**, not live. Default off — flipping it is a deliberate per-profile action.

## How to use (the profiling procedure)

1. Deploy this SHA to estuary.
2. Open the shell, DevTools console: `commonfabric.concurrentWatchRefresh(true)`, reload. Capture a HAR of the cold load.
3. `commonfabric.concurrentWatchRefresh(false)`, reload, capture the baseline HAR — same build, clean A/B.
4. Compare `session.watch.add` overlap / cold-load wall-clock.

## Test plan

```
deno test -A packages/shell/test/concurrent-watch-refresh.test.ts \
  packages/shell/test/host-toggles.test.ts \
  packages/runtime-client/client/initialize-init-data.test.ts \
  packages/lib-shell/test/runtime.test.ts
```

- New `concurrent-watch-refresh.test.ts` mirrors `render-ceiling.test.ts`: default-off, `"true"`-only truthiness, silent-while-disabled, ON hint, persist + reload-notice, clear-on-disable, fail-closed on storage errors.
- `host-toggles.test.ts` updated: command installed + `runtimeHostFlags()` includes the new flag across the persisted-state matrix.
- **`initialize-init-data.test.ts`**: new guard that `concurrentWatchRefresh: true` survives `RuntimeClient.initialize`'s hand-built `InitializationData` literal into the worker payload — mirrors the existing `patternCoverage` guard and proves the flag isn't silently dropped at the IPC boundary.
- Full CI parity verified locally: `deno task check` (the type gate) → "Type check complete."; `deno fmt --check` + `deno lint` clean on all touched files; `lib-shell/test/runtime.test.ts` (35 steps) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
