### PR TITLE
feat(cli): return the tool result cell's address (verb contract WS-B)

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -95,13 +95,16 @@ Size S–M (~2–4 days). No dependencies. `packages/patterns/topics`.
 
 Size S (~1 day). No dependencies. `packages/cli`.
 
-- Replace `defaultWaitForResult` (25 ms poll, 15 s ceiling,
-  `lib/callable.ts:206-222`) with settlement observed through the existing
-  `running.sink(…)` path. The default time bound remains until WS-F makes the
-  wait caller-controlled, but it bounds an observation, not a poll.
-- Surface the tool result cell's address in `ExecutedCallable` output.
-- **Exit:** no sleep/poll in the callable wait path; `deno task test` in
-  `packages/cli` green.
+- ~~Replace the `defaultWaitForResult` poll with observed settlement~~ —
+  **landed independently as #4946** (2026-07-24): the wait is
+  `runtime.settled()`, draining scheduler, storage, and in-flight async
+  builtins with no poll interval and no deadline. Scope change recorded; this
+  workstream shrank to the second bullet.
+- Surface the tool result cell's address in `ExecutedCallable` output
+  (`resultRef`), threaded through the exec/piece-call wrappers and printed to
+  stderr so stdout stays exactly the tool's JSON result.
+- **Exit:** no sleep/poll in the callable wait path (met by #4946);
+  `resultRef` returned and printed; `deno task test` in `packages/cli` green.
 
 ### WS-C — verb results authoring surface *(critical path)*
 

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -427,9 +427,11 @@ receipt, return — never the graph going quiet. An acceptance test must prove a
 slow derived recomputation cannot delay acknowledgement (implementation plan,
 WS-D).
 
-Waiting is a caller-side choice — whether to wait at all, and for how long. This
-replaces the current fixed 15 s `DEFAULT_TOOL_RESULT_TIMEOUT_MS`, and the wait
-observes settlement rather than polling for it.
+Waiting is a caller-side choice — whether to wait at all, and for how long. The
+tool path already observes settlement rather than polling for it —
+`runtime.settled()` drains scheduler, storage, and in-flight async builtins
+with no interval under it and no deadline over it (#4946); what remains is
+making the wait bound caller-controlled.
 
 ### Choosing an id
 
@@ -634,17 +636,14 @@ client-side sugar, not protocol.
 
 ## Defects and unknowns in the current machinery
 
-- **The tool result wait is a poll.** `defaultWaitForResult`
-  (`packages/cli/lib/callable.ts:206-222`) calls `resultCell.pull()` every 25 ms
-  up to a 15 s timeout, then throws — a timeout, a sleep, and a retry loop, the
-  trio `AGENTS.md` says to flag. An observation mechanism is already present:
-  `running.sink(…)` at `:353` is used as a fast path when it fires before
-  commit. Settlement should await the sink.
 - **Tool result cells are unlinked, and their collection status is unknown.**
-  Created with a random UUID whose address is never returned. A search of the
+  Created with a random UUID; the CLI hands the address back to the caller
+  (`resultRef`), but nothing in the fabric links the cell. A search of the
   memory and storage layers turned up no collection of unreferenced cells; that
   search was not exhaustive, and the answer should be confirmed before the
-  retention design is settled.
+  retention design is settled. (A second defect once listed here — the tool
+  result wait was a 25 ms poll under a 15 s deadline — is fixed: the wait is
+  `runtime.settled()`, #4946.)
 
 ## Checking the design against other patterns
 

--- a/packages/cli/commands/exec.ts
+++ b/packages/cli/commands/exec.ts
@@ -33,7 +33,7 @@ export const exec = new Command()
         if (result.resultRef) {
           // stderr, so stdout stays exactly the tool's JSON result.
           console.error(
-            `Tool result cell: ${result.resultRef.id} (space ${result.resultRef.space})`,
+            `Tool result cell: ${result.resultRef.id} (space ${result.resultRef.space}, scope ${result.resultRef.scope})`,
           );
         }
       }

--- a/packages/cli/commands/exec.ts
+++ b/packages/cli/commands/exec.ts
@@ -30,6 +30,12 @@ export const exec = new Command()
       }
       if (result.outputText) {
         console.log(result.outputText);
+        if (result.resultRef) {
+          // stderr, so stdout stays exactly the tool's JSON result.
+          console.error(
+            `Tool result cell: ${result.resultRef.id} (space ${result.resultRef.space})`,
+          );
+        }
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1135,6 +1135,13 @@ after --. Handlers interpret piped input when no input argument is present.`,
       }
       if (result.outputText) {
         render(result.outputText);
+        if (result.resultRef) {
+          // stderr, so stdout stays exactly the tool's JSON result.
+          hint(
+            `Tool result cell: ${result.resultRef.id} (space ${result.resultRef.space})`,
+            false,
+          );
+        }
         return;
       }
       const confirmation =

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1136,9 +1136,14 @@ after --. Handlers interpret piped input when no input argument is present.`,
       if (result.outputText) {
         render(result.outputText);
         if (result.resultRef) {
-          // stderr, so stdout stays exactly the tool's JSON result.
+          // stderr, so stdout stays exactly the tool's JSON result. Routed
+          // through hint() DELIBERATELY: under --quiet the ref is suppressed —
+          // it is advisory until the invocation protocol carries it in the
+          // stdout Invocation JSON (verb contract WS-D), and --quiet callers
+          // asked for the bare result.
+          const ref = result.resultRef;
           hint(
-            `Tool result cell: ${result.resultRef.id} (space ${result.resultRef.space})`,
+            `Tool result cell: ${ref.id} (space ${ref.space}, scope ${ref.scope})`,
             false,
           );
         }

--- a/packages/cli/lib/callable-command.ts
+++ b/packages/cli/lib/callable-command.ts
@@ -1,6 +1,7 @@
 import {
   type CallableExecutionDeps,
   type CallableResolution,
+  type CallableResultRef,
   executeResolvedCallable,
 } from "./callable.ts";
 import {
@@ -14,6 +15,8 @@ import {
 export interface CallableCommandExecutionResult<TResolved> {
   helpText?: string;
   outputText?: string;
+  /** Tool result cell address, passed through from ExecutedCallable. */
+  resultRef?: CallableResultRef;
   parsed: ParsedExecArgs;
   resolved: TResolved;
 }
@@ -108,6 +111,7 @@ export async function executeCallableCommand<
 
   return {
     outputText: executed.outputText,
+    resultRef: executed.resultRef,
     parsed,
     resolved,
   };

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -33,7 +33,11 @@ export interface CallableCellLike {
   asSchemaFromLinks?: () => CallableCellLike;
   key: (segment: string) => CallableCellLike;
   pull?: () => Promise<unknown>;
-  getAsNormalizedFullLink?: () => { scope?: CellScope };
+  getAsNormalizedFullLink?: () => {
+    scope?: CellScope;
+    id?: string;
+    space?: string;
+  };
   send?: (
     value: unknown,
     onCommit?: (tx: CallableTransactionLike) => void,
@@ -97,8 +101,19 @@ export interface CallableExecutionDeps {
   uuid?: () => string;
 }
 
+/** Durable address of a tool's per-invocation result cell. */
+export interface CallableResultRef {
+  space: string;
+  id: string;
+}
+
 export interface ExecutedCallable {
   outputText?: string;
+  /** The tool result cell's address, when the runtime exposes it — the handle
+   * a caller can revisit later instead of re-running the tool (verb contract
+   * Part 2, docs/plans/pattern-verb-contract.md). Handlers gain their
+   * equivalent with the invocation protocol's caller-supplied ids. */
+  resultRef?: CallableResultRef;
 }
 
 interface CallablePatternLike extends Record<string, unknown> {
@@ -398,7 +413,15 @@ export async function executeResolvedCallable(
     cancelSink?.();
   }
 
+  // The result cell's durable address rides along when the runtime exposes
+  // it: today the cell is otherwise unlinked — reachable by nobody once this
+  // process exits (a named defect in the verb-contract design). Handing the
+  // address back is the smallest honest handle.
+  const resultLink = resultCell.getAsNormalizedFullLink?.();
   return {
     outputText: JSON.stringify(outputValue, null, 2),
+    ...(resultLink?.id && resultLink?.space
+      ? { resultRef: { space: resultLink.space, id: resultLink.id } }
+      : {}),
   };
 }

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -101,10 +101,13 @@ export interface CallableExecutionDeps {
   uuid?: () => string;
 }
 
-/** Durable address of a tool's per-invocation result cell. */
+/** Durable address of a tool's per-invocation result cell. The scope is part
+ * of the address: reopening a user- or session-scoped cell without it
+ * resolves the space-scoped instance — a different cell. */
 export interface CallableResultRef {
   space: string;
   id: string;
+  scope: CellScope;
 }
 
 export interface ExecutedCallable {
@@ -421,7 +424,14 @@ export async function executeResolvedCallable(
   return {
     outputText: JSON.stringify(outputValue, null, 2),
     ...(resultLink?.id && resultLink?.space
-      ? { resultRef: { space: resultLink.space, id: resultLink.id } }
+      ? {
+        resultRef: {
+          space: resultLink.space,
+          id: resultLink.id,
+          // Absent scope on a normalized link means the space scope.
+          scope: resultLink.scope ?? "space",
+        },
+      }
       : {}),
   };
 }

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -13,6 +13,7 @@ import {
   callableCommandSpec,
   type CallableManagerLike,
   type CallablePieceLike,
+  type CallableResultRef,
   detectCallableKind,
 } from "./callable.ts";
 import { executeCallableCommand } from "./callable-command.ts";
@@ -69,6 +70,8 @@ export interface ExecDependencies {
 export interface ExecutedMountedCallableFile {
   helpText?: string;
   outputText?: string;
+  /** Tool result cell address, passed through from ExecutedCallable. */
+  resultRef?: CallableResultRef;
   parsed: ParsedExecArgs;
   resolved: ResolvedMountedCallableFile;
 }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -53,6 +53,7 @@ import {
   callableCommandSpec,
   type CallableExecutionDeps,
   type CallableResolution,
+  type CallableResultRef,
   CF_RUNTIME_ERROR_LOG,
   type CliRuntimeErrorRecord,
   detectCallableKind,
@@ -164,6 +165,8 @@ export interface PieceCallableDependencies extends CallableExecutionDeps {
 export interface ExecutedPieceCallable {
   helpText?: string;
   outputText?: string;
+  /** Tool result cell address, passed through from ExecutedCallable. */
+  resultRef?: CallableResultRef;
   parsed: ParsedExecArgs;
   resolved: ResolvedPieceCallable;
 }

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -206,6 +206,12 @@ describe("executePieceCallable", () => {
       summary: "bound-source:tea",
       source: "bound-source",
     });
+    // The result cell's durable address rides along — the handle a caller can
+    // revisit instead of re-running the tool (verb contract Part 2).
+    expect(result.resultRef).toEqual({
+      id: "of:tool-result-cell",
+      space: "did:key:test-home",
+    });
   });
 
   it("passes the configured piece scope when resolving callables", async () => {
@@ -772,6 +778,10 @@ function createPieceCallableHarness(options: {
     pull: () => Promise.resolve(state.value),
     key: (_key: string) => resultCell,
     asSchemaFromLinks: () => resultCell,
+    getAsNormalizedFullLink: () => ({
+      id: "of:tool-result-cell",
+      space: "did:key:test-home",
+    }),
   };
 
   const piece = {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -211,6 +211,7 @@ describe("executePieceCallable", () => {
     expect(result.resultRef).toEqual({
       id: "of:tool-result-cell",
       space: "did:key:test-home",
+      scope: "space",
     });
   });
 
@@ -275,7 +276,7 @@ describe("executePieceCallable", () => {
       toolResult: { ok: true },
     });
 
-    await executePieceCallable(
+    const result = await executePieceCallable(
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
@@ -292,6 +293,9 @@ describe("executePieceCallable", () => {
     );
 
     expect(harness.tracker.toolResultScope).toBe("user");
+    // The returned handle preserves the scope — dropping it would silently
+    // retarget a user-scoped result to the space-scoped instance.
+    expect(result.resultRef?.scope).toBe("user");
   });
 
   it("reads primitive handler input from --value-file", async () => {
@@ -781,6 +785,7 @@ function createPieceCallableHarness(options: {
     getAsNormalizedFullLink: () => ({
       id: "of:tool-result-cell",
       space: "did:key:test-home",
+      scope: options.callableScope ?? "space",
     }),
   };
 


### PR DESCRIPTION
## Why

WS-B of the verb-contract implementation plan (#4968), stacked on #4991. A tool's per-invocation result cell is minted with a random UUID whose address is never returned to the caller — the cell is permanent and unreachable at once, which the design doc names as a defect: deterministic addressing without linkage is how storage becomes invisible. Handing the address back is the smallest honest handle, and it is the seam WS-D's invocation readback will widen.

Half of WS-B as planned — replacing the 25 ms tool-result poll — turned out to be already done: #4946 landed `runtime.settled()` as the wait (no poll interval, no deadline) after the plan was written. This PR trues up the two live plan docs to record that instead of re-doing it.

## What Changed

- `ExecutedCallable` gains `resultRef?: { space, id }`, populated from the result cell's normalized link when the runtime exposes one; threaded through `CallableCommandExecutionResult`, `ExecutedMountedCallableFile`, and `ExecutedPieceCallable`.
- `cf piece call` and `cf exec` print the ref to **stderr** (`Tool result cell: <id> (space <did>)`) — stdout remains exactly the tool's JSON result.
- Docs trued up: the design doc's defects section (poll defect → fixed, #4946) and settlement note; the implementation plan's WS-B scope records the landed-independently half.
- Test: the tool-execution case in `piece-call.test.ts` asserts the ref.

## Test plan

- `deno task test` in `packages/cli` — 112 passed, 0 failed.
- `deno check` on all touched files; `deno fmt --check`; `deno task check-docs plans` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787505074&installation_model_id=428580&pr_number=4992&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4992&signature=57a65f8a9bb3ddc73424fcb34cc766b339831bec06c76fc32a06d344f3548a40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns the tool result cell’s durable address — space, id, and scope — from CLI tool invocations and prints it to stderr so callers can revisit results without re-running the tool. Docs note the wait now uses `runtime.settled()` (no polling) and that WS‑B narrows to handing this address back.

- **New Features**
  - `ExecutedCallable` exposes `resultRef { space, id, scope }`, threaded through `CallableCommandExecutionResult`, `ExecutedMountedCallableFile`, and `ExecutedPieceCallable`.
  - `cf exec` and `cf piece call` print “Tool result cell: <id> (space <did>, scope <scope>)” to stderr; `cf piece call` suppresses this under `--quiet`; stdout stays the tool’s JSON.
  - Tests assert the returned ref, and that user-scoped results preserve `scope`.

<sup>Written for commit 4667468d54e04d259b4400bf43e903441afd8a84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---
Coverage note: `resultRef` behavior is unit-covered at the lib layer (piece-call tests assert the ref including scope); the uncovered lines are the two stderr print blocks inside Cliffy command actions — the same never-unit-covered class as the package's existing baseline debt, pending a command-IO harness (tracked as WS-D's integration surface).

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/cli uncovered lines = 3888 lines