### PR TITLE
refactor(memory): declare `Ok` and `Fail` as type aliases

### DIFF
--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -595,21 +595,21 @@ export type Result<T extends Unit = Unit, E extends Error = Error> =
   | Ok<T>
   | Fail<E>;
 
-export interface Ok<T extends Unit> {
+export type Ok<T extends Unit> = {
   ok: T;
   /**
    * Discriminant to differentiate between Ok and Fail.
    */
   error?: undefined;
-}
+};
 
-export interface Fail<E extends Error> {
+export type Fail<E extends Error> = {
   error: E;
   /**
    * Discriminant to differentiate between Ok and Fail.
    */
   ok?: undefined;
-}
+};
 
 export type Conflict = {
   /**


### PR DESCRIPTION
`Result<T, E>` is `Ok<T> | Fail<E>` — two closed data shapes describing a returned
outcome. Declaring them with `interface` denies them an implicit index signature
(TypeScript won't infer one for an interface, since declaration merging means it
can't prove later properties would conform), so neither can satisfy
`Record<string, FabricValue>`.

Same change as #5024, for two shapes that PR missed.

## Safety

- Nothing `extends` or merges either one, repo-wide.
- `identity` has its own independent `Ok`/`Fail` pair — untouched.
- Workspace `deno task check` clean; full repo suite green (200.4s).

## What this does *not* fix

`Fail<E extends Error>` carries an `Error`, which is a `FabricNativeObject` and
never a `FabricValue`. So a `Receipt`'s `Result` still can't satisfy `Receipt`'s
own constraint:

```ts
export type Receipt<
  Command extends NonNullable<unknown>,
  Result extends FabricValue,   // ← untrue of the actual type
  Effect,
> = …
```

That constraint is what makes `ProviderCommand<Protocol>` collapse to `never`
under a branded `FabricSpecialObject`, taking `storage/inspector.ts` and its test
with it (11 errors). It type-checks today only because the empty-class
`FabricSpecialObject` makes every object a `FabricValue`.

**Receipts are not durably stored**, so relaxing that constraint is sound.
Verified rather than assumed: `ProviderCommand` has six non-test references
repo-wide — three declaring the types in `memory/interface.ts`, three in
`runner/src/storage/inspector.ts`. The inspector's `Model` is consumed by exactly
one caller, `StorageTelemetry.processCommand`, which folds it into in-memory
state and emits telemetry. No `writeOrThrow`, no `setRaw`, no serialization of a
receipt anywhere.

Relaxing the constraint is the follow-up, deliberately kept separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `Ok<T>` and `Fail<E>` into type aliases to make the `Result<T, E>` union a closed shape and allow TypeScript to infer index signatures. This avoids interface declaration merging pitfalls in the `memory` protocol.

<sup>Written for commit 5de43abc428a653dc691c1e33aa9c1eca02a225c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

