### PR TITLE
fix(runner): make mergeable collection writes safe under count depend…

### DIFF
--- a/docs/development/mergeable-collection-writes.md
+++ b/docs/development/mergeable-collection-writes.md
@@ -155,16 +155,25 @@ The same machinery carries three mergeable ops. `append` is described below;
   with an edit to an existing element (whose path is a different descendant and
   leaves the length unchanged). The carve-out rescues the length reads recorded
   *only* at this child path — a `for...of`/spread over the array (the proxy
-  iterator reads `[...opPath, "length"]`), a `key("length")` read, and an
-  enumeration of the array's keys (`Object.keys`/`values`/`entries`, an object
-  spread). Enumeration observes the count as the number of index keys, but the
-  proxy's `ownKeys` trap records only a nonRecursive shape read AT the op path,
-  which is dropped as the op's incidental container read; so the trap records an
-  explicit `length` read for an array, which this carve-out then keeps. The other
+  iterator reads `[...opPath, "length"]`) and a `key("length")` read. The other
   ways to observe the count read the whole array and are already kept: a bare
   `.length` on the query-result proxy, `.get()`, and the read-only array methods
   (`.map`/`.filter`/`.some`/…) all record a *recursive* read AT the op path,
-  which is the handler's explicit read (below). The carve-out applies to every
+  which is the handler's explicit read (below).
+
+  Key enumeration and index probing are a stronger case than the length: an array
+  here can be **sparse** (holes below `length`), and filling or punching a hole
+  changes the present-key set with no `length` write (a write at `[...opPath, i]`
+  only). `Object.keys`/`values`/`entries`/spread/`for...in` (the `ownKeys` trap)
+  and `n in arr` (the `has` trap) observe that present-key set, so a length read
+  — or a nonRecursive shape read at the array path, which the engine does not
+  conflict against a same-length element-slot write — would miss a concurrent
+  hole edit and let an enumeration-derived push merge on a stale key set. Those
+  two traps instead record a **recursive** read of the array, the one kept read a
+  hole edit invalidates, marked `ignoreReadForScheduling` so it adds only the
+  conflict dependency (reactivity stays on the nonRecursive shape read). It is
+  gated to arrays, so object enumeration keeps the shape-only conflict granularity
+  of the conflict-granularity work. The carve-out applies to every
   mergeable op: a length read before an `addUnique` or `removeByValue` likewise
   conflicts with a concurrent count-changing op, so a transaction that
   gratuitously reads the length forfeits that op's distinct-element merge — the

--- a/docs/development/mergeable-collection-writes.md
+++ b/docs/development/mergeable-collection-writes.md
@@ -99,11 +99,13 @@ no read dependency on the array, and dropping the array read from the conflict
 set loses no necessary safety.
 
 The limitation: an append whose decision depends on the current contents — for
-example "append only if the list has fewer than N elements" — is not expressible
-as a pure append, because the conditional read is dropped from conflict
-detection. Such a write should continue to use a read-modify-write `set`, which
-keeps its read in the conflict set. `Cell.push` is unconditional, so it qualifies
-for the mergeable path.
+example "append only if the list has fewer than N elements" — cannot both merge
+and stay correct. Its read is *kept* in the conflict set (the narrowing below
+drops only the op's own incidental reads, and the array's `length` child is
+explicitly kept), so a concurrent append makes the commit conflict and retry
+rather than merge — correct, but at the cost of the mergeability the op exists
+for. See the *Read-set builder* and *Conditional pushes stay protected* sections
+for exactly which reads are kept. `Cell.push` is unconditional, so it merges.
 
 ## Mechanics
 
@@ -143,7 +145,31 @@ The same machinery carries three mergeable ops. `append` is described below;
   itself*: the read the op's `Cell` method marks as its own (`mergeableOpRead`),
   a read marked as an attempted write, the `["cfc"]` write-policy label, and any
   strict descendant of an op path (the link-resolution sub-reads the write makes
-  beneath the value). A handler's *own* explicit `.get()` of the list is not
+  beneath the value). The one strict descendant that is *not* dropped is the
+  array's own `length` child (`[...opPath, "length"]`): a read of it is the
+  handler depending on the element count, which a mergeable append / add-unique /
+  remove-by-value changes, and the op itself never reads `length`. So a push
+  whose new element's index, id, or position came from the length conflicts
+  against a concurrent append instead of merging with a stale index. This is
+  precise: the `length` read conflicts with a change to the element count, not
+  with an edit to an existing element (whose path is a different descendant and
+  leaves the length unchanged). The carve-out rescues the length reads recorded
+  *only* at this child path — a `for...of`/spread over the array (the proxy
+  iterator reads `[...opPath, "length"]`), a `key("length")` read, and an
+  enumeration of the array's keys (`Object.keys`/`values`/`entries`, an object
+  spread). Enumeration observes the count as the number of index keys, but the
+  proxy's `ownKeys` trap records only a nonRecursive shape read AT the op path,
+  which is dropped as the op's incidental container read; so the trap records an
+  explicit `length` read for an array, which this carve-out then keeps. The other
+  ways to observe the count read the whole array and are already kept: a bare
+  `.length` on the query-result proxy, `.get()`, and the read-only array methods
+  (`.map`/`.filter`/`.some`/…) all record a *recursive* read AT the op path,
+  which is the handler's explicit read (below). The carve-out applies to every
+  mergeable op: a length read before an `addUnique` or `removeByValue` likewise
+  conflicts with a concurrent count-changing op, so a transaction that
+  gratuitously reads the length forfeits that op's distinct-element merge — the
+  same tradeoff as any explicit read kept in the conflict set. A handler's *own*
+  explicit `.get()` of the list is not
   marked, so it is kept — which is what makes a conditional push or keyed write
   still conflict-and-retry (see "Danger" below). This is narrower than the
   earlier path-level exclusion, which dropped any read overlapping the array path
@@ -238,10 +264,24 @@ first, since the op carries only the delta.
   predetermined order. Code must not assume a specific interleaving of
   independently-issued appends.
 
