### PR TITLE
feat(topics): body at create + thrown rejections (verb contract WS-A)

### DIFF
--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -237,7 +237,9 @@ return {
 
 In multi-user tests the flags are per participant: one participant opting out
 does not mask another participant's errors. (The same applies to the
-pre-existing `allowRuntimeErrors` flag for scheduler-level errors.)
+pre-existing `allowRuntimeErrors` flag for scheduler-level errors; use
+`expectRuntimeErrors: true | <count>` when the errors are the point — it
+REQUIRES them, failing the run if none fire.)
 
 ## Multi-User Tests
 

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -297,6 +297,12 @@ export interface TestRunResult {
   runtimeErrors: string[];
   /** If true, runtime errors are expected and should not fail the test */
   allowRuntimeErrors?: boolean;
+  /** If set, runtime errors are REQUIRED: the run fails when none (or, for a
+   * number, a different count) were captured. Like expectNonIdempotent, this
+   * asserts the loudness fires — it is not a mere tolerance — so reverting a
+   * throwing rejection to a silent return fails the suite. Implies
+   * allowRuntimeErrors for the captured errors themselves. */
+  expectRuntimeErrors?: boolean | number;
   /** Non-idempotent computation names detected by the idempotency check */
   nonIdempotent: string[];
   /** If true, non-idempotent computations are expected: detected violations
@@ -1252,6 +1258,12 @@ export async function runTestPattern(
         await (patternResult.key("allowRuntimeErrors") as Cell<unknown>)
           .pull() === true,
     );
+    const expectRuntimeErrors = await withPhase(
+      ["runTestPattern", "expectRuntimeErrors"],
+      async () =>
+        await (patternResult.key("expectRuntimeErrors") as Cell<unknown>)
+          .pull() as boolean | number | undefined,
+    );
     const expectNonIdempotent = await withPhase(
       ["runTestPattern", "expectNonIdempotent"],
       async () =>
@@ -1786,6 +1798,7 @@ export async function runTestPattern(
       navigations,
       runtimeErrors: errorMessages,
       allowRuntimeErrors,
+      expectRuntimeErrors,
       nonIdempotent,
       expectNonIdempotent,
       consoleErrors,
@@ -1936,8 +1949,24 @@ export async function runTests(
         );
       }
 
-      // Report runtime errors
-      if (result.runtimeErrors.length > 0) {
+      // Report runtime errors. An expectation both tolerates the captured
+      // errors and REQUIRES them (exact count when numeric): the flag asserts
+      // the loudness fires, so silently-absorbed rejections fail here.
+      const expectedErrors = result.expectRuntimeErrors;
+      if (expectedErrors !== undefined && expectedErrors !== false) {
+        const want = typeof expectedErrors === "number"
+          ? expectedErrors
+          : undefined;
+        const got = result.runtimeErrors.length;
+        if (got === 0 || (want !== undefined && got !== want)) {
+          totalFailed++;
+          console.log(
+            `  ✗ expected ${want ?? "some"} runtime error(s), saw ${got}`,
+          );
+        } else {
+          console.log(`  ⊘ ${got} runtime error(s) (expected)`);
+        }
+      } else if (result.runtimeErrors.length > 0) {
         if (result.allowRuntimeErrors) {
           console.log(
             `  ⊘ ${result.runtimeErrors.length} runtime error(s) (allowed)`,

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-and-throwing.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-and-throwing.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Fixture: a throwing action with expectRuntimeErrors: 1.
+ * The runner must treat the error as required-and-satisfied — no failure.
+ */
+import { action, computed, pattern, Writable } from "commonfabric";
+
+export default pattern(() => {
+  const untouched = new Writable(true);
+  const stillUntouched = computed(() => untouched.get());
+
+  const throwingAction = action(() => {
+    throw new Error("verb rejected: intentional fixture throw");
+  });
+
+  return {
+    tests: [
+      { action: throwingAction },
+      { assertion: stillUntouched },
+    ],
+    expectRuntimeErrors: 1,
+  };
+});

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-but-silent.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-but-silent.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Fixture: expectRuntimeErrors: true but nothing throws.
+ * The expectation asserts the loudness FIRES — zero errors must fail the run,
+ * so a rejection quietly reverting to a silent return cannot pass.
+ */
+import { action, computed, pattern, Writable } from "commonfabric";
+
+export default pattern(() => {
+  const fine = new Writable(true);
+  const stillFine = computed(() => fine.get());
+
+  const silentAction = action(() => {
+    // Deliberately does not throw.
+  });
+
+  return {
+    tests: [
+      { action: silentAction },
+      { assertion: stillFine },
+    ],
+    expectRuntimeErrors: true,
+  };
+});

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-count-mismatch.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-count-mismatch.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Fixture: expectRuntimeErrors: 2 but only one throw occurs.
+ * A numeric expectation is exact — a count mismatch must fail the run.
+ */
+import { action, computed, pattern, Writable } from "commonfabric";
+
+export default pattern(() => {
+  const fine = new Writable(true);
+  const stillFine = computed(() => fine.get());
+
+  const throwsOnce = action(() => {
+    throw new Error("verb rejected: only one of the expected two");
+  });
+
+  return {
+    tests: [
+      { action: throwsOnce },
+      { assertion: stillFine },
+    ],
+    expectRuntimeErrors: 2,
+  };
+});

--- a/packages/cli/test/test-runner-expect-runtime-errors.test.ts
+++ b/packages/cli/test/test-runner-expect-runtime-errors.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Integration-level guard for expectRuntimeErrors semantics: the flag REQUIRES
+ * runtime errors (exact count when numeric) rather than merely tolerating
+ * them, so a thrown rejection quietly reverting to a silent return fails the
+ * suite that depends on it.
+ *
+ * Mirrors the design of test-runner-console-capture.test.ts.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { resolve } from "@std/path";
+import { runTests } from "../lib/test-runner.ts";
+
+const FIXTURES = resolve(
+  import.meta.dirname!,
+  "fixtures/expect-runtime-errors",
+);
+
+function fixture(name: string): string {
+  return resolve(FIXTURES, name);
+}
+
+describe(
+  "expectRuntimeErrors semantics",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it("passes when the expected error fires, and tolerates it", async () => {
+      const { passed, failed } = await runTests(
+        fixture("expected-and-throwing.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(passed).toBe(1);
+      expect(failed).toBe(0);
+    });
+
+    it("fails when errors were expected but none fired", async () => {
+      const { passed, failed } = await runTests(
+        fixture("expected-but-silent.test.tsx"),
+        { root: FIXTURES },
+      );
+      // The pattern's own assertion passes; the unmet expectation must fail.
+      expect(passed).toBe(1);
+      expect(failed).toBe(1);
+    });
+
+    it("fails on an exact-count mismatch", async () => {
+      const { passed, failed } = await runTests(
+        fixture("expected-count-mismatch.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(passed).toBe(1);
+      expect(failed).toBe(1);
+    });
+  },
+);

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -77,7 +77,8 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
 Agents are first-class participants. Against a deployed board piece:
 
 ```bash
-cf piece call --piece <board> addTopic '{"title":"...","agentName":"Sol"}'
+cf piece call --piece <board> addTopic \
+  '{"title":"...","body":"the initial living document","agentName":"Sol"}'
 cf piece get  --piece <board> topics --input      # then address a topic piece
 cf piece call --piece <topic> addComment \
   '{"body":"point-in-time progress update","agentName":"Sol"}'
@@ -90,3 +91,16 @@ cf piece call --piece <topic> addLink \
 Every agent-authored mutation carries `agentName`; there is no preceding “set
 current name” call. Fabric's operation history retains the authenticated human
 principal, while the stored snapshot disambiguates which agent acted.
+
+`addTopic` takes the body at create (optional): a topic born with a body appears
+with it atomically — no reader observes a title-only halfway state, and no
+follow-up `setBody` is needed to finish filing (the verb contract's atomic-unit
+rule, `docs/plans/pattern-verb-contract.md`). Body-at-create is not a body
+_update_: `bodyUpdatedBy`/`bodyUpdatedAt` stay unset.
+
+Invalid mutations **throw** instead of silently returning (verb contract rule
+4): an empty title, an empty comment body, a blank or non-http(s) link URL, and
+a blank `agentName` on any verb all surface as a failed call — a nonzero CLI
+exit — never as apparent success. An _omitted_ `agentName` remains the tolerated
+legacy-caller path. The UI composer wrappers keep their silent guards: an empty
+draft is a non-event in a composer, not a headless mutation.

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -74,7 +74,13 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
 
 ## Headless / agent use
 
-Agents are first-class participants. Against a deployed board piece:
+Agents are first-class participants. **Deployed lag:** a live board can run an
+older pattern than this source — the Estuary team board does today — and an
+older schema silently discards fields it does not declare. Until a migration
+lands, `body`-at-create and the loud rejections described here may not be live
+on a given board; check `cf piece verbs`, whose listing carries the deployed
+pattern's source identity, before relying on either. Against a deployed board
+piece:
 
 ```bash
 cf piece call --piece <board> addTopic \

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -181,7 +181,9 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
       title: trimmed,
       // Body at create is part of the create's atomic unit; created-with is
       // not an update, so bodyUpdatedBy/At stay unset (createdBy covers it).
-      body: (body ?? "").trim(),
+      // Preserved verbatim, matching setBody and the UI save path — trimming
+      // would corrupt whitespace-sensitive Markdown (indented code blocks).
+      body: body ?? "",
       createdAt: Date.now(),
       createdBy: author,
       createdByName: legacyName,

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -21,6 +21,7 @@ import Topic, {
   crossrefJoin,
   fidPayload,
   openTopic,
+  rejectMutation,
   snippet,
   topicAuthorFromAgent,
   topicAuthorFromPerson,
@@ -56,6 +57,11 @@ export interface TopicsInput {
 
 export interface AddTopicEvent {
   title: string;
+  /** The topic's initial living-document body. A topic born with a body
+   * appears with it atomically — no reader observes the title-only halfway
+   * state, and no follow-up `setBody` call is needed to finish a create
+   * (verb contract: the atomic-unit rule). */
+  body?: string;
   /** The agent making this mutation. The authenticated principal remains the
    * human whose identity key invoked the stream; this is the agent's explicit
    * content-level signature under that shared principal. Optional only so
@@ -161,15 +167,21 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
     profileName.trim().length > 0 && profileWish.result !== undefined
   );
 
-  const addTopic = action(({ title, agentName }: AddTopicEvent) => {
+  const addTopic = action(({ title, body, agentName }: AddTopicEvent) => {
     const trimmed = (title ?? "").trim();
     const author = topicAuthorFromAgent(agentName ?? "");
-    if (!trimmed || (agentName !== undefined && !author)) return;
+    if (agentName !== undefined && !author) {
+      rejectMutation("addTopic", "agentName must be non-blank when given");
+    }
+    if (!trimmed) rejectMutation("addTopic", "title must be non-empty");
     const legacyName = author
       ? topicAuthorLabel(author)
       : (myName.get() ?? "").trim() || "someone";
     const piece = Topic({
       title: trimmed,
+      // Body at create is part of the create's atomic unit; created-with is
+      // not an update, so bodyUpdatedBy/At stay unset (createdBy covers it).
+      body: (body ?? "").trim(),
       createdAt: Date.now(),
       createdBy: author,
       createdByName: legacyName,

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -250,6 +250,17 @@ export const topicAuthorFromPerson = (
   return avatar ? { kind: "person", name, avatar } : { kind: "person", name };
 };
 
+/** Reject a mutation loudly. To a headless caller a silent early-return is
+ * indistinguishable from success (verb contract rule 4,
+ * docs/plans/pattern-verb-contract.md); a throw surfaces as a failed handler
+ * transaction and a nonzero CLI exit. Stable error codes arrive with the
+ * invocation protocol; until then the message carries a stable
+ * "<verb> rejected:" prefix. UI composer wrappers keep their silent guards —
+ * an empty draft is a non-event in a composer. */
+export const rejectMutation = (verb: string, reason: string): never => {
+  throw new Error(`${verb} rejected: ${reason}`);
+};
+
 /** Structured author first, legacy string second. Agent snapshots are labelled
  * explicitly because they share the authenticated principal's identity key. */
 export const topicAuthorLabel = (
@@ -535,7 +546,10 @@ export default pattern<TopicInput, TopicOutput>(
     const addComment = action(({ body: text, agentName }: AddCommentEvent) => {
       const trimmed = (text ?? "").trim();
       const author = topicAuthorFromAgent(agentName ?? "");
-      if (!trimmed || (agentName !== undefined && !author)) return;
+      if (agentName !== undefined && !author) {
+        rejectMutation("addComment", "agentName must be non-blank when given");
+      }
+      if (!trimmed) rejectMutation("addComment", "body must be non-empty");
       const legacyName = author
         ? topicAuthorLabel(author)
         : (myName.get() ?? "").trim() || "someone";
@@ -552,10 +566,13 @@ export default pattern<TopicInput, TopicOutput>(
       ({ kind, url, label, agentName }: AddLinkEvent) => {
         const trimmedUrl = (url ?? "").trim();
         const author = topicAuthorFromAgent(agentName ?? "");
-        if (
-          !trimmedUrl || !isSafeLinkUrl(trimmedUrl) ||
-          (agentName !== undefined && !author)
-        ) return;
+        if (agentName !== undefined && !author) {
+          rejectMutation("addLink", "agentName must be non-blank when given");
+        }
+        if (!trimmedUrl) rejectMutation("addLink", "url must be non-empty");
+        if (!isSafeLinkUrl(trimmedUrl)) {
+          rejectMutation("addLink", "url must be http(s)");
+        }
         links.push({
           kind: kind ?? "web",
           url: trimmedUrl,
@@ -568,7 +585,9 @@ export default pattern<TopicInput, TopicOutput>(
 
     const setBody = action(({ body: text, agentName }: SetBodyEvent) => {
       const author = topicAuthorFromAgent(agentName ?? "");
-      if (agentName !== undefined && !author) return;
+      if (agentName !== undefined && !author) {
+        rejectMutation("setBody", "agentName must be non-blank when given");
+      }
       body.set(text ?? "");
       if (author) {
         bodyUpdatedBy.set(author);

--- a/packages/patterns/topics/topics-rejections.test.tsx
+++ b/packages/patterns/topics/topics-rejections.test.tsx
@@ -2,8 +2,9 @@
  * Rejection-path tests for the Topics mutating verbs (verb contract rule 4,
  * docs/plans/pattern-verb-contract.md: rejection is a value, never a silent
  * no-op). Every action here makes a verb throw, so the runtime errors are
- * expected (`allowRuntimeErrors`); each assertion then verifies the write did
- * NOT land. Happy and legacy paths live in topics.test.tsx — including the UI
+ * required (`expectRuntimeErrors: 9` — exact count, so a rejection quietly
+ * reverting to a silent return fails the suite); each assertion then verifies
+ * the write did NOT land. Happy and legacy paths live in topics.test.tsx — including the UI
  * composer wrappers, whose silent guards are correct behavior (an empty draft
  * is a non-event in a composer, not a headless mutation).
  */
@@ -96,8 +97,11 @@ export default pattern(() => {
   );
 
   return {
-    // Every rejection below surfaces as a thrown handler error by design.
-    allowRuntimeErrors: true,
+    // Every rejection below MUST surface as a thrown handler error — nine
+    // throwing actions, nine runtime errors. The exact count means a single
+    // verb quietly reverting to a silent early-return fails this suite; the
+    // no-write assertions then prove the throw also blocked the write.
+    expectRuntimeErrors: 9,
     tests: [
       { action: action_seed_topic },
       { assertion: assert_seeded },

--- a/packages/patterns/topics/topics-rejections.test.tsx
+++ b/packages/patterns/topics/topics-rejections.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Rejection-path tests for the Topics mutating verbs (verb contract rule 4,
+ * docs/plans/pattern-verb-contract.md: rejection is a value, never a silent
+ * no-op). Every action here makes a verb throw, so the runtime errors are
+ * expected (`allowRuntimeErrors`); each assertion then verifies the write did
+ * NOT land. Happy and legacy paths live in topics.test.tsx — including the UI
+ * composer wrappers, whose silent guards are correct behavior (an empty draft
+ * is a non-event in a composer, not a headless mutation).
+ */
+import { action, computed } from "commonfabric";
+import { pattern } from "commonfabric";
+import Topics from "./main.tsx";
+
+export default pattern(() => {
+  const board = Topics({});
+  const legacyBoard = Topics({});
+
+  // One valid signed topic so the child-verb rejections have a target.
+  const action_seed_topic = action(() => {
+    board.addTopic.send({ title: "Seed", agentName: "Sol" });
+  });
+
+  // addTopic: empty title; blank (provided) agentName. An *omitted* agentName
+  // is the legacy caller path and stays accepted — covered in topics.test.tsx.
+  const action_add_blank_title = action(() => {
+    board.addTopic.send({ title: "   ", agentName: "Sol" });
+  });
+  const action_add_unsigned_topic = action(() => {
+    board.addTopic.send({ title: "Unsigned", agentName: "   " });
+  });
+  const action_add_blank_legacy_agent = action(() => {
+    legacyBoard.addTopic.send({ title: "must not land", agentName: " " });
+  });
+
+  // addComment: empty body; blank agentName.
+  const action_blank_comment = action(() => {
+    board.topics?.[0]?.addComment.send({ body: "   ", agentName: "Sol" });
+  });
+  const action_comment_unsigned = action(() => {
+    board.topics?.[0]?.addComment.send({
+      body: "unsigned",
+      agentName: "   ",
+    });
+  });
+
+  // addLink: unsafe scheme; blank URL; blank agentName.
+  const action_link_unsafe = action(() => {
+    board.topics?.[0]?.addLink.send({
+      kind: "web",
+      url: "javascript:alert(1)",
+      label: "evil",
+      agentName: "Sol",
+    });
+  });
+  const action_link_blank = action(() => {
+    board.topics?.[0]?.addLink.send({
+      kind: "web",
+      url: "   ",
+      label: "x",
+      agentName: "Sol",
+    });
+  });
+  const action_link_unsigned = action(() => {
+    board.topics?.[0]?.addLink.send({
+      kind: "web",
+      url: "https://example.com/ok",
+      label: "ok",
+      agentName: "   ",
+    });
+  });
+
+  // setBody: blank agentName. (An empty body is legal — clearing a body is a
+  // legitimate edit — so only the signature is guarded here.)
+  const action_set_body_unsigned = action(() => {
+    board.topics?.[0]?.setBody.send({
+      body: "should not land",
+      agentName: "   ",
+    });
+  });
+
+  const assert_seeded = computed(() =>
+    board.topicCount === 1 &&
+    board.topics?.[0]?.title === "Seed"
+  );
+
+  // The one seeded topic, untouched: no comments, no links, empty body.
+  const assert_board_unchanged = computed(() =>
+    board.topicCount === 1 &&
+    board.topics?.[0]?.commentCount === 0 &&
+    (board.topics?.[0]?.links ?? []).length === 0 &&
+    board.topics?.[0]?.body === ""
+  );
+
+  const assert_legacy_board_empty = computed(() =>
+    legacyBoard.topicCount === 0
+  );
+
+  return {
+    // Every rejection below surfaces as a thrown handler error by design.
+    allowRuntimeErrors: true,
+    tests: [
+      { action: action_seed_topic },
+      { assertion: assert_seeded },
+      { action: action_add_blank_title },
+      { assertion: assert_board_unchanged },
+      { action: action_add_unsigned_topic },
+      { assertion: assert_board_unchanged },
+      { action: action_add_blank_legacy_agent },
+      { assertion: assert_legacy_board_empty },
+      { action: action_blank_comment },
+      { assertion: assert_board_unchanged },
+      { action: action_comment_unsigned },
+      { assertion: assert_board_unchanged },
+      { action: action_link_unsafe },
+      { assertion: assert_board_unchanged },
+      { action: action_link_blank },
+      { assertion: assert_board_unchanged },
+      { action: action_link_unsigned },
+      { assertion: assert_board_unchanged },
+      { action: action_set_body_unsigned },
+      { assertion: assert_board_unchanged },
+    ],
+  };
+});

--- a/packages/patterns/topics/topics-rejections.test.tsx
+++ b/packages/patterns/topics/topics-rejections.test.tsx
@@ -8,7 +8,7 @@
  * composer wrappers, whose silent guards are correct behavior (an empty draft
  * is a non-event in a composer, not a headless mutation).
  */
-import { action, computed } from "commonfabric";
+import { action, assert } from "commonfabric";
 import { pattern } from "commonfabric";
 import Topics from "./main.tsx";
 
@@ -79,22 +79,20 @@ export default pattern(() => {
     });
   });
 
-  const assert_seeded = computed(() =>
+  const assert_seeded = assert(() =>
     board.topicCount === 1 &&
     board.topics?.[0]?.title === "Seed"
   );
 
   // The one seeded topic, untouched: no comments, no links, empty body.
-  const assert_board_unchanged = computed(() =>
+  const assert_board_unchanged = assert(() =>
     board.topicCount === 1 &&
     board.topics?.[0]?.commentCount === 0 &&
     (board.topics?.[0]?.links ?? []).length === 0 &&
     board.topics?.[0]?.body === ""
   );
 
-  const assert_legacy_board_empty = computed(() =>
-    legacyBoard.topicCount === 0
-  );
+  const assert_legacy_board_empty = assert(() => legacyBoard.topicCount === 0);
 
   return {
     // Every rejection below MUST surface as a thrown handler error — nine

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -135,7 +135,7 @@ export default pattern(() => {
   const action_add_third_topic = action(() => {
     board.addTopic.send({
       title: "Composed topic",
-      body: "  seeded at create  ",
+      body: "    indented code\nline two\n",
       agentName: "Sol",
     });
   });
@@ -298,9 +298,10 @@ export default pattern(() => {
     board.topicCount === 3 &&
     board.topics?.[2]?.title === "Composed topic" &&
     board.topics?.[2]?.createdBy?.name === "Sol" &&
-    // Body-at-create: trimmed, present immediately, and NOT a body update —
-    // the update stamps stay unset (createdBy covers create authorship).
-    board.topics?.[2]?.body === "seeded at create" &&
+    // Body-at-create: preserved VERBATIM (whitespace-sensitive Markdown must
+    // survive, matching setBody), and NOT a body update — the update stamps
+    // stay unset (createdBy covers create authorship).
+    board.topics?.[2]?.body === "    indented code\nline two\n" &&
     (board.topics?.[2]?.bodyUpdatedBy?.name ?? "") === "" &&
     (board.topics?.[2]?.bodyUpdatedAt ?? 0) === 0
   );

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -1,13 +1,14 @@
 /**
  * Single-runtime pattern tests for Topics (CT-1878).
  *
- * Complements multi-user.test.tsx (which covers cross-runtime isolation and
- * merge behavior): this file drives every exposed stream and derived value in
- * one runtime — action guards, atomic agent signatures, legacy authorship
- * fallback/shadow fields, the unsafe-scheme link rejection, label defaulting,
- * body updates, activity-based sorting, the derived crossref graph (edges from
- * fids pasted in bodies, comments, and link URLs; never persisted), and the
- * exported pure helpers.
+ * Complements multi-user.test.tsx (cross-runtime isolation and merge
+ * behavior) and topics-rejections.test.tsx (thrown rejections on the mutating
+ * verbs — those runs expect runtime errors): this file drives the happy and
+ * legacy paths in one runtime — atomic agent signatures, body-at-create,
+ * legacy authorship fallback/shadow fields, label defaulting, body updates,
+ * activity-based sorting, the derived crossref graph (edges from fids pasted
+ * in bodies, comments, and link URLs; never persisted), and the exported pure
+ * helpers. UI composer wrappers keep silent guards, exercised here.
  */
 import { action, assert, Default, NAME, UI, Writable } from "commonfabric";
 import { pattern } from "commonfabric";
@@ -122,20 +123,21 @@ export default pattern(() => {
 
   // --- actions ---
 
-  const action_add_blank_topic = action(() => {
-    board.addTopic.send({ title: "   ", agentName: "Sol" });
-  });
-  const action_add_unsigned_topic = action(() => {
-    board.addTopic.send({ title: "Unsigned", agentName: "   " });
-  });
   const action_add_first_topic = action(() => {
     board.addTopic.send({ title: "  First topic  ", agentName: "  Sol  " });
   });
   const action_add_second_topic = action(() => {
     board.addTopic.send({ title: "Second topic", agentName: "Fable" });
   });
+  // Body at create: the create's atomic unit — no reader observes a
+  // title-only halfway state, and created-with is not an update (the
+  // bodyUpdatedBy/At stamps stay unset; createdBy covers authorship).
   const action_add_third_topic = action(() => {
-    board.addTopic.send({ title: "Composed topic", agentName: "Sol" });
+    board.addTopic.send({
+      title: "Composed topic",
+      body: "  seeded at create  ",
+      agentName: "Sol",
+    });
   });
 
   // The previous deployed event shapes remain operational while callers
@@ -161,19 +163,7 @@ export default pattern(() => {
   const action_update_legacy_topic_body = action(() => {
     legacyBoard.topics?.[0]?.setBody.send({ body: "legacy body" });
   });
-  const action_reject_explicit_blank_legacy_agent = action(() => {
-    legacyBoard.addTopic.send({ title: "must not land", agentName: " " });
-  });
 
-  const action_blank_comment = action(() => {
-    board.topics?.[0]?.addComment.send({ body: "   ", agentName: "Sol" });
-  });
-  const action_comment_unsigned = action(() => {
-    board.topics?.[0]?.addComment.send({
-      body: "unsigned",
-      agentName: "   ",
-    });
-  });
   const action_comment_signed = action(() => {
     board.topics?.[0]?.addComment.send({
       body: "hello thread",
@@ -183,22 +173,6 @@ export default pattern(() => {
   const action_set_body = action(() => {
     board.topics?.[0]?.setBody.send({
       body: "line one\nline two",
-      agentName: "Sol",
-    });
-  });
-  const action_link_unsafe = action(() => {
-    board.topics?.[0]?.addLink.send({
-      kind: "web",
-      url: "javascript:alert(1)",
-      label: "evil",
-      agentName: "Sol",
-    });
-  });
-  const action_link_blank = action(() => {
-    board.topics?.[0]?.addLink.send({
-      kind: "web",
-      url: "   ",
-      label: "x",
       agentName: "Sol",
     });
   });
@@ -271,12 +245,10 @@ export default pattern(() => {
     (board.mentionable ?? []).length === 0
   );
 
-  // Blank titles are rejected by the addTopic guard.
-  const assert_still_empty = assert(() => board.topicCount === 0);
-
   const assert_first_topic = assert(() =>
     board.topicCount === 1 &&
     board.topics?.[0]?.title === "First topic" &&
+    board.topics?.[0]?.body === "" &&
     board.topics?.[0]?.createdBy?.kind === "agent" &&
     board.topics?.[0]?.createdBy?.name === "Sol" &&
     board.topics?.[0]?.createdByName === "Sol (agent)" &&
@@ -284,10 +256,6 @@ export default pattern(() => {
     board.topics?.[0]?.commentCount === 0 &&
     board.topics?.[0]?.lastActivityAt === board.topics?.[0]?.createdAt &&
     board.topics?.[0]?.[NAME] === "First topic"
-  );
-
-  const assert_blank_comment_rejected = assert(() =>
-    board.topics?.[0]?.commentCount === 0
   );
 
   const assert_comment_landed = assert(() =>
@@ -308,11 +276,7 @@ export default pattern(() => {
     (board.topics?.[0]?.bodyUpdatedAt ?? 0) > 0
   );
 
-  // javascript: and blank URLs are rejected; a valid https link with a blank
-  // label defaults its label to the URL.
-  const assert_links_guarded = assert(() =>
-    (board.topics?.[0]?.links ?? []).length === 0
-  );
+  // A valid https link with a blank label defaults its label to the URL.
   const assert_link_added = assert(() =>
     (board.topics?.[0]?.links ?? []).length === 1 &&
     board.topics?.[0]?.links?.[0]?.kind === "pr" &&
@@ -333,7 +297,12 @@ export default pattern(() => {
   const assert_third_topic = assert(() =>
     board.topicCount === 3 &&
     board.topics?.[2]?.title === "Composed topic" &&
-    board.topics?.[2]?.createdBy?.name === "Sol"
+    board.topics?.[2]?.createdBy?.name === "Sol" &&
+    // Body-at-create: trimmed, present immediately, and NOT a body update —
+    // the update stamps stay unset (createdBy covers create authorship).
+    board.topics?.[2]?.body === "seeded at create" &&
+    (board.topics?.[2]?.bodyUpdatedBy?.name ?? "") === "" &&
+    (board.topics?.[2]?.bodyUpdatedAt ?? 0) === 0
   );
 
   const assert_blank_draft_rejected = assert(() =>
@@ -664,31 +633,17 @@ export default pattern(() => {
       { assertion: assert_legacy_link_landed },
       { action: action_update_legacy_topic_body },
       { assertion: assert_legacy_body_landed },
-      { action: action_reject_explicit_blank_legacy_agent },
-      { assertion: assert_legacy_body_landed },
       // Render the Profile-authored rows after their mutations land, then the
       // edit state whose Save control is disabled until #profile resolves.
       { render: profileTopic[UI] },
       { action: action_start_profile_body_edit },
       { render: profileTopic[UI] },
-      { action: action_add_blank_topic },
-      { assertion: assert_still_empty },
-      { action: action_add_unsigned_topic },
-      { assertion: assert_still_empty },
       { action: action_add_first_topic },
       { assertion: assert_first_topic },
-      { action: action_blank_comment },
-      { assertion: assert_blank_comment_rejected },
-      { action: action_comment_unsigned },
-      { assertion: assert_blank_comment_rejected },
       { action: action_comment_signed },
       { assertion: assert_comment_landed },
       { action: action_set_body },
       { assertion: assert_body_set },
-      { action: action_link_unsafe },
-      { assertion: assert_links_guarded },
-      { action: action_link_blank },
-      { assertion: assert_links_guarded },
       { action: action_link_valid_unlabeled },
       { assertion: assert_link_added },
       { action: action_add_second_topic },


### PR DESCRIPTION
## Why

First implementation slice of the pattern verb contract (docs/plans/pattern-verb-contract.md, merged in #4968; this is WS-A of the implementation plan). Filing a topic headlessly today forces a follow-up `setBody` on every create — a reader can observe the title-only halfway state — and a rejected mutation (empty title, blank `agentName`, unsafe link URL) silently early-returns, which to a headless caller is indistinguishable from success. Both defects are contract rule violations the design names directly (the atomic-unit rule; rule 4, rejection is a value).

## What Changed

- `AddTopicEvent` gains optional `body`; the board's `addTopic` seeds the child with it at create. Created-with is not an update — `bodyUpdatedBy`/`bodyUpdatedAt` stay unset.
- Silent early-returns on the mutating verbs (`addTopic`, `addComment`, `addLink`, `setBody`) become throws via a shared `rejectMutation` helper with a stable `"<verb> rejected:" ` message prefix (typed codes arrive with the invocation protocol, WS-C). The compat contract is preserved exactly: an *omitted* `agentName` remains the accepted legacy-caller path; only a provided-but-blank one rejects. UI composer wrappers keep their silent guards — an empty draft is a non-event in a composer.
- Rejection cases move to a new `topics-rejections.test.tsx` (`allowRuntimeErrors`, asserting no write landed, plus new coverage: `setBody`/`addLink` blank-signature rejections); the strict suite keeps happy and legacy paths and gains the body-at-create assertions.
- README documents body-at-create and the loud-rejection behavior.

Deliberately **not** here: no `setsrc` of the deployed Estuary board. That remains gated on the generated-cell identity-versioning fix landing on main, then a scratch-space old→new rehearsal (see the implementation plan's rollout notes). The skill (`skills/topics/SKILL.md`) is also untouched — it documents the deployed board, and updating it before the board would recreate the skill/deployment mismatch we just diagnosed.

## Test plan

- `deno task cf test packages/patterns/topics/topics.test.tsx packages/patterns/topics/topics-rejections.test.tsx` — 42 passed.
- `deno task cf test packages/patterns/topics/multi-user.test.tsx` — 7 passed.
- `deno fmt --check`, `deno task check-skill-facts` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787503914&installation_model_id=428580&pr_number=4991&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4991&signature=81e922cb76f35de39c86a15590454aaee35705525b26bbb9af5ed4609b1787d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create topics with an initial body and make invalid mutations throw, so creates are atomic and rejections are visible to callers (verb contract WS‑A; Linear CT‑1878). Legacy omitted `agentName` stays accepted; UI composers still ignore empty drafts.

- **New Features**
  - `addTopic` accepts optional `body`; set at create, preserved verbatim, and not stamped as an update. README notes deployed lag and updates the CLI example; check `cf piece verbs` for the deployed pattern identity.
  - Mutating verbs (`addTopic`, `addComment`, `addLink`, `setBody`) now throw via `rejectMutation` with a `"<verb> rejected:"` prefix. Rejects: empty title, empty comment body, blank or non-http(s) link URL, blank provided `agentName`. `setBody` allows empty.
  - Test runner adds `expectRuntimeErrors: true | <count>` and REQUIRES the errors; the rejections suite uses `expectRuntimeErrors: 9` and asserts no writes land. Docs clarify the flag, and the CLI adds unit tests that cover expected, silent, and count‑mismatch cases.

<sup>Written for commit 1d8349dbd37d83a0142b74c8ff7753938d42c3ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---
Coverage note: the `expectRuntimeErrors` reporting branch is fully unit-covered in-lane (test-runner-expect-runtime-errors.test.ts, all three branches); one residual line remains over the ratchet baseline.

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/cli uncovered lines = 3875 lines