### PR TITLE
ci: cache the SQLite native library across runs

### DIFF
--- a/.github/actions/deno-setup/action.yml
+++ b/.github/actions/deno-setup/action.yml
@@ -107,3 +107,81 @@ runs:
         restore-keys: |
           deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}-
           deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-
+
+    # The @db/sqlite FFI driver downloads its native library (libsqlite3) from a
+    # GitHub release the first time a process opens a database, via @denosaurs/plug.
+    # Plug caches the library under <DENO_DIR>/plug, which is ~/.cache/deno/plug on
+    # the Linux runners. Left to the deno-deps cache above, that library would be
+    # evicted on every unrelated dependency change, because that cache's key hashes
+    # the whole lockfile; each eviction re-exposes the run-time download, and a
+    # transient GitHub failure there fails the job. A separate cache keyed on only
+    # the resolved driver version survives unrelated dependency changes, so the
+    # download happens at most once per driver version.
+    #
+    # The provisioning is best-effort. The download runs in every job that opts into
+    # dependency caching, but a failure only warns, so a job that never opens a
+    # database (lint, build, deploy) is not failed by a SQLite download. The cache is
+    # saved only after `deno task initialize-db` both fetches the library and opens a
+    # database with it, and only when the library is present under a cached path — so
+    # a flaked, partial, or misplaced (custom DENO_DIR) download never persists an
+    # empty entry under the immutable version key. Restore and save are split for
+    # that reason: the combined actions/cache saves in a post-job step that runs even
+    # after the job fails.
+    #
+    # Cache version: bump the `deno-sqlite-v1` token to invalidate all SQLite caches.
+    - name: 🔍 Resolve SQLite driver version
+      id: sqlite
+      if: inputs.cache == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # deno.lock's specifiers map records the exact resolved version in a line
+        # of the form "jsr:@db/sqlite@<version>": "<version>". Take the first such
+        # mapping's value and stop there.
+        version="$(awk -F'"' '/^[[:space:]]*"jsr:@db\/sqlite@[^"]*":[[:space:]]*"[0-9]/ { print $4; exit }' deno.lock)"
+        if [ -z "$version" ]; then
+          # Degrade to the lazy run-time download rather than failing every job that
+          # uses this action.
+          echo "::warning::Could not resolve the @db/sqlite version from deno.lock; skipping the SQLite library cache."
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: 🗃️ Restore SQLite native library ${{ steps.sqlite.outputs.version }}
+      id: sqlite-cache
+      if: inputs.cache == 'true' && steps.sqlite.outputs.version != ''
+      uses: actions/cache/restore@v6
+      with:
+        path: |
+          ~/.cache/deno/plug
+          ~/Library/Caches/deno/plug
+        key: deno-sqlite-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.sqlite.outputs.version }}
+
+    - name: 📥 Download SQLite native library ${{ steps.sqlite.outputs.version }}
+      id: sqlite-download
+      # Open an in-memory database once so @db/sqlite fetches and exercises the
+      # native library, then confirm it landed under a cached directory. Non-fatal:
+      # on failure the library is left to be fetched lazily at run time.
+      if: inputs.cache == 'true' && steps.sqlite.outputs.version != '' && steps.sqlite-cache.outputs.cache-hit != 'true'
+      continue-on-error: true
+      shell: bash
+      run: |
+        set -euo pipefail
+        deno task initialize-db
+        for dir in "$HOME/.cache/deno/plug" "$HOME/Library/Caches/deno/plug"; do
+          if [ -n "$(find "$dir" -type f \( -name '*.so' -o -name '*.dylib' -o -name '*.dll' \) 2>/dev/null)" ]; then
+            exit 0
+          fi
+        done
+        echo "::warning::SQLite library not found under the cached plug directories; skipping cache save."
+        exit 1
+
+    - name: 💾 Save SQLite native library ${{ steps.sqlite.outputs.version }}
+      # Runs only after a verified download, so a failed or misplaced download never
+      # persists an empty cache under this version's key.
+      if: inputs.cache == 'true' && steps.sqlite.outputs.version != '' && steps.sqlite-cache.outputs.cache-hit != 'true' && steps.sqlite-download.outcome == 'success'
+      uses: actions/cache/save@v6
+      with:
+        path: |
+          ~/.cache/deno/plug
+          ~/Library/Caches/deno/plug
+        key: deno-sqlite-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.sqlite.outputs.version }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,9 +25,6 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 📥 Download Deno dependency binaries
-        run: deno task initialize-db
-
       - name: 🏋️ Run benchmarks
         env:
           CF_LOG_LEVEL: silent

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -173,9 +173,6 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 📥 Download Deno dependency binaries
-        run: deno task initialize-db
-
       - name: 🧪 Run runner tests
         working-directory: packages/runner
         env:
