### PR TITLE
fix(runner/memory): compare collection-write values with `valueEqual`

### DIFF
--- a/docs/common/concepts/identity.md
+++ b/docs/common/concepts/identity.md
@@ -29,7 +29,9 @@ This shift has several benefits:
 
 ## The `equals()` Function
 
-Use `equals()` to compare cells or values. For cells, this checks reference equality (same object in the graph). For plain values, it checks structural equality.
+Use `equals()` to ask whether two things are the *same* thing. It resolves each side to what it points at in the graph — following links — and compares those referents. It never compares contents: two separately-created values are not `equals()` however identical they look, and a value with no place in the graph (a fresh object literal, say) has nothing to compare, so it is never `equals()` to anything but itself.
+
+To compare *contents* instead, use `valueEqual()`, also exported from `commonfabric`.
 
 ```typescript
 // Shown for illustration only.
@@ -47,6 +49,9 @@ equals(data, data.get());              // => true
 
 // Does not compare cell values!
 equals(new Writable({ name: "Gideon" }), { name: "Gideon" });  // => false
+
+// Two object literals have no referents to compare
+equals({ name: "Gideon" }, { name: "Gideon" });  // => false
 
 // Works when navigating via .key()
 const deepData = new Writable({ address: { street: "123 Main" } });

--- a/docs/development/mergeable-collection-writes.md
+++ b/docs/development/mergeable-collection-writes.md
@@ -174,10 +174,11 @@ optimistic-replay switch cases — differing only in the op they emit and how it
 applies:
 
 - **`add-unique`** (`{ op: "add-unique"; path; values }`, `addUniqueAtPath`) —
-  appends each value only if no existing element equals it by stored-value deep
-  equality, creating the array if absent. `Cell.addUnique(...)` does the same
-  dedup locally (against its possibly-incomplete view) and records the count it
-  added; the server re-dedups against durable state. Suppression is identical to
+  appends each value only if no existing element equals it by stored-value
+  content equality (`valueEqual`), creating the array if absent.
+  `Cell.addUnique(...)` does the same dedup locally (against its
+  possibly-incomplete view) and records the count it added; the server re-dedups
+  against durable state. Suppression is identical to
   `append` (the added elements are at the tail). A `Cell` argument dedups by its
   link rather than by value (see below), so re-adding the same entity is a no-op.
 
@@ -194,18 +195,19 @@ applies:
 
 - **`remove-by-value`** (`{ op: "remove-by-value"; path; value }`,
   `removeByValueAtPath`) — removes every element of the array at `path` that
-  equals `value` by stored-value deep equality; absent or non-array is a no-op.
-  `Cell.removeByValue(ref)` matches by link when `ref` is a `Cell` and by value
-  otherwise, filters the matches locally, and records one op per removed element,
-  carrying the element's stored representation so the server matches the durable
-  element exactly. Because it identifies what to remove by value rather than by
-  position, concurrent removes of distinct entries merge instead of clobbering
-  through a whole-array rewrite. Suppression drops the whole subtree at the array
-  path that the local positional removal produced.
+  equals `value` by stored-value content equality (`valueEqual`); absent or
+  non-array is a no-op. `Cell.removeByValue(ref)` matches by link when `ref` is a
+  `Cell` and by value otherwise, filters the matches locally, and records one op
+  per removed element, carrying the element's stored representation so the server
+  matches the durable element exactly. Because it identifies what to remove by
+  value rather than by position, concurrent removes of distinct entries merge
+  instead of clobbering through a whole-array rewrite. Suppression drops the
+  whole subtree at the array path that the local positional removal produced.
 
-`add-unique` and `remove-by-value` compare by stored-value deep equality. For an
-element that is a separate entity, that stored value is a link, so the comparison
-is by same-target — identity, not deep content. `Cell.addUnique`/`removeByValue`
+`add-unique` and `remove-by-value` compare by stored-value content equality. For
+an element that is a separate entity, that stored value is a link, so the
+comparison is by same-target — identity, not deep content.
+`Cell.addUnique`/`removeByValue`
 accept either a plain value (compared by content) or a `Cell` (compared by its
 link); passing the cell returned by `elementById` is how a handler adds or
 removes a keyed element by identity (see `keyed-collection-writes.md`). Because a

--- a/docs/development/migrating-collection-writes.md
+++ b/docs/development/migrating-collection-writes.md
@@ -61,11 +61,11 @@ implementation, nothing more:
 // Shown for illustration only.
 isCell(candidate)
   ? areLinksSame(element, candidate, ...)  // compares by link identity
-  : deepEqual(element, candidate)          // compares against the stored link
+  : valueEqual(element, candidate)         // compares against the stored link
 ```
 
 A value read back out of `.get()` is a query-result proxy. It carries a link,
