### PR TITLE
fix(patterns): record — smart-default module labels and Notes/TypePic…

### DIFF
--- a/packages/patterns/record.test.tsx
+++ b/packages/patterns/record.test.tsx
@@ -18,13 +18,18 @@
  * initialData overrides the default. Replacing getNextUnusedLabel's body with
  * `return undefined` now fails the label assertions.
  *
- * The list starts empty. The lift that seeds a notes module and a type picker
- * assigns its result to a variable nothing reads, and an unconsumed lift does
- * not run; the list stays empty here even with `$UI` mounted.
+ * Seeding is demand-gated. A fresh Record fills its list with a pinned Notes
+ * module and a TypePicker, but only once the module list is rendered: the seeder
+ * (`seedRecord` in record.tsx) writes those entries when `allEntriesWithIndex`
+ * reads its result, and a computation the runtime never demands never runs. The
+ * add-module cases below drive `subject`, whose UI is never rendered, so its
+ * list stays empty and the adds land from index 0 — the headless path an
+ * addModule caller takes. A second Record, `renderedSubject`, is driven through
+ * a `{ render }` step to pin the seeded Notes + TypePicker entries.
  *
  * Run: deno task cf test packages/patterns/record.test.tsx --root packages/patterns --verbose
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, UI, Writable } from "commonfabric";
 import RecordPattern from "./record.tsx";
 
 interface AddResult {
@@ -41,6 +46,45 @@ export default pattern(() => {
     subPieces: [],
     trashedSubPieces: [],
   });
+
+  // A separate Record used only to exercise the seeding path: rendering its UI
+  // demands `seedRecord`, which fills the empty list with the default modules.
+  const renderedSubject = RecordPattern({
+    title: "Rendered Record",
+    subPieces: [],
+    trashedSubPieces: [],
+  });
+
+  // Before anything reads the module list, the seeder has not run.
+  const assert_rendered_starts_empty = computed(() =>
+    [...(renderedSubject.subPieces ?? [])].length === 0
+  );
+
+  // After a render step demands the module list, the Record holds exactly the
+  // seeded pair: a pinned Notes module followed by the TypePicker.
+  const assert_rendered_seeded = computed(() => {
+    const entries = [...(renderedSubject.subPieces ?? [])];
+    return entries.length === 2 &&
+      entries[0]?.type === "notes" && entries[0]?.pinned === true &&
+      entries[1]?.type === "type-picker" && entries[1]?.pinned === false;
+  });
+
+  // A module added to the already-seeded Record lands after the two seeded
+  // entries (the seed is not repeated, and the add does not disturb it).
+  const renderedAdd = new Writable<AddResult>();
+  const action_rendered_add_email = action(() => {
+    renderedSubject.addModule!.send({ type: "email", result: renderedAdd });
+  });
+  const assert_rendered_add_after_seeds = computed(() => {
+    const entries = [...(renderedSubject.subPieces ?? [])];
+    return entries.length === 3 &&
+      entries[0]?.type === "notes" &&
+      entries[1]?.type === "type-picker" &&
+      entries[2]?.type === "email";
+  });
+  const assert_rendered_add_result = computed(() =>
+    renderedAdd.get()?.moduleIndex === 2
+  );
 
   // Each add reports into its own cell so the assertions can tell the adds
   // apart rather than reading whichever one wrote last.
@@ -198,6 +242,17 @@ export default pattern(() => {
 
   return {
     tests: [
+      // Seeding: empty until the module list is rendered, then the default
+      // Notes + TypePicker pair appears, and a later add lands after them.
+      { assertion: assert_rendered_starts_empty },
+      { render: renderedSubject[UI] },
+      { assertion: assert_rendered_seeded },
+      { action: action_rendered_add_email },
+      { assertion: assert_rendered_add_after_seeds },
+      { assertion: assert_rendered_add_result },
+
+      // Add-module behavior runs against the never-rendered `subject`, which
+      // stays empty, so the adds land from index 0.
       { assertion: assert_starts_empty },
 
       { action: action_add_first_email },

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -12,6 +12,7 @@
  */
 
 import {
+  type Cell,
   computed,
   type Default,
   handler,
@@ -24,6 +25,7 @@ import {
   type Stream,
   toCompactDebugString,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 import {
@@ -34,11 +36,12 @@ import {
 import { getNextUnusedLabel } from "./record/standard-labels.ts";
 // Import Note directly - we create it inline with proper linkPattern
 // (avoids global state for passing Record's pattern JSON)
-import Note from "./notes/note.tsx";
+import Note, { type NoteOutput } from "./notes/note.tsx";
 import { inferTypeFromModules } from "./record/template-registry.ts";
-import { TypePickerModule } from "./type-picker.tsx";
+import { TypePickerModule, type TypePickerOutput } from "./type-picker.tsx";
 import { ExtractorModule } from "./record/extraction/extractor-module.tsx";
 import { getResultSchema } from "./record/extraction/schema-utils.ts";
+import type { JSONSchema } from "./record/extraction/schema-utils-pure.ts";
 import type { SubPieceEntry, TrashedSubPieceEntry } from "./record/types.ts";
 
 // ===== Types =====
@@ -50,6 +53,7 @@ interface RecordInput {
 }
 
 export interface RecordOutput {
+  [UI]?: VNode;
   title?: string | Default<"">;
   subPieces?: SubPieceEntry[] | Default<[]>;
   trashedSubPieces?: TrashedSubPieceEntry[] | Default<[]>;
@@ -63,89 +67,58 @@ export interface RecordOutput {
   }>;
 }
 
-// ===== Auto-Initialize Notes + TypePicker (Two-Lift Pattern) =====
-// Based on chatbot-list-view.tsx pattern:
-// - Outer lift creates the pieces and calls inner lift
-// - Inner lift receives pieces as input and stores them
-// This works because the inner lift provides proper cause context
-//
-// TypePicker is a "controller module" - it receives parent Cells as input
-// so it can modify the parent's subPieces list when a template is selected.
-
-// Inner lift: stores the initial pieces (receives pieces as input)
-const storeInitialPieces = lift<{
-  notesPiece: any;
-  notesSchema: any;
-  typePickerPiece: any;
-  typePickerSchema: any;
+// ===== Auto-initialize Notes + TypePicker =====
+// Seed an empty Record with a pinned Notes module and a TypePicker module. The
+// two pieces and their schemas are built in the pattern body, which supplies
+// their durable identity, and passed in; this lift writes them into `subPieces`
+// when the Record is empty. It runs when something reads its result, which the
+// body does in `allEntriesWithIndex`, so the seed happens the first time the
+// module list is rendered. `isInitialized` latches on the first run whether or
+// not it seeded, so the seed happens at most once and a Record that is later
+// emptied is not re-seeded.
+const seedRecord = lift<{
+  currentPieces: SubPieceEntry[]; // Unwrapped value, used only for the guard
   subPieces: Writable<SubPieceEntry[]>;
+  // The pieces the seeder stores on the entries. Typed as cells so the handle
+  // survives the lift boundary; a plain `unknown` is read back as undefined and
+  // the module is lost.
+  notesPiece: Cell<NoteOutput>;
+  notesSchema: JSONSchema | undefined;
+  typePickerPiece: Cell<TypePickerOutput>;
+  typePickerSchema: JSONSchema | undefined;
   isInitialized: Writable<boolean>;
 }>(({
+  currentPieces,
+  subPieces,
   notesPiece,
   notesSchema,
   typePickerPiece,
   typePickerSchema,
-  subPieces,
   isInitialized,
 }) => {
   if (!isInitialized.get()) {
-    subPieces.set([
-      { type: "notes", pinned: true, piece: notesPiece, schema: notesSchema },
-      {
-        type: "type-picker",
-        pinned: false,
-        piece: typePickerPiece,
-        schema: typePickerSchema,
-      },
-    ]);
+    if ((currentPieces || []).length === 0) {
+      subPieces.set([
+        {
+          type: "notes",
+          pinned: true,
+          piece: notesPiece,
+          schema: notesSchema,
+        },
+        {
+          type: "type-picker",
+          pinned: false,
+          piece: typePickerPiece,
+          schema: typePickerSchema,
+        },
+      ]);
+    }
     isInitialized.set(true);
-    return notesPiece; // Return notes piece as primary reference
   }
-});
 
-// Outer lift: checks if empty, creates pieces, calls inner lift
-// TypePicker uses ContainerCoordinationContext protocol for parent access
-// Note: We receive recordPatternJson as input to avoid capturing Record before it's defined
-const initializeRecord = lift<{
-  currentPieces: SubPieceEntry[]; // Unwrapped value, not Cell
-  subPieces: Writable<SubPieceEntry[]>;
-  trashedSubPieces: Writable<TrashedSubPieceEntry[]>;
-  isInitialized: Writable<boolean>;
-  recordPatternJson: string; // Computed that returns Record JSON string
-}>(({
-  currentPieces,
-  subPieces,
-  trashedSubPieces,
-  isInitialized,
-  recordPatternJson,
-}) => {
-  if ((currentPieces || []).length === 0) {
-    // Create Note as default module (rendered via cf-render variant="tile" → its [TILE_UI])
-    // Pass recordPatternJson so [[wiki-links]] create Record pieces instead of Note pieces
-    const notesPiece = Note({ linkPattern: recordPatternJson });
-
-    // Capture schema for dynamic discovery
-    const notesSchema = getResultSchema(notesPiece);
-
-    // TypePicker receives Cells as top-level props (CTS handles serialization correctly)
-    // NOTE: Cells must be top-level, not nested in a context object!
-    const typePickerPiece = TypePickerModule({
-      entries: subPieces,
-      trashedEntries: trashedSubPieces,
-    });
-
-    // Capture schema for dynamic discovery
-    const typePickerSchema = getResultSchema(typePickerPiece);
-
-    return storeInitialPieces({
-      notesPiece,
-      notesSchema,
-      typePickerPiece,
-      typePickerSchema,
-      subPieces,
-      isInitialized,
-    });
-  }
+  // A stable, readable result so the pattern body can put this lift in the
+  // Record UI's demand graph.
+  return true;
 });
 
 // Helper to check if a module has settings UI
@@ -837,14 +810,28 @@ const Record = pattern<RecordInput, RecordOutput>(
     const recordPatternJson = computed(() => JSON.stringify(Record));
 
     // ===== Auto-initialize Notes + TypePicker =====
-    // Capture return value to force lift execution (fixes wiki-link creation)
+    // Build the two default modules in the pattern body, which supplies their
+    // durable identity. The Note carries recordPatternJson so its [[wiki-links]]
+    // resolve to Record pieces rather than Note pieces; the TypePicker gets the
+    // parent list cells so it can rewrite them when the user picks a template.
+    // `seedRecord` writes these into an empty Record, and reading its result (in
+    // `allEntriesWithIndex`) is what demands the seed.
     const isInitialized = new Writable(false);
-    const _initialized = initializeRecord({
+    const seedNotesPiece = Note({ linkPattern: recordPatternJson });
+    const seedNotesSchema = getResultSchema(seedNotesPiece);
+    const seedTypePickerPiece = TypePickerModule({
+      entries: subPieces,
+      trashedEntries: trashedSubPieces,
+    });
+    const seedTypePickerSchema = getResultSchema(seedTypePickerPiece);
+    const recordSeeded = seedRecord({
       currentPieces: subPieces,
       subPieces,
-      trashedSubPieces,
+      notesPiece: seedNotesPiece,
+      notesSchema: seedNotesSchema,
+      typePickerPiece: seedTypePickerPiece,
+      typePickerSchema: seedTypePickerSchema,
       isInitialized,
-      recordPatternJson,
     });
 
     // ===== Computed Values =====
@@ -870,6 +857,10 @@ const Record = pattern<RecordInput, RecordOutput>(
     // IMPORTANT: displayInfo uses getDisplayInfo (plain helper) - this works because
     //   computed() transforms .map() callbacks to properly unwrap reactive values
     const allEntriesWithIndex = computed(() => {
+      // Reading `recordSeeded` puts `seedRecord` in this UI's demand graph, so a
+      // fresh Record fills in its Notes + TypePicker modules the first time it
+      // is rendered; there is nothing to list until the seeder has run.
+      if (!recordSeeded) return [];
       const expandedIdx = expandedIndex.get();
       return subPieces.map((entry, index) => {
         // Get display info using plain helper function


### PR DESCRIPTION
…ker auto-seed

Two fixes to the Record container's module handling.

Smart-default labels. When a second module of a label-bearing type (email, phone, address) is added, getNextUnusedLabel is meant to pick the next unused standard label, so a second email defaults to "Work" after the first took "Personal". It never did: it collected the in-use labels by reading entry.piece.label, but SubPieceEntry.piece is typed `unknown`, which the runner reads back as undefined rather than materializing it, so the used-label set was always empty and every add got the first label — every email "Personal", every phone "Mobile", every address "Home". The chosen label is now mirrored on the SubPieceEntry in a new `label` field with a real string schema, written at every creation site: the "+ Add" dropdown, the LLM-callable add handler (recording the effective label, since caller-supplied initialData may override the default), the per-module "add another" button, and the template builder. getNextUnusedLabel reads entry.label instead, and the label survives a trash round-trip.

The label logic and its STANDARD_LABELS table move out of record.tsx into record/standard-labels.ts, which depends only on the SubPieceEntry type and so, unlike the pattern files, can be exercised by a plain unit test; record/standard-labels.test.ts drives the selection directly (empty list yields the first label, taken labels are skipped, a different type starts its own sequence, other types and unlabeled entries are ignored, a type with no standard labels returns undefined). Applying a template now labels its modules the same way, so an add after a template picks the next label rather than colliding with the template's own; type-picker.test.tsx pins that end to end (TypePickerOutput gains a [UI] member so the test can walk the rendered tree).

This mirrors the label at creation time. A later manual relabel through a module's own UI updates the sub-piece's label but not the entry's copy, so a subsequent add can still collide with the renamed one; reading the live label is not possible while piece is typed `unknown`. The mirror gives correct distinct defaults for the common case of successive quick-adds, which is what the feature is for.

Notes + TypePicker auto-seed. An empty Record was meant to seed itself with a pinned Notes module and a TypePicker, but the seeding never happened. The old code built the two pieces inside a lift and assigned that lift's result to a variable nothing read. The runner is demand-driven: a computation runs only when its output is read by something itself demanded, or when it is an effect or a materializer. The lift's result was read by no one and it wrote nothing through a captured cell, so it was never demanded and never ran; the comment claiming that capturing the return value forced execution was wrong. As a result a fresh Record stayed empty and the TypePicker's applyTemplate — which requires the pre-existing Notes entry — could never fire. A latent second failure sat underneath: creating a piece inside a lift throws, because a lift's action frame has no cause with which to mint the piece's identity.

The two default pieces are now built in the pattern body, where the setup frame gives each a durable, resume-stable identity, and passed to a single seedRecord lift that writes them when the Record is empty. The body reads that lift's result inside allEntriesWithIndex, the computed the module list renders from, so rendering the Record demands the lift and the seed fires the first time the list is shown. isInitialized latches on the first run whether or not it seeded, so the seed happens at most once and a Record later emptied is not re-seeded. [UI] is declared on RecordOutput (already returned) so a test can drive a render step. The pattern test keeps the add-module cases on a never-rendered Record — the headless path where seeding is demand-gated and the list stays empty — and adds a rendered Record to pin the seeded entries and check a later add lands after them.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787472495&installation_model_id=428580&pr_number=4978&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4978&signature=3967546e1d15ee9569dfdad605d33138937df147bfb9d4d8f0aa9a04ed66ace7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes smart-default module labels and makes the Record auto-seed run on first render so new emails/phones/addresses get distinct defaults and fresh Records show a pinned Notes + TypePicker.

- **Bug Fixes**
  - Smart-default labels: the chosen label is stored on `SubPieceEntry.label`, and `getNextUnusedLabel` reads it to pick the next unused standard label. Applies to all add paths and survives trash/restore.
  - Record auto-seed: Notes and TypePicker are built in the pattern body and passed as `Cell<NoteOutput>`/`Cell<TypePickerOutput>` (plus schemas) to a single `seedRecord` lift that writes them only when the list is empty. Its result is read in `allEntriesWithIndex` so seeding is demand-gated and runs on first render, latches via `isInitialized`, and avoids creating pieces inside lifts.

- **Tests**
  - Added rendered vs headless Record cases: a render step seeds Notes (pinned) + TypePicker, and later adds land after them; the headless path stays empty until explicitly added. `RecordOutput` exposes `[UI]` to drive the render step.

<sup>Written for commit 64c375ffc8df543ebee8e7f31557b2d2bd6c8029. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

