### PR TITLE
fix(runner): retry a reactive recompute off-budget on a same-replica …

### DIFF
--- a/packages/runner/src/scheduler/constants.ts
+++ b/packages/runner/src/scheduler/constants.ts
@@ -38,6 +38,15 @@ export const MAX_ACTION_RUN_TRACE_HISTORY = 2000;
 // above any normal burst, so it never changes ordinary delivery.
 export const MAX_EVENT_BACKLOG_PER_STREAM = 256;
 export const MAX_RETRIES_FOR_REACTIVE = 10;
+// A stale-basis rejection (conflict / same-replica race) is retried off the
+// bounded budget, on the assumption that the action's subscription will
+// eventually deliver the value it is waiting on. That holds for pattern-created
+// reactive functions, which go through the cell machinery, but a bug that never
+// closes the loop — historically a serialization round-trip that fails to
+// preserve a value (a stray `-0`, say) — would spin here forever. Emit a
+// non-fatal diagnostic every this-many off-budget re-queues of one action so the
+// loop is visible rather than silent.
+export const OFF_BUDGET_RETRY_WARN_INTERVAL = 100;
 export const AUTO_DEBOUNCE_THRESHOLD_MS = 50;
 export const AUTO_DEBOUNCE_MIN_RUNS = 3;
 export const AUTO_DEBOUNCE_DELAY_MS = 100;

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -425,6 +425,7 @@ export class Scheduler {
   private triggerIndex = new SchedulerTriggerIndex();
   private actionChangeGroups = new WeakMap<Action, ChangeGroup>();
   private retries = new WeakMap<Action, number>();
+  private offBudgetRetries = new WeakMap<Action, number>();
 
   // Effect/computation tracking for pull-based scheduling
   private nodes = new NodeRegistry();
@@ -2499,6 +2500,7 @@ export class Scheduler {
       actionChangeGroups: this.actionChangeGroups,
       actionTimingState: this.actionTimingState,
       retries: this.retries,
+      offBudgetRetries: this.offBudgetRetries,
       pending: this.pending,
       actionRunTrace: this.actionRunTrace,
       nodes: this.nodes,

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -201,11 +201,12 @@ export function watchReactiveActionCommit(state: {
     }
 
     // Non-conflict failures are NOT re-triggered by reader-dirty — a transient
-    // transport error, or the path-blind local StorageTransactionInconsistent
-    // guard that fires before the engine's granular matcher — so they still
-    // warrant a bounded retry. On every attempt we still resubscribe, so even
-    // after the budget is exhausted the action is re-triggered when its input
-    // data changes.
+    // transport or malformed-store error — so they still warrant a bounded
+    // retry to make progress. Unlike a stale basis (a conflict or the local
+    // same-replica-race guard, both handled off-budget above), re-running does
+    // not resolve them, so the budget bounds the wasted attempts. On every
+    // attempt we still resubscribe, so even after the budget is exhausted the
+    // action is re-triggered when its input data changes.
     const retries = (state.retries.get(state.action) ?? 0) + 1;
     state.retries.set(state.action, retries);
     if (retries < MAX_RETRIES_FOR_REACTIVE) {

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -11,6 +11,7 @@ import type {
 import {
   isConflictRejection,
   isPermanentRejection,
+  isStorageTransactionInconsistent,
   isTerminalRejection,
 } from "../storage/rejection.ts";
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
@@ -128,14 +129,22 @@ export function watchReactiveActionCommit(state: {
       error,
     );
 
-    // A reactive compute is not a transactional retrier. A CONFLICT (stale read)
-    // means one of its inputs moved: the authoritative version is ahead of this
-    // replica, and the action's read set is stale until the replica catches up
-    // (the conflict's `readyToRetry` gates exactly that catch-up). Re-arm the
-    // subscription, wait for the catch-up, then re-run the action against the
-    // fresh state. A conflict is a WAIT, not a failure, so it does NOT consume
-    // the retry budget — otherwise sustained contention would exhaust the budget
-    // and strand the compute as a zombie against rolled-back data.
+    // A reactive compute is not a transactional retrier. A stale-basis rejection
+    // means the value the action read is no longer current, so re-running against
+    // fresh state and committing again converges. Two rejections are stale-basis.
+    // A CONFLICT is an upstream stale read: the authoritative version is ahead of
+    // this replica, and the action's read set is stale until the replica catches
+    // up (the conflict's `readyToRetry` gates exactly that catch-up). A
+    // STORAGE-TRANSACTION-INCONSISTENT is the local analogue: a value the
+    // transaction read changed on this replica between the read and the commit,
+    // which re-running against the settled replica resolves. It carries no
+    // `readyToRetry`, so the re-queue below runs it afresh once the local write
+    // completes. Re-arm the subscription, wait for any catch-up, then re-run.
+    // Both are a WAIT, not a failure, so neither consumes the retry budget —
+    // otherwise sustained contention would exhaust the budget and strand the
+    // compute as a zombie against rolled-back data. Only a rejection that
+    // re-running cannot resolve (transport, malformed store) takes the bounded
+    // budget below.
     //
     // Reader-dirty propagation also re-triggers the action when the catch-up
     // write lands as a fresh notification, but that does not cover every
@@ -146,7 +155,7 @@ export function watchReactiveActionCommit(state: {
     // reader-dirty is a redundant fast path (the re-dirty/pending/queue calls
     // coalesce). Restore the consumed trigger reads (§8.9.2) so the re-run's
     // transaction still carries their flow labels.
-    if (isConflictRejection(error)) {
+    if (isConflictRejection(error) || isStorageTransactionInconsistent(error)) {
       // Re-arm immediately (restore the consumed trigger reads §8.9.2, then
       // resubscribe) so the subscription stays fresh and a concurrent
       // reader-dirty can re-trigger the action while we wait for the catch-up.

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -18,6 +18,7 @@ import { sortAndCompactPaths } from "../reactive-dependencies.ts";
 import {
   MAX_ACTION_RUN_TRACE_HISTORY,
   MAX_RETRIES_FOR_REACTIVE,
+  OFF_BUDGET_RETRY_WARN_INTERVAL,
 } from "./constants.ts";
 import {
   captureDiagnosisRecord,
@@ -109,17 +110,20 @@ export function watchReactiveActionCommit(state: {
   readonly tx: IExtendedStorageTransaction;
   readonly log: ReactivityLog;
   readonly retries: WeakMap<Action, number>;
+  readonly offBudgetRetries: WeakMap<Action, number>;
   readonly pending: Set<Action>;
   readonly commitPromise: ReturnType<IExtendedStorageTransaction["commit"]>;
   readonly resubscribe: (action: Action, log: ReactivityLog) => void;
   readonly markInvalid: (action: Action) => void;
   readonly queueExecution: () => void;
   readonly restoreInvalidCauses: () => void;
+  readonly getActionId: (action: Action) => string;
 }): void {
   state.commitPromise.then(async ({ error }) => {
     if (!error) {
       // Clear retries after successful commit.
       state.retries.delete(state.action);
+      state.offBudgetRetries.delete(state.action);
       return;
     }
 
@@ -139,8 +143,11 @@ export function watchReactiveActionCommit(state: {
     // transaction read changed on this replica between the read and the commit,
     // which re-running against the settled replica resolves. It carries no
     // `readyToRetry`, so the re-queue below runs it afresh once the local write
-    // completes. Re-arm the subscription, wait for any catch-up, then re-run.
-    // Both are a WAIT, not a failure, so neither consumes the retry budget —
+    // completes. Wait for any catch-up, then re-queue the action to re-run
+    // against fresh state; its subscription is already live, so the steps below
+    // refresh it and restore the trigger reads the run consumed rather than
+    // establishing a subscription that was torn down. Both are a WAIT, not a
+    // failure, so neither consumes the retry budget —
     // otherwise sustained contention would exhaust the budget and strand the
     // compute as a zombie against rolled-back data. Only a rejection that
     // re-running cannot resolve (transport, malformed store) takes the bounded
@@ -156,6 +163,27 @@ export function watchReactiveActionCommit(state: {
     // coalesce). Restore the consumed trigger reads (§8.9.2) so the re-run's
     // transaction still carries their flow labels.
     if (isConflictRejection(error) || isStorageTransactionInconsistent(error)) {
+      // This retry rides off the bounded budget on the assumption that the
+      // subscription eventually delivers the awaited value — true for
+      // pattern-created reactive functions, which go through the cell machinery.
+      // A bug that never closes the loop (historically a serialization
+      // round-trip that dropped a value) would re-queue forever, so surface a
+      // non-fatal diagnostic every OFF_BUDGET_RETRY_WARN_INTERVAL re-queues
+      // rather than spinning silently. The count clears on the next successful,
+      // permanent, or terminal commit.
+      const offBudgetRetries = (state.offBudgetRetries.get(state.action) ?? 0) +
+        1;
+      state.offBudgetRetries.set(state.action, offBudgetRetries);
+      if (offBudgetRetries % OFF_BUDGET_RETRY_WARN_INTERVAL === 0) {
+        logger.error(
+          "reactive-retry-not-converging",
+          () => [
+            `reactive action ${state.getActionId(state.action)} re-queued ` +
+            `${offBudgetRetries} times on a stale-basis rejection without ` +
+            `converging; its subscription may never deliver the awaited value`,
+          ],
+        );
+      }
       // Re-arm immediately (restore the consumed trigger reads §8.9.2, then
       // resubscribe) so the subscription stays fresh and a concurrent
       // reader-dirty can re-trigger the action while we wait for the catch-up.
@@ -197,6 +225,7 @@ export function watchReactiveActionCommit(state: {
     // change re-triggers.
     if (isPermanentRejection(error) || isTerminalRejection(error)) {
       state.retries.delete(state.action);
+      state.offBudgetRetries.delete(state.action);
       return;
     }
 
@@ -278,6 +307,7 @@ export interface SchedulerActionRunState {
   readonly actionChangeGroups: WeakMap<Action, ChangeGroup>;
   readonly actionTimingState: ActionTimingState;
   readonly retries: WeakMap<Action, number>;
+  readonly offBudgetRetries: WeakMap<Action, number>;
   readonly pending: Set<Action>;
   readonly actionRunTrace: ActionRunTraceEntry[];
   readonly nodes: NodeRegistry;
@@ -546,11 +576,13 @@ function finalizeReactiveActionCommit(
     tx: args.tx,
     log: committedLog,
     retries: state.retries,
+    offBudgetRetries: state.offBudgetRetries,
     pending: state.pending,
     commitPromise,
     resubscribe: state.resubscribe,
     markInvalid: state.markInvalid,
     queueExecution: state.queueExecution,
+    getActionId: state.getActionId,
     restoreInvalidCauses: () => {
       const record = state.nodes.get(args.action);
       if (

--- a/packages/runner/src/storage/rejection.ts
+++ b/packages/runner/src/storage/rejection.ts
@@ -53,8 +53,12 @@ export function isTerminalRejection(
  * wait-for-catch-up, not a failure. (Reader-dirty propagation re-triggers it too
  * when the catch-up write lands as a fresh notification, but that does not cover
  * a conflict whose triggering write was already delivered, so the re-queue is
- * what guarantees re-evaluation.) Other non-permanent errors are not
- * catch-up-recoverable and keep their bounded retry instead.
+ * what guarantees re-evaluation.) The reactive path recovers the local
+ * stale-basis guard (`isStorageTransactionInconsistent`) the same way — it too
+ * converges by re-running, so it re-queues off the budget rather than stranding
+ * a compute as a zombie under a contention burst. Only a non-permanent error
+ * that re-running cannot resolve — a transport or malformed-store error — keeps
+ * the bounded retry.
  *
  * The event-handler commit path treats the same rejection as the signal to
  * apply committed-write backpressure: re-running the handler against fresh

--- a/packages/runner/test/reactive-stale-basis-strand.test.ts
+++ b/packages/runner/test/reactive-stale-basis-strand.test.ts
@@ -1,0 +1,231 @@
+// Regression for a reactive-compute convergence strand: a subscription-driven
+// recompute that hits a burst of same-replica-race rejections
+// (StorageTransactionInconsistent) must converge, not exhaust a bounded retry
+// budget and strand at its stale value.
+//
+// This is the reactive-path analogue of the event-handler residual closed in
+// mergeable-append-multispace-conflict.test.ts. StorageTransactionInconsistent
+// is a stale-basis rejection: a value the transaction read changed on this
+// replica between the read and the commit, which re-running against the settled
+// replica resolves (see packages/runner/src/storage/rejection.ts). A conflict —
+// the upstream stale-read analogue — has always been retried off the reactive
+// budget (a WAIT for catch-up, not a failure). The local same-replica race was
+// not: it fell into the bounded MAX_RETRIES_FOR_REACTIVE path alongside genuinely
+// terminal transport/malformed errors, so a burst longer than the budget left the
+// compute a permanent zombie against the pre-storm value — nothing re-triggers it
+// once the input stops changing.
+//
+// The multiplayer symptom this guards against: two sessions share a piece; a
+// second session's per-session derived view (its own materialized recompute of
+// shared state) reacts to the first session's write. Under contention its
+// commits hit the same-replica race; past ten of them the view sticks at the
+// stale value while the writer's own view is correct. Multiplayer "the other
+// browser's view is stuck" flakes can take this shape.
+//
+// The test drives it deterministically: two runtimes share one piece; the second
+// runtime's replica commits are failed with a StorageTransactionInconsistent
+// burst longer than the budget, then let through. The first runtime bumps the
+// shared input; the second must still converge its own derived output.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { MAX_RETRIES_FOR_REACTIVE } from "../src/scheduler/constants.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("reactive-stale-basis-strand");
+const space = signer.did();
+
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+  private sharedServer!: MemoryV2Server.Server;
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+
+// Shared `input`; a per-session `output` each session materializes from the input
+// via a lift. The second session reacting to the first session's input change is
+// a standalone reactive commit (the subscription-triggered recompute path), not a
+// lift folded into its own runtime's event commit. `output` is per-session so the
+// reacting session's strand is observable on its own partition rather than masked
+// by the writer's committed value arriving over the wire.
+const SRC = [
+  "import { pattern, handler, lift, Writable } from 'commonfabric';",
+  "const bump = handler<{ v: number }, { input: Writable<number> }>((e, { input }) => { input.set(e.v); });",
+  "const mirror = lift<{ input: number; output: Writable<number> }, void>(({ input, output }) => { output.set(input * 2); });",
+  "export default pattern(() => {",
+  "  const input = new Writable<number>(1).for('input');",
+  "  const output = Writable.perSession.of<number>(0);",
+  "  mirror({ input, output });",
+  "  return { input, output, bump: bump({ input }) };",
+  "});",
+].join("\n");
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents: SRC }],
+};
+
+const RESULT_CAUSE = "reactive-stale-basis-strand host";
+
+function makeRuntime(server: MemoryV2Server.Server) {
+  const storage = SharedServerStorageManager.connectTo(server, { as: signer });
+  const rt = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: storage,
+  });
+  return { rt, storage };
+}
+
+describe("reactive recompute survives a same-replica-race burst", () => {
+  let server: MemoryV2Server.Server;
+  beforeEach(() => {
+    server = newSharedServer();
+  });
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it("a subscription-driven recompute converges past a StorageTransactionInconsistent burst", async () => {
+    const { rt: rt1, storage: s1 } = makeRuntime(server);
+    const { rt: rt2, storage: s2 } = makeRuntime(server);
+    try {
+      // rt1 creates the piece; rt2 opens the same piece by result cause.
+      const tx1 = rt1.edit();
+      const parent1 = await rt1.patternManager.compilePattern(PROGRAM, {
+        space,
+        tx: tx1,
+      });
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx1,
+      );
+      // deno-lint-ignore no-explicit-any
+      const h1 = rt1.run(tx1, parent1 as any, {}, resultCell1);
+      rt1.prepareTxForCommit(tx1);
+      expect((await tx1.commit()).error).toBeUndefined();
+      h1.key("output").sink(() => {});
+      await h1.pull();
+      await rt1.idle();
+      await s1.synced();
+
+      const tx2 = rt2.edit();
+      const parent2 = await rt2.patternManager.compilePattern(PROGRAM, {
+        space,
+        tx: tx2,
+      });
+      const resultCell2 = rt2.getCell<Record<string, unknown>>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx2,
+      );
+      // deno-lint-ignore no-explicit-any
+      const h2 = rt2.run(tx2, parent2 as any, {}, resultCell2);
+      rt2.prepareTxForCommit(tx2);
+      // rt2 opens an already-created piece, so its setup write may conflict with
+      // rt1's committed setup; it re-derives from confirmed state, so a conflict
+      // here is expected and benign.
+      await tx2.commit();
+      h2.key("output").sink(() => {});
+      await h2.pull();
+      await rt2.idle();
+      await s2.synced();
+
+      // Both sessions seeded output = input * 2 = 2.
+      expect(h1.key("output").get()).toBe(2);
+      expect(h2.key("output").get()).toBe(2);
+
+      // Fail rt2's replica commits with a same-replica-race rejection for a burst
+      // LONGER than the reactive retry budget, then let them through. Pre-fix the
+      // recompute exhausts the budget on the burst and gives up; post-fix it
+      // rides the burst out off the budget, exactly as it does for a conflict.
+      const injectTotal = MAX_RETRIES_FOR_REACTIVE + 5;
+      const replica2 = s2.open(space).replica as unknown as {
+        commitNative: (...args: unknown[]) => Promise<unknown>;
+      };
+      const realCommit = replica2.commitNative.bind(replica2);
+      let gate = false;
+      let injectedRemaining = injectTotal;
+      replica2.commitNative = (...args: unknown[]) => {
+        if (gate && injectedRemaining > 0) {
+          injectedRemaining--;
+          return Promise.resolve({
+            error: {
+              name: "StorageTransactionInconsistent",
+              message: "injected same-replica race",
+            },
+          });
+        }
+        return realCommit(...args);
+      };
+
+      // rt1 bumps the shared input; rt2's per-session recompute reacts under the
+      // burst.
+      gate = true;
+      const bumpTx = rt1.edit();
+      h1.withTx(bumpTx).key("bump").send({ v: 7 });
+      expect((await bumpTx.commit()).error).toBeUndefined();
+      await rt1.idle();
+      await s1.synced();
+
+      // Settle rt2 across the burst: receive the subscription push and re-run the
+      // recompute. A fixed number of drain rounds — each awaits real completion,
+      // no wall-clock wait.
+      for (let i = 0; i < 12; i++) {
+        await h2.pull();
+        await rt2.idle();
+        await s2.synced();
+      }
+      gate = false;
+      for (let i = 0; i < 8; i++) {
+        await h2.pull();
+        await rt2.idle();
+        await s2.synced();
+      }
+
+      // rt1 (uninjected) always converges.
+      expect(h1.key("output").get()).toBe(14);
+      // The burst was consumed in full — the recompute rode it out rather than
+      // giving up at the budget.
+      expect(injectedRemaining).toBe(0);
+      // rt2's per-session recompute converges to the fresh value instead of
+      // stranding at the pre-storm 2.
+      expect(h2.key("output").get()).toBe(14);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+      await s1.close();
+      await s2.close();
+    }
+  });
+});

--- a/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
+++ b/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
@@ -233,11 +233,13 @@ describe("trigger reads survive failed runs", () => {
       tx,
       log: { reads: [], shallowReads: [], writes: [] },
       retries: args.retries ?? new WeakMap(),
+      offBudgetRetries: new WeakMap(),
       pending: new Set(),
       commitPromise,
       resubscribe: () => args.onResubscribe?.(),
       markInvalid: () => args.onMarkInvalid?.(),
       queueExecution: () => args.onQueueExecution?.(),
+      getActionId: () => "test-action",
       restoreInvalidCauses: args.onRestore,
     });
     return commitPromise.then(async () => {

--- a/packages/runner/test/scheduler-retries.test.ts
+++ b/packages/runner/test/scheduler-retries.test.ts
@@ -163,6 +163,20 @@ describe("reactive retries", () => {
   );
 
   it(
+    "retries a same-replica-race rejection off the bounded budget",
+    async () => {
+      // StorageTransactionInconsistent is a stale-basis rejection, like a
+      // conflict: re-running against the settled replica resolves it. It re-arms
+      // and re-queues WITHOUT charging the counter, so a burst longer than the
+      // budget cannot strand the compute as a zombie. Contrast the generic
+      // TransactionError above, which does charge the counter.
+      const r = await runWatcher("StorageTransactionInconsistent", 0);
+      expect(r.queued).toBe(1);
+      expect(r.retries.has(r.action)).toBe(false);
+    },
+  );
+
+  it(
     "should preserve dependencies when retrying failed commits",
     async () => {
       // This test documents expected behavior for the conflict storm fix:

--- a/packages/runner/test/scheduler-retries.test.ts
+++ b/packages/runner/test/scheduler-retries.test.ts
@@ -94,10 +94,15 @@ describe("reactive retries", () => {
   const runWatcher = async (
     errorName: string | undefined,
     initialRetries: number,
+    // Share `action` + `offBudgetRetries` across calls to accumulate an
+    // off-budget streak; both default to fresh per call.
+    shared?: { action: Action; offBudgetRetries: WeakMap<Action, number> },
   ) => {
-    const action = (() => {}) as unknown as Action;
+    const action = shared?.action ?? ((() => {}) as unknown as Action);
     const retries = new WeakMap<Action, number>();
     if (initialRetries > 0) retries.set(action, initialRetries);
+    const offBudgetRetries = shared?.offBudgetRetries ??
+      new WeakMap<Action, number>();
     let queued = 0;
     let resubscribed = 0;
     const error = errorName === undefined
@@ -111,6 +116,7 @@ describe("reactive retries", () => {
       tx: {} as IExtendedStorageTransaction,
       log: {} as ReactivityLog,
       retries,
+      offBudgetRetries,
       pending: new Set<Action>(),
       commitPromise,
       resubscribe: () => {
@@ -120,11 +126,12 @@ describe("reactive retries", () => {
       queueExecution: () => {
         queued++;
       },
+      getActionId: () => "test-action",
       restoreInvalidCauses: () => {},
     });
     await commitPromise;
     await new Promise((r) => setTimeout(r, 0));
-    return { queued, resubscribed, retries, action };
+    return { queued, resubscribed, retries, offBudgetRetries, action };
   };
 
   it(
@@ -173,6 +180,30 @@ describe("reactive retries", () => {
       const r = await runWatcher("StorageTransactionInconsistent", 0);
       expect(r.queued).toBe(1);
       expect(r.retries.has(r.action)).toBe(false);
+      // Off-budget re-queues are counted separately, for the never-converging
+      // diagnostic, without charging the bounded budget.
+      expect(r.offBudgetRetries.get(r.action)).toBe(1);
+    },
+  );
+
+  it(
+    "accumulates the off-budget re-queue count across stale-basis retries and clears it on convergence",
+    async () => {
+      // The off-budget retry assumes the subscription eventually delivers the
+      // value. Its re-queue count accumulates across attempts (both stale-basis
+      // classes), separate from the bounded budget, so a never-closing loop can
+      // be surfaced every OFF_BUDGET_RETRY_WARN_INTERVAL re-queues. It clears
+      // when the action finally converges.
+      const shared = {
+        action: (() => {}) as unknown as Action,
+        offBudgetRetries: new WeakMap<Action, number>(),
+      };
+      await runWatcher("StorageTransactionInconsistent", 0, shared);
+      await runWatcher("ConflictError", 0, shared);
+      expect(shared.offBudgetRetries.get(shared.action)).toBe(2);
+      // A successful commit ends the streak and clears the count.
+      await runWatcher(undefined, 0, shared);
+      expect(shared.offBudgetRetries.has(shared.action)).toBe(false);
     },
   );
 


### PR DESCRIPTION
…race

A reactive compute's commit can fail with StorageTransactionInconsistent: a value the transaction read changed on this replica between the read and the commit. Like a ConflictError, this is a stale-basis rejection that converges by re-running against the settled replica. The reactive commit-result path in the scheduler already handles a ConflictError that way — it re-arms the subscription and re-queues the action off the retry budget, because a stale basis is a wait for catch-up, not a failure — but it did not extend the same treatment to the local same-replica race. StorageTransactionInconsistent instead fell into the bounded MAX_RETRIES_FOR_REACTIVE path, alongside genuinely terminal transport and malformed-store errors.

The consequence is a permanent strand. Under a burst of same-replica races longer than the budget, the recompute exhausts its retries and gives up, leaving its output at the pre-burst value. Nothing re-triggers it once its inputs stop changing, so the stale value persists. In a multi-session setup this shows as a second session's per-session derived view — its own recompute of shared state — that never advances to reflect a write it observed, while the writer's own view is correct.

Treat StorageTransactionInconsistent like a ConflictError in the reactive commit-result path: re-arm and re-queue without charging the retry budget, so the recompute rides out a burst of any length and converges once it clears. This mirrors the event-handler commit path, which already windows the same local stale-basis guard. Only a rejection that re-running cannot resolve keeps the bounded budget.

Pinned by two tests: a scheduler-retries unit assertion that a same-replica race re-queues off the budget (contrasting a generic transient, which charges it), and a two-runtime integration test in which a per-session reactive recompute, its commits failed with a StorageTransactionInconsistent burst longer than the budget, must still converge to the fresh value instead of stranding. The second fails against the pre-fix scheduler. The rejection.ts comment describing the reactive path's retry classification is updated to match.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787481810&installation_model_id=428580&pr_number=4985&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4985&signature=dd21b6464cbe9b3606b9e7ca70075a5998796983359cc1bd966dec5a70bff256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries reactive recomputes off-budget on same-replica race bursts to prevent strands. Aligns `StorageTransactionInconsistent` with conflicts, and adds a periodic diagnostic if off-budget retries never converge.

- **Bug Fixes**
  - Treat `StorageTransactionInconsistent` as stale-basis in the reactive commit path: restore trigger reads, resubscribe, and re-queue without charging `MAX_RETRIES_FOR_REACTIVE`; clear on success or permanent/terminal rejection.
  - Count off-budget retry streaks per action and log a non-fatal diagnostic every `OFF_BUDGET_RETRY_WARN_INTERVAL` (100). Added unit tests for classification and streak accumulate/clear, plus a two-runtime integration test verifying convergence past a burst longer than the budget.
  - Plumb `offBudgetRetries` through the scheduler and update test harnesses to pass `offBudgetRetries` and `getActionId` to `watchReactiveActionCommit`.

<sup>Written for commit a18ddd852e5417ce336425d4ad245a93859b8d93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

