### PR TITLE
memory/storage/cli: surface authorization failures as a terminating e…

### DIFF
--- a/docs/development/authorization-failure-surfacing.md
+++ b/docs/development/authorization-failure-surfacing.md
@@ -1,0 +1,117 @@
+# Surfacing authorization failures from storage sync
+
+An authorization failure — a client and server disagreeing over an
+`EXPERIMENTAL_*` option that trips the ACL, an audience mismatch, or a plain ACL
+denial — must reach a caller waiting on storage sync as a real, typed error
+rather than a silent absent read or an endless wait. Getting there spans three
+layers: the memory protocol classifies the failure, the memory client acts on
+that classification during reconnect, the runner storage layer records it per
+space, and the CLI surfaces it. This document describes how the pieces fit.
+
+## The classification: recoverable versus permanent
+
+The pivot is telling apart an authorization failure a retry can heal from one it
+never will. A `session.open` is denied for one of two kinds of reason:
+
+- **Recoverable (retriable).** The connection-challenge and invocation-freshness
+  anti-replay checks: an expired, already-used, or mismatched challenge, or a
+  stale signed `exp`. Each reconnect runs a fresh `hello` that issues a new
+  challenge, so these do not recur — a token-refresh window or a challenge race
+  heals on the next attempt.
+- **Permanent.** An audience or protocol mismatch, a malformed invocation, or an
+  ACL capability shortfall (the principal lacks `READ`, a malformed or ownerless
+  ACL, a genesis requirement). The same configuration or ACL state produces the
+  same denial every time.
+
+The server marks the recoverable subset with `retriable: true` on the
+`AuthorizationError` response (see
+[`../specs/memory-v2/04-protocol.md`](../specs/memory-v2/04-protocol.md)); every
+other authorization failure is permanent. The marker rides the wire so the
+client classifies without parsing error messages. A server that sends no marker
+is read as permanent — the safe default for an authorization decision.
+
+## Memory client: terminate rather than loop
+
+`packages/memory/v2/client.ts` acts on the classification during reconnect:
+
+- A **permanent** authorization denial reopening a session terminates just that
+  session with the real error, the same way a `session/revoked` does: its
+  outstanding commits and caught-up waiters reject with it, and its next watch or
+  transact rethrows it. This holds for a denial anywhere in the reopen — the
+  `session.open` itself or the watch re-establishment a fresh (non-resumed)
+  reopen issues. Sessions for other spaces on the same client keep running: a
+  denial on one space is not a client-wide failure.
+- A **retriable** authorization race and every transport-level disconnect retry,
+  so a transient blip or a fresh-challenge race heals.
+- A **permanent protocol-flag mismatch at `hello`** — the peers disagree on a
+  data-model wire contract, so no session can open at all — stops the whole
+  reconnect loop and is remembered, so every request on that
+  fundamentally-incompatible transport fails fast with the real error.
+
+The reconnect loop therefore has no unbounded retry-on-anything path: a permanent
+failure ends it (per session for an authorization denial, client-wide for a
+handshake mismatch), and only recoverable and transport-level conditions retry.
+
+## Runner storage: record it per space, keep the barrier silent
+
+`packages/runner/src/storage/v2.ts` preserves the failure and exposes it without
+changing what the sync barrier does:
+
+- `toPullError` keeps a real `AuthorizationError` — its name, message, and the
+  `retriable` marker — rather than flattening it to a `ConnectionError`.
+  `PullError` admits `AuthorizationError`.
+- Each replica holds its current authorization status: a permanent
+  (non-retriable) `AuthorizationError` from a watch refresh is remembered, and a
+  successful refresh clears it. A transient connection error or a retriable race
+  leaves it unchanged, so a blip neither masks nor manufactures a denial.
+- `synced()` resolves quietly on a denial, and a per-doc `sync()` reads the doc
+  as absent. This is deliberate: a denied read collapses to a silent absent
+  value, so a denied CROSS-SPACE link — a pattern that reads data in a space the
+  viewer cannot access — does not fail the reader. The global sync barrier
+  aggregates every open space, so rejecting there would fail a whole runtime
+  settle on one incidental unauthorized link.
+- `StorageManager.authorizationError(space)` returns the remembered, throwable
+  error for a SPECIFIC space, or undefined when it is authorized. A caller that
+  must reach a particular space reads this after `synced()` and surfaces it
+  deliberately, so the denial is scoped to the space the caller asked for and
+  never leaks onto an unrelated cross-space read.
+
+## CLI: surface the denial for the space it was asked to reach
+
+The CLI waits on storage sync in three places — `loadManager`, the ACL
+operations, and the headless wish read — and none uses a wall-clock guard. Each
+calls `synced()`, then reads `storageManager.authorizationError(space)` for the
+one space it operates on, after that space has been pulled, and throws the real
+`AuthorizationError` when it is set. The ACL check runs after the ACL read or
+write, since that access is what opens and pulls the space; the wish check reads
+only its own space, so a denied cross-space profile load stays the expected "no
+profile yet" absent read.
+
+The `newPiece` 60-second bound is unrelated and remains. That hang is a scheduler
+`idle()` park in `getResult(piece).pull()` waiting for a pattern to quiesce — a
+different mechanism this signal does not cover.
+
+## Scope and trade-offs
+
+The reconnect classification governs reconnection for **every** memory client —
+shell, toolshed, the background piece service, and the CLI — not only the CLI. A
+permanent authorization failure terminates with a typed error, and the holder is
+expected to surface or recover from that error.
+
+Two properties follow from terminating rather than looping:
+
+- **No in-process auto-heal after a later grant.** A terminated session does not
+  reopen on its own, so a holder that wants to pick up an ACL granted moments
+  later recreates the session (or the storage manager). Retrying a denied reopen
+  until an administrator acts is the retry-loop the engineering principles
+  forbid; the CLI reports the error and exits. A genuinely transient or
+  recoverable condition — a token-refresh window, a challenge race, every
+  transport blip — still heals, because it is classified retriable.
+- **A wedged-but-reachable backend still waits.** With no wall-clock guard, a
+  backend that completes the handshake but then never answers the authenticated
+  sync (and never closes the transport) leaves `synced()` waiting with no event
+  to terminate it — the same liveness gap the builtins and the scheduler share,
+  not specific to authorization. A backend that is simply down is caught earlier:
+  the CLI's `healthCheck()` probe fails first. A wall-clock bound here would again
+  fail a legitimately slow but healthy sync, so the liveness signal belongs in
+  the transport layer.

--- a/docs/history/packages/cli/piece-timeout-hangs-investigation.md
+++ b/docs/history/packages/cli/piece-timeout-hangs-investigation.md
@@ -3,6 +3,7 @@ status: historical
 created: 2026-07-22
 archived: 2026-07-22
 reason: "Investigation of the three CLI piece-library timeouts; records why the tool-result poll was replaced event-driven and why the piece-start and sync bounds could not be removed at the CLI layer."
+superseded-by: docs/development/authorization-failure-surfacing.md
 ---
 
 # CLI piece-library timeouts: which are removable, and why

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -222,6 +222,16 @@ Rules:
 - after reconnect, the client resumes the session, replays retained commits,
   applies inline catch-up `sync` when present, and only re-establishes the
   watch set if the session was reopened fresh
+- a `session.open` denied with an `AuthorizationError` the server did NOT mark
+  `retriable` is permanent: the client stops reopening that session and
+  terminates it with the real error rather than retrying the identical handshake
+  forever. A `retriable` authorization race (an expired, used, or mismatched
+  challenge; a stale signed `exp`) and every transport-level disconnect still
+  retry, so a transient blip or a fresh-challenge race heals. A permanent
+  protocol-flag mismatch at `hello` ends the whole connection the same way. See
+  [`../../development/authorization-failure-surfacing.md`](../../development/authorization-failure-surfacing.md)
+  for how the client, the runner storage layer, and the CLI act on this
+  classification end to end.
 
 ## 4.2 Message Format
 
