### PR TITLE
test(patterns): share one marked-click tail with the note-button helpers

### DIFF
--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -9,7 +9,14 @@ import {
 import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
 
 const DEFAULT_CFC_BROWSER_TIMEOUT = 30_000;
-const CLICK_TARGET_ATTR = "data-cfc-click-target";
+/**
+ * Attribute a mark predicate stamps on the element it resolved, so the test can
+ * then address exactly that element. What identifies a mark is the attribute's
+ * value — a fresh unique token per click — so the predicates here and in
+ * `note-button-helpers.ts` all stamp this one attribute name, and no helper
+ * resolves or clears a mark another one made.
+ */
+export const CLICK_TARGET_ATTR = "data-cfc-click-target";
 
 // Predicates evaluated in the page by `waitForCondition`. Each is self-contained
 // — it closes over nothing in this module — so it can be serialized and run in
@@ -675,10 +682,11 @@ export async function clickNthCfButton(
 
 /**
  * Resolve the element tagged with `token` and click it, then clear the tag.
- * Shared by the click helpers above: each one marks its target through its own
- * predicate, and the resolve/click/untag tail is the same for all of them.
+ * Shared by `clickCfButton`, `clickNthCfButton`, and the text-matching click
+ * helpers in `note-button-helpers.ts`: each one marks its target through its
+ * own predicate, and the resolve/click/untag tail is the same for all of them.
  */
-async function clickMarked(
+export async function clickMarked(
   page: Page,
   token: string,
 ): Promise<void> {

--- a/packages/patterns/integration/note-button-helpers.ts
+++ b/packages/patterns/integration/note-button-helpers.ts
@@ -3,14 +3,19 @@ import {
   type ProbeApi,
   waitForCondition,
 } from "@commonfabric/integration";
-import { settleView } from "./cfc-browser-helpers.ts";
+import {
+  CLICK_TARGET_ATTR,
+  clickMarked,
+  settleView,
+} from "./cfc-browser-helpers.ts";
 
 // Find-and-click-a-button-by-text helpers shared by the default-app
-// integration tests. A click predicate stamps the button it resolved with a
-// marker attribute, so the test can then resolve that exact element and
-// dispatch a single trusted click on it. Mirrors the CLICK_TARGET_ATTR flow of
-// clickCfButton in cfc-browser-helpers.ts.
-const NOTE_BUTTON_CLICK_TARGET_ATTR = "data-cfc-note-button-target";
+// integration tests. The predicate below stamps the button it resolved with
+// CLICK_TARGET_ATTR, and clickMarked then resolves that exact element and
+// dispatches a single trusted click on it. The predicate is what this module
+// adds: it picks a button by its text, its exact text, or its title, where the
+// predicates in cfc-browser-helpers.ts pick one by CSS selector, by index
+// within a selector, or by data-ui-action value.
 
 // Serialized into the page by waitForCondition: find the first rendered
 // button/link whose text or title matches and stamp its inner click target with
@@ -44,26 +49,6 @@ const markNoteButton = (
   return true;
 };
 
-// Remove every element carrying `attr=token`, descending through shadow roots.
-async function clearNoteButtonMark(
-  page: Page,
-  token: string,
-): Promise<void> {
-  await page.evaluate((targetToken, targetAttr) => {
-    function collect(root: Document | ShadowRoot, result: Element[]): void {
-      for (const element of root.querySelectorAll("*")) {
-        if (element.getAttribute(targetAttr) === targetToken) {
-          result.push(element);
-        }
-        if (element.shadowRoot) collect(element.shadowRoot, result);
-      }
-    }
-    const matches: Element[] = [];
-    collect(document, matches);
-    for (const element of matches) element.removeAttribute(targetAttr);
-  }, { args: [token, NOTE_BUTTON_CLICK_TARGET_ATTR] }).catch(() => {});
-}
-
 // Settle the view, tag a matching button, and dispatch a single trusted click
 // on it. Throws if no matching button becomes clickable.
 async function settleAndClickNoteButton(
@@ -78,7 +63,7 @@ async function settleAndClickNoteButton(
   const token = `cfc-note-button-${crypto.randomUUID()}`;
   try {
     await waitForCondition(page, markNoteButton, {
-      args: [selector, match, needle, token, NOTE_BUTTON_CLICK_TARGET_ATTR],
+      args: [selector, match, needle, token, CLICK_TARGET_ATTR],
     });
   } catch (cause) {
     throw new Error(
@@ -88,15 +73,7 @@ async function settleAndClickNoteButton(
       { cause },
     );
   }
-  try {
-    const clickTarget = await page.waitForSelector(
-      `[${NOTE_BUTTON_CLICK_TARGET_ATTR}="${token}"]`,
-      { strategy: "pierce" },
-    );
-    await clickTarget.click();
-  } finally {
-    await clearNoteButtonMark(page, token);
-  }
+  await clickMarked(page, token);
 }
 
 // The click helpers resolve `true` once the single click has landed (they throw


### PR DESCRIPTION
The note-button click helpers carried their own copy of machinery that cfc-browser-helpers.ts already had. `clearNoteButtonMark` was `clearClickMark` with one constant changed: the same walk over the document and every shadow root, removing a marker attribute whose value matched a token. Below it, `settleAndClickNoteButton` repeated the body of `clickMarked` inline — resolve the element carrying the mark, click it, clear the mark in a `finally`.

Both copies existed only because the note-button helpers stamped their own attribute name, `data-cfc-note-button-target`, instead of the `data-cfc-click-target` the other click helpers use. Nothing depends on the two names being distinct. What identifies a mark is the attribute's value, a freshly generated unique token per click, and both the resolve selector and the cleanup predicate match on that value, so no helper can resolve or clear a mark another one made. Nothing outside these two modules refers to either attribute name.

So the note-button helpers now stamp CLICK_TARGET_ATTR and call clickMarked, and the two copies are deleted; the attribute constant and clickMarked become exported. What stays local to the note-button module is its mark predicate, whose semantics really are different: it picks a button by its text, its exact text, or its title, where the shared predicates pick one by CSS selector, by index within a selector, or by data-ui-action value.

Behavior is unchanged. The shared tail resolves the marked element through the same shadow-piercing selector wait on the same page-level selector timeout, and clears the mark in a `finally` that swallows its own failure, which is what the deleted copy did.

Verified by running the two integration suites that exercise these helpers, patterns default-app and patterns-reload, against local dev servers; both passed. `deno fmt --check` repo-wide and `deno lint` on the touched files are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share one marked-click tail between note-button helpers and browser helpers to remove duplicate logic and use a single mark attribute. Exports `CLICK_TARGET_ATTR` and `clickMarked`; behavior is unchanged.

- **Refactors**
  - Exported `CLICK_TARGET_ATTR` and `clickMarked` from `packages/patterns/integration/cfc-browser-helpers.ts`.
  - Updated `packages/patterns/integration/note-button-helpers.ts` to stamp `CLICK_TARGET_ATTR` and call `clickMarked`; removed `NOTE_BUTTON_CLICK_TARGET_ATTR`, `clearNoteButtonMark`, and inline click/cleanup.
  - Kept the local text/title match predicate; the shared tail now handles resolve, click, and cleanup across helpers.

<sup>Written for commit 7070df5ecf116beb519ef19db3cec2f7c44bbd03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

