### PR TITLE
test(runner): run mergeable-append-multispace-conflict under the fake…

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -366,17 +366,32 @@ logical time to zero and drops pending timers: one frozen clock wraps a whole
 `describe`, so a suite whose cases each read absolute coarsened time (the `#now`
 grid tests) calls it from `beforeEach` to start each case from a known instant.
 
-Three files stay on the real clock, listed with their reasons at the top of the
+Two files stay on the real clock, listed with their reasons at the top of the
 preload. A resume runtime drives a real loopback memory-client transport whose
 connect/mount/sync does not complete under the fake clock, so the resume
-deadlocks. A multi-space mergeable-commit test asserts on the retry-backoff
-_windowing_ of transient rejections — which rejection fails fast versus is
-retried within a window — a distinction auto-advance collapses. And a
-nested-subagent generateObject aborts its delegate tool because the tool-calling
-path's own timeout auto-advances against the subagent's outbox progress rather
-than the wall clock, so the delegate reports "tool call timed out" before it
-completes. These are the honest exceptions: the clock they need is the real one,
-and their own sleeps are the honest way to wait.
+deadlocks. And a nested-subagent generateObject aborts its delegate tool because
+the tool-calling path's own timeout auto-advances against the subagent's outbox
+progress rather than the wall clock, so the delegate reports "tool call timed
+out" before it completes. These are the honest exceptions: the clock they need
+is the real one, and their own sleeps are the honest way to wait.
+
+One caveat governs whether a runner test can leave the exemption list, and it is
+worth stating because it is easy to trip over. The `test/` versus `src/`
+classification reads the caller's stack frame through `new Error().stack`, and
+SES's `errorTaming` blanks that stack once a runtime locks down. From the first
+`Runtime` a test builds, the harness can no longer see the `test/` frame that
+scheduled a timer, so a positive-delay `setTimeout` written in test code is
+classified as a production timer and auto-advances instead of freezing. A test
+that schedules its own wall-clock deadline — a `setTimeout(reject, ms)` guarding
+a wait — therefore has that deadline fire early under auto-advance rather than
+acting as a backstop. The fix is the same one the rest of this note prescribes:
+resolve the wait on the event itself with no deadline, and let a signal that
+never arrives quiesce the loop so Deno fails the pending wait. That is what let
+the multi-space mergeable-commit test move onto the fake clock — its retry
+backoff is a `src/` timer that auto-advances, and the fast-fail-versus-windowed
+distinction it checks is decided by the rejection's error type rather than by
+elapsed time, so collapsing the backoff timing preserves the outcome each case
+asserts.
 
 ## The runtime-client suite stays on the real clock
 

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -265,11 +265,6 @@ const REAL_CLOCK_FILES = [
   // whose connect/mount/sync machinery does not complete under the fake clock:
   // the resume deadlocks rather than settling.
   "list-resume-container-defer",
-  // Asserts on the retry-backoff *windowing* of transient multi-space commit
-  // rejections — which rejection fails fast versus is retried within a window.
-  // Auto-advance collapses those windows instantly, erasing the distinction the
-  // tests check.
-  "mergeable-append-multispace-conflict",
   // Drives a nested-subagent generateObject: a delegate tool runs a child
   // pattern whose result feeds back to the parent through the post-commit
   // outbox across several cycles. The tool-calling path carries its own

--- a/packages/runner/test/mergeable-append-multispace-conflict.test.ts
+++ b/packages/runner/test/mergeable-append-multispace-conflict.test.ts
@@ -114,23 +114,18 @@ type EventCommitMarker = {
   permanentRejection?: "origin-committed" | "receipt-exists";
 };
 
+// Resolve on the first `scheduler.event.commit` marker the predicate accepts.
 function waitForEventCommit(
   runtime: Runtime,
   predicate: (marker: EventCommitMarker) => boolean,
-  message: string,
 ): Promise<EventCommitMarker> {
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      runtime.telemetry.removeEventListener("telemetry", listener);
-      reject(new Error(message));
-    }, 5_000);
+  return new Promise((resolve) => {
     const listener = (event: Event) => {
       const marker = (event as CustomEvent<{ marker: EventCommitMarker }>)
         .detail.marker;
       if (marker.type !== "scheduler.event.commit" || !predicate(marker)) {
         return;
       }
-      clearTimeout(timeout);
       runtime.telemetry.removeEventListener("telemetry", listener);
       resolve(marker);
     };
@@ -250,7 +245,6 @@ describe("mergeable append in a multi-space commit survives a transient storm", 
     const committed = waitForEventCommit(
       rt,
       (marker) => injectedRemaining === 0 && marker.error === undefined,
-      "multi-space append did not commit after the transient storm",
     );
     const addTx = rt.edit();
     handle.withTx(addTx).key("addItem").send({ seed: "X" });
@@ -327,7 +321,6 @@ describe("mergeable append in a multi-space commit survives a transient storm", 
     const rejected = waitForEventCommit(
       rt,
       (marker) => marker.error === "injected non-stale-basis rejection",
-      "non-stale-basis rejection was not observed",
     );
     const addTx = rt.edit();
     handle.withTx(addTx).key("addItem").send({ seed: "Y" });


### PR DESCRIPTION
… clock

The runner suite runs under a fake clock (test/clock-preload.ts) that auto-advances positive-delay timers scheduled from src/ and freezes those scheduled from test/ code. mergeable-append-multispace-conflict.test.ts sat on the real-clock exemption list, on the belief that its two windowing tests could not run under auto-advance: they assert which transient multi-space commit rejection fails fast versus is retried within a backoff window, and auto-advance collapses those windows instantly.

That distinction is time-independent. classifyCommitDisposition decides fast-fail versus windowed-retry from the rejection's error type, not from elapsed time, so auto-advance collapses only the backoff timing while preserving the outcome each test checks: whether the append lands, and whether a backoff marker is emitted. Injecting a regression that widens a non-stale-basis rejection into the retry window still fails the fast-fail test under the fake clock, confirming the guard keeps its teeth.

The real blocker was the test's own telemetry-wait helper, which armed a setTimeout(reject, 5000) as a backstop. SES errorTaming blanks new Error().stack once a runtime locks down, so the harness can no longer see the test/ frame that scheduled that timer and classifies it as a src/ (auto-advancing) timer; under the fake clock it fires the deadline early and aborts the wait before the storm resolves. Resolving purely on the telemetry event, with no deadline, makes the wait event-driven: a marker that never arrives lets the loop go quiet and Deno fails the pending wait, so the wait no longer depends on wall-clock timing.

Drop the file from REAL_CLOCK_FILES and record the SES/stack-classification caveat in waiting-in-tests.md so a future conversion knows why a test-scheduled deadline misbehaves under the fake clock.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the multi-space mergeable-append test under the fake clock with event-driven telemetry waits. This removes flakiness and keeps the runner suite consistent while preserving fast-fail vs windowed-retry checks.

- **Bug Fixes**
  - Resolve waits on telemetry events and remove `setTimeout(reject, 5000)` to prevent early abort under auto-advance caused by SES `errorTaming` stack blanking.
  - Drop `mergeable-append-multispace-conflict` from `REAL_CLOCK_FILES` in `packages/runner/test/clock-preload.ts`.
  - Document the SES/stack classification caveat and guidance in `docs/development/waiting-in-tests.md`.

<sup>Written for commit a6164fb10a9ba92c72c259a5ba0d7f9ee09380ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