@@ -276,7 +286,18 @@ interface ResponseMessage<Result> {
   type: "response";
   requestId: string;
   ok?: Result;
-  error?: { name: string; message: string };
+  error?: {
+    name: string;
+    message: string;
+    // On an AuthorizationError, present and `true` when the denial is an
+    // anti-replay handshake race a fresh reconnect heals (an expired, used, or
+    // mismatched connection challenge; a stale signed `exp`). Absent marks a
+    // permanent denial — an audience or protocol mismatch, or an ACL capability
+    // shortfall — that no retry changes. The client uses it to decide whether to
+    // keep reopening a denied session or to terminate it. An older server sends
+    // no marker, so its AuthorizationError is read as permanent.
+    retriable?: boolean;
+  };
 }
 
 interface SessionEffect<Effect> {

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -13,7 +13,6 @@ import {
   type Capability,
   isACLUser,
 } from "@commonfabric/memory/acl";
-import { awaitSyncWithTimeout } from "./utils.ts";
 
 export interface SpaceConfig {
   apiUrl: URL;
@@ -56,8 +55,21 @@ export async function createRuntime(
     throw new Error(`Could not connect to "${config.apiUrl.toString()}".`);
   }
 
-  await awaitSyncWithTimeout(runtime.storageManager.synced());
+  await runtime.storageManager.synced();
   return runtime;
+}
+
+// Surface a permanent authorization denial (an ACL shortfall, an audience or
+// protocol mismatch) on this space with the server's real error. Called AFTER an
+// ACL read/write has pulled the space, since that pull is what opens the space's
+// provider and records the denial; a denied read otherwise collapses to a silent
+// "no ACL" and a denied write already rejects on its own, but this makes a
+// read-only `get` fail loudly with the real cause too.
+function throwIfSpaceDenied(runtime: Runtime, space: Session["space"]): void {
+  const authError = runtime.storageManager.authorizationError?.(space);
+  if (authError) {
+    throw authError;
+  }
 }
 
 // Add or update an ACL entry for a DID
@@ -71,6 +83,7 @@ export async function setAclEntry(
   await using runtime = await createRuntime(config, session);
   const aclManager = new ACLManager(runtime, session.space);
   await aclManager.set(userDid, capability);
+  throwIfSpaceDenied(runtime, session.space);
 }
 
 // Remove an ACL entry for a DID
@@ -83,6 +96,7 @@ export async function removeAclEntry(
   await using runtime = await createRuntime(config, session);
   const aclManager = new ACLManager(runtime, session.space);
   await aclManager.remove(userDid);
+  throwIfSpaceDenied(runtime, session.space);
 }
 
 // Get the current ACL for a space
@@ -92,7 +106,9 @@ export async function getAcl(
   const session = await loadSession(config);
   await using runtime = await createRuntime(config, session);
   const aclManager = new ACLManager(runtime, session.space);
-  return await aclManager.get();
+  const acl = await aclManager.get();
+  throwIfSpaceDenied(runtime, session.space);
+  return acl;
 }
 
 // Use "ANYONE" on the command line to map to "*"

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -13,6 +13,7 @@ import {
   type Capability,
   isACLUser,
 } from "@commonfabric/memory/acl";
+import { throwOnSpaceAuthorizationError } from "./utils.ts";
 
 export interface SpaceConfig {
   apiUrl: URL;
@@ -59,19 +60,6 @@ export async function createRuntime(
   return runtime;
 }
 
-// Surface a permanent authorization denial (an ACL shortfall, an audience or
-// protocol mismatch) on this space with the server's real error. Called AFTER an
-// ACL read/write has pulled the space, since that pull is what opens the space's
-// provider and records the denial; a denied read otherwise collapses to a silent
-// "no ACL" and a denied write already rejects on its own, but this makes a
-// read-only `get` fail loudly with the real cause too.
-function throwIfSpaceDenied(runtime: Runtime, space: Session["space"]): void {
-  const authError = runtime.storageManager.authorizationError?.(space);
-  if (authError) {
-    throw authError;
-  }
-}
-
 // Add or update an ACL entry for a DID
 export async function setAclEntry(
   config: SpaceConfig,
@@ -83,7 +71,10 @@ export async function setAclEntry(
   await using runtime = await createRuntime(config, session);
   const aclManager = new ACLManager(runtime, session.space);
   await aclManager.set(userDid, capability);
-  throwIfSpaceDenied(runtime, session.space);
+  // Checked AFTER the ACL access, which is what pulls the space and records any
+  // denial. A denied write already rejects above; this also fails a read that
+  // otherwise collapses to a silent "no ACL".
+  throwOnSpaceAuthorizationError(runtime.storageManager, session.space);
 }
 
 // Remove an ACL entry for a DID
@@ -96,7 +87,7 @@ export async function removeAclEntry(
   await using runtime = await createRuntime(config, session);
   const aclManager = new ACLManager(runtime, session.space);
   await aclManager.remove(userDid);
-  throwIfSpaceDenied(runtime, session.space);
+  throwOnSpaceAuthorizationError(runtime.storageManager, session.space);
 }
 
 // Get the current ACL for a space
@@ -107,7 +98,7 @@ export async function getAcl(
   await using runtime = await createRuntime(config, session);
   const aclManager = new ACLManager(runtime, session.space);
   const acl = await aclManager.get();
-  throwIfSpaceDenied(runtime, session.space);
+  throwOnSpaceAuthorizationError(runtime.storageManager, session.space);
   return acl;
 }
 

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -48,7 +48,6 @@ import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { isPlainObject, isRecord } from "@commonfabric/utils/types";
 import { pinProgramFabricImports, renderPinRewrite } from "./fabric-deps.ts";
 import { isHandlerCell } from "../../fuse/callables.ts";
-import { awaitSyncWithTimeout } from "./utils.ts";
 import {
   callableCommandSpec,
   type CallableExecutionDeps,
@@ -355,10 +354,21 @@ export async function loadManager(config: SpaceConfig): Promise<PieceManager> {
       () => new PieceManager(session, runtime),
     );
     pieceManagerRef.current = pieceManager;
+    // `synced()` settles even when this space is permanently denied: the memory
+    // client terminates a denied session rather than retrying its reopen. It
+    // settles quietly, though — a denied cross-space link stays a silent absent
+    // read — so surface a denial on THIS space deliberately, with the server's
+    // real AuthorizationError.
     await timeCliPhase(
       "loadManager.synced",
-      () => awaitSyncWithTimeout(pieceManager.synced()),
+      () => pieceManager.synced(),
     );
+    const authError = runtime.storageManager.authorizationError?.(
+      session.space,
+    );
+    if (authError) {
+      throw authError;
+    }
     return pieceManager;
   });
 }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -48,6 +48,7 @@ import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { isPlainObject, isRecord } from "@commonfabric/utils/types";
 import { pinProgramFabricImports, renderPinRewrite } from "./fabric-deps.ts";
 import { isHandlerCell } from "../../fuse/callables.ts";
+import { throwOnSpaceAuthorizationError } from "./utils.ts";
 import {
   callableCommandSpec,
   type CallableExecutionDeps,
@@ -363,12 +364,7 @@ export async function loadManager(config: SpaceConfig): Promise<PieceManager> {
       "loadManager.synced",
       () => pieceManager.synced(),
     );
-    const authError = runtime.storageManager.authorizationError?.(
-      session.space,
-    );
-    if (authError) {
-      throw authError;
-    }
+    throwOnSpaceAuthorizationError(runtime.storageManager, session.space);
     return pieceManager;
   });
 }

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -8,33 +8,3 @@ export function absPath(relpath: string, cwd = Deno.cwd()): string {
   }
   return join(cwd, relpath);
 }
-
-const SYNC_TIMEOUT_MS = 30_000;
-
-/**
- * Await a `synced()` promise with a timeout. If sync takes too long,
- * throw with an actionable error message instead of hanging silently.
- */
-export async function awaitSyncWithTimeout(
-  syncPromise: Promise<void>,
-  timeoutMs: number = SYNC_TIMEOUT_MS,
-): Promise<void> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      reject(
-        new Error(
-          `Sync timed out after ${timeoutMs / 1000}s. ` +
-            `This often indicates a client/server configuration mismatch ` +
-            `(e.g., an EXPERIMENTAL_* option enabled on the server but not the CLI). ` +
-            `Check toolshed logs for AuthorizationError details.`,
-        ),
-      );
-    }, timeoutMs);
-  });
-  try {
-    await Promise.race([syncPromise, timeout]);
-  } finally {
-    clearTimeout(timer);
-  }
-}

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, join } from "@std/path";
+import type { MemorySpace } from "@commonfabric/runner";
 
 export function absPath(relpath: string, cwd = Deno.cwd()): string {
   // TODO(js): homedir check is not cross platform
@@ -7,4 +8,25 @@ export function absPath(relpath: string, cwd = Deno.cwd()): string {
     return relpath;
   }
   return join(cwd, relpath);
+}
+
+/**
+ * Surface a permanent authorization denial for `space` by throwing the storage
+ * layer's real `AuthorizationError`. The storage manager records a permanent
+ * denial (an ACL shortfall, an audience or protocol mismatch) per space but
+ * keeps `synced()` quiet — a denied cross-space link must stay a silent absent
+ * read — so a caller that must reach a specific space reads the per-space status
+ * after `synced()` and rethrows the real error here. A no-op when the space is
+ * authorized, or when the storage manager does not expose the status.
+ */
+export function throwOnSpaceAuthorizationError(
+  storageManager: {
+    authorizationError?: (space: MemorySpace) => Error | undefined;
+  },
+  space: MemorySpace,
+): void {
+  const authError = storageManager.authorizationError?.(space);
+  if (authError) {
+    throw authError;
+  }
 }

