### PR TITLE
feat(cli): cf piece verbs — enumerate a piece's callables (verb contract F1)

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -237,9 +237,8 @@ Size M, mostly parallel. `packages/cli`, `skills/cf`.
   Walks result-then-input with the same classification `cf piece call`
   resolves through — including the forced-stream fallback path. v1 lists
   everything per the decided semantics; handler result schemas appear once
-  WS-C lands, tier filtering with the marker, later. Remaining from the
-  2026-07-24 amendments: the deployed pattern's source identity in the
-  listing (skew detection).
+  WS-C lands, tier filtering with the marker, later. The 2026-07-24 amendment is absorbed: the listing carries the
+  deployed pattern's source identity (skew detection).
 - Generic identity annotation for data reads and callable results. Start with
   an exploration form such as `--include-ids` that annotates points where the
   backing identity changes; evaluate a narrower path-selected form if broad

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -232,13 +232,14 @@ The provenance half is a separate CFC-gated track:
 
 Size M, mostly parallel. `packages/cli`, `skills/cf`.
 
-- `cf piece verbs --json` — name, kind, input schema per verb from the
-  existing classification (`packages/fuse/callables.ts:88`), plus the
-  deployed pattern's source identity so a skill can detect it targets a newer
-  contract than the live piece; result schemas appear once WS-C lands; v1
-  lists everything, per the decided semantics (every verb listable; tier
-  filtering arrives with the marker, later). **Independent — can ship
-  first.**
+- ~~`cf piece verbs --json`~~ — **shipped** (F1): name, kind, on
+  (result/input), input schema per verb; tools carry their output schema.
+  Walks result-then-input with the same classification `cf piece call`
+  resolves through — including the forced-stream fallback path. v1 lists
+  everything per the decided semantics; handler result schemas appear once
+  WS-C lands, tier filtering with the marker, later. Remaining from the
+  2026-07-24 amendments: the deployed pattern's source identity in the
+  listing (skew detection).
 - Generic identity annotation for data reads and callable results. Start with
   an exploration form such as `--include-ids` that annotates points where the
   backing identity changes; evaluate a narrower path-selected form if broad

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -557,21 +557,20 @@ without reading pattern source. The pieces exist:
 - **Per verb**, `cf piece call <piece> <verb> --help --json` already emits the
   machine-readable command spec — kind, default verb, input schema — derived
   from the pattern's own types (`packages/cli/lib/callable.ts:260-286`).
-- **Enumeration** exists only through FUSE, which classifies a piece's result
-  entries (`packages/fuse/callables.ts:88`) and projects `.handler` / `.tool`
-  files plus a `.handlers` listing — flagged on the board as neither universal
-  nor complete. The CLI has no listing at all; `cf piece call` requires the
-  name. The topics skill compensates by hand-listing the verbs in prose — a
-  maintained copy of what the durable result schema already knows.
+- **Enumeration**: `cf piece verbs --json` lists every callable — name, kind
+  (handler/tool), which cell it lives on, and its input schema (tools also
+  carry their output schema) — walking result-then-input with the same
+  classification `cf piece call` resolves through, so the listing and the
+  dispatcher cannot disagree. FUSE independently classifies the same entries
+  (`packages/fuse/callables.ts:88`) into `.handler` / `.tool` files plus a
+  `.handlers` listing — flagged on the board as neither universal nor
+  complete.
 
-Two additions close it:
+What remains:
 
-1. A CLI listing (`cf piece verbs --json`, or a `callables` section in
-   `piece inspect --json`): name, kind, and schemas per verb in one read —
-   the same classification FUSE already performs, exposed generically. The
-   listing also carries the deployed pattern's source identity, so a client or
-   skill can detect that it targets a newer contract than the live piece
-   instead of discovering skew through a silently dropped field.
+1. **Deployed source identity in the listing**, so a client or skill can
+   detect that it targets a newer contract than the live piece instead of
+   discovering skew through a silently dropped field.
 2. **Result schemas for handlers.** The command spec carries an output schema
    only for tools, because handlers return nothing today. Rule 3's declared
    result must reach the piece's **durable schema** — otherwise introspection

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -566,12 +566,13 @@ without reading pattern source. The pieces exist:
   `.handlers` listing — flagged on the board as neither universal nor
   complete.
 
