### PR TITLE
fix(data-model): re-export `isFabricValue`; prove before narrowing

### DIFF
--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -25,7 +25,11 @@ export {
   shallowMutableClone,
 } from "./value-clone.ts";
 
-export { isFabricPlainObject, isFabricValueLayer } from "./type-check.ts";
+export {
+  isFabricPlainObject,
+  isFabricValue,
+  isFabricValueLayer,
+} from "./type-check.ts";
 
 export {
   fabricFromNativeValue,

--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -1,6 +1,7 @@
 import {
   type FabricValue,
   isFabricPlainObject,
+  isFabricValue,
   shallowMutableClone,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
@@ -676,7 +677,8 @@ function mergeSchemaDefaultsInternal(
     if (defaults === undefined && !traversesPresentObject) return value;
     if (
       defaults !== undefined &&
-      (!isFabricPlainObject(defaults) || isCellLink(defaults))
+      (!(isFabricValue(defaults) && isFabricPlainObject(defaults)) ||
+        isCellLink(defaults))
     ) {
       return valuePresent ? value : defaults;
     }


### PR DESCRIPTION
`fabric-value.ts` re-exports `isFabricPlainObject` and `isFabricValueLayer` from
`type-check.ts` — but not `isFabricValue`, which sits beside them and is the most
fundamental of the three. Nothing outside `data-model` could ask the basic
question *"is this a fabric value?"*.

That omission also left callers stuck. `isFabricPlainObject` narrows a value
**already known** to be a `FabricValue` — that restriction is deliberate — so a
caller holding something looser has no legitimate way to reach it.
`runner-utils.ts` called it anyway, on a value typed `{} | null`, which compiles
today only because `FabricSpecialObject` has no members and therefore makes
`FabricValue` structurally satisfied by any object.

With the guard exported, that call site can say what it means:

```ts
isFabricValue(defaults) && isFabricPlainObject(defaults)
```

Prove it is a fabric value, *then* narrow.

## No behavior change

`isFabricValue()` returns true for every value that previously reached
`isFabricPlainObject()` at this site, so the composed condition is equivalent at
runtime. No test moved.

## Measurement

Against the `FabricSpecialObject` branding experiment: residue **79 → 77**.

Small on purpose. The remaining residue is dominated by clusters that need design
decisions rather than mechanical fixes — `IFCLabel` / CFC atom typing (~22), the
`ServerMessage` chain (~11, blocked on where `SchedulerActionObservation` should
live), `inspector.ts`'s collapsed union (11), and the authored-vs-stored shape of
LLM requests (6).

Workspace `deno task check` clean; full repo suite green (201.0s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-exported `isFabricValue` from the data model and updated a call site to prove-before-narrowing. This fixes type-guard usage without changing runtime behavior.

- **Bug Fixes**
  - Re-export `isFabricValue` from `packages/data-model/src/fabric-value.ts` so callers can ask “is this a fabric value?”.
  - In `packages/runner/src/runner-utils.ts`, check `isFabricValue(defaults) && isFabricPlainObject(defaults)` instead of only `isFabricPlainObject(defaults)`.
  - No behavior change; improves type safety and aligns with future branding work.

<sup>Written for commit 9c58f25f4e91ee5f8dcfa529735ef33eba7a15da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

