### PR TITLE
docs(static): record the CI-only checks that the withheld-globals gat…

### DIFF
--- a/packages/static/README.md
+++ b/packages/static/README.md
@@ -32,3 +32,21 @@ a real compartment against each other in both directions.
 That test requires zero gaps: every global the compiler declares must be one the
 compartment installs. A newly declared global that the compartment lacks fails
 the test until it is endowed or added to the withheld list.
+
+### Checks that run only in CI
+
+Two things depend on this list that neither `deno task cfcheck` nor
+`deno task check` catches, so a change that passes both locally can still fail
+in CI:
+
+- The `packages/ts-transformers` and `packages/schema-generator` fixture suites
+  type-check their fixture inputs against the pattern type libraries, so a
+  fixture that uses a now-withheld global stops compiling. `deno task cfcheck`
+  only checks `packages/patterns`, and `deno task check` type-checks source;
+  neither compiles those fixtures. After changing the withheld list or the type
+  libraries, run `deno task test` in both packages, and regenerate the
+  transformer goldens with `UPDATE_GOLDENS=1` (see
+  `packages/ts-transformers/AGENTS.md`).
+- The Performance Check job ratchets `packages/static` uncovered lines. New code
+  in `scripts/strip-withheld-globals.ts` needs matching tests, or it trips the
+  ratchet. Neither `cfcheck` nor `deno task check` measures coverage.

--- a/packages/utils/src/sandbox-contract.ts
+++ b/packages/utils/src/sandbox-contract.ts
@@ -21,6 +21,10 @@ export const SHADOWED_FACTORY_BINDINGS = [
  * against a real compartment. Endowing one of these globals means dropping it
  * from this list and restoring its declaration; the test fails until both
  * happen.
+ *
+ * Changing this list also affects the `ts-transformers` and `schema-generator`
+ * fixture suites, which type-check their fixtures against the type libraries and
+ * are checked only in CI; see `packages/static/README.md`.
  */
 export const SANDBOX_WITHHELD_GLOBALS = Object.freeze(
   [


### PR DESCRIPTION
…es miss

The withheld-globals README documents the stripper task, the check task, and the runner contract test, but not two checks that only CI runs. A change to the withheld list or the pattern type libraries can pass `deno task cfcheck` and `deno task check` locally and still fail in CI.

The ts-transformers and schema-generator fixture suites type-check their fixture inputs against the pattern type libraries, so a fixture that reaches for a now-withheld global stops compiling. Neither cfcheck (which checks only packages/patterns) nor `deno task check` (which type-checks source) compiles those fixtures, so nothing local catches it. Separately, the Performance Check job ratchets packages/static uncovered lines, so new stripper code without matching tests trips the ratchet, and neither local gate measures coverage.

Note both in the README's "Withheld globals" section and point at the README from the SANDBOX_WITHHELD_GLOBALS doc comment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787483124&installation_model_id=428580&pr_number=4987&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4987&signature=a7a25f2935af6b5e29b4cf0d2d36fc2159427d81316d136b1a4871109044d13a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document CI-only checks tied to withheld globals so local `deno task cfcheck`/`deno task check` can pass while CI still catches issues.
Adds a “Checks that run only in CI” section to `packages/static/README.md` covering fixture type-checks in `packages/ts-transformers` and `packages/schema-generator` (incl. running `deno task test` and `UPDATE_GOLDENS=1` to refresh goldens) and the coverage ratchet on `scripts/strip-withheld-globals.ts`, and links this README from the `SANDBOX_WITHHELD_GLOBALS` doc comment.

<sup>Written for commit 9b7ab48db06a7e24f6f4e49e346aeff096d87934. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

