### PR TITLE
Fix `isNecessarilyFrozenValue()`: recognize `FabricPrimitive`, reject functions; simplify deepFreeze

### DIFF
--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -38,27 +38,21 @@ function isInDeepFrozenCache(obj: object): boolean {
 /**
  * Indicates whether the given value is "necessarily frozen" -- immutable by its
  * very nature, without any `Object.freeze()` having been applied. This covers
- * every non-`function` primitive (`null`, `undefined`, booleans, numbers,
- * strings, `bigint`s, symbols) and `FabricPrimitive` instances, which self-freeze
- * at construction and hold no outbound references.
+ * every primitive (`null`, `undefined`, booleans, numbers, strings, `bigint`s,
+ * symbols) and `FabricPrimitive` instances, which self-freeze at construction
+ * and hold no outbound references. Ordinary objects and arrays are not, nor are
+ * `FabricInstance`s (whose frozen-ness depends on `Object.freeze()` and their
+ * `[IS_DEEP_FROZEN]` report).
  *
- * A `function` is an ordinary mutable object, so it is NOT necessarily frozen.
- * Ordinary objects and arrays are not either -- nor are `FabricInstance`s, whose
- * frozen-ness depends on `Object.freeze()` and their `[IS_DEEP_FROZEN]` report.
+ * Functions never reach here: `isDeepFrozen()` and `deepFreeze()` intercept them
+ * first (a function is not a `FabricValue`), so a non-`object` `typeof` here is
+ * a genuine primitive.
  */
 function isNecessarilyFrozenValue(value: unknown): boolean {
-  switch (typeof value) {
-    case "object": {
-      return (value === null) || BaseFabricPrimitive.isInstance(value);
-    }
-    case "function": {
-      return false;
-    }
-    default: {
-      // Every other `typeof` is a non-`function` primitive.
-      return true;
-    }
+  if (typeof value === "object") {
+    return (value === null) || BaseFabricPrimitive.isInstance(value);
   }
+  return true;
 }
 
 /**
@@ -67,8 +61,8 @@ function isNecessarilyFrozenValue(value: unknown): boolean {
  */
 function isNecessarilyOrKnownDeepFrozen(value: unknown): boolean {
   // The `as` cast is safe: a `false` antecedent means `value` is a
-  // non-`FabricPrimitive` object or a `function` -- both are heap objects and
-  // valid `WeakSet` keys.
+  // non-`FabricPrimitive` object (functions are intercepted upstream), which is
+  // a valid `WeakSet` key.
   return isNecessarilyFrozenValue(value) ||
     isInDeepFrozenCache(value as object);
 }
@@ -81,6 +75,14 @@ function isNecessarilyOrKnownDeepFrozen(value: unknown): boolean {
  * Handles circular references and sparse arrays.
  */
 export function isDeepFrozen(value: unknown): boolean {
+  // A function is never deep-frozen: its `prototype` object and closure state
+  // are mutable and unprovable, so freezing its shell does not make it deeply
+  // immutable. (Checked here rather than left to the walk, which would read a
+  // frozen function's empty enumerable props as deep-frozen.)
+  if (typeof value === "function") {
+    return false;
+  }
+
   // Fast leaf paths first, so a primitive or already-cached value answers
   // without allocating the cycle-tracking set or the recursion closure below.
   if (isNecessarilyOrKnownDeepFrozen(value)) {
@@ -94,6 +96,10 @@ export function isDeepFrozen(value: unknown): boolean {
   // layer rather than allocating an equivalent `(v) => …` per descent.
   const inProgress = new Set<object>();
   const check = (value: unknown): boolean => {
+    if (typeof value === "function") {
+      // Never deep-frozen (see the entry check).
+      return false;
+    }
     if (isNecessarilyOrKnownDeepFrozen(value)) {
       return true;
     } else if (!Object.isFrozen(value)) {
@@ -177,6 +183,14 @@ export function isDeepFrozen(value: unknown): boolean {
  * recursing infinitely.
  */
 export function deepFreeze<T>(value: T): T {
+  // `deepFreeze()` operates on `FabricValue` graphs; a function is not a
+  // `FabricValue` and cannot be made deeply immutable (mutable `prototype` +
+  // closures), so refuse it rather than freeze an unfreezable shell -- which
+  // would also let a graph reaching it be cached as deep-frozen.
+  if (typeof value === "function") {
+    throw new Error("deepFreeze(): cannot deep-freeze a function.");
+  }
+
   // Arm 1: necessarily- or already-known-deep-frozen (primitives,
   // `FabricPrimitive`s, and cached objects). Handling this here, before
   // allocating the cycle-tracking set or the recursion closure below, keeps
@@ -197,6 +211,11 @@ export function deepFreeze<T>(value: T): T {
   // cycle-arrival defers to it.
   const inProgress = new Set<object>();
   const freeze = <U>(value: U): U => {
+    if (typeof value === "function") {
+      // Not a `FabricValue`; refuse (see the entry check).
+      throw new Error("deepFreeze(): cannot deep-freeze a function.");
+    }
+
     // Leaf short-circuits, repeated for nested values reached by recursion.
     if (isNecessarilyOrKnownDeepFrozen(value)) {
       return value;

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -45,12 +45,12 @@ function isInDeepFrozenCache(obj: object): boolean {
  * `Object.freeze()` and their `[IS_DEEP_FROZEN]` report).
  *
  * A function reports `true` here (its `typeof` is not `"object"`): `deepFreeze()`
- * relies on that to treat a function as an opaque immutable leaf -- a code
+ * and `isDeepFrozen()` treat a function as an opaque immutable leaf -- a code
  * reference, not fabric data -- so general-purpose callers that freeze
- * objects-with-methods keep working. `isDeepFrozen()` answers the stricter query
- * separately and reports `false` for a function (its `prototype`/closure state
- * is mutable). Making `deepFreeze()` strictly `FabricValue`-only is a separate
- * follow-up.
+ * objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`) keep working. Its
+ * internal (`prototype`/closure) mutability is a deliberate known limitation;
+ * making `deepFreeze()`/`isDeepFrozen()` strictly `FabricValue`-only (which would
+ * exclude functions) is a separate follow-up.
  */
 function isNecessarilyFrozenValue(value: unknown): boolean {
   if (typeof value === "object") {
@@ -79,16 +79,6 @@ function isNecessarilyOrKnownDeepFrozen(value: unknown): boolean {
  * Handles circular references and sparse arrays.
  */
 export function isDeepFrozen(value: unknown): boolean {
-  // A function is never deep-frozen: its `prototype` object and closure state
-  // are mutable and unprovable, so freezing its shell does not make it deeply
-  // immutable. (`deepFreeze()` is separately permissive -- it treats a function
-  // as an opaque immutable leaf so general-purpose callers that freeze
-  // objects-with-methods keep working; this stricter query still answers
-  // `false`.)
-  if (typeof value === "function") {
-    return false;
-  }
-
   // Fast leaf paths first, so a primitive or already-cached value answers
   // without allocating the cycle-tracking set or the recursion closure below.
   if (isNecessarilyOrKnownDeepFrozen(value)) {
@@ -102,10 +92,6 @@ export function isDeepFrozen(value: unknown): boolean {
   // layer rather than allocating an equivalent `(v) => …` per descent.
   const inProgress = new Set<object>();
   const check = (value: unknown): boolean => {
-    if (typeof value === "function") {
-      // Never deep-frozen (see the entry check).
-      return false;
-    }
     if (isNecessarilyOrKnownDeepFrozen(value)) {
       return true;
     } else if (!Object.isFrozen(value)) {

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -36,31 +36,29 @@ function isInDeepFrozenCache(obj: object): boolean {
 }
 
 /**
- * Indicates whether or not a value is "necessarily frozen." As of this writing,
- * this is _intended_ to be the same as asking if it's a primitive value, but
- * with an emphasis on the point. However, at some point we'll end up with
- * special knowledge about objects which are also "necessarily frozen" by
- * construction, and this is the place where we'll get to expand the logic
- * accordingly.
+ * Indicates whether the given value is "necessarily frozen" -- immutable by its
+ * very nature, without any `Object.freeze()` having been applied. This covers
+ * every non-`function` primitive (`null`, `undefined`, booleans, numbers,
+ * strings, `bigint`s, symbols) and `FabricPrimitive` instances, which self-freeze
+ * at construction and hold no outbound references.
  *
- * TODO(danfuzz): This produces an incorrect result for values of type
- * `function`, which are neither primitives nor necessarily frozen: a function
- * is an ordinary mutable object, but `typeof fn !== "object"` lets it pass here
- * as "necessarily frozen." Two consequences, both live: `isDeepFrozen()`
- * reports `true` for any graph that reaches a function, and `deepFreeze()`
- * silently declines to freeze one -- so a graph both of them call deep-frozen
- * can still be mutated through it.
- *
- * The deeper trouble is that this file isn't consistent about which of its
- * functions answer a question about arbitrary JavaScript values and which
- * answer one about `FabricValue`s. For a function the two answers legitimately
- * differ -- it's a mutable JS object, and it isn't a `FabricValue` at all --
- * and only the `FabricValue`-shaped one (`isDeepFrozenFabricValue()`) is
- * currently right. Sorting out that distinction is the actual fix; patching
- * `typeof` tests one at a time is not.
+ * A `function` is an ordinary mutable object, so it is NOT necessarily frozen.
+ * Ordinary objects and arrays are not either -- nor are `FabricInstance`s, whose
+ * frozen-ness depends on `Object.freeze()` and their `[IS_DEEP_FROZEN]` report.
  */
 function isNecessarilyFrozenValue(value: unknown): boolean {
-  return (value === null) || (typeof value !== "object");
+  switch (typeof value) {
+    case "object": {
+      return (value === null) || BaseFabricPrimitive.isInstance(value);
+    }
+    case "function": {
+      return false;
+    }
+    default: {
+      // Every other `typeof` is a non-`function` primitive.
+      return true;
+    }
+  }
 }
 
 /**
@@ -68,8 +66,9 @@ function isNecessarilyFrozenValue(value: unknown): boolean {
  * to be_ deep-frozen.
  */
 function isNecessarilyOrKnownDeepFrozen(value: unknown): boolean {
-  // Note: The `as` cast here is safe because the antecedent being `false` means
-  // that `value` must be an `object` consequent.
+  // The `as` cast is safe: a `false` antecedent means `value` is a
+  // non-`FabricPrimitive` object or a `function` -- both are heap objects and
+  // valid `WeakSet` keys.
   return isNecessarilyFrozenValue(value) ||
     isInDeepFrozenCache(value as object);
 }
@@ -121,9 +120,9 @@ export function isDeepFrozen(value: unknown): boolean {
       // `BaseFabricInstance.isInstance()` keeps this generic (and enforces the
       // "every `FabricInstance` is a `BaseFabricInstance`" invariant); the
       // member is abstract on `BaseFabricInstance`, so every instance implements
-      // it. (A `FabricPrimitive` is necessarily frozen with no outbound
-      // references, so the `Object.values` arm below answers it correctly by
-      // accident -- its empty enumerable props yield `true`.)
+      // it. (A `FabricPrimitive` never reaches here: it is necessarily frozen,
+      // so it short-circuits at the `isNecessarilyOrKnownDeepFrozen` check
+      // above.)
       result = obj[IS_DEEP_FROZEN](check);
     } else if (Array.isArray(obj)) {
       for (let i = 0; i < obj.length; i++) {
@@ -153,19 +152,17 @@ export function isDeepFrozen(value: unknown): boolean {
 }
 
 /**
- * Recursively freezes the given value in place. Dispatches on four arms, in
+ * Recursively freezes the given value in place. Dispatches on three arms, in
  * order:
  *
- * 1. Necessarily- or already-known-deep-frozen value (primitives and cached
- *    objects): short-circuit unchanged.
- * 2. `FabricPrimitive` instance: short-circuit unchanged -- these self-freeze
- *    at construction and have no outbound references.
- * 3. Fabric instance: delegate generically to its `[DEEP_FREEZE]` protocol
+ * 1. Necessarily- or already-known-deep-frozen value (primitives,
+ *    `FabricPrimitive`s, and cached objects): short-circuit unchanged.
+ * 2. Fabric instance: delegate generically to its `[DEEP_FREEZE]` protocol
  *    member, handing recursion through as the `subFreeze` callback. The
  *    dispatch gates via `BaseFabricInstance.isInstance()` (where the member is
  *    declared) -- it operates generically and does not enumerate concrete
  *    subclasses.
- * 4. Plain object or array: recursively freeze children, then freeze the
+ * 3. Plain object or array: recursively freeze children, then freeze the
  *    container.
  *
  * Arrays and plain objects are frozen after their children are recursively
@@ -180,16 +177,11 @@ export function isDeepFrozen(value: unknown): boolean {
  * recursing infinitely.
  */
 export function deepFreeze<T>(value: T): T {
-  // Arm 1: necessarily- or already-known-deep-frozen.
+  // Arm 1: necessarily- or already-known-deep-frozen (primitives,
+  // `FabricPrimitive`s, and cached objects). Handling this here, before
+  // allocating the cycle-tracking set or the recursion closure below, keeps
+  // them off the heavyweight path.
   if (isNecessarilyOrKnownDeepFrozen(value)) {
-    return value;
-  }
-
-  // Arm 2: `FabricPrimitive`s are by definition frozen (they self-freeze at
-  // construction) and have no outbound references. Handling arms 1 and 2 here,
-  // before allocating the cycle-tracking set or the recursion closure below,
-  // keeps primitives and `FabricPrimitive`s off the heavyweight path.
-  if (BaseFabricPrimitive.isInstance(value)) {
     return value;
   }
 
@@ -209,9 +201,6 @@ export function deepFreeze<T>(value: T): T {
     if (isNecessarilyOrKnownDeepFrozen(value)) {
       return value;
     }
-    if (BaseFabricPrimitive.isInstance(value)) {
-      return value;
-    }
 
     const obj = value as object;
 
@@ -224,7 +213,7 @@ export function deepFreeze<T>(value: T): T {
     }
     inProgress.add(obj);
 
-    // Arm 3: a fabric instance freezes itself in place via its `[DEEP_FREEZE]`
+    // Arm 2: a fabric instance freezes itself in place via its `[DEEP_FREEZE]`
     // protocol member. `freeze` is handed in as the `subFreeze` callback: it
     // closes over `inProgress`, so the impl's recursion into nested
     // `FabricValue`s shares cycle state with this call -- the participating
@@ -237,7 +226,7 @@ export function deepFreeze<T>(value: T): T {
       return result;
     }
 
-    // Arm 4: plain object or array -- recurse into children, then freeze.
+    // Arm 3: plain object or array -- recurse into children, then freeze.
     const alreadyFrozen = Object.isFrozen(value);
 
     if (Array.isArray(value)) {

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -37,16 +37,20 @@ function isInDeepFrozenCache(obj: object): boolean {
 
 /**
  * Indicates whether the given value is "necessarily frozen" -- immutable by its
- * very nature, without any `Object.freeze()` having been applied. This covers
- * every primitive (`null`, `undefined`, booleans, numbers, strings, `bigint`s,
- * symbols) and `FabricPrimitive` instances, which self-freeze at construction
- * and hold no outbound references. Ordinary objects and arrays are not, nor are
- * `FabricInstance`s (whose frozen-ness depends on `Object.freeze()` and their
- * `[IS_DEEP_FROZEN]` report).
+ * very nature, without any `Object.freeze()` having been applied. Reports `true`
+ * for every primitive (`null`, `undefined`, booleans, numbers, strings,
+ * `bigint`s, symbols) and `FabricPrimitive` instances (which self-freeze at
+ * construction and hold no outbound references). Ordinary objects and arrays are
+ * `false`, as are `FabricInstance`s (whose frozen-ness depends on
+ * `Object.freeze()` and their `[IS_DEEP_FROZEN]` report).
  *
- * Functions never reach here: `isDeepFrozen()` and `deepFreeze()` intercept them
- * first (a function is not a `FabricValue`), so a non-`object` `typeof` here is
- * a genuine primitive.
+ * A function reports `true` here (its `typeof` is not `"object"`): `deepFreeze()`
+ * relies on that to treat a function as an opaque immutable leaf -- a code
+ * reference, not fabric data -- so general-purpose callers that freeze
+ * objects-with-methods keep working. `isDeepFrozen()` answers the stricter query
+ * separately and reports `false` for a function (its `prototype`/closure state
+ * is mutable). Making `deepFreeze()` strictly `FabricValue`-only is a separate
+ * follow-up.
  */
 function isNecessarilyFrozenValue(value: unknown): boolean {
   if (typeof value === "object") {
@@ -61,8 +65,8 @@ function isNecessarilyFrozenValue(value: unknown): boolean {
  */
 function isNecessarilyOrKnownDeepFrozen(value: unknown): boolean {
   // The `as` cast is safe: a `false` antecedent means `value` is a
-  // non-`FabricPrimitive` object (functions are intercepted upstream), which is
-  // a valid `WeakSet` key.
+  // non-`FabricPrimitive` object (primitives and functions short-circuit `true`
+  // above), which is a valid `WeakSet` key.
   return isNecessarilyFrozenValue(value) ||
     isInDeepFrozenCache(value as object);
 }
@@ -77,8 +81,10 @@ function isNecessarilyOrKnownDeepFrozen(value: unknown): boolean {
 export function isDeepFrozen(value: unknown): boolean {
   // A function is never deep-frozen: its `prototype` object and closure state
   // are mutable and unprovable, so freezing its shell does not make it deeply
-  // immutable. (Checked here rather than left to the walk, which would read a
-  // frozen function's empty enumerable props as deep-frozen.)
+  // immutable. (`deepFreeze()` is separately permissive -- it treats a function
+  // as an opaque immutable leaf so general-purpose callers that freeze
+  // objects-with-methods keep working; this stricter query still answers
+  // `false`.)
   if (typeof value === "function") {
     return false;
   }
@@ -183,14 +189,6 @@ export function isDeepFrozen(value: unknown): boolean {
  * recursing infinitely.
  */
 export function deepFreeze<T>(value: T): T {
-  // `deepFreeze()` operates on `FabricValue` graphs; a function is not a
-  // `FabricValue` and cannot be made deeply immutable (mutable `prototype` +
-  // closures), so refuse it rather than freeze an unfreezable shell -- which
-  // would also let a graph reaching it be cached as deep-frozen.
-  if (typeof value === "function") {
-    throw new Error("deepFreeze(): cannot deep-freeze a function.");
-  }
-
   // Arm 1: necessarily- or already-known-deep-frozen (primitives,
   // `FabricPrimitive`s, and cached objects). Handling this here, before
   // allocating the cycle-tracking set or the recursion closure below, keeps
@@ -211,11 +209,6 @@ export function deepFreeze<T>(value: T): T {
   // cycle-arrival defers to it.
   const inProgress = new Set<object>();
   const freeze = <U>(value: U): U => {
-    if (typeof value === "function") {
-      // Not a `FabricValue`; refuse (see the entry check).
-      throw new Error("deepFreeze(): cannot deep-freeze a function.");
-    }
-
     // Leaf short-circuits, repeated for nested values reached by recursion.
     if (isNecessarilyOrKnownDeepFrozen(value)) {
       return value;

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -44,13 +44,17 @@ function isInDeepFrozenCache(obj: object): boolean {
  * `false`, as are `FabricInstance`s (whose frozen-ness depends on
  * `Object.freeze()` and their `[IS_DEEP_FROZEN]` report).
  *
- * A function reports `true` here (its `typeof` is not `"object"`): `deepFreeze()`
- * and `isDeepFrozen()` treat a function as an opaque immutable leaf -- a code
- * reference, not fabric data -- so general-purpose callers that freeze
- * objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`) keep working. Its
- * internal (`prototype`/closure) mutability is a deliberate known limitation;
- * making `deepFreeze()`/`isDeepFrozen()` strictly `FabricValue`-only (which would
- * exclude functions) is a separate follow-up.
+ * KNOWN LIMITATION -- these do the wrong thing for `function`s, specifically. A
+ * function reports `true` here (its `typeof` is not `"object"`), so `deepFreeze()`
+ * and `isDeepFrozen()` treat it as an opaque immutable leaf: `isDeepFrozen(fn)` is
+ * `true`, and a frozen graph reaching a function reads as deep-frozen, even
+ * though the function's internals -- its `prototype` object and closure state --
+ * remain mutable. This is deliberate, so general-purpose callers that freeze
+ * objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`) keep working; the
+ * honest fix is a strict `FabricValue`-only `deepFreeze()` migration (tracked as
+ * TASK-0086).
+ *
+ * TODO(danfuzz): Fix the problem.
  */
 function isNecessarilyFrozenValue(value: unknown): boolean {
   if (typeof value === "object") {

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -44,24 +44,32 @@ describe("deep-freeze", () => {
 
     describe("functions", () => {
       it("returns `false` for an unfrozen function", () => {
-        // A function is a mutable object, not necessarily frozen.
+        // A function is a mutable object, never deep-frozen.
         expect(isDeepFrozen(() => {})).toBe(false);
         expect(isDeepFrozen(function () {})).toBe(false);
+      });
+
+      it("returns `false` for a frozen function (never deep-frozen)", () => {
+        // Freezing a function's shell leaves its `prototype` object and closure
+        // state mutable, so it is never deeply immutable.
+        expect(isDeepFrozen(Object.freeze(() => {}))).toBe(false);
+        expect(isDeepFrozen(Object.freeze(function () {}))).toBe(false);
       });
 
       it("returns `false` for a frozen graph reaching a function", () => {
         expect(isDeepFrozen(Object.freeze({ fn: () => {} }))).toBe(false);
       });
 
-      it("returns `true` for a frozen function with no mutable own properties", () => {
-        expect(isDeepFrozen(Object.freeze(() => {}))).toBe(true);
+      it("throws when `deepFreeze()` is given a function", () => {
+        expect(() => deepFreeze(() => {})).toThrow(
+          "cannot deep-freeze a function",
+        );
       });
 
-      it("freezes a function passed to `deepFreeze()` (no longer skipped)", () => {
-        const fn = () => {};
-        deepFreeze(fn);
-        expect(Object.isFrozen(fn)).toBe(true);
-        expect(isDeepFrozen(fn)).toBe(true);
+      it("throws when `deepFreeze()` reaches a function within a graph", () => {
+        expect(() => deepFreeze({ fn: () => {} })).toThrow(
+          "cannot deep-freeze a function",
+        );
       });
     });
 

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -42,6 +42,29 @@ describe("deep-freeze", () => {
       });
     });
 
+    describe("functions", () => {
+      it("returns `false` for an unfrozen function", () => {
+        // A function is a mutable object, not necessarily frozen.
+        expect(isDeepFrozen(() => {})).toBe(false);
+        expect(isDeepFrozen(function () {})).toBe(false);
+      });
+
+      it("returns `false` for a frozen graph reaching a function", () => {
+        expect(isDeepFrozen(Object.freeze({ fn: () => {} }))).toBe(false);
+      });
+
+      it("returns `true` for a frozen function with no mutable own properties", () => {
+        expect(isDeepFrozen(Object.freeze(() => {}))).toBe(true);
+      });
+
+      it("freezes a function passed to `deepFreeze()` (no longer skipped)", () => {
+        const fn = () => {};
+        deepFreeze(fn);
+        expect(Object.isFrozen(fn)).toBe(true);
+        expect(isDeepFrozen(fn)).toBe(true);
+      });
+    });
+
     describe("objects", () => {
       it("returns `false` for an unfrozen empty object", () => {
         expect(isDeepFrozen({})).toBe(false);

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -42,22 +42,19 @@ describe("deep-freeze", () => {
       });
     });
 
-    describe("functions", () => {
-      // `isDeepFrozen()` answers the strict query -- a function is never deeply
-      // immutable (mutable `prototype`/closure), so `false`. `deepFreeze()` is
-      // separately permissive: it treats a function as an opaque immutable leaf
-      // (a code reference, not fabric data) so general-purpose callers that
-      // freeze objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`) keep
-      // working. Reconciling the two under a strict `FabricValue`-only contract
-      // is a separate follow-up.
-      it("returns `false` from `isDeepFrozen()` for a function", () => {
-        expect(isDeepFrozen(() => {})).toBe(false);
-        expect(isDeepFrozen(function () {})).toBe(false);
-        expect(isDeepFrozen(Object.freeze(() => {}))).toBe(false);
+    describe("functions (opaque immutable leaves)", () => {
+      // `deepFreeze()`/`isDeepFrozen()` treat a function as an opaque immutable
+      // leaf -- a code reference, not fabric data -- so general-purpose callers
+      // that freeze objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`) keep
+      // working. Its internal `prototype`/closure mutability is a known
+      // limitation, closed by the strict `FabricValue`-only migration follow-up.
+      it("returns `true` for a function", () => {
+        expect(isDeepFrozen(() => {})).toBe(true);
+        expect(isDeepFrozen(function () {})).toBe(true);
       });
 
-      it("returns `false` for an uncached frozen graph reaching a function", () => {
-        expect(isDeepFrozen(Object.freeze({ fn: () => {} }))).toBe(false);
+      it("returns `true` for a frozen graph containing a function", () => {
+        expect(isDeepFrozen(Object.freeze({ a: 1, fn: () => {} }))).toBe(true);
       });
 
       it("returns the function unchanged from `deepFreeze()` (does not throw)", () => {

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -43,33 +43,33 @@ describe("deep-freeze", () => {
     });
 
     describe("functions", () => {
-      it("returns `false` for an unfrozen function", () => {
-        // A function is a mutable object, never deep-frozen.
+      // `isDeepFrozen()` answers the strict query -- a function is never deeply
+      // immutable (mutable `prototype`/closure), so `false`. `deepFreeze()` is
+      // separately permissive: it treats a function as an opaque immutable leaf
+      // (a code reference, not fabric data) so general-purpose callers that
+      // freeze objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`) keep
+      // working. Reconciling the two under a strict `FabricValue`-only contract
+      // is a separate follow-up.
+      it("returns `false` from `isDeepFrozen()` for a function", () => {
         expect(isDeepFrozen(() => {})).toBe(false);
         expect(isDeepFrozen(function () {})).toBe(false);
-      });
-
-      it("returns `false` for a frozen function (never deep-frozen)", () => {
-        // Freezing a function's shell leaves its `prototype` object and closure
-        // state mutable, so it is never deeply immutable.
         expect(isDeepFrozen(Object.freeze(() => {}))).toBe(false);
-        expect(isDeepFrozen(Object.freeze(function () {}))).toBe(false);
       });
 
-      it("returns `false` for a frozen graph reaching a function", () => {
+      it("returns `false` for an uncached frozen graph reaching a function", () => {
         expect(isDeepFrozen(Object.freeze({ fn: () => {} }))).toBe(false);
       });
 
-      it("throws when `deepFreeze()` is given a function", () => {
-        expect(() => deepFreeze(() => {})).toThrow(
-          "cannot deep-freeze a function",
-        );
+      it("returns the function unchanged from `deepFreeze()` (does not throw)", () => {
+        const fn = () => {};
+        expect(() => deepFreeze(fn)).not.toThrow();
+        expect(deepFreeze(fn)).toBe(fn);
       });
 
-      it("throws when `deepFreeze()` reaches a function within a graph", () => {
-        expect(() => deepFreeze({ fn: () => {} })).toThrow(
-          "cannot deep-freeze a function",
-        );
+      it("freezes a graph containing a function, leaving the function a leaf", () => {
+        const o = deepFreeze({ a: 1, fn: () => {} }) as Record<string, unknown>;
+        expect(Object.isFrozen(o)).toBe(true);
+        expect(typeof o.fn).toBe("function");
       });
     });
 


### PR DESCRIPTION
Fixes and clarifies function / `FabricPrimitive` handling in `deep-freeze.ts` (the TASK-0083 correctness pass). Two parts: (1) **Recognize `FabricPrimitive`** — these self-freeze at construction, so `isNecessarilyFrozenValue()` returns `true` for them, letting `deepFreeze()` drop its now-redundant arm-2 + freeze-closure `FabricPrimitive` short-circuits. (2) **Functions are opaque immutable leaves** (below).

## Function handling (option B, maintainer-approved)

`deepFreeze()` and `isDeepFrozen()` treat a function as an opaque immutable leaf — a code reference, not fabric data — so general-purpose callers that freeze objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`, a module-level API namespace) keep working. `isDeepFrozen(fn)` is `true`; `deepFreeze(fn)` returns it unchanged. This is the pre-existing behavior; an earlier revision tried to make `isDeepFrozen(fn)→false` + `deepFreeze` throw, which broke `cfcPattern` et al., and was reverted. The `deepFreeze→isDeepFrozen` postcondition holds. cubic's P2 (a function's `prototype`/closure stays mutable) is an accepted known-limitation, closed by the `FabricValue`-only migration follow-up.

## Tree-wide audit

The only other `BaseFabricPrimitive.isInstance()` site is `isFabricValue()` in `type-check.ts` — a *membership* arm (is-this-a-`FabricValue`), a different question from frozen-ness, so it is correctly **unaffected**. No wider-system simplification is unlocked; the change is confined to `deep-freeze.ts`.

## Tests

`functions` describe: `isDeepFrozen(fn) → true` (bare + a frozen graph containing one); `deepFreeze(fn)` returns it unchanged; `deepFreeze({…, fn})` freezes the container, function a leaf. `FabricPrimitive` tests stay green (arm-2 deletion behavior-preserving). Full data-model suite **47 passed (2122 steps) / 0 failed**; runner back to the pre-fix baseline (**1034 / 7**, the 7 pre-existing local `commonfabric` stale-build noise; **0** `deepFreeze` throws). fmt/lint/check clean.

## cubic

cubic (restored) reviewed this PR and flagged the function-immutability residual — a **P2** on a bare frozen function (its non-enumerable `prototype`/closure stays mutable while `isDeepFrozen(f)` reports `true`) and, re-reviewing the option-B revision, a **P1** on the cached-container case (`isDeepFrozen()` reads `true` for a `deepFreeze`-cached function-bearing graph). **Note the severity change:** cubic **escalated** this residual from P2 to **P1** on re-review — higher than the P2 framing that was weighed when option B was chosen — surfaced here explicitly so it is re-weighed at the merge gate at its current severity. **Both findings are the same accepted known-limitation** under option B (maintainer-approved), not open defects to fix here: functions are opaque immutable leaves (see "Function handling" above) — an earlier revision that made `isDeepFrozen(fn)→false` + `deepFreeze` throw broke legitimate general-purpose freezing (`cfcPattern` et al.) and was reverted. Full closure needs a strict `FabricValue`-only `deepFreeze()` (a scoped migration, ~67 sites concentrated in `api/cfc.ts`) — filed as **TASK-0086**, with an in-code `TODO(danfuzz)` breadcrumb at the site. (Replaces the retired "cubic did not review" boilerplate.)

## Performance Check — baseline-drift noise override (disclosed)

`Performance Check` is the known-noisy / being-replaced check. It flagged 3 unrelated wall-time drifts (the `generated patterns integration` step + 2 `pattern-unit` subtests — `cfc-group-chat-demo`, `lunch-poll/multi-user`); **zero `data-model` metrics**, and the deterministic `data-model` coverage-debt is flat (`52 → 52`, `OK`) — consistent with B being behaviorally the pre-fix baseline (no real perf surface). Declared noise via the sanctioned per-PR override below (foreman-concurred). Per-PR only — not a durable baseline change.

```
NEW_PERF_BASELINE: step: generated patterns integration = 33s
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/cfc-group-chat-demo/main.test.tsx = 7s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/multi-user.test.tsx = 10s
```

This description written and maintained by:

— upstream-liaison-bolt (Claude Opus 4.8)
