### PR TITLE
fix(api): `FabricValue` is missing `symbol`

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -161,6 +161,7 @@ export type FabricValue =
   | number
   | string
   | bigint
+  | symbol
   | FabricSpecialObject
   | FabricArray
   | FabricPlainObject


### PR DESCRIPTION
`data-model`'s `FabricValue` has included `symbol` all along:

```ts
// packages/data-model/src/interface.ts
export type FabricValue =
  | null | boolean | number | string | bigint | symbol
  | FabricSpecialObject | FabricArray | FabricPlainObject | undefined;
```

`api`'s omits it — and the spec says `data-model` is right.
`docs/specs/space-model-formal-spec/1-fabric-values.md` puts `symbol` in the
fabric-value universe:

```
| symbol    // registry-interned symbols only (`Symbol.keyFor(s)` returns a string)
```

with the narrowing spelled out in Section 1.3: registry-interned symbols
(`Symbol.for(key)`) are first-class fabric values because they are portable
across realms and processes via their registry key, while unique symbols are
rejected. The spec anticipates the TypeScript situation directly — "The
TypeScript `symbol` type cannot express this distinction, so it is enforced at
runtime by the conversion, hashing, and serialization boundaries" — so `| symbol`
in the TS union is correct by design, with the condition enforced at runtime.

## Why nobody noticed

It is unobservable on `main`. `FabricSpecialObject` is declared with no members,
so structurally *every* object satisfies it, and both unions collapse to "any
object" wherever they are checked — so the two never have to agree.

Branding that class in a local experiment makes them have to, and this one
missing union member accounts for **131** of the resulting type errors
(241 → 110). Nearly all are the same shape: `Immutable<FabricValue>`
(`data-model`, with `symbol`) not assignable to `FabricValue` (`api`, without),
through every `IExtendedStorageTransaction.readOrThrow()` call site.

## Scope

Deliberately one line. The branding work that surfaced it is a larger arc with
~110 remaining per-site decisions and will need real review; this fix is
obviously correct on its own terms and shouldn't wait on it.

Workspace `deno task check` passes; full repo suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `symbol` to `FabricValue` in `api` to match `data-model`, keeping the type definitions in sync. This fixes cross-package assignment errors (e.g., `Immutable<FabricValue>` → `FabricValue`) and unblocks branding work.

<sup>Written for commit 1878e73f615234554050ff1f6fc1709d1cf97ed5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