--- a/packages/cli/lib/wish.ts
+++ b/packages/cli/lib/wish.ts
@@ -8,7 +8,6 @@ import {
   type Runtime,
 } from "@commonfabric/runner";
 import { loadManager, type SpaceConfig } from "./piece.ts";
-import { awaitSyncWithTimeout } from "./utils.ts";
 
 /**
  * The blessed, headless read path for wish targets (CT-1834).
@@ -52,8 +51,6 @@ export interface WishSpec {
   schema?: JSONSchema;
   scope?: (DID | "~" | "." | "profile")[];
 }
-
-const WISH_SYNC_TIMEOUT_MS = 30_000;
 
 /**
  * Resolve a wish target headlessly against an already-constructed runtime.
@@ -110,10 +107,14 @@ export async function resolveWish(
   // when they materialize; pulling the result and syncing storage drains that.
   await result.pull();
   await runtime.idle();
-  await awaitSyncWithTimeout(
-    runtime.storageManager.synced(),
-    WISH_SYNC_TIMEOUT_MS,
-  );
+  await runtime.storageManager.synced();
+  // Surface a permanent authorization denial on the wish's own space with the
+  // real error. Scoped to `space`: a denied cross-space profile load stays a
+  // silent absent read, which is the wish's expected "no profile yet" outcome.
+  const authError = runtime.storageManager.authorizationError?.(space);
+  if (authError) {
+    throw authError;
+  }
   await result.pull();
   await runtime.idle();
 

--- a/packages/cli/lib/wish.ts
+++ b/packages/cli/lib/wish.ts
@@ -8,6 +8,7 @@ import {
   type Runtime,
 } from "@commonfabric/runner";
 import { loadManager, type SpaceConfig } from "./piece.ts";
+import { throwOnSpaceAuthorizationError } from "./utils.ts";
 
 /**
  * The blessed, headless read path for wish targets (CT-1834).
@@ -111,10 +112,7 @@ export async function resolveWish(
   // Surface a permanent authorization denial on the wish's own space with the
   // real error. Scoped to `space`: a denied cross-space profile load stays a
   // silent absent read, which is the wish's expected "no profile yet" outcome.
-  const authError = runtime.storageManager.authorizationError?.(space);
-  if (authError) {
-    throw authError;
-  }
+  throwOnSpaceAuthorizationError(runtime.storageManager, space);
   await result.pull();
   await runtime.idle();
 

--- a/packages/cli/test/utils.test.ts
+++ b/packages/cli/test/utils.test.ts
@@ -1,0 +1,44 @@
+import { assertEquals, assertStrictEquals, assertThrows } from "@std/assert";
+import type { MemorySpace } from "@commonfabric/runner";
+import { throwOnSpaceAuthorizationError } from "../lib/utils.ts";
+
+const SPACE = "did:key:z6Mk-cli-utils-authz-space" as MemorySpace;
+
+Deno.test("throwOnSpaceAuthorizationError rethrows the recorded denial", () => {
+  const denial = Object.assign(new Error("Principal lacks READ on space"), {
+    name: "AuthorizationError",
+  });
+  let asked: MemorySpace | undefined;
+  const error = assertThrows(
+    () =>
+      throwOnSpaceAuthorizationError({
+        authorizationError: (space) => {
+          asked = space;
+          return denial;
+        },
+      }, SPACE),
+    Error,
+    "lacks READ",
+  );
+  // The real error object is rethrown unchanged, scoped to the queried space.
+  assertStrictEquals(error, denial);
+  assertEquals((error as Error).name, "AuthorizationError");
+  assertEquals(asked, SPACE);
+});
+
+Deno.test("throwOnSpaceAuthorizationError is a no-op when the space is authorized", () => {
+  let asked: MemorySpace | undefined;
+  throwOnSpaceAuthorizationError({
+    authorizationError: (space) => {
+      asked = space;
+      return undefined;
+    },
+  }, SPACE);
+  assertEquals(asked, SPACE);
+});
+
+Deno.test("throwOnSpaceAuthorizationError is a no-op when the status is unavailable", () => {
+  // An emulated or older storage manager may not expose the per-space status;
+  // the optional call resolves to undefined and nothing is thrown.
+  throwOnSpaceAuthorizationError({}, SPACE);
+});

--- a/packages/cli/test/wish.test.ts
+++ b/packages/cli/test/wish.test.ts
@@ -113,6 +113,28 @@ describe("cf wish headless read (resolveWish)", () => {
     expect(error).toBe("No profile exists yet");
   });
 
+  it("surfaces a permanent authorization denial for the wish's space", async () => {
+    const denial = Object.assign(
+      new Error("Principal lacks READ on space"),
+      { name: "AuthorizationError" },
+    );
+    // The storage layer keeps synced() quiet on a denial and records it per
+    // space; resolveWish reads that status for its own space after syncing and
+    // rethrows the real error instead of returning an empty "no profile" result.
+    (storageManager as unknown as {
+      authorizationError: () => Error | undefined;
+    }).authorizationError = () => denial;
+
+    let thrown: unknown;
+    try {
+      await resolveWish(runtime, userIdentity.did(), { query: "#profile" });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBe(denial);
+    expect((thrown as Error).name).toBe("AuthorizationError");
+  });
+
   it("appends extra path segments to the resolved target", async () => {
     await seedProfile();
     const { result, error } = await resolveWish(runtime, userIdentity.did(), {

--- a/packages/memory/test/v2-client-reconnect-auth-test.ts
+++ b/packages/memory/test/v2-client-reconnect-auth-test.ts
@@ -1,0 +1,372 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+} from "../v2.ts";
+import { connect, type Transport } from "../v2/client.ts";
+
+const TEST_AUDIENCE = "did:key:z6Mk-reconnect-auth-audience";
+
+const helloOk = (flags = getMemoryProtocolFlags()) => ({
+  type: "hello.ok",
+  protocol: MEMORY_PROTOCOL,
+  flags,
+  sessionOpen: {
+    audience: TEST_AUDIENCE,
+    challenge: { value: "challenge:reconnect-auth", expiresAt: 1_000_000 },
+  },
+});
+
+const sessionOpenFor = (id: string) => ({
+  audience: TEST_AUDIENCE,
+  challenge: {
+    value: `challenge:reconnect-auth:${id}`,
+    expiresAt: 1_000_000,
+  },
+});
+
+const transactCommit = {
+  localSeq: 1,
+  reads: { confirmed: [], pending: [] },
+  operations: [{
+    op: "set" as const,
+    id: "of:doc:1",
+    value: { value: { version: 1 } },
+  }],
+};
+
+/**
+ * A transport whose Nth `session.open` returns a chosen response. Open #1 (the
+ * initial mount) always succeeds; a later open — a reopen driven by
+ * `session.restore()` — can be scripted to fail with an authorization error.
+ */
+class ScriptedOpenTransport implements Transport {
+  #receiver: (payload: string) => void = () => {};
+  #openCount = 0;
+
+  constructor(
+    private readonly openResponse: (
+      count: number,
+      requestId: string,
+    ) => FabricValue,
+  ) {}
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(): void {}
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+    };
+    switch (message.type) {
+      case "hello":
+        this.#respond(helloOk());
+        return Promise.resolve();
+      case "session.open":
+        this.#openCount += 1;
+        this.#respond(this.openResponse(this.#openCount, message.requestId!));
+        return Promise.resolve();
+      default:
+        throw new Error(`Unhandled scripted message: ${message.type}`);
+    }
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
+const openOk = (requestId: string): FabricValue => ({
+  type: "response",
+  requestId,
+  ok: {
+    sessionId: "session-A",
+    sessionToken: "token:session-A",
+    serverSeq: 0,
+    sessionOpen: sessionOpenFor(requestId),
+  },
+});
+
+const openAuthError = (
+  requestId: string,
+  message: string,
+  retriable?: boolean,
+): FabricValue => ({
+  type: "response",
+  requestId,
+  error: {
+    name: "AuthorizationError",
+    message,
+    ...(retriable ? { retriable: true } : {}),
+  },
+});
+
+Deno.test(
+  "a permanent authorization denial on reopen terminates only that session",
+  async () => {
+    const transport = new ScriptedOpenTransport((count, requestId) =>
+      count === 2
+        ? openAuthError(
+          requestId,
+          "Principal did:key:z6Mk-stranger lacks READ on space",
+        )
+        : openOk(requestId)
+    );
+    const client = await connect({ transport });
+    const session = await client.mount("did:key:z6Mk-reconnect-auth-space");
+
+    try {
+      // Reopen is denied for a reason no retry can change; restore terminates
+      // this session with the real error rather than rethrowing into a loop.
+      await session.restore();
+
+      const error = await assertRejects(
+        () => session.transact(transactCommit),
+        Error,
+        "lacks READ",
+      );
+      assertEquals(error.name, "AuthorizationError");
+
+      // The client stays connected; a fresh mount (open #3) still succeeds, so a
+      // denial on one space did not kill the whole client.
+      assertEquals(client.isConnected(), true);
+      const other = await client.mount("did:key:z6Mk-reconnect-auth-other");
+      assertEquals(other.sessionId, "session-A");
+    } finally {
+      await client.close();
+    }
+  },
+);
+
+Deno.test(
+  "a retriable authorization race on reopen does not terminate the session",
+  async () => {
+    const transport = new ScriptedOpenTransport((count, requestId) =>
+      count === 2
+        ? openAuthError(
+          requestId,
+          "memory session.open challenge expired",
+          true,
+        )
+        : openOk(requestId)
+    );
+    const client = await connect({ transport });
+    const session = await client.mount("did:key:z6Mk-reconnect-auth-retriable");
+
+    try {
+      // A retriable auth race is rethrown (the reconnect loop retries it with a
+      // fresh handshake) rather than terminating the session.
+      await assertRejects(
+        () => session.restore(),
+        Error,
+        "challenge expired",
+      );
+      assertEquals(session.sessionId, "session-A");
+    } finally {
+      await client.close();
+    }
+  },
+);
+
+const EMPTY_SYNC = {
+  type: "sync" as const,
+  fromSeq: 0,
+  toSeq: 0,
+  upserts: [],
+  removes: [],
+};
+
+/**
+ * A transport that opens and installs a watch normally, but denies the
+ * `session.watch.set` that a fresh (non-resumed) reopen issues to re-establish
+ * the watch. This drives the reopen-followup path in `restore()` — the denial
+ * arrives AFTER `session.open` succeeded — which must still terminate only this
+ * session, not escalate to a client-wide failure.
+ */
+class DenyWatchSetOnRestoreTransport implements Transport {
+  #receiver: (payload: string) => void = () => {};
+  #openCount = 0;
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(): void {}
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+    };
+    switch (message.type) {
+      case "hello":
+        this.#respond(helloOk());
+        return Promise.resolve();
+      case "session.open":
+        this.#openCount += 1;
+        // A non-resumed reopen (no `resumed: true`), so restore() re-establishes
+        // the watch set with a session.watch.set.
+        this.#respond(openOk(message.requestId!));
+        return Promise.resolve();
+      case "session.watch.add":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: { serverSeq: 0, sync: EMPTY_SYNC },
+        });
+        return Promise.resolve();
+      case "session.watch.set":
+        // The reopen already succeeded; the watch re-establishment is denied.
+        this.#respond(openAuthError(
+          message.requestId!,
+          "Principal did:key:z6Mk-stranger lacks READ on space",
+        ));
+        return Promise.resolve();
+      default:
+        throw new Error(`Unhandled watch-set-deny message: ${message.type}`);
+    }
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
+Deno.test(
+  "a permanent denial re-establishing the watch on reopen terminates only that session",
+  async () => {
+    const transport = new DenyWatchSetOnRestoreTransport();
+    const client = await connect({ transport });
+    const session = await client.mount("did:key:z6Mk-reconnect-auth-watchset");
+
+    try {
+      await session.watchAdd([{
+        id: "root",
+        kind: "graph",
+        query: {
+          roots: [{ id: "of:doc:1", selector: { path: [], schema: false } }],
+        },
+      }]);
+
+      // Reopen succeeds, but re-establishing the watch is denied permanently.
+      // This denial arrives OUTSIDE the reopen() call, so it must be caught by
+      // restore()'s outer handler and terminate only this session.
+      await session.restore();
+
+      const error = await assertRejects(
+        () => session.transact(transactCommit),
+        Error,
+        "lacks READ",
+      );
+      assertEquals(error.name, "AuthorizationError");
+
+      // The client is not fatal: a fresh mount still succeeds.
+      assertEquals(client.isConnected(), true);
+      const other = await client.mount("did:key:z6Mk-reconnect-auth-watchset2");
+      assertEquals(other.sessionId, "session-A");
+    } finally {
+      await client.close();
+    }
+  },
+);
+
+/**
+ * A transport that answers the first `hello` compatibly, then — after its close
+ * receiver is fired — answers the reconnect `hello` with an incompatible
+ * data-model flag, the permanent handshake failure.
+ */
+class FlagMismatchOnReconnectTransport implements Transport {
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+  #helloCount = 0;
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  triggerClose(): void {
+    this.#closeReceiver(new Error("disconnect"));
+  }
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+    };
+    switch (message.type) {
+      case "hello": {
+        this.#helloCount += 1;
+        const flags = getMemoryProtocolFlags();
+        this.#respond(
+          this.#helloCount === 1
+            ? helloOk()
+            : helloOk({ ...flags, modernCellRep: !flags.modernCellRep }),
+        );
+        return Promise.resolve();
+      }
+      case "session.open":
+        this.#respond(openOk(message.requestId!));
+        return Promise.resolve();
+      default:
+        throw new Error(`Unhandled flag-mismatch message: ${message.type}`);
+    }
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
+Deno.test(
+  "a permanent handshake mismatch on reconnect fails fast instead of looping",
+  async () => {
+    const transport = new FlagMismatchOnReconnectTransport();
+    const client = await connect({ transport });
+    await client.mount("did:key:z6Mk-reconnect-auth-flags");
+
+    try {
+      transport.triggerClose();
+
+      // The reconnect handshake is incompatible and no retry changes that, so
+      // the client gives up and every request fails fast with the real error —
+      // it does not spin the reconnect loop forever.
+      const error = await assertRejects(
+        () => client.restoreConnection(),
+        Error,
+        "flag mismatch",
+      );
+      assertEquals(error.name, "ProtocolError");
+      // Still fatal on the next attempt, without reconnecting.
+      await assertRejects(
+        () => client.restoreConnection(),
+        Error,
+        "flag mismatch",
+      );
+    } finally {
+      await client.close();
+    }
+  },
+);

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -296,6 +296,7 @@ Deno.test("memory v2 server consumes a challenged session open", async () => {
       error: {
         name: "AuthorizationError",
         message: "memory session.open challenge mismatch",
+        retriable: true,
       },
     });
   } finally {
@@ -342,6 +343,7 @@ Deno.test("memory v2 server rejects an expired session open challenge", async ()
       error: {
         name: "AuthorizationError",
         message: "memory session.open challenge expired",
+        retriable: true,
       },
     });
   } finally {
@@ -389,6 +391,8 @@ Deno.test("memory v2 server rejects invalid session open auth metadata", async (
           challenge: "challenge:wrong",
         },
         message: "memory session.open challenge mismatch",
+        // A stale challenge is an anti-replay race a fresh handshake heals.
+        retriable: true,
       },
     ];
 
