### PR TITLE
test(runtime-client): make dispose and pending-diagnostics waits even…

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -378,6 +378,47 @@ than the wall clock, so the delegate reports "tool call timed out" before it
 completes. These are the honest exceptions: the clock they need is the real one,
 and their own sleeps are the honest way to wait.
 
+## The runtime-client suite stays on the real clock
+
+`packages/runtime-client` keeps its unit tests on the real clock, and the
+reasons are worth recording because the package looks, at a glance, like a
+candidate for the runner preload above.
+
+Most of its tests need no wait at all, or only a macrotask drain — a
+`setTimeout(fn, 0)` that lets the scheduler's own `queueTask` dispatch land, an
+awaited round-trip, or a sink fire once. Those drains cross one macrotask
+boundary, carry no real-time floor, and stay as they are. The two positive-delay
+sleeps that were not drains have been made event-driven instead. The test that
+proves `dispose()` stays pending until the worker confirms its flush now drains
+the task queue rather than sleeping ten milliseconds: nothing resolves the held
+Dispose reply, so once every queued continuation has run a correct dispose is
+still pending. The pending-request age-ordering test steps a frozen
+`performance.now()` forward between its two sends rather than sleeping, so the
+first request is measurably older and the descending-age sort is exercised
+deterministically — with equal ages a stable sort preserves insertion order
+whichever way the comparator runs, leaving the direction untested.
+
+Two tests genuinely measure real time and cannot move to a fake clock: the
+main-thread loop-lag probe (`loop/mainLag`, armed in `client/connection.ts`) and
+its worker twin (`runner.loop/workerLag`, armed at the `backends/web-worker`
+entry). Each arms a 100-millisecond `setInterval` and records how far past
+schedule a tick fires; each test blocks the thread with a busy-wait past one
+sample so the due tick can only fire late, then reads the recorded lag. A fake
+clock fires timers exactly on schedule, never late, and cannot advance while a
+synchronous busy-wait holds the thread, so it cannot reproduce loop lag at all.
+These stay on real wall-clock time, and their busy-wait plus short trailing
+yield is the honest way to observe a late fire.
+
+The package also cannot adopt the runner preload wholesale. Those two loop-lag
+intervals are armed unconditionally — in the connection constructor and at the
+worker entry's import — and only unref'd, not gated behind an off-by-default flag
+the way runner's one repeating timer is. Unref keeps them from tripping Deno's
+op-leak sanitizer under the real clock, but auto-advance ignores unref: a
+`setInterval` scheduled from `src/` re-arms forever, so every connection a test
+builds would drive the clock to the runaway guard. Adopting the harness would
+mean excluding the very files that own timers, and no test in the suite observes
+a controllable time window a fake clock would help with.
+
 ## Proving a negative
 
 A test that asserts something never happens has no event of its own to wait for.

--- a/packages/runtime-client/client/connection.test.ts
+++ b/packages/runtime-client/client/connection.test.ts
@@ -137,9 +137,11 @@ describe("RuntimeConnection disposal", () => {
       done = true;
     });
 
-    // Dispose stays pending until the worker confirms its flush (which arrives
-    // well within the default request timeout).
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // Dispose stays pending until the worker confirms its flush. Draining the
+    // task queue (all microtasks, then one macrotask) runs every continuation a
+    // completed dispose would take; the held Dispose reply never arrives, so a
+    // correct dispose is still pending and the transport is untouched.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(done).toBe(false);
     expect(transport.disposeCalls).toBe(0);
 
