### PR TITLE
refactor(patterns): drop the redundant scrollIntoView from the group-…

### DIFF
--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -18,11 +18,6 @@ import {
 } from "./cfc-browser-helpers.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
-// 60s (was 30s): the imported-message authorship row completes in ~17s locally
-// but exceeds 30s on slower CI runners, causing intermittent timeouts in
-// `waitForInvalidAuthorshipState`. Bumping the headroom stabilizes CI; the test
-// logic is unchanged.
-const CFC_GROUP_CHAT_TIMEOUT = 60_000;
 const IMPORTED_MESSAGE_MARKERS = [
   "Jumping in late here.",
   "I think we already covered this above.",
@@ -87,7 +82,6 @@ describe("cfc group chat demo integration test", () => {
     await waitForText(page, "#group-chat-manager-chip", "No profile");
     await waitForDisabled(page, "#trusted-send-button", true);
 
-    await scrollIntoView(page, "#trusted-profile-name");
     await fillCfInput(
       page,
       "#trusted-profile-name",
@@ -108,14 +102,12 @@ describe("cfc group chat demo integration test", () => {
     );
     await waitForRuntimeIdle(page);
 
-    await scrollIntoView(page, "#trusted-room-name");
     await fillCfInput(
       page,
       "#trusted-room-name",
       "Ops",
     );
     await waitForDisabled(page, "#trusted-room-add-button", false);
-    await scrollIntoView(page, "#trusted-admin-panel");
     await waitForText(
       page,
       '[data-ui-control="admin-user-toggle"]',
@@ -132,7 +124,6 @@ describe("cfc group chat demo integration test", () => {
     await waitForText(page, "#rooms-panel", "1 room");
     await waitForText(page, "#rooms-panel", "Ops");
 
-    await scrollIntoView(page, "#host-message-draft");
     await fillCfInput(
       page,
       "#host-message-draft",
@@ -146,7 +137,6 @@ describe("cfc group chat demo integration test", () => {
       "Fake hello from Alice",
     );
 
-    await scrollIntoView(page, "#trusted-message-draft");
     await fillCfInput(
       page,
       "#trusted-message-draft",
@@ -187,7 +177,6 @@ describe("cfc group chat demo integration test", () => {
     );
     await waitForDisabled(page, "#trusted-send-button", true);
 
-    await scrollIntoView(page, "#trusted-profile-name");
     await fillCfInput(
       page,
       "#trusted-profile-name",
@@ -198,7 +187,6 @@ describe("cfc group chat demo integration test", () => {
     await waitForText(page, "#trusted-profile-status", "Bob");
     await waitForRuntimeIdle(page);
 
-    await scrollIntoView(page, "#trusted-message-draft");
     await fillCfInput(
       page,
       "#trusted-message-draft",
@@ -234,7 +222,6 @@ describe("cfc group chat demo integration test", () => {
       "#trusted-conversation-preview",
     );
 
-    await scrollIntoView(page, "#trusted-message-draft");
     await fillCfInput(
       page,
       "#trusted-message-draft",
@@ -254,19 +241,6 @@ describe("cfc group chat demo integration test", () => {
     );
   });
 });
-
-async function scrollIntoView(page: Page, selector: string) {
-  const node = await page.waitForSelector(selector, {
-    strategy: "pierce",
-    timeout: CFC_GROUP_CHAT_TIMEOUT,
-  });
-  await node.evaluate(async (element: Element) => {
-    element.scrollIntoView({ block: "center", inline: "center" });
-    await new Promise((resolve) =>
-      requestAnimationFrame(() => requestAnimationFrame(resolve))
-    );
-  });
-}
 
 async function waitForAuthorshipState(
   page: Page,


### PR DESCRIPTION
…chat demo test

The cfc-group-chat-demo integration test called a local scrollIntoView helper before eight interactions: seven fillCfInput calls and one waitForText. Like the tag-then-click predicates cleaned up in #4913 and #4948, these scrolls are vestigial from the era when the fill predicate gated on the viewport-dependent isVisible and so needed the field on-screen. The test installs no presentation interactions — no cursor, no captions — so the "demo" is the pattern under test, not a screen recording, and the scroll served no framing purpose either.

None of the eight scrolls gates anything today. fillCfInput drives its field through focus and dispatched events with no coordinate click, so it is viewport-independent (and in a recorded run its presentation path scrolls the field itself). waitForText reads text through the DOM regardless of scroll position. Remove all eight calls and the now-unused helper.

Removing the helper leaves CFC_GROUP_CHAT_TIMEOUT unused, so drop it and its comment. The comment claimed the 60s value gave waitForInvalidAuthorshipState headroom against slow CI runners, but that wait calls waitForCondition without a timeout and so already gets waitForCondition's own 60s default; the constant fed only the removed helper's waitForSelector. The one behavioral effect is that resolving each field before a fill now uses fillCfInput's standard 30s timeout rather than 60s — the same default every other fillCfInput in the suite already relies on, and each fill here is preceded by waitForText and waitForRuntimeIdle gates that ensure the field is present first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787474265&installation_model_id=428580&pr_number=4981&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4981&signature=50abc9dd2b2349f155338b88875eebefe69884da3dc690e9494a2f598f201970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove redundant scrollIntoView calls from the cfc group chat demo integration test and delete the helper, since fills and text checks are viewport‑independent. Simplifies the test and aligns pre-fill timeouts with the suite’s 30s default with no behavior change.

- **Refactors**
  - Removed eight scrollIntoView usages and the helper function.
  - Dropped unused CFC_GROUP_CHAT_TIMEOUT and its comment.
  - Pre-fill resolution now uses the standard 30s timeout; prior waits ensure fields are present.

<sup>Written for commit 3fc2722f46f58f12991ad08acda451a9e83fdec8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

