### PR TITLE
refactor(cfc): type the confidentiality clause layer

### DIFF
--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -16,6 +16,7 @@ import {
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
 import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
+import type { CfcConfClause } from "../../cfc/clause.ts";
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
 import { clauseAlternatives } from "../../cfc/clause.ts";
 
@@ -129,7 +130,7 @@ function readerAdmitsLabel(
   reader: string,
 ): boolean {
   return confidentiality.every((clause) =>
-    clauseAlternatives(clause).some((alt) => alt === reader)
+    clauseAlternatives(clause as CfcConfClause).some((alt) => alt === reader)
   );
 }
 

--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -1,4 +1,5 @@
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import type { CfcConfClause } from "./clause.ts";
 import { encodePointer } from "../../../memory/v2/path.ts";
 import type {
   AttemptedWrite,
@@ -248,7 +249,9 @@ export const canonicalizeCfcLabel = (label: IFCLabel): IFCLabel => {
   }
   return {
     ...label,
-    confidentiality: confidentiality.map(normalizeClause),
+    confidentiality: (confidentiality as readonly CfcConfClause[]).map(
+      normalizeClause,
+    ),
   };
 };
 

--- a/packages/runner/src/cfc/clause.ts
+++ b/packages/runner/src/cfc/clause.ts
@@ -1,4 +1,4 @@
-import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { CFC_ATOM_TYPE, type CfcAtom } from "@commonfabric/api/cfc";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
@@ -22,10 +22,14 @@ import { uniqueCfcAtoms } from "./observation.ts";
  * `anyOf` (with an array value) is recognized as a clause; any other shape
  * stays an opaque atom (unsatisfiable against ceilings — restrictive).
  */
-export type CfcOrClause = { readonly anyOf: readonly unknown[] };
+export type CfcOrClause = { readonly anyOf: readonly CfcAtom[] };
 
 /** A confidentiality clause: a bare atom, or an OR of atoms. */
-export type CfcConfClause = unknown;
+export type CfcConfClause = CfcAtom | CfcOrClause;
+
+// TODO(danfuzz): The label and ceiling types that carry clause lists still
+// declare them as `unknown[]`, so callers cast on the way in. Drop those casts
+// once those types name clauses.
 
 export const isOrClause = (value: unknown): value is CfcOrClause =>
   isRecord(value) &&
@@ -35,9 +39,9 @@ export const isOrClause = (value: unknown): value is CfcOrClause =>
 /** The alternatives of a clause; a bare atom is its own single alternative. */
 export const clauseAlternatives = (
   clause: CfcConfClause,
-): readonly unknown[] => isOrClause(clause) ? clause.anyOf : [clause];
+): readonly CfcAtom[] => isOrClause(clause) ? clause.anyOf : [clause];
 