@@ -406,6 +410,9 @@ Deno.test("memory v2 server rejects invalid session open auth metadata", async (
         error: {
           name: "AuthorizationError",
           message: testCase.message,
+          ...((testCase as { retriable?: boolean }).retriable
+            ? { retriable: true }
+            : {}),
         },
       });
     }
@@ -437,6 +444,7 @@ Deno.test("memory v2 server rejects session open before issuing challenge", asyn
       error: {
         name: "AuthorizationError",
         message: "memory session.open challenge unavailable",
+        retriable: true,
       },
     });
   } finally {
@@ -493,6 +501,7 @@ Deno.test("memory v2 server consumes challenge before denied session open", asyn
       error: {
         name: "AuthorizationError",
         message: "memory session.open challenge already used",
+        retriable: true,
       },
     });
   } finally {

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -637,6 +637,16 @@ export interface V2Error {
   message: string;
   precondition?: string;
   retryAfterSeq?: number;
+  /**
+   * Present on an `AuthorizationError` that a fresh handshake can heal — the
+   * connection-challenge and invocation-freshness anti-replay races (an expired,
+   * already-used, or mismatched challenge; a stale signed `exp`). Each reconnect
+   * runs a new `hello` that issues a fresh challenge, so these do not recur. Its
+   * absence marks a permanent denial (an audience mismatch, a malformed
+   * invocation, or an ACL capability shortfall) that retrying cannot fix — the
+   * client stops reopening the session and surfaces the error instead of looping.
+   */
+  retriable?: boolean;
 }
 
 export type V2Result<Value> = { ok: Value } | { error: V2Error };

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -112,6 +112,13 @@ export class Client {
   #cancelReconnectDelay: (() => void) | null = null;
   #connected = false;
   #closed = false;
+  // Set when a reconnect handshake fails for a reason retrying cannot change (a
+  // protocol-flag mismatch — the transport is fundamentally incompatible). The
+  // client stops reconnecting and fails every further request with it, instead
+  // of looping forever. A per-session authorization denial does NOT land here:
+  // it terminates only that session (see SpaceSession.restore), leaving sessions
+  // for other spaces on this client alive.
+  #fatalError: Error | null = null;
 
   private constructor(
     private readonly transport: Transport,
@@ -195,6 +202,10 @@ export class Client {
       if (result.error.retryAfterSeq !== undefined) {
         (error as Error & { retryAfterSeq?: number }).retryAfterSeq =
           result.error.retryAfterSeq;
+      }
+      if (result.error.retriable !== undefined) {
+        (error as Error & { retriable?: boolean }).retriable =
+          result.error.retriable;
       }
       throw error;
     }
@@ -285,12 +296,15 @@ export class Client {
       if (helloOk !== null) {
         const expectedFlags = getMemoryProtocolFlags();
         if (!compatibleMemoryProtocolFlags(helloOk.flags, expectedFlags)) {
-          const error = new Error(
+          // A data-model wire-contract mismatch: this client and server cannot
+          // talk at all, and no retry changes that. Mark it permanent so a
+          // reconnect that hits it gives up rather than retrying a doomed
+          // handshake.
+          const error = permanentProtocolError(
             `memory flag mismatch: client=${
               toCompactDebugString(expectedFlags)
             } server=${toCompactDebugString(helloOk.flags)}`,
           );
-          error.name = "ProtocolError";
           this.#helloPending.reject(error);
           return;
         }
@@ -371,10 +385,18 @@ export class Client {
     if (this.#closed) {
       throw new Error("memory client is closed");
     }
+    if (this.#fatalError) {
+      throw this.#fatalError;
+    }
     if (this.#connected) {
       return;
     }
     await this.reconnect();
+    // reconnect() resolves without connecting when it gives up on a permanent
+    // handshake failure; surface it here rather than returning as if connected.
+    if (this.#fatalError) {
+      throw this.#fatalError;
+    }
   }
 
   private onClose(error?: Error): void {
@@ -393,6 +415,9 @@ export class Client {
     if (this.#closed) {
       throw new Error("memory client is closed");
     }
+    if (this.#fatalError) {
+      throw this.#fatalError;
+    }
     if (this.#reconnecting) {
       return await this.#reconnecting;
     }
@@ -407,9 +432,16 @@ export class Client {
           return;
         } catch (error) {
           this.#connected = false;
-          this.rejectPending(
-            error instanceof Error ? error : new Error(String(error)),
-          );
+          const err = error instanceof Error ? error : new Error(String(error));
+          if (isPermanentConnectionFailure(err)) {
+            // A handshake the server refuses identically every time (a
+            // protocol-flag mismatch). Stop looping and remember the failure so
+            // every present and future request fails fast with it.
+            this.#fatalError = err;
+            this.rejectPending(err);
+            return;
+          }
+          this.rejectPending(err);
           await this.waitForReconnectDelay(reconnectDelayMs(attempt));
           attempt += 1;
         }
@@ -815,6 +847,19 @@ export class SpaceSession {
         }
       }
       await Promise.all(replayTasks);
+    } catch (error) {
+      // A permanent authorization denial ANYWHERE in the reopen — the initial
+      // session.open OR the watch re-establishment (watchSetSync) that follows a
+      // fresh, non-resumed session — terminates just this session with the real
+      // error: its pending commits and waiters reject with it, and its next watch
+      // or transact rethrows it. It must NOT propagate to the client-wide
+      // reconnect loop, which would then fail sessions for other spaces on the
+      // same client. Every other error propagates so the loop retries it.
+      if (isPermanentAuthorizationError(error)) {
+        this.terminateSession(error as Error);
+        return;
+      }
+      throw error;
     } finally {
       this.#restoring = false;
       if (!this.#closed && this.#outstandingCommits.size > 0) {
@@ -850,6 +895,17 @@ export class SpaceSession {
     }
     const error = new Error(`memory session revoked: ${reason}`);
     error.name = "SessionRevokedError";
+    this.terminateSession(error);
+  }
+
+  /**
+   * Close this session terminally with `error`: reject its outstanding commits
+   * and caught-up waiters, forget it from the client, and drop its watch state.
+   * The stored error is what `#assertOpen()` rethrows for any later call, so a
+   * storage subscriber observes the real cause on its next watch or transact.
+   * Shared by session revocation and a permanent reopen authorization denial.
+   */
+  private terminateSession(error: Error): void {
     this.#closed = true;
     this.#closeError = error;
     this.#readyOnConnection = false;
@@ -1449,6 +1505,27 @@ const protocolError = (message: string): Error => {
   error.name = "ProtocolError";
   return error;
 };
+
+// A ProtocolError that no retry can heal (the peers disagree on a data-model
+// wire contract). Tagged so the reconnect loop gives up rather than retrying it.
+const permanentProtocolError = (message: string): Error =>
+  Object.assign(new Error(message), { name: "ProtocolError", permanent: true });
+
+// An authorization denial retrying cannot change. A retriable auth failure — an
+// anti-replay race the server marked `retriable` (an expired/used/mismatched
+// challenge, a stale signed `exp`) — is excluded, so the client keeps reopening
+// through a token-refresh window or a challenge race a fresh handshake heals.
+const isPermanentAuthorizationError = (error: unknown): boolean =>
+  error instanceof Error && error.name === "AuthorizationError" &&
+  (error as { retriable?: unknown }).retriable !== true;
+
+// A reconnect handshake failure the whole client must give up on rather than
+// retry: an incompatible protocol negotiation at hello. An authorization denial
+// is deliberately NOT here — it is per-space, handled inside restore() by
+// terminating just that session, so it never escalates to a client-wide failure
+// that would take down sessions for other spaces.
+const isPermanentConnectionFailure = (error: Error): boolean =>
+  (error as { permanent?: unknown }).permanent === true;
 
 const requireSessionOpenAuthMetadata = (
   value: unknown,

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -558,6 +558,15 @@ export class SpaceSession {
     return this.#serverSeq;
   }
 
+  /** The error this session was terminated with, or undefined while it is open.
+   *  A permanent reopen denial stores its `AuthorizationError` here (see
+   *  `restore`), which is what `#assertOpen` rethrows; a storage subscriber reads
+   *  it to observe a denial that terminated the session without a fresh watch
+   *  result to carry it. */
+  get closeError(): Error | undefined {
+    return this.#closeError ?? undefined;
+  }
+
   #assertOpen(): void {
     if (this.#closed) {
       throw this.#closeError ?? new Error("memory session closed");

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -465,19 +465,27 @@ class Connection {
 
     const challenge = this.#sessionOpenChallenge;
     if (challenge === null) {
-      throw authorizationError("memory session.open challenge unavailable");
+      throw authorizationError("memory session.open challenge unavailable", {
+        retriable: true,
+      });
     }
     if (challenge.consumed) {
-      throw authorizationError("memory session.open challenge already used");
+      throw authorizationError("memory session.open challenge already used", {
+        retriable: true,
+      });
     }
     if (challenge.expiresAt <= this.server.nowSeconds()) {
-      throw authorizationError("memory session.open challenge expired");
+      throw authorizationError("memory session.open challenge expired", {
+        retriable: true,
+      });
     }
     if (typeof invocation.challenge !== "string") {
       throw authorizationError("memory session.open requires challenge");
     }
     if (invocation.challenge !== challenge.value) {
-      throw authorizationError("memory session.open challenge mismatch");
+      throw authorizationError("memory session.open challenge mismatch", {
+        retriable: true,
+      });
     }
 
     return {
@@ -1881,17 +1889,25 @@ export class Server {
         },
       };
     } catch (error) {
-      return respondTypedError<SessionOpenResult>(
-        message.requestId,
-        toError(
-          error instanceof Error && error.name === "AuthorizationError"
-            ? "AuthorizationError"
-            : error instanceof Error && error.name === "SessionRevokedError"
-            ? "SessionRevokedError"
-            : "ProtocolError",
-          error instanceof Error ? error.message : String(error),
-        ),
+      const name = error instanceof Error && error.name === "AuthorizationError"
+        ? "AuthorizationError"
+        : error instanceof Error && error.name === "SessionRevokedError"
+        ? "SessionRevokedError"
+        : "ProtocolError";
+      const wireError = toError(
+        name,
+        error instanceof Error ? error.message : String(error),
       );
+      // Carry the retriable marker (an anti-replay race a fresh handshake heals)
+      // so the client distinguishes it from a permanent denial without parsing
+      // the message.
+      if (
+        name === "AuthorizationError" &&
+        (error as { retriable?: unknown }).retriable === true
+      ) {
+        wireError.retriable = true;
+      }
+      return respondTypedError<SessionOpenResult>(message.requestId, wireError);
     }
   }
 

--- a/packages/memory/v2/session-open-auth.ts
+++ b/packages/memory/v2/session-open-auth.ts
@@ -28,8 +28,24 @@ import { MEMORY_PROTOCOL, type SessionOpenChallenge } from "../v2.ts";
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 
-export const authorizationError = (message: string): Error =>
-  Object.assign(new Error(message), { name: "AuthorizationError" });
+/**
+ * Build an `AuthorizationError`. Pass `retriable: true` for the anti-replay
+ * races a fresh handshake heals (an expired, already-used, or mismatched
+ * challenge; a stale signed `exp`); omit it for a permanent denial (an audience
+ * mismatch, a malformed invocation, an ACL shortfall) that retrying cannot fix.
+ * The flag rides on the thrown error and is copied onto the wire `V2Error` so
+ * the client can classify the failure without parsing its message.
+ */
+export const authorizationError = (
+  message: string,
+  options?: { retriable?: boolean },
+): Error =>
+  Object.assign(
+    new Error(message),
+    options?.retriable === true
+      ? { name: "AuthorizationError", retriable: true }
+      : { name: "AuthorizationError" },
+  );
 
 const sameSessionDescriptor = (
   left: Record<string, unknown>,
@@ -104,11 +120,15 @@ export const verifySessionOpenAuthorization = async (
     throw authorizationError("memory session.open requires challenge");
   }
   if (invocation.challenge !== options.challenge.value) {
-    throw authorizationError("memory session.open challenge mismatch");
+    throw authorizationError("memory session.open challenge mismatch", {
+      retriable: true,
+    });
   }
   const challengeNow = options.nowSeconds ?? Math.floor(Date.now() / 1000);
   if (options.challenge.expiresAt <= challengeNow) {
-    throw authorizationError("memory session.open challenge expired");
+    throw authorizationError("memory session.open challenge expired", {
+      retriable: true,
+    });
   }
 
   if (typeof invocation.iat !== "number" || !Number.isFinite(invocation.iat)) {
@@ -120,7 +140,9 @@ export const verifySessionOpenAuthorization = async (
   const now = options.nowSeconds ?? Math.floor(Date.now() / 1000);
   const skew = options.clockSkewSeconds ?? DEFAULT_CLOCK_SKEW_SECONDS;
   if (invocation.exp < now - skew) {
-    throw authorizationError("memory session.open authorization expired");
+    throw authorizationError("memory session.open authorization expired", {
+      retriable: true,
+    });
   }
 
   const issuer = await fromDID(invocation.iss);

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -177,6 +177,17 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
   synced(): Promise<void>;
 
   /**
+   * A throwable `AuthorizationError` when `space` is under a permanent
+   * authorization denial (an ACL shortfall, an audience or protocol mismatch),
+   * or undefined when it is authorized or was never opened. Scoped to one space
+   * on purpose: `synced()` stays silent so a denied cross-space link stays a
+   * silent absent read, and a caller that must reach a specific space reads this
+   * after `synced()` to surface the real failure. Optional: emulated/test
+   * managers may omit it.
+   */
+  authorizationError?(space: MemorySpace): Error | undefined;
+
+  /**
    * Register an in-flight commit so the durability barrier
    * (`hasPendingCommits` / `pendingCommitsSettled`) covers it. Called by the
    * transaction layer at `commit()` entry, synchronously with the commit

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1687,6 +1687,11 @@ class SpaceReplica implements ISpaceReplica {
   /** The client of the last RESOLVED session handle — for synchronous
    *  capability reads (`sqliteServerCommitRowLabelEval`). */
   #sessionClient?: MemoryV2Client.Client;
+  /** The session of the last RESOLVED handle — read synchronously so
+   *  `authorizationError()` can observe a denial that terminated the session
+   *  during reconnect, which closes its watch view without a fresh watch result
+   *  to record. */
+  #sessionSession?: MemoryV2Client.SpaceSession;
   readonly #docs = new Map<string, DocumentRecord>();
   readonly #syncTasks = new Map<string, SyncTask>();
   readonly #commitPromises = new Set<
@@ -1823,11 +1828,28 @@ class SpaceReplica implements ISpaceReplica {
    * whole runtime settle on an incidental unauthorized link. A caller that cares
    * about a SPECIFIC space — the CLI, opening the space it was asked to act on —
    * reads this after `synced()` and surfaces it deliberately.
+   *
+   * A watch refresh records the denial in most cases. A permanent denial during
+   * RECONNECT is the exception: the memory client terminates the session and
+   * closes its watch view without another refresh result (see the client's
+   * `SpaceSession.restore`), so `#lastAuthorizationError` never captures it and a
+   * caller that only reaches `synced()` without a further pull would see the
+   * space as authorized. Consult the terminated session directly for that case.
    */
   authorizationError(): Error | undefined {
-    return this.#lastAuthorizationError === null
-      ? undefined
-      : authorizationErrorToThrow(this.#lastAuthorizationError);
+    if (this.#lastAuthorizationError !== null) {
+      return authorizationErrorToThrow(this.#lastAuthorizationError);
+    }
+    // `terminateSession` stores a permanent AuthorizationError as the session's
+    // close error; a graceful close ("memory session closed") or a takeover
+    // revocation (SessionRevokedError) carries a different name and is not an
+    // authorization denial for this space, so only the AuthorizationError is
+    // surfaced here.
+    const closeError = this.#sessionSession?.closeError;
+    if (closeError !== undefined && closeError.name === "AuthorizationError") {
+      return closeError;
+    }
+    return undefined;
   }
 
   /**
@@ -3538,6 +3560,7 @@ class SpaceReplica implements ISpaceReplica {
       const handle = Promise.resolve().then(() => this.#createSession()).then(
         (resolved) => {
           this.#sessionClient = resolved.client;
+          this.#sessionSession = resolved.session;
           return resolved;
         },
       ).catch((error) => {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -7,6 +7,7 @@ import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
 import type { Entity } from "@commonfabric/memory/interface";
 import type { RuntimeTelemetryMarker } from "../telemetry.ts";
 import {
+  type AuthorizationError as IAuthorizationError,
   type ConflictError as IConflictError,
   type ConnectionError as IConnectionError,
   type MemorySpace,
@@ -1036,6 +1037,18 @@ export class StorageManager implements IStorageManager {
     return promise;
   }
 
+  /**
+   * A throwable `AuthorizationError` when `space` is under a permanent
+   * authorization denial (an ACL shortfall, an audience or protocol mismatch),
+   * or undefined when it is authorized or was never opened. Scoped to one space
+   * on purpose: `synced()` stays silent so a denied cross-space link does not
+   * fail an unrelated caller, and a caller that must access a specific space
+   * reads this after `synced()` to surface the real failure.
+   */
+  authorizationError(space: MemorySpace): Error | undefined {
+    return this.#providers.get(space)?.authorizationError();
+  }
+
   trackPendingCommit(promise: Promise<unknown>): void {
     // Normalize so a rejected commit settles the barrier instead of leaking an
     // unhandled rejection; the caller keeps the original promise for results.
@@ -1549,6 +1562,10 @@ class Provider implements IStorageProviderWithReplica {
     return this.replica.synced();
   }
 
+  authorizationError(): Error | undefined {
+    return this.replica.authorizationError();
+  }
+
   listSchedulerActionSnapshots(
     query: SchedulerActionSnapshotQuery = {},
   ): Promise<SchedulerSnapshotListResult> {
@@ -1715,6 +1732,14 @@ class SpaceReplica implements ISpaceReplica {
   // otherwise) so a large incrementally-discovered wave cannot put an unbounded
   // number of requests on the wire.
   #watchRefreshInFlight = 0;
+  // The current PERMANENT authorization denial for this space (an ACL shortfall,
+  // an audience or protocol mismatch), or null when the space is authorized. A
+  // non-retriable AuthorizationError from a watch refresh sets it; a successful
+  // refresh clears it; a retriable auth race and a transient transport error
+  // leave it untouched, so a blip or token-refresh window does not register as a
+  // denial. `authorizationError()` reports it as a throwable error; `synced()`
+  // stays silent so a denied cross-space link remains a silent absent read.
+  #lastAuthorizationError: IAuthorizationError | null = null;
 
   #settings: IRemoteStorageProviderSettings;
 
@@ -1787,6 +1812,43 @@ class SpaceReplica implements ISpaceReplica {
       await this.flushSchedulerObservationBatch();
     }
     await Promise.all([...this.#syncPromises, ...this.#commitPromises]);
+  }
+
+  /**
+   * A real, throwable `AuthorizationError` when this space is under a permanent
+   * authorization denial, or undefined when it is authorized. `synced()`
+   * deliberately does NOT throw this: a denied cross-space link must stay a
+   * silent absent read (the sync-load-failure surfacing contract), and the
+   * global sync barrier aggregates every space, so throwing there would fail a
+   * whole runtime settle on an incidental unauthorized link. A caller that cares
+   * about a SPECIFIC space — the CLI, opening the space it was asked to act on —
+   * reads this after `synced()` and surfaces it deliberately.
+   */
+  authorizationError(): Error | undefined {
+    return this.#lastAuthorizationError === null
+      ? undefined
+      : authorizationErrorToThrow(this.#lastAuthorizationError);
+  }
+
+  /**
+   * Record the authorization status a watch refresh result implies. A permanent
+   * (non-retriable) AuthorizationError becomes the sticky failure
+   * `authorizationError()` reports; a successful refresh proves the session is
+   * authorized and clears it. A transient connection error or a retriable auth
+   * race leaves the last known status unchanged, so a blip does not mask or
+   * manufacture a denial.
+   */
+  private noteAuthorizationStatus(result: Result<Unit, PullError>): void {
+    if (result.error) {
+      if (
+        result.error.name === "AuthorizationError" &&
+        (result.error as { retriable?: unknown }).retriable !== true
+      ) {
+        this.#lastAuthorizationError = result.error as IAuthorizationError;
+      }
+      return;
+    }
+    this.#lastAuthorizationError = null;
   }
 
   async sqliteQuery(
@@ -2285,7 +2347,7 @@ class SpaceReplica implements ISpaceReplica {
       }
       return { ok: {} };
     } catch (error) {
-      return { error: toConnectionError(error) };
+      return { error: toPullError(error) };
     }
   }
 
@@ -2367,11 +2429,16 @@ class SpaceReplica implements ISpaceReplica {
     batch: WatchRefreshBatch,
   ): Promise<void> {
     try {
-      batch.pending.resolve(
-        await this.refreshWatchSet(batch.entries.values(), batch.type),
+      const result = await this.refreshWatchSet(
+        batch.entries.values(),
+        batch.type,
       );
+      this.noteAuthorizationStatus(result);
+      batch.pending.resolve(result);
     } catch (error) {
-      batch.pending.resolve({ error: toConnectionError(error) });
+      const result: Result<Unit, PullError> = { error: toPullError(error) };
+      this.noteAuthorizationStatus(result);
+      batch.pending.resolve(result);
     } finally {
       this.#watchRefreshInFlight -= 1;
       this.scheduleWatchRefreshFlush();
@@ -3508,6 +3575,26 @@ const toConnectionError = (error: unknown): IConnectionError =>
       code: 500,
     },
   }) as IConnectionError;
+
+// Preserve a real AuthorizationError (name, message, and the server's retriable
+// marker) instead of flattening it to a generic ConnectionError, so a caller can
+// tell an authorization denial apart from a transport failure. Everything else
+// remains a ConnectionError.
+const toPullError = (error: unknown): PullError =>
+  error instanceof Error && error.name === "AuthorizationError"
+    ? ({
+      name: "AuthorizationError",
+      message: error.message,
+      ...((error as { retriable?: unknown }).retriable === true
+        ? { retriable: true }
+        : {}),
+    }) as unknown as IAuthorizationError
+    : toConnectionError(error);
+
+// Rebuild a throwable Error from a stored AuthorizationError result so `synced()`
+// rejects with a proper Error instance a caller can match on by name.
+const authorizationErrorToThrow = (error: IAuthorizationError): Error =>
+  Object.assign(new Error(error.message), { name: "AuthorizationError" });
 
 const toRejectedError = (
   error: unknown,

--- a/packages/runner/test/storage-synced-authorization.test.ts
+++ b/packages/runner/test/storage-synced-authorization.test.ts
@@ -1,0 +1,127 @@
+import { assert, assertEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+} from "@commonfabric/memory/v2";
+import type { SessionFactory } from "../src/storage/v2.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+  TestStorageManager,
+} from "./memory-v2-test-utils.ts";
+
+function makeServer(): MemoryV2Server.Server {
+  return new MemoryV2Server.Server({
+    authorizeSessionOpen(m) {
+      const p = (m.authorization as { principal?: unknown })?.principal;
+      return typeof p === "string" ? p : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+}
+
+/**
+ * A session whose handshake and session.open succeed against a real server, but
+ * whose `session.watch.add` — the request a pull issues — is answered directly
+ * with an `AuthorizationError` response instead of being forwarded. This is the
+ * denial the storage layer must surface from `synced()`: the watch (and thus the
+ * pull, and thus the sync) fails authorization.
+ */
+class DenyingWatchSessionFactory implements SessionFactory {
+  constructor(
+    private readonly server: MemoryV2Server.Server,
+    private readonly retriable: boolean,
+  ) {}
+
+  async create(id: string, signer?: Signer) {
+    const base = MemoryV2Client.loopback(this.server);
+    let receive: (payload: string) => void = () => {};
+    const transport: MemoryV2Client.Transport = {
+      send: (payload: string) => {
+        const message = decodeMemoryBoundary(payload) as {
+          type?: string;
+          requestId?: string;
+        };
+        if (message.type === "session.watch.add") {
+          receive(encodeMemoryBoundary({
+            type: "response",
+            requestId: message.requestId!,
+            error: {
+              name: "AuthorizationError",
+              message: "Principal lacks READ on space",
+              ...(this.retriable ? { retriable: true } : {}),
+            },
+          }));
+          return Promise.resolve();
+        }
+        return base.send(payload);
+      },
+      close: () => base.close(),
+      setReceiver: (r) => {
+        receive = r;
+        base.setReceiver(r);
+      },
+      setCloseReceiver: (r) => base.setCloseReceiver?.(r),
+    };
+    const client = await MemoryV2Client.connect({ transport });
+    const session = await client.mount(
+      id as MemorySpace,
+      {},
+      testPrincipalSessionOpenAuthFactory(signer),
+    );
+    return { client, session };
+  }
+}
+
+Deno.test(
+  "authorizationError() surfaces a permanent watch denial for the space",
+  async () => {
+    const signer = await Identity.fromPassphrase("storage-synced-authz-perm");
+    const storage = TestStorageManager.create(
+      { as: signer, memoryHost: new URL("memory://") },
+      new DenyingWatchSessionFactory(makeServer(), false),
+    );
+
+    try {
+      const provider = storage.open(signer.did());
+      void provider.sync("of:storage-synced-authz-perm" as URI);
+
+      // synced() stays quiet — a denied read is a silent absent read at the sync
+      // barrier — but the per-space status carries the real, throwable error.
+      await storage.synced();
+      const error = storage.authorizationError(signer.did());
+      assert(error !== undefined);
+      assertEquals(error.name, "AuthorizationError");
+      assert(error.message.includes("lacks READ"));
+    } finally {
+      await storage.close();
+    }
+  },
+);
+
+Deno.test(
+  "authorizationError() stays undefined on a retriable authorization race",
+  async () => {
+    const signer = await Identity.fromPassphrase("storage-synced-authz-retry");
+    const storage = TestStorageManager.create(
+      { as: signer, memoryHost: new URL("memory://") },
+      new DenyingWatchSessionFactory(makeServer(), true),
+    );
+
+    try {
+      const provider = storage.open(signer.did());
+      void provider.sync("of:storage-synced-authz-retry" as URI);
+
+      // A retriable auth race (an anti-replay handshake failure a fresh
+      // reconnect heals) is not a permanent denial, so nothing is surfaced.
+      await storage.synced();
+      assertEquals(storage.authorizationError(signer.did()), undefined);
+    } finally {
+      await storage.close();
+    }
+  },
+);

--- a/packages/runner/test/storage-synced-authorization.test.ts
+++ b/packages/runner/test/storage-synced-authorization.test.ts
@@ -1,15 +1,19 @@
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
 } from "@commonfabric/memory/v2";
 import type { SessionFactory } from "../src/storage/v2.ts";
 import {
   TEST_MEMORY_SERVER_AUTH,
+  TEST_SESSION_OPEN_AUDIENCE,
   testPrincipalSessionOpenAuthFactory,
   TestStorageManager,
 } from "./memory-v2-test-utils.ts";
@@ -120,6 +124,165 @@ Deno.test(
       // reconnect heals) is not a permanent denial, so nothing is surfaced.
       await storage.synced();
       assertEquals(storage.authorizationError(signer.did()), undefined);
+    } finally {
+      await storage.close();
+    }
+  },
+);
+
+const EMPTY_SYNC = {
+  type: "sync" as const,
+  fromSeq: 0,
+  toSeq: 0,
+  upserts: [],
+  removes: [],
+};
+
+const helloOk = (): FabricValue => ({
+  type: "hello.ok",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+  sessionOpen: {
+    audience: TEST_SESSION_OPEN_AUDIENCE,
+    challenge: { value: "challenge:reconnect-terminal", expiresAt: 1_000_000 },
+  },
+});
+
+const openOk = (requestId: string): FabricValue => ({
+  type: "response",
+  requestId,
+  ok: {
+    sessionId: "session-A",
+    sessionToken: "token:session-A",
+    serverSeq: 0,
+    sessionOpen: {
+      audience: TEST_SESSION_OPEN_AUDIENCE,
+      challenge: {
+        value: `challenge:reconnect-terminal:${requestId}`,
+        expiresAt: 1_000_000,
+      },
+    },
+  },
+});
+
+/**
+ * A scripted transport whose first `session.open` succeeds but whose reopen (the
+ * second `session.open`, driven by a reconnect) is permanently denied. It lets
+ * the test fire the transport's close receiver to start the reconnect.
+ */
+class ReopenDenyTransport implements MemoryV2Client.Transport {
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+  #openCount = 0;
+
+  triggerClose(): void {
+    this.#closeReceiver(new Error("disconnect"));
+  }
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+    };
+    switch (message.type) {
+      case "hello":
+        this.#respond(helloOk());
+        return Promise.resolve();
+      case "session.open":
+        this.#openCount += 1;
+        this.#respond(
+          this.#openCount === 1 ? openOk(message.requestId!) : {
+            type: "response",
+            requestId: message.requestId!,
+            error: {
+              name: "AuthorizationError",
+              message: "Principal lacks READ on space",
+            },
+          },
+        );
+        return Promise.resolve();
+      case "session.watch.add":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: { serverSeq: 0, sync: EMPTY_SYNC },
+        });
+        return Promise.resolve();
+      case "session.ack":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: { serverSeq: 0 },
+        });
+        return Promise.resolve();
+      default:
+        return Promise.resolve();
+    }
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
+class ReconnectDenyingSessionFactory implements SessionFactory {
+  readonly transport = new ReopenDenyTransport();
+  client?: MemoryV2Client.Client;
+
+  async create(id: string, signer?: Signer) {
+    const client = await MemoryV2Client.connect({ transport: this.transport });
+    this.client = client;
+    const session = await client.mount(
+      id as MemorySpace,
+      {},
+      testPrincipalSessionOpenAuthFactory(signer),
+    );
+    return { client, session };
+  }
+}
+
+Deno.test(
+  "authorizationError() surfaces a permanent denial that terminated the session on reconnect",
+  async () => {
+    const signer = await Identity.fromPassphrase(
+      "storage-synced-authz-reconnect",
+    );
+    const factory = new ReconnectDenyingSessionFactory();
+    const storage = TestStorageManager.create(
+      { as: signer, memoryHost: new URL("memory://") },
+      factory,
+    );
+
+    try {
+      const provider = storage.open(signer.did());
+      // Establish the session and a watch while authorized.
+      await provider.sync("of:storage-synced-authz-reconnect" as URI);
+      assertEquals(storage.authorizationError(signer.did()), undefined);
+
+      // Drop the connection and drive the reconnect to completion: the reopen is
+      // permanently denied, so the client terminates the session. No further
+      // pull runs, so the watch-refresh path never records the denial — the gap
+      // this test pins.
+      factory.transport.triggerClose();
+      await factory.client!.restoreConnection();
+
+      await storage.synced();
+      const error = storage.authorizationError(signer.did());
+      assert(error !== undefined);
+      assertEquals(error.name, "AuthorizationError");
+      assert(error.message.includes("lacks READ"));
     } finally {
       await storage.close();
     }


### PR DESCRIPTION
…rror

An authorization failure — a client and server disagreeing over an EXPERIMENTAL_* option that trips the ACL, an audience mismatch, or a plain ACL denial — had no honest way to reach a caller waiting on storage sync. The pull path flattened the server's real AuthorizationError into a generic ConnectionError and `synced()` discarded it, so the denial vanished and the caller proceeded with missing data; or, when the failure surfaced during a reconnect, the memory client retried the denied session reopen in an unbounded loop, so every request blocked and `synced()` hung with nothing to observe. The CLI papered over the hang with a 30-second wall-clock timeout — the only thing turning it into a message, at the cost of also failing a slow-but-healthy sync.

This replaces that guard with a real, typed, terminating error, built from a recoverable-versus-permanent classification.

Classify at the source. The connection-challenge and invocation-freshness anti-replay checks (an expired, used, or mismatched challenge; a stale signed `exp`) are races a fresh handshake heals — each reconnect runs a new `hello` that issues a fresh challenge — so they are marked `retriable` on the wire V2Error. Every other authorization failure (audience or protocol mismatch, malformed invocation, ACL capability shortfall) is permanent. An older server sends no marker, so its denial reads as permanent, the safe default.

Terminate rather than loop (memory client). A permanent denial reopening a session terminates just that session with the real error — anywhere in restore(), including the watch re-establishment a fresh reopen issues — mirroring the existing terminal handling of a revoked session: its pending commits and waiters reject with it, and its next watch or transact rethrows it. Sessions for other spaces on the same client are untouched. A permanent protocol-flag mismatch at `hello` dooms the whole connection and stops the reconnect loop. A retriable race and every transport-level disconnect still retry, so a transient blip or a token-refresh window heals as before.

Surface it per space, keep the barrier silent (runner storage). `toPullError` preserves the real AuthorizationError instead of flattening it. Each replica records its current permanent-authorization status (set on a non-retriable denial, cleared on a successful refresh). `synced()` still resolves quietly and a per-doc `sync()` still reads a denied doc as absent — a denied cross-space link must not fail the reader, and the global barrier aggregates every space. A new space-scoped `StorageManager.authorizationError(space)` returns the remembered, throwable error for one space, so the denial never leaks onto an unrelated cross-space read.

Lean on the real error (CLI). `awaitSyncWithTimeout` and its constants are gone from utils.ts and its three callers. `loadManager`, the ACL operations, and the headless wish read call `synced()` directly, then read `authorizationError(space)` for the one space they act on — after that space has been pulled — and throw the real error. The `newPiece` 60-second bound stays: its hang is a scheduler `idle()` park, a different mechanism this signal does not cover.

Documents the behavior in docs/development/authorization-failure-surfacing.md (including the deliberate trade-offs: no in-process auto-heal after a later ACL grant, and a wedged-but-reachable backend still waiting), adds the `retriable` marker to the memory-v2 protocol spec, and points the superseded historical CLI-timeout investigation at the new live document.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787482581&installation_model_id=428580&pr_number=4986&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4986&signature=731623e05d550e7c2ed64525834a943903582dd5604b566357f9ff9a1616f5df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface authorization failures from storage sync as real, typed errors and stop reconnect loops. Replace the CLI sync timeout with per-space error reporting, including denials seen during reconnect and permanent handshake mismatches that now fail fast.

- **Bug Fixes**
  - Protocol: add `retriable` to `memory‑v2` `AuthorizationError` and document it; older servers default to permanent.
  - Memory client: terminate only the denied session on a permanent reopen denial (including watch re‑establishment after reopen); remember a permanent `hello` flag mismatch as a fatal error so future requests fail fast; keep retrying retriable races and transport blips.
  - Runner storage: keep `AuthorizationError` (no flattening); remember per‑space permanent denials, clear on successful refresh; also surface reconnect denials that terminate the session by consulting the session’s close error; `synced()` stays quiet; expose `StorageManager.authorizationError(space)`.
  - CLI: remove `awaitSyncWithTimeout`; call `synced()` then read `authorizationError(space)` in `loadManager`, ACL ops, and headless wish reads.

- **Migration**
  - When acting on a specific space, call `synced()` then `authorizationError(space)` to surface a permanent denial.
  - No automatic in‑process heal after a later ACL grant; recreate the session/manager to retry.

<sup>Written for commit 7f8d9dd6b90d838845a53c32c69660d3751b8930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

