### PR TITLE
fix(runner): heal nested system pieces (profiles) that brick on cold-start instantiate

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1495,6 +1495,42 @@ export class Runner {
     }
   }
 
+  /**
+   * True when `resultCell` is its space's default/root pattern — the piece the
+   * PieceController's own cold-start repair (startEnsuredDefaultPattern) owns,
+   * including its roll-forward-to-official backstop and clear-error contract.
+   * The runner's initial-start setup repair must DEFER to the controller for
+   * the root and heal only the nested pieces the controller never sees (a
+   * profile mounted via a #wish, say). Profiles are plain `inSpace` pieces and
+   * are never a space's `defaultPattern` (only the controller sets that), so
+   * they are correctly not excluded. Called only on the rare brick path, so the
+   * space-cell read costs nothing on a healthy start. A read failure returns
+   * false: better to attempt the idempotent, fail-closed repair than to leave a
+   * piece bricked because a lookup raced.
+   */
+  private isSpaceDefaultPattern(resultCell: Cell<unknown>): boolean {
+    try {
+      const defaultPatternCell = this.runtime
+        .getSpaceCell(resultCell.space)
+        .key("defaultPattern")
+        .get() as Cell<unknown> | undefined;
+      if (defaultPatternCell === undefined) return false;
+      const a = resultCell.getAsNormalizedFullLink();
+      const b = defaultPatternCell.getAsNormalizedFullLink();
+      // Full document identity: space + scope + id. `scope` (space/user/session)
+      // is part of the address — a user- or session-scoped nested cell can share
+      // an entity id with the space-scoped root, so omitting scope would
+      // misclassify it as the root and silently suppress its heal. `path` is
+      // intentionally not compared: doStart normalizes a subpath input to its
+      // root before startCore, so resultCell is always a root cell here.
+      return a.space === b.space &&
+        (a.scope ?? "space") === (b.scope ?? "space") &&
+        a.id === b.id;
+    } catch {
+      return false;
+    }
+  }
+
   /** Convert a module to pattern format */
   private moduleToPattern(module: Module): Pattern {
     const resultSchema = module.resultSchema ?? {};
@@ -1743,6 +1779,112 @@ export class Runner {
       );
     };
 
