### PR TITLE
feat(ui): a context menu for pieces, showing their source and origin

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -441,6 +441,24 @@ See `packages/patterns/examples/ui-variants-demo.tsx` for a full example.
 > separate concept — not size variants. A vended `uiVariant()` helper for
 > render paths outside `cf-render` is a planned follow-up and does not exist yet.
 
+### The piece context menu
+
+Right-clicking a rendered piece opens `cf-piece-menu` for it, with two entries:
+**View source** shows the piece's retained authored files, and **Origin and
+history** shows the origin it records and the pattern identities it has run. The
+menu comes with `cf-render` — importing the component registers it — and mounts
+itself on `document.body` so a piece's clipping or a tile's scaling cannot reach
+it.
+
+The innermost rendered piece claims the click, so right-clicking a tile inside a
+piece addresses the tile. Three cases keep the browser's own menu instead: a
+click on a text entry, a click held with Shift, and a `cf-render` whose cell is a
+value inside a piece rather than a whole piece.
+
+Before opening, `cf-render` announces the click as `cf-piece-context-menu`; a host
+can cancel that event to show its own menu for the piece instead. The seam is
+written up in [HOST_EMBEDDING.md §3a](../../development/HOST_EMBEDDING.md).
+
 ---
 
 ## cf-screen

--- a/docs/development/HOST_EMBEDDING.md
+++ b/docs/development/HOST_EMBEDDING.md
@@ -30,6 +30,7 @@ weeks later.
 | 1 | Wish targets + result semantics | API | `runner` | yes | `test/wish.test.ts` — `host embedding contract: profile wish targets` |
 | 2 | `runtimeContext` / `spaceContext` | API | `ui` | yes | `src/v2/runtime-context.test.ts` |
 | 3 | Navigation events | API | `shell`, `lib-shell` | `cf-navigate` yes; `cf-open-external` yes (with CT-1830); others available, not bound | `test/navigate-contract.test.ts` |
+| 3a | Piece menu | API + component | `ui` | available, not bound | `src/v2/components/cf-render/cf-render.test.ts` — `CFRender piece context menu`; `src/v2/components/cf-piece-menu/cf-piece-menu.test.ts` |
 | 4 | `getCfcLabel` egress check | API | `ui` (label shape in `runner`) | yes | `src/v2/core/cfc-label.test.ts` — `cfcLabelViewIsPublic (egress check)` |
 | 5 | Guarded-define idiom | API | `ui` | yes | `src/v2/components/host-embedding-guarded-define.test.ts` |
 | 6 | Trusted-mark threat model | policy record | `runner` | n/a | `test/cfc-ui-contract.test.ts` — `host embedding contract: trusted-mark threat model` |
@@ -134,6 +135,59 @@ DOM). A host embeds by listening for:
 and detail shapes); the pattern-side shape is also guarded by
 `packages/shell/test/runtime-navigation.test.ts`. `cf-open-external` is
 untested here by design — it lands and is tested with CT-1830.
+
+---
+
+## 3a. The piece menu
+
+**Contract.** A right-click on a piece rendered by `cf-render` opens
+`cf-piece-menu` for that piece, with two entries: **View source** shows the
+piece's retained authored files, and **Origin and history** shows the origin it
+records and the pattern identities it has run. Nothing is required of the host to
+have them — importing `cf-render` registers the menu, and the menu reads its data
+through `RuntimeClient.getPieceSource()` on the runtime the piece already runs in.
+The menu mounts itself on `document.body`, not inside the piece, because a piece's
+own `overflow: hidden` would clip it and the tile variant's
+`transform: scale(0.5)` would shrink it; it copies the `--cf-theme-*` tokens
+across from the element that opened it, so it follows the host's theme.
+
+Before the menu opens, `cf-render` announces the click. The event is
+**cancellable, and cancelling it takes the click**: the built-in menu does not
+open, and the host is responsible for what appears instead. Either way the
+browser's own context menu is suppressed. Unlike the navigation events, this one
+BUBBLES from the DOM (`bubbles`, `composed`), so a host may listen on its mount
+container or on `globalThis`.
+
+```ts
+import type { DID } from "@commonfabric/identity";
+
+// packages/ui/src/v2/components/cf-render/cf-render.ts
+export const PIECE_CONTEXT_MENU_EVENT = "cf-piece-context-menu";
+
+export interface PieceContextMenuDetail {
+  space: DID;
+  /** The piece's full schemed id (`of:fid1:…`). */
+  pieceId: string;
+  /** Client coordinates of the click, for placing the menu. */
+  x: number;
+  y: number;
+  variant: "full" | "chip" | "tile";
+}
+```
+
+Three clicks are never announced, so a host needs no special cases for them: a
+click on a text entry, a click held with Shift, and a `cf-render` bound to a
+value inside a piece rather than to a whole piece. The innermost rendered piece
+announces, so a right-click on a tile inside a piece names the tile.
+
+See [docs/specs/piece-source-lifecycle.md](../specs/piece-source-lifecycle.md)
+for what an origin means.
+
+**Test.** `packages/ui/src/v2/components/cf-render/cf-render.test.ts`,
+`describe("CFRender piece context menu")` — the event name, the detail shape, and
+when the click is taken. `packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts`
+— the entries and their test hooks. The menu's DOM behaviour is driven end to end
+by `packages/shell/integration/piece-menu.test.ts`.
 
 ---
 

--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -241,6 +241,12 @@ This happens when OAuth or API calls hit port 5173 (frontend) instead of port 80
 
 When editing `cf-*` components in `packages/ui/`, restart the local dev server to ensure the updated code is running.
 
+The shell's dev server watches `packages/shell/src` only, so a change anywhere
+else in the workspace — `packages/ui`, `packages/runtime-client`, and the rest —
+does not trigger a rebuild, and the browser keeps serving the previous bundle.
+Touching any file under `packages/shell/src` rebuilds everything the shell
+bundles, which is quicker than a restart.
+
 ---
 
 ## Background Piece Service (Optional)

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -14,13 +14,14 @@ today and must be migrated into this lifecycle.
 ## Status
 
 The content-addressed source and in-place pattern replacement foundations are
-implemented. Local command-line creation is implemented end to end. Automatic
-updates exist only through a specialized path for same-toolshed system sources.
-That path reconciles roots before bootstrap and checks other successfully
-instantiated patterns in the background. It is not the target model: a space
-root is an ordinary piece under this entire lifecycle. The general origin,
-history, forking, following, reverting, and repointing model in this document
-requires work unless the implementation table says otherwise.
+implemented. Local command-line creation is implemented end to end. A piece
+context menu reads a piece's origin, pattern identity, and retained source.
+Automatic updates exist only through a specialized path for same-toolshed system
+sources. That path reconciles roots before bootstrap and
+checks other successfully instantiated patterns in the background. It is not the
+target model: a space root is an ordinary piece under this entire lifecycle. The
+general origin, history, forking, following, reverting, and repointing model in
+this document requires work unless the implementation table says otherwise.
 
 Status labels in this document have exact meanings:
 
@@ -37,7 +38,7 @@ otherwise complete first-time creation command into an unimplemented command.
 
 ## Last updated
 
-2026-07-22
+2026-07-24
 
 ## Terms
 
@@ -217,7 +218,7 @@ storage schema to use these exact TypeScript field names.
 | Retained authored program | An immutable version-1 manifest for the complete authored program accepted by the current revision, including unreachable files and its exact public-subpath map | **Manifest and exports required**: source documents can retain extra roots, but no piece revision binds the exact accepted file set or public map |
 | Runtime fingerprint | The trusted runtime identity used to calculate the accepted executable pattern identity | **Authoritative provider required**: the optional module-hash input exists, but production compilation and source verification still use the empty default |
 | Runtime-neutral program digest | The version-1 digest of the canonical main filename, every authored file's runtime-neutral module identity, and the public-subpath map | **Digest and lifecycle required**: the module hash can run with the empty fingerprint, but the complete program digest is not recorded |
-| Active origin | No origin, an external `https://` URL with an entry export, a stable mutable fabric-entity URL, or a content-addressed fabric pattern URL with an export symbol | Partial: `patternSource` stores a string for system roots, but general web and fabric URL origins are not supported end to end |
+| Active origin | No origin, an external `https://` URL with an entry export, a stable mutable fabric-entity URL, or a content-addressed fabric pattern URL with an export symbol | Partial: `patternSource` stores a string for system roots, and `classifyOrigin` reads it as a web, mutable-piece, or exact-pattern origin for display. No operation records a general web or fabric URL origin, and nothing reconciles one |
 | Revision head | The stable identifier of the latest accepted source and origin state | Revision head required |
 | Source revision log | Ordered records of every accepted source and origin state, with a durable reference to each immutable authored-program manifest | Revision log required |
 | Descriptive repository | Optional locator shown by tooling; never followed | Implemented as `patternRepository` metadata |
@@ -748,6 +749,17 @@ update even when its historical runtime is no longer executable. If the current
 immutable origin is incompatible, the UI offers detach and rebuild without
 mislabeling the current creation revision as a revert target.
 
+The piece menu, opened by right-clicking a rendered piece, covers the reading
+half of that requirement today. It belongs to `cf-piece-menu` in the component
+package rather than to the shell, so every host that renders pieces has it. It
+names the origin kind, shows the canonical origin URL alongside the string
+recorded on the piece when normalization changed it, and says a piece is detached
+when it records no origin. It shows the current pattern identity and export symbol, the identity
+whose setup state was installed, and the pattern identity a specialized update
+displaced, with the time it was displaced. It lists the piece's retained
+authored source files. It does not offer detach, revert, or repoint, and it says
+that no per-revision history is recorded, because none of those exist yet.
+
 ## Current implementation
 
 | Requested interaction | Status | Evidence and remaining work |
@@ -786,6 +798,13 @@ The implementation evidence for this table is concentrated in:
   for URL-backed page creation without origin stamping;
 - [`packages/piece/src/ops/pieces-controller.ts`](../../packages/piece/src/ops/pieces-controller.ts)
   for system-root origin stamping and pre-start reconciliation;
