### PR TITLE
test(runner): run the whole suite under a fake clock, wire the guard

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -186,9 +186,13 @@ jobs:
           printf 'Runner test shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
           printf '  %s\n' $TEST_FILES
           # --no-check: the Check job type-checks packages/runner
-          # (tasks/check.sh).
+          # (tasks/check.sh). --preload runs the fake clock before every test
+          # module, the same as the package test task; without it the global
+          # `clock` the converted tests use is undefined. See
+          # test/clock-preload.ts.
           ENV=test deno test \
             --no-check \
+            --preload=test/clock-preload.ts \
             --allow-ffi \
             --allow-env \
             --allow-read \

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -326,6 +326,58 @@ sanitizer reports at once rather than letting the sleep pass by luck. No test in
 the package needs a real positive-delay timer; one that did would deadlock and
 announce itself.
 
+## The runner suite: advancing the runtime's own timers
+
+`packages/runner` has the same preload (`packages/runner/test/clock-preload.ts`,
+wired through `--preload` on the package test task) and the same rule for test
+sleeps, but it cannot simply freeze positive-delay timers the way the reconciler
+tests do. Runner's own reactivity is time-coupled: the scheduler, the wake
+shaper, and storage arm positive-delay timers — throttle and debounce windows,
+committed-write backoff, conflict retries — that `runtime.idle()`,
+`cell.pull()`, and commit then await. Freeze those and a plain reactive test
+deadlocks on the runtime's own machinery, not on any sleep it wrote.
+
+So the runner clock sorts a positive-delay `setTimeout` by who scheduled it,
+using the immediate stack frame:
+
+- A timer scheduled from `src/` — the runtime's own — **auto-advances**: when
+  the event loop would otherwise go idle, logical time jumps to the earliest
+  pending one and fires it, in fire order, with `Date.now` and `performance.now`
+  moving in lockstep. So a throttle window or a backoff retry elapses instantly
+  and deterministically, and the reactive waits above resolve on their own, with
+  no real time passing.
+- A timer scheduled from a `test/` file — a wall-clock sleep — **freezes**, so a
+  test that waits on one still deadlocks and the sanitizer reports it. Delete
+  the sleep and wait on `runtime.idle()`/`cell.pull()`/`runtime.settled()`,
+  which now settle on their own.
+
+Because the runner tests are mostly `describe`/`it` blocks, whose callbacks
+receive the framework's context rather than the one the preload wraps, the
+controls are a global `clock` (typed in `test/clock.d.ts`) rather than methods
+on the test context. `clock.settle()` drains reactive work without moving time,
+and pauses auto-advance while it does, so a test can observe a state partway
+through a window before the timer that ends it fires. `clock.tick(ms)` advances
+logical time explicitly, firing the runtime's and the test's own timers, so a
+test that genuinely measures time — a throttle expiring, a debounce trailing
+run, a backoff schedule — steps through its windows deterministically instead of
+sleeping. An intermediate "has not fired yet" check uses `clock.settle()`; the
+step that lets the window elapse uses `clock.tick`. `clock.reset()` returns
+logical time to zero and drops pending timers: one frozen clock wraps a whole
+`describe`, so a suite whose cases each read absolute coarsened time (the `#now`
+grid tests) calls it from `beforeEach` to start each case from a known instant.
+
+Three files stay on the real clock, listed with their reasons at the top of the
+preload. A resume runtime drives a real loopback memory-client transport whose
+connect/mount/sync does not complete under the fake clock, so the resume
+deadlocks. A multi-space mergeable-commit test asserts on the retry-backoff
+_windowing_ of transient rejections — which rejection fails fast versus is
+retried within a window — a distinction auto-advance collapses. And a
+nested-subagent generateObject aborts its delegate tool because the tool-calling
+path's own timeout auto-advances against the subagent's outbox progress rather
+than the wall clock, so the delegate reports "tool call timed out" before it
+completes. These are the honest exceptions: the clock they need is the real one,
+and their own sleeps are the honest way to wait.
+
 ## Proving a negative
 
 A test that asserts something never happens has no event of its own to wait for.