+    // Initial instantiation with a cold-start setup repair for pieces mounted
+    // WITHOUT a setup phase. A nested/embedded piece — a profile mounted via a
+    // `#wish`, say — is instantiated by the runtime's start walk, and no
+    // pattern watcher is armed yet to self-heal (setupPatternWatcher runs only
+    // AFTER a successful instantiate). If such a piece's stored doc predates its
+    // pattern's setup (a pre-manifest internal-cell layout, or a handler stream
+    // added after the doc was created), the `{ "$stream": true }` markers were
+    // never materialized and instantiation throws "Handler used as lift … marker
+    // was never written". A fresh run() would materialize them; this is the same
+    // repair the home ROOT got in startEnsuredDefaultPattern, reachable at last
+    // for the nested pieces that never pass through it.
+    //
+    // Gated on the systemPatternAutoUpdate experimental flag. On EXACTLY that
+    // failure, re-run the pinned pattern's OWN setup state (samePattern=true:
+    // materializes the missing internal cells but leaves the existing argument
+    // — the piece's data — untouched; no roll-forward, no user-data rewrite),
+    // then retry once. Fail-closed: a non-matching or failed repair rethrows the
+    // ORIGINAL error, so the caller's cleanup leaves the piece exactly as it was.
+    // Only the plain start path is repaired — a caller-supplied `useTx` is a
+    // setup/run transaction that is already materializing state and never hits
+    // this failure, so it is skipped rather than reasoned about.
+    const instantiateInitialPattern = (
+      pattern: Pattern,
+      ref: { identity: string; symbol: string } | undefined,
+      useTx?: IExtendedStorageTransaction,
+    ) => {
+      try {
+        instantiatePattern(pattern, useTx);
+      } catch (instantiateError) {
+        if (
+          useTx !== undefined ||
+          ref === undefined ||
+          !this.runtime.experimental.systemPatternAutoUpdate ||
+          !isMissingStreamMarkerFailure(instantiateError) ||
+          // The root/default pattern is the PieceController's to repair (it has
+          // the richer roll-forward + clear-error path); defer to it there.
+          this.isSpaceDefaultPattern(resultCell)
+        ) {
+          throw instantiateError;
+        }
+        // Tear down the nodes the failed attempt partially wired.
+        cancelNodes?.();
+        // ONE repair transaction holds the precondition re-read, the setup
+        // state, the retry instantiate, AND prepare — staged together or not at
+        // all, so there is no window in which setup commits and the retry then
+        // races it. EVERY step sits inside the try: any failure (including the
+        // precondition read or prepare throwing) aborts the tx and rethrows the
+        // ORIGINAL instantiate error, so the piece is left exactly as it was.
+        const repairTx = this.runtime.edit();
+        try {
+          // Precondition: the pinned identity must still equal the ref diagnosed
+          // above. A concurrent updater or boot may have moved it; re-running
+          // the stale pinned pattern's setup would roll that newer identity
+          // back. The read is through repairTx so it also participates in commit
+          // conflict detection (mirrors the controller repair's
+          // expectedPatternIdentity).
+          const currentRef = getPatternIdentityRef(resultCell.withTx(repairTx));
+          if (
+            currentRef === undefined ||
+            currentRef.identity !== ref.identity ||
+            currentRef.symbol !== ref.symbol
+          ) {
+            throw instantiateError;
+          }
+          this.applySetupState(
+            repairTx,
+            pattern,
+            ref,
+            true,
+            undefined,
+            resultCell,
+          );
+          // Instantiate into the SAME tx: it reads the just-staged setup writes,
+          // so the once-missing markers resolve and node wiring succeeds.
+          instantiatePattern(pattern, repairTx);
+          this.runtime.prepareTxForCommit(repairTx);
+        } catch {
+          repairTx.abort();
+          throw instantiateError;
+        }
+        // Staging succeeded, so this is a SPECULATIVE start: the graph is wired
+        // locally and start() returns success. The commit is deliberately not
+        // awaited (consistent with every other start path), so its outcome can
+        // NOT be thrown back to a start() that has already resolved. Instead a
+        // committed-with-{error} result OR a rejected commit Promise tears the
+        // piece down so a later start() re-heals it rather than taking the
+        // "already started" fast path over a dead registration.
+        //
+        // Scope-safe teardown: unregister ONLY this start's own `cancel`. A
+        // stop+restart during the pending commit installs a NEWER cancel under
+        // the same key; deleting `this.cancels[key]` unconditionally (as
+        // cleanup() does) would clobber that live registration and orphan its
+        // graph. Delete the key only while it still holds our cancel — the same
+        // guard createDeferredStartOwnership uses — and always drop/invoke ours.
+        const teardownAfterFailedCommit = () => {
+          if (this.cancels.get(key) === cancel) this.cancels.delete(key);
+          this.allCancels.delete(cancel);
+          cancel();
+        };
+        repairTx.addCommitCallback((_committedTx, result) => {
+          if (result.error) teardownAfterFailedCommit();
+        });
+        repairTx.commit().catch(() => teardownAfterFailedCommit());
+      }
+    };
+
     const resultCellForRead = tx ? resultCell.withTx(tx) : resultCell;
     const initialRef = getPatternIdentityRef(resultCellForRead);
 
