### PR TITLE
fix(dashboard): classify Discord team by Team role

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -310,6 +310,9 @@ Use a normal key, not a **Management** key — management keys can't call
 
 Powers **discord online**. Needs a bot with the **Server Members** and
 **Presence** privileged intents, invited to the server, plus the server id.
+The guild must contain a role named exactly `Team` or `Team Member`; without
+either, the tile remains unknown. The names are equivalent. Online members with
+either role count as team; every other online member counts as a visitor.
 
 1. **discord.com/developers/applications → New Application**, name it, **Create**.
 2. **Bot** (left sidebar) → **Reset Token** → copy the token (shown once).

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -410,11 +410,11 @@ Deno.test("gated tiles gray out cleanly without their env", async () => {
   }
 });
 
-Deno.test("discord snapshot: splits online members into Team Member and Visitors", () => {
+Deno.test("discord snapshot: splits online members into Team and Visitors", () => {
   const guild = {
     id: "g",
     roles: [
-      { id: "team", name: "Team Member", color: 0x2ecc71, position: 5 },
+      { id: "team", name: "Team", color: 0x2ecc71, position: 5 },
       { id: "g", name: "@everyone", color: 0, position: 0 },
     ],
     members: [
@@ -431,6 +431,7 @@ Deno.test("discord snapshot: splits online members into Team Member and Visitors
     ],
   };
   const snap = buildSnapshot(guild);
+  assert(snap);
   assertEquals(snap.online, 3); // a, b, d (c is offline)
   assertEquals(snap.team, 2); // a, d carry the role and are online
   assertEquals(snap.visitors, 1); // b

--- a/packages/dashboard/tiles/discord-online.test.ts
+++ b/packages/dashboard/tiles/discord-online.test.ts
@@ -30,7 +30,7 @@ function ctx(env: Record<string, string> = {}): Ctx {
 const GUILD = {
   id: "g1",
   roles: [
-    { id: "team", name: "Team Member", color: 0x2ecc71, position: 5 },
+    { id: "team", name: "Team", color: 0x2ecc71, position: 5 },
     { id: "g1", name: "@everyone", color: 0, position: 0 },
   ],
   members: [
@@ -203,41 +203,82 @@ Deno.test("discord online: neither the token nor the guild id alone earns a colo
 Deno.test("discord snapshot: an online user with no member record counts as a visitor, not team", () => {
   const snap = buildSnapshot({
     id: "g1",
-    roles: [{ id: "team", name: "Team Member", color: 255, position: 5 }],
+    roles: [{ id: "team", name: "Team", color: 255, position: 5 }],
     members: [{ user: { id: "a" }, roles: ["team"] }],
     presences: [
       { user: { id: "a" }, status: "online" },
       { user: { id: "ghost" }, status: "online" }, // present, but not in the member list
     ],
   });
+  assert(snap);
   assertEquals(snap.online, 2);
   assertEquals(snap.team, 1);
   assertEquals(snap.visitors, 1);
   assertEquals(snap.teamColor, "#0000ff"); // a decimal Discord color, zero-padded
 });
 
-Deno.test("discord snapshot: a colorless or absent Team Member role falls back to the visitor grey", () => {
+Deno.test("discord snapshot: a colorless Team role uses the visitor grey", () => {
   const online = [{ user: { id: "a" }, status: "online" }];
   const members = [{ user: { id: "a" }, roles: ["team"] }];
   // The role exists and is counted, but carries Discord's "no color" sentinel.
   const colorless = buildSnapshot({
     id: "g1",
-    roles: [{ id: "team", name: "Team Member", color: 0, position: 5 }],
+    roles: [{ id: "team", name: "Team", color: 0, position: 5 }],
     members,
     presences: online,
   });
+  assert(colorless);
   assertEquals(colorless.team, 1);
   assertEquals(colorless.teamColor, VISITOR_GREY);
-  // No such role in the guild: nobody is team, and there is no color to borrow.
+});
+
+Deno.test("discord snapshot: Team Member remains an alias for Team", () => {
+  const legacy = buildSnapshot({
+    id: "g1",
+    roles: [{ id: "legacy", name: "Team Member", color: 0x123456, position: 5 }],
+    members: [{ user: { id: "a" }, roles: ["legacy"] }],
+    presences: [{ user: { id: "a" }, status: "online" }],
+  });
+  assert(legacy);
+  assertEquals(legacy.team, 1);
+  assertEquals(legacy.visitors, 0);
+  assertEquals(legacy.teamColor, "#123456");
+});
+
+Deno.test("discord snapshot: Team and Team Member roles are counted together", () => {
+  const snap = buildSnapshot({
+    id: "g1",
+    roles: [
+      { id: "team", name: "Team", color: 0x2ecc71, position: 6 },
+      { id: "legacy", name: "Team Member", color: 0x123456, position: 5 },
+    ],
+    members: [
+      { user: { id: "a" }, roles: ["team"] },
+      { user: { id: "b" }, roles: ["legacy"] },
+      { user: { id: "c" }, roles: ["team", "legacy"] },
+      { user: { id: "d" }, roles: [] },
+    ],
+    presences: [
+      { user: { id: "a" }, status: "online" },
+      { user: { id: "b" }, status: "online" },
+      { user: { id: "c" }, status: "online" },
+      { user: { id: "d" }, status: "online" },
+    ],
+  });
+  assert(snap);
+  assertEquals(snap.team, 3);
+  assertEquals(snap.visitors, 1);
+  assertEquals(snap.teamColor, "#2ecc71");
+});
+
+Deno.test("discord snapshot: absent Team aliases do not produce a valid snapshot", () => {
   const missing = buildSnapshot({
     id: "g1",
     roles: [{ id: "g1", name: "@everyone", color: 0, position: 0 }],
-    members,
-    presences: online,
+    members: [{ user: { id: "a" }, roles: ["team"] }],
+    presences: [{ user: { id: "a" }, status: "online" }],
   });
-  assertEquals(missing.team, 0);
-  assertEquals(missing.visitors, 1);
-  assertEquals(missing.teamColor, VISITOR_GREY);
+  assertEquals(missing, null);
 });
 
 // This is the first test that reaches the history, so it is the one that sees the
@@ -271,6 +312,7 @@ Deno.test("discord online: a snapshot -> good; the reloaded history draws the ch
     // What was persisted: the retained sample plus the fresh one. The ancient
     // sample and the entries that are not points are gone.
     assertEquals(w.reads.length, 1);
+    assertStringIncludes(w.reads[0], "fabric-wall-discord-history.json");
     assertEquals(w.writes.length, 1);
     assertEquals(JSON.parse(w.writes[0].data), [
       { t: T0 - 2 * DAY, team: 3, visitors: 4 },
@@ -364,6 +406,24 @@ Deno.test("discord online: an invalid session (op 9) -> gray, never a false gree
     assertEquals(v.status, "unknown");
     assertEquals(v.value, "—");
     assertStringIncludes(v.sub ?? "", "enable the presences + members intents");
+  });
+});
+
+Deno.test("discord online: missing Team aliases -> gray", async () => {
+  await withWire({}, async (w) => {
+    const view = connect(w);
+    w.socket().deliver({
+      op: 0,
+      t: "GUILD_CREATE",
+      d: {
+        ...GUILD,
+        roles: [{ id: "g1", name: "@everyone", color: 0, position: 0 }],
+      },
+    });
+    const v = await view;
+    assertEquals(v.status, "unknown");
+    assertEquals(v.value, "—");
+    assertStringIncludes(v.sub ?? "", "Team or Team Member role");
   });
 });
 

--- a/packages/dashboard/tiles/discord-online.ts
+++ b/packages/dashboard/tiles/discord-online.ts
@@ -247,7 +247,8 @@ export const discordOnline: Tile = {
         label,
         status: "unknown",
         value: "—",
-        sub: "enable the presences + members intents on the bot",
+        sub:
+          "enable the presences + members intents; add a Team or Team Member role",
       };
     }
 

--- a/packages/dashboard/tiles/discord-online.ts
+++ b/packages/dashboard/tiles/discord-online.ts
@@ -1,5 +1,6 @@
 // discord online: a one-shot Discord gateway snapshot of currently-online guild
-// members, split into the "Team Member" role and everyone else ("Visitors").
+// members, split into the "Team" and "Team Member" roles and everyone else
+// ("Visitors").
 // Each poll opens a fresh gateway connection, identifies, waits for the initial
 // GUILD_CREATE, tallies presences against members, then tears the socket and
 // heartbeat down. Successive polls accumulate a rolling history (persisted to
@@ -18,9 +19,10 @@ const SNAPSHOT_TIMEOUT_MS = 12_000;
 // Intents: GUILDS (1) | GUILD_MEMBERS (2) | GUILD_PRESENCES (256).
 const INTENTS = 259;
 
-// Online members carrying this role are counted as team; everyone else online is
-// a visitor. Matched against the Discord role name exactly.
-const TEAM_ROLE_NAME = "Team Member";
+// Online members carrying either exact role name are counted as team. "Team
+// Member" is the former name of the "Team" role.
+const TEAM_ROLE_NAME = "Team";
+const TEAM_ROLE_NAMES = new Set([TEAM_ROLE_NAME, "Team Member"]);
 const VISITOR_COLOR = "#7c828c";
 // The chart lines fade from this (a shade darker than the good-status tile
 // background) on the far left up to their own color, matching the ci-duration
@@ -112,25 +114,28 @@ function roleColor(color: number): string {
   return "#" + (color & 0xffffff).toString(16).padStart(6, "0");
 }
 
-// Count online users carrying the "Team Member" role as team; everyone else
-// online is a visitor. Also returns the team role's own color. Exported for
-// unit testing.
-export function buildSnapshot(g: GuildCreate): Snapshot {
+// Count online users carrying either team role name as team; everyone else
+// online is a visitor. A guild without either role has no valid snapshot. Also
+// returns the current role's color. Exported for unit testing.
+export function buildSnapshot(g: GuildCreate): Snapshot | null {
   const byId = new Map<string, Member>();
   for (const m of g.members) byId.set(m.user.id, m);
-  const teamRole = g.roles.find((r) => r.name === TEAM_ROLE_NAME);
+  const teamRoles = g.roles.filter((r) => TEAM_ROLE_NAMES.has(r.name));
+  if (teamRoles.length === 0) return null;
+  const teamRoleIds = new Set(teamRoles.map((r) => r.id));
+  const colorRole = teamRoles.find((r) => r.name === TEAM_ROLE_NAME) ?? teamRoles[0];
 
   const online = g.presences.filter((p) => p.status !== "offline");
   let team = 0;
   for (const p of online) {
     const member = byId.get(p.user.id);
-    if (teamRole && member && member.roles.includes(teamRole.id)) team++;
+    if (member && member.roles.some((roleId) => teamRoleIds.has(roleId))) team++;
   }
   return {
     online: online.length,
     team,
     visitors: online.length - team,
-    teamColor: teamRole ? roleColor(teamRole.color) : VISITOR_COLOR,
+    teamColor: roleColor(colorRole.color),
   };
 }
 


### PR DESCRIPTION
The Discord server uses the exact role name Team, while the tile matched Team Member. That mismatch classified every online member as a visitor while still reporting a healthy snapshot.

Match the Team role and reject snapshots when that exact role is absent. Start a new history file so counts produced by different role definitions are not charted as one series. Update tests and the setup guide to cover the exact role requirement and the unknown state.

Verified with the full dashboard test suite, repository-wide formatting checks, and repository-wide linting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats Discord `Team` and `Team Member` roles as aliases in the online tile, counting members with either role once and preferring the `Team` role color. The tile stays unknown when neither role exists, and the existing history file is kept to preserve charts.

- **Bug Fixes**
  - Recognize both exact role names; avoid double counting; prefer the `Team` color when both exist.
  - Show recovery guidance when the tile is unknown: enable privileged intents and add a `Team` or `Team Member` role.
  - Retain `fabric-wall-discord-history.json` to preserve history; update tests and the setup guide for the alias behavior.

- **Migration**
  - Ensure your Discord guild has a role named exactly `Team` or `Team Member`; otherwise the tile remains unknown.

<sup>Written for commit 4586789406e48269f4b5753deb8584455649902f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

