### PR TITLE
refactor(cfc): the atom matcher speaks `CfcAtom`

### DIFF
--- a/packages/runner/src/cfc/atom-pattern.ts
+++ b/packages/runner/src/cfc/atom-pattern.ts
@@ -1,4 +1,5 @@
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
 import {
@@ -41,10 +42,13 @@ import {
  * structurally equal values — this IS the post-match equality constraint
  * between variables (§4.3.3 `constraints`, plan B1 "constraint correlation").
  */
+// NOT a `CfcAtom`: a pattern is atom-shaped but admits things an atom cannot
+// -- `{ var }` placeholders, and an explicitly-`undefined` field, which is an
+// absence check (`CfcJsonValue` has no `undefined`).
 export type AtomPattern = unknown;
 
 /** A binding environment produced by matching (spec §4.3.3 `Bindings`). */
-export type AtomPatternBindings = Readonly<Record<string, unknown>>;
+export type AtomPatternBindings = Readonly<Record<string, CfcAtom>>;
 
 export const EMPTY_ATOM_PATTERN_BINDINGS: AtomPatternBindings = Object.freeze(
   {},
@@ -97,8 +101,8 @@ const patternIsConcrete = (pattern: unknown): boolean => {
  * structural equality.
  */
 const matchPatternValue = (
-  pattern: unknown,
-  value: unknown,
+  pattern: AtomPattern,
+  value: CfcAtom,
   bindings: AtomPatternBindings,
 ): AtomPatternBindings | null => {
   // Reserved-key discipline applies in EITHER direction (module doc): a
@@ -183,7 +187,7 @@ const matchPatternValue = (
       if (!Object.hasOwn(value, key)) return null;
       current = matchPatternValue(
         fieldPattern,
-        (value as Record<string, unknown>)[key],
+        (value as Record<string, CfcAtom>)[key],
         current,
       );
       if (current === null) return null;
@@ -199,7 +203,7 @@ const matchPatternValue = (
  */
 export const matchAtomPattern = (
   pattern: AtomPattern,
-  atom: unknown,
+  atom: CfcAtom,
   bindings: AtomPatternBindings = EMPTY_ATOM_PATTERN_BINDINGS,
 ): AtomPatternBindings | null => matchPatternValue(pattern, atom, bindings);
 
@@ -241,7 +245,7 @@ const pushUniqueBindings = (
  */
 export const matchAtomPatternAgainstAtoms = (
   pattern: AtomPattern,
-  atoms: readonly unknown[],
+  atoms: readonly CfcAtom[],
   bindings: AtomPatternBindings = EMPTY_ATOM_PATTERN_BINDINGS,
 ): AtomPatternBindings[] => {
   const matched: AtomPatternBindings[] = [];
@@ -265,7 +269,7 @@ export const matchAtomPatternAgainstAtoms = (
  */
 export const matchAtomPatternConjunction = (
   patterns: readonly AtomPattern[],
-  atoms: readonly unknown[],
+  atoms: readonly CfcAtom[],
   bindings: AtomPatternBindings = EMPTY_ATOM_PATTERN_BINDINGS,
 ): AtomPatternBindings[] => {
   let environments: AtomPatternBindings[] = [bindings];

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -1,4 +1,5 @@
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { utf8Compare } from "@commonfabric/utils/utf8";
 import {
   type AtomPatternBindings,
@@ -211,7 +212,12 @@ const extendThroughPattern = (
   const next: AtomPatternBindings[] = [];
   for (const environment of environments) {
     for (
-      const extended of matchAtomPatternAgainstAtoms(pattern, pool, environment)
+      const extended of matchAtomPatternAgainstAtoms(
+        pattern,
+        // TODO(danfuzz): drop once clause alternatives are typed as `CfcAtom`.
+        pool as readonly CfcAtom[],
+        environment,
+      )
     ) {
       if (!next.some((existing) => deepEqual(existing, extended))) {
         next.push(extended);
@@ -589,7 +595,11 @@ const matchRule = (
     if (homeClauses !== undefined && !homeClauses.has(clauseIndex)) continue;
     const alternatives = clauseAlternatives(confidentiality[clauseIndex]);
     for (const alternative of alternatives) {
-      const target = matchAtomPattern(rule.appliesTo, alternative);
+      // TODO(danfuzz): drop the cast once clause alternatives are typed.
+      const target = matchAtomPattern(
+        rule.appliesTo,
+        alternative as CfcAtom,
+      );
       if (target === null) continue;
 
       let environments: AtomPatternBindings[] = [target];

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -210,12 +210,14 @@ const extendThroughPattern = (
   pool: readonly unknown[],
 ): AtomPatternBindings[] => {
   const next: AtomPatternBindings[] = [];
+  // TODO(danfuzz): drop the cast once clause alternatives are typed as
+  // `CfcAtom`.
+  const atoms = pool as readonly CfcAtom[];
   for (const environment of environments) {
     for (
       const extended of matchAtomPatternAgainstAtoms(
         pattern,
-        // TODO(danfuzz): drop once clause alternatives are typed as `CfcAtom`.
-        pool as readonly CfcAtom[],
+        atoms,
         environment,
       )
     ) {
@@ -596,10 +598,7 @@ const matchRule = (
     const alternatives = clauseAlternatives(confidentiality[clauseIndex]);
     for (const alternative of alternatives) {
       // TODO(danfuzz): drop the cast once clause alternatives are typed.
-      const target = matchAtomPattern(
-        rule.appliesTo,
-        alternative as CfcAtom,
-      );
+      const target = matchAtomPattern(rule.appliesTo, alternative as CfcAtom);
       if (target === null) continue;
 
       let environments: AtomPatternBindings[] = [target];

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -1,4 +1,5 @@
 import type { ImmutableJSONValue, JSONSchema } from "@commonfabric/api";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
@@ -228,7 +229,8 @@ const integrityAtomSatisfies = (
         trust.actingPrincipal,
       );
   }
-  return matchAtomPattern(required, actual) !== null ||
+  // TODO(danfuzz): drop the cast once clause alternatives are typed.
+  return matchAtomPattern(required, actual as CfcAtom) !== null ||
     atomEntails(actual, required);
 };
 

--- a/packages/runner/src/cfc/trust.ts
+++ b/packages/runner/src/cfc/trust.ts
@@ -279,9 +279,9 @@ export const createTrustResolver = (
     const reached = new Set<string>();
     for (const statement of admissible) {
       if (reached.has(statement.implements)) continue;
+      // TODO(danfuzz): drop the cast once clause alternatives are typed.
       if (
         integrityAtoms.some((atom) =>
-          // TODO(danfuzz): drop the cast once clause alternatives are typed.
           matchAtomPattern(statement.concrete, atom as CfcAtom) !== null
         )
       ) {

--- a/packages/runner/src/cfc/trust.ts
+++ b/packages/runner/src/cfc/trust.ts
@@ -1,4 +1,5 @@
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isRecord } from "@commonfabric/utils/types";
 import { type AtomPattern, matchAtomPattern } from "./atom-pattern.ts";
@@ -280,7 +281,8 @@ export const createTrustResolver = (
       if (reached.has(statement.implements)) continue;
       if (
         integrityAtoms.some((atom) =>
-          matchAtomPattern(statement.concrete, atom) !== null
+          // TODO(danfuzz): drop the cast once clause alternatives are typed.
+          matchAtomPattern(statement.concrete, atom as CfcAtom) !== null
         )
       ) {
         reached.add(statement.implements);

--- a/packages/runner/test/cfc-commitment-matching.test.ts
+++ b/packages/runner/test/cfc-commitment-matching.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
 import {
   CFC_ATOM_TYPE,
@@ -84,13 +85,15 @@ describe("CFC commitment-form matching (inv-12 Stage 1)", () => {
         reader,
       );
       expect(matchAtomPattern(plain, {
+        // Spreading a discriminated union leaves `?: never` fields behind,
+        // which no `CfcAtom` admits; the runtime value is a policy-ref atom.
         ...plain,
         subject: commitCfcFieldValue(reader),
-      })).not.toBeNull();
+      } as unknown as CfcAtom)).not.toBeNull();
       expect(matchAtomPattern(plain, {
         ...plain,
         subject: commitCfcFieldValue(stranger),
-      })).toBeNull();
+      } as unknown as CfcAtom)).toBeNull();
     });
 
     it("digest-matches a CONCRETE pattern value against a committed field", () => {


### PR DESCRIPTION
First of a planned series typing the CFC label plumbing against the atom
vocabulary that `@commonfabric/api/cfc` has carried all along — `CfcAtom` plus 25
named shapes (`CfcCaveatAtom`, `CfcResourceAtom`, …). The runner's CFC code
currently uses none of it: the only mention of `CfcAtom` under
`packages/runner/src/cfc/` is inside a *comment*.

## This PR

`atom-pattern.ts` typed both sides of a match as `unknown`, though the value side
is an atom. The atom side now says `CfcAtom`:

- `matchAtomPattern`'s atom parameter
- the atom pools taken by `matchAtomPatternAgainstAtoms` / `matchAtomPatternConjunction`
- `AtomPatternBindings` (bindings hold matched atoms)
- the internal record descent

## `AtomPattern` stays `unknown`, on purpose

A pattern is atom-*shaped* but admits what an atom cannot: `{ var }` placeholders,
and an explicitly-`undefined` field, which is an **absence check** —

```ts
const pattern = { type: CFC_ATOM_TYPE.User, extra: undefined };
expect(matchAtomPattern(pattern, userA)).toEqual({});
expect(matchAtomPattern(pattern, { ...userA, extra: 1 })).toBeNull();
```

`CfcJsonValue` has no `undefined`, so **a pattern is not an atom**. The
declaration now says so.

## Four casts, each with a `TODO`

Four call sites still hold atoms as `unknown` because they read them out of
clause alternatives (`readonly unknown[]`). Each carries a cast and a
`TODO(danfuzz)` naming the follow-up that deletes it — typing the clause layer.
One test casts through `unknown`, since spreading a discriminated union leaves
`?: never` fields no `CfcAtom` admits.

## Scoping

Deliberately stops at the module boundary. Typing the clause layer in the same
PR is **50 errors**; this one is **0**.

Planned follow-ups: clause layer → `IFCLabel`/`LabelMapEntry` → remaining src
consumers → tests.

Workspace `deno task check` clean, lint clean; runner suite 1068 passed; full
repo suite green (241.3s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed the CFC atom matcher to use `CfcAtom` for value inputs and bindings, improving type safety with no behavior changes. `AtomPattern` stays `unknown` because patterns allow `{ var }` placeholders and explicit `undefined` for absence checks.

- **Refactors**
  - Switched matcher inputs and outputs to `CfcAtom`: `matchAtomPattern` value, atom pools in `matchAtomPatternAgainstAtoms` and `matchAtomPatternConjunction`, `AtomPatternBindings`, and record descent.
  - Kept four temporary casts at clause-alternative call sites with TODOs; hoisted the TODOs above calls and cast the pool once in `extendThroughPattern` for clarity.
  - Updated one test to cast through `unknown` when spreading a discriminated union that leaves `?: never` fields unsupported by `CfcAtom`.

<sup>Written for commit f653fc588751085b6f18017b89efb0433f00480d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

