### PR TITLE
Remove the CI performance gate; keep the coverage-debt gate

### DIFF
--- a/.github/actions/record-compile-cache-state/action.yml
+++ b/.github/actions/record-compile-cache-state/action.yml
@@ -1,20 +1,20 @@
 name: "Record compile cache state"
 description: >
   Record a pattern job's compile-byte-cache restore result and upload it as a
-  cache-state artifact for the Performance Check. The cache file exists on
+  cache-state artifact for the Coverage Check. The cache file exists on
   disk iff the restore found something (primary key or restore key); any
   restore implies the compiler fingerprint is unchanged, so cold := file
   absent. The combined actions/cache action only exposes cache-hit (exact
   match), not the matched key, so file presence is the restore signal.
   Family names must stay in sync with COMPILE_CACHE_FAMILIES in
-  tasks/perf-lib.ts — a family emitted here but unknown there is silently
-  ignored (reports as unknown, gates normally), so adding a pattern job
-  family means updating both places.
+  tasks/ci-check-lib.ts — a family emitted here but unknown there is silently
+  ignored (reports as unknown, does not affect the coverage ratchet), so adding
+  a pattern job family means updating both places.
 inputs:
   family:
     description: >
       Compile-cache job family (one of COMPILE_CACHE_FAMILIES in
-      tasks/perf-lib.ts, e.g. pattern-unit).
+      tasks/ci-check-lib.ts, e.g. pattern-unit).
     required: true
   shard:
     description: "Matrix shard/chunk number for this job."

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,6 +1,6 @@
 name: Coverage Comment
 
-# Posts the coverage-debt suggestion comment produced by the Performance Check
+# Posts the coverage-debt suggestion comment produced by the Coverage Check
 # gate in the Deno Workflow. That gate runs on `pull_request`, where fork PRs
 # only get a read-only token, so it cannot comment directly — it uploads the
 # comment as the `coverage-comment` artifact instead. This workflow runs in the

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -315,7 +315,7 @@ jobs:
           restore-keys: |
             cc-generated-patterns-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-
 
-      - name: 🧾 Record compile cache state for the Performance Check
+      - name: 🧾 Record compile cache state for the Coverage Check
         uses: ./.github/actions/record-compile-cache-state
         with:
           family: generated-patterns
@@ -677,7 +677,7 @@ jobs:
           restore-keys: |
             cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.shard }}-
 
-      - name: 🧾 Record compile cache state for the Performance Check
+      - name: 🧾 Record compile cache state for the Coverage Check
         uses: ./.github/actions/record-compile-cache-state
         with:
           family: pattern-integration
@@ -743,7 +743,7 @@ jobs:
         run: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts coverage/raw/pattern-integration-${{ matrix.shard }} coverage/lcov/pattern-integration-${{ matrix.shard }}.lcov
 
       # The whole directory: the V8 report plus the authored-pattern LCOV the
-      # harness wrote under pattern-runtime/. perf-check joins every .lcov in
+      # harness wrote under pattern-runtime/. coverage-check joins every .lcov in
       # the artifact, so both streams reach the gate.
       - name: 📤 Upload coverage report
         if: always()
@@ -851,7 +851,7 @@ jobs:
           restore-keys: |
             cc-pattern-unit-coverage-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.chunk }}-
 
-      - name: 🧾 Record compile cache state for the Performance Check
+      - name: 🧾 Record compile cache state for the Coverage Check
         uses: ./.github/actions/record-compile-cache-state
         with:
           family: pattern-unit
@@ -901,8 +901,8 @@ jobs:
   # Tier 2 – Post-test gates and deployments
   # ---------------------------------------------------------------------------
 
-  perf-check:
-    name: "Performance Check"
+  coverage-check:
+    name: "Coverage Check"
     if: (github.event_name == 'pull_request') || (github.ref_name == 'main')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
@@ -945,13 +945,13 @@ jobs:
           skip-decompress: false
           digest-mismatch: error
 
-      - name: 📊 Run performance check
+      - name: 📊 Run coverage check
         env:
           COVERAGE_ARTIFACTS_DIR: coverage-artifacts
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: deno run --allow-net --allow-env --allow-read --allow-run --allow-write tasks/perf-check.ts
+        run: deno run --allow-net --allow-env --allow-read --allow-run --allow-write tasks/coverage-check.ts
 
       - name: 📤 Upload coverage regression comment
         if: always()
@@ -962,21 +962,16 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-      - name: 📤 Upload performance metrics
+      # The per-run coverage baseline (this run's coverage-debt metrics and
+      # compile cache states). Named perf-metrics for historical continuity —
+      # the coverage ratchet reads recent main runs' artifacts by this name, so
+      # keeping it avoids a baseline migration.
+      - name: 📤 Upload coverage baseline
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: perf-metrics
           path: perf-metrics.json
-          retention-days: 90
-          if-no-files-found: ignore
-
-      - name: 📤 Upload performance metrics backfill
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: perf-metrics-backfill
-          path: perf-metrics-backfill.json
           retention-days: 90
           if-no-files-found: ignore
 

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -18,11 +18,10 @@ The team ops dashboard charts benchmark trends on its `/bench` page, sampling
 one successful run per four-hour window from those artifacts. Each
 benchmark's series is identified by its origin file, group, and name.
 
-Benchmark numbers are not gated: the per-PR performance gate
-(`tasks/perf-check.ts`) covers CI job, step, and test timings plus the
-coverage-debt ratchet, and never ingests benchmark results, so a bench
-regression shows up as trend drift on the dashboard rather than as a failing
-check.
+Benchmark numbers are not gated, and neither is CI wall time. The only per-PR
+gate is the coverage-debt ratchet (`tasks/coverage-check.ts`), which never
+ingests benchmark results, so a bench regression shows up as trend drift on the
+dashboard rather than as a failing check.
 
 Most packages with benches define a `bench` task for running them locally
 (see `packages/runner/deno.jsonc`); otherwise invoke `deno bench` on a

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -13,7 +13,7 @@ same rough band. As a default, stop when:
 - The slowest required test job is around 2 minutes.
 - The expected critical-path win is under about 30 seconds.
 - The proposed split adds comparable maintenance cost: more matrix entries,
-  ports, artifacts, sharding rules, or performance baselines.
+  ports, artifacts, or sharding rules.
 
 At that point, keep the timing instrumentation and wait for a concrete trigger
 instead of continuing to split jobs proactively.
@@ -28,25 +28,17 @@ normal runs:
   at least 30 seconds slower in absolute terms.
 - Required non-deploy checks take more than 8 minutes from first start to last
   completion.
-- The same job repeatedly appears as `OVER` or `CLOSE` in Performance Check,
-  rather than as a one-run fluctuation.
 - New tests clearly cluster in one shard or suite and make it consistently
   heavier.
 
-Performance Check prints a non-blocking `CI Wall-Time Revisit Signals` section
-for the first three triggers. Treat it as a prompt to inspect the data, not as a
-failure by itself.
-
 ## How To Respond
 
-1. Start from the latest completed `main` run and its Performance Check log.
+1. Start from the latest completed `main` run and its Coverage Check log.
 2. Prefer timing artifacts and repeated runs over a single outlier.
 3. First look for a low-maintenance rebalance, such as moving a heavy test file
    between existing shards.
 4. Split a job only when the boundary is already clear and the split preserves
    local developer workflows.
-5. If Performance Check asks for a `NEW_PERF_BASELINE`, make sure the metric is
-   understood and note whether it is related to the CI change.
 
 Good CI optimization PRs should reduce critical-path wall time without making
 the workflow harder to reason about.
@@ -204,8 +196,8 @@ printed by `tasks/test.ts`. The round-robin split carries no per-package
 weighting, so first check whether one shard simply drew several slow packages.
 Changing the shard count in the workflow matrix reshuffles the assignment. A
 shard-count change must also update the `coverage-profile-workspace-*` entries
