### PR TITLE
fix(runner): an authored request is a `FabricValueLayer`, not a `FabricValue`

### DIFF
--- a/packages/runner/src/cfc/request-snapshot.ts
+++ b/packages/runner/src/cfc/request-snapshot.ts
@@ -1,5 +1,6 @@
 import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
 import type { FabricValue } from "@commonfabric/api";
+import type { FabricValueLayer } from "@commonfabric/data-model/interface";
 
 /**
  * Produces a detached, deep-frozen snapshot of a request `value`, for use as a
@@ -7,15 +8,21 @@ import type { FabricValue } from "@commonfabric/api";
  * is a deep clone, so later mutation of the input does not leak into the
  * snapshot.
  *
- * The `value` is treated as a `FabricValue`: `cloneIfNecessary()` deep-clones
- * to a frozen result, preserving `FabricInstance` / `FabricPrimitive` class
- * identity (which a `structuredClone()` would silently strip). Cyclic values
- * are not yet supported (see `cloneIfNecessary`).
+ * `cloneIfNecessary()` deep-clones to a frozen result, preserving
+ * `FabricInstance` / `FabricPrimitive` class identity (which a
+ * `structuredClone()` would silently strip). Cyclic values are not yet
+ * supported (see `cloneIfNecessary`).
+ *
+ * A request is a `FabricValueLayer` rather than a `FabricValue`: an authored
+ * request may still hold native content awaiting conversion (an LLM image part
+ * accepts a `Uint8Array`, an `ArrayBuffer`, or a `URL`). `cloneIfNecessary()`
+ * handles those natives at runtime; its parameter type names only the
+ * already-converted case, hence the cast.
  */
-export function createFrozenRequestSnapshot<T extends FabricValue>(
+export function createFrozenRequestSnapshot<T extends FabricValueLayer>(
   value: T,
 ): T {
   // `cloneIfNecessary`'s frozen default is typed `Immutable<T>`; callers
   // consume the snapshot as a (read-only-in-practice) `T`.
-  return cloneIfNecessary(value) as T;
+  return cloneIfNecessary(value as FabricValue) as T;
 }

--- a/packages/runner/src/cfc/sink-request.ts
+++ b/packages/runner/src/cfc/sink-request.ts
@@ -1,5 +1,5 @@
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import type { FabricValue } from "@commonfabric/api";
+import type { FabricValueLayer } from "@commonfabric/data-model/interface";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { createFrozenRequestSnapshot } from "./request-snapshot.ts";
 import type { CfcPrepareState, WritePolicyInput } from "./types.ts";
@@ -27,7 +27,7 @@ const preparedSinkRequestInputs = (
 export function createSinkRequestPolicyInput(
   sink: string,
   effectId: string,
-  request: FabricValue,
+  request: FabricValueLayer,
 ): SinkRequestPolicyInput {
   return {
     kind: "sink-request",
@@ -41,7 +41,7 @@ export function recordSinkRequestPolicyInput(
   tx: Pick<IExtendedStorageTransaction, "recordCfcWritePolicyInput">,
   sink: string,
   effectId: string,
-  request: FabricValue,
+  request: FabricValueLayer,
 ): void {
   tx.recordCfcWritePolicyInput(
     createSinkRequestPolicyInput(sink, effectId, request),
@@ -52,7 +52,7 @@ export function verifySinkRequestRelease(
   tx: { getCfcState(): SinkRequestPolicyState },
   sink: string,
   effectId: string,
-  request: FabricValue,
+  request: FabricValueLayer,
   preparedInput?: SinkRequestPolicyInput,
 ): string | undefined {
   const state = tx.getCfcState();
@@ -88,7 +88,7 @@ export function enqueueSinkRequestPostCommitEffect(
   >,
   sink: string,
   effectId: string,
-  request: FabricValue,
+  request: FabricValueLayer,
   kind: string,
   flush: (tx: IExtendedStorageTransaction) => void | Promise<void>,
 ): void {

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -1,4 +1,5 @@
 import type { CellScope, JSONSchema } from "../builder/types.ts";
+import type { FabricValueLayer } from "@commonfabric/data-model/interface";
 import type { FabricValue } from "@commonfabric/api";
 import type { CfcModulePolicyRefAtom } from "@commonfabric/api/cfc";
 import type { MemorySpace } from "@commonfabric/memory/interface";
@@ -425,7 +426,9 @@ export type WritePolicyInput =
     readonly kind: "sink-request";
     readonly effectId: string;
     readonly sink: string;
-    readonly request: FabricValue;
+    // A request as authored: its contents may still hold native values
+    // awaiting conversion (see `createFrozenRequestSnapshot`).
+    readonly request: FabricValueLayer;
   }
   | {
     readonly kind: "custom";


### PR DESCRIPTION
`BuiltInLLMImagePart.image` is `string | Uint8Array | ArrayBuffer | URL` — an
LLM request legitimately carries **native** values a caller handed in. The
request path nevertheless declared its values `FabricValue`, which they are not
until conversion.

`FabricValueLayer` is the data-model type for exactly this case: *"the shape is
right, the contents may still need converting."*

## Retyped

- `createFrozenRequestSnapshot`'s constraint
- the four `request` parameters in `cfc/sink-request.ts`
- the `request` field of the `sink-request` write-policy input

Nothing outside `sink-request.ts` reads that field, so the change **stops there**
rather than propagating — I checked before widening it, having recently measured
what happens when a tightening doesn't stop (`IFCLabel`: 86 errors and growing).

## Four of six errors were cascades

`createFrozenRequestSnapshot` is already generic (`<T extends FabricValue>`), so
when its argument failed the constraint, `T` fell back to `FabricValue` and the
assignment back to `llmParams: LLMRequest` failed too. Fixing the constraint
fixed both ends — one root, four symptoms.

## The one cast, deliberately

`cloneIfNecessary()` handles these natives at runtime — its tag dispatch covers
`Date`, `RegExp`, and `Uint8Array` — but its *parameter type* names only the
already-converted case. Hence `cloneIfNecessary(value as FabricValue)` inside the
snapshot helper, with a comment saying so.

The alternative is widening `cloneIfNecessary` itself, which reaches much further
into `data-model` than this change should. Flagging it explicitly as the
judgement call in here.

## Measurement

Against the `FabricSpecialObject` branding experiment (which is what makes these
failures visible): residue **79 → 73**.

No behavior change; no test moved. Workspace `deno task check` clean; full repo
suite green (199.2s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch authored sink requests to `FabricValueLayer` instead of `FabricValue` so LLM requests can include native values (e.g., `Uint8Array`, `ArrayBuffer`, `URL`). Fixes type errors with no behavior changes.

- **Bug Fixes**
  - Retyped `createFrozenRequestSnapshot<T extends FabricValueLayer>` and cast to `FabricValue` when calling `cloneIfNecessary`.
  - Updated four `request` parameters in `cfc/sink-request.ts` and the `sink-request` `WritePolicyInput.request` field to `FabricValueLayer` (change contained to this module).
  - Reduced type-check residue from the `FabricSpecialObject` branding experiment (79 → 73).

<sup>Written for commit 37c5b04c8e5856e07bc2ee2d60cc2a5b4d09c9c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

