### PR TITLE
refactor(toolshed): don't import the app graph in the --background pa…

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -779,7 +779,7 @@ Server Process (Deno)
   |
   +-- runner/runtime-presets.ts  --> experimentalOptionsFromEnv(Deno.env.get)
   +-- toolshed/runtime-options.ts --> runtimePresets.productionServer({ experimental, ... })
-  +-- toolshed/index.ts           --> new Runtime(toolshedRuntimeOptions(...))
+  +-- toolshed/server.ts          --> new Runtime(toolshedRuntimeOptions(...))
 ```
 
 The background piece service and the CLI use the same mapping and the same

--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -146,7 +146,7 @@ dial is not yet producing. The states a deployment is expected to pass through:
 | State | enforcement | flow | write-floor | trigger | Meaning |
 |---|---|---|---|---|---|
 | **Operator (explicitly disabled)** | `disabled` | `off` | `off` | `false` | CFC descriptive only; provenance mints run, nothing rejects. Requires explicitly passing `cfcEnforcementMode: "disabled"` — no shipped host does today. |
-| **Server hosts today (toolshed, background-piece-service)** | `enforce-explicit` | `off` | `off` | `false` | Neither host passes any CFC option ([toolshed/index.ts](../../packages/toolshed/index.ts), [background-piece-service main.ts](../../packages/background-piece-service/src/main.ts)), so both inherit the `Runtime` defaults. Conforming: explicit checks consume no derived labels. |
+| **Server hosts today (toolshed, background-piece-service)** | `enforce-explicit` | `off` | `off` | `false` | Neither host passes any CFC option ([toolshed/server.ts](../../packages/toolshed/server.ts), [background-piece-service main.ts](../../packages/background-piece-service/src/main.ts)), so both inherit the `Runtime` defaults. Conforming: explicit checks consume no derived labels. |
 | **Shell today** | `enforce-explicit` | `persist` | `off` | `false` | Explicit checks enforce; flow labels persisted (H2, inv-9 active); floor not yet dialed. |
 | **Shell + floor observe** | `enforce-explicit` | `persist` | `observe` | `false` | Add the write floor as diagnostics (D3 dial-up step). |
 | **Shell + floor enforce** | `enforce-explicit` | `persist` | `enforce` | `false` | Floor rejects; complete on flow-endorsed writes (flow persists). |

--- a/packages/toolshed/README.md
+++ b/packages/toolshed/README.md
@@ -40,7 +40,8 @@ toolshed/
 │   └── health/   # Health checks
 ├── app.ts        # Main app setup, where we mount all the routes
 ├── env.ts        # Environment variable configuration
-└── index.ts      # Main hono entry point
+├── server.ts     # Server bootstrap: runtime, startServer, graceful shutdown
+└── index.ts      # Thin entry point that launches the server or its background parent
 ```
 
 ## Getting Started

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -1,5 +1,3 @@
-import app from "@/app.ts";
-import env from "@/env.ts";
 import {
   backgroundLogFile,
   classifyLaunch,
@@ -8,154 +6,42 @@ import {
   runBackgroundParent,
   writeListeningMarker,
 } from "@/background.ts";
-import { identity } from "@/lib/identity.ts";
-import type { Runtime } from "@commonfabric/runner";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { createToolshedRuntime } from "@/runtime-options.ts";
-import { memory } from "@/routes/storage/memory.ts";
-import { shutdownOpenTelemetry } from "@/lib/otel.ts";
 
-// Create a global runtime instance for the server
-let runtime: Runtime;
-
-// Initialize runtime with storage and signer
-// FIXME(ja): should we do this even on memory-only toolsheds?
-const initializeRuntime = () => {
-  try {
-    console.log(`Initializing runtime with signer ${identity.did()}...`);
-
-    // Options assembly (the MEMORY_URL/API_URL split, EXPERIMENTAL_* wiring)
-    // lives in runtime-options.ts, where it is unit-tested (CT-1814).
-    runtime = createToolshedRuntime(
-      env,
-      StorageManager.open({
-        memoryHost: new URL(env.MEMORY_URL),
-        as: identity,
-      }),
-    );
-    console.log("Runtime initialized successfully");
-    console.log("Configured to remote storage:", env.MEMORY_URL);
-  } catch (error) {
-    console.error("Failed to initialize runtime:", error);
-    throw error;
-  }
-};
-
-// Export runtime for use in other parts of the application
-export { runtime };
-
-export type AppType = typeof app;
-
-// Graceful shutdown with timeout
-const ac = new AbortController();
-let isShuttingDown = false;
-const SHUTDOWN_TIMEOUT = 10000; // 10 seconds
-
-const handleShutdown = async () => {
-  if (isShuttingDown) {
-    console.log("Shutdown already in progress...");
-    return;
-  }
-
-  isShuttingDown = true;
-  console.log("Shutdown signal received, closing server...");
-
-  // Create a timeout promise
-  const timeoutPromise = new Promise((_, reject) => {
-    setTimeout(() => reject(new Error("Shutdown timed out")), SHUTDOWN_TIMEOUT);
-  });
-
-  try {
-    // Race between graceful shutdown and timeout
-    await Promise.race([
-      (async () => {
-        // Remove signal listeners to prevent multiple shutdown attempts
-        Deno.removeSignalListener("SIGINT", handleShutdown);
-        Deno.removeSignalListener("SIGTERM", handleShutdown);
-
-        ac.abort();
-
-        console.log("Closing memory system...");
-        const result = await memory.close();
-        if ("error" in result) {
-          console.error("Error closing memory:", result.error);
-        } else {
-          console.log("Memory system closed successfully");
-        }
-
-        // Flush buffered spans so the last batch isn't dropped on exit. No-op
-        // when telemetry is disabled; bounded by the SHUTDOWN_TIMEOUT race above.
-        await shutdownOpenTelemetry();
-      })(),
-      timeoutPromise,
-    ]);
-  } catch (err) {
-    console.error("Error during shutdown:", err);
-  }
-
-  console.log("Shutdown complete");
-  Deno.exit(0);
-};
-
-// Start server with the abort controller
-function startServer(onListening?: () => void) {
-  console.log(`Server is starting on port http://${env.HOST}:${env.PORT}`);
-  initializeRuntime();
-
-  const serverOptions = {
-    hostname: env.HOST,
-    port: env.PORT,
-    signal: ac.signal,
-    onError: (error: unknown) => {
-      console.error("Server error:", error);
-      return new Response("Internal Server Error", { status: 500 });
-    },
-    onListen: ({ port, hostname }: { port: number; hostname: string }) => {
-      console.log(`Server running on http://${hostname}:${port}`);
-      onListening?.();
-    },
-  };
-
-  try {
-    Deno.serve(serverOptions, app.fetch);
-  } catch (err) {
-    if (err instanceof Deno.errors.AddrInUse) {
-      console.error(`Port ${env.PORT} is already in use`);
-      // Distinct exit code so callers can tell a port collision from other
-      // startup failures and retry on a different port.
-      Deno.exit(3);
-    }
-    console.error("Failed to start server:", err);
-    Deno.exit(1);
-  }
-}
-
-Deno.addSignalListener("SIGINT", handleShutdown);
-Deno.addSignalListener("SIGTERM", handleShutdown);
+// Thin launcher for the toolshed. This module decides which half of a launch
+// the process is and imports the heavy server graph only on the path that
+// actually serves. @/server.ts runs startup side effects at import time —
+// opening the memory-store provider and fetching the gateway model list — so a
+// `--background` parent, which only spawns the real server as a child and waits
+// for it to bind, must not import it. The app graph is pulled in through a
+// dynamic import on the serving path alone, so index.ts itself stays thin: it
+// imports only @/background.ts, which pulls in nothing heavy.
 
 if (import.meta.main) {
   const backgroundLog = backgroundLogFile();
-  if (backgroundLog) {
-    // This process is the server half of a background launch. Its request
-    // logger already targets the log file (pino-logger.ts reads the same
-    // environment variable); route console output there too, so stdout carries
-    // only the readiness marker, and record uncaught errors that would
-    // otherwise reach a discarded stderr.
-    redirectConsoleToFile(backgroundLog);
-    logUncaughtErrors();
-    startServer(writeListeningMarker);
+  const launch = classifyLaunch(Deno.args);
+  if (launch.background && !backgroundLog) {
+    // This process is the background parent: spawn the server as a child and
+    // wait for it to bind. The call exits the process once the child is
+    // listening (or has failed to start), and never imports the app graph.
+    await runBackgroundParent({
+      execPath: Deno.execPath(),
+      mainModule: import.meta.url,
+      serverArgs: launch.serverArgs,
+      logFile: launch.logFile,
+    });
   } else {
-    const launch = classifyLaunch(Deno.args);
-    if (launch.background) {
-      // Spawn the server as a background child and wait for it to bind; this
-      // call exits the process once the child is listening (or has failed to
-      // start).
-      await runBackgroundParent({
-        execPath: Deno.execPath(),
-        mainModule: import.meta.url,
-        serverArgs: launch.serverArgs,
-        logFile: launch.logFile,
-      });
+    // This process serves: a foreground launch, or the server half of a
+    // background launch. Pull in the server graph now, on the path that uses it.
+    const { startServer } = await import("@/server.ts");
+    if (backgroundLog) {
+      // The server half of a background launch. Its request logger already
+      // targets the log file (pino-logger.ts reads the same environment
+      // variable); route console output there too, so stdout carries only the
+      // readiness marker, and record uncaught errors that would otherwise reach
+      // a discarded stderr.
+      redirectConsoleToFile(backgroundLog);
+      logUncaughtErrors();
+      startServer(writeListeningMarker);
     } else {
       startServer();
     }

--- a/packages/toolshed/routes/ingest/ingest.handlers.ts
+++ b/packages/toolshed/routes/ingest/ingest.handlers.ts
@@ -8,7 +8,7 @@
 // targets someone else's space) does not exist here — channels are provisioned
 // out-of-band by an operator. See the design proposal.
 import type { AppRouteHandler } from "@/lib/types.ts";
-import { runtime } from "@/index.ts";
+import { runtime } from "@/server.ts";
 import { identity } from "@/lib/identity.ts";
 import { processIngest } from "./ingest.utils.ts";
 import type { IngestRoute } from "./ingest.routes.ts";

--- a/packages/toolshed/routes/ingest/ingest.routes.test.ts
+++ b/packages/toolshed/routes/ingest/ingest.routes.test.ts
@@ -9,7 +9,7 @@ if (env.ENV !== "test") {
 
 // Smoke tests: confirm POST /api/ingest/:id is mounted and its transport-level
 // branches behave. Driven through the real `app` (not a freshly-mounted router)
-// because the handler imports the `runtime` singleton from `@/index.ts`, which
+// because the handler imports the `runtime` singleton from `@/server.ts`, which
 // is uninitialized under test — so any path that reaches storage yields 502,
 // which is itself the storage-error contract. The full auth + validation
 // contract is unit-tested against a real runtime in ingest.utils.test.ts

--- a/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.handlers.ts
+++ b/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.handlers.ts
@@ -2,7 +2,7 @@ import type { Tokens } from "@cmd-johnson/oauth2-client";
 import type { Context } from "@hono/hono";
 import { getLogger } from "@commonfabric/utils/logger";
 import { setBGPiece } from "@commonfabric/background-piece";
-import { runtime } from "@/index.ts";
+import { runtime } from "@/server.ts";
 import { OAuth2TokenSchema } from "@commonfabric/runner";
 import type { JSONSchema } from "@commonfabric/runner";
 import type {

--- a/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.utils.ts
+++ b/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.utils.ts
@@ -1,7 +1,7 @@
 import { OAuth2Client, type Tokens } from "@cmd-johnson/oauth2-client";
 import type { Context } from "@hono/hono";
 import { getLogger } from "@commonfabric/utils/logger";
-import { runtime } from "@/index.ts";
+import { runtime } from "@/server.ts";
 import type { JSONSchema } from "@commonfabric/runner";
 import {
   custodyIngest,

--- a/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.handlers.ts
+++ b/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.handlers.ts
@@ -21,7 +21,7 @@ import {
   parseLink,
   type SigilLink,
 } from "@commonfabric/runner";
-import { runtime } from "@/index.ts";
+import { runtime } from "@/server.ts";
 import env from "@/env.ts";
 import {
   CountryCode,

--- a/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.utils.ts
+++ b/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.utils.ts
@@ -1,5 +1,5 @@
 import { type SigilLink } from "@commonfabric/runner";
-import { runtime } from "@/index.ts";
+import { runtime } from "@/server.ts";
 import {
   type JSONSchema,
   type Mutable,

--- a/packages/toolshed/routes/webhooks/webhooks.delivery.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.delivery.test.ts
@@ -15,7 +15,7 @@ import {
 // cell link serialized to the `fcl1:` wire string (as `CellHandle.toWireString`
 // produces it) must decode, resolve to the right cell, and deliver a payload to
 // that cell's inbox stream. This mirrors `sendToStream`'s decode -> resolve ->
-// send path; that function reaches the `@/index.ts` runtime singleton (which is
+// send path; that function reaches the `@/server.ts` runtime singleton (which is
 // uninitialized in tests), so it can't be called directly here, but the logic
 // exercised is identical, against the house in-memory `StorageManager.emulate`
 // runtime.

--- a/packages/toolshed/routes/webhooks/webhooks.routes.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.routes.test.ts
@@ -13,7 +13,7 @@ if (env.ENV !== "test") {
 // so they need no runtime fixture. End-to-end delivery is covered separately.
 //
 // Driven through the real `app` (not a freshly-mounted router) because the
-// webhook handlers import the `runtime` singleton from `@/index.ts`, which
+// webhook handlers import the `runtime` singleton from `@/server.ts`, which
 // imports `@/app.ts` — re-mounting the router standalone hits that import cycle.
 
 describe("Webhook routes (smoke: wired up + error paths)", () => {

--- a/packages/toolshed/routes/webhooks/webhooks.utils.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.utils.ts
@@ -1,6 +1,6 @@
 import { getLogger } from "@commonfabric/utils/logger";
 import { sha256 } from "@/lib/sha2.ts";
-import { runtime } from "@/index.ts";
+import { runtime } from "@/server.ts";
 import { identity } from "@/lib/identity.ts";
 import { WebhookConfigSchema } from "@commonfabric/runner";
 import {

--- a/packages/toolshed/server.ts
+++ b/packages/toolshed/server.ts
@@ -1,0 +1,131 @@
+import app from "@/app.ts";
+import env from "@/env.ts";
+import { identity } from "@/lib/identity.ts";
+import type { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { createToolshedRuntime } from "@/runtime-options.ts";
+import { memory } from "@/routes/storage/memory.ts";
+import { shutdownOpenTelemetry } from "@/lib/otel.ts";
+
+// The server half of the toolshed. Importing this module runs the startup side
+// effects — opening the memory-store provider and fetching the gateway model
+// list — so the thin launcher in index.ts pulls it in only on the path that
+// actually serves, never in the background parent that just spawns a child.
+
+// Create a global runtime instance for the server
+let runtime: Runtime;
+
+// Initialize runtime with storage and signer
+// FIXME(ja): should we do this even on memory-only toolsheds?
+const initializeRuntime = () => {
+  try {
+    console.log(`Initializing runtime with signer ${identity.did()}...`);
+
+    // Options assembly (the MEMORY_URL/API_URL split, EXPERIMENTAL_* wiring)
+    // lives in runtime-options.ts, where it is unit-tested (CT-1814).
+    runtime = createToolshedRuntime(
+      env,
+      StorageManager.open({
+        memoryHost: new URL(env.MEMORY_URL),
+        as: identity,
+      }),
+    );
+    console.log("Runtime initialized successfully");
+    console.log("Configured to remote storage:", env.MEMORY_URL);
+  } catch (error) {
+    console.error("Failed to initialize runtime:", error);
+    throw error;
+  }
+};
+
+// Export runtime for use in other parts of the application
+export { runtime };
+
+export type AppType = typeof app;
+
+// Graceful shutdown with timeout
+const ac = new AbortController();
+let isShuttingDown = false;
+const SHUTDOWN_TIMEOUT = 10000; // 10 seconds
+
+const handleShutdown = async () => {
+  if (isShuttingDown) {
+    console.log("Shutdown already in progress...");
+    return;
+  }
+
+  isShuttingDown = true;
+  console.log("Shutdown signal received, closing server...");
+
+  // Create a timeout promise
+  const timeoutPromise = new Promise((_, reject) => {
+    setTimeout(() => reject(new Error("Shutdown timed out")), SHUTDOWN_TIMEOUT);
+  });
+
+  try {
+    // Race between graceful shutdown and timeout
+    await Promise.race([
+      (async () => {
+        // Remove signal listeners to prevent multiple shutdown attempts
+        Deno.removeSignalListener("SIGINT", handleShutdown);
+        Deno.removeSignalListener("SIGTERM", handleShutdown);
+
+        ac.abort();
+
+        console.log("Closing memory system...");
+        const result = await memory.close();
+        if ("error" in result) {
+          console.error("Error closing memory:", result.error);
+        } else {
+          console.log("Memory system closed successfully");
+        }
+
+        // Flush buffered spans so the last batch isn't dropped on exit. No-op
+        // when telemetry is disabled; bounded by the SHUTDOWN_TIMEOUT race above.
+        await shutdownOpenTelemetry();
+      })(),
+      timeoutPromise,
+    ]);
+  } catch (err) {
+    console.error("Error during shutdown:", err);
+  }
+
+  console.log("Shutdown complete");
+  Deno.exit(0);
+};
+
+// Start server with the abort controller
+export function startServer(onListening?: () => void) {
+  console.log(`Server is starting on port http://${env.HOST}:${env.PORT}`);
+  initializeRuntime();
+
+  const serverOptions = {
+    hostname: env.HOST,
+    port: env.PORT,
+    signal: ac.signal,
+    onError: (error: unknown) => {
+      console.error("Server error:", error);
+      return new Response("Internal Server Error", { status: 500 });
+    },
+    onListen: ({ port, hostname }: { port: number; hostname: string }) => {
+      console.log(`Server running on http://${hostname}:${port}`);
+      onListening?.();
+    },
+  };
+
+  try {
+    Deno.serve(serverOptions, app.fetch);
+  } catch (err) {
+    if (err instanceof Deno.errors.AddrInUse) {
+      console.error(`Port ${env.PORT} is already in use`);
+      // Distinct exit code so callers can tell a port collision from other
+      // startup failures and retry on a different port.
+      Deno.exit(3);
+    }
+    console.error("Failed to start server:", err);
+    Deno.exit(1);
+  }
+}
+
+Deno.addSignalListener("SIGINT", handleShutdown);
+Deno.addSignalListener("SIGTERM", handleShutdown);


### PR DESCRIPTION
…rent

The toolshed's `--background` mode has the foreground process spawn a second copy of itself as the real server, wait for that copy to report it has bound its port, and then exit. The foreground process is only a launcher: it decides which half of the launch it is, spawns the child, and returns once the child is listening.

The entry module imported the whole application graph statically, at the very top:

    import app from "@/app.ts";

Importing `@/app.ts` runs startup side effects before the process has decided whether it is the launcher or the server. It opens the memory-store provider and fetches the gateway model list over the network. So the `--background` launcher ran all of that work too, redundantly: the memory store was briefly opened by two processes, and a failure while importing the app killed the launcher before it could spawn the child or surface anything through the child's log file. (Continuous integration masks this because it sets an empty gateway URL, which suppresses the network fetch.)

This splits the entry module in two so the app graph is imported only on the path that actually serves.

`index.ts` is now a thin launcher. It imports only `@/background.ts`, which pulls in nothing heavy — just the standard-library path helpers and Deno APIs. In its `import.meta.main` block it reads the background-log environment variable and classifies the command line. When this process is the background parent (the caller asked to background it and no log variable marks it as the server half), it spawns the child and waits, and never imports the app graph. Otherwise — a foreground launch, or the server half of a background launch — it dynamically imports `@/server.ts` and starts the server, applying the child-mode console redirect, uncaught-error logging, and readiness marker when this process is the server half.

The new `server.ts` holds the server itself: the `import app from "@/app.ts"`, the shared `runtime` binding and its initialization, the abort controller and signal handlers, the graceful shutdown, and `startServer`. Importing this module is what runs the startup side effects, so only the serving path reaches it.

The `runtime` binding moved from `index.ts` to `server.ts`; the handler files that read it now import it from `@/server.ts`. There is a cycle here — the server imports the app, the app imports the handlers, and the handlers import `runtime` back from the server — but it is the same shape the entry module already had, and it works because `runtime` is read when a request is served, not when the module is imported, so the live binding is populated by the time any handler runs.

`index.ts` remains the entry module. The child command the parent builds still points at it: the compiled binary re-runs itself, and a `deno run` launch re-runs Deno against `index.ts`. The child boots through `index.ts`, takes the serving branch, and dynamically imports `server.ts`. `deno compile` bundles that dynamic import because its specifier is a string literal, so the compiled binary carries `server.ts` and the background child starts from it.

Because the runtime binding and the runtime construction around it moved out of `index.ts`, references that named `index.ts` as their home are updated to `server.ts`: the wiring diagram in the experimental-options registry, the server-hosts row of the CFC enforcement matrix, three test-file comments that explain the import cycle, and the module listing in the toolshed README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the toolshed entry so the `--background` parent never imports the app graph; moved server startup and the shared `runtime` into `server.ts`. Background launches are faster and errors surface reliably.

- **Bug Fixes**
  - Background parent no longer opens the memory store or fetches the gateway model list; startup failures now show in the child’s log.
  - Avoids import-time side effects in the launcher by deferring the server import to the serving path.

- **Refactors**
  - `index.ts` is now a thin launcher; the serving path dynamically imports `@/server.ts` (string-literal specifier preserved for `deno compile`).
  - Added `server.ts` to own `runtime` init, graceful shutdown, and `startServer`; handlers now import `runtime` from `@/server.ts`, and README/docs/tests reference `server.ts` instead of `index.ts`.

<sup>Written for commit ad1e678f88311351e2ae88456ecdde85606fe4cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

