### PR TITLE
Drop the dead delay counter from the Gmail read client

### DIFF
--- a/packages/patterns/google/core/util/gmail-client.ts
+++ b/packages/patterns/google/core/util/gmail-client.ts
@@ -3,7 +3,7 @@
  *
  * This module provides a reusable Gmail client that handles:
  * - Token refresh on 401 errors
- * - Rate limit handling (429) with exponential backoff
+ * - Rate limit handling (429) with immediate retry
  * - Configurable retry logic
  * - Batch API requests for efficiency
  *

--- a/packages/patterns/google/core/util/gmail-client.ts
+++ b/packages/patterns/google/core/util/gmail-client.ts
@@ -28,10 +28,6 @@ import type { Auth } from "../gmail-importer.tsx";
 export interface GmailClientConfig {
   /** How many times the client will retry after an HTTP failure */
   retries?: number;
-  /** In milliseconds, the delay between making any subsequent requests due to failure */
-  delay?: number;
-  /** In milliseconds, the amount to permanently increment to the `delay` on every 429 response */
-  delayIncrement?: number;
   /** Enable verbose console logging */
   debugMode?: boolean;
   /**
@@ -194,14 +190,10 @@ export function gmailClient(
   auth: Writable<Auth>,
   {
     retries = 3,
-    delay: initialDelay = 1000,
-    delayIncrement = 100,
     debugMode = false,
     onRefresh,
   }: GmailClientConfig = {},
 ): GmailClient {
-  let delay = initialDelay;
-
   async function refreshAuth(): Promise<void> {
     if (onRefresh) {
       debugLog(debugMode, "Refreshing auth token via external callback...");
@@ -315,9 +307,6 @@ export function gmailClient(
 
     if (status === 401) {
       await refreshAuth();
-    } else if (status === 429) {
-      delay += delayIncrement;
-      debugLog(debugMode, `Rate limited, incrementing delay to ${delay}`);
     }
 
     return googleRequest(url, _options, remainingRetries - 1);


### PR DESCRIPTION
The read client `gmailClient` in gmail-client.ts carried a backoff counter that never backed off. Its config exposed `delay` and `delayIncrement`, the factory seeded `let delay = initialDelay`, and the 429 branch of `googleRequest` ran `delay += delayIncrement` and logged the new value. Nothing ever awaited `delay`: there was no sleep, so the counter only incremented and printed. It was the residue of a backoff loop whose timer was never wired up, left stranded once the sandbox stopped providing `setTimeout`.

Remove the whole mechanism: the two config fields and their JSDoc, the destructured `delay`/`delayIncrement` params and defaults, the `let delay = initialDelay` line, and the increment-and-log block on the 429 path. The 429 case now falls through to the shared recursion that already retries every non-401 failure immediately, so rate limits keep surfacing and retrying exactly as before, minus the no-op counter. No caller passed either field, so the config-interface change is source compatible. This mirrors the earlier cleanup of the sibling Airtable, Google Docs, and Gmail-send clients.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the dead backoff counter from the Gmail read client and its 429 log, and updated the module JSDoc to reflect immediate retry on 429s. Dropped `delay` and `delayIncrement` from `GmailClientConfig`; behavior and callers remain unchanged.

<sup>Written for commit 7bb7e7c9765cb90a96ccc95331124ca3e0c9bde0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

