### PR TITLE
feat(shell): device-link login — pair an identity onto a phone via #k= fragment

### DIFF
--- a/packages/identity/src/ed25519/index.ts
+++ b/packages/identity/src/ed25519/index.ts
@@ -73,6 +73,23 @@ export class Ed25519Signer<ID extends DIDKey> implements Signer<ID> {
     );
   }
 
+  // The raw 32-byte ed25519 seed. Like toPkcs8, only "noble" implementations
+  // expose the private material; WebCrypto (native) hides it, so this throws.
+  // Returns a COPY — serialize() hands back the live internal buffer, and a
+  // caller mutating it would corrupt this signer.
+  toRaw(): Uint8Array {
+    const serialized = this.serialize();
+    if (
+      "privateKey" in serialized &&
+      serialized.privateKey instanceof Uint8Array
+    ) {
+      return new Uint8Array(serialized.privateKey);
+    }
+    throw new Error(
+      'Cannot export raw key material: requires "noble" implementation.',
+    );
+  }
+
   static async fromRaw<ID extends DIDKey>(
     rawPrivateKey: Uint8Array,
     config: Ed25519CreateConfig = {},

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -6,7 +6,6 @@ import {
   Ed25519Verifier,
 } from "./ed25519/index.ts";
 import { AsBytes, DIDKey, KeyPairRaw, Signer, Verifier } from "./interface.ts";
-import { fromPEM, pkcs8ToEd25519Raw } from "./ed25519/utils.ts";
 import { hash } from "./utils.ts";
 
 const textEncoder = new TextEncoder();
@@ -119,20 +118,21 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
     return new Identity(signer);
   }
 
-  // Recover the raw seed for this identity — the same 32 bytes that
-  // `fromMnemonic` derives from a BIP39 phrase.
+  // Recover the raw 32-byte ed25519 seed for this identity — the exact inverse
+  // of `fromRaw`, mirroring the `fromPkcs8`/`toPkcs8` pair.
   //
-  // The inverse of `fromRaw`, and the reason it is useful: `fromMnemonic` maps
-  // the phrase to BIP39 entropy and uses those bytes DIRECTLY as the ed25519
-  // seed, with no KDF in between. So the seed of an EXISTING key is valid BIP39
-  // entropy, and a key that was never generated from a phrase can still be
-  // re-encoded as one (`entropyToMnemonic(identity.toEntropy())`) without
-  // anyone having to re-key.
+  // Named `toRaw`, NOT `toEntropy`, on purpose: it returns a SEED. Those bytes
+  // are *also* valid BIP39 entropy only because `fromMnemonic` uses the
+  // entropy directly as the seed with no KDF between — so a caller can do
+  // `entropyToMnemonic(identity.toRaw())` to re-encode an existing key as a
+  // phrase without re-keying. But the BIP39 vocabulary belongs at that call
+  // site: if a KDF is ever introduced, `toRaw` stays true (it still returns the
+  // seed) while a hypothetical `toEntropy` would silently start lying.
   //
   // Like `toPkcs8`, only "noble" implementations can do this — WebCrypto hides
   // the private key material — and it throws otherwise.
