### PR TITLE
feat(cli): jump to a file or commit from the cf view diff pager

### DIFF
--- a/packages/cli/lib/view/commitmsg.ts
+++ b/packages/cli/lib/view/commitmsg.ts
@@ -14,6 +14,8 @@ export const MESSAGE_INDENT = "    ";
 const OBJECT_ID = "[0-9a-f]{4,64}";
 const COMMIT_RE = new RegExp(`^commit (${OBJECT_ID})\\b`);
 const ONELINE_COMMIT_RE = new RegExp(`^(${OBJECT_ID})\\s+\\S`);
+// The subject text of a compact one-line header: everything after the hash.
+const ONELINE_SUBJECT_RE = new RegExp(`^${OBJECT_ID}\\s+(\\S.*)$`);
 const EMAIL_COMMIT_RE = new RegExp(
   `^From (${OBJECT_ID}) Mon Sep 17 00:00:00 2001$`,
 );
@@ -172,6 +174,57 @@ export function extractMessage(
     );
   }
   return body.join("\n");
+}
+
+/**
+ * Each commit's subject line, keyed by hash. The subject is the first line of
+ * the indented message (standard `git show` / `git log -p`), the text after the
+ * hash on a compact one-line header, or the `Subject:` header of a
+ * `git format-patch` email — whichever the input carries. Absent for a commit
+ * whose subject cannot be found.
+ */
+export function commitSubjects(lines: readonly string[]): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const m of findCommitMessages(lines)) {
+    const first = withoutTransportCR(lines[m.start] ?? "").trim();
+    if (first.length > 0 && !out.has(m.sha)) out.set(m.sha, first);
+  }
+  // The compact and email formats have no indented body; their subject rides the
+  // header itself, so fill only the commits the message scan did not cover.
+  for (const header of findCommitHeaders(lines)) {
+    if (out.has(header.sha)) continue;
+    const subject = inlineSubject(lines, header);
+    if (subject.length > 0) out.set(header.sha, subject);
+  }
+  return out;
+}
+
+/** The subject a header carries inline: the text after the hash on a compact
+ * (`git log --oneline`) header, or the `Subject:` header of a `git format-patch`
+ * email with its `[PATCH …]` prefix removed. Empty when neither shape applies. */
+function inlineSubject(
+  lines: readonly string[],
+  header: CommitHeader,
+): string {
+  const line = withoutTransportCR(lines[header.line] ?? "");
+  const compact = ONELINE_SUBJECT_RE.exec(line);
+  if (compact) return compact[1];
+  if (!EMAIL_COMMIT_RE.test(line)) return "";
+  // The email envelope runs to the first blank line; the Subject may wrap onto
+  // continuation lines (leading whitespace), which join with a single space.
+  let subject: string | null = null;
+  for (let i = header.line + 1; i < lines.length; i++) {
+    const h = withoutTransportCR(lines[i]);
+    if (h === "") break;
+    if (subject !== null) {
+      if (/^\s/.test(h)) subject += ` ${h.trim()}`;
+      else break; // a later header ends the Subject
+    } else {
+      const m = /^Subject:\s*(.*)$/.exec(h);
+      if (m) subject = m[1];
+    }
+  }
+  return subject === null ? "" : subject.replace(/^\[[^\]]*\]\s*/, "").trim();
 }
 
 /** Whether `sha` names the same commit as `head` (either may be abbreviated). */

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -5,8 +5,15 @@
  * the renderer. `pager.ts` drives it against a real TTY, but it is fully
  * exercisable from tests by feeding keys and inspecting `view()`.
  */
-import type { Document, Line, StructureNode, TokenClass } from "./model.ts";
+import type {
+  Document,
+  Line,
+  Span,
+  StructureNode,
+  TokenClass,
+} from "./model.ts";
 import type { Key } from "./keys.ts";