-- **Mixed whole-array reshape.** A transaction that both pushes and reshapes the
-  whole array in another way (sort, reverse, splice-out) in the same commit
-  emits the append and may drop the whole-array reshape op. Reshapes should be
-  committed separately from a push.
+- **Mixed ops on one path fall back to the whole-array diff.** A tail-relative
+  intent can only carry the change it recorded. When one transaction records more
+  than one kind of mergeable op at the same array path (an `addUnique` and a
+  `push`, a `removeByValue` and an `addUnique` — the "remove the old value, add
+  the new" idiom), or reshapes the array with an in-place mutator after a push
+  (`sort`, `reverse`, `splice`, `unshift`, `fill`), the recorded tail no longer
+  identifies what the op should carry. The path is *poisoned*: its mergeable
+  intent is dropped and the commit emits the whole-array diff, which reflects the
+  correct combined local value. That transaction's write to that path forfeits
+  merge-friendliness (it commits as a value diff, so it can false-conflict under
+  contention) but is never silently corrupted. Three sites poison via
+  `poisonMergeableOp`: `recordMergeableOp` on a second, different op kind; the
+  query-result proxy on any non-`push` in-place mutator; and `Cell.set` on a
+  whole-value overwrite of a path that already carries an intent. `poisonMergeableOp`
+  only acts when an intent is already present at the exact path, so a same-kind
+  repeat (two `push`es, two `increment`s) still folds into one op, an element edit
+  (`cell.key(i).set(...)`, whose path carries no intent) still composes with a
+  push, and a reshape or `set` *before* any op leaves a later push mergeable.
 
 ## Conditional pushes stay protected: the read-set narrowing
 

--- a/docs/development/patch-operations.md
+++ b/docs/development/patch-operations.md
@@ -52,8 +52,14 @@ Take `Cell.increment(2)`:
    calling `tx.recordMergeableOp(link, { op: "increment", by: 2 })`.
 2. **Intent** — the transaction folds the delta into a per-path intent
    (`packages/runner/src/storage/mergeable-ops.ts`, `foldMergeableIntent`).
-   Repeated calls at one path combine (increments sum, tail counts sum, removed
-   values accumulate); a different op at the same path replaces the intent.
+   Repeated same-kind calls at one path combine (increments sum, tail counts sum,
+   removed values accumulate). A different op kind at the same path cannot share
+   one intent, so `recordMergeableOp` poisons the path — it drops the intent and
+   the commit falls back to the whole-array diff for that path (correct, but not
+   merge-friendly), rather than letting the second op replace and silently drop
+   the first. A foreign write that reshapes the array after an op — a proxy
+   in-place mutator (`sort`/`splice`/`unshift`/…) or a whole-value `Cell.set` —
+   poisons the same way via `poisonMergeableOp`.
 3. **Commit** — at commit the intent becomes wire ops plus the diff-suppression
    they imply (`buildMergeableIntent`), and the whole-value diff for the paths the
    op covers is dropped. The op travels in `ClientCommit.operations`.

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1328,22 +1328,32 @@ export class CellImpl<T extends FabricValue>
         resolvedToValueLink.schema ?? this.schema,
       );
 
+      const writeLink = resolveLink(
+        this.runtime,
+        this.tx,
+        this.link,
+        "writeRedirect",
+      );
+
       // TODO(@ubik2) investigate whether i need to check confidential as i walk down my own obj
       diffAndUpdate(
         this.runtime,
         this.tx,
-        resolveLink(this.runtime, this.tx, this.link, "writeRedirect"),
+        writeLink,
         transformedValue,
         this._frame?.cause,
       );
 
-      // A whole-value set over a path that already carries a mergeable op intent
-      // (an earlier push / addUnique / increment / removeByValue in this
-      // transaction) reshapes what the op's recorded tail refers to. Poison the
-      // intent so the commit emits this set's whole-array diff rather than a stale
-      // tail op. A set to a child path (an element edit) carries no intent at that
-      // path, so poisonMergeableOp is a no-op there and the append still composes.
-      this.tx.poisonMergeableOp?.(resolvedToValueLink);
+      // A whole-value set over the path it writes reshapes what a mergeable op
+      // intent recorded there (an earlier push / addUnique / increment /
+      // removeByValue in this transaction) refers to. Poison that intent —
+      // keyed on `writeLink`, the exact path diffAndUpdate wrote — so the commit
+      // emits this set's whole-array diff rather than a stale tail op. Keying on
+      // the written path is what keeps this correct across aliases and child
+      // writes: a set that lands on a different slot than the op's target (a
+      // non-redirect alias) or on a child path (an element edit) finds no intent
+      // there, so poisonMergeableOp is a no-op and the append stays mergeable.
+      this.tx.poisonMergeableOp?.(writeLink);
 
       // Register commit callback if provided.
       if (onCommit) {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1337,6 +1337,14 @@ export class CellImpl<T extends FabricValue>
         this._frame?.cause,
       );
 