@@ -390,33 +392,45 @@ describe("RuntimeConnection pending-request diagnostics", () => {
     const transport = new FakeTransport([RequestType.Idle]);
     const connection = await initializedConnection(transport);
 
-    const first = connection.request<RequestType.Idle>({
-      type: RequestType.Idle,
-    });
-    const firstSettled = first.then(() => undefined, (error) => error);
-    await new Promise((resolve) => setTimeout(resolve, 3));
-    const second = connection.request<RequestType.Idle>({
-      type: RequestType.Idle,
-    });
-    const secondSettled = second.then(() => undefined, (error) => error);
+    // Give the two in-flight requests a deterministic age gap without sleeping:
+    // freeze performance.now() and step it forward between the sends, so the
+    // first request is measurably older. This is what exercises the
+    // descending-age sort — with equal ages a stable sort preserves insertion
+    // order whichever way the comparator runs, leaving the direction untested.
+    const realNow = performance.now;
+    let fakeNow = realNow.call(performance);
+    Reflect.set(performance, "now", () => fakeNow);
+    try {
+      const first = connection.request<RequestType.Idle>({
+        type: RequestType.Idle,
+      });
+      const firstSettled = first.then(() => undefined, (error) => error);
+      fakeNow += 5;
+      const second = connection.request<RequestType.Idle>({
+        type: RequestType.Idle,
+      });
+      const secondSettled = second.then(() => undefined, (error) => error);
 
-    const pending = connection.getPendingRequestDiagnostics();
-    expect(pending.length).toBe(2);
-    for (const entry of pending) {
-      expect(entry.type).toBe(RequestType.Idle);
-      expect(typeof entry.msgId).toBe("number");
-      expect(entry.ageMs).toBeGreaterThanOrEqual(0);
+      const pending = connection.getPendingRequestDiagnostics();
+      expect(pending.length).toBe(2);
+      for (const entry of pending) {
+        expect(entry.type).toBe(RequestType.Idle);
+        expect(typeof entry.msgId).toBe("number");
+        expect(entry.ageMs).toBeGreaterThanOrEqual(0);
+      }
+      // Sorted oldest (largest age) first — the request a stalled caller has
+      // been waiting on longest names the wedged layer.
+      expect(pending[0].ageMs).toBeGreaterThan(pending[1].ageMs);
+      expect(pending[0].msgId).toBeLessThan(pending[1].msgId);
+
+      await connection.dispose();
+      await firstSettled;
+      await secondSettled;
+      // Disposal settled both as cancellation; nothing is pending anymore.
+      expect(connection.getPendingRequestDiagnostics()).toEqual([]);
+    } finally {
+      Reflect.set(performance, "now", realNow);
     }
-    // Sorted oldest (largest age) first — the request a stalled caller has
-    // been waiting on longest names the wedged layer.
-    expect(pending[0].ageMs).toBeGreaterThanOrEqual(pending[1].ageMs);
-    expect(pending[0].msgId).toBeLessThan(pending[1].msgId);
-
-    await connection.dispose();
-    await firstSettled;
-    await secondSettled;
-    // Disposal settled both as cancellation; nothing is pending anymore.
-    expect(connection.getPendingRequestDiagnostics()).toEqual([]);
   });
 });
 


### PR DESCRIPTION
…t-driven

Two unit tests in the runtime-client suite waited on real-time sleeps. A positive-delay sleep puts a floor under how long the run takes and can fail spuriously: wall-clock time advances during a host pause between scheduling a timer and its firing, so a sleep can elapse while no work happened.

The test that proves dispose() stays pending until the worker confirms its flush slept ten milliseconds and then checked that dispose had not completed. Nothing resolves the held Dispose reply, so the sleep only needed to let any continuation a completed dispose would take run first. It now drains the task queue with a zero-delay macrotask flush: every queued microtask and one macrotask run, after which a correct dispose is still pending with the transport untouched. A mutation that drops the await on the Dispose reply still fails this test.

The pending-request diagnostics test slept three milliseconds between its two sends so the first request would be measurably older, exercising the descending-age sort. Removing the sleep outright would have left the sort direction untested: with equal ages a stable sort preserves insertion order whichever way the comparator runs. Instead the test now freezes performance.now() and steps it forward between the sends, giving a deterministic age gap with no real-time floor; a reversed comparator now fails the test.

This also records in docs/development/waiting-in-tests.md why the package keeps its remaining waits on the real clock rather than adopting the runner fake-clock preload. Two loop-lag probe tests genuinely measure a timer firing late while a busy-wait holds the thread, which a fake clock — firing timers exactly on schedule, and unable to advance during a synchronous busy-wait — cannot reproduce. The package's loop-lag intervals are also armed unconditionally, so a fake clock's auto-advance would re-arm them forever and hit its runaway guard. No fake clock is warranted here; the remaining waits are macrotask drains, awaited round-trips, or genuine real-time measurements.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace real-time sleeps in `packages/runtime-client` tests with event-driven waits to remove flakiness and speed up runs. Also document why this suite stays on the real clock instead of using the runner fake clock.

- **Refactors**
  - `dispose()` test: replace 10ms sleep with a macrotask drain using `setTimeout(..., 0)` to verify dispose stays pending and the transport is untouched.
  - Pending diagnostics test: freeze and step `performance.now()` between two sends to create a deterministic age gap and validate the descending-age sort.
  - Docs: add rationale in `docs/development/waiting-in-tests.md` for keeping the real clock (loop-lag measurements and unref’d intervals make a fake clock inaccurate and prone to runaway).

<sup>Written for commit dc5cb78db27178459efb3cd731fcbd6bc8ad7742. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