-but it is not a cell, so it takes the `deepEqual` branch and is compared
+but it is not a cell, so it takes the `valueEqual` branch and is compared
 against a link sigil, which it never equals. The consequences:
 
 ```ts

--- a/packages/memory/test/v2-patch-test.ts
+++ b/packages/memory/test/v2-patch-test.ts
@@ -422,6 +422,42 @@ Deno.test("memory v2 add-unique compares by stored value (objects)", () => {
   assertEquals(out.value, [{ id: 1 }, { id: 2 }]);
 });
 
+// A `FabricSpecialObject` keeps its state in private `#fields`, so its content
+// is what distinguishes two instances, not its (empty) own-property set.
+Deno.test("memory v2 add-unique compares special objects by content", () => {
+  const out = applyPatch({ value: [new FabricBytes(new Uint8Array([1, 2]))] }, [
+    {
+      op: "add-unique",
+      path: "/value",
+      values: [
+        new FabricBytes(new Uint8Array([1, 2])),
+        new FabricBytes(new Uint8Array([3, 4])),
+        new FabricEpochNsec(1234n),
+      ],
+    },
+  ]) as { value: unknown[] };
+  assertEquals(out.value, [
+    new FabricBytes(new Uint8Array([1, 2])),
+    new FabricBytes(new Uint8Array([3, 4])),
+    new FabricEpochNsec(1234n),
+  ]);
+});
+
+// `NaN` is the same value as `NaN`; `-0` and `+0` are different values.
+Deno.test("memory v2 add-unique on the weird numbers", () => {
+  const nan = applyPatch({ value: [NaN] }, [
+    { op: "add-unique", path: "/value", values: [NaN] },
+  ]) as { value: number[] };
+  assertEquals(nan.value.length, 1);
+
+  const zero = applyPatch({ value: [-0] }, [
+    { op: "add-unique", path: "/value", values: [+0] },
+  ]) as { value: number[] };
+  assertEquals(zero.value.length, 2);
+  assert(Object.is(zero.value[0], -0), "the stored -0 must survive");
+  assert(Object.is(zero.value[1], +0), "the added +0 must be distinct");
+});
+
 // `increment` adds `by` to the number at the path, treats an absent value as 0,
 // creates the path if absent, and sums when composed.
 Deno.test("memory v2 increment adds to an existing number", () => {
@@ -512,6 +548,35 @@ Deno.test("memory v2 remove-by-value matches by stored value (links/objects)", (
     },
   ]) as { value: unknown[] };
   assertEquals(out.value, [other]);
+});
+
+Deno.test("memory v2 remove-by-value matches special objects by content", () => {
+  const out = applyPatch({
+    value: [
+      new FabricBytes(new Uint8Array([1, 2])),
+      new FabricBytes(new Uint8Array([3, 4])),
+    ],
+  }, [
+    {
+      op: "remove-by-value",
+      path: "/value",
+      value: new FabricBytes(new Uint8Array([1, 2])),
+    },
+  ]) as { value: unknown[] };
+  assertEquals(out.value, [new FabricBytes(new Uint8Array([3, 4]))]);
+});
+
+Deno.test("memory v2 remove-by-value on the weird numbers", () => {
+  const nan = applyPatch({ value: [NaN, 1] }, [
+    { op: "remove-by-value", path: "/value", value: NaN },
+  ]) as { value: number[] };
+  assertEquals(nan.value, [1]);
+
+  const zero = applyPatch({ value: [-0, +0] }, [
+    { op: "remove-by-value", path: "/value", value: +0 },
+  ]) as { value: number[] };
+  assertEquals(zero.value.length, 1);
+  assert(Object.is(zero.value[0], -0), "only the +0 may be removed");
 });
 
 Deno.test("memory v2 remove-by-value is a no-op when absent", () => {

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -4,9 +4,9 @@ import {
   cloneForMutation,
   CloneForMutationError,
   cloneIfNecessary,
+  valueEqual,
 } from "@commonfabric/data-model/fabric-value";
 import { isInstance, isObject } from "@commonfabric/utils/types";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 import type { PatchOp } from "../v2.ts";
 import { encodePointer, parsePointer } from "./path.ts";
 
@@ -270,9 +270,9 @@ const appendAtPath = (
 };
 
 // Set-add by identity: append each value to the tail only if no existing element
-// equals it (by stored-value deep equality), creating the array if absent. The
-// dedup runs against durable state on the server, so it is idempotent and merges
-// with concurrent adds of distinct elements.
+// equals it (by stored-value content equality), creating the array if absent.
+// The dedup runs against durable state on the server, so it is idempotent and
+// merges with concurrent adds of distinct elements.
 const addUniqueAtPath = (
   root: FabricValue,
   path: string[],
@@ -289,7 +289,7 @@ const addUniqueAtPath = (
     );
   }
   for (const value of values) {
-    if (!container.some((existing) => deepEqual(existing, value))) {
+    if (!container.some((existing) => valueEqual(existing, value))) {
       container.push(cloneValue(value));
     }
   }
@@ -297,7 +297,7 @@ const addUniqueAtPath = (
 };
 
 // Remove every element of the array at `path` that equals `value` by stored-value
-// deep equality. A missing path or non-array target is a no-op (nothing to
+// content equality. A missing path or non-array target is a no-op (nothing to
 // remove). Resolved against durable state, so it never clobbers via a whole-array
 // rewrite.
 const removeByValueAtPath = (
@@ -309,7 +309,7 @@ const removeByValueAtPath = (
   if (!Array.isArray(existing)) {
     return root;
   }
-  if (!existing.some((element) => deepEqual(element, value))) {
+  if (!existing.some((element) => valueEqual(element, value))) {
     return root;
   }
   const { root: newRoot, container } = thawSpine(root, path, path);
@@ -317,7 +317,7 @@ const removeByValueAtPath = (
   // container is that same array.
   const array = container as FabricValue[];
   for (let index = array.length - 1; index >= 0; index -= 1) {
-    if (deepEqual(array[index], value)) {
+    if (valueEqual(array[index], value)) {
       array.splice(index, 1);
     }
   }

--- a/packages/patterns/test/source-coverage/commonfabric-shim.test.ts
+++ b/packages/patterns/test/source-coverage/commonfabric-shim.test.ts
@@ -36,7 +36,11 @@
 
 // The generated child import map resolves the transitive
 // `data-model`/`content-hash`/`leb128` graph these pull in.
-export { valueEqual } from "@commonfabric/data-model/fabric-value";
+import {
+  type FabricValue,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
+export { valueEqual };
 export {
   toCompactDebugString,
   toIndentedDebugString,
@@ -132,18 +136,18 @@ export class Writable<T = unknown> {
     if (!Array.isArray(this.#value)) {
       throw new Error("addUnique requires an array value");
     }
-    const current = this.#value as unknown[];
+    const current = this.#value as FabricValue[];
     for (const value of values) {
-      if (!current.some((item) => equals(item, value))) {
-        current.push(value);
+      if (!current.some((item) => valueEqual(item, value as FabricValue))) {
+        current.push(value as FabricValue);
       }
     }
   }
 
   removeByValue(value: unknown): void {
     if (!Array.isArray(this.#value)) return;
-    this.#value = (this.#value as unknown[]).filter((item) =>
-      !equals(item, value)
+    this.#value = (this.#value as FabricValue[]).filter((item) =>
+      !valueEqual(item, value as FabricValue)
     ) as T;
   }
 

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -20,7 +20,6 @@ import {
   linkRefFrom,
 } from "@commonfabric/data-model/cell-rep";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   deepFrozenCloneAndInternSchema,
   internSchema,
@@ -1534,7 +1533,7 @@ export class CellImpl<T extends FabricValue>
     });
     const cause = this._frame?.cause;
 
-    let array = currentValue as unknown[];
+    let array = currentValue as FabricValue[];
     if (array !== undefined && !Array.isArray(array)) {
       throw new Error(
         "Cell.addUnique() requires transaction and array value\n" +
@@ -1559,14 +1558,14 @@ export class CellImpl<T extends FabricValue>
     // server re-dedups against durable state, catching elements the local
     // replica had not loaded.
     const anchored = recursivelyAddIDIfNeeded(
-      value as unknown[],
+      value as FabricValue[],
       this._frame,
-    ) as unknown[];
+    );
     const existing = array;
     // A cell candidate matches an existing element by its (deterministic) link,
     // so re-adding the same keyed entity is a local no-op; a plain value matches
-    // by stored-value equality, mirroring the server's keyless dedup.
-    const alreadyPresent = (candidate: unknown) =>
+    // by content, mirroring the server's keyless dedup.
+    const alreadyPresent = (candidate: FabricValue) =>
       existing.some((element) =>
         isCell(candidate)
           ? areLinksSame(
@@ -1577,7 +1576,7 @@ export class CellImpl<T extends FabricValue>
             this.tx!,
             this.runtime,
           )
-          : deepEqual(element, candidate)
+          : valueEqual(element, candidate)
       );
     const toAdd = anchored.filter((candidate) => !alreadyPresent(candidate));
     if (toAdd.length === 0) {
@@ -1661,7 +1660,7 @@ export class CellImpl<T extends FabricValue>
     const currentValue = this.tx.readValueOrThrow(resolvedLink, {
       meta: mergeableOpRead,
     });
-    const array = currentValue as unknown[];
+    const array = currentValue as FabricValue[];
     if (array === undefined) {
       return;
     }
@@ -1675,7 +1674,7 @@ export class CellImpl<T extends FabricValue>
     // matches by stored-value equality. The removed elements are the array's
     // stored representations (links stay as their sigil), so recording each one
     // as the op's value lets the server match the durable element exactly.
-    const matches = (element: unknown) =>
+    const matches = (element: FabricValue) =>
       isCell(ref)
         ? areLinksSame(
           element,
@@ -1685,7 +1684,7 @@ export class CellImpl<T extends FabricValue>
           this.tx!,
           this.runtime,
         )
-        : deepEqual(element, ref);
+        : valueEqual(element, ref as FabricValue);
     const removed = array.filter(matches);
     if (removed.length === 0) {
       return;
@@ -2160,11 +2159,7 @@ export class CellImpl<T extends FabricValue>
     // is marked `ignoreReadForScheduling` (it must not register a
     // self-dependency that would re-trigger the writer) and
     // `internalVerifierRead` (it must not taint the transaction's CFC labels
-    // with this cell's own value). Comparison uses `valueEqual`, the
-    // `Fabric`-aware content equality the storage no-op gates rely on:
-    // `deepEqual` walks enumerable own-props and so conflates distinct
-    // same-class `FabricSpecialObject`s (e.g. `FabricBytes`/`FabricHash`),
-    // which would drop a real change.
+    // with this cell's own value).
     if (onlyIfDifferent) {
       const current = this.tx.readValueOrThrow(this.link, {
         meta: { ...ignoreReadForScheduling, ...internalVerifierRead },

--- a/packages/runner/test/collection-write-value-equality.test.ts
+++ b/packages/runner/test/collection-write-value-equality.test.ts
@@ -1,0 +1,158 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import { JSONSchema } from "../src/builder/types.ts";
+
+// `addUnique` and `removeByValue` match a plain (non-cell) argument against the
+// stored elements by content. These cases pin what "same content" means for the
+// values an own-property walk gets wrong: a `FabricSpecialObject` keeps its
+// state in private `#fields`, and the weird numbers whose identity `===` does
+// not capture.
+
+const signer = await Identity.fromPassphrase("collection-write-value-equality");
+const space = signer.did();
+
+const bytesListSchema = {
+  type: "array",
+  items: { type: "object", properties: {} },
+} as const satisfies JSONSchema;
+
+const numberListSchema = {
+  type: "array",
+  items: { type: "number" },
+} as const satisfies JSONSchema;
+
+function withSeeded<T>(
+  cause: string,
+  schema: JSONSchema,
+  seed: T[],
+  run: (rt: Runtime) => Promise<void>,
+): () => Promise<void> {
+  return async () => {
+    const storage = EmulatedStorageManager.emulate({ as: signer });
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+    try {
+      const tx = rt.edit();
+      rt.getCell<T[]>(space, cause, schema, tx).set(seed);
+      await tx.commit();
+      await run(rt);
+    } finally {
+      await rt.dispose();
+      await storage.close();
+    }
+  };
+}
+
+describe("collection writes compare plain values by content", () => {
+  it(
+    "addUnique keeps a FabricBytes with different bytes",
+    withSeeded("bytes-distinct", bytesListSchema, [
+      new FabricBytes(new Uint8Array([1, 2, 3])),
+    ], async (rt) => {
+      const tx = rt.edit();
+      rt.getCell<FabricBytes[]>(space, "bytes-distinct", bytesListSchema, tx)
+        .addUnique(new FabricBytes(new Uint8Array([9, 9, 9])));
+      await tx.commit();
+
+      const after = rt.getCell<FabricBytes[]>(
+        space,
+        "bytes-distinct",
+        bytesListSchema,
+      ).get();
+      expect(after.length).toBe(2);
+      expect(after[1]).toEqual(new FabricBytes(new Uint8Array([9, 9, 9])));
+    }),
+  );
+
+  it(
+    "addUnique dedups a FabricBytes with the same bytes",
+    withSeeded("bytes-same", bytesListSchema, [
+      new FabricBytes(new Uint8Array([1, 2, 3])),
+    ], async (rt) => {
+      const tx = rt.edit();
+      rt.getCell<FabricBytes[]>(space, "bytes-same", bytesListSchema, tx)
+        .addUnique(new FabricBytes(new Uint8Array([1, 2, 3])));
+      await tx.commit();
+
+      const after = rt.getCell<FabricBytes[]>(
+        space,
+        "bytes-same",
+        bytesListSchema,
+      ).get();
+      expect(after.length).toBe(1);
+    }),
+  );
+
+  it(
+    "removeByValue removes only the FabricBytes it matches",
+    withSeeded("bytes-remove", bytesListSchema, [
+      new FabricBytes(new Uint8Array([1, 2, 3])),
+      new FabricBytes(new Uint8Array([9, 9, 9])),
+    ], async (rt) => {
+      const tx = rt.edit();
+      rt.getCell<FabricBytes[]>(space, "bytes-remove", bytesListSchema, tx)
+        .removeByValue(new FabricBytes(new Uint8Array([1, 2, 3])));
+      await tx.commit();
+
+      const after = rt.getCell<FabricBytes[]>(
+        space,
+        "bytes-remove",
+        bytesListSchema,
+      ).get();
+      expect(after).toEqual([new FabricBytes(new Uint8Array([9, 9, 9]))]);
+    }),
+  );
+
+  it(
+    "NaN is the same value as NaN",
+    withSeeded("nan", numberListSchema, [NaN], async (rt) => {
+      const tx = rt.edit();
+      rt.getCell<number[]>(space, "nan", numberListSchema, tx).addUnique(NaN);
+      await tx.commit();
+
+      const added = rt.getCell<number[]>(space, "nan", numberListSchema).get();
+      expect(added.length).toBe(1);
+
+      const tx2 = rt.edit();
+      rt.getCell<number[]>(space, "nan", numberListSchema, tx2)
+        .removeByValue(NaN);
+      await tx2.commit();
+
+      const after = rt.getCell<number[]>(space, "nan", numberListSchema).get();
+      expect(after).toEqual([]);
+    }),
+  );
+
+  it(
+    "-0 and +0 are different values",
+    withSeeded("signed-zero", numberListSchema, [-0], async (rt) => {
+      const tx = rt.edit();
+      rt.getCell<number[]>(space, "signed-zero", numberListSchema, tx)
+        .addUnique(+0);
+      await tx.commit();
+
+      const added = rt.getCell<number[]>(space, "signed-zero", numberListSchema)
+        .get();
+      expect(added.length).toBe(2);
+      expect(Object.is(added[0], -0)).toBe(true);
+      expect(Object.is(added[1], +0)).toBe(true);
+
+      const tx2 = rt.edit();
+      rt.getCell<number[]>(space, "signed-zero", numberListSchema, tx2)
+        .removeByValue(+0);
+      await tx2.commit();
+
+      const after = rt.getCell<number[]>(space, "signed-zero", numberListSchema)
+        .get();
+      expect(after.length).toBe(1);
+      expect(Object.is(after[0], -0)).toBe(true);
+    }),
+  );
+});


### PR DESCRIPTION
## The bug

`Cell.addUnique` / `Cell.removeByValue` and their server-side counterparts
`addUniqueAtPath` / `removeByValueAtPath` matched a plain (non-cell) argument
against the stored elements with `deepEqual`.

A `FabricSpecialObject` keeps its state in private `#fields`, so it presents zero
enumerable own-properties: an own-property walk finds two same-class instances
indistinguishable. Measured:

```
deepEqual(bytesA, bytesB)  = true      // Uint8Array([1,2,3]) vs ([9,9,9])
valueEqual(bytesA, bytesB) = false
```

So an array of `FabricBytes` (or `FabricHash`, `FabricEpoch*`, ...) deduped down
to a single element on `addUnique`, and `removeByValue` removed every element of
that class rather than the one asked for. Client and server used the same
comparator, so the two never diverged — they were consistently wrong.

`valueEqual` is the `Fabric`-aware content equality the storage no-op gates
already use, and is what these four sites want. Its own doc comment names
`deepEqual`'s special-object blind spot as the reason it exists.

## Also in here

* **Typing.** The locals holding the stored array were widened to `unknown[]`
  even though `readValueOrThrow` returns `FabricValue`; the widening only forced
  casts back at the comparison. They are `FabricValue[]` now, which removes the
  casts (including one that predates this change). The single remaining cast is
  on `removeByValue`'s `ref`, whose public type is element-shaped
  (`T extends (infer U)[] ? U | AnyCell<U> : never`) and does not reduce.
* **`docs/common/concepts/identity.md`** claimed `equals()` "checks structural
  equality" for plain values. It never has: `equals()` parses both sides as
  links, resolves them, and compares referents — two separately-created values
  are never equal however identical their contents. Corrected, with `valueEqual`
  named as the content comparator. (That false claim looks like the ancestor of
  the source-coverage shim's `JSON.stringify` implementation: the shim
  implemented the docs rather than the code.)
* **`mergeable-collection-writes.md`** / **`migrating-collection-writes.md`**
  updated from "stored-value deep equality".
* **The source-coverage shim** compared with `JSON.stringify` in its own
  `addUnique` / `removeByValue`. It already re-exports the real `valueEqual`, so
  it uses that now — one less copy of equality machinery, and it mirrors what the
  real methods do. The shim's `equals()` is deliberately untouched.

## Behavior change worth naming

`valueEqual` throws on a function value where `deepEqual` returned `false`.
Reachable only by passing a function to `removeByValue` against an array of
objects: previously a silent no-op, now a loud error.

## Tests

New `packages/runner/test/collection-write-value-equality.test.ts` (5 cases) and
4 new cases in `packages/memory/test/v2-patch-test.ts`.

The `FabricBytes` cases are genuine regression guards — verified failing against
the old comparator (distinct bytes deduped away; `removeByValue` removed both
elements). The `NaN` / `±0` cases pass under both comparators, since both bottom
out at `Object.is` for number leaves, so they pin rather than catch. They were
still worth running: this change routes object comparison through the content
hash, and they confirm the hash distinguishes `-0` from `+0` and treats `NaN` as
reflexive — including via the deep-frozen cached-hash fast path.

Full repo suite green locally (224.7s, all packages `ok`); `deno task check-docs`
passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `valueEqual` for collection-write comparisons so `addUnique` and `removeByValue` match plain values by content. Fixes incorrect dedup/removal for `FabricBytes` and other `FabricSpecialObject`s, and aligns docs and tests.

- **Bug Fixes**
  - `Cell.addUnique`/`Cell.removeByValue` and `addUniqueAtPath`/`removeByValueAtPath` now use `valueEqual` instead of `deepEqual`.
  - Correctly dedups and removes `FabricBytes`, `FabricHash`, `FabricEpoch*`; no longer conflates distinct instances.
  - Behavior change: passing a function to `removeByValue` now throws (was a silent no-op).

- **Refactors**
  - Typed stored arrays as `FabricValue[]` to remove casts; kept a single cast for `removeByValue`’s element-shaped param.
  - Updated source-coverage shim to reuse `valueEqual` in its `addUnique`/`removeByValue`.
  - Docs: clarified that `equals()` compares referents, not contents; referenced `valueEqual` for content equality. Added tests for `FabricBytes`, `NaN`, and `±0`.

<sup>Written for commit 9f08eee249f1af8f7867b1d2466bc0fb8587525a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## CI overrides

The coverage gate went red on `packages/runner`, 6949 → 6951. That is **not from
this change**. Reproduced CI's numbers locally from its own uploaded artifacts
(6951 for this PR, 6949 for the main run at this PR's base commit `b3825717e`,
workspace 297054 vs 297049 — all matching the job output), then diffed per file
and per line. The two lines are:

| file | base | this PR | line |
| --- | ---: | ---: | --- |
| `packages/runner/src/builtins/llm-dialog.ts` | 508 | 509 | 1983 |
| `packages/runner/src/scheduler/facade.ts` | 150 | 151 | 1247 |

`facade.ts:1247` is `pendingCommitsSettled().then(recheck)`, reached only when
commits happen to be in flight at an idle check; `llm-dialog.ts:1983` is the
`Array.isArray(content)` branch of assistant-message normalization. Both are
timing-dependent branches in files this diff does not touch, and neither is
reachable from a change to how `addUnique`/`removeByValue` compare values.
Measured directly: the runner suite run against this branch and against the base
yields an identical 7774 uncovered lines, with an identical uncovered set for
`cell.ts`. The baseline history in the job log shows recent PRs reporting both
6949 and 6950 for an unchanged runner — one flake per line, and this run drew
two.

So the coverage reset marker is used rather than
`NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 6951`,
which would permanently raise the ceiling by two lines nobody owes. The timing
entries are the usual scattershot drift across unrelated jobs.

NEW_COVERAGE_BASELINE
NEW_PERF_BASELINE: job: Test (4/6) = 100s
NEW_PERF_BASELINE: job: Test (6/6) = 135s
NEW_PERF_BASELINE: step: Build application = 12s
NEW_PERF_BASELINE: step: Build toolshed binary = 12s
NEW_PERF_BASELINE: step: CLI integration (fuse) = 50s
NEW_PERF_BASELINE: job: Runner Tests (3/5) = 195s
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/google/extractors/auth-availability.test.tsx = 6s