+- [`packages/piece/src/ops/piece-origin.ts`](../../packages/piece/src/ops/piece-origin.ts)
+  for origin classification and reading a piece's source state;
+- [`packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts`](../../packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts)
+  and
+  [`packages/ui/src/v2/components/cf-render/cf-render.ts`](../../packages/ui/src/v2/components/cf-render/cf-render.ts)
+  for the piece menu, its source and origin panels, and the right-click that
+  opens them;
 - [`packages/patterns/system/common-fabric.tsx`](../../packages/patterns/system/common-fabric.tsx),
   [`packages/patterns/system/omnibox-fab.tsx`](../../packages/patterns/system/omnibox-fab.tsx),
   and

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -8,6 +8,7 @@ import {
   FavoritesManager,
   JSONValue,
   PageHandle,
+  type PieceSourceView,
   Program,
   RuntimeClient,
   RuntimeClientEvents,
@@ -360,6 +361,15 @@ export class RuntimeInternals extends EventTarget {
       throw new Error("Could not create piece");
     }
     return page;
+  }
+
+  /**
+   * A piece's source state: the pattern it runs, the origin it tracks, the
+   * history metadata it carries, and its authored source files.
+   */
+  getPieceSource(space: DID, pieceId: string): Promise<PieceSourceView> {
+    this.#check();
+    return this.#client.getPieceSource(pieceId, space);
   }
 
   getPiecesListCell<T>(space: DID): Promise<CellHandle<T[]>> {

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -58,6 +58,14 @@ class MockRuntimeClient {
     return Promise.resolve(this.slugByPageId.get(pageId));
   }
 
+  /** Records the (pieceId, space) argument order source reads arrive in. */
+  pieceSourceCalls: Array<{ pieceId: string; space: DID }> = [];
+
+  getPieceSource(pieceId: string, space: DID): Promise<{ pieceId: string }> {
+    this.pieceSourceCalls.push({ pieceId, space });
+    return Promise.resolve({ pieceId });
+  }
+
   /** Records which space each root-pattern request targeted. */
   spaceRootCalls: DID[] = [];
 
@@ -108,6 +116,26 @@ type NavigationDetail = {
 };
 
 describe("RuntimeInternals", () => {
+  it("reads a piece's source state through the client", async () => {
+    const { RuntimeInternals } = await import("@commonfabric/lib-shell");
+    const client = new MockRuntimeClient();
+    const runtime = new RuntimeInternals(client as any);
+    const space = "did:key:z6Mk-source-space" as DID;
+    try {
+      const source = await runtime.getPieceSource(space, "of:fid1:piece");
+
+      expect(source).toEqual({ pieceId: "of:fid1:piece" });
+      // The shell method takes (space, pieceId); the client takes them the
+      // other way round, so the order is worth pinning.
+      expect(client.pieceSourceCalls).toEqual([{
+        pieceId: "of:fid1:piece",
+        space,
+      }]);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
   it("resolves named spaces through the worker client", async () => {
     const { RuntimeInternals } = await import("@commonfabric/lib-shell");
     const client = new MockRuntimeClient();

--- a/packages/piece/src/ops/mod.ts
+++ b/packages/piece/src/ops/mod.ts
@@ -5,3 +5,12 @@ export {
   type PiecePatternRef,
   type PiecePatternSourceRef,
 } from "./piece-controller.ts";
+export {
+  classifyOrigin,
+  type PieceOrigin,
+  PieceOriginError,
+  type PieceOriginKind,
+  type PieceSourceState,
+  readPieceOrigin,
+  readPieceSourceState,
+} from "./piece-origin.ts";

--- a/packages/piece/src/ops/piece-origin.ts
+++ b/packages/piece/src/ops/piece-origin.ts
@@ -97,11 +97,21 @@ export function classifyOrigin(
     throw new PieceOriginError("origin is empty");
   }
 
-  if (source.startsWith("cf:")) {
-    const ref = parseFabricRef(source);
-    if (ref === undefined) {
-      throw new PieceOriginError(`${source} is not a fabric URL`);
-    }
+  // The fabric parser decides whether this is a fabric URL: it returns undefined
+  // for anything that is not one, and throws for a fabric URL it cannot read. A
+  // malformed one reports as an unusable origin like any other unusable string,
+  // rather than as a parser error from a layer below.
+  let ref;
+  try {
+    ref = parseFabricRef(source);
+  } catch (cause) {
+    throw new PieceOriginError(
+      `${source} is not a usable fabric URL: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+    );
+  }
+  if (ref !== undefined) {
     return {
       url: source,
       kind: pinnedPatternIdentity(ref) === undefined

--- a/packages/piece/src/ops/piece-origin.ts
+++ b/packages/piece/src/ops/piece-origin.ts
@@ -1,0 +1,221 @@
+/**
+ * Reading the source facts a piece records: the pattern it runs, the origin it
+ * tracks, the history metadata it carries, and its authored source files.
+ *
+ * An origin is the source URL a piece remembers: either an external web URL or
+ * a fabric `cf:` URL. `docs/specs/piece-source-lifecycle.md` is the design of
+ * record.
+ */
+
+import {
+  type Cell,
+  type FabricRef,
+  getPatternIdentityRef,
+  getPatternRepository,
+  getPatternSource,
+  type MemorySpace,
+  NAME,
+  parseFabricRef,
+  type Runtime,
+} from "@commonfabric/runner";
+import { nameSchema } from "@commonfabric/runner/schemas";
+
+/**
+ * How an origin URL resolves.
+ *
+ * - `web`: an external program endpoint that can return new source later.
+ * - `fabric-piece`: a stable, mutable fabric entity whose current pattern the
+ *   origin names.
+ * - `fabric-pattern`: exact content-addressed pattern source, either named
+ *   directly or fixed by a trailing pin.
+ */
+export type PieceOriginKind = "web" | "fabric-piece" | "fabric-pattern";
+
+export interface PieceOrigin {
+  /** The canonical origin URL. */
+  url: string;
+  kind: PieceOriginKind;
+  /**
+   * The URL as it was recorded on the piece, when normalization changed it. A
+   * legacy toolshed-relative path becomes an absolute web URL, so the recorded
+   * form is kept for display.
+   */
+  recorded?: string;
+}
+
+/** Everything the source surfaces read off one piece. */
+export interface PieceSourceState {
+  space: MemorySpace;
+  pieceId: string;
+  name?: string;
+  /** The exact executable export the piece runs. */
+  pattern?: { identity: string; symbol: string };
+  /** The identity whose complete setup state was installed. */
+  setupPattern?: { identity: string; symbol: string };
+  /** The pattern identity an in-place update replaced, when one did. */
+  displacedPattern?: { identity: string; symbol: string; displacedAt?: number };
+  /** The active origin, absent when the piece is detached. */
+  origin?: PieceOrigin;
+  /** Descriptive repository locator; never followed. */
+  repository?: string;
+  /** The canonical entry filename of the retained source, when readable. */
+  entry?: string;
+  /** The authored source files of the current pattern, when readable. */
+  files: { name: string; contents: string }[];
+}
+
+export class PieceOriginError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PieceOriginError";
+  }
+}
+
+/** The identity a fabric ref pins, when the ref is immutable. */
+function pinnedPatternIdentity(ref: FabricRef): string | undefined {
+  if (ref.pin !== undefined) return ref.pin;
+  return ref.ref.kind === "uri" && ref.ref.scheme === "pattern"
+    ? ref.ref.hash
+    : undefined;
+}
+
+/**
+ * Classify a recorded source string as an origin.
+ *
+ * A toolshed-relative path — the legacy shape system roots are stamped with —
+ * resolves against the host accepted for `space`, so the origin that leaves
+ * this function is always absolute. An unusable string throws rather than
+ * becoming a silently inert origin.
+ */
+export function classifyOrigin(
+  runtime: Runtime,
+  space: MemorySpace,
+  recorded: string,
+): PieceOrigin {
+  const source = recorded.trim();
+  if (source.length === 0) {
+    throw new PieceOriginError("origin is empty");
+  }
+
+  if (source.startsWith("cf:")) {
+    const ref = parseFabricRef(source);
+    if (ref === undefined) {
+      throw new PieceOriginError(`${source} is not a fabric URL`);
+    }
+    return {
+      url: source,
+      kind: pinnedPatternIdentity(ref) === undefined
+        ? "fabric-piece"
+        : "fabric-pattern",
+    };
+  }
+
+  if (source.startsWith("/")) {
+    const host = runtime.hostForSpace(space);
+    return {
+      url: new URL(source, host).href,
+      kind: "web",
+      recorded: source,
+    };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(source);
+  } catch {
+    throw new PieceOriginError(`${source} is not an absolute URL`);
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new PieceOriginError(`${source} is not a web URL`);
+  }
+  return { url: url.href, kind: "web" };
+}
+
+/**
+ * The active origin recorded on `piece`, or undefined when it is detached.
+ * A recorded string this runtime cannot classify is reported as detached: it
+ * names no place the source can be resolved from.
+ */
+export function readPieceOrigin(
+  runtime: Runtime,
+  piece: Cell<unknown>,
+): PieceOrigin | undefined {
+  const recorded = getPatternSource(piece);
+  if (recorded === undefined) return undefined;
+  try {
+    return classifyOrigin(runtime, piece.space, recorded);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read every source fact a piece carries, with its authored source files. */
+export async function readPieceSourceState(
+  runtime: Runtime,
+  piece: Cell<unknown>,
+): Promise<PieceSourceState> {
+  await piece.sync();
+  const pattern = getPatternIdentityRef(piece);
+  const state: PieceSourceState = {
+    space: piece.space,
+    pieceId: piece.getAsNormalizedFullLink().id,
+    files: [],
+  };
+  const name = piece.asSchema(nameSchema).get()?.[NAME];
+  if (typeof name === "string") state.name = name;
+  if (pattern !== undefined) state.pattern = pattern;
+  const setupPattern = piece.getMetaRaw("patternSetupIdentity");
+  if (isPatternRef(setupPattern)) state.setupPattern = setupPattern;
+  const displaced = readDisplacedPattern(piece.getMetaRaw("displacedPattern"));
+  if (displaced !== undefined) state.displacedPattern = displaced;
+  const origin = readPieceOrigin(runtime, piece);
+  if (origin !== undefined) state.origin = origin;
+  const repository = getPatternRepository(piece);
+  if (repository !== undefined) state.repository = repository;
+
+  if (pattern !== undefined) {
+    const program = await runtime.patternManager
+      .getPatternSourceProgramByIdentity(pattern.identity, piece.space);
+    if (program !== undefined) {
+      state.entry = program.main;
+      state.files = sortSourceFiles(program.files, program.main);
+    }
+  }
+  return state;
+}
+
+function isPatternRef(
+  value: unknown,
+): value is { identity: string; symbol: string } {
+  return typeof value === "object" && value !== null &&
+    typeof (value as { identity?: unknown }).identity === "string" &&
+    typeof (value as { symbol?: unknown }).symbol === "string";
+}
+
+/**
+ * The pattern an in-place update replaced, from the `displacedPattern` meta the
+ * pattern updater writes. Its timestamp is optional.
+ */
+function readDisplacedPattern(
+  value: unknown,
+): PieceSourceState["displacedPattern"] {
+  if (!isPatternRef(value)) return undefined;
+  const displacedAt = (value as { displacedAt?: unknown }).displacedAt;
+  return {
+    identity: value.identity,
+    symbol: value.symbol,
+    ...(typeof displacedAt === "number" ? { displacedAt } : {}),
+  };
+}
+
+/** Entry file first, then the rest by filename. */
+function sortSourceFiles(
+  files: { name: string; contents: string }[],
+  entry: string,
+): { name: string; contents: string }[] {
+  return [...files].sort((a, b) => {
+    if (a.name === entry) return -1;
+    if (b.name === entry) return 1;
+    return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+  });
+}

--- a/packages/piece/src/ops/piece-origin.ts
+++ b/packages/piece/src/ops/piece-origin.ts
@@ -122,11 +122,7 @@ export function classifyOrigin(
 
   if (source.startsWith("/")) {
     const host = runtime.hostForSpace(space);
-    return {
-      url: new URL(source, host).href,
-      kind: "web",
-      recorded: source,
-    };
+    return webOrigin(new URL(source, host), source);
   }
 
   let url: URL;
@@ -138,7 +134,22 @@ export function classifyOrigin(
   if (url.protocol !== "https:" && url.protocol !== "http:") {
     throw new PieceOriginError(`${source} is not a web URL`);
   }
-  return { url: url.href, kind: "web" };
+  return webOrigin(url, source);
+}
+
+/**
+ * A web origin at its canonical URL, keeping the recorded string whenever
+ * canonicalizing changed it — a relative path resolved against a host, but also
+ * an absolute URL the URL parser rewrote, such as one with no path or a default
+ * port. The panel shows the recorded form beside the canonical one, so what a
+ * piece stores stays visible.
+ */
+function webOrigin(url: URL, recorded: string): PieceOrigin {
+  return {
+    url: url.href,
+    kind: "web",
+    ...(url.href === recorded ? {} : { recorded }),
+  };
 }
 
 /**

--- a/packages/piece/test/piece-origin.test.ts
+++ b/packages/piece/test/piece-origin.test.ts
@@ -11,8 +11,10 @@ import {
 import {
   classifyOrigin,
   PieceOriginError,
+  readPieceOrigin,
   readPieceSourceState,
 } from "../src/ops/piece-origin.ts";
+import type { Cell } from "@commonfabric/runner";
 
 const signer = await Identity.fromPassphrase("piece origin");
 
@@ -106,6 +108,154 @@ describe("classifyOrigin", () => {
     expect(() => classifyOrigin(runtime, SPACE, "file:///tmp/p.tsx")).toThrow(
       PieceOriginError,
     );
+  });
+
+  it("reports a malformed fabric URL as an unusable origin", () => {
+    // The parser's own error is a layer below; callers see one kind of failure.
+    expect(() => classifyOrigin(runtime, SPACE, "cf:of:fid1:short")).toThrow(
+      PieceOriginError,
+    );
+    expect(() => classifyOrigin(runtime, SPACE, "cf:module/x")).toThrow(
+      PieceOriginError,
+    );
+  });
+});
+
+/**
+ * A piece stands in for its recorded metadata here: these cases are about what
+ * the reader makes of metadata combinations, and a real piece cannot be given a
+ * displaced-pattern record or a repository locator without the operations that
+ * write them.
+ */
+function pieceWith(
+  { meta = {}, name, files = [], entry }: {
+    meta?: Record<string, unknown>;
+    name?: string;
+    files?: { name: string; contents: string }[];
+    entry?: string;
+  },
+): { piece: Cell<unknown>; runtime: Runtime } {
+  const piece = {
+    space: SPACE,
+    sync: () => Promise.resolve(),
+    getMetaRaw: (field: string) => meta[field],
+    getAsNormalizedFullLink: () => ({ id: `of:fid1:${HASH}` }),
+    asSchema: () => ({
+      get: () => (name === undefined ? {} : { $NAME: name }),
+    }),
+  } as unknown as Cell<unknown>;
+  const runtime = {
+    hostForSpace: () => new URL("https://toolshed.test"),
+    patternManager: {
+      getPatternSourceProgramByIdentity: () =>
+        Promise.resolve(
+          entry === undefined ? undefined : { main: entry, files },
+        ),
+    },
+  } as unknown as Runtime;
+  return { piece, runtime };
+}
+
+describe("readPieceOrigin", () => {
+  it("reads a piece with no recorded source as detached", () => {
+    const { piece, runtime } = pieceWith({});
+    expect(readPieceOrigin(runtime, piece)).toBeUndefined();
+  });
+
+  it("reads an unclassifiable recorded source as detached", () => {
+    // The string names no place the source could be resolved from, so it is no
+    // more an origin than an absent one.
+    const { piece, runtime } = pieceWith({
+      meta: { patternSource: "not a url" },
+    });
+    expect(readPieceOrigin(runtime, piece)).toBeUndefined();
+  });
+});
+
+describe("readPieceSourceState collects every recorded fact", () => {
+  it("reports the setup, displaced, and repository metadata a piece carries", async () => {
+    const { piece, runtime } = pieceWith({
+      name: "Recipe",
+      entry: "/main.tsx",
+      files: [
+        { name: "/helper.tsx", contents: "helper" },
+        { name: "/main.tsx", contents: "main" },
+        { name: "/aaa.tsx", contents: "aaa" },
+      ],
+      meta: {
+        patternSource: "https://example.test/recipe.tsx",
+        patternIdentity: { identity: "abc", symbol: "default" },
+        patternSetupIdentity: { identity: "older", symbol: "default" },
+        displacedPattern: {
+          identity: "displaced",
+          symbol: "default",
+          displacedAt: 1_700_000_000_000,
+        },
+        patternRepository: "https://github.com/example/recipes",
+      },
+    });
+
+    const state = await readPieceSourceState(runtime, piece);
+    expect(state.name).toBe("Recipe");
+    expect(state.pattern).toEqual({ identity: "abc", symbol: "default" });
+    expect(state.setupPattern).toEqual({
+      identity: "older",
+      symbol: "default",
+    });
+    expect(state.displacedPattern).toEqual({
+      identity: "displaced",
+      symbol: "default",
+      displacedAt: 1_700_000_000_000,
+    });
+    expect(state.repository).toBe("https://github.com/example/recipes");
+    expect(state.origin).toEqual({
+      url: "https://example.test/recipe.tsx",
+      kind: "web",
+    });
+    // Entry file first, then the rest by name.
+    expect(state.files.map((file) => file.name)).toEqual([
+      "/main.tsx",
+      "/aaa.tsx",
+      "/helper.tsx",
+    ]);
+  });
+
+  it("drops a displaced-pattern record with no timestamp", async () => {
+    const { piece, runtime } = pieceWith({
+      meta: {
+        patternIdentity: { identity: "abc", symbol: "default" },
+        displacedPattern: { identity: "displaced", symbol: "default" },
+      },
+    });
+    const state = await readPieceSourceState(runtime, piece);
+    expect(state.displacedPattern).toEqual({
+      identity: "displaced",
+      symbol: "default",
+    });
+  });
+
+  it("ignores metadata that is not a pattern reference", async () => {
+    const { piece, runtime } = pieceWith({
+      meta: {
+        patternIdentity: { identity: "abc", symbol: "default" },
+        patternSetupIdentity: { nonsense: true },
+        displacedPattern: "not a record",
+        patternRepository: 42,
+      },
+    });
+    const state = await readPieceSourceState(runtime, piece);
+    expect(state.setupPattern).toBeUndefined();
+    expect(state.displacedPattern).toBeUndefined();
+    expect(state.repository).toBeUndefined();
+  });
+
+  it("reports no files when the source closure is unreadable", async () => {
+    const { piece, runtime } = pieceWith({
+      meta: { patternIdentity: { identity: "abc", symbol: "default" } },
+    });
+    const state = await readPieceSourceState(runtime, piece);
+    expect(state.entry).toBeUndefined();
+    expect(state.files).toEqual([]);
   });
 });
 

--- a/packages/piece/test/piece-origin.test.ts
+++ b/packages/piece/test/piece-origin.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { type MemorySpace, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { createSession, Identity } from "@commonfabric/identity";
+import { PieceManager } from "../src/manager.ts";
+import {
+  DEFAULT_APP_PATTERN_URL,
+  PiecesController,
+} from "../src/ops/pieces-controller.ts";
+import {
+  classifyOrigin,
+  PieceOriginError,
+  readPieceSourceState,
+} from "../src/ops/piece-origin.ts";
+
+const signer = await Identity.fromPassphrase("piece origin");
+
+const COUNTER_SOURCE = [
+  "import { pattern, Writable, NAME } from 'commonfabric';",
+  "export default pattern<{ label: string }>(({ label }) => {",
+  "  const count = new Writable(0).for('count');",
+  "  return { [NAME]: 'Counter', label, count };",
+  "});",
+  "",
+].join("\n");
+
+const DEFAULT_APP_SOURCE = [
+  "import { pattern } from 'commonfabric';",
+  "export default pattern<{ items: string[] }>(({ items }) => ({ items }));",
+  "",
+].join("\n");
+
+/**
+ * Serve pattern source from memory, so the resolver and runtime.fetch need no
+ * network. Mirrors the stub in pattern-source-provenance.test.ts.
+ */
+function installFetchStub(sources: Record<string, string>): () => void {
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const url = new URL(
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.href
+        : input.url,
+    );
+    const source = sources[url.pathname];
+    if (source === undefined) {
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    }
+    return Promise.resolve(
+      new Response(source, {
+        headers: { "content-type": "text/typescript-jsx" },
+      }),
+    );
+  }) as typeof globalThis.fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+const HASH = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const SPACE = "did:key:z6MkspaceAAAA" as MemorySpace;
+
+describe("classifyOrigin", () => {
+  const runtime = {
+    hostForSpace: () => new URL("https://toolshed.test"),
+  } as unknown as Runtime;
+
+  it("resolves a toolshed-relative path against the space's host", () => {
+    expect(classifyOrigin(runtime, SPACE, "/api/patterns/system/home.tsx"))
+      .toEqual({
+        url: "https://toolshed.test/api/patterns/system/home.tsx",
+        kind: "web",
+        recorded: "/api/patterns/system/home.tsx",
+      });
+  });
+
+  it("keeps an absolute web URL as it is", () => {
+    expect(classifyOrigin(runtime, SPACE, "https://example.test/p.tsx"))
+      .toEqual({ url: "https://example.test/p.tsx", kind: "web" });
+  });
+
+  it("reads an unpinned entity reference as a mutable piece origin", () => {
+    expect(classifyOrigin(runtime, SPACE, `cf:/${SPACE}/of:fid1:${HASH}`))
+      .toEqual({ url: `cf:/${SPACE}/of:fid1:${HASH}`, kind: "fabric-piece" });
+  });
+
+  it("reads a content-addressed pattern reference as immutable", () => {
+    expect(classifyOrigin(runtime, SPACE, `cf:pattern:${HASH}`))
+      .toEqual({ url: `cf:pattern:${HASH}`, kind: "fabric-pattern" });
+  });
+
+  it("reads a pinned entity reference as immutable", () => {
+    const url = `cf:/${SPACE}/of:fid1:${HASH}@${HASH}`;
+    expect(classifyOrigin(runtime, SPACE, url))
+      .toEqual({ url, kind: "fabric-pattern" });
+  });
+
+  it("rejects a string that names no place source can be fetched from", () => {
+    expect(() => classifyOrigin(runtime, SPACE, "")).toThrow(PieceOriginError);
+    expect(() => classifyOrigin(runtime, SPACE, "counter.tsx")).toThrow(
+      PieceOriginError,
+    );
+    expect(() => classifyOrigin(runtime, SPACE, "file:///tmp/p.tsx")).toThrow(
+      PieceOriginError,
+    );
+  });
+});
+
+describe("reading a piece's source state", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+  let controller: PiecesController;
+  let restoreFetch: () => void;
+
+  beforeEach(async () => {
+    restoreFetch = installFetchStub({
+      [DEFAULT_APP_PATTERN_URL]: DEFAULT_APP_SOURCE,
+    });
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    manager = new PieceManager(
+      await createSession({
+        identity: signer,
+        spaceName: `source-state-${crypto.randomUUID()}`,
+      }),
+      runtime,
+    );
+    await manager.synced();
+    controller = new PiecesController(manager);
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager?.close();
+    restoreFetch();
+  });
+
+  it("reports a directly-created piece as detached, with its source", async () => {
+    const piece = await controller.create({
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: COUNTER_SOURCE }],
+    });
+
+    const state = await readPieceSourceState(runtime, piece.getCell());
+    // A piece pushed from local code records no origin: it is the only durable
+    // reference to the source it runs.
+    expect(state.origin).toBeUndefined();
+    expect(state.name).toBe("Counter");
+    expect(state.pattern?.symbol).toBe("default");
+    expect(state.entry).toBe("/main.tsx");
+    expect(state.files.map((file) => file.name)).toEqual(["/main.tsx"]);
+    expect(state.space).toBe(manager.getSpace());
+  });
+
+  it("reports a space root's stamped path as an absolute web origin", async () => {
+    const root = await controller.ensureDefaultPattern();
+
+    const state = await readPieceSourceState(runtime, root.getCell());
+    // The root is stamped with a toolshed-relative path; the origin that comes
+    // back is absolute, with the recorded form kept alongside it.
+    expect(state.origin).toEqual({
+      url: `http://toolshed.test${DEFAULT_APP_PATTERN_URL}`,
+      kind: "web",
+      recorded: DEFAULT_APP_PATTERN_URL,
+    });
+    expect(state.files.length).toBeGreaterThan(0);
+    expect(state.files[0].name).toBe(state.entry);
+  });
+});

--- a/packages/piece/test/piece-origin.test.ts
+++ b/packages/piece/test/piece-origin.test.ts
@@ -84,6 +84,23 @@ describe("classifyOrigin", () => {
       .toEqual({ url: "https://example.test/p.tsx", kind: "web" });
   });
 
+  it("keeps the recorded form of an absolute URL the parser rewrote", () => {
+    // Canonicalizing adds the path a bare origin omits, and drops a default
+    // port. What the piece stores stays visible beside what it resolves to.
+    expect(classifyOrigin(runtime, SPACE, "https://example.test"))
+      .toEqual({
+        url: "https://example.test/",
+        kind: "web",
+        recorded: "https://example.test",
+      });
+    expect(classifyOrigin(runtime, SPACE, "https://example.test:443/p.tsx"))
+      .toEqual({
+        url: "https://example.test/p.tsx",
+        kind: "web",
+        recorded: "https://example.test:443/p.tsx",
+      });
+  });
+
   it("reads an unpinned entity reference as a mutable piece origin", () => {
     expect(classifyOrigin(runtime, SPACE, `cf:/${SPACE}/of:fid1:${HASH}`))
       .toEqual({ url: `cf:/${SPACE}/of:fid1:${HASH}`, kind: "fabric-piece" });

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -30,7 +30,7 @@ import {
   getCell,
   mapCellRefsToSigilLinks,
 } from "./utils.ts";
-import { Runtime } from "@commonfabric/runner";
+import { entityIdFrom, Runtime } from "@commonfabric/runner";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import * as V2Storage from "../../runner/src/storage/v2.ts";
 import { parseLink } from "../../runner/src/link-utils.ts";
@@ -329,9 +329,13 @@ describe("piece source state", () => {
       });
 
     expect(synced).toEqual(["cell"]);
+    // The handler addresses the cell by the entity id `entityIdFrom` builds
+    // from the routing form of the request's pieceId. That is a FabricHash, and
+    // its string form is the tagged hash — the `of:` scheme is added later, by
+    // the `getCellFromEntityId` this stub stands in for.
     expect(readFor).toEqual([{
       space,
-      entityId: fid("sourced-piece"),
+      entityId: String(entityIdFrom(fid("sourced-piece"))),
     }]);
     // The reader saw a piece with no metadata at all, which is a detached piece
     // with no readable source — reported as such rather than as a failure.

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -283,6 +283,63 @@ describe("renderMembershipProviderFor (§4.9.3 Stage 2)", () => {
   });
 });
 
+describe("piece source state", () => {
+  it("reads the piece named by the request, in that request's space", async () => {
+    const space = "did:key:z6Mk-runtime-processor-source" as const;
+    const synced: string[] = [];
+    const readFor: unknown[] = [];
+    const cell = {
+      space,
+      sync: () => {
+        synced.push("cell");
+        return Promise.resolve();
+      },
+      // A piece with no metadata at all: the reader's own behaviour on each
+      // field is covered in packages/piece; this asserts the addressing.
+      getMetaRaw: () => undefined,
+      getAsNormalizedFullLink: () => ({ id: "of:fid1:sourced" }),
+      asSchema: () => ({ get: () => ({}) }),
+    };
+    const processor = {
+      getSpaceCtx: (requested: string) => ({
+        pieceManager: { getSpace: () => requested },
+      }),
+      runtime: {
+        // Stands in for readPieceSourceState's reads: the handler's own job is
+        // to address the right cell and hand back what the reader produced.
+        getCellFromEntityId: (
+          requestedSpace: string,
+          entityId: unknown,
+        ) => {
+          readFor.push({ space: requestedSpace, entityId: String(entityId) });
+          return cell;
+        },
+        patternManager: {
+          getPatternSourceProgramByIdentity: () => Promise.resolve(undefined),
+        },
+        hostForSpace: () => new URL("https://toolshed.test"),
+      },
+    };
+
+    const result = await (RuntimeProcessor.prototype as any)
+      .handlePieceGetSource.call(processor, {
+        type: RequestType.PieceGetSource,
+        space,
+        pieceId: fid("sourced-piece"),
+      });
+
+    expect(synced).toEqual(["cell"]);
+    expect(readFor).toEqual([{
+      space,
+      entityId: fid("sourced-piece"),
+    }]);
+    // The reader saw a piece with no metadata at all, which is a detached piece
+    // with no readable source — reported as such rather than as a failure.
+    expect(result.source.origin).toBeUndefined();
+    expect(result.source.files).toEqual([]);
+  });
+});
+
 describe("page slug metadata", () => {
   it("reads slug metadata from the page document root", async () => {
     const reads: unknown[] = [];

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1294,21 +1294,15 @@ export class RuntimeProcessor {
     await pieceManager.synced();
   }
 
-  /** The result cell of `pieceId` in `space`, synced. */
-  async #pieceCell(space: DID, pieceId: string): Promise<Cell<unknown>> {
-    const { pieceManager } = this.getSpaceCtx(space);
-    const cell = this.runtime.getCellFromEntityId(
-      pieceManager.getSpace(),
-      entityIdFrom(pageIdForRouting(pieceId)),
-    );
-    await cell.sync();
-    return cell;
-  }
-
   async handlePieceGetSource(
     request: PieceGetSourceRequest,
   ): Promise<PieceSourceResponse> {
-    const cell = await this.#pieceCell(request.space, request.pieceId);
+    const { pieceManager } = this.getSpaceCtx(request.space);
+    // The reader syncs the piece itself, as its first step.
+    const cell = this.runtime.getCellFromEntityId(
+      pieceManager.getSpace(),
+      entityIdFrom(pageIdForRouting(request.pieceId)),
+    );
     const state = await readPieceSourceState(this.runtime, cell);
     return { source: { ...state, space: state.space as DID } };
   }

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -3,7 +3,10 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { JsonEncodingContext } from "@commonfabric/data-model/codec-json";
 import { PieceManager } from "@commonfabric/piece";
-import { PiecesController } from "@commonfabric/piece/ops";
+import {
+  PiecesController,
+  readPieceSourceState,
+} from "@commonfabric/piece/ops";
 import {
   getLogger,
   getLoggerCountsBreakdown,
@@ -106,6 +109,8 @@ import {
   type PageSyncedRequest,
   type PatternCoverageResponse,
   type PatternSourcesResponse,
+  type PieceGetSourceRequest,
+  type PieceSourceResponse,
   type RecreateSpaceRootPatternRequest,
   type RegisterSpaceHostRequest,
   RequestType,
@@ -1289,6 +1294,25 @@ export class RuntimeProcessor {
     await pieceManager.synced();
   }
 
+  /** The result cell of `pieceId` in `space`, synced. */
+  async #pieceCell(space: DID, pieceId: string): Promise<Cell<unknown>> {
+    const { pieceManager } = this.getSpaceCtx(space);
+    const cell = this.runtime.getCellFromEntityId(
+      pieceManager.getSpace(),
+      entityIdFrom(pageIdForRouting(pieceId)),
+    );
+    await cell.sync();
+    return cell;
+  }
+
+  async handlePieceGetSource(
+    request: PieceGetSourceRequest,
+  ): Promise<PieceSourceResponse> {
+    const cell = await this.#pieceCell(request.space, request.pieceId);
+    const state = await readPieceSourceState(this.runtime, cell);
+    return { source: { ...state, space: state.space as DID } };
+  }
+
   handleRegisterSpaceHost(
     request: RegisterSpaceHostRequest,
   ): BooleanResponse {
@@ -1598,6 +1622,8 @@ export class RuntimeProcessor {
         return await this.handlePageStop(request);
       case RequestType.PageGetAll:
         return await this.handlePageGetAll(request);
+      case RequestType.PieceGetSource:
+        return await this.handlePieceGetSource(request);
       case RequestType.PageSynced:
         return await this.handlePageSynced(request);
       case RequestType.RuntimeSynced:

--- a/packages/runtime-client/integration/client.test.ts
+++ b/packages/runtime-client/integration/client.test.ts
@@ -394,6 +394,29 @@ describe("RuntimeClient", () => {
       assertExists(page.id());
     });
 
+    it("reads a created piece's source state", async () => {
+      const session = await createTestSession();
+      await using rt = await createRuntimeClient(session);
+
+      const page = await rt.createPage(TEST_PROGRAM, session.space, {
+        run: true,
+      });
+      const source = await rt.getPieceSource(page.id(), session.space);
+
+      assertEquals(source.space, session.space);
+      assertExists(source.pattern);
+      // A piece created from a program records no origin: nothing supplies new
+      // code for it.
+      assertEquals(source.origin, undefined);
+      // Its authored source is retained in its own space, entry file first.
+      assertExists(source.entry);
+      assertEquals(source.files[0].name, source.entry);
+      assertEquals(
+        source.files.some((file) => file.contents.includes("home")),
+        true,
+      );
+    });
+
     it("retrieves a page with its result schema, including UI", async () => {
       const session = await createTestSession();
       await using rt = await createRuntimeClient(session);

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -89,6 +89,7 @@ export enum RequestType {
   PageStop = "page:stop",
   PageGetAll = "page:getAll",
   PageSynced = "page:synced",
+  PieceGetSource = "piece:getSource",
 
   // VDOM operations (main -> worker)
   VDomMount = "vdom:mount",
@@ -627,6 +628,49 @@ export interface PageSyncedRequest extends BaseRequest {
   space: DID;
 }
 
+/**
+ * Read one piece's source state: the pattern it runs, the origin it tracks, the
+ * history metadata it carries, and its authored source files. See
+ * `docs/specs/piece-source-lifecycle.md`.
+ */
+export interface PieceGetSourceRequest extends BaseRequest {
+  type: RequestType.PieceGetSource;
+  space: DID;
+  pieceId: string;
+}
+
+/** How a piece's origin URL resolves. */
+export type PieceOriginKind = "web" | "fabric-piece" | "fabric-pattern";
+
+export interface PieceOriginView {
+  url: string;
+  kind: PieceOriginKind;
+  /** The URL as recorded on the piece, when normalization changed it. */
+  recorded?: string;
+}
+
+export interface PiecePatternRefView {
+  identity: string;
+  symbol: string;
+}
+
+export interface PieceSourceView {
+  space: DID;
+  pieceId: string;
+  name?: string;
+  pattern?: PiecePatternRefView;
+  setupPattern?: PiecePatternRefView;
+  displacedPattern?: PiecePatternRefView & { displacedAt?: number };
+  origin?: PieceOriginView;
+  repository?: string;
+  entry?: string;
+  files: PatternSourceFile[];
+}
+
+export interface PieceSourceResponse {
+  source: PieceSourceView;
+}
+
 /** Common shape for one-way main -> worker notifications. */
 export interface BaseClientNotification {
   type: ClientNotificationType;
@@ -777,6 +821,7 @@ export type IPCClientRequest =
   | PageStopRequest
   | PageGetAllRequest
   | PageSyncedRequest
+  | PieceGetSourceRequest
   | RuntimeSyncedRequest
   | ResolveSpaceNameRequest
   | RegisterSpaceHostRequest
@@ -955,6 +1000,7 @@ export type RemoteResponse =
   | TriggerTraceResponse
   | WriteStackTraceResponse
   | PageResponse
+  | PieceSourceResponse
   | SlugResponse
   | SpaceResponse
   | VDomMountResponse
@@ -1145,6 +1191,10 @@ export type Commands = {
   [RequestType.PageGetAll]: {
     request: PageGetAllRequest;
     response: CellResponse;
+  };
+  [RequestType.PieceGetSource]: {
+    request: PieceGetSourceRequest;
+    response: PieceSourceResponse;
   };
   [RequestType.GetSpaceRootPattern]: {
     request: PageGetSpaceDefault;

--- a/packages/runtime-client/runtime-client.test.ts
+++ b/packages/runtime-client/runtime-client.test.ts
@@ -85,6 +85,40 @@ describe("RuntimeClient.setForwardWorkerConsole", () => {
   });
 });
 
+describe("RuntimeClient.getPieceSource", () => {
+  it("asks the worker for one piece's source state", async () => {
+    const source = {
+      space: "did:key:z6Mk-runtime-client-source",
+      pieceId: "of:fid1:piece",
+      files: [{ name: "/main.tsx", contents: "export default 1;" }],
+    };
+    const requests: unknown[] = [];
+    const conn = {
+      on: () => {},
+      request: (message: unknown) => {
+        requests.push(message);
+        return Promise.resolve({ source });
+      },
+    } as unknown as never;
+    const client = new (RuntimeClient as unknown as {
+      new (conn: never, options: unknown): RuntimeClient;
+    })(conn, {});
+
+    const result = await client.getPieceSource(
+      "of:fid1:piece",
+      "did:key:z6Mk-runtime-client-source" as never,
+    );
+
+    expect(requests).toEqual([{
+      type: RequestType.PieceGetSource,
+      pieceId: "of:fid1:piece",
+      space: "did:key:z6Mk-runtime-client-source",
+    }]);
+    // The response is unwrapped: callers get the source state, not the envelope.
+    expect(result).toBe(source);
+  });
+});
+
 describe("RuntimeClient.resolveSpaceName", () => {
   it("resolves the name inside the worker runtime", async () => {
     const space = "did:key:z6Mk-runtime-client-named-space";

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -35,6 +35,7 @@ import {
   NavigateRequestNotification,
   type PatternSourcesResponse,
   PendingWritesNotification,
+  type PieceSourceView,
   RequestType,
   TelemetryNotification,
   type UploadBlobResponse,
@@ -298,6 +299,22 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     if (!response) return null;
 
     return new PageHandle<T>(this, response.page);
+  }
+
+  /**
+   * Read a piece's source state: the pattern it runs, the origin it tracks, the
+   * history metadata it carries, and its authored source files.
+   */
+  async getPieceSource(
+    pieceId: string,
+    space: DID,
+  ): Promise<PieceSourceView> {
+    const response = await this.#conn.request<RequestType.PieceGetSource>({
+      type: RequestType.PieceGetSource,
+      pieceId,
+      space,
+    });
+    return response.source;
   }
 
   async getPageSlug(pageId: string, space: DID): Promise<string | undefined> {

--- a/packages/shell/integration/piece-menu.test.ts
+++ b/packages/shell/integration/piece-menu.test.ts
@@ -1,0 +1,100 @@
+import { env, waitForCondition } from "@commonfabric/integration";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
+import { describe, it } from "@std/testing/bdd";
+import "../src/globals.ts";
+import { clickPierce } from "./shadow-dom.ts";
+
+const { FRONTEND_URL, SPACE_NAME } = env;
+
+/** Wait until the space root piece has rendered into the body view. */
+async function waitForRenderedPiece(
+  page: ReturnType<ShellIntegration["page"]>,
+): Promise<void> {
+  await waitForCondition(page, () => {
+    const rootView = document.querySelector("x-root-view");
+    const appView = rootView?.shadowRoot?.querySelector("x-app-view");
+    const bodyView = appView?.shadowRoot?.querySelector("x-body-view");
+    return !!bodyView?.shadowRoot?.querySelector("cf-render");
+  });
+}
+
+/**
+ * Right-click the rendered piece. The click is dispatched on the `cf-render`
+ * element itself, which is what a real right-click on the piece reaches.
+ */
+async function rightClickRenderedPiece(
+  page: ReturnType<ShellIntegration["page"]>,
+): Promise<void> {
+  await page.evaluate(() => {
+    const rootView = document.querySelector("x-root-view");
+    const appView = rootView?.shadowRoot?.querySelector("x-app-view");
+    const bodyView = appView?.shadowRoot?.querySelector("x-body-view");
+    const render = bodyView?.shadowRoot?.querySelector("cf-render");
+    if (!render) throw new Error("no rendered piece to right-click");
+    render.dispatchEvent(
+      new MouseEvent("contextmenu", {
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+        clientX: 80,
+        clientY: 80,
+      }),
+    );
+  });
+}
+
+/** The text of the piece menu's panel, once a panel with `testId` is open. */
+async function waitForPanelText(
+  page: ReturnType<ShellIntegration["page"]>,
+  testId: string,
+  expected: string,
+): Promise<void> {
+  await waitForCondition(
+    page,
+    (probe, id: string, text: string) =>
+      probe.collect(`[test-id="${id}"]`).some((el) =>
+        probe.deepText(el).includes(text)
+      ),
+    { args: [testId, expected] },
+  );
+}
+
+describe("piece context menu", () => {
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
+
+  // The menu and its panels are cf-piece-menu's, mounted on document.body by
+  // cf-render. Driving them through a real right-click is what proves the
+  // announcement, the portalled overlay, and the worker read all line up.
+  it("shows a piece's source and the origin it records", async () => {
+    const page = shell.page();
+    const { identity } = await writeTempIdentity({ implementation: "noble" });
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: SPACE_NAME },
+      identity,
+    });
+    await waitForRenderedPiece(page);
+
+    await rightClickRenderedPiece(page);
+    await clickPierce(page, '[test-id="piece-menu-source"]');
+    // The space root runs the default app, so its entry file is that pattern.
+    await waitForPanelText(
+      page,
+      "piece-panel-source",
+      "/api/patterns/system/default-app.tsx",
+    );
+
+    await rightClickRenderedPiece(page);
+    await clickPierce(page, '[test-id="piece-menu-origin"]');
+    // A root created from the default-app URL records it as a web origin.
+    await waitForPanelText(page, "piece-panel-origin", "External web URL");
+    await waitForPanelText(
+      page,
+      "piece-panel-origin",
+      "/api/patterns/system/default-app.tsx",
+    );
+  });
+});

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -156,11 +156,11 @@ Useful references:
 
 ### Runtime And Interaction
 
-| Element        | Element           | Element        | Element          |
-| -------------- | ----------------- | -------------- | ---------------- |
-| `cf-autostart` | `cf-cell-context` | `cf-cell-link` | `cf-drag-source` |
-| `cf-draggable` | `cf-drop-zone`    | `cf-keybind`   | `cf-piece`       |
-| `cf-render`    | `cf-toolbar`      | `cf-updater`   |                  |
+| Element         | Element           | Element        | Element          |
+| --------------- | ----------------- | -------------- | ---------------- |
+| `cf-autostart`  | `cf-cell-context` | `cf-cell-link` | `cf-drag-source` |
+| `cf-draggable`  | `cf-drop-zone`    | `cf-keybind`   | `cf-piece`       |
+| `cf-piece-menu` | `cf-render`       | `cf-toolbar`   | `cf-updater`     |
 
 ## 🔒 Security Constraints
 

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
@@ -212,6 +212,25 @@ describe("the source panel", () => {
     expect(shows(menu)).not.toContain("gone");
   });
 
+  it("drops a failed read that a later opening replaced", async () => {
+    let failRead!: (error: Error) => void;
+    const menu = openMenu(
+      pieceCell(() =>
+        new Promise<PieceSourceView>((_resolve, reject) => {
+          failRead = reject;
+        })
+      ),
+    );
+    const pending = menu.showPanel("source");
+
+    menu.open({ cell: pieceCell(), x: 0, y: 0 });
+    failRead(new Error("failed after reopening"));
+    await pending;
+
+    // The failure belongs to the piece the menu no longer shows.
+    expect(shows(menu)).not.toContain("failed after reopening");
+  });
+
   it("drops a read that a later opening replaced", async () => {
     let resolveRead!: (source: PieceSourceView) => void;
     const menu = openMenu(

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { pieceMenuEntries } from "./cf-piece-menu.ts";
+import {
+  describeOrigin,
+  formatTimestamp,
+  shortIdentity,
+} from "./origin-view.ts";
+
+// The menu's DOM behaviour (portalling onto document.body, positioning, opening
+// a panel) needs a real DOM and is covered by the shell's integration test,
+// which drives the menu through a real right-click. What is verifiable here is
+// the part with no DOM in it: the entries the component contributes, and how a
+// piece's recorded source facts read.
+
+describe("piece menu entries", () => {
+  it("offers exactly the two read actions, in order", () => {
+    expect(pieceMenuEntries().map((entry) => entry.label)).toEqual([
+      "View source",
+      "Origin and history",
+    ]);
+  });
+
+  it("gives each entry a stable hook a host's tests can select", () => {
+    expect(pieceMenuEntries().map((entry) => entry.testId)).toEqual([
+      "piece-menu-source",
+      "piece-menu-origin",
+    ]);
+  });
+});
+
+describe("describeOrigin", () => {
+  it("names the detached case without inventing an origin", () => {
+    const description = describeOrigin(undefined);
+    expect(description.label).toBe("Detached");
+    expect(description.detail).toContain("no origin");
+  });
+
+  it("distinguishes a mutable piece origin from an exact pattern", () => {
+    expect(
+      describeOrigin({
+        url: "cf:/did:key:z6Mk/of:fid1:x",
+        kind: "fabric-piece",
+      }).label,
+    ).toBe("Fabric piece");
+    expect(
+      describeOrigin({ url: "cf:pattern:x", kind: "fabric-pattern" }).label,
+    ).toBe("Exact pattern");
+    expect(
+      describeOrigin({ url: "https://example.test/p.tsx", kind: "web" }).label,
+    ).toBe("External web URL");
+  });
+
+  it("says what each kind of origin can do", () => {
+    expect(describeOrigin({ url: "https://e.test/p.tsx", kind: "web" }).detail)
+      .toContain("can return new source later");
+    expect(
+      describeOrigin({ url: "cf:pattern:x", kind: "fabric-pattern" }).detail,
+    ).toContain("always resolves to");
+  });
+});
+
+describe("shortIdentity", () => {
+  it("abbreviates a content identity but keeps short values whole", () => {
+    expect(shortIdentity("abcdefghijklmnopqrstuvwxyz")).toBe("abcdefghijkl…");
+    expect(shortIdentity("abcdef")).toBe("abcdef");
+  });
+});
+
+describe("formatTimestamp", () => {
+  it("renders a recorded timestamp as local time", () => {
+    const stamped = formatTimestamp(Date.UTC(2026, 6, 24, 12, 0, 0));
+    expect(stamped).toContain("2026");
+    expect(stamped.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
@@ -1,17 +1,104 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { pieceMenuEntries } from "./cf-piece-menu.ts";
+import type { CellHandle, PieceSourceView } from "@commonfabric/runtime-client";
+import {
+  CFPieceMenu,
+  openPieceMenu,
+  pieceMenuEntries,
+} from "./cf-piece-menu.ts";
 import {
   describeOrigin,
   formatTimestamp,
   shortIdentity,
 } from "./origin-view.ts";
 
-// The menu's DOM behaviour (portalling onto document.body, positioning, opening
-// a panel) needs a real DOM and is covered by the shell's integration test,
-// which drives the menu through a real right-click. What is verifiable here is
-// the part with no DOM in it: the entries the component contributes, and how a
-// piece's recorded source facts read.
+// The menu renders through Lit templates rather than into a real DOM here: the
+// assertions read the template a render produced, which is enough to say what
+// the menu shows and when. Its behaviour against a live piece — the portalled
+// overlay, positioning, the click path — is driven end to end by
+// packages/shell/integration/piece-menu.test.ts.
+
+/** The static text and interpolated values of a rendered Lit template. */
+function textOf(node: unknown): string {
+  // `nothing` — Lit's render-nothing sentinel — is a symbol, and contributes no
+  // text, like the other empty values.
+  if (
+    node === null || node === undefined || typeof node === "boolean" ||
+    typeof node === "symbol"
+  ) {
+    return "";
+  }
+  if (Array.isArray(node)) return node.map(textOf).join(" ");
+  if (typeof node === "object") {
+    const template = node as {
+      strings?: readonly string[];
+      values?: unknown[];
+    };
+    if (template.strings && template.values) {
+      return template.strings
+        .map((part, index) => part + textOf(template.values![index]))
+        .join("");
+    }
+    return "";
+  }
+  return String(node);
+}
+
+/** What the menu shows now. `render` is the component's own protected hook. */
+function shows(menu: CFPieceMenu): string {
+  return textOf((menu as unknown as { render(): unknown }).render());
+}
+
+const SPACE = "did:key:z6Mk-piece-menu" as const;
+
+const SOURCE: PieceSourceView = {
+  space: SPACE,
+  pieceId: "of:fid1:piece",
+  name: "Recipe",
+  pattern: { identity: "pattern-identity-value", symbol: "default" },
+  origin: { url: "https://example.test/recipe.tsx", kind: "web" },
+  entry: "/main.tsx",
+  files: [
+    { name: "/main.tsx", contents: "the main file" },
+    { name: "/helper.tsx", contents: "the helper file" },
+  ],
+};
+
+/**
+ * A piece whose runtime answers one source read. `read` decides what that read
+ * does, so a test can resolve it, reject it, or leave it pending.
+ */
+function pieceCell(
+  read: () => Promise<PieceSourceView> = () => Promise.resolve(SOURCE),
+  { aborted = false } = {},
+): CellHandle {
+  return {
+    id: () => "of:fid1:piece",
+    space: () => SPACE,
+    runtime: () => ({
+      getPieceSource: read,
+      signal: { aborted },
+    }),
+  } as unknown as CellHandle;
+}
+
+/**
+ * A menu whose state changes do not schedule a Lit update: there is no DOM to
+ * render into here, and every assertion renders explicitly.
+ */
+function newMenu(): CFPieceMenu {
+  const menu = new CFPieceMenu();
+  // Lit's own update pass wants a DOM to render into; every assertion here
+  // renders explicitly instead.
+  (menu as unknown as { performUpdate(): void }).performUpdate = () => {};
+  return menu;
+}
+
+function openMenu(cell: CellHandle = pieceCell()): CFPieceMenu {
+  const menu = newMenu();
+  menu.open({ cell, x: 40, y: 60 });
+  return menu;
+}
 
 describe("piece menu entries", () => {
   it("offers exactly the two read actions, in order", () => {
@@ -26,6 +113,359 @@ describe("piece menu entries", () => {
       "piece-menu-source",
       "piece-menu-origin",
     ]);
+  });
+});
+
+describe("the menu a right-click opens", () => {
+  it("names the piece and offers every entry", () => {
+    const rendered = shows(openMenu());
+    expect(rendered).toContain("of:fid1:piece");
+    for (const entry of pieceMenuEntries()) {
+      expect(rendered).toContain(entry.label);
+      expect(rendered).toContain(entry.testId);
+    }
+  });
+
+  it("shows nothing until it is opened, or once closed", () => {
+    const menu = newMenu();
+    expect(shows(menu)).toBe("");
+    menu.open({ cell: pieceCell(), x: 0, y: 0 });
+    expect(shows(menu)).toContain("View source");
+    menu.close();
+    expect(shows(menu)).toBe("");
+  });
+
+  it("keeps itself inside the viewport", () => {
+    const menu = newMenu();
+    menu.open({ cell: pieceCell(), x: 1_000_000, y: 1_000_000 });
+    const placement = shows(menu);
+    // Clamped rather than drawn off-screen, wherever the click landed.
+    expect(placement).toContain("left: ");
+    expect(placement).not.toContain("left: 1000000px");
+  });
+});
+
+describe("the source panel", () => {
+  it("shows the entry file, with a tab per file", async () => {
+    const menu = openMenu();
+    await menu.showPanel("source");
+
+    const rendered = shows(menu);
+    expect(rendered).toContain("Source");
+    expect(rendered).toContain("Recipe");
+    expect(rendered).toContain("the main file");
+    expect(rendered).toContain("/helper.tsx");
+  });
+
+  it("switches to the file a tab selects", async () => {
+    const menu = openMenu();
+    await menu.showPanel("source");
+    expect(shows(menu)).toContain("the main file");
+
+    menu.selectFile(1);
+    expect(shows(menu)).toContain("the helper file");
+  });
+
+  it("reads the piece once for both panels", async () => {
+    let reads = 0;
+    const menu = openMenu(pieceCell(() => {
+      reads++;
+      return Promise.resolve(SOURCE);
+    }));
+
+    await menu.showPanel("source");
+    await menu.showPanel("origin");
+    await menu.showPanel("source");
+
+    expect(reads).toBe(1);
+  });
+
+  it("says so when the piece's source is not in its space", async () => {
+    const menu = openMenu(
+      pieceCell(() =>
+        Promise.resolve({ ...SOURCE, entry: undefined, files: [] })
+      ),
+    );
+    await menu.showPanel("source");
+
+    const rendered = shows(menu);
+    expect(rendered).toContain("not available in its space");
+    expect(rendered).toContain("pattern-identity-value");
+  });
+
+  it("reports a read that failed", async () => {
+    const menu = openMenu(
+      pieceCell(() => Promise.reject(new Error("no read"))),
+    );
+    await menu.showPanel("source");
+
+    expect(shows(menu)).toContain("no read");
+  });
+
+  it("stays quiet when the runtime was disposed mid-read", async () => {
+    // A disposal race is cancellation, not a failure to report.
+    const menu = openMenu(
+      pieceCell(() => Promise.reject(new Error("gone")), { aborted: true }),
+    );
+    await menu.showPanel("source");
+
+    expect(shows(menu)).not.toContain("gone");
+  });
+
+  it("drops a read that a later opening replaced", async () => {
+    let resolveRead!: (source: PieceSourceView) => void;
+    const menu = openMenu(
+      pieceCell(() =>
+        new Promise<PieceSourceView>((resolve) => {
+          resolveRead = resolve;
+        })
+      ),
+    );
+    const pending = menu.showPanel("source");
+
+    // Reopening for another piece invalidates the read in flight.
+    menu.open({ cell: pieceCell(), x: 0, y: 0 });
+    resolveRead({ ...SOURCE, name: "Stale" });
+    await pending;
+
+    expect(shows(menu)).not.toContain("Stale");
+  });
+});
+
+describe("the origin and history panel", () => {
+  it("names the origin and the facts behind it", async () => {
+    const menu = openMenu();
+    await menu.showPanel("origin");
+
+    const rendered = shows(menu);
+    expect(rendered).toContain("External web URL");
+    expect(rendered).toContain("https://example.test/recipe.tsx");
+    expect(rendered).toContain(shortIdentity("pattern-identity-value"));
+    expect(rendered).toContain("/main.tsx");
+    expect(rendered).toContain("of:fid1:piece");
+    expect(rendered).toContain(SPACE);
+    expect(rendered).toContain("not recorded yet");
+  });
+
+  it("says a piece with no origin is detached", async () => {
+    const menu = openMenu(
+      pieceCell(() => Promise.resolve({ ...SOURCE, origin: undefined })),
+    );
+    await menu.showPanel("origin");
+
+    expect(shows(menu)).toContain("Detached");
+  });
+
+  it("shows the recorded form of an origin that was normalized", async () => {
+    const menu = openMenu(
+      pieceCell(() =>
+        Promise.resolve({
+          ...SOURCE,
+          origin: {
+            url: "https://toolshed.test/api/patterns/system/home.tsx",
+            kind: "web",
+            recorded: "/api/patterns/system/home.tsx",
+          },
+        })
+      ),
+    );
+    await menu.showPanel("origin");
+
+    const rendered = shows(menu);
+    expect(rendered).toContain("Recorded as");
+    expect(rendered).toContain("/api/patterns/system/home.tsx");
+  });
+
+  it("shows a setup identity only when it differs from the running one", async () => {
+    const same = openMenu(
+      pieceCell(() =>
+        Promise.resolve({ ...SOURCE, setupPattern: SOURCE.pattern })
+      ),
+    );
+    await same.showPanel("origin");
+    expect(shows(same)).not.toContain("Setup applied for");
+
+    const differs = openMenu(
+      pieceCell(() =>
+        Promise.resolve({
+          ...SOURCE,
+          setupPattern: { identity: "older-identity", symbol: "default" },
+        })
+      ),
+    );
+    await differs.showPanel("origin");
+    expect(shows(differs)).toContain("Setup applied for");
+  });
+
+  it("shows a displaced pattern with the time it was replaced", async () => {
+    const displacedAt = Date.UTC(2026, 6, 24, 12, 0, 0);
+    const menu = openMenu(
+      pieceCell(() =>
+        Promise.resolve({
+          ...SOURCE,
+          displacedPattern: {
+            identity: "displaced-identity",
+            symbol: "default",
+            displacedAt,
+          },
+          repository: "https://github.com/example/recipes",
+        })
+      ),
+    );
+    await menu.showPanel("origin");
+
+    const rendered = shows(menu);
+    expect(rendered).toContain("Previously ran");
+    expect(rendered).toContain(formatTimestamp(displacedAt));
+    expect(rendered).toContain("Repository");
+    expect(rendered).toContain("https://github.com/example/recipes");
+  });
+});
+
+describe("dismissing the menu", () => {
+  /** Send a keydown the way the browser would, since the menu listens globally. */
+  function pressKey(key: string): void {
+    const event = new Event("keydown", { cancelable: true });
+    (event as unknown as { key: string }).key = key;
+    globalThis.dispatchEvent(event);
+  }
+
+  it("steps back from a panel to the menu, then closes", async () => {
+    const menu = openMenu();
+    menu.connectedCallback();
+    try {
+      await menu.showPanel("origin");
+      expect(shows(menu)).toContain("Origin and history");
+
+      pressKey("Escape");
+      expect(shows(menu)).toContain("View source");
+
+      pressKey("Escape");
+      expect(shows(menu)).toBe("");
+    } finally {
+      menu.disconnectedCallback();
+    }
+  });
+
+  it("dismisses on a right-click on the backdrop", () => {
+    const menu = openMenu();
+    let prevented = false;
+    (menu as unknown as { _onBackdropContextMenu(e: Event): void })
+      ._onBackdropContextMenu(
+        { preventDefault: () => (prevented = true) } as unknown as Event,
+      );
+
+    // The platform menu does not open over the dismissed piece menu.
+    expect(prevented).toBe(true);
+    expect(shows(menu)).toBe("");
+  });
+
+  it("ignores keys that are not Escape", () => {
+    const menu = openMenu();
+    menu.connectedCallback();
+    try {
+      pressKey("Enter");
+      expect(shows(menu)).toContain("View source");
+    } finally {
+      menu.disconnectedCallback();
+    }
+  });
+});
+
+describe("openPieceMenu", () => {
+  /** A document stub: the menu mounts on `document.body`, outside any piece. */
+  function installDocument(): { restore: () => void; appended: unknown[] } {
+    const appended: unknown[] = [];
+    const original = Object.getOwnPropertyDescriptor(globalThis, "document");
+    const originalComputed = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "getComputedStyle",
+    );
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      writable: true,
+      value: {
+        createElement: () => {
+          const element = newMenu();
+          // The shim element has no style object of its own.
+          (element as unknown as { style: unknown }).style = {
+            setProperty: () => {},
+            removeProperty: () => {},
+          };
+          return element;
+        },
+        body: {
+          appendChild: (element: unknown) => {
+            appended.push(element);
+            (element as { isConnected?: boolean }).isConnected = true;
+            return element;
+          },
+        },
+      },
+    });
+    Object.defineProperty(globalThis, "getComputedStyle", {
+      configurable: true,
+      writable: true,
+      value: () => ({
+        getPropertyValue: (name: string) =>
+          name === "--cf-theme-color-surface" ? "#101010" : "",
+      }),
+    });
+    return {
+      appended,
+      restore: () => {
+        if (original) Object.defineProperty(globalThis, "document", original);
+        else Reflect.deleteProperty(globalThis, "document");
+        if (originalComputed) {
+          Object.defineProperty(
+            globalThis,
+            "getComputedStyle",
+            originalComputed,
+          );
+        } else Reflect.deleteProperty(globalThis, "getComputedStyle");
+      },
+    };
+  }
+
+  it("mounts one menu and reuses it for the next right-click", () => {
+    const { appended, restore } = installDocument();
+    try {
+      const first = openPieceMenu({ cell: pieceCell(), x: 10, y: 20 });
+      const second = openPieceMenu({ cell: pieceCell(), x: 30, y: 40 });
+
+      // One overlay, reopened — a second right-click replaces the menu rather
+      // than stacking another on top of it.
+      expect(second).toBe(first);
+      expect(appended.length).toBe(1);
+      expect(shows(second)).toContain("View source");
+    } finally {
+      restore();
+    }
+  });
+
+  it("adopts the theme of the element the click came from", () => {
+    const { restore } = installDocument();
+    const applied: Array<[string, string]> = [];
+    try {
+      const themeFrom = {} as unknown as Element;
+      const menu = openPieceMenu({
+        cell: pieceCell(),
+        x: 0,
+        y: 0,
+        themeFrom,
+      });
+      (menu as unknown as { style: unknown }).style = {
+        setProperty: (name: string, value: string) =>
+          applied.push([name, value]),
+        removeProperty: () => {},
+      };
+      // Reopening with the same host re-copies onto the recorded style stub.
+      openPieceMenu({ cell: pieceCell(), x: 0, y: 0, themeFrom });
+
+      expect(applied).toContainEqual(["--cf-theme-color-surface", "#101010"]);
+    } finally {
+      restore();
+    }
   });
 });
 

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -1,0 +1,590 @@
+import { css, html, nothing, type TemplateResult } from "lit";
+import { state } from "lit/decorators.js";
+import { BaseElement } from "../../core/base-element.ts";
+import type { CellHandle, PieceSourceView } from "@commonfabric/runtime-client";
+import {
+  describeOrigin,
+  formatTimestamp,
+  shortIdentity,
+} from "./origin-view.ts";
+
+/** Which panel is showing, if any. */
+type Panel = "source" | "origin";
+
+/** One entry in the menu, and the panel it opens. */
+interface MenuEntry {
+  label: string;
+  /** Stable hook for tests, exposed as the entry's `test-id`. */
+  testId: string;
+  panel: Panel;
+}
+
+const ENTRIES: readonly MenuEntry[] = [
+  { label: "View source", testId: "piece-menu-source", panel: "source" },
+  {
+    label: "Origin and history",
+    testId: "piece-menu-origin",
+    panel: "origin",
+  },
+];
+
+/** The entries every piece menu shows, in order. */
+export function pieceMenuEntries(): readonly MenuEntry[] {
+  return ENTRIES;
+}
+
+/**
+ * CFPieceMenu — the menu a right-click on a piece opens, with the panels for
+ * the two things it can show about that piece: its authored source, and the
+ * origin and history it records.
+ *
+ * @element cf-piece-menu
+ *
+ * Mounted on `document.body` by {@link openPieceMenu}, never inside the piece
+ * it describes: a piece's own `overflow: hidden` would clip it, and the tile
+ * variant's `transform: scale(0.5)` would both contain and shrink a
+ * `position: fixed` overlay rendered in that subtree.
+ *
+ * A host that wants a different menu for a piece cancels the
+ * `cf-piece-context-menu` announcement and shows its own; see
+ * `docs/development/HOST_EMBEDDING.md`.
+ */
+export class CFPieceMenu extends BaseElement {
+  static override styles = css`
+    :host {
+      position: fixed;
+      inset: 0;
+      z-index: 2147483000;
+      display: block;
+      font-family: var(--cf-theme-font-family, system-ui, sans-serif);
+      color: var(--cf-theme-color-text, #111827);
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    .backdrop {
+      position: absolute;
+      inset: 0;
+    }
+
+    .backdrop.dimmed {
+      background: rgba(0, 0, 0, 0.32);
+    }
+
+    .menu {
+      position: absolute;
+      min-width: 15rem;
+      padding: 0.25rem;
+      background: var(--cf-theme-color-surface, #ffffff);
+      border-radius: 8px;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12), 0 0 3px rgba(0, 0, 0, 0.16);
+    }
+
+    .menu-item {
+      display: block;
+      width: 100%;
+      padding: 0.5rem 0.75rem;
+      border: none;
+      border-radius: 6px;
+      background: none;
+      font: inherit;
+      font-size: 0.8125rem;
+      color: inherit;
+      text-align: left;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+
+    .menu-item:hover,
+    .menu-item:focus-visible {
+      background: var(--cf-theme-color-surface-hover, rgba(0, 0, 0, 0.06));
+    }
+
+    .menu-title {
+      padding: 0.375rem 0.75rem;
+      font-size: 0.6875rem;
+      color: var(--cf-theme-color-text-muted, #6b7280);
+      max-width: 18rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .panel {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      display: flex;
+      flex-direction: column;
+      width: min(56rem, 92vw);
+      max-height: 86vh;
+      background: var(--cf-theme-color-surface, #ffffff);
+      border-radius: 12px;
+      box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
+      overflow: hidden;
+    }
+
+    .panel-head {
+      display: flex;
+      align-items: baseline;
+      gap: 0.75rem;
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid var(--cf-theme-color-border, rgba(0, 0, 0, 0.1));
+    }
+
+    .panel-head h2 {
+      margin: 0;
+      font-size: 0.9375rem;
+    }
+
+    .panel-head .subject {
+      flex: 1;
+      font-size: 0.75rem;
+      color: var(--cf-theme-color-text-muted, #6b7280);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .panel-close {
+      padding: 0.25rem 0.5rem;
+      border: none;
+      border-radius: 6px;
+      background: none;
+      font: inherit;
+      font-size: 0.875rem;
+      color: inherit;
+      cursor: pointer;
+    }
+
+    .panel-close:hover {
+      background: var(--cf-theme-color-surface-hover, rgba(0, 0, 0, 0.06));
+    }
+
+    .panel-body {
+      flex: 1;
+      min-height: 0;
+      overflow: auto;
+      padding: 1rem 1.25rem;
+    }
+
+    .file-tabs {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+      padding: 0.5rem 1.25rem 0;
+    }
+
+    .file-tab {
+      padding: 0.25rem 0.625rem;
+      border: 1px solid var(--cf-theme-color-border, rgba(0, 0, 0, 0.15));
+      border-radius: 6px;
+      background: none;
+      font: inherit;
+      font-size: 0.6875rem;
+      color: var(--cf-theme-color-text-muted, #6b7280);
+      cursor: pointer;
+    }
+
+    .file-tab.active {
+      color: inherit;
+      background: var(--cf-theme-color-surface-hover, rgba(0, 0, 0, 0.06));
+    }
+
+    pre.source {
+      margin: 0;
+      font-family: var(--cf-theme-font-mono, "SF Mono", monospace);
+      font-size: 12px;
+      line-height: 1.5;
+      white-space: pre;
+      tab-size: 2;
+    }
+
+    dl.facts {
+      display: grid;
+      grid-template-columns: minmax(8rem, max-content) 1fr;
+      gap: 0.375rem 1rem;
+      margin: 0;
+      font-size: 0.8125rem;
+    }
+
+    dl.facts dt {
+      color: var(--cf-theme-color-text-muted, #6b7280);
+    }
+
+    dl.facts dd {
+      margin: 0;
+      overflow-wrap: anywhere;
+      font-family: var(--cf-theme-font-mono, "SF Mono", monospace);
+    }
+
+    dl.facts dd.prose {
+      font-family: inherit;
+    }
+
+    .note {
+      margin: 1rem 0 0;
+      font-size: 0.75rem;
+      color: var(--cf-theme-color-text-muted, #6b7280);
+    }
+
+    .error {
+      margin: 0.75rem 0 0;
+      font-size: 0.8125rem;
+      color: var(--cf-theme-color-error, #b91c1c);
+      overflow-wrap: anywhere;
+    }
+  `;
+
+  /** The piece the menu addresses. */
+  declare cell?: CellHandle;
+
+  /** Where the click landed, in client coordinates. */
+  declare x: number;
+  declare y: number;
+
+  static override properties = {
+    cell: { attribute: false },
+    x: { attribute: false },
+    y: { attribute: false },
+  };
+
+  @state()
+  private accessor panel: Panel | undefined = undefined;
+
+  @state()
+  private accessor selectedFile = 0;
+
+  @state()
+  private accessor source: PieceSourceView | undefined = undefined;
+
+  @state()
+  private accessor readError: string | undefined = undefined;
+
+  /** Identifies the read a late response belongs to, so a stale one is dropped. */
+  private readToken = 0;
+
+  constructor() {
+    super();
+    this.x = 0;
+    this.y = 0;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    globalThis.addEventListener("keydown", this.#onKeyDown);
+  }
+
+  override disconnectedCallback() {
+    globalThis.removeEventListener("keydown", this.#onKeyDown);
+    super.disconnectedCallback();
+  }
+
+  /** Show the menu for `cell` at a click position. */
+  open({ cell, x, y }: { cell: CellHandle; x: number; y: number }): void {
+    this.cell = cell;
+    this.x = x;
+    this.y = y;
+    this.panel = undefined;
+    this.selectedFile = 0;
+    this.source = undefined;
+    this.readError = undefined;
+    this.readToken++;
+    this.hidden = false;
+  }
+
+  /** Hide the menu and forget the piece it was describing. */
+  close(): void {
+    this.hidden = true;
+    this.panel = undefined;
+    this.cell = undefined;
+    this.source = undefined;
+    this.readToken++;
+  }
+
+  #onKeyDown = (e: KeyboardEvent) => {
+    if (this.hidden || e.key !== "Escape") return;
+    e.preventDefault();
+    // Escape steps back from a panel to the menu, then closes.
+    if (this.panel) this.panel = undefined;
+    else this.close();
+  };
+
+  async #openPanel(panel: Panel) {
+    this.panel = panel;
+    this.selectedFile = 0;
+    this.readError = undefined;
+    const cell = this.cell;
+    if (!cell || this.source !== undefined) return;
+    const token = this.readToken;
+    try {
+      const source = await cell.runtime().getPieceSource(
+        cell.id(),
+        cell.space(),
+      );
+      if (token !== this.readToken) return;
+      this.source = source;
+    } catch (error) {
+      if (token !== this.readToken) return;
+      // A disposal race (logout, runtime swap) cancels the read; that is
+      // cancellation, not a failure to report.
+      if (cell.runtime().signal.aborted) return;
+      this.readError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  protected override render() {
+    if (this.hidden || !this.cell) return nothing;
+    return this.panel ? this.#renderPanel(this.panel) : this.#renderMenu();
+  }
+
+  #renderMenu(): TemplateResult {
+    // Keep the menu inside the viewport: a click near the right or bottom edge
+    // clamps it back into view.
+    const width = 240;
+    const height = 40 + ENTRIES.length * 34;
+    const left = Math.max(
+      4,
+      Math.min(this.x, globalThis.innerWidth - width - 4),
+    );
+    const top = Math.max(
+      4,
+      Math.min(this.y, globalThis.innerHeight - height - 4),
+    );
+    return html`
+      <div
+        class="backdrop"
+        @click="${() => this.close()}"
+        @contextmenu="${(e: Event) => {
+          e.preventDefault();
+          this.close();
+        }}"
+      >
+      </div>
+      <div class="menu" role="menu" style="left: ${left}px; top: ${top}px">
+        <div class="menu-title">Piece ${this.cell!.id()}</div>
+        ${ENTRIES.map((entry) =>
+          html`
+            <button
+              class="menu-item"
+              role="menuitem"
+              test-id="${entry.testId}"
+              @click="${() => this.#openPanel(entry.panel)}"
+            >
+              ${entry.label}
+            </button>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  #renderPanel(panel: Panel): TemplateResult {
+    const title = panel === "source" ? "Source" : "Origin and history";
+    const subject = this.source?.name ?? this.cell?.id() ?? "";
+    return html`
+      <div class="backdrop dimmed" @click="${() => this.close()}"></div>
+      <div
+        class="panel"
+        role="dialog"
+        aria-label="${title}"
+        test-id="piece-panel-${panel}"
+      >
+        <div class="panel-head">
+          <h2>${title}</h2>
+          <span class="subject">${subject}</span>
+          <button class="panel-close" @click="${() => this.close()}">
+            Close
+          </button>
+        </div>
+        ${panel === "source" ? this.#renderSourceTabs() : nothing}
+        <div class="panel-body">
+          ${this.readError
+            ? html`
+              <p class="error">
+                Could not read this piece's source: ${this.readError}
+              </p>
+            `
+            : this.source === undefined
+            ? html`
+              <p>Reading source…</p>
+            `
+            : panel === "source"
+            ? this.#renderSource(this.source)
+            : this.#renderOrigin(this.source)}
+        </div>
+      </div>
+    `;
+  }
+
+  #renderSourceTabs() {
+    const files = this.source?.files ?? [];
+    if (files.length < 2) return nothing;
+    return html`
+      <div class="file-tabs">
+        ${files.map((file, index) =>
+          html`
+            <button
+              class="file-tab ${index === this.selectedFile ? "active" : ""}"
+              @click="${() => {
+                this.selectedFile = index;
+              }}"
+            >
+              ${file.name}
+            </button>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  #renderSource(source: PieceSourceView): TemplateResult {
+    if (source.files.length === 0) {
+      return html`
+        <p>
+          This piece's source is not available in its space. Its pattern is ${source
+              .pattern
+            ? html`
+              <code>${source.pattern.identity}</code>
+            `
+            : "not recorded"}.
+        </p>
+      `;
+    }
+    const file =
+      source.files[Math.min(this.selectedFile, source.files.length - 1)];
+    return html`
+      <pre class="source">${file.contents}</pre>
+    `;
+  }
+
+  #renderOrigin(source: PieceSourceView): TemplateResult {
+    const origin = describeOrigin(source.origin);
+    return html`
+      <dl class="facts">
+        <dt>Origin</dt>
+        <dd class="prose">
+          ${origin.label}${source.origin
+            ? html`
+              — <code>${source.origin.url}</code>
+            `
+            : nothing}
+          <div class="note">${origin.detail}</div>
+        </dd>
+        ${source.origin?.recorded
+          ? html`
+            <dt>Recorded as</dt>
+            <dd>${source.origin.recorded}</dd>
+          `
+          : nothing} ${source.pattern
+          ? html`
+            <dt>Pattern</dt>
+            <dd title="${source.pattern.identity}">
+              ${shortIdentity(source.pattern.identity)} · ${source.pattern
+                .symbol}
+            </dd>
+          `
+          : nothing} ${source.setupPattern &&
+            (source.setupPattern.identity !== source.pattern?.identity ||
+              source.setupPattern.symbol !== source.pattern?.symbol)
+          ? html`
+            <dt>Setup applied for</dt>
+            <dd title="${source.setupPattern.identity}">
+              ${shortIdentity(source.setupPattern.identity)} · ${source
+                .setupPattern.symbol}
+            </dd>
+          `
+          : nothing} ${source.displacedPattern
+          ? html`
+            <dt>Previously ran</dt>
+            <dd title="${source.displacedPattern.identity}">
+              ${shortIdentity(source.displacedPattern.identity)} · ${source
+                .displacedPattern.symbol}${source.displacedPattern.displacedAt
+                ? ` · replaced ${
+                  formatTimestamp(source.displacedPattern.displacedAt)
+                }`
+                : ""}
+            </dd>
+          `
+          : nothing} ${source.repository
+          ? html`
+            <dt>Repository</dt>
+            <dd>${source.repository}</dd>
+          `
+          : nothing} ${source.entry
+          ? html`
+            <dt>Entry file</dt>
+            <dd>${source.entry}</dd>
+          `
+          : nothing}
+        <dt>Files retained</dt>
+        <dd>${source.files.length}</dd>
+        <dt>Piece</dt>
+        <dd>${source.pieceId}</dd>
+        <dt>Space</dt>
+        <dd>${source.space}</dd>
+      </dl>
+      <p class="note">
+        These are the source facts this piece records. A per-revision history of
+        earlier source and origin states is not recorded yet, so reverting to an
+        earlier version is not offered here.
+      </p>
+    `;
+  }
+}
+
+/**
+ * The theme tokens the menu reads. Mounting outside `cf-theme`'s subtree is what
+ * keeps the menu clear of a piece's clipping and scaling, and it also puts it
+ * out of reach of the inherited theme variables, so these are copied across from
+ * the element that opened it.
+ */
+const THEME_VARIABLES = [
+  "--cf-theme-font-family",
+  "--cf-theme-font-mono",
+  "--cf-theme-color-text",
+  "--cf-theme-color-text-muted",
+  "--cf-theme-color-surface",
+  "--cf-theme-color-surface-hover",
+  "--cf-theme-color-border",
+  "--cf-theme-color-error",
+];
+
+/** Copy the menu's theme tokens from `from`, resolved, onto `to`. */
+function copyThemeVariables(from: Element, to: HTMLElement): void {
+  const computed = globalThis.getComputedStyle(from);
+  for (const name of THEME_VARIABLES) {
+    const value = computed.getPropertyValue(name).trim();
+    if (value) to.style.setProperty(name, value);
+    else to.style.removeProperty(name);
+  }
+}
+
+/**
+ * The one menu element, mounted on `document.body`. A single shared instance
+ * means a right-click while a menu is open replaces it rather than stacking
+ * another overlay, and the element outlives the `cf-render` that opened it (a
+ * piece can re-render, or stop, while its menu is up).
+ */
+let shared: CFPieceMenu | undefined;
+
+/** Show the piece menu for `cell` at a click position. */
+export function openPieceMenu(
+  { cell, x, y, themeFrom }: {
+    cell: CellHandle;
+    x: number;
+    y: number;
+    /** The element the click came from, whose theme the menu adopts. */
+    themeFrom?: Element;
+  },
+): CFPieceMenu {
+  if (!shared || !shared.isConnected) {
+    shared = globalThis.document.createElement("cf-piece-menu") as CFPieceMenu;
+    globalThis.document.body.appendChild(shared);
+  }
+  if (themeFrom) copyThemeVariables(themeFrom, shared);
+  shared.open({ cell, x, y });
+  return shared;
+}

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -9,7 +9,7 @@ import {
 } from "./origin-view.ts";
 
 /** Which panel is showing, if any. */
-type Panel = "source" | "origin";
+export type Panel = "source" | "origin";
 
 /** One entry in the menu, and the panel it opens. */
 interface MenuEntry {
@@ -312,7 +312,25 @@ export class CFPieceMenu extends BaseElement {
     else this.close();
   };
 
-  async #openPanel(panel: Panel) {
+  /** Show the source file at `index`, as choosing its tab does. */
+  selectFile(index: number): void {
+    this.selectedFile = index;
+  }
+
+  /**
+   * A right-click on the backdrop dismisses the menu rather than opening a
+   * second one behind it.
+   */
+  private _onBackdropContextMenu = (e: Event) => {
+    e.preventDefault();
+    this.close();
+  };
+
+  /**
+   * Show one of the panels, as choosing its entry does, reading the piece's
+   * source state the first time a panel is opened for that piece.
+   */
+  async showPanel(panel: Panel) {
     this.panel = panel;
     this.selectedFile = 0;
     this.readError = undefined;
@@ -357,10 +375,7 @@ export class CFPieceMenu extends BaseElement {
       <div
         class="backdrop"
         @click="${() => this.close()}"
-        @contextmenu="${(e: Event) => {
-          e.preventDefault();
-          this.close();
-        }}"
+        @contextmenu="${this._onBackdropContextMenu}"
       >
       </div>
       <div class="menu" role="menu" style="left: ${left}px; top: ${top}px">
@@ -371,7 +386,7 @@ export class CFPieceMenu extends BaseElement {
               class="menu-item"
               role="menuitem"
               test-id="${entry.testId}"
-              @click="${() => this.#openPanel(entry.panel)}"
+              @click="${() => this.showPanel(entry.panel)}"
             >
               ${entry.label}
             </button>
@@ -428,9 +443,7 @@ export class CFPieceMenu extends BaseElement {
           html`
             <button
               class="file-tab ${index === this.selectedFile ? "active" : ""}"
-              @click="${() => {
-                this.selectedFile = index;
-              }}"
+              @click="${() => this.selectFile(index)}"
             >
               ${file.name}
             </button>

--- a/packages/ui/src/v2/components/cf-piece-menu/index.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/index.ts
@@ -1,0 +1,10 @@
+import { CFPieceMenu } from "./cf-piece-menu.ts";
+
+if (!customElements.get("cf-piece-menu")) {
+  customElements.define("cf-piece-menu", CFPieceMenu);
+}
+
+export type { CFPieceMenu as CFPieceMenuElement } from "./cf-piece-menu.ts";
+
+export * from "./cf-piece-menu.ts";
+export * from "./origin-view.ts";

--- a/packages/ui/src/v2/components/cf-piece-menu/origin-view.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/origin-view.ts
@@ -1,0 +1,58 @@
+/**
+ * How a piece's recorded source facts read to a person.
+ *
+ * The origin kinds these describe are defined by
+ * `docs/specs/piece-source-lifecycle.md`; the runtime classifies a piece's
+ * recorded source into one of them and the panel names it.
+ */
+
+import type { PieceOriginView } from "@commonfabric/runtime-client";
+
+export interface OriginDescription {
+  /** Short label naming the kind of origin. */
+  label: string;
+  /** One sentence on what that origin can do. */
+  detail: string;
+}
+
+/** How an origin reads to a person, including the detached case. */
+export function describeOrigin(
+  origin: PieceOriginView | undefined,
+): OriginDescription {
+  if (origin === undefined) {
+    return {
+      label: "Detached",
+      detail: "This piece records no origin, so nothing supplies new code " +
+        "for it. It is the only durable reference to the source it runs.",
+    };
+  }
+  switch (origin.kind) {
+    case "web":
+      return {
+        label: "External web URL",
+        detail: "A program endpoint that can return new source later.",
+      };
+    case "fabric-piece":
+      return {
+        label: "Fabric piece",
+        detail: "A stable piece in the fabric; the origin names whichever " +
+          "pattern that piece currently runs.",
+      };
+    case "fabric-pattern":
+      return {
+        label: "Exact pattern",
+        detail: "Content-addressed source: this origin always resolves to " +
+          "the same code.",
+      };
+  }
+}
+
+/** A content identity abbreviated for display; the full value stays in a title. */
+export function shortIdentity(identity: string): string {
+  return identity.length > 14 ? `${identity.slice(0, 12)}…` : identity;
+}
+
+/** A recorded timestamp as a readable local time. */
+export function formatTimestamp(ms: number): string {
+  return new Date(ms).toLocaleString();
+}

--- a/packages/ui/src/v2/components/cf-render/cf-render.test.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.test.ts
@@ -277,6 +277,62 @@ describe("CFRender piece context menu", () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
+  it("opens the built-in menu when no host takes the click", () => {
+    // The menu mounts on document.body, outside the piece — see cf-piece-menu.
+    const mounted: unknown[] = [];
+    const original = Object.getOwnPropertyDescriptor(globalThis, "document");
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      writable: true,
+      value: {
+        createElement: () => ({
+          open: () => {},
+          close: () => {},
+          style: { setProperty: () => {}, removeProperty: () => {} },
+        }),
+        body: {
+          appendChild: (element: unknown) => {
+            mounted.push(element);
+            (element as { isConnected?: boolean }).isConnected = true;
+            return element;
+          },
+        },
+      },
+    });
+    const originalComputed = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "getComputedStyle",
+    );
+    Object.defineProperty(globalThis, "getComputedStyle", {
+      configurable: true,
+      writable: true,
+      value: () => ({ getPropertyValue: () => "" }),
+    });
+
+    try {
+      const element = new CFRender();
+      element.cell = createMockCellHandle({ name: "piece" }, {
+        id: "of:fid1:piece" as never,
+        space: "did:key:zSpace" as never,
+      }) as CellHandle;
+      const event = contextMenuEvent();
+
+      // No listener at all: the announcement goes uncancelled and cf-render
+      // opens the menu itself.
+      (element as unknown as { _onContextMenu(e: MouseEvent): void })
+        ._onContextMenu(event);
+
+      expect(mounted.length).toBe(1);
+      expect(event.defaultPrevented).toBe(true);
+    } finally {
+      if (original) Object.defineProperty(globalThis, "document", original);
+      else Reflect.deleteProperty(globalThis, "document");
+      if (originalComputed) {
+        Object.defineProperty(globalThis, "getComputedStyle", originalComputed);
+      } else Reflect.deleteProperty(globalThis, "getComputedStyle");
+    }
+  });
+
   it("reports the resolved root when a chip or tile resolved a link", () => {
     const element = new CFRender();
     element.variant = "tile";

--- a/packages/ui/src/v2/components/cf-render/cf-render.test.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.test.ts
@@ -17,6 +17,19 @@ import {
 // handling, cell assignment, variant configuration, and disconnectedCallback
 // state reset. For full integration tests, use a browser-based test harness.
 
+/** Record what a call logged as an error, leaving the console untouched. */
+function captureConsoleError(fn: () => void): unknown[][] {
+  const calls: unknown[][] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => calls.push(args);
+  try {
+    fn();
+  } finally {
+    console.error = original;
+  }
+  return calls;
+}
+
 describe("CFRender", () => {
   it("should be defined", () => {
     expect(CFRender).toBeDefined();
@@ -113,18 +126,6 @@ describe("CFRender render-error handling", () => {
     } as unknown as CellHandle;
   }
 
-  function captureConsoleError(fn: () => void): unknown[][] {
-    const calls: unknown[][] = [];
-    const original = console.error;
-    console.error = (...args: unknown[]) => calls.push(args);
-    try {
-      fn();
-    } finally {
-      console.error = original;
-    }
-    return calls;
-  }
-
   it("logs render errors while the runtime is alive", () => {
     const element = new CFRender();
     element.cell = cellWithSignal(false);
@@ -146,7 +147,109 @@ describe("CFRender render-error handling", () => {
   });
 });
 
+describe("CFRender tile navigation", () => {
+  /** Collect the navigation events the shell (or an embedder) listens for. */
+  function captureNavigation(name: string, run: () => void): unknown[] {
+    const seen: unknown[] = [];
+    const listener = (e: Event) => seen.push((e as CustomEvent).detail);
+    globalThis.addEventListener(name, listener);
+    try {
+      run();
+    } finally {
+      globalThis.removeEventListener(name, listener);
+    }
+    return seen;
+  }
+
+  function tileClick(modifiers: Partial<MouseEvent> = {}): MouseEvent {
+    return {
+      stopPropagation: () => {},
+      ...modifiers,
+    } as unknown as MouseEvent;
+  }
+
+  function navigatingElement(): CFRender {
+    const element = new CFRender();
+    element.cell = createMockCellHandle({ name: "piece" }, {
+      id: "of:fid1:tile-piece" as never,
+      space: "did:key:zSpace" as never,
+    }) as CellHandle;
+    return element;
+  }
+
+  it("navigates to the piece a clicked tile renders", () => {
+    const element = navigatingElement();
+    const seen = captureNavigation("cf-navigate", () => {
+      (element as unknown as { _navigateToPiece(e: MouseEvent): void })
+        ._navigateToPiece(tileClick());
+    });
+
+    expect(seen).toEqual([{
+      spaceDid: "did:key:zSpace",
+      pieceId: "of:fid1:tile-piece",
+    }]);
+  });
+
+  it("offers the same target to a host on a modifier-click", () => {
+    const element = navigatingElement();
+    // The new-tab hook is cancellable so a host can own the new tab; cancelling
+    // it here keeps the shell's `globalThis.open` fallback out of the test.
+    const seen = captureNavigation("cf-open-external", () => {
+      globalThis.addEventListener(
+        "cf-open-external",
+        (e: Event) => e.preventDefault(),
+        { once: true },
+      );
+      (element as unknown as { _navigateToPiece(e: MouseEvent): void })
+        ._navigateToPiece(tileClick({ metaKey: true }));
+    });
+
+    expect(seen).toEqual([{
+      spaceDid: "did:key:zSpace",
+      pieceId: "of:fid1:tile-piece",
+    }]);
+  });
+
+  it("reports a navigation it could not address, rather than throwing", () => {
+    const element = new CFRender();
+    element.cell = {
+      space: () => {
+        throw new Error("no space");
+      },
+      id: () => "of:fid1:tile-piece",
+    } as unknown as CellHandle;
+
+    const calls = captureConsoleError(() => {
+      (element as unknown as { _navigateToPiece(e: MouseEvent): void })
+        ._navigateToPiece(tileClick());
+    });
+    expect(calls.length).toBe(1);
+  });
+});
+
 describe("CFRender disconnectedCallback", () => {
+  it("listens for right-clicks while connected, and stops when disconnected", () => {
+    const element = new CFRender();
+    const listened: string[] = [];
+    const removed: string[] = [];
+    (element as unknown as { addEventListener(t: string): void })
+      .addEventListener = (type: string) => listened.push(type);
+    (element as unknown as { removeEventListener(t: string): void })
+      .removeEventListener = (type: string) => removed.push(type);
+    // Connecting makes Lit build a render root and schedule its first update,
+    // both of which want a DOM. This test is about the listener the callback
+    // wires, not about rendering.
+    (element as unknown as { createRenderRoot(): unknown }).createRenderRoot =
+      () => ({ adoptedStyleSheets: [] });
+    (element as unknown as { performUpdate(): void }).performUpdate = () => {};
+
+    element.connectedCallback();
+    element.disconnectedCallback();
+
+    expect(listened).toContain("contextmenu");
+    expect(removed).toContain("contextmenu");
+  });
+
   it("should reset state on disconnect", () => {
     const element = new CFRender();
     const cell = createMockCellHandle({ name: "test" });

--- a/packages/ui/src/v2/components/cf-render/cf-render.test.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.test.ts
@@ -2,7 +2,13 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
 import type { CellHandle } from "@commonfabric/runtime-client";
-import { CFRender, hasVariantValue, normalizeVariant } from "./index.ts";
+import {
+  CFRender,
+  hasVariantValue,
+  normalizeVariant,
+  PIECE_CONTEXT_MENU_EVENT,
+  type PieceContextMenuDetail,
+} from "./index.ts";
 
 // NOTE: Full rendering lifecycle tests (cell swap cleanup, subscription
 // management, render-into-container) require a real DOM with document.body
@@ -162,5 +168,131 @@ describe("CFRender disconnectedCallback", () => {
     const element = new CFRender();
     // Should not throw even with no cell
     element.disconnectedCallback();
+  });
+});
+
+describe("CFRender piece context menu", () => {
+  /** A right-click, recording whether the platform menu was suppressed. */
+  function contextMenuEvent(
+    deepestTarget?: EventTarget,
+    modifiers: { shiftKey?: boolean } = {},
+  ): MouseEvent & { defaultPrevented: boolean; propagationStopped: boolean } {
+    const event = {
+      clientX: 120,
+      clientY: 48,
+      shiftKey: modifiers.shiftKey ?? false,
+      defaultPrevented: false,
+      propagationStopped: false,
+      composedPath: () => (deepestTarget ? [deepestTarget] : []),
+      preventDefault() {
+        event.defaultPrevented = true;
+      },
+      stopPropagation() {
+        event.propagationStopped = true;
+      },
+    };
+    return event as unknown as MouseEvent & {
+      defaultPrevented: boolean;
+      propagationStopped: boolean;
+    };
+  }
+
+  /**
+   * Right-click `element`, with a listener that cancels the announcement — what
+   * a host showing its own menu does, and what these tests use because opening
+   * the built-in menu needs a real DOM (see the shell's integration test).
+   */
+  function rightClick(
+    element: CFRender,
+    event: ReturnType<typeof contextMenuEvent>,
+  ): PieceContextMenuDetail | undefined {
+    let detail: PieceContextMenuDetail | undefined;
+    element.addEventListener(PIECE_CONTEXT_MENU_EVENT, (e: Event) => {
+      detail = (e as CustomEvent<PieceContextMenuDetail>).detail;
+      e.preventDefault();
+    });
+    (element as unknown as { _onContextMenu(e: MouseEvent): void })
+      ._onContextMenu(event);
+    return detail;
+  }
+
+  it("announces the piece under the pointer and takes the click", () => {
+    const element = new CFRender();
+    element.cell = createMockCellHandle({ name: "piece" }, {
+      id: "of:fid1:piece" as never,
+      space: "did:key:zSpace" as never,
+    }) as CellHandle;
+    const event = contextMenuEvent();
+    const detail = rightClick(element, event);
+
+    expect(detail).toEqual({
+      space: "did:key:zSpace",
+      pieceId: "of:fid1:piece",
+      x: 120,
+      y: 48,
+      variant: "full",
+    });
+    // The platform menu is suppressed, and an enclosing piece does not also
+    // claim the click.
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.propagationStopped).toBe(true);
+  });
+
+  it("leaves the click alone when the rendered cell is not a whole piece", () => {
+    const element = new CFRender();
+    element.cell = createMockCellHandle({ name: "piece" }, {
+      id: "of:fid1:piece" as never,
+      space: "did:key:zSpace" as never,
+      path: ["items", "0"],
+    }) as CellHandle;
+    const event = contextMenuEvent();
+
+    expect(rightClick(element, event)).toBeUndefined();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("leaves text entry to the platform menu", () => {
+    const element = new CFRender();
+    element.cell = createMockCellHandle({ name: "piece" }, {
+      id: "of:fid1:piece" as never,
+      space: "did:key:zSpace" as never,
+    }) as CellHandle;
+    const event = contextMenuEvent(
+      { tagName: "TEXTAREA" } as unknown as EventTarget,
+    );
+
+    expect(rightClick(element, event)).toBeUndefined();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("leaves a shift-held click to the platform menu", () => {
+    const element = new CFRender();
+    element.cell = createMockCellHandle({ name: "piece" }, {
+      id: "of:fid1:piece" as never,
+      space: "did:key:zSpace" as never,
+    }) as CellHandle;
+    const event = contextMenuEvent(undefined, { shiftKey: true });
+
+    expect(rightClick(element, event)).toBeUndefined();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("reports the resolved root when a chip or tile resolved a link", () => {
+    const element = new CFRender();
+    element.variant = "tile";
+    element.cell = createMockCellHandle({ name: "link" }, {
+      id: "of:fid1:list" as never,
+      space: "did:key:zSpace" as never,
+      path: ["0"],
+    }) as CellHandle;
+    (element as unknown as { _resolvedCell?: CellHandle })._resolvedCell =
+      createMockCellHandle({ name: "piece" }, {
+        id: "of:fid1:tile-piece" as never,
+        space: "did:key:zSpace" as never,
+      }) as CellHandle;
+
+    const detail = rightClick(element, contextMenuEvent());
+    expect(detail?.pieceId).toBe("of:fid1:tile-piece");
+    expect(detail?.variant).toBe("tile");
   });
 });

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -6,8 +6,11 @@ import { render } from "@commonfabric/html/client";
 import type { CellHandle } from "@commonfabric/runtime-client";
 import { CHIP_UI, TILE_UI, type VNode } from "@commonfabric/runtime-client";
 import { navigate, openInNewTab } from "@commonfabric/shell/shared";
+import type { DID } from "@commonfabric/identity";
 import "../cf-loader/index.ts";
 import "../cf-cell-link/index.ts";
+import "../cf-piece-menu/index.ts";
+import { openPieceMenu } from "../cf-piece-menu/cf-piece-menu.ts";
 
 // Set to true to enable debug logging
 const DEBUG_LOGGING = false;
@@ -26,6 +29,43 @@ const DEBUG_LOGGING = false;
  *              Default: the full [UI] rendered small at ~0.5 scale.
  */
 export type UIVariant = "full" | "chip" | "tile";
+
+/**
+ * The event a right-click on a rendered piece dispatches, announcing which
+ * piece the pointer is over before the piece menu opens.
+ *
+ * It is cancellable: a host that calls `preventDefault()` takes the click and
+ * is responsible for what happens next, and the built-in menu does not open.
+ */
+export const PIECE_CONTEXT_MENU_EVENT = "cf-piece-context-menu";
+
+/** Where the click landed, and which piece it landed on. */
+export interface PieceContextMenuDetail {
+  /** The space holding the piece. */
+  space: DID;
+  /** The piece's full schemed id. */
+  pieceId: string;
+  /** Client coordinates of the click, for placing the menu. */
+  x: number;
+  y: number;
+  /** The variant the piece was rendered at. */
+  variant: UIVariant;
+}
+
+/**
+ * True for a target whose own context menu is the useful one: text editing
+ * offers cut, copy, and paste, which a piece menu would replace. Read
+ * structurally, so a target from another document or realm still matches.
+ */
+function isTextEntry(target: EventTarget | undefined): boolean {
+  const element = target as
+    | { tagName?: unknown; isContentEditable?: unknown }
+    | undefined;
+  if (!element || typeof element.tagName !== "string") return false;
+  const tag = element.tagName.toUpperCase();
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" ||
+    element.isContentEditable === true;
+}
 
 /**
  * Normalize the `variant` attribute to the size spectrum. Anything unrecognized
@@ -343,6 +383,69 @@ export class CFRender extends BaseElement {
     };
   }
 
+  /**
+   * The piece this element renders, when the rendered cell IS a piece: a
+   * whole result cell, not a value inside one. A chip or tile resolves its
+   * (possibly link) cell during render, so that resolved root is the target.
+   */
+  private _pieceTarget(): CellHandle | undefined {
+    const cell = this._resolvedCell ?? this.cell;
+    if (!cell) return undefined;
+    try {
+      return cell.ref().path.length === 0 ? cell : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Open the piece's menu on right-click. The innermost rendered piece claims
+   * the click, so right-clicking a tile inside a piece addresses the tile.
+   *
+   * The announcement goes out first, so a host can cancel it and show its own
+   * menu for the piece instead. Either way the platform menu is suppressed,
+   * because either way something replaces it.
+   *
+   * A click with no piece target, one on a text entry, and one held with Shift
+   * are not announced at all; Shift is how to reach the browser's own menu over
+   * piece content.
+   */
+  private _onContextMenu = (e: MouseEvent) => {
+    if (e.shiftKey || isTextEntry(e.composedPath()[0])) return;
+    const target = this._pieceTarget();
+    if (!target) return;
+    const detail: PieceContextMenuDetail = {
+      space: target.space(),
+      pieceId: target.id(),
+      x: e.clientX,
+      y: e.clientY,
+      variant: normalizeVariant(this.variant),
+    };
+    const claimed = !this.dispatchEvent(
+      new CustomEvent<PieceContextMenuDetail>(PIECE_CONTEXT_MENU_EVENT, {
+        detail,
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      }),
+    );
+    e.preventDefault();
+    e.stopPropagation();
+    // A host that cancelled is showing its own menu for this piece.
+    if (claimed) return;
+    openPieceMenu({
+      cell: target,
+      x: e.clientX,
+      y: e.clientY,
+      themeFrom: this,
+    });
+  };
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener("contextmenu", this._onContextMenu);
+  }
+
   /** Navigate to the rendered piece (same behavior as cf-cell-link). */
   private _navigateToPiece(e: MouseEvent) {
     e.stopPropagation();
@@ -388,6 +491,7 @@ export class CFRender extends BaseElement {
 
   override disconnectedCallback() {
     this._log("disconnectedCallback called");
+    this.removeEventListener("contextmenu", this._onContextMenu);
     super.disconnectedCallback();
     this._renderingCellId = undefined;
     this._resolvedCell = undefined;

--- a/packages/ui/src/v2/components/host-embedding-guarded-define.test.ts
+++ b/packages/ui/src/v2/components/host-embedding-guarded-define.test.ts
@@ -17,6 +17,7 @@ import { expect } from "@std/expect";
 const components: Array<{ tag: string; path: string }> = [
   { tag: "cf-render", path: "./cf-render/index.ts" },
   { tag: "cf-cell-link", path: "./cf-cell-link/index.ts" },
+  { tag: "cf-piece-menu", path: "./cf-piece-menu/index.ts" },
   { tag: "cf-profile-badge", path: "./cf-profile-badge/index.ts" },
   { tag: "cf-toolbar", path: "./cf-toolbar/index.ts" },
 ];

--- a/packages/ui/src/v2/index.ts
+++ b/packages/ui/src/v2/index.ts
@@ -37,6 +37,7 @@ export * from "./components/cf-canvas/index.ts";
 export * from "./components/cf-card/index.ts";
 export * from "./components/cf-chart/index.ts";
 export * from "./components/cf-piece/index.ts";
+export * from "./components/cf-piece-menu/index.ts";
 export * from "./components/cf-chat/index.ts";
 export * from "./components/cf-chat-message/index.ts";
 export * from "./components/cf-checkbox/index.ts";


### PR DESCRIPTION
A piece runs a pattern that came from somewhere, and until now nothing in the product let a person see either part. The piece's source was reachable only through the scheduler debugger, which shows the source of every pattern in the graph rather than the source of the piece in front of you. The origin a piece records — the `patternSource` metadata the lifecycle calls its active origin — was not surfaced at all, so a piece tracking a toolshed URL and a piece tracking nothing looked identical.

Right-clicking a rendered piece now opens a menu with two entries:

- View source shows the piece's retained authored files, entry file first, with a tab per file.
- Origin and history names the origin kind, shows the canonical origin URL next to the string recorded on the piece when normalization changed it, and lists the current pattern identity and export symbol, the identity whose setup state was installed, the pattern identity a specialized update displaced with the time it happened, the repository locator, and the entry file. It says the piece is detached when it records no origin, and says that no per-revision history is recorded, because none is.

## Where it lives

`cf-piece-menu` in the component package, not shell chrome. Both panels are reads of `RuntimeClient.getPieceSource()`, and `cf-render` already holds the client for the piece under the pointer, so nothing about them needs a shell; any host that renders pieces gets the menu by importing `cf-render`, which registers it. Nothing in the shell changed.

The menu mounts itself on `document.body` rather than inside the piece. That is load-bearing, not tidiness: `cf-render`'s host box and the tile clip box are both `overflow: hidden`, and the tile's inner box carries `transform: scale(0.5)`, which becomes the containing block for fixed-position descendants — a menu rendered in that subtree would be positioned against the scaled box, drawn at half size, and clipped. Mounting outside also puts it beyond `cf-theme`'s subtree, so it copies the theme tokens it reads from the element that opened it and follows the host's theme.

## The seam

`cf-render` announces the right-click as `cf-piece-context-menu` before opening anything, carrying the piece address, the click position, and the variant it was rendered at. The event is cancellable, and cancelling it takes the click: the built-in menu stays shut and the host shows whatever it wants instead. Either way the browser's own context menu is suppressed, because either way something replaces it. Three clicks are never announced, so a host needs no special cases for them: a click on a text entry, a click held with Shift, and a `cf-render` bound to a value inside a piece rather than to a whole piece. The innermost rendered piece announces, so right-clicking a tile inside a piece addresses the tile.

Recorded in the host-embedding contract as §3a, with a test per rule, because an embedder losing its context menu to a menu nothing shows is exactly the kind of drift that document exists to catch.

## Under the UI

A new `piece:getSource` runtime-client operation reads one piece's source state in the worker: its pattern pointer, the origin it records, the history metadata it carries, and its authored source files, read back through the verified source closure in the piece's own space so it works for any piece rather than only ones live in this session.

`piece-origin.ts` in the piece package classifies a recorded `patternSource` as an external web URL, a mutable fabric piece, or an exact content-addressed pattern. A legacy toolshed-relative path resolves against the host accepted for the piece's space, so the origin that leaves classification is always absolute, with the recorded form kept alongside it for display. A string this runtime cannot classify reads as detached: it names no place the source could be resolved from.

## What this does not do

Reverting, repointing, detaching, and following are not offered, and nothing reconciles an origin when a piece loads. Those need the revision log and the reconciliation path the lifecycle spec still lists as required work; that spec's status tables and UI section are updated to record exactly what this change does and does not provide.

## Also

Records the shell dev server's watch scope, learned while building this. It watches packages/shell/src, so editing a component in packages/ui or anything else the shell bundles leaves the browser serving the previous build with no sign that a rebuild was skipped; touching a file under the watched directory rebuilds the lot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a right-click context menu for rendered pieces with “View source” and “Origin and history”. Ships `cf-piece-menu`, a cancellable `cf-piece-context-menu` event from `cf-render`, and a new `piece:getSource` read via `RuntimeClient.getPieceSource()`; improves origin display and adds test coverage.

- **New Features**
  - `cf-piece-menu`: opens on right-click with Source (retained files, entry first) and Origin and history (origin kind + canonical URL beside recorded string, current/setup identities, displaced pattern + timestamp, repository, entry). Mounts on `document.body` and copies theme tokens; auto-registered by `cf-render`.
  - Runtime: `piece:getSource` via `RuntimeClient.getPieceSource()` returns source, origin, history, and files; available through `lib-shell`. `cf-render` announces `cf-piece-context-menu` (bubbles, composed); cancelling takes the click and suppresses the browser menu, otherwise the built-in menu opens. Not fired for text entries, Shift-clicks, or when `cf-render` is bound inside a piece; the innermost piece announces.

- **Bug Fixes**
  - Origin classification reports unusable `cf:` URLs as `PieceOriginError`, normalizes toolshed-relative paths to absolute web URLs, and now keeps the recorded origin when canonicalization rewrites any web URL.
  - Added tests for the menu’s replaced/failed read path and `cf-render` tile navigation (plain click navigates; modifier-click offers new tab; failures are reported). Ensured uncancelled announcements open the built-in menu.

<sup>Written for commit 919a331c34f4272fa8bbd216aa97ba0e7c711636. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

