### PR TITLE
fix(patterns): record — run the auto-seed and revive the dead LLM str…

### DIFF
--- a/packages/patterns/record-llm-streams.test.tsx
+++ b/packages/patterns/record-llm-streams.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * Test: the LLM-callable streams a Record exposes for Omnibot's invoke() tool.
+ *
+ * Record's body returns six streams under the "LLM-callable streams" comment;
+ * addModule has its own positioning-and-labels test in record.test.tsx, and
+ * this file covers the other five: getSummary, updateModule, removeModule,
+ * setTitle, and listModuleTypes. Reaching any of them needs it declared in
+ * RecordOutput, because the pattern's Output type decides what the result
+ * schema materializes on the instance; a stream returned from the body but
+ * absent from the Output reads back as undefined and cannot be invoked. Each
+ * case below sends the stream and asserts on what the handler writes, so
+ * removing a stream's declaration turns its `subject.<stream>!.send(...)` into
+ * a call on undefined and fails the case.
+ *
+ * A handler returns its payload to the caller by writing the injected `result`
+ * cell (its return value is ignored). A `Writable<unknown>` reads back as
+ * undefined, so every result cell here is typed with the concrete shape its
+ * handler writes.
+ *
+ * getSummary and updateModule reach the module pieces the list holds. The piece
+ * is declared `unknown` on SubPieceEntry, and a field typed `unknown` reads
+ * back across a handler boundary as undefined, so both handlers type the piece
+ * as a live Cell to keep the handle. getSummary's per-module `data` therefore
+ * carries the real field values (the email module's smart-default label reads
+ * "Personal"), and updateModule's write is visible in the next getSummary.
+ *
+ * The Record is never rendered, so its seeder never runs and its module list
+ * starts empty — the headless path an invoke() caller takes. Modules are added
+ * with addModule before the cases that read or mutate them, so the indices are
+ * known.
+ *
+ * Run: deno task cf test packages/patterns/record-llm-streams.test.tsx --root packages/patterns --verbose
+ */
+import { action, assert, pattern, Writable } from "commonfabric";
+import RecordPattern from "./record.tsx";
+
+interface ModuleTypeInfo {
+  type?: string;
+  label?: string;
+  icon?: string;
+  allowMultiple?: boolean;
+}
+interface ListTypesResult {
+  types?: ModuleTypeInfo[];
+}
+interface SummaryModule {
+  index?: number;
+  type?: string;
+  label?: string;
+  pinned?: boolean;
+  data?: { label?: string; number?: string };
+}
+interface SummaryResult {
+  title?: string;
+  moduleCount?: number;
+  modules?: SummaryModule[];
+}
+interface OpResult {
+  success?: boolean;
+  message?: string;
+  error?: string;
+  title?: string;
+}
+interface AddResult {
+  success?: boolean;
+  moduleIndex?: number;
+  type?: string;
+}
+
+export default pattern(() => {
+  const subject = RecordPattern({
+    title: "Test Record",
+    subPieces: [],
+    trashedSubPieces: [],
+  });
+
+  // Each invocation reports into its own cell so the assertions read the value
+  // its own send produced rather than whichever handler wrote last.
+  const typesResult = new Writable<ListTypesResult>();
+  const setTitleResult = new Writable<OpResult>();
+  const emailAdd = new Writable<AddResult>();
+  const phoneAdd = new Writable<AddResult>();
+  const summaryBefore = new Writable<SummaryResult>();
+  const summaryAfter = new Writable<SummaryResult>();
+  const updateOk = new Writable<OpResult>();
+  const updateBadIndex = new Writable<OpResult>();
+  const updateBadField = new Writable<OpResult>();
+  const updateInherited = new Writable<OpResult>();
+  const removeOk = new Writable<OpResult>();
+  const removeBadIndex = new Writable<OpResult>();
+
+  // listModuleTypes — read-only. Lists the types addModule accepts.
+  const action_list_types = action(() => {
+    subject.listModuleTypes!.send({ result: typesResult });
+  });
+  const assert_list_types = assert(() => {
+    const types = typesResult.get()?.types ?? [];
+    return types.length > 0 &&
+      types.every((t) =>
+        typeof t.type === "string" && typeof t.label === "string" &&
+        typeof t.icon === "string"
+      ) &&
+      types.some((t) => t.type === "email");
+  });
+
+  // setTitle — sets the record title and echoes it back.
+  const action_set_title = action(() => {
+    subject.setTitle!.send({
+      newTitle: "Renamed Record",
+      result: setTitleResult,
+    });
+  });
+  const assert_title_updated = assert(() => subject.title === "Renamed Record");
+  const assert_set_title_result = assert(() => {
+    const r = setTitleResult.get();
+    return r?.success === true && r?.title === "Renamed Record";
+  });
+
+  // Two modules so the summary, update, and remove cases have known indices.
+  const action_add_email = action(() => {
+    subject.addModule!.send({ type: "email", result: emailAdd });
+  });
+  const action_add_phone = action(() => {
+    subject.addModule!.send({ type: "phone", result: phoneAdd });
+  });
+  const assert_two_modules = assert(() => {
+    const entries = [...(subject.subPieces ?? [])];
+    return entries.length === 2 &&
+      entries[0].type === "email" && entries[1].type === "phone";
+  });
+
+  // getSummary — read-only. Reports the title, module count, and per-module
+  // type and field values in list order. The field values come from the live
+  // piece, so each module's smart-default label reads back (email "Personal",
+  // phone "Mobile").
+  const action_summary_before = action(() => {
+    subject.getSummary!.send({ result: summaryBefore });
+  });
+  const assert_summary = assert(() => {
+    const s = summaryBefore.get();
+    const modules = s?.modules ?? [];
+    return s?.title === "Renamed Record" && s?.moduleCount === 2 &&
+      modules.length === 2 &&
+      modules[0].type === "email" && modules[0].data?.label === "Personal" &&
+      modules[1].type === "phone" && modules[1].data?.label === "Mobile";
+  });
+
+  // updateModule — sets a directly-settable field on a module, and reports the
+  // reason when the index is out of range or the field is not on the module.
+  const action_update_label = action(() => {
+    subject.updateModule!.send({
+      index: 0,
+      field: "label",
+      value: "Updated",
+      result: updateOk,
+    });
+  });
+  const action_update_bad_index = action(() => {
+    subject.updateModule!.send({
+      index: 9,
+      field: "label",
+      value: "x",
+      result: updateBadIndex,
+    });
+  });
+  const action_update_bad_field = action(() => {
+    subject.updateModule!.send({
+      index: 0,
+      field: "nonesuch",
+      value: "x",
+      result: updateBadField,
+    });
+  });
+  // An inherited name is not an own field, so the guard rejects it rather than
+  // writing a stray key onto the piece.
+  const action_update_inherited = action(() => {
+    subject.updateModule!.send({
+      index: 0,
+      field: "constructor",
+      value: "x",
+      result: updateInherited,
+    });
+  });
+  const assert_update_ok = assert(() => {
+    const r = updateOk.get();
+    return r?.success === true &&
+      typeof r?.message === "string" && r.message.includes("label");
+  });
+  const assert_update_bad_index = assert(() => {
+    const r = updateBadIndex.get();
+    return r?.success === false &&
+      typeof r?.error === "string" && r.error.includes("Invalid module index");
+  });
+  const assert_update_bad_field = assert(() => {
+    const r = updateBadField.get();
+    return r?.success === false &&
+      typeof r?.error === "string" &&
+      r.error.includes("not a settable field");
+  });
+  const assert_update_inherited_rejected = assert(() => {
+    const r = updateInherited.get();
+    return r?.success === false &&
+      typeof r?.error === "string" &&
+      r.error.includes("not a settable field");
+  });
+
+  // The write updateModule made is visible: the next summary reads the new
+  // label off the same piece.
+  const action_summary_after = action(() => {
+    subject.getSummary!.send({ result: summaryAfter });
+  });
+  const assert_update_took_effect = assert(() =>
+    summaryAfter.get()?.modules?.[0]?.data?.label === "Updated"
+  );
+
+  // removeModule — moves a module to the trash (a soft delete) and reports the
+  // reason when the index is out of range.
+  const action_remove_email = action(() => {
+    subject.removeModule!.send({ index: 0, result: removeOk });
+  });
+  const action_remove_bad_index = action(() => {
+    subject.removeModule!.send({ index: 9, result: removeBadIndex });
+  });
+  const assert_remove_ok = assert(() => {
+    const r = removeOk.get();
+    const entries = [...(subject.subPieces ?? [])];
+    const trashed = [...(subject.trashedSubPieces ?? [])];
+    return r?.success === true &&
+      entries.length === 1 && entries[0].type === "phone" &&
+      trashed.length === 1 && trashed[0].type === "email";
+  });
+  const assert_remove_bad_index = assert(() => {
+    const r = removeBadIndex.get();
+    return r?.success === false &&
+      typeof r?.error === "string" &&
+      r.error.includes("Invalid module index") &&
+      [...(subject.subPieces ?? [])].length === 1;
+  });
+
+  return {
+    tests: [
+      { action: action_list_types },
+      { assertion: assert_list_types },
+
+      { action: action_set_title },
+      { assertion: assert_title_updated },
+      { assertion: assert_set_title_result },
+
+      { action: action_add_email },
+      { action: action_add_phone },
+      { assertion: assert_two_modules },
+
+      { action: action_summary_before },
+      { assertion: assert_summary },
+
+      { action: action_update_label },
+      { assertion: assert_update_ok },
+      { action: action_update_bad_index },
+      { assertion: assert_update_bad_index },
+      { action: action_update_bad_field },
+      { assertion: assert_update_bad_field },
+      { action: action_update_inherited },
+      { assertion: assert_update_inherited_rejected },
+
+      { action: action_summary_after },
+      { assertion: assert_update_took_effect },
+
+      { action: action_remove_email },
+      { assertion: assert_remove_ok },
+      { action: action_remove_bad_index },
+      { assertion: assert_remove_bad_index },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -65,6 +65,21 @@ export interface RecordOutput {
     initialData?: Record<string, unknown>;
     result?: Writable<unknown>;
   }>;
+  /** Writes a structured summary of every module into the result cell. */
+  getSummary?: Stream<{ result?: Writable<unknown> }>;
+  /** Sets a directly-settable field on the module at the given index. */
+  updateModule?: Stream<{
+    index: number;
+    field: string;
+    value: unknown;
+    result?: Writable<unknown>;
+  }>;
+  /** Moves the module at the given index to the trash. */
+  removeModule?: Stream<{ index: number; result?: Writable<unknown> }>;
+  /** Sets this record's title. */
+  setTitle?: Stream<{ newTitle: string; result?: Writable<unknown> }>;
+  /** Writes the list of addable module types into the result cell. */
+  listModuleTypes?: Stream<{ result?: Writable<unknown> }>;
 }
 
 // ===== Auto-initialize Notes + TypePicker =====
@@ -433,13 +448,23 @@ const toggleTrashExpanded = handler<unknown, { expanded: Writable<boolean> }>(
 // IMPORTANT: Handlers must use result.set() to return data to the LLM.
 // The 'result' Cell is injected by llm-dialog.ts invoke() - return statements are ignored!
 
+// SubPieceEntry as an LLM handler that touches the piece must type it. The
+// shared SubPieceEntry declares `piece: unknown`, and a field typed `unknown`
+// reads back across the handler boundary as undefined, so a handler that needs
+// to read the piece's fields or write them types the piece as a live Cell
+// instead. The handler still receives the same `subPieces` cell; the call site
+// casts to bridge the two views.
+type SubPieceEntryHandle =
+  & Omit<SubPieceEntry, "piece">
+  & { piece: Cell<Record<string, unknown>> };
+
 // Get a structured summary of all modules in this record
 // Returns module types, their data, and schemas for LLM context
 const handleGetSummary = handler<
   { result?: Writable<unknown> },
   {
     title: Writable<string>;
-    subPieces: Writable<SubPieceEntry[]>;
+    subPieces: Writable<SubPieceEntryHandle[]>;
   }
 >(({ result }, { title, subPieces }) => {
   const modules = subPieces.get() || [];
@@ -448,38 +473,20 @@ const handleGetSummary = handler<
     moduleCount: modules.length,
     modules: modules.map((entry, index) => {
       const def = getDefinition(entry.type);
-      // Extract data from piece - access common fields reactively
-      // deno-lint-ignore no-explicit-any
-      const piece = entry.piece as any;
+      // Read the piece's current field values. The piece is a live Cell here,
+      // so `get()` resolves the whole module value; a plain read off the
+      // `unknown`-typed handle would come back undefined. Every own field is
+      // reported except callable outputs (streams); a module whose value cannot
+      // be resolved contributes empty data rather than failing the whole
+      // summary.
       const moduleData: Record<string, unknown> = {};
-
-      // Try to extract common fields based on module type
       try {
-        // Most modules have a primary value field
-        if (piece?.label !== undefined) moduleData.label = piece.label;
-        if (piece?.value !== undefined) moduleData.value = piece.value;
-        if (piece?.content !== undefined) moduleData.content = piece.content;
-        if (piece?.address !== undefined) moduleData.address = piece.address;
-        if (piece?.email !== undefined) moduleData.email = piece.email;
-        if (piece?.phone !== undefined) moduleData.phone = piece.phone;
-        if (piece?.rating !== undefined) moduleData.rating = piece.rating;
-        if (piece?.tags !== undefined) moduleData.tags = piece.tags;
-        if (piece?.status !== undefined) moduleData.status = piece.status;
-        if (piece?.nickname !== undefined) moduleData.nickname = piece.nickname;
-        if (piece?.icon !== undefined) moduleData.icon = piece.icon;
-        if (piece?.birthDate !== undefined) {
-          moduleData.birthDate = piece.birthDate;
-        }
-        if (piece?.birthYear !== undefined) {
-          moduleData.birthYear = piece.birthYear;
-        }
-        if (piece?.url !== undefined) moduleData.url = piece.url;
-        if (piece?.notes !== undefined) moduleData.notes = piece.notes;
-        if (piece?.occurrences !== undefined) {
-          moduleData.occurrences = piece.occurrences;
+        const pieceValue = entry.piece?.get() ?? {};
+        for (const [key, fieldValue] of Object.entries(pieceValue)) {
+          if (typeof fieldValue !== "function") moduleData[key] = fieldValue;
         }
       } catch {
-        // Ignore errors from pieces without expected fields
+        // A module whose value cannot be resolved contributes no data.
       }
 
       return {
@@ -601,7 +608,7 @@ const handleAddModule = handler<
 // value: new value
 const handleUpdateModule = handler<
   { index: number; field: string; value: unknown; result?: Writable<unknown> },
-  { subPieces: Writable<SubPieceEntry[]> }
+  { subPieces: Writable<SubPieceEntryHandle[]> }
 >(({ index, field, value, result }, { subPieces: sc }) => {
   const current = sc.get() || [];
 
@@ -618,42 +625,40 @@ const handleUpdateModule = handler<
   }
 
   const entry = current[index];
-  // deno-lint-ignore no-explicit-any
-  const piece = entry.piece as any;
+  const piece = entry.piece;
 
   if (!piece) {
     if (result) result.set({ success: false, error: "Module piece not found" });
     return;
   }
 
+  // Only the piece's own, non-callable fields may be written. A path write
+  // through `piece.key(field)` would otherwise create whatever field it is
+  // handed; `Object.hasOwn` keeps a caller to the module's real fields (an `in`
+  // test would also admit inherited names like `constructor`), and the callable
+  // check keeps it off the module's streams.
+  const pieceValue = piece.get();
+  if (
+    !pieceValue || !Object.hasOwn(pieceValue, field) ||
+    typeof pieceValue[field] === "function"
+  ) {
+    if (result) {
+      result.set({
+        success: false,
+        error:
+          `Field ${field} is not a settable field on module type ${entry.type}`,
+      });
+    }
+    return;
+  }
+
   try {
-    // Try to access the field as a Cell and set it
-    const fieldCell = piece[field];
-    if (fieldCell && typeof fieldCell.set === "function") {
-      fieldCell.set(value);
-      if (result) {
-        result.set({
-          success: true,
-          message: `Updated ${field} to ${toCompactDebugString(value)}`,
-        });
-      }
-    } else if (fieldCell && typeof fieldCell.key === "function") {
-      // It might be a nested cell - try setting via parent
-      if (result) {
-        result.set({
-          success: false,
-          error:
-            `Field ${field} exists but is not directly settable. Try a more specific path.`,
-        });
-      }
-    } else {
-      if (result) {
-        result.set({
-          success: false,
-          error:
-            `Field ${field} not found or not a Cell on module type ${entry.type}`,
-        });
-      }
+    piece.key(field).set(value);
+    if (result) {
+      result.set({
+        success: true,
+        message: `Updated ${field} to ${toCompactDebugString(value)}`,
+      });
     }
   } catch (err) {
     if (result) {
@@ -2214,9 +2219,15 @@ const Record = pattern<RecordInput, RecordOutput>(
       "#record": true,
       // LLM-callable streams for Omnibot integration
       // Omnibot can invoke these via: invoke({ "@link": "/of:record-id/getSummary" }, {})
-      getSummary: handleGetSummary({ title, subPieces }),
+      // getSummary and updateModule read the piece handles the list holds, so
+      // they take the `SubPieceEntryHandle` view of `subPieces`, which types
+      // the piece as a live Cell. The cell is the same either way; the cast
+      // only bridges the two static views.
+      // deno-lint-ignore no-explicit-any
+      getSummary: handleGetSummary({ title, subPieces: subPieces as any }),
       addModule: handleAddModule({ subPieces, trashedSubPieces, title }),
-      updateModule: handleUpdateModule({ subPieces }),
+      // deno-lint-ignore no-explicit-any
+      updateModule: handleUpdateModule({ subPieces: subPieces as any }),
       removeModule: handleRemoveModule({ subPieces, trashedSubPieces }),
       setTitle: handleSetTitle({ title }),
       listModuleTypes: handleListModuleTypes({}),


### PR DESCRIPTION
…eams

Two fixes to the record pattern, both about scaffolding that was present in the code but never actually ran: the empty-Record auto-seed, and five of the six LLM-callable streams.

## Actually run the Notes + TypePicker auto-seed

An empty Record was meant to seed itself with a pinned Notes module and a TypePicker module, but the seeding never happened. The old code built the two pieces inside a lift and assigned that lift's result to a local variable that nothing read. The runner is demand-driven: a computation runs only when its output is read by something that is itself demanded, or when the computation is an effect or a materializer. The seeding lift's result was read by no one and it wrote nothing through a captured cell, so it was never demanded and never ran. A comment claimed that capturing the return value forced the lift to execute; it does not.

Two consequences followed. A freshly created Record stayed empty, and the TypePicker's applyTemplate handler — which looks up the pre-existing Notes entry and bails when it is missing — could never fire, so the whole empty-Record scaffolding flow was dead. There was also a latent second failure underneath the first: creating a piece inside a lift throws, because a lift's action frame has no cause with which to mint the piece's identity.

The fix builds the two default pieces in the pattern body, where the setup frame gives each a durable, resume-stable identity, and passes them to a single seedRecord lift that writes them into the list when the Record is empty. The pattern body reads that lift's boolean result inside allEntriesWithIndex, the computed the module list renders from, so rendering the Record puts the lift in the demand graph and the seed fires the first time the list is shown. isInitialized latches on the first run whether or not it seeded, so the seed happens at most once and a Record that is later emptied is not re-seeded.

The two piece handles the seeder writes are typed Cell<NoteOutput> and Cell<TypePickerOutput> as lift inputs: a cell reference is carried across the lift boundary, whereas a plain unknown is read back as undefined and the seeded module is lost. [UI] is declared on RecordOutput (the pattern already returned it) so a test can drive a render step.

## Make the five dead LLM-callable streams reachable

The record pattern's body returns six streams for Omnibot's invoke() tool, but only addModule was declared in RecordOutput. A pattern's Output type decides what the runner materializes on the instance, so a stream returned from the body but absent from the Output reads back as undefined and cannot be invoked. Five of the six advertised entry points — getSummary, updateModule, removeModule, setTitle, and listModuleTypes — were therefore dead, and the comment documenting how to invoke getSummary described something that could not work.

Declare all five in RecordOutput with event types matching each handler's event parameter. setTitle and listModuleTypes work as soon as they are reachable. removeModule is a soft delete that moves a module to the trash, mirroring the UI trash button; it is exposed while the destructive permanentlyDelete and emptyTrash stay UI-only.

getSummary and updateModule could not work even once reachable, because both read the module piece and SubPieceEntry.piece is typed unknown. A field typed unknown is read back across a handler boundary as undefined, so getSummary saw no field data and updateModule always reported "Module piece not found". Type the piece as a live Cell on those two handlers' operands (a SubPieceEntryHandle view of the same subPieces cell) so the handle survives the read. getSummary then reports each module's real field values; updateModule validates the field against the piece's own value with Object.hasOwn, rejects callable outputs so a caller cannot overwrite a module's streams, and writes through piece.key(field).set(value), with the write wrapped so a failed write is reported rather than thrown.

getSummary previously extracted a fixed list of field names that did not match several modules — a phone module stores its number under `number`, not `phone` — so once reachable it would have dropped real data. Report every own, non-callable field instead, which also keeps getSummary and updateModule consistent about which fields a module has.

## Tests

The add-module cases stay on a Record whose UI is never rendered — the headless path, where seeding is correctly demand-gated and the list stays empty, so the adds land from index 0 — and a second Record driven through a render step pins the seeded Notes + TypePicker entries and checks that a later add lands after them. A separate test invokes all five newly-reachable streams: it lists the module types, sets and reads back the title, reads a summary whose per-module data carries each module's real smart-default label, applies an updateModule write and confirms the next summary reflects it, and drives the index, unknown-field, and inherited-name rejection paths. Removing a stream's declaration turns its send into a call on undefined and fails its case, so the test guards reachability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the empty-record auto-seed (Notes + TypePicker) and revives five LLM-callable streams so Omnibot `invoke()` can use them. New Records now work out of the box; programmatic reads/updates are enabled.

- **Bug Fixes**
  - Auto-seed runs on first render and only once; seeds Notes + TypePicker with durable identities.
  - Declared `getSummary`, `updateModule`, `removeModule`, `setTitle`, `listModuleTypes` in `RecordOutput` so they materialize and are callable; `removeModule` is a soft delete to trash (destructive deletes stay UI-only).
  - `getSummary` reads the live module `piece` via a typed `Cell` and returns all own, non-callable fields.
  - `updateModule` validates ownership and non-callable fields, writes with `piece.key(field).set(value)`, and returns structured success/error.

- **Tests**
  - Added `packages/patterns/record-llm-streams.test.tsx` covering type listing, title set, summary (smart-default labels), update validation/effects, remove behavior, and stream reachability.

<sup>Written for commit 8e49fc00238927a4fc0afea537c6f6932b5d6106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

