### PR TITLE
test: say what these tests actually pass, not `unknown`

### DIFF
--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { createSession, Identity } from "@commonfabric/identity";
 import {
   getPatternIdentityRef,
@@ -1451,7 +1452,7 @@ describe("piece pull materialization", () => {
             includeSchema: true,
           }),
         },
-        ...(originalInternal as unknown[]),
+        ...(originalInternal as FabricValue[]),
       ]);
       orphan.withTx(tx).setMetaRaw(
         "result",

--- a/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
+++ b/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -36,7 +37,7 @@ describe("CFC: array shrink clears truncated slots' link labels", () => {
   const seedLabeledDoc = async (
     rt: Runtime,
     cause: string,
-    value: unknown,
+    value: FabricValue,
     atom: string,
   ): Promise<string> => {
     const seed = rt.edit();

--- a/packages/runner/test/cfc-creation-membership-anchor.test.ts
+++ b/packages/runner/test/cfc-creation-membership-anchor.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -41,7 +42,7 @@ describe("CFC: creation anchors membership at the canonical container path", () 
   const seedLabeledDoc = async (
     rt: Runtime,
     cause: string,
-    value: unknown,
+    value: FabricValue,
     atom: string,
   ): Promise<string> => {
     const seed = rt.edit();

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -86,7 +87,7 @@ const seedLabeledDoc = async (
   runtime: Runtime,
   space: MemorySpace,
   id: string,
-  value: unknown,
+  value: FabricValue,
   entries: LabelMapEntry[],
 ): Promise<string> => {
   const seed = runtime.edit();

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { StorageManager } from "../src/storage/cache.deno.ts";
@@ -54,7 +55,7 @@ describe("CFC existence channel (SC-4, freeze-at-creation)", () => {
   const seedDoc = async (
     rt: Runtime,
     cause: string,
-    value: unknown,
+    value: FabricValue,
     entries: LabelMapEntry[],
   ): Promise<string> => {
     const seed = rt.edit();

--- a/packages/runner/test/cfc-flow-pointwise.test.ts
+++ b/packages/runner/test/cfc-flow-pointwise.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -36,7 +37,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
   const seedLabeledDoc = async (
     rt: Runtime,
     cause: string,
-    value: unknown,
+    value: FabricValue,
     atom: string,
   ): Promise<string> => {
     const seed = rt.edit();
@@ -718,7 +719,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     const { pattern, lift } = commonfabric as unknown as {
       pattern: typeof commonfabric.pattern;
       lift: (fn: (value: { n: number }) => unknown) => (
-        value: unknown,
+        value: FabricValue,
       ) => unknown;
     };
     // Reads element content, drops everything: the result stays [] across

--- a/packages/runner/test/cfc-observation-classes.test.ts
+++ b/packages/runner/test/cfc-observation-classes.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
@@ -55,7 +56,7 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
   const seedDoc = async (
     rt: Runtime,
     cause: string,
-    value: unknown,
+    value: FabricValue,
     entries: LabelMapEntry[],
   ): Promise<string> => {
     const seed = rt.edit();

--- a/packages/runner/test/cfc-persist-split.test.ts
+++ b/packages/runner/test/cfc-persist-split.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { StorageManager } from "../src/storage/cache.deno.ts";
@@ -53,7 +54,7 @@ describe("CFC observation classes (C2 persist split)", () => {
   const seedDoc = async (
     rt: Runtime,
     cause: string,
-    value: unknown,
+    value: FabricValue,
     entries: LabelMapEntry[],
   ): Promise<string> => {
     const seed = rt.edit();

--- a/packages/runner/test/cfc-prefix-provenance-stats.test.ts
+++ b/packages/runner/test/cfc-prefix-provenance-stats.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -57,7 +58,7 @@ const makeRuntime = (options: {
 const seedLabeledDoc = async (
   runtime: Runtime,
   id: string,
-  value: unknown,
+  value: FabricValue,
   label: { integrity?: unknown[]; confidentiality?: unknown[] },
 ): Promise<void> => {
   const seed = runtime.edit();
@@ -82,7 +83,7 @@ const seedLabeledDoc = async (
 const seedPlainDoc = async (
   runtime: Runtime,
   id: string,
-  value: unknown,
+  value: FabricValue,
 ): Promise<void> => {
   const seed = runtime.edit();
   const cell = runtime.getCell(signer.did(), id, undefined, seed);

--- a/packages/runner/test/cfc-privileged-system-write.test.ts
+++ b/packages/runner/test/cfc-privileged-system-write.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { URI } from "@commonfabric/memory/interface";
@@ -53,7 +54,7 @@ describe("CFC privileged system write (S18)", () => {
         id,
         type: "application/json",
         path: ["cfc"],
-      }, forgedMetadata as unknown as Record<string, unknown>);
+      }, forgedMetadata as unknown as FabricValue);
 
       const result = await tx.commit();
       expect(result.error).toBeDefined();
@@ -87,7 +88,7 @@ describe("CFC privileged system write (S18)", () => {
         id,
         type: "application/json",
         path: ["cfc"],
-      }, forgedMetadata as unknown as Record<string, unknown>);
+      }, forgedMetadata as unknown as FabricValue);
 
       const result = await tx.commit();
       expect(result.ok).toBeDefined();
@@ -194,7 +195,7 @@ describe("CFC privileged system write (S18)", () => {
         id,
         type: "application/json",
         path: ["cfc"],
-      }, forgedMetadata as unknown as Record<string, unknown>);
+      }, forgedMetadata as unknown as FabricValue);
       // The forgery is recorded even though enforcement is disabled.
       expect(tx.getCfcState().unprivilegedSystemWrites.length).toBe(1);
 
@@ -235,7 +236,7 @@ describe("CFC privileged system write (S18)", () => {
         id,
         type: "application/json",
         path: ["cfc"],
-      }, forgedMetadata as unknown as Record<string, unknown>);
+      }, forgedMetadata as unknown as FabricValue);
 
       const result = await tx.commit();
       expect(result.ok).toBeDefined();
@@ -313,7 +314,7 @@ describe("CFC privileged system write (S18)", () => {
       const base = current && typeof current === "object" ? current : {};
       tx.writeOrThrow(
         docAddress,
-        { ...base, cfc: forgedMetadata } as unknown as Record<string, unknown>,
+        { ...base, cfc: forgedMetadata } as unknown as FabricValue,
       );
       expect(tx.getCfcState().unprivilegedSystemWrites.length).toBe(0);
 

--- a/packages/runner/test/cfc-required-integrity-provenance.test.ts
+++ b/packages/runner/test/cfc-required-integrity-provenance.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -36,7 +37,7 @@ const ADMIN_ATOM = "group-chat-admin";
 const seedLabeledDoc = async (
   runtime: Runtime,
   id: string,
-  value: unknown,
+  value: FabricValue,
   label: { integrity?: unknown[]; confidentiality?: unknown[] },
 ): Promise<void> => {
   const seed = runtime.edit();

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
@@ -110,7 +111,7 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
   const seedDoc = async (
     rt: Runtime,
     cause: string,
-    value: unknown,
+    value: FabricValue,
     entries: LabelMapEntry[],
   ): Promise<string> => {
     const seed = rt.edit();

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
@@ -71,7 +72,7 @@ describe("CFC template population (Stage A): the two under-taints", () => {
   const seedDoc = async (
     rt: Runtime,
     cause: string,
-    value: unknown,
+    value: FabricValue,
     entries: LabelMapEntry[],
   ): Promise<string> => {
     const seed = rt.edit();
@@ -558,7 +559,7 @@ describe("CFC template population (SC-8 remainder): generic pure-link containers
   const seedDoc = async (
     rt: Runtime,
     cause: string,
-    value: unknown,
+    value: FabricValue,
     entries: LabelMapEntry[],
   ): Promise<string> => {
     const seed = rt.edit();
@@ -775,7 +776,7 @@ describe("CFC template population (Stage A): class-split resolution", () => {
   const seedDoc = async (
     rt: Runtime,
     cause: string,
-    value: unknown,
+    value: FabricValue,
     entries: LabelMapEntry[],
   ): Promise<string> => {
     const seed = rt.edit();
@@ -1056,7 +1057,7 @@ describe("CFC template population (Stage A): record-only additionalProperties wa
     rt: Runtime,
     cause: string,
     schema: JSONSchema,
-    value: unknown,
+    value: FabricValue,
   ): Promise<string> => {
     const interned = internSchema(schema, true);
     const tx = rt.edit();

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -65,7 +66,7 @@ const makeRuntime = (opts: {
 const seedLabeledDoc = async (
   runtime: Runtime,
   id: string,
-  value: unknown,
+  value: FabricValue,
   label: { integrity?: unknown[]; confidentiality?: unknown[] },
   path: string[] = [],
 ): Promise<void> => {

--- a/packages/runner/test/cfc-write-prefix-provenance.test.ts
+++ b/packages/runner/test/cfc-write-prefix-provenance.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -91,7 +92,7 @@ const makeRuntime = (options: {
 const seedLabeledDoc = async (
   runtime: Runtime,
   id: string,
-  value: unknown,
+  value: FabricValue,
   label: { integrity?: unknown[]; confidentiality?: unknown[] },
 ): Promise<void> => {
   const seed = runtime.edit();
@@ -119,7 +120,7 @@ const seedLabeledDoc = async (
 const seedPlainDoc = async (
   runtime: Runtime,
   id: string,
-  value: unknown,
+  value: FabricValue,
 ): Promise<void> => {
   const seed = runtime.edit();
   const cell = runtime.getCell(signer.did(), id, undefined, seed);

--- a/packages/runner/test/frozen-reads-cache.bench.ts
+++ b/packages/runner/test/frozen-reads-cache.bench.ts
@@ -23,6 +23,7 @@
  *     --allow-write=/tmp,/var/folders test/frozen-reads-cache.bench.ts
  */
 
+import type { FabricPlainObject } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
@@ -35,7 +36,7 @@ const ITERATIONS = 200;
 const ID = "of:frozen-reads-cache-bench" as const;
 
 const seedSiblings = (subtreeCount: number) => {
-  const value: Record<string, unknown> = {};
+  const value: FabricPlainObject = {};
   for (let i = 0; i < subtreeCount; i++) {
     value[`sub${i}`] = { count: 0, label: `sub${i}` };
   }

--- a/packages/runner/test/json-utils.test.ts
+++ b/packages/runner/test/json-utils.test.ts
@@ -11,11 +11,7 @@ import {
   moduleToJSON,
   toJSONWithAliasBindings,
 } from "../src/builder/json-utils.ts";
-import {
-  type FabricValue,
-  type JSONSchema,
-  type JSONSchemaObj,
-} from "../src/builder/types.ts";
+import { type JSONSchema, type JSONSchemaObj } from "../src/builder/types.ts";
 import { isInternedSchema } from "@commonfabric/data-model/schema-hash";
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
 import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
@@ -487,7 +483,9 @@ describe("json-utils", () => {
         },
       );
 
-      const create = (value: FabricValue) =>
+      // `createJsonSchema()` accepts cells as well as fabric data -- which is
+      // exactly what these cases exercise -- so this cannot be `FabricValue`.
+      const create = (value: unknown) =>
         createJsonSchema(value, false, runtime);
 
       // Preflight expectations.

--- a/packages/runner/test/traverse-required-links.test.ts
+++ b/packages/runner/test/traverse-required-links.test.ts
@@ -47,7 +47,7 @@ function getTraverser(
 function putDoc(
   store: Map<string, Revision<State>>,
   uri: URI,
-  value: unknown,
+  value: FabricValue,
   since = 1,
 ): void {
   const revision: Revision<State> = {


### PR DESCRIPTION
Eighteen test files annotate the values they hand to fabric APIs with types that
don't describe what they pass. Every one of them compiles today only because
`FabricSpecialObject` is declared with no members — which makes `FabricValue`
structurally satisfied by *any* object, so a wrong annotation there costs nothing
and communicates nothing.

## What changed

| | files | what it was |
| --- | ---: | --- |
| Seeding helpers `value: unknown` → `FabricValue` | 14 | Helpers feeding `writeOrThrow(address, value: FabricValue)` declared the parameter `unknown`. It is fabric data. |
| `json-utils.test.ts` helper `FabricValue` → `unknown` | 1 | The opposite error: it claimed fabric data while deliberately passing `Cell`s, which `createJsonSchema()` accepts. A `Cell` is a class with `toJSON()`, not a `FabricValue`. |
| Mis-targeted casts → the parameter's type | 2 | `as unknown as Record<string, unknown>` in a `FabricValue` position; an `as unknown[]` spread into a fabric array. |
| Bench seed → `FabricPlainObject` | 1 | Was `Record<string, unknown>`. |

Deliberately **not** changed: the one cast in `cfc-privileged-system-write.test.ts`
that reaches into a transaction's internals — that really is a
`Record<string, unknown>` reach-in, and retargeting it would be wrong.

## Why it's separable

No behavior change. Every touched test passes unchanged, and the annotations are
more truthful regardless of what happens to `FabricValue` — so this doesn't
depend on the work that surfaced it.

## Where it came from

Measuring what it would take to brand `FabricSpecialObject`, so that
`FabricValue` means something to the type checker rather than "any object".
Under that experiment these account for ~31 errors (110 → 79).

The rest need `src` changes and are **not** in here. Worth flagging one, since
it dominates the remainder: `IFCLabel` is declared
`{ confidentiality?: unknown[]; integrity?: unknown[] }`, and that single type is
the root of both the `LabelMapEntry[]` cluster and the `{integrity?: unknown[]}`
literal cluster — roughly 20 errors. Those tests are faithfully mirroring a `src`
type whose members are `unknown[]`; giving them a real element type is a `src`
decision, not a test fix.

Workspace `deno task check` clean; full repo suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns test type annotations with actual fabric data passed to APIs, replacing unknown with FabricValue where appropriate and fixing one helper that intentionally passes Cells. No behavior change; test suite remains green.

- **Refactors**
  - Switch seeding helpers to `value: FabricValue` across CFC tests calling `writeOrThrow`.
  - Update `json-utils.test.ts` helper to accept `unknown` since `createJsonSchema()` accepts `Cell`s.
  - Correct mis-typed casts to use the real parameter type (e.g., `FabricValue[]`, `FabricValue`); keep the one intentional internal `Record<string, unknown>` cast.
  - Use `FabricPlainObject` for bench seed instead of `Record<string, unknown>`.
  - Add needed `FabricValue` imports and param types to tests.

<sup>Written for commit 89b619ada87186263bb07f99b2b35ffea78bbac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