-const compareByCanonicalHash = (left: unknown, right: unknown): number => {
+const compareByCanonicalHash = (left: CfcAtom, right: CfcAtom): number => {
   const leftHash = hashStringOf(left);
   const rightHash = hashStringOf(right);
   return leftHash < rightHash ? -1 : leftHash > rightHash ? 1 : 0;

--- a/packages/runner/src/cfc/declared-monotonicity.ts
+++ b/packages/runner/src/cfc/declared-monotonicity.ts
@@ -142,12 +142,17 @@ export const collectDeclaredMonotonicityViolations = (input: {
     for (const stored of storedAt) {
       for (const storedClause of stored.label.confidentiality ?? []) {
         const witnessed = proposedClauses.some((proposedClause) =>
-          clauseSubsumes(proposedClause, storedClause)
+          clauseSubsumes(
+            proposedClause as CfcConfClause,
+            storedClause as CfcConfClause,
+          )
         );
         if (witnessed) {
           continue;
         }
-        const storedDigest = cfcCanonicalClauseDigest(storedClause);
+        const storedDigest = cfcCanonicalClauseDigest(
+          storedClause as CfcConfClause,
+        );
         if (
           exemption !== undefined &&
           samePath(exemption.path, storedPath) &&
@@ -165,7 +170,9 @@ export const collectDeclaredMonotonicityViolations = (input: {
         violations.push(
           `declared-monotonicity confidentiality violation ${at} ` +
             `(canUpdateStoreLabel, §8.12.1): stored clause ` +
-            `${JSON.stringify(normalizeClause(storedClause))} dropped or ` +
+            `${
+              JSON.stringify(normalizeClause(storedClause as CfcConfClause))
+            } dropped or ` +
             `weakened ` +
             `(clauses may be added and alternatives removed, never the reverse)`,
         );

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -16,6 +16,7 @@ import {
 } from "@commonfabric/api/cfc";
 import {
   type CfcConfClause,
+  type CfcOrClause,
   clauseAlternatives,
   isOrClause,
   normalizeClause,
@@ -210,7 +211,7 @@ const extendThroughPattern = (
   pool: readonly unknown[],
 ): AtomPatternBindings[] => {
   const next: AtomPatternBindings[] = [];
-  // TODO(danfuzz): drop the cast once clause alternatives are typed as
+  // TODO(danfuzz): drop the cast once the integrity guard pool is typed as
   // `CfcAtom`.
   const atoms = pool as readonly CfcAtom[];
   for (const environment of environments) {
@@ -597,8 +598,7 @@ const matchRule = (
     if (homeClauses !== undefined && !homeClauses.has(clauseIndex)) continue;
     const alternatives = clauseAlternatives(confidentiality[clauseIndex]);
     for (const alternative of alternatives) {
-      // TODO(danfuzz): drop the cast once clause alternatives are typed.
-      const target = matchAtomPattern(rule.appliesTo, alternative as CfcAtom);
+      const target = matchAtomPattern(rule.appliesTo, alternative);
       if (target === null) continue;
 
       let environments: AtomPatternBindings[] = [target];
@@ -751,9 +751,9 @@ const applyRuleMatch = (
   if (added.length === 0) return { confidentiality };
 
   const next = [...confidentiality];
-  next[match.clauseIndex] = normalizeClause({
-    anyOf: [...alternatives, ...added],
-  });
+  next[match.clauseIndex] = normalizeClause(
+    { anyOf: [...alternatives, ...added] } as CfcOrClause,
+  );
   return {
     confidentiality: next,
     firing: { clauseIndex: match.clauseIndex, kind: "add", added },
@@ -778,7 +778,9 @@ export const evaluateExchangeRules = (
   fuel: number = DEFAULT_EXCHANGE_FUEL,
 ): ExchangeEvalResult => {
   const confidentialityInput = label.confidentiality ?? [];
-  const selected = collectSelectedModulePolicyRefs(confidentialityInput);
+  const selected = collectSelectedModulePolicyRefs(
+    confidentialityInput as readonly CfcConfClause[],
+  );
   if (selected.failures.length > 0) {
     return {
       label,
@@ -864,9 +866,10 @@ export const evaluateExchangeRules = (
     ...(ctx.integrity ?? []),
   ];
 
-  let confidentiality: readonly CfcConfClause[] = label.confidentiality.map(
-    normalizeClause,
-  );
+  let confidentiality: readonly CfcConfClause[] =
+    (label.confidentiality as readonly CfcConfClause[]).map(
+      normalizeClause,
+    );
   const firings: RuleFiring[] = [];
   let remainingFuel = fuel;
   let changed = true;

--- a/packages/runner/src/cfc/label-introspection.ts
+++ b/packages/runner/src/cfc/label-introspection.ts
@@ -1,4 +1,5 @@
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import type { CfcConfClause } from "./clause.ts";
 import { isRecord } from "@commonfabric/utils/types";
 import { encodePointer, parsePointer } from "../../../memory/v2/path.ts";
 import type { NormalizedFullLink } from "../link-utils.ts";
@@ -469,7 +470,7 @@ export const evaluateConfLabelQuery = (
       continue;
     }
     for (const clause of entry.label.confidentiality ?? []) {
-      const alternatives = clauseAlternatives(clause);
+      const alternatives = clauseAlternatives(clause as CfcConfClause);
       for (
         let alternativeIndex = 0;
         alternativeIndex < alternatives.length;

--- a/packages/runner/src/cfc/label-metadata-population.ts
+++ b/packages/runner/src/cfc/label-metadata-population.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
+import type { CfcConfClause } from "./clause.ts";
 import { canonicalizeLogicalPath } from "./canonical.ts";
 import { clauseAlternatives } from "./clause.ts";
 import { classifyAtomField } from "./label-field-classification.ts";
@@ -226,7 +227,7 @@ export const deriveLabelMetadataTemplateEntries = (
     const fields = new Set<string>();
     let anyProtected = false;
     for (const clause of confidentiality) {
-      for (const alternative of clauseAlternatives(clause)) {
+      for (const alternative of clauseAlternatives(clause as CfcConfClause)) {
         if (scanAlternative(alternative, fields)) {
           anyProtected = true;
         }

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -1,4 +1,5 @@
 import { encodePointer } from "../../../memory/v2/path.ts";
+import type { CfcConfClause } from "./clause.ts";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { uniqueCfcAtoms } from "./observation.ts";
 import { normalizeClause } from "./clause.ts";
@@ -190,7 +191,7 @@ export const mergeLabel = (
     // and `normalizeClause` is identity on non-clause atoms, so it is applied
     // only to confidentiality to keep intent explicit.
     const normalized = key === "confidentiality"
-      ? values.map(normalizeClause)
+      ? (values as readonly CfcConfClause[]).map(normalizeClause)
       : values;
     // Dedup structurally via `uniqueCfcAtoms()` rather than by reference
     // (`new Set()`). Atoms can be fabric-converted clones (each call to

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -15,6 +15,7 @@ import {
 import { atomEntails, conceptGuard, matchAtomPattern } from "./atom-pattern.ts";
 import type { TrustResolver } from "./trust.ts";
 import {
+  type CfcConfClause,
   clauseAlternatives,
   clausesEqual,
   clauseSubsumes,
@@ -47,7 +48,7 @@ export const CFC_LABEL_READ_FAILED_ATOM = "cfc:label-read-failed";
 // equality now commitment-aware, a marker-naming ceiling would otherwise
 // subsume that spelling. Recognize it here so BOTH forms stay ungrantable.
 const clauseBearsReadFailedMarker = (clause: unknown): boolean =>
-  clauseAlternatives(clause).some((alternative) =>
+  clauseAlternatives(clause as CfcConfClause).some((alternative) =>
     deepEqual(alternative, CFC_LABEL_READ_FAILED_ATOM) ||
     commitmentAwareEquals(alternative, CFC_LABEL_READ_FAILED_ATOM)
   );
@@ -229,7 +230,8 @@ const integrityAtomSatisfies = (
         trust.actingPrincipal,
       );
   }
-  // TODO(danfuzz): drop the cast once clause alternatives are typed.
+  // TODO(danfuzz): drop the cast once integrity atom lists are typed as
+  // `CfcAtom`.
   return matchAtomPattern(required, actual as CfcAtom) !== null ||
     atomEntails(actual, required);
 };
@@ -362,7 +364,9 @@ export const atomsOutsideCeiling = (
   }
   return confidentiality.filter((clause) =>
     clauseBearsReadFailedMarker(clause) ||
-    !ceiling.some((allowed) => clauseSubsumes(allowed, clause))
+    !ceiling.some((allowed) =>
+      clauseSubsumes(allowed as CfcConfClause, clause as CfcConfClause)
+    )
   ) as ImmutableJSONValue[];
 };
 
@@ -426,15 +430,17 @@ export const meetCfcObservationCeilings = (
   if (b === undefined) return a;
   const met: unknown[] = [];
   for (const clauseA of a) {
-    const alternativesA = clauseAlternatives(clauseA);
+    const alternativesA = clauseAlternatives(clauseA as CfcConfClause);
     if (alternativesA.length === 0) continue;
     for (const clauseB of b) {
-      const alternativesB = clauseAlternatives(clauseB);
+      const alternativesB = clauseAlternatives(clauseB as CfcConfClause);
       if (alternativesB.length === 0) continue;
       const union = normalizeClause({
         anyOf: [...alternativesA, ...alternativesB],
       });
-      if (!met.some((existing) => clausesEqual(existing, union))) {
+      if (
+        !met.some((existing) => clausesEqual(existing as CfcConfClause, union))
+      ) {
         met.push(union);
       }
     }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -50,6 +50,7 @@ import {
   canonicalizeLogicalPath,
 } from "./canonical.ts";
 import {
+  type CfcConfClause,
   clauseAlternatives,
   FORBIDDEN_OR_CLAUSE_ALTERNATIVE_TYPES,
   isOrClause,
@@ -3961,13 +3962,18 @@ const derivePersistedLabel = (
     // clauses coalesce. `normalizeClause` is identity on flat atoms, so flat
     // labels are unchanged. Integrity carries no OR-clauses.
     confidentiality: mergeLabelValues(
-      resolvePolicyOfConfidentiality(
+      (resolvePolicyOfConfidentiality(
         tx,
         schemaLabel.confidentiality,
         owningSpace,
-      )?.map(normalizeClause),
-      copiedInputLabel?.confidentiality?.map(normalizeClause),
-      projectedInputLabel?.confidentiality?.map(normalizeClause),
+      ) as readonly CfcConfClause[] | undefined)?.map(normalizeClause),
+      (copiedInputLabel?.confidentiality as
+        | readonly CfcConfClause[]
+        | undefined)
+        ?.map(normalizeClause),
+      (projectedInputLabel?.confidentiality as
+        | readonly CfcConfClause[]
+        | undefined)?.map(normalizeClause),
     ),
     integrity: mergeLabelValues(
       resolveCurrentPrincipalLabelValues(
@@ -6085,7 +6091,9 @@ export const prepareBoundaryCommit = (
       // list and one spurious envelope rewrite (the SC-11 churn class).
       // normalizeClause each clause first; non-clause atoms pass through.
       const foldedUnique = (atoms: readonly unknown[]): unknown[] =>
-        uniqueCfcAtoms(atoms.map((atom) => normalizeClause(atom)));
+        uniqueCfcAtoms(
+          atoms.map((atom) => normalizeClause(atom as CfcConfClause)),
+        );
       const frozenConfidentialityFor = (
         path: readonly string[],
       ): unknown[] => {

--- a/packages/runner/src/cfc/render-ceiling.ts
+++ b/packages/runner/src/cfc/render-ceiling.ts
@@ -1,4 +1,5 @@
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
+import type { CfcConfClause } from "./clause.ts";
 import { isRecord } from "@commonfabric/utils/types";
 import {
   buildCfcPolicySnapshot,
@@ -148,7 +149,7 @@ export const spaceAtomIdsInConfidentiality = (
 ): readonly string[] => {
   const ids: string[] = [];
   for (const clause of confidentiality) {
-    for (const alternative of clauseAlternatives(clause)) {
+    for (const alternative of clauseAlternatives(clause as CfcConfClause)) {
       if (
         isRecord(alternative) &&
         (alternative as { type?: unknown }).type === CFC_ATOM_TYPE.Space &&

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -1,4 +1,5 @@
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import type { CfcConfClause } from "./clause.ts";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
 import type { JSONSchema, JSONSchemaObj } from "../builder/types.ts";
@@ -201,10 +202,10 @@ const mergeSetLikeIfcArray = (
       // identity on flat atoms and integrity carries no OR-clauses, so the
       // other keys are untouched.
       const existingArray = key === "confidentiality"
-        ? (existing as readonly unknown[]).map(normalizeClause)
+        ? (existing as readonly CfcConfClause[]).map(normalizeClause)
         : existing as readonly unknown[];
       const candidateArray = key === "confidentiality"
-        ? (candidate as readonly unknown[]).map(normalizeClause)
+        ? (candidate as readonly CfcConfClause[]).map(normalizeClause)
         : candidate as readonly unknown[];
       if (!arraySubsetOf(existingArray, candidateArray)) {
         throw new Error(`${key} cannot be weakened at ${path || "/"}`);

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -1,4 +1,5 @@
 import type { ImmutableJSONValue, JSONSchema } from "@commonfabric/api";
+import type { CfcConfClause } from "./clause.ts";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import {
   cloneIfNecessary,
@@ -150,7 +151,8 @@ export const dischargeMaterialRiskAtoms = (
   // which this set cannot have.
   const normalized = atoms.map(normalizeMaterialRiskStringForms);
   const alternativeCount = normalized.reduce(
-    (total: number, clause) => total + clauseAlternatives(clause).length,
+    (total: number, clause) =>
+      total + clauseAlternatives(clause as CfcConfClause).length,
     0,
   );
   const result = evaluateExchangeRules(

--- a/packages/runner/src/cfc/trust.ts
+++ b/packages/runner/src/cfc/trust.ts
@@ -279,7 +279,8 @@ export const createTrustResolver = (
     const reached = new Set<string>();
     for (const statement of admissible) {
       if (reached.has(statement.implements)) continue;
-      // TODO(danfuzz): drop the cast once clause alternatives are typed.
+      // TODO(danfuzz): drop the cast once integrity atom lists are typed as
+      // `CfcAtom`.
       if (
         integrityAtoms.some((atom) =>
           matchAtomPattern(statement.concrete, atom as CfcAtom) !== null

--- a/packages/runner/test/cfc-clause-join.test.ts
+++ b/packages/runner/test/cfc-clause-join.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import { type CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import { mergeCfcLabelViews, mergeLabel } from "../src/cfc/label-view-core.ts";
 import { clauseAlternatives, isOrClause } from "../src/cfc/clause.ts";
@@ -34,7 +35,8 @@ describe("CFC clause join (mergeLabel)", () => {
     // merged/unioned clause.
     expect(merged.confidentiality).toHaveLength(1);
     expect(isOrClause(merged.confidentiality![0])).toBe(true);
-    expect(clauseAlternatives(merged.confidentiality![0])).toHaveLength(2);
+    expect(clauseAlternatives(merged.confidentiality![0] as CfcConfClause))
+      .toHaveLength(2);
   });
 
   it("never merges distinct clauses or unions their alternative sets", () => {
@@ -45,7 +47,7 @@ describe("CFC clause join (mergeLabel)", () => {
     // {A∨B} and {B∨C} are DIFFERENT constraints — both survive, no {A∨B∨C}.
     expect(merged.confidentiality).toHaveLength(2);
     for (const clause of merged.confidentiality!) {
-      expect(clauseAlternatives(clause)).toHaveLength(2);
+      expect(clauseAlternatives(clause as CfcConfClause)).toHaveLength(2);
     }
   });
 

--- a/packages/runner/test/cfc-clause-meet.test.ts
+++ b/packages/runner/test/cfc-clause-meet.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import { type CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import {
   CFC_LABEL_READ_FAILED_ATOM,
@@ -24,7 +25,11 @@ const clauseSetsEqual = (
   right: readonly unknown[],
 ): boolean =>
   left.length === right.length &&
-  left.every((clause) => right.some((other) => clausesEqual(clause, other)));
+  left.every((clause) =>
+    right.some((other) =>
+      clausesEqual(clause as CfcConfClause, other as CfcConfClause)
+    )
+  );
 
 describe("CFC ceiling meet (pairwise alternative-set union)", () => {
   describe("edge cases", () => {

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import { type CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
@@ -735,8 +736,16 @@ const clauseSetsEqual = (
   b: readonly unknown[],
 ): boolean =>
   a.length === b.length &&
-  a.every((clause) => b.some((other) => clausesEqual(clause, other))) &&
-  b.every((clause) => a.some((other) => clausesEqual(clause, other)));
+  a.every((clause) =>
+    b.some((other) =>
+      clausesEqual(clause as CfcConfClause, other as CfcConfClause)
+    )
+  ) &&
+  b.every((clause) =>
+    a.some((other) =>
+      clausesEqual(clause as CfcConfClause, other as CfcConfClause)
+    )
+  );
 
 // A value confined to space A may be released to a reader of space A: the rule
 // adds User($p) as an alternative to the Space($s) clause when the label proves

--- a/packages/runner/test/cfc-exchange-eval.test.ts
+++ b/packages/runner/test/cfc-exchange-eval.test.ts
@@ -11,6 +11,8 @@ import {
 } from "../src/cfc/policy.ts";
 import { buildCfcTrustConfig, createTrustResolver } from "../src/cfc/trust.ts";
 import {
+  type CfcConfClause,
+  type CfcOrClause,
   clauseAlternatives,
   clausesEqual,
   normalizeClause,
@@ -68,8 +70,16 @@ const clauseSetsEqual = (
   b: readonly unknown[],
 ): boolean =>
   a.length === b.length &&
-  a.every((clause) => b.some((other) => clausesEqual(clause, other))) &&
-  b.every((clause) => a.some((other) => clausesEqual(clause, other)));
+  a.every((clause) =>
+    b.some((other) =>
+      clausesEqual(clause as CfcConfClause, other as CfcConfClause)
+    )
+  ) &&
+  b.every((clause) =>
+    a.some((other) =>
+      clausesEqual(clause as CfcConfClause, other as CfcConfClause)
+    )
+  );
 
 describe("CFC exchange-rule evaluation (B4)", () => {
   describe("guarded rewrite", () => {
@@ -554,8 +564,10 @@ describe("CFC exchange-rule evaluation (B4)", () => {
       // (ii) no clause creation or merging: counts match, index-aligned.
       expect(output.length).toBe(input.length);
       for (let i = 0; i < input.length; i++) {
-        const inputAlternatives = clauseAlternatives(input[i]);
-        const outputAlternatives = clauseAlternatives(output[i]);
+        const inputAlternatives = clauseAlternatives(input[i] as CfcConfClause);
+        const outputAlternatives = clauseAlternatives(
+          output[i] as CfcConfClause,
+        );
         for (const alternative of inputAlternatives) {
           expect(
             outputAlternatives.some((other) => deepEqual(other, alternative)),
@@ -577,10 +589,13 @@ describe("CFC exchange-rule evaluation (B4)", () => {
       const output = result.label.confidentiality!;
       // Only the Space(X) clause fired; Space(Y) (no matching role) and the
       // owner clause are exactly their input selves.
-      expect(clausesEqual(output[0], { anyOf: [spaceX, userAlice] }))
+      expect(clausesEqual(
+        output[0] as CfcConfClause,
+        { anyOf: [spaceX, userAlice] } as CfcOrClause,
+      ))
         .toBe(true);
-      expect(clausesEqual(output[1], spaceY)).toBe(true);
-      expect(clausesEqual(output[2], userOwner)).toBe(true);
+      expect(clausesEqual(output[1] as CfcConfClause, spaceY)).toBe(true);
+      expect(clausesEqual(output[2] as CfcConfClause, userOwner)).toBe(true);
     });
 
     it("(iii) is deterministic across record/rule/clause/alternative orderings", () => {
@@ -771,9 +786,11 @@ describe("CFC exchange-rule evaluation (B4)", () => {
         // evaluator dedups duplicate authored alternatives on ingest, A3).
         for (let i = 0; i < clauses.length; i++) {
           const inputAlternatives = clauseAlternatives(
-            normalizeClause(clauses[i]),
+            normalizeClause(clauses[i] as CfcConfClause),
           );
-          const outputAlternatives = clauseAlternatives(output[i]);
+          const outputAlternatives = clauseAlternatives(
+            output[i] as CfcConfClause,
+          );
           expect(outputAlternatives.length)
             .toBeGreaterThanOrEqual(inputAlternatives.length);
           for (const alternative of inputAlternatives) {

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import { type CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
@@ -85,8 +86,16 @@ const clauseSetsEqual = (
   b: readonly unknown[],
 ): boolean =>
   a.length === b.length &&
-  a.every((clause) => b.some((other) => clausesEqual(clause, other))) &&
-  b.every((clause) => a.some((other) => clausesEqual(clause, other)));
+  a.every((clause) =>
+    b.some((other) =>
+      clausesEqual(clause as CfcConfClause, other as CfcConfClause)
+    )
+  ) &&
+  b.every((clause) =>
+    a.some((other) =>
+      clausesEqual(clause as CfcConfClause, other as CfcConfClause)
+    )
+  );
 
 // A verified, live grant FACT pool entry as the runner-side resolver expands
 // it: the grant's scalar fields plus ONE audience entry per fact (§4.3.4

--- a/packages/runner/test/cfc-standard-profile.test.ts
+++ b/packages/runner/test/cfc-standard-profile.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import { type CfcConfClause, type CfcOrClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import {
   CFC_ATOM_TYPE,
@@ -62,7 +63,9 @@ const legacyStrip = (atoms: readonly unknown[]): unknown[] =>
         const kept = (clause as { anyOf: unknown[] }).anyOf.filter(
           (alternative) => !isMaterialRisk(alternative),
         );
-        return kept.length === 0 ? undefined : normalizeClause({ anyOf: kept });
+        return kept.length === 0
+          ? undefined
+          : normalizeClause({ anyOf: kept } as CfcOrClause);
       })
       .filter((clause) => clause !== undefined),
   );
@@ -76,8 +79,16 @@ const dischargeViaProfile = (atoms: readonly unknown[]): unknown[] =>
 
 const clauseSetsEqual = (a: readonly unknown[], b: readonly unknown[]) =>
   a.length === b.length &&
-  a.every((clause) => b.some((other) => clausesEqual(clause, other))) &&
-  b.every((clause) => a.some((other) => clausesEqual(clause, other)));
+  a.every((clause) =>
+    b.some((other) =>
+      clausesEqual(clause as CfcConfClause, other as CfcConfClause)
+    )
+  ) &&
+  b.every((clause) =>
+    a.some((other) =>
+      clausesEqual(clause as CfcConfClause, other as CfcConfClause)
+    )
+  );
 
 describe("CFC standard prompt-caveat profile (B6)", () => {
   describe("material-risk discharge reproduces the retired strip (goldens)", () => {
@@ -205,7 +216,7 @@ describe("CFC standard prompt-caveat profile (B6)", () => {
         },
       );
       const clause = result.label.confidentiality![0];
-      const alternatives = clauseAlternatives(clause);
+      const alternatives = clauseAlternatives(clause as CfcConfClause);
       // Lower tier remains; higher tier added as an alternative.
       expect(alternatives).toContainEqual(
         caveat(CFC_CONCEPT_KIND.PromptInjectionRiskUnscreened, source),


### PR DESCRIPTION
Types the CFC **clause layer** against the atom vocabulary. `CfcConfClause` was
declared as `unknown`, so the name existed but carried no constraint:

```ts
export type CfcOrClause = { readonly anyOf: readonly unknown[] };
export type CfcConfClause = unknown;
```

Now:

```ts
export type CfcOrClause = { readonly anyOf: readonly CfcAtom[] };
export type CfcConfClause = CfcAtom | CfcOrClause;
```

`clauseAlternatives()` returns `readonly CfcAtom[]` instead of `readonly
unknown[]`, and `compareByCanonicalHash()` takes `CfcAtom`s.

Since `CfcAtom` is `CfcJsonValue`, the constraint this adds is "validated JSON,
not `unknown`" — call sites now have to have established JSON-ness rather than
passing anything at all. It already pays off inside the layer: the
`normalizeClause({ anyOf: [...alternativesA, ...alternativesB] })` construction
in `meetCfcObservationCeilings()` type-checks with no cast, because the
alternatives it splices are now known to be atoms.

## Why the casts

The label and ceiling types that *carry* clause lists (`IFCLabel`,
`CfcObservedConfidentiality`, the per-row/ceiling records, the exchange and
introspection inputs) still declare them as `unknown[]`. So this change adds 37
`as CfcConfClause` / `as CfcOrClause` casts where such a list enters the clause
layer, and a `TODO(danfuzz)` on `CfcConfClause` recording that they come out
when those types name clauses.

That seam is deliberate. Typing the carrier types in the same change was
measured at 122 type errors reaching `api/index.ts`, `cell.ts`,
`html/src/worker`, and `runtime-client` — and typing each successive wave of
declarations moved the error count 115 → 118 rather than down, because every CFC
atom list in the repo is one type-connected component. TypeScript will not
compile a subset of it, so a reviewable change has to buy its boundary with
casts.

Three casts left by #5031 keep their `as CfcAtom` but get corrected TODO text:
they are blocked by the *integrity* atom lists, not by clause alternatives,
which this change does type. One (`matchAtomPattern(rule.appliesTo,
alternative)` in `exchange-eval.ts`) is now unnecessary and is deleted.

## Notes

- No runtime change: annotations, casts, and comments only.
- `clauseSetsEqual` is copy-pasted in five CFC test files; each needed the same
  two casts. Worth hoisting into test-support at some point — not done here.

## Test plan

- `deno task check` clean.
- `deno fmt` / `deno lint` clean.
- `packages/runner`: 1068 passed, 0 failed.
- Full repo suite green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed the CFC confidentiality clause layer against `CfcAtom` to replace `unknown` with validated JSON types. This tightens type safety and improves tooling with no runtime changes.

- **Refactors**
  - `CfcOrClause` is `{ anyOf: readonly CfcAtom[] }`; `CfcConfClause = CfcAtom | CfcOrClause`.
  - `clauseAlternatives()` returns `readonly CfcAtom[]`; `compareByCanonicalHash()` uses `CfcAtom`.
  - Added narrow casts at boundaries where carrier types still use `unknown[]`; added TODO to remove when carriers are typed.
  - Removed one obsolete cast; clarified remaining casts are blocked by integrity atom lists.
  - Tests and type checks pass; no behavior changes.

<sup>Written for commit 46624fecc5e0d7d0a9ec3905a631fc5b2ff61330. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

