### PR TITLE
fix(topics): make legacy migration safe

### DIFF
--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -44,6 +44,7 @@ export type {
   TopicLinkKind,
   TopicOutput,
   TopicPiece,
+  TopicReference,
 } from "./topic.tsx";
 
 export interface TopicsInput {

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -96,7 +96,7 @@ export interface TopicInput {
    * tracker's array, wired at creation like `myName` (and backfillable as a
    * one-time link-bind on pieces created before it existed). Absent, the
    * detail page simply derives no connections. */
-  mentionable?: Writable<TopicPiece[] | Default<[]>>;
+  mentionable?: Writable<TopicReference[] | Default<[]>>;
 }
 
 /**
@@ -111,7 +111,7 @@ export interface TopicInput {
  * controls are intentionally excluded: a TopicPiece can be followed from a
  * shared list even when the viewer has no matching session-local cells.
  */
-export interface TopicPiece {
+export interface TopicReference {
   [NAME]: string;
   title: string;
   body: string;
@@ -127,6 +127,17 @@ export interface TopicPiece {
   commentCount: number;
   /** Max of creation, comments, body saves, and link additions. */
   lastActivityAt: number;
+  addComment: Stream<AddCommentEvent>;
+  addLink: Stream<AddLinkEvent>;
+  setBody: Stream<SetBodyEvent>;
+}
+
+/**
+ * The board-facing Topic projection. Crossref targets deliberately use the
+ * non-recursive TopicReference contract: a Topic needs enough sibling data to
+ * render and navigate chips, not each sibling's entire crossref graph.
+ */
+export interface TopicPiece extends TopicReference {
   /** This topic's own place in the board's prose graph, derived read-side
    * from `mentionable` (the sibling pieces it links, resolved from the
    * board's own list). Both sets stay empty until `mentionable` is wired.
@@ -135,12 +146,9 @@ export interface TopicPiece {
    * undefined outside the minting session; the list projection must accept
    * that rather than fail argument validation. */
   crossrefs?:
-    | { refsOut: TopicPiece[]; referencedBy: TopicPiece[] }
+    | { refsOut: TopicReference[]; referencedBy: TopicReference[] }
     | Default<{ refsOut: []; referencedBy: [] }>
     | undefined;
-  addComment: Stream<AddCommentEvent>;
-  addLink: Stream<AddLinkEvent>;
-  setBody: Stream<SetBodyEvent>;
 }
 
 /** The complete result available when a Topic is instantiated directly. */
@@ -248,7 +256,9 @@ export const topicAuthorLabel = (
   author: TopicAuthor | undefined,
   legacyName: string | undefined = "",
 ): string => {
-  const name = (author?.name ?? legacyName ?? "").trim() || "someone";
+  const name = (author?.name ?? "").trim() ||
+    (legacyName ?? "").trim() ||
+    "someone";
   return author?.kind === "agent" ? `${name} (agent)` : name;
 };
 
@@ -336,7 +346,7 @@ export const crossrefJoin = (
 /** Row navigation, bound per topic card and per crossref chip. Module-scope
  * handler (not an inline closure) so embedders and tests can bind and drive
  * it directly. */
-export const openTopic = handler<void, { topic: TopicPiece }>(
+export const openTopic = handler<void, { topic: TopicReference }>(
   (_, { topic }) => {
     navigateTo(topic);
   },
@@ -354,7 +364,7 @@ export const openTopic = handler<void, { topic: TopicPiece }>(
 export const crossrefChipRow = (
   caption: string,
   accent: boolean,
-  pieces: TopicPiece[],
+  pieces: TopicReference[],
 ) =>
   pieces.length === 0
     ? null
@@ -508,6 +518,17 @@ export default pattern<TopicInput, TopicOutput>(
     const hasProfile = computed(() =>
       profileName.trim().length > 0 && profileWish.result !== undefined
     );
+    // A legacy Topic has only `createdByName`. Project that snapshot into the
+    // structured result instead of returning a dangling link to an absent
+    // optional input path; sibling Topic schemas can then validate the piece.
+    const createdByView = computed(() => {
+      const name = (createdBy?.name ?? "").trim();
+      if (name) return createdBy;
+      const legacyName = (createdByName ?? "").trim();
+      return legacyName
+        ? { kind: "person" as const, name: legacyName }
+        : undefined;
+    });
 
     // --- Streams (external API; also usable headlessly via CLI) ---
 
@@ -662,7 +683,7 @@ export default pattern<TopicInput, TopicOutput>(
               />
               <cf-hstack justify="between" align="center">
                 <cf-text variant="caption" tone="muted">
-                  started by {topicAuthorLabel(createdBy, createdByName)}
+                  started by {topicAuthorLabel(createdByView, createdByName)}
                   {createdAt ? ` · ${whenLabel(createdAt)}` : ""}
                 </cf-text>
                 <cf-hstack gap="2" align="center">
@@ -913,7 +934,7 @@ export default pattern<TopicInput, TopicOutput>(
       comments,
       links,
       createdAt,
-      createdBy,
+      createdBy: createdByView,
       createdByName,
       bodyUpdatedBy,
       bodyUpdatedAt,

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -353,7 +353,8 @@ export default pattern(() => {
 
   const assert_legacy_fields_load = assert(() =>
     legacy.createdByName === "Legacy Person" &&
-    legacy.createdBy === undefined &&
+    legacy.createdBy?.kind === "person" &&
+    legacy.createdBy?.name === "Legacy Person" &&
     legacy.comments?.[0]?.authorName === "Old Agent" &&
     legacy.comments?.[0]?.author === undefined &&
     topicAuthorLabel(legacy.createdBy, legacy.createdByName) ===
@@ -371,7 +372,8 @@ export default pattern(() => {
   const assert_legacy_topic_created = assert(() =>
     legacyBoard.topicCount === 1 &&
     legacyBoard.topics?.[0]?.title === "Legacy-shaped topic" &&
-    legacyBoard.topics?.[0]?.createdBy === undefined &&
+    legacyBoard.topics?.[0]?.createdBy?.kind === "person" &&
+    legacyBoard.topics?.[0]?.createdBy?.name === "Legacy User" &&
     legacyBoard.topics?.[0]?.createdByName === "Legacy User"
   );
 
@@ -448,7 +450,11 @@ export default pattern(() => {
     isSafeLinkUrl("https://example.com") === true &&
     isSafeLinkUrl("HTTP://EXAMPLE.COM") === true &&
     isSafeLinkUrl("javascript:alert(1)") === false &&
-    isSafeLinkUrl("   ") === false
+    isSafeLinkUrl("   ") === false &&
+    topicAuthorLabel(
+        { kind: "person", name: "" },
+        "Legacy Person",
+      ) === "Legacy Person"
   );
 
   // --- crossrefs: the derived prose reference graph ---


### PR DESCRIPTION
## Summary

Make the current Topics patterns safe to apply directly to stored legacy Topics before repointing the board:

- project legacy `createdByName` snapshots into the structured `createdBy` result, avoiding a dangling optional-input link that sibling Topic validation rejects
- introduce a non-recursive `TopicReference` projection for mentionable/crossref targets, so schema validation does not recursively traverse the full board graph
- preserve the richer board-facing `TopicPiece` contract and add regression coverage for legacy author projection and fallback labeling

This is intentionally standalone from #4975: that PR improves the general `setsrc` compatibility/checker contract, while this PR fixes two Topics-specific result-schema problems discovered by exercising the real migration shape.

## Migration rehearsal

Rehearsed against a copy-on-write clone of an Estuary Topics space:

- updated all 73 legacy Topics serially, then updated the board last
- zero update failures
- durable Topic content fingerprint unchanged
- all 59 comments and 56 links preserved
- a cold board read returned all 73 Topics
- a cold crossref read resolved a linked Topic
- commit/revision counts settled and remained stable after the migration

The rehearsal also reproduced both failures fixed here:

1. legacy Topics without a structured `createdBy` exposed a dangling result link and failed sibling validation
2. recursive `TopicPiece` crossrefs made validation stop making progress after a connected portion of the graph had migrated

No Estuary production data was mutated during this rehearsal.

## Validation

- `deno check packages/patterns/topics/topic.tsx packages/patterns/topics/main.tsx packages/patterns/topics/topics.test.tsx packages/patterns/topics/multi-user.test.tsx`
- `deno task cf test packages/patterns/topics/topics.test.tsx` — 39 passed
- `deno task cf test packages/patterns/topics/multi-user.test.tsx` — 7 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make legacy Topics migration safe by projecting legacy author snapshots and using a non-recursive crossref type. Prevents schema validation failures and lets boards read migrated Topics reliably.

- **Bug Fixes**
  - Project `createdByName` into structured `createdBy` for legacy Topics to avoid dangling optional links during sibling validation.
  - Introduce non-recursive `TopicReference`; use it for `mentionable`, `crossrefs`, `openTopic`, and chip rendering while keeping the board-facing `TopicPiece` contract and switching crossref arrays to `TopicReference[]`.
  - Improve `topicAuthorLabel` to prefer structured names, then legacy, else "someone"; use the projected `createdBy` in UI and results.
  - Export `TopicReference` from `main.tsx` and update tests to cover legacy author projection and labeling.

<sup>Written for commit e1f87cfe600f85159d99d9ebed6742138b31ae29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

