### PR TITLE
test(memory): give two fixture shapes their real types

### DIFF
--- a/packages/memory/test/v2-graph.fixture.ts
+++ b/packages/memory/test/v2-graph.fixture.ts
@@ -1,3 +1,4 @@
+import type { JSONSchema } from "@commonfabric/api";
 import type { URI } from "../interface.ts";
 
 type GraphLink = {
@@ -24,7 +25,7 @@ export type GraphFixture = {
   hiddenRootId: URI;
   initialReachableIds: URI[];
   expandedReachableIds: URI[];
-  schema: Record<string, unknown>;
+  schema: JSONSchema;
   expandedRootValue: GraphDoc;
 };
 
@@ -64,7 +65,7 @@ const nodeSchema = {
   },
   required: ["name", "metadata"],
   additionalProperties: false,
-};
+} as const satisfies JSONSchema;
 
 export const createGraphFixture = (space: string): GraphFixture => {
   const docs = new Map<URI, GraphDoc>();

--- a/packages/memory/test/v2-server-acl-test.ts
+++ b/packages/memory/test/v2-server-acl-test.ts
@@ -8,6 +8,7 @@ import {
   type GraphQueryResult,
   type HelloOkMessage,
   MEMORY_PROTOCOL,
+  type Operation,
   type ResponseMessage,
   type ServerMessage,
   type SessionDescriptor,
@@ -119,7 +120,9 @@ const transactOperation = async (
     commit: {
       localSeq,
       reads: { confirmed: [], pending: [] },
-      operations: [operation],
+      // Deliberately malformed: this suite feeds the server operations it
+      // must reject, so the payload is not an `Operation`.
+      operations: [operation as unknown as Operation],
     },
   }));
   return assertResponse<{ seq: number }>(shiftMessage(messages));


### PR DESCRIPTION
Two `Record<string, unknown>` stand-ins in the memory test support — kept for
**opposite** reasons, which is the interesting part.

## `v2-graph.fixture.ts`: a real tightening

`GraphFixture.schema` is declared `Record<string, unknown>` for what is a JSON
Schema, and is handed to a `SchemaPathSelector` whose `schema` is a `JSONSchema`.
It now says `JSONSchema`, with `as const satisfies JSONSchema` on the literal so
its property types don't widen to `string`.

## `v2-server-acl-test.ts`: deliberately loose, left alone

`transactOperation`'s `operation: Record<string, unknown>` is **not** an
oversight — that suite feeds it `invalidOperations`, deliberately malformed
payloads the server must reject:

```ts
const invalidOperations: Record<string, unknown>[] = [
  { op: "set", id: `of:${space}`, value: { value: {} } },
  …
];
```

Typing it `Operation` would defeat the test. So the parameter stays loose, and
the cast moves to the point where the payload enters a wire message, where a
comment can say it's malformed on purpose.

## Why they compile today

Both only type-check because `FabricSpecialObject` is declared with no members,
which makes `FabricValue` structurally satisfied by any object.

No behavior change. Memory suite 438 passed; workspace `deno task check` clean;
full repo suite green (200.1s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened test types: use `JSONSchema` for the graph fixture schema and keep ACL test `operation` intentionally loose, casting only at the wire boundary. No behavior changes; improves type safety and test clarity.

- **Refactors**
  - `v2-graph.fixture.ts`: `schema` is now `JSONSchema`; literal marked `as const satisfies JSONSchema`.
  - `v2-server-acl-test.ts`: keep `operation: Record<string, unknown>` for invalid cases; cast to `Operation` only when building the message, with an inline comment.

<sup>Written for commit e8b3c9ce34187aa1afb2c15c4c1661076df87df9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

