### PR TITLE
fix(memory): a `Receipt`'s result is transport, not a `FabricValue`

### DIFF
--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -264,13 +264,44 @@ export interface InvocationView<
 
 export type Task<Return, Command = never> = Iterable<Command, Return>;
 
+/**
+ * What a provider sends back for an invocation: either the invocation's return
+ * value (`task/return`) or an effect it produced along the way
+ * (`task/effect`).
+ *
+ * `Result` is deliberately unconstrained, which deserves explanation, since
+ * what actually flows through it is narrower: a receipt reports an `Ok`/`Fail`
+ * outcome, possibly awaited (see `AwaitResult`).
+ *
+ * It is *not* a `FabricValue`. A receipt is in-process transport rather than
+ * stored data -- a `Fail` carries an `Error`, which is a `FabricNativeObject`
+ * and never a `FabricValue` -- and nothing durably stores a receipt. The
+ * `extends FabricValue` this parameter used to carry was therefore untrue; it
+ * type-checked only because `FabricSpecialObject` is declared with no members,
+ * which makes `FabricValue` structurally satisfied by any object.
+ *
+ * Nor can it say `extends AwaitResult<Unit, Error>`, true though that is.
+ * `ProviderCommand` reaches this parameter through inference:
+ *
+ * ```ts
+ * ProtocolMethod<Protocol> extends {
+ *   ProviderCommand: Receipt<infer Command, infer Result, infer Effect>;
+ * } ? Receipt<Command, Result, Effect> : never
+ * ```
+ *
+ * and a constraint inside an `infer ... extends ...` position is enforced by
+ * silent non-match, not by a diagnostic: a method whose result did not conform
+ * would drop to the `never` arm and vanish from the protocol type, with the
+ * damage surfacing far away as member access on `never`. That is exactly the
+ * failure the old `FabricValue` constraint produced once `FabricValue` meant
+ * something. An unconstrained parameter reports a wrong result type at the use
+ * site instead, noisily.
+ *
+ * Constraining it becomes safe once the inference in `InferProtoMethods` is
+ * total -- i.e. once a non-conforming method is reported rather than dropped.
+ */
 export type Receipt<
   Command extends NonNullable<unknown>,
-  // A receipt is in-process transport, not stored data: its result is an
-  // `Ok`/`Fail` outcome, and a `Fail` carries an `Error` -- a
-  // `FabricNativeObject`, never a `FabricValue`. Constraining this to
-  // `FabricValue` was only ever satisfiable because an unbranded
-  // `FabricSpecialObject` made every object one.
   Result,
   Effect,
 > =

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -269,19 +269,14 @@ export type Task<Return, Command = never> = Iterable<Command, Return>;
  * value (`task/return`) or an effect it produced along the way
  * (`task/effect`).
  *
- * `Result` is deliberately unconstrained, which deserves explanation, since
- * what actually flows through it is narrower: a receipt reports an `Ok`/`Fail`
- * outcome, possibly awaited (see `AwaitResult`).
+ * `Result` is unconstrained, though what flows through it is narrower: a
+ * receipt reports an `Ok`/`Fail` outcome, possibly awaited (see
+ * `AwaitResult`). It is not a `FabricValue` -- a receipt is in-process
+ * transport rather than stored data, and a `Fail` carries an `Error`, which is
+ * a `FabricNativeObject`.
  *
- * It is *not* a `FabricValue`. A receipt is in-process transport rather than
- * stored data -- a `Fail` carries an `Error`, which is a `FabricNativeObject`
- * and never a `FabricValue` -- and nothing durably stores a receipt. The
- * `extends FabricValue` this parameter used to carry was therefore untrue; it
- * type-checked only because `FabricSpecialObject` is declared with no members,
- * which makes `FabricValue` structurally satisfied by any object.
- *
- * Nor can it say `extends AwaitResult<Unit, Error>`, true though that is.
- * `ProviderCommand` reaches this parameter through inference:
+ * The narrower constraint cannot be stated here. `ProviderCommand` reaches this
+ * parameter through inference:
  *
  * ```ts
  * ProtocolMethod<Protocol> extends {
@@ -289,16 +284,13 @@ export type Task<Return, Command = never> = Iterable<Command, Return>;
  * } ? Receipt<Command, Result, Effect> : never
  * ```
  *
