### PR TITLE
refactor: declare closed protocol and record shapes as type aliases

### DIFF
--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -82,7 +82,7 @@ export interface LLMToolResult {
 }
 
 export type LLMRequestMetadata = Record<string, string | undefined | object>;
-export interface LLMRequest {
+export type LLMRequest = {
   cache?: boolean;
   messages: readonly BuiltInLLMMessage[];
   model: ModelName;
@@ -94,7 +94,7 @@ export interface LLMRequest {
   metadata?: LLMRequestMetadata;
   tools?: Record<string, LLMTool>;
   nativeModelToolIds?: readonly LLMNativeModelToolId[];
-}
+};
 
 export interface LLMGenerateObjectRequest {
   schema: Record<string, unknown>;

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -209,7 +209,7 @@ export type CommitPrecondition =
     valueHash: string | null;
   };
 
-export interface ClientCommit {
+export type ClientCommit = {
   localSeq: number;
   reads: {
     confirmed: ConfirmedRead[];
@@ -227,7 +227,7 @@ export interface ClientCommit {
     baseBranch: BranchName;
     baseSeq: number;
   };
-}
+};
 
 export interface SessionOpenArgs {
   sessionId?: SessionId;
@@ -252,7 +252,7 @@ export interface SessionOpenResult {
   sessionOpen: SessionOpenAuthMetadata;
 }
 
-export interface MemoryProtocolFlags {
+export type MemoryProtocolFlags = {
   modernCellRep: boolean;
   persistentSchedulerState: boolean;
   commitPreconditions: boolean;
@@ -283,7 +283,7 @@ export interface MemoryProtocolFlags {
    * version always advertises it.
    */
   pendingReadStacks: boolean;
-}
+};
 
 /**
  * Wire-format flags object.
@@ -304,28 +304,28 @@ export interface HelloMessage {
   flags: WireMemoryProtocolFlags;
 }
 
-export interface HelloOkMessage {
+export type HelloOkMessage = {
   type: "hello.ok";
   protocol: typeof MEMORY_PROTOCOL;
   flags: WireMemoryProtocolFlags;
   sessionOpen?: SessionOpenAuthMetadata;
-}
+};
 
-export interface SessionOpenChallenge {
+export type SessionOpenChallenge = {
   value: string;
   expiresAt: number;
-}
+};
 
-export interface SessionOpenAuthMetadata {
+export type SessionOpenAuthMetadata = {
   challenge: SessionOpenChallenge;
   audience: string;
-}
+};
 
-export interface SessionDescriptor {
+export type SessionDescriptor = {
   sessionId?: SessionId;
   seenSeq?: number;
   sessionToken?: SessionToken;
-}
+};
 
 export interface SessionOpenRequest {
   type: "session.open";
@@ -391,7 +391,7 @@ export interface SessionSyncRemove {
   scope?: CellScope;
 }
 
-export interface SessionSync {
+export type SessionSync = {
   type: "sync";
   fromSeq: number;
   toSeq: number;
@@ -407,7 +407,7 @@ export interface SessionSync {
   // scheduler.snapshot.list result; `observation` is intentionally
   // `unknown` — the runner owns validation.
   observations?: SchedulerActionSnapshotResult[];
-}
+};
 
 export interface WatchSetResult {
   serverSeq: number;
@@ -634,28 +634,28 @@ export interface SchedulerSnapshotListRequest {
   query: SchedulerActionSnapshotQuery;
 }
 
-export interface ResponseMessage<Result> {
+export type ResponseMessage<Result> = {
   type: "response";
   requestId: string;
   ok?: Result;
   error?: V2Error;
-}
+};
 
-export interface SessionEffectMessage {
+export type SessionEffectMessage = {
   type: "session/effect";
   space: string;
   sessionId: SessionId;
   effect: SessionSync;
-}
+};
 
-export interface SessionRevokedMessage {
+export type SessionRevokedMessage = {
   type: "session/revoked";
   space: string;
   sessionId: SessionId;
   reason: "taken-over" | "unauthorized";
-}
+};
 
-export interface V2Error {
+export type V2Error = {
   name: string;
   message: string;
   precondition?: string;
@@ -670,7 +670,7 @@ export interface V2Error {
    * client stops reopening the session and surfaces the error instead of looping.
    */
   retriable?: boolean;
-}
+};
 
 export type V2Result<Value> = { ok: Value } | { error: V2Error };
 

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -799,14 +799,14 @@ export interface OpenOptions {
   snapshotRetention?: number;
 }
 
-export interface InvocationRecord {
+export type InvocationRecord = {
   iss: string;
   aud?: string | null;
   cmd: string;
   sub: string;
   args?: FabricValue;
   [key: string]: unknown;
-}
+};
 
 export type AuthorizationRecord = FabricValue;
 
@@ -871,12 +871,12 @@ export type SchedulerObservationTransactionKind =
   | "action-run"
   | "event-preflight";
 
-export interface SchedulerObservationAddress {
+export type SchedulerObservationAddress = {
   space: string;
   id: EntityId;
   scope?: CellScope;
   path: readonly string[];
-}
+};
 
 export interface ResolvedSchedulerObservationAddress
   extends SchedulerObservationAddress {
@@ -887,7 +887,7 @@ type SchedulerWriteAddress = SchedulerObservationAddress & {
   scopeKey?: string;
 };
 
-export interface CompleteActionScopeSummary {
+export type CompleteActionScopeSummary = {
   version: 1;
   complete: true;
   implementationFingerprint: string;
@@ -897,9 +897,9 @@ export interface CompleteActionScopeSummary {
   writes: SchedulerObservationAddress[];
   materializerWriteEnvelopes: SchedulerObservationAddress[];
   directOutputs: SchedulerObservationAddress[];
-}
+};
 
-export interface SchedulerActionObservation {
+export type SchedulerActionObservation = {
   version: 1 | 2;
   ownerSpace?: string;
   branch: BranchName;
@@ -927,7 +927,7 @@ export interface SchedulerActionObservation {
   };
   status: "success" | "failed";
   errorFingerprint?: string;
-}
+};
 
 const isSchedulerRecord = (
   value: unknown,

--- a/packages/runner/src/scheduler/persistent-observation.ts
+++ b/packages/runner/src/scheduler/persistent-observation.ts
@@ -28,7 +28,7 @@ export interface SchedulerActionOptions {
  * binds the proof to the exact implementation/runtime fingerprints. Runtime
  * observations without this object are deliberately incomplete.
  */
-export interface CompleteActionScopeSummary {
+export type CompleteActionScopeSummary = {
   version: 1;
   complete: true;
   implementationFingerprint: string;
@@ -38,14 +38,14 @@ export interface CompleteActionScopeSummary {
   writes: IMemorySpaceAddress[];
   materializerWriteEnvelopes: IMemorySpaceAddress[];
   directOutputs: IMemorySpaceAddress[];
-}
+};
 
 export type CompleteActionScopeSummaryInput = Omit<
   CompleteActionScopeSummary,
   "implementationFingerprint" | "runtimeFingerprint"
 >;
 
-export interface SchedulerActionObservation {
+export type SchedulerActionObservation = {
   version: 1 | 2;
   ownerSpace?: string;
   branch: string;
@@ -69,7 +69,7 @@ export interface SchedulerActionObservation {
   actionOptions?: SchedulerActionOptions;
   status: "success" | "failed";
   errorFingerprint?: string;
-}
+};
 
 export interface PersistedSchedulerObservationSnapshot {
   executionContextKey: SchedulerExecutionContextKey;


### PR DESCRIPTION
Sixteen wire-message and record shapes are declared with `interface`. That denies
them an **implicit index signature** — TypeScript won't infer one for an
interface, because declaration merging means it can't prove that properties added
elsewhere would conform. A `type` alias is closed at its declaration, so the same
shape gets the index signature and can satisfy `Record<string, FabricValue>`.

```ts
type Bag = Record<string, boolean>;
interface AsInterface { a: boolean }   // ✗ not assignable to Bag
type AsAlias = { a: boolean };         // ✓ assignable
```

These shapes **are** fabric data — serialized, stored, and compared as such. The
only thing standing between them and being recognized as fabric values was the
keyword they were declared with.

Notably this converts all four members of the `ServerMessage` union, so a
`ServerMessage` can be passed where a `FabricValue` is expected — which is
exactly how the memory protocol uses them today.

Giving up declaration merging here is the point rather than the cost: nothing
should be grafting a property onto a serialized protocol message from another
module.

## Converted

- **`memory/v2.ts`** — `MemoryProtocolFlags`, `HelloOkMessage`,
  `ResponseMessage`, `SessionEffectMessage`, `SessionRevokedMessage`,
  `ClientCommit`, `SessionDescriptor`, `SessionOpenAuthMetadata`,
  `SessionOpenChallenge`, `SessionSync`, `V2Error`
- **`memory/v2/engine.ts`** — `CompleteActionScopeSummary`, `InvocationRecord`,
  `SchedulerActionObservation`, `SchedulerObservationAddress`
- **`runner/src/scheduler/persistent-observation.ts`** — the mirrored
  `CompleteActionScopeSummary` and `SchedulerActionObservation`
- **`llm/src/types.ts`** — `LLMRequest`

## Why now, and what it's worth

`FabricValue` currently means "any object" to the type checker, because
`FabricSpecialObject` is declared with no members and is therefore structurally
satisfied by anything. That's not academic — it's how a `valueEqual()` call on an
unconvertible value compiled and shipped, aborting space-root pattern load
(#5001).

Branding that class locally is how these failures become visible. Measured on
current `main`:

| | type errors under the brand |
| --- | ---: |
| brand alone | 166 |
| brand + this change | **79** |

So this is worth **87** — more than half the residue — and it is the largest
remaining lever that requires no semantic decision.

## What's next (not in here)

- **`IFCLabel`-rooted cluster (~22)** — `IFCLabel` is declared
  `{ confidentiality?: unknown[]; integrity?: unknown[] }`. Typing it properly
  cascades to ~86 errors and turns on a CFC-semantics question (may a Caveat
  atom's `source` hold arbitrary data?). Measured, not attempted.
- **`storage/inspector.ts` `never`-union (11)** — behavioral, not annotation.

No behavior change; no test moved. Workspace `deno task check` clean; full repo
suite green (201.7s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored protocol and record shapes from `interface` to closed `type` aliases to make them `FabricValue`-compatible and satisfy `Record<string, FabricValue>`. This enables passing server messages as `FabricValue` and reduces 87 type errors in the `FabricSpecialObject` branding check.

- **Refactors**
  - Re-declared 16 wire/record shapes as `type` aliases across `memory/v2.ts`, `memory/v2/engine.ts`, `runner/src/scheduler/persistent-observation.ts`, and `llm/src/types.ts`.
  - `ServerMessage` members now pass where `FabricValue` is expected.
  - No behavior change; tests unchanged.

<sup>Written for commit c15165d75f6ff02d3d671ab8597b809ac8926e41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

