### PR TITLE
fix(runner): restore link-resolution bench after $alias stopped being…

### DIFF
--- a/packages/runner/test/link-resolution.bench.ts
+++ b/packages/runner/test/link-resolution.bench.ts
@@ -3,7 +3,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import { resolveLink } from "../src/link-resolution.ts";
 import { Runtime } from "../src/runtime.ts";
-import { parseLink } from "../src/link-utils.ts";
+import { parseAliasBinding } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -26,9 +26,16 @@ Deno.bench("followWriteRedirects with simple alias", () => {
     tx,
   );
   testCell.set({ value: 42 });
-  const binding = { $alias: { path: ["value"] } };
+  // `$alias` is a Pattern binding, not a link, so parse it against the base
+  // full link via parseAliasBinding; `cell` satisfies the AliasBinding shape.
+  const binding = { $alias: { cell: "result" as const, path: ["value"] } };
 
-  resolveLink(runtime, tx, parseLink(binding, testCell)!, "writeRedirect");
+  resolveLink(
+    runtime,
+    tx,
+    parseAliasBinding(binding, testCell.getAsNormalizedFullLink()),
+    "writeRedirect",
+  );
 
   tx.commit();
   runtime.dispose();
@@ -66,8 +73,13 @@ Deno.bench("followWriteRedirects with nested aliases (5 levels)", () => {
     });
   }
 
-  const binding = { $alias: { path: ["next"] } };
-  resolveLink(runtime, tx, parseLink(binding, cells[0])!, "writeRedirect");
+  const binding = { $alias: { cell: "result" as const, path: ["next"] } };
+  resolveLink(
+    runtime,
+    tx,
+    parseAliasBinding(binding, cells[0].getAsNormalizedFullLink()),
+    "writeRedirect",
+  );
 
   tx.commit();
   runtime.dispose();


### PR DESCRIPTION
… a link

The scheduled Benchmarks workflow has been red on every run since the "$alias is a binding form, not a link" refactor (#4895) landed. That change made isWriteRedirectLink, parseLink, isCellLink, and isPrimitiveCellLink stop matching `$alias` records: they are Pattern-object bindings, and in data they are plain values. parseLink now returns undefined for an `$alias` record.

link-resolution.bench.ts was not updated alongside that refactor. Its two write-redirect benchmarks still built a legacy `{ $alias: { path } }` record and fed parseLink(binding, cell)! straight into resolveLink. After the refactor parseLink returns undefined, so resolveLink received undefined and threw "Cannot read properties of undefined (reading 'space')" on its first cycle-key read. `deno bench` records the per-bench failure, runs the rest, and exits non-zero, so the whole workflow failed even though the other 369 benches passed. Benchmarks run only on the scheduled Benchmarks workflow, not in PR CI, so the refactor's PR was green and the breakage surfaced only on the next four-hourly run.

Parse the binding the way the refactor's own test suite now does: via parseAliasBinding against the base cell's full link, with the `cell: "result"` discriminant that the AliasBinding shape requires. parseAliasBinding yields the same redirect link the old parseLink did for this shape — same base document, same path, overwrite "redirect" — so the two benchmarks measure the same single- and multi-hop write-redirect resolution as before and their names, groups, and trend history stay stable. The other five benches in the file already used the sigil link API and were untouched.

Verified by running the file's benches to completion (exit 0, all seven present) plus deno fmt --check and deno lint.

deflaked by Hixie's agent (Claude Opus 4.8)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the link-resolution benchmarks by parsing `$alias` as a binding against the base cell link, fixing the failing scheduled Benchmarks workflow.

- **Bug Fixes**
  - Replaced parseLink(...) with parseAliasBinding(binding, cell.getAsNormalizedFullLink()) in the two write-redirect benches.
  - Updated binding to `{ $alias: { cell: "result", path: [...] } }`.
  - Preserves benchmark semantics and names; all seven benches run to completion.

<sup>Written for commit 35f08d196d541a877a7cd8aee3687f758bc7cfed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/factory-outputs/lot-watch/main.test.tsx = 14s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc/trusted-surfaces/main.test.tsx = 11s
NEW_PERF_BASELINE: test: pattern-unit-2/pattern-unit-tests = 74s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-trusted-component-examples/main.test.tsx = 6s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-spec-gallery/main.test.tsx = 5s
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/battleship/multiplayer/lobby.test.tsx = 5s
NEW_PERF_BASELINE: step: generated patterns integration = 33s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/multi-user.test.tsx = 9s
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/cfc-group-chat-demo/main.test.tsx = 7s
NEW_COVERAGE_BASELINE