+import { cpLen } from "./ansi.ts";
 import {
   type DialogButton,
   type DialogState,
@@ -49,7 +56,11 @@ import {
   identityFold,
 } from "./fold.ts";
 import { parseDiff } from "./diff.ts";
-import { findCommitMessages } from "./commitmsg.ts";
+import {
+  commitSubjects,
+  findCommitHeaders,
+  findCommitMessages,
+} from "./commitmsg.ts";
 import type { Semantics } from "./semantics.ts";
 import { EditBuffer } from "./editbuffer.ts";
 import type {
@@ -80,7 +91,8 @@ type Mode =
   | "savePrompt"
   | "amendPrompt"
   | "revertPrompt"
-  | "filePicker";
+  | "filePicker"
+  | "jumpList";
 
 /**
  * Overlay content. A peek carries both an info card and the verbatim source and
@@ -133,6 +145,20 @@ interface FoldAnchor {
   readonly sourceCol: number;
   /** Display column within a collapsed summary that remains collapsed. */
   readonly syntheticDisplayCol?: number;
+}
+
+/** One row of the jump list (the `i` dialog): a file the diff touches or a
+ * commit whose message it carries, with where selecting it moves the view. */
+interface JumpEntry {
+  /** Document line the jump lands the viewport on (a file header or a `commit`
+   * header line). */
+  readonly line: number;
+  /** The styled row shown in the list. */
+  readonly display: Line;
+  /** Lower-cased text the filter matches against. */
+  readonly filterText: string;
+  /** Short name for the "Jumped to …" confirmation. */
+  readonly name: string;
 }
 
 export class Session {
@@ -241,6 +267,14 @@ export class Session {
   private pickerFilter = "";
   private pickerEntries: DirEntry[] = [];
   private pickerSel = 0;
+
+  // --- jump list (i) ---
+  /** Every file and commit in the diff, in document order; the filter narrows
+   * this into the shown {@link jumpEntries}. */
+  private jumpAll: JumpEntry[] = [];
+  private jumpEntries: JumpEntry[] = [];
+  private jumpFilter = "";
+  private jumpSel = 0;
 
   constructor(
     doc: Document,
@@ -572,6 +606,8 @@ export class Session {
     const o = this.overlay;
     const ov: OverlayState | null = this.mode === "filePicker"
       ? this.pickerOverlay()
+      : this.mode === "jumpList"
+      ? this.jumpOverlay()
       : o
       ? {
         title: o.title,
@@ -608,6 +644,8 @@ export class Session {
         ? `definition: ${this.input}`
         : this.mode === "filePicker"
         ? `find file: ${this.files?.join(this.pickerDir, this.pickerFilter)}`
+        : this.mode === "jumpList"
+        ? `jump to: ${this.jumpFilter}`
         : null,
       dialog: this.promptDialog(),
       overlay: ov,
@@ -753,6 +791,10 @@ export class Session {
     }
     if (this.mode === "filePicker") {
       this.handleFilePicker(key);
+      return;
+    }
+    if (this.mode === "jumpList") {
+      this.handleJumpList(key);
       return;
     }
     if (this.mode === "search" || this.mode === "deflookup") {
@@ -1517,6 +1559,9 @@ export class Session {
         return;
       case "f":
         this.toggleCurrentFile();
+        return;
+      case "i":
+        this.openJumpList();
         return;
       case "F":
         this.collapseAllFiles();
@@ -3074,11 +3119,18 @@ export class Session {
   }
 
   private ensurePickerVisible(): void {
+    this.scrollListToSelection(this.pickerSel);
+  }
+
+  /** Scroll the overlay list so row `sel` sits inside the box. Shared by the
+   * file picker and the jump list, which both project a selectable list into an
+   * {@link OverlayState} scrolled by `overlayScroll`. */
+  private scrollListToSelection(sel: number): void {
     const innerH = overlayBox(this.width, this.height).innerH;
-    if (this.pickerSel < this.overlayScroll) {
-      this.overlayScroll = this.pickerSel;
-    } else if (this.pickerSel >= this.overlayScroll + innerH) {
-      this.overlayScroll = this.pickerSel - innerH + 1;
+    if (sel < this.overlayScroll) {
+      this.overlayScroll = sel;
+    } else if (sel >= this.overlayScroll + innerH) {
+      this.overlayScroll = sel - innerH + 1;
     }
   }
 
@@ -3219,6 +3271,163 @@ export class Session {
     };
   }
 
+  // --- jump list (i) ---------------------------------------------------------
+
+  /** Open the list of the diff's files and commit messages, so Enter jumps the
+   * view to the one chosen. Only a diff has this list; a plain source view says
+   * so and stays put. */
+  private openJumpList(): void {
+    const entries = this.buildJumpEntries();
+    if (entries.length === 0) {
+      this.message = "The jump list is only available in a diff view.";
+      return;
+    }
+    this.jumpAll = entries;
+    this.jumpFilter = "";
+    this.overlayScroll = 0;
+    this.mode = "jumpList";
+    this.refreshJump();
+    // Open focused on the file the viewport is already reading, so the list
+    // starts where the eye is.
+    this.jumpSel = this.jumpEntryAtViewport();
+    this.scrollListToSelection(this.jumpSel);
+  }
+
+  /** Every file the diff touches and every commit whose message it carries, in
+   * document order. Empty for a non-diff view. */
+  private buildJumpEntries(): JumpEntry[] {
+    if (!this.source?.isDiff) return [];
+    const texts = this.currentDoc.lines.map((l) => l.text);
+    const subjects = commitSubjects(texts);
+    const entries: JumpEntry[] = [];
+    for (const header of findCommitHeaders(texts)) {
+      const subject = subjects.get(header.sha) ?? "";
+      const short = header.sha.slice(0, 9);
+      entries.push({
+        line: header.line,
+        display: commitJumpLine(short, subject),
+        filterText: `commit ${header.sha} ${subject}`.toLowerCase(),
+        name: `commit ${short}`,
+      });
+    }
+    for (const file of this.foldFiles()) {
+      entries.push({
+        line: file.headerLine,
+        display: file.summary,
+        filterText: file.path.toLowerCase(),
+        name: file.path,
+      });
+    }
+    entries.sort((a, b) => a.line - b.line);
+    return entries;
+  }
+
+  /** Re-derive the shown rows from the filter, keeping the selection in range. */
+  private refreshJump(): void {
+    const f = this.jumpFilter.toLowerCase();
+    this.jumpEntries = f.length === 0
+      ? this.jumpAll
+      : this.jumpAll.filter((e) => e.filterText.includes(f));
+    this.jumpSel = clamp(
+      this.jumpSel,
+      0,
+      Math.max(0, this.jumpEntries.length - 1),
+    );
+    this.scrollListToSelection(this.jumpSel);
+  }
+
+  /** The index of the entry the viewport currently sits on: the last one whose
+   * jump line is at or above the top document line. */
+  private jumpEntryAtViewport(): number {
+    const line = this.toDoc(this.top);
+    let idx = 0;
+    for (let i = 0; i < this.jumpEntries.length; i++) {
+      if (this.jumpEntries[i].line <= line) idx = i;
+      else break;
+    }
+    return idx;
+  }
+
+  private handleJumpList(key: Key): void {
+    this.message = "";
+    const last = Math.max(0, this.jumpEntries.length - 1);
+    switch (key.name) {
+      case "escape":
+        this.mode = "normal";
+        this.overlayScroll = 0;
+        this.message = "Cancelled";
+        return;
+      case "down":
+      case "ctrl-n":
+        this.jumpSel = clamp(this.jumpSel + 1, 0, last);
+        return this.scrollListToSelection(this.jumpSel);
+      case "up":
+      case "ctrl-p":
+        this.jumpSel = clamp(this.jumpSel - 1, 0, last);
+        return this.scrollListToSelection(this.jumpSel);
+      case "pagedown":
+        this.jumpSel = clamp(this.jumpSel + 10, 0, last);
+        return this.scrollListToSelection(this.jumpSel);
+      case "pageup":
+        this.jumpSel = clamp(this.jumpSel - 10, 0, last);
+        return this.scrollListToSelection(this.jumpSel);
+      case "backspace":
+        if (this.jumpFilter.length > 0) {
+          this.jumpFilter = this.jumpFilter.slice(0, -1);
+          this.jumpSel = 0;
+          this.refreshJump();
+        }
+        return;
+      case "tab":
+      case "enter":
+        this.activateJump();
+        return;
+    }
+    if (key.char && key.char >= " " && !key.ctrl) {
+      this.jumpFilter += key.char;
+      this.jumpSel = 0;
+      this.refreshJump();
+    }
+  }
+
+  /** Jump to the highlighted entry and close the list. A filter that matches
+   * nothing leaves the list open so it can be edited. */
+  private activateJump(): void {
+    const entry = this.jumpEntries[this.jumpSel];
+    if (!entry) return;
+    this.mode = "normal";
+    this.overlayScroll = 0;
+    this.jumpToLine(entry.line);
+    this.message = `Jumped to ${entry.name}`;
+  }
+
+  /** Land document line `docLine` at the top of the viewport, dropping any node
+   * selection so tree navigation resumes from where the jump landed. */
+  private jumpToLine(docLine: number): void {
+    this.selectedIndex = null;
+    this.top = clamp(
+      this.toDisplay(docLine),
+      0,
+      maxTop(this.displayCount(), this.height),
+    );
+    this.left = 0;
+  }
+
+  private jumpOverlay(): OverlayState {
+    const lines: Line[] = this.jumpEntries.map((e) => e.display);
+    if (lines.length === 0) {
+      const text = "(no matches)";
+      lines.push({ text, spans: [{ col: 0, text, cls: "comment" }] });
+    }
+    return {
+      title: "Jump to file or commit",
+      lines,
+      scroll: this.overlayScroll,
+      footer: "↑/↓ select · enter jump · esc cancel",
+      selectedLine: this.jumpEntries.length > 0 ? this.jumpSel : undefined,
+    };
+  }
+
   private navigateTree(
     step: (flat: readonly StructureNode[], idx: number) => number,
   ): void {
@@ -3310,6 +3519,21 @@ function isArrowName(name: string): boolean {
     name === "right";
 }
 
+/** The styled jump-list row for a commit: a bullet, the short hash, and the
+ * subject when one is known. */
+function commitJumpLine(shortSha: string, subject: string): Line {
+  const spans: Span[] = [];
+  let text = "";
+  const add = (s: string, cls: TokenClass) => {
+    spans.push({ col: cpLen(text), text: s, cls });
+    text += s;
+  };
+  add("● ", "diffMeta");
+  add(`commit ${shortSha}`, "sectionHeader");
+  if (subject) add(`  ${subject}`, "plain");
+  return { text, spans };
+}
+
 export function helpOverlay(): {
   title: string;
   info: Line[];
@@ -3336,6 +3560,7 @@ export function helpOverlay(): {
     ["  f", "hide / show the file under the cursor (collapse to a summary)"],
     ["  F / E", "hide all files / show all files"],
     ["  T", "hide test and test-support files"],
+    ["  i", "list the diff's files and commits, jump to one"],
     ["", ""],
     ["Structure tree", ""],
     ["  W / S", "previous / next sibling (W → parent, S → out, at ends)"],

--- a/packages/cli/support/profiling/cf-profile-lib.test.ts
+++ b/packages/cli/support/profiling/cf-profile-lib.test.ts
@@ -1,8 +1,11 @@
 import { assert, assertEquals, assertMatch, assertThrows } from "@std/assert";
 import {
+  createProfileOutputRelay,
+  DEBUGGER_WAITING_MESSAGE,
   escapeRegex,
   findInspectorWebSocketUrl,
   inspectWaitFlag,
+  type KillableProcess,
   mirrorOutput,
   parseProfileArgs,
   pickInspectPort,
@@ -202,6 +205,58 @@ Deno.test("stopCaptureOnce records a sent signal when kill fails", () => {
   });
 
   assertEquals(state.sent, true);
+});
+
+Deno.test("createProfileOutputRelay resolves the inspector URL exactly once", () => {
+  const urls: string[] = [];
+  const { onCliOutput } = createProfileOutputRelay({
+    captureRef: {},
+    captureStopState: { sent: false },
+    captureStopSignal: "SIGTERM",
+    onInspectorUrl: (url) => urls.push(url),
+  });
+
+  onCliOutput("startup noise\n");
+  onCliOutput("Debugger listening on ws://127.0.0.1:9229/abc\n");
+  // A later inspector line does not resolve a second time.
+  onCliOutput("Debugger listening on ws://127.0.0.1:9229/def\n");
+
+  assertEquals(urls, ["ws://127.0.0.1:9229/abc"]);
+});
+
+Deno.test("createProfileOutputRelay stops the capture on the debugger-waiting message", () => {
+  const signals: Deno.Signal[] = [];
+  const captureStopState = { sent: false };
+  const captureRef: { current?: KillableProcess } = {
+    current: { kill: (signal) => signals.push(signal) },
+  };
+  const { onCliOutput } = createProfileOutputRelay({
+    captureRef,
+    captureStopState,
+    captureStopSignal: "SIGTERM",
+    onInspectorUrl: () => {},
+  });
+
+  onCliOutput(`${DEBUGGER_WAITING_MESSAGE}\n`);
+
+  assertEquals(signals, ["SIGTERM"]);
+  assertEquals(captureStopState.sent, true);
+});
+
+Deno.test("createProfileOutputRelay's stopCapture is inert before a capture starts", () => {
+  const captureStopState = { sent: false };
+  const { onCliOutput, stopCapture } = createProfileOutputRelay({
+    captureRef: {}, // the capture process has not spawned yet
+    captureStopState,
+    captureStopSignal: "SIGTERM",
+    onInspectorUrl: () => {},
+  });
+
+  // The debugger message can arrive before the capture exists; nothing to signal.
+  onCliOutput(`${DEBUGGER_WAITING_MESSAGE}\n`);
+  stopCapture();
+
+  assertEquals(captureStopState.sent, false);
 });
 
 Deno.test("waitForCliStatusOrStopOnCaptureFailure stops the CLI after capture failure", async () => {

--- a/packages/cli/support/profiling/cf-profile-lib.ts
+++ b/packages/cli/support/profiling/cf-profile-lib.ts
@@ -18,7 +18,7 @@ export type CaptureStopState = {
 
 type CommandStatus = Deno.CommandStatus;
 
-type KillableProcess = {
+export type KillableProcess = {
   kill(signal: Deno.Signal): void;
 };
 
@@ -147,6 +147,50 @@ export function stopCaptureOnce(
   } catch {
     // Already exited.
   }
+}
+
+/**
+ * The pair of handlers cf-profile attaches to its child's mirrored stdout and
+ * stderr. `onCliOutput` keeps a bounded window of recent output, hands back the
+ * child's inspector WebSocket URL the first time it appears (through
+ * `onInspectorUrl`), and once the child prints the debugger-waiting message
+ * stops the capture. `stopCapture` signals the capture process, but only when
+ * one is running — its reference is filled in after the capture spawns. The
+ * recent-output window and the "URL already seen" flag live here so the caller
+ * only wires the dependencies.
+ */
+export function createProfileOutputRelay(deps: {
+  captureRef: { current?: KillableProcess };
+  captureStopState: CaptureStopState;
+  captureStopSignal: Deno.Signal;
+  onInspectorUrl: (url: string) => void;
+}): {
+  onCliOutput: (text: string) => void;
+  stopCapture: () => void;
+} {
+  let recentOutput = "";
+  let inspectorUrlFound = false;
+  const stopCapture = () => {
+    if (deps.captureRef.current) {
+      stopCaptureOnce(
+        deps.captureStopState,
+        deps.captureRef.current,
+        deps.captureStopSignal,
+      );
+    }
+  };
+  const onCliOutput = (text: string) => {
+    recentOutput = (recentOutput + text).slice(-8192);
+    const foundInspectorUrl = findInspectorWebSocketUrl(recentOutput);
+    if (foundInspectorUrl && !inspectorUrlFound) {
+      inspectorUrlFound = true;
+      deps.onInspectorUrl(foundInspectorUrl);
+    }
+    if (recentOutput.includes(DEBUGGER_WAITING_MESSAGE)) {
+      stopCapture();
+    }
+  };
+  return { onCliOutput, stopCapture };
 }
 
 export async function waitForCliStatusOrStopOnCaptureFailure(

--- a/packages/cli/support/profiling/cf-profile.ts
+++ b/packages/cli/support/profiling/cf-profile.ts
@@ -1,18 +1,17 @@
 import { dirname, fromFileUrl, join, resolve } from "@std/path";
 import { CAPTURE_STOP_SIGNAL } from "./capture-deno-inspector-profile-lib.ts";
 import {
-  DEBUGGER_WAITING_MESSAGE,
+  createProfileOutputRelay,
   DEFAULT_SUMMARY_PATTERN,
   DISABLED_SUMMARY_PATTERN,
-  findInspectorWebSocketUrl,
   inspectWaitFlag,
+  type KillableProcess,
   mirrorOutput,
   parseProfileArgs,
   pickInspectPort,
   profileTimestamp,
   profilingChildEnv,
   slugifyProfileName,
-  stopCaptureOnce,
   waitForCliStatusOrStopOnCaptureFailure,
 } from "./cf-profile-lib.ts";
 
@@ -80,29 +79,16 @@ const cliCommand = new Deno.Command(Deno.execPath(), {
 const captureStopState = { sent: false };
 const inspectorUrl = Promise.withResolvers<string>();
 const cliStatusPromise = cliCommand.status;
-let recentOutput = "";
-let inspectorUrlFound = false;
-const captureRef: { current?: Deno.ChildProcess } = {};
-const stopCapture = () => {
-  if (captureRef.current) {
-    // SIGTERM, not SIGINT, so an interactive Ctrl-C stays available to the user;
-    // the capture handles both identically, and its exit-time guard covers this
-    // signal (see guardCaptureStopSignal).
-    stopCaptureOnce(captureStopState, captureRef.current, CAPTURE_STOP_SIGNAL);
-  }
-};
-
-const onCliOutput = (text: string) => {
-  recentOutput = (recentOutput + text).slice(-8192);
-  const foundInspectorUrl = findInspectorWebSocketUrl(recentOutput);
-  if (foundInspectorUrl && !inspectorUrlFound) {
-    inspectorUrlFound = true;
-    inspectorUrl.resolve(foundInspectorUrl);
-  }
-  if (recentOutput.includes(DEBUGGER_WAITING_MESSAGE)) {
-    stopCapture();
-  }
-};
+const captureRef: { current?: KillableProcess } = {};
+const { onCliOutput, stopCapture } = createProfileOutputRelay({
+  captureRef,
+  captureStopState,
+  // SIGTERM, not SIGINT, so an interactive Ctrl-C stays available to the user;
+  // the capture handles both identically, and its exit-time guard covers this
+  // signal (see guardCaptureStopSignal).
+  captureStopSignal: CAPTURE_STOP_SIGNAL,
+  onInspectorUrl: (url) => inspectorUrl.resolve(url),
+});
 const stdoutDone = mirrorOutput(
   cliCommand.stdout,
   Deno.stdout,

--- a/packages/cli/test/view-commitmsg.test.ts
+++ b/packages/cli/test/view-commitmsg.test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import {
+  commitSubjects,
   extractMessage,
   findCommitHeaders,
   findCommitMessages,
@@ -129,6 +130,71 @@ Deno.test("findCommitMessages: a commit with no message body yields no region", 
   const lines = ["commit deadbeef", "Author: A", "", "diff --git a/f b/f"];
   assertEquals(findCommitMessages(lines).length, 0);
   assertEquals(findCommitHeaders(lines), [{ sha: "deadbeef", line: 0 }]);
+});
+
+Deno.test("commitSubjects: the first indented body line of a standard commit", () => {
+  const subjects = commitSubjects(SHOW);
+  assertEquals(
+    subjects.get("0123456789abcdef0123456789abcdef01234567"),
+    "Subject line",
+  );
+});
+
+Deno.test("commitSubjects: the text after the hash of a compact header", () => {
+  const full = "0123456789abcdef0123456789abcdef01234567";
+  assertEquals(
+    commitSubjects([`${full} Add the feature`, "diff --git a/f b/f"]).get(full),
+    "Add the feature",
+  );
+});
+
+Deno.test("commitSubjects: the Subject header of an email patch, prefix stripped", () => {
+  const full = "0123456789abcdef0123456789abcdef01234567";
+  const subjects = commitSubjects([
+    `From ${full} Mon Sep 17 00:00:00 2001`,
+    "From: A B <a@b.example>",
+    "Date: Wed, 1 Jul 2026 12:00:00 -0700",
+    "Subject: [PATCH] Fix the alignment",
+    "",
+    "diff --git a/f b/f",
+  ]);
+  assertEquals(subjects.get(full), "Fix the alignment");
+});
+
+Deno.test("commitSubjects: an email Subject wrapped over continuation lines", () => {
+  const full = "0123456789abcdef0123456789abcdef01234567";
+  const subjects = commitSubjects([
+    `From ${full} Mon Sep 17 00:00:00 2001`,
+    "From: A B <a@b.example>",
+    "Date: Wed, 1 Jul 2026 12:00:00 -0700",
+    "Subject: [PATCH v2 2/3] Rework the reconciliation path so that it",
+    " no longer drops pending writes",
+    "",
+    "diff --git a/f b/f",
+  ]);
+  assertEquals(
+    subjects.get(full),
+    "Rework the reconciliation path so that it no longer drops pending writes",
+  );
+});
+
+Deno.test("commitSubjects: a header after the email Subject ends it", () => {
+  const full = "0123456789abcdef0123456789abcdef01234567";
+  const subjects = commitSubjects([
+    `From ${full} Mon Sep 17 00:00:00 2001`,
+    "From: A B <a@b.example>",
+    "Date: Wed, 1 Jul 2026 12:00:00 -0700",
+    "Subject: [PATCH] Fix it",
+    "Content-Type: text/plain; charset=UTF-8",
+    "",
+    "diff --git a/f b/f",
+  ]);
+  assertEquals(subjects.get(full), "Fix it");
+});
+
+Deno.test("commitSubjects: a commit with no discernible subject is absent", () => {
+  const lines = ["commit deadbeef", "Author: A", "", "diff --git a/f b/f"];
+  assertEquals(commitSubjects(lines).has("deadbeef"), false);
 });
 
 Deno.test("messageAt: maps a row to its region or null", () => {

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -1,0 +1,319 @@
+/**
+ * The jump list (`i`): a dialog over a diff view listing the files it touches
+ * and any commit messages it carries, with Enter jumping the viewport to the
+ * chosen one. A read-only diff (its files do not resolve on disk) is enough —
+ * the list is derived from the diff text itself.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Session } from "../lib/view/session.ts";
+import { parseDiff } from "../lib/view/diff.ts";
+import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
+import { diffSource } from "../lib/view/diffedit.ts";
+import { parseDocument } from "../lib/view/parse.ts";
+
+function press(s: Session, ...names: string[]): void {
+  for (const name of names) {
+    s.handleKey(
+      name.length === 1 && name >= " " ? { name, char: name } : { name },
+    );
+  }
+}
+
+function type(s: Session, text: string): void {
+  for (const ch of text) s.handleKey({ name: ch, char: ch });
+}
+
+/** A diff session over `diffText` whose files do not resolve on disk (read-only,
+ * but still a diff, so the jump list is offered). */
+function diffSession(diffText: string, height = 20): Session {
+  const ws: DiffWorkspace = { resolve: () => null, read: () => null };
+  const model = parseDiff(diffText)!;
+  const { doc, edit } = buildDiffDocument(diffText, model, ws);
+  return new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 80, height },
+    undefined,
+    diffSource(ws, edit),
+  );
+}
+
+function entryText(s: Session): string[] {
+  return s.view().overlay?.lines.map((l) => l.text) ?? [];
+}
+
+const TWO_FILES = [
+  "diff --git a/src/app.ts b/src/app.ts",
+  "index 1111111..2222222 100644",
+  "--- a/src/app.ts",
+  "+++ b/src/app.ts",
+  "@@ -1,2 +1,2 @@",
+  " keep",
+  "-old",
+  "+new",
+  "diff --git a/src/app.test.ts b/src/app.test.ts",
+  "index 3333333..4444444 100644",
+  "--- a/src/app.test.ts",
+  "+++ b/src/app.test.ts",
+  "@@ -1 +1,2 @@",
+  " x",
+  "+added",
+  "",
+].join("\n");
+
+// A `git show` of a single commit: the header, its indented message, then the
+// diff. app.ts's header is line 6, its test file's line 14.
+const SHOW = [
+  "commit 0123456789abcdef0123456789abcdef01234567",
+  "Author: Someone <someone@example.com>",
+  "Date:   Mon Jul 21 12:00:00 2026 +0000",
+  "",
+  "    Fix the widget alignment",
+  "",
+  "diff --git a/src/app.ts b/src/app.ts",
+  "index 1111111..2222222 100644",
+  "--- a/src/app.ts",
+  "+++ b/src/app.ts",
+  "@@ -1,2 +1,2 @@",
+  " keep",
+  "-old",
+  "+new",
+  "diff --git a/src/app.test.ts b/src/app.test.ts",
+  "index 3333333..4444444 100644",
+  "--- a/src/app.test.ts",
+  "+++ b/src/app.test.ts",
+  "@@ -1 +1,2 @@",
+  " x",
+  "+added",
+  "",
+].join("\n");
+
+Deno.test("jumplist: i lists the diff's files, dirs summarised", () => {
+  const s = diffSession(TWO_FILES);
+  press(s, "i");
+  assertEquals(entryText(s), [
+    "▸ src/app.ts  +1 −1",
+    "▸ src/app.test.ts  +1 −0",
+  ]);
+  assertEquals(s.view().inputLine, "jump to: ");
+  assertEquals(s.view().overlay?.title, "Jump to file or commit");
+  assertEquals(s.view().overlay?.selectedLine, 0);
+});
+
+Deno.test("jumplist: a git show lists the commit message before its files", () => {
+  const s = diffSession(SHOW);
+  press(s, "i");
+  assertEquals(entryText(s), [
+    "● commit 012345678  Fix the widget alignment",
+    "▸ src/app.ts  +1 −1",
+    "▸ src/app.test.ts  +1 −0",
+  ]);
+});
+
+Deno.test("jumplist: enter on a file jumps the viewport to its header line", () => {
+  // A short viewport, so the last file's header can reach the very top.
+  const s = diffSession(SHOW, 6);
+  press(s, "i");
+  press(s, "down", "down"); // commit -> app.ts -> app.test.ts
+  assertEquals(s.view().overlay?.selectedLine, 2);
+  press(s, "enter");
+  assertEquals(s.view().overlay, null, "list closed");
+  assertEquals(s.view().top, 14, "app.test.ts header is line 14");
+  assert(s.view().message.includes("src/app.test.ts"));
+});
+
+Deno.test("jumplist: enter on the commit entry jumps to the commit header", () => {
+  const s = diffSession(SHOW, 8);
+  press(s, "G"); // scroll to the bottom, away from the commit
+  assert(s.view().top > 0);
+  press(s, "i");
+  press(s, "up", "up", "up", "up"); // climb back to the commit entry (index 0)
+  assertEquals(s.view().overlay?.selectedLine, 0);
+  press(s, "enter");
+  assertEquals(s.view().top, 0, "the commit header is line 0");
+  assert(s.view().message.includes("commit 012345678"));
+});
+
+Deno.test("jumplist: pagedown and pageup jump the selection to the ends", () => {
+  const s = diffSession(LOG);
+  press(s, "i");
+  assertEquals(s.view().overlay?.selectedLine, 0);
+  press(s, "pagedown");
+  assertEquals(s.view().overlay?.selectedLine, 3, "clamped to the last entry");
+  press(s, "pageup");
+  assertEquals(s.view().overlay?.selectedLine, 0, "clamped to the first entry");
+});
+
+Deno.test("jumplist: tab jumps the same as enter", () => {
+  const s = diffSession(SHOW, 6);
+  press(s, "i", "down"); // preselected commit -> src/app.ts
+  press(s, "tab");
+  assertEquals(s.view().overlay, null, "list closed");
+  assertEquals(s.view().message, "Jumped to src/app.ts");
+});
+
+Deno.test("jumplist: typing filters the list", () => {
+  const s = diffSession(SHOW);
+  press(s, "i");
+  type(s, "test");
+  assertEquals(entryText(s), ["▸ src/app.test.ts  +1 −0"]);
+  assertEquals(s.view().inputLine, "jump to: test");
+  // Backspacing widens it again.
+  press(s, "backspace", "backspace", "backspace", "backspace");
+  assertEquals(entryText(s).length, 3);
+});
+
+Deno.test("jumplist: a filter matching the commit subject keeps the commit", () => {
+  const s = diffSession(SHOW);
+  press(s, "i");
+  type(s, "widget");
+  assertEquals(entryText(s), ["● commit 012345678  Fix the widget alignment"]);
+});
+
+Deno.test("jumplist: enter with no match leaves the list open", () => {
+  const s = diffSession(SHOW);
+  press(s, "down", "down"); // scroll off the top so "unmoved" is meaningful
+  const top = s.view().top;
+  assert(top > 0);
+  press(s, "i");
+  type(s, "zzz");
+  assertEquals(entryText(s), ["(no matches)"]);
+  press(s, "enter");
+  assert(s.view().overlay !== null, "still open");
+  assertEquals(s.view().top, top, "viewport unmoved");
+});
+
+Deno.test("jumplist: escape cancels and leaves the viewport put", () => {
+  const s = diffSession(SHOW);
+  press(s, "down"); // move the viewport off line 0
+  const top = s.view().top;
+  press(s, "i", "down", "down"); // open and move the selection
+  press(s, "escape");
+  assertEquals(s.view().overlay, null);
+  assertEquals(s.view().message, "Cancelled");
+  assertEquals(s.view().top, top, "the view did not move");
+});
+
+Deno.test("jumplist: opening preselects the file the viewport is on", () => {
+  const s = diffSession(SHOW, 6);
+  // Put app.test.ts's header (line 14) at the top of the viewport.
+  press(s, "i", "down", "down", "enter");
+  assertEquals(s.view().top, 14);
+  press(s, "i");
+  assertEquals(
+    s.view().overlay?.selectedLine,
+    2,
+    "reopening lands on app.test.ts",
+  );
+});
+
+// A `git log -p` of two commits, newest first, each with its own file.
+const LOG = [
+  "commit a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+  "Author: A <a@example.com>",
+  "Date:   Mon Jul 21 13:00:00 2026 +0000",
+  "",
+  "    Second change",
+  "",
+  "diff --git a/b.ts b/b.ts",
+  "index 3333333..4444444 100644",
+  "--- a/b.ts",
+  "+++ b/b.ts",
+  "@@ -1 +1 @@",
+  "-p",
+  "+q",
+  "commit b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+  "Author: B <b@example.com>",
+  "Date:   Mon Jul 21 12:00:00 2026 +0000",
+  "",
+  "    First change",
+  "",
+  "diff --git a/a.ts b/a.ts",
+  "index 1111111..2222222 100644",
+  "--- a/a.ts",
+  "+++ b/a.ts",
+  "@@ -1 +1 @@",
+  "-x",
+  "+y",
+  "",
+].join("\n");
+
+Deno.test("jumplist: git log -p interleaves each commit with its own files", () => {
+  const s = diffSession(LOG);
+  press(s, "i");
+  assertEquals(entryText(s), [
+    "● commit a1a1a1a1a  Second change",
+    "▸ b.ts  +1 −1",
+    "● commit b2b2b2b2b  First change",
+    "▸ a.ts  +1 −1",
+  ]);
+});
+
+Deno.test("jumplist: files stay listed and jumpable while collapsed", () => {
+  const s = diffSession(SHOW, 6);
+  press(s, "F"); // collapse every file to a summary line
+  press(s, "i");
+  assertEquals(entryText(s).length, 3, "commit and both files still listed");
+  press(s, "down", "down", "enter"); // commit -> app.ts -> app.test.ts
+  assert(s.view().message.includes("src/app.test.ts"));
+  // The jump scrolls the collapsed file's summary row into the viewport.
+  const rows = s.displayDoc().lines.map((l) => l.text);
+  const summaryRow = rows.findIndex((t) => t.startsWith("▸ src/app.test.ts"));
+  const top = s.view().top;
+  assert(
+    summaryRow >= top && summaryRow < top + 5,
+    `summary row ${summaryRow} visible in [${top}, ${top + 5})`,
+  );
+});
+
+Deno.test("jumplist: i on a non-diff view says it is diff-only", () => {
+  const doc = parseDocument("const a = 1;\n", "a.ts");
+  const s = new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 80, height: 20 },
+  );
+  press(s, "i");
+  assertEquals(s.view().overlay, null);
+  assert(s.view().message.includes("only available in a diff view"));
+});
+
+// `git format-patch` output: an email envelope whose subject sits on the
+// `Subject:` header rather than an indented body.
+const EMAIL = [
+  "From 0123456789abcdef0123456789abcdef01234567 Mon Sep 17 00:00:00 2001",
+  "From: Someone <someone@example.com>",
+  "Date: Mon, 21 Jul 2026 12:00:00 +0000",
+  "Subject: [PATCH] Fix the widget alignment",
+  "",
+  "diff --git a/src/app.ts b/src/app.ts",
+  "index 1111111..2222222 100644",
+  "--- a/src/app.ts",
+  "+++ b/src/app.ts",
+  "@@ -1,2 +1,2 @@",
+  " keep",
+  "-old",
+  "+new",
+  "",
+].join("\n");
+
+Deno.test("jumplist: an email patch shows and filters by its Subject", () => {
+  const s = diffSession(EMAIL);
+  press(s, "i");
+  assertEquals(entryText(s), [
+    "● commit 012345678  Fix the widget alignment",
+    "▸ src/app.ts  +1 −1",
+  ]);
+  // The subject (with its [PATCH] prefix stripped) is filterable.
+  type(s, "widget");
+  assertEquals(entryText(s), ["● commit 012345678  Fix the widget alignment"]);
+});
+
+Deno.test("jumplist: a plain diff with no commit lists only files", () => {
+  const s = diffSession(TWO_FILES);
+  press(s, "i");
+  assert(
+    entryText(s).every((t) => t.startsWith("▸")),
+    "no commit entry without a commit header",
+  );
+});


### PR DESCRIPTION
Reading a large diff in the `cf view` pager, moving to a specific file means paging or searching for its header. This adds a jump list: pressing `i` while viewing a diff opens a dialog listing every file the diff touches (shown with the same path and add/remove-count summary as a collapsed file) and, for `git show` / `git log -p` / `git format-patch` output, each commit whose message the diff carries. Selecting an entry moves the viewport to that file's header or the commit's `commit <hash>` line.

The list opens on the file the viewport is already reading, supports the same up/down/page and Ctrl-N/Ctrl-P motions as the file picker, and filters incrementally as you type — matching file paths as well as commit hashes and subjects, so a big multi-commit log can be narrowed quickly. Enter or Tab jumps; Escape cancels without moving. The list is offered only for a diff view; a plain source view reports that and stays put.

Commit rows are located with findCommitHeaders, which recognises the standard, compact, and email formats, so a commit appears and jumps correctly regardless of format. Their subjects come from a new commitSubjects in commitmsg.ts, which sits alongside the rest of the commit-format parsing and covers all three shapes: the first line of the indented message, the text after the hash on a compact one-line header, and the `Subject:` header of a format-patch email — with its `[PATCH …]` prefix removed and any continuation lines folded in.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787475999&installation_model_id=428580&pr_number=4983&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4983&signature=9a6d9ffda2728f1995b7c103d67bc7c0795054a85809d0c257a4db844d8068ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Jump to file or commit” dialog to the `cf view` diff pager (press i) to quickly navigate large diffs; also extract the profiler’s output relay for deterministic behavior and unit tests.

- **New Features**
  - Press `i` in a diff to open “Jump to file or commit”; lists each file (+/− summary) and each commit from `git show` / `git log -p` / `git format-patch`. Type to filter by path, hash, or subject (handles wrapped email Subjects; `[PATCH …]` stripped). Navigate with ↑/↓, PageUp/PageDown, or Ctrl‑N/Ctrl‑P; Enter/Tab jump; Esc cancels. Opens on the current file; works with collapsed files and read‑only diffs; diff‑only. Help updated. Adds `commitSubjects` and detects commit headers/subjects across standard, compact (`--oneline`), and email formats. Tests cover subject parsing and jump behavior.

- **Refactors**
  - Extracted `createProfileOutputRelay` to `cf-profile-lib.ts` and updated `cf-profile.ts` to use it. Resolves the inspector URL exactly once and stops the capture on the debugger‑waiting message; inert before the capture starts. Exported `KillableProcess`. Added unit tests to make coverage deterministic.

<sup>Written for commit b99c68c797d5bf462654f07cc108af73eb281898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