@@ -321,9 +318,6 @@ jobs:
           shard: ${{ matrix.shard }}
           cache-file: ${{ github.workspace }}/.compile-cache/generated-patterns-${{ matrix.shard }}.json
           exact-hit: ${{ steps.compile-cache.outputs.cache-hit }}
-
-      - name: 📥 Download Deno dependency binaries
-        run: deno task initialize-db
 
       - name: 🧪 Run generated patterns integration tests
         working-directory: packages/generated-patterns
@@ -843,9 +837,6 @@ jobs:
 
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
-
-      - name: 📥 Download Deno dependency binaries
-        run: deno task initialize-db
 
       - name: ♻️ Restore/save pattern unit compile byte cache
         id: compile-cache


### PR DESCRIPTION
CI jobs that touch SQLite intermittently fail while loading the native library. The @db/sqlite FFI driver fetches libsqlite3 from a GitHub release the first time any process opens a database, through @denosaurs/plug, and that fetch runs at test time against github.com on every run. A transient failure there fails the job; one Generated Patterns integration run died with "error reading a body from connection" while downloading libsqlite3.so.

Plug caches the library under <DENO_DIR>/plug, which is ~/.cache/deno/plug on the Linux runners. The existing deno-deps cache nominally spans that path but cannot carry the library: its key hashes the whole lockfile, so the binary is evicted on every unrelated dependency change, and the cache is saved by whichever job first misses the key — usually a job that populates the module graph without ever opening a database, so the saved tarball holds no plug binary. Three jobs front-loaded the fetch with an explicit "deno task initialize-db" step, but front-loading only moves the same flaky download earlier; it does not remove it, and every other SQLite job stayed exposed.

Cache the plug directory under its own key — the resolved @db/sqlite version read from deno.lock — mirroring how the Deno toolchain binary is already cached. On a hit the library loads from disk with no network contact; on a miss a single in-memory database open fetches it and it is saved for later runs. The download then happens at most once per driver version rather than on every run. Keying on the driver version rather than the whole lockfile keeps an unrelated dependency change from evicting the library.

The provisioning lives in the shared deno-setup action so every SQLite job is covered, not just the three that front-loaded it; those explicit "deno task initialize-db" steps (in the runner, generated-patterns, pattern-unit, and benchmarks jobs) are removed. Three properties keep the cache robust:

- Restore and save are split. The combined actions/cache saves in a post-job step that runs even after the job fails; because plug creates its cache directory before reading the release body, a body-read failure would leave an empty directory that the post-job save then stored under the immutable version key, wedging every later run into a cache hit that skips the download yet has no library. The save step now runs only after the download step both fetches the library and opens a database with it, and only once the library is confirmed present under a cached path — so a flaked, partial, or misplaced (custom DENO_DIR) download never persists an empty entry.

- The download is best-effort. It runs in every job that opts into dependency caching, including lint, build, and deploy jobs that never open a database. Marking it continue-on-error means a transient GitHub failure only warns: a job that does not use SQLite is never failed by a SQLite download, and a job that does use it falls back to the run-time fetch it would otherwise have done.

- The version parse degrades gracefully. It reads deno.lock with an awk match that stops at the first specifier mapping, avoiding the SIGPIPE fragility of sed piped into head under pipefail. An unresolvable version warns and skips the cache instead of failing every job that uses the action, so a future lockfile-format change cannot wedge the whole pipeline.

The steps follow the same input gate as the deno-deps cache, so jobs that opt out of dependency caching (deploys, coverage aggregation) skip the SQLite provisioning entirely.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787481503&installation_model_id=428580&pr_number=4984&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4984&signature=a645ee72987eb90dd3a4ddcd3780c01d2d4023ed826afa5a2a13df896299d104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache the SQLite native library across CI runs via the shared `deno-setup` action, keyed by the resolved `@db/sqlite` version, to remove flaky `@denosaurs/plug` downloads and stabilize SQLite jobs. On a cache miss, we prefetch with an in-memory DB open and save only after verifying the library.

- **Bug Fixes**
  - Cache the `@denosaurs/plug` directory by `@db/sqlite` version from `deno.lock`, so unrelated dependency changes don’t evict the binary.
  - Prefetch is best-effort (`continue-on-error`): non-SQLite jobs never fail; SQLite jobs fall back to the runtime fetch.

- **Refactors**
  - Split restore/save and only save after verification; version parsing uses `awk` and degrades to runtime fetch if unresolved.
  - Moved provisioning into `deno-setup` and removed manual `initialize-db` steps in runner, generated-patterns, pattern-unit, and benchmarks workflows.

<sup>Written for commit c2b161a7067d8c5b4fb761bc76d091330e3ecbeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