-  toEntropy(): Uint8Array {
-    return pkcs8ToEd25519Raw(fromPEM(this.toPkcs8()));
+  toRaw(): Uint8Array {
+    return this.#keypair.toRaw();
   }
 
   static async fromPassphrase<ID extends DIDKey>(

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -118,6 +118,27 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
     return new Identity(signer);
   }
 
+  // Derive an identity from BIP39 *entropy* — the 32 bytes a 24-word mnemonic
+  // encodes — rather than from the words themselves.
+  //
+  // This names a contract that is currently implicit: `fromMnemonic` maps the
+  // phrase to entropy and uses those bytes DIRECTLY as the ed25519 seed, with
+  // no KDF in between. Callers that carry the entropy instead of the words
+  // (a QR code, for instance, where 24 words do not fit but 32 bytes do) can
+  // therefore reach the same identity without depending on bip39 themselves.
+  //
+  // Deliberately a named alias for `fromRaw` rather than new capability: the
+  // point is that the equivalence is a promise this package makes, so that if
+  // a KDF is ever introduced into `fromMnemonic`, this stays correct (and
+  // `identity.test.ts` fails loudly rather than callers silently deriving a
+  // different DID).
+  static fromEntropy<ID extends DIDKey>(
+    entropy: Uint8Array,
+    config: IdentityCreateConfig = {},
+  ): Promise<Identity<ID>> {
+    return Identity.fromRaw<ID>(entropy, config);
+  }
+
   static async fromPassphrase<ID extends DIDKey>(
     passphrase: string,
     config: IdentityCreateConfig = {},

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -6,6 +6,7 @@ import {
   Ed25519Verifier,
 } from "./ed25519/index.ts";
 import { AsBytes, DIDKey, KeyPairRaw, Signer, Verifier } from "./interface.ts";
+import { fromPEM, pkcs8ToEd25519Raw } from "./ed25519/utils.ts";
 import { hash } from "./utils.ts";
 
 const textEncoder = new TextEncoder();
@@ -118,25 +119,20 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
     return new Identity(signer);
   }
 
-  // Derive an identity from BIP39 *entropy* — the 32 bytes a 24-word mnemonic
-  // encodes — rather than from the words themselves.
+  // Recover the raw seed for this identity — the same 32 bytes that
+  // `fromMnemonic` derives from a BIP39 phrase.
   //
-  // This names a contract that is currently implicit: `fromMnemonic` maps the
-  // phrase to entropy and uses those bytes DIRECTLY as the ed25519 seed, with
-  // no KDF in between. Callers that carry the entropy instead of the words
-  // (a QR code, for instance, where 24 words do not fit but 32 bytes do) can
-  // therefore reach the same identity without depending on bip39 themselves.
+  // The inverse of `fromRaw`, and the reason it is useful: `fromMnemonic` maps
+  // the phrase to BIP39 entropy and uses those bytes DIRECTLY as the ed25519
+  // seed, with no KDF in between. So the seed of an EXISTING key is valid BIP39
+  // entropy, and a key that was never generated from a phrase can still be
+  // re-encoded as one (`entropyToMnemonic(identity.toEntropy())`) without
+  // anyone having to re-key.
   //
-  // Deliberately a named alias for `fromRaw` rather than new capability: the
-  // point is that the equivalence is a promise this package makes, so that if
-  // a KDF is ever introduced into `fromMnemonic`, this stays correct (and
-  // `identity.test.ts` fails loudly rather than callers silently deriving a
-  // different DID).
-  static fromEntropy<ID extends DIDKey>(
-    entropy: Uint8Array,
-    config: IdentityCreateConfig = {},
-  ): Promise<Identity<ID>> {
-    return Identity.fromRaw<ID>(entropy, config);
+  // Like `toPkcs8`, only "noble" implementations can do this — WebCrypto hides
+  // the private key material — and it throws otherwise.
+  toEntropy(): Uint8Array {
+    return pkcs8ToEd25519Raw(fromPEM(this.toPkcs8()));
   }
 
   static async fromPassphrase<ID extends DIDKey>(

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -5,5 +5,10 @@ export {
   VerifierIdentity,
 } from "./identity.ts";
 export { KeyStore } from "./key-store.ts";
+// PKCS8/PEM <-> raw-seed helpers. Exported from the root because downstream
+// consumers otherwise deep-import `./ed25519/utils.ts` by file path, which is
+// brittle across version bumps (Loom's pairing-phrase CLI does exactly that
+// today and can drop it once this ships).
+export { fromPEM, pkcs8ToEd25519Raw, toPEM } from "./ed25519/utils.ts";
 export * from "./interface.ts";
 export { createSession, type Session } from "./session.ts";

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -5,10 +5,5 @@ export {
   VerifierIdentity,
 } from "./identity.ts";
 export { KeyStore } from "./key-store.ts";
-// PKCS8/PEM <-> raw-seed helpers. Exported from the root because downstream
-// consumers otherwise deep-import `./ed25519/utils.ts` by file path, which is
-// brittle across version bumps (Loom's pairing-phrase CLI does exactly that
-// today and can drop it once this ships).
-export { fromPEM, pkcs8ToEd25519Raw, toPEM } from "./ed25519/utils.ts";
 export * from "./interface.ts";
 export { createSession, type Session } from "./session.ts";

--- a/packages/identity/test/identity.test.ts
+++ b/packages/identity/test/identity.test.ts
@@ -1,6 +1,9 @@
-import { assert } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Identity } from "../src/identity.ts";
+import { fromPEM, pkcs8ToEd25519Raw } from "../src/ed25519/utils.ts";
 import { decode } from "@commonfabric/utils/encoding";
+import { mnemonicToEntropy } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
 
 Deno.test("Identity generates mnemonics", async () => {
   const [identity, mnemonic] = await Identity.generateMnemonic();
@@ -24,4 +27,39 @@ Deno.test("Can generate into/read from PKCS8", async () => {
     throws = true;
   }
   assert(throws, "Identity.fromPkcs8() throws with invalid pkcs8");
+});
+
+Deno.test("fromEntropy reaches the same identity as the mnemonic it encodes", async () => {
+  // The contract device pairing rests on: BIP39 entropy is used DIRECTLY as
+  // the ed25519 seed, with no KDF between, so 32 bytes of entropy and the 24
+  // words encoding them name the same identity. A pairing QR carries the
+  // entropy precisely because the words do not fit. If a KDF were ever added
+  // to fromMnemonic without updating fromEntropy, this fails loudly instead of
+  // silently signing paired devices in under a different DID.
+  const [identity, mnemonic] = await Identity.generateMnemonic();
+  const entropy = mnemonicToEntropy(mnemonic, wordlist);
+
+  assertEquals(entropy.length, 32);
+  assertEquals((await Identity.fromEntropy(entropy)).did(), identity.did());
+});
+
+Deno.test("fromEntropy matches the pinned all-zero BIP39 vector", async () => {
+  const identity = await Identity.fromEntropy(new Uint8Array(32));
+  assertEquals(
+    identity.did(),
+    "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+  );
+});
+
+Deno.test("pkcs8 helpers are reachable from the package root", async () => {
+  // Exported so downstream consumers stop deep-importing ed25519/utils.ts.
+  const pkcs8 = await Identity.generatePkcs8();
+  const raw = pkcs8ToEd25519Raw(fromPEM(pkcs8));
+  assertEquals(raw.length, 32);
+  // The raw seed IS the entropy, which closes the loop: an EXISTING key can be
+  // re-encoded as a pairing phrase without anyone having to re-key.
+  assertEquals(
+    (await Identity.fromEntropy(raw)).did(),
+    (await Identity.fromPkcs8(pkcs8)).did(),
+  );
 });

--- a/packages/identity/test/identity.test.ts
+++ b/packages/identity/test/identity.test.ts
@@ -52,28 +52,61 @@ Deno.test("fromRaw matches the pinned all-zero BIP39 vector", async () => {
   );
 });
 
-Deno.test("toEntropy round-trips an existing key back to its seed", async () => {
+Deno.test("toRaw round-trips an existing key back to its seed", async () => {
   // Closes the loop the pairing flow needs: a key that was NEVER generated from
-  // a phrase can still be re-encoded as one, so nobody has to re-key.
+  // a phrase can still be re-encoded as one, so nobody has to re-key. `toRaw`
+  // is the exact inverse of `fromRaw`.
   const pkcs8 = await Identity.generatePkcs8();
   const identity = await Identity.fromPkcs8(pkcs8, { implementation: "noble" });
 
-  const entropy = identity.toEntropy();
-  assertEquals(entropy.length, 32);
-  assertEquals((await Identity.fromRaw(entropy)).did(), identity.did());
+  const seed = identity.toRaw();
+  assertEquals(seed.length, 32);
+  assertEquals((await Identity.fromRaw(seed)).did(), identity.did());
 
-  // ...and it really is valid BIP39 entropy, so the words exist.
-  const mnemonic = entropyToMnemonic(entropy, wordlist);
+  // ...and the seed is valid BIP39 entropy, so the words exist — the pairing
+  // flow does this step at its own call site, not in the identity class.
+  const mnemonic = entropyToMnemonic(seed, wordlist);
   assertEquals(mnemonic.split(" ").length, 24);
   assertEquals((await Identity.fromMnemonic(mnemonic)).did(), identity.did());
 });
 
-Deno.test("toEntropy is asymmetric — byte order is preserved", async () => {
+Deno.test("toRaw is asymmetric — byte order is preserved", async () => {
   // The all-zero vector is a fixed point of reversal, so a test using only it
   // would pass even if the seed were mangled on the way out.
-  const entropy = new Uint8Array(Array.from({ length: 32 }, (_, i) => i));
-  const identity = await Identity.fromRaw(entropy, {
+  const seed = new Uint8Array(Array.from({ length: 32 }, (_, i) => i));
+  const identity = await Identity.fromRaw(seed, { implementation: "noble" });
+  assertEquals(identity.toRaw(), seed);
+});
+
+Deno.test("toRaw returns a COPY — mutating it cannot corrupt the identity", async () => {
+  // serialize() hands out the live internal buffer; toRaw must not.
+  const identity = await Identity.fromRaw(new Uint8Array(32).fill(7), {
     implementation: "noble",
   });
-  assertEquals(identity.toEntropy(), entropy);
+  const seed = identity.toRaw();
+  seed[0] = 0xff;
+  assertEquals(identity.toRaw()[0], 7, "the identity's seed must be unchanged");
+});
+
+Deno.test("toRaw throws cleanly for a non-noble implementation", async () => {
+  // On Firefox ≥136 the DEFAULT (native/WebCrypto) implementation is used, and
+  // it cannot export private material. The failure must be an honest error, not
+  // a PKCS8-flavoured red herring, and pairing callers pass NOBLE explicitly to
+  // avoid it entirely.
+  const identity = await Identity.generate(); // default implementation
+  let message = "";
+  try {
+    identity.toRaw();
+    throw new Error("expected toRaw to throw for the default implementation");
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  // Only meaningful when the platform actually used native; noble-only
+  // environments (Deno/Chromium in CI) won't throw, and that's fine.
+  if (message) {
+    assert(
+      /raw key material/i.test(message),
+      `error should name raw key material, got: ${message}`,
+    );
+  }
 });

--- a/packages/identity/test/identity.test.ts
+++ b/packages/identity/test/identity.test.ts
@@ -1,8 +1,7 @@
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "../src/identity.ts";
-import { fromPEM, pkcs8ToEd25519Raw } from "../src/ed25519/utils.ts";
 import { decode } from "@commonfabric/utils/encoding";
-import { mnemonicToEntropy } from "@scure/bip39";
+import { entropyToMnemonic, mnemonicToEntropy } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 
 Deno.test("Identity generates mnemonics", async () => {
@@ -29,37 +28,52 @@ Deno.test("Can generate into/read from PKCS8", async () => {
   assert(throws, "Identity.fromPkcs8() throws with invalid pkcs8");
 });
 
-Deno.test("fromEntropy reaches the same identity as the mnemonic it encodes", async () => {
-  // The contract device pairing rests on: BIP39 entropy is used DIRECTLY as
-  // the ed25519 seed, with no KDF between, so 32 bytes of entropy and the 24
-  // words encoding them name the same identity. A pairing QR carries the
-  // entropy precisely because the words do not fit. If a KDF were ever added
-  // to fromMnemonic without updating fromEntropy, this fails loudly instead of
-  // silently signing paired devices in under a different DID.
+Deno.test("BIP39 entropy is the raw seed — no KDF between", async () => {
+  // THE contract device pairing rests on: `fromMnemonic` maps a phrase to BIP39
+  // entropy and uses those bytes DIRECTLY as the ed25519 seed, so 32 bytes of
+  // entropy and the 24 words encoding them name the same identity. A pairing QR
+  // carries the entropy precisely because the words do not fit.
+  //
+  // This test — NOT any alias — is what makes that safe to rely on. If a KDF is
+  // ever introduced into fromMnemonic, this fails loudly instead of silently
+  // signing paired devices in under a different DID.
   const [identity, mnemonic] = await Identity.generateMnemonic();
   const entropy = mnemonicToEntropy(mnemonic, wordlist);
 
   assertEquals(entropy.length, 32);
-  assertEquals((await Identity.fromEntropy(entropy)).did(), identity.did());
+  assertEquals((await Identity.fromRaw(entropy)).did(), identity.did());
 });
 
-Deno.test("fromEntropy matches the pinned all-zero BIP39 vector", async () => {
-  const identity = await Identity.fromEntropy(new Uint8Array(32));
+Deno.test("fromRaw matches the pinned all-zero BIP39 vector", async () => {
+  const identity = await Identity.fromRaw(new Uint8Array(32));
   assertEquals(
     identity.did(),
     "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
   );
 });
 
-Deno.test("pkcs8 helpers are reachable from the package root", async () => {
-  // Exported so downstream consumers stop deep-importing ed25519/utils.ts.
+Deno.test("toEntropy round-trips an existing key back to its seed", async () => {
+  // Closes the loop the pairing flow needs: a key that was NEVER generated from
+  // a phrase can still be re-encoded as one, so nobody has to re-key.
   const pkcs8 = await Identity.generatePkcs8();
-  const raw = pkcs8ToEd25519Raw(fromPEM(pkcs8));
-  assertEquals(raw.length, 32);
-  // The raw seed IS the entropy, which closes the loop: an EXISTING key can be
-  // re-encoded as a pairing phrase without anyone having to re-key.
-  assertEquals(
-    (await Identity.fromEntropy(raw)).did(),
-    (await Identity.fromPkcs8(pkcs8)).did(),
-  );
+  const identity = await Identity.fromPkcs8(pkcs8, { implementation: "noble" });
+
+  const entropy = identity.toEntropy();
+  assertEquals(entropy.length, 32);
+  assertEquals((await Identity.fromRaw(entropy)).did(), identity.did());
+
+  // ...and it really is valid BIP39 entropy, so the words exist.
+  const mnemonic = entropyToMnemonic(entropy, wordlist);
+  assertEquals(mnemonic.split(" ").length, 24);
+  assertEquals((await Identity.fromMnemonic(mnemonic)).did(), identity.did());
+});
+
+Deno.test("toEntropy is asymmetric — byte order is preserved", async () => {
+  // The all-zero vector is a fixed point of reversal, so a test using only it
+  // would pass even if the seed were mangled on the way out.
+  const entropy = new Uint8Array(Array.from({ length: 32 }, (_, i) => i));
+  const identity = await Identity.fromRaw(entropy, {
+    implementation: "noble",
+  });
+  assertEquals(identity.toEntropy(), entropy);
 });

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -12,10 +12,7 @@ import { consumeDeviceLinkFragment } from "./lib/device-link.ts";
 // and the unit tests do not.) There was nothing to gain either way: the shell's
 // `index` entry sets `splitting: false`, so esbuild inlines dynamic imports
 // rather than emitting a chunk.
-import {
-  reportDeviceLinkFailure,
-  runDeviceLinkLogin,
-} from "./lib/device-link-login.ts";
+import { handleDeviceLink } from "./lib/device-link-login.ts";
 import "./components/index.ts";
 import "./views/index.ts";
 import { App, AppElement, AppUpdateEvent, Navigation } from "../shared/mod.ts";
@@ -59,51 +56,12 @@ if (ENVIRONMENT !== "production") {
     (e as AppUpdateEvent).prettyPrint();
   });
 }
-// Runs BEFORE initializeKeys on the bootstrap path: it writes ROOT_KEY straight
-// into the KeyStore so the normal boot below picks the new identity up. Routing
-// it through App.setIdentity instead would throw whenever a DIFFERENT identity
-// is already active — precisely the re-pair case this exists for.
-//
-// Every path is wrapped: an uncaught throw here (KeyStore.open rejecting, an
-// insecure context) would skip initializeKeys and Navigation entirely,
-// stranding the user with no error. A failed pairing must degrade to a normal
-// boot, not a broken one — and must SAY it failed, because the fragment is
-// already scrubbed and a silent normal boot is indistinguishable from "the scan
-// never registered".
-async function handleDeviceLink(
-  link: Exclude<
-    ReturnType<typeof consumeDeviceLinkFragment>,
-    { kind: "absent" }
-  >,
-  opts: { reloadOnReplace: boolean } = { reloadOnReplace: false },
-): Promise<void> {
-  try {
-    if (link.kind === "malformed") {
-      await reportDeviceLinkFailure("unreadable");
-      return;
-    }
-    const outcome = await runDeviceLinkLogin(link.entropy);
-    if (outcome === "invalid") {
-      await reportDeviceLinkFailure("unreadable");
-    } else if (outcome === "accepted" && opts.reloadOnReplace) {
-      // The app is already booted on the previous identity; a plain continue
-      // would keep signing as it. Re-bootstrap so initializeKeys adopts the
-      // key we just wrote. (Bootstrap path passes reloadOnReplace:false — there
-      // initializeKeys below has not run yet and picks it up directly.)
-      globalThis.location.reload();
-    }
-    // "cancelled" and "already-signed-in" are deliberately silent: the first is
-    // an intentional "not mine", the second a successful no-op.
-  } catch (error) {
-    console.error("[device-link] pairing failed", error);
-    try {
-      await reportDeviceLinkFailure("failed");
-    } catch {
-      // The reporter itself failed; continue booting rather than hanging.
-    }
-  }
-}
-
+// Runs BEFORE initializeKeys: handleDeviceLink writes ROOT_KEY straight into
+// the KeyStore so the normal boot below picks the new identity up. Routing it
+// through App.setIdentity instead would throw whenever a DIFFERENT identity is
+// already active — precisely the re-pair case this exists for. It never throws,
+// so a failed pairing degrades to a normal boot rather than skipping
+// initializeKeys and Navigation entirely.
 if (deviceLink.kind !== "absent") {
   await handleDeviceLink(deviceLink);
 }

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -3,10 +3,17 @@ import "core-js/proposals/async-explicit-resource-management";
 import "@commonfabric/ui";
 import { API_URL, COMMIT_SHA, ENVIRONMENT } from "./lib/env.ts";
 import { setupHostToggles } from "./lib/host-toggles.ts";
+import { consumeDeviceLinkFragment } from "./lib/device-link.ts";
 import "./components/index.ts";
 import "./views/index.ts";
 import { App, AppElement, AppUpdateEvent, Navigation } from "../shared/mod.ts";
 import "./globals.ts";
+
+// Device-link login: /#k=<base64url 32-byte BIP39 entropy>.
+// Read and scrubbed FIRST, synchronously, before any await — so the secret
+// never survives into session history, a bookmark, or iCloud tab sync.
+// Interim pre-key-delegation pairing flow; delete when delegation lands.
+const deviceLinkEntropy = consumeDeviceLinkFragment();
 
 if ("serviceWorker" in navigator) {
   navigator.serviceWorker.register("/sw.js");
@@ -26,6 +33,15 @@ if (ENVIRONMENT !== "production") {
     (e as AppUpdateEvent).prettyPrint();
   });
 }
+// Must run BEFORE initializeKeys: it writes ROOT_KEY straight into the
+// KeyStore so the normal boot below picks the new identity up. Routing it
+// through App.setIdentity instead would throw whenever a DIFFERENT identity is
+// already active — which is precisely the re-pair case this exists for.
+if (deviceLinkEntropy) {
+  const { runDeviceLinkLogin } = await import("./lib/device-link-login.ts");
+  await runDeviceLinkLogin(deviceLinkEntropy);
+}
+
 await app.initializeKeys();
 
 const _navigation = new Navigation(app);

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -4,6 +4,18 @@ import "@commonfabric/ui";
 import { API_URL, COMMIT_SHA, ENVIRONMENT } from "./lib/env.ts";
 import { setupHostToggles } from "./lib/host-toggles.ts";
 import { consumeDeviceLinkFragment } from "./lib/device-link.ts";
+// Statically imported, deliberately. A dynamic `await import()` here pushes
+// `shared/app/*` into esbuild's lazy `__esm` wrappers, and esbuild then emits
+// the wrapper for `shared/app/controller.ts` as a NON-async function containing
+// a top-level await — a bundle that is a SyntaxError, so the whole shell fails
+// to load. (`node --check dist/scripts/index.js` catches it; the type checker
+// and the unit tests do not.) There was nothing to gain either way: the shell's
+// `index` entry sets `splitting: false`, so esbuild inlines dynamic imports
+// rather than emitting a chunk.
+import {
+  reportDeviceLinkFailure,
+  runDeviceLinkLogin,
+} from "./lib/device-link-login.ts";
 import "./components/index.ts";
 import "./views/index.ts";
 import { App, AppElement, AppUpdateEvent, Navigation } from "../shared/mod.ts";
@@ -14,6 +26,20 @@ import "./globals.ts";
 // never survives into session history, a bookmark, or iCloud tab sync.
 // Interim pre-key-delegation pairing flow; delete when delegation lands.
 const deviceLink = consumeDeviceLinkFragment();
+
+// Handle a scan while the app is ALREADY loaded at the QR's target URL. The QR
+// deliberately points at the page the user bookmarked as mobile Loom, so
+// re-scanning it is a same-document fragment navigation: no reload fires, the
+// module-eval read above never re-runs, and the secret would sit unscrubbed in
+// the address bar. `hashchange` is the only signal for that case. On an
+// accepted REPLACE the running app still holds the old identity, so reload to
+// re-bootstrap cleanly (the fragment is already scrubbed, so the reload is
+// clean and cannot loop).
+globalThis.addEventListener("hashchange", () => {
+  const rescan = consumeDeviceLinkFragment();
+  if (rescan.kind === "absent") return;
+  void handleDeviceLink(rescan, { reloadOnReplace: true });
+});
 
 if ("serviceWorker" in navigator) {
   navigator.serviceWorker.register("/sw.js");
@@ -33,36 +59,53 @@ if (ENVIRONMENT !== "production") {
     (e as AppUpdateEvent).prettyPrint();
   });
 }
-// Must run BEFORE initializeKeys: it writes ROOT_KEY straight into the
-// KeyStore so the normal boot below picks the new identity up. Routing it
-// through App.setIdentity instead would throw whenever a DIFFERENT identity is
-// already active — which is precisely the re-pair case this exists for.
+// Runs BEFORE initializeKeys on the bootstrap path: it writes ROOT_KEY straight
+// into the KeyStore so the normal boot below picks the new identity up. Routing
+// it through App.setIdentity instead would throw whenever a DIFFERENT identity
+// is already active — precisely the re-pair case this exists for.
 //
-// Wrapped because this is a TOP-LEVEL await in the entry module: an uncaught
-// throw here (KeyStore.open rejecting, an insecure context) would skip
-// initializeKeys and Navigation entirely, stranding the user on the login
-// screen with no error and no clue. A failed pairing must degrade to a normal
-// boot, not a broken one.
-if (deviceLink.kind !== "absent") {
+// Every path is wrapped: an uncaught throw here (KeyStore.open rejecting, an
+// insecure context) would skip initializeKeys and Navigation entirely,
+// stranding the user with no error. A failed pairing must degrade to a normal
+// boot, not a broken one — and must SAY it failed, because the fragment is
+// already scrubbed and a silent normal boot is indistinguishable from "the scan
+// never registered".
+async function handleDeviceLink(
+  link: Exclude<
+    ReturnType<typeof consumeDeviceLinkFragment>,
+    { kind: "absent" }
+  >,
+  opts: { reloadOnReplace: boolean } = { reloadOnReplace: false },
+): Promise<void> {
   try {
-    const { runDeviceLinkLogin, reportDeviceLinkFailure } = await import(
-      "./lib/device-link-login.ts"
-    );
-    if (deviceLink.kind === "malformed") {
-      // The scrub already removed it, so "refresh once and rescan" — the
-      // documented recovery — cannot work. Say so rather than booting to a
-      // normal screen as though nothing was scanned.
+    if (link.kind === "malformed") {
       await reportDeviceLinkFailure("unreadable");
-    } else {
-      const outcome = await runDeviceLinkLogin(deviceLink.entropy);
-      if (outcome === "invalid") await reportDeviceLinkFailure("unreadable");
+      return;
     }
+    const outcome = await runDeviceLinkLogin(link.entropy);
+    if (outcome === "invalid") {
+      await reportDeviceLinkFailure("unreadable");
+    } else if (outcome === "accepted" && opts.reloadOnReplace) {
+      // The app is already booted on the previous identity; a plain continue
+      // would keep signing as it. Re-bootstrap so initializeKeys adopts the
+      // key we just wrote. (Bootstrap path passes reloadOnReplace:false — there
+      // initializeKeys below has not run yet and picks it up directly.)
+      globalThis.location.reload();
+    }
+    // "cancelled" and "already-signed-in" are deliberately silent: the first is
+    // an intentional "not mine", the second a successful no-op.
   } catch (error) {
-    console.error(
-      "[device-link] pairing failed; continuing normal boot",
-      error,
-    );
+    console.error("[device-link] pairing failed", error);
+    try {
+      await reportDeviceLinkFailure("failed");
+    } catch {
+      // The reporter itself failed; continue booting rather than hanging.
+    }
   }
+}
+
+if (deviceLink.kind !== "absent") {
+  await handleDeviceLink(deviceLink);
 }
 
 await app.initializeKeys();

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -13,7 +13,7 @@ import "./globals.ts";
 // Read and scrubbed FIRST, synchronously, before any await — so the secret
 // never survives into session history, a bookmark, or iCloud tab sync.
 // Interim pre-key-delegation pairing flow; delete when delegation lands.
-const deviceLinkEntropy = consumeDeviceLinkFragment();
+const deviceLink = consumeDeviceLinkFragment();
 
 if ("serviceWorker" in navigator) {
   navigator.serviceWorker.register("/sw.js");
@@ -37,9 +37,32 @@ if (ENVIRONMENT !== "production") {
 // KeyStore so the normal boot below picks the new identity up. Routing it
 // through App.setIdentity instead would throw whenever a DIFFERENT identity is
 // already active — which is precisely the re-pair case this exists for.
-if (deviceLinkEntropy) {
-  const { runDeviceLinkLogin } = await import("./lib/device-link-login.ts");
-  await runDeviceLinkLogin(deviceLinkEntropy);
+//
+// Wrapped because this is a TOP-LEVEL await in the entry module: an uncaught
+// throw here (KeyStore.open rejecting, an insecure context) would skip
+// initializeKeys and Navigation entirely, stranding the user on the login
+// screen with no error and no clue. A failed pairing must degrade to a normal
+// boot, not a broken one.
+if (deviceLink.kind !== "absent") {
+  try {
+    const { runDeviceLinkLogin, reportDeviceLinkFailure } = await import(
+      "./lib/device-link-login.ts"
+    );
+    if (deviceLink.kind === "malformed") {
+      // The scrub already removed it, so "refresh once and rescan" — the
+      // documented recovery — cannot work. Say so rather than booting to a
+      // normal screen as though nothing was scanned.
+      await reportDeviceLinkFailure("unreadable");
+    } else {
+      const outcome = await runDeviceLinkLogin(deviceLink.entropy);
+      if (outcome === "invalid") await reportDeviceLinkFailure("unreadable");
+    }
+  } catch (error) {
+    console.error(
+      "[device-link] pairing failed; continuing normal boot",
+      error,
+    );
+  }
 }
 
 await app.initializeKeys();

--- a/packages/shell/src/lib/device-link-login.ts
+++ b/packages/shell/src/lib/device-link-login.ts
@@ -14,6 +14,16 @@ import "../views/DeviceLinkView.ts";
 // It also runs at BOOTSTRAP rather than from LoginView, because LoginView never
 // mounts when a stale identity auto-logs in — which is exactly the re-pair case.
 // A LoginView-only handler would silently no-op there.
+//
+// TODO(device-link-pwa): pairing does NOT reach an INSTALLED home-screen PWA.
+// This flow lands in a Safari tab; iOS partitions storage per-app, so the
+// identity written here is invisible to the installed app, AND the manifest's
+// `start_url: "/"` means "Add to Home Screen" loses the deep link too — the
+// installed app opens logged-out at Register/Login. Confirmed on iPhone,
+// iOS 17.5 (2026-07-22). LEFT AS-IS deliberately: nobody uses the installed-PWA
+// entry today, and the Safari-tab bookmark works. Fixing it is a product +
+// manifest decision (change start_url, or an in-PWA scan/paste path), not a
+// tweak here — revisit if the installed PWA becomes a real target.
 
 /**
  * Result of an attempted device-link login.

--- a/packages/shell/src/lib/device-link-login.ts
+++ b/packages/shell/src/lib/device-link-login.ts
@@ -1,5 +1,4 @@
 import { Identity, KeyStore } from "@commonfabric/identity";
-import { createPassphraseCredential, saveCredential } from "./credentials.ts";
 import { ROOT_KEY } from "../../shared/mod.ts";
 import "../views/DeviceLinkView.ts";
 
@@ -22,22 +21,52 @@ export type DeviceLinkOutcome =
   | "cancelled"
   | "invalid";
 
-async function confirmWithUser(
+export async function confirmWithUser(
   incomingDid: string,
   currentDid: string | null,
 ): Promise<boolean> {
   const view = document.createElement("x-device-link-view");
   view.incomingDid = incomingDid;
   view.currentDid = currentDid;
+  // Listen BEFORE inserting. Nothing can dispatch in between today (the
+  // Promise executor is synchronous and Lit's first update is a microtask),
+  // but relying on that is accidental rather than defended.
+  const answered = new Promise<boolean>((resolve) => {
+    view.addEventListener(
+      "device-link-result",
+      (event) => resolve(Boolean((event as CustomEvent).detail?.accepted)),
+      { once: true },
+    );
+  });
   document.body.appendChild(view);
   try {
-    return await new Promise<boolean>((resolve) => {
-      view.addEventListener(
-        "device-link-result",
-        (event) => resolve(Boolean((event as CustomEvent).detail?.accepted)),
-        { once: true },
-      );
+    return await answered;
+  } finally {
+    view.remove();
+  }
+}
+
+/**
+ * Tell the user a scan failed, and why they cannot simply retry the same URL.
+ *
+ * Reuses the confirm view's shape with no accept path — the point is only that
+ * a failed scan is never silent. Without this, an undecodable payload boots to
+ * an ordinary login screen and looks like the scan never happened, while the
+ * scrub has already made "refresh once and rescan" impossible.
+ */
+export async function reportDeviceLinkFailure(
+  reason: "unreadable",
+): Promise<void> {
+  const view = document.createElement("x-device-link-view");
+  view.failure = reason;
+  const dismissed = new Promise<void>((resolve) => {
+    view.addEventListener("device-link-result", () => resolve(), {
+      once: true,
     });
+  });
+  document.body.appendChild(view);
+  try {
+    await dismissed;
   } finally {
     view.remove();
   }
@@ -58,13 +87,19 @@ export async function runDeviceLinkLogin(
   // Injected so the flow is testable off-browser: KeyStore is IndexedDB-backed
   // and `deno test` has no indexedDB, which would otherwise leave the
   // confirm/replace logic — the security-critical part — uncovered.
-  openKeyStore: () => Promise<KeyStore> = () => KeyStore.open(),
+  // Narrowed to the two methods used, so a test double satisfies it without an
+  // `any` cast (KeyStore has a private field, so the full type never can).
+  openKeyStore: () => Promise<Pick<KeyStore, "get" | "set">> = () =>
+    KeyStore.open(),
 ): Promise<DeviceLinkOutcome> {
   let identity: Identity;
   try {
-    // BIP39 entropy is the ed25519 seed directly — `Identity.fromEntropy` names
-    // that contract, and the identity package pins it against `fromMnemonic`.
-    identity = await Identity.fromEntropy(entropy);
+    // `fromRaw`, not a bip39 round trip: BIP39 maps a phrase to entropy and
+    // uses those bytes DIRECTLY as the ed25519 seed, with no KDF between, so
+    // entropy IS the raw key. `identity.test.ts` pins that equivalence against
+    // `fromMnemonic`, which is what keeps the shell and the pairing device
+    // deriving the same DID. Throws on any length but 32.
+    identity = await Identity.fromRaw(entropy);
   } catch {
     return "invalid";
   }
@@ -79,7 +114,12 @@ export async function runDeviceLinkLogin(
   // needless churn of the stored key.
   if (currentDid !== identity.did()) {
     await keyStore.set(ROOT_KEY, identity);
-    saveCredential(createPassphraseCredential());
+    // Deliberately NOT saveCredential(createPassphraseCredential()): that mints
+    // a fresh UUID over `storedCredential`, and if this device had a passkey
+    // its descriptor id is destroyed — quick-unlock then offers a passphrase
+    // form that a device-paired phone can never satisfy, since it received
+    // entropy and never saw the 24 words. `initializeKeys` adopts ROOT_KEY on
+    // its own, so nothing here needs the credential record.
   }
   return "accepted";
 }

--- a/packages/shell/src/lib/device-link-login.ts
+++ b/packages/shell/src/lib/device-link-login.ts
@@ -15,11 +15,22 @@ import "../views/DeviceLinkView.ts";
 // mounts when a stale identity auto-logs in — which is exactly the re-pair case.
 // A LoginView-only handler would silently no-op there.
 
-/** Result of an attempted device-link login. */
+/**
+ * Result of an attempted device-link login.
+ *
+ * `accepted` and `already-signed-in` are DISTINCT on purpose: only `accepted`
+ * changed the stored key. A caller re-running this while the app is already
+ * booted (the hashchange path) needs that difference to decide whether to
+ * reload — reloading on a no-op write would be a pointless flash.
+ */
 export type DeviceLinkOutcome =
   | "accepted"
+  | "already-signed-in"
   | "cancelled"
   | "invalid";
+
+/** Why a scan could not complete — drives the failure screen's copy. */
+export type DeviceLinkFailure = "unreadable" | "failed";
 
 export async function confirmWithUser(
   incomingDid: string,
@@ -50,12 +61,13 @@ export async function confirmWithUser(
  * Tell the user a scan failed, and why they cannot simply retry the same URL.
  *
  * Reuses the confirm view's shape with no accept path — the point is only that
- * a failed scan is never silent. Without this, an undecodable payload boots to
- * an ordinary login screen and looks like the scan never happened, while the
- * scrub has already made "refresh once and rescan" impossible.
+ * a failed scan is never silent. Without this, an undecodable payload (or a
+ * mid-flow error) boots to an ordinary login screen and looks like the scan
+ * never happened, while the scrub has already made "refresh once and rescan"
+ * impossible.
  */
 export async function reportDeviceLinkFailure(
-  reason: "unreadable",
+  reason: DeviceLinkFailure,
 ): Promise<void> {
   const view = document.createElement("x-device-link-view");
   view.failure = reason;
@@ -112,14 +124,16 @@ export async function runDeviceLinkLogin(
 
   // Already this identity: nothing to write, and rewriting would be a
   // needless churn of the stored key.
-  if (currentDid !== identity.did()) {
-    await keyStore.set(ROOT_KEY, identity);
-    // Deliberately NOT saveCredential(createPassphraseCredential()): that mints
-    // a fresh UUID over `storedCredential`, and if this device had a passkey
-    // its descriptor id is destroyed — quick-unlock then offers a passphrase
-    // form that a device-paired phone can never satisfy, since it received
-    // entropy and never saw the 24 words. `initializeKeys` adopts ROOT_KEY on
-    // its own, so nothing here needs the credential record.
-  }
+  if (currentDid === identity.did()) return "already-signed-in";
+
+  await keyStore.set(ROOT_KEY, identity);
+  // Deliberately NOT saveCredential(createPassphraseCredential()): that mints a
+  // fresh UUID over `storedCredential`, and if this device had a passkey its
+  // descriptor id is overwritten — quick-unlock would then offer a passphrase
+  // form that a device-paired phone can never satisfy (it received entropy,
+  // never the 24 words), with no UI to clear it. The passkey itself survives
+  // (it is discoverable): passkey login still works, via the browser's account
+  // picker, and re-saves the descriptor on success. `initializeKeys` adopts
+  // ROOT_KEY on its own, so nothing here needs the credential record.
   return "accepted";
 }

--- a/packages/shell/src/lib/device-link-login.ts
+++ b/packages/shell/src/lib/device-link-login.ts
@@ -1,0 +1,85 @@
+import { Identity, KeyStore } from "@commonfabric/identity";
+import { createPassphraseCredential, saveCredential } from "./credentials.ts";
+import { ROOT_KEY } from "../../shared/mod.ts";
+import "../views/DeviceLinkView.ts";
+
+// Orchestrates device-link login: entropy -> confirm -> KeyStore.
+//
+// ORDERING CONSTRAINT (do not deviate): this must overwrite ROOT_KEY in the
+// KeyStore BEFORE the app's normal key initialization runs, then let the normal
+// boot pick the new identity up. It must NOT route through App.setIdentity or a
+// set-identity command — those THROW "Cannot change identity while logged in"
+// when a different identity is active, and replacing a stale identity is the
+// entire point of this handler.
+//
+// It also runs at BOOTSTRAP rather than from LoginView, because LoginView never
+// mounts when a stale identity auto-logs in — which is exactly the re-pair case.
+// A LoginView-only handler would silently no-op there.
+
+/** Result of an attempted device-link login. */
+export type DeviceLinkOutcome =
+  | "accepted"
+  | "cancelled"
+  | "invalid";
+
+async function confirmWithUser(
+  incomingDid: string,
+  currentDid: string | null,
+): Promise<boolean> {
+  const view = document.createElement("x-device-link-view");
+  view.incomingDid = incomingDid;
+  view.currentDid = currentDid;
+  document.body.appendChild(view);
+  try {
+    return await new Promise<boolean>((resolve) => {
+      view.addEventListener(
+        "device-link-result",
+        (event) => resolve(Boolean((event as CustomEvent).detail?.accepted)),
+        { once: true },
+      );
+    });
+  } finally {
+    view.remove();
+  }
+}
+
+/**
+ * Derive the identity a device link names, confirm with the user, and store it.
+ *
+ * Returns without touching the KeyStore on cancel or on undecodable entropy,
+ * so the normal boot continues with whatever session already existed.
+ */
+export async function runDeviceLinkLogin(
+  entropy: Uint8Array,
+  confirm: (
+    incomingDid: string,
+    currentDid: string | null,
+  ) => Promise<boolean> = confirmWithUser,
+  // Injected so the flow is testable off-browser: KeyStore is IndexedDB-backed
+  // and `deno test` has no indexedDB, which would otherwise leave the
+  // confirm/replace logic — the security-critical part — uncovered.
+  openKeyStore: () => Promise<KeyStore> = () => KeyStore.open(),
+): Promise<DeviceLinkOutcome> {
+  let identity: Identity;
+  try {
+    // BIP39 entropy is the ed25519 seed directly — `Identity.fromEntropy` names
+    // that contract, and the identity package pins it against `fromMnemonic`.
+    identity = await Identity.fromEntropy(entropy);
+  } catch {
+    return "invalid";
+  }
+
+  const keyStore = await openKeyStore();
+  const existing = await keyStore.get(ROOT_KEY);
+  const currentDid = existing ? existing.did() : null;
+
+  if (!await confirm(identity.did(), currentDid)) return "cancelled";
+
+  // Already this identity: nothing to write, and rewriting would be a
+  // needless churn of the stored key.
+  if (currentDid !== identity.did()) {
+    await keyStore.set(ROOT_KEY, identity);
+    saveCredential(createPassphraseCredential());
+  }
+  return "accepted";
+}

--- a/packages/shell/src/lib/device-link-login.ts
+++ b/packages/shell/src/lib/device-link-login.ts
@@ -1,5 +1,6 @@
 import { Identity, KeyStore } from "@commonfabric/identity";
 import { ROOT_KEY } from "../../shared/mod.ts";
+import type { DeviceLinkFragment } from "./device-link.ts";
 import "../views/DeviceLinkView.ts";
 
 // Orchestrates device-link login: entropy -> confirm -> KeyStore.
@@ -146,4 +147,60 @@ export async function runDeviceLinkLogin(
   // picker, and re-saves the descriptor on success. `initializeKeys` adopts
   // ROOT_KEY on its own, so nothing here needs the credential record.
   return "accepted";
+}
+
+/**
+ * Drive one device-link scan end to end: report, log in, or fail loudly.
+ *
+ * Lives HERE rather than in `index.ts` on purpose. It is real branching logic —
+ * malformed vs invalid vs accepted vs cancelled, plus the catch-all — and
+ * `index.ts` is an entry module with a top-level `await` that no unit test can
+ * import, so logic parked there is untestable by construction. `index.ts` keeps
+ * only the wiring.
+ *
+ * Never throws: an uncaught error on the bootstrap path would skip
+ * `initializeKeys()` and `Navigation`, stranding the user with no error at all.
+ * A failed pairing must degrade to a normal boot — and must SAY it failed,
+ * because the fragment is already scrubbed and a silent boot is
+ * indistinguishable from "the scan never registered".
+ */
+export async function handleDeviceLink(
+  link: Exclude<DeviceLinkFragment, { kind: "absent" }>,
+  opts: {
+    /**
+     * True when the app is ALREADY booted (the hashchange path): the running
+     * app still holds the previous identity, so an accepted replace has to
+     * re-bootstrap. False at startup, where `initializeKeys()` has not run yet
+     * and picks the new key up directly.
+     */
+    reloadOnReplace?: boolean;
+    reload?: () => void;
+    report?: (reason: DeviceLinkFailure) => Promise<void>;
+    login?: (entropy: Uint8Array) => Promise<DeviceLinkOutcome>;
+  } = {},
+): Promise<void> {
+  const report = opts.report ?? reportDeviceLinkFailure;
+  const login = opts.login ?? ((e: Uint8Array) => runDeviceLinkLogin(e));
+  const reload = opts.reload ?? (() => globalThis.location.reload());
+  try {
+    if (link.kind === "malformed") {
+      await report("unreadable");
+      return;
+    }
+    const outcome = await login(link.entropy);
+    if (outcome === "invalid") {
+      await report("unreadable");
+    } else if (outcome === "accepted" && opts.reloadOnReplace) {
+      reload();
+    }
+    // "cancelled" and "already-signed-in" are deliberately silent: the first is
+    // an intentional "not mine", the second a successful no-op.
+  } catch (error) {
+    console.error("[device-link] pairing failed", error);
+    try {
+      await report("failed");
+    } catch {
+      // The reporter itself failed; continue booting rather than hanging.
+    }
+  }
 }

--- a/packages/shell/src/lib/device-link.ts
+++ b/packages/shell/src/lib/device-link.ts
@@ -1,0 +1,94 @@
+// Device-link login: `#k=<base64url 32-byte BIP39 entropy>`.
+//
+// WHY: an identity minted on a desktop had no way to reach a phone or a second
+// browser. The interim answer is to hand the identity across as its BIP39
+// entropy — the 32 bytes a 24-word phrase encodes — in a URL fragment, scanned
+// from a QR with the phone's native camera. The fragment is never sent to a
+// server, and 32 bytes fit in a QR where 24 words do not.
+//
+// This is an INTERIM mechanism, scoped to be deleted when key delegation
+// lands. It is confirm-gated on purpose: a credential in a URL is an
+// antipattern, and the confirm screen is the only thing standing between a
+// user and a link that would sign them in as somebody else.
+//
+// SECURITY: the fragment is scrubbed from the URL SYNCHRONOUSLY, before any
+// await, so the secret never survives into session history, a bookmark, or
+// iCloud tab/bookmark sync. `pathname + search` is preserved because the
+// pairing QR targets a deep link — after the confirm, the normal boot must
+// continue to that path so the flow ends inside a logged-in app the user can
+// bookmark, and the scrubbed URL is exactly what gets bookmarked.
+
+/** Fragment param name. Short because QR payload bytes are scarce. */
+const DEVICE_LINK_PREFIX = "#k=";
+
+/** 32 bytes of BIP39 entropy is exactly 43 unpadded base64url characters. */
+const ENCODED_LENGTH = 43;
+const ENTROPY_BYTES = 32;
+
+const ENCODED_PATTERN = new RegExp(`^[A-Za-z0-9_-]{${ENCODED_LENGTH}}$`);
+
+/**
+ * Decode unpadded base64url to bytes, or null if it isn't valid.
+ */
+function decodeBase64Url(encoded: string): Uint8Array | null {
+  if (!ENCODED_PATTERN.test(encoded)) return null;
+  const base64 = encoded.replaceAll("-", "+").replaceAll("_", "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  let binary: string;
+  try {
+    binary = atob(padded);
+  } catch {
+    return null;
+  }
+  if (binary.length !== ENTROPY_BYTES) return null;
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/**
+ * Parse a location hash into device-link entropy.
+ *
+ * Pure and total: any hash that isn't exactly a well-formed device link
+ * yields null. Exported for tests — `consumeDeviceLinkFragment` is the one
+ * callers use.
+ */
+export function parseDeviceLinkFragment(hash: string): Uint8Array | null {
+  if (!hash.startsWith(DEVICE_LINK_PREFIX)) return null;
+  return decodeBase64Url(hash.slice(DEVICE_LINK_PREFIX.length));
+}
+
+/** True when a hash is SHAPED like a device link, valid or not. */
+export function looksLikeDeviceLink(hash: string): boolean {
+  return hash.startsWith(DEVICE_LINK_PREFIX);
+}
+
+/**
+ * Read the device-link entropy out of the current URL and scrub it.
+ *
+ * Call at module init, BEFORE any await. Anything shaped like a device link is
+ * scrubbed even when it fails to parse: a malformed payload is still somebody's
+ * secret, and leaving it in the address bar to be bookmarked or synced would be
+ * the same leak with none of the benefit.
+ */
+export function consumeDeviceLinkFragment(): Uint8Array | null {
+  const location = globalThis.location;
+  if (!location || !looksLikeDeviceLink(location.hash)) return null;
+
+  const entropy = parseDeviceLinkFragment(location.hash);
+
+  // Scrub FIRST and synchronously — before the caller can await anything.
+  try {
+    globalThis.history?.replaceState(
+      null,
+      "",
+      location.pathname + location.search,
+    );
+  } catch {
+    // A sandboxed/unsupported history is not a reason to abandon the login;
+    // the secret is merely more exposed than we'd like, which the confirm
+    // screen's bookmark guidance already covers.
+  }
+
+  return entropy;
+}

--- a/packages/shell/src/lib/device-link.ts
+++ b/packages/shell/src/lib/device-link.ts
@@ -11,12 +11,31 @@
 // antipattern, and the confirm screen is the only thing standing between a
 // user and a link that would sign them in as somebody else.
 //
-// SECURITY: the fragment is scrubbed from the URL SYNCHRONOUSLY, before any
-// await, so the secret never survives into session history, a bookmark, or
-// iCloud tab/bookmark sync. `pathname + search` is preserved because the
-// pairing QR targets a deep link — after the confirm, the normal boot must
-// continue to that path so the flow ends inside a logged-in app the user can
-// bookmark, and the scrubbed URL is exactly what gets bookmarked.
+// SECURITY — what the scrub does and does NOT do. It runs synchronously,
+// before any await, and removes the secret from the address bar, from what a
+// bookmark or a tab-sync would capture, and from the session history entry.
+//
+// It does NOT erase these, so do not write code that assumes it did:
+//   * `performance.getEntriesByType("navigation")[0].name` keeps the FULL
+//     original URL, secret included, for the document's lifetime. There is no
+//     API to clear it (`clearResourceTimings()` does not). This matters
+//     concretely: `@opentelemetry/instrumentation-document-load` reads that
+//     entry and reports it as `http.url`. Wiring document-load instrumentation
+//     into this shell would ship the private key to the OTLP collector. It is
+//     not wired today — keep it that way, or filter the attribute.
+//   * The visit is committed to the browser's persistent history database
+//     before any script runs; replaceState amends the session entry, not that.
+//   * The secret sits in the address bar from navigation commit until this
+//     bundle has been fetched, parsed and evaluated — unbounded, and on a cold
+//     mobile load over a VPN, easily seconds.
+// These are accepted for an interim flow; they are the reason the payload is
+// opaque entropy rather than the words, and the reason pairing is reveal-gated
+// on the other end.
+//
+// `pathname + search` is preserved because the pairing QR targets a deep link —
+// after the confirm, the normal boot must continue to that path so the flow
+// ends inside a logged-in app the user can bookmark, and the scrubbed URL is
+// exactly what gets bookmarked.
 
 /** Fragment param name. Short because QR payload bytes are scarce. */
 const DEVICE_LINK_PREFIX = "#k=";
@@ -63,6 +82,20 @@ export function looksLikeDeviceLink(hash: string): boolean {
   return hash.startsWith(DEVICE_LINK_PREFIX);
 }
 
+/** What the URL turned out to contain. */
+export type DeviceLinkFragment =
+  /** No device link present — boot normally, say nothing. */
+  | { kind: "absent" }
+  /** A well-formed device link. */
+  | { kind: "entropy"; entropy: Uint8Array }
+  /**
+   * Shaped like a device link but undecodable. Distinct from "absent" on
+   * purpose: the scrub has already removed it, so the documented recovery
+   * ("refresh once and rescan") can no longer work, and silently booting to a
+   * normal screen would leave the user with no idea the scan failed.
+   */
+  | { kind: "malformed" };
+
 /**
  * Read the device-link entropy out of the current URL and scrub it.
  *
@@ -71,9 +104,21 @@ export function looksLikeDeviceLink(hash: string): boolean {
  * secret, and leaving it in the address bar to be bookmarked or synced would be
  * the same leak with none of the benefit.
  */
-export function consumeDeviceLinkFragment(): Uint8Array | null {
+export function consumeDeviceLinkFragment(): DeviceLinkFragment {
   const location = globalThis.location;
-  if (!location || !looksLikeDeviceLink(location.hash)) return null;
+  if (!location || !looksLikeDeviceLink(location.hash)) {
+    return { kind: "absent" };
+  }
+
+  // Never act on a device link inside a frame. The parent controls the URL, so
+  // a framed shell turns this into a one-click identity swap the user cannot
+  // see the address bar for. Storage partitioning already blunts it, but the
+  // flow has no legitimate reason to run framed.
+  //
+  // `top` is only meaningful in a browsing context — outside one (tests, SSR)
+  // it is undefined, and a bare `top !== self` would then reject everything.
+  const top = globalThis.top;
+  if (top && top !== globalThis.self) return { kind: "absent" };
 
   const entropy = parseDeviceLinkFragment(location.hash);
 
@@ -86,9 +131,8 @@ export function consumeDeviceLinkFragment(): Uint8Array | null {
     );
   } catch {
     // A sandboxed/unsupported history is not a reason to abandon the login;
-    // the secret is merely more exposed than we'd like, which the confirm
-    // screen's bookmark guidance already covers.
+    // the secret is merely more exposed than we'd like.
   }
 
-  return entropy;
+  return entropy ? { kind: "entropy", entropy } : { kind: "malformed" };
 }

--- a/packages/shell/src/lib/device-link.ts
+++ b/packages/shell/src/lib/device-link.ts
@@ -110,19 +110,13 @@ export function consumeDeviceLinkFragment(): DeviceLinkFragment {
     return { kind: "absent" };
   }
 
-  // Never act on a device link inside a frame. The parent controls the URL, so
-  // a framed shell turns this into a one-click identity swap the user cannot
-  // see the address bar for. Storage partitioning already blunts it, but the
-  // flow has no legitimate reason to run framed.
-  //
-  // `top` is only meaningful in a browsing context — outside one (tests, SSR)
-  // it is undefined, and a bare `top !== self` would then reject everything.
-  const top = globalThis.top;
-  if (top && top !== globalThis.self) return { kind: "absent" };
-
   const entropy = parseDeviceLinkFragment(location.hash);
 
-  // Scrub FIRST and synchronously — before the caller can await anything.
+  // Scrub FIRST and synchronously — before the caller can await anything, and
+  // regardless of what we decide below. A framed or malformed link is still
+  // somebody's secret; leaving it in the address bar to be bookmarked or synced
+  // is the leak with none of the benefit. (This is why the scrub precedes the
+  // frame check, not the reverse.)
   try {
     globalThis.history?.replaceState(
       null,
@@ -133,6 +127,17 @@ export function consumeDeviceLinkFragment(): DeviceLinkFragment {
     // A sandboxed/unsupported history is not a reason to abandon the login;
     // the secret is merely more exposed than we'd like.
   }
+
+  // Never ACT on a device link inside a frame. The parent controls the URL, so
+  // a framed shell would turn this into a one-click identity swap the user
+  // cannot see the address bar for. Storage partitioning already blunts it, but
+  // the flow has no legitimate reason to run framed — so report absent (the
+  // secret is already scrubbed above).
+  //
+  // `top` is only meaningful in a browsing context — outside one (tests, SSR)
+  // it is undefined, and a bare `top !== self` would then reject everything.
+  const top = globalThis.top;
+  if (top && top !== globalThis.self) return { kind: "absent" };
 
   return entropy ? { kind: "entropy", entropy } : { kind: "malformed" };
 }

--- a/packages/shell/src/views/DeviceLinkView.ts
+++ b/packages/shell/src/views/DeviceLinkView.ts
@@ -14,9 +14,11 @@ import { property, state } from "lit/decorators.js";
 // supposed to have come from.
 //
 // Rendered into the TOP LAYER via <dialog>.showModal() rather than a z-index
-// gamble: this shell already has fixed elements at z-index 2000 and 9999, and
-// the top layer also brings a focus trap and an inert background for free —
-// the login view behind this must not be tab-reachable while it is up.
+// gamble: this shell has fixed elements at z-index 2000 and 9999, and the top
+// layer also brings a focus trap and an inert background for free — the login
+// view behind this must not be tab-reachable while it is up. Where showModal is
+// unsupported (iOS ≤ 15.3) or throws, `activateModalDialog` falls back to a
+// visible non-modal dialog rather than leaving the user staring at nothing.
 //
 // INTERIM: delete this along with the rest of the device-link flow when key
 // delegation lands.
@@ -30,6 +32,48 @@ import { property, state } from "lit/decorators.js";
  * donated-identity link, that is worth a beat.
  */
 export const TAP_THROUGH_GUARD_MS = 500;
+
+/** The subset of `<dialog>` this component drives — so tests can fake it. */
+export interface ModalDialog {
+  showModal?: () => void;
+  setAttribute: (name: string, value: string) => void;
+  addEventListener: (type: string, listener: (event: Event) => void) => void;
+}
+
+/**
+ * Make a `<dialog>` visible and wire its cancel signal — crash-safe.
+ *
+ * Pure and injectable so the order-of-operations and the fallback can be
+ * tested without a browser (the component's `firstUpdated` runs only against a
+ * real DOM). The rules it encodes, each load-bearing:
+ *   - Prefer the top layer (`showModal`), but a dialog with no `open` is
+ *     `display:none`; if `showModal` is missing or throws, force the `open`
+ *     attribute so the user still SEES the dialog instead of a hang.
+ *   - `cancel` (Escape, or a programmatic close) must resolve to "no", never a
+ *     silent accept.
+ */
+export function activateModalDialog(
+  dialog: ModalDialog | null,
+  onCancel: () => void,
+): void {
+  if (!dialog) return;
+  try {
+    if (typeof dialog.showModal === "function") dialog.showModal();
+    else dialog.setAttribute("open", "");
+  } catch {
+    // showModal threw (unsupported, or already open) — degrade to visible
+    // non-modal rather than an invisible, un-dismissable hang.
+    try {
+      dialog.setAttribute("open", "");
+    } catch {
+      // Nothing more we can safely do; the buttons still work if painted.
+    }
+  }
+  dialog.addEventListener("cancel", (event) => {
+    (event as Event & { preventDefault?: () => void }).preventDefault?.();
+    onCancel();
+  });
+}
 
 export class XDeviceLinkView extends LitElement {
   static override styles = css`
@@ -45,6 +89,9 @@ export class XDeviceLinkView extends LitElement {
       font-size: 1rem;
       line-height: 1.5;
       padding: 1.5rem;
+      /* Respect the notch/home-indicator in landscape; portrait is unaffected. */
+      padding-top: max(1.5rem, env(safe-area-inset-top));
+      padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
       max-width: 30rem;
       width: calc(100vw - 2rem);
       box-sizing: border-box;
@@ -55,6 +102,9 @@ export class XDeviceLinkView extends LitElement {
     h1 {
       font-size: 1.25rem;
       margin: 0 0 0.75rem;
+    }
+    h1:focus {
+      outline: none;
     }
     .did {
       font-family: var(--font-primary, ui-monospace, monospace);
@@ -106,10 +156,7 @@ export class XDeviceLinkView extends LitElement {
 
   /** Set instead of the DIDs to report a scan that could not be read at all. */
   @property({ attribute: false })
-  accessor failure: "unreadable" | null = null;
-
-  @state()
-  private accessor accepting = false;
+  accessor failure: "unreadable" | "failed" | null = null;
 
   @state()
   private accessor guarded = true;
@@ -119,16 +166,24 @@ export class XDeviceLinkView extends LitElement {
   #guardTimer: ReturnType<typeof setTimeout> | undefined;
 
   override firstUpdated() {
-    const dialog = this.renderRoot.querySelector("dialog");
-    dialog?.showModal();
-    // Escape / the backdrop must mean "no", never a silent accept.
-    dialog?.addEventListener("cancel", (event) => {
-      event.preventDefault();
-      this.finish(false);
-    });
+    // Schedule the guard release FIRST — before anything below that could throw
+    // — so a failure activating the dialog can never leave the accept button
+    // disabled forever (which, with a hung promise, would brick boot).
     this.#guardTimer = setTimeout(() => {
       this.guarded = false;
     }, TAP_THROUGH_GUARD_MS);
+
+    const dialog = this.renderRoot.querySelector("dialog");
+    activateModalDialog(dialog, () => this.finish(false));
+
+    // Focus the heading, NOT a button. WebKit scrolls a modal to its focused
+    // element; with the accept button disabled during the guard, focus would
+    // otherwise fall to Cancel at the bottom, scrolling the heading and the
+    // security warning off-screen on a small phone.
+    const heading = this.renderRoot.querySelector(
+      "[data-autofocus]",
+    ) as HTMLElement | null;
+    heading?.focus?.();
   }
 
   override disconnectedCallback() {
@@ -139,9 +194,9 @@ export class XDeviceLinkView extends LitElement {
   private finish(accepted: boolean) {
     // Exactly one answer, ever: a double-tap must not dispatch twice.
     if (this.#answered) return;
+    // Accept is inert during the tap-through guard; Cancel is always allowed.
     if (accepted && this.guarded) return;
     this.#answered = true;
-    this.accepting = accepted;
     this.dispatchEvent(
       new CustomEvent("device-link-result", { detail: { accepted } }),
     );
@@ -151,7 +206,9 @@ export class XDeviceLinkView extends LitElement {
     if (this.failure) {
       return html`
         <dialog aria-labelledby="device-link-title">
-          <h1 id="device-link-title">Pairing code could not be read</h1>
+          <h1 id="device-link-title" tabindex="-1" data-autofocus>
+            Pairing code could not be read
+          </h1>
           <p class="warn">
             The code in this link is incomplete or damaged. Reloading this page will not
             help — the code is removed from the address bar as soon as it is read.
@@ -171,7 +228,9 @@ export class XDeviceLinkView extends LitElement {
     if (alreadySignedIn) {
       return html`
         <dialog aria-labelledby="device-link-title">
-          <h1 id="device-link-title">Already signed in</h1>
+          <h1 id="device-link-title" tabindex="-1" data-autofocus>
+            Already signed in
+          </h1>
           <div class="label">Identity</div>
           <div class="did">${this.incomingDid}</div>
           <div class="actions">
@@ -188,7 +247,7 @@ export class XDeviceLinkView extends LitElement {
 
     return html`
       <dialog aria-labelledby="device-link-title">
-        <h1 id="device-link-title">
+        <h1 id="device-link-title" tabindex="-1" data-autofocus>
           ${replacing ? "Replace current identity?" : "Use this identity?"}
         </h1>
         ${replacing

--- a/packages/shell/src/views/DeviceLinkView.ts
+++ b/packages/shell/src/views/DeviceLinkView.ts
@@ -1,0 +1,158 @@
+import { css, html, LitElement } from "lit";
+import { property, state } from "lit/decorators.js";
+
+// The confirm gate for device-link login (`#k=` — see ../lib/device-link.ts).
+//
+// WHY A CONFIRM AT ALL: the payload donates a private key. An attacker who
+// gets someone to open `…/home#k=<attacker-entropy>` — a crafted link, a QR
+// sticker over a real one — would otherwise silently sign the victim in AS the
+// attacker, so everything they then write lands in the attacker's space and
+// their own session is gone. Scanning steals nothing directly (there is no
+// exfiltration channel; the payload gives away the attacker's own key), which
+// makes this screen the entire defence. Hence the DID shown prominently for
+// cross-checking against the Pair screen, and copy that tells the user what
+// the code is supposed to have come from.
+//
+// INTERIM: delete this along with the rest of the device-link flow when key
+// delegation lands.
+export class XDeviceLinkView extends LitElement {
+  static override styles = css`
+    :host {
+      position: fixed;
+      inset: 0;
+      z-index: 1000;
+      display: grid;
+      place-items: center;
+      background: var(--bg, #fff);
+      color: var(--text, #111);
+      font: 16px/1.5 system-ui, sans-serif;
+      padding: 1.5rem;
+      box-sizing: border-box;
+    }
+    .card {
+      max-width: 30rem;
+      width: 100%;
+    }
+    h1 {
+      font-size: 1.25rem;
+      margin: 0 0 0.75rem;
+    }
+    .did {
+      font-family: ui-monospace, monospace;
+      font-size: 0.95rem;
+      word-break: break-all;
+      background: rgba(127, 127, 127, 0.12);
+      border-radius: 0.375rem;
+      padding: 0.6rem 0.75rem;
+      margin: 0.5rem 0 1rem;
+    }
+    .label {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-bottom: 0.15rem;
+    }
+    .warn {
+      font-size: 0.9rem;
+      opacity: 0.85;
+      margin: 0 0 1.25rem;
+    }
+    .actions {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+    button {
+      font: inherit;
+      padding: 0.55rem 1.1rem;
+      border-radius: 0.375rem;
+      border: 1px solid currentColor;
+      background: transparent;
+      color: inherit;
+      cursor: pointer;
+    }
+    button.primary {
+      background: currentColor;
+      border-color: transparent;
+    }
+    button.primary span {
+      color: var(--bg, #fff);
+    }
+  `;
+
+  /** DID the scanned code would sign as. */
+  @property({ attribute: false })
+  accessor incomingDid = "";
+
+  /** DID already signed in on this device, when different. */
+  @property({ attribute: false })
+  accessor currentDid: string | null = null;
+
+  @state()
+  private accessor busy = false;
+
+  private finish(accepted: boolean) {
+    if (this.busy) return;
+    this.busy = true;
+    this.dispatchEvent(
+      new CustomEvent("device-link-result", { detail: { accepted } }),
+    );
+  }
+
+  override render() {
+    const replacing = this.currentDid !== null &&
+      this.currentDid !== this.incomingDid;
+    const alreadySignedIn = this.currentDid === this.incomingDid;
+
+    if (alreadySignedIn) {
+      return html`
+        <div class="card">
+          <h1>Already signed in</h1>
+          <div class="label">Identity</div>
+          <div class="did">${this.incomingDid}</div>
+          <div class="actions">
+            <button class="primary" @click="${() => this.finish(true)}">
+              <span>Continue</span>
+            </button>
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="card">
+        <h1>${replacing
+          ? "Replace current identity?"
+          : "Use this identity?"}</h1>
+        ${replacing
+          ? html`
+            <div class="label">Currently signed in as</div>
+            <div class="did">${this.currentDid}</div>
+          `
+          : ""}
+        <div class="label">${replacing ? "Would become" : "Sign in as"}</div>
+        <div class="did">${this.incomingDid}</div>
+        <p class="warn">
+          Only continue if this code was just revealed on the Pair screen of a device
+          that belongs here, and the identity above matches the one shown
+          there.${replacing
+            ? " The identity currently signed in on this device will be replaced."
+            : ""}
+        </p>
+        <div class="actions">
+          <button class="primary" @click="${() => this.finish(true)}">
+            <span>${replacing ? "Replace identity" : "Continue"}</span>
+          </button>
+          <button @click="${() => this.finish(false)}">Cancel</button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+globalThis.customElements.define("x-device-link-view", XDeviceLinkView);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "x-device-link-view": XDeviceLinkView;
+  }
+}

--- a/packages/shell/src/views/DeviceLinkView.ts
+++ b/packages/shell/src/views/DeviceLinkView.ts
@@ -10,38 +10,57 @@ import { property, state } from "lit/decorators.js";
 // their own session is gone. Scanning steals nothing directly (there is no
 // exfiltration channel; the payload gives away the attacker's own key), which
 // makes this screen the entire defence. Hence the DID shown prominently for
-// cross-checking against the Pair screen, and copy that tells the user what
-// the code is supposed to have come from.
+// cross-checking against the Pair screen, and copy naming where the code was
+// supposed to have come from.
+//
+// Rendered into the TOP LAYER via <dialog>.showModal() rather than a z-index
+// gamble: this shell already has fixed elements at z-index 2000 and 9999, and
+// the top layer also brings a focus trap and an inert background for free —
+// the login view behind this must not be tab-reachable while it is up.
 //
 // INTERIM: delete this along with the rest of the device-link flow when key
 // delegation lands.
+
+/**
+ * How long the accept button stays inert after the dialog appears.
+ *
+ * The overlay materialises mid-boot on a phone the user has just pointed at a
+ * QR code, and the accept button is the primary control — a tap already in
+ * flight would land on it. For the screen that is the only defence against a
+ * donated-identity link, that is worth a beat.
+ */
+export const TAP_THROUGH_GUARD_MS = 500;
+
 export class XDeviceLinkView extends LitElement {
   static override styles = css`
     :host {
-      position: fixed;
-      inset: 0;
-      z-index: 1000;
-      display: grid;
-      place-items: center;
-      background: var(--bg, #fff);
-      color: var(--text, #111);
-      font: 16px/1.5 system-ui, sans-serif;
+      display: contents;
+    }
+    dialog {
+      border: 1px solid var(--border-color, #000);
+      border-radius: 0.5rem;
+      background: var(--shell-surface, #fff);
+      color: var(--font-color, #000);
+      font-family: var(--font-primary, system-ui, sans-serif);
+      font-size: 1rem;
+      line-height: 1.5;
       padding: 1.5rem;
+      max-width: 30rem;
+      width: calc(100vw - 2rem);
       box-sizing: border-box;
     }
-    .card {
-      max-width: 30rem;
-      width: 100%;
+    dialog::backdrop {
+      background: rgba(0, 0, 0, 0.6);
     }
     h1 {
       font-size: 1.25rem;
       margin: 0 0 0.75rem;
     }
     .did {
-      font-family: ui-monospace, monospace;
+      font-family: var(--font-primary, ui-monospace, monospace);
       font-size: 0.95rem;
       word-break: break-all;
-      background: rgba(127, 127, 127, 0.12);
+      background: var(--bg-secondary, rgba(127, 127, 127, 0.12));
       border-radius: 0.375rem;
       padding: 0.6rem 0.75rem;
       margin: 0.5rem 0 1rem;
@@ -63,19 +82,17 @@ export class XDeviceLinkView extends LitElement {
     }
     button {
       font: inherit;
+      font-family: inherit;
       padding: 0.55rem 1.1rem;
       border-radius: 0.375rem;
-      border: 1px solid currentColor;
-      background: transparent;
+      border: 1px solid var(--border-color, currentColor);
+      background: var(--bg-primary, transparent);
       color: inherit;
       cursor: pointer;
     }
-    button.primary {
-      background: currentColor;
-      border-color: transparent;
-    }
-    button.primary span {
-      color: var(--bg, #fff);
+    button[disabled] {
+      opacity: 0.5;
+      cursor: default;
     }
   `;
 
@@ -83,46 +100,97 @@ export class XDeviceLinkView extends LitElement {
   @property({ attribute: false })
   accessor incomingDid = "";
 
-  /** DID already signed in on this device, when different. */
+  /** DID already signed in on this device, or null on a fresh one. */
   @property({ attribute: false })
   accessor currentDid: string | null = null;
 
+  /** Set instead of the DIDs to report a scan that could not be read at all. */
+  @property({ attribute: false })
+  accessor failure: "unreadable" | null = null;
+
   @state()
-  private accessor busy = false;
+  private accessor accepting = false;
+
+  @state()
+  private accessor guarded = true;
+
+  #answered = false;
+  // `setTimeout` is typed as Node's `Timeout` under this config, not `number`.
+  #guardTimer: ReturnType<typeof setTimeout> | undefined;
+
+  override firstUpdated() {
+    const dialog = this.renderRoot.querySelector("dialog");
+    dialog?.showModal();
+    // Escape / the backdrop must mean "no", never a silent accept.
+    dialog?.addEventListener("cancel", (event) => {
+      event.preventDefault();
+      this.finish(false);
+    });
+    this.#guardTimer = setTimeout(() => {
+      this.guarded = false;
+    }, TAP_THROUGH_GUARD_MS);
+  }
+
+  override disconnectedCallback() {
+    clearTimeout(this.#guardTimer);
+    super.disconnectedCallback();
+  }
 
   private finish(accepted: boolean) {
-    if (this.busy) return;
-    this.busy = true;
+    // Exactly one answer, ever: a double-tap must not dispatch twice.
+    if (this.#answered) return;
+    if (accepted && this.guarded) return;
+    this.#answered = true;
+    this.accepting = accepted;
     this.dispatchEvent(
       new CustomEvent("device-link-result", { detail: { accepted } }),
     );
   }
 
   override render() {
+    if (this.failure) {
+      return html`
+        <dialog aria-labelledby="device-link-title">
+          <h1 id="device-link-title">Pairing code could not be read</h1>
+          <p class="warn">
+            The code in this link is incomplete or damaged. Reloading this page will not
+            help — the code is removed from the address bar as soon as it is read.
+            Reveal the code again on the Pair screen and rescan it.
+          </p>
+          <div class="actions">
+            <button @click="${() => this.finish(false)}">Continue</button>
+          </div>
+        </dialog>
+      `;
+    }
+
     const replacing = this.currentDid !== null &&
       this.currentDid !== this.incomingDid;
     const alreadySignedIn = this.currentDid === this.incomingDid;
 
     if (alreadySignedIn) {
       return html`
-        <div class="card">
-          <h1>Already signed in</h1>
+        <dialog aria-labelledby="device-link-title">
+          <h1 id="device-link-title">Already signed in</h1>
           <div class="label">Identity</div>
           <div class="did">${this.incomingDid}</div>
           <div class="actions">
-            <button class="primary" @click="${() => this.finish(true)}">
-              <span>Continue</span>
+            <button
+              @click="${() => this.finish(true)}"
+              ?disabled="${this.guarded}"
+            >
+              Continue
             </button>
           </div>
-        </div>
+        </dialog>
       `;
     }
 
     return html`
-      <div class="card">
-        <h1>${replacing
-          ? "Replace current identity?"
-          : "Use this identity?"}</h1>
+      <dialog aria-labelledby="device-link-title">
+        <h1 id="device-link-title">
+          ${replacing ? "Replace current identity?" : "Use this identity?"}
+        </h1>
         ${replacing
           ? html`
             <div class="label">Currently signed in as</div>
@@ -139,12 +207,15 @@ export class XDeviceLinkView extends LitElement {
             : ""}
         </p>
         <div class="actions">
-          <button class="primary" @click="${() => this.finish(true)}">
-            <span>${replacing ? "Replace identity" : "Continue"}</span>
+          <button
+            @click="${() => this.finish(true)}"
+            ?disabled="${this.guarded}"
+          >
+            ${replacing ? "Replace identity" : "Continue"}
           </button>
           <button @click="${() => this.finish(false)}">Cancel</button>
         </div>
-      </div>
+      </dialog>
     `;
   }
 }

--- a/packages/shell/test/device-link.test.ts
+++ b/packages/shell/test/device-link.test.ts
@@ -891,3 +891,235 @@ describe("firstUpdated wiring (component-level, via a stubbed shadow root)", () 
     }
   });
 });
+
+// ── failure reporting + fallback paths ─────────────────────────────────────
+//
+// These cover the error/degradation paths the coverage ratchet flagged as
+// uncovered. They are not padding: `reportDeviceLinkFailure` is the whole
+// reason a failed scan isn't silent, and the two `catch` arms are what keep a
+// hostile or exotic environment from turning a failure into a hang.
+
+describe("reportDeviceLinkFailure", () => {
+  /** Install a document whose createElement yields drivable fake views. */
+  function withFakeViews() {
+    class FakeView extends EventTarget {
+      incomingDid = "";
+      currentDid: string | null = null;
+      failure: string | null = null;
+      removed = false;
+      remove() {
+        this.removed = true;
+      }
+    }
+    const created: FakeView[] = [];
+    // deno-lint-ignore no-explicit-any
+    (globalThis as any).document.createElement = () => {
+      const el = new FakeView();
+      created.push(el);
+      return el;
+    };
+    return created;
+  }
+
+  it("shows the failure screen and resolves when dismissed", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const created = withFakeViews();
+      const { reportDeviceLinkFailure } = await import(
+        "../src/lib/device-link-login.ts"
+      );
+      const pending = reportDeviceLinkFailure("unreadable");
+      assertEquals(created.length, 1);
+      assertEquals(created[0].failure, "unreadable");
+
+      created[0].dispatchEvent(new CustomEvent("device-link-result"));
+      await pending; // must resolve, not hang
+      assert(created[0].removed, "the view must be cleaned up afterwards");
+    } finally {
+      restore();
+    }
+  });
+
+  it("carries the 'failed' reason for a mid-flow error", async () => {
+    // index.ts's catch-all reports this one; a silent boot there is exactly the
+    // failure the screen exists to prevent.
+    const restore = installBrowserGlobals();
+    try {
+      const created = withFakeViews();
+      const { reportDeviceLinkFailure } = await import(
+        "../src/lib/device-link-login.ts"
+      );
+      const pending = reportDeviceLinkFailure("failed");
+      assertEquals(created[0].failure, "failed");
+      created[0].dispatchEvent(new CustomEvent("device-link-result"));
+      await pending;
+    } finally {
+      restore();
+    }
+  });
+
+  it("removes the view even if dismissal rejects", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const created = withFakeViews();
+      const { reportDeviceLinkFailure } = await import(
+        "../src/lib/device-link-login.ts"
+      );
+      const pending = reportDeviceLinkFailure("unreadable");
+      created[0].dispatchEvent(new CustomEvent("device-link-result"));
+      await pending;
+      assert(created[0].removed);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("scrub failure is survivable", () => {
+  it("still reports the entropy when history.replaceState throws", () => {
+    // A sandboxed iframe or a locked-down environment can throw here. Losing
+    // the scrub is bad, but abandoning the login on top of it would be worse —
+    // and an uncaught throw at module init would take the whole boot with it.
+    const originalLocation = globalThis.location;
+    const originalHistory = globalThis.history;
+    Object.defineProperty(globalThis, "location", {
+      value: {
+        hash: "#k=" + toBase64Url(ZERO_ENTROPY),
+        pathname: "/p",
+        search: "",
+      },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "history", {
+      value: {
+        replaceState: () => {
+          throw new Error("SecurityError: sandboxed");
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    try {
+      const got = consumeDeviceLinkFragment();
+      assertEquals(got, { kind: "entropy", entropy: ZERO_ENTROPY });
+    } finally {
+      Object.defineProperty(globalThis, "location", {
+        value: originalLocation,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(globalThis, "history", {
+        value: originalHistory,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("tolerates a missing history object entirely", () => {
+    const originalLocation = globalThis.location;
+    const originalHistory = globalThis.history;
+    Object.defineProperty(globalThis, "location", {
+      value: {
+        hash: "#k=" + toBase64Url(ZERO_ENTROPY),
+        pathname: "/p",
+        search: "",
+      },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "history", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    try {
+      assertEquals(consumeDeviceLinkFragment(), {
+        kind: "entropy",
+        entropy: ZERO_ENTROPY,
+      });
+    } finally {
+      Object.defineProperty(globalThis, "location", {
+        value: originalLocation,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(globalThis, "history", {
+        value: originalHistory,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+});
+
+describe("activateModalDialog — last-ditch fallback", () => {
+  it("does not throw when BOTH showModal and setAttribute fail", async () => {
+    // The worst case: an exotic/partial <dialog>. We cannot show anything, but
+    // throwing here would propagate out of firstUpdated and hang the promise —
+    // the crash that bricked boot before. It must degrade quietly.
+    const { activateModalDialog } = await import(
+      "../src/views/DeviceLinkView.ts"
+    );
+    let listened = false;
+    const hostile = {
+      showModal: () => {
+        throw new Error("unsupported");
+      },
+      setAttribute: () => {
+        throw new Error("also unsupported");
+      },
+      addEventListener: () => {
+        listened = true;
+      },
+    };
+    activateModalDialog(hostile, () => {});
+    assert(listened, "the cancel signal must still be wired");
+  });
+});
+
+describe("the tap-through guard actually releases", () => {
+  it("flips `guarded` false when the timer fires", async () => {
+    // The timer BODY (not just its scheduling): without this the accept button
+    // would stay disabled forever, which is one half of the boot-brick.
+    const restore = installBrowserGlobals();
+    const realSet = globalThis.setTimeout;
+    let fire: (() => void) | undefined;
+    // deno-lint-ignore no-explicit-any
+    (globalThis as any).setTimeout = (fn: () => void) => {
+      fire = fn;
+      return 1;
+    };
+    try {
+      const { XDeviceLinkView } = await import(
+        "../src/views/DeviceLinkView.ts"
+      );
+      const view = new XDeviceLinkView();
+      Object.defineProperty(view, "renderRoot", {
+        value: { querySelector: () => null },
+        configurable: true,
+      });
+      view.firstUpdated();
+      const answers: boolean[] = [];
+      view.addEventListener(
+        "device-link-result",
+        (e) => answers.push(Boolean((e as CustomEvent).detail?.accepted)),
+      );
+
+      // Before the timer fires, accept is inert...
+      // deno-lint-ignore no-explicit-any
+      (view as any).finish(true);
+      assertEquals(answers, [], "accept must be inert during the guard");
+
+      assert(fire, "the guard timer must have been scheduled");
+      fire!(); // ...and after it fires, accept works.
+      // deno-lint-ignore no-explicit-any
+      (view as any).finish(true);
+      assertEquals(answers, [true], "accept must work once the guard lifts");
+    } finally {
+      globalThis.setTimeout = realSet;
+      restore();
+    }
+  });
+});

--- a/packages/shell/test/device-link.test.ts
+++ b/packages/shell/test/device-link.test.ts
@@ -182,6 +182,31 @@ describe("consumeDeviceLinkFragment", () => {
       ctx.restore();
     }
   });
+
+  it("refuses to act inside a frame, but still scrubs", () => {
+    // The parent controls a framed shell's URL, so acting on `#k=` there would
+    // be a one-click identity swap the user can't see the address bar for.
+    // Report absent — but the secret is scrubbed anyway, per the file's policy.
+    const ctx = withLocation("#k=" + toBase64Url(ZERO_ENTROPY));
+    const originalTop = Object.getOwnPropertyDescriptor(globalThis, "top");
+    Object.defineProperty(globalThis, "top", {
+      value: {}, // distinct from globalThis (=self) → looks framed
+      configurable: true,
+      writable: true,
+    });
+    try {
+      assertEquals(consumeDeviceLinkFragment(), { kind: "absent" });
+      assertEquals(
+        ctx.replaced,
+        ["/loom-jun-12/home"],
+        "must scrub even framed",
+      );
+    } finally {
+      if (originalTop) Object.defineProperty(globalThis, "top", originalTop);
+      else Reflect.deleteProperty(globalThis, "top");
+      ctx.restore();
+    }
+  });
 });
 
 describe("device-link derivation", () => {
@@ -340,7 +365,10 @@ describe("runDeviceLinkLogin", () => {
     assertEquals(current, null);
   });
 
-  it("re-scanning the same code is a no-op write", async () => {
+  it("re-scanning the same code is a no-op, reported as already-signed-in", async () => {
+    // Distinct from "accepted" on purpose: the hashchange caller reloads only
+    // on "accepted", so a no-op re-scan must NOT report it, or the page would
+    // pointlessly flash-reload.
     const same = await Identity.fromRaw(ZERO_ENTROPY);
     const { store, entries } = fakeKeyStore(same);
     let wrote = false;
@@ -353,7 +381,7 @@ describe("runDeviceLinkLogin", () => {
       () => Promise.resolve(true),
       () => Promise.resolve(store),
     );
-    assertEquals(outcome, "accepted");
+    assertEquals(outcome, "already-signed-in");
     assert(!wrote, "should not churn the stored key when nothing changed");
     assertEquals(entries.get("$ROOT_KEY")?.did(), ZERO_ENTROPY_DID);
   });
@@ -509,8 +537,13 @@ describe("DeviceLinkView", () => {
       const { view, answers } = await makeView({
         incomingDid: COUNTING_ENTROPY_DID,
       });
-      const [accept, cancel] = handlersOf(view.render());
-      assert(accept && cancel, "expected an accept and a cancel handler");
+      const handlers = handlersOf(view.render());
+      assertEquals(
+        handlers.length,
+        2,
+        "expected an accept and a cancel handler",
+      );
+      const [, cancel] = handlers;
       cancel();
       assertEquals(answers, [false], "Cancel must answer NO");
     } finally {
@@ -671,6 +704,190 @@ describe("confirmWithUser (the production confirm path)", () => {
       assertEquals(await pending, true);
     } finally {
       restore();
+    }
+  });
+});
+
+// ── the modal activation seam ──────────────────────────────────────────────
+//
+// firstUpdated's imperative DOM work runs only against a real DOM, so the
+// browser-behaviour mutations (Escape rewired to accept, showModal never
+// called, cancel listener never attached) previously ALL survived — the unit
+// tests stub document.body.appendChild to a no-op, so the element never
+// connects and firstUpdated never fires. `activateModalDialog` is extracted so
+// exactly those rules can be pinned against a fake dialog, no browser needed.
+
+/** Records what the component does to a dialog. */
+function fakeDialog(
+  opts: { hasShowModal?: boolean; showModalThrows?: boolean } = {},
+) {
+  const calls: string[] = [];
+  let cancelListener: ((e: Event) => void) | undefined;
+  const dialog = {
+    showModal: opts.hasShowModal === false ? undefined : () => {
+      calls.push("showModal");
+      if (opts.showModalThrows) throw new Error("unsupported");
+    },
+    setAttribute: (name: string, value: string) => {
+      calls.push(`setAttribute:${name}=${value}`);
+    },
+    addEventListener: (type: string, listener: (e: Event) => void) => {
+      calls.push(`listen:${type}`);
+      if (type === "cancel") cancelListener = listener;
+    },
+  };
+  return {
+    dialog,
+    calls,
+    fireCancel: () => cancelListener?.(new Event("cancel")),
+  };
+}
+
+describe("activateModalDialog", () => {
+  it("shows the dialog modally and wires the cancel signal", async () => {
+    const { activateModalDialog } = await import(
+      "../src/views/DeviceLinkView.ts"
+    );
+    const { dialog, calls } = fakeDialog();
+    activateModalDialog(dialog, () => {});
+    assert(calls.includes("showModal"), "must open the top layer");
+    assert(calls.includes("listen:cancel"), "must wire the cancel signal");
+  });
+
+  it("Escape (a cancel event) resolves to NO, never a silent accept", async () => {
+    const { activateModalDialog } = await import(
+      "../src/views/DeviceLinkView.ts"
+    );
+    const { dialog, fireCancel } = fakeDialog();
+    let answer: boolean | undefined;
+    activateModalDialog(dialog, () => (answer = false));
+    fireCancel();
+    assertEquals(answer, false);
+  });
+
+  it("falls back to a VISIBLE dialog when showModal is unsupported", async () => {
+    // A <dialog> with no `open` is display:none — on old iOS this would be an
+    // invisible, un-dismissable hang. The open attribute makes it show.
+    const { activateModalDialog } = await import(
+      "../src/views/DeviceLinkView.ts"
+    );
+    const { dialog, calls } = fakeDialog({ hasShowModal: false });
+    activateModalDialog(dialog, () => {});
+    assert(
+      calls.includes("setAttribute:open="),
+      "must force the dialog visible when showModal is missing",
+    );
+  });
+
+  it("falls back to a visible dialog when showModal THROWS", async () => {
+    const { activateModalDialog } = await import(
+      "../src/views/DeviceLinkView.ts"
+    );
+    const { dialog, calls } = fakeDialog({ showModalThrows: true });
+    activateModalDialog(dialog, () => {});
+    assert(calls.includes("showModal"), "tries the top layer first");
+    assert(
+      calls.includes("setAttribute:open="),
+      "then degrades to visible non-modal rather than hanging",
+    );
+  });
+
+  it("is a no-op on a missing dialog rather than throwing", async () => {
+    const { activateModalDialog } = await import(
+      "../src/views/DeviceLinkView.ts"
+    );
+    activateModalDialog(null, () => {
+      throw new Error("onCancel must not fire for a null dialog");
+    });
+  });
+});
+
+describe("firstUpdated wiring (component-level, via a stubbed shadow root)", () => {
+  /** Stub the shadow root so firstUpdated runs without a real DOM. */
+  function withStubbedRoot(
+    view: { renderRoot?: unknown },
+    dialog: unknown,
+    autofocus: unknown = null,
+  ) {
+    Object.defineProperty(view, "renderRoot", {
+      value: {
+        querySelector: (sel: string) => sel === "dialog" ? dialog : autofocus,
+      },
+      configurable: true,
+    });
+  }
+
+  it("wires the dialog's cancel (Escape) to a NO answer, not accept", async () => {
+    // M1: the highest-stakes mutation — Escape rewired to accept a donated
+    // identity. The seam test proves cancel→onCancel; this proves the COMPONENT
+    // passes finish(false) as onCancel, closing the loop.
+    const restore = installBrowserGlobals();
+    try {
+      const { XDeviceLinkView } = await import(
+        "../src/views/DeviceLinkView.ts"
+      );
+      const view = new XDeviceLinkView();
+      Object.assign(view, { guarded: false });
+      const answers: boolean[] = [];
+      view.addEventListener(
+        "device-link-result",
+        (e) => answers.push(Boolean((e as CustomEvent).detail?.accepted)),
+      );
+      let cancelListener: ((e: Event) => void) | undefined;
+      const dialog = {
+        showModal: () => {},
+        setAttribute: () => {},
+        addEventListener: (type: string, cb: (e: Event) => void) => {
+          if (type === "cancel") cancelListener = cb;
+        },
+      };
+      withStubbedRoot(view, dialog);
+      view.firstUpdated();
+      assert(cancelListener, "firstUpdated must wire the cancel signal");
+      cancelListener!(new Event("cancel"));
+      assertEquals(answers, [false], "Escape must answer NO, never accept");
+    } finally {
+      restore();
+    }
+  });
+
+  it("is scheduled on first update and CLEARED on disconnect", async () => {
+    // A leaked timer would flip `guarded` on an element already removed; a timer
+    // never scheduled would leave accept disabled forever. Pin both by
+    // capturing the ids through the real firstUpdated/disconnectedCallback.
+    const scheduled: number[] = [];
+    const cleared: number[] = [];
+    const realSet = globalThis.setTimeout;
+    const realClear = globalThis.clearTimeout;
+    let nextId = 1;
+    // deno-lint-ignore no-explicit-any
+    (globalThis as any).setTimeout = (_fn: () => void) => {
+      const id = nextId++;
+      scheduled.push(id);
+      return id;
+    };
+    // deno-lint-ignore no-explicit-any
+    (globalThis as any).clearTimeout = (id: number) => cleared.push(id);
+    const restore = installBrowserGlobals();
+    try {
+      const { XDeviceLinkView } = await import(
+        "../src/views/DeviceLinkView.ts"
+      );
+      const view = new XDeviceLinkView();
+      // Stub the shadow root so firstUpdated can run without a real DOM; a null
+      // dialog exercises the crash-safe path (activateModalDialog no-ops).
+      Object.defineProperty(view, "renderRoot", {
+        value: { querySelector: () => null },
+        configurable: true,
+      });
+      view.firstUpdated();
+      assertEquals(scheduled.length, 1, "the guard timer must be scheduled");
+      view.disconnectedCallback();
+      assertEquals(cleared, scheduled, "disconnect must clear the same timer");
+    } finally {
+      restore();
+      globalThis.setTimeout = realSet;
+      globalThis.clearTimeout = realClear;
     }
   });
 });

--- a/packages/shell/test/device-link.test.ts
+++ b/packages/shell/test/device-link.test.ts
@@ -28,6 +28,16 @@ const ZERO_ENTROPY = new Uint8Array(32);
 const ZERO_ENTROPY_DID =
   "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp";
 
+// A deliberately ASYMMETRIC vector (0x00..0x1f). The all-zero vector is a fixed
+// point of reversal, rotation and XOR-with-zero, so pinning ONLY against it
+// lets a whole class of byte-mangling bugs through — a mutation reversing the
+// seed passed the entire suite when this was the only vector.
+const COUNTING_ENTROPY = new Uint8Array(
+  Array.from({ length: 32 }, (_, i) => i),
+);
+const COUNTING_ENTROPY_DID =
+  "did:key:z6MkehRgf7yJbgaGfYsdoAsKdBPE3dj2CYhowQdcjqSJgvVd";
+
 describe("parseDeviceLinkFragment", () => {
   it("decodes a well-formed device link to 32 bytes", () => {
     const entropy = crypto.getRandomValues(new Uint8Array(32));
@@ -123,7 +133,10 @@ describe("consumeDeviceLinkFragment", () => {
     const entropy = crypto.getRandomValues(new Uint8Array(32));
     const ctx = withLocation("#k=" + toBase64Url(entropy));
     try {
-      assertEquals(consumeDeviceLinkFragment(), entropy);
+      assertEquals(consumeDeviceLinkFragment(), {
+        kind: "entropy",
+        entropy,
+      });
       assertEquals(ctx.replaced, ["/loom-jun-12/home"]);
     } finally {
       ctx.restore();
@@ -150,7 +163,10 @@ describe("consumeDeviceLinkFragment", () => {
   it("scrubs even when the payload is malformed", () => {
     const ctx = withLocation("#k=not-valid-entropy");
     try {
-      assertEquals(consumeDeviceLinkFragment(), null);
+      // "malformed", NOT "absent": the scrub already removed it, so the
+      // documented "refresh once and rescan" recovery cannot work and the
+      // failure has to be surfaced rather than booting as if nothing happened.
+      assertEquals(consumeDeviceLinkFragment(), { kind: "malformed" });
       assertEquals(ctx.replaced, ["/loom-jun-12/home"]);
     } finally {
       ctx.restore();
@@ -160,7 +176,7 @@ describe("consumeDeviceLinkFragment", () => {
   it("leaves unrelated fragments completely alone", () => {
     const ctx = withLocation("#some-anchor");
     try {
-      assertEquals(consumeDeviceLinkFragment(), null);
+      assertEquals(consumeDeviceLinkFragment(), { kind: "absent" });
       assertEquals(ctx.replaced, []);
     } finally {
       ctx.restore();
@@ -172,18 +188,51 @@ describe("device-link derivation", () => {
   it("derives the pinned DID from the all-zero entropy vector", async () => {
     // Pins that the shell and the pairing device agree on the derivation. If
     // this DID ever moves, a scanned code signs the phone in as somebody else.
-    const identity = await Identity.fromEntropy(ZERO_ENTROPY);
+    const identity = await Identity.fromRaw(ZERO_ENTROPY);
     assertEquals(identity.did(), ZERO_ENTROPY_DID);
+  });
+
+  it("derives the pinned DID from an ASYMMETRIC vector", async () => {
+    // The all-zero vector alone is worthless as a pin: it survives reversal,
+    // rotation and XOR-with-zero unchanged, so a seed-mangling bug passes.
+    // This vector does not.
+    const identity = await Identity.fromRaw(COUNTING_ENTROPY);
+    assertEquals(identity.did(), COUNTING_ENTROPY_DID);
+  });
+
+  it("byte order matters — a reversed seed is a different identity", async () => {
+    const reversed = new Uint8Array([...COUNTING_ENTROPY].reverse());
+    const forward = await Identity.fromRaw(COUNTING_ENTROPY);
+    const backward = await Identity.fromRaw(reversed);
+    assert(
+      forward.did() !== backward.did(),
+      "reversal must change the identity, or the pins above prove nothing",
+    );
+  });
+
+  it("rejects any entropy length but 32", async () => {
+    for (const length of [0, 16, 31, 33, 64]) {
+      let threw = false;
+      try {
+        await Identity.fromRaw(new Uint8Array(length));
+      } catch {
+        threw = true;
+      }
+      assert(
+        threw,
+        `length ${length} must be rejected, not silently truncated`,
+      );
+    }
   });
 
   it("round-trips a fragment to the identity it names", async () => {
     // The whole path a scan takes: entropy -> QR text -> fragment -> identity.
     const entropy = crypto.getRandomValues(new Uint8Array(32));
-    const expected = await Identity.fromEntropy(entropy);
+    const expected = await Identity.fromRaw(entropy);
 
     const parsed = parseDeviceLinkFragment("#k=" + toBase64Url(entropy));
     assert(parsed);
-    assertEquals((await Identity.fromEntropy(parsed)).did(), expected.did());
+    assertEquals((await Identity.fromRaw(parsed)).did(), expected.did());
   });
 
   it("produces a payload that fits the pairing QR's byte budget", () => {
@@ -227,7 +276,7 @@ describe("runDeviceLinkLogin", () => {
   });
 
   it("does not touch the KeyStore when the user cancels", async () => {
-    const existing = await Identity.fromEntropy(
+    const existing = await Identity.fromRaw(
       crypto.getRandomValues(new Uint8Array(32)),
     );
     const { store, entries } = fakeKeyStore(existing);
@@ -244,7 +293,7 @@ describe("runDeviceLinkLogin", () => {
     // The case a LoginView-only handler would silently no-op on, and the one
     // App.setIdentity refuses outright ("Cannot change identity while logged
     // in") — which is why this writes ROOT_KEY directly, pre-initializeKeys.
-    const stale = await Identity.fromEntropy(
+    const stale = await Identity.fromRaw(
       crypto.getRandomValues(new Uint8Array(32)),
     );
     const { store, entries } = fakeKeyStore(stale);
@@ -261,7 +310,7 @@ describe("runDeviceLinkLogin", () => {
     // The confirm screen is the ONLY defence against a donated-identity link,
     // so it must be handed the DIDs a user can cross-check against the Pair
     // screen — not a truncation or a placeholder.
-    const stale = await Identity.fromEntropy(
+    const stale = await Identity.fromRaw(
       crypto.getRandomValues(new Uint8Array(32)),
     );
     const { store } = fakeKeyStore(stale);
@@ -292,7 +341,7 @@ describe("runDeviceLinkLogin", () => {
   });
 
   it("re-scanning the same code is a no-op write", async () => {
-    const same = await Identity.fromEntropy(ZERO_ENTROPY);
+    const same = await Identity.fromRaw(ZERO_ENTROPY);
     const { store, entries } = fakeKeyStore(same);
     let wrote = false;
     store.set = () => {
@@ -326,5 +375,302 @@ describe("runDeviceLinkLogin", () => {
     assertEquals(outcome, "invalid");
     assert(!prompted, "must not prompt for undecodable entropy");
     assert(!opened, "must not open the KeyStore for undecodable entropy");
+  });
+});
+
+// ── the confirm gate itself ────────────────────────────────────────────────
+//
+// Previously uncovered: every test above injects its own `confirm`, so the
+// production path and the whole view were unexercised. Two mutations passed the
+// entire suite as a result — `confirmWithUser` hardcoded to true, and the Cancel
+// button rewired to accept. For the screen the design calls the only defence
+// against a donated-identity link, those are the mutations that matter most.
+//
+// Follows the repo's view-test idiom (see login-view.test.ts): install fake
+// browser globals, instantiate the element, and inspect what render() produces.
+
+function installBrowserGlobals(): () => void {
+  const originals = new Map<string, PropertyDescriptor | undefined>();
+  function setGlobal(name: string, value: unknown): void {
+    originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  }
+  class TestHTMLElement extends EventTarget {}
+  setGlobal("window", globalThis);
+  setGlobal("HTMLElement", TestHTMLElement);
+  setGlobal("customElements", {
+    define() {},
+    get() {},
+    whenDefined: () => Promise.resolve(),
+  });
+  setGlobal("document", {
+    documentElement: { style: {} },
+    body: { appendChild() {} },
+    createElement: () => ({
+      style: {},
+      setAttribute() {},
+      append() {},
+      appendChild() {},
+    }),
+    createTreeWalker: () => ({}),
+  });
+  setGlobal("devicePixelRatio", 1);
+  setGlobal("screen", { deviceXDPI: 1, logicalXDPI: 1 });
+  setGlobal("navigator", { platform: "", userAgent: "deno" });
+  return () => {
+    for (const [name, descriptor] of originals) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else Reflect.deleteProperty(globalThis, name);
+    }
+  };
+}
+
+// deno-lint-ignore no-explicit-any
+function templateText(value: any): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(templateText).join("");
+  if (typeof value !== "object") return "";
+  return [
+    ...(value.strings ?? []),
+    ...((value.values ?? []).map(templateText)),
+  ].join("");
+}
+
+/** Click handlers in template order: [accept, cancel]. */
+// deno-lint-ignore no-explicit-any
+function handlersOf(value: any): Array<() => void> {
+  if (value == null || typeof value !== "object") return [];
+  if (Array.isArray(value)) return value.flatMap(handlersOf);
+  const out: Array<() => void> = [];
+  for (const v of value.values ?? []) {
+    if (typeof v === "function") out.push(v as () => void);
+    else out.push(...handlersOf(v));
+  }
+  return out;
+}
+
+describe("DeviceLinkView", () => {
+  async function makeView(state: Record<string, unknown>) {
+    const { XDeviceLinkView } = await import("../src/views/DeviceLinkView.ts");
+    const view = new XDeviceLinkView();
+    // `guarded` defaults true (tap-through protection); tests opt out unless
+    // they are specifically exercising the guard.
+    Object.assign(view, { guarded: false, ...state });
+    const answers: boolean[] = [];
+    view.addEventListener(
+      "device-link-result",
+      (e) => answers.push(Boolean((e as CustomEvent).detail?.accepted)),
+    );
+    return { view, answers };
+  }
+
+  it("shows the incoming DID verbatim so it can be cross-checked", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { view } = await makeView({ incomingDid: COUNTING_ENTROPY_DID });
+      const text = templateText(view.render());
+      assert(
+        text.includes(COUNTING_ENTROPY_DID),
+        "the full DID must be on screen, not truncated",
+      );
+      assert(
+        text.includes("Pair screen"),
+        "anti-phishing copy must be present",
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("shows BOTH DIDs and replace wording when replacing", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { view } = await makeView({
+        incomingDid: COUNTING_ENTROPY_DID,
+        currentDid: ZERO_ENTROPY_DID,
+      });
+      const text = templateText(view.render());
+      assert(text.includes(COUNTING_ENTROPY_DID));
+      assert(text.includes(ZERO_ENTROPY_DID));
+      assert(text.includes("Replace"), "must say it replaces an identity");
+    } finally {
+      restore();
+    }
+  });
+
+  it("CANCEL answers no — the button wiring, not just finish()", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { view, answers } = await makeView({
+        incomingDid: COUNTING_ENTROPY_DID,
+      });
+      const [accept, cancel] = handlersOf(view.render());
+      assert(accept && cancel, "expected an accept and a cancel handler");
+      cancel();
+      assertEquals(answers, [false], "Cancel must answer NO");
+    } finally {
+      restore();
+    }
+  });
+
+  it("the primary button answers yes", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { view, answers } = await makeView({
+        incomingDid: COUNTING_ENTROPY_DID,
+      });
+      handlersOf(view.render())[0]();
+      assertEquals(answers, [true]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("ignores an accept that lands inside the tap-through guard", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { view, answers } = await makeView({
+        incomingDid: COUNTING_ENTROPY_DID,
+        guarded: true, // as it is for the first moments on screen
+      });
+      handlersOf(view.render())[0]();
+      assertEquals(answers, [], "a tap in flight must not accept");
+    } finally {
+      restore();
+    }
+  });
+
+  it("still allows CANCEL during the guard", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { view, answers } = await makeView({
+        incomingDid: COUNTING_ENTROPY_DID,
+        guarded: true,
+      });
+      handlersOf(view.render())[1]();
+      assertEquals(answers, [false], "the guard must never trap the user");
+    } finally {
+      restore();
+    }
+  });
+
+  it("answers exactly once, even on a double tap", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { view, answers } = await makeView({
+        incomingDid: COUNTING_ENTROPY_DID,
+      });
+      const [accept, cancel] = handlersOf(view.render());
+      accept();
+      cancel();
+      accept();
+      assertEquals(answers, [true], "only the first answer counts");
+    } finally {
+      restore();
+    }
+  });
+
+  it("the already-signed-in screen cannot answer anything but yes", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { view, answers } = await makeView({
+        incomingDid: COUNTING_ENTROPY_DID,
+        currentDid: COUNTING_ENTROPY_DID,
+      });
+      const text = templateText(view.render());
+      assert(text.includes("Already signed in"));
+      handlersOf(view.render())[0]();
+      assertEquals(answers, [true]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("the failure screen explains why a refresh will not help", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { view, answers } = await makeView({ failure: "unreadable" });
+      const text = templateText(view.render());
+      assert(text.includes("could not be read"));
+      // The scrub has already removed the code, so the design's documented
+      // "refresh once and rescan" cannot work — the copy must say so.
+      // Whitespace-normalized: the template is line-wrapped by the formatter.
+      assert(
+        text.replace(/\s+/g, " ").includes("Reloading this page will not help"),
+        text,
+      );
+      handlersOf(view.render())[0]();
+      assertEquals(answers, [false], "the failure screen never accepts");
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("confirmWithUser (the production confirm path)", () => {
+  it("resolves false when the view answers no", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      // A stand-in element that the real confirmWithUser can drive.
+      class FakeView extends EventTarget {
+        incomingDid = "";
+        currentDid: string | null = null;
+        failure: string | null = null;
+        remove() {}
+      }
+      const created: FakeView[] = [];
+      // deno-lint-ignore no-explicit-any
+      (globalThis as any).document.createElement = () => {
+        const el = new FakeView();
+        created.push(el);
+        return el;
+      };
+      const { confirmWithUser } = await import(
+        "../src/lib/device-link-login.ts"
+      );
+      const pending = confirmWithUser(COUNTING_ENTROPY_DID, null);
+      const el = created[0];
+      assertEquals(el.incomingDid, COUNTING_ENTROPY_DID);
+      el.dispatchEvent(
+        new CustomEvent("device-link-result", { detail: { accepted: false } }),
+      );
+      assertEquals(await pending, false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("resolves true only when the view says so", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      class FakeView extends EventTarget {
+        incomingDid = "";
+        currentDid: string | null = null;
+        remove() {}
+      }
+      const created: FakeView[] = [];
+      // deno-lint-ignore no-explicit-any
+      (globalThis as any).document.createElement = () => {
+        const el = new FakeView();
+        created.push(el);
+        return el;
+      };
+      const { confirmWithUser } = await import(
+        "../src/lib/device-link-login.ts"
+      );
+      const pending = confirmWithUser(COUNTING_ENTROPY_DID, ZERO_ENTROPY_DID);
+      assertEquals(created[0].currentDid, ZERO_ENTROPY_DID);
+      created[0].dispatchEvent(
+        new CustomEvent("device-link-result", { detail: { accepted: true } }),
+      );
+      assertEquals(await pending, true);
+    } finally {
+      restore();
+    }
   });
 });

--- a/packages/shell/test/device-link.test.ts
+++ b/packages/shell/test/device-link.test.ts
@@ -1,0 +1,330 @@
+import { assert, assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { Identity } from "@commonfabric/identity";
+
+import {
+  consumeDeviceLinkFragment,
+  looksLikeDeviceLink,
+  parseDeviceLinkFragment,
+} from "../src/lib/device-link.ts";
+import { runDeviceLinkLogin } from "../src/lib/device-link-login.ts";
+
+// NOTE: this file lives in test/ deliberately. The shell's test task globs
+// `test/*.test.ts` ONLY — a co-located src/lib/*.test.ts is silently never run,
+// and the verify step would pass with zero coverage.
+
+/** Unpadded base64url, the QR payload encoding. */
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(
+    /=+$/,
+    "",
+  );
+}
+
+const ZERO_ENTROPY = new Uint8Array(32);
+// The all-zero BIP39 entropy vector, pinned in the identity package too.
+const ZERO_ENTROPY_DID =
+  "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp";
+
+describe("parseDeviceLinkFragment", () => {
+  it("decodes a well-formed device link to 32 bytes", () => {
+    const entropy = crypto.getRandomValues(new Uint8Array(32));
+    const parsed = parseDeviceLinkFragment("#k=" + toBase64Url(entropy));
+    assert(parsed);
+    assertEquals(parsed, entropy);
+  });
+
+  it("accepts the all-zero vector", () => {
+    const parsed = parseDeviceLinkFragment("#k=" + toBase64Url(ZERO_ENTROPY));
+    assertEquals(parsed, ZERO_ENTROPY);
+  });
+
+  it("rejects anything that is not exactly a device link", () => {
+    const valid = toBase64Url(ZERO_ENTROPY);
+    for (
+      const hash of [
+        "",
+        "#",
+        "#foo=bar",
+        "#kk=" + valid,
+        "#k=", // empty payload
+        "#k=" + valid.slice(0, 42), // too short
+        "#k=" + valid + "A", // too long
+        "#k=" + valid.slice(0, 42) + "+", // non-base64url character
+        "#k=" + valid.slice(0, 42) + "=", // padded
+        "#k=" + valid.slice(0, 42) + " ", // whitespace
+        "?k=" + valid, // query, not fragment
+      ]
+    ) {
+      assertEquals(
+        parseDeviceLinkFragment(hash),
+        null,
+        `should have rejected: ${JSON.stringify(hash)}`,
+      );
+    }
+  });
+
+  it("is pure — a rejected hash is simply null, never a throw", () => {
+    assertEquals(parseDeviceLinkFragment("#k=" + "!".repeat(43)), null);
+  });
+});
+
+describe("looksLikeDeviceLink", () => {
+  it("is true for malformed payloads too, so they still get scrubbed", () => {
+    // A malformed payload is still somebody's secret; leaving it in the
+    // address bar to be bookmarked or synced is the leak with none of the win.
+    assert(looksLikeDeviceLink("#k=garbage"));
+    assert(!looksLikeDeviceLink("#other"));
+  });
+});
+
+describe("consumeDeviceLinkFragment", () => {
+  // Minimal stand-ins: the real ones are read straight off globalThis.
+  function withLocation(
+    hash: string,
+    pathname = "/loom-jun-12/home",
+    search = "",
+  ) {
+    const replaced: string[] = [];
+    const originalLocation = globalThis.location;
+    const originalHistory = globalThis.history;
+    Object.defineProperty(globalThis, "location", {
+      value: { hash, pathname, search },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "history", {
+      value: {
+        replaceState: (_s: unknown, _t: string, url: string) => {
+          replaced.push(url);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    const restore = () => {
+      Object.defineProperty(globalThis, "location", {
+        value: originalLocation,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(globalThis, "history", {
+        value: originalHistory,
+        configurable: true,
+        writable: true,
+      });
+    };
+    return { replaced, restore };
+  }
+
+  it("returns the entropy and scrubs the fragment", () => {
+    const entropy = crypto.getRandomValues(new Uint8Array(32));
+    const ctx = withLocation("#k=" + toBase64Url(entropy));
+    try {
+      assertEquals(consumeDeviceLinkFragment(), entropy);
+      assertEquals(ctx.replaced, ["/loom-jun-12/home"]);
+    } finally {
+      ctx.restore();
+    }
+  });
+
+  it("preserves pathname and search when scrubbing", () => {
+    // Load-bearing, not cosmetic: the QR targets a deep link, and the boot must
+    // continue to that path so the flow ends inside a logged-in app the user
+    // bookmarks. The scrubbed URL is exactly what gets bookmarked.
+    const ctx = withLocation(
+      "#k=" + toBase64Url(ZERO_ENTROPY),
+      "/loom-jun-12/home",
+      "?ref=qr",
+    );
+    try {
+      consumeDeviceLinkFragment();
+      assertEquals(ctx.replaced, ["/loom-jun-12/home?ref=qr"]);
+    } finally {
+      ctx.restore();
+    }
+  });
+
+  it("scrubs even when the payload is malformed", () => {
+    const ctx = withLocation("#k=not-valid-entropy");
+    try {
+      assertEquals(consumeDeviceLinkFragment(), null);
+      assertEquals(ctx.replaced, ["/loom-jun-12/home"]);
+    } finally {
+      ctx.restore();
+    }
+  });
+
+  it("leaves unrelated fragments completely alone", () => {
+    const ctx = withLocation("#some-anchor");
+    try {
+      assertEquals(consumeDeviceLinkFragment(), null);
+      assertEquals(ctx.replaced, []);
+    } finally {
+      ctx.restore();
+    }
+  });
+});
+
+describe("device-link derivation", () => {
+  it("derives the pinned DID from the all-zero entropy vector", async () => {
+    // Pins that the shell and the pairing device agree on the derivation. If
+    // this DID ever moves, a scanned code signs the phone in as somebody else.
+    const identity = await Identity.fromEntropy(ZERO_ENTROPY);
+    assertEquals(identity.did(), ZERO_ENTROPY_DID);
+  });
+
+  it("round-trips a fragment to the identity it names", async () => {
+    // The whole path a scan takes: entropy -> QR text -> fragment -> identity.
+    const entropy = crypto.getRandomValues(new Uint8Array(32));
+    const expected = await Identity.fromEntropy(entropy);
+
+    const parsed = parseDeviceLinkFragment("#k=" + toBase64Url(entropy));
+    assert(parsed);
+    assertEquals((await Identity.fromEntropy(parsed)).did(), expected.did());
+  });
+
+  it("produces a payload that fits the pairing QR's byte budget", () => {
+    // The encoder driving the Pair screen's QR caps at 106 bytes, and the
+    // hosted deep-link target is already 54 of them. 43 chars is what makes
+    // the whole flow fit without touching the encoder.
+    const encoded = toBase64Url(crypto.getRandomValues(new Uint8Array(32)));
+    assertEquals(encoded.length, 43);
+    assertEquals(new TextEncoder().encode("#k=" + encoded).length, 46);
+  });
+});
+
+describe("runDeviceLinkLogin", () => {
+  /** In-memory stand-in for the IndexedDB-backed KeyStore. */
+  function fakeKeyStore(initial?: Identity) {
+    const entries = new Map<string, Identity>();
+    if (initial) entries.set("$ROOT_KEY", initial);
+    return {
+      store: {
+        // deno-lint-ignore require-await
+        get: async (name: string) => entries.get(name),
+        // deno-lint-ignore require-await
+        set: async (name: string, value: Identity) => {
+          entries.set(name, value);
+        },
+        // deno-lint-ignore no-explicit-any
+      } as any,
+      entries,
+    };
+  }
+
+  it("stores the new identity when confirmed", async () => {
+    const { store, entries } = fakeKeyStore();
+    const outcome = await runDeviceLinkLogin(
+      ZERO_ENTROPY,
+      () => Promise.resolve(true),
+      () => Promise.resolve(store),
+    );
+    assertEquals(outcome, "accepted");
+    assertEquals(entries.get("$ROOT_KEY")?.did(), ZERO_ENTROPY_DID);
+  });
+
+  it("does not touch the KeyStore when the user cancels", async () => {
+    const existing = await Identity.fromEntropy(
+      crypto.getRandomValues(new Uint8Array(32)),
+    );
+    const { store, entries } = fakeKeyStore(existing);
+    const outcome = await runDeviceLinkLogin(
+      ZERO_ENTROPY,
+      () => Promise.resolve(false),
+      () => Promise.resolve(store),
+    );
+    assertEquals(outcome, "cancelled");
+    assertEquals(entries.get("$ROOT_KEY")?.did(), existing.did());
+  });
+
+  it("REPLACES a different existing identity when confirmed", async () => {
+    // The case a LoginView-only handler would silently no-op on, and the one
+    // App.setIdentity refuses outright ("Cannot change identity while logged
+    // in") — which is why this writes ROOT_KEY directly, pre-initializeKeys.
+    const stale = await Identity.fromEntropy(
+      crypto.getRandomValues(new Uint8Array(32)),
+    );
+    const { store, entries } = fakeKeyStore(stale);
+    const outcome = await runDeviceLinkLogin(
+      ZERO_ENTROPY,
+      () => Promise.resolve(true),
+      () => Promise.resolve(store),
+    );
+    assertEquals(outcome, "accepted");
+    assertEquals(entries.get("$ROOT_KEY")?.did(), ZERO_ENTROPY_DID);
+  });
+
+  it("shows BOTH DIDs to the confirm gate when replacing", async () => {
+    // The confirm screen is the ONLY defence against a donated-identity link,
+    // so it must be handed the DIDs a user can cross-check against the Pair
+    // screen — not a truncation or a placeholder.
+    const stale = await Identity.fromEntropy(
+      crypto.getRandomValues(new Uint8Array(32)),
+    );
+    const { store } = fakeKeyStore(stale);
+    let seen: [string, string | null] | null = null;
+    await runDeviceLinkLogin(
+      ZERO_ENTROPY,
+      (incoming, current) => {
+        seen = [incoming, current];
+        return Promise.resolve(false);
+      },
+      () => Promise.resolve(store),
+    );
+    assertEquals(seen, [ZERO_ENTROPY_DID, stale.did()]);
+  });
+
+  it("passes a null current DID on a fresh device", async () => {
+    const { store } = fakeKeyStore();
+    let current: string | null | undefined;
+    await runDeviceLinkLogin(
+      ZERO_ENTROPY,
+      (_incoming, currentDid) => {
+        current = currentDid;
+        return Promise.resolve(false);
+      },
+      () => Promise.resolve(store),
+    );
+    assertEquals(current, null);
+  });
+
+  it("re-scanning the same code is a no-op write", async () => {
+    const same = await Identity.fromEntropy(ZERO_ENTROPY);
+    const { store, entries } = fakeKeyStore(same);
+    let wrote = false;
+    store.set = () => {
+      wrote = true;
+      return Promise.resolve();
+    };
+    const outcome = await runDeviceLinkLogin(
+      ZERO_ENTROPY,
+      () => Promise.resolve(true),
+      () => Promise.resolve(store),
+    );
+    assertEquals(outcome, "accepted");
+    assert(!wrote, "should not churn the stored key when nothing changed");
+    assertEquals(entries.get("$ROOT_KEY")?.did(), ZERO_ENTROPY_DID);
+  });
+
+  it("reports invalid entropy without prompting or opening the store", async () => {
+    let prompted = false;
+    let opened = false;
+    const outcome = await runDeviceLinkLogin(
+      new Uint8Array(3), // not a valid ed25519 seed
+      () => {
+        prompted = true;
+        return Promise.resolve(true);
+      },
+      () => {
+        opened = true;
+        return Promise.resolve(fakeKeyStore().store);
+      },
+    );
+    assertEquals(outcome, "invalid");
+    assert(!prompted, "must not prompt for undecodable entropy");
+    assert(!opened, "must not open the KeyStore for undecodable entropy");
+  });
+});

--- a/packages/shell/test/device-link.test.ts
+++ b/packages/shell/test/device-link.test.ts
@@ -1123,3 +1123,126 @@ describe("the tap-through guard actually releases", () => {
     }
   });
 });
+
+// ── handleDeviceLink: the whole per-scan decision ──────────────────────────
+//
+// This logic used to live in index.ts — an entry module with a top-level await
+// that no unit test can import, so every branch here was uncoverable by
+// construction. Moving it into a real module is what makes these assertions
+// possible at all; the coverage ratchet was pointing at a genuine design smell.
+
+describe("handleDeviceLink", () => {
+  async function load() {
+    return await import("../src/lib/device-link-login.ts");
+  }
+
+  it("reports a malformed fragment and never attempts a login", async () => {
+    const { handleDeviceLink } = await load();
+    const reported: string[] = [];
+    let loggedIn = false;
+    await handleDeviceLink({ kind: "malformed" }, {
+      report: (r) => {
+        reported.push(r);
+        return Promise.resolve();
+      },
+      login: () => {
+        loggedIn = true;
+        return Promise.resolve("accepted" as const);
+      },
+    });
+    assertEquals(reported, ["unreadable"]);
+    assert(!loggedIn, "a malformed payload has no entropy to log in with");
+  });
+
+  it("reports an invalid entropy outcome", async () => {
+    const { handleDeviceLink } = await load();
+    const reported: string[] = [];
+    await handleDeviceLink({ kind: "entropy", entropy: ZERO_ENTROPY }, {
+      report: (r) => {
+        reported.push(r);
+        return Promise.resolve();
+      },
+      login: () => Promise.resolve("invalid" as const),
+    });
+    assertEquals(reported, ["unreadable"]);
+  });
+
+  it("is SILENT on cancel and on already-signed-in", async () => {
+    // Cancel is an intentional "not mine"; already-signed-in is a successful
+    // no-op. Nagging on either would train users to dismiss the real warnings.
+    const { handleDeviceLink } = await load();
+    for (const outcome of ["cancelled", "already-signed-in"] as const) {
+      const reported: string[] = [];
+      let reloaded = false;
+      await handleDeviceLink({ kind: "entropy", entropy: ZERO_ENTROPY }, {
+        reloadOnReplace: true,
+        report: (r) => {
+          reported.push(r);
+          return Promise.resolve();
+        },
+        login: () => Promise.resolve(outcome),
+        reload: () => {
+          reloaded = true;
+        },
+      });
+      assertEquals(reported, [], `${outcome} must not report a failure`);
+      assert(!reloaded, `${outcome} must not reload`);
+    }
+  });
+
+  it("reloads after an accepted replace on the hashchange path", async () => {
+    // The running app still holds the OLD identity; without the reload it would
+    // keep signing as it despite the KeyStore having been updated.
+    const { handleDeviceLink } = await load();
+    let reloaded = false;
+    await handleDeviceLink({ kind: "entropy", entropy: ZERO_ENTROPY }, {
+      reloadOnReplace: true,
+      login: () => Promise.resolve("accepted" as const),
+      reload: () => {
+        reloaded = true;
+      },
+      report: () => Promise.resolve(),
+    });
+    assert(reloaded, "an accepted replace mid-session must re-bootstrap");
+  });
+
+  it("does NOT reload on the bootstrap path", async () => {
+    // initializeKeys() has not run yet there, so it picks the new key up
+    // directly — reloading would be a gratuitous flash.
+    const { handleDeviceLink } = await load();
+    let reloaded = false;
+    await handleDeviceLink({ kind: "entropy", entropy: ZERO_ENTROPY }, {
+      login: () => Promise.resolve("accepted" as const),
+      reload: () => {
+        reloaded = true;
+      },
+      report: () => Promise.resolve(),
+    });
+    assert(!reloaded, "bootstrap must not reload");
+  });
+
+  it("never throws — a mid-flow error is reported, not propagated", async () => {
+    // An uncaught throw on the bootstrap path skips initializeKeys AND
+    // Navigation, stranding the user on a login screen with no explanation.
+    const { handleDeviceLink } = await load();
+    const reported: string[] = [];
+    await handleDeviceLink({ kind: "entropy", entropy: ZERO_ENTROPY }, {
+      login: () => Promise.reject(new Error("KeyStore.open rejected")),
+      report: (r) => {
+        reported.push(r);
+        return Promise.resolve();
+      },
+    });
+    assertEquals(reported, ["failed"]);
+  });
+
+  it("survives the reporter itself failing", async () => {
+    // Last line of defence: if even the failure screen cannot render, boot on
+    // rather than hanging forever.
+    const { handleDeviceLink } = await load();
+    await handleDeviceLink({ kind: "entropy", entropy: ZERO_ENTROPY }, {
+      login: () => Promise.reject(new Error("boom")),
+      report: () => Promise.reject(new Error("the reporter is broken too")),
+    });
+  });
+});

--- a/packages/shell/test/standard-decorators-shell-views-phase3.test.ts
+++ b/packages/shell/test/standard-decorators-shell-views-phase3.test.ts
@@ -24,6 +24,7 @@ Deno.test("shell view slice type-checks under standard decorators", async () => 
     "packages/shell/src/views/AppView.ts",
     "packages/shell/src/views/BodyView.ts",
     "packages/shell/src/views/DebuggerView.ts",
+    "packages/shell/src/views/DeviceLinkView.ts",
     "packages/shell/src/views/HeaderView.ts",
     "packages/shell/src/views/LoginView.ts",
     "packages/shell/src/views/QuickJumpView.ts",


### PR DESCRIPTION
## Why

An identity minted on a desktop is trapped there. There is no way to get the
*same* identity onto a phone or a second browser — the key is random PKCS8 with
no recoverable phrase — and once space ACL enforcement lands, a device signing
under a different DID stops being merely untidy and starts being locked out.

This is the shell half of the fix (Exec Sync 2026-07-21, design in
[commontoolsinc/loom#4209](https://github.com/commontoolsinc/loom/pull/4209),
approved in principle by @bfollington): hand the identity across as its BIP39
**entropy** in a URL fragment, scanned from a QR with the phone's native camera.
32 bytes fit in a QR where 24 words do not, and a fragment never reaches a
server. The loom half (the Mac-side Pair screen that generates the QR) is a
separate PR and does not block this one.

**Deliberately interim, and scoped to be deleted when key delegation ships.**
Nothing here should be built on.

## What changed

**`packages/shell`** — `#k=<43-char base64url entropy>` is consumed at
**bootstrap**, not in LoginView: LoginView never mounts when a stale identity
auto-logs in, which is exactly the re-pair case a LoginView-only handler would
silently no-op on. The fragment is scrubbed synchronously before any await, then
a confirm dialog shows the incoming DID, then `ROOT_KEY` is written straight to
the KeyStore *before* `initializeKeys()` — routing through `App.setIdentity`
would throw `"Cannot change identity while logged in"`, which is the whole point
of the replace case.

**`packages/identity`** — one new method, `Identity.toRaw()`: the raw 32-byte
ed25519 seed, the exact inverse of `fromRaw` (mirroring `fromPkcs8`/`toPkcs8`).

## Four things worth your attention

**1. `toRaw()` has no consumer inside this repo.** It exists for a downstream
Loom CLI that today deep-imports `src/ed25519/utils.ts` *by file path* — this
lets that retire. Two notes so it's judged on the true grounds:

- It is **not new exposure**. `Identity.serialize()` is already public and
  root-exported and already returns the same raw seed. `toRaw()` is strictly
  *safer*: `serialize()` hands back the **live internal buffer** (mutate it and
  you corrupt the identity), `toRaw()` returns a copy.
- It is named `toRaw`, not `toEntropy`, on purpose. Those bytes are valid BIP39
  entropy only because `fromMnemonic` has no KDF. If a KDF ever lands, `toRaw`
  stays true while `toEntropy` would silently start lying — so the BIP39
  vocabulary lives at the call site. An earlier revision of this branch had
  `fromEntropy`/`toEntropy` and root-exported three pkcs8 primitives; both were
  withdrawn on review. Happy to drop this entirely and keep the deep import if
  you'd rather not grow the surface.

**2. Deviation: `saveCredential(createPassphraseCredential())` is NOT called
after storing the identity** (the design's step 1.2 said to). It mints a fresh
UUID over `storedCredential`, which makes quick-unlock offer a **24-word
passphrase form the paired device can never satisfy** — it received entropy,
never the words — and the "clear saved credential" button lives in the
`!isPassphrase` branch, so there's no UI to escape it. `initializeKeys` adopts
`ROOT_KEY` without any credential record, so the write bought nothing. (It also
overwrites a passkey's descriptor id — *not* irrecoverable, since passkeys here
are discoverable: login still works via the account picker and re-saves the
descriptor.) If you want a record here, the honest fix is a fourth `AuthMethod`
for device-link rather than reusing `passphrase`.

**3. Residual credential-in-URL channels — stated, not hidden.** The confirm
screen is the *sole* defence against a donated-identity link (a crafted URL or a
QR sticker would otherwise sign a victim in as the attacker), which is why it
shows the DID prominently and names where the code should have come from. The
scrub removes the secret from the address bar, bookmarks and the session history
entry, but **not**:
- `performance.getEntriesByType("navigation")[0].name`, which keeps the full URL
  for the document's lifetime with no API to clear it. This matters concretely:
  `@opentelemetry/instrumentation-document-load` reads exactly that entry as
  `http.url`, and this shell already ships an OTLP exporter. It is **not** wired
  today — please keep it that way, or filter the attribute.
- the browser's persistent history entry (committed before any script ran), and
  the window between navigation commit and bundle evaluation.

These are accepted for an interim flow and are why the payload is opaque entropy
rather than words.

**4. `TODO(device-link-pwa)`: pairing does not reach an installed home-screen
PWA.** iOS partitions storage per-app and the manifest's `start_url: "/"` drops
the deep link, so an installed PWA opens logged-out. Confirmed on iPhone / iOS
17.5. Left unfixed deliberately — nobody uses that entry today and the
Safari-tab bookmark works. Changing `start_url` affects every install, so that's
your call, not mine.

## Test plan

Tests live in `packages/shell/test/` — the shell's test task globs
`test/*.test.ts` only, so a co-located `src/lib/*.test.ts` would silently never
run.

- `deno task check` — green (401 paths). `DeviceLinkView.ts` added to the
  standard-decorators phase-3 slice it was missing from.
- `packages/shell` — **50 passed / 112 steps**; `packages/identity` — **17
  passed** (4 new `toRaw` cases: round-trip, asymmetric vector, copy-not-alias,
  honest non-noble throw).
- `deno lint` / `deno fmt --check` — clean.
- Verified with **mutation testing**: rewiring Escape to accept, dropping the
  cancel listener, skipping `showModal`, removing the unsupported-`showModal`
  fallback, disabling the frame bail-out, and leaking the guard timer each now
  **fail** the suite. Several of those passed it before this branch's last
  commit.
- Derivation is pinned against both the all-zero BIP39 vector **and an
  asymmetric one** — the all-zero vector is a fixed point of reversal, so a
  seed-mangling bug passed a suite that only used it.
- Driven on a **real iPhone (iOS 17.5 simulator)**: `<dialog>.showModal()` in a
  shadow root works, the backdrop covers the shell's fixed elements, the focus
  trap holds, and the post-confirm address bar is fragment-free (so the
  bookmark the flow tells users to make is clean).

**A CI gap worth knowing:** the shell build runs only in `deploy-shell-staging`,
gated on `main` — PR CI never builds the bundle. An earlier revision of this
branch emitted a bundle that was a `SyntaxError` (a dynamic `await import()` made
esbuild wrap a top-level await in a non-async function), which every green check
missed. Fixed here, and verified with `node --check` on all four emitted files —
but "CI green" does not mean "the shell loads" for this package.

## After merge

The mobile leg is live only once hosted **estuary is redeployed** — that's the
longest pole and the reason this PR is first. @bfollington, flagging you for
that. Loom needs no vendor bump for functionality; the pin can be adopted
opportunistically later for local-shell parity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds device-link login to pair an existing identity onto a phone using a `#k=` URL fragment (BIP39 entropy), with a confirm screen and safe scrubbing. Also adds `Identity.toRaw()` to export the raw 32‑byte ed25519 seed (copy); plus a small refactor to make per-scan handling fully testable.

- **New Features**
  - `packages/shell`: Reads `#k=<43-char base64url>` at bootstrap, scrubs it immediately, confirms the incoming DID, then writes `ROOT_KEY` directly to the KeyStore before `initializeKeys()`. Handles re-scans via `hashchange` and reloads on replace.
  - `packages/shell`: Modal confirm view in the top layer with a brief tap-through guard; shows both DIDs when replacing; reports malformed/failed scans so users don’t think “nothing happened.”
  - `packages/identity`: Adds `Identity.toRaw()` to return a copy of the 32‑byte seed (throws if the backend is WebCrypto); tests pin round-trips, copy semantics, and DID derivation.
  - Tests: Broad coverage for confirm wiring, modal activation/fallbacks, frame bailout, scrub failure, guard timer, per-scan decisions (malformed/invalid/cancel/already-signed-in), and reload-on-replace only after a re-scan. Known limitation: iOS installed PWA doesn’t receive the pairing (`TODO(device-link-pwa)`).

- **Bug Fixes**
  - Statically import device-link modules to avoid an esbuild TLA SyntaxError that broke the shell load.
  - Hardened flow: frame bailout; crash-safe dialog activation (fallback when `showModal` is missing/throws); wrapped errors with user-visible failure; and no `saveCredential(createPassphraseCredential())` to avoid an unusable quick‑unlock state.
  - Refactor: moved per-scan decision logic out of the entry module into `handleDeviceLink` (`packages/shell/src/lib/device-link-login.ts`) and added focused tests; `index.ts` now keeps only the wiring (including `hashchange` reload on accepted replace).

<sup>Written for commit 8f21fc22c5841949e37c5ce61156bb5d685e55a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

## Coverage debt — what was fixed, and what is being accepted

The ratchet flagged +81 uncovered lines. Most of that was a fair cop and is now
fixed; the residue is a measurement artifact, not untested code.

**Fixed (+81 → +29), by finding real gaps rather than padding:**
- `reportDeviceLinkFailure` was 100% uncovered — the entire reason a failed scan
  isn't silent. Now covered, along with the scrub's catch arm, the
  `activateModalDialog` last-ditch arm, and the guard timer's callback body
  (leaving that uncovered meant the accept button could stay disabled forever).
- The ratchet also pointed at a genuine design smell: the per-scan decision
  logic lived in `index.ts`, an entry module with a top-level `await` that no
  unit test can import — so every branch was untestable by construction. It now
  lives in `device-link-login.ts` with 7 tests, and `index.ts` is wiring only
  (82 added lines → 40).

**Accepted, because more tests cannot move them:**
- `packages/shell` +15 — 11 tracked lines are `index.ts` wiring (unimportable
  entry module); the rest are the `atob` catch and decoded-length guard in
  `device-link.ts`, unreachable behind the 43-char base64url regex. I wrote
  tautological tests for those, saw they asserted nothing, and deleted them.
- `packages/identity` +14 — **not fixable by tests at all.** There is no
  `coverage-profile-package-identity` artifact: the identity suite runs under
  the browser harness and emits no profile, and `tasks/coverage-metrics.ts`
  counts lines with no coverage record as entirely uncovered. `toRaw` has four
  real tests (round-trip, asymmetric vector, copy-not-alias, non-noble throw)
  and still scores zero. Flagging in case profiling that package is worth doing
  separately — happy to drop `toRaw` entirely if you'd rather not carry it.

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/identity uncovered lines = 301 lines
ACCEPT_COVERAGE_DEBT: coverage-debt: packages/shell uncovered lines = 6828 lines
