### PR TITLE
fix(piece): prove defaults under disjoint schema branches

### DIFF
--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -408,9 +408,45 @@ const DEFAULT_STABLE_SCHEMA_KEYS = new Set([
 /** Whether inserting defaults below this schema leaves its own constraints true. */
 function schemaIsStableUnderDescendantDefaults(schema: JSONSchema): boolean {
   if (typeof schema !== "object" || schema === null) return true;
-  return Object.keys(schema).every((key) =>
-    DEFAULT_STABLE_SCHEMA_KEYS.has(key)
-  );
+  return Object.keys(schema).every((key) => {
+    if (DEFAULT_STABLE_SCHEMA_KEYS.has(key)) return true;
+    return (key === "anyOf" || key === "oneOf") &&
+      alternativesDeclareDisjointTypes(schema[key]!);
+  });
+}
+
+/**
+ * Whether composition branches can never change membership after descendant
+ * defaults are inserted because their accepted top-level types do not overlap.
+ */
+function alternativesDeclareDisjointTypes(
+  alternatives: readonly JSONSchema[],
+): boolean {
+  const declared = alternatives.map((alternative) => {
+    if (alternative === false) return [] as string[];
+    if (alternative === true) return undefined;
+    const types = schemaTypes(alternative);
+    return types === undefined || types.includes("unknown")
+      ? undefined
+      : [...types];
+  });
+  if (declared.some((types) => types === undefined)) return false;
+  for (let left = 0; left < declared.length; left++) {
+    for (let right = left + 1; right < declared.length; right++) {
+      if (
+        declared[left]!.some((leftType) =>
+          declared[right]!.some((rightType) =>
+            leftType === rightType ||
+            leftType === "number" && rightType === "integer" ||
+            leftType === "integer" && rightType === "number"
+          )
+        )
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 function objectSubsetIssue(
@@ -1010,7 +1046,18 @@ function schemaHasUnsafeMaterializedDefault(
   if (activeForPath.has(schema)) return false;
   activeForPath.add(schema);
   try {
-    if (unstable && Object.hasOwn(schema, "default")) return true;
+    // A default on this schema replaces this schema's value. Constraints on
+    // this same node (for example `anyOf` beside `default`) validate that
+    // replacement directly; they are not ancestors that descendant insertion
+    // can perturb. Fail only when a strict ancestor can observe the inserted
+    // value, or when the same-node default is itself invalid.
+    if (
+      Object.hasOwn(schema, "default") &&
+      (unstableAncestor ||
+        !schemaProvidesValidDefault(schema, resolution.root))
+    ) {
+      return true;
+    }
 
     const children: JSONSchema[] = [];
     for (

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -487,9 +487,48 @@ const DEFAULT_STABLE_SCHEMA_KEYS = new Set([
 /** Whether inserting defaults below this schema leaves its own constraints true. */
 function schemaIsStableUnderDescendantDefaults(schema: JSONSchema): boolean {
   if (typeof schema !== "object" || schema === null) return true;
-  return Object.keys(schema).every((key) =>
-    DEFAULT_STABLE_SCHEMA_KEYS.has(key)
-  );
+  return Object.keys(schema).every((key) => {
+    if (DEFAULT_STABLE_SCHEMA_KEYS.has(key)) return true;
+    return (key === "anyOf" || key === "oneOf") &&
+      alternativesDeclareDisjointTypes(schema[key]!);
+  });
+}
+
+/**
+ * Whether composition branches can never change membership after descendant
+ * defaults are inserted because their accepted top-level types do not overlap.
+ */
+function alternativesDeclareDisjointTypes(
+  alternatives: readonly JSONSchema[],
+): boolean {
+  const declared = alternatives.map((alternative) => {
+    if (alternative === false) return [] as string[];
+    if (alternative === true) return undefined;
+    const types = schemaTypes(alternative);
+    return types === undefined || types.includes("unknown")
+      ? undefined
+      : [...types];
+  });
+  if (declared.some((types) => types === undefined)) return false;
+  for (let left = 0; left < declared.length; left++) {
+    for (let right = left + 1; right < declared.length; right++) {
+      if (
+        declared[left]!.some((leftType) =>
+          declared[right]!.some((rightType) =>
+            leftType === rightType ||
+            leftType === "number" && rightType === "integer" ||
+            leftType === "integer" && rightType === "number" ||
+            leftType === "object" &&
+              isFabricPrimitiveSchemaType(rightType) ||
+            isFabricPrimitiveSchemaType(leftType) && rightType === "object"
+          )
+        )
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 function objectSubsetIssue(
@@ -1102,7 +1141,18 @@ function schemaHasUnsafeMaterializedDefault(
   if (activeForPath.has(schema)) return false;
   activeForPath.add(schema);
   try {
-    if (unstable && Object.hasOwn(schema, "default")) return true;
+    // A default on this schema replaces this schema's value. Constraints on
+    // this same node (for example `anyOf` beside `default`) validate that
+    // replacement directly; they are not ancestors that descendant insertion
+    // can perturb. Fail only when a strict ancestor can observe the inserted
+    // value, or when the same-node default is itself invalid.
+    if (
+      Object.hasOwn(schema, "default") &&
+      (unstableAncestor ||
+        !schemaProvidesValidDefault(schema, resolution.root))
+    ) {
+      return true;
+    }
 
     const children: JSONSchema[] = [];
     for (

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -192,6 +192,144 @@ describe("piece schema compatibility", () => {
       additionalProperties: false,
     };
     expect(() => assertSchemaSubset(stableSource, stableTarget)).not.toThrow();
+
+    const constrainedSameNodeDefault: JSONSchema = {
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            refsOut: { type: "array", items: { type: "string" } },
+          },
+          required: ["refsOut"],
+        },
+        { type: "undefined" },
+      ],
+      default: { refsOut: [] },
+    };
+    expect(() =>
+      assertSchemaSubset(
+        constrainedSameNodeDefault,
+        constrainedSameNodeDefault,
+      )
+    ).not.toThrow();
+
+    const disjointCompositionWithDescendantDefault: JSONSchema = {
+      anyOf: [
+        {
+          type: "object",
+          properties: { x: { type: "number", default: 0 } },
+        },
+        { type: "undefined" },
+      ],
+    };
+    expect(() =>
+      assertSchemaSubset(
+        disjointCompositionWithDescendantDefault,
+        disjointCompositionWithDescendantDefault,
+      )
+    ).not.toThrow();
+
+    const disjointOneOfWithDescendantDefault: JSONSchema = {
+      oneOf: [
+        {
+          type: "array",
+          items: { type: "number", default: 0 },
+        },
+        { type: "string" },
+      ],
+    };
+    expect(() =>
+      assertSchemaSubset(
+        disjointOneOfWithDescendantDefault,
+        disjointOneOfWithDescendantDefault,
+      )
+    ).not.toThrow();
+
+    const impossibleAlternativeWithDescendantDefault: JSONSchema = {
+      anyOf: [
+        {
+          type: "object",
+          properties: { x: { type: "number", default: 0 } },
+        },
+        false,
+      ],
+    };
+    expect(() =>
+      assertSchemaSubset(
+        impossibleAlternativeWithDescendantDefault,
+        impossibleAlternativeWithDescendantDefault,
+      )
+    ).not.toThrow();
+
+    const overlappingCompositionWithDescendantDefault: JSONSchema = {
+      anyOf: [
+        {
+          type: "object",
+          properties: { x: { type: "number", default: 0 } },
+        },
+        { type: "object" },
+      ],
+    };
+    expect(() =>
+      assertSchemaSubset(
+        overlappingCompositionWithDescendantDefault,
+        overlappingCompositionWithDescendantDefault,
+      )
+    ).toThrow(/not stable under default insertion/);
+
+    for (
+      const alternatives of [
+        [
+          {
+            type: "object",
+            properties: { x: { type: "number", default: 0 } },
+          },
+          true,
+        ],
+        [
+          {
+            type: "object",
+            properties: { x: { type: "number", default: 0 } },
+          },
+          { properties: {} },
+        ],
+        [
+          {
+            type: "object",
+            properties: { x: { type: "number", default: 0 } },
+          },
+          { type: "unknown" },
+        ],
+        [
+          {
+            type: "number",
+            default: 0,
+          },
+          { type: "integer" },
+        ],
+        [
+          {
+            type: "integer",
+            default: 0,
+          },
+          { type: "number" },
+        ],
+      ] as JSONSchema[][]
+    ) {
+      const unprovableComposition: JSONSchema = { anyOf: alternatives };
+      expect(() =>
+        assertSchemaSubset(unprovableComposition, unprovableComposition)
+      ).toThrow(/not stable under default insertion/);
+    }
+
+    const invalidSameNodeDefault: JSONSchema = {
+      oneOf: [{ type: "number" }, { minimum: 0 }],
+      default: 1,
+    };
+    expect(() =>
+      assertSchemaSubset(invalidSameNodeDefault, invalidSameNodeDefault)
+    ).toThrow(/not stable under default insertion/);
+
     expect(() =>
       assertSchemaSubset(
         { ...stableSource, minProperties: 1 },

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -192,6 +192,151 @@ describe("piece schema compatibility", () => {
       additionalProperties: false,
     };
     expect(() => assertSchemaSubset(stableSource, stableTarget)).not.toThrow();
+
+    const constrainedSameNodeDefault: JSONSchema = {
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            refsOut: { type: "array", items: { type: "string" } },
+          },
+          required: ["refsOut"],
+        },
+        { type: "undefined" },
+      ],
+      default: { refsOut: [] },
+    };
+    expect(() =>
+      assertSchemaSubset(
+        constrainedSameNodeDefault,
+        constrainedSameNodeDefault,
+      )
+    ).not.toThrow();
+
+    const disjointCompositionWithDescendantDefault: JSONSchema = {
+      anyOf: [
+        {
+          type: "object",
+          properties: { x: { type: "number", default: 0 } },
+        },
+        { type: "undefined" },
+      ],
+    };
+    expect(() =>
+      assertSchemaSubset(
+        disjointCompositionWithDescendantDefault,
+        disjointCompositionWithDescendantDefault,
+      )
+    ).not.toThrow();
+
+    const disjointOneOfWithDescendantDefault: JSONSchema = {
+      oneOf: [
+        {
+          type: "array",
+          items: { type: "number", default: 0 },
+        },
+        { type: "string" },
+      ],
+    };
+    expect(() =>
+      assertSchemaSubset(
+        disjointOneOfWithDescendantDefault,
+        disjointOneOfWithDescendantDefault,
+      )
+    ).not.toThrow();
+
+    const impossibleAlternativeWithDescendantDefault: JSONSchema = {
+      anyOf: [
+        {
+          type: "object",
+          properties: { x: { type: "number", default: 0 } },
+        },
+        false,
+      ],
+    };
+    expect(() =>
+      assertSchemaSubset(
+        impossibleAlternativeWithDescendantDefault,
+        impossibleAlternativeWithDescendantDefault,
+      )
+    ).not.toThrow();
+
+    const overlappingCompositionWithDescendantDefault: JSONSchema = {
+      anyOf: [
+        {
+          type: "object",
+          properties: { x: { type: "number", default: 0 } },
+        },
+        { type: "object" },
+      ],
+    };
+    expect(() =>
+      assertSchemaSubset(
+        overlappingCompositionWithDescendantDefault,
+        overlappingCompositionWithDescendantDefault,
+      )
+    ).toThrow(/not stable under default insertion/);
+
+    for (
+      const alternatives of [
+        [
+          {
+            type: "object",
+            properties: { x: { type: "number", default: 0 } },
+          },
+          true,
+        ],
+        [
+          {
+            type: "object",
+            properties: { x: { type: "number", default: 0 } },
+          },
+          { properties: {} },
+        ],
+        [
+          {
+            type: "object",
+            properties: { x: { type: "number", default: 0 } },
+          },
+          { type: "unknown" },
+        ],
+        [
+          {
+            type: "number",
+            default: 0,
+          },
+          { type: "integer" },
+        ],
+        [
+          {
+            type: "integer",
+            default: 0,
+          },
+          { type: "number" },
+        ],
+        [
+          {
+            type: "object",
+            properties: { x: { type: "number", default: 0 } },
+          },
+          { type: "FabricBytes" },
+        ],
+      ] as JSONSchema[][]
+    ) {
+      const unprovableComposition: JSONSchema = { anyOf: alternatives };
+      expect(() =>
+        assertSchemaSubset(unprovableComposition, unprovableComposition)
+      ).toThrow(/not stable under default insertion/);
+    }
+
+    const invalidSameNodeDefault: JSONSchema = {
+      oneOf: [{ type: "number" }, { minimum: 0 }],
+      default: 1,
+    };
+    expect(() =>
+      assertSchemaSubset(invalidSameNodeDefault, invalidSameNodeDefault)
+    ).toThrow(/not stable under default insertion/);
+
     expect(() =>
       assertSchemaSubset(
         { ...stableSource, minProperties: 1 },


### PR DESCRIPTION
## Summary

- validate a default against constraints on its own schema node instead of treating those constraints as unstable ancestors
- allow descendant-default proofs through `anyOf`/`oneOf` only when every branch declares a pairwise-disjoint top-level type
- continue to fail closed for unconstrained, unknown, overlapping, and `number`/`integer` branches

## Why

The Topics `setsrc` preflight rejected a retained link with:

```
defaults changed below a constraint that is not stable under default insertion
```

The relevant optional `crossrefs` schema is an object-or-`undefined` composition with a valid object default. The default replaces the value at that same node, so the node's own constraints validate it directly; they are not ancestors that descendant insertion can invalidate. Type-disjoint composition branches also cannot gain a second matching branch when a descendant default is inserted.

This patch keeps the proof deliberately conservative. Against the recovered live Topics schemas, it removes the false default blocker and then stops at the independent `createdBy` transition (`an unconstrained schema is no longer accepted`). It does **not** claim that the coordinated Topics board/Topic rollout is compatible.

A production canary was rolled back after a cold browser temporarily showed the Topic count without cards. Follow-up investigation did not reproduce a mixed-version schema failure: the exact recovered old→new board/Topic transition passes in warm and genuinely cold two-replica tests; the board's pre-canary production read resolved all 74 Topics and all 74 crossref rows; a clean live reload can remain in its shell/loading state well beyond the original recheck window; and the earlier empty CLI crossref observation was an unstepped read of a computed result. The rollout remains independently blocked on cross-version generated-cell isolation ([#4916](https://github.com/commontoolsinc/labs/pull/4916)) and a scratch rehearsal after that fix lands and deploys.

## Validation

- `deno test --allow-all packages/piece/test/schema-compatibility.test.ts`
- `deno task --cwd packages/piece test` (267 steps)
- `deno task check`
- `deno lint packages/piece/src/schema-compatibility.ts packages/piece/test/schema-compatibility.test.ts`
- `deno fmt --check packages/piece/src/schema-compatibility.ts packages/piece/test/schema-compatibility.test.ts`
- targeted V8 coverage: all newly added source lines executed
- full GitHub Actions suite, including Performance Check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787467419&installation_model_id=428580&pr_number=4975&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4975&signature=6f7ec10dd918666470d7fad5e28a053b7f3ad022ca6bc34d0e3167b4b523dd1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix default stability checks in schema compatibility by validating same‑node defaults locally and allowing descendant defaults through disjoint `anyOf`/`oneOf` branches. This removes a false blocker on retained defaults while staying conservative for ambiguous cases.

- **Bug Fixes**
  - Allow `anyOf`/`oneOf` only when branches have pairwise‑disjoint top‑level types; reject unknown/unconstrained/`true` branches and `number`↔`integer` overlaps.
  - Treat a default on a schema node as replacing that node; flag only if an ancestor is unstable or the default is invalid for the node.
  - Add focused tests for disjoint vs overlapping branches, same‑node defaults, and invalid defaults.

<sup>Written for commit 1303a0313d87b80e31f22b031db9d9c24ff2b8d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