@@ -1750,7 +1892,7 @@ export class Runner {
     if (givenPattern) {
       currentPatternKey = initialRef ? patternIdentityKey(initialRef) : KEYLESS;
       try {
-        instantiatePattern(givenPattern, tx);
+        instantiateInitialPattern(givenPattern, initialRef, tx);
       } catch (error) {
         // Without cleanup the piece stays registered in `this.cancels`, so
         // every later start() reports "already running" for a piece that has
@@ -1784,7 +1926,11 @@ export class Runner {
 
     // Sync path - instantiate immediately
     currentPatternKey = patternIdentityKey(initialRef);
-    instantiatePattern(this.resolveToPattern(initialResolved), tx);
+    instantiateInitialPattern(
+      this.resolveToPattern(initialResolved),
+      initialRef,
+      tx,
+    );
     if (!doNotUpdateOnPatternChange) {
       setupPatternWatcher();
     }
@@ -5707,6 +5853,21 @@ function describeHandlerStreamFailure(
     `marker — { "$stream": true } was overwritten (found: ${
       toCompactDebugString(eventTarget.value, 80)
     })`;
+}
+
+/**
+ * True only for the "marker was never written" variant of the handler-stream
+ * failure above: a piece instantiated over a stored doc whose setup never
+ * materialized the handler's `{ "$stream": true }` marker (a pre-manifest
+ * internal-cell layout, or a handler stream added after the doc was created).
+ * That is the case a fresh setup pass repairs. The sibling variants — "is not a
+ * stream reference" and "was overwritten" — are NOT setup-missing and must not
+ * match, so this keys on the distinctive `never written` phrasing rather than
+ * the shared `Handler used as lift` prefix.
+ */
+export function isMissingStreamMarkerFailure(error: unknown): boolean {
+  return error instanceof Error &&
+    error.message.includes("marker was never written");
 }
 
 /**

--- a/packages/runner/test/nested-piece-setup-repair.test.ts
+++ b/packages/runner/test/nested-piece-setup-repair.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { isMissingStreamMarkerFailure } from "../src/runner.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// A nested/embedded piece — a profile mounted via a `#wish`, say — is
+// instantiated by the runtime's start walk WITHOUT a setup phase and with no
+// pattern watcher armed to self-heal. If its stored doc predates the pattern's
+// setup (here: set up for V1, then re-pointed at the handler-bearing V3 whose
+// `bump` stream marker the V1 doc never materialized), instantiation throws
+// "Handler used as lift … marker was never written". Runner.startCore's initial
+// instantiation re-runs the pinned pattern's OWN setup on that failure (gated by
+// systemPatternAutoUpdate) and retries — the same repair the home ROOT gets in
+// startEnsuredDefaultPattern, reachable at last for the nested pieces that never
+// pass through the PieceController. The root itself is EXCLUDED (the controller
+// owns it); a nested piece is never a space's defaultPattern, so it heals here.
+
+const signer = await Identity.fromPassphrase("nested-piece-setup-repair");
+const space = signer.did();
+
+const V1_NO_HANDLER = [
+  "import { Writable, pattern } from 'commonfabric';",
+  "export default pattern<Record<string, never>, { count: Writable<number> }>(() => {",
+  "  const count = new Writable<number>(0).for('count');",
+  "  return { count };",
+  "});",
+  "",
+].join("\n");
+
+// Identical result shape plus a `bump` handler — its { \"$stream\": true } marker
+// is absent from a doc set up for V1, so instantiating V3 over that doc bricks.
+const V3_WITH_HANDLER = [
+  "import { Writable, handler, pattern } from 'commonfabric';",
+  "const bump = handler<void, { count: Writable<number> }>((_, { count }) => {",
+  "  count.set((count.get() ?? 0) + 1);",
+  "});",
+  "export default pattern<Record<string, never>, { count: Writable<number> }>(() => {",
+  "  const count = new Writable<number>(0).for('count');",
+  "  return { count, bump: bump({ count }) };",
+  "});",
+  "",
+].join("\n");
+
+const programOf = (contents: string): RuntimeProgram => ({
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents }],
+});
+
+// The repair keys on ONE variant of the handler-stream failure — the
+// setup-missing "marker was never written" case. Its two siblings are NOT
+// setup-missing (re-running setup would not fix them), so they must not trigger
+// a repair. These messages mirror `describeHandlerStreamFailure`'s three shapes.
+describe("isMissingStreamMarkerFailure discriminates the setup-missing variant", () => {
+  it("matches the marker-never-written variant", () => {
+    expect(
+      isMissingStreamMarkerFailure(
+        new Error(
+          'Handler used as lift: node "bump"\'s $event input resolves to ' +
+            'of:fid1:abc, which reads undefined — the { "$stream": true } ' +
+            "marker was never written there.",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT match the not-a-stream-reference sibling", () => {
+    expect(
+      isMissingStreamMarkerFailure(
+        new Error(
+          "Handler used as lift: node's $event input is not a stream " +
+            "reference (got: 42)",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT match the overwritten-marker sibling", () => {
+    expect(
+      isMissingStreamMarkerFailure(
+        new Error(
+          "Handler used as lift: node's $event input resolves to of:fid1:abc, " +
+            'whose value is not a stream marker — { "$stream": true } was ' +
+            "overwritten (found: 7)",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT match non-Error values", () => {
+    expect(isMissingStreamMarkerFailure("marker was never written")).toBe(
+      false,
+    );
+    expect(isMissingStreamMarkerFailure(undefined)).toBe(false);
+  });
+});
+
+describe("nested-piece cold-start setup repair", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  const newRuntime = (systemPatternAutoUpdate: boolean) =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { systemPatternAutoUpdate },
+    });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  // Build the bricked nested piece: set up for V1 (data + V1 markers), then
+  // re-point patternIdentity at V3 without re-running setup, so V3's `bump`
+  // stream marker is missing. Returns the stopped piece cell, ready to start.
+  const brickedNestedPiece = async (rt: Runtime) => {
+    const tx = rt.edit();
+    const pm = rt.patternManager;
+    const v1 = await pm.compilePattern(programOf(V1_NO_HANDLER), { space, tx });
+    const v3 = await pm.compilePattern(programOf(V3_WITH_HANDLER), {
+      space,
+      tx,
+    });
+    const v3Ref = pm.getArtifactEntryRef(v3)!;
+    const cell = rt.getCell<Record<string, unknown>>(
+      space,
+      "nested-piece-brick",
+      undefined,
+      tx,
+    );
+    const running = rt.run(tx, v1, {}, cell);
+    await tx.commit();
+    await running.pull();
+    // Stop, then move the pinned identity to V3 with NO setup for it — the
+    // exact "identity moved without setup" durable state, one level down.
+    rt.runner.stop(cell);
+    const tx2 = rt.edit();
+    cell.withTx(tx2).setMetaRaw("patternIdentity", {
+      identity: v3Ref.identity,
+      symbol: v3Ref.symbol,
+    });
+    await tx2.commit();
+    // It is not the space's defaultPattern, so the runner repair (not the
+    // controller) is what must heal it.
+    return { cell, v3Ref };
+  };
+
+  it("bricks on start when the repair flag is OFF (locks in the gap)", async () => {
+    const rt = newRuntime(false);
+    try {
+      const { cell } = await brickedNestedPiece(rt);
+      await expect(rt.start(cell)).rejects.toThrow("marker was never written");
+    } finally {
+      await rt.dispose();
+    }
+  });
+
+  it("heals a nested piece by re-running its setup on start (flag ON)", async () => {
+    const rt = newRuntime(true);
+    try {
+      const { cell, v3Ref } = await brickedNestedPiece(rt);
+      // Starts WITHOUT throwing: the setup repair materializes the missing
+      // internal cells for V3, then instantiation succeeds.
+      const started = await rt.start(cell);
+      expect(started).toBe(true);
+      await cell.pull();
+      // The identity is still V3 (a re-setup, not a roll-forward)…
+      const idRaw = (cell as unknown as {
+        getMetaRaw: (k: string) => unknown;
+      }).getMetaRaw("patternIdentity") as { identity?: string } | undefined;
+      expect(idRaw?.identity).toBe(v3Ref.identity);
+      // …and the once-missing handler stream now fires end to end.
+      const before = (cell.getAsQueryResult() as { count: number }).count;
+      (cell.key("bump") as unknown as { send: (e: unknown) => void }).send({});
+      await cell.pull();
+      const after = (cell.getAsQueryResult() as { count: number }).count;
+      expect(after).toBe(before + 1);
+    } finally {
+      await rt.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Why

After #4967 healed bricked home **roots** on Estuary and both previously-dead
homes rendered, a follow-on surfaced: interacting with a **profile** threw
`Handler used as lift: … the { "$stream": true } marker was never written
there`. That is the *same* brick as the original home-root failure, one level
down — and #4967 doesn't reach it.

A profile is a nested piece (a `ProfileHome` in its own space, mounted into the
home via a `#wish`). The runtime's start walk instantiates it **without a setup
phase**, and no pattern watcher is armed to self-heal (the watcher arms only
*after* a successful instantiate). If the profile's stored doc predates its
pattern's setup — a pre-manifest internal-cell layout, or a handler stream added
after the doc was created — its `{ "$stream": true }` markers were never
materialized, so instantiation dies. #4967's repair lives in
`startEnsuredDefaultPattern`, which only the **root** passes through; nested
pieces go straight through `runtime.start → startCore` and were left bricked.

This is a **pre-existing** condition (profile docs bricked at/near creation,
independent of #4967) that #4967 merely made *reachable* by letting homes load.
It fixes profiles whose home always loaded too.

## What Changed

`packages/runner/src/runner.ts`, in `startCore`'s initial instantiation:

- On the specific `"…marker was never written"` failure, re-run the pinned
  pattern's **own** setup (`applySetupState`, `samePattern=true`: materializes
  the missing internal cells, **leaves the piece's argument/data untouched** —
  no roll-forward, no user-data rewrite), then retry once. This reuses the exact
  setup-then-instantiate mechanism `swapToPattern` already uses for hot-swaps.
- **Gated** on the `systemPatternAutoUpdate` experimental flag.
- **Fail-closed:** a non-matching or failed repair rethrows the *original*
  error, so the piece is left exactly as it was.
- **The root/default pattern is excluded** — it is the `PieceController`'s to
  repair, with its richer roll-forward-to-official + clear-error path. A
  per-piece guard skips the repair when the cell *is* its space's
  `defaultPattern` (only the controller ever sets that; profiles never are). The
  guard runs only on the rare brick path, so a healthy start pays nothing.

Matched to the *specific* `"marker was never written"` variant, not the shared
`Handler used as lift` prefix — the sibling "not a stream reference" /
"overwritten" variants are not setup-missing and must not trigger a re-setup.

## Test plan

- New `packages/runner/test/nested-piece-setup-repair.test.ts`: a nested piece
  set up for V1 then re-pointed at a handler-bearing V3 (whose `bump` marker the
  V1 doc lacks). **Flag off** → still bricks (`marker was never written`, locks
  in the gap). **Flag on** → starts clean and the once-dead handler fires end to
  end (`bump` → `count` increments) — a functional read, not just "started".
- The full **piece heal suite** stays green **unchanged** — the exclusion guard
  keeps the runner repair from pre-empting the controller's root roll-forward /
  fail-closed behavior (the interaction this PR was careful to get right).
- Green locally: full runner suite (1018 files / 5435 steps) and piece suite
  (22 / 267), fmt + lint clean on touched files.

## Follow-up (separate PR, not here)

The cross-space `StorageTransactionWriteIsolationError` on profile events (a CFC
boundary-commit companion write spanning two spaces without a multi-space
opt-in) is a distinct bug in CFC-integrity code and gets its own focused PR.

## Coverage

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 6978 lines

The review-driven fail-closed fixes add defensive branches whose *success* paths
are covered by the heal test, but whose *failure* paths are not faithfully
unit-testable in the current harness: the precondition-mismatch abort needs the
pinned identity to change between two synchronous reads inside one `start()`;
the setup/retry abort needs a re-setup that still can't materialize the marker;
and the commit-`{error}` / Promise-rejection teardown needs a storage-level
commit-failure injector the emulated storage doesn't expose (a mock would bypass
the very `addCommitCallback` / `.catch` path under test). Rather than fake
coverage on paths that can't be driven, these correctness branches are accepted
as debt — the scope-collision fix is independently verified by the reviewer's
own repro, and the teardown mirrors the runtime's existing
`startAfterSuccessfulCommit` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787470441&installation_model_id=428580&pr_number=4977&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4977&signature=e1c15443d52e9238979bd564f520793c5eb6a65f0bc74a762b85464a3f2223a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Heals nested system pieces (e.g., profiles) that brick on cold-start instantiate by re-running the piece’s setup on the specific “marker was never written” error. The fix is atomic, fail-closed, preserves user data, and uses scope-safe teardown on commit failure; gated by `systemPatternAutoUpdate`.

- **Bug Fixes**
  - On the “marker was never written” failure during nested piece instantiate, re-run the piece’s own setup (`samePattern=true`) and retry once; arguments/data are unchanged.
  - Single-transaction repair with an identity precondition; any staging failure aborts and rethrows the original error. Commit is not awaited; on commit error or rejection, perform scope-safe teardown that unregisters only this start’s cancel if it’s still current.
  - Skipped when a `useTx` is provided or when the piece is the space’s `defaultPattern` (guard compares space + scope + id).
  - Exported `isMissingStreamMarkerFailure`; tests cover only the “never written” variant and verify brick with the flag off and end-to-end heal with the flag on (`packages/runner/test/nested-piece-setup-repair.test.ts`).

<sup>Written for commit 53f0bd8b017ffeeafa83d30e774270d275d95a66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