+      // A whole-value set over a path that already carries a mergeable op intent
+      // (an earlier push / addUnique / increment / removeByValue in this
+      // transaction) reshapes what the op's recorded tail refers to. Poison the
+      // intent so the commit emits this set's whole-array diff rather than a stale
+      // tail op. A set to a child path (an element edit) carries no intent at that
+      // path, so poisonMergeableOp is a no-op there and the append still composes.
+      this.tx.poisonMergeableOp?.(resolvedToValueLink);
+
       // Register commit callback if provided.
       if (onCommit) {
         this.tx.addCommitCallback((committedTx) => {

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -13,7 +13,10 @@ import {
   type IExtendedStorageTransaction,
   type IReadOptions,
 } from "./storage/interface.ts";
-import { mergeableOpRead } from "./storage/reactivity-log.ts";
+import {
+  ignoreReadForScheduling,
+  mergeableOpRead,
+} from "./storage/reactivity-log.ts";
 import { toURI } from "./uri-utils.ts";
 import {
   type CfcLabelView,
@@ -550,15 +553,20 @@ export function createQueryResultProxy<T>(
         if (!keys.includes("length")) {
           keys.push("length");
         }
-        // Enumerating an array's keys observes how many elements it has — the
-        // count of index keys is its `length`, which a mergeable append /
-        // add-unique / remove-by-value changes. The SHAPE_READ above tracks the
-        // container shape but is dropped at commit as the op's incidental
-        // container read, so record an explicit `length` read (as the iterator
-        // and get trap do). An `Object.keys(arr).length`-derived write then stays
-        // in the conflict set and retries against a concurrent count change
-        // instead of merging with a stale count.
-        readTx.readValueOrThrow({ ...link, path: [...link.path, "length"] });
+        // Enumerating an array's keys (`Object.keys`/`values`/`entries`, a spread,
+        // `for...in`) observes which index keys are present. For a dense array
+        // that is its `length`, but an array here can be sparse (holes below
+        // `length`), and filling or punching a hole changes the present-key set
+        // without changing `length` — a write at `/arr/<i>` with no `/arr/length`
+        // write. The SHAPE_READ above is dropped at commit as the op's incidental
+        // container read, and neither a `length` read nor a nonRecursive shape
+        // read at the array path conflicts with a same-length element-slot write.
+        // Record a recursive (by-value) read of the array — the one read the
+        // mergeable narrowing keeps that a hole edit invalidates — so an
+        // enumeration-derived mergeable write conflicts and retries instead of
+        // merging on a stale key set. It is marked `ignoreReadForScheduling` so it
+        // adds only the conflict dependency; reactivity stays on the SHAPE_READ.
+        readTx.readValueOrThrow(link, { meta: ignoreReadForScheduling });
       }
       return keys;
     },
@@ -612,14 +620,15 @@ export function createQueryResultProxy<T>(
       const readTx = runtime.readTx(tx);
       const current = readTx.readValueOrThrow(link, SHAPE_READ);
       if (isRecord(current) || Array.isArray(current)) {
-        // Probing whether a numeric index is present observes the array's
-        // element count — an index exists only below `length`, which a mergeable
-        // append / add-unique / remove-by-value changes. Record an explicit
-        // `length` read (as ownKeys and the iterator do), dropped shape read at
-        // the op path notwithstanding, so an `n in arr`-derived write stays in
-        // the conflict set.
+        // Probing whether a numeric index is present (`n in arr`) observes the
+        // array's key set: for a dense array the answer is `n < length`, but a
+        // sparse array has holes, so the answer depends on whether index `n` is
+        // specifically present — which a same-length hole fill or punch changes
+        // with no `length` write. Record a recursive read of the array (marked
+        // conflict-only, like ownKeys above) so an `n in arr`-derived mergeable
+        // write conflicts and retries instead of merging on a stale key set.
         if (Array.isArray(current) && /^\d+$/.test(prop)) {
-          readTx.readValueOrThrow({ ...link, path: [...link.path, "length"] });
+          readTx.readValueOrThrow(link, { meta: ignoreReadForScheduling });
         }
         return prop in current;
       }

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -371,24 +371,28 @@ export function createQueryResultProxy<T>(
             // Wraps values in a proxy that remembers the original index and
             // creates cell value proxies on demand.
             let copy: any;
+            // The base array a mutator operates on. Read fresh from the
+            // transaction, not the proxy-creation-time `value`, which is stale
+            // after an earlier write in this transaction (CT-1173). Without this a
+            // `push("b")` then `sort()` sorts the stale pre-push array and drops
+            // "b" from the local result. WriteOnly and ReadWrite both read fresh;
+            // ReadWrite also unwraps against this array below.
+            const readTx = runtime.readTx(tx);
+            // For `push`, this base-array read is the op's own incidental read:
+            // mark it `mergeableOpRead` so the commit drops it from conflict
+            // detection and the tail append merges, matching `Cell.push`. The
+            // handler's own explicit `.get()` of the list stays in the conflict
+            // set. Other mutators (fill, unshift, sort, splice, ...) are not
+            // mergeable tail appends and keep their read.
+            const currentValue = readTx.readValueOrThrow(
+              link,
+              prop === "push" ? { meta: mergeableOpRead } : undefined,
+            ) as any[];
+            const base = Array.isArray(currentValue) ? currentValue : [];
             if (isReadWrite === ArrayMethodType.WriteOnly) {
-              // CT-1173: Read fresh value from transaction, not stale proxy target.
-              // The proxy target (value) is captured at proxy creation time and
-              // becomes stale after writes. We must read current state from tx.
-              const readTx = runtime.readTx(tx);
-              // For `push`, this base-array read is the op's own incidental read:
-              // mark it `mergeableOpRead` so the commit drops it from conflict
-              // detection and the tail append merges, matching `Cell.push`. The
-              // handler's own explicit `.get()` of the list stays in the conflict
-              // set. Other write-only methods (fill, unshift) are not mergeable
-              // tail appends and keep their read.
-              const currentValue = readTx.readValueOrThrow(
-                link,
-                prop === "push" ? { meta: mergeableOpRead } : undefined,
-              ) as any[];
-              copy = [...currentValue];
+              copy = [...base];
             } else {
-              copy = value.map((_, index) =>
+              copy = base.map((_, index) =>
                 createProxyForArrayValue(
                   runtime,
                   proxyTx,
@@ -413,7 +417,7 @@ export function createQueryResultProxy<T>(
             if (isReadWrite === ArrayMethodType.ReadWrite) {
               // Undo the proxy wrapping and assign original items.
               copy = copy.map((item: any) =>
-                isProxyForArrayValue(item) ? value[item[originalIndex]] : item
+                isProxyForArrayValue(item) ? base[item[originalIndex]] : item
               );
             }
 
@@ -434,13 +438,19 @@ export function createQueryResultProxy<T>(
 
             // A tail append records its intent so the commit emits a
             // tail-relative, mergeable operation rather than a position diffed
-            // against a possibly-stale base. Other mutators (splice, unshift,
-            // ...) are not tail appends and keep the read-modify-write path.
+            // against a possibly-stale base. Any other in-place mutator (splice,
+            // unshift, sort, reverse, fill, ...) reshapes the array: if a
+            // mergeable push was recorded on it earlier in the transaction, the
+            // recorded tail no longer identifies the appended elements, so
+            // abandon the intent and let the whole-array diff carry the reshaped
+            // result.
             if (prop === "push") {
               tx.recordMergeableOp?.(link, {
                 op: "append",
                 count: args.length,
               });
+            } else {
+              tx.poisonMergeableOp?.(link);
             }
 
             // CT-1173 FIX: Don't mutate proxy target (value) after writes.
@@ -536,8 +546,19 @@ export function createQueryResultProxy<T>(
       const keys = isRecord(current) || Array.isArray(current)
         ? Reflect.ownKeys(current)
         : Reflect.ownKeys(value);
-      if (Array.isArray(proxyTarget) && !keys.includes("length")) {
-        keys.push("length");
+      if (Array.isArray(proxyTarget)) {
+        if (!keys.includes("length")) {
+          keys.push("length");
+        }
+        // Enumerating an array's keys observes how many elements it has — the
+        // count of index keys is its `length`, which a mergeable append /
+        // add-unique / remove-by-value changes. The SHAPE_READ above tracks the
+        // container shape but is dropped at commit as the op's incidental
+        // container read, so record an explicit `length` read (as the iterator
+        // and get trap do). An `Object.keys(arr).length`-derived write then stays
+        // in the conflict set and retries against a concurrent count change
+        // instead of merging with a stale count.
+        readTx.readValueOrThrow({ ...link, path: [...link.path, "length"] });
       }
       return keys;
     },
@@ -591,6 +612,15 @@ export function createQueryResultProxy<T>(
       const readTx = runtime.readTx(tx);
       const current = readTx.readValueOrThrow(link, SHAPE_READ);
       if (isRecord(current) || Array.isArray(current)) {
+        // Probing whether a numeric index is present observes the array's
+        // element count — an index exists only below `length`, which a mergeable
+        // append / add-unique / remove-by-value changes. Record an explicit
+        // `length` read (as ownKeys and the iterator do), dropped shape read at
+        // the op path notwithstanding, so an `n in arr`-derived write stays in
+        // the conflict set.
+        if (Array.isArray(current) && /^\d+$/.test(prop)) {
+          readTx.readValueOrThrow({ ...link, path: [...link.path, "length"] });
+        }
         return prop in current;
       }
       return prop in value;

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1480,7 +1480,14 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // reserved `grant:cfc:` documents are keyed by ID, and the mergeable
     // path must not slip an unprivileged grant mutation past the gate.
     this.noteSystemWrite(address);
-    this.tx.recordMergeableOp?.(address, delta);
+    // Record a mergeable intent only when the underlying transaction can also
+    // poison it. Recording an intent that can never be poisoned would let a
+    // later reshape or mixed-op leave a stale tail op in the commit — silent
+    // corruption. When poison is unavailable the intent is simply not recorded,
+    // so the commit falls back to the plain whole-array diff already written.
+    if (this.tx.poisonMergeableOp) {
+      this.tx.recordMergeableOp?.(address, delta);
+    }
   }
 
   poisonMergeableOp(link: NormalizedFullLink): void {
@@ -2187,7 +2194,11 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
   }
 
   recordMergeableOp(link: NormalizedFullLink, delta: MergeableOpDelta): void {
-    this.wrapped.recordMergeableOp?.(link, delta);
+    // Only record when the wrapped transaction can also poison — see the same
+    // guard in ExtendedStorageTransaction.recordMergeableOp.
+    if (this.wrapped.poisonMergeableOp) {
+      this.wrapped.recordMergeableOp?.(link, delta);
+    }
   }
 
   poisonMergeableOp(link: NormalizedFullLink): void {

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1483,6 +1483,11 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.tx.recordMergeableOp?.(address, delta);
   }
 
+  poisonMergeableOp(link: NormalizedFullLink): void {
+    this.assertWritable("poisonMergeableOp");
+    this.tx.poisonMergeableOp?.(toMemorySpaceAddress(link));
+  }
+
   recordSqliteWrite(space: MemorySpace, op: SqliteOperation): void {
     // A folded SQLite write is a write — honor the wrapper's read-only mode the
     // same way cell writes do, instead of silently recording it.
@@ -2183,6 +2188,10 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
 
   recordMergeableOp(link: NormalizedFullLink, delta: MergeableOpDelta): void {
     this.wrapped.recordMergeableOp?.(link, delta);
+  }
+
+  poisonMergeableOp(link: NormalizedFullLink): void {
+    this.wrapped.poisonMergeableOp?.(link);
   }
 
   recordSqliteWrite(space: MemorySpace, op: SqliteOperation): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -823,6 +823,16 @@ export interface IStorageTransaction {
   ): void;
 
   /**
+   * Abandon the mergeable fast path for the array at `address`. A caller that
+   * rewrites the whole array in a way a recorded mergeable op cannot represent —
+   * an in-place reshape such as sort/reverse/splice after a push — calls this so
+   * the commit emits the whole-array diff (the correct local value) instead of a
+   * tail-relative op whose recorded tail no longer identifies the appended
+   * elements. A path with no recorded op is left untouched.
+   */
+  poisonMergeableOp?(address: IMemorySpaceAddress): void;
+
+  /**
    * The document addresses for which this transaction recorded a mergeable op.
    * The commit's read-set builder uses these to drop reads of those paths from
    * conflict detection.
@@ -1045,6 +1055,13 @@ export interface IExtendedStorageTransaction
    * resolving the link to a memory address.
    */
   recordMergeableOp?(link: NormalizedFullLink, delta: MergeableOpDelta): void;
+
+  /**
+   * Abandon the mergeable fast path for the array addressed by `link`, forwarded
+   * to the underlying transaction after resolving the link. See
+   * {@link IStorageTransaction.poisonMergeableOp}.
+   */
+  poisonMergeableOp?(link: NormalizedFullLink): void;
 
   getCfcState(): Readonly<CfcTxState>;
   setCfcEnforcementMode(mode: CfcEnforcementMode): void;

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -122,6 +122,14 @@ type WritableDocumentEntry = {
   // possibly-stale base, and drops the op's path from the commit's conflict read
   // set. See ./mergeable-ops.ts.
   mergeableOps?: Map<string, MergeableOpIntent>;
+  // Paths where a mergeable intent cannot faithfully carry the transaction's
+  // local change — a second mergeable op of a different kind was recorded, or a
+  // foreign write (a reshape such as sort/splice) rewrote the array after an op
+  // was recorded. Such a path abandons the mergeable fast path and commits the
+  // whole-array diff, which reflects the correct combined local value. Once
+  // poisoned a path stays poisoned for the rest of the transaction, so a later
+  // op does not resurrect a partial intent. Keyed like mergeableOps.
+  mergeableOpsPoisoned?: Set<string>;
 };
 
 type DocumentEntry = ReadDocumentEntry | WritableDocumentEntry;
@@ -1038,12 +1046,48 @@ export class V2StorageTransaction implements IStorageTransaction {
     }
     const doc = this.writableMergeableTarget(address);
     if (!doc) throw new Error(`${delta.op} target is not writable`);
-    doc.mergeableOps ??= new Map();
     const pathKey = encodePointer(address.path);
+    // A poisoned path has already fallen back to the whole-array diff; a further
+    // op does not revive it.
+    if (doc.mergeableOpsPoisoned?.has(pathKey)) {
+      return;
+    }
+    const existing = doc.mergeableOps?.get(pathKey);
+    // A different mergeable op kind at the same path in one transaction cannot be
+    // carried alongside the first: the intent map holds one op per path, so the
+    // second would replace the first and the diff-suppression would then drop the
+    // first op's element changes from the commit — silent data loss. Poison the
+    // path instead so the whole-array diff carries both changes.
+    if (existing !== undefined && existing.op !== delta.op) {
+      doc.mergeableOps?.delete(pathKey);
+      (doc.mergeableOpsPoisoned ??= new Set()).add(pathKey);
+      return;
+    }
+    doc.mergeableOps ??= new Map();
     doc.mergeableOps.set(
       pathKey,
-      foldMergeableIntent(doc.mergeableOps.get(pathKey), address.path, delta),
+      foldMergeableIntent(existing, address.path, delta),
     );
+  }
+
+  // Abandon the mergeable fast path for `address`: a foreign write (a reshape
+  // that is not itself a mergeable op) has rewritten the array after an op was
+  // recorded, so the recorded tail no longer identifies the appended elements.
+  // Drop any intent and mark the path poisoned so the commit emits the
+  // whole-array diff (the correct local value) instead. A path with no recorded
+  // intent is left untouched — a reshape before any op is fine, and a later op on
+  // that path is still mergeable.
+  poisonMergeableOp(address: IMemorySpaceAddress): void {
+    const ready = this.editable();
+    if (ready.error) return;
+    const doc = this.writableMergeableTarget(address);
+    if (!doc) return;
+    const pathKey = encodePointer(address.path);
+    if (!doc.mergeableOps?.has(pathKey)) {
+      return;
+    }
+    doc.mergeableOps.delete(pathKey);
+    (doc.mergeableOpsPoisoned ??= new Set()).add(pathKey);
   }
 
   // The caller wrote through this same transaction, so the entry is writable.

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1078,8 +1078,10 @@ export class V2StorageTransaction implements IStorageTransaction {
   // intent is left untouched — a reshape before any op is fine, and a later op on
   // that path is still mergeable.
   poisonMergeableOp(address: IMemorySpaceAddress): void {
-    const ready = this.editable();
-    if (ready.error) return;
+    // Only ever called right after a write on this transaction, so the tx is
+    // editable — no editable() re-check. The write also made the address's
+    // document writable, but a caller could resolve to a different (read-only)
+    // slot, so a non-writable target is a real no-op.
     const doc = this.writableMergeableTarget(address);
     if (!doc) return;
     const pathKey = encodePointer(address.path);

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -116,6 +116,18 @@ const isSamePath = (
   b: readonly string[],
 ): boolean =>
   a.length === b.length && a.every((segment, index) => b[index] === segment);
+
+// True when `path` is the immediate `length` child of `arrayPath` — i.e. a read
+// of that array's own element count. A mergeable append / add-unique /
+// remove-by-value changes this count, so such a read is a genuine dependency of
+// the writer, not one of the op's own incidental sub-reads.
+const isArrayLengthChildPath = (
+  arrayPath: readonly string[],
+  path: readonly string[],
+): boolean =>
+  path.length === arrayPath.length + 1 &&
+  path[arrayPath.length] === "length" &&
+  arrayPath.every((segment, index) => path[index] === segment);
 import { toTransactionDocumentValue } from "./v2-document.ts";
 import {
   hasValueAtPath,
@@ -2923,8 +2935,17 @@ class SpaceReplica implements ISpaceReplica {
       const scope = normalizeCellScope(read.scope);
 
       const opPaths = mergeableOpPathsByEntity.get(`${read.id}\0${scope}`);
+      // A read of the op array's own `length` is the handler depending on the
+      // element count, which a mergeable append / add-unique / remove-by-value
+      // changes. The op itself never reads `length` (it reads the array value
+      // and its new-element slots), so this read is a genuine dependency and is
+      // kept from every drop below: a push whose new element's index or id came
+      // from the length conflicts and retries against a concurrent append.
+      const readsMergeableOpArrayLength = opPaths !== undefined &&
+        opPaths.some((opPath) => isArrayLengthChildPath(opPath, read.path));
       if (
         opPaths !== undefined &&
+        !readsMergeableOpArrayLength &&
         (isMergeableOpRead(read.meta) ||
           isReadMarkedAsAttemptedWrite(read.meta) ||
           isCfcLabelPath(read.path) ||

--- a/packages/runner/test/array-push-mergeable.test.ts
+++ b/packages/runner/test/array-push-mergeable.test.ts
@@ -5,6 +5,7 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
+import type { Cell } from "../src/cell.ts";
 import { Runtime } from "../src/runtime.ts";
 import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
@@ -271,6 +272,290 @@ describe("mergeable array appends", () => {
     }
   });
 
+  // A push whose new element is derived from the array's LENGTH is a conditional
+  // push: its correctness depends on the count it read. The length read is
+  // recorded as the array's own `length` child path — the shape produced by a
+  // `for...of`/spread over the array, a shape-only `length` access, or
+  // `key("length")`. That read must stay in the conflict set: a mergeable append
+  // changes the length, so a concurrent append has to make this commit conflict
+  // (and retry against the new tail) instead of the push merging with a stale
+  // index. Before the length read was kept, session 2 read length 1, both
+  // sessions computed the same index, and the append silently merged with a
+  // duplicate index.
+  it("a length-derived push conflicts with a concurrent append", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<string[]>(space, CAUSE, stringListSchema);
+      await cell2.sync();
+      await cell2.pull();
+
+      // Session 1 appends "A", moving the durable length from 1 to 2.
+      const txA = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, txA).push("A");
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      // Session 2, still at the pre-"A" basis, reads the length (1) and pushes an
+      // element positioned at that length. The length read conflicts with session
+      // 1's append.
+      const txB = rt2.edit();
+      const cellB = rt2.getCell<string[]>(space, CAUSE, stringListSchema, txB);
+      const len = (cellB.key("length") as unknown as Cell<number>).get();
+      cellB.push(`item-${len}`);
+      const result = await txB.commit();
+
+      expect(result.error).toBeDefined();
+      const durable = await readDurable(server);
+      expect(durable).toEqual(["seed", "A"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // The same protection through the query-result proxy's iterator: a handler that
+  // counts the array with `for...of` (or a spread) before pushing records the
+  // array's `length` read, so a concurrent append conflicts.
+  it("a for...of count before a proxy push conflicts with a concurrent append", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<string[]>(space, CAUSE, stringListSchema);
+      await cell2.sync();
+      await cell2.pull();
+
+      const txA = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, txA).push("A");
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      const txB = rt2.edit();
+      const proxy = rt2.getCell<string[]>(space, CAUSE, stringListSchema, txB)
+        .getAsQueryResult([], txB, true) as unknown as string[];
+      let count = 0;
+      for (const _ of proxy) count++;
+      proxy.push(`item-${count}`);
+      const result = await txB.commit();
+
+      expect(result.error).toBeDefined();
+      const durable = await readDurable(server);
+      expect(durable).toEqual(["seed", "A"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // The length read stays precise: it conflicts with a change to the element
+  // COUNT (an append), not with an edit to an existing element. A concurrent
+  // edit to an element the length-reading session did not append leaves the
+  // length unchanged, so the append still merges — the length read must not
+  // over-conflict the way a whole-array `.get()` read would.
+  it("a length-derived push merges past a concurrent edit to an existing element", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<string[]>(space, CAUSE, stringListSchema);
+      await cell2.sync();
+      await cell2.pull();
+
+      // Session 1 edits the existing element 0 in place; the length stays 1.
+      const txA = rt1.edit();
+      (rt1.getCell<string[]>(space, CAUSE, stringListSchema, txA)
+        .key("0") as unknown as Cell<string>).set("edited");
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      // Session 2 reads the length and pushes; the length did not change, so the
+      // append merges on top of the edit.
+      const txB = rt2.edit();
+      const cellB = rt2.getCell<string[]>(space, CAUSE, stringListSchema, txB);
+      const len = (cellB.key("length") as unknown as Cell<number>).get();
+      cellB.push(`item-${len}`);
+      const result = await txB.commit();
+      await rt2.storageManager.synced();
+
+      expect(result.error).toBeUndefined();
+      const durable = await readDurable(server);
+      expect(durable).toEqual(["edited", "item-1"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // Bare `.length` on the query-result proxy (the get trap) reads the whole
+  // array recursively at the op path, so it is already kept as the handler's
+  // explicit read and conflicts with a concurrent append even without the
+  // length-child carve-out. This pins that end-to-end guarantee for the most
+  // common form: a change that ever recorded bare `.length` as a shape-only read
+  // AT the op path (which `buildReads` drops as the proxy's incidental container
+  // read) would fail here, forcing the count dependency to stay in the conflict
+  // set.
+  it("a bare proxy `.length` read before a push conflicts with a concurrent append", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<string[]>(space, CAUSE, stringListSchema);
+      await cell2.sync();
+      await cell2.pull();
+
+      const txA = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, txA).push("A");
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      const txB = rt2.edit();
+      const proxy = rt2.getCell<string[]>(space, CAUSE, stringListSchema, txB)
+        .getAsQueryResult([], txB, true) as unknown as string[];
+      const len = proxy.length;
+      proxy.push(`item-${len}`);
+      const result = await txB.commit();
+
+      expect(result.error).toBeDefined();
+      const durable = await readDurable(server);
+      expect(durable).toEqual(["seed", "A"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // Enumerating the array's keys (`Object.keys`/`values`/`entries`, or an object
+  // spread) observes the element count the same way a length read does — the
+  // proxy's ownKeys trap records an explicit `length` read for an array. So a
+  // push whose new element came from `Object.keys(arr).length` conflicts with a
+  // concurrent append; an unconditional push, which never enumerates, still
+  // merges.
+  it("an Object.keys(proxy).length-derived push conflicts with a concurrent append", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<string[]>(space, CAUSE, stringListSchema);
+      await cell2.sync();
+      await cell2.pull();
+
+      const txA = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, txA).push("A");
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      const txB = rt2.edit();
+      const proxy = rt2.getCell<string[]>(space, CAUSE, stringListSchema, txB)
+        .getAsQueryResult([], txB, true) as unknown as string[];
+      const len = Object.keys(proxy).length;
+      proxy.push(`item-${len}`);
+      const result = await txB.commit();
+
+      expect(result.error).toBeDefined();
+      const durable = await readDurable(server);
+      expect(durable).toEqual(["seed", "A"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // The carve-out is not push-specific: it keeps the length read for every
+  // mergeable op. An addUnique whose added value or decision depended on the
+  // count must conflict with a concurrent count-changing op, even when the added
+  // element is a distinct key that would otherwise merge. A transaction that
+  // reads the length forfeits that transaction's distinct-element merge.
+  it("a length-read addUnique conflicts with a concurrent addUnique", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<string[]>(space, CAUSE, stringListSchema);
+      await cell2.sync();
+      await cell2.pull();
+
+      const txA = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, txA).addUnique("A");
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      const txB = rt2.edit();
+      const cellB = rt2.getCell<string[]>(space, CAUSE, stringListSchema, txB);
+      const len = (cellB.key("length") as unknown as Cell<number>).get();
+      cellB.addUnique(`item-${len}`);
+      const result = await txB.commit();
+
+      expect(result.error).toBeDefined();
+      const durable = await readDurable(server);
+      expect(durable).toEqual(["seed", "A"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
   // A single session appends to a list whose durable head it has not yet
   // observed (the rehydration-race shape): it reads the list as shorter/empty
   // than it durably is, then appends. The append must land at the durable tail,
@@ -349,6 +634,237 @@ describe("mergeable array appends", () => {
       const durable = await readDurable(server);
       expect(durable).toEqual(["ONE", "two", "three"]);
     } finally {
+      await rt1.dispose();
+    }
+  });
+
+  // Two different mergeable op kinds on the same array path in one transaction.
+  // The intent map holds one op per path, so the second would replace the first
+  // and the diff-suppression would then drop the first op's element from the
+  // commit. The path is poisoned instead and the whole-array diff carries both
+  // changes.
+  it("addUnique then push in one tx commits both (no silent drop)", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const tx1 = rt1.edit();
+      const cell = rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx1);
+      cell.addUnique("a");
+      cell.push("b");
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      expect(await readDurable(server)).toEqual(["seed", "a", "b"]);
+    } finally {
+      await rt1.dispose();
+    }
+  });
+
+  // The "update my entry" idiom: remove the old value and add the new one in one
+  // handler. remove-by-value and add-unique are different op kinds, so the path
+  // is poisoned and the whole-array diff commits the correct result.
+  it("removeByValue then addUnique in one tx commits both", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0)
+        .set(["seed", "old"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const tx1 = rt1.edit();
+      const cell = rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx1);
+      cell.removeByValue("old");
+      cell.addUnique("new");
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      expect(await readDurable(server)).toEqual(["seed", "new"]);
+    } finally {
+      await rt1.dispose();
+    }
+  });
+
+  // A reshape (an in-place mutator that is not a mergeable push) after a push
+  // rewrites the array, so the recorded append tail no longer identifies the
+  // pushed element. The push intent is abandoned and the whole-array diff commits
+  // the reshaped result. `unshift` reads the array fresh, so the local value is
+  // exact.
+  it("push then unshift on a proxy commits the reshaped array", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const tx1 = rt1.edit();
+      const proxy = rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx1)
+        .getAsQueryResult([], tx1, true) as unknown as string[];
+      proxy.push("b");
+      proxy.unshift("z");
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      expect(await readDurable(server)).toEqual(["z", "seed", "b"]);
+    } finally {
+      await rt1.dispose();
+    }
+  });
+
+  // A reshape after a push commits the correctly reshaped array. The reshape
+  // reads the array fresh (so `sort` sees the pushed "b"), and the push intent is
+  // poisoned so the commit emits the reshaped whole-array diff rather than a stale
+  // tail op.
+  it("push then sort on a proxy commits the sorted array with the pushed element", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set([
+        "c",
+        "a",
+      ]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const tx1 = rt1.edit();
+      const cell = rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx1);
+      const proxy = cell.getAsQueryResult([], tx1, true) as unknown as string[];
+      proxy.push("b");
+      proxy.sort();
+      expect(cell.get()).toEqual(["a", "b", "c"]);
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      expect(await readDurable(server)).toEqual(["a", "b", "c"]);
+    } finally {
+      await rt1.dispose();
+    }
+  });
+
+  // A whole-array Cell.set after a push reshapes the array; the append intent is
+  // poisoned so the commit emits the set's array, not a tail op sliced from it.
+  it("push then a whole-array set commits the set array", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const tx1 = rt1.edit();
+      const cell = rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx1);
+      cell.push("b");
+      cell.set(["x", "y", "z"]);
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      expect(await readDurable(server)).toEqual(["x", "y", "z"]);
+    } finally {
+      await rt1.dispose();
+    }
+  });
+
+  // A poisoned path forfeits merge-friendliness: because it commits as a
+  // whole-array diff whose reads are kept, a mixed-op transaction conflicts with
+  // a concurrent append instead of merging — the intended trade for never losing
+  // data on the mixed-op path.
+  it("a mixed-op (poisoned) transaction conflicts with a concurrent append", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0)
+        .set(["seed", "old"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<string[]>(space, CAUSE, stringListSchema);
+      await cell2.sync();
+      await cell2.pull();
+
+      const txA = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, txA).push("A");
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      // Session 2, at the pre-"A" basis, does the mixed-op "update my entry"
+      // (remove old, add new) — a poisoned path, committed as a value diff.
+      const txB = rt2.edit();
+      const cellB = rt2.getCell<string[]>(space, CAUSE, stringListSchema, txB);
+      cellB.removeByValue("old");
+      cellB.addUnique("new");
+      const result = await txB.commit();
+
+      expect(result.error).toBeDefined();
+      expect(await readDurable(server)).toEqual(["seed", "old", "A"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // Probing whether a numeric index exists (`n in arr`) observes the element
+  // count, so an `n in arr`-derived push conflicts with a concurrent append.
+  it("an `n in arr`-derived push conflicts with a concurrent append", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<string[]>(space, CAUSE, stringListSchema);
+      await cell2.sync();
+      await cell2.pull();
+
+      const txA = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, txA).push("A");
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      const txB = rt2.edit();
+      const proxy = rt2.getCell<string[]>(space, CAUSE, stringListSchema, txB)
+        .getAsQueryResult([], txB, true) as unknown as string[];
+      proxy.push(1 in proxy ? "had-1" : "no-1");
+      const result = await txB.commit();
+
+      expect(result.error).toBeDefined();
+      expect(await readDurable(server)).toEqual(["seed", "A"]);
+    } finally {
+      await rt2.dispose();
       await rt1.dispose();
     }
   });

--- a/packages/runner/test/array-push-mergeable.test.ts
+++ b/packages/runner/test/array-push-mergeable.test.ts
@@ -467,11 +467,11 @@ describe("mergeable array appends", () => {
   });
 
   // Enumerating the array's keys (`Object.keys`/`values`/`entries`, or an object
-  // spread) observes the element count the same way a length read does — the
-  // proxy's ownKeys trap records an explicit `length` read for an array. So a
-  // push whose new element came from `Object.keys(arr).length` conflicts with a
-  // concurrent append; an unconditional push, which never enumerates, still
-  // merges.
+  // spread) observes the present-key set — the proxy's ownKeys trap records a
+  // recursive read of the array for that. So a push whose new element came from
+  // `Object.keys(arr).length` conflicts with a concurrent append (and, per the
+  // sparse test below, with a concurrent hole edit); an unconditional push, which
+  // never enumerates, still merges.
   it("an Object.keys(proxy).length-derived push conflicts with a concurrent append", async () => {
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
@@ -863,6 +863,56 @@ describe("mergeable array appends", () => {
 
       expect(result.error).toBeDefined();
       expect(await readDurable(server)).toEqual(["seed", "A"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // Arrays can be sparse (holes below `length`). Filling or punching a hole
+  // changes the present-key set without changing `length`, so an enumeration or
+  // `n in arr` probe that fed a push must conflict with a concurrent same-length
+  // hole edit. A `length`-only dependency would miss it; the ownKeys/has traps
+  // record a recursive read for arrays, which a hole edit invalidates.
+  it("an `n in arr`-derived push conflicts with a concurrent same-length hole fill", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    try {
+      const tx0 = rt1.edit();
+      // ["a", <hole>, "c"] — length 3, index 1 absent.
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(
+        ["a", , "c"] as string[],
+      );
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<string[]>(space, CAUSE, stringListSchema);
+      await cell2.sync();
+      await cell2.pull();
+
+      // Session 1 fills the hole at index 1: same length (3), present-key set
+      // changes. No `length` write.
+      const txA = rt1.edit();
+      (rt1.getCell<string[]>(space, CAUSE, stringListSchema, txA)
+        .key(1) as unknown as Cell<string>).set("b");
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      // Session 2, at the pre-fill basis, probes `1 in arr` (false) and pushes.
+      const txB = rt2.edit();
+      const proxy = rt2.getCell<string[]>(space, CAUSE, stringListSchema, txB)
+        .getAsQueryResult([], txB, true) as unknown as string[];
+      proxy.push(1 in proxy ? "had-1" : "no-1");
+      const result = await txB.commit();
+
+      expect(result.error).toBeDefined();
+      expect(await readDurable(server)).toEqual(["a", "b", "c"]);
     } finally {
       await rt2.dispose();
       await rt1.dispose();

--- a/packages/runner/test/mergeable-op-registry.test.ts
+++ b/packages/runner/test/mergeable-op-registry.test.ts
@@ -87,3 +87,37 @@ describe("mergeable op createsKey stamping", () => {
     ).toEqual([{ op: "increment", path: "/value/n", by: 3 }]);
   });
 });
+
+// The tail op builder (append / add-unique) bails to a no-op in two guarded
+// cases, leaving the commit to carry the plain diff. A handler reaches these
+// only through sequences the poison fallback now short-circuits before build, so
+// they are covered directly here.
+describe("mergeable tail-op build guards", () => {
+  // The op path holds no array at commit — the value is absent, or was
+  // overwritten with a non-array — so there is nothing to slice a tail from.
+  it("a tail op with no working array emits no op and no suppression", () => {
+    for (const op of ["append", "add-unique"] as const) {
+      expect(
+        buildMergeableIntent(
+          { op, path: ["value"], count: 1 },
+          {
+            workingArray: undefined,
+            hadInitialArray: false,
+            hadInitialValue: false,
+          },
+        ),
+      ).toEqual({ ops: [], suppress: [] });
+    }
+  });
+
+  // The recorded tail slice is empty: an empty working array against an existing
+  // base makes `array.slice(length - count)` empty, so the op carries nothing.
+  it("a tail op whose recorded tail is empty emits no op and no suppression", () => {
+    expect(
+      buildMergeableIntent(
+        { op: "append", path: ["value"], count: 2 },
+        { workingArray: [], hadInitialArray: true, hadInitialValue: true },
+      ),
+    ).toEqual({ ops: [], suppress: [] });
+  });
+});

--- a/packages/runner/test/scheduler-idle-parked-event.test.ts
+++ b/packages/runner/test/scheduler-idle-parked-event.test.ts
@@ -1,0 +1,161 @@
+// idle() consults the head event's park state while a wake timer is armed.
+//
+// waitForQuiescence has a branch that fires when a wake timer is pending and the
+// event queue is non-empty: it asks whether the head event is parked (a
+// time-gated retry, or a handler still loading) before deciding to keep idle()
+// open. Reaching the head-park check needs two facts true at the same re-check —
+// a wake timer armed and an event queued.
+//
+// This drives both from the real scheduler: a debounced computation that is
+// invalidated after its first run arms the shared wake timer and waits, and an
+// event queued against a piece stream sits in the queue until the next tick
+// dispatches it. idle()'s first evaluation runs synchronously when called, so
+// with the wake armed and the event still queued it takes the head-park check.
+
+import {
+  afterEach,
+  beforeEach,
+  createSchedulerTestRuntime,
+  describe,
+  disposeSchedulerTestRuntime,
+  expect,
+  it,
+  Runtime,
+  space,
+  toMemorySpaceAddress,
+} from "./scheduler-test-utils.ts";
+import type {
+  Action,
+  Cell,
+  IExtendedStorageTransaction,
+  SchedulerTestStorageManager,
+} from "./scheduler-test-utils.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { resolveLink } from "../src/link-resolution.ts";
+
+describe("idle consults head-event park with a wake timer armed", () => {
+  let storageManager: SchedulerTestStorageManager;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+      import.meta.url,
+    ));
+  });
+
+  afterEach(async () => {
+    await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+  });
+
+  it("evaluates the head-park branch with a debounce wake pending", async () => {
+    // A debounced computation: reads `source`, writes `derived`. Once it has run
+    // and is then invalidated, the scheduler arms the shared wake timer and
+    // holds the re-run for the debounce window instead of running it now.
+    const source = runtime.getCell<number>(
+      space,
+      "idle-park-source",
+      undefined,
+      tx,
+    );
+    const derived = runtime.getCell<number>(
+      space,
+      "idle-park-derived",
+      undefined,
+      tx,
+    );
+    source.set(0);
+    derived.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let runs = 0;
+    const compute: Action = (actionTx) => {
+      runs++;
+      const value = (source.withTx(actionTx).get() ?? 0) as number;
+      derived.withTx(actionTx).send(value + 1);
+    };
+    // A long debounce so the armed wake stays pending for the whole test rather
+    // than firing mid-flight; it is cancelled when the runtime is disposed.
+    const DEBOUNCE_MS = 30_000;
+    runtime.scheduler.setDebounce(compute, DEBOUNCE_MS);
+    runtime.scheduler.subscribe(compute, {
+      reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [toMemorySpaceAddress(derived.getAsNormalizedFullLink())],
+    }, {});
+    // First run, so a later invalidation is a re-run the debounce can hold.
+    await derived.pull();
+
+    // An event handler on a separate piece; queuing an event puts it in the
+    // queue for the next tick to dispatch.
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { cell, handler, pattern } = commonfabric;
+    let invocations = 0;
+    const bump = handler<{ value: number }, { effects: { total: number } }>(
+      (event, { effects }) => {
+        invocations++;
+        effects.total += event.value;
+      },
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => {
+      const effects = cell({ total: 0 });
+      return { effects, stream: bump({ effects }) };
+    });
+    const rootCell = runtime.getCell<
+      { effects: { total: number }; stream: unknown }
+    >(space, "idle-park-piece", undefined, tx);
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.idle();
+
+    const streamLink = resolveLink(
+      runtime,
+      runtime.readTx(),
+      root.key("stream").getAsNormalizedFullLink(),
+    );
+
+    // Invalidate the debounced computation: it has run once, so this arms the
+    // shared wake timer and parks the re-run for the debounce window rather than
+    // running it now.
+    source.withTx(tx).send(5);
+    await tx.commit();
+    tx = runtime.edit();
+    // Let the invalidation settle. idle() does not flush a pull computation that
+    // nothing demands, so it returns with the debounce wake still armed.
+    await runtime.idle();
+
+    // Guard the coverage intent: the head-event park branch is only reached with
+    // a wake timer pending, so fail loudly if the debounce did not arm one
+    // rather than pass while silently skipping the branch under test.
+    const gates = (runtime.scheduler as unknown as {
+      gates: { hasWakeTimer(): boolean };
+    }).gates;
+    expect(gates.hasWakeTimer()).toBe(true);
+
+    // Queue the event (now in the queue) and, in the same synchronous turn, ask
+    // for idle. idle()'s first check sees the wake timer armed and the event
+    // queued, so it evaluates the head-event park branch.
+    runtime.scheduler.queueEvent(
+      streamLink,
+      { value: 3 },
+      true,
+      undefined,
+      false,
+      { eventId: "evt:idle-park:0:idle-park-piece" },
+    );
+    await runtime.idle();
+
+    // The event converged while the wake timer was pending, and idle() returned
+    // rather than hanging. The debounced re-run stays parked: idle() does not
+    // wait for a pull computation that nothing is demanding, so `compute` has
+    // still run only once and `derived` is unchanged.
+    const total = (root.key("effects").key("total") as Cell<number>).get();
+    expect(total).toBe(3);
+    expect(invocations).toBe(1);
+    expect(runs).toBe(1);
+    expect(derived.get() ?? 0).toBe(1);
+  });
+});


### PR DESCRIPTION
…encies and op composition

A mergeable collection write (Cell.push/append, addUnique, increment, removeByValue) commits as a tail-relative operation the durable store resolves against live state, so concurrent and stale-base writes merge instead of clobbering. To make that merge possible the commit drops the op's own reads from conflict detection and suppresses the whole-array diff the op replaces. That optimism was unsafe in two directions: a write whose correctness depends on the collection's element count still merged with a stale count, and combining a mergeable op with another write to the same array in one transaction dropped or garbled data. This closes both classes and one adjacent proxy bug.

## Count-derived writes now conflict

A handler that reads an array's length (or otherwise observes its element count) and derives the new element's index, id, or position from it must conflict with a concurrent append: an append changes the count, so a second writer that read the same count has to retry against the new tail rather than reuse a stale index.

The length read is recorded at the array's own `length` child (`[...opPath, "length"]`), a strict descendant of the op path, which the commit read-set builder dropped along with the op's genuine incidental sub-reads. `buildReads` now exempts that one child from the drop (`isArrayLengthChildPath`), keeping it in the conflict set. This is precise: the length read conflicts with a change to the element count, not with an edit to an existing element (a different descendant that leaves the length unchanged).

Enumerating an array's keys observes the count the same way. `Object.keys`, `Object.values`, `Object.entries`, and an object spread reach the query-result proxy's `ownKeys` trap, which recorded only a shape read the commit drops; it now records an explicit `length` read so an `Object.keys(arr).length`-derived push conflicts. The `has` trap does the same for a numeric-index `n in arr` probe. Merge-friendliness is preserved: an unconditional push never enumerates (it operates on a plain array copy and creates its proxy through a separate shape read), so it still merges.

## Mixed ops and reshapes no longer corrupt

A tail-relative intent can only carry the one change it recorded. Combining it with an incompatible second write to the same array in one transaction lost or garbled data, deterministically:

- Two different mergeable op kinds on one path. The intent map holds one intent per path, so a second op of a different kind replaced the first, and the diff-suppression then removed the whole-array diff that carried the first op's elements. `addUnique("a"); push("b")` committed `["seed","b"]` (the "a" lost); the "update my entry" idiom `removeByValue(old); addUnique(new)` committed `["seed","old","new"]` (the removal lost).

- A reshape after a push. An in-place mutator (sort/reverse/splice/unshift/fill) or a whole-array Cell.set rewrites the array after the push recorded its append count, so the recorded tail no longer identifies the appended elements and the commit sliced the wrong elements.

The fix poisons such a path: the intent is dropped and the path is marked poisoned, so the commit falls back to the whole-array diff — which always holds the correct combined local value. The write forfeits merge-friendliness (it commits as a value diff that can false-conflict under contention) but is never silently corrupted. `recordMergeableOp` poisons on a second, different op kind; the query-result proxy poisons on any non-push in-place mutator; and `Cell.set` poisons on a whole-value overwrite. Poisoning acts only when an intent already exists at the exact path, so a same-kind repeat still folds into one op, an element edit (`key(i).set`, a child path) still composes with a push, and a reshape or set before any op leaves a later push mergeable.

## Stale read in the proxy's read-write array methods

The query-result proxy's read-write array methods (sort/reverse/pop/shift/splice) operated on the array snapshot captured at proxy creation, which is stale after any earlier write in the same transaction, so `push("b"); sort()` produced a locally wrong array that dropped "b" before any commit. They now read the array fresh from the transaction, matching the write-only methods. This also makes the local value correct for a reshape after a push, so the poison fallback above commits the right array.

Adds regression tests for each class — the length-derived and enumeration-derived conflicts, the precision case (a length read does not conflict with a disjoint element edit), the mixed-op and reshape poison (via a proxy mutator and via Cell.set), the corrected sort-after-push result, the `n in arr` conflict, and that a poisoned path correctly conflicts under contention. Updates the mergeable-collection-writes and patch-operations notes, replacing the earlier descriptions that a length read is dropped, that a different op replaces the intent, and that a reshape op may be dropped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787472905&installation_model_id=428580&pr_number=4979&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4979&signature=61b409c0d757436787bc2310da8e367de6f982fa71b425b5d395b5b18f1d6d96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes mergeable collection writes correct under count/key dependencies and mixed operations; array proxy mutators now read fresh state and trigger safe fallbacks. Prevents stale-index writes, dropped elements, and local glitches; updates read tracking for arrays, including sparse cases.

- **Bug Fixes**
  - Count/key-derived writes now conflict: keep reads of `[path, "length"]`; for arrays `ownKeys`/`has` record a recursive, conflict-only read so `Object.keys/values/entries`, spreads, and `n in arr` retry on stale counts or key sets; precise — a `length` read doesn’t conflict with unrelated element edits.
  - Mixed ops and reshapes fall back safely: a second mergeable op kind or a non-`push` reshape (proxy mutators or whole-value `Cell.set`) poisons the exact written path and commits the whole-array diff; same-kind repeats still fold, child edits compose, and a reshape or `set` before any op leaves a later push mergeable.
  - Proxy fixes: read-write array methods read fresh state; non-`push` mutators call `poisonMergeableOp`.
  - Capability guard and coverage: record a mergeable intent only when the transaction also supports poisoning; added tests for enumeration/holes and `n in arr`, tail-op build guards, and a deterministic scheduler-idle head-event park case; updated docs.

<sup>Written for commit 3e84fa6cd7b32b98ccbfbb61d4b12c30f0133960. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