+The listing also carries the deployed pattern's source identity, so a client
+or skill can detect that it targets a newer contract than the live piece
+instead of discovering skew through a silently dropped field.
+
 What remains:
 
-1. **Deployed source identity in the listing**, so a client or skill can
-   detect that it targets a newer contract than the live piece instead of
-   discovering skew through a silently dropped field.
-2. **Result schemas for handlers.** The command spec carries an output schema
+1. **Result schemas for handlers.** The command spec carries an output schema
    only for tools, because handlers return nothing today. Rule 3's declared
    result must reach the piece's **durable schema** — otherwise introspection
    can name a verb and its arguments but never what it returns. This rides

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -12,6 +12,7 @@ import {
   linkPieces,
   linkSqliteDiskSource,
   LinkValidationError,
+  listPieceCallables,
   listPieces,
   MapFormat,
   newPiece,
@@ -1167,6 +1168,45 @@ after --. Handlers interpret piped input when no input argument is present.`,
       console.error(message);
       Deno.exit(1);
     }
+  })
+  /* piece verbs */
+  .command(
+    "verbs",
+    "List a piece's callable verbs (handlers and tools) with their schemas.",
+  )
+  .usage(pieceUsage)
+  .example(
+    cliText(`cf piece verbs ${EX_ID} ${EX_COMP_PIECE}`),
+    `List every verb piece "${RAW_EX_COMP.piece!}" exposes.`,
+  )
+  .example(
+    cliText(`cf piece verbs ${EX_ID} ${EX_URL} --json`),
+    "Machine-readable listing: name, kind, and input schema per verb.",
+  )
+  .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option("--json", "Output machine-readable JSON.")
+  .action(async (options) => {
+    const pieceConfig = parsePieceOptions(options);
+    const verbs = await listPieceCallables(pieceConfig);
+    if (options.json) {
+      render(verbs, { json: true });
+      return;
+    }
+    if (verbs.length === 0) {
+      render("<no callable verbs>");
+      return;
+    }
+    render(
+      Table.from([
+        ["NAME", "KIND", "ON"],
+        ...verbs.map((v) => [v.name, v.kind, v.on]),
+      ]).toString(),
+    );
+    hint(
+      cliText(
+        `TIP: --json includes each verb's input schema; 'cf piece call --piece ${pieceConfig.piece} <verb> --help --json' has the full command spec.`,
+      ),
+    );
   })
   /* piece rm */
   .command("rm", "Remove a piece")

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1186,6 +1186,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
   .option("-c,--piece <piece:string>", "The target piece ID.")
   .option("--json", "Output machine-readable JSON.")
   .action(async (options) => {
+    setQuietMode(!!options.quiet);
     const pieceConfig = parsePieceOptions(options);
     const verbs = await listPieceCallables(pieceConfig);
     if (options.json) {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1188,19 +1188,22 @@ after --. Handlers interpret piped input when no input argument is present.`,
   .action(async (options) => {
     setQuietMode(!!options.quiet);
     const pieceConfig = parsePieceOptions(options);
-    const verbs = await listPieceCallables(pieceConfig);
+    const listing = await listPieceCallables(pieceConfig);
     if (options.json) {
-      render(verbs, { json: true });
+      render(listing, { json: true });
       return;
     }
-    if (verbs.length === 0) {
+    if (listing.verbs.length === 0) {
       render("<no callable verbs>");
       return;
+    }
+    if (listing.pattern) {
+      render(`PATTERN ${formatPatternIdentity(listing.pattern)}`);
     }
     render(
       Table.from([
         ["NAME", "KIND", "ON"],
-        ...verbs.map((v) => [v.name, v.kind, v.on]),
+        ...listing.verbs.map((v) => [v.name, v.kind, v.on]),
       ]).toString(),
     );
     hint(

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -22,7 +22,7 @@ import {
   VNode,
 } from "@commonfabric/runner";
 import { validateSchemaValue } from "@commonfabric/runner/cfc";
-import type { CellScope } from "@commonfabric/api";
+import type { CellScope, JSONSchema } from "@commonfabric/api";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
 import {
   assignSlug,
@@ -1391,11 +1391,18 @@ async function tryResolveLivePieceToolCallable(
   return callableKind === "tool" ? callableCell : null;
 }
 
-async function resolvePieceCallable(
+/** Load the target piece and its manager for callable resolution/listing —
+ * one shared path so `cf piece call` and `cf piece verbs` always see the same
+ * piece state. */
+async function loadPieceForCallables(
   config: PieceConfig,
-  callableName: string,
   deps: PieceCallableDependencies = {},
-): Promise<ResolvedPieceCallable> {
+): Promise<{
+  manager: any;
+  piece: any;
+  space: string;
+  resolvedConfig: Awaited<ReturnType<typeof resolvePieceConfigWithManager>>;
+}> {
   const manager = await (deps.loadManager ?? loadManager)(config);
   const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
   const pieces = new PiecesController(manager);
@@ -1425,6 +1432,18 @@ async function resolvePieceCallable(
       resolvedConfig.pieceScope,
     ));
   const space = manager.getSpace?.() ?? config.space;
+  return { manager, piece, space, resolvedConfig };
+}
+
+async function resolvePieceCallable(
+  config: PieceConfig,
+  callableName: string,
+  deps: PieceCallableDependencies = {},
+): Promise<ResolvedPieceCallable> {
+  const { manager, piece, space, resolvedConfig } = await loadPieceForCallables(
+    config,
+    deps,
+  );
 
   const resolved = (await tryResolvePieceCallableAt(
     piece,
@@ -1465,6 +1484,67 @@ async function resolvePieceCallable(
   }
 
   return resolved;
+}
+
+/** One row of `cf piece verbs`: a callable the piece exposes. */
+export interface PieceCallableListing {
+  name: string;
+  kind: "handler" | "tool";
+  /** Which cell the callable lives on. `result` shadows `input` on a name
+   * collision, matching `cf piece call`'s resolution order. */
+  on: "result" | "input";
+  /** The verb's input schema — the same schema `call <verb> --help --json`
+   * serves. `true` means unconstrained. */
+  inputSchema: JSONSchema | true;
+  /** Tools only, until handlers gain declared results (verb contract WS-C). */
+  outputSchema?: JSONSchema;
+}
+
+/**
+ * Enumerate every callable a piece exposes (verb contract: Verb discovery,
+ * docs/plans/pattern-verb-contract.md). Everything in the durable schema is
+ * listed — hiding is a display default that arrives with the wrapper-tier
+ * marker, never a capability boundary; until the marker exists, the list IS
+ * the full surface. Walks result then input with the same classification
+ * `cf piece call` resolves through, so the listing and the dispatcher can
+ * never disagree about what is callable.
+ */
+export async function listPieceCallables(
+  config: PieceConfig,
+  deps: PieceCallableDependencies = {},
+): Promise<PieceCallableListing[]> {
+  const { piece } = await loadPieceForCallables(config, deps);
+
+  const listings = new Map<string, PieceCallableListing>();
+  for (const cellProp of ["result", "input"] as const) {
+    const rootCell = await piece[cellProp].getCell();
+    const value = rootCell.get?.();
+    const schema = rootCell.schema;
+    const schemaKeys = isRecord(schema) && isRecord(schema.properties)
+      ? Object.keys(schema.properties)
+      : [];
+    const valueKeys = isRecord(value) ? Object.keys(value) : [];
+    for (const name of new Set([...valueKeys, ...schemaKeys])) {
+      if (listings.has(name)) continue; // result shadows input, like call
+      const callableCell = rootCell.key(name).asSchemaFromLinks();
+      const kind = detectCallableKind(
+        getCallableValue(value, name),
+        callableCell,
+      );
+      if (!kind) continue;
+      const spec = callableCommandSpec(callableCell, kind);
+      listings.set(name, {
+        name,
+        kind,
+        on: cellProp,
+        inputSchema: spec.inputSchema,
+        ...(spec.outputSchemaSummary !== undefined
+          ? { outputSchema: spec.outputSchemaSummary }
+          : {}),
+      });
+    }
+  }
+  return [...listings.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export async function executePieceCallable(

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1487,6 +1487,18 @@ async function resolvePieceCallable(
   return resolved;
 }
 
+/** `cf piece verbs` output: the deployed pattern's source identity plus one
+ * row per callable. The identity is the skew detector — a client or skill
+ * comparing it against the contract it was written for can tell it targets a
+ * newer pattern than the live piece, instead of discovering the mismatch
+ * through a silently dropped field (design: Verb discovery). */
+export interface PieceCallablesListing {
+  /** The deployed pattern's source identity; null when the piece exposes
+   * none (e.g. harness doubles). */
+  pattern: PiecePatternRef | null;
+  verbs: PieceCallableListing[];
+}
+
 /** One row of `cf piece verbs`: a callable the piece exposes. */
 export interface PieceCallableListing {
   name: string;
@@ -1513,8 +1525,16 @@ export interface PieceCallableListing {
 export async function listPieceCallables(
   config: PieceConfig,
   deps: PieceCallableDependencies = {},
-): Promise<PieceCallableListing[]> {
+): Promise<PieceCallablesListing> {
   const { piece } = await loadPieceForCallables(config, deps);
+  let pattern: PiecePatternRef | null = null;
+  if (typeof piece.getPatternRef === "function") {
+    try {
+      pattern = (await piece.getPatternRef()) ?? null;
+    } catch {
+      pattern = null; // Identity is advisory; the listing itself still holds.
+    }
+  }
 
   const listings = new Map<string, PieceCallableListing>();
   // Names ordinary detection rejected: candidates for the forced-stream
@@ -1590,7 +1610,10 @@ export async function listPieceCallables(
 
   // Byte-order, not locale collation: this is a machine-readable surface and
   // must sort identically on every host (utf8Compare is the repo comparator).
-  return [...listings.values()].sort((a, b) => utf8Compare(a.name, b.name));
+  return {
+    pattern,
+    verbs: [...listings.values()].sort((a, b) => utf8Compare(a.name, b.name)),
+  };
 }
 
 export async function executePieceCallable(

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -23,6 +23,7 @@ import {
 } from "@commonfabric/runner";
 import { validateSchemaValue } from "@commonfabric/runner/cfc";
 import type { CellScope, JSONSchema } from "@commonfabric/api";
+import { utf8Compare } from "@commonfabric/utils/utf8";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
 import {
   assignSlug,
@@ -1516,8 +1517,13 @@ export async function listPieceCallables(
   const { piece } = await loadPieceForCallables(config, deps);
 
   const listings = new Map<string, PieceCallableListing>();
+  // Names ordinary detection rejected: candidates for the forced-stream
+  // fallback below, so the listing covers every path `cf piece call` resolves.
+  const rejected = new Set<string>();
+  let resultRoot: any;
   for (const cellProp of ["result", "input"] as const) {
     const rootCell = await piece[cellProp].getCell();
+    if (cellProp === "result") resultRoot = rootCell;
     const value = rootCell.get?.();
     const schema = rootCell.schema;
     const schemaKeys = isRecord(schema) && isRecord(schema.properties)
@@ -1531,7 +1537,11 @@ export async function listPieceCallables(
         getCallableValue(value, name),
         callableCell,
       );
-      if (!kind) continue;
+      if (!kind) {
+        rejected.add(name);
+        continue;
+      }
+      rejected.delete(name);
       const spec = callableCommandSpec(callableCell, kind);
       listings.set(name, {
         name,
@@ -1544,7 +1554,43 @@ export async function listPieceCallables(
       });
     }
   }
-  return [...listings.values()].sort((a, b) => a.name.localeCompare(b.name));
+
+  // Third resolution path, mirrored from resolvePieceCallable: a handler whose
+  // schema lost the stream marker still dispatches via the forced stream cast
+  // (tryResolvePieceHandler). Probe every rejected name the same way so a
+  // callable-by-name verb can never be absent from the listing.
+  const pieceCell = typeof piece.getCell === "function"
+    ? piece.getCell()
+    : undefined;
+  if (pieceCell && typeof pieceCell.asSchema === "function") {
+    const pieceValue = pieceCell.get?.();
+    if (isRecord(pieceValue)) {
+      for (const name of Object.keys(pieceValue)) {
+        if (!listings.has(name)) rejected.add(name);
+      }
+    }
+    for (const name of rejected) {
+      if (listings.has(name)) continue;
+      const streamRoot = pieceCell.asSchema({
+        type: "object",
+        properties: { [name]: { asCell: ["stream"] } },
+        required: [name],
+      });
+      if (!isHandlerCell(streamRoot.key(name))) continue;
+      const callableCell = resultRoot.key(name).asSchemaFromLinks();
+      const spec = callableCommandSpec(callableCell, "handler");
+      listings.set(name, {
+        name,
+        kind: "handler",
+        on: "result",
+        inputSchema: spec.inputSchema,
+      });
+    }
+  }
+
+  // Byte-order, not locale collation: this is a machine-readable surface and
+  // must sort identically on every host (utf8Compare is the repo comparator).
+  return [...listings.values()].sort((a, b) => utf8Compare(a.name, b.name));
 }
 
 export async function executePieceCallable(

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -104,9 +104,23 @@ describe("listPieceCallables", () => {
       },
     );
 
+    // "hiddenPing" defeats ordinary detection (plain object value/schema) but
+    // succeeds through the forced stream cast — resolvePieceCallable's third
+    // path — so the listing must include it. "\u00e9dit" pins byte ordering:
+    // utf8Compare puts it AFTER "setup"/"search" (0xC3 > s), where locale
+    // collation would interleave it linguistically.
+    const pieceRootValue = { hiddenPing: {}, "\u00e9dit": { $stream: true } };
     const piece = {
       result: { getCell: () => Promise.resolve(resultRoot) },
       input: { getCell: () => Promise.resolve(inputRoot) },
+      getCell: () => ({
+        get: () => pieceRootValue,
+        asSchema: (_s: unknown) => ({
+          key: (name: string) => ({
+            isStream: () => name === "hiddenPing" || name === "\u00e9dit",
+          }),
+        }),
+      }),
     };
     const manager = { getSpace: () => "home" };
 
@@ -123,9 +137,20 @@ describe("listPieceCallables", () => {
       },
     );
 
-    expect(verbs.map((v) => v.name)).toEqual(["addTopic", "search", "setup"]);
+    expect(verbs.map((v) => v.name)).toEqual([
+      "addTopic",
+      "hiddenPing",
+      "search",
+      "setup",
+      "\u00e9dit",
+    ]);
 
-    const [addTopic, search, setup] = verbs;
+    const [addTopic, hiddenPing, search, setup, accented] = verbs;
+    // Fallback-resolved handlers are listed as handlers on the result cell,
+    // exactly as tryResolvePieceHandler dispatches them.
+    expect(hiddenPing.kind).toBe("handler");
+    expect(hiddenPing.on).toBe("result");
+    expect(accented.kind).toBe("handler");
     expect(addTopic).toEqual({
       name: "addTopic",
       kind: "handler",

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -1,0 +1,172 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { JSONSchema } from "@commonfabric/api";
+import { listPieceCallables } from "../lib/piece.ts";
+
+/** Minimal schema-aware cell double: enough surface for the lister's walk —
+ * value/schema access, key() descent, and asSchemaFromLinks identity. */
+function cell(value: unknown, schema?: JSONSchema): {
+  schema?: JSONSchema;
+  get: () => unknown;
+  getRaw: () => unknown;
+  asSchemaFromLinks: () => unknown;
+  key: (name: string) => unknown;
+} {
+  const self = {
+    schema,
+    get: () => value,
+    getRaw: () => value,
+    asSchemaFromLinks: () => self,
+    key: (name: string) => {
+      const childValue =
+        typeof value === "object" && value !== null && !Array.isArray(value)
+          ? (value as Record<string, unknown>)[name]
+          : undefined;
+      const childSchema =
+        schema && typeof schema === "object" && "properties" in schema
+          ? (schema.properties as Record<string, JSONSchema>)?.[name]
+          : undefined;
+      return cell(childValue, childSchema);
+    },
+  };
+  return self;
+}
+
+const ADD_TOPIC_EVENT: JSONSchema = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    body: { type: "string" },
+    agentName: { type: "string" },
+  },
+  required: ["title"],
+};
+
+const SEARCH_ARGUMENTS: JSONSchema = {
+  type: "object",
+  properties: { query: { type: "string" } },
+  required: ["query"],
+};
+
+const SEARCH_RESULT: JSONSchema = {
+  type: "object",
+  properties: { summary: { type: "string" } },
+};
+
+describe("listPieceCallables", () => {
+  it("lists handlers and tools with schemas; excludes data; result shadows input", async () => {
+    const resultRoot = cell(
+      {
+        addTopic: { $stream: true },
+        search: {
+          pattern: {
+            argumentSchema: SEARCH_ARGUMENTS,
+            resultSchema: SEARCH_RESULT,
+          },
+          extraParams: { source: "bound-source" },
+        },
+        topicCount: 3,
+      },
+      {
+        type: "object",
+        properties: {
+          addTopic: ADD_TOPIC_EVENT,
+          search: {
+            type: "object",
+            properties: {
+              pattern: {
+                type: "object",
+                properties: {
+                  argumentSchema: { type: "object" },
+                  resultSchema: { type: "object" },
+                },
+              },
+              extraParams: { type: "object" },
+            },
+          },
+          topicCount: { type: "number" },
+        },
+      },
+    );
+    // `addTopic` also present input-side: the result-side entry must win,
+    // matching `cf piece call`'s result-then-input resolution order.
+    const inputRoot = cell(
+      {
+        addTopic: { $stream: true },
+        setup: { $stream: true },
+      },
+      {
+        type: "object",
+        properties: {
+          addTopic: { type: "object" },
+          setup: { type: "object", properties: { seed: { type: "string" } } },
+        },
+      },
+    );
+
+    const piece = {
+      result: { getCell: () => Promise.resolve(resultRoot) },
+      input: { getCell: () => Promise.resolve(inputRoot) },
+    };
+    const manager = { getSpace: () => "home" };
+
+    const verbs = await listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      {
+        loadManager: () => Promise.resolve(manager as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+
+    expect(verbs.map((v) => v.name)).toEqual(["addTopic", "search", "setup"]);
+
+    const [addTopic, search, setup] = verbs;
+    expect(addTopic).toEqual({
+      name: "addTopic",
+      kind: "handler",
+      on: "result",
+      inputSchema: ADD_TOPIC_EVENT,
+    });
+    expect(search.kind).toBe("tool");
+    expect(search.on).toBe("result");
+    expect(search.inputSchema).toEqual(SEARCH_ARGUMENTS);
+    expect(search.outputSchema).toEqual(SEARCH_RESULT);
+    expect(setup.kind).toBe("handler");
+    expect(setup.on).toBe("input");
+    // Plain data is not a verb.
+    expect(verbs.some((v) => v.name === "topicCount")).toBe(false);
+  });
+
+  it("returns an empty list for a piece with no callables", async () => {
+    const piece = {
+      result: {
+        getCell: () =>
+          Promise.resolve(
+            cell({ title: "x" }, {
+              type: "object",
+              properties: { title: { type: "string" } },
+            }),
+          ),
+      },
+      input: { getCell: () => Promise.resolve(cell({})) },
+    };
+    const verbs = await listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-456",
+        space: "home",
+      },
+      {
+        loadManager: () => Promise.resolve({ getSpace: () => "home" } as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+    expect(verbs).toEqual([]);
+  });
+});

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -3,6 +3,14 @@ import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
 import { listPieceCallables } from "../lib/piece.ts";
 
+const TEST_PATTERN_REF = {
+  source: {
+    ref: "sha256:deadbeef",
+    repository: "labs",
+    entry: "packages/patterns/topics/main.tsx",
+  },
+} as never;
+
 /** Minimal schema-aware cell double: enough surface for the lister's walk —
  * value/schema access, key() descent, and asSchemaFromLinks identity. */
 function cell(value: unknown, schema?: JSONSchema): {
@@ -113,6 +121,7 @@ describe("listPieceCallables", () => {
     const piece = {
       result: { getCell: () => Promise.resolve(resultRoot) },
       input: { getCell: () => Promise.resolve(inputRoot) },
+      getPatternRef: () => Promise.resolve(TEST_PATTERN_REF),
       getCell: () => ({
         get: () => pieceRootValue,
         asSchema: (_s: unknown) => ({
@@ -124,7 +133,7 @@ describe("listPieceCallables", () => {
     };
     const manager = { getSpace: () => "home" };
 
-    const verbs = await listPieceCallables(
+    const listing = await listPieceCallables(
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
@@ -137,6 +146,9 @@ describe("listPieceCallables", () => {
       },
     );
 
+    // The deployed pattern's identity rides the listing — the skew detector.
+    expect(listing.pattern).toEqual(TEST_PATTERN_REF);
+    const verbs = listing.verbs;
     expect(verbs.map((v) => v.name)).toEqual([
       "addTopic",
       "hiddenPing",
@@ -180,7 +192,7 @@ describe("listPieceCallables", () => {
       },
       input: { getCell: () => Promise.resolve(cell({})) },
     };
-    const verbs = await listPieceCallables(
+    const listing = await listPieceCallables(
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
@@ -192,6 +204,8 @@ describe("listPieceCallables", () => {
         loadPiece: () => Promise.resolve(piece as never),
       },
     );
-    expect(verbs).toEqual([]);
+    // No getPatternRef on the double: identity degrades to null, honestly.
+    expect(listing.pattern).toBeNull();
+    expect(listing.verbs).toEqual([]);
   });
 });

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -130,6 +130,7 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Step + get        | `deno task cf piece get --piece ID fieldPath --step ...`                                             |
 | Set field         | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
 | Call handler      | `deno task cf piece call --piece ID handlerName ...`                                                 |
+| List verbs        | `deno task cf piece verbs --piece ID --json ...`                                                     |
 | Trigger recompute | `deno task cf piece step --piece ID ...`                                                             |
 | List pieces       | `deno task cf piece ls -i key -a url -s space`                                                       |
 | Visualize         | `deno task cf piece map ...`                                                                         |


### PR DESCRIPTION
## Why

F1 of the verb-contract implementation plan (#4968), stacked on #4992. An agent holding a piece URL cannot ask "what can I call here?" without reading pattern source: `cf piece call` requires the verb name, enumeration exists only through FUSE's `.handlers` projection (flagged on the board as neither universal nor complete), and the topics skill compensates by hand-listing verbs in prose — a maintained copy of what the durable schema already knows. The design doc's Verb discovery section names the listing as one of the two closers; this is it.

## What Changed

- `cf piece verbs [--json]`: every callable the piece exposes — name, kind (handler/tool), which cell it lives on (`result` shadows `input`, matching `call`'s resolution order), and input schema; tools also carry their output schema. Human view is a compact table with a `--json` hint; JSON is the agent surface.
- The listing walks with the **same classification `cf piece call` resolves through** (`detectCallableKind` → `callableCommandSpec`), so the listing and the dispatcher cannot disagree about what is callable. The shared piece-load is extracted (`loadPieceForCallables`) rather than duplicated.
- v1 lists everything, implementing the design's decided semantics: every verb listable, hiding is a display default (arrives with the wrapper-tier marker), permission stays with CFC at commit. Handler result schemas appear once WS-C lands.
- Docs trued up in the same change: design doc Verb discovery ("the CLI has no listing" is no longer true), implementation plan F1 checked off, `skills/cf` command table gains the row.

## Test plan

- New `piece-verbs.test.ts`: handler + tool + plain-data + input-side cases; schema content, result-shadows-input precedence, non-callable exclusion, empty-piece case.
- `deno task test` in `packages/cli` — 112 passed, 0 failed. `deno check`, `deno fmt --check`, `check-skill-facts`, `check-docs plans` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787506242&installation_model_id=428580&pr_number=4993&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4993&signature=a93e32f341b9d2e100523b1f044549bea1f799e7660d0f03b811ce3efc34330d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cf piece verbs` to list a piece’s callable verbs with schemas and the deployed pattern’s source identity. Makes verb discovery easy and helps detect contract skew without reading source.

- **New Features**
  - `cf piece verbs [--json]`: shows name, kind (handler/tool), location (`result`/`input`), input schema; tools include output schema.
  - JSON returns `{ pattern, verbs }`; human view prints a PATTERN line. Shares `loadPieceForCallables` with `cf piece call` to keep listing and dispatcher in sync. Docs and `skills/cf` table updated.

- **Bug Fixes**
  - Includes handlers resolved via the forced-stream fallback so the listing matches `cf piece call`.
  - Uses `utf8Compare` for stable byte-order sorting; `--quiet` now suppresses the hint.

<sup>Written for commit 9c9017425b168d16506e773d67a579b35e7aed42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---
Coverage note: the listing's behavior is unit-covered in-lane (piece-verbs suite: enumeration, forced-stream fallback parity, source identity, utf8 ordering, empty/degraded cases). The uncovered lines are the `verbs` Cliffy command action — the same never-unit-covered class as the package baseline, pending a command-IO harness — plus the `loadPieceForCallables` extraction, whose real-load path was equally uncovered before the refactor moved it.

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/cli uncovered lines = 3924 lines