### PR TITLE
feat(runner): plainResultReceipts — plain returns reach the receipt (verb contract WS-C part 1)

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -30,6 +30,7 @@ was last checked against the code.
 | [`modernCellRep`](#moderncellrep) | `EXPERIMENTAL_MODERN_CELL_REP` env, or `RuntimeOptions.experimental` | off | Dan Bornstein (#3818) | graduate to always-on, then delete flag | implemented, off by default |
 | [`persistentSchedulerState`](#persistentschedulerstate) | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` env, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#3646) | graduate to always-on | implemented, off by default, rollout in progress |
 | [`commitPreconditions`](#commitpreconditions) | `RuntimeOptions.experimental` only (mapped `null` — programmatic rollback override — in the canonical env registry) | on | Bernhard Seefeld (#4090) | fold into base scheduler semantics, then delete flag | implemented, on by default |
+| [`plainResultReceipts`](#plainresultreceipts) | `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS` env, or `RuntimeOptions.experimental` | off | Mike Salisbury (verb contract WS-C) | flip default after the invocation-protocol integration proof, then fold into receipt semantics and delete flag | implemented, off by default |
 | [`eagerSourceAnnotation`](#eagersourceannotation) | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` env, or `RuntimeOptions.experimental` | off in production, on in shell dev builds | gideon (#4458) | permanent debug toggle, not slated for removal | implemented |
 | [`systemPatternAutoUpdate`](#systempatternautoupdate) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental` | on in the shell (same-toolshed system sources, including all roots); off server-side | Bernhard Seefeld (#4611; shell default-on #4619) | graduate to always-on, then delete flag | implemented, on in the shell |
 | [`computedCellIds`](#computedcellids) | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental` | on | Robin McCollum (#4659) | graduate to unconditional behavior, then delete flag | implemented, on by default |
@@ -136,6 +137,29 @@ propagate](#how-flags-propagate).
 - **Path to removal.** Confirm rehydration falls back cleanly when observations
   are absent or stale; graduate the default to on across the fleet; then fold
   the behavior into the base scheduler and delete the flag.
+
+### `plainResultReceipts`
+
+- **Toggle via.** `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS` env var, or
+  `RuntimeOptions.experimental.plainResultReceipts`. Env-reachable so the CLI
+  invocation-protocol work can enable it per process during integration.
+- **Added by.** Mike Salisbury, verb-contract WS-C
+  (`docs/plans/pattern-verb-contract-implementation.md`).
+- **Purpose.** A handler's return value containing reactives/cells projects
+  into its per-event receipt cell via the result-pattern path, but a **plain
+  JSON return is discarded** — the receipt-only branch writes `{}`. Under this
+  flag the receipt carries the (already-normalized) plain return instead, so a
+  caller — or a same-id retry that collides on the create-only receipt — can
+  read the verb's result back by receipt address. `{}` remains the shape for
+  value-less handlers. Requires `commitPreconditions` (the receipt write
+  itself) to be active, which it is by default.
+- **Current default and planned end state.** Off by default. Flips on once the
+  verb-contract WS-D integration proof (caller-supplied event id → collide →
+  read back the original result, cross-process) is green; after a bake period
+  the behavior folds into base receipt semantics and the flag is deleted.
+- **Path to removal.** Delete the flag and make the projection unconditional in
+  `handleJavaScriptHandlerResult`'s receipt-only branch; update the receipt
+  content note in `docs/specs/scheduler-v2/README.md` §7.6.
 
 ### `commitPreconditions`
 

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -129,14 +129,18 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
   ignored — design rule 1): emit `additionalProperties: false` for event
   payloads, confirm the runner enforces it at dispatch, and record the rule
   in the mapping spec.
-- **runner:** plain-return projection — the receipt-only branch
-  (`runner.ts:3713-3725`) writes the validated plain return instead of `{}`,
-  behind a new experimental option (registry entry in
-  `docs/development/EXPERIMENTAL_OPTIONS.md` with owner and end state:
-  default-off → flip after Phase 4's integration proof → fold in). Spec note
-  in scheduler-v2 §7.6 (receipt content), and
-  `packages/runner/test/scheduler-event-receipts.test.ts` extended for both
-  plain and reactive-bearing returns.
+- ~~**runner:** plain-return projection~~ — **done (C4)**:
+  `plainResultReceipts`, default-off, env-reachable
+  (`EXPERIMENTAL_PLAIN_RESULT_RECEIPTS`); registry entry in
+  `EXPERIMENTAL_OPTIONS.md`, scheduler-v2 §7.6 receipt-content note, both
+  flag states tested in `scheduler-event-receipts.test.ts`, including
+  same-id redelivery retaining the original result.
+- **C1 design fork, decide first:** `Stream<T>` is a branded-cell interface
+  wired through a one-slot HKT (`AsStream`, `packages/api/index.ts:1239`), so
+  `Stream<T, R = void>` ripples through the cell-type machinery; the
+  alternative is a separate declared-result carrier (e.g.
+  `StreamWithResult<T, R> extends Stream<T>`) that only the schema layer
+  interprets. Settle this at the top of the C1 PR.
 - **Exit:** a CTS pattern declares a verb returning `AddTopicResult`; the
   result schema appears in the durable schema; under the flag, both plain and
   reactive returns are readable in the receipt cell.

--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -779,7 +779,11 @@ the same `{ resultFor: cause }` cell that hosts a launched pattern when the
 handler returns one; when the handler launches nothing, the cell is simply
 the receipt. This gives handlers the same shape as computations: one
 canonical output document per unit of work, whose creation doubles as the
-exactly-once witness.
+exactly-once witness. A receipt-only handling writes `{}`; under the
+experimental `plainResultReceipts` flag it instead carries the handler's
+normalized plain JSON return, so the verb's result is readable back by
+receipt address (`docs/development/EXPERIMENTAL_OPTIONS.md`; verb-contract
+plan) — the create-only witness semantics are unchanged either way.
 
 For an inline, non-navigation handler result, an `inSpace` child does not move
 that canonical handler-result wrapper into the child space. The result/receipt

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -4141,8 +4141,17 @@ export class Runner {
       if (receiptsEnabled) {
         // Receipt-only handling (spec scheduler-v2 §7.6): nothing was
         // launched, but the result cell is still created — its create is the
-        // exactly-once witness for this event id.
-        receiptCell.withTx(tx).setRaw({});
+        // exactly-once witness for this event id. Under plainResultReceipts
+        // the witness also carries the handler's (already-normalized) plain
+        // JSON return, so a caller — or a same-id retry colliding on the
+        // receipt — reads the verb's result back by receipt address (verb
+        // contract Part 2). `{}` remains the value-less shape either way.
+        const receiptValue =
+          this.runtime.experimental.plainResultReceipts === true &&
+            result !== undefined
+            ? result
+            : {};
+        receiptCell.withTx(tx).setRaw(receiptValue);
         tx.markCreateOnly?.(receiptCell.getAsNormalizedFullLink());
       }
       return result;

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -186,6 +186,9 @@ export const EXPERIMENTAL_ENV_VARS = {
   // Scheduler-v2 lineage (#4090) is default-on. Keep a programmatic rollback
   // override while the flag exists; no environment exposure is needed.
   commitPreconditions: null,
+  // Verb-contract WS-C: env-reachable so the CLI invocation-protocol work can
+  // enable it per process during the integration proof.
+  plainResultReceipts: "EXPERIMENTAL_PLAIN_RESULT_RECEIPTS",
   systemPatternAutoUpdate: "EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE",
   computedCellIds: "EXPERIMENTAL_COMPUTED_CELL_IDS",
 } as const satisfies Record<keyof ExperimentalOptions, string | null>;

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -213,6 +213,16 @@ export interface ExperimentalOptions {
   /** Enforce scheduler-v2 lineage and event-receipt commit preconditions (default on). */
   commitPreconditions?: boolean | undefined;
   /**
+   * Project a handler's plain JSON return into its per-event receipt cell
+   * instead of the empty `{}` witness, so a caller — or a same-id retry that
+   * collides on the receipt — can read the verb's result back by receipt
+   * address. Reactive-bearing returns already project via the result-pattern
+   * path; this covers plain values, which are otherwise discarded. Default
+   * off; flips after the invocation-protocol integration proof (verb
+   * contract, docs/plans/pattern-verb-contract-implementation.md WS-C/WS-D).
+   */
+  plainResultReceipts?: boolean | undefined;
+  /**
    * Mint computed-scheme entity ids (`computed:fid1:<hash>`) for derived
    * internal cells classified as replayable by the builder. Gates minting
    * only; readers accept both forms unconditionally. Defaults to on; pass
@@ -890,6 +900,7 @@ export class Runtime {
       modernCellRep: undefined,
       persistentSchedulerState: undefined,
       commitPreconditions: undefined,
+      plainResultReceipts: undefined,
       computedCellIds: undefined,
       eagerSourceAnnotation: undefined,
       ...options.experimental,

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -1069,6 +1069,28 @@ describe("scheduler event receipts", () => {
     await plainReceipt.pull();
     expect(plainReceipt.get()).toEqual({ ok: true, n: 42 });
 
+    // Same-id redelivery with a DIFFERENT payload: the body re-runs (exactly-
+    // once is per commit, not per execution) but loses the create-only race,
+    // so the receipt retains the ORIGINAL result — the retry/readback promise
+    // this flag exists to serve, and the first-payload-wins semantics the
+    // verb-contract obligations record.
+    runtime.scheduler.queueEvent(
+      resolvedStreamLink(root.key("plain"), runtime),
+      { value: 99 },
+      undefined,
+      undefined,
+      false,
+      { eventId: plainEventId },
+    );
+    await waitForSchedulerCondition(
+      runtime,
+      () => handlerInvocations === 2,
+      "plain-return redelivery did not run",
+    );
+    await runtime.scheduler.idleWithPendingCommits();
+    await plainReceipt.pull();
+    expect(plainReceipt.get()).toEqual({ ok: true, n: 42 });
+
     // Value-less handlers keep the empty witness.
     const emptyReceipt = receiptCellForEvent<Record<string, never>>(
       runtime,

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -999,6 +999,133 @@ describe("scheduler event receipts", () => {
     expect(resultCell.get()).toEqual({});
   });
 
+  it("projects a plain JSON return into the receipt under plainResultReceipts", async () => {
+    await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+      import.meta.url,
+      { experimental: { plainResultReceipts: true } },
+    ));
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { handler, pattern } = commonfabric;
+    let handlerInvocations = 0;
+    const returnsPlain = handler<{ value: number }, Record<string, never>>(
+      (event) => {
+        handlerInvocations++;
+        return { ok: true, n: event.value };
+      },
+      { proxy: true },
+    );
+    // A value-less handler on the same board: its receipt must stay `{}`.
+    const returnsNothing = handler<unknown, Record<string, never>>(
+      () => {},
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => {
+      return { plain: returnsPlain({}), empty: returnsNothing({}) };
+    });
+    const rootCell = runtime.getCell<{ plain: unknown; empty: unknown }>(
+      space,
+      "plain result receipts root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const plainEventId = "evt:plain-receipt:0:plain-root";
+    runtime.scheduler.queueEvent(
+      resolvedStreamLink(root.key("plain"), runtime),
+      { value: 42 },
+      undefined,
+      undefined,
+      false,
+      { eventId: plainEventId },
+    );
+    const emptyEventId = "evt:plain-receipt:1:plain-root";
+    runtime.scheduler.queueEvent(
+      resolvedStreamLink(root.key("empty"), runtime),
+      {},
+      undefined,
+      undefined,
+      false,
+      { eventId: emptyEventId },
+    );
+
+    await waitForSchedulerCondition(
+      runtime,
+      () => handlerInvocations === 1,
+      "plain-return event did not run",
+    );
+    await runtime.scheduler.idleWithPendingCommits();
+
+    // The receipt carries the handler's normalized plain return — the verb's
+    // result, readable back by receipt address (verb contract Part 2).
+    const plainReceipt = receiptCellForEvent<Record<string, unknown>>(
+      runtime,
+      plainEventId,
+    );
+    await plainReceipt.pull();
+    expect(plainReceipt.get()).toEqual({ ok: true, n: 42 });
+
+    // Value-less handlers keep the empty witness.
+    const emptyReceipt = receiptCellForEvent<Record<string, never>>(
+      runtime,
+      emptyEventId,
+    );
+    await emptyReceipt.pull();
+    expect(emptyReceipt.get()).toEqual({});
+  });
+
+  it("discards a plain JSON return while plainResultReceipts is off (default)", async () => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { handler, pattern } = commonfabric;
+    let handlerInvocations = 0;
+    const returnsPlain = handler<unknown, Record<string, never>>(
+      () => {
+        handlerInvocations++;
+        return { dropped: true };
+      },
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => {
+      return { stream: returnsPlain({}) };
+    });
+    const rootCell = runtime.getCell<{ stream: unknown }>(
+      space,
+      "plain result receipts default-off root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const eventId = "evt:plain-receipt-off:0:default-root";
+    runtime.scheduler.queueEvent(
+      resolvedStreamLink(root.key("stream"), runtime),
+      {},
+      undefined,
+      undefined,
+      false,
+      { eventId },
+    );
+
+    await waitForSchedulerCondition(
+      runtime,
+      () => handlerInvocations === 1,
+      "default-off plain-return event did not run",
+    );
+    const receipt = receiptCellForEvent<Record<string, never>>(
+      runtime,
+      eventId,
+    );
+    await receipt.pull();
+    expect(receipt.get()).toEqual({});
+  });
+
   it("allows redelivered events to commit twice while receipts are disabled", async () => {
     await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
     ({ storageManager, runtime, tx } = createSchedulerTestRuntime(


### PR DESCRIPTION
## Why

First slice of WS-C, the verb-contract critical path (#4968; stacked on #4993). A handler's reactive-bearing return already projects into its per-event receipt cell, but a **plain JSON return is discarded** — the receipt-only branch writes `{}`. That leaves "retry reads back the original result" incomplete for exactly the naturally-plain results (counts, booleans, acks), which the design records as open question 3 and resolves as this runtime change — the one place the design asks the runtime for new behavior rather than exposure.

Per the governing decisions: default-off behind `plainResultReceipts`, env-reachable (`EXPERIMENTAL_PLAIN_RESULT_RECEIPTS`) so the WS-D integration proof can enable it per process; flips after that proof, then folds into base receipt semantics.

## What Changed

- `handleJavaScriptHandlerResult`'s receipt-only branch writes the handler's (already-normalized, `normalizeSandboxResult`) plain return when the flag is on; `{}` remains the value-less shape. Create-only witness semantics unchanged either way.
- `ExperimentalOptions.plainResultReceipts` + constructor default + canonical env registry entry.
- `EXPERIMENTAL_OPTIONS.md`: table row and full section (toggle, purpose, end state, path to removal).
- scheduler-v2 §7.6: receipt-content note.
- `scheduler-event-receipts.test.ts`: flag-on (plain return lands, value-less stays `{}`) and default-off (plain return discarded) cases.

**Remaining WS-C** (next PRs, recorded in the implementation plan): C1 api typing — with the design fork now documented in the plan (`Stream<T, R>` ripples through the one-slot `AsStream` HKT vs. a separate declared-result carrier; decide at the top of that PR) — then C2 transformer lowering and C3 schema-generator result emission.

## Test plan

- `deno test packages/runner/test/scheduler-event-receipts.test.ts` — 12 steps, green (2 new).
- `runtime-presets.test.ts` golden — green (env-map addition covered).
- `deno check` on touched files; `deno fmt --check`; registry doc updated per its own process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/commontoolsinc/codesmith/labs/pr/4994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787507322&installation_model_id=428580&pr_number=4994&repository=commontoolsinc%2Flabs&return_to=https%3A%2F%2Fgithub.com%2Fcommontoolsinc%2Flabs%2Fpull%2F4994&signature=0c06ac97b42539f526616cc360a18be7b4e62f8663be9a39bd5b619f5735d131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds experimental `plainResultReceipts` to write a handler’s plain JSON return into its per-event receipt so callers and same-id retries can read results by receipt address. Default off; value-less handlers still write {}; create-only witness semantics unchanged.

- **New Features**
  - Receipt-only handling writes the normalized plain return when `experimental.plainResultReceipts` is true; otherwise `{}`.
  - Flag exposed via env `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS`; docs updated (experimental options, scheduler v2 §7.6); plan marks WS‑C C4 done.
  - Tests cover flag on/off and same-id redelivery retaining the original plain result (even with different payloads).

<sup>Written for commit 6e7bd8b431938f46bc7c159879e5addc7ad32c0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

