### PR TITLE
docs(plans): verb contract — live-session + post-merge review amendments

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -4,6 +4,16 @@
 [`pattern-verb-contract.md`](pattern-verb-contract.md) (PR #4968). Keep current
 as work proceeds: check off exit criteria, record scope changes.
 
+**Amended 2026-07-24** from the first live headless session (a three-topic
+graph, ~24 CLI operations): compact discovery index (A2), closed-world inputs
+(C5), transaction-local acknowledgement as a WS-D exit criterion, phase
+reporting and timings (D2), four timeout/retry integration scenarios (D3), the
+three-topic end-to-end fixture (D4), the live-acceptance checklist, and the
+`setsrc` write-storm gate named in Risks. Merged the same day with the
+post-merge review amendments (decisions 5–7: attribution via CFC provenance,
+patterns return references while clients render identity, `@name` deferred);
+index and fixture wording follows the references model.
+
 ## Governing decisions
 
 Made 2026-07-24, shaping everything below:
@@ -19,6 +29,16 @@ Made 2026-07-24, shaping everything below:
    live-board acceptance pass.
 4. **This document plus tracked issues** (breakdown at the end) is the plan of
    record; the design doc's staging section defers here.
+5. **Attribution uses CFC provenance.** The invocation envelope does not grow a
+   parallel `actor` field. `topics.agentName` stays as an interim atomic
+   argument until trusted `cf` ingress can mint and propagate general
+   `AgentActor` provenance.
+6. **Patterns return references; clients render identity.** Discovery indexes
+   carry stable child references and summaries. Fid/path annotation belongs to
+   the CLI, which can see backing cell identities.
+7. **Client-local `@name` bindings are deferred.** Their overlap with
+   fabric-side slugs needs a separate naming design and is not required by this
+   plan.
 
 ## Non-goals
 
@@ -26,17 +46,25 @@ Named so their absence reads as intent, not oversight:
 
 - The **wrapper-tier marker** for verb listing (semantics are settled in the
   design; the marker mechanism ships after the listing).
-- **Actor authentication / delegation** (design OQ2) — the envelope carries an
-  unverified actor regardless of how that lands.
+- **Cryptographic agent identity / delegation** (design OQ2) — the CFC track
+  distinguishes runtime-attested execution context from a separately keyed or
+  delegated agent, but does not deliver delegation.
+- **Client-local aliases** — `@name` / `cf bind` are deferred pending a
+  separate comparison with existing slugs and configured host/space addressing.
 - **Cross-space effect atomicity** — the spec's I11 gap stands; the guarantee
   is same-space, which covers `topics`.
-- **Batch / session mode** for the CLI — orthogonal call-cost work.
+- **Batch / session mode** for the CLI — orthogonal call-cost work, linked
+  rather than orphaned: even perfect verbs leave a fresh runtime paying boot
+  and sync per call (20–80 s per mutation observed live), so this gets its
+  own tracked topic and a dogfood latency target once WS-D's phase timings
+  show how much of that is fresh-runtime tax versus quiescence-wait tax. The
+  verb surface never changes shape for it (design: the atomic-unit rule).
 
 ## Workstreams
 
 ### WS-A — `topics` Part 1 finish
 
-Size S (~1–2 days). No dependencies. `packages/patterns/topics`.
+Size S–M (~2–4 days). No dependencies. `packages/patterns/topics`.
 
 - `AddTopicEvent` gains optional `body` — argument widening, compat-checker
   clean — and `addTopic` creates the child with it, making `setBody` an
@@ -45,13 +73,23 @@ Size S (~1–2 days). No dependencies. `packages/patterns/topics`.
   `agentName`, empty comment body, invalid link URL. UI composer wrappers
   (`submitTopic`, `submitComment`, `saveBody`, …) keep their silent guards —
   an empty draft is a non-event in a composer, a defect headlessly.
-- Tests: `topics.test.tsx` / `multi-user.test.tsx` cover body-at-create and
-  each thrown rejection (asserting no write happened).
+- A compact discovery `index` result on the board — one reference-plus-summary
+  row per topic: the child reference plus scalar summaries (`title`,
+  `createdAt`, `createdBy`, `commentCount`, `lastActivityAt`) and reference
+  edges as sibling references — never expanded pieces, and no pattern-authored
+  fid fields (identity rendering is the CLI's job — decision 6, F2).
+  `crossrefs` stays as the UI's reference graph; it is not compact — each row
+  expands to full pieces, and a live full-board read through it exceeded 300k
+  tokens — and stops being the documented survey surface.
+- Tests: `topics.test.tsx` / `multi-user.test.tsx` cover body-at-create,
+  each thrown rejection (asserting no write happened), and the index
+  (asserting no expanded piece/action/runtime values serialize).
 - Docs riding the change: `packages/patterns/topics/README.md`,
   `skills/topics/SKILL.md` (`addTopic` example gains `body`;
   `deno task check-skill-facts` gates the citations).
 - **Exit:** filing-with-body is five CLI calls; a blank `agentName` fails with
-  a nonzero exit; live board updated via `setsrc`.
+  a nonzero exit; a full-board survey is one bounded read of `index`; live
+  board updated via `setsrc` (gated — see Risks).
 
 ### WS-B — CLI settlement hygiene
 
@@ -83,7 +121,11 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
 - **schema-generator:** emit a result schema for stream/handler properties so
   it reaches the piece's **durable** schema — the dependency verb discovery
   named; mapping spec update in
-  `docs/specs/schema-generator/ts_to_json_schema_mapping.md`.
+  `docs/specs/schema-generator/ts_to_json_schema_mapping.md`. Verb **input**
+  schemas become closed-world (an undeclared field is a rejection, never
+  ignored — design rule 1): emit `additionalProperties: false` for event
+  payloads, confirm the runner enforces it at dispatch, and record the rule
+  in the mapping spec.
 - **runner:** plain-return projection — the receipt-only branch
   (`runner.ts:3713-3725`) writes the validated plain return instead of `{}`,
   behind a new experimental option (registry entry in
@@ -98,7 +140,7 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
 
 ### WS-D — invocation plumbing
 
-Size M (~3–5 days). Idempotency portion has no dependencies; result readback
+Size M (~1 week). Idempotency portion has no dependencies; result readback
 joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
 
 - **runner:** thread a caller-supplied `eventId` from `cell.send()` to
@@ -114,19 +156,42 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   `precondition: "receipt-exists"` as success-with-readback, exit 0. Output is
   the `Invocation` JSON — `status` and `id` from day one, `result` once WS-C
   lands.
-- Integration test (isolated toolshed, `isolated-test-processes`
-  conventions): file a topic, kill the process, retry the same id from a
-  fresh process; assert exactly one topic exists and the retry exits 0.
+- **cli, pre-dispatch validation:** `piece call` validates the payload against
+  the *deployed* verb schema before sending — an undeclared or malformed
+  field is an immediate local rejection. This is the half that catches
+  skill-versus-deployment skew (the live board accepted and discarded
+  `agentName`); the closed-world schema (C5) is the server-side backstop for
+  other callers.
+- **cli, phase reporting:** every output — success, failure, timeout — carries
+  the furthest observed `phase`
+  (`initial_sync | dispatched | committed | readback`) beside the invocation
+  id; verbose output adds per-phase timings (initial sync / dispatch /
+  handler / commit / result sync / readback). With a caller-supplied id a
+  retry is safe in every phase, so phase is diagnosis; a derived `retrySafe`
+  convenience flag may ride along.
+- **Acknowledgement is transaction-local.** The call path awaits *this
+  handling's* commit (D1's commit callback) plus receipt sync — never
+  `runtime.idle()` / full-sync quiescence, which today holds a committed
+  write hostage to downstream recomputation (60–80 s body writes observed
+  live while `crossrefs` re-derived). Acceptance test: a deliberately slow
+  derived recomputation cannot delay `addTopic` acknowledgement.
+- Integration tests (isolated toolshed, `isolated-test-processes`
+  conventions), four timeout/retry scenarios: timeout before dispatch (retry
+  re-executes; one topic); timeout after dispatch, before commit
+  acknowledgement; commit succeeded but the response was lost (retry
+  collides, reads the original back, exits 0); and a retry from a fresh
+  process with the same id — in every case exactly one topic exists
+  afterwards.
 - **Exit (Phase 2, before WS-C):** the duplicate-on-retry bug is dead on the
   live board. **Exit (Phase 4, with WS-C):** the retry returns the original
   result.
 
-### WS-E — envelope and retention *(gated)*
+### WS-E — retention and CFC execution provenance *(gated)*
 
 Size L, most unknowns. After WS-C and WS-D. `packages/runner`,
-`packages/piece`, `packages/patterns/topics`.
+`packages/piece`, `packages/cli`, `packages/patterns/topics`.
 
-Gated on three resolutions, in order:
+The retention half is gated on three resolutions, in order:
 
 1. Design OQ1 — the default retention window (it bounds the idempotency
    guarantee).
@@ -135,41 +200,64 @@ Gated on three resolutions, in order:
 3. Confirmation of the storage layer's collection story for unreferenced
    cells (the open unknown in the design's defects section).
 
-Then: `actor` / timestamps / typed error shape in the record (schema authored
-open-world); the collection linked from the piece with pattern-declared
-range + default and read-and-expire; retire `AgentAuthoredEvent` in `topics`
-(dropping a required input field is argument widening — compatible).
+Then: timestamps / typed error shape in the record (schema authored
+open-world); the collection linked from the piece with pattern-declared range +
+default and read-and-expire.
 
-- **Exit:** an agent passes no `agentName`; attribution rides the envelope;
-  records are enumerable and expire per policy.
+The provenance half is a separate CFC-gated track:
+
+- Specify a runtime-minted provenance atom, provisionally `AgentActor`, for
+  trusted execution context at ingress. Its metadata may include agent role,
+  tool/session context, or a protected reference to the triggering request; it
+  is not reduced to a display name.
+- Fix the external `cf` call boundary so it mints the atom from trusted client
+  context and attaches it to the invocation input. Prove that CFC flow labels
+  carry it to writes affected by that input.
+- Define metadata confidentiality and extraction/display helpers before rich
+  context is exposed. Prompt or user-request content must not be copied into an
+  ordinary invocation payload.
+- Keep `AgentAuthoredEvent { agentName }` in `topics` until the provenance path
+  works end to end. Only then retire it; dropping the required input field is
+  argument widening and compatible.
+
+- **Exit:** records are enumerable and expire per policy; CFC inspection proves
+  execution provenance reaches affected writes from `cf`; Topics can omit
+  `agentName` without losing display attribution; the invocation record has no
+  independent canonical actor field.
 
 ### WS-F — client affordances
 
 Size M, mostly parallel. `packages/cli`, `skills/cf`.
 
 - `cf piece verbs --json` — name, kind, input schema per verb from the
-  existing classification (`packages/fuse/callables.ts:88`); result schemas
-  appear once WS-C lands; v1 lists everything, per the decided semantics
-  (every verb listable; tier filtering arrives with the marker, later).
-  **Independent — can ship first.**
-- `@name` client-side binding: `cf bind <name> <url>`, resolution in
-  `piece call` / `piece get`; stored client-side (it must resolve before the
-  fabric is reachable).
+  existing classification (`packages/fuse/callables.ts:88`), plus the
+  deployed pattern's source identity so a skill can detect it targets a newer
+  contract than the live piece; result schemas appear once WS-C lands; v1
+  lists everything, per the decided semantics (every verb listable; tier
+  filtering arrives with the marker, later). **Independent — can ship
+  first.**
+- Generic identity annotation for data reads and callable results. Start with
+  an exploration form such as `--include-ids` that annotates points where the
+  backing identity changes; evaluate a narrower path-selected form if broad
+  output is too noisy. Patterns return child references and never manufacture
+  their own fid fields for this purpose.
 - `--await` / `--no-wait` and the caller-controlled wait bound — with WS-D.
-- Skill updates ride each surface (`skills/cf`, `skills/topics`): the fid
+- Skill updates ride each surface (`skills/cf`, `skills/topics`): the handle
   lookup and verification read leave the documented workflow when Phase 4
   makes them unnecessary.
 
 ## Phases
 
 ```text
-Phase 1 (parallel, now): WS-A, WS-B, WS-F verbs-listing + binding; WS-C starts
+Phase 1 (parallel, now): WS-A, WS-B, WS-F verb listing + identity
+                         annotation; WS-C starts
 Phase 2: WS-D idempotency-only  → duplicate bug dead on the live board
 Phase 3: WS-C lands             → topics verbs return values; flag still off
 Phase 4: WS-C + WS-D join       → full Invocation JSON; --await; flag flips
-                                   after the integration proof; skills drop
-                                   the lookup/verification steps
-Phase 5: WS-E                   → envelope, retention, AgentAuthoredEvent gone
+                                   after the three-topic fixture (D4) passes;
+                                   skills drop the lookup/verification steps
+Phase 5: WS-E                   → retention + CFC provenance; only then may
+                                   AgentAuthoredEvent go
 ```
 
 Every phase ends with a live-board acceptance pass (continuous dogfood), and
@@ -181,12 +269,33 @@ change that alters them.
 - **Unit**, per package, riding each change: pattern tests (WS-A), CLI tests
   (WS-B/D/F), `scheduler-event-receipts.test.ts` extensions (WS-C/D),
   transformer fixtures and schema-generator goldens (WS-C).
-- **Integration:** the cross-process retry test (WS-D) is the load-bearing
-  one — it exercises id plumbing, collision, reclassification, and readback in
-  one scenario, against an isolated toolshed.
-- **Live acceptance**, per phase, against the Estuary board: the six-call
-  filing sequence shrinking to five (Phase 1), a deliberate duplicate retry
-  (Phase 2), a returned handle (Phase 4).
+- **Integration:** the four timeout/retry scenarios (WS-D) exercise id
+  plumbing, collision, reclassification, and readback against an isolated
+  toolshed.
+- **End-to-end fixture (D4, Phase 4):** the three-topic graph from the live
+  session, run as an integration test and as the live pass — create an
+  umbrella with body (returns its child reference); create two children whose
+  bodies reference it; revise the umbrella to reference both; deliberately
+  drop one create response and retry with the same invocation id. Verify
+  exactly three topics; each returned reference renders to a fid that opens
+  the canonical child; reciprocal derived references; every write attributed
+  to the acting agent. Record command
+  count, payload sizes, per-phase timings, and cold/warm durations — the
+  baseline the session-mode decision (Non-goals) reads.
+- **Live acceptance checklist**, per phase, against the Estuary board — a
+  scenario per phase (six-call filing shrinking to five in Phase 1, a
+  deliberate duplicate retry in Phase 2, a returned handle in Phase 4), and
+  on every pass:
+  - deployed verb schema / source identity matches the skill driving it;
+  - body-at-create preserves exact Markdown;
+  - the returned reference, rendered as a fid/path by the CLI, opens the
+    canonical child, not an intermediate wrapper;
+  - attribution persists in `createdBy` / `bodyUpdatedBy`;
+  - an undeclared field fails with a nonzero exit;
+  - a full-board discovery read stays bounded;
+  - commit acknowledgement does not wait on cross-reference recomputation;
+  - update rehearsal and commit-rate monitoring pass before any live
+    `setsrc` (Risks — the write-storm gate).
 - **Doc gates:** `deno task check-docs`, `deno task check-skill-facts` on
   every change touching docs or skills.
 
@@ -201,8 +310,19 @@ change that alters them.
 - **Live-board regressions** (decision 3): mitigated by the compat checker on
   every `setsrc`, phase-scoped changes, and the board being explicitly a
   dogfood surface.
-- **WS-E's gates may stall it** (OQ1, CFC review, collection unknown): it is
-  last and severable; everything through Phase 4 delivers without it.
+- **Decision 3 is not yet satisfiable: the live board still runs the legacy
+  schema.** Prod updates are gated by the write-storm incident history (a
+  prior update drove cross-version write storms to 96% of all commits):
+  before any live `setsrc`, rehearse old→populate→new in a scratch space
+  watching commit rates, and verify the generated-cell identity-versioning
+  fix is an ancestor of the deployed revision (`git merge-base
+  --is-ancestor`; the computed-cell-identity arc — #4659, default-on in
+  #4956, merged 2026-07-24 — is the candidate fix; confirm before the first
+  Phase 1 deploy). Until the gate clears, a "live-board acceptance pass"
+  degrades to a scratch board and must say so rather than pass silently.
+- **WS-E's gates may stall it** (OQ1, CFC review, collection unknown, trusted
+  ingress mint and propagation): it is last and severable; everything through
+  Phase 4 delivers without it, and `topics.agentName` remains the safe interim.
 
 ## Issue breakdown
 
@@ -211,16 +331,21 @@ Importable one-to-one into the tracker; `blocks →` names the dependency edge.
 | id | title | size | depends on |
 | --- | --- | --- | --- |
 | A1 | topics: body at create + thrown rejections | S | — |
+| A2 | topics: reference-plus-summary discovery index | S | — |
 | B1 | cli: sink-based settlement, result cell address | S | — |
 | C1 | api: action return types, `Stream<T, R>`, VerbError | M | — |
 | C2 | ts-transformers: value-returning action lowering + CTS spec | M | C1 |
 | C3 | schema-generator: result schemas for streams + mapping spec | M | C1 |
 | C4 | runner: plain-return projection behind flag + registry entry | S | — |
+| C5 | schema-generator/runner: closed-world verb input schemas | S | C1 |
 | D1 | runner: eventId through send; structured receipt link on dispatch | M | — |
-| D2 | cli: --invocation, readback, receipt-exists reclassification | M | D1 |
-| D3 | integration: cross-process idempotent retry test | S | D2 |
-| E1 | envelope fields + linked retention collection | L | C1–C4, D1–D3, OQ1, CFC review |
-| E2 | topics: retire AgentAuthoredEvent | S | E1 |
+| D2 | cli: --invocation, readback, receipt-exists reclassification, pre-dispatch validation, phase reporting, transaction-local ack | M | D1 |
+| D3 | integration: four timeout/retry scenarios | S | D2 |
+| D4 | integration + live: three-topic end-to-end fixture | S | C1–C3, D2 |
+| E1 | timestamps, error shape + linked retention collection | L | C1–C5, D1–D4, OQ1, CFC review |
+| E2 | CFC: specify `AgentActor` mint, propagation, metadata protection + extraction | L | CFC review |
+| E3 | cli: trusted ingress provenance for `cf` calls | M | E2 |
+| E4 | topics: retire AgentAuthoredEvent | S | E3 + end-to-end provenance proof |
 | F1 | cli: `cf piece verbs --json` | S | — (result schemas after C3) |
-| F2 | cli: `@name` binding | S | — |
+| F2 | cli: generic identity/path annotation | M | — |
 | F3 | cli: `--await` / `--no-wait`, caller-controlled bound | S | D2 |

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -10,8 +10,15 @@ lossy — a create returns no handle, a rejection looks like success, a retry ca
 duplicate. Part 1 is the authoring contract for verbs: named fields, atomic
 units, declared results, typed rejections, no call-order dependence. Part 2
 makes results durable and retries idempotent by exposing the scheduler's
-existing event-id and receipt machinery through the callable layer. One small
-runtime change; everything else is exposure.
+existing event-id and receipt machinery through the callable layer. The core
+invocation path needs one small runtime change; general execution attribution
+is a separate, CFC-gated track.
+
+**Review update (2026-07-24).** Post-merge review of PR #4968 corrected three
+boundaries in the draft: generic actor attribution belongs in CFC provenance,
+not a parallel invocation field; patterns return child references while clients
+render their ids and paths; and client-local `@name` bindings are deferred
+because they overlap confusingly with fabric-side slugs.
 
 ## Goal
 
@@ -195,7 +202,14 @@ relies on. Closing them is safe; what it costs is two commitments:
 
 1. **Named fields only.** Every argument is a named field in a declared input
    schema. A client may offer positional sugar when the schema has exactly one
-   required field; the contract itself stays named.
+   required field; the contract itself stays named. **An undeclared field is a
+   typed rejection, never ignored**: input schemas are closed-world, and a
+   client validates against the *deployed* schema before dispatch, so a caller
+   targeting a newer contract than the live piece fails loudly instead of
+   silently losing data — the live board accepted and discarded `agentName`
+   exactly this way. A transitional compatibility field is declared like any
+   other; tolerated-but-undeclared is the failure mode this rule exists to
+   kill.
 2. **Valid on its own.** A verb leaves the piece in a state a reader can accept,
    without depending on a follow-up call to become correct.
 3. **Declared result.** A verb that produces something declares a result schema
@@ -204,10 +218,10 @@ relies on. Closing them is safe; what it costs is two commitments:
    typed error with a stable code. (Authorization is not the contract's job:
    CFC already rejects unauthorized commits and the runner surfaces the error,
    `packages/runner/src/runner.ts:835-840`.)
-5. **Address by identity, never by position.** `{ topicFid }`, not `{ index }`;
-   indices shift under concurrent writes. `topics` already works this way —
-   `crossrefs` rows carry their topic precisely so consumers never correlate by
-   index.
+5. **Address by identity, never by position.** Pass a child reference, or a
+   client-rendered fid/path derived from one, never `{ index }`; indices shift
+   under concurrent writes. A pattern need not and generally cannot manufacture
+   its own runtime fid.
 6. **No implicit dependence on state set by an earlier call.** A verb may take a
    cell reference as an explicit argument; what it may not do is read state that
    some prior verb was expected to set. Verbs written for UI convenience may
@@ -217,12 +231,12 @@ relies on. Closing them is safe; what it costs is two commitments:
 Rule 6 has teeth: any "call A, then call B" sequence where A configures B is a
 race under concurrency. Its canonical instance is attribution.
 
-### Attribution: two parties, not one
+### Attribution: principal and execution provenance
 
 A write carries two attributions — who authorized it and who performed it.
 Conflating them in one settable display-name cell that each caller resets
 before mutating is the rule 6 race in its purest form. They are separate
-facts and are carried separately; `topics` is the template:
+facts and belong at different layers:
 
 - The **principal** — whose key authorized the write — stays fabric-level:
   CFC carries it in its integrity labels (`packages/api/cfc.ts:829-841`). For
@@ -231,29 +245,59 @@ facts and are carried separately; `topics` is the template:
   `docs/common/patterns/multi-user-patterns.md:263-272` — "the viewer is
   whoever the runtime says they are") and stamps a structured
   `TopicAuthor { kind: "person", name, avatar? }`.
-- The **actor** — what performed the write on the principal's behalf — is a
-  required field on every mutating event (`AgentAuthoredEvent { agentName }`),
-  stored as `TopicAuthor { kind: "agent", … }`. Its own doc comment states the
-  contract: display attribution only; write authority remains the principal's.
+- The **execution provenance** — what performed the write on the principal's
+  behalf and in what context — belongs in CFC labels. The intended general
+  mechanism is a trusted-ingress-minted atom, provisionally `AgentActor`, whose
+  metadata can carry more than a display name: for example an agent role,
+  session/tool context, or a protected reference to the triggering request.
+  CFC already has runtime-minted provenance families such as `ExternalIngest`,
+  `LlmDerived`, and `TransformedBy` (`packages/api/cfc.ts:66-85,111-113`), but
+  no `AgentActor` atom exists and the external `cf` call path does not yet
+  preserve this distinction.
 
-The actor as an explicit verb argument — per call, no prelude, no shared cell
-to interleave on — is the interim form. The end state is Part 2's: carry the
-actor in the invocation envelope, so `AgentAuthoredEvent` stops being
-boilerplate every pattern re-declares on every mutating event. Either way the
-actor is a claim, not an authenticated fact — the principal vouches for it,
-the way a git signature vouches for an unverified author string. Whether an
-actor can ever be *authenticated* is a separate question about keys (open
-question 2).
+Until that ingress path exists, `topics` keeps the explicit per-call
+`AgentAuthoredEvent { agentName }`, stored as
+`TopicAuthor { kind: "agent", … }`. Its own doc comment states the interim
+contract: display attribution only; write authority remains the principal's.
+This keeps attribution atomic with the mutation without pretending that a
+topic-specific string is the generic provenance model.
+
+The invocation protocol must not create a second canonical actor record.
+Invocation output may eventually expose a policy-safe view extracted from CFC
+provenance, but CFC remains the source of truth. Rich provenance metadata can
+itself be confidential — a prompt or triggering user request is the obvious
+case — so extraction and display are gated on the label-metadata confidentiality
+rules, not merely on an open-world JSON shape. Authentication through a separate
+agent key or delegation remains useful when cryptographic agent identity is
+required, but is not a prerequisite for runtime-attested execution provenance
+(open question 2).
 
 ### Discovery
 
 A client holding only a board URL must reach the board's children without an
 O(children) sweep of per-child reads. So a parent exposes a **compact index** on
-its result — one row per child carrying its fid and the summary fields a survey
-needs (name, author, timestamps, counts) — making the whole board one read and
-every child addressable by the fid in its row. `topics` already has the shape in
-`crossrefs`; the step is to treat that as the deliberate discovery surface, not
-a by-product of the cross-reference graph.
+its result — one row per child carrying a stable child reference and the summary
+fields a survey needs (name, author, timestamps, counts) — making the whole
+board one read. The pattern owns the reference and summary; the client, which
+can inspect the backing cells, owns rendering the reference as a fid or full
+path.
+
+`topics.crossrefs` already carries each `topic` reference, but it is the
+cross-reference graph, not a compact index: each row's `topic`, `refsOut`, and
+`referencedBy` expand to full pieces on read
+(`packages/patterns/topics/main.tsx:70-78`), and a headless survey of the live
+board through it produced over 300k tokens of output. Its explicit `fid` field
+is not the general model either: it is derived indirectly from runtime-only
+cell surface, reads `""` while unresolved, and a pattern cannot reliably see
+its own runtime address. The index is therefore a separate result — one
+reference-plus-summary row per child, reference edges as sibling references,
+never expanded pieces — and generic clients render identity on top: a coarse
+exploration mode such as `--include-ids` can annotate every point where the
+backing identity changes, with a narrower path-selected form to follow if the
+broad form proves too noisy. Both are projections of existing references, not
+fields every pattern must maintain. Acceptance for an index: its serialization
+contains no expanded piece, action, or runtime values, and a full-board read
+stays bounded.
 
 Discovery is the parent's job; the child's own verbs are the child's. A comment
 is addressed to the topic, not routed through the board — **but that depends on
@@ -305,13 +349,14 @@ required field later stops the sugar applying rather than silently misbinding.
 
 ### Applied to `topics`
 
-`topics` already satisfies the attribution rules; filing is six invocations.
-The rest of Part 1 — a body argument on `addTopic` so `setBody` becomes an
-editing verb rather than part of every create, and thrown rejections in place
-of silent early-returns — makes it five. The remaining waste — the fid lookup
-and the verification read — is exactly what a returned result removes, and
-that is Part 2's job: with it, filing is `addTopic`, `addComment`, `addLink` —
-one call per thing the author meant to do.
+`topics` already satisfies the interim atomic-attribution rule; filing is six
+invocations. The rest of Part 1 — a body argument on `addTopic` so `setBody`
+becomes an editing verb rather than part of every create, and thrown rejections
+in place of silent early-returns — makes it five. The remaining waste — the
+handle lookup and the verification read — is exactly what a returned child
+reference removes, and that is Part 2's job: with it, filing is `addTopic`,
+`addComment`, `addLink` — one call per thing the author meant to do. The CLI
+renders the returned reference as a usable fid/path.
 
 ## Part 2 — the invocation protocol
 
@@ -329,15 +374,6 @@ builds the `Invocation` and hands it back as the verb's return value:
 interface Invocation<Out> {
   /** Caller-supplied. Doubles as the idempotency key. */
   id: string;
-  /**
-   * The second attribution party — the agent when acting under a human's key,
-   * the human when the agent holds its own. The principal always comes from
-   * the write, never from here. An object rather than a bare string so a
-   * `verified: true` field can be added once delegation exists (absent means
-   * unverified) — additive only because this schema is authored open-world
-   * (see Results and schema evolution).
-   */
-  actor?: { name: string };
   status: "pending" | "settled" | "failed";
   result?: Out;
   error?: { code: string; message: string };
@@ -351,8 +387,10 @@ durable entry that same caller can revisit later by id — deliberately not
 named a result, which would capture only the first half. It is a **view over
 the existing receipt cell** — per the
 scheduler spec, "the receipt is the handling's result cell", not a new document
-kind — plus envelope fields (`actor`, timestamps, the error shape) that the
-receipt does not carry today.
+kind — plus envelope fields (timestamps and the error shape) that the receipt
+does not carry today. Actor/execution attribution is deliberately absent: CFC
+provenance is canonical, and a client may later render an authorized extracted
+view beside this record.
 
 What it provides:
 
@@ -378,9 +416,16 @@ transaction committed: `return` settles, `throw` fails. Effects that propagate
 downstream are not part of settlement, which keeps the term bounded for verbs
 with fan-out.
 
-This is not a new semantic — it is when the receipt commits today. The work is
-exposure: the CLI currently awaits the commit and then discards everything
-(`callable.ts:294-320`).
+This is not a new semantic — it is when the receipt commits today. But the CLI
+waits for far more than that: the handler branch awaits `runtime.idle()` and
+`manager.synced()` — the whole reactive graph quiescing, then full sync — so
+acknowledgement of an already-committed write is held hostage to every derived
+recomputation it triggered. On the live topics board that is `crossrefs`
+re-deriving over the whole board; mutations were observed taking 60–80 s. The
+work is exposure *and narrowing*: await this handling's commit, sync the
+receipt, return — never the graph going quiet. An acceptance test must prove a
+slow derived recomputation cannot delay acknowledgement (implementation plan,
+WS-D).
 
 Waiting is a caller-side choice — whether to wait at all, and for how long. This
 replaces the current fixed 15 s `DEFAULT_TOOL_RESULT_TIMEOUT_MS`, and the wait
@@ -435,7 +480,11 @@ Scope is not the whole confidentiality story: a result derived from labelled
 data carries CFC confidentiality labels of its own, so a stored invocation
 record is subject to the same label rules as any other cell
 (`docs/specs/cfc-label-metadata-confidentiality.md`). Retention and readback
-therefore need checking against those rules, not only against cell scope.
+therefore need checking against those rules, not only against cell scope. The
+same is true of any extracted execution-provenance view: rich `AgentActor`
+metadata may contain a role, tool/session context, or a reference to a
+confidential prompt, so the invocation record must not copy it into ordinary
+payload fields by default.
 
 ### Retries and failure
 
@@ -476,7 +525,8 @@ and results in **opposite directions** (`:151-183`):
 That second direction matters here: a declared result is easier to shrink than
 to extend, so the result shape wants to be right early, or deliberately
 open-world. The `Invocation` shape is the first schema this applies to — it
-must be authored open-world so fields like `verified` can be added later.
+must be authored open-world so protocol fields such as a payload digest or
+retention metadata can be added later.
 
 ### Authoring
 
@@ -516,7 +566,10 @@ Two additions close it:
 
 1. A CLI listing (`cf piece verbs --json`, or a `callables` section in
    `piece inspect --json`): name, kind, and schemas per verb in one read —
-   the same classification FUSE already performs, exposed generically.
+   the same classification FUSE already performs, exposed generically. The
+   listing also carries the deployed pattern's source identity, so a client or
+   skill can detect that it targets a newer contract than the live piece
+   instead of discovering skew through a silently dropped field.
 2. **Result schemas for handlers.** The command spec carries an output schema
    only for tools, because handlers return nothing today. Rule 3's declared
    result must reach the piece's **durable schema** — otherwise introspection
@@ -543,28 +596,41 @@ contract.
 ### Client surface
 
 ```text
-$ cf @topics addTopic --title "Verb contract" --body @body.md
+$ cf piece call --url "$TOPICS_BOARD_URL" addTopic \
+    --title "Verb contract" --body @body.md
 { "invocation": "inv_7f3a", "status": "settled",
   "result": { "topic": "fid1:abc" } }
 
 # The client mints the id before sending and prints it even when its wait
 # times out. Retrying with it returns the original — no re-execution.
-$ cf @topics addTopic --title "Verb contract" --invocation inv_7f3a
+$ cf piece call --url "$TOPICS_BOARD_URL" addTopic \
+    --title "Verb contract" --invocation inv_7f3a
 { "invocation": "inv_7f3a", "status": "settled",
   "result": { "topic": "fid1:abc" } }
 
 # The caller chooses whether and how long to wait
-$ cf @topics summarize --topic fid1:abc --no-wait
+$ cf piece call --url "$TOPICS_BOARD_URL" summarize \
+    --topic fid1:abc --no-wait
 { "invocation": "inv_9c1b", "status": "pending" }
-$ cf @topics invocation inv_9c1b --await
+$ cf piece invocation --url "$TOPICS_BOARD_URL" inv_9c1b --await
 { "invocation": "inv_9c1b", "status": "settled",
   "result": { "summary": "..." } }
 ```
 
-`@topics` is a client-side binding of a name to a piece URL, stored by the
-invoking tool: different clients may want different names, and the binding has
-to resolve before the fabric is reachable. Slugs (`cf piece set-slug`) provide
-fabric-side naming within a space; a binding supplies the host and space half.
+Client-local `@name` bindings are deferred. They can encode host + space +
+piece, while slugs (`cf piece set-slug`) are fabric-side names within a space,
+but two overlapping naming systems are too easy to confuse and aliases are not
+required for agent-drivable verbs. Revisit them separately only after concrete
+usage shows that full URLs, configured host/space, and slugs are insufficient.
+
+On any early exit — a timed-out wait, a lost connection — the client reports
+the furthest phase it observed as a structured field beside the invocation id
+it printed before network work began:
+`initial_sync | dispatched | committed | readback`. Phase is diagnosis, not a
+safety gate: with a caller-supplied id, a retry of that id is safe in every
+phase — before dispatch nothing committed; after it, the retry collides on the
+receipt and reads the original back. A `retrySafe` flag is derivable
+client-side sugar, not protocol.
 
 ## Defects and unknowns in the current machinery
 
@@ -600,12 +666,12 @@ The loom fuse-fabric-access arc (loom PR 4183) reached this territory first: it
 put an agent handle on loom's mobile root piece and wrote down the conventions
 that made it drivable. Its topics-board incarnation — the board topic *"Give
 the topics board an agent handle"* (Ben + Claude, 2026-07-22) — asks for five
-things: atomic `addTopic {title, body?}` returning the new fid, idempotency on
-create, a board index cell, board-level `addComment {topicFid}`, and an
-identity guard on mutating verbs. Every ask maps to a section above — the
-identity guard is the required `agentName` on every mutating event. This
-document is their pattern-agnostic generalization. Deeper detail lives in the
-arc's defect register and
+things: atomic `addTopic {title, body?}` returning the new topic reference,
+idempotency on create, a board index cell, board-level
+`addComment {topicFid}`, and an identity guard on mutating verbs. Every ask maps to a section above — the
+identity guard is the interim required `agentName` on every mutating event,
+pending general CFC ingress provenance. This document is their pattern-agnostic
+generalization. Deeper detail lives in the arc's defect register and
 `docs/development/projects/fuse-fabric-access/topics-agent-ergonomics.md` on
 the loom PR.
 
@@ -614,12 +680,26 @@ absorbed into the atomic-unit rule (Composition), and child-owned verbs are
 preferred to parent-routed ones, with board-level routing as the documented
 workaround until nested-stream dispatch lands (Discovery).
 
+A second, independent confirmation arrived 2026-07-24: the first headless
+session driving the live board through the current CLI needed ~24 remote
+operations to create a three-topic graph — every extra call a handle lookup, a
+`setBody` that could not ride the create, or a verification read — with four
+fixed-timeout sync failures, roughly six minutes of mutation waits, and one
+field silently discarded by a stale deployed schema. Each failure maps to a
+section above, and the session's three-topic scenario is adopted as the
+end-to-end acceptance fixture in the implementation plan.
+
 ## Open questions
 
 1. **What is the right default retention window**, given that it bounds the
    idempotency guarantee?
-2. **Can the actor ever be authenticated — does an invocation need two keys?**
-   Three arrangements, unequal:
+2. **What does `AgentActor` provenance attest, and when does it need a key?**
+   Runtime-minted ingress provenance can attest that a trusted boundary
+   observed a particular execution context without making the agent a
+   cryptographic principal. That is enough for honest provenance and richer
+   than an invocation-owned display name, but it does not authenticate a
+   self-asserted real-world identity. When cryptographic agent identity is
+   required, three arrangements remain unequal:
 
    | arrangement | cost | authenticated |
    | --- | --- | --- |
@@ -627,17 +707,18 @@ workaround until nested-stream dispatch lands (Discovery).
    | agent holds its own key | a DID, home space and profile per agent | agent only |
    | agent signs under a delegation from its human | delegation credentials | both |
 
-   Only delegation authenticates both, and it is infrastructure — issuance,
-   expiry, revocation. A standalone agent key is cheaper but inverts the
-   problem, leaving the accountable human unverified; it is also not small,
+   Only delegation cryptographically authenticates both, and it is
+   infrastructure — issuance, expiry, revocation. A standalone agent key is
+   cheaper but inverts the problem, leaving the accountable human unverified;
+   it is also not small,
    since a key is a DID, a DID is a home space
    (`getHomeSpaceCell = getCell(did, did)`), and homes are private under
    now-default ACL enforcement — an agent key implies a home and profile, not
-   just a credential. Until this settles, every actor claim is unverified: the
-   record stores the actor as an object so a `verified` field can be added
-   without migration, and a renderer should lead with the authenticated
-   principal and mark the actor unverified. Nothing here forecloses delegation
-   or delivers it.
+   just a credential. The CFC design must specify the atom's trusted mint,
+   propagation, metadata confidentiality, and extraction helpers. A renderer
+   should lead with the authenticated principal and distinguish
+   runtime-attested execution context from cryptographically authenticated
+   agent identity. Nothing here forecloses delegation or delivers it.
 3. **How do plain JSON returns reach the receipt?** A return value containing
    reactives/cells projects into the receipt, while a **plain JSON return is
    discarded** (the receipt-only branch writes `{}`, `runner.ts:3713-3725`).
@@ -670,6 +751,15 @@ workaround until nested-stream dispatch lands (Discovery).
   verb to any reader, and permission stays with CFC at commit. Patterns may
   mark UI-convenience wrappers so the default view shows the contract tier;
   `--all` always shows everything.
+- **Execution attribution is CFC provenance, not an invocation payload field.**
+  `topics.agentName` remains an atomic interim argument until trusted `cf`
+  ingress can mint and propagate the general provenance.
+- **Patterns return references; clients render identities.** A compact index
+  carries stable child references and summaries. Generic `--include-ids`
+  annotation belongs to the CLI because the pattern cannot reliably author its
+  own fid.
+- **Client-local `@name` bindings are deferred.** Their distinction from slugs
+  is real but confusing, and they are unnecessary for the core contract.
 
 ## Staging
 
@@ -680,10 +770,11 @@ the steps below are the design-level order.
 1. Agree this document — particularly the open questions.
 2. Finish the Part 1 rework of `topics` / `topic` — the attribution rules
    already hold. Remaining, with no runtime change: a body argument on
-   `addTopic`, and thrown rejections in place of silent early-returns — empty
-   titles and blank agent names both drop without a trace today. (A thrown
-   handler error already surfaces as a nonzero CLI exit; stable codes arrive
-   with the protocol.)
+   `addTopic`, thrown rejections in place of silent early-returns — empty
+   titles and blank agent names both drop without a trace today — and the
+   reference-plus-summary discovery index (Discovery). (A thrown handler
+   error already surfaces as a nonzero CLI exit; stable codes arrive with the
+   protocol.)
 3. Replace the tool-result poll with sink-based settlement and return the
    result cell's address to the caller. Standing fix, useful regardless.
 4. Plumb the id and the readback: pass a caller-supplied `eventId` from
@@ -693,11 +784,12 @@ the steps below are the design-level order.
    returns `undefined`), and reclassify `precondition: "receipt-exists"` as
    success-with-readback rather than failure. Plus the one runtime change from
    open question 3 if plain returns are to survive.
-5. Add the envelope fields the receipt does not carry — `actor`, timestamps,
-   the typed error shape, the linked retention collection — and retire the
-   per-event `agentName` fields (`AgentAuthoredEvent`) in its favor.
-6. Add the client-side binding (`@name`), the client surface around invocation
-   ids (mint-and-print, `--invocation`, `--await` / `--no-wait`), and the verb
-   listing (Verb discovery).
+5. Add timestamps, the typed error shape, and the linked retention collection.
+   In a separate CFC-gated track, design trusted `cf` ingress provenance,
+   `AgentActor` propagation, metadata protection, and extraction. Retire
+   per-event `agentName` fields only after that path is proven end to end.
+6. Add the client surface around invocation ids (mint-and-print,
+   `--invocation`, `--await` / `--no-wait`), verb listing, and generic
+   identity annotation for returned references and discovery indexes.
 
 Steps 2 and 3 stand on their own regardless of how the open questions land.


### PR DESCRIPTION
## Why

The verb-contract plan (#4968) merged with two claims the first day of real use disproved: that `crossrefs` already had the shape of a compact discovery index (it expands full pieces — a live full-board read exceeded 300k tokens), and that settlement narrowing was mere "exposure" (the CLI actually awaits full-graph quiescence, producing 60–80 s mutation acks). The first live headless session also hit a silently-dropped field (`agentName` discarded by the stale deployed schema) and four ambiguous sync timeouts. Separately, post-merge review corrected three design boundaries: actor attribution belongs in CFC provenance rather than a parallel invocation field, patterns return references while clients render identity, and `@name` bindings overlap confusingly with slugs. This PR folds both amendment sets into the plan of record so implementation starts from validated premises.

## What Changed

- **Design doc:** rule 1 gains "an undeclared field is a typed rejection, never ignored" (closed-world inputs + pre-dispatch validation); Discovery corrected to the reference-plus-summary index with bounded-read acceptance; settlement section names the quiescence-wait gap; phase reporting added to the client surface; attribution rewritten around a CFC-gated `AgentActor` provenance track (no `actor` in the Invocation envelope); `@name` deferred; the live session cited as independent confirmation in Prior art.
- **Implementation doc:** new issues A2 (discovery index), C5 (closed-world inputs), D4 (three-topic end-to-end fixture); D2 expanded (pre-dispatch validation, phase reporting/timings, transaction-local ack); D3 becomes four timeout/retry scenarios; WS-E split into retention + CFC provenance (E1–E4); F2 repurposed to generic identity annotation; live acceptance becomes an explicit checklist; Risks names the `setsrc` write-storm gate (decision 3 currently unsatisfiable; #4956 is the candidate fix to verify); session/batch mode linked as tracked adjacent work.

## Test plan

- `deno task check-docs` — all 518 code blocks pass.
- Citations verified against source: `TopicCrossref` shape (`main.tsx:70-78`), CFC provenance atoms and `AgentActor` absence (`packages/api/cfc.ts`), `createdBy`/`bodyUpdatedBy` field names (`topic.tsx`), #4659/#4956 in history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the verb contract docs with fixes from the first live headless session and post‑merge review. Adds a compact discovery index, closed‑world inputs, and transaction‑local acks with phase reporting, and moves execution attribution to CFC provenance.

- New Features
  - Compact board discovery index: reference‑plus‑summary rows; `crossrefs` is no longer the survey surface.
  - Closed‑world verb inputs and CLI pre‑dispatch validation; undeclared fields are rejected.
  - Transaction‑local acknowledgement; per‑phase reporting/timings and idempotent retry/readback across four timeout scenarios.
  - Three‑topic end‑to‑end fixture and a live acceptance checklist; CLI verb listing carries deployed source identity; generic identity annotation (e.g. `--include-ids`) moves fid rendering to the client.

- Refactors
  - Execution attribution moves to CFC provenance (`AgentActor`); no `actor` in the invocation record; keep `topics.agentName` only as an interim.
  - Patterns return references; clients render ids/paths; no pattern‑authored fid fields; `crossrefs` stays a graph, not discovery.
  - WS‑E split into retention and CFC provenance with trusted `cf` ingress.
  - Deferred `@name` bindings; add a risk gate before any live `setsrc` deploys (write‑storm regression).

<sup>Written for commit 668a7179cfce6f30e10e731ed204b54937897b0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