--- a/packages/runner/deno.jsonc
+++ b/packages/runner/deno.jsonc
@@ -1,7 +1,12 @@
 {
   "name": "@commonfabric/runner",
   "tasks": {
-    "test": "ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git test/*.test.ts",
+    // --preload runs test/clock-preload.ts before the test modules; it replaces
+    // the clock so the runtime's own timers auto-advance and test sleeps freeze.
+    // See that file and docs/development/waiting-in-tests.md. --no-check: the
+    // global `clock` type lives in test/clock.d.ts, which `deno task check` sees
+    // by type-checking the package directory as one program.
+    "test": "ENV=test deno test --no-check --preload=test/clock-preload.ts --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git test/*.test.ts",
     "bench": {
       "description": "Run Cell benchmarks for performance analysis",
       "command": "deno bench --allow-read --allow-write --allow-net --allow-ffi --allow-env --no-check test/*.bench.ts"

--- a/packages/runner/test/cell-notification-shaping.test.ts
+++ b/packages/runner/test/cell-notification-shaping.test.ts
@@ -119,7 +119,7 @@ describe("wake shaper (cell path)", () => {
     s.hold("pattern-a", "cell-1", commit(), () => seen.push("1"));
     s.dispose();
     expect(s.hasPending()).toBe(false);
-    await new Promise((r) => setTimeout(r, 5));
+    await clock.settle();
     expect(seen).toEqual([]); // the deferred delivery is cancelled by dispose
   });
 });

--- a/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
+++ b/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
@@ -300,7 +300,6 @@ describe("CFC sink ceiling on values pulled through schema-less links", () => {
     await runtime.idle();
     // The fetch (if any) fires from a post-commit effect and writes its result
     // via separate transactions — give those a chance to run, then settle.
-    await new Promise((resolve) => setTimeout(resolve, 100));
     await result.pull();
     await runtime.idle();
 

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -1,0 +1,300 @@
+// Runs before every test module in this package (wired in through `--preload`
+// on the package's test task). It replaces the clock so tests run under
+// controllable time, and adds `settle` and `tick` to a global `clock`.
+//
+// Runner's own reactivity is time-coupled: the scheduler, storage, and wake
+// shaper arm positive-delay timers (throttle windows, backoff, conflict
+// retries) that `runtime.idle()`, `cell.pull()`, and commit await. So the clock
+// distinguishes two callers of a positive-delay `setTimeout`:
+//
+//   - Production timers (scheduled from `src/`) AUTO-ADVANCE: when the event
+//     loop would otherwise idle, logical time jumps to the earliest pending one
+//     and fires it, in order. `Date.now`/`performance.now` move with it. So a
+//     throttle window or backoff elapses instantly and deterministically, and
+//     the reactive waits above resolve on their own — no real sleeping.
+//
+//   - Test timers (scheduled from a `test/` file — a wall-clock sleep) FREEZE.
+//     They never fire, so a test that waits on one deadlocks, which Deno's
+//     async-op sanitizer reports at once. The lesson: delete the sleep and wait
+//     on `runtime.idle()`/`cell.pull()`, which now settle on their own, or use
+//     `clock.tick(ms)` when the test needs to observe an intermediate instant.
+//
+// `clock.settle()` drains reactive (zero-delay) work without moving time.
+// `clock.tick(ms)` advances logical time by `ms`, firing production timers in
+// lockstep; the auto-advance pump is paused while it runs, so a test can
+// observe a state partway through a window.
+
+const realSetTimeout = globalThis.setTimeout;
+const realClearTimeout = globalThis.clearTimeout;
+const realSetInterval = globalThis.setInterval;
+const realClearInterval = globalThis.clearInterval;
+const realDateNow = Date.now;
+const realPerformanceNow = performance.now.bind(performance);
+
+const DATE_ORIGIN = 1_700_000_000_000;
+
+type Kind = "zero" | "prod" | "test";
+interface Timer {
+  id: number;
+  cb: (...args: unknown[]) => void;
+  fireAt: number;
+  args: unknown[];
+  kind: Kind;
+  interval?: number;
+}
+
+// The immediate caller of setTimeout: the first stack frame outside this file.
+// A frame in a `test/` directory (or a `.test.ts` file) is test code.
+function callerIsTest(): boolean {
+  const stack = new Error().stack ?? "";
+  for (const line of stack.split("\n").slice(1)) {
+    if (line.includes("clock-preload.ts")) continue;
+    return /\/test\//.test(line) || /\.test\.ts/.test(line);
+  }
+  return false;
+}
+
+function freezeAround(
+  fn: (t: Deno.TestContext) => void | Promise<void>,
+): (t: Deno.TestContext) => Promise<void> {
+  return async (t: Deno.TestContext) => {
+    let elapsed = 0;
+    let seq = 1;
+    let ticking = false;
+    let kickScheduled = false;
+    let autoScheduled = false;
+    const timers = new Map<number, Timer>();
+
+    const drainMicrotasks = () =>
+      new Promise<void>((resolve) => realSetTimeout(resolve, 0));
+
+    // Fire pending zero-delay timers (scheduler dispatch) on a real macrotask.
+    const kick = () => {
+      kickScheduled = false;
+      for (const tm of [...timers.values()]) {
+        if (tm.kind !== "zero" || tm.fireAt > elapsed) continue;
+        timers.delete(tm.id);
+        tm.cb(...tm.args);
+      }
+    };
+    const scheduleKick = () => {
+      if (kickScheduled) return;
+      kickScheduled = true;
+      realSetTimeout(kick, 0);
+    };
+
+    const hasPendingZero = () =>
+      kickScheduled ||
+      [...timers.values()].some((tm) =>
+        tm.kind === "zero" && tm.fireAt <= elapsed
+      );
+
+    const settle = async () => {
+      // Pause auto-advance while draining, so `settle()` observes reactive work
+      // without letting a production timer (a throttle/debounce window) fire —
+      // that is what lets a test check a state partway through a window.
+      const wasTicking = ticking;
+      ticking = true;
+      try {
+        for (let guard = 0; guard < 100_000; guard++) {
+          await drainMicrotasks();
+          if (!hasPendingZero()) return;
+          kick();
+        }
+        throw new Error(
+          "settle() did not converge: zero-delay work regenerated",
+        );
+      } finally {
+        ticking = wasTicking;
+        if (!ticking) scheduleAuto();
+      }
+    };
+
+    // Auto-advance: fire the earliest future production timer, jumping the clock
+    // to it, so runner's reactive waits resolve without real time passing.
+    // The earliest future timer to fire. `onlyProd` restricts to the runtime's
+    // own timers (used by the auto-advance pump, so a test's frozen sleep is
+    // never fired on its own); `tick` passes false, advancing test timers too,
+    // so a test can model a slow async step with `setTimeout` and step through
+    // it explicitly.
+    const nextTimer = (limit: number, onlyProd: boolean): Timer | undefined => {
+      let next: Timer | undefined;
+      for (const tm of timers.values()) {
+        if (tm.kind === "zero" || tm.fireAt <= elapsed || tm.fireAt > limit) {
+          continue;
+        }
+        if (onlyProd && tm.kind !== "prod") continue;
+        if (!next || tm.fireAt < next.fireAt) next = tm;
+      }
+      return next;
+    };
+    const nextProd = (limit: number) => nextTimer(limit, true);
+    let autoCount = 0;
+    const autoAdvance = () => {
+      autoScheduled = false;
+      if (ticking) return;
+      const next = nextProd(Infinity);
+      if (!next) return;
+      if (++autoCount > 200_000) {
+        throw new Error(
+          "clock auto-advance runaway: a production timer keeps re-arming. " +
+            "This test likely needs explicit clock.tick(ms) control.",
+        );
+      }
+      elapsed = next.fireAt;
+      if (next.interval === undefined) timers.delete(next.id);
+      else next.fireAt = elapsed + next.interval;
+      next.cb(...next.args);
+      if (nextProd(Infinity)) scheduleAuto();
+    };
+    const scheduleAuto = () => {
+      if (autoScheduled || ticking) return;
+      autoScheduled = true;
+      realSetTimeout(autoAdvance, 0);
+    };
+
+    const settleObj = {
+      settle,
+      async tick(ms: number) {
+        if (ms < 0) throw new Error("tick(ms) requires ms >= 0");
+        ticking = true;
+        try {
+          const target = elapsed + ms;
+          for (let guard = 0; guard < 1_000_000; guard++) {
+            await settle();
+            const next = nextTimer(target, false);
+            if (!next) break;
+            elapsed = next.fireAt;
+            if (next.interval === undefined) timers.delete(next.id);
+            else next.fireAt = elapsed + next.interval;
+            next.cb(...next.args);
+          }
+          elapsed = target;
+          await settle();
+        } finally {
+          ticking = false;
+          scheduleAuto();
+        }
+      },
+      // Return logical time to zero and drop every pending timer. One
+      // `freezeAround` wraps a whole `describe`, so a suite whose cases each
+      // start from a known instant — reading absolute, coarsened wall-clock
+      // values — calls this from `beforeEach` to keep a clock an earlier case
+      // built from leaking into the next.
+      reset() {
+        elapsed = 0;
+        seq = 1;
+        autoCount = 0;
+        ticking = false;
+        kickScheduled = false;
+        autoScheduled = false;
+        timers.clear();
+      },
+    };
+
+    const fakeSetTimeout = (
+      cb: (...args: unknown[]) => void,
+      delay = 0,
+      ...args: unknown[]
+    ): number => {
+      const id = seq++;
+      const ms = Number(delay) || 0;
+      if (ms <= 0) {
+        timers.set(id, { id, cb, fireAt: elapsed, args, kind: "zero" });
+        scheduleKick();
+      } else if (callerIsTest()) {
+        timers.set(id, { id, cb, fireAt: elapsed + ms, args, kind: "test" });
+      } else {
+        timers.set(id, { id, cb, fireAt: elapsed + ms, args, kind: "prod" });
+        scheduleAuto();
+      }
+      return id;
+    };
+    const fakeSetInterval = (
+      cb: (...args: unknown[]) => void,
+      delay = 0,
+      ...args: unknown[]
+    ): number => {
+      const id = seq++;
+      const ms = Math.max(1, Number(delay) || 0);
+      const kind: Kind = callerIsTest() ? "test" : "prod";
+      timers.set(id, {
+        id,
+        cb,
+        fireAt: elapsed + ms,
+        args,
+        kind,
+        interval: ms,
+      });
+      if (kind === "prod") scheduleAuto();
+      return id;
+    };
+    const fakeClear = (id: number): void => {
+      timers.delete(id);
+    };
+
+    Reflect.set(globalThis, "setTimeout", fakeSetTimeout);
+    Reflect.set(globalThis, "setInterval", fakeSetInterval);
+    Reflect.set(globalThis, "clearTimeout", fakeClear);
+    Reflect.set(globalThis, "clearInterval", fakeClear);
+    Reflect.set(Date, "now", () => DATE_ORIGIN + elapsed);
+    Reflect.set(performance, "now", () => elapsed);
+    Reflect.set(globalThis, "clock", settleObj);
+
+    try {
+      await fn(t);
+      await settle();
+    } finally {
+      Reflect.set(globalThis, "setTimeout", realSetTimeout);
+      Reflect.set(globalThis, "setInterval", realSetInterval);
+      Reflect.set(globalThis, "clearTimeout", realClearTimeout);
+      Reflect.set(globalThis, "clearInterval", realClearInterval);
+      Reflect.set(Date, "now", realDateNow);
+      Reflect.set(performance, "now", realPerformanceNow);
+      Reflect.set(globalThis, "clock", undefined);
+    }
+  };
+}
+
+const realTest = Deno.test;
+
+// Test files kept on the real clock for now. These should be converted to use
+// a fake clock. // TODO: convert these tests to a fake clock
+const REAL_CLOCK_FILES = [
+  // A second (resuming) runtime drives a real loopback memory-client transport
+  // whose connect/mount/sync machinery does not complete under the fake clock:
+  // the resume deadlocks rather than settling.
+  "list-resume-container-defer",
+  // Asserts on the retry-backoff *windowing* of transient multi-space commit
+  // rejections — which rejection fails fast versus is retried within a window.
+  // Auto-advance collapses those windows instantly, erasing the distinction the
+  // tests check.
+  "mergeable-append-multispace-conflict",
+  // Drives a nested-subagent generateObject: a delegate tool runs a child
+  // pattern whose result feeds back to the parent through the post-commit
+  // outbox across several cycles. The tool-calling path carries its own
+  // timeout, which auto-advance fires against the subagent's own outbox
+  // progress rather than the wall clock, aborting the delegate ("tool call
+  // timed out") before it can complete. Real time paces the two together.
+  "generate-object-tools",
+];
+function registeredFromRealClockFile(): boolean {
+  const stack = new Error().stack ?? "";
+  // Match the whole test-file name, not a bare substring: a name like `wish`
+  // must not also claim `wish-now-interval.test.ts`.
+  return REAL_CLOCK_FILES.some((name) => stack.includes(`${name}.test.ts`));
+}
+
+function frozenTest(
+  nameOrDef: string | Deno.TestDefinition,
+  fn?: (t: Deno.TestContext) => void | Promise<void>,
+): void {
+  const wrap = registeredFromRealClockFile() ? <T>(f: T) => f : freezeAround;
+  if (typeof nameOrDef === "string") {
+    realTest(nameOrDef, wrap(fn!));
+  } else {
+    realTest({ ...nameOrDef, fn: wrap(nameOrDef.fn) });
+  }
+}
+
+Reflect.set(Deno, "test", frozenTest);

--- a/packages/runner/test/clock.d.ts
+++ b/packages/runner/test/clock.d.ts
@@ -1,0 +1,13 @@
+// Ambient types for the clock preload (`clock-preload.ts`). `deno check` sees
+// this because it type-checks the package directory as one program; test files
+// reference `clock` with no import.
+declare const clock: {
+  // Drain reactive (zero-delay) work to a fixpoint without moving the clock.
+  settle(): Promise<void>;
+  // Advance logical time by `ms`, firing positive-delay timers in lockstep with
+  // Date.now and performance.now.
+  tick(ms: number): Promise<void>;
+  // Return logical time to zero and drop every pending timer. Call from
+  // `beforeEach` in a suite whose cases each start from a known instant.
+  reset(): void;
+};

--- a/packages/runner/test/computed-id-e2e.test.ts
+++ b/packages/runner/test/computed-id-e2e.test.ts
@@ -61,7 +61,7 @@ describe("computed-cell id end-to-end (default-on instantiation)", () => {
     await runtime.dispose();
     await remoteClient.close();
     await storageManager.close();
-    await new Promise((resolve) => setTimeout(resolve, 1));
+    await clock.settle();
   });
 
   it("stores and syncs a computed:fid1: doc as an ordinary document", async () => {

--- a/packages/runner/test/conflict-repro.test.ts
+++ b/packages/runner/test/conflict-repro.test.ts
@@ -127,7 +127,7 @@ describe("Conflict Reproduction", () => {
     // Give time for async conflict notifications to be processed
     // The conflict happens during the optimistic transaction retry,
     // which completes asynchronously after runtime.idle()
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await runtime.idle();
 
     // Verify that conflicts were NOT captured
     expect(conflictErrors.length).toBe(0);
@@ -196,7 +196,7 @@ describe("Conflict Reproduction", () => {
     expect(result.get().sequence).toBe(1);
 
     // Give time for async conflict notifications
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await runtime.idle();
 
     // Verify that NO conflicts were captured
     expect(conflictErrors.length).toBe(0);

--- a/packages/runner/test/delivery-shaping.test.ts
+++ b/packages/runner/test/delivery-shaping.test.ts
@@ -198,7 +198,7 @@ describe("wake shaper (event path)", () => {
     await shaper.whenDrained();
     expect(calls.map((c) => c.event)).toEqual([{ n: 1 }, { n: 2 }]);
     // Let the bucket refill to full and the idle group close.
-    await new Promise((r) => setTimeout(r, 80));
+    await clock.tick(80);
     // A fresh event bursts immediately again — synchronously, since the delivery
     // shaper's burst is synchronous and the bucket is full.
     shaper.hold(undefined, link("a"), { n: 3 }, true, undefined);
@@ -313,7 +313,7 @@ describe("wake shaper (event path)", () => {
     expect(calls.map((c) => c.event)).toEqual([{ n: 1 }]);
     shaper.dispose();
     expect(shaper.hasPending()).toBe(false);
-    await new Promise((r) => setTimeout(r, 5));
+    await clock.tick(5);
     expect(calls.map((c) => c.event)).toEqual([{ n: 1 }]); // n:2 never delivered
     shaper.dispose();
   });

--- a/packages/runner/test/dynamic-builder-call-throw.test.ts
+++ b/packages/runner/test/dynamic-builder-call-throw.test.ts
@@ -66,7 +66,7 @@ describe("builder calls inside a running action throw", () => {
     await runInActionExecution(async () => {
       await Promise.resolve();
       expect(() => lift((x: number) => x)).toThrow(/module level/);
-      await new Promise((resolve) => setTimeout(resolve, 1));
+      await clock.settle();
       expect(() => lift((x: number) => x)).toThrow(/module level/);
     });
     expect(() => lift((x: number) => x)).not.toThrow();
@@ -78,7 +78,7 @@ describe("builder calls inside a running action throw", () => {
     // module-scope builder calls are the LEGAL mints the transformer
     // produces. The window must not leak into them.
     const pending = runInActionExecution(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 5));
+      await clock.settle();
     });
     const frame = pushFrame({
       sourceLocationContext: {

--- a/packages/runner/test/effect-conflict-recovery.test.ts
+++ b/packages/runner/test/effect-conflict-recovery.test.ts
@@ -91,7 +91,7 @@ const waitFor = async (
   const started = Date.now();
   while (!predicate()) {
     if (Date.now() - started > timeout) return false;
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await clock.tick(5);
   }
   return true;
 };

--- a/packages/runner/test/ensure-piece-running.test.ts
+++ b/packages/runner/test/ensure-piece-running.test.ts
@@ -362,7 +362,6 @@ describe("ensurePieceRunning", () => {
 
     // Wait for processing - should complete without errors
     await runtime.idle();
-    await new Promise((resolve) => setTimeout(resolve, 50));
     await runtime.idle();
 
     // If we get here, the event was handled gracefully (dropped)
@@ -505,7 +504,6 @@ describe("queueEvent with auto-start", () => {
     runtime.scheduler.queueEvent(eventsLink, { type: "click" });
 
     await runtime.idle();
-    await new Promise((resolve) => setTimeout(resolve, 50));
     await runtime.idle();
 
     // Lift should still only have run once because runSynced is idempotent
@@ -646,7 +644,6 @@ describe("queueEvent with auto-start", () => {
 
     // Wait for processing
     await resultCell.pull();
-    await new Promise((resolve) => setTimeout(resolve, 100));
     await runtime.idle();
 
     // The piece should have been started
@@ -660,7 +657,6 @@ describe("queueEvent with auto-start", () => {
     runtime.scheduler.queueEvent(eventsLink, { type: "click", x: 20 });
 
     await runtime.idle();
-    await new Promise((resolve) => setTimeout(resolve, 50));
     await runtime.idle();
 
     // Handler should have run twice now
@@ -787,7 +783,6 @@ describe("queueEvent with auto-start", () => {
     runtime.scheduler.queueEvent(eventsLink, { type: "click", x: 42 });
 
     await resultCell.pull();
-    await new Promise((resolve) => setTimeout(resolve, 100));
     await runtime.idle();
 
     expect(liftRunCount).toBe(1);

--- a/packages/runner/test/fetch-builtins.test.ts
+++ b/packages/runner/test/fetch-builtins.test.ts
@@ -42,7 +42,7 @@ describe("fetch builtins (fetchBinary / fetchText / fetchJson)", () => {
 
     fetchCalls = [];
     originalFetch = globalThis.fetch;
-    globalThis.fetch = async (
+    globalThis.fetch = (
       input: string | URL | Request,
       init?: RequestInit,
     ) => {
@@ -54,32 +54,38 @@ describe("fetch builtins (fetchBinary / fetchText / fetchJson)", () => {
 
       fetchCalls.push({ url, init });
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
       if (url.endsWith("/text")) {
-        return new Response("hello fetch builtins", {
-          status: 200,
-          headers: { "Content-Type": "text/plain; charset=utf-8" },
-        });
+        return Promise.resolve(
+          new Response("hello fetch builtins", {
+            status: 200,
+            headers: { "Content-Type": "text/plain; charset=utf-8" },
+          }),
+        );
       }
       if (url.endsWith("/binary")) {
-        return new Response(BINARY_BODY.slice(), {
-          status: 200,
-          headers: { "Content-Type": "Image/PNG; some=param" },
-        });
+        return Promise.resolve(
+          new Response(BINARY_BODY.slice(), {
+            status: 200,
+            headers: { "Content-Type": "Image/PNG; some=param" },
+          }),
+        );
       }
       if (url.endsWith("/tuple")) {
-        return new Response(JSON.stringify([{ id: "a", extra: 1 }, 42]), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
+        return Promise.resolve(
+          new Response(JSON.stringify([{ id: "a", extra: 1 }, 42]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       }
-      return new Response(
-        JSON.stringify({ name: "widget", count: 3, extra: "ignored" }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        },
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ name: "widget", count: 3, extra: "ignored" }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
       );
     };
   });
@@ -108,9 +114,7 @@ describe("fetch builtins (fetchBinary / fetchText / fetchJson)", () => {
     tx.commit();
     tx = runtime.edit();
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
     await result.pull();
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await result.pull();
 
     return result.get() as { pending: any; result: any; error: any };
@@ -302,7 +306,6 @@ describe("fetch builtins (fetchBinary / fetchText / fetchJson)", () => {
     tx = runtime.edit();
 
     await resultCell.pull();
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await resultCell.pull();
 
     expect((resultCell.get() as { result: unknown }).result).toBe(
@@ -316,7 +319,6 @@ describe("fetch builtins (fetchBinary / fetchText / fetchJson)", () => {
     tx = runtime.edit();
 
     await resultCell.pull();
-    await new Promise((resolve) => setTimeout(resolve, 100));
     await resultCell.pull();
 
     const cleared = resultCell.get() as {

--- a/packages/runner/test/fetch-mutex-auth.test.ts
+++ b/packages/runner/test/fetch-mutex-auth.test.ts
@@ -44,7 +44,7 @@ describe("fetch-json mutex mechanism: protected request auth", () => {
     // Mock fetch
     fetchCalls = [];
     originalFetch = globalThis.fetch;
-    globalThis.fetch = async (
+    globalThis.fetch = (
       input: string | URL | Request,
       init?: RequestInit,
     ) => {
@@ -56,15 +56,14 @@ describe("fetch-json mutex mechanism: protected request auth", () => {
 
       fetchCalls.push({ url, init });
 
-      // Simulate a small delay
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      return new Response(
-        JSON.stringify({ mocked: true, url }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        },
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ mocked: true, url }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
       );
     };
   });
@@ -107,7 +106,6 @@ describe("fetch-json mutex mechanism: protected request auth", () => {
     tx.commit();
 
     await result.pull();
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await result.pull();
 
     const call = fetchCalls.find((call) =>
@@ -180,7 +178,6 @@ describe("fetch-json mutex mechanism: protected request auth", () => {
     tx.commit();
 
     await result.pull();
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await result.pull();
 
     const call = fetchCalls.find((call) =>
@@ -246,7 +243,6 @@ describe("fetch-json mutex mechanism: protected request auth", () => {
     tx.commit();
 
     await result.pull();
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await result.pull();
 
     const call = fetchCalls.find((call) =>

--- a/packages/runner/test/fetch-mutex-core.test.ts
+++ b/packages/runner/test/fetch-mutex-core.test.ts
@@ -50,7 +50,7 @@ describe("fetch-json mutex mechanism: core mutex behavior", () => {
     // Mock fetch
     fetchCalls = [];
     originalFetch = globalThis.fetch;
-    globalThis.fetch = async (
+    globalThis.fetch = (
       input: string | URL | Request,
       init?: RequestInit,
     ) => {
@@ -62,15 +62,14 @@ describe("fetch-json mutex mechanism: core mutex behavior", () => {
 
       fetchCalls.push({ url, init });
 
-      // Simulate a small delay
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      return new Response(
-        JSON.stringify({ mocked: true, url }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        },
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ mocked: true, url }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
       );
     };
   });
@@ -94,14 +93,8 @@ describe("fetch-json mutex mechanism: core mutex behavior", () => {
     }, resultCell);
     tx.commit();
 
-    // Give promises time to resolve
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
     // Pull the result to trigger computation
     await result.pull();
-
-    // Wait even more to ensure all transactions are committed
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await result.pull();
 
     const rawData = result.get() as {
@@ -146,7 +139,6 @@ describe("fetch-json mutex mechanism: core mutex behavior", () => {
     tx.commit();
 
     await result.pull();
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await result.pull();
 
     expect(fetchCalls.length).toBeGreaterThan(0);
@@ -184,12 +176,11 @@ describe("fetch-json mutex mechanism: core mutex behavior", () => {
     try {
       tx.commit();
       await result.pull();
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      await runtime.idle();
 
       expect(committed).toBe(true);
       expect(fetchCalls.length).toBeGreaterThan(0);
       expect(fetchCalls[0].url).toContain("/api/pre-commit");
-      await new Promise((resolve) => setTimeout(resolve, 100));
     } finally {
       txPrototype.commit = originalTxCommit;
       wrapperPrototype.commit = originalWrapperCommit;
@@ -229,7 +220,6 @@ describe("fetch-json mutex mechanism: core mutex behavior", () => {
       }, resultCell);
       tx.commit();
       await result.pull();
-      await new Promise((resolve) => setTimeout(resolve, 50));
 
       const expectedHash = computeInputHashFromValue({
         url: "http://mock-test-server.local/api/idempotency",
@@ -319,9 +309,6 @@ describe("fetch-json mutex mechanism: core mutex behavior", () => {
     // Pull first to trigger computation (starts the fetch)
     await resultCell1.pull();
     await resultCell2.pull();
-
-    // Wait for async promises to resolve
-    await new Promise((resolve) => setTimeout(resolve, 200));
 
     // Pull again to get final results
     const data1 = (await resultCell1.pull()) as { result?: unknown };

--- a/packages/runner/test/fetch-mutex-reactivity.test.ts
+++ b/packages/runner/test/fetch-mutex-reactivity.test.ts
@@ -42,7 +42,7 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
     // Mock fetch
     fetchCalls = [];
     originalFetch = globalThis.fetch;
-    globalThis.fetch = async (
+    globalThis.fetch = (
       input: string | URL | Request,
       init?: RequestInit,
     ) => {
@@ -54,15 +54,14 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
 
       fetchCalls.push({ url, init });
 
-      // Simulate a small delay
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      return new Response(
-        JSON.stringify({ mocked: true, url }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        },
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ mocked: true, url }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
       );
     };
   });
@@ -93,8 +92,6 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
     // Pull first to trigger computation (starts the fetch)
     await resultCell.pull();
 
-    // Wait for async work
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await resultCell.pull();
 
     const firstCallCount =
@@ -109,8 +106,6 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
     // Pull first to trigger computation with new URL
     await resultCell.pull();
 
-    // Wait for async work
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await resultCell.pull();
 
     // Should have made a new fetch with the new URL
@@ -135,8 +130,6 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
     // Pull first to trigger computation
     await resultCell1.pull();
 
-    // Wait for async work
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await resultCell1.pull();
 
     const jsonCallCount = fetchCalls.length;
@@ -156,8 +149,6 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
     // Pull first to trigger computation
     await resultCell2.pull();
 
-    // Wait for async work
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await resultCell2.pull();
 
     // Should have made additional fetch calls for the different builtin
@@ -167,7 +158,7 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
   it("should set pending to true during fetch and false after", async () => {
     // Use a longer delay to observe pending state
     const slowFetch = globalThis.fetch;
-    globalThis.fetch = async (
+    globalThis.fetch = (
       input: string | URL | Request,
       init?: RequestInit,
     ) => {
@@ -178,13 +169,12 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
         : input.url;
       fetchCalls.push({ url, init });
 
-      // Longer delay
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      return new Response(JSON.stringify({ mocked: true }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+      return Promise.resolve(
+        new Response(JSON.stringify({ mocked: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
     };
 
     const fetchJson = byRef("fetchJson");
@@ -204,12 +194,6 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
     // Pull first to trigger computation (starts the fetch)
     await result.pull();
 
-    // Wait a bit for request to start
-    await new Promise((resolve) => setTimeout(resolve, 20));
-
-    // Wait for completion
-    await new Promise((resolve) => setTimeout(resolve, 200));
-
     const finalData = (await result.pull()) as {
       pending?: boolean;
       result?: unknown;
@@ -224,9 +208,8 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
   });
 
   const error404Fetch = () => {
-    globalThis.fetch = async () => {
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      return new Response("Not Found", { status: 404 });
+    globalThis.fetch = () => {
+      return Promise.resolve(new Response("Not Found", { status: 404 }));
     };
   };
 
@@ -259,7 +242,6 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
     localTx.commit();
 
     await result.pull();
-    await new Promise((resolve) => setTimeout(resolve, 200));
 
     const data = (await result.pull()) as {
       error?: unknown;
@@ -308,8 +290,7 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
     urlCell.withTx(tx).send("");
     tx.commit();
 
-    // Wait for async work
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await runtime.idle();
 
     const data = (await resultCell.pull()) as {
       error?: unknown;
@@ -354,7 +335,6 @@ describe("fetch-json mutex mechanism: reactive fetch state", () => {
 
     // Pull and wait for the fetch to complete
     await result.pull();
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await result.pull();
 
     // Filter to only the calls that hit our endpoint

--- a/packages/runner/test/fetch-program-outbox.test.ts
+++ b/packages/runner/test/fetch-program-outbox.test.ts
@@ -43,7 +43,7 @@ describe("fetch-program outbox mechanism", () => {
 
     fetchCalls = [];
     originalFetch = globalThis.fetch;
-    globalThis.fetch = async (
+    globalThis.fetch = (
       input: string | URL | Request,
       init?: RequestInit,
     ) => {
@@ -55,12 +55,12 @@ describe("fetch-program outbox mechanism", () => {
 
       fetchCalls.push({ url, init });
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      return new Response("export const value = 1;\n", {
-        status: 200,
-        headers: { "Content-Type": "text/plain" },
-      });
+      return Promise.resolve(
+        new Response("export const value = 1;\n", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      );
     };
   });
 
@@ -105,13 +105,12 @@ describe("fetch-program outbox mechanism", () => {
 
     try {
       await result.pull();
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      await result.pull();
+      await runtime.settled();
 
       expect(committed).toBe(true);
       expect(fetchCalls.length).toBeGreaterThan(0);
       expect(fetchCalls[0].url).toContain("/program.ts");
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await runtime.settled();
     } finally {
       txPrototype.commit = originalTxCommit;
       wrapperPrototype.commit = originalWrapperCommit;
@@ -151,7 +150,6 @@ describe("fetch-program outbox mechanism", () => {
       }, resultCell);
       tx.commit();
       await result.pull();
-      await new Promise((resolve) => setTimeout(resolve, 50));
 
       const expectedHash = computeInputHashFromValue({
         url: "http://mock-test-server.local/program-idempotency.ts",

--- a/packages/runner/test/generate-object-outbox.test.ts
+++ b/packages/runner/test/generate-object-outbox.test.ts
@@ -305,7 +305,7 @@ describe("generateObject outbox mechanism", () => {
       action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();
       expect(rejectedResult.error).toBeDefined();
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await runtime.idle();
       expect(generateObjectCalls).toEqual([]);
 
       const retryTx = runtime.edit();
@@ -406,7 +406,7 @@ describe("generateObject outbox mechanism", () => {
       action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();
       expect(rejectedResult.error).toBeDefined();
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await runtime.idle();
       expect(sendRequestCalls).toEqual([]);
 
       const retryTx = runtime.edit();

--- a/packages/runner/test/generate-text-outbox.test.ts
+++ b/packages/runner/test/generate-text-outbox.test.ts
@@ -186,7 +186,7 @@ describe("generateText outbox mechanism", () => {
       action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();
       expect(rejectedResult.error).toBeDefined();
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await runtime.idle();
       expect(sendRequestCalls).toEqual([]);
 
       const retryTx = runtime.edit();
@@ -263,7 +263,7 @@ describe("generateText outbox mechanism", () => {
       action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();
       expect(rejectedResult.error).toBeDefined();
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await runtime.idle();
       expect(sendRequestCalls).toEqual([]);
 
       const retryTx = runtime.edit();

--- a/packages/runner/test/memory-v2-emulation.test.ts
+++ b/packages/runner/test/memory-v2-emulation.test.ts
@@ -47,7 +47,7 @@ describe("Memory v2 emulation", () => {
   afterEach(async () => {
     await tx.commit();
     await storageManager.close();
-    await new Promise((resolve) => setTimeout(resolve, 1));
+    await clock.settle();
   });
 
   it("persists and reloads documents through the runtime cutover seam", async () => {

--- a/packages/runner/test/memory-v2-pull-reactivity.test.ts
+++ b/packages/runner/test/memory-v2-pull-reactivity.test.ts
@@ -24,7 +24,7 @@ const waitFor = async (
     if (Date.now() - started > timeout) {
       throw new Error("Timed out waiting for condition");
     }
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await clock.tick(5);
   }
 };
 
@@ -76,7 +76,7 @@ describe("Memory v2 pull reactivity", () => {
     await runtime.dispose();
     await remoteClient.close();
     await storageManager.close();
-    await new Promise((resolve) => setTimeout(resolve, 1));
+    await clock.tick(1);
   });
 
   it("marks pull-mode computations dirty after remote integrate and recomputes on pull", async () => {

--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -154,7 +154,7 @@ class RejectThenSucceedTransport extends ScriptedSessionTransport {
         const commit = message.commit as { localSeq?: number } | undefined;
         const localSeq = commit?.localSeq ?? -1;
         if (localSeq === 1) {
-          await new Promise((resolve) => setTimeout(resolve, 5));
+          await clock.tick(5);
           this.respond({
             type: "response",
             requestId: message.requestId!,
@@ -198,7 +198,7 @@ const waitFor = async (
     if (Date.now() - start > timeout) {
       throw new Error("Timed out waiting for condition");
     }
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await clock.tick(5);
   }
 };
 

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -571,7 +571,7 @@ const createHarness = () => {
     pushSync: (options: PushSyncOptions) => transport.pushSync(options),
     close: async () => {
       await storageManager.close();
-      await new Promise((resolve) => setTimeout(resolve, 30));
+      await clock.tick(30);
     },
   };
 };
@@ -923,7 +923,7 @@ const waitForCondition = async (
     if (predicate()) {
       return;
     }
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await clock.tick(5);
   }
   throw new Error(`timed out waiting for ${label}`);
 };
@@ -1889,7 +1889,7 @@ Deno.test("memory v2 stacked commits: conflict rejection delivered before the wi
           ?.debug ?? 0) > conflictBaseline,
       "the conflict rejection to reach the runner",
     );
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await clock.tick(30);
 
     // Rejection processed-but-held: the commit promise must not settle, the
     // optimistic value stays visible, and no revert is emitted before the

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -70,7 +70,7 @@ const waitFor = async (
     if (Date.now() - start > timeout) {
       throw new Error("Timed out waiting for condition");
     }
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await clock.tick(5);
   }
 };
 
@@ -193,7 +193,7 @@ describe("Memory v2 storage notifications", () => {
     await runtime.dispose();
     await remoteClient.close();
     await storageManager.close();
-    await new Promise((resolve) => setTimeout(resolve, 1));
+    await clock.tick(1);
   });
 
   it("emits a commit notification with optimistic changes", async () => {

--- a/packages/runner/test/oncommit-race.test.ts
+++ b/packages/runner/test/oncommit-race.test.ts
@@ -147,13 +147,10 @@ describe("onCommit callback final outcome", () => {
         },
       );
 
-      // The first commit fails on the server asynchronously; wait for the
-      // backoff retry to re-run the handler before asserting.
-      const deadline = performance.now() + 2_000;
-      while (attempts < 2 && performance.now() < deadline) {
-        await runtime.idle();
-        await new Promise((resolve) => setTimeout(resolve, 5));
-      }
+      // The first commit fails on the server asynchronously; the scheduler's
+      // backoff retry re-runs the handler. Advancing the clock fires the
+      // backoff timer so the retry lands before we assert.
+      await clock.tick(2_000);
       await runtime.idle();
       await runtime.storageManager.synced();
     } finally {

--- a/packages/runner/test/patterns-async.test.ts
+++ b/packages/runner/test/patterns-async.test.ts
@@ -81,9 +81,11 @@ describe("Pattern Runner - Async", () => {
     const pullPromise = result.pull();
 
     // Give time for the lift to start but not complete
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await clock.tick(10);
     expect(liftCalled).toBe(true);
     expect(timeoutCalled).toBe(false);
+
+    await clock.tick(100);
 
     // Now await the pull to wait for completion
     const value = await pullPromise;
@@ -131,9 +133,11 @@ describe("Pattern Runner - Async", () => {
     piece.key("updater").send({ value: 5 });
 
     // Give a small delay to start the handler but not enough to complete
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await clock.tick(10);
     expect(handlerCalled).toBe(true);
     expect(timeoutCalled).toBe(false);
+
+    await clock.tick(100);
 
     // Now pull should wait for the handler's promise to resolve
     const value = await piece.pull();
@@ -189,6 +193,8 @@ describe("Pattern Runner - Async", () => {
     await piece.pull();
     expect(handlerCalled).toBe(true);
     expect(timeoutCalled).toBe(false);
+
+    await clock.tick(100);
 
     // Now wait for the timeout promise to resolve
     await timeoutPromise;

--- a/packages/runner/test/pending-commit-durability.test.ts
+++ b/packages/runner/test/pending-commit-durability.test.ts
@@ -109,7 +109,7 @@ function rejectServerTransacts(
   };
 }
 
-const tick = (ms = 15) => new Promise((resolve) => setTimeout(resolve, ms));
+const tick = (_ms = 0) => clock.settle();
 
 describe("pending-commit durability barrier", () => {
   let storageManager: SchedulerTestStorageManager;

--- a/packages/runner/test/queue.test.ts
+++ b/packages/runner/test/queue.test.ts
@@ -2,10 +2,6 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { AsyncSemaphoreQueue } from "../src/queue.ts";
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 describe("AsyncSemaphoreQueue", () => {
   it("processes a single job", async () => {
     const queue = new AsyncSemaphoreQueue({ maxConcurrency: 1 });
@@ -25,7 +21,7 @@ describe("AsyncSemaphoreQueue", () => {
       queue.enqueue(async () => {
         currentConcurrent++;
         maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
-        await delay(50);
+        await clock.settle();
         currentConcurrent--;
         return maxConcurrent;
       });
@@ -53,7 +49,7 @@ describe("AsyncSemaphoreQueue", () => {
     const makeJob = (id: number) =>
       queue.enqueue(async () => {
         order.push(id);
-        await delay(10);
+        await clock.settle();
       });
 
     await Promise.all([makeJob(1), makeJob(2), makeJob(3), makeJob(4)]);
@@ -123,7 +119,7 @@ describe("AsyncSemaphoreQueue", () => {
       queue.enqueue(async () => {
         concurrent++;
         maxConcurrent = Math.max(maxConcurrent, concurrent);
-        await delay(100);
+        await clock.settle();
         concurrent--;
       });
 

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -3014,7 +3014,7 @@ describe("runner utils", () => {
       const runner = runtime.runner as any;
       const originalSync = runner.syncCellsForRunningPattern.bind(runner);
       runner.syncCellsForRunningPattern = async (...args: any[]) => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await clock.settle();
         return originalSync(...args);
       };
 

--- a/packages/runner/test/runtime-dispose-withheld-commit.test.ts
+++ b/packages/runner/test/runtime-dispose-withheld-commit.test.ts
@@ -82,7 +82,7 @@ Deno.test("runtime.dispose() resolves while a commit is withheld in flight", asy
   const writeTx = runtime.edit();
   cell.withTx(writeTx).set({ value: 1 });
   writeTx.commit().catch(() => {});
-  await new Promise((resolve) => setTimeout(resolve, 50));
+  await clock.settle();
   // Guard the precondition: if the commit is not actually in flight, dispose
   // would not exercise the deadlock and the test would pass vacuously.
   assertEquals(storageManager.hasPendingCommits(), true);

--- a/packages/runner/test/scheduler-commit-backpressure.test.ts
+++ b/packages/runner/test/scheduler-commit-backpressure.test.ts
@@ -126,7 +126,7 @@ async function waitFor(
   const deadline = performance.now() + timeoutMs;
   while (!condition() && performance.now() < deadline) {
     await runtime.idle();
-    await new Promise((resolve) => setTimeout(resolve, 1));
+    await clock.tick(1);
   }
   if (!condition()) {
     throw new Error(message);
@@ -357,7 +357,7 @@ describe("committed-write backpressure", () => {
 
         // Give any erroneous retry a chance to run, then confirm none did.
         await runtime.idle();
-        await new Promise((resolve) => setTimeout(resolve, 30));
+        await clock.tick(30);
         await runtime.idle();
 
         // Failed fast: the handler ran exactly once (no windowed re-queue) and
@@ -425,7 +425,7 @@ describe("committed-write backpressure", () => {
         await commitTelemetry.firstMarker;
         // Give any erroneous retry a chance to run, then confirm none did.
         await runtime.idle();
-        await new Promise((resolve) => setTimeout(resolve, 30));
+        await clock.tick(30);
         await runtime.idle();
 
         // The handler ran once; a permanent rejection must not re-run it.
@@ -489,7 +489,7 @@ describe("committed-write backpressure", () => {
         // misclassification would re-run the handler up to
         // DEFAULT_RETRIES_FOR_EVENTS more times), then confirm none did.
         await runtime.idle();
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await clock.tick(50);
         await runtime.idle();
 
         // The doomed handler ran exactly once — no retry budget consumed.
@@ -615,7 +615,7 @@ describe("committed-write backpressure", () => {
 
         // Give any erroneous retry a chance to run, then confirm none did.
         await runtime.idle();
-        await new Promise((resolve) => setTimeout(resolve, 20));
+        await clock.tick(20);
         await runtime.idle();
 
         // Loud, not silent: a terminal error surfaced.

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -411,11 +411,12 @@ describe("scheduler", () => {
     await tx.commit();
     tx = runtime.edit();
 
-    const deadline = performance.now() + 1_000;
-    while (c.get() !== 1 && performance.now() < deadline) {
-      await runtime.scheduler.idle();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
+    // The intermediate delays its own commit by 25ms (a modeled slow
+    // computation). Drive the scheduler so it arms the delay, fire it, then let
+    // the downstream effect re-run against the committed value.
+    await runtime.scheduler.idle();
+    await clock.tick(25);
+    await runtime.scheduler.idle();
 
     expect(c.get()).toBe(1);
   });

--- a/packages/runner/test/scheduler-event-lineage.test.ts
+++ b/packages/runner/test/scheduler-event-lineage.test.ts
@@ -144,7 +144,6 @@ async function waitForSchedulerCondition(
   const deadline = performance.now() + 1_000;
   while (!condition() && performance.now() < deadline) {
     await runtime.idle();
-    await new Promise((resolve) => setTimeout(resolve, 0));
   }
   if (!condition()) {
     throw new Error(message);
@@ -171,18 +170,11 @@ async function waitForSignal(
 async function expectIdlePending(
   idlePromise: Promise<void>,
 ): Promise<void> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  try {
-    const result = await Promise.race([
-      idlePromise.then(() => "resolved" as const),
-      new Promise<"pending">((resolve) => {
-        timeoutId = setTimeout(() => resolve("pending"), 100);
-      }),
-    ]);
-    expect(result).toBe("pending");
-  } finally {
-    if (timeoutId !== undefined) clearTimeout(timeoutId);
-  }
+  const result = await Promise.race([
+    idlePromise.then(() => "resolved" as const),
+    clock.settle().then(() => "pending" as const),
+  ]);
+  expect(result).toBe("pending");
 }
 
 describe("scheduler event lineage", () => {
@@ -539,7 +531,7 @@ describe("scheduler event lineage", () => {
       );
       gate.fail();
       await runtime.idle();
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await clock.tick(50);
       await runtime.idle();
 
       expect(payloads.get()).toEqual([]);

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -116,7 +116,6 @@ async function waitForSchedulerCondition(
   const deadline = performance.now() + 1_000;
   while (!condition() && performance.now() < deadline) {
     await runtime.idle();
-    await new Promise((resolve) => setTimeout(resolve, 0));
   }
   if (!condition()) {
     throw new Error(message);
@@ -1158,7 +1157,6 @@ Deno.test("navigateTo handler results navigate once and deduplicate redelivery",
       "redelivered navigateTo event did not run",
     );
     await runtime.idle();
-    await new Promise((resolve) => setTimeout(resolve, 50));
     await runtime.idle();
 
     expect(navigations.length).toBe(1);

--- a/packages/runner/test/scheduler-events.test.ts
+++ b/packages/runner/test/scheduler-events.test.ts
@@ -31,7 +31,6 @@ async function waitForSchedulerCondition(
   const deadline = performance.now() + 1_000;
   while (!condition() && performance.now() < deadline) {
     await runtime.idle();
-    await new Promise((resolve) => setTimeout(resolve, 0));
   }
 }
 
@@ -144,7 +143,7 @@ describe("event handling", () => {
 
     // Give the scheduler a chance to dispatch; the handler must not run while
     // presync is pending.
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await clock.settle();
     expect(order).toEqual(["presync:7"]);
 
     releasePresync();
@@ -1053,7 +1052,6 @@ describe("event handling", () => {
 
       await runtime.idle();
       // Give any erroneous retry a chance to run, then confirm none did.
-      await new Promise((resolve) => setTimeout(resolve, 20));
       await runtime.idle();
 
       expect(attempts).toBe(1);
@@ -1104,7 +1102,6 @@ describe("event handling", () => {
 
       await runtime.idle();
       // Give any erroneous re-run a chance to run, then confirm none did.
-      await new Promise((resolve) => setTimeout(resolve, 20));
       await runtime.idle();
 
       // The one-shot ran once and dropped without re-running to resolve names.

--- a/packages/runner/test/scheduler-pull-handlers.test.ts
+++ b/packages/runner/test/scheduler-pull-handlers.test.ts
@@ -667,13 +667,13 @@ describe("handler dependency pulling", () => {
     runtime.scheduler.resetFilterStats();
     runtime.scheduler.queueEvent(eventStream.getAsNormalizedFullLink(), 3);
 
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await clock.tick(50);
 
     expect(computedRuns).toBe(1);
     expect(handlerRuns).toBe(0);
     expect(runtime.scheduler.getFilterStats().filtered).toBeLessThan(5);
 
-    await new Promise((resolve) => setTimeout(resolve, 70));
+    await clock.tick(70);
     await runtime.scheduler.idle();
 
     expect(computedRuns).toBe(2);
@@ -776,10 +776,10 @@ describe("handler dependency pulling", () => {
     tx = runtime.edit();
 
     runtime.scheduler.queueEvent(eventStream.getAsNormalizedFullLink(), 3);
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await clock.tick(25);
     runtime.scheduler.queueExecution();
 
-    await new Promise((resolve) => setTimeout(resolve, 120));
+    await clock.tick(120);
     await runtime.scheduler.idle();
 
     expect(computedRuns).toBe(2);
@@ -965,10 +965,10 @@ describe("handler dependency pulling", () => {
 
     runtime.scheduler.queueEvent(eventStream.getAsNormalizedFullLink(), 1);
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await clock.tick(20);
     runtime.scheduler.queueEvent(eventStream.getAsNormalizedFullLink(), 2);
 
-    await new Promise((resolve) => setTimeout(resolve, 90));
+    await clock.tick(90);
     await runtime.scheduler.idle();
 
     expect(computedRuns).toBe(2);

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -135,7 +135,7 @@ describe("pull-based scheduling", () => {
     tx = runtime.edit();
 
     // Give time for the storage notification to process
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await runtime.idle();
 
     // In pull mode with no effect depending on this computation,
     // the computation should be marked dirty but not run

--- a/packages/runner/test/scheduler-throttle.test.ts
+++ b/packages/runner/test/scheduler-throttle.test.ts
@@ -88,7 +88,7 @@ describe("throttle - bounded freshness", () => {
     tx = runtime.edit();
     // Yield through the already-queued scheduler tick so it observes the dirty
     // gated node and arms the shared wake before the clear.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await clock.settle();
     expect(observed).toBe(1);
 
     runtime.scheduler.clearThrottle(effect);
@@ -206,7 +206,7 @@ describe("throttle - bounded freshness", () => {
     expect(runCount).toBe(1);
 
     // Wait for throttle to expire
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await clock.tick(100);
 
     // Now should run
     runtime.scheduler.subscribe(
@@ -319,13 +319,13 @@ describe("throttle - bounded freshness", () => {
     source.withTx(tx).send(5);
     await tx.commit();
     tx = runtime.edit();
-    await new Promise((resolve) => setTimeout(resolve, 80));
+    await clock.tick(80);
     expect(effectCount).toBe(1);
     expect(result.get()).toBe(2);
 
     // Wait for throttle to expire
-    await new Promise((resolve) => setTimeout(resolve, 700));
-    await runtime.scheduler.idle();
+    await clock.tick(700);
+    await clock.settle();
     expect(effectCount).toBe(2);
     expect(result.get()).toBe(10);
 
@@ -333,7 +333,7 @@ describe("throttle - bounded freshness", () => {
     source.withTx(tx).send(10);
     await tx.commit();
     tx = runtime.edit();
-    await result.pull();
+    await clock.tick(500);
 
     // Now effect should run again
     expect(effectCount).toBe(3);
@@ -384,12 +384,12 @@ describe("throttle - bounded freshness", () => {
     await tx.commit();
     tx = runtime.edit();
 
-    await new Promise((resolve) => setTimeout(resolve, 80));
+    await clock.tick(80);
     expect(effectCount).toBe(1);
     expect(runtime.scheduler.getFilterStats().filtered).toBeLessThan(5);
 
-    await new Promise((resolve) => setTimeout(resolve, 700));
-    await runtime.scheduler.idle();
+    await clock.tick(700);
+    await clock.settle();
 
     expect(effectCount).toBe(2);
     expect(result.get()).toBe(10);

--- a/packages/runner/test/scheduler-timing.test.ts
+++ b/packages/runner/test/scheduler-timing.test.ts
@@ -88,7 +88,7 @@ describe("debounce and throttling", () => {
     expect(runCount).toBe(0);
 
     // Wait for debounce period
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await clock.tick(100);
     await cell.pull();
 
     // Now it should have run
@@ -126,14 +126,14 @@ describe("debounce and throttling", () => {
         },
         {},
       );
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await clock.tick(10);
     }
 
     // Should not have run yet (debounce keeps resetting)
     expect(runCount).toBe(0);
 
     // Wait for debounce to complete
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await clock.tick(100);
     await cell.pull();
 
     // Should have run only once
@@ -175,7 +175,7 @@ describe("debounce and throttling", () => {
     expect(runCount).toBe(0);
 
     // Wait for debounce
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await clock.tick(100);
     await cell.pull();
 
     expect(runCount).toBe(1);
@@ -224,21 +224,21 @@ describe("debounce and throttling", () => {
     await tx.commit();
     tx = runtime.edit();
 
-    await result.pull();
+    await clock.settle();
     expect(runCount).toBe(1);
     expect(result.get()).toBe(10);
 
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await clock.tick(25);
     source.withTx(tx).send(3);
     await tx.commit();
     tx = runtime.edit();
 
-    await new Promise((resolve) => setTimeout(resolve, 30));
-    await result.pull();
+    await clock.tick(30);
+    await clock.settle();
     expect(runCount).toBe(1);
     expect(result.get()).toBe(10);
 
-    await new Promise((resolve) => setTimeout(resolve, 40));
+    await clock.tick(40);
     await runtime.idle();
     await result.pull();
 
@@ -280,7 +280,7 @@ describe("debounce and throttling", () => {
     cancel();
 
     // Wait past the debounce period
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await clock.tick(150);
     await runtime.idle();
 
     // Action should NOT have run because we unsubscribed
@@ -307,7 +307,7 @@ describe("debounce and throttling", () => {
 
     // Let the settle pass arm the debounce wake. The first run is deferred, so
     // the effect has not run yet.
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await clock.tick(20);
     expect(runCount).toBe(0);
 
     // idle() is blocked behind the armed wake + idle-blocking effect.
@@ -349,7 +349,7 @@ describe("debounce and throttling", () => {
 
       local.runtime.scheduler.dispose();
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await clock.tick(100);
 
       expect(runCount).toBe(0);
     } finally {
@@ -584,7 +584,7 @@ describe("debounce and throttling", () => {
     expect(runCount).toBe(0);
 
     // Wait for debounce
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await clock.tick(100);
     await result.pull();
 
     // Should have run

--- a/packages/runner/test/selector-tracker.test.ts
+++ b/packages/runner/test/selector-tracker.test.ts
@@ -31,8 +31,7 @@ describe("SelectorTracker", () => {
 
   afterEach(async () => {
     await storageManager?.close();
-    // _processCurrentBatch leaves sleep behind that makes deno error
-    await new Promise((wake) => setTimeout(wake, 1));
+    await runtime.idle();
   });
 
   const vnodeSchema = {

--- a/packages/runner/test/sqlite-builtins.test.ts
+++ b/packages/runner/test/sqlite-builtins.test.ts
@@ -138,7 +138,12 @@ describe("sqlite builtins (Phase 0 wiring)", () => {
         await runtime.idle();
         expect(view.get().pending).toBe(true);
 
-        await runtime.settled();
+        // The slow server read is a frozen test-side timer. Begin the settled()
+        // wait, fire the read, and confirm settled() stayed open until the flush
+        // wrote the result back.
+        const settledPromise = runtime.settled();
+        await clock.tick(50);
+        await settledPromise;
         const v = view.get();
         expect(v.pending).toBe(false);
         expect(v.error).toBeUndefined();

--- a/packages/runner/test/storage-close.test.ts
+++ b/packages/runner/test/storage-close.test.ts
@@ -162,7 +162,7 @@ Deno.test("StorageManager.close drains a watch long-poll still in flight", async
   // with "Promise resolution is still pending...".
   void provider.sync("of:storage-close-watch-inflight" as URI);
   // Let the pull reach the transport before closing.
-  await new Promise((resolve) => setTimeout(resolve, 20));
+  await clock.settle();
 
   // close() must resolve without waiting on the withheld watch response: a
   // close() that blocked on the in-flight read would deadlock here. The default

--- a/packages/runner/test/stream-data-outbox.test.ts
+++ b/packages/runner/test/stream-data-outbox.test.ts
@@ -113,7 +113,7 @@ describe("stream-data outbox mechanism", () => {
       expect(fetchCalls).toEqual([]);
 
       await commitPromise;
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await runtime.settled();
 
       expect(outboxEffects.length).toBeGreaterThan(0);
       expect(outboxEffects[0].kind).toBe("streamData-start");
@@ -160,7 +160,7 @@ describe("stream-data outbox mechanism", () => {
       }, resultCell);
       const commitPromise = tx.commit();
       await commitPromise;
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await runtime.settled();
 
       const expectedHash = hashOf(
         createFrozenRequestSnapshot({
@@ -220,14 +220,14 @@ describe("stream-data outbox mechanism", () => {
     action(rejectedTx);
     const rejectedResult = await rejectedTx.commit();
     expect(rejectedResult.error).toBeDefined();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await runtime.settled();
     expect(fetchCalls).toEqual([]);
 
     const retryTx = runtime.edit();
     action(retryTx);
     const retryResult = await retryTx.commit();
     expect(retryResult.ok).toBeDefined();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await runtime.settled();
 
     expect(fetchCalls.length).toBe(1);
     expect(fetchCalls[0].url).toContain("/stream-retry");
@@ -274,7 +274,7 @@ describe("stream-data outbox mechanism", () => {
     action(firstTx);
     const firstResult = await firstTx.commit();
     expect(firstResult.ok).toBeDefined();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await runtime.settled();
     expect(fetchCalls.length).toBe(1);
 
     const linkTx = runtime.edit();
@@ -298,7 +298,7 @@ describe("stream-data outbox mechanism", () => {
     action(secondTx);
     const secondResult = await secondTx.commit();
     expect(secondResult.ok).toBeDefined();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await runtime.settled();
 
     expect(fetchCalls.length).toBe(2);
   });

--- a/packages/runner/test/time-capability.test.ts
+++ b/packages/runner/test/time-capability.test.ts
@@ -65,16 +65,24 @@ describe("time/entropy capability gate", () => {
     });
   });
 
-  it("handler context: the clock is frozen — repeated reads never advance", () => {
+  it("handler context: the clock is frozen — repeated reads never advance", async () => {
     // The load-bearing property: time does not move during a handler's own work,
-    // so a read before and after an await (or any elapsed real time) is identical
-    // and cannot serve as an intra-run clock.
-    inFrame({ inHandler: true, eventTime: 1_700_000_000_500 }, () => {
-      const first = sandboxDateNow();
-      const spinUntil = Date.now() + 5;
-      while (Date.now() < spinUntil) { /* burn real wall-clock time */ }
-      expect(sandboxDateNow()).toBe(first);
+    // so a read before and after elapsed live time is identical and cannot serve
+    // as an intra-run clock. Advance the live clock between the two reads — a
+    // handler clock that read it would change; the event-bound one does not.
+    const frame = pushFrame({
+      runtime: fakeRuntime(),
+      inHandler: true,
+      eventTime: 1_700_000_000_500,
     });
+    try {
+      const first = sandboxDateNow();
+      await clock.tick(5000);
+      expect(Date.now()).toBeGreaterThan(first);
+      expect(sandboxDateNow()).toBe(first);
+    } finally {
+      popFrame(frame);
+    }
   });
 
   it("handler context with no event time recorded: throws (no live-clock fallback)", () => {

--- a/packages/runner/test/wish-now-interval.test.ts
+++ b/packages/runner/test/wish-now-interval.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { createBuilder } from "../src/builder/factory.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("wish built-in tests");
+const space = signer.did();
+
+// The `#now/N` grid ticks on a recurring wall-clock-boundary timer. These cases
+// observe the grid value advancing across a second, driving the beat with
+// `clock.tick` and reading the coarsened value before and after. They are split
+// out of `wish.test.ts` because the grid's heartbeat and its shared result cell
+// carry state across a suite's cases: run alongside the ~30 other `#now` cases,
+// the beat fires but the observed value stays frozen. In their own file each
+// case starts from a clean grid.
+describe("interval #now wish", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: ReturnType<Runtime["edit"]>;
+  let wish: ReturnType<typeof createBuilder>["commonfabric"]["wish"];
+  let pattern: ReturnType<typeof createBuilder>["commonfabric"]["pattern"];
+
+  beforeEach(() => {
+    // One frozen clock wraps the whole describe; these cases read absolute
+    // coarsened time, so start each from logical zero.
+    clock.reset();
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+
+    tx = runtime.edit();
+
+    const { commonfabric } = createTrustedBuilder(runtime);
+    ({ wish, pattern } = commonfabric);
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  it("#now/1 ticks and updates value", async () => {
+    const wishPattern = pattern(() => {
+      return { nowValue: wish({ query: "#now/1" }) };
+    });
+
+    const resultCell = runtime.getCell<{ nowValue?: { result?: number } }>(
+      space,
+      "ticking now result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, wishPattern, {}, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+
+    await result.pull();
+    const initial = result.key("nowValue").get()?.result;
+    expect(typeof initial).toBe("number");
+    expect(initial! % 1000).toBe(0);
+
+    // Advance one second: the interval fires, the value re-coarsens, and the
+    // reactive read reflects the next grid instant.
+    await clock.tick(1000);
+    await result.pull();
+    const updated = result.key("nowValue").get()?.result;
+    expect(updated).toBeGreaterThan(initial!);
+    expect(updated! % 1000).toBe(0);
+
+    runtime.runner.stop(resultCell);
+  });
+
+  it("#now interval keeps ticking when other dependencies change", async () => {
+    // Regression: re-running the wish action (here via an unrelated cell the
+    // pattern reads) must not reset or starve the shared interval timer.
+    const triggerCell = runtime.getCell<number>(
+      space,
+      "tick collision trigger",
+      undefined,
+      tx,
+    );
+    triggerCell.set(0);
+
+    const wishPattern = pattern(() => {
+      triggerCell.get();
+      return { nowValue: wish({ query: "#now/1" }) };
+    });
+
+    const resultCell = runtime.getCell<{ nowValue?: { result?: number } }>(
+      space,
+      "collision now result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, wishPattern, {}, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+
+    await result.pull();
+    const initial = result.key("nowValue").get()?.result;
+    expect(typeof initial).toBe("number");
+
+    // Flip the trigger to re-run the wish action, then advance a second: the
+    // shared interval must still fire and update the value regardless of the
+    // unrelated re-run.
+    triggerCell.withTx(tx).set(1);
+    await tx.commit();
+    tx = runtime.edit();
+
+    await clock.tick(1000);
+    await result.pull();
+    const updated = result.key("nowValue").get()?.result;
+    expect(updated).toBeGreaterThan(initial!);
+
+    runtime.runner.stop(resultCell);
+  });
+});

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -2894,13 +2894,13 @@ describe("wish built-in", () => {
         await result.pull();
 
         // The missing-profile UI kicks off a deferred profile-create fetch.
+        // `recordedUrls` is a plain array, not a cell, so there is no sink to
+        // wait on; drain the runtime (including post-commit effects) until the
+        // deferred fetch has routed through, bounded as a stuck-condition guard.
         const expectedUrl =
           "https://pattern-env.test/api/patterns/system/profile-create.tsx";
-        const deadline = Date.now() + 5_000;
-        while (
-          !recordedUrls.includes(expectedUrl) && Date.now() < deadline
-        ) {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+        for (let i = 0; i < 50 && !recordedUrls.includes(expectedUrl); i++) {
+          await runtime.settled();
         }
         expect(recordedUrls).toContain(expectedUrl);
       } finally {
@@ -3942,13 +3942,14 @@ describe("wish built-in", () => {
           // Give the deferred fetch a moment to route through and commit.
           const pickerCell = result.key("profile").key(UI).key("props")
             .key("$cell").resolveAsCell();
-          const deadline = Date.now() + 5_000;
+          // The deferred fetch rejects and the error UI commits into the picker
+          // cell; drain the runtime until it lands, bounded as a stuck-condition
+          // guard.
           let errorNode: any;
-          while (Date.now() < deadline) {
-            await runtime.idle();
+          for (let i = 0; i < 50; i++) {
+            await runtime.settled();
             errorNode = pickerCell.key(UI).get() as any;
             if (errorNode) break;
-            await new Promise((resolve) => setTimeout(resolve, 20));
           }
           expect(errorNode).toBeDefined();
         } finally {
@@ -4258,7 +4259,7 @@ describe("interval #now wish", () => {
     const first = result.key("nowValue").get()?.result;
     expect(typeof first).toBe("number");
 
-    await new Promise((r) => setTimeout(r, 1100));
+    await clock.tick(1100);
     triggerCell.withTx(tx).set(1);
     await tx.commit();
     tx = runtime.edit();
@@ -4288,7 +4289,7 @@ describe("interval #now wish", () => {
     // wish-action closure, exactly what a piece stop/start or a reload in another
     // runtime produces — after crossing the 1s coarsening boundary.
     runtime.runner.stop(resultCell);
-    await new Promise((r) => setTimeout(r, 1100));
+    await clock.tick(1100);
 
     const result2 = runtime.run(tx, wishPattern, {}, resultCell.withTx(tx));
     await tx.commit();
@@ -4605,93 +4606,9 @@ describe("interval #now wish", () => {
     // Stop the runner for this cell — should clear the timer without errors
     runtime.runner.stop(resultCell);
 
-    // Wait briefly to confirm no timer errors after cleanup
-    await new Promise((r) => setTimeout(r, 100));
-  });
-
-  it("#now/1 ticks and updates value", async () => {
-    const wishPattern = pattern(() => {
-      return { nowValue: wish({ query: "#now/1" }) };
-    });
-
-    const resultCell = runtime.getCell<{ nowValue?: { result?: number } }>(
-      space,
-      "ticking now result",
-      undefined,
-      tx,
-    );
-    const result = runtime.run(tx, wishPattern, {}, resultCell);
-    await tx.commit();
-    tx = runtime.edit();
-
-    await result.pull();
-
-    const initial = result.key("nowValue").get()?.result;
-    expect(typeof initial).toBe("number");
-    expect(initial! % 1000).toBe(0);
-
-    // Poll until value changes, with a generous deadline for CI
-    const deadline = Date.now() + 5000;
-    let updated = initial;
-    while (updated === initial && Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, 200));
-      await result.pull();
-      updated = result.key("nowValue").get()?.result;
-    }
-    expect(updated).toBeGreaterThan(initial!);
-    expect(updated! % 1000).toBe(0);
-
-    // Clean up timer
-    runtime.runner.stop(resultCell);
-  });
-
-  it("#now interval keeps ticking when other dependencies change", async () => {
-    // Regression: re-running the wish action (here via an unrelated cell the
-    // pattern reads) must not reset or starve the shared interval timer.
-    const triggerCell = runtime.getCell<number>(
-      space,
-      "tick collision trigger",
-      undefined,
-      tx,
-    );
-    triggerCell.set(0);
-
-    const wishPattern = pattern(() => {
-      triggerCell.get();
-      return { nowValue: wish({ query: "#now/1" }) };
-    });
-
-    const resultCell = runtime.getCell<{ nowValue?: { result?: number } }>(
-      space,
-      "collision now result",
-      undefined,
-      tx,
-    );
-    const result = runtime.run(tx, wishPattern, {}, resultCell);
-    await tx.commit();
-    tx = runtime.edit();
-
-    await result.pull();
-
-    const initial = result.key("nowValue").get()?.result;
-    expect(typeof initial).toBe("number");
-
-    // Flip the trigger repeatedly while the 1s timer must advance regardless.
-    const deadline = Date.now() + 5000;
-    let updated = initial;
-    let flip = 0;
-    while (updated === initial && Date.now() < deadline) {
-      flip += 1;
-      triggerCell.withTx(tx).set(flip);
-      await tx.commit();
-      tx = runtime.edit();
-      await new Promise((r) => setTimeout(r, 200));
-      await result.pull();
-      updated = result.key("nowValue").get()?.result;
-    }
-    expect(updated).toBeGreaterThan(initial!);
-
-    runtime.runner.stop(resultCell);
+    // With the interval cleared, the runtime drains to idle. A leftover timer
+    // would auto-advance forever and hang here instead.
+    await runtime.idle();
   });
 });
 


### PR DESCRIPTION
Runner's tests waited on real time in two incompatible ways. Most only needed the runtime's own reactivity to settle, which the scheduler, storage, and wake shaper drive through positive-delay timers (throttle windows, backoff, conflict retries) that runtime.idle(), cell.pull(), and commit await. A handful genuinely observe time-based behaviour — a throttle window elapsing, a backoff retry firing. Both were served by real setTimeout sleeps, which are slow and flaky.

This adds test/clock-preload.ts, run before every test module through --preload on the package test task, and converts the suite onto it.

The clock tells three kinds of timer apart. Zero-delay timers pass through the real event loop, so scheduler dispatch and runtime.idle() resolve on their own. Positive-delay timers scheduled from src/ auto-advance: when the loop would otherwise idle, logical time jumps to the earliest pending one and fires it in order, with Date.now/performance.now moving in lockstep, so a window or backoff elapses instantly and deterministically. Positive-delay timers scheduled from a test/ file — a wall-clock sleep — freeze: they never fire, so a test that waits on one deadlocks and the async-op sanitizer reports it at once. The two callers are told apart by the immediate stack frame.

clock.settle() drains reactive work without moving time, pausing the auto-advance pump so a test can observe a state partway through a window. clock.tick(ms) advances logical time explicitly, firing the runtime's and the test's own timers, so a test can model a slow async step and step through it. clock.reset() returns logical time to zero and drops pending timers, so a describe whose cases each read absolute coarsened time can start each from a known instant. A runaway cap turns a production timer that re-arms forever into a clear failure rather than a hang.

Across the files that were waiting on real time, most sleeps are simply deleted: the reactive waits they padded now settle on their own. The genuinely time-based tests step through their windows with clock.tick, and intermediate "not yet" checks use clock.settle so the pump does not run past them. The mocked fetch in the fetch and fetch-mutex suites drops an artificial await and returns an already-resolved response, so it no longer models an async hop that never existed. Where a test burned real time to prove a value did not track the clock — the time capability's frozen handler clock, the sqlite builtin's slow post-commit flush, the scheduler's delayed-commit re-check — it advances the fake clock with clock.tick and asserts the same property. The wish #now grid tests that observe the grid value advance across a second move to their own file, wish-now-interval.test.ts: run beside the other #now cases the shared grid heartbeat left the observed value frozen, so in isolation each case starts from a clean grid and drives the beat with clock.tick.

Three files stay on the real clock, each listed with its reason in the preload: a resume runtime drives a loopback memory-client transport whose connect/mount/sync deadlocks under the fake clock; a multi-space mergeable-commit test asserts on the retry-backoff windowing that auto-advance collapses; and a nested-subagent generateObject aborts its delegate tool because the tool-calling timeout auto-advances against the subagent's own outbox progress rather than the wall clock. The exemption list matches the whole test-file name, so a short entry does not also claim a longer one. docs/development/waiting-in-tests.md explains the clock and lists the exemptions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787483292&installation_model_id=428580&pr_number=4988&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4988&signature=fff99412ae0a2fee2ac0f0ea6ec4a1add0fd8e37ad226b07647b8b195079afe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the entire `@commonfabric/runner` test suite under a fake clock to make tests fast and deterministic. Runtime timers auto-advance; test-side sleeps freeze; tests now settle via reactivity or explicit ticks.

- **New Features**
  - Added `test/clock-preload.ts` (via `--preload`) that overrides timers and `Date.now`/`performance.now`: zero-delay pass-through; positive-delay from `src/` auto-advance; positive-delay from `test/` freeze. Exposes a global `clock` with `settle()`, `tick(ms)`, and `reset()` (types in `test/clock.d.ts`); `settle()` pauses auto-advance for mid-window assertions.
  - Split `#now` interval cases into `test/wish-now-interval.test.ts`; three test files stay on the real clock with documented reasons; docs updated with runner-specific guidance.

- **Refactors**
  - Updated package task and CI shard to run with `--preload=test/clock-preload.ts` and `--no-check` so `clock` is defined in all environments.
  - Replaced real sleeps with `clock.settle()`, `clock.tick(ms)`, or `runtime.idle()`/`runtime.settled()`; simplified fetch mocks to return already-resolved `Response`s.

<sup>Written for commit 7bdd344b45e1a05778a20d276bb1de2c88b98207. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

