### PR TITLE
ci(dashboard): publish the image only from push to main

### DIFF
--- a/.github/workflows/dashboard-image.yml
+++ b/.github/workflows/dashboard-image.yml
@@ -101,10 +101,19 @@ jobs:
           if [[ "$BUILD_RESULT" == "success" ]]; then
             if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" && "$TEST_RESULT" == "success" ]]; then
               allowed=true
-            elif [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$member" == "true" ]]; then
-              if [[ "$TEST_RESULT" == "success" || ("$PUSH_BRANCH" == "true" && "$RUN_ATTEMPT" -gt 1) ]]; then
-                allowed=true
-              fi
+            # PR-actor publishing is disabled (commented out, not removed):
+            # the GCP workload-identity provider's attribute condition
+            # rejects pull_request-context OIDC tokens, so this path could
+            # only ever fail the run at the Google auth step — every PR by
+            # an allow-listed actor went red on "Publish image" once CI
+            # started calling this workflow for all PRs (#4963). Publishing
+            # is main-only until the provider condition deliberately admits
+            # PR tokens; then this block (and the member/env plumbing
+            # above) can be restored as-is.
+            # elif [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$member" == "true" ]]; then
+            #   if [[ "$TEST_RESULT" == "success" || ("$PUSH_BRANCH" == "true" && "$RUN_ATTEMPT" -gt 1) ]]; then
+            #     allowed=true
+            #   fi
             fi
           fi
 


### PR DESCRIPTION
## Problem

Since #4963 made CI invoke the Dashboard workflow on every pull request, any PR whose triggering actor is in `DASHBOARD_PUBLISHER_ACTOR_IDS` runs `Publish image` — and it always fails at the Google Cloud auth step:

> `google-github-actions/auth failed ... "The given credential is rejected by the attribute condition."`

The workload-identity provider (`github-actions-labs-dashboard`) rejects pull_request-context OIDC tokens (a PR run presents `refs/pull/N/merge`, not `refs/heads/main`), so the workflow's PR-actor publish path can only ever fail — it authorizes publishes GCP will never allow. Every PR by an allow-listed actor now goes red on `Dashboard / Publish image`, `Dashboard / Status`, and `Status` (e.g. #5015), while all tests pass.

## Change

Comment out — deliberately not remove, so the intent stays visible to the file owner — the `pull_request` branch of the publish policy in `publish_authorization`. Publishing becomes main-only, matching what the GCP attribute condition actually enforces. The `member` computation and env plumbing are left intact so the path can be restored as-is if the provider condition is ever deliberately widened to admit PR tokens (at which point the `RUN_ATTEMPT > 1` escape hatch — which allows publishing an image whose tests failed — deserves a second look too).

## Behavior verified

Extracted the policy script and ran it under both contexts (`bash -n` clean, YAML parses):

- `push` + `refs/heads/main` + tests green → `allowed=true` (unchanged)
- `pull_request` + allow-listed actor + `PUSH_BRANCH=true` + `RUN_ATTEMPT=2` → `allowed=false`

On PRs the publish job now skips; the aggregate `Status` job already treats a skipped publish as success (it only requires `publish` success when `allowed == 'true'`), so PR checks go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish the dashboard image only on pushes to `main`. This prevents PR runs from failing on Google Cloud auth that rejects pull_request OIDC tokens.

- **Bug Fixes**
  - Commented out the `pull_request` branch of the publish policy in `.github/workflows/dashboard-image.yml`, keeping publish main-only when tests pass.
  - On PRs, the publish job now skips and `Status` stays green since publish is not required when not allowed.

<sup>Written for commit 95def36967fcb418bbcc5a0b0aa2818d6cd60989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

