### PR TITLE
test(test-support): make the lockfile-drift check hermetic

### DIFF
--- a/packages/test-support/src/isolated-deno.test.ts
+++ b/packages/test-support/src/isolated-deno.test.ts
@@ -3,6 +3,7 @@ import { join } from "@std/path";
 import {
   readDenoConfig,
   runDenoCheckWithTemporaryConfig,
+  runFrozenDriftCheck,
 } from "./isolated-deno.ts";
 
 const ROOT = join(import.meta.dirname!, "..", "..", "..");
@@ -33,28 +34,50 @@ Deno.test("nested checks use the checked-in dependency graph", async () => {
   assertEquals(await Deno.readTextFile(lockPath), lockBefore);
 });
 
-Deno.test("nested checks reject dependency graph changes", async () => {
-  const rootConfig = await readDenoConfig(join(ROOT, "deno.jsonc"));
-  const shellConfig = await readDenoConfig(
-    join(ROOT, "packages", "shell", "deno.jsonc"),
+Deno.test("nested frozen checks reject dependency graph drift", async () => {
+  // A frozen check rejects a config whose dependency graph no longer matches
+  // its lockfile. Proving that against the whole workspace would force Deno to
+  // re-resolve every npm package from the registry, so this uses a small
+  // self-contained workspace instead. The imports are two of the repository's
+  // own JSR dependencies, pinned to the versions the checked-in lock resolves,
+  // so generating the baseline lock needs only manifests the dependency cache
+  // already holds and the check needs no network.
+  const rootImports =
+    (await readDenoConfig(join(ROOT, "deno.jsonc"))).imports ?? {};
+  const lock = JSON.parse(await Deno.readTextFile(join(ROOT, "deno.lock")));
+  const pathRange = rootImports["@std/path"];
+  const assertRange = rootImports["@std/assert"];
+  assert(
+    pathRange && assertRange,
+    "root config should declare @std/path and @std/assert",
   );
-  const rootImports = rootConfig.imports ?? {};
-  const packageImport = Object.entries(shellConfig.imports ?? {}).find(
-    ([name]) => !(name in rootImports),
+  const pathVersion = lock.specifiers?.[pathRange];
+  const assertVersion = lock.specifiers?.[assertRange];
+  assert(
+    pathVersion && assertVersion,
+    "deno.lock should pin @std/path and @std/assert",
   );
+  const pathImport = `jsr:@std/path@${pathVersion}`;
+  const assertImport = `jsr:@std/assert@${assertVersion}`;
 
-  assert(packageImport, "shell config should contain a package-only import");
-  const [name, specifier] = packageImport;
-  rootConfig.imports = { ...rootImports, [name]: specifier };
-
-  const output = await runDenoCheckWithTemporaryConfig({
-    root: ROOT,
-    config: rootConfig,
-    files: ["packages/test-support/src/mod.ts"],
-    tempConfigPrefix: "deno.test-support.changed-dependencies",
+  const { generate, check } = await runFrozenDriftCheck({
+    baselineImports: {
+      "@std/path": pathImport,
+      "@std/assert": assertImport,
+    },
+    // The entry never imports @std/assert, so dropping it leaves an entry that
+    // still type-checks while the config no longer matches the generated lock.
+    driftedImports: { "@std/path": pathImport },
+    entrySource: `import { join } from "@std/path";\n` +
+      `export const joined = join("a", "b");\n`,
   });
-  const stderr = decode(output.stderr);
 
-  assert(!output.success, "a changed dependency graph should fail the check");
-  assertMatch(stderr, /lockfile is out of date/i);
+  assert(
+    generate.success,
+    `baseline lock generation failed:\n${decode(generate.stdout)}\n${
+      decode(generate.stderr)
+    }`,
+  );
+  assert(!check.success, "a drifted dependency graph should fail the check");
+  assertMatch(decode(check.stderr), /lockfile is out of date/i);
 });

--- a/packages/test-support/src/isolated-deno.ts
+++ b/packages/test-support/src/isolated-deno.ts
@@ -19,6 +19,26 @@ export interface DenoCheckWithTemporaryConfigOptions {
   tempConfigPrefix: string;
 }
 
+export interface FrozenDriftCheckOptions {
+  /** Import map the baseline lockfile is generated from. */
+  baselineImports: Record<string, string>;
+  /**
+   * Import map the frozen check runs against. It must differ from
+   * `baselineImports`, and the entry module must only import specifiers that it
+   * still maps.
+   */
+  driftedImports: Record<string, string>;
+  /** Source of the entry module the checks type-check. */
+  entrySource: string;
+}
+
+export interface FrozenDriftCheckResult {
+  /** Output of generating the baseline lockfile from `baselineImports`. */
+  generate: Deno.CommandOutput;
+  /** Output of the frozen check run against `driftedImports`. */
+  check: Deno.CommandOutput;
+}
+
 // Read and parse a Deno config file (`deno.json` / `deno.jsonc`) with the JSONC
 // parser, so a config that carries comments is read correctly.
 export async function readDenoConfig(
@@ -96,5 +116,54 @@ export async function runDenoCheckWithTemporaryConfig(
     });
   } finally {
     await removeIfPresent(tempConfig);
+  }
+}
+
+// Build a self-contained Deno workspace in a temporary directory, generate a
+// lockfile for `baselineImports`, then run a frozen check against
+// `driftedImports`. Everything lives under the temporary directory, so the
+// repository config and lockfile are untouched.
+//
+// The check needs no network when the metadata for the imports it resolves is
+// already cached. A frozen check recomputes the whole graph only when the
+// config differs from the lockfile, so the generate step is what pins the
+// baseline offline, and the frozen check resolves `driftedImports` against that
+// baseline. Choose imports the repository already depends on so their metadata
+// is present in any cache that can build the repository.
+export async function runFrozenDriftCheck(
+  options: FrozenDriftCheckOptions,
+): Promise<FrozenDriftCheckResult> {
+  const tempDir = await Deno.makeTempDir({
+    prefix: "commonfabric-frozen-drift-",
+  });
+  const configPath = join(tempDir, "deno.json");
+  const lockPath = join(tempDir, "deno.lock");
+  const entryPath = join(tempDir, "entry.ts");
+
+  const runCheck = async (imports: Record<string, string>, frozen: boolean) => {
+    await Deno.writeTextFile(configPath, JSON.stringify({ imports }, null, 2));
+    return await new Deno.Command("deno", {
+      cwd: tempDir,
+      args: [
+        "check",
+        "--config",
+        configPath,
+        "--lock",
+        lockPath,
+        ...(frozen ? ["--frozen=true"] : []),
+        entryPath,
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+  };
+
+  try {
+    await Deno.writeTextFile(entryPath, options.entrySource);
+    const generate = await runCheck(options.baselineImports, false);
+    const check = await runCheck(options.driftedImports, true);
+    return { generate, check };
+  } finally {
+    await removeIfPresent(tempDir, { recursive: true });
   }
 }


### PR DESCRIPTION
The test that proves a nested `deno check --frozen=true` rejects a dependency graph that no longer matches the checked-in lockfile did so by adding a package-only npm import to a copy of the root config and running the frozen check against it. Adding an import that the lockfile does not record forces Deno to re-resolve the workspace to conclude the lock is stale, and that re-resolution fetches package metadata from the npm registry. The test therefore depended on the network. It flaked in CI when the connection dropped mid-download: the process failed with a network error instead of the expected staleness error, so the assertion on the "lockfile is out of date" message failed.

The re-resolution is unavoidable for any config that differs from the lock, whether an import is added or removed. When the config differs, the frozen check rebuilds the whole dependency graph from the registry to produce the exact diff, and it needs registry metadata for every package to do so. The cache-warming step used in CI (`deno install --frozen=true`) does not leave that metadata in a form the re-resolution reuses offline, so a changed config re-fetches whatever is missing. Removing an import instead of adding one does not avoid this.

The check needs no network only when the config matches the lock, because Deno then trusts the lock without re-resolving. This replaces the whole- workspace mutation with a small self-contained workspace in a temporary directory whose entire import set is two of the repository's own JSR dependencies, pinned to the versions the checked-in lock resolves. A first `deno check` generates a baseline lock for that workspace from the already cached manifests, then a second `deno check --frozen=true` runs against a config that drops one of the imports. The entry module never imports the dropped dependency, so it still type-checks while the config no longer matches the generated lock, and the frozen check reports "lockfile is out of date" using only cached data. Pinning to the locked versions means the generate step needs only the version manifests the dependency cache already holds, so the whole test runs offline.

A new `runFrozenDriftCheck` helper builds the temporary workspace, runs both checks, and removes the directory afterward, so the repository config and lockfile are never touched. It stays local to the isolated-deno module rather than the package barrel, since the neighbouring test is its only consumer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the lockfile-drift test hermetic so it runs fully offline and stops flaking in CI by using a temporary, self-contained workspace and cached JSR dependencies.

- **Bug Fixes**
  - Added `runFrozenDriftCheck` to create a temp workspace, generate a baseline lock, then run `deno check --frozen=true` against drifted imports using cached `@std/path` and `@std/assert`.
  - Updated the test to use the helper, avoiding registry re-resolution and network access while still asserting the "lockfile is out of date" error.

<sup>Written for commit a2533572e80d88eb9f0e4087048126c7f2f41ede. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

