### PR TITLE
fix(cli): correct cf view comment and removed-code highlighting

### DIFF
--- a/packages/cli/deno.jsonc
+++ b/packages/cli/deno.jsonc
@@ -15,6 +15,7 @@
     // Held at the release candidate alongside @cliffy/command; the two share
     // internal packages and resolve as a set.
     "@cliffy/table": "jsr:@cliffy/table@1.0.0-rc.8",
+    "@node/child_process": "node:child_process",
     // Pinned to @cliffy/command's own dependency range so lib/color-mode.ts
     // shares Cliffy's module instance — setColorEnabled() on a second copy
     // would not de-colorize Cliffy help/version/usage output. Guarded by the

--- a/packages/cli/lib/view/diff.ts
+++ b/packages/cli/lib/view/diff.ts
@@ -47,6 +47,8 @@ export interface DiffFile {
   readonly oldPath?: string;
   /** Path on the new side (`b/…` stripped), absent for a deleted file. */
   readonly newPath?: string;
+  /** Old blob named by a Git `index old..new` header, when present. */
+  readonly oldObject?: string;
   /** 0-based diff-text line index where this file's headers begin. */
   readonly headerLine: number;
   /** 0-based diff-text line index of the file's last line. */
@@ -96,6 +98,7 @@ export function parseDiff(text: string): DiffModel | null {
   interface OpenFile {
     oldPath?: string;
     newPath?: string;
+    oldObject?: string;
     headerLine: number;
     hunks: DiffHunk[];
     endLine: number;
@@ -113,6 +116,7 @@ export function parseDiff(text: string): DiffModel | null {
       files.push({
         oldPath: file.oldPath,
         newPath: file.newPath,
+        oldObject: file.oldObject,
         headerLine: file.headerLine,
         endLine: file.endLine,
         hunks: file.hunks,
@@ -168,6 +172,12 @@ export function parseDiff(text: string): DiffModel | null {
     }
 
     if (file && isFileMeta(line)) {
+      const objects = line.match(
+        /^index ([0-9a-f]{4,64})\.\.[0-9a-f]{4,64}(?:\s|$)/,
+      );
+      if (objects) {
+        file.oldObject = objects[1];
+      }
       lines[i] = { kind: "meta" };
       file.endLine = i;
       i++;

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -121,40 +121,48 @@ function validGitObject(object: string): boolean {
 function readGitBlobs(
   repoRoot: string,
   objects: readonly string[],
+  run: typeof spawnSync = spawnSync,
 ): Map<string, string> {
   const blobs = new Map<string, string>();
   if (objects.length === 0) return blobs;
   try {
-    const result = spawnSync("git", ["cat-file", "--batch"], {
+    const result = run("git", ["cat-file", "--batch"], {
       cwd: repoRoot,
       env: { ...Deno.env.toObject(), GIT_NO_LAZY_FETCH: "1" },
       input: `${objects.join("\n")}\n`,
       maxBuffer: Number.MAX_SAFE_INTEGER,
     });
     if (result.status !== 0 || !result.stdout) return blobs;
-    const output = new Uint8Array(result.stdout);
-    const decoder = new TextDecoder();
-    let offset = 0;
-    for (const object of objects) {
-      const headerEnd = output.indexOf(10, offset);
-      if (headerEnd < 0) break;
-      const header = decoder.decode(output.subarray(offset, headerEnd));
-      offset = headerEnd + 1;
-      const match = header.match(/^[0-9a-f]{4,64} ([^ ]+) ([0-9]+)$/);
-      if (!match) continue;
-      const size = Number(match[2]);
-      if (
-        !Number.isSafeInteger(size) || size < 0 ||
-        offset + size >= output.length || output[offset + size] !== 10
-      ) {
-        break;
-      }
-      const content = output.subarray(offset, offset + size);
-      offset += size + 1;
-      if (match[1] === "blob") blobs.set(object, decoder.decode(content));
-    }
+    return parseGitBatchOutput(objects, new Uint8Array(result.stdout));
   } catch {
     return blobs;
+  }
+}
+
+function parseGitBatchOutput(
+  objects: readonly string[],
+  output: Uint8Array,
+): Map<string, string> {
+  const blobs = new Map<string, string>();
+  const decoder = new TextDecoder();
+  let offset = 0;
+  for (const object of objects) {
+    const headerEnd = output.indexOf(10, offset);
+    if (headerEnd < 0) break;
+    const header = decoder.decode(output.subarray(offset, headerEnd));
+    offset = headerEnd + 1;
+    const match = header.match(/^[0-9a-f]{4,64} ([^ ]+) ([0-9]+)$/);
+    if (!match) continue;
+    const size = Number(match[2]);
+    if (
+      !Number.isSafeInteger(size) ||
+      offset + size >= output.length || output[offset + size] !== 10
+    ) {
+      break;
+    }
+    const content = output.subarray(offset, offset + size);
+    offset += size + 1;
+    if (match[1] === "blob") blobs.set(object, decoder.decode(content));
   }
   return blobs;
 }
@@ -1048,3 +1056,10 @@ function lineEndOffset(
   if (line + 1 < lineStarts.length) return lineStarts[line + 1] - 1;
   return text.length;
 }
+
+export const _internal = {
+  parseGitBatchOutput,
+  readGitBlobs,
+  reconstructOldFile,
+  shiftCompleteLineSpans,
+};

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -117,11 +117,25 @@ function validGitObject(object: string): boolean {
   return /^[0-9a-f]{4,64}$/.test(object) && !/^0+$/.test(object);
 }
 
+interface GitBatchOptions {
+  cwd: string;
+  env: Record<string, string>;
+  input: string;
+  maxBuffer: number;
+}
+
+type GitBatchRunner = (
+  command: string,
+  args: string[],
+  options: GitBatchOptions,
+) => { status: number | null; stdout: Uint8Array | null };
+
 /** Read several locally available Git objects in one batch. */
 function readGitBlobs(
   repoRoot: string,
   objects: readonly string[],
-  run: typeof spawnSync = spawnSync,
+  run: GitBatchRunner = (command, args, options) =>
+    spawnSync(command, args, options),
 ): Map<string, string> {
   const blobs = new Map<string, string>();
   if (objects.length === 0) return blobs;

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -3,11 +3,11 @@
  * semantic layer needs to answer type/definition queries against the CURRENT
  * workspace files the diff names.
  *
- * Rendering keeps the diff text verbatim (colour only). Code lines get full
- * syntax highlighting: a context/addition line whose content matches the
- * workspace file reuses that file's parsed spans (shifted past the marker
- * column); anything else — removals, drifted lines, missing files — falls back
- * to a per-hunk fragment parse, so even the old side reads as code.
+ * Rendering keeps the diff text verbatim (colour only). Context and addition
+ * lines whose content matches the workspace file reuse that file's parsed
+ * spans. Removed lines reuse spans from the complete old file, loaded from the
+ * Git object named by the diff or reconstructed from the complete new file.
+ * Lines without either complete file fall back to a per-hunk fragment parse.
  *
  * The structure tree is: file (a `section` node) → hunk → the workspace file's
  * own structure nodes, clamped and remapped into diff coordinates. So WASD and
@@ -22,12 +22,13 @@ import type {
   StructureNode,
 } from "./model.ts";
 import { flattenStructure } from "./model.ts";
-import type { DiffHunk, DiffModel } from "./diff.ts";
+import type { DiffFile, DiffHunk, DiffModel } from "./diff.ts";
 import { computeLineStarts, lineIndexOf } from "./lines.ts";
 import type { Language } from "./languages/language.ts";
 import { languageForFile } from "./languages/language.ts";
 import { cpLen } from "./ansi.ts";
 import { dirname, isAbsolute, join, relative } from "@std/path";
+import { spawnSync } from "@node/child_process";
 
 /** How the diff document reaches the workspace. Injectable for tests. */
 export interface DiffWorkspace {
@@ -35,6 +36,12 @@ export interface DiffWorkspace {
   resolve(path: string): string | null;
   /** Read an absolute path's current content, or null. */
   read(absPath: string): string | null;
+  /** Read a Git blob by object name, or null when it is unavailable. */
+  readBlob?(object: string): string | null;
+  /** Read available Git blobs in one local Git operation. */
+  readBlobs?(
+    objects: readonly string[],
+  ): ReadonlyMap<string, string>;
 }
 
 /**
@@ -60,6 +67,25 @@ export function realWorkspace(cwd: string): DiffWorkspace {
     const real = safeRealPath(abs);
     return real !== null && realBases.some((base) => within(real, base));
   };
+  const blobCache = new Map<string, string | null>();
+  const readBlobs = (
+    objects: readonly string[],
+  ): ReadonlyMap<string, string> => {
+    const valid = [...new Set(objects.filter(validGitObject))];
+    const missing = valid.filter((object) => !blobCache.has(object));
+    const loaded = repoRoot === null
+      ? new Map<string, string>()
+      : readGitBlobs(repoRoot, missing);
+    for (const object of missing) {
+      blobCache.set(object, loaded.get(object) ?? null);
+    }
+    const found = new Map<string, string>();
+    for (const object of valid) {
+      const text = blobCache.get(object);
+      if (text !== null && text !== undefined) found.set(object, text);
+    }
+    return found;
+  };
   return {
     resolve(path) {
       if (isAbsolute(path)) return null; // diff paths are repo-relative
@@ -80,7 +106,57 @@ export function realWorkspace(cwd: string): DiffWorkspace {
         return null;
       }
     },
+    readBlob(object) {
+      return readBlobs([object]).get(object) ?? null;
+    },
+    readBlobs,
   };
+}
+
+function validGitObject(object: string): boolean {
+  return /^[0-9a-f]{4,64}$/.test(object) && !/^0+$/.test(object);
+}
+
+/** Read several locally available Git objects in one batch. */
+function readGitBlobs(
+  repoRoot: string,
+  objects: readonly string[],
+): Map<string, string> {
+  const blobs = new Map<string, string>();
+  if (objects.length === 0) return blobs;
+  try {
+    const result = spawnSync("git", ["cat-file", "--batch"], {
+      cwd: repoRoot,
+      env: { ...Deno.env.toObject(), GIT_NO_LAZY_FETCH: "1" },
+      input: `${objects.join("\n")}\n`,
+      maxBuffer: Number.MAX_SAFE_INTEGER,
+    });
+    if (result.status !== 0 || !result.stdout) return blobs;
+    const output = new Uint8Array(result.stdout);
+    const decoder = new TextDecoder();
+    let offset = 0;
+    for (const object of objects) {
+      const headerEnd = output.indexOf(10, offset);
+      if (headerEnd < 0) break;
+      const header = decoder.decode(output.subarray(offset, headerEnd));
+      offset = headerEnd + 1;
+      const match = header.match(/^[0-9a-f]{4,64} ([^ ]+) ([0-9]+)$/);
+      if (!match) continue;
+      const size = Number(match[2]);
+      if (
+        !Number.isSafeInteger(size) || size < 0 ||
+        offset + size >= output.length || output[offset + size] !== 10
+      ) {
+        break;
+      }
+      const content = output.subarray(offset, offset + size);
+      offset += size + 1;
+      if (match[1] === "blob") blobs.set(object, decoder.decode(content));
+    }
+  } catch {
+    return blobs;
+  }
+  return blobs;
 }
 
 function safeRealPath(path: string): string | null {
@@ -128,6 +204,9 @@ export interface DiffEdit {
   /** The captured new-side content of each touched file, for splicing edited
    * lines back in on save. */
   readonly fileText: ReadonlyMap<string, string>;
+  /** Complete highlighted old files, aligned with the parsed diff's files.
+   * The live highlighter uses these spans when an edit creates a removed line. */
+  readonly oldFileLines: readonly (readonly Line[] | null)[];
   /** Every hunk, in document order, with the file and new-side range it covers
    * and whether its new side matched the workspace (so the captured content is
    * known to be the hunk's new side). Save matches the edited diff's hunks to
@@ -168,12 +247,11 @@ interface FileMapping {
 }
 
 /**
- * Per-session cache of each workspace file's content and parse, keyed by
- * absolute path. The diff is edited, not the workspace, so these are stable: a
- * cache lets the deferred re-parse on every keystroke pause reuse the (costly)
- * parsed documents instead of re-reading and re-parsing every named file. It is
- * also consistent with the save map, which captures the same construction-time
- * content.
+ * Per-session cache of complete new and old files. New files use their absolute
+ * paths as keys. Old Git files use their path and object name. Reconstructed
+ * old files use their stable file-section position and paths. File headers are
+ * not editable, so repeated versions remain distinct while a deferred re-parse
+ * can reuse both highlighted files.
  */
 export type WorkspaceCache = Map<string, LoadedFile>;
 
@@ -181,6 +259,8 @@ interface LoadedFile {
   fileText: string | null;
   fileDoc: Document | null;
   fileLineStarts: number[];
+  /** Syntax-only lines used by complete old files. */
+  highlightedLines?: readonly Line[] | null;
 }
 
 function loadFile(
@@ -201,6 +281,264 @@ function loadFile(
   return entry;
 }
 
+function isNoNewlineMarker(line: string | undefined): boolean {
+  return line?.replace(/\r$/, "") === "\\ No newline at end of file";
+}
+
+/** A hunk body line without its diff marker. */
+function diffBodyText(
+  rawLines: string[],
+  hunk: DiffHunk,
+  line: number,
+  stripTransport = false,
+): string {
+  let text = rawLines[line].slice(1);
+  if (
+    rawLines[hunk.headerLine].endsWith("\r") &&
+    (stripTransport || isNoNewlineMarker(rawLines[line + 1])) &&
+    text.endsWith("\r")
+  ) {
+    text = text.slice(0, -1);
+  }
+  return text;
+}
+
+function diffBodyMatches(
+  sourceText: string,
+  rawLines: string[],
+  hunk: DiffHunk,
+  line: number,
+): boolean {
+  return sourceText === diffBodyText(rawLines, hunk, line) ||
+    sourceText === diffBodyText(rawLines, hunk, line, true);
+}
+
+function contentLines(text: string): string[] {
+  if (text.length === 0) return [];
+  const lines = text.split("\n");
+  if (text.endsWith("\n")) lines.pop();
+  return lines;
+}
+
+function belongsToSide(
+  kind: DiffModel["lines"][number]["kind"] | undefined,
+  side: "old" | "new",
+): boolean {
+  return kind === "ctx" || kind === (side === "old" ? "del" : "add");
+}
+
+function noTrailingNewline(
+  hunk: DiffHunk,
+  side: "old" | "new",
+  rawLines: string[],
+  modelLines: DiffModel["lines"],
+): boolean {
+  for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
+    if (!isNoNewlineMarker(rawLines[i])) continue;
+    const previous = modelLines[i - 1]?.kind;
+    if (belongsToSide(previous, side)) return true;
+  }
+  return false;
+}
+
+/** Whether every visible line on one side agrees with a complete file. */
+function fileMatchesSide(
+  file: DiffFile,
+  side: "old" | "new",
+  text: string,
+  rawLines: string[],
+  modelLines: DiffModel["lines"],
+): boolean {
+  const sourceLines = contentLines(text);
+  for (const hunk of file.hunks) {
+    for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
+      const entry = modelLines[i];
+      if (!belongsToSide(entry?.kind, side)) continue;
+      const sourceLine = side === "old" ? entry.oldLine : entry.newLine;
+      if (
+        sourceLine === undefined ||
+        !diffBodyMatches(sourceLines[sourceLine], rawLines, hunk, i)
+      ) {
+        return false;
+      }
+    }
+    if (
+      noTrailingNewline(hunk, side, rawLines, modelLines) &&
+      text.endsWith("\n")
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function hunkSideLines(
+  hunk: DiffHunk,
+  side: "old" | "new",
+  rawLines: string[],
+  modelLines: DiffModel["lines"],
+  stripTransport = false,
+): string[] {
+  const out: string[] = [];
+  for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
+    const kind = modelLines[i]?.kind;
+    if (belongsToSide(kind, side)) {
+      out.push(diffBodyText(rawLines, hunk, i, stripTransport));
+    }
+  }
+  return out;
+}
+
+function hunkStart(start: number, count: number): number {
+  return count === 0 ? start : start - 1;
+}
+
+/**
+ * Reverse every hunk against a verified complete new file. Applying from the
+ * bottom preserves the line numbers of the hunks above.
+ */
+function reconstructOldFile(
+  file: DiffFile,
+  newText: string,
+  rawLines: string[],
+  modelLines: DiffModel["lines"],
+): string | null {
+  if (!fileMatchesSide(file, "new", newText, rawLines, modelLines)) return null;
+
+  const lines = contentLines(newText);
+  let trailingNewline = newText.endsWith("\n");
+  const hunks = [...file.hunks].sort((a, b) => {
+    const byStart = hunkStart(b.newStart, b.newCount) -
+      hunkStart(a.newStart, a.newCount);
+    return byStart || b.headerLine - a.headerLine;
+  });
+  for (const hunk of hunks) {
+    let oldSide = hunkSideLines(hunk, "old", rawLines, modelLines);
+    let newSide = hunkSideLines(hunk, "new", rawLines, modelLines);
+    if (
+      oldSide.length !== hunk.oldCount || newSide.length !== hunk.newCount
+    ) {
+      return null;
+    }
+    const start = hunkStart(hunk.newStart, hunk.newCount);
+    if (
+      start < 0 || start + newSide.length > lines.length
+    ) {
+      return null;
+    }
+    const current = lines.slice(start, start + newSide.length);
+    if (current.some((line, i) => line !== newSide[i])) {
+      newSide = hunkSideLines(hunk, "new", rawLines, modelLines, true);
+      if (current.some((line, i) => line !== newSide[i])) return null;
+      oldSide = hunkSideLines(hunk, "old", rawLines, modelLines, true);
+    }
+    const touchesEnd = start + newSide.length === lines.length;
+    lines.splice(start, newSide.length, ...oldSide);
+    if (touchesEnd) {
+      trailingNewline = !noTrailingNewline(
+        hunk,
+        "old",
+        rawLines,
+        modelLines,
+      );
+    }
+  }
+  const oldText = lines.length === 0
+    ? ""
+    : lines.join("\n") + (trailingNewline ? "\n" : "");
+  return fileMatchesSide(file, "old", oldText, rawLines, modelLines)
+    ? oldText
+    : null;
+}
+
+function reconstructedOldFileCacheKey(
+  file: DiffFile,
+  fileIndex: number,
+): string {
+  return `\0diff-old:${
+    JSON.stringify([
+      fileIndex,
+      file.oldPath,
+      file.newPath,
+      file.oldObject,
+    ])
+  }`;
+}
+
+function highlightedFile(
+  fileText: string | null,
+  fileName: string | undefined,
+  language: Language,
+): LoadedFile {
+  return {
+    fileText,
+    fileDoc: null,
+    fileLineStarts: [],
+    highlightedLines: fileText === null
+      ? null
+      : language.highlightLines(fileText, fileName),
+  };
+}
+
+/** Load and highlight the complete old side represented by one diff file. */
+function loadOldFile(
+  file: DiffFile,
+  fileIndex: number,
+  language: Language,
+  newFile: LoadedFile | null,
+  oldBlobs: ReadonlyMap<string, string> | undefined,
+  ws: DiffWorkspace,
+  rawLines: string[],
+  modelLines: DiffModel["lines"],
+  cache?: WorkspaceCache,
+): LoadedFile {
+  if (file.hunks.length === 0) {
+    return {
+      fileText: null,
+      fileDoc: null,
+      fileLineStarts: [],
+      highlightedLines: null,
+    };
+  }
+  const fileName = file.oldPath ?? file.newPath;
+  if (
+    file.oldObject && validGitObject(file.oldObject) &&
+    (oldBlobs !== undefined || ws.readBlob)
+  ) {
+    const blobKey = `\0diff-old-blob:${
+      JSON.stringify([fileName, file.oldObject])
+    }`;
+    let blob = cache?.get(blobKey);
+    if (!blob) {
+      const blobText = oldBlobs
+        ? oldBlobs.get(file.oldObject) ?? null
+        : ws.readBlob!(file.oldObject);
+      blob = highlightedFile(blobText, fileName, language);
+      cache?.set(blobKey, blob);
+    }
+    if (
+      blob.fileText !== null &&
+      fileMatchesSide(file, "old", blob.fileText, rawLines, modelLines)
+    ) {
+      return blob;
+    }
+  }
+
+  const key = reconstructedOldFileCacheKey(file, fileIndex);
+  const hit = cache?.get(key);
+  if (hit) return hit;
+  const newText = newFile?.fileText ?? null;
+  const fileText = newText === null ? null : reconstructOldFile(
+    file,
+    newText,
+    rawLines,
+    modelLines,
+  );
+  const entry = highlightedFile(fileText, fileName, language);
+  cache?.set(key, entry);
+  return entry;
+}
+
 export function buildDiffDocument(
   text: string,
   model: DiffModel,
@@ -214,6 +552,15 @@ export function buildDiffDocument(
   const definitions = new Map<string, Definition[]>();
   const mappings = new Map<string, FileMapping>(); // by abs path
   const hunks: DiffHunkInfo[] = [];
+  const oldFileLines: (readonly Line[] | null)[] = [];
+  const oldBlobs = ws.readBlobs?.(
+    model.files.flatMap((file) =>
+      file.hunks.length > 0 && file.oldObject &&
+        validGitObject(file.oldObject)
+        ? [file.oldObject]
+        : []
+    ),
+  );
 
   // Lines not claimed by any file/hunk below default to plain text.
   for (let i = 0; i < rawLines.length; i++) {
@@ -223,7 +570,7 @@ export function buildDiffDocument(
     }
   }
 
-  for (const file of model.files) {
+  for (const [fileIndex, file] of model.files.entries()) {
     // The language is chosen once per file, from its path, and every operation
     // on the file — parsing the workspace copy, colouring fragments, projecting
     // structure — dispatches through it. A rename can change the extension, so
@@ -235,6 +582,18 @@ export function buildDiffDocument(
     const fileText = loaded?.fileText ?? null;
     const fileDoc = loaded?.fileDoc ?? null;
     const fileLineStarts = loaded?.fileLineStarts ?? [];
+    const oldFile = loadOldFile(
+      file,
+      fileIndex,
+      oldLanguage,
+      loaded,
+      oldBlobs,
+      ws,
+      rawLines,
+      model.lines,
+      cache,
+    );
+    oldFileLines.push(oldFile.highlightedLines ?? null);
 
     let mapping: FileMapping | undefined;
     if (absPath && fileText !== null) {
@@ -270,6 +629,7 @@ export function buildDiffDocument(
         fileDoc,
         fileText,
         fileLineStarts,
+        oldFileLines: oldFile.highlightedLines ?? null,
         mapping,
         definitions,
         hunks,
@@ -311,7 +671,7 @@ export function buildDiffDocument(
   return {
     doc,
     maps: buildMaps(diffLineStarts, rawLines, mappings),
-    edit: buildEdit(text, rawLines, mappings, hunks),
+    edit: buildEdit(text, rawLines, mappings, hunks, oldFileLines),
   };
 }
 
@@ -323,6 +683,7 @@ function buildEdit(
   rawLines: string[],
   mappings: Map<string, FileMapping>,
   hunks: DiffHunkInfo[],
+  oldFileLines: readonly (readonly Line[] | null)[],
 ): DiffEdit {
   const lines = new Map<
     number,
@@ -336,7 +697,7 @@ function buildEdit(
       lines.set(diffLine, { absPath: m.absPath, newLine, markerLen });
     }
   }
-  return { sourceText, lines, fileText, hunks };
+  return { sourceText, lines, fileText, oldFileLines, hunks };
 }
 
 // --- hunk rendering + structure ------------------------------------------------
@@ -355,6 +716,7 @@ interface HunkCtx {
   fileDoc: Document | null;
   fileText: string | null;
   fileLineStarts: number[];
+  oldFileLines: readonly Line[] | null;
   mapping: FileMapping | undefined;
   definitions: Map<string, Definition[]>;
   hunks: DiffHunkInfo[];
@@ -370,9 +732,6 @@ interface HunkCtx {
 
 function buildHunk(hunk: DiffHunk, ctx: HunkCtx): StructureNode {
   const { rawLines, modelLines, lines, diffLineStarts } = ctx;
-  const isNoNewlineMarker = (line: string | undefined): boolean =>
-    line?.replace(/\r$/, "") === "\\ No newline at end of file";
-  const crlfTransport = rawLines[hunk.headerLine].endsWith("\r");
 
   // Header line.
   lines[hunk.headerLine].spans = [{
@@ -390,31 +749,28 @@ function buildHunk(hunk: DiffHunk, ctx: HunkCtx): StructureNode {
   // type/definition queries about the wrong occurrence. All-or-nothing keeps
   // the maps honest: an unverified hunk renders via fragments and maps to
   // nothing.
-  let oldNoTrailingNewline = false;
-  let newNoTrailingNewline = false;
-  for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
-    if (!isNoNewlineMarker(rawLines[i])) continue;
-    const previous = modelLines[i - 1]?.kind;
-    if (previous === "del" || previous === "ctx") {
-      oldNoTrailingNewline = true;
-    }
-    if (previous === "add" || previous === "ctx") {
-      newNoTrailingNewline = true;
-    }
-  }
+  const oldNoTrailingNewline = noTrailingNewline(
+    hunk,
+    "old",
+    rawLines,
+    modelLines,
+  );
+  const newNoTrailingNewline = noTrailingNewline(
+    hunk,
+    "new",
+    rawLines,
+    modelLines,
+  );
 
   let verified = ctx.fileDoc !== null;
   for (let i = hunk.headerLine + 1; verified && i <= hunk.endLine; i++) {
     const entry = modelLines[i];
     if (entry?.kind !== "ctx" && entry?.kind !== "add") continue;
-    let diffText = rawLines[i].slice(1);
+    const fileText = fileLineText(ctx, entry.newLine!);
     if (
-      crlfTransport && isNoNewlineMarker(rawLines[i + 1]) &&
-      diffText.endsWith("\r")
+      fileText === null ||
+      !diffBodyMatches(fileText, rawLines, hunk, i)
     ) {
-      diffText = diffText.slice(0, -1);
-    }
-    if (fileLineText(ctx, entry.newLine!) !== diffText) {
       verified = false;
     }
   }
@@ -456,8 +812,14 @@ function buildHunk(hunk: DiffHunk, ctx: HunkCtx): StructureNode {
     if (entry.kind === "del") lines[i].bg = "del";
 
     if (entry.kind === "del") {
-      oldFragment.push({ diffLine: i, code });
-      continue; // spans assigned from the old fragment below
+      const oldSpans = ctx.oldFileLines?.[entry.oldLine!]?.spans;
+      const shifted = oldSpans ? shiftCompleteLineSpans(t, oldSpans) : null;
+      if (shifted) {
+        lines[i].spans = shifted;
+      } else {
+        oldFragment.push({ diffLine: i, code });
+      }
+      continue;
     }
     const n = entry.newLine!;
     if (verified && ctx.fileDoc) {
@@ -468,7 +830,15 @@ function buildHunk(hunk: DiffHunk, ctx: HunkCtx): StructureNode {
       if (ctx.mapping && !ctx.mapping.newToDiff.has(n)) {
         ctx.mapping.newToDiff.set(n, i);
       }
-      lines[i].spans = shiftSpans(markerSpan(t), ctx.fileDoc.lines[n].spans);
+      const shifted = shiftCompleteLineSpans(
+        t,
+        ctx.fileDoc.lines[n].spans,
+      );
+      if (shifted) {
+        lines[i].spans = shifted;
+      } else {
+        newFragment.push({ diffLine: i, code });
+      }
     } else {
       newFragment.push({ diffLine: i, code });
     }
@@ -577,6 +947,28 @@ function shiftSpans(marker: Span, spans: readonly Span[]): Span[] {
   const out: Span[] = [marker];
   for (const s of spans) out.push({ ...s, col: s.col + 1 });
   return out;
+}
+
+/**
+ * Shift complete-file spans and retain a carriage return added by the diff's
+ * CRLF transport. Null means the source spans do not describe this line.
+ */
+function shiftCompleteLineSpans(
+  lineText: string,
+  spans: readonly Span[],
+): Span[] | null {
+  const code = lineText.slice(1);
+  const sourceText = spans.map((span) => span.text).join("");
+  if (code !== sourceText && code !== `${sourceText}\r`) return null;
+  const shifted = shiftSpans(markerSpan(lineText), spans);
+  if (code.length > sourceText.length) {
+    shifted.push({
+      col: cpLen(sourceText) + 1,
+      text: code.slice(sourceText.length),
+      cls: "whitespace",
+    });
+  }
+  return shifted;
 }
 
 /**

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -117,6 +117,14 @@ function validGitObject(object: string): boolean {
   return /^[0-9a-f]{4,64}$/.test(object) && !/^0+$/.test(object);
 }
 
+function tryOrNull<T>(operation: () => T): T | null {
+  try {
+    return operation();
+  } catch {
+    return null;
+  }
+}
+
 interface GitBatchOptions {
   cwd: string;
   env: Record<string, string>;
@@ -139,7 +147,7 @@ function readGitBlobs(
 ): Map<string, string> {
   const blobs = new Map<string, string>();
   if (objects.length === 0) return blobs;
-  try {
+  return tryOrNull(() => {
     const result = run("git", ["cat-file", "--batch"], {
       cwd: repoRoot,
       env: { ...Deno.env.toObject(), GIT_NO_LAZY_FETCH: "1" },
@@ -148,9 +156,7 @@ function readGitBlobs(
     });
     if (result.status !== 0 || !result.stdout) return blobs;
     return parseGitBatchOutput(objects, new Uint8Array(result.stdout));
-  } catch {
-    return blobs;
-  }
+  }) ?? blobs;
 }
 
 function parseGitBatchOutput(
@@ -182,11 +188,7 @@ function parseGitBatchOutput(
 }
 
 function safeRealPath(path: string): string | null {
-  try {
-    return Deno.realPathSync(path);
-  } catch {
-    return null;
-  }
+  return tryOrNull(() => Deno.realPathSync(path));
 }
 
 /** Nearest ancestor of `cwd` containing `.git` (a directory or a file). */

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -1184,6 +1184,7 @@ export const _internal = {
   pendingAmend,
   dropHeaderBetween,
   joinAdjacent,
+  oldLineSpansAt,
 };
 
 function reparse(

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -11,6 +11,7 @@
  * recomputed from the edited text.
  */
 import type { Document, Line, Span } from "./model.ts";
+import { cpLen } from "./ansi.ts";
 import {
   buildDiffDocument,
   type DiffEdit,
@@ -212,7 +213,8 @@ export function diffSource(
     // workspace-file syntax highlighting) for the rest. Cost tracks the edit,
     // not the whole diff, and the unchanged headers never flicker colour. The
     // full parse on pause restores workspace-verified spans across the edit.
-    createHighlighter: (text, seed) => createDiffHighlighter(text, seed),
+    createHighlighter: (text, seed) =>
+      createDiffHighlighter(text, seed, edit.oldFileLines),
     dirtyLabels: (original, current) =>
       [
         ...collectFileOutputs(
@@ -970,21 +972,26 @@ function applyExpansion(
  * An incremental highlighter for a diff. It recolours only the lines an edit
  * changes (found by a common prefix/suffix of the line arrays) and keeps `seed`
  * — the colours {@link buildDiffDocument} produced for the unedited text — for
- * every line the edit leaves alone. Edited lines are always body lines (headers
- * are not editable), so a per-line marker-aware render is right for them; the
- * headers stay in the unchanged prefix/suffix and never change colour. When no
- * seed is given (it always is, in the session) it renders every line itself.
+ * every line the edit leaves alone. Edited removed lines use the complete old
+ * file's spans. Other edited body lines use a marker-aware single-line parse.
+ * The headers stay in the unchanged prefix or suffix. When no seed is given,
+ * the highlighter renders every line itself.
  */
 export function createDiffHighlighter(
   initialText: string,
   seed?: readonly Line[],
+  oldFileLines?: readonly (readonly Line[] | null)[],
 ): Highlighter {
   let text = initialText;
   const initialRaw = initialText.split("\n");
   const initialModel = seed ? null : parseDiff(initialText);
   let lines: Line[] = (seed ??
     initialRaw.map((line, index) =>
-      diffLineRender(line, diffFileNameAt(initialRaw, index, initialModel))
+      diffLineRender(
+        line,
+        diffFileNameAt(initialRaw, index, initialModel),
+        oldLineSpansAt(initialModel, index, oldFileLines),
+      )
     )).slice();
   return {
     get lines() {
@@ -1006,7 +1013,11 @@ export function createDiffHighlighter(
       }
       const model = parseDiff(next);
       const recoloured = newRaw.slice(p, newRaw.length - s).map((l, i) =>
-        diffLineRender(l, diffFileNameAt(newRaw, p + i, model))
+        diffLineRender(
+          l,
+          diffFileNameAt(newRaw, p + i, model),
+          oldLineSpansAt(model, p + i, oldFileLines),
+        )
       );
       lines = lines.slice(0, p).concat(
         recoloured,
@@ -1069,7 +1080,11 @@ function editableStart(
  * diff document builder paints a line, so a live edit re-colours correctly
  * without rebuilding the whole diff.
  */
-function diffLineRender(lineText: string, fileName?: string): Line {
+function diffLineRender(
+  lineText: string,
+  fileName?: string,
+  oldSpans?: readonly Span[],
+): Line {
   if (lineText.length === 0) return { text: "", spans: [] };
   // A hunk header carries its own colour and its counts change when an edit
   // grows or shrinks the hunk, so colour it the way the full parse does rather
@@ -1088,13 +1103,41 @@ function diffLineRender(lineText: string, fileName?: string): Line {
     : "whitespace";
   const spans: Span[] = [{ col: 0, text: marker, cls }];
   const code = lineText.slice(1);
-  const content = languageForFile(fileName).highlightLines(code, fileName)[0]
-    ?.spans;
+  const oldText = oldSpans?.map((span) => span.text).join("");
+  const useOld = oldText !== undefined &&
+    (oldText === code || `${oldText}\r` === code);
+  const content = useOld
+    ? oldSpans
+    : languageForFile(fileName).highlightLines(code, fileName)[0]?.spans;
   for (const s of content ?? []) {
     spans.push({ ...s, col: s.col + 1 });
   }
+  if (useOld && oldText !== code) {
+    spans.push({
+      col: cpLen(oldText) + 1,
+      text: code.slice(oldText.length),
+      cls: "whitespace",
+    });
+  }
   const bg = marker === "+" ? "add" : marker === "-" ? "del" : undefined;
   return bg ? { text: lineText, spans, bg } : { text: lineText, spans };
+}
+
+/** Complete-old-file spans for a removed diff line. */
+function oldLineSpansAt(
+  model: DiffModel | null,
+  line: number,
+  oldFileLines?: readonly (readonly Line[] | null)[],
+): readonly Span[] | undefined {
+  const entry = model?.lines[line];
+  if (!model || entry?.kind !== "del" || entry.oldLine === undefined) {
+    return undefined;
+  }
+  const fileIndex = model.files.findIndex((file) =>
+    line >= file.headerLine && line <= file.endLine
+  );
+  if (fileIndex < 0) return undefined;
+  return oldFileLines?.[fileIndex]?.[entry.oldLine]?.spans;
 }
 
 /** The old- or new-side file containing `lineIdx`, found from the nearest diff

--- a/packages/cli/lib/view/languages/markdown/markdown.ts
+++ b/packages/cli/lib/view/languages/markdown/markdown.ts
@@ -87,7 +87,7 @@ function oneSpan(text: string, cls: TokenClass): Line {
 function renderLine(t: string): Line {
   if (t.length === 0) return { text: "", spans: [] };
   if (/^#{1,6}(\s|$)/.test(t)) return oneSpan(t, "sectionHeader");
-  if (/^\s*>/.test(t)) return oneSpan(t, "comment");
+  if (/^\s*>/.test(t)) return oneSpan(t, "markdownQuote");
   if (/^\s*([-*_])(\s*\1){2,}\s*$/.test(t)) return oneSpan(t, "punctuation");
 
   const cps = [...t];

--- a/packages/cli/lib/view/model.ts
+++ b/packages/cli/lib/view/model.ts
@@ -28,6 +28,7 @@ export type TokenClass =
   | "regex"
   | "comment"
   | "docComment"
+  | "markdownQuote"
   | "sectionHeader" // `// transformed: <name>` divider lines
   | "typeName" // identifier used in a type position
   | "typeKeyword" // string/number/boolean/any/unknown… in a type position

--- a/packages/cli/lib/view/theme.ts
+++ b/packages/cli/lib/view/theme.ts
@@ -1,12 +1,12 @@
 /**
  * Colour theme for the `cf view` pager: a modern dark scheme. Light-grey text on
  * a near-black editor surface, with a One-Dark-inspired accent palette — purple
- * keywords, green strings, amber types, blue functions, orange numbers, grey
- * comments — and a slightly lighter surface for the status bar and dialogs. Each
- * {@link TokenClass} maps to an ANSI {@link Style}; the chrome styles (status
- * bar, selection, search, overlay) and the rainbow bracket cycle round it out.
- * The general aesthetic (double-line dialog frames, drop shadows, green buttons)
- * is unchanged — only the colours differ.
+ * keywords, green strings, amber types, blue functions, orange numbers, and
+ * bright-white comments. A slightly lighter surface holds the status bar and
+ * dialogs. Each {@link TokenClass} maps to an ANSI {@link Style}; the chrome
+ * styles (status bar, selection, search, overlay) and the rainbow bracket cycle
+ * round it out. The general aesthetic (double-line dialog frames, drop shadows,
+ * green buttons) is unchanged — only the colours differ.
  */
 import { hex, type Rgb, type Style } from "./ansi.ts";
 import type { Line, TokenClass } from "./model.ts";
@@ -23,7 +23,7 @@ const C = {
   // Text.
   fg: hex("#abb2bf"), // default text
   fgBright: hex("#e6e6e6"), // titles, the current file, emphasis
-  fgDim: hex("#5c6370"), // comments, punctuation, muted labels
+  fgDim: hex("#5c6370"), // punctuation and muted labels
   ink: hex("#1b1e24"), // dark text drawn on a bright accent (buttons, search)
   // Accents.
   red: hex("#e06c75"),
@@ -55,8 +55,9 @@ const TOKEN_STYLES: Record<TokenClass, Style> = {
   number: { fg: C.orange },
   boolean: { fg: C.orange },
   regex: { fg: C.cyan },
-  comment: { fg: C.fgDim },
-  docComment: { fg: C.fgDim },
+  comment: { fg: C.white },
+  docComment: { fg: C.white },
+  markdownQuote: { fg: C.fgDim },
   sectionHeader: { fg: C.fgBright, bold: true, underline: true },
   typeName: { fg: C.yellow },
   typeKeyword: { fg: C.yellow },
@@ -100,12 +101,12 @@ export function styleFor(cls: TokenClass): Style {
   return TOKEN_STYLES[cls];
 }
 
-/** Token colours for content shown inside a dialog. A dialog panel is only a
- * shade lighter than the editor, so it takes the editor's colours unchanged;
- * only the key column (builderCall) differs, drawn red to match the status bar's
- * shortcut keys rather than the editor's builder-call purple. */
+/** Token colours for content shown inside a dialog. The comment token marks
+ * muted labels there, while builderCall marks shortcut keys. */
 const DIALOG_TOKEN_STYLES: Record<TokenClass, Style> = {
   ...TOKEN_STYLES,
+  comment: { fg: C.fgDim },
+  docComment: { fg: C.fgDim },
   builderCall: { fg: C.red, bold: true },
 };
 

--- a/packages/cli/test/view-diff.test.ts
+++ b/packages/cli/test/view-diff.test.ts
@@ -39,6 +39,18 @@ function stubWs(root: string): DiffWorkspace {
   };
 }
 
+function runGit(root: string, args: string[]): string {
+  const output = new Deno.Command("git", {
+    args,
+    cwd: root,
+    stdout: "piped",
+    stderr: "piped",
+  }).outputSync();
+  const stderr = new TextDecoder().decode(output.stderr).trim();
+  assert(output.success, stderr || `git ${args[0]} failed`);
+  return new TextDecoder().decode(output.stdout);
+}
+
 // --- fixtures ---------------------------------------------------------------
 
 const FILE_TEXT = `export function double(n: number): number {
@@ -59,6 +71,41 @@ index 0000000..1111111 100644
 -export const answer = 42;
 +export const answer = double(21);
 +const extra = answer + 1;
+`;
+
+const OLD_COMMENT_FILE = `/*
+first
+second
+third
+fourth
+const hidden = 1;
+sixth
+*/
+export const shown = 2;
+`;
+
+const NEW_COMMENT_FILE = `/*
+first
+second
+third
+fourth
+sixth
+*/
+export const shown = 2;
+`;
+
+const PARTIAL_COMMENT_DIFF = `diff --git a/comment.ts b/comment.ts
+index 0000000..1111111 100644
+--- a/comment.ts
++++ b/comment.ts
+@@ -3,7 +3,6 @@
+ second
+ third
+ fourth
+-const hidden = 1;
+ sixth
+ */
+ export const shown = 2;
 `;
 
 /** A workspace rooted in a temp dir holding `m.ts` with FILE_TEXT. */
@@ -113,6 +160,7 @@ Deno.test("diff: parses files, hunks and per-line old/new numbering", () => {
   const f = model.files[0];
   assertEquals(f.oldPath, "m.ts");
   assertEquals(f.newPath, "m.ts");
+  assertEquals(f.oldObject, "0000000");
   assertEquals(f.hunks.length, 1);
   const h = f.hunks[0];
   assertEquals(
@@ -198,8 +246,8 @@ Deno.test("diff doc: verbatim text, tints, markers and syntax colour", () => {
     // Markers classified.
     assertEquals(doc.lines[9].spans[0].cls, "diffAdd");
     assertEquals(doc.lines[8].spans[0].cls, "diffDel");
-    // Syntax colour under the diff: the `export` keyword on an added line is a
-    // storage keyword (file-span reuse), and on the removed line too (fragment).
+    // Syntax colour under the diff: both complete file parses classify the
+    // `export` keyword as a storage keyword.
     const cls = (line: number, text: string) =>
       doc.lines[line].spans.find((s) => s.text === text)?.cls;
     assertEquals(cls(9, "export"), "storageKeyword", "added line is code");
@@ -210,6 +258,157 @@ Deno.test("diff doc: verbatim text, tints, markers and syntax colour", () => {
   } finally {
     done();
   }
+});
+
+Deno.test("diff doc: removed lines use the reconstructed complete old file", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(join(root, "comment.ts"), NEW_COMMENT_FILE);
+    const model = parseDiff(PARTIAL_COMMENT_DIFF)!;
+    const { doc } = buildDiffDocument(
+      PARTIAL_COMMENT_DIFF,
+      model,
+      stubWs(root),
+    );
+    const removed = PARTIAL_COMMENT_DIFF.split("\n").indexOf(
+      "-const hidden = 1;",
+    );
+    assertEquals(
+      doc.lines[removed].spans.find((span) => span.text.includes("hidden"))
+        ?.cls,
+      "comment",
+      "the block comment opener outside the hunk controls the removed line",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diff doc: CRLF transport matches complete LF files", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(join(root, "comment.ts"), NEW_COMMENT_FILE);
+    const diff = PARTIAL_COMMENT_DIFF.replaceAll("\n", "\r\n");
+    const { doc } = buildDiffDocument(diff, parseDiff(diff)!, stubWs(root));
+    assertEquals(
+      doc.lines.map((line) => line.spans.map((span) => span.text).join(""))
+        .join("\n"),
+      diff,
+      "highlighting preserves the CRLF transport",
+    );
+    const removed = diff.split("\n").findIndex((line) =>
+      line.startsWith("-const hidden = 1;")
+    );
+    assertEquals(
+      doc.lines[removed].spans.find((span) => span.text.includes("hidden"))
+        ?.cls,
+      "comment",
+      "the LF old file remains available to the CRLF diff",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diff doc: old-file cache separates reconstruction sources", () => {
+  const visibleNewSide = `sharedOne;
+sharedTwo;
+sharedThree;
+sharedFour;
+sharedFive;
+sharedSix;
+`;
+  const diff = `--- common.ts
++++ first.ts
+@@ -3,7 +3,6 @@
+ sharedOne;
+ sharedTwo;
+ sharedThree;
+-export const removed = 1;
+ sharedFour;
+ sharedFive;
+ sharedSix;
+--- common.ts
++++ second.ts
+@@ -3,7 +3,6 @@
+ sharedOne;
+ sharedTwo;
+ sharedThree;
+-export const removed = 1;
+ sharedFour;
+ sharedFive;
+ sharedSix;
+`;
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(
+      join(root, "first.ts"),
+      `/*
+prefix
+${visibleNewSide}`,
+    );
+    Deno.writeTextFileSync(
+      join(root, "second.ts"),
+      `const first = 1;
+const second = 2;
+${visibleNewSide}`,
+    );
+    const { doc } = buildDiffDocument(
+      diff,
+      parseDiff(diff)!,
+      stubWs(root),
+      new Map(),
+    );
+    const removed = diff.split("\n").flatMap((line, index) =>
+      line === "-export const removed = 1;" ? [index] : []
+    );
+    assertEquals(removed.length, 2);
+    const classAt = (line: number) =>
+      doc.lines[line].spans.find((span) => span.text.includes("export"))?.cls;
+    assertEquals(classAt(removed[0]), "comment");
+    assertEquals(classAt(removed[1]), "storageKeyword");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diff doc: old-file cache separates repeated file versions", () => {
+  const diff = [
+    "diff --git a/m.ts b/m.ts",
+    "--- a/m.ts",
+    "+++ b/m.ts",
+    "@@ -2,1 +2,1 @@",
+    "-value",
+    "+new1",
+    "diff --git a/m.ts b/m.ts",
+    "--- a/m.ts",
+    "+++ b/m.ts",
+    "@@ -2,1 +2,1 @@",
+    "-value",
+    "+new2",
+    "",
+  ].join("\n");
+  const ws: DiffWorkspace = {
+    resolve: () => "/m.ts",
+    read: () => "/*\nnew1\n*/\n",
+  };
+  const { doc } = buildDiffDocument(
+    diff,
+    parseDiff(diff)!,
+    ws,
+    new Map(),
+  );
+  const removed = diff.split("\n").flatMap((line, index) =>
+    line === "-value" ? [index] : []
+  );
+  const classAt = (line: number) =>
+    doc.lines[line].spans.find((span) => span.text === "value")?.cls;
+  assertEquals(classAt(removed[0]), "comment");
+  assertEquals(
+    classAt(removed[1]),
+    "identifier",
+    "the nonmatching version uses its own fragment highlighting",
+  );
 });
 
 Deno.test("diff doc: structure is file → hunk → the workspace file's nodes", () => {
@@ -747,6 +946,70 @@ Deno.test("diff workspace: realWorkspace resolves via the repo root and blocks e
     Deno.removeSync(root, { recursive: true });
     Deno.removeSync(outside, { recursive: true });
   }
+});
+
+Deno.test("diff workspace: removed lines use the complete old Git blob", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    runGit(root, ["init", "-q"]);
+    const source = join(root, "source.ts");
+    Deno.writeTextFileSync(source, OLD_COMMENT_FILE);
+    const oldObject = runGit(root, ["hash-object", "-w", "source.ts"]).trim();
+    const otherText = "export const other = 3;\n";
+    Deno.writeTextFileSync(source, otherText);
+    const otherObject = runGit(root, ["hash-object", "-w", "source.ts"]).trim();
+    Deno.removeSync(source);
+
+    const diff = PARTIAL_COMMENT_DIFF.replace("0000000", oldObject);
+    const ws = realWorkspace(root);
+    const blobs = ws.readBlobs?.([oldObject, otherObject]);
+    assertEquals(blobs?.get(oldObject), OLD_COMMENT_FILE);
+    assertEquals(blobs?.get(otherObject), otherText);
+    assertEquals(ws.readBlob?.(oldObject), OLD_COMMENT_FILE);
+    assertEquals(ws.readBlob?.("not-an-object"), null);
+    assertEquals(ws.readBlob?.("0000000"), null);
+    const { doc } = buildDiffDocument(diff, parseDiff(diff)!, ws);
+    const removed = diff.split("\n").indexOf("-const hidden = 1;");
+    assertEquals(
+      doc.lines[removed].spans.find((span) => span.text.includes("hidden"))
+        ?.cls,
+      "comment",
+      "the old blob highlights a file that is absent from the workspace",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diff doc: old-file spans preserve CRLF diff transport", () => {
+  const diff = [
+    "diff --git a/comment.ts b/comment.ts\r",
+    "index 1234..5678 100644\r",
+    "--- a/comment.ts\r",
+    "+++ /dev/null\r",
+    "@@ -1 +0,0 @@\r",
+    "-/* open\r",
+    "\\ No newline at end of file\r",
+    "",
+  ].join("\n");
+  const ws: DiffWorkspace = {
+    resolve: () => null,
+    read: () => null,
+    readBlob: (object) => object === "1234" ? "/* open" : null,
+  };
+  const { doc } = buildDiffDocument(diff, parseDiff(diff)!, ws);
+  assertEquals(
+    doc.lines.map((line) => line.spans.map((span) => span.text).join(""))
+      .join("\n"),
+    diff,
+    "complete-file spans retain the transport carriage return",
+  );
+  const removed = diff.split("\n").indexOf("-/* open\r");
+  assertEquals(
+    doc.lines[removed].spans.find((span) => span.text === "/* open")?.cls,
+    "comment",
+  );
+  assertEquals(doc.lines[removed].spans.at(-1)?.text, "\r");
 });
 
 Deno.test("diff workspace: an in-repo symlink pointing outside is rejected", () => {

--- a/packages/cli/test/view-diffedit-cov.test.ts
+++ b/packages/cli/test/view-diffedit-cov.test.ts
@@ -652,6 +652,7 @@ Deno.test("diffedit cov: a diff matching no file on disk yields a read-only sour
   const emptyEdit: DiffEdit = {
     lines: new Map(),
     fileText: new Map(),
+    oldFileLines: [],
     hunks: [],
   };
   const ws: DiffWorkspace = { resolve: () => null, read: () => null };
@@ -677,6 +678,7 @@ Deno.test("diffedit cov: save skips a verified hunk whose file was not captured 
   const edit: DiffEdit = {
     lines: new Map([[5, { absPath: "/ghost/m.ts", newLine: 0, markerLen: 1 }]]),
     fileText: new Map(), // deliberately missing /ghost/m.ts
+    oldFileLines: [],
     hunks: [
       { absPath: "/ghost/m.ts", newStart: 1, newCount: 1, verified: true },
     ],

--- a/packages/cli/test/view-diffedit-gate.test.ts
+++ b/packages/cli/test/view-diffedit-gate.test.ts
@@ -32,6 +32,7 @@ Deno.test("diffedit gate: save skips a verified hunk whose path parsed but has n
   const edit: DiffEdit = {
     lines: new Map([[5, { absPath: "/ghost/m.ts", newLine: 0, markerLen: 1 }]]),
     fileText: new Map([["/unrelated/other.ts", "kept\n"]]),
+    oldFileLines: [],
     hunks: [
       { absPath: "/ghost/m.ts", newStart: 1, newCount: 1, verified: true },
     ],

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -7,7 +7,11 @@
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
 import { parseDiff } from "../lib/view/diff.ts";
-import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
+import {
+  buildDiffDocument,
+  type DiffWorkspace,
+  type WorkspaceCache,
+} from "../lib/view/diffdoc.ts";
 import { createDiffHighlighter, diffSource } from "../lib/view/diffedit.ts";
 import { type GitRunner, realGit } from "../lib/view/commitmsg.ts";
 import { Session } from "../lib/view/session.ts";
@@ -256,6 +260,70 @@ Deno.test("diffedit: the incremental highlighter recolours only edited lines", (
     }
   } finally {
     done();
+  }
+});
+
+Deno.test("diffedit: newly removed lines use the complete old file", () => {
+  const newText = `/*
+first
+second
+third
+fourth
+sixth
+*/
+export const shown = 2;
+`;
+  const diff = `diff --git a/comment.ts b/comment.ts
+--- a/comment.ts
++++ b/comment.ts
+@@ -3,7 +3,6 @@
+ second
+ third
+ fourth
+-const hidden = 1;
+ sixth
+ */
+ export const shown = 2;
+`;
+  const root = Deno.makeTempDirSync();
+  try {
+    const path = join(root, "comment.ts");
+    Deno.writeTextFileSync(path, newText);
+    const ws: DiffWorkspace = {
+      resolve: () => path,
+      read: () => newText,
+    };
+    const model = parseDiff(diff)!;
+    const cache: WorkspaceCache = new Map();
+    const { doc, edit } = buildDiffDocument(diff, model, ws, cache);
+    const source = diffSource(ws, edit, cache);
+    const highlighter = source.createHighlighter!(diff, doc.lines);
+    const edited = diff.split("\n");
+    const context = edited.indexOf(" third");
+    edited.splice(context, 1, "-third", "+third changed");
+    const lines = highlighter.update(edited.join("\n"));
+    const removed = edited.indexOf("-third");
+    assertEquals(
+      lines[removed].spans.find((span) => span.text === "third")?.cls,
+      "comment",
+      "the block comment opener outside the hunk controls the live removed line",
+    );
+    const reparsed = source.parse(edited.join("\n"));
+    assertEquals(
+      reparsed.lines[removed].spans.find((span) => span.text === "third")?.cls,
+      "comment",
+      "the deferred parse keeps the complete old file",
+    );
+    const originalRemoval = edited.indexOf("-const hidden = 1;");
+    assertEquals(
+      reparsed.lines[originalRemoval].spans.find((span) =>
+        span.text.includes("hidden")
+      )?.cls,
+      "comment",
+      "the deferred parse keeps original removed lines in context",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
   }
 });
 

--- a/packages/cli/test/view-highlight-cov.test.ts
+++ b/packages/cli/test/view-highlight-cov.test.ts
@@ -1,5 +1,9 @@
 import { assertEquals } from "@std/assert";
-import { renderLineColored, renderLinePlain } from "../lib/view/highlight.ts";
+import {
+  renderLineColored,
+  renderLinePlain,
+  spanStyle,
+} from "../lib/view/highlight.ts";
 import type { Line } from "../lib/view/model.ts";
 import { stripAnsi } from "../lib/view/ansi.ts";
 import { parseDocument, SAMPLE } from "./view-helpers.ts";
@@ -37,6 +41,15 @@ Deno.test("renderLinePlain ignores spans and background tint entirely", () => {
 
 Deno.test("renderLinePlain handles an empty line", () => {
   assertEquals(renderLinePlain({ text: "", spans: [] }), "");
+});
+
+Deno.test("spanStyle renders comments in bright white", () => {
+  for (const cls of ["comment", "docComment"] as const) {
+    assertEquals(
+      spanStyle({ col: 0, text: "comment", cls }).fg,
+      [255, 255, 255],
+    );
+  }
 });
 
 Deno.test("renderLinePlain matches every parsed line of the sample blob", () => {

--- a/packages/cli/test/view-json.test.ts
+++ b/packages/cli/test/view-json.test.ts
@@ -260,7 +260,7 @@ Deno.test("json: a .json file in a diff is coloured and navigated as JSON", () =
         s.text === '"count"' && s.cls === "propertyName"
       ),
     );
-    // The removed line (old side) fragment-parses as JSON too.
+    // The removed line uses the old side's JSON language too.
     const removed = doc.lines.find((l) => l.text.startsWith('-  "name"'))!;
     assert(
       removed.spans.some((s) =>

--- a/packages/cli/test/view-markdown.test.ts
+++ b/packages/cli/test/view-markdown.test.ts
@@ -14,6 +14,7 @@ import { languageForFile } from "../lib/view/languages/language.ts";
 import { parseDiff } from "../lib/view/diff.ts";
 import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { createDiffHighlighter } from "../lib/view/diffedit.ts";
+import { spanStyle } from "../lib/view/highlight.ts";
 
 Deno.test("markdown: isMarkdownPath recognises markdown extensions", () => {
   assert(isMarkdownPath("README.md"));
@@ -57,8 +58,9 @@ deno task cf
   assertEquals(lines[3].spans.map((s) => s.cls), ["punctuation"]); // ```bash
   assertEquals(lines[4].spans.map((s) => s.cls), ["string"]); // deno task cf
   assertEquals(lines[5].spans.map((s) => s.cls), ["punctuation"]); // ```
-  // A block quote is a comment.
-  assertEquals(lines[6].spans.map((s) => s.cls), ["comment"]);
+  // A block quote has its own muted style, separate from source comments.
+  assertEquals(lines[6].spans.map((s) => s.cls), ["markdownQuote"]);
+  assertEquals(spanStyle(lines[6].spans[0]).fg, [92, 99, 112]);
 });
 
 Deno.test("markdown: a link's URL is a string, brackets/parens punctuation", () => {

--- a/packages/cli/test/view-removed-code-cov.test.ts
+++ b/packages/cli/test/view-removed-code-cov.test.ts
@@ -1,0 +1,213 @@
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { parseDiff } from "../lib/view/diff.ts";
+import {
+  _internal as _dd,
+  buildDiffDocument,
+  type DiffWorkspace,
+  type WorkspaceCache,
+} from "../lib/view/diffdoc.ts";
+import {
+  _internal as _de,
+  createDiffHighlighter,
+} from "../lib/view/diffedit.ts";
+import { computeLineStarts } from "../lib/view/lines.ts";
+import { languageForFile } from "../lib/view/languages/language.ts";
+import type { Document, Line } from "../lib/view/model.ts";
+
+const NO_WS: DiffWorkspace = { resolve: () => null, read: () => null };
+const encode = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+Deno.test("diffdoc cov: Git batch output accepts blobs and rejects malformed records", () => {
+  const a = "a".repeat(40);
+  const b = "b".repeat(40);
+  const parsed = _dd.parseGitBatchOutput(
+    ["aaaa", "bbbb"],
+    encode(`aaaa missing\n${b} blob 4\ntext\n`),
+  );
+  assertEquals([...parsed], [["bbbb", "text"]]);
+
+  assertEquals(
+    _dd.parseGitBatchOutput(["aaaa"], encode(`${a} blob 4\ntext`)).size,
+    0,
+    "a payload without its delimiter is incomplete",
+  );
+  assertEquals(
+    _dd.parseGitBatchOutput(["aaaa"], encode(`${a} blob 4\ntex`)).size,
+    0,
+    "a truncated payload is incomplete",
+  );
+  assertEquals(
+    _dd.parseGitBatchOutput(
+      ["aaaa"],
+      encode(`${a} blob 9007199254740992\n`),
+    ).size,
+    0,
+    "an unsafe payload size is rejected",
+  );
+  assertEquals(
+    _dd.parseGitBatchOutput(["aaaa"], encode("header without newline")).size,
+    0,
+    "an incomplete header is ignored",
+  );
+});
+
+Deno.test("diffdoc cov: Git blob reads return empty results after command failures", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    assertEquals(
+      _dd.readGitBlobs(root, ["aaaa"]).size,
+      0,
+      "git cat-file fails outside a repository",
+    );
+    assertEquals(
+      _dd.readGitBlobs(root, ["aaaa"], () => {
+        throw new Error("spawn failed");
+      }).size,
+      0,
+      "command launch failures return no blobs",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffdoc cov: old-file reconstruction rejects inconsistent hunk metadata", () => {
+  const diff = `diff --git a/m.ts b/m.ts
+--- a/m.ts
++++ b/m.ts
+@@ -2 +2 @@
+-old
++new
+`;
+  const model = parseDiff(diff)!;
+  const file = model.files[0];
+  const hunk = file.hunks[0];
+  const rawLines = diff.split("\n");
+  const newText = "first\nnew\nlast\n";
+  const reconstruct = (changes: Partial<typeof hunk>) =>
+    _dd.reconstructOldFile(
+      { ...file, hunks: [{ ...hunk, ...changes }] },
+      newText,
+      rawLines,
+      model.lines,
+    );
+
+  assertEquals(
+    reconstruct({ oldCount: 2 }),
+    null,
+    "counts must match the body",
+  );
+  assertEquals(reconstruct({ newStart: 99 }), null, "ranges must fit the file");
+  assertEquals(
+    reconstruct({ newStart: 1 }),
+    null,
+    "the selected new-file range must match the hunk",
+  );
+});
+
+Deno.test("diffdoc cov: a file section without hunks has no old-file lines", () => {
+  const diff = `diff --git a/image.png b/image.png
+Binary files a/image.png and b/image.png differ
+`;
+  const { doc, edit } = buildDiffDocument(diff, parseDiff(diff)!, NO_WS);
+  assertEquals(edit.oldFileLines, [null]);
+  assertEquals(doc.text, diff);
+});
+
+Deno.test("diffdoc cov: mismatched cached spans fall back to fragment highlighting", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const path = join(root, "m.ts");
+    const fileText = "export const value = 2;\n";
+    Deno.writeTextFileSync(path, fileText);
+    const wrongDoc = languageForFile(path).parseDocument(
+      "export const value = 3;\n",
+      path,
+    );
+    const entries = new Map<string, {
+      fileText: string;
+      fileDoc: Document;
+      fileLineStarts: number[];
+    }>([[
+      path,
+      {
+        fileText,
+        fileDoc: wrongDoc,
+        fileLineStarts: computeLineStarts(fileText),
+      },
+    ]]);
+    const cache = entries as unknown as WorkspaceCache;
+    const ws: DiffWorkspace = {
+      resolve: () => path,
+      read: () => fileText,
+    };
+    const diff = `diff --git a/m.ts b/m.ts
+--- a/m.ts
++++ b/m.ts
+@@ -1 +1 @@
+-export const value = 1;
++export const value = 2;
+`;
+    const { doc } = buildDiffDocument(diff, parseDiff(diff)!, ws, cache);
+    const added = diff.split("\n").indexOf("+export const value = 2;");
+    assertEquals(
+      doc.lines[added].spans.map((span) => span.text).join(""),
+      "+export const value = 2;",
+    );
+    assert(
+      doc.lines[added].spans.some((span) => span.text === "2"),
+      "the fragment parse supplies the new line's spans",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffdoc cov: complete-line spans reject different source text", () => {
+  assertEquals(
+    _dd.shiftCompleteLineSpans("-actual", [{
+      col: 0,
+      text: "different",
+      cls: "identifier",
+    }]),
+    null,
+  );
+});
+
+Deno.test("diffedit cov: live removed lines retain CRLF transport after old-file highlighting", () => {
+  const diff = [
+    "diff --git a/m.ts b/m.ts\r",
+    "--- a/m.ts\r",
+    "+++ /dev/null\r",
+    "@@ -1 +0,0 @@\r",
+    "-removed\r",
+    "",
+  ].join("\n");
+  const oldLines: readonly Line[] = [{
+    text: "removed",
+    spans: [{ col: 0, text: "removed", cls: "comment" }],
+  }];
+  const highlighter = createDiffHighlighter(diff, undefined, [oldLines]);
+  const removed = diff.split("\n").indexOf("-removed\r");
+  assertEquals(
+    highlighter.lines[removed].spans.find((span) => span.text === "removed")
+      ?.cls,
+    "comment",
+  );
+  assertEquals(highlighter.lines[removed].spans.at(-1), {
+    col: 8,
+    text: "\r",
+    cls: "whitespace",
+  });
+
+  const model = parseDiff(diff)!;
+  const outside = {
+    ...model,
+    files: model.files.map((file) => ({
+      ...file,
+      endLine: file.headerLine,
+    })),
+  };
+  assertEquals(_de.oldLineSpansAt(outside, removed, [oldLines]), undefined);
+});

--- a/packages/cli/test/view-removed-code-cov.test.ts
+++ b/packages/cli/test/view-removed-code-cov.test.ts
@@ -52,24 +52,37 @@ Deno.test("diffdoc cov: Git batch output accepts blobs and rejects malformed rec
   );
 });
 
-Deno.test("diffdoc cov: Git blob reads return empty results after command failures", () => {
-  const root = Deno.makeTempDirSync();
-  try {
-    assertEquals(
-      _dd.readGitBlobs(root, ["aaaa"]).size,
-      0,
-      "git cat-file fails outside a repository",
-    );
-    assertEquals(
-      _dd.readGitBlobs(root, ["aaaa"], () => {
-        throw new Error("spawn failed");
-      }).size,
-      0,
-      "command launch failures return no blobs",
-    );
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-  }
+Deno.test("diffdoc cov: Git blob reads stay local and return empty results after command failures", () => {
+  const failed = _dd.readGitBlobs(
+    "/repo",
+    ["aaaa"],
+    (command, args, options) => {
+      assertEquals(command, "git");
+      assertEquals(args, ["cat-file", "--batch"]);
+      assertEquals(options.cwd, "/repo");
+      assertEquals(options.env?.GIT_NO_LAZY_FETCH, "1");
+      assertEquals(options.input, "aaaa\n");
+      assertEquals(options.maxBuffer, Number.MAX_SAFE_INTEGER);
+      const empty = new Uint8Array();
+      return {
+        pid: 1,
+        output: [null, empty, empty],
+        stdout: empty,
+        stderr: empty,
+        status: 1,
+        signal: null,
+      };
+    },
+  );
+  assertEquals(failed.size, 0, "a nonzero Git result returns no blobs");
+
+  assertEquals(
+    _dd.readGitBlobs("/repo", ["aaaa"], () => {
+      throw new Error("spawn failed");
+    }).size,
+    0,
+    "command launch failures return no blobs",
+  );
 });
 
 Deno.test("diffdoc cov: old-file reconstruction rejects inconsistent hunk metadata", () => {

--- a/packages/cli/test/view-removed-code-cov.test.ts
+++ b/packages/cli/test/view-removed-code-cov.test.ts
@@ -53,28 +53,30 @@ Deno.test("diffdoc cov: Git batch output accepts blobs and rejects malformed rec
 });
 
 Deno.test("diffdoc cov: Git blob reads stay local and return empty results after command failures", () => {
+  type GitBatchRunner = NonNullable<
+    Parameters<typeof _dd.readGitBlobs>[2]
+  >;
+  const invocations: Parameters<GitBatchRunner>[] = [];
   const failed = _dd.readGitBlobs(
     "/repo",
     ["aaaa"],
     (command, args, options) => {
-      assertEquals(command, "git");
-      assertEquals(args, ["cat-file", "--batch"]);
-      assertEquals(options.cwd, "/repo");
-      assertEquals(options.env?.GIT_NO_LAZY_FETCH, "1");
-      assertEquals(options.input, "aaaa\n");
-      assertEquals(options.maxBuffer, Number.MAX_SAFE_INTEGER);
-      const empty = new Uint8Array();
+      invocations.push([command, args, options]);
       return {
-        pid: 1,
-        output: [null, empty, empty],
-        stdout: empty,
-        stderr: empty,
+        stdout: new Uint8Array(),
         status: 1,
-        signal: null,
       };
     },
   );
   assertEquals(failed.size, 0, "a nonzero Git result returns no blobs");
+  assertEquals(invocations.length, 1);
+  const [command, args, options] = invocations[0];
+  assertEquals(command, "git");
+  assertEquals(args, ["cat-file", "--batch"]);
+  assertEquals(options.cwd, "/repo");
+  assertEquals(options.env.GIT_NO_LAZY_FETCH, "1");
+  assertEquals(options.input, "aaaa\n");
+  assertEquals(options.maxBuffer, Number.MAX_SAFE_INTEGER);
 
   assertEquals(
     _dd.readGitBlobs("/repo", ["aaaa"], () => {

--- a/packages/cli/test/view-removed-code-cov.test.ts
+++ b/packages/cli/test/view-removed-code-cov.test.ts
@@ -79,6 +79,12 @@ Deno.test("diffdoc cov: Git blob reads stay local and return empty results after
   assertEquals(options.maxBuffer, Number.MAX_SAFE_INTEGER);
 
   assertEquals(
+    _dd.readGitBlobs("\0", ["aaaa"]).size,
+    0,
+    "invalid command working directories return no blobs",
+  );
+
+  assertEquals(
     _dd.readGitBlobs("/repo", ["aaaa"], () => {
       throw new Error("spawn failed");
     }).size,


### PR DESCRIPTION
Source comments shared dim styling with secondary dialog labels, which made comments difficult to read. Render syntax comments in bright white and give dialog, card, and Markdown quote text dedicated styles so their existing visual hierarchy remains intact.

Removed diff lines were highlighted as isolated hunk fragments, losing lexical state established elsewhere in the original file. Reuse complete old Git blobs when locally available, reconstruct the old file from a verified current file otherwise, and retain fragment parsing as the final fallback. Preserve those spans through live edits and deferred reparses, handle CRLF transport correctly, separate repeated historical versions in the cache, and prevent blob reads from triggering lazy network fetches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves cf view readability and accuracy: comments render in bright white, and removed lines are highlighted from complete old files (Git blobs or reconstruction), with CRLF‑safe rendering, local‑only blob reads, and stable live updates.

- **Bug Fixes**
  - Comments now bright white; dialog/card labels and Markdown block quotes use dedicated muted styles.
  - Removed lines reuse spans from complete old files (Git blob via `index old..new` or reconstructed from a verified new file). Works during live edits and deferred parses; preserves CRLF transport; separates repeated historical versions in cache.
  - Batch‑read Git blobs locally via `git cat-file --batch` with `GIT_NO_LAZY_FETCH`; strict batch parser; shared null‑on‑error helper for Git spawn and real‑path resolution; no lazy network fetches.

- **Dependencies**
  - Added `@node/child_process` for spawning local Git processes.

<sup>Written for commit d4a2adf051d4e0f39d83b129d1d08e12e0d2edeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

