### PR TITLE
dashboard: rework the benchmarks tile to trend a scale-invariant perf…

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -177,7 +177,7 @@ surveillance tool.
 | prod errors | SigNoz trace error rate for one service (errored spans / all spans): last-12h headline, with a per-hour sparkline over the retained trace history (~2 weeks) and the last-12h slice that feeds the headline highlighted. Scoped to `PROD_SERVICE` — the same SigNoz holds staging and one-off perf runs, whose rates are not production's. Gray (not red) when SigNoz is unreachable. Pops out to the SigNoz logs explorer | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `SIGNOZ_UI_URL` for the pop-out |
 | cloud spend | BigQuery billing export, via the REST API | `GCP_BILLING_TABLE` (+ Workload Identity, or `GCP_SA_KEY` locally), optional `GCP_DAILY_BUDGET` |
 | ci spend | GitHub Actions and Blacksmith billing, projected to month-end in USD. Each configured source gets a line in the shared 45-day chart and an MTD label. The header shows combined MTD spend. A source that cannot be read shows `$???`, while the headline remains a lower bound from the sources that did respond | either or both of `GH_TOKEN` (with org billing read) and `BLACKSMITH_API_TOKEN`; optional `GH_BILLING_ORG`, `BLACKSMITH_ORG`, `CI_MONTHLY_BUDGET` |
-| benchmark | a runtime benchmark's ~45-day trend, from the `benchmarks.yml` deno-bench artifacts on main | `GH_TOKEN`; optional `BENCH_METRIC` |
+| benchmarks | a scale-invariant index of benchmark performance on `benchmarks.yml` main runs, trended over ~45 days (each run vs the last, geometric mean of per-benchmark changes, so every benchmark weighs the same): red when the most recent run failed or produced no valid data (the main signal), orange only on a broad across-the-board rise. Adding or removing a benchmark is a non-event. Drills through to the per-benchmark history | `GH_TOKEN` |
 | performance history → `/bench?view=runtime` | runtime benchmark trends, labs or loom CI duration history, and a detailed CI run Gantt. Historical views support windows from 1 through 45 days, date axes, and duration sorting. CI includes end-to-end workflow time, every job, and slowest-shard group lines | `GH_TOKEN` |
 | model spend | OpenAI + Anthropic + OpenRouter usage APIs. Headline is the projected full-month spend (extrapolated from the recent daily rate, spilling into last month when this month is under two weeks old), summed across providers. OpenAI and Anthropic (which expose per-day cost) are charted as one line each over ~45 days, dimmed except for the current-month slice that feeds the headline, with each line's MTD in the right gutter; OpenRouter (monthly total only, abbreviated "OR") is folded into the totals. The subtitle is the bullet-separated key (`OpenAI • Anthropic • OR $0`); the combined MTD sits in the header (the `aside` slot); the span the chart covers is in its bottom-left corner (the `duration` slot). A provider we can't read shows `$???` and drops the tile to gray, but the rest still chart and total | any of `OPENAI_ADMIN_KEY`, `ANTHROPIC_ADMIN_KEY`, `OPENROUTER_KEY`; optional `MODEL_MONTHLY_BUDGET` |
 | discord online | Discord gateway presence, team vs visitors over time | `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID` (Server Members + Presence intents) |
@@ -378,7 +378,6 @@ it.
 | `COMMON_TOOLS_URL` | common.tools | override the public-site URL (e.g. the `www` host if the apex redirects). |
 | `DASHBOARD_REPO` | CI tiles, github users | which repo the CI tiles read. Its owner is the organization the **github users** tile reads (default `commontoolsinc/labs`). |
 | `DASHBOARD_CACHE_DIR` | server caches | directory for all persistent dashboard cache files (default: the platform temp directory). |
-| `BENCH_METRIC` | benchmark | substring that pins which benchmark the grid tile shows; unset, it rotates hourly through all of them (see the note below). |
 | `SIGNOZ_UI_URL` | prod errors | browser-facing SigNoz URL for the "logs" pop-out. Defaults to `SIGNOZ_URL` when that is a public `https://` URL; set it when the server reaches SigNoz over an in-cluster URL a browser can't. |
 | `PROD_SERVICE` | prod errors, dau | the `service.name` production reports under in SigNoz, which both trace-reading tiles scope to. Defaults to `toolshed-production`. A name outside `[A-Za-z0-9._-]` is ignored, since it lands inside a query expression. |
 | `DAU_EXCLUDE_DIDS` | dau | comma-separated identity DIDs to leave out of the count — the server's own identity, `MEMORY_SERVICE_DIDS`, background services. Until it is set the count is an upper bound. See [dau](#dau) below. |
@@ -431,34 +430,58 @@ Notes:
   gray and shows `$???` for that source. The values from responding sources
   remain as a lower bound. A GitHub classic-plan setup still falls back to
   minutes when Blacksmith is not configured.
-- **`benchmark`** trends one `deno bench` measurement over ~45 days. The
-  `benchmarks.yml` job on main runs `deno bench --json` over the runner, cache,
-  and deep-equal benchmarks and uploads the report as a `bench-results` artifact
-  (90-day retention; there is no committed history). The tile lists benchmark runs
-  on main, samples one run per shortest-view bucket, downloads that artifact, unzips it
-  in-process, and reads each benchmark's timings. Each completed artifact check is
-  persisted before it is counted as finished, so only new runs and new attempts are
-  fetched after the first fill or a server restart. The grid tile plots **p99**. With
-  `BENCH_METRIC` set it pins to the benchmark whose `<file> > <group>/<name>` key
-  contains that substring; otherwise it **rotates** — showing one benchmark per
-  clock-hour, chosen deterministically from the hour so a fresh dashboard on any
-  machine shows the same one for the same hour. It goes **orange** when that
-  benchmark's 45-day trend rises past 5% and **red** past 20% ("trending up
-  rapidly"); flat or falling is green. A large regression reads as a fold
-  multiplier (`▲44×`) once it passes 4x, rather than a long percentage. The trend
-  is a robust **daily-median Theil–Sen** fit: the sub-daily samples are first
-  collapsed to one median per calendar day, then the trend is the median of the
-  pairwise log-slopes between days, projected across the day span. The daily median
-  absorbs within-day spikes, the median-of-slopes tolerates roughly a third of the
-  days being outliers, and working per calendar day (not per sample or per
-  millisecond) keeps it time-aware without letting two noisy runs a few hours apart
-  blow up the slope — which is what naive per-millisecond weighting does. A
-  benchmark with fewer than 7 distinct days in the window is marked as new and
-  left gray: there is too little data to claim a trend. The window is capped by
-  the 90-day artifact retention, so it shows at most ~45 days and only as far
-  back as the job has run.
-  (The shortest-view buckets are about 16 minutes wide, so the first cache fill
-  can download correspondingly more artifacts.)
+- **`benchmarks`** trends a **scale-invariant index** of benchmark performance on the
+  `benchmarks.yml` runs on main over ~45 days. The job runs `deno bench --json` over
+  the runner, cache, and deep-equal benchmarks and uploads the report as a
+  `bench-results` artifact (90-day retention; there is no committed history). Each
+  run's index is the previous run's index times the **geometric mean of the
+  per-benchmark changes** between the two runs, so every benchmark weighs the same
+  regardless of size and **only a broad, across-the-board move shifts it** — a
+  regression in one benchmark, however slow, barely registers (that is the
+  drill-down's job; a summed total, by contrast, is dominated by the few slowest
+  benchmarks). The headline is the **trend** itself — the fractional change of the
+  index across the recent window — over a second line naming how many benchmarks the
+  latest run measured and, when a recent window is highlighted, how many days that
+  window spans. **Red** — the signal this tile is mainly here to
+  raise — is the **most recent run failing outright, or finishing green on CI with no
+  readable benchmark data** (it ran and made nothing usable, so it is as good as
+  failed); red reads the workflow-run list and the latest run's cached result, so it
+  fires even when the artifacts cannot be read. **Orange** is the index **trending
+  up** (past 5%). The trend reads a recent window only — the runs in the last
+  `BENCH_TREND_MAX_AGE_DAYS` or the newest `BENCH_TREND_MIN_RUNS`, whichever is more,
+  the same "larger of the two" idea as CI duration's median window — while the
+  sparkline still spans the full ~45 days with that window drawn brighter. Green
+  while flat or falling. `deno bench` samples
+  each benchmark to a fixed time budget, so the run's wall clock barely moves with
+  performance; the per-op times do, which is why the tile trends those rather than
+  the run's duration. Because the index comes from the artifacts, the tile grays when
+  no in-window run has readable data and the latest run is neither failed nor empty:
+  **collecting…** while a fetch is still in progress — shown from the moment a
+  collection starts, before the run list is even fetched, so a freshly loaded
+  dashboard is never blank — and **benchmark data unavailable** once a fetch has
+  finished and found none. Chaining the per-run ratios makes **adding or removing a benchmark
+  a non-event**: it is in only one run of the adjacent pair at that step, so it drops
+  out of the geometric mean and the index does not step — no reset needed. A large
+  rise reads as a fold multiplier (`▲44×`) once it passes 4x, rather
+  than a long percentage. The trend is a robust
+  **daily-median Theil–Sen** fit: the sub-daily samples are first collapsed to one
+  median per calendar day, then the trend is the median of the pairwise log-slopes
+  between days, projected across the day span. The daily median absorbs within-day
+  spikes, the median-of-slopes tolerates roughly a third of the days being outliers,
+  and working per calendar day (not per sample or per millisecond) keeps it
+  time-aware without letting two noisy runs a few hours apart blow up the slope —
+  which is what naive per-millisecond weighting does. With fewer than 7 distinct
+  days in the window the trend is marked new: there is too little data to claim one.
+  The window is capped by the 90-day artifact retention, so it shows at most ~45
+  days and only as far back as the job has run.
+  - The tile drills through to the per-benchmark history behind `/bench`, which the
+    tile's collection keeps warm in the background. That collection lists benchmark
+    runs on main, samples one run per shortest-view bucket, downloads that artifact,
+    unzips it in-process, and reads each benchmark's timings. Each completed
+    artifact check is persisted before it is counted as finished, so only new runs
+    and new attempts are fetched after the first fill or a server restart. (The
+    shortest-view buckets are about 16 minutes wide, so the first cache fill can
+    download correspondingly more artifacts.)
   - Its **runtime benchmarks** view at `/bench?view=runtime` shows a sparkline
     for **every** benchmark on a shared calendar-time axis, so a late-starting
     benchmark sits at the right and a stale one visibly ends short of it.
@@ -553,7 +576,7 @@ Notes:
 Everything below is a tunable constant in `config.ts`:
 
 - **Status thresholds:** `TRUST_GOOD`/`TRUST_WARN` (first-try-green %), `DUR_GOOD`/`DUR_WARN` (median CI minutes).
-- **Data windows:** The shared fetch returns at most `CI_RUNS_MAX=200` workflow runs and stops at `CI_RUNS_MAX_AGE_DAYS=60` days. CI trust uses the entire fetched window. CI duration uses whichever is larger: `DUR_MIN_RUNS=20` passing runs or `DUR_MAX_AGE_HOURS=6` hours. Recent runs shows `RECENT_DISPLAY=50` entries.
+- **Data windows:** The shared fetch returns at most `CI_RUNS_MAX=200` workflow runs and stops at `CI_RUNS_MAX_AGE_DAYS=60` days. CI trust uses the entire fetched window. CI duration uses whichever is larger: `DUR_MIN_RUNS=20` passing runs or `DUR_MAX_AGE_HOURS=6` hours. The benchmark trend uses the same larger-of-the-two idea in days: `BENCH_TREND_MIN_RUNS=20` runs or `BENCH_TREND_MAX_AGE_DAYS=14` days. Recent runs shows `RECENT_DISPLAY=50` entries.
 - **ci-trust cell grid:** `TRUST_COLS=40` sets the column count. The grid has up to `CI_RUNS_MAX=200` cells, one for every fetched run. First-try successes are green. In-progress runs are blue. Completed runs that lower the trust percentage are red. Ignored runs are gray.
 
 ## Local development

