### PR TITLE
fix(cf-harness): disable reasoning for Chat Completions tool runs

### DIFF
--- a/packages/cf-harness/src/gateway/openai-client.ts
+++ b/packages/cf-harness/src/gateway/openai-client.ts
@@ -78,6 +78,7 @@ export interface OpenAIChatCompletionRequest {
   tools?: readonly OpenAIChatCompletionRequestTool[];
   native_model_tools?: readonly OpenAIChatCompletionNativeModelTool[];
   tool_choice?: "auto" | "none" | Record<string, unknown>;
+  reasoning_effort?: "none";
 }
 
 export interface OpenAIChatCompletionRequestDiagnosticSummary {

--- a/packages/cf-harness/src/model/openai-compatible-gateway.ts
+++ b/packages/cf-harness/src/model/openai-compatible-gateway.ts
@@ -157,6 +157,11 @@ export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
       messages: await Promise.all(request.transcript.map(toOpenAIChatMessage)),
       tools: [...tools, ...toNativeModelTools(request.nativeModelToolIds)],
       tool_choice: "auto",
+      // OpenAI's reasoning models default reasoning on at the gateway, but
+      // Chat Completions rejects reasoning together with function tools.
+      // cf-harness needs function tools here, so make the compatible setting
+      // explicit instead of inheriting a provider/model default.
+      reasoning_effort: "none",
     };
     const response = await this.gatewayClient.createChatCompletionJson(
       payload,

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -1186,6 +1186,12 @@ Deno.test("CfHarnessPromptLoop inserts context messages before the user prompt",
   ]);
   assertEquals(request?.messages[1].content, "Configured skills context.");
   assertEquals(request?.messages[2].content, "Do the task.");
+  assertEquals(
+    (request as OpenAIChatCompletionRequest & {
+      reasoning_effort?: string;
+    })?.reasoning_effort,
+    "none",
+  );
 });
 
 Deno.test("CfHarnessPromptLoop materializes image attachments for gateway requests only", async () => {


### PR DESCRIPTION
## Why

The OpenAI-compatible gateway now defaults reasoning on for GPT reasoning models. `/v1/chat/completions` rejects function tools when reasoning is enabled, so every cf-harness run using Loom's `gpt-5.6-terra` alias fails before its first model turn. An explicit `reasoning_effort: "none"` is the gateway-supported compatibility mode for Chat Completions tool calls.

## What Changed

- Add `reasoning_effort` to the Chat Completions request contract.
- Pin it to `none` for the OpenAI-compatible gateway client.
- Cover the serialized prompt-loop request with a regression test.

## Test plan

- `deno task --cwd packages/cf-harness test` — 500 passed.
- Live clone-backed Loom acceptance: a `gpt-5.6-terra` cf-harness Scout completed connector discovery and pinned its frontier; the parent materializer completed W-36.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable reasoning for Chat Completions tool calls to restore tool support with the OpenAI-compatible gateway, unblocking `gpt-5.6-terra` runs in `cf-harness`.

- **Bug Fixes**
  - Added `reasoning_effort: "none"` to the Chat Completions payload and `OpenAIChatCompletionRequest` type so tool calls are accepted.
  - Added a regression test to assert the prompt loop includes `reasoning_effort: "none"`.

<sup>Written for commit b249988f796a9731e6fee4c38210b0a98183eed2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