-in `EXPECTED_COVERAGE_ARTIFACT_NAMES` in `tasks/perf-check.ts`, which the
-Performance Check gate uses to require every shard's coverage artifact.
+in `EXPECTED_COVERAGE_ARTIFACT_NAMES` in `tasks/coverage-check.ts`, which the
+Coverage Check gate uses to require every shard's coverage artifact.
 
 A package too heavy for any single shard can be split internally: the cli
 package runs as three units via `CLI_TEST_SHARD` (see
@@ -231,92 +223,3 @@ Known serial CLI tests:
 
 The CLI package keeps those tests in a serial group and runs the rest of its
 test modules with `--parallel`.
-
-## Coverage Debt Baselines
-
-Performance Check also tracks coverage debt as uncovered source lines. See
-[COVERAGE.md](COVERAGE.md) for how that coverage is collected and which CI job
-measures which code. Coverage debt uses a latest-main ratchet for source groups
-changed by the PR: any increase in a changed group fails unless the PR
-explicitly accepts it. Debt metrics for unchanged groups are still reported, but
-they do not block the PR.
-
-Use the narrow per-metric form when a PR intentionally increases one coverage
-debt metric:
-
-```text
-NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 123 lines
-```
-
-Use the broad reset marker only to bootstrap coverage data for the first time,
-or when the upstream coverage baseline is known to be bogus and should be
-re-seeded for one cycle:
-
-```text
-NEW_COVERAGE_BASELINE
-```
-
-When that PR merges, the main run's coverage metrics become the new ratchet
-baseline for later PRs. Performance Check still requires the full expected
-coverage artifact set during that reset cycle. Jobs with no reportable covered
-files upload an empty LCOV report so missing artifacts mean the report upload
-itself failed.
-
-The workflow downloads the current run's `coverage-profile-*` artifacts before
-starting `tasks/perf-check.ts`. `COVERAGE_ARTIFACTS_DIR` points the script at one
-subdirectory per artifact. The download step checks the artifact digests. The
-script separately checks the expected artifact names. It also rejects an
-artifact containing no coverage files. A manual run without the environment
-variable uses the GitHub API download path instead.
-
-## Compile Cache State and Cold Runs
-
-The pattern test jobs restore a compile byte cache keyed on a fingerprint hash
-over the compiler packages. A PR that changes that fingerprint runs cold: every
-pattern compiles from scratch, pattern tests run roughly 1.7–2× slower, and the
-timing gate would trip against warm baselines. The other direction is just as
-bad: a cold main run covers compile branches that only execute on a cold cache,
-which lowers the coverage-debt baseline, so later warm PRs fail the coverage
-ratchet with phantom uncovered lines.
-
-The pattern-integration process owns one shared cache in
-`packages/patterns/integration/pieces-controller.ts`. Its controller helper and
-the capability-gate controller both inject that cache into every runtime they
-create. A custom runtime in this suite must do the same. Setting
-`CF_COMPILE_CACHE_FILE` only tells the test-support cache where to persist its
-bytes; a runtime uses those bytes only when it receives the cache through its
-`moduleByteCache` option.
-
-To compare like with like, each pattern job uploads a small `cache-state-*`
-artifact recording its cache restore result. Performance Check aggregates those
-into `compileCacheStates` in `perf-metrics.json`. A job family is cold when any
-of its shards had a full cache miss, detected as the cache file being absent
-after the restore step (the combined `actions/cache` action does not expose the
-matched key). A partial hit through a restore key counts as warm: both key
-forms start with the fingerprint hash, so any restore means the compiled bytes
-are current.
-
-The comparison rules follow from the tagging:
-
-- When the current run is cold for a family, that family's cache-sensitive
-  timing metrics get the non-blocking `COLD` status instead of being gated.
-  The remedy is to re-run the pattern jobs: the cold attempt already saved the
-  new cache, so the re-run is warm and gates normally.
-- When the current run is warm, known-cold baseline samples are excluded from
-  the timing comparison.
-- The coverage-debt ratchet uses the latest non-cold main sample, so a cold
-  main run cannot lower the baseline that warm PRs are held to.
-
-A run without a recorded cache state — an artifact carrying no stamp, a
-backfill-derived run, or a run whose cache-state artifact failed to upload — is
-retro-classified from the compile fingerprint (`tasks/perf-cache-state.ts`
-mirrors the `cc-*` key globs, drift-guarded by a test that parses the workflow):
-if the fingerprint paths changed against the run's predecessor, every family is
-treated as cold; if unchanged, warm. The same fingerprint inference backstops
-the current run when its cache-state artifact is missing. Fingerprint inference
-cannot see non-fingerprint cold causes (cache eviction, cache-service outages):
-a run cold for those reasons and lacking a recorded state stays unknown, so its
-samples are kept and gate normally.
-
-Cold compile duration itself is not gated, so a regression that shows up only on
-a cold cache passes unnoticed; a dedicated cold-compile bench would cover it.

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -65,8 +65,8 @@ These properties of this mechanism are worth keeping in mind:
   stream on the node's prop: a test walks the rendered tree to the node, reads
   the prop, and sends it an event. A derived expression such as `{count * 2}`
   runs when a test reads the node it builds. So UI raises the uncovered-line
-  count only until a test drives it; write that test rather than taking a
-  `NEW_PERF_BASELINE` marker.
+  count only until a test drives it; write that test rather than taking an
+  `ACCEPT_COVERAGE_DEBT` marker.
   [pattern-testing.md](../common/workflows/pattern-testing.md) shows how.
 
 `CF_PATTERN_COVERAGE_DIR` names the directory the `*.pattern-coverage.lcov`
@@ -79,16 +79,16 @@ jobs collect authored-pattern coverage").
 
 ## How the two feed the coverage gate
 
-The Performance Check job downloads every `coverage-profile-*` artifact with
+The Coverage Check job downloads every `coverage-profile-*` artifact with
 `actions/download-artifact`. The action checks each artifact's recorded digest.
-`tasks/perf-check.ts` verifies that every expected artifact is present. It joins
-all the downloaded LCOV files together and hands them to
+`tasks/coverage-check.ts` verifies that every expected artifact is present. It
+joins all the downloaded LCOV files together and hands them to
 `tasks/coverage-metrics.ts`. That code walks the tracked source files under
 `packages` and `tasks`. For each file, it counts how many lines no test covered.
 The top-level `scripts` directory is excluded from this gate. The counts roll up
 into
 `coverage-debt: <group> uncovered lines` metrics, for example
-`coverage-debt: packages/patterns uncovered lines`, and the performance check
+`coverage-debt: packages/patterns uncovered lines`, and the coverage check
 gates a pull request on them.
 
 Authored pattern files under `packages/patterns` are tracked source files, so
@@ -115,6 +115,85 @@ of the file's lines and the rest stop being counted, so it settles at a lower �
 and therefore stricter — bar rather than failing anything. The instrumented
 statements are also the only lines this mechanism can speak to: a line the
 instrumentation cannot reach is not a line a pattern test could cover.
+
+## Ratchet baselines and accepting debt
+
+The ratchet applies per source group and only to the groups a PR changes: for
+each such group the uncovered-line count must not rise above the latest non-cold
+`main` run's count. Debt in unchanged groups is still reported, but does not
+block the PR.
+
+Accept one metric's increase with the narrow per-metric marker in the PR
+description:
+
+```text
+ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 123 lines
+```
+
+Use the broad reset marker only to bootstrap coverage data for the first time,
+or when the `main` baseline is known to be bogus and should be re-seeded for one
+cycle:
+
+```text
+NEW_COVERAGE_BASELINE
+```
+
+When that PR merges, the main run's coverage metrics become the new ratchet
+baseline for later PRs. The check still requires the full expected coverage
+artifact set during that reset cycle. Jobs with no reportable covered files
+upload an empty LCOV report, so a missing artifact means the report upload
+itself failed.
+
+Each run writes a per-run baseline artifact recording its coverage-debt metrics
+and its compile cache states. It is named `perf-metrics` for historical reasons
+— it once also carried CI timing metrics for the removed performance gate — and
+keeps that name so the ratchet needs no migration; a run from before the gate
+was removed reads as a valid baseline unchanged. A later PR run reads the most
+recent `main` run's `perf-metrics` artifact as its ratchet baseline; there is no
+separate history store. The workflow downloads the current run's
+`coverage-profile-*` artifacts before starting `tasks/coverage-check.ts`.
+`COVERAGE_ARTIFACTS_DIR` points the script at one subdirectory per artifact. The
+download step checks the artifact digests. The script separately checks the
+expected artifact names (`EXPECTED_COVERAGE_ARTIFACT_NAMES`). It also rejects an
+artifact containing no coverage files. A manual run without the environment
+variable uses the GitHub API download path instead.
+
+## Compile cache state and cold runs
+
+The pattern test jobs restore a compile byte cache keyed on a fingerprint hash
+over the compiler packages. A PR that changes that fingerprint runs cold: every
+pattern compiles from scratch. A cold run covers compile branches that only
+execute on a cold cache, which lowers its coverage debt, so ratcheting a warm PR
+against a cold `main` run would fail it with phantom uncovered lines.
+
+The pattern-integration process owns one shared cache in
+`packages/patterns/integration/pieces-controller.ts`. Its controller helper and
+the capability-gate controller both inject that cache into every runtime they
+create. A custom runtime in this suite must do the same. Setting
+`CF_COMPILE_CACHE_FILE` only tells the test-support cache where to persist its
+bytes; a runtime uses those bytes only when it receives the cache through its
+`moduleByteCache` option.
+
+To tell cold from warm, each pattern job uploads a small `cache-state-*`
+artifact recording its cache restore result. The coverage check aggregates those
+into `compileCacheStates` in `perf-metrics.json`. A job family is cold when
+any of its shards had a full cache miss, detected as the cache file being absent
+after the restore step (the combined `actions/cache` action does not expose the
+matched key). A partial hit through a restore key counts as warm: both key forms
+start with the fingerprint hash, so any restore means the compiled bytes are
+current. The ratchet then uses the latest non-cold `main` sample, so a cold
+`main` run cannot lower the baseline that warm PRs are held to.
+
+A run without a recorded cache state — an artifact carrying no stamp, or a run
+whose cache-state artifact failed to upload — is retro-classified from the
+compile fingerprint (`tasks/compile-cache-state.ts` mirrors the `cc-*` key globs,
+drift-guarded by a test that parses the workflow): if the fingerprint paths
+changed against the run's predecessor, every family is treated as cold; if
+unchanged, warm. The same fingerprint inference backstops the current run when
+its cache-state artifact is missing. Fingerprint inference cannot see
+non-fingerprint cold causes (cache eviction, cache-service outages): a run cold
+for those reasons and lacking a recorded state stays unknown, so it is treated
+as not-cold and may still be used as a baseline.
 
 ## A combined report for IDEs
 
@@ -277,9 +356,7 @@ like a pattern nobody tested. Writing one warns.
 
 - [TESTING.md](TESTING.md) — how to run the test suites whose execution this
   coverage is measured from.
-- [CI_PERFORMANCE.md](CI_PERFORMANCE.md) — the coverage-debt baseline and ratchet
-  markers (`NEW_PERF_BASELINE` and `NEW_COVERAGE_BASELINE`) that gate a pull
-  request on the metrics described here.
+- [CI_PERFORMANCE.md](CI_PERFORMANCE.md) — CI wall-time optimization policy.
 - [../common/workflows/pattern-testing.md](../common/workflows/pattern-testing.md)
   — writing the pattern unit tests that the `pattern-unit-test` job runs through
   `cf test`, the source of the gated authored-pattern coverage.

--- a/docs/development/PERFORMANCE_PROGRAM.md
+++ b/docs/development/PERFORMANCE_PROGRAM.md
@@ -24,10 +24,11 @@ toylike even when it's functionally correct.
    problem and validates the fix. Connect micro-optimizations to user-visible
    outcomes.
 
-4. **Protect what you've gained.** Every improvement should be defended by an
-   existing benchmark. CI already runs the benchmark suite every four hours
-   and gates PRs on CI timing regressions — lean on that rather than building
-   new infrastructure.
+4. **Protect what you've gained.** Every improvement should be defended by a
+   benchmark. CI runs the benchmark suite every four hours and charts the trend
+   on the team ops dashboard (see [BENCHMARKS.md](BENCHMARKS.md)). Benchmarks
+   and CI wall time are not gated, so the dashboard is where you catch drift —
+   watch it rather than assuming a check will fail on a regression.
 
 5. **Balance direct wins with leverage.** We're a tiny team, so we can't
    afford to spend a month on infrastructure before delivering improvements.
@@ -59,8 +60,6 @@ step, and we'll ratchet targets down as we improve.
 - CI benchmarks every four hours on main (dedicated runner group), JSON
   artifacts with 90-day retention, charted on the team ops dashboard's /bench
   page (see [BENCHMARKS.md](BENCHMARKS.md))
-- Per-PR performance gate comparing CI timings against recent main runs
-  (median + 3σ or +50%)
 - Recent wins: compilation cache (~100-500ms saved), schema freeze caching,
   LLM queue batching, scheduler debouncing, scheduler writer-index cleanup
   (`writersByEntity` is Set-backed), refer() caching (~2x)
@@ -167,7 +166,7 @@ debating when the timing is right.
 | INFRA-2 | Local benchmark comparison | High | S | `deno task bench` wrapper that saves `bench-baseline.json` and diffs against it. See results in seconds instead of waiting for CI. Every optimization project gets faster. |
 | INFRA-3 | Selective benchmark filtering | Medium | S | Verify and document `deno bench --filter` for subsystem-specific runs. Faster inner loop when working on a specific area. |
 | INFRA-4 | Single "pattern load" benchmark | High | M | One representative pattern that compiles, loads, receives data, and renders. The top-level number that tells you whether an optimization actually moved the user-visible needle. Without this you're optimizing components without knowing if they're the bottleneck. (Partly done in [#3133](https://github.com/commontoolsinc/labs/pull/3133)) |
-| INFRA-5 | PR benchmark bot | High | M | CI job on PRs touching critical packages, runs the benchmarks, compares against main, posts a before/after comment. The per-PR gate from [#3125](https://github.com/commontoolsinc/labs/pull/3125) compares CI job, step, and test timings but never runs benchmarks, so benchmark regressions surface only in the dashboard trends, after merge. The benchmark suite, the four-hourly bench-results artifacts, and the generic baseline math in `tasks/perf-lib.ts` are reusable; the deno-bench ingestion was removed with the scheduled detector, so a bot would need to rebuild it. |
+| INFRA-5 | PR benchmark bot | High | M | CI job on PRs touching critical packages, runs the benchmarks, compares against main, posts a before/after comment. Nothing gates benchmarks or CI timings on a PR today, so benchmark regressions surface only in the dashboard trends, after merge. The benchmark suite and the four-hourly bench-results artifacts are reusable; the deno-bench ingestion and the per-PR CI-timing gate have both been removed, so a bot would build its comparison from scratch. |
 | INFRA-6 | Benchmark trend visualization | Medium | M | Script that pulls 90 days of benchmark JSON artifacts and produces charts or CSVs. Spots gradual drift that per-PR checks miss. (done: the team ops dashboard charts benchmark trends on its /bench page) |
 | INFRA-7 | Automated budget enforcement | High | L | Hard budgets on critical metrics, CI fails if exceeded. Performance becomes a contract. Requires careful calibration for CI-vs-local variance and a warmup period as warnings-only. Risk of false positives creating CI noise. |
 | INFRA-8 | End-to-end performance test suite | High | L | Multiple representative user journeys (simple load, 100-cell pattern, LLM pattern, large list) measured wall-clock on every PR. Guarantees user-visible performance is protected, not just micro-benchmarks. Each scenario needs a pattern, test data, and harness. Maintenance scales with scenario count. (Note that the pattern unit tests integration test is the closest we have to that. It also run the backend in-memory, so it happens to measure both client and server in one go.) |

--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -1323,8 +1323,8 @@ Summary table; the full per-mechanism walkthrough with file references is in
 
     *Efficiency-only and accepted.* Final results are identical and single-runtime
     / static-graph workloads are neutral-to-faster (note-create @128 −22%,
-    unchanged-recompute −42%, targeted-dirty-rehydrate −50%). Accepted via
-    `NEW_PERF_BASELINE`.
+    unchanged-recompute −42%, targeted-dirty-rehydrate −50%). Accepted as a
+    deliberate efficiency-only tradeoff.
 
     *Corrected mechanism — single-runtime control (2026-06-28; SUPERSEDES the
     "per-node hash/freeze + idle sync" wording below).* The decisive control: the

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -260,6 +260,38 @@ Deno.test("baseline override parser rejects non-coverage-debt metrics", () => {
   );
 });
 
+Deno.test("baseline override parser reads legacy coverage-debt acceptance only when asked", () => {
+  const body =
+    "NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 123 lines";
+
+  // New PRs must use ACCEPT_COVERAGE_DEBT: the legacy form is ignored by default.
+  assertEquals(parseBaselineOverrides(body).metrics.size, 0);
+
+  // Merged baseline PRs from before the rename still count, so their
+  // acceptance truncates the baseline timeline.
+  const legacy = parseBaselineOverrides(body, true);
+  assertEquals(
+    legacy.metrics.get("coverage-debt: packages/runner uncovered lines"),
+    123,
+  );
+});
+
+Deno.test("legacy override parsing ignores the defunct timing form", () => {
+  // NEW_PERF_BASELINE once accepted timing regressions too; those gate nothing
+  // now, so a legacy timing line is ignored rather than rejected — a merged PR
+  // that carried one must still yield its coverage-debt acceptance.
+  const overrides = parseBaselineOverrides(
+    "NEW_PERF_BASELINE: job: Check = 7s\n" +
+      "NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 9 lines",
+    true,
+  );
+  assertEquals(overrides.metrics.size, 1);
+  assertEquals(
+    overrides.metrics.get("coverage-debt: packages/runner uncovered lines"),
+    9,
+  );
+});
+
 Deno.test("coverage baseline reset marker parses from PR body", () => {
   const overrides = parseBaselineOverrides(
     `Reset coverage debt for one cycle\n${COVERAGE_BASELINE_RESET_MARKER}\n`,

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -1,5 +1,4 @@
 import {
-  assertAlmostEquals,
   assertEquals,
   assertExists,
   assertFalse,
@@ -13,575 +12,33 @@ import {
   type Artifact,
   buildCoverageDebtSuggestionComment,
   buildCoverageResolvedComment,
-  compileCacheFamilyForMetric,
-  type CompileCacheState,
   type CompileCacheStates,
-  computeBaseline,
-  computeCiWallTimeRevisitSignals,
   COVERAGE_BASELINE_RESET_MARKER,
   COVERAGE_SUGGESTION_MARKER,
   coverageGroupsForChangedFiles,
   coverageMetricGroupName,
   downloadAndExtractArtifact,
-  dropColdSamples,
-  extractMetrics,
-  extractTimingArtifactMetrics,
   fetchArtifactsForRun,
   fetchCurrentPRBody,
   fetchPRBody,
   fetchPRFiles,
-  formatMetricValue,
   formatOverrideSuggestion,
   githubGet,
   githubPatch,
   githubPost,
-  type Job,
   latestNonColdSample,
   newestArtifactsByName,
-  newestTimingArtifacts,
   parseAddedLinesFromPatch,
   parseBaselineOverrides,
   parseCacheStateFiles,
-  parsePerfMetricsBackfillFile,
-  parsePerfMetricsFile,
-  parsePerfMetricsFileDetailed,
-  serializePerfMetrics,
-  serializePerfMetricsBackfill,
+  parseCoverageBaseline,
+  parseCoverageBaselineDetailed,
+  serializeCoverageBaseline,
   shouldGateCoverageDebtMetric,
-  type Step,
-  timingArtifactLabel,
   type TimingSample,
-  type WorkflowRun,
-} from "./perf-lib.ts";
+} from "./ci-check-lib.ts";
 
-function makeRun(): WorkflowRun {
-  return {
-    id: 1,
-    html_url: "https://example.test/run/1",
-    head_sha: "deadbeef",
-    created_at: "2026-01-01T00:00:00Z",
-    conclusion: "success",
-    event: "push",
-  };
-}
-
-function makeStep(
-  name: string,
-  started_at: string,
-  completed_at: string,
-): Step {
-  return { name, started_at, completed_at };
-}
-
-function makeJob(
-  id: number,
-  name: string,
-  started_at: string,
-  completed_at: string,
-  steps: Step[],
-): Job {
-  return { id, name, started_at, completed_at, steps };
-}
-
-Deno.test("extractMetrics keeps CLI core and fuse timings separate", () => {
-  const metrics = extractMetrics(makeRun(), [
-    makeJob(
-      1,
-      "CLI Integration Tests (core)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:03:20Z",
-      [
-        makeStep(
-          "🧪 Run CLI integration suite",
-          "2026-01-01T00:01:00Z",
-          "2026-01-01T00:03:00Z",
-        ),
-      ],
-    ),
-    makeJob(
-      2,
-      "CLI Integration Tests (fuse)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:35Z",
-      [
-        makeStep(
-          "🧪 Run CLI FUSE integration suite",
-          "2026-01-01T00:01:00Z",
-          "2026-01-01T00:01:30Z",
-        ),
-      ],
-    ),
-  ]);
-
-  assertEquals(
-    metrics.get("job: CLI Integration Tests (core)")?.durationSeconds,
-    200,
-  );
-  assertEquals(
-    metrics.get("job: CLI Integration Tests (fuse)")?.durationSeconds,
-    95,
-  );
-  assertEquals(
-    metrics.get("step: CLI integration (core)")?.durationSeconds,
-    120,
-  );
-  assertEquals(
-    metrics.get("step: CLI integration (fuse)")?.durationSeconds,
-    30,
-  );
-  assertEquals(metrics.has("job: CLI Integration Tests"), false);
-  assertEquals(metrics.has("step: CLI integration"), false);
-});
-
-Deno.test("extractMetrics aggregates split CLI core jobs", () => {
-  const metrics = extractMetrics(makeRun(), [
-    makeJob(
-      1,
-      "CLI Integration Tests (core-piece-values)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:40Z",
-      [
-        makeStep(
-          "🧪 Run CLI integration suite",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:01:20Z",
-        ),
-      ],
-    ),
-    makeJob(
-      2,
-      "CLI Integration Tests (core-piece-links)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:03:20Z",
-      [
-        makeStep(
-          "🧪 Run CLI integration suite",
-          "2026-01-01T00:01:00Z",
-          "2026-01-01T00:03:00Z",
-        ),
-      ],
-    ),
-    makeJob(
-      3,
-      "CLI Integration Tests (core-piece-call)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:02:40Z",
-      [
-        makeStep(
-          "🧪 Run CLI integration suite",
-          "2026-01-01T00:01:00Z",
-          "2026-01-01T00:02:30Z",
-        ),
-      ],
-    ),
-  ]);
-
-  assertEquals(
-    metrics.get("job: CLI Integration Tests (core-piece-values)")
-      ?.durationSeconds,
-    100,
-  );
-  assertEquals(
-    metrics.get("job: CLI Integration Tests (core-piece-links)")
-      ?.durationSeconds,
-    200,
-  );
-  assertEquals(
-    metrics.get("job: CLI Integration Tests (core-piece-call)")
-      ?.durationSeconds,
-    160,
-  );
-  assertEquals(
-    metrics.get("job: CLI Integration Tests (core)")?.durationSeconds,
-    200,
-  );
-  assertEquals(
-    metrics.get("step: CLI integration (core)")?.durationSeconds,
-    120,
-  );
-  assertEquals(metrics.has("job: CLI Integration Tests"), false);
-  assertEquals(metrics.has("step: CLI integration"), false);
-});
-
-Deno.test("extractMetrics aggregates package integration matrix jobs", () => {
-  const metrics = extractMetrics(makeRun(), [
-    makeJob(
-      1,
-      "Package Integration Tests (runner)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:20Z",
-      [
-        makeStep(
-          "🧪 Run runner integration tests",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:01:00Z",
-        ),
-      ],
-    ),
-    makeJob(
-      2,
-      "Package Integration Tests (shell)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:40Z",
-      [
-        makeStep(
-          "🧪 Run shell integration tests",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:01:30Z",
-        ),
-      ],
-    ),
-  ]);
-
-  assertEquals(
-    metrics.get("job: Package Integration Tests (runner)")?.durationSeconds,
-    80,
-  );
-  assertEquals(
-    metrics.get("job: Package Integration Tests (shell)")?.durationSeconds,
-    100,
-  );
-  assertEquals(
-    metrics.get("job: Package Integration Tests")?.durationSeconds,
-    100,
-  );
-  assertEquals(metrics.get("step: runner integration")?.durationSeconds, 50);
-  assertEquals(metrics.get("step: shell integration")?.durationSeconds, 80);
-});
-
-Deno.test("extractMetrics aggregates pattern integration matrix shards", () => {
-  const metrics = extractMetrics(makeRun(), [
-    makeJob(
-      1,
-      "Pattern Integration Tests (1/4)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:40Z",
-      [
-        makeStep(
-          "🧩 Run end-to-end patterns integration tests",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:01:30Z",
-        ),
-      ],
-    ),
-    makeJob(
-      2,
-      "Pattern Integration Tests (2/4)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:10Z",
-      [
-        makeStep(
-          "🧩 Run end-to-end patterns integration tests",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:01:00Z",
-        ),
-      ],
-    ),
-  ]);
-
-  assertEquals(
-    metrics.get("job: Pattern Integration Tests (1/4)")?.durationSeconds,
-    100,
-  );
-  assertEquals(
-    metrics.get("job: Pattern Integration Tests (2/4)")?.durationSeconds,
-    70,
-  );
-  assertEquals(
-    metrics.get("job: Pattern Integration Tests")?.durationSeconds,
-    100,
-  );
-  assertEquals(
-    metrics.get("step: patterns integration")?.durationSeconds,
-    80,
-  );
-});
-
-Deno.test("extractMetrics records pattern reload integration job", () => {
-  const metrics = extractMetrics(makeRun(), [
-    makeJob(
-      1,
-      "Pattern Reload Integration Tests",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:20Z",
-      [
-        makeStep(
-          "🧩 Run pattern reload integration tests",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:01:10Z",
-        ),
-      ],
-    ),
-  ]);
-
-  assertEquals(
-    metrics.get("job: Pattern Reload Integration Tests")?.durationSeconds,
-    80,
-  );
-  assertEquals(
-    metrics.get("step: pattern reload integration")?.durationSeconds,
-    60,
-  );
-});
-
-Deno.test("extractMetrics aggregates generated patterns matrix shards", () => {
-  const metrics = extractMetrics(makeRun(), [
-    makeJob(
-      1,
-      "Generated Patterns Integration Tests (1/4)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:40Z",
-      [
-        makeStep(
-          "🧪 Run generated patterns integration tests",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:01:30Z",
-        ),
-      ],
-    ),
-    makeJob(
-      2,
-      "Generated Patterns Integration Tests (2/4)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:10Z",
-      [
-        makeStep(
-          "🧪 Run generated patterns integration tests",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:01:00Z",
-        ),
-      ],
-    ),
-  ]);
-
-  assertEquals(
-    metrics.get("job: Generated Patterns Integration Tests (1/4)")
-      ?.durationSeconds,
-    100,
-  );
-  assertEquals(
-    metrics.get("job: Generated Patterns Integration Tests (2/4)")
-      ?.durationSeconds,
-    70,
-  );
-  assertEquals(
-    metrics.get("job: Generated Patterns Integration Tests")?.durationSeconds,
-    100,
-  );
-  assertEquals(
-    metrics.get("step: generated patterns integration")?.durationSeconds,
-    80,
-  );
-});
-
-Deno.test("extractMetrics aggregates runner test matrix shards", () => {
-  const metrics = extractMetrics(makeRun(), [
-    makeJob(
-      1,
-      "Runner Tests (1/5)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:40Z",
-      [
-        makeStep(
-          "🧪 Run runner tests",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:01:30Z",
-        ),
-      ],
-    ),
-    makeJob(
-      2,
-      "Runner Tests (2/5)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:10Z",
-      [
-        makeStep(
-          "🧪 Run runner tests",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:01:00Z",
-        ),
-      ],
-    ),
-  ]);
-
-  assertEquals(
-    metrics.get("job: Runner Tests (1/5)")?.durationSeconds,
-    100,
-  );
-  assertEquals(
-    metrics.get("job: Runner Tests (2/5)")?.durationSeconds,
-    70,
-  );
-  assertEquals(metrics.get("job: Runner Tests")?.durationSeconds, 100);
-  assertEquals(metrics.get("step: runner tests")?.durationSeconds, 80);
-});
-
-Deno.test("extractMetrics aggregates workspace test matrix shards", () => {
-  const metrics = extractMetrics(makeRun(), [
-    makeJob(
-      1,
-      "Test (1/4)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:03:20Z",
-      [
-        makeStep(
-          "🧪 Run parallel workspace tests",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:03:10Z",
-        ),
-      ],
-    ),
-    makeJob(
-      2,
-      "Test (2/4)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:02:30Z",
-      [
-        makeStep(
-          "🧪 Run parallel workspace tests",
-          "2026-01-01T00:00:10Z",
-          "2026-01-01T00:02:00Z",
-        ),
-      ],
-    ),
-  ]);
-
-  assertEquals(metrics.get("job: Test (1/4)")?.durationSeconds, 200);
-  assertEquals(metrics.get("job: Test (2/4)")?.durationSeconds, 150);
-  assertEquals(metrics.get("job: Test")?.durationSeconds, 200);
-  assertEquals(metrics.get("step: workspace tests")?.durationSeconds, 180);
-});
-
-Deno.test("extractMetrics records separate binary builds and their critical path", () => {
-  const metrics = extractMetrics(makeRun(), [
-    makeJob(
-      1,
-      "Build Binary (toolshed)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:03:20Z",
-      [
-        makeStep(
-          "🏗️ Build toolshed binary",
-          "2026-01-01T00:00:20Z",
-          "2026-01-01T00:03:00Z",
-        ),
-      ],
-    ),
-    makeJob(
-      2,
-      "Build Binary (bg-piece-service)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:40Z",
-      [
-        makeStep(
-          "🏗️ Build bg-piece-service binary",
-          "2026-01-01T00:00:20Z",
-          "2026-01-01T00:01:20Z",
-        ),
-      ],
-    ),
-    makeJob(
-      3,
-      "Build Binary (cf)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:02:30Z",
-      [
-        makeStep(
-          "🏗️ Build cf binary",
-          "2026-01-01T00:00:20Z",
-          "2026-01-01T00:02:10Z",
-        ),
-      ],
-    ),
-  ]);
-
-  assertEquals(
-    metrics.get("job: Build Binary (toolshed)")?.durationSeconds,
-    200,
-  );
-  assertEquals(
-    metrics.get("job: Build Binary (bg-piece-service)")?.durationSeconds,
-    100,
-  );
-  assertEquals(metrics.get("job: Build Binary (cf)")?.durationSeconds, 150);
-  assertEquals(metrics.get("job: Build Binaries")?.durationSeconds, 200);
-  assertEquals(
-    metrics.get("step: Build toolshed binary")?.durationSeconds,
-    160,
-  );
-  assertEquals(
-    metrics.get("step: Build bg-piece-service binary")?.durationSeconds,
-    60,
-  );
-  assertEquals(metrics.get("step: Build cf binary")?.durationSeconds, 110);
-  assertEquals(metrics.get("step: Build application")?.durationSeconds, 160);
-});
-
-Deno.test("timingArtifactLabel normalizes matrix shard artifacts", () => {
-  assertEquals(
-    timingArtifactLabel("test-timing-package-integration-runner"),
-    "package-integration",
-  );
-  assertEquals(
-    timingArtifactLabel("test-timing-pattern-integration-1"),
-    "pattern-integration",
-  );
-  assertEquals(
-    timingArtifactLabel("test-timing-pattern-reload-integration"),
-    "pattern-reload-integration",
-  );
-  assertEquals(
-    timingArtifactLabel("test-timing-generated-patterns-1"),
-    "generated-patterns",
-  );
-  assertEquals(
-    timingArtifactLabel("test-timing-package-integration"),
-    "package-integration",
-  );
-});
-
-Deno.test("timing artifacts combine internally sharded suites once per run", () => {
-  const suiteName =
-    "packages/patterns/integration/time-capability-full.test.ts";
-  const metrics = extractTimingArtifactMetrics(makeRun(), [
-    {
-      name: "test-timing-pattern-integration-1",
-      suites: [{
-        name: suiteName,
-        time: 117,
-        tests: [{ name: "case a", time: 30 }],
-      }],
-    },
-    {
-      name: "test-timing-pattern-integration-2",
-      suites: [{
-        name: suiteName,
-        time: 50,
-        tests: [{ name: "case b", time: 20 }],
-      }],
-    },
-  ]);
-
-  assertEquals(
-    metrics.get(`test: pattern-integration/${suiteName}`)?.durationSeconds,
-    117,
-  );
-  assertEquals(
-    metrics.get(
-      `subtest: pattern-integration/${suiteName} > case a`,
-    )?.durationSeconds,
-    30,
-  );
-  assertEquals(
-    metrics.get(
-      `subtest: pattern-integration/${suiteName} > case b`,
-    )?.durationSeconds,
-    20,
-  );
-  assertEquals(metrics.size, 3);
-});
-
-Deno.test("perf metrics files round-trip stable metric samples", () => {
+Deno.test("coverage baseline files round-trip stable metric samples", () => {
   const metrics = new Map([
     [
       "step: Type check",
@@ -605,48 +62,19 @@ Deno.test("perf metrics files round-trip stable metric samples", () => {
     ],
   ]);
 
-  const serialized = serializePerfMetrics(metrics);
+  const serialized = serializeCoverageBaseline(metrics);
   assertEquals(
     serialized.metrics.map((metric) => metric.name),
     ["job: Check", "step: Type check"],
   );
 
   assertEquals(
-    parsePerfMetricsFile(JSON.stringify(serialized)),
+    parseCoverageBaseline(JSON.stringify(serialized)),
     metrics,
   );
 });
 
-Deno.test("perf metrics backfill files round-trip run-keyed samples", () => {
-  const runMetrics = new Map([
-    [
-      123,
-      new Map([
-        [
-          "job: Check",
-          {
-            runId: 123,
-            runUrl: "https://example.test/run/123",
-            sha: "abc123",
-            createdAt: "2026-01-01T00:00:00Z",
-            durationSeconds: 60,
-          },
-        ],
-      ]),
-    ],
-  ]);
-
-  const serialized = serializePerfMetricsBackfill(runMetrics);
-  assertEquals(serialized.runs.map((run) => run.runId), [123]);
-  assertEquals(serialized.runs[0].metrics[0].name, "job: Check");
-
-  assertEquals(
-    parsePerfMetricsBackfillFile(JSON.stringify(serialized)),
-    runMetrics,
-  );
-});
-
-Deno.test("perf metrics files round-trip compile cache states", () => {
+Deno.test("coverage baseline files round-trip compile cache states", () => {
   const metrics = new Map<string, TimingSample>([
     [
       "job: Check",
@@ -664,32 +92,32 @@ Deno.test("perf metrics files round-trip compile cache states", () => {
     "pattern-unit": "warm",
   };
 
-  const serialized = JSON.stringify(serializePerfMetrics(metrics, states));
+  const serialized = JSON.stringify(serializeCoverageBaseline(metrics, states));
 
-  const detailed = parsePerfMetricsFileDetailed(serialized);
+  const detailed = parseCoverageBaselineDetailed(serialized);
   assertEquals(detailed.metrics, metrics);
   assertEquals(detailed.compileCacheStates, states);
 
   // The tagged file stays version 1, so the legacy parser still accepts it.
-  assertEquals(parsePerfMetricsFile(serialized), metrics);
+  assertEquals(parseCoverageBaseline(serialized), metrics);
 });
 
-Deno.test("parsePerfMetricsFileDetailed treats legacy files as untagged", () => {
-  const legacy = JSON.stringify(serializePerfMetrics(new Map()));
+Deno.test("parseCoverageBaselineDetailed treats legacy files as untagged", () => {
+  const legacy = JSON.stringify(serializeCoverageBaseline(new Map()));
   assertFalse(legacy.includes("compileCacheStates"));
 
-  const detailed = parsePerfMetricsFileDetailed(legacy);
+  const detailed = parseCoverageBaselineDetailed(legacy);
   assertEquals(detailed.compileCacheStates, null);
   assertEquals(detailed.metrics.size, 0);
 
   // Empty states are omitted too, so an all-unknown run stays untagged.
   assertFalse(
-    JSON.stringify(serializePerfMetrics(new Map(), {}))
+    JSON.stringify(serializeCoverageBaseline(new Map(), {}))
       .includes("compileCacheStates"),
   );
 });
 
-Deno.test("parsePerfMetricsFileDetailed drops invalid compile cache states", () => {
+Deno.test("parseCoverageBaselineDetailed drops invalid compile cache states", () => {
   const file = JSON.stringify({
     version: 1,
     generatedAt: "2026-01-01T00:00:00Z",
@@ -701,85 +129,9 @@ Deno.test("parsePerfMetricsFileDetailed drops invalid compile cache states", () 
     },
   });
 
-  assertEquals(parsePerfMetricsFileDetailed(file).compileCacheStates, {
+  assertEquals(parseCoverageBaselineDetailed(file).compileCacheStates, {
     "pattern-unit": "warm",
   });
-});
-
-Deno.test("compileCacheFamilyForMetric maps job, step, and test metrics to families", () => {
-  // Aggregate and per-shard job metrics.
-  assertEquals(
-    compileCacheFamilyForMetric("job: Generated Patterns Integration Tests"),
-    "generated-patterns",
-  );
-  assertEquals(
-    compileCacheFamilyForMetric(
-      "job: Generated Patterns Integration Tests (2/4)",
-    ),
-    "generated-patterns",
-  );
-  assertEquals(
-    compileCacheFamilyForMetric("job: Pattern Integration Tests"),
-    "pattern-integration",
-  );
-  assertEquals(
-    compileCacheFamilyForMetric("job: Pattern Integration Tests (3/4)"),
-    "pattern-integration",
-  );
-  assertEquals(
-    compileCacheFamilyForMetric("job: Pattern Unit Tests (3/5)"),
-    "pattern-unit",
-  );
-
-  // Step metrics.
-  assertEquals(
-    compileCacheFamilyForMetric("step: generated patterns integration"),
-    "generated-patterns",
-  );
-  assertEquals(
-    compileCacheFamilyForMetric("step: patterns integration"),
-    "pattern-integration",
-  );
-  assertEquals(
-    compileCacheFamilyForMetric("step: pattern unit tests"),
-    "pattern-unit",
-  );
-
-  // Per-test and per-subtest metrics keyed by timing-artifact label.
-  assertEquals(
-    compileCacheFamilyForMetric(
-      "test: generated-patterns/packages/patterns/foo.test.tsx",
-    ),
-    "generated-patterns",
-  );
-  assertEquals(
-    compileCacheFamilyForMetric(
-      "subtest: pattern-integration/packages/patterns/foo.test.tsx > case",
-    ),
-    "pattern-integration",
-  );
-  assertEquals(
-    compileCacheFamilyForMetric(
-      "test: pattern-unit-3/packages/patterns/foo.test.tsx",
-    ),
-    "pattern-unit",
-  );
-});
-
-Deno.test("compileCacheFamilyForMetric returns null for metrics without a compile cache", () => {
-  for (
-    const metric of [
-      "job: Runner Tests",
-      "job: Pattern Reload Integration Tests",
-      "step: runner tests",
-      "test: pattern-reload-integration/packages/patterns/foo.test.tsx",
-      "test: package-integration/packages/runner/foo.test.ts",
-      "subtest: pattern-unit/packages/patterns/foo.test.tsx > case",
-      "coverage-debt: workspace uncovered lines",
-    ]
-  ) {
-    assertEquals(compileCacheFamilyForMetric(metric), null, metric);
-  }
 });
 
 Deno.test("cache state aggregation treats any restore hit as warm", () => {
@@ -852,28 +204,6 @@ Deno.test("cache state parsing keeps valid unknown-family records inert", () => 
   });
 });
 
-Deno.test("dropColdSamples removes known-cold runs and keeps unknown ones", () => {
-  const sample = (runId: number): TimingSample => ({
-    runId,
-    runUrl: `https://example.test/run/${runId}`,
-    sha: `sha${runId}`,
-    createdAt: `2026-01-0${runId}T00:00:00Z`,
-    durationSeconds: runId,
-  });
-  const states = new Map<number, CompileCacheState>([
-    [1, "warm"],
-    [2, "cold"],
-    // Run 3 has no recorded state: unknown runs are kept.
-  ]);
-
-  const kept = dropColdSamples(
-    [sample(1), sample(2), sample(3)],
-    (runId) => states.get(runId),
-  );
-
-  assertEquals(kept.map((s) => s.runId), [1, 3]);
-});
-
 Deno.test("latestNonColdSample skips trailing cold runs and falls back when all are cold", () => {
   const sample = (runId: number): TimingSample => ({
     runId,
@@ -895,180 +225,38 @@ Deno.test("latestNonColdSample skips trailing cold runs and falls back when all 
   assertEquals(latestNonColdSample([], () => false), undefined);
 });
 
-Deno.test("computeCiWallTimeRevisitSignals stays quiet for balanced CI", () => {
-  const signals = computeCiWallTimeRevisitSignals([
-    makeJob(
-      1,
-      "Pattern Integration Tests (1/4)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:02:00Z",
-      [],
-    ),
-    makeJob(
-      2,
-      "CLI Integration Tests (core-piece-call)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:50Z",
-      [],
-    ),
-    makeJob(
-      3,
-      "Package Integration Tests (shell)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:45Z",
-      [],
-    ),
-    makeJob(
-      4,
-      "Generated Patterns Integration Tests (1/4)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:40Z",
-      [],
-    ),
-    makeJob(
-      5,
-      "Runner Tests (1/5)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:35Z",
-      [],
-    ),
-  ]);
-
-  assertEquals(signals, []);
-});
-
-Deno.test("computeCiWallTimeRevisitSignals flags slow and imbalanced jobs", () => {
-  const signals = computeCiWallTimeRevisitSignals([
-    makeJob(
-      1,
-      "Pattern Integration Tests (2/4)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:04:00Z",
-      [],
-    ),
-    makeJob(
-      2,
-      "CLI Integration Tests (core-piece-call)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:40Z",
-      [],
-    ),
-    makeJob(
-      3,
-      "Package Integration Tests (shell)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:35Z",
-      [],
-    ),
-    makeJob(
-      4,
-      "Generated Patterns Integration Tests (1/4)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:30Z",
-      [],
-    ),
-    makeJob(
-      5,
-      "Runner Tests (1/5)",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:25Z",
-      [],
-    ),
-  ]);
-
-  assertEquals(
-    signals.map((signal) => signal.kind),
-    ["slow-job", "job-imbalance"],
-  );
-  assertEquals(
-    signals[0].detail,
-    "Pattern Integration Tests (2/4) took 4m 0s",
-  );
-});
-
-Deno.test("computeCiWallTimeRevisitSignals flags long required wall time", () => {
-  const signals = computeCiWallTimeRevisitSignals([
-    makeJob(
-      1,
-      "Check",
-      "2026-01-01T00:00:00Z",
-      "2026-01-01T00:01:00Z",
-      [],
-    ),
-    makeJob(
-      2,
-      "Pattern Integration Tests (1/4)",
-      "2026-01-01T00:07:30Z",
-      "2026-01-01T00:08:30Z",
-      [],
-    ),
-    makeJob(
-      3,
-      "Deploy to Toolshed (Staging)",
-      "2026-01-01T00:20:00Z",
-      "2026-01-01T00:25:00Z",
-      [],
-    ),
-  ]);
-
-  assertEquals(
-    signals.map((signal) => signal.kind),
-    ["required-wall-time"],
-  );
-  assertEquals(
-    signals[0].detail,
-    "Required non-deploy jobs took 8m 30s from first start to last completion",
-  );
-});
-
-Deno.test("computeBaseline enforces the 50 percent floor for low-variance samples", () => {
-  const baseline = computeBaseline([100, 100, 100, 100, 100]);
-
-  assertEquals(baseline?.median, 100);
-  assertEquals(baseline?.stddev, 0);
-  assertAlmostEquals(baseline?.threshold ?? 0, 150, 1e-9);
-});
-
-Deno.test("computeBaseline uses the 3 sigma threshold when it exceeds 50 percent", () => {
-  const baseline = computeBaseline([100, 100, 100, 100, 150]);
-
-  assertEquals(baseline?.median, 100);
-  assertAlmostEquals(baseline?.stddev ?? 0, 20, 1e-9);
-  assertEquals(baseline?.threshold, 160);
-});
-
 Deno.test("coverage debt metrics format and parse line units", () => {
   const metric = "coverage-debt: workspace uncovered lines";
-  assertEquals(formatMetricValue(metric, 12), "12 lines");
-  assertEquals(formatMetricValue(metric, 1), "1 line");
-  assertEquals(formatOverrideSuggestion(metric, 12.2), "13 lines");
+  assertEquals(formatOverrideSuggestion(12.2), "13 lines");
+  assertEquals(formatOverrideSuggestion(1), "1 line");
 
   const overrides = parseBaselineOverrides(
-    "NEW_PERF_BASELINE: coverage-debt: workspace uncovered lines = 7 lines",
+    "ACCEPT_COVERAGE_DEBT: coverage-debt: workspace uncovered lines = 7 lines",
   );
   assertEquals(overrides.metrics.get(metric), 7);
   assertEquals(overrides.coverageBaselineReset, false);
 });
 
-Deno.test("baseline override parser rejects line units for non-coverage metrics", () => {
-  assertThrows(
-    () =>
-      parseBaselineOverrides(
-        "NEW_PERF_BASELINE: job: Check = 7 lines",
-      ),
-    Error,
-    "line units are only valid for coverage-debt metrics",
+Deno.test("baseline override parser accepts coverage-debt line overrides", () => {
+  const overrides = parseBaselineOverrides(
+    "ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 123 lines",
   );
+
+  assertEquals(
+    overrides.metrics.get("coverage-debt: packages/runner uncovered lines"),
+    123,
+  );
+  assertEquals(overrides.coverageBaselineReset, false);
 });
 
-Deno.test("baseline override parser rejects time units for coverage metrics", () => {
+Deno.test("baseline override parser rejects non-coverage-debt metrics", () => {
   assertThrows(
     () =>
       parseBaselineOverrides(
-        "NEW_PERF_BASELINE: coverage-debt: workspace uncovered lines = 7s",
+        "ACCEPT_COVERAGE_DEBT: job: Check = 7 lines",
       ),
     Error,
-    "coverage-debt metrics must use line units",
+    "only coverage-debt metrics can be accepted",
   );
 });
 
@@ -1140,7 +328,7 @@ Deno.test("coverage debt gating follows changed source groups", () => {
     "packages/runner/src/cell.ts",
     "packages/patterns/README.md",
     "packages/ui/src/button.test.tsx",
-    "tasks/perf-check.ts",
+    "tasks/coverage-check.ts",
     "scripts/build.ts",
   ]);
 
@@ -1805,34 +993,6 @@ Deno.test("newestArtifactsByName keeps the latest re-run upload per name", () =>
     [
       ["test-timing-pattern-unit-1", 150],
       ["test-timing-pattern-unit-4", 200],
-    ],
-  );
-});
-
-Deno.test("newestTimingArtifacts drops stale, expired, and unrelated artifacts", () => {
-  const artifact = (
-    id: number,
-    name: string,
-    expired = false,
-  ): Artifact => ({
-    id,
-    name,
-    size_in_bytes: 1,
-    expired,
-  });
-  const result = newestTimingArtifacts([
-    artifact(200, "test-timing-pattern-integration-3"),
-    artifact(150, "test-timing-pattern-integration-1"),
-    artifact(100, "test-timing-pattern-integration-3"),
-    artifact(300, "test-timing-pattern-integration-4", true),
-    artifact(400, "coverage-profile-pattern-integration-2"),
-  ]);
-
-  assertEquals(
-    result.map((item) => [item.name, item.id]).sort(),
-    [
-      ["test-timing-pattern-integration-1", 150],
-      ["test-timing-pattern-integration-3", 200],
     ],
   );
 });

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -1,8 +1,8 @@
 /**
- * Shared library for CI performance regression detection.
+ * Shared library for the CI coverage-debt gate.
  *
  * Used by:
- *   - perf-check.ts            (per-PR CI gate)
+ *   - coverage-check.ts        (per-PR coverage-debt gate)
  *   - post-coverage-comment.ts (posts the gate's coverage comment)
  */
 
@@ -13,10 +13,19 @@
 export const REPO = Deno.env.get("GITHUB_REPOSITORY") ?? "commontoolsinc/labs";
 export const TOKEN = Deno.env.get("GITHUB_TOKEN");
 export const WORKFLOW_FILE = "deno.yml";
+
+/**
+ * The per-run artifact and file the coverage check writes: this run's
+ * coverage-debt metrics and its per-family compile cache states, so a later PR
+ * run can read a recent main run's coverage as the ratchet baseline and know
+ * whether that run was cold. The name `perf-metrics` is historical — the
+ * artifact once also carried CI timing metrics for the removed performance gate
+ * — and is kept so the ratchet baseline needs no migration. A run from before
+ * the gate was removed recorded the same coverage metrics and cache states here
+ * in the identical JSON shape, so it reads as a valid baseline unchanged.
+ */
 export const PERF_METRICS_ARTIFACT_NAME = "perf-metrics";
 export const PERF_METRICS_FILE = "perf-metrics.json";
-export const PERF_METRICS_BACKFILL_ARTIFACT_NAME = "perf-metrics-backfill";
-export const PERF_METRICS_BACKFILL_FILE = "perf-metrics-backfill.json";
 
 /**
  * Prefix of the per-shard artifacts the pattern jobs upload to record whether
@@ -83,18 +92,6 @@ export const COVERAGE_LOCAL_CHECK_COMMAND = [
   '  --profile-dir="$(pwd)/coverage/raw/local" --root="$(pwd)"',
 ].join("\n");
 
-/** Minimum number of historical samples before we compute a baseline. */
-export const MIN_SAMPLES = 5;
-
-/** Standard deviations above the median to flag a regression. */
-export const STDDEV_FACTOR = 3;
-
-/** Minimum percentage increase over median to flag a regression. */
-export const MIN_REGRESSION_PCT = 0.50;
-
-/** Minimum absolute increase (in seconds) over median. */
-export const MIN_ABSOLUTE_DELTA = 2;
-
 /** Concurrency limit for API calls. */
 export const API_CONCURRENCY = 5;
 
@@ -109,20 +106,6 @@ export interface WorkflowRun {
   created_at: string;
   conclusion: string;
   event: string;
-}
-
-export interface Job {
-  id: number;
-  name: string;
-  started_at: string | null;
-  completed_at: string | null;
-  steps: Step[];
-}
-
-export interface Step {
-  name: string;
-  started_at: string | null;
-  completed_at: string | null;
 }
 
 export interface Artifact {
@@ -145,7 +128,7 @@ export interface TimingSample {
   durationSeconds: number;
 }
 
-export interface PerfMetricRecord extends TimingSample {
+export interface MetricRecord extends TimingSample {
   name: string;
 }
 
@@ -171,9 +154,9 @@ export type CompileCacheFamily = (typeof COMPILE_CACHE_FAMILIES)[number];
 export type CompileCacheState = "cold" | "warm";
 
 /**
- * Per-family compile cache states for a run. An absent family is unknown
- * (pre-rollout runs, backfill-derived runs) and is treated like today: no
- * filtering, no special status.
+ * Per-family compile cache states for a run. An absent family is unknown (a
+ * run whose cache-state artifact never recorded or could not be read) and is
+ * treated as not-cold: it is not excluded from the coverage ratchet baseline.
  */
 export type CompileCacheStates = Partial<
   Record<CompileCacheFamily, CompileCacheState>
@@ -193,50 +176,20 @@ export interface CacheStateRecord {
   exactHit: boolean;
 }
 
-export interface PerfMetricsFile {
+export interface CoverageBaselineFile {
   version: 1;
   generatedAt: string;
-  metrics: PerfMetricRecord[];
+  metrics: MetricRecord[];
   /**
    * Per-family compile cache states for the run this file describes. Absent
-   * in files written before cache-state tagging rolled out.
+   * when no cache-state artifact recorded for the run.
    */
   compileCacheStates?: CompileCacheStates;
-}
-
-export interface PerfMetricsBackfillRun {
-  runId: number;
-  metrics: PerfMetricRecord[];
-}
-
-export interface PerfMetricsBackfillFile {
-  version: 1;
-  generatedAt: string;
-  runs: PerfMetricsBackfillRun[];
 }
 
 export interface MetricTimeline {
   name: string;
   samples: TimingSample[];
-}
-
-export interface Baseline {
-  median: number;
-  stddev: number;
-  variance: number;
-  count: number;
-  threshold: number;
-}
-
-export interface JUnitTestSuite {
-  name: string;
-  time: number;
-  tests: { name: string; time: number }[];
-}
-
-export interface ParsedTimingArtifact {
-  name: string;
-  suites: JUnitTestSuite[];
 }
 
 export interface PRInfo {
@@ -267,21 +220,10 @@ export interface CurrentPRBody {
 }
 
 export interface BaselineOverrides {
-  /** Metric name -> value in the metric's native unit. */
+  /** Coverage-debt metric name -> accepted uncovered-line count. */
   metrics: Map<string, number>;
   /** Reset all coverage-debt metrics at the commit carrying this marker. */
   coverageBaselineReset: boolean;
-}
-
-export type CiWallTimeRevisitSignalKind =
-  | "slow-job"
-  | "job-imbalance"
-  | "required-wall-time";
-
-export interface CiWallTimeRevisitSignal {
-  kind: CiWallTimeRevisitSignalKind;
-  title: string;
-  detail: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -450,15 +392,8 @@ export async function mapConcurrent<T, R>(
 }
 
 // ---------------------------------------------------------------------------
-// Fetch jobs / artifacts
+// Fetch artifacts
 // ---------------------------------------------------------------------------
-
-export async function fetchJobsForRun(runId: number): Promise<Job[]> {
-  const data = await githubGet<{ jobs: Job[] }>(
-    `/repos/${REPO}/actions/runs/${runId}/jobs?per_page=100`,
-  );
-  return data.jobs;
-}
 
 export async function fetchArtifactsForRun(
   runId: number,
@@ -505,44 +440,11 @@ export function newestArtifactsByName(artifacts: Artifact[]): Artifact[] {
   return [...byName.values()];
 }
 
-export function newestTimingArtifacts(artifacts: Artifact[]): Artifact[] {
-  return newestArtifactsByName(
-    artifacts.filter((artifact) =>
-      artifact.name.startsWith("test-timing-") && !artifact.expired
-    ),
-  );
-}
-
-// ---------------------------------------------------------------------------
-// JUnit artifact parsing
-// ---------------------------------------------------------------------------
-
-export async function downloadAndParseJUnit(
-  artifactId: number,
-): Promise<JUnitTestSuite[]> {
-  const tmpDir = await downloadAndExtractArtifact(artifactId, "perf-junit-");
-  if (!tmpDir) return [];
-  try {
-    const suites: JUnitTestSuite[] = [];
-    for await (const entry of walkFiles(tmpDir)) {
-      if (entry.endsWith(".xml")) {
-        const content = await Deno.readTextFile(entry);
-        suites.push(...parseJUnitXml(content));
-      }
-    }
-    return suites;
-  } finally {
-    try {
-      await Deno.remove(tmpDir, { recursive: true });
-    } catch { /* ignore cleanup errors */ }
-  }
-}
-
-export function serializePerfMetrics(
+export function serializeCoverageBaseline(
   metrics: Map<string, TimingSample>,
   compileCacheStates?: CompileCacheStates,
-): PerfMetricsFile {
-  const file: PerfMetricsFile = {
+): CoverageBaselineFile {
+  const file: CoverageBaselineFile = {
     version: 1,
     generatedAt: new Date().toISOString(),
     metrics: metricsToRecords(metrics),
@@ -555,18 +457,18 @@ export function serializePerfMetrics(
 
 function metricsToRecords(
   metrics: Map<string, TimingSample>,
-): PerfMetricRecord[] {
+): MetricRecord[] {
   return [...metrics.entries()]
     .map(([name, sample]) => ({ name, ...sample }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export function parsePerfMetricsFile(
+export function parseCoverageBaseline(
   content: string,
 ): Map<string, TimingSample> {
-  const parsed = JSON.parse(content) as Partial<PerfMetricsFile>;
+  const parsed = JSON.parse(content) as Partial<CoverageBaselineFile>;
   if (parsed.version !== 1 || !Array.isArray(parsed.metrics)) {
-    throw new Error("Unsupported perf metrics file format.");
+    throw new Error("Unsupported coverage baseline file format.");
   }
 
   const metrics = new Map<string, TimingSample>();
@@ -579,7 +481,7 @@ export function parsePerfMetricsFile(
       typeof metric.createdAt !== "string" ||
       typeof metric.durationSeconds !== "number"
     ) {
-      throw new Error("Invalid perf metric record.");
+      throw new Error("Invalid coverage baseline metric record.");
     }
 
     metrics.set(metric.name, {
@@ -593,10 +495,10 @@ export function parsePerfMetricsFile(
   return metrics;
 }
 
-/** Parsed perf metrics plus the run's compile cache states, when tagged. */
-export interface PerfMetricsDetailed {
+/** Parsed coverage baseline plus the run's compile cache states, when tagged. */
+export interface CoverageBaselineDetailed {
   metrics: Map<string, TimingSample>;
-  /** Null when the file predates cache-state tagging. */
+  /** Null when the file recorded no compile cache states. */
   compileCacheStates: CompileCacheStates | null;
 }
 
@@ -606,15 +508,15 @@ const COMPILE_CACHE_FAMILY_SET: ReadonlySet<string> = new Set(
 
 /**
  * Parse a perf metrics file, also surfacing its optional compile cache
- * states. Metric validation matches {@link parsePerfMetricsFile}; unknown
+ * states. Metric validation matches {@link parseCoverageBaseline}; unknown
  * families and invalid state values are dropped rather than failing, so a
  * malformed tag degrades to "unknown" instead of losing the run's metrics.
  */
-export function parsePerfMetricsFileDetailed(
+export function parseCoverageBaselineDetailed(
   content: string,
-): PerfMetricsDetailed {
-  const metrics = parsePerfMetricsFile(content);
-  const parsed = JSON.parse(content) as Partial<PerfMetricsFile>;
+): CoverageBaselineDetailed {
+  const metrics = parseCoverageBaseline(content);
+  const parsed = JSON.parse(content) as Partial<CoverageBaselineFile>;
 
   const rawStates = parsed.compileCacheStates;
   if (rawStates === undefined || rawStates === null) {
@@ -632,48 +534,7 @@ export function parsePerfMetricsFileDetailed(
   return { metrics, compileCacheStates };
 }
 
-export function serializePerfMetricsBackfill(
-  metricsByRunId: Map<number, Map<string, TimingSample>>,
-): PerfMetricsBackfillFile {
-  return {
-    version: 1,
-    generatedAt: new Date().toISOString(),
-    runs: [...metricsByRunId.entries()]
-      .map(([runId, metrics]) => ({
-        runId,
-        metrics: metricsToRecords(metrics),
-      }))
-      .sort((a, b) => a.runId - b.runId),
-  };
-}
-
-export function parsePerfMetricsBackfillFile(
-  content: string,
-): Map<number, Map<string, TimingSample>> {
-  const parsed = JSON.parse(content) as Partial<PerfMetricsBackfillFile>;
-  if (parsed.version !== 1 || !Array.isArray(parsed.runs)) {
-    throw new Error("Unsupported perf metrics backfill file format.");
-  }
-
-  const metricsByRunId = new Map<number, Map<string, TimingSample>>();
-  for (const run of parsed.runs) {
-    if (typeof run.runId !== "number" || !Array.isArray(run.metrics)) {
-      throw new Error("Invalid perf metrics backfill run.");
-    }
-
-    metricsByRunId.set(
-      run.runId,
-      parsePerfMetricsFile(JSON.stringify({
-        version: 1,
-        generatedAt: parsed.generatedAt ?? "",
-        metrics: run.metrics,
-      })),
-    );
-  }
-  return metricsByRunId;
-}
-
-export async function writePerfMetricsFile(
+export async function writeCoverageBaselineFile(
   path: string,
   metrics: Map<string, TimingSample>,
   compileCacheStates?: CompileCacheStates,
@@ -682,22 +543,10 @@ export async function writePerfMetricsFile(
     path,
     `${
       JSON.stringify(
-        serializePerfMetrics(metrics, compileCacheStates),
+        serializeCoverageBaseline(metrics, compileCacheStates),
         null,
         2,
       )
-    }\n`,
-  );
-}
-
-export async function writePerfMetricsBackfillFile(
-  path: string,
-  metricsByRunId: Map<number, Map<string, TimingSample>>,
-): Promise<void> {
-  await Deno.writeTextFile(
-    path,
-    `${
-      JSON.stringify(serializePerfMetricsBackfill(metricsByRunId), null, 2)
     }\n`,
   );
 }
@@ -796,42 +645,18 @@ export async function downloadAndExtractArtifact(
 }
 
 /**
- * Download a perf-metrics artifact and parse its metrics along with the run's
- * compile cache states (null when the file predates cache-state tagging).
+ * Download the per-run perf-metrics artifact and parse the coverage baseline it
+ * records — its coverage-debt metrics along with the run's compile cache states
+ * (null when the file recorded no cache states).
  */
-export async function downloadAndParsePerfMetricsDetailed(
+export async function downloadAndParseCoverageBaseline(
   artifactId: number,
-): Promise<PerfMetricsDetailed | null> {
-  const tmpDir = await downloadAndExtractArtifact(
-    artifactId,
-    "perf-metrics-",
-  );
+): Promise<CoverageBaselineDetailed | null> {
+  const tmpDir = await downloadAndExtractArtifact(artifactId, "perf-metrics-");
   if (!tmpDir) return null;
   try {
-    const jsonPath = `${tmpDir}/${PERF_METRICS_FILE}`;
-    const content = await Deno.readTextFile(jsonPath);
-    return parsePerfMetricsFileDetailed(content);
-  } catch {
-    return null;
-  } finally {
-    try {
-      await Deno.remove(tmpDir, { recursive: true });
-    } catch { /* ignore cleanup errors */ }
-  }
-}
-
-export async function downloadAndParsePerfMetricsBackfill(
-  artifactId: number,
-): Promise<Map<number, Map<string, TimingSample>> | null> {
-  const tmpDir = await downloadAndExtractArtifact(
-    artifactId,
-    "perf-metrics-backfill-",
-  );
-  if (!tmpDir) return null;
-  try {
-    const jsonPath = `${tmpDir}/${PERF_METRICS_BACKFILL_FILE}`;
-    const content = await Deno.readTextFile(jsonPath);
-    return parsePerfMetricsBackfillFile(content);
+    const content = await Deno.readTextFile(`${tmpDir}/${PERF_METRICS_FILE}`);
+    return parseCoverageBaselineDetailed(content);
   } catch {
     return null;
   } finally {
@@ -847,433 +672,6 @@ export async function* walkFiles(dir: string): AsyncGenerator<string> {
     if (entry.isDirectory) yield* walkFiles(full);
     else yield full;
   }
-}
-
-export function parseJUnitXml(xml: string): JUnitTestSuite[] {
-  const suites: JUnitTestSuite[] = [];
-
-  const suiteRegex =
-    /<testsuite\s[^>]*?name="([^"]*)"[^>]*?time="([^"]*)"[^>]*?>([\s\S]*?)<\/testsuite>/g;
-  const caseRegex =
-    /<testcase\s[^>]*?name="([^"]*)"[^>]*?time="([^"]*)"[^>]*?\/?>(?:<\/testcase>)?/g;
-
-  let suiteMatch;
-  while ((suiteMatch = suiteRegex.exec(xml)) !== null) {
-    const [, suiteName, suiteTime, suiteBody] = suiteMatch;
-    const tests: { name: string; time: number }[] = [];
-
-    let caseMatch;
-    while ((caseMatch = caseRegex.exec(suiteBody)) !== null) {
-      tests.push({
-        name: caseMatch[1],
-        time: parseFloat(caseMatch[2]) || 0,
-      });
-    }
-
-    suites.push({
-      name: suiteName,
-      time: parseFloat(suiteTime) || 0,
-      tests,
-    });
-  }
-
-  return suites;
-}
-
-export function timingArtifactLabel(artifactName: string): string {
-  const label = artifactName.replace(/^test-timing-/, "");
-  return label
-    .replace(/^package-integration-.+$/, "package-integration")
-    .replace(/^pattern-integration-\d+$/, "pattern-integration")
-    .replace(/^generated-patterns-\d+$/, "generated-patterns");
-}
-
-// ---------------------------------------------------------------------------
-// Metric extraction from jobs/steps
-// ---------------------------------------------------------------------------
-
-function durationSeconds(
-  start: string | null,
-  end: string | null,
-): number {
-  if (!start || !end) return 0;
-  return (new Date(end).getTime() - new Date(start).getTime()) / 1000;
-}
-
-function normalizeName(name: string): string {
-  return name
-    .replace(
-      /[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{FE00}-\u{FE0F}\u{1FA00}-\u{1FAFF}]/gu,
-      "",
-    )
-    .trim();
-}
-
-const JOB_METRIC_NAMES: Record<string, string> = {
-  "Package Integration Tests": "job: Package Integration Tests",
-  "CLI Integration Tests (core)": "job: CLI Integration Tests (core)",
-  "CLI Integration Tests (core-piece-basics)":
-    "job: CLI Integration Tests (core-piece-basics)",
-  "CLI Integration Tests (core-piece-values)":
-    "job: CLI Integration Tests (core-piece-values)",
-  "CLI Integration Tests (core-piece-links)":
-    "job: CLI Integration Tests (core-piece-links)",
-  "CLI Integration Tests (core-piece-call)":
-    "job: CLI Integration Tests (core-piece-call)",
-  "CLI Integration Tests (fuse)": "job: CLI Integration Tests (fuse)",
-  // Legacy pre-matrix job name retained for older baselines and overrides.
-  "CLI Integration Tests": "job: CLI Integration Tests",
-  "Pattern Integration Tests": "job: Pattern Integration Tests",
-  "Pattern Reload Integration Tests": "job: Pattern Reload Integration Tests",
-  "Generated Patterns Integration Tests":
-    "job: Generated Patterns Integration Tests",
-  "Runner Tests": "job: Runner Tests",
-  "Build Binary (toolshed)": "job: Build Binary (toolshed)",
-  "Build Binary (bg-piece-service)": "job: Build Binary (bg-piece-service)",
-  "Build Binary (cf)": "job: Build Binary (cf)",
-  "Build Binaries": "job: Build Binaries",
-  "Test": "job: Test",
-  "Check": "job: Check",
-  "Test and Build": "job: Test and Build",
-};
-
-/** Pattern for matrix jobs like "Pattern Unit Tests (1/5)". */
-export const PACKAGE_INTEGRATION_RE = /Package Integration Tests\s*\(([^)]+)\)/;
-export const PATTERN_UNIT_RE = /Pattern Unit Tests\s*\((\d+)\/(\d+)\)/;
-export const PATTERN_INTEGRATION_RE =
-  /Pattern Integration Tests\s*\((\d+)\/(\d+)\)/;
-export const GENERATED_PATTERNS_RE =
-  /Generated Patterns Integration Tests\s*\((\d+)\/(\d+)\)/;
-export const RUNNER_TEST_RE = /Runner Tests\s*\((\d+)\/(\d+)\)/;
-export const CLI_CORE_SPLIT_RE = /CLI Integration Tests\s*\((core-[^)]+)\)/;
-// Anchored so it does not match the other sharded "... Tests (n/m)" jobs.
-export const WORKSPACE_TEST_RE = /^Test\s*\((\d+)\/(\d+)\)$/;
-
-interface StepMetricMatcher {
-  jobName: string;
-  stepKeyword: string;
-  metricName: string;
-}
-
-const STEP_METRIC_MATCHERS: StepMetricMatcher[] = [
-  {
-    jobName: "Package Integration Tests",
-    stepKeyword: "runner integration",
-    metricName: "step: runner integration",
-  },
-  {
-    jobName: "Package Integration Tests",
-    stepKeyword: "runtime-client integration",
-    metricName: "step: runtime-client integration",
-  },
-  {
-    jobName: "Package Integration Tests",
-    stepKeyword: "shell integration",
-    metricName: "step: shell integration",
-  },
-  {
-    jobName: "Package Integration Tests",
-    stepKeyword: "background worker integration",
-    metricName: "step: background worker integration",
-  },
-  {
-    jobName: "Pattern Integration Tests",
-    stepKeyword: "patterns integration",
-    metricName: "step: patterns integration",
-  },
-  {
-    jobName: "Pattern Reload Integration Tests",
-    stepKeyword: "pattern reload integration",
-    metricName: "step: pattern reload integration",
-  },
-  {
-    jobName: "Generated Patterns Integration Tests",
-    stepKeyword: "generated patterns integration",
-    metricName: "step: generated patterns integration",
-  },
-  {
-    jobName: "Runner Tests",
-    stepKeyword: "runner tests",
-    metricName: "step: runner tests",
-  },
-  {
-    jobName: "CLI Integration Tests (core)",
-    stepKeyword: "cli integration suite",
-    metricName: "step: CLI integration (core)",
-  },
-  {
-    jobName: "CLI Integration Tests (fuse)",
-    stepKeyword: "cli fuse integration suite",
-    metricName: "step: CLI integration (fuse)",
-  },
-  {
-    jobName: "CLI Integration Tests",
-    stepKeyword: "cli integration suite",
-    metricName: "step: CLI integration",
-  },
-  {
-    jobName: "Pattern Unit Tests",
-    stepKeyword: "pattern unit tests",
-    metricName: "step: pattern unit tests",
-  },
-  {
-    jobName: "Check",
-    stepKeyword: "type check",
-    metricName: "step: Type check",
-  },
-  {
-    jobName: "Test",
-    stepKeyword: "workspace tests",
-    metricName: "step: workspace tests",
-  },
-  {
-    jobName: "Build Binaries",
-    stepKeyword: "build application",
-    metricName: "step: Build application",
-  },
-  {
-    jobName: "Build Binary (toolshed)",
-    stepKeyword: "build toolshed binary",
-    metricName: "step: Build toolshed binary",
-  },
-  {
-    jobName: "Build Binary (bg-piece-service)",
-    stepKeyword: "build bg-piece-service binary",
-    metricName: "step: Build bg-piece-service binary",
-  },
-  {
-    jobName: "Build Binary (cf)",
-    stepKeyword: "build cf binary",
-    metricName: "step: Build cf binary",
-  },
-];
-
-const BUILD_BINARY_RE = /^Build Binary \((toolshed|bg-piece-service|cf)\)$/;
-
-export function extractMetrics(
-  run: WorkflowRun,
-  jobs: Job[],
-): Map<string, TimingSample> {
-  const metrics = new Map<string, TimingSample>();
-
-  const makeSample = (duration: number): TimingSample => ({
-    runId: run.id,
-    runUrl: run.html_url,
-    sha: run.head_sha,
-    createdAt: run.created_at,
-    durationSeconds: duration,
-  });
-
-  const setMaxMetric = (name: string, sample: TimingSample) => {
-    const existing = metrics.get(name);
-    if (!existing || sample.durationSeconds > existing.durationSeconds) {
-      metrics.set(name, sample);
-    }
-  };
-
-  for (const job of jobs) {
-    const jobDuration = durationSeconds(job.started_at, job.completed_at);
-    if (jobDuration <= 0) continue;
-
-    const normalizedJobName = normalizeName(job.name);
-    const buildBinaryMatch = BUILD_BINARY_RE.exec(normalizedJobName);
-
-    const jobMetricName = JOB_METRIC_NAMES[normalizedJobName];
-    if (jobMetricName) {
-      const sample = makeSample(jobDuration);
-      metrics.set(jobMetricName, sample);
-      if (buildBinaryMatch) {
-        setMaxMetric("job: Build Binaries", sample);
-      }
-    }
-
-    const packageIntegrationMatch = PACKAGE_INTEGRATION_RE.exec(
-      normalizedJobName,
-    );
-    const unitMatch = PATTERN_UNIT_RE.exec(normalizedJobName);
-    const patternIntegrationMatch = PATTERN_INTEGRATION_RE.exec(
-      normalizedJobName,
-    );
-    const generatedPatternsMatch = GENERATED_PATTERNS_RE.exec(
-      normalizedJobName,
-    );
-    const runnerTestMatch = RUNNER_TEST_RE.exec(normalizedJobName);
-    const cliCoreSplitMatch = CLI_CORE_SPLIT_RE.exec(normalizedJobName);
-    const workspaceTestMatch = WORKSPACE_TEST_RE.exec(normalizedJobName);
-
-    const matcherJobName = packageIntegrationMatch
-      ? "Package Integration Tests"
-      : unitMatch
-      ? "Pattern Unit Tests"
-      : patternIntegrationMatch
-      ? "Pattern Integration Tests"
-      : generatedPatternsMatch
-      ? "Generated Patterns Integration Tests"
-      : runnerTestMatch
-      ? "Runner Tests"
-      : cliCoreSplitMatch
-      ? "CLI Integration Tests (core)"
-      : workspaceTestMatch
-      ? "Test"
-      : normalizedJobName;
-
-    if (packageIntegrationMatch) {
-      const sample = makeSample(jobDuration);
-      metrics.set(
-        `job: Package Integration Tests (${packageIntegrationMatch[1]})`,
-        sample,
-      );
-      setMaxMetric("job: Package Integration Tests", sample);
-    }
-
-    if (unitMatch) {
-      metrics.set(
-        `job: Pattern Unit Tests (${unitMatch[1]}/${unitMatch[2]})`,
-        makeSample(jobDuration),
-      );
-    }
-
-    if (patternIntegrationMatch) {
-      const sample = makeSample(jobDuration);
-      metrics.set(
-        `job: Pattern Integration Tests (${patternIntegrationMatch[1]}/${
-          patternIntegrationMatch[2]
-        })`,
-        sample,
-      );
-      setMaxMetric("job: Pattern Integration Tests", sample);
-    }
-
-    if (generatedPatternsMatch) {
-      const sample = makeSample(jobDuration);
-      metrics.set(
-        `job: Generated Patterns Integration Tests (${
-          generatedPatternsMatch[1]
-        }/${generatedPatternsMatch[2]})`,
-        sample,
-      );
-      setMaxMetric("job: Generated Patterns Integration Tests", sample);
-    }
-
-    if (runnerTestMatch) {
-      const sample = makeSample(jobDuration);
-      metrics.set(
-        `job: Runner Tests (${runnerTestMatch[1]}/${runnerTestMatch[2]})`,
-        sample,
-      );
-      setMaxMetric("job: Runner Tests", sample);
-    }
-
-    if (workspaceTestMatch) {
-      const sample = makeSample(jobDuration);
-      metrics.set(
-        `job: Test (${workspaceTestMatch[1]}/${workspaceTestMatch[2]})`,
-        sample,
-      );
-      // Rolls up to the pre-shard "job: Test" metric so the sharded jobs
-      // compare against the existing single-job baselines.
-      setMaxMetric("job: Test", sample);
-    }
-
-    if (cliCoreSplitMatch) {
-      const sample = makeSample(jobDuration);
-      metrics.set(
-        `job: CLI Integration Tests (${cliCoreSplitMatch[1]})`,
-        sample,
-      );
-      setMaxMetric("job: CLI Integration Tests (core)", sample);
-    }
-
-    if (normalizedJobName.includes("Test and Build")) {
-      metrics.set("job: Test and Build", makeSample(jobDuration));
-    }
-
-    for (const step of job.steps) {
-      const stepDuration = durationSeconds(step.started_at, step.completed_at);
-      if (stepDuration <= 0) continue;
-
-      const normalizedStepName = normalizeName(step.name).toLowerCase();
-      if (
-        buildBinaryMatch && normalizedStepName.includes("build") &&
-        normalizedStepName.includes("binary")
-      ) {
-        setMaxMetric("step: Build application", makeSample(stepDuration));
-      }
-      for (const matcher of STEP_METRIC_MATCHERS) {
-        if (
-          matcher.jobName === matcherJobName &&
-          normalizedStepName.includes(matcher.stepKeyword)
-        ) {
-          const sample = makeSample(stepDuration);
-          if (
-            packageIntegrationMatch || patternIntegrationMatch ||
-            generatedPatternsMatch || runnerTestMatch || cliCoreSplitMatch ||
-            workspaceTestMatch
-          ) {
-            setMaxMetric(matcher.metricName, sample);
-          } else {
-            metrics.set(matcher.metricName, sample);
-          }
-        }
-      }
-    }
-  }
-
-  return metrics;
-}
-
-export function extractTestFileMetrics(
-  run: WorkflowRun,
-  artifactName: string,
-  suites: JUnitTestSuite[],
-): Map<string, TimingSample> {
-  const metrics = new Map<string, TimingSample>();
-
-  const makeSample = (duration: number): TimingSample => ({
-    runId: run.id,
-    runUrl: run.html_url,
-    sha: run.head_sha,
-    createdAt: run.created_at,
-    durationSeconds: duration,
-  });
-
-  for (const suite of suites) {
-    if (suite.time <= 0) continue;
-    const key = `test: ${artifactName}/${suite.name}`;
-    metrics.set(key, makeSample(suite.time));
-
-    for (const test of suite.tests) {
-      if (test.time <= 0) continue;
-      const testKey = `subtest: ${artifactName}/${suite.name} > ${test.name}`;
-      metrics.set(testKey, makeSample(test.time));
-    }
-  }
-
-  return metrics;
-}
-
-/** Keeps the longest slice when normalized artifact labels share a metric. */
-export function extractTimingArtifactMetrics(
-  run: WorkflowRun,
-  artifacts: Iterable<ParsedTimingArtifact>,
-): Map<string, TimingSample> {
-  const metrics = new Map<string, TimingSample>();
-
-  for (const artifact of artifacts) {
-    const artifactMetrics = extractTestFileMetrics(
-      run,
-      timingArtifactLabel(artifact.name),
-      artifact.suites,
-    );
-    for (const [name, sample] of artifactMetrics) {
-      const existing = metrics.get(name);
-      if (!existing || sample.durationSeconds > existing.durationSeconds) {
-        metrics.set(name, sample);
-      }
-    }
-  }
-
-  return metrics;
 }
 
 // ---------------------------------------------------------------------------
@@ -1348,194 +746,6 @@ export function aggregateCacheStates(
     );
   }
   return states;
-}
-
-/** Job-metric prefixes (aggregate and per-shard forms) per cache family. */
-const COMPILE_CACHE_JOB_METRIC_PREFIXES: readonly (readonly [
-  string,
-  CompileCacheFamily,
-])[] = [
-  ["job: Generated Patterns Integration Tests", "generated-patterns"],
-  ["job: Pattern Integration Tests", "pattern-integration"],
-  ["job: Pattern Unit Tests", "pattern-unit"],
-];
-
-/** The exact step-metric names emitted for the cache-restoring jobs. */
-const COMPILE_CACHE_STEP_METRIC_FAMILIES: Record<string, CompileCacheFamily> = {
-  "step: generated patterns integration": "generated-patterns",
-  "step: patterns integration": "pattern-integration",
-  "step: pattern unit tests": "pattern-unit",
-};
-
-/** Extracts the timing-artifact label from a `test:`/`subtest:` metric. */
-const COMPILE_CACHE_TEST_LABEL_RE = /^(?:sub)?test: ([^/]+)\//;
-
-/**
- * Map a metric name to the compile-cache family whose cold cache inflates
- * it, or null for metrics with no compile cache (Runner Tests,
- * pattern-reload-integration, `coverage-debt:`, ...). The mapping
- * mirrors the names `extractMetrics` and `extractTestFileMetrics` emit.
- */
-export function compileCacheFamilyForMetric(
-  metric: string,
-): CompileCacheFamily | null {
-  for (const [prefix, family] of COMPILE_CACHE_JOB_METRIC_PREFIXES) {
-    if (
-      metric === prefix ||
-      (metric.startsWith(prefix) && metric[prefix.length] === " ")
-    ) {
-      return family;
-    }
-  }
-
-  const stepFamily = COMPILE_CACHE_STEP_METRIC_FAMILIES[metric];
-  if (stepFamily) return stepFamily;
-
-  const labelMatch = COMPILE_CACHE_TEST_LABEL_RE.exec(metric);
-  if (labelMatch) {
-    const label = labelMatch[1];
-    if (label === "generated-patterns") return "generated-patterns";
-    if (label === "pattern-integration") return "pattern-integration";
-    if (/^pattern-unit-\d+$/.test(label)) return "pattern-unit";
-  }
-
-  return null;
-}
-
-// ---------------------------------------------------------------------------
-// CI wall-time revisit signals
-// ---------------------------------------------------------------------------
-
-export const CI_WALL_TIME_SLOW_JOB_SECONDS = 180;
-export const CI_WALL_TIME_REQUIRED_CHECK_SECONDS = 8 * 60;
-export const CI_WALL_TIME_IMBALANCE_RATIO = 1.5;
-export const CI_WALL_TIME_IMBALANCE_MIN_DELTA_SECONDS = 30;
-export const CI_WALL_TIME_COMPARABLE_JOB_COUNT = 5;
-
-const CI_WALL_TIME_EXCLUDED_JOB_PATTERNS = [
-  /^Deploy /,
-  /^Attest and Upload Binaries$/,
-  /^Toolshed Post-Deploy Patterns Test$/,
-];
-
-function medianNumber(values: number[]): number {
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0
-    ? (sorted[mid - 1] + sorted[mid]) / 2
-    : sorted[mid];
-}
-
-function shouldIncludeCiWallTimeJob(name: string): boolean {
-  return !CI_WALL_TIME_EXCLUDED_JOB_PATTERNS.some((re) => re.test(name));
-}
-
-export function computeCiWallTimeRevisitSignals(
-  jobs: Job[],
-): CiWallTimeRevisitSignal[] {
-  const measuredJobs = jobs
-    .map((job) => {
-      const name = normalizeName(job.name);
-      const startMs = job.started_at ? Date.parse(job.started_at) : NaN;
-      const endMs = job.completed_at ? Date.parse(job.completed_at) : NaN;
-      return {
-        name,
-        startMs,
-        endMs,
-        durationSeconds: durationSeconds(job.started_at, job.completed_at),
-      };
-    })
-    .filter((job) =>
-      shouldIncludeCiWallTimeJob(job.name) &&
-      Number.isFinite(job.startMs) &&
-      Number.isFinite(job.endMs) &&
-      job.durationSeconds > 0
-    );
-
-  if (measuredJobs.length === 0) return [];
-
-  const signals: CiWallTimeRevisitSignal[] = [];
-  const sortedByDuration = [...measuredJobs].sort((a, b) =>
-    b.durationSeconds - a.durationSeconds
-  );
-  const slowest = sortedByDuration[0];
-
-  if (slowest.durationSeconds >= CI_WALL_TIME_SLOW_JOB_SECONDS) {
-    signals.push({
-      kind: "slow-job",
-      title: "Slowest required CI job is over 3m",
-      detail: `${slowest.name} took ${formatDuration(slowest.durationSeconds)}`,
-    });
-  }
-
-  const comparableJobs = sortedByDuration.slice(
-    0,
-    Math.min(CI_WALL_TIME_COMPARABLE_JOB_COUNT, sortedByDuration.length),
-  );
-  const comparableMedian = medianNumber(
-    comparableJobs.map((job) => job.durationSeconds),
-  );
-  if (
-    slowest.durationSeconds >=
-      comparableMedian * CI_WALL_TIME_IMBALANCE_RATIO &&
-    slowest.durationSeconds - comparableMedian >=
-      CI_WALL_TIME_IMBALANCE_MIN_DELTA_SECONDS
-  ) {
-    signals.push({
-      kind: "job-imbalance",
-      title: "One required CI job is much slower than nearby jobs",
-      detail: `${slowest.name} took ${
-        formatDuration(slowest.durationSeconds)
-      }; top-${comparableJobs.length} median is ${
-        formatDuration(comparableMedian)
-      }`,
-    });
-  }
-
-  const requiredStartMs = Math.min(...measuredJobs.map((job) => job.startMs));
-  const requiredEndMs = Math.max(...measuredJobs.map((job) => job.endMs));
-  const requiredWallTimeSeconds = (requiredEndMs - requiredStartMs) / 1000;
-  if (requiredWallTimeSeconds >= CI_WALL_TIME_REQUIRED_CHECK_SECONDS) {
-    signals.push({
-      kind: "required-wall-time",
-      title: "Required CI checks are over the wall-time budget",
-      detail: `Required non-deploy jobs took ${
-        formatDuration(requiredWallTimeSeconds)
-      } from first start to last completion`,
-    });
-  }
-
-  return signals;
-}
-
-// ---------------------------------------------------------------------------
-// Statistics
-// ---------------------------------------------------------------------------
-
-export function computeBaseline(
-  samples: number[],
-  minAbsoluteDelta = 0,
-): Baseline | null {
-  if (samples.length < MIN_SAMPLES) return null;
-
-  const sorted = [...samples].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  const median = sorted.length % 2 === 0
-    ? (sorted[mid - 1] + sorted[mid]) / 2
-    : sorted[mid];
-
-  const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
-  const variance = samples.reduce((sum, v) => sum + (v - mean) ** 2, 0) /
-    samples.length;
-  const stddev = Math.sqrt(variance);
-
-  const threshold = Math.max(
-    median + STDDEV_FACTOR * stddev,
-    median * (1 + MIN_REGRESSION_PCT),
-    median + minAbsoluteDelta,
-  );
-
-  return { median, stddev, variance, count: samples.length, threshold };
 }
 
 // ---------------------------------------------------------------------------
@@ -1790,7 +1000,7 @@ export function buildCoverageDebtSuggestionComment(
   out.push("");
   out.push(
     "This PR adds source lines that no test exercises, so the coverage gate in " +
-      "the **Performance Check** job is failing. The gate ratchets each changed " +
+      "the **Coverage Check** job is failing. The gate ratchets each changed " +
       "source group against its uncovered-line count on `main`: the group must " +
       "not end up with more uncovered lines than that baseline.",
   );
@@ -1888,14 +1098,14 @@ export function buildCoverageResolvedComment(
   out.push("");
   out.push(
     overridden
-      ? "The coverage gate in the **Performance Check** job passes because this " +
+      ? "The coverage gate in the **Coverage Check** job passes because this " +
         "PR's coverage debt was accepted with an override rather than covered " +
         "by new tests. Here is where it left each changed source group:"
       : improvedLines > 0
-      ? "The coverage gate in the **Performance Check** job passes again. This " +
+      ? "The coverage gate in the **Coverage Check** job passes again. This " +
         `PR now covers ${uncoveredLineCount(improvedLines)} that no test ` +
         "reached on `main`. Here is where it left each changed source group:"
-      : "The coverage gate in the **Performance Check** job passes again. Here " +
+      : "The coverage gate in the **Coverage Check** job passes again. Here " +
         "is where this PR left each changed source group:",
   );
   out.push("");
@@ -1920,21 +1130,6 @@ export function buildCoverageResolvedComment(
   out.push("</details>");
 
   return out.join("\n");
-}
-
-export function formatDuration(seconds: number): string {
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
-  return `${m}m ${s.toFixed(0)}s`;
-}
-
-export function formatMetricValue(name: string, value: number): string {
-  if (isCoverageDebtMetric(name)) {
-    const rounded = Math.round(value);
-    return `${rounded} ${rounded === 1 ? "line" : "lines"}`;
-  }
-  return formatDuration(value);
 }
 
 // ---------------------------------------------------------------------------
@@ -2035,20 +1230,18 @@ export async function fetchCurrentPRBody(
 }
 
 // ---------------------------------------------------------------------------
-// Baseline override parsing
+// Coverage override parsing
 // ---------------------------------------------------------------------------
 
 /**
- * Parse a PR body for performance baseline overrides.
+ * Parse a PR body for coverage-debt overrides.
  *
  * Format (visible markdown, one per line):
- *   NEW_PERF_BASELINE: job: Package Integration Tests = 300s
+ *   ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 123 lines
  *   NEW_COVERAGE_BASELINE
  *
- * Values require a unit suffix: s, ms, us/µs, ns, line, or lines.
- * The value is stored in the metric's native unit.
- * Coverage-debt metrics must use line units; non-coverage metrics must use
- * time units.
+ * `ACCEPT_COVERAGE_DEBT` accepts one metric's uncovered-line count. Its value
+ * must use line units and its metric must be a `coverage-debt:` metric.
  * `NEW_COVERAGE_BASELINE` is a whole-coverage ratchet reset marker; it has no
  * value and lets the PR's/main run's coverage metrics become the next baseline.
  */
@@ -2061,45 +1254,16 @@ export function parseBaselineOverrides(body: string): BaselineOverrides {
     ).test(body),
   };
 
-  const re =
-    /NEW_PERF_BASELINE:\s*(.+?)\s*=\s*(\d+(?:\.\d+)?)\s*(ns|µs|us|ms|s|lines?)/g;
+  const re = /ACCEPT_COVERAGE_DEBT:\s*(.+?)\s*=\s*(\d+(?:\.\d+)?)\s*(lines?)/g;
   let match;
   while ((match = re.exec(body)) !== null) {
     const metric = match[1].trim();
-    let value = parseFloat(match[2]);
-    const unit = match[3];
-    const isLineUnit = unit === "line" || unit === "lines";
-    const isCoverageMetric = isCoverageDebtMetric(metric);
+    const value = parseFloat(match[2]);
 
-    if (isLineUnit && !isCoverageMetric) {
+    if (!isCoverageDebtMetric(metric)) {
       throw new Error(
-        `Invalid NEW_PERF_BASELINE override for "${metric}": line units are only valid for coverage-debt metrics.`,
+        `Invalid ACCEPT_COVERAGE_DEBT override for "${metric}": only coverage-debt metrics can be accepted.`,
       );
-    }
-    if (!isLineUnit && isCoverageMetric) {
-      throw new Error(
-        `Invalid NEW_PERF_BASELINE override for "${metric}": coverage-debt metrics must use line units.`,
-      );
-    }
-
-    if (isLineUnit) {
-      result.metrics.set(metric, value);
-      continue;
-    }
-
-    switch (unit) {
-      case "ns":
-        value /= 1e9;
-        break;
-      case "us":
-      case "µs":
-        value /= 1e6;
-        break;
-      case "ms":
-        value /= 1e3;
-        break;
-      case "s":
-        break;
     }
 
     result.metrics.set(metric, value);
@@ -2109,19 +1273,12 @@ export function parseBaselineOverrides(body: string): BaselineOverrides {
 }
 
 /**
- * Format a metric value as a suggested override string for PR descriptions.
- * Uses a human-friendly unit.
+ * Format a coverage-debt value as a suggested override string for PR
+ * descriptions, rounded up to whole lines.
  */
-export function formatOverrideSuggestion(
-  metric: string,
-  value: number,
-): string {
-  if (isCoverageDebtMetric(metric)) {
-    const rounded = Math.ceil(value);
-    return `${rounded} ${rounded === 1 ? "line" : "lines"}`;
-  }
-  // value is in seconds
-  return `${Math.ceil(value)}s`;
+export function formatOverrideSuggestion(value: number): string {
+  const rounded = Math.ceil(value);
+  return `${rounded} ${rounded === 1 ? "line" : "lines"}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -2181,23 +1338,12 @@ export function applyBaselineOverrides(
 }
 
 /**
- * Drop samples from runs whose compile cache is known-cold for the metric's
- * family, so a warm (or unknown) current run is not gated against inflated
- * cold baselines. Unknown runs are kept — pre-rollout baselines behave
- * exactly as they do today.
- */
-export function dropColdSamples(
-  samples: TimingSample[],
-  stateOfRun: (runId: number) => CompileCacheState | undefined,
-): TimingSample[] {
-  return samples.filter((sample) => stateOfRun(sample.runId) !== "cold");
-}
-
-/**
- * The latest sample whose run is not known-cold, for ratchets that compare
- * against the most recent baseline (the coverage-debt gate). Falls back to
- * the last sample when every sample is known-cold, preserving the
- * override-truncation reset semantics of `samples.at(-1)`.
+ * The latest sample whose run is not known-cold, for the coverage-debt ratchet
+ * that compares against the most recent baseline. A cold main run covers
+ * cold-compile-only branches, so ratcheting against its lower debt would fail
+ * later warm PRs with phantom regressions. Falls back to the last sample when
+ * every sample is known-cold, preserving the override-truncation reset
+ * semantics of `samples.at(-1)`.
  */
 export function latestNonColdSample(
   samples: TimingSample[],

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -1244,8 +1244,22 @@ export async function fetchCurrentPRBody(
  * must use line units and its metric must be a `coverage-debt:` metric.
  * `NEW_COVERAGE_BASELINE` is a whole-coverage ratchet reset marker; it has no
  * value and lets the PR's/main run's coverage metrics become the next baseline.
+ *
+ * `includeLegacyCoverageAcceptance` additionally reads the marker's former name,
+ * `NEW_PERF_BASELINE: <coverage-debt metric> = N lines`. Merged PRs from before
+ * the rename accepted coverage debt that way, and their acceptance still has to
+ * truncate the baseline timeline — otherwise a previously accepted increase
+ * re-gates once its group's recent `main` runs go cold, because the ratchet
+ * reaches back past the acceptance to a lower pre-acceptance sample. It is
+ * enabled only when rebuilding merged-PR baselines, never for the current PR:
+ * new PRs must use `ACCEPT_COVERAGE_DEBT`. The timing forms `NEW_PERF_BASELINE`
+ * also carried gate nothing now, so any non-coverage-debt legacy line is
+ * ignored rather than rejected.
  */
-export function parseBaselineOverrides(body: string): BaselineOverrides {
+export function parseBaselineOverrides(
+  body: string,
+  includeLegacyCoverageAcceptance = false,
+): BaselineOverrides {
   const result: BaselineOverrides = {
     metrics: new Map(),
     coverageBaselineReset: new RegExp(
@@ -1267,6 +1281,19 @@ export function parseBaselineOverrides(body: string): BaselineOverrides {
     }
 
     result.metrics.set(metric, value);
+  }
+
+  if (includeLegacyCoverageAcceptance) {
+    const legacyRe =
+      /NEW_PERF_BASELINE:\s*(.+?)\s*=\s*(\d+(?:\.\d+)?)\s*lines?\b/g;
+    let legacyMatch;
+    while ((legacyMatch = legacyRe.exec(body)) !== null) {
+      const metric = legacyMatch[1].trim();
+      if (!isCoverageDebtMetric(metric)) continue;
+      if (!result.metrics.has(metric)) {
+        result.metrics.set(metric, parseFloat(legacyMatch[2]));
+      }
+    }
   }
 
   return result;

--- a/tasks/compile-cache-state.test.ts
+++ b/tasks/compile-cache-state.test.ts
@@ -10,8 +10,8 @@ import {
   pathTouchesCompileCacheKey,
   recordUnstampedBaselineRunState,
   uniformCacheStates,
-} from "./perf-cache-state.ts";
-import type { CompileCacheStates } from "./perf-lib.ts";
+} from "./compile-cache-state.ts";
+import type { CompileCacheStates } from "./ci-check-lib.ts";
 
 async function captureLogs(fn: () => void | Promise<void>): Promise<string[]> {
   const logs: string[] = [];

--- a/tasks/compile-cache-state.ts
+++ b/tasks/compile-cache-state.ts
@@ -1,15 +1,15 @@
 /**
- * Compile-cache key state derivation for perf-check.
+ * Compile-cache key state derivation for the coverage check.
  *
  * The pattern-test jobs restore a compile byte cache under keys whose PREFIX
  * hashes a transformer-adjacent path set (the `cc-*` cache keys in
  * .github/workflows/deno.yml). The restore-keys prefix includes that hash, so
  * a run whose commit changes any file in the set gets no cache fallback at
- * all: every pattern compiles cold, and compile-dominated wall times inflate
- * roughly 1.6-1.9x. Gating such a run against warm baselines is a false
- * positive by construction — and the first main-branch run after such a merge
- * is equally cold, polluting the baseline history the same way (observed as
- * the recurring "single-test outlier" spikes).
+ * all: every pattern compiles cold. A cold run also covers cold-compile-only
+ * branches, which lowers its coverage debt. The coverage ratchet must not use
+ * such a run as its baseline, or later warm PRs fail against a stricter,
+ * unreachable bar — and the first main-branch run after a fingerprint-changing
+ * merge is equally cold, so its coverage baseline is tainted the same way.
  *
  * Only the prefix inputs matter for coldness: each job's key suffix (its
  * pattern sources) still restores through the prefix restore-key when it
@@ -28,14 +28,14 @@ import {
   type CompileCacheStates,
   githubGet,
   REPO,
-} from "./perf-lib.ts";
+} from "./ci-check-lib.ts";
 
 /** Run-level fingerprint verdict; "unknown" must fail open (keep + gate). */
 export type CacheKeyState = "cold" | "warm";
 
 /**
  * Mirror of the FIRST hashFiles(...) argument list of every `cc-*` compile
- * cache key in .github/workflows/deno.yml. perf-cache-state.test.ts parses
+ * cache key in .github/workflows/deno.yml. compile-cache-state.test.ts parses
  * the workflow and asserts set equality, so the two cannot drift silently.
  */
 export const COMPILE_CACHE_KEY_GLOBS = [

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -394,6 +394,22 @@ Deno.test("valid merged PR baseline override metadata is parsed", () => {
   );
 });
 
+Deno.test("merged PR legacy coverage-debt acceptance is honored", () => {
+  // A baseline PR merged before the marker rename accepted debt with
+  // NEW_PERF_BASELINE; its acceptance must still register so it truncates the
+  // baseline timeline.
+  const overrides = parseMergedBaselineOverrides({
+    number: 125,
+    body:
+      "NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7 lines",
+  });
+
+  assertEquals(
+    overrides?.metrics.get("coverage-debt: packages/runner uncovered lines"),
+    7,
+  );
+});
+
 function coverageRow(
   metric: string,
   current: number,

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -7,24 +7,20 @@ import {
 import * as path from "@std/path";
 import {
   type Artifact,
-  type BaselineOverrides,
-  type CompileCacheState,
-  type MetricTimeline,
+  COVERAGE_SUGGESTION_MARKER,
+  type CoverageCommentPayload,
   PERF_METRICS_ARTIFACT_NAME,
-  PERF_METRICS_BACKFILL_ARTIFACT_NAME,
   type PRInfo,
   type TimingSample,
   type WorkflowRun,
-} from "./perf-lib.ts";
+} from "./ci-check-lib.ts";
 import {
-  addPerfMetricsFromArtifacts,
+  addCoverageBaselineFromArtifacts,
   type BaselineRunContext,
   buildBaselineRunContexts,
-  buildExtraBackfillContexts,
   collectCurrentCacheStates,
   copyCoverageArtifactFiles,
   currentWorkflowRunFromEvent,
-  evaluateTimingMetric,
   fetchArtifactsForRunBestEffort,
   fetchBaselineRunsForCheck,
   fetchCommitsBehindMain,
@@ -45,9 +41,8 @@ import {
   metricDisplayParts,
   metricTableRows,
   newestArtifactNamed,
+  parseCoverageBaselineFromArtifacts,
   parseMergedBaselineOverrides,
-  parsePerfMetricBackfillFromArtifacts,
-  parsePerfMetricsFromArtifacts,
   printMetricTable,
   reportBaselineContextResults,
   reportBaselineRunAvailability,
@@ -60,11 +55,7 @@ import {
   writeCoverageComment,
   writeCoverageDebtSuggestion,
   writeCoverageResolved,
-} from "./perf-check.ts";
-import {
-  COVERAGE_SUGGESTION_MARKER,
-  type CoverageCommentPayload,
-} from "./perf-lib.ts";
+} from "./coverage-check.ts";
 
 const SHA_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const SHA_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
@@ -212,20 +203,20 @@ Deno.test("copyCoverageArtifactFiles rejects an empty pre-downloaded artifact", 
   }
 });
 
-Deno.test("performance check pre-downloads coverage with strict integrity checks", async () => {
+Deno.test("coverage check pre-downloads coverage with strict integrity checks", async () => {
   const workflow = await Deno.readTextFile(
     new URL("../.github/workflows/deno.yml", import.meta.url),
   );
-  const start = workflow.indexOf("  perf-check:\n");
+  const start = workflow.indexOf("  coverage-check:\n");
   const end = workflow.indexOf("\n  attest-binaries:", start);
-  assert(start >= 0 && end > start, "Performance Check job not found");
+  assert(start >= 0 && end > start, "Coverage Check job not found");
 
   const job = workflow.slice(start, end);
   const downloadStart = job.indexOf("- name: 📥 Download coverage reports");
-  const checkStart = job.indexOf("- name: 📊 Run performance check");
+  const checkStart = job.indexOf("- name: 📊 Run coverage check");
   assert(
     downloadStart >= 0 && checkStart > downloadStart,
-    "coverage reports must be downloaded before Performance Check runs",
+    "coverage reports must be downloaded before Coverage Check runs",
   );
 
   const downloadStep = job.slice(downloadStart, checkStart);
@@ -375,7 +366,8 @@ Deno.test("invalid merged PR baseline override metadata is ignored", () => {
   const overrides = parseMergedBaselineOverrides(
     {
       number: 123,
-      body: "NEW_PERF_BASELINE: job: Check = 7 lines",
+      // "job: Check" is not a coverage-debt metric, so accepting it throws.
+      body: "ACCEPT_COVERAGE_DEBT: job: Check = 7 lines",
     },
     (message) => warnings.push(message),
   );
@@ -385,17 +377,21 @@ Deno.test("invalid merged PR baseline override metadata is ignored", () => {
   assertStringIncludes(warnings[0], "merged PR #123");
   assertStringIncludes(
     warnings[0],
-    "line units are only valid for coverage-debt metrics",
+    "only coverage-debt metrics can be accepted",
   );
 });
 
 Deno.test("valid merged PR baseline override metadata is parsed", () => {
   const overrides = parseMergedBaselineOverrides({
     number: 124,
-    body: "NEW_PERF_BASELINE: job: Check = 7s",
+    body:
+      "ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 7 lines",
   });
 
-  assertEquals(overrides?.metrics.get("job: Check"), 7);
+  assertEquals(
+    overrides?.metrics.get("coverage-debt: packages/runner uncovered lines"),
+    7,
+  );
 });
 
 function coverageRow(
@@ -420,7 +416,7 @@ function coverageRow(
 async function payloadFrom(
   write: () => Promise<void>,
 ): Promise<CoverageCommentPayload | null> {
-  const dir = await Deno.makeTempDir({ prefix: "perf-check-comment-" });
+  const dir = await Deno.makeTempDir({ prefix: "coverage-check-comment-" });
   const file = path.join(dir, "coverage-comment.json");
   Deno.env.set("COVERAGE_COMMENT_FILE", file);
   try {
@@ -796,7 +792,10 @@ Deno.test("githubApiOrSkip writes metrics and exits on rate limits", async () =>
 
     assertEquals(captured.result, 0);
     assertStringIncludes(captured.warnings.join("\n"), "rate limit");
-    assertStringIncludes(captured.logs.join("\n"), "Wrote perf-metrics.json");
+    assertStringIncludes(
+      captured.logs.join("\n"),
+      "Wrote perf-metrics.json",
+    );
     const file = JSON.parse(await Deno.readTextFile("perf-metrics.json"));
     assertEquals(file.metrics[0].name, "job: Check");
   } finally {
@@ -823,9 +822,6 @@ Deno.test("metric table helpers format task and metric details", () => {
     status: "OK" as const,
     current: 12.4,
     median: 10,
-    variance: 0,
-    stddev: 0,
-    threshold: 10,
     n: 5,
     pctIncrease: 24,
   };
@@ -836,20 +832,10 @@ Deno.test("metric table helpers format task and metric details", () => {
     n: 0,
   };
 
-  assertEquals(
-    formatMetricValueForTable(coverageRow.metric, coverageRow.current),
-    "12",
-  );
-  assertEquals(formatMetricValueForTable("job: Check", undefined), "-");
-  assertEquals(formatMetricDelta("job: Check", pendingRow), "-");
-  assertEquals(
-    formatMetricDelta(coverageRow.metric, coverageRow),
-    "+2 (+24%)",
-  );
-  assertEquals(metricDisplayParts("test: runner > file.test.ts"), {
-    task: "runner",
-    metric: "file.test.ts",
-  });
+  assertEquals(formatMetricValueForTable(coverageRow.current), "12");
+  assertEquals(formatMetricValueForTable(undefined), "-");
+  assertEquals(formatMetricDelta(pendingRow), "-");
+  assertEquals(formatMetricDelta(coverageRow), "+2 (+24%)");
   assertEquals(metricDisplayParts("coverage-debt: tasks uncovered lines"), {
     task: "coverage-debt",
     metric: "tasks",
@@ -876,9 +862,6 @@ Deno.test("printMetricTable renders status and non-status tables", () => {
     status: "OK" as const,
     current: 9,
     median: 8,
-    variance: 0,
-    stddev: 0,
-    threshold: 10,
     n: 5,
     pctIncrease: 12.5,
   };
@@ -1090,18 +1073,31 @@ Deno.test("baseline main validation accepts current main as newest run", () => {
   assertEquals(result, { ok: true, issues: [] });
 });
 
-Deno.test("reportBaselineRunAvailability warns for stale and sparse baselines", () => {
+Deno.test("reportBaselineRunAvailability warns when newest run is not current main head", () => {
   const warnings: string[] = [];
   const result = reportBaselineRunAvailability(
     [makeRun(1, SHA_A)],
     SHA_B,
-    5,
     (message) => warnings.push(message),
   );
 
   assertEquals(result.ok, false);
   assertStringIncludes(warnings.join("\n"), "current main head");
-  assertStringIncludes(warnings.join("\n"), "only 1 baseline runs available");
+});
+
+Deno.test("reportBaselineRunAvailability warns when no baseline runs exist", () => {
+  const warnings: string[] = [];
+  const result = reportBaselineRunAvailability(
+    [],
+    SHA_B,
+    (message) => warnings.push(message),
+  );
+
+  assertEquals(result.ok, false);
+  assertStringIncludes(
+    warnings.join("\n"),
+    "no baseline runs available; coverage debt will bootstrap from this run.",
+  );
 });
 
 Deno.test("fetchArtifactsForRunBestEffort returns artifacts or an empty fallback", async () => {
@@ -1166,64 +1162,14 @@ Deno.test("buildBaselineRunContexts collects artifacts, PRs, and commit distance
   ]);
 });
 
-Deno.test("buildExtraBackfillContexts creates context shells", async () => {
-  const run = makeRun(12, SHA_B);
-  const artifact = makeArtifact(6, PERF_METRICS_BACKFILL_ARTIFACT_NAME);
-
-  const contexts = await buildExtraBackfillContexts(
-    [run],
-    (requestedRun) => {
-      assertEquals(requestedRun, run);
-      return Promise.resolve([artifact]);
-    },
-    1,
-  );
-
-  assertEquals(contexts, [
-    {
-      run,
-      artifacts: [artifact],
-      pr: null,
-      prLookupError: null,
-      commitsBehindMain: null,
-    },
-  ]);
-});
-
-Deno.test("parsePerfMetricBackfillFromArtifacts uses newest backfill artifact", async () => {
-  const parsed = new Map<number, Map<string, TimingSample>>([[1, new Map()]]);
-  let parsedArtifactId = 0;
-
-  const result = await parsePerfMetricBackfillFromArtifacts(
-    [
-      makeArtifact(1, PERF_METRICS_BACKFILL_ARTIFACT_NAME),
-      makeArtifact(3, PERF_METRICS_BACKFILL_ARTIFACT_NAME),
-      makeArtifact(4, PERF_METRICS_BACKFILL_ARTIFACT_NAME, true),
-    ],
-    (artifactId) => {
-      parsedArtifactId = artifactId;
-      return Promise.resolve(parsed);
-    },
-  );
-
-  assertEquals(result, parsed);
-  assertEquals(parsedArtifactId, 3);
-  assertEquals(
-    await parsePerfMetricBackfillFromArtifacts([], () => {
-      throw new Error("should not parse without an artifact");
-    }),
-    null,
-  );
-});
-
-Deno.test("parsePerfMetricsFromArtifacts uses newest perf metrics artifact", async () => {
+Deno.test("parseCoverageBaselineFromArtifacts uses newest coverage baseline artifact", async () => {
   const parsed = {
     metrics: new Map<string, TimingSample>([["job: Check", makeSample()]]),
     compileCacheStates: { "pattern-unit": "warm" as const },
   };
   let parsedArtifactId = 0;
 
-  const result = await parsePerfMetricsFromArtifacts(
+  const result = await parseCoverageBaselineFromArtifacts(
     [
       makeArtifact(1, PERF_METRICS_ARTIFACT_NAME),
       makeArtifact(3, PERF_METRICS_ARTIFACT_NAME),
@@ -1238,33 +1184,37 @@ Deno.test("parsePerfMetricsFromArtifacts uses newest perf metrics artifact", asy
   assertEquals(result, parsed);
   assertEquals(parsedArtifactId, 3);
   assertEquals(
-    await parsePerfMetricsFromArtifacts([], () => {
+    await parseCoverageBaselineFromArtifacts([], () => {
       throw new Error("should not parse without an artifact");
     }),
     null,
   );
 });
 
-Deno.test("addPerfMetricsFromArtifacts adds parsed samples to timelines", async () => {
+Deno.test("addCoverageBaselineFromArtifacts adds parsed samples to timelines", async () => {
   const artifacts = [makeArtifact(1, PERF_METRICS_ARTIFACT_NAME)];
   const sample = makeSample();
   const timelines = new Map();
 
   assertEquals(
-    await addPerfMetricsFromArtifacts(timelines, artifacts, (requested) => {
-      assertEquals(requested, artifacts);
-      return Promise.resolve({
-        metrics: new Map([["job: Check", sample]]),
-        compileCacheStates: { "generated-patterns": "cold" as const },
-      });
-    }),
+    await addCoverageBaselineFromArtifacts(
+      timelines,
+      artifacts,
+      (requested) => {
+        assertEquals(requested, artifacts);
+        return Promise.resolve({
+          metrics: new Map([["job: Check", sample]]),
+          compileCacheStates: { "generated-patterns": "cold" as const },
+        });
+      },
+    ),
     { added: true, compileCacheStates: { "generated-patterns": "cold" } },
   );
   assertEquals(timelines.get("job: Check")?.samples, [sample]);
 
   // An untagged (pre-rollout) artifact still adds samples, with null states.
   assertEquals(
-    await addPerfMetricsFromArtifacts(
+    await addCoverageBaselineFromArtifacts(
       timelines,
       artifacts,
       () =>
@@ -1277,7 +1227,7 @@ Deno.test("addPerfMetricsFromArtifacts adds parsed samples to timelines", async 
   );
 
   assertEquals(
-    await addPerfMetricsFromArtifacts(
+    await addCoverageBaselineFromArtifacts(
       timelines,
       [],
       () => Promise.resolve(null),
@@ -1413,182 +1363,14 @@ Deno.test("formatCompileCacheStates shows every family, absent as unknown", () =
   );
 });
 
-const NO_OVERRIDES: BaselineOverrides = {
-  metrics: new Map(),
-  coverageBaselineReset: false,
-};
-
-function timingSampleAt(runId: number, durationSeconds: number): TimingSample {
-  return {
-    runId,
-    runUrl: `https://github.com/commontoolsinc/labs/actions/runs/${runId}`,
-    sha: SHA_A,
-    createdAt: `2026-06-18T10:00:${String(runId).padStart(2, "0")}Z`,
-    durationSeconds,
-  };
-}
-
-function timingTimeline(name: string, samples: TimingSample[]): MetricTimeline {
-  return { name, samples };
-}
-
-/** Runs 1-6 are warm at 10s; runs 7-8 are known-cold at 30s. */
-const MIXED_COLD_SAMPLES = [
-  ...[1, 2, 3, 4, 5, 6].map((runId) => timingSampleAt(runId, 10)),
-  timingSampleAt(7, 30),
-  timingSampleAt(8, 30),
-];
-
-function coldForRuns(
-  coldRunIds: number[],
-): (runId: number) => CompileCacheState | undefined {
-  return (runId) => coldRunIds.includes(runId) ? "cold" : undefined;
-}
-
-Deno.test("evaluateTimingMetric reports a cold-family metric as COLD, never a failure", () => {
-  const { row, failure } = evaluateTimingMetric({
-    metric: "step: patterns integration",
-    // Far over any threshold the warm baseline would allow.
-    current: 25,
-    timeline: timingTimeline(
-      "step: patterns integration",
-      [1, 2, 3, 4, 5].map((runId) => timingSampleAt(runId, 10)),
-    ),
-    prOverrides: NO_OVERRIDES,
-    currentCacheStates: { "pattern-integration": "cold" },
-    stateOfRunForFamily: () => () => undefined,
-  });
-
-  assertEquals(row.status, "COLD");
-  assertEquals(failure, false);
-  assertEquals(row.median, undefined);
-  // A COLD row renders with a `-` baseline and no change column.
-  assertEquals(metricTableRows([row], true)[0], [
-    "COLD",
-    "-",
-    "25s",
-    "-",
-    "step",
-    "patterns integration",
-  ]);
-});
-
-Deno.test("evaluateTimingMetric reports COLD even without baseline samples", () => {
-  const { row, failure } = evaluateTimingMetric({
-    metric: "test: generated-patterns/foo.test.tsx",
-    current: 12,
-    timeline: undefined,
-    prOverrides: NO_OVERRIDES,
-    currentCacheStates: { "generated-patterns": "cold" },
-    stateOfRunForFamily: () => () => undefined,
-  });
-
-  assertEquals(row.status, "COLD");
-  assertEquals(failure, false);
-});
-
-Deno.test("evaluateTimingMetric keeps excl precedence over COLD", () => {
-  const { row, failure } = evaluateTimingMetric({
-    metric: "step: pattern unit tests",
-    current: 100,
-    timeline: undefined,
-    prOverrides: NO_OVERRIDES,
-    currentCacheStates: { "pattern-unit": "cold" },
-    stateOfRunForFamily: () => () => undefined,
-  });
-
-  assertEquals(row.status, "excl");
-  assertEquals(failure, false);
-});
-
-Deno.test("evaluateTimingMetric excludes known-cold baseline samples for a warm run", () => {
-  const { row, failure } = evaluateTimingMetric({
-    metric: "step: patterns integration",
-    current: 20,
-    timeline: timingTimeline("step: patterns integration", MIXED_COLD_SAMPLES),
-    prOverrides: NO_OVERRIDES,
-    currentCacheStates: { "pattern-integration": "warm" },
-    stateOfRunForFamily: () => coldForRuns([7, 8]),
-  });
-
-  // Against the six warm 10s samples the threshold is 15s, so 20s fails.
-  // With the two cold 30s samples included, the inflated stddev would have
-  // pushed the threshold past 35s and hidden the regression.
-  assertEquals(row.status, "OVER");
-  assertEquals(failure, true);
-  assertEquals(row.median, 10);
-  assertEquals(row.n, 6);
-});
-
-Deno.test("evaluateTimingMetric falls back to n/a when too few warm samples remain", () => {
-  const { row, failure } = evaluateTimingMetric({
-    metric: "step: patterns integration",
-    current: 20,
-    timeline: timingTimeline("step: patterns integration", MIXED_COLD_SAMPLES),
-    prOverrides: NO_OVERRIDES,
-    currentCacheStates: {},
-    stateOfRunForFamily: () => coldForRuns([3, 4, 5, 6, 7, 8]),
-  });
-
-  assertEquals(row.status, "n/a");
-  assertEquals(failure, false);
-  assertEquals(row.n, 2);
-});
-
-Deno.test("evaluateTimingMetric with all-unknown states matches pre-rollout behavior", () => {
-  const unknownEverywhere = {
-    metric: "step: patterns integration",
-    current: 20,
-    timeline: timingTimeline("step: patterns integration", MIXED_COLD_SAMPLES),
-    prOverrides: NO_OVERRIDES,
-    currentCacheStates: {},
-    stateOfRunForFamily: () => () => undefined,
-  };
-  const { row, failure } = evaluateTimingMetric(unknownEverywhere);
-
-  // All eight samples gate as before tagging: median 10s, stddev ~8.66s,
-  // threshold ~36s, so 20s stays OK.
-  assertEquals(row.status, "OK");
-  assertEquals(failure, false);
-  assertEquals(row.median, 10);
-  assertEquals(row.n, 8);
-
-  // A metric with no compile cache family ignores cache states entirely.
-  const noFamily = evaluateTimingMetric({
-    ...unknownEverywhere,
-    metric: "step: runner tests",
-    timeline: timingTimeline("step: runner tests", MIXED_COLD_SAMPLES),
-    currentCacheStates: {
-      "generated-patterns": "cold",
-      "pattern-integration": "cold",
-      "pattern-unit": "cold",
-    },
-    stateOfRunForFamily: () => coldForRuns([7, 8]),
-  });
-  assertEquals(noFamily.row.status, "OK");
-  assertEquals(noFamily.row.n, 8);
-});
-
-Deno.test("main runs informational check with mocked latest baseline data", async () => {
+Deno.test("main reports no coverage data and exits cleanly without coverage artifacts", async () => {
   const eventPath = await Deno.makeTempFile({ suffix: ".json" });
   await Deno.writeTextFile(eventPath, JSON.stringify({ after: SHA_C }));
 
   const currentRunId = 123;
-  const baselineRuns = [
-    makeRun(201, SHA_A, "2026-06-18T10:00:00Z"),
-    makeRun(202, SHA_B, "2026-06-18T09:00:00Z"),
-    makeRun(203, SHA_C, "2026-06-18T08:00:00Z"),
-    makeRun(
-      204,
-      "dddddddddddddddddddddddddddddddddddddddd",
-      "2026-06-18T07:00:00Z",
-    ),
-    makeRun(
-      205,
-      "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-      "2026-06-18T06:00:00Z",
-    ),
-  ];
+  // The newest main-push run seeds the compile-fingerprint fallback; its head
+  // differs from this run's SHA, so the classifier compares them.
+  const latestBaselineRun = makeRun(201, SHA_A, "2026-06-18T10:00:00Z");
   const jobsForRun = (runId: number) => ({
     jobs: [
       {
@@ -1622,24 +1404,15 @@ Deno.test("main runs informational check with mocked latest baseline data", asyn
           withMockFetch(
             (input) => {
               const url = String(input);
-              if (url.endsWith("/branches/main")) {
-                return jsonResponse({ commit: { sha: SHA_A } });
-              }
               if (url.includes("/actions/workflows/deno.yml/runs?")) {
-                return jsonResponse({ workflow_runs: baselineRuns });
+                return jsonResponse({ workflow_runs: [latestBaselineRun] });
               }
               if (url.includes(`/actions/runs/${currentRunId}/jobs`)) {
                 return jsonResponse(jobsForRun(currentRunId));
               }
-              const baselineRun = baselineRuns.find((run) =>
-                url.includes(`/actions/runs/${run.id}/jobs`)
-              );
-              if (baselineRun) return jsonResponse(jobsForRun(baselineRun.id));
+              // No coverage-profile artifacts were uploaded for this run.
               if (url.includes("/artifacts?")) {
                 return jsonResponse({ total_count: 0, artifacts: [] });
-              }
-              if (url.includes("/commits/") && url.endsWith("/pulls")) {
-                return jsonResponse([]);
               }
               if (url.includes("/compare/")) {
                 return jsonResponse({ ahead_by: 1 });
@@ -1654,19 +1427,24 @@ Deno.test("main runs informational check with mocked latest baseline data", asyn
     );
     const output = captured.logs.join("\n");
 
+    // With no coverage-profile artifacts, extraction fails and the run has no
+    // coverage metrics to gate, so the informational run exits cleanly.
     assertEquals(captured.result, 0);
-    assertStringIncludes(output, "Current main head is");
     assertStringIncludes(
       output,
       "Compile cache states: generated-patterns=unknown, pattern-integration=unknown, pattern-unit=unknown",
     );
-    assertStringIncludes(output, "Using 5 main-branch runs as baseline.");
-    assertStringIncludes(output, "Baseline source runs:");
-    assertStringIncludes(output, "All metrics within normal range.");
+    assertStringIncludes(
+      captured.errors.join("\n"),
+      "could not extract coverage debt metrics for current run",
+    );
+    assertStringIncludes(
+      output,
+      "No coverage metrics extracted from current run. Nothing to check.",
+    );
   } finally {
     await Deno.remove(eventPath).catch(() => {});
     await Deno.remove("perf-metrics.json").catch(() => {});
-    await Deno.remove("perf-metrics-backfill.json").catch(() => {});
   }
 });
 

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -144,7 +144,10 @@ export function parseMergedBaselineOverrides(
   warn: (message: string) => void = console.warn,
 ): BaselineOverrides | null {
   try {
-    return parseBaselineOverrides(pr.body ?? "");
+    // Merged baseline PRs predating the marker rename accepted coverage debt
+    // with NEW_PERF_BASELINE; still honor that so their acceptance truncates
+    // the baseline timeline (see parseBaselineOverrides).
+    return parseBaselineOverrides(pr.body ?? "", true);
   } catch (error) {
     warn(
       `  Warning: ignoring invalid baseline override in merged PR #${pr.number}: ${error}`,

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env -S deno run --allow-net --allow-env --allow-read --allow-run --allow-write
 
 /**
- * PR Performance Check
+ * PR Coverage Check
  *
- * Runs as part of PR CI after all test jobs complete. Compares the current
- * run's job/step timings against a baseline computed from recent main-branch
- * push runs.  Fails (exit 1) if any metric exceeds the baseline threshold,
- * unless the PR description contains an override.
+ * Runs as part of PR CI after all test jobs complete. Joins the coverage
+ * profiles every test job uploaded and gates the PR on coverage debt: for each
+ * source group the PR changed, the count of uncovered lines must not rise above
+ * the latest non-cold `main` run's count, unless the PR description accepts the
+ * increase. Fails (exit 1) when a changed group regresses.
  *
  * Environment:
  *   GITHUB_TOKEN        - Required.
@@ -27,14 +28,10 @@ import {
   buildCoverageDebtSuggestionComment,
   CACHE_STATE_ARTIFACT_PREFIX,
   COMPILE_CACHE_FAMILIES,
-  type CompileCacheFamily,
-  compileCacheFamilyForMetric,
-  type CompileCacheState,
   type CompileCacheStates,
-  computeBaseline,
-  computeCiWallTimeRevisitSignals,
   COVERAGE_BASELINE_RESET_MARKER,
   COVERAGE_COMMENT_FILE,
+  type CoverageBaselineDetailed,
   type CoverageCommentPayload,
   coverageGroupForChangedFile,
   coverageGroupsForChangedFiles,
@@ -43,55 +40,38 @@ import {
   type CoverageSuggestionFileLines,
   type CoverageSuggestionGroup,
   downloadAndExtractArtifact,
-  downloadAndParseJUnit,
-  downloadAndParsePerfMetricsBackfill,
-  downloadAndParsePerfMetricsDetailed,
-  dropColdSamples,
-  extractMetrics,
-  extractTimingArtifactMetrics,
+  downloadAndParseCoverageBaseline,
   fetchArtifactsForRun,
   fetchCurrentPRBody,
-  fetchJobsForRun,
   fetchPRFiles,
-  formatMetricValue,
   formatOverrideSuggestion,
   githubGet,
   isCoverageDebtMetric,
   latestNonColdSample,
   mapConcurrent,
   type MetricTimeline,
-  MIN_ABSOLUTE_DELTA,
-  MIN_REGRESSION_PCT,
-  MIN_SAMPLES,
   newestArtifactsByName,
-  newestTimingArtifacts,
   parseAddedLinesFromPatch,
   parseBaselineOverrides,
   parseCacheStateFiles,
-  type ParsedTimingArtifact,
   PERF_METRICS_ARTIFACT_NAME,
-  PERF_METRICS_BACKFILL_ARTIFACT_NAME,
-  PERF_METRICS_BACKFILL_FILE,
   PERF_METRICS_FILE,
-  type PerfMetricsDetailed,
   type PRFile,
   type PRInfo,
   readAndParseEvent,
   REPO,
   shouldGateCoverageDebtMetric,
-  STDDEV_FACTOR,
   type TimingSample,
   walkFiles,
   WORKFLOW_FILE,
   type WorkflowRun,
-  writePerfMetricsBackfillFile,
-  writePerfMetricsFile,
-} from "./perf-lib.ts";
+  writeCoverageBaselineFile,
+} from "./ci-check-lib.ts";
 import {
   fillMissingFamiliesFromFingerprint,
   inferCurrentRunFallbackState,
   recordUnstampedBaselineRunState,
-} from "./perf-cache-state.ts";
+} from "./compile-cache-state.ts";
 import * as path from "@std/path";
 import {
   collectCoverageDebtMetricsFromLcov,
@@ -100,11 +80,8 @@ import {
   lcovFromCoverageProfile,
 } from "./coverage-metrics.ts";
 
-/** How many recent main-branch runs to use for baseline. */
+/** How many recent main-branch runs to scan for the coverage baseline. */
 const BASELINE_RUNS = 20;
-
-/** Recent completed workflow runs to scan for fallback backfill artifacts. */
-const BACKFILL_SOURCE_RUNS = 20;
 
 export function currentWorkflowRunFromEvent(
   event: object | undefined,
@@ -151,12 +128,12 @@ export async function githubApiOrSkip<T>(
     console.warn(
       `  Warning: GitHub API rate limit while ${description}: ${error}`,
     );
-    await writePerfMetricsFile(PERF_METRICS_FILE, metricsForArtifact);
+    await writeCoverageBaselineFile(PERF_METRICS_FILE, metricsForArtifact);
     console.log(
       `Wrote ${PERF_METRICS_FILE} with ${metricsForArtifact.size} metrics.`,
     );
     console.log(
-      "Skipping performance regression check because GitHub API rate limits prevent collecting required CI timing data.",
+      "Skipping coverage check because GitHub API rate limits prevent collecting the baseline data.",
     );
     Deno.exit(0);
   }
@@ -373,7 +350,7 @@ export function logBaselineSourceRuns(
   for (
     const { run, artifacts, pr, prLookupError, commitsBehindMain } of contexts
   ) {
-    const perfMetricsArtifact = newestArtifactNamed(
+    const baselineArtifact = newestArtifactNamed(
       artifacts,
       PERF_METRICS_ARTIFACT_NAME,
     );
@@ -382,8 +359,8 @@ export function logBaselineSourceRuns(
       : prLookupError
       ? "PR lookup failed"
       : "no PR found";
-    const artifactLabel = perfMetricsArtifact
-      ? `perf-metrics artifact ${perfMetricsArtifact.id}`
+    const artifactLabel = baselineArtifact
+      ? `perf-metrics artifact ${baselineArtifact.id}`
       : "no perf-metrics artifact";
     const ageLabel = formatBaselineSourceRunAge(
       run.created_at,
@@ -483,7 +460,6 @@ export async function fetchBaselineRunsForCheck(
 export function reportBaselineRunAvailability(
   baselineRuns: WorkflowRun[],
   mainHeadSha: string,
-  minSamples = MIN_SAMPLES,
   warn: (message: string) => void = console.warn,
 ): BaselineMainHeadValidation {
   const baselineMainHead = validateBaselineRunsForMainHead(
@@ -499,9 +475,9 @@ export function reportBaselineRunAvailability(
     }
   }
 
-  if (baselineRuns.length < minSamples) {
+  if (baselineRuns.length === 0) {
     warn(
-      `  Warning: only ${baselineRuns.length} baseline runs available (need ${minSamples}). Metrics with too few samples will be reported as n/a.`,
+      "  Warning: no baseline runs available; coverage debt will bootstrap from this run.",
     );
   }
 
@@ -549,25 +525,6 @@ export async function buildBaselineRunContexts(
   );
 }
 
-export async function buildExtraBackfillContexts(
-  runs: WorkflowRun[],
-  fetchArtifactsForRun: (run: WorkflowRun) => Promise<Artifact[]> =
-    fetchArtifactsForRunBestEffort,
-  concurrency = API_CONCURRENCY,
-): Promise<BaselineRunContext[]> {
-  return await mapConcurrent(
-    runs,
-    concurrency,
-    async (run): Promise<BaselineRunContext> => ({
-      run,
-      artifacts: await fetchArtifactsForRun(run),
-      pr: null,
-      prLookupError: null,
-      commitsBehindMain: null,
-    }),
-  );
-}
-
 export function reportBaselineContextResults(
   contexts: BaselineRunContext[],
   currentRunCreatedAt: string,
@@ -576,35 +533,19 @@ export function reportBaselineContextResults(
   const prLookupFailures = reportPRLookupResults(contexts);
   if (prLookupFailures > 0) {
     console.warn(
-      "  Warning: running performance regression check with incomplete PR metadata. Some merged baseline overrides may be missing.",
+      "  Warning: running the coverage check with incomplete PR metadata. Some merged baseline overrides may be missing.",
     );
   }
   return prLookupFailures;
 }
 
-export async function parsePerfMetricBackfillFromArtifacts(
-  artifacts: Artifact[],
-  parseBackfill: (
-    artifactId: number,
-  ) => Promise<Map<number, Map<string, TimingSample>> | null> =
-    downloadAndParsePerfMetricsBackfill,
-): Promise<Map<number, Map<string, TimingSample>> | null> {
-  const artifact = newestArtifactNamed(
-    artifacts,
-    PERF_METRICS_BACKFILL_ARTIFACT_NAME,
-  );
-  if (!artifact) return null;
-
-  return await parseBackfill(artifact.id);
-}
-
-export async function parsePerfMetricsFromArtifacts(
+export async function parseCoverageBaselineFromArtifacts(
   artifacts: Artifact[],
   parseMetrics: (
     artifactId: number,
-  ) => Promise<PerfMetricsDetailed | null> =
-    downloadAndParsePerfMetricsDetailed,
-): Promise<PerfMetricsDetailed | null> {
+  ) => Promise<CoverageBaselineDetailed | null> =
+    downloadAndParseCoverageBaseline,
+): Promise<CoverageBaselineDetailed | null> {
   const artifact = newestArtifactNamed(
     artifacts,
     PERF_METRICS_ARTIFACT_NAME,
@@ -614,19 +555,20 @@ export async function parsePerfMetricsFromArtifacts(
   return await parseMetrics(artifact.id);
 }
 
-export interface AddPerfMetricsResult {
+export interface AddCoverageBaselineResult {
   added: boolean;
   /** Null when the run has no perf-metrics artifact or an untagged one. */
   compileCacheStates: CompileCacheStates | null;
 }
 
-export async function addPerfMetricsFromArtifacts(
+export async function addCoverageBaselineFromArtifacts(
   timelines: Map<string, MetricTimeline>,
   artifacts: Artifact[],
   parseMetrics: (
     artifacts: Artifact[],
-  ) => Promise<PerfMetricsDetailed | null> = parsePerfMetricsFromArtifacts,
-): Promise<AddPerfMetricsResult> {
+  ) => Promise<CoverageBaselineDetailed | null> =
+    parseCoverageBaselineFromArtifacts,
+): Promise<AddCoverageBaselineResult> {
   const detailed = await parseMetrics(artifacts);
   if (!detailed) return { added: false, compileCacheStates: null };
 
@@ -711,16 +653,6 @@ export async function collectCurrentCacheStates(
     return {};
   }
 }
-
-/**
- * Metrics to exclude from regression checks because their aggregate values
- * naturally grow as new tests are added.  Per-test timings from JUnit
- * artifacts are tracked instead.
- */
-const EXCLUDED_METRIC_PATTERNS = [
-  /^job: Pattern Unit Tests/,
-  /^step: pattern unit tests$/,
-];
 
 const EXPECTED_COVERAGE_ARTIFACT_NAMES = [
   ...[1, 2, 3, 4, 5, 6].map((shard) => `coverage-profile-workspace-${shard}`),
@@ -835,10 +767,8 @@ async function readCombinedLcov(lcovDir: string): Promise<string> {
 type TableAlign = "left" | "right";
 export type Status =
   | "OVER"
-  | "CLOSE"
   | "OK"
   | "ovrd"
-  | "COLD"
   | "excl"
   | "n/a";
 
@@ -868,28 +798,19 @@ function printTextTable(
   }
 }
 
-function trimTrailingZero(value: string): string {
-  return value.replace(/\.0(?=[a-z])/g, "");
-}
-
 export function formatMetricValueForTable(
-  metric: string,
   value: number | undefined,
 ): string {
   if (value === undefined) return "-";
-  if (isCoverageDebtMetric(metric)) return `${Math.round(value)}`;
-  return trimTrailingZero(formatMetricValue(metric, value));
+  return `${Math.round(value)}`;
 }
 
-export function formatMetricDelta(metric: string, row: Row): string {
+export function formatMetricDelta(row: Row): string {
   if (row.median === undefined || row.pctIncrease === undefined) return "-";
 
   const delta = row.current - row.median;
   const sign = delta >= 0 ? "+" : "-";
-  const absolute = Math.abs(delta);
-  const formattedAbsolute = isCoverageDebtMetric(metric)
-    ? `${Math.round(absolute)}`
-    : trimTrailingZero(formatMetricValue(metric, absolute));
+  const formattedAbsolute = `${Math.round(Math.abs(delta))}`;
   const pctSign = row.pctIncrease >= 0 ? "+" : "";
   const pctDigits = row.pctIncrease !== 0 && Math.abs(row.pctIncrease) < 1
     ? 1
@@ -907,15 +828,6 @@ export function metricDisplayParts(
 
   const kind = metric.slice(0, colon);
   const rest = metric.slice(colon + 1).trim();
-  const subtaskSeparator = " > ";
-
-  if (
-    (kind === "test" || kind === "subtest") &&
-    rest.includes(subtaskSeparator)
-  ) {
-    const [task, ...metricParts] = rest.split(subtaskSeparator);
-    return { task, metric: metricParts.join(subtaskSeparator) };
-  }
 
   if (kind === "coverage-debt") {
     return {
@@ -931,18 +843,10 @@ export interface Row {
   metric: string;
   status: Status;
   current: number;
+  /** Latest non-cold `main` ratchet baseline (uncovered lines). */
   median?: number;
-  variance?: number;
-  stddev?: number;
-  threshold?: number;
   n: number;
   pctIncrease?: number;
-  /**
-   * How much of the median-to-threshold margin the current value has consumed,
-   * as a percentage. 0 percent means the current value is at the median.
-   * 100 percent means the current value is at the threshold.
-   */
-  headroomPct?: number;
 }
 
 export function metricTableRows(
@@ -952,9 +856,9 @@ export function metricTableRows(
   return rows.map((row) => {
     const display = metricDisplayParts(row.metric);
     const cells = [
-      formatMetricValueForTable(row.metric, row.median),
-      formatMetricValueForTable(row.metric, row.current),
-      formatMetricDelta(row.metric, row),
+      formatMetricValueForTable(row.median),
+      formatMetricValueForTable(row.current),
+      formatMetricDelta(row),
       display.task,
       display.metric,
     ];
@@ -970,116 +874,6 @@ export function printMetricTable(rows: Row[], includeStatus = false): void {
     ? ["left", "right", "right", "right", "left", "left"] as TableAlign[]
     : ["right", "right", "right", "left", "left"] as TableAlign[];
   printTextTable(headers, metricTableRows(rows, includeStatus), align);
-}
-
-export interface EvaluateTimingMetricOptions {
-  metric: string;
-  current: number;
-  timeline: MetricTimeline | undefined;
-  prOverrides: BaselineOverrides;
-  /** The current run's per-family compile cache states. */
-  currentCacheStates: CompileCacheStates;
-  /** Baseline-run cache state lookup, per family. */
-  stateOfRunForFamily: (
-    family: CompileCacheFamily,
-  ) => (runId: number) => CompileCacheState | undefined;
-}
-
-export interface TimingMetricEvaluation {
-  row: Row;
-  failure: boolean;
-}
-
-/**
- * Evaluate one timing (non-coverage) metric against its baseline timeline.
- *
- * Compile-cache handling: when the metric maps to a cache family whose cache
- * is cold this run, the metric gets a non-blocking `COLD` status — a full
- * recompile inflates it, and cold baselines essentially never reach
- * MIN_SAMPLES, so there is no cold-vs-cold gating. When the current run is
- * warm or unknown, known-cold baseline samples are dropped before computing
- * the baseline; too few remaining samples fall back to the `n/a` path.
- * Metrics excluded via EXCLUDED_METRIC_PATTERNS stay `excl` even when cold.
- */
-export function evaluateTimingMetric(
-  options: EvaluateTimingMetricOptions,
-): TimingMetricEvaluation {
-  const { metric, current, timeline, prOverrides } = options;
-
-  const family = compileCacheFamilyForMetric(metric);
-  const currentIsCold = family !== null &&
-    options.currentCacheStates[family] === "cold";
-  const samples = family !== null && !currentIsCold
-    ? dropColdSamples(
-      timeline?.samples ?? [],
-      options.stateOfRunForFamily(family),
-    )
-    : timeline?.samples ?? [];
-  const n = samples.length;
-
-  const baseline = computeBaseline(
-    samples.map((s) => s.durationSeconds),
-    MIN_ABSOLUTE_DELTA,
-  );
-
-  const stats = baseline && {
-    median: baseline.median,
-    variance: baseline.variance,
-    stddev: baseline.stddev,
-    threshold: baseline.threshold,
-    pctIncrease: ((current - baseline.median) / baseline.median) * 100,
-    headroomPct: baseline.threshold > baseline.median
-      ? ((current - baseline.median) /
-        (baseline.threshold - baseline.median)) * 100
-      : 0,
-  };
-
-  // Metrics whose aggregate values grow as tests are added — never fail,
-  // but still shown so the log has full context. Takes precedence over COLD.
-  if (EXCLUDED_METRIC_PATTERNS.some((re) => re.test(metric))) {
-    return {
-      row: { metric, status: "excl", current, n, ...(stats ?? {}) },
-      failure: false,
-    };
-  }
-
-  // Cold compile cache for this metric's job family — report without gating.
-  if (currentIsCold) {
-    return { row: { metric, status: "COLD", current, n }, failure: false };
-  }
-
-  // Not enough baseline data — show anyway.
-  if (!baseline) {
-    return { row: { metric, status: "n/a", current, n }, failure: false };
-  }
-
-  // PR has an override saving this metric.
-  if (prOverrides.metrics.has(metric)) {
-    const override = prOverrides.metrics.get(metric)!;
-    if (current <= override) {
-      return {
-        row: { metric, status: "ovrd", current, n, ...stats! },
-        failure: false,
-      };
-    }
-  }
-
-  if (current > baseline.threshold) {
-    return {
-      row: { metric, status: "OVER", current, n, ...stats! },
-      failure: true,
-    };
-  }
-  if ((stats!.headroomPct ?? 0) >= 50) {
-    return {
-      row: { metric, status: "CLOSE", current, n, ...stats! },
-      failure: false,
-    };
-  }
-  return {
-    row: { metric, status: "OK", current, n, ...stats! },
-    failure: false,
-  };
 }
 
 async function extractCoverageDebtSamples(
@@ -1400,7 +1194,7 @@ export async function main() {
 
   if (prOverrides.metrics.size > 0) {
     console.log(
-      `PR description contains ${prOverrides.metrics.size} NEW_PERF_BASELINE override(s).`,
+      `PR description contains ${prOverrides.metrics.size} ACCEPT_COVERAGE_DEBT override(s).`,
     );
   }
   if (prOverrides.coverageBaselineReset) {
@@ -1409,18 +1203,12 @@ export async function main() {
     );
   }
 
-  // 2. Get current run's job/step metrics and per-test timing artifacts
-  console.log(`Fetching jobs for current run ${runId}...`);
+  // 2. Extract the current run's coverage.
   const runIdNum = parseInt(runId);
   const currentMetrics = new Map<string, TimingSample>();
-  const currentJobs = await githubApiOrSkip(
-    `fetching jobs for current run ${runId}`,
-    () => fetchJobsForRun(runIdNum),
-    currentMetrics,
-  );
 
   // The event payload has the metadata needed for samples, so avoid spending
-  // another API request on the current workflow run.
+  // an API request on the current workflow run.
   const currentRunInfo = currentWorkflowRunFromEvent(event, runIdNum);
   let changedCoverageGroups: Set<string> | undefined;
   let prFiles: PRFile[] = [];
@@ -1450,16 +1238,9 @@ export async function main() {
     }
   }
 
-  // Extract job/step metrics
-  for (const [name, sample] of extractMetrics(currentRunInfo, currentJobs)) {
-    currentMetrics.set(name, sample);
-  }
-
   let currentArtifacts: Artifact[] = [];
   let currentArtifactsError: unknown;
 
-  // Fetch artifacts once; coverage extraction depends on this, while timing
-  // artifact parsing below is best-effort.
   try {
     currentArtifacts = await fetchArtifactsForRun(runIdNum);
     console.log(
@@ -1471,8 +1252,8 @@ export async function main() {
   }
 
   // Aggregate the current run's compile cache states so this run's
-  // perf-metrics artifact is tagged (main-push runs included — future
-  // baselines must know whether this run was cold).
+  // perf-metrics artifact is tagged (main-push runs included — a later
+  // PR's coverage ratchet must know whether this run was cold).
   const currentCacheStates = await collectCurrentCacheStates(currentArtifacts);
   console.log(
     `Compile cache states: ${formatCompileCacheStates(currentCacheStates)}`,
@@ -1491,29 +1272,6 @@ export async function main() {
     fetchLatestBaselineSha: fetchLatestBaselineRunSha,
   });
   fillMissingFamiliesFromFingerprint(currentCacheStates, inferredRunState);
-
-  // Extract per-test metrics from JUnit artifacts.
-  const parsedTimingArtifacts: ParsedTimingArtifact[] = [];
-  try {
-    // Newest per name: a re-run of a flagged test job must refresh its metric.
-    const timingArtifacts = newestTimingArtifacts(currentArtifacts);
-    for (const artifact of timingArtifacts) {
-      const suites = await downloadAndParseJUnit(artifact.id);
-      parsedTimingArtifacts.push({ name: artifact.name, suites });
-    }
-  } catch (e) {
-    console.warn(
-      `  Warning: could not extract timing metrics from current run artifacts: ${e}`,
-    );
-  }
-  for (
-    const [name, sample] of extractTimingArtifactMetrics(
-      currentRunInfo,
-      parsedTimingArtifacts,
-    )
-  ) {
-    currentMetrics.set(name, sample);
-  }
 
   // Extract coverage debt metrics from coverage profile artifacts.
   let coverageDataError: unknown;
@@ -1540,7 +1298,7 @@ export async function main() {
     );
   }
 
-  await writePerfMetricsFile(
+  await writeCoverageBaselineFile(
     PERF_METRICS_FILE,
     currentMetrics,
     currentCacheStates,
@@ -1557,12 +1315,15 @@ export async function main() {
   }
 
   if (currentMetrics.size === 0) {
-    console.log("No metrics extracted from current run. Nothing to check.");
+    console.log(
+      "No coverage metrics extracted from current run. Nothing to check.",
+    );
     Deno.exit(0);
   }
 
-  console.log(`Extracted ${currentMetrics.size} metrics from current run.`);
-  const wallTimeSignals = computeCiWallTimeRevisitSignals(currentJobs);
+  console.log(
+    `Extracted ${currentMetrics.size} coverage metrics from current run.`,
+  );
 
   // 3. Fetch recent main-branch push runs for baseline
   const { mainHeadSha, baselineRuns } = await fetchBaselineRunsForCheck(
@@ -1572,13 +1333,14 @@ export async function main() {
 
   console.log(`Using ${baselineRuns.length} main-branch runs as baseline.`);
 
-  // 4. Fetch job/step metrics for baseline runs + check for baseline overrides
+  // 4. Read each recent main run's coverage metrics and compile cache states
+  // as the ratchet baseline, and pick up any coverage ratchet resets or
+  // per-metric acceptances from the merged PRs.
   const timelines = new Map<string, MetricTimeline>();
   const overridesBySha = new Map<string, BaselineOverrides>();
   const prInfoBySha = new Map<string, PRInfo>();
-  const newBackfills = new Map<number, Map<string, TimingSample>>();
   // Compile cache states per baseline run, from tagged perf-metrics
-  // artifacts. Backfill and jobs-API fallback runs stay absent (unknown).
+  // artifacts. Runs with no artifact stay absent (unknown).
   const cacheStatesByRunId = new Map<number, CompileCacheStates>();
 
   const baselineContexts = await githubApiOrSkip(
@@ -1589,62 +1351,10 @@ export async function main() {
 
   reportBaselineContextResults(baselineContexts, currentRunInfo.created_at);
 
-  console.log("Fetching recent perf metric backfills...");
-  const backfillSourceData = await githubApiOrSkip(
-    "fetching recent perf metric backfill sources",
-    () =>
-      githubGet<{ workflow_runs: WorkflowRun[] }>(
-        workflowRunsPathForBaseline(BACKFILL_SOURCE_RUNS),
-      ),
-    currentMetrics,
-  );
-  const baselineRunIds = new Set(baselineRuns.map((run) => run.id));
-  const backfillSourceRuns = backfillSourceData.workflow_runs.filter((run) =>
-    !baselineRunIds.has(run.id) && run.id !== runIdNum
-  );
-  const extraBackfillContexts = await githubApiOrSkip(
-    "fetching extra perf metric backfill context",
-    () => buildExtraBackfillContexts(backfillSourceRuns),
-    currentMetrics,
-  );
-
-  const backfilledMetricsByRunId = new Map<number, Map<string, TimingSample>>();
-  const backfillSourceContexts = [
-    ...baselineContexts,
-    ...extraBackfillContexts,
-  ].sort((a, b) =>
-    b.run.created_at.localeCompare(a.run.created_at) || b.run.id - a.run.id
-  );
-  const parsedBackfillSources = await githubApiOrSkip(
-    "downloading perf metric backfills",
-    () =>
-      mapConcurrent(
-        backfillSourceContexts,
-        API_CONCURRENCY,
-        ({ artifacts }) => parsePerfMetricBackfillFromArtifacts(artifacts),
-      ),
-    currentMetrics,
-  );
-
-  for (const backfills of parsedBackfillSources) {
-    if (!backfills) continue;
-
-    for (const [backfilledRunId, metrics] of backfills) {
-      if (!backfilledMetricsByRunId.has(backfilledRunId)) {
-        backfilledMetricsByRunId.set(backfilledRunId, metrics);
-      }
-    }
-  }
-  if (backfilledMetricsByRunId.size > 0) {
-    console.log(
-      `Loaded perf metric backfills for ${backfilledMetricsByRunId.size} run(s).`,
-    );
-  }
-
   // For each baseline run, its predecessor in the (newest-first) baseline
   // list — the run whose saved compile cache it would have restored. Fuels
-  // retro-classification of runs whose artifacts predate the recorded stamp;
-  // once stamped artifacts fill the window this map goes unused.
+  // retro-classification of a run whose perf-metrics artifact carries no
+  // recorded cache state.
   const runsNewestFirst = [...baselineRuns].sort((a, b) =>
     b.created_at.localeCompare(a.created_at) || b.id - a.id
   );
@@ -1673,16 +1383,17 @@ export async function main() {
           }
         }
 
-        const artifactResult = await addPerfMetricsFromArtifacts(
+        const artifactResult = await addCoverageBaselineFromArtifacts(
           timelines,
           artifacts,
         );
         if (artifactResult.added && artifactResult.compileCacheStates) {
           cacheStatesByRunId.set(run.id, artifactResult.compileCacheStates);
         } else {
-          // Unstamped run (an artifact carrying no recorded stamp — a backfill
-          // or a live extraction): retro-classify it from the compile
-          // fingerprint against its predecessor (see
+          // A run whose perf-metrics artifact is missing or carries no
+          // recorded cache state: retro-classify it from the compile
+          // fingerprint against its predecessor, so a cold main run is not
+          // picked as the coverage ratchet baseline (see
           // recordUnstampedBaselineRunState).
           await recordUnstampedBaselineRunState(
             cacheStatesByRunId,
@@ -1691,76 +1402,15 @@ export async function main() {
             pr ? `PR #${pr.number}` : run.head_sha.slice(0, 8),
           );
         }
-        if (artifactResult.added) {
-          return;
-        }
-
-        const backfilledMetrics = backfilledMetricsByRunId.get(run.id);
-        if (backfilledMetrics) {
-          for (const [name, sample] of backfilledMetrics) {
-            addSample(timelines, name, sample);
-          }
-          return;
-        }
-
-        const jobs = await fetchJobsForRun(run.id);
-        const metrics = new Map(extractMetrics(run, jobs));
-        for (const [name, sample] of metrics) {
-          addSample(timelines, name, sample);
-        }
-
-        // Fetch per-test timing artifacts
-        let canBackfill = true;
-        const parsedTimingArtifacts: ParsedTimingArtifact[] = [];
-        try {
-          const timingArtifacts = newestTimingArtifacts(artifacts);
-          for (const artifact of timingArtifacts) {
-            const suites = await downloadAndParseJUnit(artifact.id);
-            if (suites.length === 0) {
-              canBackfill = false;
-              continue;
-            }
-            parsedTimingArtifacts.push({ name: artifact.name, suites });
-          }
-        } catch {
-          // Artifacts may not exist for older runs
-          canBackfill = false;
-        }
-        const testMetrics = extractTimingArtifactMetrics(
-          run,
-          parsedTimingArtifacts,
-        );
-        for (const [name, sample] of testMetrics) {
-          metrics.set(name, sample);
-          addSample(timelines, name, sample);
-        }
-
-        if (metrics.size > 0 && canBackfill) {
-          newBackfills.set(run.id, metrics);
-        }
       }),
     currentMetrics,
   );
-
-  if (newBackfills.size > 0) {
-    await writePerfMetricsBackfillFile(
-      PERF_METRICS_BACKFILL_FILE,
-      newBackfills,
-    );
-    console.log(
-      `Wrote ${PERF_METRICS_BACKFILL_FILE} for ${newBackfills.size} fallback run(s).`,
-    );
-  }
 
   // Sort timelines chronologically
   for (const timeline of timelines.values()) {
     timeline.samples.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   }
 
-  const stateOfRunForFamily =
-    (family: CompileCacheFamily) =>
-    (runId: number): CompileCacheState | undefined =>
-      cacheStatesByRunId.get(runId)?.[family];
   const isRunCold = (runId: number): boolean => {
     const states = cacheStatesByRunId.get(runId);
     return states !== undefined && Object.values(states).includes("cold");
@@ -1773,108 +1423,83 @@ export async function main() {
   // Apply baseline overrides from merged PRs
   if (overridesBySha.size > 0) {
     console.log(
-      `Found ${overridesBySha.size} baseline override(s) from merged PRs.`,
+      `Found ${overridesBySha.size} coverage baseline override(s) from merged PRs.`,
     );
     applyBaselineOverrides(timelines, overridesBySha);
   }
 
-  // 5. Compare current metrics against baseline
+  // 5. Compare the current run's coverage debt against the ratchet baseline.
   const rows: Row[] = [];
   const failures: Row[] = [];
 
   for (const [metric, currentSample] of currentMetrics) {
     const current = currentSample.durationSeconds;
     const timeline = timelines.get(metric);
-    const isCoverageMetric = isCoverageDebtMetric(metric);
+    const n = timeline?.samples.length ?? 0;
+    // Ratchet against the latest run that was not known-cold: a cold main
+    // run covers rare cold-compile-only branches, and ratcheting against
+    // its lower debt would fail later warm PRs with phantom regressions.
+    const latestBaseline = timeline
+      ? latestNonColdSample(timeline.samples, isRunCold)?.durationSeconds
+      : undefined;
+    const override = prOverrides.metrics.get(metric);
+    const coverageReset = prOverrides.coverageBaselineReset;
+    const shouldGateCoverage = shouldGateCoverageDebtMetric(
+      metric,
+      changedCoverageGroups,
+    );
 
-    if (isCoverageMetric) {
-      const n = timeline?.samples.length ?? 0;
-      // Ratchet against the latest run that was not known-cold: a cold main
-      // run covers rare cold-compile-only branches, and ratcheting against
-      // its lower debt would fail later warm PRs with phantom regressions.
-      const latestBaseline = timeline
-        ? latestNonColdSample(timeline.samples, isRunCold)?.durationSeconds
-        : undefined;
-      const override = prOverrides.metrics.get(metric);
-      const coverageReset = prOverrides.coverageBaselineReset;
-      const shouldGateCoverage = shouldGateCoverageDebtMetric(
-        metric,
-        changedCoverageGroups,
-      );
-
-      if (latestBaseline === undefined) {
-        if (
-          coverageReset || (override !== undefined && current <= override)
-        ) {
-          rows.push({ metric, status: "ovrd", current, n });
-        } else if (!shouldGateCoverage) {
-          rows.push({ metric, status: "excl", current, n });
-        } else if (current > 0) {
-          const row: Row = {
-            metric,
-            status: "OVER",
-            current,
-            median: 0,
-            variance: 0,
-            stddev: 0,
-            threshold: 0,
-            n,
-            pctIncrease: 100,
-          };
-          rows.push(row);
-          failures.push(row);
-        } else {
-          rows.push({ metric, status: "n/a", current, n });
-        }
-        continue;
-      }
-
-      const pctIncrease = latestBaseline === 0
-        ? current > 0 ? 100 : 0
-        : ((current - latestBaseline) / latestBaseline) * 100;
-      const stats = {
-        median: latestBaseline,
-        variance: 0,
-        stddev: 0,
-        threshold: latestBaseline,
-        pctIncrease,
-      };
-
-      if (coverageReset) {
-        rows.push({ metric, status: "ovrd", current, n, ...stats });
-        continue;
-      }
-
-      if (override !== undefined && current <= override) {
-        rows.push({ metric, status: "ovrd", current, n, ...stats });
-        continue;
-      }
-
-      if (!shouldGateCoverage) {
-        rows.push({ metric, status: "excl", current, n, ...stats });
-        continue;
-      }
-
-      if (current > latestBaseline) {
-        const row: Row = { metric, status: "OVER", current, n, ...stats };
+    if (latestBaseline === undefined) {
+      if (
+        coverageReset || (override !== undefined && current <= override)
+      ) {
+        rows.push({ metric, status: "ovrd", current, n });
+      } else if (!shouldGateCoverage) {
+        rows.push({ metric, status: "excl", current, n });
+      } else if (current > 0) {
+        const row: Row = {
+          metric,
+          status: "OVER",
+          current,
+          median: 0,
+          n,
+          pctIncrease: 100,
+        };
         rows.push(row);
         failures.push(row);
       } else {
-        rows.push({ metric, status: "OK", current, n, ...stats });
+        rows.push({ metric, status: "n/a", current, n });
       }
       continue;
     }
 
-    const { row, failure } = evaluateTimingMetric({
-      metric,
-      current,
-      timeline,
-      prOverrides,
-      currentCacheStates,
-      stateOfRunForFamily,
-    });
-    rows.push(row);
-    if (failure) failures.push(row);
+    const pctIncrease = latestBaseline === 0
+      ? current > 0 ? 100 : 0
+      : ((current - latestBaseline) / latestBaseline) * 100;
+    const stats = { median: latestBaseline, pctIncrease };
+
+    if (coverageReset) {
+      rows.push({ metric, status: "ovrd", current, n, ...stats });
+      continue;
+    }
+
+    if (override !== undefined && current <= override) {
+      rows.push({ metric, status: "ovrd", current, n, ...stats });
+      continue;
+    }
+
+    if (!shouldGateCoverage) {
+      rows.push({ metric, status: "excl", current, n, ...stats });
+      continue;
+    }
+
+    if (current > latestBaseline) {
+      const row: Row = { metric, status: "OVER", current, n, ...stats };
+      rows.push(row);
+      failures.push(row);
+    } else {
+      rows.push({ metric, status: "OK", current, n, ...stats });
+    }
   }
 
   // 6. Report results
@@ -1883,26 +1508,14 @@ export async function main() {
   if (failures.length > 0) {
     console.log(
       "\n!!!" +
-        `\n!!! PERFORMANCE REGRESSION DETECTED in ${failures.length} metric(s) !!!` +
+        `\n!!! COVERAGE DEBT REGRESSION in ${failures.length} source group(s) !!!` +
         "\n!!!",
     );
   }
 
-  // 6b. Informational CI wall-time policy signals. These are intentionally
-  // non-blocking; they tell us when to consider CI split/rebalance work again.
-  if (wallTimeSignals.length > 0) {
-    console.log("\n## CI Wall-Time Revisit Signals");
-    console.log(
-      "Informational only. See docs/development/CI_PERFORMANCE.md before starting CI-splitting work.",
-    );
-    printTextTable(
-      ["Signal", "Detail"],
-      wallTimeSignals.map((signal) => [signal.title, signal.detail]),
-    );
-  }
-
-  // 6c. Cold compile cache callout — the affected timing metrics are shown
-  // as COLD and not gated this run.
+  // 6b. Cold compile cache note. A cold run covers cold-compile-only branches,
+  // so it is recorded cold and a later PR's coverage ratchet skips it as a
+  // baseline in favour of the latest warm main run.
   const coldFamilies = COMPILE_CACHE_FAMILIES.filter(
     (family) => currentCacheStates[family] === "cold",
   );
@@ -1912,183 +1525,72 @@ export async function main() {
       `The pattern compile byte cache missed for: ${coldFamilies.join(", ")}.`,
     );
     console.log(
-      "Timing metrics for these job families run a full recompile (~1.7-2x slower per test),",
+      "This run is recorded cold. A cold run covers cold-compile-only branches,",
     );
     console.log(
-      "so they are reported as COLD and not gated — comparing them against warm baselines",
+      "so a later PR's coverage ratchet skips it and uses the latest warm main run",
     );
     console.log(
-      "would flag phantom regressions, and cold baselines are too rare to gate against.",
-    );
-    console.log(
-      "To get a warm, fully gated run, re-run the pattern jobs: this cold run already saved the new compile cache.",
+      "instead — otherwise warm PRs would be held to a stricter, unreachable bar.",
     );
   }
 
-  // 6d. Full metric table — always emitted, grouped by metric kind.
+  // 6c. Full coverage-debt table.
   console.log(
-    "\n::group::All collected metrics:" +
-      `\nThresholds: median + ${STDDEV_FACTOR}σ or +${
-        MIN_REGRESSION_PCT * 100
-      }% (whichever is higher); timing metrics also require at least +${MIN_ABSOLUTE_DELTA}s.`,
+    "\n::group::All coverage debt metrics:\n" +
+      "Ratchet: for a source group the PR changed, uncovered lines must not rise\n" +
+      "above the latest non-cold main run's count.\n" +
+      "Status key: OVER = above baseline (fails); OK = at or below baseline;\n" +
+      "  ovrd = accepted by a PR override/reset; excl = not gated for this PR;\n" +
+      "  n/a = no baseline yet and no new uncovered lines.",
   );
-  console.log(
-    "Coverage debt metrics use a latest-main ratchet for changed source groups.",
-  );
-  console.log(
-    "Status key: OVER = over threshold (fails); CLOSE = ≥50% of margin consumed;",
-  );
-  console.log(
-    "  OK = <50% consumed; ovrd = saved by a PR override/reset;",
-  );
-  console.log(
-    "  COLD = compile cache cold for this metric's job family; not gated (rerun to go warm);",
-  );
-  console.log(
-    "  excl = metric excluded from the check;",
-  );
-  console.log(
-    `  n/a = fewer than ${MIN_SAMPLES} baseline samples.`,
-  );
-  console.log(
-    `  head% = fraction of the median→threshold margin currently consumed.`,
-  );
-
-  const kindOf = (metric: string): string => {
-    const colon = metric.indexOf(":");
-    if (colon < 0) return "other";
-    const prefix = metric.slice(0, colon);
-    switch (prefix) {
-      case "job":
-        return "Jobs";
-      case "step":
-        return "Steps";
-      case "test":
-        return "Test files";
-      case "subtest":
-        return "Subtests";
-      case "coverage-debt":
-        return "Coverage Debt";
-      default:
-        return prefix;
-    }
-  };
-  const KIND_ORDER = [
-    "Jobs",
-    "Steps",
-    "Test files",
-    "Subtests",
-    "Coverage Debt",
-  ];
-  // Sort order within each kind: most at-risk of failing the check first.
-  // `ovrd` sits below `OK` because an override-protected metric is at strictly
-  // lower risk of tripping the check than an unguarded OK metric — the author
-  // has already authorized its current level. `COLD` sits below `ovrd`: a
-  // cold metric is not gated this run at all.
+  // Sort order: most at-risk of failing first. `ovrd` sits below `OK` because
+  // an override-protected metric is at strictly lower risk than an unguarded OK
+  // metric — the author has already authorized its current level.
   const STATUS_ORDER: Record<Status, number> = {
-    OVER: 6,
-    CLOSE: 5,
-    OK: 4,
-    ovrd: 3,
-    COLD: 2,
+    OVER: 4,
+    OK: 3,
+    ovrd: 2,
     excl: 1,
     "n/a": 0,
   };
 
-  const byKind = new Map<string, Row[]>();
-  for (const r of rows) {
-    const k = kindOf(r.metric);
-    if (!byKind.has(k)) byKind.set(k, []);
-    byKind.get(k)!.push(r);
-  }
-  const kindsSeen = [
-    ...KIND_ORDER.filter((k) => byKind.has(k)),
-    ...[...byKind.keys()].filter((k) => !KIND_ORDER.includes(k)).sort(),
-  ];
-
   const counts = {
     OVER: 0,
-    CLOSE: 0,
     OK: 0,
     ovrd: 0,
-    COLD: 0,
     excl: 0,
     "n/a": 0,
   } as Record<Status, number>;
   for (const r of rows) counts[r.status]++;
 
   console.log(
-    `\n## All metrics checked  (${rows.length} total — OVER: ${counts.OVER}, CLOSE: ${counts.CLOSE}, OK: ${counts.OK}, ovrd: ${counts.ovrd}, COLD: ${counts.COLD}, excl: ${counts.excl}, n/a: ${
+    `\n## Coverage debt metrics  (${rows.length} total — OVER: ${counts.OVER}, OK: ${counts.OK}, ovrd: ${counts.ovrd}, excl: ${counts.excl}, n/a: ${
       counts["n/a"]
     })`,
   );
 
-  for (const kind of kindsSeen) {
-    const rs = byKind.get(kind)!;
-    rs.sort((a, b) => {
-      const s = STATUS_ORDER[b.status] - STATUS_ORDER[a.status];
-      if (s !== 0) return s;
-      return (b.headroomPct ?? -Infinity) - (a.headroomPct ?? -Infinity);
-    });
-    console.log(`\n### ${kind}  (${rs.length})`);
-    printMetricTable(rs, true);
-  }
+  const sortedRows = [...rows].sort((a, b) => {
+    const s = STATUS_ORDER[b.status] - STATUS_ORDER[a.status];
+    if (s !== 0) return s;
+    return (b.pctIncrease ?? -Infinity) - (a.pctIncrease ?? -Infinity);
+  });
+  printMetricTable(sortedRows, true);
 
   console.log("::endgroup::");
 
-  // 6e. Failure metric details.
+  // 6d. Failure detail.
   if (failures.length > 0) {
     failures.sort((a, b) => (b.pctIncrease ?? 0) - (a.pctIncrease ?? 0));
 
-    console.log("\n## Performance regression details:\n");
+    console.log("\n## Coverage debt regression details:\n");
     printMetricTable(failures);
-
-    console.log("\n::group::Baseline sample breakdown:\n");
-    for (const f of failures) {
-      const timeline = timelines.get(f.metric);
-      if (!timeline) continue;
-
-      // Show the samples the gate actually used: for cache-family metrics
-      // that is the timeline minus known-cold runs (a failing metric was
-      // gated warm — cold current runs never fail). Runs cold in any family
-      // keep a [cold] suffix so the warm-run stats stay auditable.
-      const family = compileCacheFamilyForMetric(f.metric);
-      const samples = family !== null
-        ? dropColdSamples(timeline.samples, stateOfRunForFamily(family))
-        : timeline.samples;
-
-      const fmt = (v: number) => formatMetricValue(f.metric, v);
-      console.log(
-        `  ${f.metric} (n=${samples.length}, median=${
-          fmt(f.median!)
-        }, variance=${fmt(f.variance!)}, stddev=${fmt(f.stddev!)}):`,
-      );
-      for (const s of samples) {
-        const pr = prInfoBySha.get(s.sha);
-        const prStr = pr ? `PR #${pr.number}` : s.sha.slice(0, 8);
-        const coldSuffix = isRunCold(s.runId) ? " [cold]" : "";
-        console.log(
-          `    ${fmt(s.durationSeconds)} — ${prStr} (${
-            s.createdAt.slice(0, 10)
-          })${coldSuffix}`,
-        );
-      }
-    }
-
-    console.log("::endgroup::");
   }
 
-  // 6f. Pass/fail outcome + override copy-paste block pinned at the bottom.
+  // 6e. Pass/fail outcome + acceptance copy-paste block pinned at the bottom.
   if (informationalOnly) {
     console.log("\nInformational Only:");
   }
-
-  const coverageFailures = failures.filter((f) =>
-    isCoverageDebtMetric(f.metric)
-  );
-  const perMetricFailures = failures.filter((f) =>
-    !isCoverageDebtMetric(f.metric)
-  );
 
   // Coverage-debt PR comment, written for the coverage-comment workflow to post
   // (fork PRs get a read-only token on pull_request and cannot comment here).
@@ -2097,56 +1599,35 @@ export async function main() {
   if (prNumber) {
     await writeCoverageComment(
       parseInt(prNumber),
-      coverageFailures,
-      rows.filter((row) => isCoverageDebtMetric(row.metric)),
+      failures,
+      rows,
       prFiles,
       coverageLcov,
     );
   }
 
   if (failures.length === 0) {
-    console.log("\nAll metrics within normal range.");
+    console.log("\nCoverage debt within the ratchet for every changed group.");
     Deno.exit(0);
   } else if (informationalOnly) {
-    console.log("\nOne or more metrics are out-of-range.");
+    console.log("\nOne or more changed groups regressed coverage debt.");
     console.log("This build would fail if it were a PR.");
     Deno.exit(0);
   }
 
-  if (coverageFailures.length > 0) {
-    const verb = coverageBaselineAvailable ? "reset" : "bootstrap";
-    console.log(
-      `\nTo ${verb} the coverage ratchet for one cycle, add the coverage reset marker to your PR description.`,
-    );
-    console.log(
-      "Coverage debt can still be accepted one metric at a time with NEW_PERF_BASELINE when that is the narrower change.",
-    );
-  }
-
+  const verb = coverageBaselineAvailable ? "reset" : "bootstrap";
   console.log(
-    "\nTo accept these regressions, add the following to your PR description:\n",
+    `\nTo ${verb} the coverage ratchet for one cycle, add ${COVERAGE_BASELINE_RESET_MARKER} to your PR description.`,
+  );
+  console.log(
+    "\nTo accept these coverage regressions one metric at a time, add the following to your PR description:\n",
   );
   console.log("---BEGIN COPY-PASTE---");
-  if (coverageFailures.length > 0) {
-    console.log(COVERAGE_BASELINE_RESET_MARKER);
-  }
-  for (const f of perMetricFailures) {
-    const suggested = formatOverrideSuggestion(f.metric, f.current);
-    console.log(`NEW_PERF_BASELINE: ${f.metric} = ${suggested}`);
+  for (const f of failures) {
+    const suggested = formatOverrideSuggestion(f.current);
+    console.log(`ACCEPT_COVERAGE_DEBT: ${f.metric} = ${suggested}`);
   }
   console.log("---END COPY-PASTE---");
-
-  if (coverageFailures.length > 0) {
-    console.log(
-      "\nIndividual coverage override alternatives:",
-    );
-    console.log("---BEGIN COPY-PASTE---");
-    for (const f of coverageFailures) {
-      const suggested = formatOverrideSuggestion(f.metric, f.current);
-      console.log(`NEW_PERF_BASELINE: ${f.metric} = ${suggested}`);
-    }
-    console.log("---END COPY-PASTE---");
-  }
 
   Deno.exit(1);
 }

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -110,7 +110,7 @@ Deno.test("source inventory helpers group tracked files by package", () => {
     metricGroupFor("packages/runner/src/cell.ts"),
     "packages/runner",
   );
-  assertEquals(metricGroupFor("tasks/perf-check.ts"), "tasks");
+  assertEquals(metricGroupFor("tasks/coverage-check.ts"), "tasks");
 });
 
 Deno.test("collectSourceFiles excludes generated and dependency directories", async () => {

--- a/tasks/post-coverage-comment.test.ts
+++ b/tasks/post-coverage-comment.test.ts
@@ -3,7 +3,7 @@ import * as path from "@std/path";
 import {
   buildCoverageResolvedComment,
   COVERAGE_SUGGESTION_MARKER,
-} from "./perf-lib.ts";
+} from "./ci-check-lib.ts";
 import { postCoverageComment } from "./post-coverage-comment.ts";
 
 interface RecordedRequest {

--- a/tasks/post-coverage-comment.ts
+++ b/tasks/post-coverage-comment.ts
@@ -3,8 +3,8 @@
 /**
  * Post the coverage-debt suggestion comment produced by the coverage gate.
  *
- * The gate (tasks/perf-check.ts) runs on the `pull_request` event, where fork
- * PRs only get a read-only token and cannot comment. It writes the intended
+ * The gate (tasks/coverage-check.ts) runs on the `pull_request` event, where
+ * fork PRs only get a read-only token and cannot comment. It writes the intended
  * comment to coverage-comment.json and uploads it as an artifact. The
  * `coverage-comment` workflow_run workflow runs this script from the base-repo
  * context with a write token to actually post it.
@@ -31,7 +31,7 @@ import {
   githubPost,
   REPO,
   TOKEN,
-} from "./perf-lib.ts";
+} from "./ci-check-lib.ts";
 
 /**
  * Read the pending comment payload and post or update the PR's coverage


### PR DESCRIPTION
CI had a single "Performance Check" job that gated pull requests on two unrelated things at once. The first was a timing-regression gate: it compared this run's GitHub Actions job, step, and per-test durations against a baseline computed from recent main runs, and failed the PR when a duration exceeded a median-plus-threshold bound. The second was a coverage-debt gate: a ratchet on the number of uncovered source lines per changed package. This removes the timing gate. It produced false positives from CI runner variance and from cold compile caches, it needed a large baseline-and-backfill machinery to chase that variance, and it never mapped cleanly to a user-visible regression. Benchmark trends on the team dashboard already track performance without blocking merges.

The two gates shared one script, one CI job, one baseline-fetch path, and one per-run artifact, so removing the timing gate meant untangling them rather than deleting a separate pipeline. Everything that only the timing gate needed is gone: the job, step, and test timing extraction; the median-plus-3-sigma-or-50% baseline math and its thresholds; the backfill subsystem that reconstructed timing samples for older runs; the cold-cache COLD and near-threshold CLOSE timing statuses; and the JUnit timing-artifact parsing. The informational "CI Wall-Time Revisit Signals" section is gone too, along with everything that only fed it (the wall-time thresholds and helpers, the job-list fetch, and the Job and Step types) — the same timing data is available from the team dashboard and the GitHub Actions API.

The coverage-debt gate keeps everything it depends on: the recent-main-run baseline fetch, the per-run baseline artifact (now carrying only coverage samples and compile cache states), the compile-cache cold/warm classification that stops a cold main run from lowering the ratchet, and the coverage-comment workflow.

The surviving pieces are renamed so the code reads for what it now does:

  tasks/perf-check.ts       -> tasks/coverage-check.ts
      (CI job "Performance Check" -> "Coverage Check")
  tasks/perf-lib.ts         -> tasks/ci-check-lib.ts
  tasks/perf-cache-state.ts -> tasks/compile-cache-state.ts
  PR acceptance marker NEW_PERF_BASELINE -> ACCEPT_COVERAGE_DEBT
      (it now only accepts coverage debt; NEW_COVERAGE_BASELINE still resets
      the whole ratchet)

The per-run baseline artifact keeps its historical name, perf-metrics / perf-metrics.json (constants PERF_METRICS_ARTIFACT_NAME and PERF_METRICS_FILE), so the ratchet needs no migration: a run from before the gate was removed recorded the same coverage-debt metrics and compile cache states in the identical JSON shape and reads as a valid baseline unchanged. What the artifact holds is the coverage baseline, so its serialization keeps coverage-centric names (serializeCoverageBaseline, parseCoverageBaseline, and the rest).

The coverage-gate mechanics (ratchet baselines, acceptance markers, cold-run handling) move from CI_PERFORMANCE.md into COVERAGE.md, which already documents the coverage gate, leaving CI_PERFORMANCE.md as pure CI wall-time policy. BENCHMARKS.md and PERFORMANCE_PROGRAM.md drop their claims that PRs are gated on CI timings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the CI timing regression gate and keep only the coverage-debt gate. PRs are now blocked only on coverage debt; CI wall time and benchmarks are monitored on the team dashboard.

- **Refactors**
  - Removed all timing-gate code: job/step/test timing extraction, thresholds and baseline math, backfill, JUnit timing parsing, and wall‑time “revisit signals”.
  - Renamed the gate and code: `tasks/perf-check.ts` → `tasks/coverage-check.ts`, `tasks/perf-lib.ts` → `tasks/ci-check-lib.ts`, `tasks/perf-cache-state.ts` → `tasks/compile-cache-state.ts`; CI job “Performance Check” → “Coverage Check”.
  - Kept the `perf-metrics` artifact and JSON shape; it now holds only coverage metrics and compile cache states.
  - Updated docs and workflow text to “Coverage Check”; coverage mechanics moved to `COVERAGE.md`; `CI_PERFORMANCE.md` is wall‑time policy; benches and CI timing are no longer described as gated.

- **Migration**
  - Use `ACCEPT_COVERAGE_DEBT` in PR descriptions to approve increased uncovered lines. `NEW_COVERAGE_BASELINE` still resets the ratchet.
  - Baseline rebuilds honor legacy `NEW_PERF_BASELINE` acceptances from merged PRs for coverage-line metrics; timing forms are ignored. New PRs must use `ACCEPT_COVERAGE_DEBT`.
  - No baseline migration needed; artifact name and format are unchanged. Cold-run handling for baselines is unchanged.

<sup>Written for commit 85682fe9046a97d5caed4c22dc7214d3acbe429b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