--- a/packages/dashboard/config.ts
+++ b/packages/dashboard/config.ts
@@ -27,5 +27,10 @@ export const DUR_GOOD = 12, DUR_WARN = 20; // median CI minutes
 // ci-duration median window — the larger of these two (more runs wins).
 export const DUR_MIN_RUNS = 20;
 export const DUR_MAX_AGE_HOURS = 6;
+// benchmark trend window — the same "larger of the two" idea, but in days: the
+// benchmarks.yml job runs about four-hourly, and the daily-median trend fit needs
+// several distinct days, so the recent slice is measured in days, not hours.
+export const BENCH_TREND_MIN_RUNS = 20;
+export const BENCH_TREND_MAX_AGE_DAYS = 14;
 export const RECENT_WINDOW = 10; // recent completed runs scanned for the recent-runs status
 export const RECENT_DISPLAY = 50; // rows the recent-runs tile shows

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -104,7 +104,10 @@ ${faviconLink(status)}
   .lbl .spacer{flex:1}
   .drill{font-size:10px;color:#6f757f;letter-spacing:0;text-transform:none}
   .hmtd{font-size:11px;color:#9aa0ab;letter-spacing:0;text-transform:none;font-variant-numeric:tabular-nums;margin-right:8px}
-  .big{font-size:30px;font-weight:600;margin:0}
+  /* Fixed line-height so the headline's line box is the same height regardless of
+     which font the glyph comes from: the ▲/▼ trend arrows fall back to a taller
+     symbol font, and under line-height:normal that stretched the tile. */
+  .big{font-size:30px;font-weight:600;margin:0;line-height:1.2}
   .big.good{color:#62d18d}.big.warn{color:#f0b968}.big.bad{color:#f0726c}.big.unknown{color:#9aa0ab}
   .sub{font-size:13px;color:#9aa0ab;margin:5px 0 0}
   .running{display:inline-flex;align-items:center;gap:5px;font-size:10px;color:#8a93a5;letter-spacing:.02em;text-transform:none;margin-top:10px}

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -108,7 +108,7 @@ Deno.test(
     assertEquals(cells, 200);
     assertEquals(
       view.sub,
-      "first-try green · 199 counted of last 200 runs",
+      "first-try green · 199 of last 200 runs",
     );
     assert(
       !(view.extra ?? "").includes("#e2504a"),

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -135,19 +135,31 @@ async function benchZip(json: string): Promise<Uint8Array<ArrayBuffer>> {
 interface GhRun {
   id: number;
   run_attempt: number;
+  status: string;
   created_at: string;
+  run_started_at: string;
+  updated_at: string;
   conclusion: string | null;
 }
+
+// The default benchmarks.yml wall-clock the fixtures give each run. The tile times
+// a run from run_started_at to updated_at, so a fixed span keeps the duration
+// trend flat unless a test asks for a different one.
+const RUN_MS = 5 * 60_000;
 
 const ghRun = (
   id: number,
   at: number,
   conclusion: string | null = "success",
   runAttempt = 1,
+  durationMs = RUN_MS,
 ): GhRun => ({
   id,
   run_attempt: runAttempt,
+  status: "completed",
   created_at: new Date(at).toISOString(),
+  run_started_at: new Date(at).toISOString(),
+  updated_at: new Date(at + durationMs).toISOString(),
   conclusion,
 });
 
@@ -274,6 +286,38 @@ const bench = (
 const report = (benches: unknown[], noise = "") =>
   noise + JSON.stringify({ version: 1, runtime: "deno", benches });
 
+// The tile sums each benchmark's average per-op time, so most tile tests only need
+// to control that sum. A bench-results artifact carrying one benchmark whose avg is
+// `avgNs` gives a run total of exactly `avgNs`.
+const totalZip = (avgNs: number): Promise<Uint8Array<ArrayBuffer>> =>
+  benchZip(
+    report([bench("packages/a/x.bench.ts", null, "b", { avg: avgNs } as Timings)]),
+  );
+
+// Drive collect() over a series of successful/failed runs, attaching a
+// single-benchmark artifact of the given total to each run that has one. Runs are
+// listed newest first to the stub, matching the GitHub API.
+async function withTotals(
+  entries: { id: number; at: number; total?: number; conclusion?: string }[],
+  run: (calls: string[]) => Promise<void>,
+): Promise<void> {
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (const entry of entries) {
+    runs.push(ghRun(entry.id, entry.at, entry.conclusion ?? "success"));
+    if (entry.total !== undefined) {
+      artifacts[entry.id] = [{ id: entry.id * 10, name: "bench-results", expired: false }];
+      zips[entry.id * 10] = await totalZip(entry.total);
+    }
+  }
+  await withApi({
+    pages: { 1: [...runs].sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at)) },
+    artifacts,
+    zips,
+  }, run);
+}
+
 // ----------------------------------------------------------------- the tests
 
 Deno.test("benchmark: no token -> gray, and nothing is fetched", async () => {
@@ -387,7 +431,7 @@ Deno.test("benchmark: GITHUB_TOKEN stands in for GH_TOKEN", async () => {
   });
 });
 
-Deno.test("benchmark: a fresh disk cache prevents discovery after a dashboard restart", async () => {
+Deno.test("benchmark: a fresh disk cache prevents artifact rediscovery after a restart", async () => {
   const directory = await Deno.makeTempDir({ prefix: "benchmark-restart-" });
   const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
   const originalFetch = globalThis.fetch;
@@ -418,7 +462,9 @@ Deno.test("benchmark: a fresh disk cache prevents discovery after a dashboard re
     const restartedView = await restarted.benchmark.collect(ctx({
       GH_TOKEN: token,
     }));
-    assertEquals(calls, []);
+    // The tile still reads the run list to time the latest run, but the fresh
+    // manifest keeps it from rediscovering artifacts.
+    assertEquals(calls, [`/repos/${REPO}/actions/workflows/benchmarks.yml/runs`]);
     assertEquals(restartedView.sub, "no benchmark runs");
   } finally {
     globalThis.fetch = originalFetch;
@@ -476,73 +522,60 @@ Deno.test("fresh runtime history serves the page and update check without discov
   }
 });
 
-Deno.test("benchmark: a stale disk cache is published while startup checks GitHub", async () => {
+Deno.test("benchmark: a startup collection waits for the run list, then times it", async () => {
   const directory = await Deno.makeTempDir({ prefix: "benchmark-startup-" });
   const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
   const originalFetch = globalThis.fetch;
   const token = `benchmark-startup-${crypto.randomUUID()}`;
-  const key = "packages/a/startup.bench.ts > cached";
-  const stats = {
-    min: 400,
-    avg: 500,
-    max: 1_500,
-    p75: 800,
-    p99: 1_000,
-    p995: 1_050,
-    p999: 1_200,
-  };
   Deno.env.set("DASHBOARD_CACHE_DIR", directory);
-  const store = new BenchmarkHistoryStore();
-  await store.load();
-  const cachedRuns = [
-    { runId: 81_001, runAttempt: 1, at: Date.now() - 2 * DAY },
-    { runId: 81_002, runAttempt: 1, at: Date.now() - DAY },
-  ].map((run) => ({ ...run, metrics: new Map([[key, stats]]) }));
-  for (const run of cachedRuns) store.set(run);
-  store.markRefreshed(Date.now() - 31 * 60_000, cachedRuns);
-  await store.save();
 
   let releaseDiscovery!: (response: Response) => void;
   const discovery = new Promise<Response>((resolve) => {
     releaseDiscovery = resolve;
+  });
+  const archive = await totalZip(5_000_000);
+  const handler = serve({
+    artifacts: {
+      81_003: [{ id: 810_030, name: "bench-results", expired: false }],
+      81_004: [{ id: 810_040, name: "bench-results", expired: false }],
+    },
+    zips: { 810_030: archive, 810_040: archive },
   });
   globalThis.fetch = ((input: RequestInfo | URL) => {
     const url = new URL(input instanceof Request ? input.url : String(input));
     if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
       return discovery;
     }
-    throw new Error(`unexpected request ${url.pathname}`);
+    return Promise.resolve(handler(url));
   }) as typeof fetch;
 
-  let published!: TileView;
-  let markPublished!: () => void;
-  const publishedResult = new Promise<void>((resolve) => {
-    markPublished = resolve;
-  });
   let collection: Promise<TileView> | undefined;
   try {
     const isolated = await import(
       `./benchmark.ts?startup=${crypto.randomUUID()}`
     );
-    const activeCollection = isolated.benchmark.collect(
-      ctx({ GH_TOKEN: token, BENCH_METRIC: key }),
-      (view: TileView) => {
-        published = view;
-        markPublished();
-      },
+    const active: Promise<TileView> = isolated.benchmark.collect(
+      ctx({ GH_TOKEN: token }),
     );
-    collection = activeCollection;
+    collection = active;
     let settled = false;
-    const observedCollection = activeCollection.then((view: TileView) => {
+    const observed = active.then((view) => {
       settled = true;
       return view;
     });
-    await publishedResult;
-    assertEquals(published.value, "1.0µs");
+    // The tile does not report until GitHub answers with the run list.
+    await Promise.resolve();
     assertEquals(settled, false);
 
-    releaseDiscovery(Response.json({ workflow_runs: [] }));
-    await observedCollection;
+    releaseDiscovery(Response.json({
+      workflow_runs: [
+        ghRun(81_004, Date.now() - HOUR),
+        ghRun(81_003, Date.now() - DAY),
+      ],
+    }));
+    const view = await observed;
+    assertStringIncludes(view.value ?? "", "new"); // two runs is under a week, so the trend reads "new"
+    assertEquals(view.status, "good");
   } finally {
     releaseDiscovery(Response.json({ workflow_runs: [] }));
     await collection?.catch(() => {});
@@ -836,9 +869,11 @@ Deno.test("benchmark: paging stops at the 45-day cutoff; failures and out-of-win
   ];
   await withApi({ pages: { 1: page1 } }, async (calls) => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
-    assertEquals(v.status, "unknown");
+    // The most recent run is a failure, so the tile reads red; the only success
+    // is out of the window, so there is no duration to headline.
+    assertEquals(v.status, "bad");
     assertEquals(v.value, "—");
-    assertEquals(v.sub, "no benchmark runs");
+    assertEquals(v.sub, "last run failed");
     assertEquals(v.href, "/bench?view=runtime&repo=labs");
     assertEquals(v.hint, "all metrics ↗");
     assertEquals(apiCalls(calls).length, 1); // page 2 was never asked for
@@ -853,7 +888,7 @@ Deno.test("benchmark: an empty page ends the paging", async () => {
   );
   await withApi({ pages: { 1: page1, 2: [] } }, async (calls) => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
-    assertEquals(v.sub, "no benchmark runs");
+    assertEquals(v.sub, "last run failed"); // every run in the window failed
     // A full page still inside the window is followed; the empty page 2 stops it.
     assertEquals(
       apiCalls(calls).map((c) => c.match(/[?&]page=(\d+)/)![1]),
@@ -862,8 +897,391 @@ Deno.test("benchmark: an empty page ends the paging", async () => {
   });
 });
 
-Deno.test("benchmark: unusable artifacts -> gray, never a false green", async () => {
-  // Four successful runs in four different windows, each unusable a different way.
+Deno.test("benchmark: the tile turns orange when the benchmark index trends up", async () => {
+  // Eight successful days whose one benchmark climbs from 5 to 12 ms.
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  await withTotals(
+    Array.from({ length: 8 }, (_, d) => ({ id: 9_100 + d, at: at(d), total: (5 + d) * 1e6 })),
+    async () => {
+      const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertEquals(v.status, "warn"); // trending up, not a failure
+      assertStringIncludes(v.value ?? "", "▲"); // the rising trend is the headline
+      assertEquals(v.sub, undefined); // a mere rise is not a failure
+      assertStringIncludes(v.extra ?? "", "1 benchmark"); // the count line
+    },
+  );
+});
+
+Deno.test("benchmark: a falling benchmark index stays green", async () => {
+  // Eight successful days whose one benchmark drops from 12 to 5 ms.
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  await withTotals(
+    Array.from({ length: 8 }, (_, d) => ({ id: 9_600 + d, at: at(d), total: (12 - d) * 1e6 })),
+    async () => {
+      const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertEquals(v.status, "good"); // falling is fine
+      assertStringIncludes(v.value ?? "", "▼"); // the falling trend is the headline
+    },
+  );
+});
+
+Deno.test("benchmark: a big regression in one benchmark of many barely moves the index", async () => {
+  // Eight days, forty benchmarks. One quintuples over the window; the other 39 are
+  // flat. Each weighs the same in log space, so 5x in one of 40 is only 5^(1/40) ≈
+  // 4% on the index — under the orange threshold, so the tile stays green. (With the
+  // real ~369 benchmarks the dilution is far stronger.) The sum-based tile would
+  // have flagged this; the point is that it should not.
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let d = 0; d <= 7; d++) {
+    const id = 9_900 + d;
+    runs.push(ghRun(id, at(d)));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    const benches = [
+      bench("packages/a/x.bench.ts", null, "hot", {
+        avg: 1e6 * Math.pow(5, d / 7),
+      } as Timings),
+      ...Array.from({ length: 39 }, (_, i) =>
+        bench("packages/a/x.bench.ts", null, "flat" + i, { avg: 1e6 } as Timings)),
+    ];
+    zips[id * 10] = await benchZip(report(benches));
+  }
+  await withApi({ pages: { 1: [...runs].reverse() }, artifacts, zips }, async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "good"); // one benchmark's 5x is diluted below the threshold
+    assertStringIncludes(v.value ?? "", "▲"); // it did rise, just not enough for orange
+    assertStringIncludes(v.extra ?? "", "40 benchmarks"); // the count line
+  });
+});
+
+Deno.test("benchmark: the trend reads the recent window only, not the whole history", async () => {
+  // Forty daily runs, one benchmark. It doubled over the first twenty days, then
+  // held flat for the last twenty. The whole history rose, but the tile trends only
+  // the recent window (the last 20 runs here), which is flat, so it stays green —
+  // while the sparkline still spans the full history.
+  const at = (d: number) => SAMPLED_BASE - (39 - d) * DAY;
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let d = 0; d <= 39; d++) {
+    const id = 9_950 + d;
+    runs.push(ghRun(id, at(d)));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    const avg = d < 20 ? 1e6 * Math.pow(2, d / 19) : 2e6;
+    zips[id * 10] = await benchZip(
+      report([bench("packages/a/x.bench.ts", null, "b", { avg } as Timings)]),
+    );
+  }
+  await withApi({ pages: { 1: [...runs].reverse() }, artifacts, zips }, async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "good"); // the recent window is flat, though history rose
+    assertStringIncludes(v.value ?? "", "flat"); // the window trend
+    assertEquals(v.duration, 39 * DAY); // the sparkline still spans the full history
+    // The count line names the highlighted window's span: the newest 20 daily runs
+    // (the run floor beats the 14-day age here) reach back 19 days.
+    assertStringIncludes(v.extra ?? "", "1 benchmark · last 19 days");
+  });
+});
+
+Deno.test("benchmark: the tile paints its headline from cache before the backfill finishes", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-early-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  const token = `benchmark-early-${crypto.randomUUID()}`;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  // Seed a warm cache: two runs whose one benchmark averages 5ms, so a restart has
+  // a 5.0ms total to headline immediately, before the new run's artifact arrives.
+  const key = "packages/a/x.bench.ts > b";
+  const stats = {
+    min: 5e6,
+    avg: 5e6,
+    max: 5e6,
+    p75: 5e6,
+    p99: 5e6,
+    p995: 5e6,
+    p999: 5e6,
+  };
+  const seed = new BenchmarkHistoryStore();
+  await seed.load();
+  const cachedRuns = [
+    { runId: 84_001, runAttempt: 1, at: BASE - 2 * DAY, metrics: new Map([[key, stats]]) },
+    { runId: 84_002, runAttempt: 1, at: BASE - DAY, metrics: new Map([[key, stats]]) },
+  ];
+  for (const cachedRun of cachedRuns) seed.set(cachedRun);
+  seed.markRefreshed(BASE - DAY, cachedRuns);
+  await seed.save(BASE - DAY);
+
+  const runId = 84_003;
+  let releaseArtifact!: (response: Response) => void;
+  const heldArtifact = new Promise<Response>((resolve) => {
+    releaseArtifact = resolve;
+  });
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
+      return Promise.resolve(Response.json({
+        workflow_runs: [
+          ghRun(runId, BASE),
+          ghRun(84_002, BASE - DAY),
+          ghRun(84_001, BASE - 2 * DAY),
+        ],
+      }));
+    }
+    if (url.pathname.endsWith(`/actions/runs/${runId}/artifacts`)) {
+      return heldArtifact; // the drill-down backfill blocks here
+    }
+    throw new Error(`unexpected request ${url.pathname}`);
+  }) as typeof fetch;
+  let collection: Promise<TileView> | undefined;
+  try {
+    const isolated = await import(`./benchmark.ts?early=${crypto.randomUUID()}`);
+    let published: TileView | undefined;
+    let markPublished!: () => void;
+    const painted = new Promise<void>((resolve) => {
+      markPublished = resolve;
+    });
+    const active: Promise<TileView> = isolated.benchmark.collect(
+      ctx({ GH_TOKEN: token }),
+      (view: TileView) => {
+        published = view;
+        markPublished();
+      },
+    );
+    collection = active;
+    // The headline is painted from the seeded cache while the new artifact is held.
+    await painted;
+    assertStringIncludes(published?.value ?? "", "new"); // two seeded runs: the trend reads "new"
+    assertEquals(published?.status, "good");
+
+    releaseArtifact(Response.json({ artifacts: [] })); // the new run has no usable artifact
+    const final = await active;
+    assertStringIncludes(final.value ?? "", "new"); // still the cached runs' trend
+  } finally {
+    releaseArtifact(Response.json({ artifacts: [] }));
+    await collection?.catch(() => {});
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: a cold fetch reads 'collecting…' in flight, then reports empty", async () => {
+  // Cold cache, no seed. The early paint has the run list but no artifacts yet, so
+  // the tile says it is collecting — distinct from a finished, empty fetch.
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-collecting-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  const token = `benchmark-collecting-${crypto.randomUUID()}`;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const runId = 85_001;
+  let releaseArtifact!: (response: Response) => void;
+  const heldArtifact = new Promise<Response>((resolve) => {
+    releaseArtifact = resolve;
+  });
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
+      return Promise.resolve(
+        Response.json({ workflow_runs: [ghRun(runId, BASE)] }),
+      );
+    }
+    if (url.pathname.endsWith(`/actions/runs/${runId}/artifacts`)) {
+      return heldArtifact;
+    }
+    throw new Error(`unexpected request ${url.pathname}`);
+  }) as typeof fetch;
+  let collection: Promise<TileView> | undefined;
+  try {
+    const isolated = await import(`./benchmark.ts?collecting=${crypto.randomUUID()}`);
+    let published: TileView | undefined;
+    let markPublished!: () => void;
+    const painted = new Promise<void>((resolve) => {
+      markPublished = resolve;
+    });
+    const active: Promise<TileView> = isolated.benchmark.collect(
+      ctx({ GH_TOKEN: token }),
+      (view: TileView) => {
+        published = view;
+        markPublished();
+      },
+    );
+    collection = active;
+    await painted;
+    assertEquals(published?.status, "unknown");
+    assertEquals(published?.sub, "collecting…"); // fetch still in flight
+
+    // The listing errors, so nothing settles; the finished fetch found no data.
+    releaseArtifact(new Response("no", { status: 500 }));
+    const final = await active;
+    assertEquals(final.status, "unknown");
+    assertEquals(final.sub, "benchmark data unavailable"); // done, and empty
+  } finally {
+    releaseArtifact(new Response("no", { status: 500 }));
+    await collection?.catch(() => {});
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: the tile reads 'collecting…' from the first paint, before the run list arrives", async () => {
+  // Cold cache, and even the run-list fetch is held open. The tile paints
+  // "collecting…" at once — before GitHub has answered with any runs — so a freshly
+  // loaded dashboard is never blank while the first collection gets under way.
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-start-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  const token = `benchmark-start-${crypto.randomUUID()}`;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  let releaseRuns!: (response: Response) => void;
+  const heldRuns = new Promise<Response>((resolve) => {
+    releaseRuns = resolve;
+  });
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.pathname === "/rate_limit") return Promise.resolve(serve({})(url));
+    if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
+      return heldRuns; // the run list stays held until the finally block
+    }
+    throw new Error(`unexpected request ${url.pathname}`);
+  }) as typeof fetch;
+  let collection: Promise<TileView> | undefined;
+  try {
+    const isolated = await import(`./benchmark.ts?start=${crypto.randomUUID()}`);
+    let first: TileView | undefined;
+    let markPublished!: () => void;
+    const painted = new Promise<void>((resolve) => {
+      markPublished = resolve;
+    });
+    collection = isolated.benchmark.collect(
+      ctx({ GH_TOKEN: token }),
+      (view: TileView) => {
+        first ??= view; // capture the very first paint
+        markPublished();
+      },
+    );
+    await painted;
+    assertEquals(first?.status, "unknown");
+    assertEquals(first?.sub, "collecting…"); // painted before any run list arrives
+    assertEquals(first?.label, "benchmarks"); // and under the new name
+  } finally {
+    releaseRuns(Response.json({ workflow_runs: [] }));
+    await collection?.catch(() => {});
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: a failed most-recent run turns the tile red over its last good total", async () => {
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  // The last successful run totals 7ms; the failed head has no artifact to headline.
+  await withTotals([
+    ...Array.from({ length: 7 }, (_, d) => ({ id: 9_200 + d, at: at(d), total: d === 6 ? 7e6 : 5e6 })),
+    { id: 9_299, at: SAMPLED_BASE + HOUR, conclusion: "failure" },
+  ], async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "bad"); // the newest run failed
+    assertEquals(v.sub, "last run failed");
+    assertStringIncludes(v.value ?? "", "flat"); // the trend of the runs before the failure
+  });
+});
+
+Deno.test("benchmark: a cancelled most-recent run is not a failure", async () => {
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  await withTotals([
+    ...Array.from({ length: 7 }, (_, d) => ({ id: 9_400 + d, at: at(d), total: d === 6 ? 7e6 : 5e6 })),
+    { id: 9_499, at: SAMPLED_BASE + HOUR, conclusion: "cancelled" },
+  ], async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "good"); // a cancelled run is not a red failure
+    assertStringIncludes(v.value ?? "", "flat"); // the trend over the successful runs
+  });
+});
+
+Deno.test("benchmark: adding a benchmark is not read as a rise", async () => {
+  // Two weeks of daily runs, all benchmarks flat. A second benchmark is added on
+  // day 7. It is in only one run of each adjacent pair at that step, so it drops out
+  // of the ratio and the index does not step — no reset needed, the tile stays flat.
+  const at = (d: number) => SAMPLED_BASE - (13 - d) * DAY;
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let d = 0; d <= 13; d++) {
+    const id = 9_700 + d;
+    const added = d >= 7;
+    runs.push(ghRun(id, at(d)));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    const benches = [
+      bench("packages/a/x.bench.ts", null, "one", timings(1_000)), // avg 500
+      ...(added
+        ? [bench("packages/a/x.bench.ts", null, "two", timings(2_000))] // avg 1000
+        : []),
+    ];
+    zips[id * 10] = await benchZip(report(benches));
+  }
+  await withApi({
+    pages: { 1: [...runs].reverse() },
+    artifacts,
+    zips,
+  }, async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "good"); // adding a benchmark is not a regression
+    assertStringIncludes(v.value ?? "", "flat"); // the headline trend, unmoved by the added benchmark
+    assertEquals(v.duration, 13 * DAY); // the whole span, no reset
+    assertStringIncludes(v.extra ?? "", "2 benchmarks"); // the count line
+  });
+});
+
+Deno.test("benchmark: a run that finished green but produced no valid data reads red", async () => {
+  // Seven good days, then a run that passes CI but whose artifact carries no usable
+  // measurement. It ran and made nothing, so it is as good as failed: red, over the
+  // last run whose total could be read.
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let d = 0; d <= 7; d++) {
+    const id = 9_800 + d;
+    runs.push(ghRun(id, at(d)));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    const benches = d === 7
+      ? [bench("packages/a/x.bench.ts", null, "gone", undefined)] // no ok block
+      : [bench("packages/a/x.bench.ts", null, "b", { avg: 5e6 } as Timings)];
+    zips[id * 10] = await benchZip(report(benches));
+  }
+  await withApi({
+    pages: { 1: [...runs].reverse() },
+    artifacts,
+    zips,
+  }, async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "bad"); // it ran but made nothing usable
+    assertEquals(v.sub, "no benchmark data");
+    assertStringIncludes(v.value ?? "", "flat"); // the trend over the readable runs
+  });
+});
+
+Deno.test("benchmark: unusable artifacts gray out cold, then a blipped read is retried and recovers", async () => {
+  // Four successful runs in four different windows, each with an artifact unusable
+  // a different way. On a cold cache the sum has nothing to read, so the tile grays
+  // out rather than inventing a number. 401 (only an expired artifact and the wrong
+  // one) and 403 (a zip holding no report) reach a definite answer and are settled;
+  // 402 (the zip download failed) and 404 (the listing itself failed) reach no
+  // answer and must be retried when the source recovers. An isolated cache keeps
+  // the cold-start assertion honest — a shared cache would leak another test's runs.
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-unusable-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
   const runs = [
     ghRun(401, BASE - 3 * DAY),
     ghRun(402, BASE - 2 * DAY),
@@ -875,8 +1293,9 @@ Deno.test("benchmark: unusable artifacts -> gray, never a false green", async ()
     name,
     expired,
   });
-  await withApi({
-    pages: { 1: runs },
+  const calls: string[] = [];
+  let handler = serve({
+    pages: { 1: [...runs].reverse() }, // newest first, as the API returns
     artifacts: {
       401: [art(4_010, "bench-results", true), art(4_011, "coverage")], // expired, and the wrong artifact
       402: [art(4_020)], // the zip download fails
@@ -891,47 +1310,38 @@ Deno.test("benchmark: unusable artifacts -> gray, never a false green", async ()
         data: bytes("nothing useful"),
       }]),
     },
-  }, async (calls) => {
-    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
-    assertEquals(v.status, "unknown");
-    assertEquals(v.value, "—");
-    assertEquals(v.sub, "benchmark data unavailable");
-    assertEquals(v.href, "/bench?view=runtime&repo=labs");
+  });
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    calls.push(url.pathname + url.search);
+    return Promise.resolve(handler(url));
+  }) as typeof fetch;
+  try {
+    const isolated = await import(`./benchmark.ts?unusable=${crypto.randomUUID()}`);
+    const cold = await isolated.benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(cold.status, "unknown"); // no readable data, but not a failure
+    assertEquals(cold.value, "—");
+    assertEquals(cold.sub, "benchmark data unavailable");
+    assertEquals(cold.href, "/bench?view=runtime&repo=labs");
     // The expired artifact and the coverage artifact are never downloaded.
     assert(!calls.some((c) => c.includes("/artifacts/4010/zip")));
     assert(!calls.some((c) => c.includes("/artifacts/4011/zip")));
-  });
-});
 
