### PR TITLE
fix(runner): keep three values at the types they actually have

### DIFF
--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -1,5 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
-import type { CellScope, JSONSchema } from "../builder/types.ts";
+import type { CellScope, FabricValue, JSONSchema } from "../builder/types.ts";
 import { type NormalizedFullLink, parseLink } from "../link-utils.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { findAndInlineDataUriLinks } from "../data-uri.ts";
@@ -65,8 +65,8 @@ type SerializedTrustedEvent = {
     trusted?: boolean;
     ui?: {
       pattern?: string;
-      eventIntegrity?: unknown;
-      uiContractDataset?: unknown;
+      eventIntegrity?: FabricValue;
+      uiContractDataset?: FabricValue;
     };
   };
 };

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1208,7 +1208,7 @@ export class Runner {
     argument: T,
     resultCell: Cell<R>,
   ): void {
-    const defaults = extractDefaultValues(pattern.argumentSchema) as Partial<T>;
+    const defaults = extractDefaultValues(pattern.argumentSchema);
     let argumentLink = getMetaLink(resultCell, "argument");
     const previousInternal = resultCell.getMetaRaw("internal", {
       meta: ignoreReadForScheduling,
@@ -1263,7 +1263,7 @@ export class Runner {
       }) as T | undefined;
       nextArgument = mergeSchemaDefaults<T>(
         argument === undefined ? previousArgument : argument,
-        defaults,
+        defaults as Partial<T>,
         pattern.argumentSchema,
       );
 

--- a/packages/runner/test/scheduler-observation-capability-skew.test.ts
+++ b/packages/runner/test/scheduler-observation-capability-skew.test.ts
@@ -82,7 +82,11 @@ class FlagOffServerTransport implements MemoryV2Client.Transport {
   }
 
   send(payload: string): Promise<void> {
-    const message = valueFromJson(payload, reconstructionContext) as {
+    // Decoded wire payload, asserted to the shape this fake expects.
+    const message = valueFromJson(
+      payload,
+      reconstructionContext,
+    ) as unknown as {
       type: string;
       requestId?: string;
       session?: { sessionId?: string };


### PR DESCRIPTION
Three unrelated `runner` sites, each holding a value at a looser type than it
has. All three compile today only because `FabricSpecialObject` is declared with
no members, which makes `FabricValue` structurally satisfied by any object.

## `runner.ts` — a cast that threw away the right type

`extractDefaultValues()` returns a `FabricValue`; the local immediately cast it
to `Partial<T>`, and then two of its three uses want a `FabricValue` back. The
local keeps the real type now, and the cast moves to the single
`mergeSchemaDefaults<T>()` call that genuinely wants a `Partial<T>`.

## `cfc/ui-contract.ts` — serialized provenance is fabric data

`SerializedTrustedEvent.provenance.ui.eventIntegrity` and `uiContractDataset`
are declared `unknown`. They are serialized event provenance — fabric data — so
they say `FabricValue`.

## `test/scheduler-observation-capability-skew.test.ts` — a decode boundary

A decoded wire payload was asserted straight to the shape the fake expects.
`valueFromJson()` returns a `FabricValue`, which doesn't sufficiently overlap
that shape, so the assertion goes through `unknown` — the remedy the compiler
itself names.

## Measurement

Against the `FabricSpecialObject` branding experiment: residue **66 → 62**.

No behavior change; no test moved. Workspace `deno task check` clean, lint clean,
full repo suite green (231.1s).

## Deliberately not in here

Three more `runner` sites turned out to be blocked rather than local, and are
better handled with their clusters:

- `storage/differential.ts` (2) — traces into memory's `State`/`Fact` typing,
  where `Unclaimed` and `Assertion` are interfaces and `State["is"]` picks up a
  `{}`.
- `cfc/prepare.ts` (1) — narrowed by `isRecord`, the non-fabric-aware predicate
  whose `unknown -> x` vs `FabricValue -> x` ambiguity is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tighten types in `runner` to keep values as `FabricValue` and move the only needed cast to `mergeSchemaDefaults`. Update serialized UI provenance fields to `FabricValue` and adjust a test to cast via `unknown` at the decode boundary; no behavior change.

<sup>Written for commit 42a9b50138a96e4925984b1d1a7d1f11dd45d8cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