- * and a constraint inside an `infer ... extends ...` position is enforced by
- * silent non-match, not by a diagnostic: a method whose result did not conform
- * would drop to the `never` arm and vanish from the protocol type, with the
- * damage surfacing far away as member access on `never`. That is exactly the
- * failure the old `FabricValue` constraint produced once `FabricValue` meant
- * something. An unconstrained parameter reports a wrong result type at the use
- * site instead, noisily.
- *
- * Constraining it becomes safe once the inference in `InferProtoMethods` is
- * total -- i.e. once a non-conforming method is reported rather than dropped.
+ * A constraint in an `infer ... extends ...` position is enforced by silent
+ * non-match rather than by a diagnostic: a method whose result does not conform
+ * drops to the `never` arm and vanishes from the protocol type, surfacing far
+ * away as member access on `never`. Unconstrained, a wrong result type is
+ * reported at the use site instead. Constraining becomes safe once the
+ * inference in `InferProtoMethods` is total -- that is, once a non-conforming
+ * method is reported rather than dropped.
  */
 export type Receipt<
   Command extends NonNullable<unknown>,

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -266,7 +266,12 @@ export type Task<Return, Command = never> = Iterable<Command, Return>;
 
 export type Receipt<
   Command extends NonNullable<unknown>,
-  Result extends FabricValue,
+  // A receipt is in-process transport, not stored data: its result is an
+  // `Ok`/`Fail` outcome, and a `Fail` carries an `Error` -- a
+  // `FabricNativeObject`, never a `FabricValue`. Constraining this to
+  // `FabricValue` was only ever satisfiable because an unbranded
+  // `FabricSpecialObject` made every object one.
+  Result,
   Effect,
 > =
   | {


### PR DESCRIPTION
`Receipt<Command, Result extends FabricValue, Effect>` constrained its result to
`FabricValue`. That is **untrue of the actual type**. A receipt's result is an
`Ok`/`Fail` outcome, and `Fail<E extends Error>` carries an `Error` — a
`FabricNativeObject`, never a `FabricValue`. Concretely it resolves to:

```
Ok<{}> | Fail<AuthorizationError | ConflictError | TransactionError | ConnectionError>
       | Selection<…> | EnhancedCommit<…>
```

The constraint held only because `FabricSpecialObject` is declared with no
members, which makes `FabricValue` structurally satisfied by any object.

## The cost isn't theoretical

`ProviderCommand<Protocol>` infers its receipt *through* that constraint:

```ts
ProtocolMethod<Protocol> extends {
  ProviderCommand: Receipt<infer Command, infer Result, infer Effect>;
} ? Receipt<Command, Result, Effect> : never
```

Once `FabricValue` means something, the inferred `Result` no longer satisfies the
constraint, the pattern stops unifying, and the whole type collapses to `never` —
so every member access in `storage/inspector.ts` (`command.time`, `receipt.the`,
`receipt.of`, `receipt.is`) fails, along with its tests' arguments. Eleven errors
from one silently-false constraint.

## Receipts are not stored — verified, not assumed

`ProviderCommand` has six non-test references repo-wide:

- three declaring these types in `memory/interface.ts`
- three in `runner/src/storage/inspector.ts`

The inspector's `Model` has exactly one consumer, `StorageTelemetry.processCommand`,
which folds it into in-memory state and emits telemetry. No `writeOrThrow`, no
`setRaw`, no serialization of a receipt anywhere. It is in-process transport,
which is also what the `Error` payload implies.

## Measurement

Against the `FabricSpecialObject` branding experiment: residue **77 → 66**,
clearing the entire inspector cluster (`inspector.ts` 6 + `storage-inspector.test.ts` 5).

No behavior change; no test moved. `deno task check` clean, lint clean, full repo
suite green (200.4s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `Receipt` result to be transport (Ok/Fail outcome), not a `FabricValue`. Restores `ProviderCommand` inference and clears inspector typing errors; no runtime change.

- **Bug Fixes**
  - Removed the `FabricValue` constraint and refined the `Receipt` docs to state the result is transport and explain why it stays unconstrained (cannot safely use `extends AwaitResult<Unit, Error>` due to infer-position drops).

<sup>Written for commit ba63b547c08d719f0e10d396fb18669d3ddf76ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