-Deno.test("benchmark: a read that blipped is retried; a run with a definite answer is not", async () => {
-  // Continues from the test above, which left runs 401-404 in the two states that
-  // matter. 401 (only an expired artifact and the wrong one) and 403 (a zip holding
-  // no report) each reached a definite answer: those runs have no results and never
-  // will, so they are settled and must not be asked again. 402 (the zip download
-  // failed) and 404 (the listing itself failed) reached no answer at all, so whether
-  // they have results is still unknown and they must be retried.
-  const runs = [
-    ghRun(401, BASE - 3 * DAY),
-    ghRun(402, BASE - 2 * DAY),
-    ghRun(403, BASE - 1 * DAY),
-    ghRun(404, BASE),
-  ];
-  const json = report([
-    bench("packages/a/x.bench.ts", null, "tick", timings(1_000)),
-  ]);
-  await withApi({
-    pages: { 1: runs },
-    // The source is healthy again, and now answers for the two that blipped.
-    artifacts: {
-      402: [{ id: 4_020, name: "bench-results", expired: false }],
-      404: [{ id: 4_040, name: "bench-results", expired: false }],
-    },
-    zips: { 4_020: await benchZip(json), 4_040: await benchZip(json) },
-  }, async (calls) => {
-    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
-    // The blips are asked again, so the tile recovers rather than staying dark for
-    // the life of the process.
-    assertEquals(v.value, "1.0µs");
+    // The source recovers for the two that blipped.
+    calls.length = 0;
+    const json = report([
+      bench("packages/a/x.bench.ts", null, "tick", timings(1_000)), // avg 500
+    ]);
+    handler = serve({
+      pages: { 1: [...runs].reverse() }, // newest first, as the API returns
+      artifacts: {
+        402: [{ id: 4_020, name: "bench-results", expired: false }],
+        404: [{ id: 4_040, name: "bench-results", expired: false }],
+      },
+      zips: { 4_020: await benchZip(json), 4_040: await benchZip(json) },
+    });
+    const warm = await isolated.benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertStringIncludes(warm.value ?? "", "new"); // two recovered runs is under a week
     assert(
       calls.some((c) => c.includes("/runs/402/artifacts")),
       "the failed zip download is retried",
@@ -940,7 +1350,6 @@ Deno.test("benchmark: a read that blipped is retried; a run with a definite answ
       calls.some((c) => c.includes("/runs/404/artifacts")),
       "the failed listing is retried",
     );
-    // The settled runs are answered from the cache; the healthy source is not asked.
     assert(
       !calls.some((c) => c.includes("/runs/401/artifacts")),
       "a run with no usable artifact is settled",
@@ -949,7 +1358,13 @@ Deno.test("benchmark: a read that blipped is retried; a run with a definite answ
       !calls.some((c) => c.includes("/runs/403/artifacts")),
       "a zip with no report is settled",
     );
-  });
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
 });
 
 Deno.test("benchmark: a failed newer attempt stays stale and reports an error", async () => {
@@ -980,7 +1395,7 @@ Deno.test("benchmark: a failed newer attempt stays stale and reports an error", 
     },
   }, async () => {
     const view = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
-    assertEquals(view.value, "2.0µs");
+    assertStringIncludes(view.value ?? "", "new"); // two runs is under a week, so "new"
   });
 
   const originalFetch = globalThis.fetch;
@@ -1023,7 +1438,7 @@ Deno.test("benchmark: a failed newer attempt stays stale and reports an error", 
 
     releaseAttempt(new Response("unavailable", { status: 503 }));
     const view = await collection;
-    assertEquals(view.value, "2.0µs");
+    assertStringIncludes(view.value ?? "", "new"); // the tile's trend; the drill-down errored
     while (!events.includes('"phase":"error"')) {
       const next = await reader.read();
       if (next.done) break;
@@ -1031,6 +1446,9 @@ Deno.test("benchmark: a failed newer attempt stays stale and reports an error", 
     }
     assertStringIncludes(events, '"phase":"error"');
     assertStringIncludes(events, '"failedResponses":1');
+    // The newer attempt failed, so the drill-down keeps the prior good series
+    // (latest 2µs) rather than blanking or corrupting it.
+    assertStringIncludes(await page(""), "2.0µs");
 
     globalThis.fetch = ((input: RequestInfo | URL) => {
       const url = new URL(input instanceof Request ? input.url : String(input));
@@ -1052,10 +1470,10 @@ Deno.test("benchmark: a failed newer attempt stays stale and reports an error", 
   }
 });
 
-Deno.test("benchmark: one benchmark per shortest-view bucket (the newest in the bucket wins)", async () => {
-  // Twelve days, one run a day, all at 1µs. Two runs share the last window: the
-  // older one is wildly slow, so if the wrong one were sampled the headline would
-  // read 10ms and the tile would turn red.
+Deno.test("benchmark: the tile sums the totals, and one artifact per bucket is kept", async () => {
+  // Twelve days, one run a day. Two runs share the last window; the older one is a
+  // wildly slow benchmark, so the drill-down must keep the newer one — and the tile
+  // must sum the winner's 500ns avg, not the displaced twin's ~5ms.
   const at = (d: number) => SAMPLED_BASE - (11 - d) * DAY;
   const key = "packages/runner/solo.bench.ts";
   const runs: GhRun[] = [];
@@ -1086,15 +1504,33 @@ Deno.test("benchmark: one benchmark per shortest-view bucket (the newest in the 
     zips,
   }, async () => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
-    assertEquals(v.value, "1.0µs"); // the newest run in the window, not the 10ms twin
-    assertEquals(v.status, "good"); // flat p99 over 45 days
-    assertEquals(v.label, "benchmark");
+    assertStringIncludes(v.value ?? "", "flat"); // the headline trend, flat over the window
+    assertEquals(v.status, "good");
+    assertEquals(v.label, "benchmarks");
     assertEquals(v.duration, 11 * DAY);
     assertEquals(v.sub, undefined);
     assertStringIncludes(v.extra ?? "", "<svg");
-    assertStringIncludes(v.extra ?? "", "tick"); // the benchmark's name, without its file
-    assertStringIncludes(v.extra ?? "", "p99 flat");
+    assertStringIncludes(v.extra ?? "", "1 benchmark"); // the count line, one benchmark
+    // The drill-down kept the newer run in the shared bucket: it reads the 1µs
+    // winner's metric, not the displaced 10ms twin's.
+    const tick = rows(await page("")).find((r) => r.name === "tick");
+    assertStringIncludes(tick?.value ?? "", "1.0µs");
   });
+});
+
+Deno.test("sampleBenchmarkRuns keeps the newest successful run in each bucket", () => {
+  const at = (d: number) => SAMPLED_BASE - (11 - d) * DAY;
+  const winner = ghRun(512, at(11));
+  const staleTwin = ghRun(599, at(11) - COLLECTION_BUCKET / 2);
+  const sampled = sampleBenchmarkRuns(
+    [staleTwin, winner, ...Array.from({ length: 11 }, (_, d) => ghRun(501 + d, at(d)))],
+    SAMPLED_BASE - 45 * DAY,
+  );
+  const lastBucket = sampled.filter((run) =>
+    Math.floor(Date.parse(run.created_at) / COLLECTION_BUCKET) ===
+      Math.floor(at(11) / COLLECTION_BUCKET)
+  );
+  assertEquals(lastBucket.map((run) => run.id), [512]); // the twin is displaced
 });
 
 Deno.test("benchmark: a run's results are immutable, so a cached run is not refetched", async () => {
@@ -1106,7 +1542,7 @@ Deno.test("benchmark: a run's results are immutable, so a cached run is not refe
   // Every artifact call would 500; the cache from the previous test answers instead.
   await withApi({ pages: { 1: runs } }, async (calls) => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
-    assertEquals(v.value, "1.0µs");
+    assertStringIncludes(v.value ?? "", "flat"); // the cached runs' trend
     assertEquals(v.status, "good");
     assertEquals(artifactCalls(calls), []);
   });
@@ -1234,16 +1670,18 @@ const page = async (query: string): Promise<string> => {
     .text();
 };
 
-Deno.test("benchmark: BENCH_METRIC pins the grid tile to a named benchmark", async () => {
+Deno.test("benchmark: the tile indexes every benchmark equally; the drill-down keeps them apart", async () => {
   await withApi(await fillVaried(), async () => {
-    const v = await benchmark.collect(
-      ctx({ GH_TOKEN: "t", BENCH_METRIC: "steep" }),
-    );
-    assertEquals(v.value, "20ms"); // 1ms rising twenty-fold over the 45 days
-    assertEquals(v.status, "bad"); // past RAPID_PCT -> trending up rapidly
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    // The index rises: `steep` (×20) and `fivefold` (×5) outweigh `quarter` (×¼) in
+    // log space, so the typical benchmark got ~1.7× slower even though the summed
+    // time (which `quarter` dominated) fell.
+    assertEquals(v.status, "warn");
     assertEquals(v.duration, 11 * DAY);
-    assertStringIncludes(v.extra ?? "", "hot/steep"); // group and name, file dropped
-    assertStringIncludes(v.extra ?? "", "p99 ▲20×"); // a fold, not "▲1900%"
+    assertStringIncludes(v.value ?? "", "▲"); // the rising trend is the headline
+    assertStringIncludes(v.extra ?? "", "6 benchmarks"); // the count line
+    // The per-benchmark history the drill-down reads is still assembled.
+    assert(!v.extra?.includes("hot/steep"));
   });
 });
 
@@ -1498,92 +1936,6 @@ Deno.test("/bench runtime preserves the selected CI repository across its links"
   );
 });
 
-Deno.test("benchmark: a pinned metric that disappeared yields to the current default", async () => {
-  const runs = Array.from(
-    { length: 4 },
-    (_, index) => ghRun(38_100 + index, BASE - (3 - index) * DAY),
-  );
-  const artifacts: Api["artifacts"] = {};
-  const zips: Api["zips"] = {};
-  for (let index = 0; index < runs.length; index++) {
-    const run = runs[index];
-    artifacts[run.id] = [{
-      id: run.id * 10,
-      name: "bench-results",
-      expired: false,
-    }];
-    const benches = [
-      bench(
-        "packages/runner/scheduler-persistent-state.bench.ts",
-        null,
-        "current",
-        timings(2_000),
-      ),
-      ...(index < 2
-        ? [
-          bench(
-            "packages/old/removed.bench.ts",
-            null,
-            "removed",
-            timings(9_000),
-          ),
-        ]
-        : []),
-    ];
-    zips[run.id * 10] = await benchZip(report(benches));
-  }
-
-  await withApi({ pages: { 1: runs }, artifacts, zips }, async () => {
-    const view = await benchmark.collect(ctx({
-      GH_TOKEN: "t",
-      BENCH_METRIC: "removed",
-    }));
-    assertEquals(view.value, "2.0µs");
-    assertStringIncludes(view.extra ?? "", "current");
-    assert(!view.extra?.includes("removed"));
-  });
-});
-
-Deno.test("benchmark: a BENCH_METRIC that names nothing falls back to the default benchmark", async () => {
-  // Runs 601-612 are cached from the fill above; only the pick changes.
-  const at = (d: number) => BASE - (11 - d) * DAY;
-  await withApi({
-    pages: { 1: Array.from({ length: 12 }, (_, d) => ghRun(601 + d, at(d))) },
-  }, async () => {
-    const v = await benchmark.collect(
-      ctx({ GH_TOKEN: "t", BENCH_METRIC: "no-such-benchmark" }),
-    );
-    // DEFAULT_METRIC is scheduler-persistent-state.bench.ts; "commit" is its first.
-    assertEquals(v.value, "1.1µs");
-    assertEquals(v.status, "warn");
-    assertStringIncludes(v.extra ?? "", "p99 ▲12%");
-  });
-});
-
-Deno.test("benchmark: with neither the named nor the default benchmark present, the slowest is shown", async () => {
-  const at = (d: number) => BASE - (7 - d) * DAY;
-  const artifacts: Api["artifacts"] = {};
-  const zips: Api["zips"] = {};
-  const runs: GhRun[] = [];
-  for (let d = 0; d <= 7; d++) {
-    const id = 701 + d;
-    runs.push(ghRun(id, at(d)));
-    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
-    zips[id * 10] = await benchZip(report([
-      bench("packages/a/x.bench.ts", null, "fast", timings(1_000)),
-      bench("packages/a/x.bench.ts", null, "slow", timings(500_000_000)),
-    ]));
-  }
-  await withApi({ pages: { 1: runs }, artifacts, zips }, async () => {
-    const v = await benchmark.collect(
-      ctx({ GH_TOKEN: "t", BENCH_METRIC: "nothing-matches-this" }),
-    );
-    assertEquals(v.value, "500ms"); // the slowest benchmark by p99, not the 1µs one
-    assertEquals(v.status, "good"); // flat
-    assertEquals(v.duration, 7 * DAY);
-  });
-});
-
 Deno.test("benchmark: an unreachable source grays out with a calm reason, and never reads red", async () => {
   await withApi({
     throws: new TypeError(
@@ -1591,8 +1943,8 @@ Deno.test("benchmark: an unreachable source grays out with a calm reason, and ne
     ),
   }, async () => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
-    assertEquals(v.status, "unknown"); // gray, not bad
-    assertEquals(v.value, "—");
+    assertEquals(v.status, "unknown"); // gray, never a stale red; the value is a
+    // bare dash or a grayed last-known trend — the offline tests below pin both
     assertEquals(v.sub, "source unreachable"); // not a stack trace or an api path
     assertEquals(v.href, "/bench?view=runtime&repo=labs");
   });
@@ -1602,14 +1954,178 @@ Deno.test("benchmark: a rejected token grays out as an auth failure", async () =
   await withApi({ status: 401 }, async () => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "wrong" }));
     assertEquals(v.status, "unknown");
-    assertEquals(v.value, "—");
     assertEquals(v.sub, "auth failed"); // the http status is not put on the wall
   });
 });
 
-Deno.test("benchmark: benchmarks seen in only one run give no trend to draw", async () => {
+Deno.test("benchmark: a failed fetch keeps the last-known trend grayed instead of blanking", async () => {
+  // Was online and cached two runs, then the source goes unreachable. The tile keeps
+  // its last-known trend — grayed, with the reason — rather than dropping to a bare
+  // dash, and would recover on the next collection once the source is back.
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-offline-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  const token = `benchmark-offline-${crypto.randomUUID()}`;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const key = "packages/a/x.bench.ts";
+  const healthy = serve({
+    pages: { 1: [ghRun(7_701, BASE - DAY), ghRun(7_702, BASE)] },
+    artifacts: {
+      7_701: [{ id: 77_010, name: "bench-results", expired: false }],
+      7_702: [{ id: 77_020, name: "bench-results", expired: false }],
+    },
+    zips: {
+      77_010: await benchZip(report([bench(key, null, "b", timings(1_000))])),
+      77_020: await benchZip(report([bench(key, null, "b", timings(1_000))])),
+    },
+  });
+  try {
+    const isolated = await import(`./benchmark.ts?offline=${crypto.randomUUID()}`);
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      if (url.pathname === "/rate_limit") return Promise.resolve(serve({})(url));
+      return Promise.resolve(healthy(url));
+    }) as typeof fetch;
+    const online = await isolated.benchmark.collect(ctx({ GH_TOKEN: token }));
+    assertEquals(online.status, "good");
+    assertStringIncludes(online.value ?? "", "new"); // two runs, under a week -> "new"
+
+    // The source becomes unreachable on the next collection.
+    globalThis.fetch = (() =>
+      Promise.reject(
+        new TypeError("error sending request for url (https://api.github.com/...)"),
+      )) as typeof fetch;
+    const offline = await isolated.benchmark.collect(ctx({ GH_TOKEN: token }));
+    assertEquals(offline.status, "unknown"); // grayed — never a stale red or green
+    assertEquals(offline.sub, "source unreachable");
+    assertStringIncludes(offline.value ?? "", "new"); // kept the last-known trend
+    assert((offline.value ?? "") !== "—"); // not blanked to a bare dash
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: a failed fetch with no cached history grays to a dash", async () => {
+  // Nothing cached yet and the source is unreachable: there is no trend to keep, so
+  // the tile shows a bare gray dash with the reason.
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-offline-cold-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  const token = `benchmark-offline-cold-${crypto.randomUUID()}`;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  globalThis.fetch = (() =>
+    Promise.reject(
+      new TypeError("error sending request for url (https://api.github.com/...)"),
+    )) as typeof fetch;
+  try {
+    const isolated = await import(
+      `./benchmark.ts?offline-cold=${crypto.randomUUID()}`
+    );
+    const v = await isolated.benchmark.collect(ctx({ GH_TOKEN: token }));
+    assertEquals(v.status, "unknown");
+    assertEquals(v.value, "—"); // nothing cached to fall back on
+    assertEquals(v.sub, "source unreachable");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: a fresh marker then an unreachable direct read grays with the reason", async () => {
+  // A fresh refresh marker makes the collection short-circuit, so the tile reads the
+  // run list directly for itself — and when that direct read is unreachable, it grays
+  // with the reason rather than throwing.
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-fresh-offline-" });
+  const file = `${directory}/fabric-wall-benchmark-history.json`;
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const store = new BenchmarkHistoryStore(file);
+  await store.load();
+  store.markRefreshed(Date.now(), [], "no-runs"); // recent + empty -> snapshot is fresh
+  await store.save();
+  globalThis.fetch = (() =>
+    Promise.reject(
+      new TypeError("error sending request for url (https://api.github.com/...)"),
+    )) as typeof fetch;
+  try {
+    const isolated = await import(
+      `./benchmark.ts?fresh-offline=${crypto.randomUUID()}`
+    );
+    const v = await isolated.benchmark.collect(
+      ctx({ GH_TOKEN: `t-${crypto.randomUUID()}` }),
+    );
+    assertEquals(v.status, "unknown");
+    assertEquals(v.value, "—"); // fresh but empty, and the direct read failed
+    assertEquals(v.sub, "source unreachable");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: an early-paint publish that throws is caught, and the collection still finishes", async () => {
+  // The immediate paint publishes once; when the run list is paged, paintEarly
+  // publishes again. A publish that throws on that second call is swallowed by the
+  // run-list notifier, so one bad paint never breaks the collection.
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-paint-throw-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  const token = `benchmark-paint-throw-${crypto.randomUUID()}`;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const key = "packages/a/x.bench.ts";
+  const healthy = serve({
+    pages: { 1: [ghRun(7_801, BASE - DAY), ghRun(7_802, BASE)] },
+    artifacts: {
+      7_801: [{ id: 78_010, name: "bench-results", expired: false }],
+      7_802: [{ id: 78_020, name: "bench-results", expired: false }],
+    },
+    zips: {
+      78_010: await benchZip(report([bench(key, null, "b", timings(1_000))])),
+      78_020: await benchZip(report([bench(key, null, "b", timings(1_000))])),
+    },
+  });
+  try {
+    const isolated = await import(
+      `./benchmark.ts?paint-throw=${crypto.randomUUID()}`
+    );
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      if (url.pathname === "/rate_limit") return Promise.resolve(serve({})(url));
+      return Promise.resolve(healthy(url));
+    }) as typeof fetch;
+    let calls = 0;
+    const final = await isolated.benchmark.collect(
+      ctx({ GH_TOKEN: token }),
+      () => {
+        if (++calls > 1) throw new Error("publish boom"); // throw on paintEarly
+      },
+    );
+    assert(calls >= 2); // the immediate paint and the paged-run-list paintEarly
+    assertEquals(final.status, "good"); // the thrown paint did not break the run
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: the tile totals a run even when no benchmark has a drawable series", async () => {
   // Two runs, each reporting a different benchmark: no benchmark has two points,
-  // so there is nothing to plot and the tile says so instead of guessing.
+  // so the per-benchmark drill-down has nothing to plot. The tile still totals the
+  // latest run's benchmark(s) — here the set even changed, so it resets to run 802.
   const runs = [ghRun(801, BASE - DAY), ghRun(802, BASE)];
   await withApi({
     pages: { 1: runs },
@@ -1626,13 +2142,16 @@ Deno.test("benchmark: benchmarks seen in only one run give no trend to draw", as
       ),
     },
   }, async () => {
-    const v = await benchmark.collect(
-      ctx({ GH_TOKEN: "t", BENCH_METRIC: "a" }),
-    );
-    assertEquals(v.status, "unknown");
-    assertEquals(v.value, "—");
-    assertEquals(v.sub, "no metric");
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "good");
+    assertStringIncludes(v.value ?? "", "new"); // under a week of days, the headline reads "new"
+    assertEquals(v.sub, undefined);
+    assertStringIncludes(v.extra ?? "", "1 benchmark"); // the count line
     assertEquals(v.href, "/bench?view=runtime&repo=labs");
+    // Neither single-point benchmark reaches the drill-down: it needs >= 2 points.
+    const drill = await page("");
+    assert(!drill.includes("one.bench.ts"));
+    assert(!drill.includes("two.bench.ts"));
   });
 });
 
@@ -1930,9 +2449,11 @@ Deno.test("empty runtime history asks for a token to collect data", async () => 
   }
 });
 
-Deno.test("benchmark collection reports cache writes that fail during a run or manifest", async () => {
+Deno.test("benchmark: a failed drill-down cache write does not gray the tile", async () => {
+  // The artifact was read and its metrics held in memory before the cache write
+  // failed, so the tile still totals them; only the persistence to disk failed.
   const archive = await benchZip(report([
-    bench("packages/a/write.bench.ts", null, "write", timings(1_000)),
+    bench("packages/a/write.bench.ts", null, "write", timings(1_000)), // avg 500
   ]));
   for (const failedRename of [1, 2]) {
     const directory = await Deno.makeTempDir({ prefix: "benchmark-write-" });
@@ -1971,8 +2492,10 @@ Deno.test("benchmark collection reports cache writes that fail during a run or m
       }) as typeof Deno.rename;
 
       const view = await isolated.benchmark.collect(ctx({ GH_TOKEN: "token" }));
-      assertEquals(view.status, "unknown");
-      assertEquals(renames, failedRename);
+      assertEquals(view.status, "good"); // the in-memory total is unaffected
+      assertStringIncludes(view.value ?? "", "new"); // a single run: the trend reads "new"
+      assertEquals(renames, failedRename); // the write was attempted and failed
+
     } finally {
       Deno.rename = rename;
       globalThis.fetch = originalFetch;

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -1,15 +1,42 @@
-// benchmark: trends one runtime benchmark's p99 over ~45 days, from the deno bench
-// results the benchmarks.yml job publishes on main. That job runs
-// `deno bench --json` and uploads the output as a `bench-results` artifact (90-day
-// retention); there is no committed history, so this tile lists recent benchmark
-// runs on main, keeps one artifact per shortest-view time bucket, unzips it
-// in-process, and reads every benchmark's timings. Results per run attempt are
-// immutable and persisted, so only new runs and attempts are fetched later.
+// benchmark: trends a scale-invariant index of benchmark performance on main. Each
+// run's index is the run-before's index times the geometric mean of the
+// per-benchmark changes between the two runs, so every benchmark weighs the same
+// regardless of size and only a broad, across-the-board move shifts it — a
+// regression in one benchmark, however slow, barely registers (that is the
+// drill-down's job). The colour follows the trend over a recent window only (the
+// runs in the last BENCH_TREND_MAX_AGE_DAYS or the newest BENCH_TREND_MIN_RUNS,
+// whichever is more, like ci duration's median window), while the sparkline still
+// spans the whole ~45 days with that window brighter. Red — the signal this tile is
+// mainly here to raise — when the
+// most recent run failed outright, or finished green on CI but produced no readable
+// benchmark data (it ran and made nothing usable, so it is as good as failed).
+// Orange when the index trends up (broad slowdown). Green while flat or falling.
+// deno bench samples each benchmark to a fixed time budget, so the run's wall clock
+// barely moves with performance; the per-op times do, which is why the tile trends
+// those rather than the run's duration.
 //
-// The grid tile shows one benchmark (BENCH_METRIC, default DEFAULT_METRIC; else
-// the slowest). Its /bench drill-down shows every benchmark, with a selector for
-// which measurement to plot. Colour follows the 45-day trend: green while flat or
-// falling, orange past UP_PCT, red past RAPID_PCT ("trending up rapidly").
+// Chaining per-run ratios makes a benchmark added or removed a non-event: it is in
+// only one of the two runs at that step, so it drops out of the geometric mean and
+// the index does not step. The failed state reads the workflow-run list and the
+// latest run's cached result, so it fires even when the artifacts cannot be read;
+// the index needs the artifacts, so with none in the window (and no failure) the
+// tile grays — "collecting…" while a fetch is still in progress (shown from the
+// moment a collection starts, before the run list is even fetched), "benchmark data
+// unavailable" once a fetch has finished and found none. A fetch that fails outright
+// — offline, say — keeps the last-known trend grayed with the reason rather than
+// blanking. The headline is the
+// window's trend — the fractional change of the index across the recent window —
+// over a second line naming how many benchmarks the latest run measured and, when a
+// recent window is highlighted, how long that window spans.
+//
+// The /bench drill-down keeps the deeper picture. The benchmarks.yml job runs
+// `deno bench --json` and uploads the output as a `bench-results` artifact (90-day
+// retention); there is no committed history, so the drill-down lists recent runs
+// on main, keeps one artifact per shortest-view time bucket, unzips it in-process,
+// and reads every benchmark's timings. Results per run attempt are immutable and
+// persisted, so only new runs and attempts are fetched later. That per-benchmark
+// history, plus the CI duration and Gantt views, live behind /bench; the tile's
+// collection keeps them warm in the background.
 import type { Ctx, Route, Status, Tile, TileView } from "../types.ts";
 import {
   BenchmarkHistoryStore,
@@ -30,17 +57,23 @@ import {
   ciJobHistoryResponse,
 } from "../ci-job-history.ts";
 import {
+  concDot,
   durationTag,
   escapeHtml,
   friendlyError,
   github,
   githubDownload,
+  humanSpan,
   performanceGithub,
   performanceGithubDownload,
   SPARK_FADE,
   sparkline,
 } from "../lib.ts";
-import { REPO } from "../config.ts";
+import {
+  BENCH_TREND_MAX_AGE_DAYS,
+  BENCH_TREND_MIN_RUNS,
+  REPO,
+} from "../config.ts";
 import {
   PERFORMANCE_CHECK_MS,
   performanceViewHref,
@@ -71,7 +104,6 @@ const WORKFLOW = "benchmarks.yml";
 const ARTIFACT = "bench-results";
 const SPARK_DAYS = CI_HISTORY_DAYS;
 const COLLECTION_BUCKET_MS = ciHistoryBucketMs(CI_HISTORY_MIN_DAYS);
-const DEFAULT_METRIC = "scheduler-persistent-state.bench.ts";
 const BENCHMARK_REFRESH_MS = 30 * 60_000;
 const BENCHMARK_FETCH_CONCURRENCY = 8;
 
@@ -102,12 +134,12 @@ const STATS: { label: string; field: keyof Stats }[] = [
   { label: "p99.9", field: "p999" },
   { label: "p100", field: "max" },
 ];
-const TILE_STAT: keyof Stats = "p99"; // the grid tile plots p99
 const DEFAULT_LABEL = "p99";
 
 interface Run {
   id: number;
   run_attempt?: number;
+  status?: string;
   created_at: string;
   conclusion: string | null;
 }
@@ -132,7 +164,27 @@ interface BenchmarkSeries {
 }
 
 let snapshot: BenchmarkSeries[] = [];
-let benchmarkEmptyReason: string | undefined;
+// The most recent benchmarks.yml run list fetched by a collection, reused to
+// render the tile's run-duration view. The drill-down's artifact refresh fills it
+// as a side effect of its own paging, so the tile costs no extra request in the
+// common case.
+let latestBenchmarkRuns: Run[] | undefined;
+
+// Notified with the run list the moment a collection has paged it — before the
+// slower per-run artifact backfill — so the tile can paint its headline early
+// instead of waiting on the drill-down's downloads.
+const benchmarkRunListListeners = new Set<(runs: Run[]) => void>();
+function notifyBenchmarkRunList(runs: Run[]): void {
+  const listeners = [...benchmarkRunListListeners];
+  benchmarkRunListListeners.clear();
+  for (const listener of listeners) {
+    try {
+      listener(runs);
+    } catch {
+      // A listener that throws is simply dropped; the tile still finalizes below.
+    }
+  }
+}
 
 export type BenchmarkFetchPhase =
   | "discovering"
@@ -166,14 +218,14 @@ interface BenchmarkProgressRecord {
 
 interface BenchmarkRefresh {
   progress: BenchmarkFetchProgress | null;
-  result: Promise<TileView>;
+  result: Promise<BenchmarkCollectionOutcome>;
 }
 
 type BenchmarkRefreshScope = "bench" | "dashboard";
 
 const activeBenchmarkRefreshes = new Map<BenchmarkRefreshScope, {
   progress: BenchmarkProgressRecord;
-  result: Promise<TileView>;
+  result: Promise<BenchmarkCollectionOutcome>;
 }>();
 let benchmarkCollectionTail: Promise<void> = Promise.resolve();
 let benchmarkProgressSequence = 0;
@@ -281,35 +333,6 @@ const benchKey = (b: Bench): string =>
   `${b.origin.replace(/^file:\/\/.*\/packages\//, "packages/")} > ${
     b.group ? b.group + "/" : ""
   }${b.name}`;
-
-function pickKey(stats: Map<string, Stats>, want: string): string | undefined {
-  const has = (needle: string) =>
-    [...stats.keys()].find((key) =>
-      key.toLowerCase().includes(needle.toLowerCase())
-    );
-  const match = has(want) ?? has(DEFAULT_METRIC);
-  if (match) return match;
-  let best: string | undefined;
-  let bestValue = -Infinity;
-  for (const [key, value] of stats) {
-    if (value.p99 > bestValue) {
-      best = key;
-      bestValue = value.p99;
-    }
-  }
-  return best;
-}
-
-// Deterministic, well-spread hash of a small integer. Used to rotate the grid
-// tile's benchmark by clock-hour: the same hour yields the same index on any
-// machine (no Math.random, no stored state), so a fresh dashboard elsewhere picks
-// the same benchmark for the same hour.
-function hashInt(n: number): number {
-  let x = n >>> 0;
-  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b) >>> 0;
-  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b) >>> 0;
-  return (x ^ (x >>> 16)) >>> 0;
-}
 
 // Wall-clock span of a series (first to last point), in milliseconds.
 const spanMs = (points: { at: number }[]): number =>
@@ -419,6 +442,31 @@ async function fetchZip(
   return new Uint8Array(await res.arrayBuffer());
 }
 
+// The benchmarks.yml runs on main, newest first, paging back until past the
+// window (or the 12-page ceiling). The job runs on both pushes and a schedule, so
+// this is not filtered by event.
+async function pageBenchmarkRuns(
+  github: BenchmarkGitHub,
+  token: string,
+  cutoff: number,
+): Promise<Run[]> {
+  const runs: Run[] = [];
+  for (let page = 1; page <= 12; page++) {
+    const response = await github.json<{ workflow_runs?: Run[] }>(
+      `repos/${REPO}/actions/workflows/${WORKFLOW}/runs?branch=main&per_page=100&page=${page}`,
+      token,
+    );
+    const batch = response.workflow_runs ?? [];
+    if (!batch.length) break;
+    runs.push(...batch);
+    if (
+      batch.length < 100 ||
+      Date.parse(batch[batch.length - 1].created_at) < cutoff
+    ) break;
+  }
+  return runs;
+}
+
 // Populate and persist one run. A response that establishes there is no usable
 // artifact is cached as an empty map. A failed read remains unknown.
 async function loadRun(
@@ -510,14 +558,6 @@ async function loadCachedBenchmarkSnapshot(now = Date.now()): Promise<void> {
     await benchmarkStore.save(now);
   }
   benchmarkRefreshedAt = benchmarkStore.refreshedAt;
-  const refresh = benchmarkStore.refresh;
-  benchmarkEmptyReason = refresh?.result === "no-runs"
-    ? "no benchmark runs"
-    : refresh?.result === "data-unavailable"
-    ? "benchmark data unavailable"
-    : refresh?.result === "no-metric"
-    ? "no metric"
-    : undefined;
   const cutoff = now - SPARK_DAYS * 86_400_000;
   const refreshedRuns = benchmarkStore.refreshedRuns();
   const cachedRuns = refreshedRuns ?? benchmarkStore.list(cutoff);
@@ -554,14 +594,6 @@ async function markBenchmarkRefreshed(
   if (refreshedRuns !== null) {
     snapshot = assembleCachedBenchmarkSnapshot(refreshedRuns);
   }
-  const refresh = benchmarkStore.refresh;
-  benchmarkEmptyReason = refresh?.result === "no-runs"
-    ? "no benchmark runs"
-    : refresh?.result === "data-unavailable"
-    ? "benchmark data unavailable"
-    : refresh?.result === "no-metric"
-    ? "no metric"
-    : undefined;
   benchmarkRefreshedAt = benchmarkStore.refreshedAt;
 }
 
@@ -591,64 +623,173 @@ const benchmarkDrill = {
 function benchmarkUnavailable(sub: string): TileView {
   return {
     ...benchmarkDrill,
-    label: "benchmark",
+    label: "benchmarks",
     status: "unknown",
     value: "—",
     sub,
   };
 }
 
-function benchmarkTileView(
-  ctx: Ctx,
-  currentMetrics?: Map<string, Stats>,
-): TileView {
-  const pinned = ctx.env("BENCH_METRIC");
-  let series: BenchmarkSeries | undefined;
-  if (pinned) {
-    const latest = currentMetrics ?? benchmarkStore.refreshedRuns()
-      ?.findLast((run) => run.metrics.size > 0)?.metrics;
-    const key = latest ? pickKey(latest, pinned) : undefined;
-    series = snapshot.find((item) => item.key === key) ?? snapshot[0];
-  } else {
-    series = snapshot[
-      hashInt(Math.floor(Date.now() / 3_600_000)) % snapshot.length
-    ];
-  }
-  if (!series) return benchmarkUnavailable(benchmarkEmptyReason ?? "no metric");
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
 
-  const points = series.points.map((point) => point.stats[TILE_STAT]);
-  const trend = benchmarkTrend(
-    series.points.map((point) => point.at),
-    points,
+// The geometric mean of the per-benchmark ratios between two runs, over the
+// benchmarks they share (each with a positive average). Geometric, not arithmetic,
+// so a benchmark that doubles and one that halves cancel to no change. A benchmark
+// in only one of the two runs is not in the ratio, so adding or removing one is not
+// a change. 1 when the runs share nothing.
+function benchmarkStepRatio(
+  previous: CachedBenchmarkRun,
+  current: CachedBenchmarkRun,
+): number {
+  let logSum = 0, count = 0;
+  for (const [key, stats] of current.metrics) {
+    const before = previous.metrics.get(key);
+    if (before && before.avg > 0 && stats.avg > 0) {
+      logSum += Math.log(stats.avg / before.avg);
+      count++;
+    }
+  }
+  return count ? Math.exp(logSum / count) : 1;
+}
+
+// The grid tile: a scale-invariant index of benchmark performance, trended over ~45
+// days. Each run's index is the previous run's index times the geometric mean of
+// the per-benchmark changes between them, so every benchmark weighs the same and
+// only a broad, across-the-board move shifts it — a regression in one benchmark,
+// however slow, barely registers (that is the drill-down's job). Orange when the
+// index trends up (broad slowdown), red when the most recent run failed outright or
+// produced no readable data — the failure is what this tile is mainly here to
+// catch. Red reads the workflow-run list and the latest run's cached result, so it
+// fires even when the artifacts cannot be read; the index needs the artifacts, so
+// with none in the window (and no failure) the tile grays. The headline is the
+// window's trend. `offline` names a fetch failure: the tile then keeps its
+// last-known trend grayed (never a stale red or green), or shows a bare gray dash
+// when nothing is cached.
+function benchmarkIndexView(
+  runs: Run[],
+  now: number,
+  collecting = false,
+  offline?: string,
+): TileView {
+  const cutoff = now - SPARK_DAYS * 86_400_000;
+  // The most recent completed run (the list is newest first) sets the failed
+  // state; an in-flight run at the head is skipped until it finishes. Only a
+  // genuine failure counts (concDot's red set), so a cancelled or superseded run
+  // does not raise a false alarm.
+  const latestCompleted = runs.find((run) =>
+    run.status === "completed" && run.conclusion !== null
   );
-  const name = series.key.split(" > ").slice(1).join(" > ") || series.key;
+  const failedCi = latestCompleted !== undefined &&
+    concDot(latestCompleted.conclusion, latestCompleted.run_attempt ?? 1) ===
+      "red";
+  // A run that finished green on CI but whose artifact resolved to no readable
+  // benchmark data is as good as failed: it ran and produced nothing usable. Only
+  // a cached run with an empty result counts — a run still unread (or read-failed)
+  // stays unknown and is retried, so a transient blip does not flash red.
+  const latestResult = latestCompleted?.conclusion === "success"
+    ? benchmarkStore.get(latestCompleted.id)
+    : undefined;
+  const noData = latestResult !== undefined && latestResult.metrics.size === 0;
+  const failed = failedCi || noData;
+  const failSub = failedCi ? "last run failed" : "no benchmark data";
+  // The successful runs with readable artifacts in the window, oldest -> newest.
+  const cached = (benchmarkStore.refreshedRuns() ?? benchmarkStore.list(cutoff))
+    .filter((run) => run.at >= cutoff && run.metrics.size > 0)
+    .sort((a, b) => a.at - b.at);
+  // Chain each run's geometric-mean change against the run before it into a single
+  // scale-invariant index. It starts at 1 for the oldest run; a benchmark added or
+  // removed drops out of that step's ratio, so a set change never steps the index.
+  const points: { at: number; index: number }[] = [];
+  let index = 1;
+  for (let i = 0; i < cached.length; i++) {
+    if (i > 0) index *= benchmarkStepRatio(cached[i - 1], cached[i]);
+    points.push({ at: cached[i].at, index });
+  }
+  if (!points.length) {
+    // A fetch failure with nothing cached to stand on: a gray dash and the reason.
+    if (offline) return benchmarkUnavailable(offline);
+    if (failed) {
+      return {
+        ...benchmarkDrill,
+        label: "benchmarks",
+        status: "bad",
+        value: "—",
+        sub: failSub,
+      };
+    }
+    // No data yet: "collecting…" while a fetch is still in progress (the early paints,
+    // including the one before the run list is fetched), "benchmark data unavailable"
+    // once a fetch has finished empty, "no benchmark runs" when it found none at all.
+    if (collecting) return benchmarkUnavailable("collecting…");
+    return benchmarkUnavailable(
+      runs.length ? "benchmark data unavailable" : "no benchmark runs",
+    );
+  }
+  const values = points.map((point) => point.index);
+  // Trend over a recent window only, like ci duration's median window: the runs in
+  // the last BENCH_TREND_MAX_AGE_DAYS, or the newest BENCH_TREND_MIN_RUNS — whichever
+  // is more. The sparkline still spans the whole series, with that window brighter.
+  const windowCutoff = now - BENCH_TREND_MAX_AGE_DAYS * 86_400_000;
+  const inWindow = points.filter((point) => point.at >= windowCutoff).length;
+  const windowCount = Math.min(
+    points.length,
+    Math.max(inWindow, BENCH_TREND_MIN_RUNS),
+  );
+  const windowPoints = points.slice(points.length - windowCount);
+  const trend = benchmarkTrend(
+    windowPoints.map((point) => point.at),
+    windowPoints.map((point) => point.index),
+  );
+  const rising = trend.status === "warn" || trend.status === "bad";
+  // An offline collection keeps the trend but grays it: the run list it would need
+  // to judge failed or rising could not be fetched, so it never asserts red or green.
+  const status: Status = offline
+    ? "unknown"
+    : failed
+    ? "bad"
+    : rising
+    ? "warn"
+    : "good";
+  // Headline: the window's trend.
+  const value = escapeHtml(trend.label);
+  const count = cached[cached.length - 1].metrics.size;
+  // Name the highlighted window's span beside the count, like CI duration names its
+  // median window — in days (via humanSpan), not "runs", so it does not read as the
+  // main-CI run count. Only when a window is actually highlighted; otherwise the
+  // whole sparkline is the window and its span already sits in the corner.
+  const windowLabel = windowCount < values.length
+    ? ` · last ${humanSpan(spanMs(windowPoints))}`
+    : "";
   const line =
-    `<div style="display:flex;align-items:baseline;gap:6px;font-size:13px;margin:5px 0 0">` +
-    `<span style="flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#9aa0ab">${
-      escapeHtml(name)
-    }</span>` +
-    `<span style="flex:none;color:#c7ccd4">${DEFAULT_LABEL} ${
-      escapeHtml(trend.label)
-    }</span></div>`;
+    `<div style="font-size:13px;color:#9aa0ab;margin:5px 0 0">${count} benchmark${
+      count === 1 ? "" : "s"
+    }${windowLabel}</div>`;
   return {
     ...benchmarkDrill,
-    label: "benchmark",
-    status: trend.status,
-    value: formatNs(points[points.length - 1]),
+    label: "benchmarks",
+    status,
+    value,
+    sub: offline ?? (failed ? failSub : undefined),
     extra: `${line}${
-      sparkline(points, "#727882", undefined, SPARK_FADE[trend.status])
+      sparkline(
+        values,
+        "#727882",
+        windowCount < values.length
+          ? { count: windowCount, color: "#c7ccd4" }
+          : undefined,
+        SPARK_FADE[status],
+      )
     }`,
-    duration: spanMs(series.points),
+    duration: spanMs(points),
   };
 }
 
 interface BenchmarkCollectionOutcome {
-  view: TileView;
   error?: unknown;
 }
 
 async function collectBenchmark(
-  ctx: Ctx,
   token: string,
   progress: BenchmarkProgressRecord,
   github: BenchmarkGitHub,
@@ -658,20 +799,9 @@ async function collectBenchmark(
 
   try {
     await benchmarkStore.load();
-    const runs: Run[] = [];
-    for (let page = 1; page <= 12; page++) {
-      const response = await github.json<{ workflow_runs?: Run[] }>(
-        `repos/${REPO}/actions/workflows/${WORKFLOW}/runs?branch=main&per_page=100&page=${page}`,
-        token,
-      );
-      const batch = response.workflow_runs ?? [];
-      if (!batch.length) break;
-      runs.push(...batch);
-      if (
-        batch.length < 100 ||
-        Date.parse(batch[batch.length - 1].created_at) < cutoff
-      ) break;
-    }
+    const runs = await pageBenchmarkRuns(github, token, cutoff);
+    latestBenchmarkRuns = runs;
+    notifyBenchmarkRunList(runs);
 
     const chosen = sampleBenchmarkRuns(runs, cutoff);
     const priorRefresh = benchmarkStore.refresh;
@@ -699,7 +829,7 @@ async function collectBenchmark(
     if (!chosen.length) {
       snapshot = [];
       await markBenchmarkRefreshed([], "no-runs");
-      return { view: benchmarkTileView(ctx) };
+      return {};
     }
 
     let firstReadError: unknown;
@@ -757,12 +887,7 @@ async function collectBenchmark(
       if (firstReadError === undefined) {
         await markBenchmarkRefreshed(chosen, "data-unavailable");
       }
-      return {
-        view: firstReadError === undefined
-          ? benchmarkTileView(ctx)
-          : benchmarkUnavailable("benchmark data unavailable"),
-        error: firstReadError,
-      };
+      return { error: firstReadError };
     }
     const collectedSnapshot = assembleBenchmarkSnapshot(withData);
     if (collectedSnapshot.length || firstReadError === undefined) {
@@ -774,21 +899,9 @@ async function collectBenchmark(
         collectedSnapshot.length ? "data" : "no-metric",
       );
     }
-    return {
-      view: benchmarkTileView(
-        ctx,
-        firstReadError === undefined
-          ? undefined
-          : currentRunMetrics(withData[withData.length - 1]),
-      ),
-      error: firstReadError,
-    };
+    return { error: firstReadError };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return {
-      view: benchmarkUnavailable(friendlyError(message)),
-      error,
-    };
+    return { error };
   }
 }
 
@@ -813,10 +926,7 @@ function startBenchmarkRefresh(
     };
   }
   if (snapshotIsFresh) {
-    return {
-      progress: null,
-      result: Promise.resolve(benchmarkTileView(ctx)),
-    };
+    return { progress: null, result: Promise.resolve({}) };
   }
 
   const progress = newBenchmarkProgress(baseline);
@@ -833,9 +943,9 @@ function startBenchmarkRefresh(
       Date.now() - benchmarkRefreshedAt >= 0 &&
       Date.now() - benchmarkRefreshedAt < BENCHMARK_REFRESH_MS
     ) {
-      return { view: benchmarkTileView(ctx) };
+      return {};
     }
-    return await collectBenchmark(ctx, token, progress, github);
+    return await collectBenchmark(token, progress, github);
   };
   let refreshFinished = false;
   const finishRefresh = () => {
@@ -874,7 +984,7 @@ function startBenchmarkRefresh(
         needsReload: [...progress.baselines].some((value) => value !== version),
       });
     }
-    return outcome.view;
+    return outcome;
   }).finally(finishRefresh);
   activeBenchmarkRefreshes.set(scope, { progress, result });
   return { progress: { ...progress.state }, result };
@@ -951,20 +1061,69 @@ export const benchmark: Tile = {
     await loadCachedBenchmarkSnapshot();
     const initialCollection = benchmarkInitialCollection;
     benchmarkInitialCollection = false;
-    const snapshotIsFresh = initialCollection && benchmarkSnapshotIsFresh();
-    if (
-      publish && initialCollection &&
-      (snapshot.length > 0 || benchmarkEmptyReason !== undefined) &&
-      !snapshotIsFresh
-    ) {
-      publish(benchmarkTileView(ctx));
-    }
-    return await startBenchmarkRefresh(
+    // Only trust the run list this collection fetches, never a prior one: a
+    // collection whose fetch fails must gray the tile rather than show stale runs.
+    latestBenchmarkRuns = undefined;
+    // Paint the headline as soon as the refresh has paged the run list, without
+    // waiting for it to backfill the drill-down's artifacts. This is a collection in
+    // progress, so with no cached data yet the tile reads "collecting…", not the
+    // finished-and-empty "benchmark data unavailable".
+    const paintEarly = (runs: Run[]) => {
+      // Registered only when publish exists, and the notifier fires each listener at
+      // most once, so this needs no re-entry guard.
+      if (publish) publish(benchmarkIndexView(runs, Date.now(), true));
+    };
+    if (publish) benchmarkRunListListeners.add(paintEarly);
+    // Paint at once, before the run list is even fetched, so a freshly loaded
+    // dashboard shows the cached headline immediately (warm) or "collecting…" (cold)
+    // rather than a blank tile while the first collection gets under way. The empty
+    // run list carries no failed state yet; paintEarly and the final return supply it.
+    if (publish) publish(benchmarkIndexView([], Date.now(), true));
+    // Drive the drill-down's artifact history (green while fresh, so its expensive
+    // artifact reads are skipped). Its collection also pages the benchmarks.yml run
+    // list into latestBenchmarkRuns, which the tile reuses. A read that only failed
+    // on the artifacts still leaves the run list, so the tile stands.
+    const outcome = await startBenchmarkRefresh(
       ctx,
       undefined,
-      snapshotIsFresh,
+      initialCollection && benchmarkSnapshotIsFresh(),
       "dashboard",
     ).result;
+    benchmarkRunListListeners.delete(paintEarly);
+    const now = Date.now();
+    let runs: Run[] | undefined = latestBenchmarkRuns;
+    if (!runs) {
+      // No run list this collection: on a failed fetch keep the last-known trend
+      // grayed with the reason (benchmarkIndexView with an empty run list and an
+      // offline reason); otherwise it short-circuited on a fresh snapshot, so read
+      // the list directly for the tile.
+      if (outcome.error !== undefined) {
+        return benchmarkIndexView(
+          [],
+          now,
+          false,
+          friendlyError(errorMessage(outcome.error)),
+        );
+      }
+      let directError: unknown;
+      runs = await pageBenchmarkRuns(
+        ordinaryBenchmarkGitHub,
+        token,
+        now - SPARK_DAYS * 86_400_000,
+      ).catch((error) => {
+        directError = error;
+        return undefined;
+      });
+      if (!runs) {
+        return benchmarkIndexView(
+          [],
+          now,
+          false,
+          friendlyError(errorMessage(directError)),
+        );
+      }
+    }
+    return benchmarkIndexView(runs, now);
   },
 };
 
@@ -1281,7 +1440,7 @@ export function benchPage(
 
   const rangeContent = `<div id="range-content">
     ${progressHtml}${refreshNotice}
-    <p class="legend">Percentile of per-op time across a run's samples — p0 = min, p50 = mean, p100 = max. Lower is faster; the grid tile tracks p99. Coloured by the selected ${days}-day trend; fewer than seven distinct days are marked new. Duration sort uses the latest sample.</p>
+    <p class="legend">Percentile of per-op time across a run's samples — p0 = min, p50 = mean, p100 = max. Lower is faster. Coloured by the selected ${days}-day trend; fewer than seven distinct days are marked new. Duration sort uses the latest sample.</p>
     ${body}
     <p class="note">Successful main runs come from the <a href="https://github.com/${REPO}/actions/workflows/${WORKFLOW}" target="_blank" rel="noopener">${WORKFLOW} runs ↗</a> (deno bench artifacts). Collection keeps enough samples for the shortest window, and charts reduce longer windows to about ${CI_HISTORY_POINT_TARGET} evenly spaced points.</p>
   </div>`;

--- a/packages/dashboard/tiles/ci-trust.ts
+++ b/packages/dashboard/tiles/ci-trust.ts
@@ -39,7 +39,7 @@ function makeCiTrust(opts: { id: string; label: string; repo: string; workflow: 
         : pct >= TRUST_GOOD ? "good" : pct >= TRUST_WARN ? "warn" : "bad";
       const runSummary = counted.length === scored.length
         ? `last ${scored.length} runs`
-        : `${counted.length} counted of last ${scored.length} runs`;
+        : `${counted.length} of last ${scored.length} runs`;
       const cells = [...scored].reverse().map(({ run, outcome }) => ({
         outcome,
         href: run.html_url,


### PR DESCRIPTION
…ormance index

The benchmarks tile previously surfaced one benchmark at a time and keyed its colour off that single measurement. That was noisy and easy to misread: one benchmark's movement says little about overall performance, and the wall-clock time of the whole run is a poor signal because `deno bench` samples each benchmark to a fixed time budget, so the run's duration barely moves as performance changes.

This reworks the tile around one stable question — is benchmark performance on main broadly getting worse? — and makes an outright failure the loudest thing it can say.

Headline and colour:

- The tile trends a scale-invariant index of benchmark performance across the `benchmarks.yml` main runs over about forty-five days. Each run's index is the previous run's index times the geometric mean of the per-benchmark changes between the two runs. Every benchmark weighs the same regardless of its absolute time, so only a broad, across-the-board move shifts the index; a regression in a single benchmark, however slow, barely registers — that is the drill-down's job. Chaining per-run ratios also makes adding or removing a benchmark a non-event: it appears in only one run of the adjacent pair, so it drops out of that step's ratio and the index does not step.
- The headline is that index's trend over a recent window — the runs in the last two weeks, or the newest twenty, whichever is more, the same "larger of the two" idea the CI duration tile uses — written as a percent, or as a fold multiplier once it passes four times. A second line names how many benchmarks the latest run measured and, when a recent window is highlighted, how many days that window spans (in days rather than a run count, so it does not read as the main-CI runs).
- Red is the signal the tile mainly exists to raise: the most recent run failed outright, or finished green on CI but produced no readable benchmark data (it ran and made nothing usable, so it is as good as failed). Orange is a broad slowdown, the index trending up past five percent. Green while flat or falling.

States and collection:

- The tile paints the moment a collection starts, before the run list has even been fetched, so a freshly loaded dashboard is never blank: a warm cache shows its headline at once, a cold one reads "collecting…". "collecting…" holds while a fetch is in progress; "benchmark data unavailable" once a fetch has finished and found runs but no readable data; "no benchmark runs" when it found none at all.
- The failed state reads the workflow-run list and the latest run's cached result, so it fires even when the artifacts cannot be read. The index needs the artifacts, so with none in the window and no failure the tile grays rather than inventing a number.

Presentation:

- The tile is labelled "benchmarks" — it tracks the whole suite.
- The headline's line-height is pinned so the up and down trend arrows, which fall back to a taller symbol font, no longer stretch the tile past its neighbours.

The per-benchmark drill-down behind /bench is unchanged; the tile's background collection keeps it warm. New tunables `BENCH_TREND_MIN_RUNS` and `BENCH_TREND_MAX_AGE_DAYS` set the recent-window size.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the dashboard benchmarks tile to show a scale‑invariant performance index across all `benchmarks.yml` runs, with a recent‑window trend, early “collecting…” paints, and failure‑first signaling. Also keeps the last‑known trend grayed with a reason when offline, and updates CI trust wording.

- **New Features**
  - Trends a geometric‑mean index across benchmarks; adding/removing a benchmark doesn’t step the index.
  - Headline shows the recent window’s trend (newest 20 runs or last 14 days, whichever is larger). Sparkline still covers ~45 days and highlights that slice. Subline shows benchmark count (and window span when highlighted).
  - Status: red if the latest run failed or produced no readable benchmark data; orange on a broad slowdown; green when flat/falling; gray only when no data and no failure. Early state paints “collecting…” before the run list is fetched; failed reads signal from the run list even if artifacts can’t be read.
  - Offline fetches keep the last‑known trend grayed with a reason (cold starts still show “—”). Tile label is “benchmarks”. Fixed headline line-height so ▲/▼ don’t stretch the tile. Shares the run list with `/bench` and keeps one artifact per bucket to limit fetches.
  - CI trust subtitle now reads “199 of last 200 runs” (drops “counted”).

- **Migration**
  - Remove `BENCH_METRIC` (no longer supported). The tile indexes all benchmarks equally.
  - Optional: tune `BENCH_TREND_MIN_RUNS` and `BENCH_TREND_MAX_AGE_DAYS` in `config.ts`.

<sup>Written for commit f214b81d5a1010ba425e46a53d9f7414a62584a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

