### PR TITLE
refactor(cfc): label carriers name the clauses and atoms they hold

### DIFF
--- a/packages/cf-harness/src/contracts/cfc-model-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-model-context.ts
@@ -1,4 +1,8 @@
-import type { CfcLabelView, IFCLabel } from "@commonfabric/runner/cfc";
+import type {
+  CfcConfClause,
+  CfcLabelView,
+  IFCLabel,
+} from "@commonfabric/runner/cfc";
 import type { HarnessCfcInvocationInputLabelPath } from "./cfc-invocation-context.ts";
 import type { ToolOutputId } from "./tool-result.ts";
 
@@ -81,7 +85,7 @@ const labelValueKey = (value: unknown): string => {
 export const mergeConfidentialityOnlyLabels = (
   labels: readonly (IFCLabel | undefined)[],
 ): IFCLabel | undefined => {
-  const confidentiality: unknown[] = [];
+  const confidentiality: CfcConfClause[] = [];
   const seen = new Set<string>();
   for (const label of labels) {
     const confidentialityOnly = label === undefined

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -27,6 +27,7 @@ import {
   UI,
   useCancelGroup,
 } from "@commonfabric/runner";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import type { CellRef } from "@commonfabric/runtime-client";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -170,7 +171,7 @@ export class WorkerReconciler {
     );
     this.rootRenderPolicy = ceiling === undefined ? DEFAULT_RENDER_POLICY : {
       declassifyConfidentiality: [],
-      maxConfidentiality: [...(ceiling.atoms ?? [])],
+      maxConfidentiality: [...(ceiling.atoms ?? [])] as readonly CfcAtom[],
       caveatKindAllow: [...(ceiling.caveatKinds ?? [])],
     };
   }
@@ -539,7 +540,7 @@ export class WorkerReconciler {
       policy = {
         maxConfidentiality: this.narrowMaxConfidentiality(
           parentPolicy.maxConfidentiality,
-          localMax,
+          localMax as readonly CfcAtom[] | undefined,
         ),
         // The host's caveat-kind allowance is part of the default ceiling
         // profile; boundaries narrow maxConfidentiality but never widen or
@@ -624,7 +625,7 @@ export class WorkerReconciler {
   private staticPropAsAtomList(
     props: WorkerProps | null | undefined,
     key: string,
-  ): readonly unknown[] | undefined {
+  ): readonly CfcAtom[] | undefined {
     if (!props || typeof props !== "object" || !(key in props)) {
       return undefined;
     }
@@ -636,9 +637,9 @@ export class WorkerReconciler {
       return undefined;
     }
     if (Array.isArray(value)) {
-      return value;
+      return value as readonly CfcAtom[];
     }
-    return [value];
+    return [value as CfcAtom];
   }
 
   private nodePropForRenderPolicy(
@@ -920,9 +921,9 @@ export class WorkerReconciler {
   }
 
   private narrowMaxConfidentiality(
-    parentMax: readonly unknown[] | undefined,
-    localMax: readonly unknown[] | undefined,
-  ): readonly unknown[] | undefined {
+    parentMax: readonly CfcAtom[] | undefined,
+    localMax: readonly CfcAtom[] | undefined,
+  ): readonly CfcAtom[] | undefined {
     if (parentMax === undefined) {
       return localMax;
     }
@@ -1065,8 +1066,8 @@ export class WorkerReconciler {
    * admit only bare atoms — an OR-clause never matches either, staying closed.
    */
   private resolvedConfidentialityRenderable(
-    confidentiality: readonly unknown[],
-    integrity: readonly unknown[],
+    confidentiality: readonly CfcAtom[],
+    integrity: readonly CfcAtom[],
     policy: RenderPolicy,
   ): boolean {
     const resolved = this.resolveRenderConfidentiality!({
@@ -1130,7 +1131,7 @@ export class WorkerReconciler {
     return this.canRenderConfidentialityAtom(atom, policy);
   }
 
-  private confidentialityLabels(labelView: CfcLabelView): readonly unknown[] {
+  private confidentialityLabels(labelView: CfcLabelView): readonly CfcAtom[] {
     return ContextualFlowControl.uniqueAtoms(
       labelView.entries.flatMap((entry) => [
         ...(entry.label.confidentiality ?? []),
@@ -1378,7 +1379,7 @@ export class WorkerReconciler {
     );
   }
 
-  private integrityLabels(labelView: CfcLabelView): readonly unknown[] {
+  private integrityLabels(labelView: CfcLabelView): readonly CfcAtom[] {
     return ContextualFlowControl.uniqueAtoms(
       labelView.entries.flatMap((entry) =>
         entry.path.length === 0 ? [...(entry.label.integrity ?? [])] : []

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Cancel, Cell, JSONSchema } from "@commonfabric/runner";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import type {
   RenderConfidentialityResolver,
   SpaceMembershipProvider,
@@ -101,7 +102,7 @@ export interface RenderPolicy {
    * Confidentiality atoms allowed to render in this subtree.
    * Undefined means no render-time confidentiality bound is active.
    */
-  maxConfidentiality?: readonly unknown[];
+  maxConfidentiality?: readonly CfcAtom[];
 
   /**
    * Caveat kinds admitted by the host's default render ceiling (spec

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2,6 +2,8 @@ import {
   FabricPrimitive,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
+import type { CfcAtom } from "@commonfabric/api/cfc";
+import type { CfcConfClause } from "../cfc/clause.ts";
 import {
   DEFAULT_MODEL_NAME,
   LLMClient,
@@ -164,7 +166,7 @@ type SerializeForLLMObservationParams = {
   logicalPath?: readonly string[];
   rootLink?: NormalizedFullLink;
   labelView?: CfcLabelView;
-  observationMaxConfidentiality?: readonly unknown[];
+  observationMaxConfidentiality?: readonly CfcConfClause[];
 };
 
 function normalizeInputSchema(schemaLike: unknown): JSONSchema {
@@ -865,20 +867,20 @@ type ToolCatalog = {
   dynamicToolCells: Map<string, Cell<Schema<typeof LLMToolSchema>>>;
 };
 
-type DialogMessageObservationMap = Record<string, unknown[]>;
+type DialogMessageObservationMap = Record<string, CfcConfClause[]>;
 
 type DialogRequestSnapshot = {
   llmParams: LLMRequest;
   toolCatalog: ToolCatalog;
   userResultSchema: JSONSchema | undefined;
   queueName?: string;
-  observationMaxConfidentiality?: readonly unknown[];
-  systemObservedConfidentiality: readonly unknown[];
+  observationMaxConfidentiality?: readonly CfcConfClause[];
+  systemObservedConfidentiality: readonly CfcConfClause[];
 };
 
 type AvailableCellsDocumentation = {
   docs: string;
-  observedConfidentiality: readonly unknown[];
+  observedConfidentiality: readonly CfcConfClause[];
 };
 
 function resolveDirectContextCellRef(cell: unknown): Cell<any> | undefined {
@@ -1417,7 +1419,7 @@ function materializeDialogRequestSnapshot(
     runtime,
     "llmDialog",
     inputs.key("observationMaxConfidentiality").withTx(tx).get() as
-      | readonly unknown[]
+      | readonly CfcConfClause[]
       | undefined,
   );
   const toolsCell = inputs.key("tools").withTx(tx) as Cell<
@@ -1513,7 +1515,7 @@ function buildAvailableCellsDocumentationWithObservation(
   space: MemorySpace,
   context: Record<string, unknown> | undefined,
   pinnedCells: Cell<PinnedCell[]>,
-  observationMaxConfidentiality?: readonly unknown[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ): AvailableCellsDocumentation {
   // Collect all cell entries, deduplicating by resolved path.
   // When the same cell appears multiple times (e.g., from context AND pinned),
@@ -1524,7 +1526,7 @@ function buildAvailableCellsDocumentationWithObservation(
       name: string;
       entry: string;
       hasSchema: boolean;
-      observedConfidentiality: readonly unknown[];
+      observedConfidentiality: readonly CfcConfClause[];
     }
   >();
 
@@ -1546,7 +1548,7 @@ function buildAvailableCellsDocumentationWithObservation(
     if (existing?.hasSchema && !schemaInfo) return;
 
     let entry = `## ${name} (${path})\n`;
-    let observedConfidentiality: readonly unknown[] = [];
+    let observedConfidentiality: readonly CfcConfClause[] = [];
 
     if (schemaInfo !== undefined) {
       const schemaStr = getSchemaTypeString(schemaInfo);
@@ -1664,7 +1666,7 @@ function buildAvailableCellsDocumentation(
   space: MemorySpace,
   context: Record<string, unknown> | undefined,
   pinnedCells: Cell<PinnedCell[]>,
-  observationMaxConfidentiality?: readonly unknown[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ): string {
   return buildAvailableCellsDocumentationWithObservation(
     runtime,
@@ -1681,7 +1683,7 @@ function getObservedDialogMessages(
   messageObservations: DialogMessageObservationMap,
 ): {
   messages: readonly BuiltInLLMMessage[];
-  observedConfidentiality: readonly unknown[];
+  observedConfidentiality: readonly CfcConfClause[];
 } {
   const labelView = cfcLabelViewForCellFailClosed(messagesCell);
   const observedConfidentiality = joinCfcObservedConfidentiality(
@@ -1703,10 +1705,10 @@ function getObservedDialogMessages(
 function mergeDialogMessageObservations(
   current: DialogMessageObservationMap | undefined,
   updates: Array<
-    { index: number; observedConfidentiality: readonly unknown[] }
+    { index: number; observedConfidentiality: readonly CfcConfClause[] }
   >,
 ): DialogMessageObservationMap {
-  const merged: Record<string, unknown[]> = {
+  const merged: Record<string, CfcConfClause[]> = {
     ...(current ?? {}),
   };
   for (const update of updates) {
@@ -1714,7 +1716,7 @@ function mergeDialogMessageObservations(
     merged[key] = uniqueCfcAtoms([
       ...(merged[key] ?? []),
       ...(update.observedConfidentiality ?? []),
-    ]) as unknown[];
+    ]);
   }
   return merged;
 }
@@ -1723,7 +1725,7 @@ function recordDialogMessageObservations(
   tx: IExtendedStorageTransaction,
   internal: Cell<Schema<typeof internalSchema>>,
   updates: Array<
-    { index: number; observedConfidentiality: readonly unknown[] }
+    { index: number; observedConfidentiality: readonly CfcConfClause[] }
   >,
 ): void {
   if (updates.length === 0) {
@@ -1991,7 +1993,7 @@ type ToolCallExecutionResult = {
   toolName: string;
   result?: any;
   error?: string;
-  observedConfidentiality?: readonly unknown[];
+  observedConfidentiality?: readonly CfcConfClause[];
 };
 
 /**
@@ -2012,8 +2014,8 @@ type ToolCallExecutionResult = {
 function effectiveObservationCeiling(
   runtime: Runtime,
   sink: string,
-  patternBound: readonly unknown[] | undefined,
-): readonly unknown[] | undefined {
+  patternBound: readonly CfcConfClause[] | undefined,
+): readonly CfcConfClause[] | undefined {
   const ceilings = runtime.cfcSinkMaxConfidentiality;
   // Object.hasOwn guard: the sink name is a runner-controlled literal today, but
   // a name colliding with an Object.prototype member must resolve to "no
@@ -2027,7 +2029,7 @@ function effectiveObservationCeiling(
 function toolAllowsObservedConfidentiality(
   toolCatalog: ToolCatalog,
   toolName: string,
-  observedConfidentiality: readonly unknown[] | undefined,
+  observedConfidentiality: readonly CfcConfClause[] | undefined,
 ): boolean {
   if (!observedConfidentiality || observedConfidentiality.length === 0) {
     return true;
@@ -2094,7 +2096,11 @@ function toolInputRequiredIntegrityFailure(
       // membership the commit-boundary gates use. `trust` carries the acting
       // principal's closure so a CONCEPT-valued floor accepts any concrete
       // atom above the concept (D5), consistently with the read/write gates.
-      const satisfied = cfcIntegritySatisfiesFloor(integrity, required, trust);
+      const satisfied = cfcIntegritySatisfiesFloor(
+        integrity as readonly CfcAtom[],
+        required,
+        trust,
+      );
       if (!satisfied) {
         return `field "${path || "(root)"}" requires integrity the ` +
           `model-supplied value does not carry (pass an integrity-bearing ` +
@@ -2207,8 +2213,8 @@ async function executeToolCalls(
   toolCatalog: ToolCatalog,
   toolCallParts: BuiltInLLMToolCallPart[],
   pinnedCells?: Cell<PinnedCell[]>,
-  observedConfidentiality?: readonly unknown[],
-  observationMaxConfidentiality?: readonly unknown[],
+  observedConfidentiality?: readonly CfcConfClause[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ): Promise<ToolCallExecutionResult[]> {
   const results: ToolCallExecutionResult[] = [];
   for (const part of toolCallParts) {
@@ -2482,11 +2488,11 @@ function handleSchema(
 async function handleRead(
   resolved: ResolvedToolCall & { type: "read" },
   space: MemorySpace,
-  observationMaxConfidentiality?: readonly unknown[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ): Promise<
   {
     result: { type: string; value: unknown };
-    observedConfidentiality: readonly unknown[];
+    observedConfidentiality: readonly CfcConfClause[];
   }
 > {
   let cell = resolved.cellRef.resolveAsCell().asSchemaFromLinks();
@@ -2645,10 +2651,10 @@ async function handleInvoke(
   runtime: Runtime,
   space: MemorySpace,
   resolved: ResolvedToolCall,
-  observationMaxConfidentiality?: readonly unknown[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ): Promise<{
   result: { type: string; value: any };
-  observedConfidentiality: readonly unknown[];
+  observedConfidentiality: readonly CfcConfClause[];
 }> {
   const toolCall = resolved.call;
 
@@ -2847,7 +2853,7 @@ async function invokeToolCall(
   resolved: ResolvedToolCall,
   _catalog?: ToolCatalog,
   pinnedCells?: Cell<PinnedCell[]>,
-  observationMaxConfidentiality?: readonly unknown[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ) {
   // Handle pinned cell tools
   if (resolved.type === "pin") {
@@ -3292,7 +3298,7 @@ async function startRequest(
       runtime,
       "llmDialog",
       inputs.key("observationMaxConfidentiality").get() as
-        | readonly unknown[]
+        | readonly CfcConfClause[]
         | undefined,
     );
   const builtinTools = inputs.key("builtinTools").get() !== false;
@@ -3315,7 +3321,7 @@ async function startRequest(
     messages: Schema<typeof LLMMessageSchema>[],
   ) => {
     const startIndex = (messagesCell.withTx(tx).get() as
-      | readonly unknown[]
+      | readonly CfcConfClause[]
       | undefined)?.length ?? 0;
     messagesCell.withTx(tx).push(...messages);
     if (runtime.cfcEnforcementMode === "disabled") {

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -1,4 +1,5 @@
 import { getLogger } from "@commonfabric/utils/logger";
+import type { CfcConfClause } from "../cfc/clause.ts";
 import {
   DEFAULT_GENERATE_OBJECT_MODELS,
   DEFAULT_MODEL_NAME,
@@ -233,7 +234,7 @@ function summarizeGenerateObjectRequest(details: {
   };
 }
 
-function collectCellConfidentiality(cell: Cell<any>): readonly unknown[] {
+function collectCellConfidentiality(cell: Cell<any>): readonly CfcConfClause[] {
   const labelView = cfcLabelViewForCellFailClosed(cell.resolveAsCell());
   if (labelView === undefined) {
     return [];
@@ -246,7 +247,7 @@ function collectCellConfidentiality(cell: Cell<any>): readonly unknown[] {
 
 function collectGenerateObjectPromptConfidentiality(
   inputs: Cell<any>,
-): readonly unknown[] {
+): readonly CfcConfClause[] {
   return uniqueCfcAtoms([
     ...collectCellConfidentiality(inputs.key("prompt")),
     ...collectCellConfidentiality(inputs.key("messages")),
@@ -339,8 +340,8 @@ async function executeWithToolsLoop(params: {
   toolCatalog?:
     | ReturnType<typeof llmToolExecutionHelpers.buildToolCatalog>
     | undefined;
-  initialObservedConfidentiality?: readonly unknown[];
-  observationMaxConfidentiality?: readonly unknown[];
+  initialObservedConfidentiality?: readonly CfcConfClause[];
+  observationMaxConfidentiality?: readonly CfcConfClause[];
   updatePartial: (text: string) => void;
   runtime: Runtime;
   space: any;
@@ -363,7 +364,7 @@ async function executeWithToolsLoop(params: {
 
   const executeRecursive = async (
     currentMessages: readonly BuiltInLLMMessage[],
-    observedConfidentiality: readonly unknown[],
+    observedConfidentiality: readonly CfcConfClause[],
   ): Promise<void> => {
     if (thisRun !== getCurrentRun()) return;
 
@@ -496,7 +497,7 @@ function buildContextDocumentation(
   space: any,
   tx: IExtendedStorageTransaction,
   sink: string,
-): { docs: string; observedConfidentiality: readonly unknown[] } {
+): { docs: string; observedConfidentiality: readonly CfcConfClause[] } {
   const context = inputs.key("context").withTx(tx).get();
   if (!context) {
     return {
@@ -537,7 +538,7 @@ function buildContextDocumentation(
         runtime,
         sink,
         inputs.key("observationMaxConfidentiality").withTx(tx).get() as
-          | readonly unknown[]
+          | readonly CfcConfClause[]
           | undefined,
       ),
     );
@@ -782,7 +783,7 @@ export function llm(
                     runtime,
                     "llm",
                     inputs.key("observationMaxConfidentiality").get() as
-                      | readonly unknown[]
+                      | readonly CfcConfClause[]
                       | undefined,
                   ),
                 updatePartial,
@@ -1125,7 +1126,7 @@ export function generateText(
                     runtime,
                     "generateText",
                     inputs.key("observationMaxConfidentiality").get() as
-                      | readonly unknown[]
+                      | readonly CfcConfClause[]
                       | undefined,
                   ),
                 updatePartial,
@@ -1272,7 +1273,7 @@ export function generateObject<T extends Record<string, unknown>>(
         runtime,
         "generateObject",
         inputs.key("observationMaxConfidentiality").withTx(tx).get() as
-          | readonly unknown[]
+          | readonly CfcConfClause[]
           | undefined,
       );
     const outputScope = tx.getNarrowestReadScope();
@@ -1359,7 +1360,7 @@ export function generateObject<T extends Record<string, unknown>>(
       ? toDeepFrozenSchema(schema)
       : undefined;
     const resultSchemaForObserved = (
-      observedConfidentiality: readonly unknown[],
+      observedConfidentiality: readonly CfcConfClause[],
     ) =>
       schemaSanitizePromptInjection
         ? schemaWithInjectionSafeAnnotations(
@@ -1553,13 +1554,13 @@ export function generateObject<T extends Record<string, unknown>>(
               // Execute with tools - capture presentResult when called
               let finalResult: T | undefined;
               let finalMessages: readonly BuiltInLLMMessage[] = requestMessages;
-              let finalObservedConfidentiality: readonly unknown[] =
+              let finalObservedConfidentiality: readonly CfcConfClause[] =
                 liveInitialObservedConfidentiality;
 
               // Custom execution loop for generateObject with presentResult extraction
               const executeRecursive = async (
                 currentMessages: readonly BuiltInLLMMessage[],
-                observedConfidentiality: readonly unknown[],
+                observedConfidentiality: readonly CfcConfClause[],
               ): Promise<void> => {
                 if (isRunCancelled()) return;
 

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -20,6 +20,8 @@
 // this read path.
 
 import { type Cell, createCell, encodeSqliteParams } from "../cell.ts";
+import type { CfcConfClause } from "../cfc/clause.ts";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { parseLink } from "../link-utils.ts";
 import {
   computeRowLabelRead,
@@ -167,7 +169,7 @@ function staticConfidentialityOf(
   if (!props) return [];
   const out: unknown[] = [];
   for (const p of Object.values(props)) {
-    const conf = (p as { ifc?: { confidentiality?: unknown[] } })?.ifc
+    const conf = (p as { ifc?: { confidentiality?: CfcConfClause[] } })?.ifc
       ?.confidentiality;
     if (Array.isArray(conf)) out.push(...conf);
   }
@@ -283,16 +285,16 @@ function deriveNullOriginIfc(
 }
 
 type ColumnIfc = {
-  confidentiality?: unknown[];
-  integrity?: unknown[];
-  maxConfidentiality?: unknown[];
+  confidentiality?: CfcConfClause[];
+  integrity?: CfcAtom[];
+  maxConfidentiality?: CfcConfClause[];
 };
 
 const unionAtoms = (
-  a: unknown[] | undefined,
-  b: unknown[] | undefined,
-): unknown[] | undefined => {
-  const out: unknown[] = [...(a ?? [])];
+  a: CfcConfClause[] | undefined,
+  b: CfcConfClause[] | undefined,
+): CfcConfClause[] | undefined => {
+  const out: CfcConfClause[] = [...(a ?? [])];
   for (const atom of b ?? []) {
     if (!out.some((existing) => deepEqual(existing, atom))) out.push(atom);
   }
@@ -305,9 +307,9 @@ const unionAtoms = (
 // An EMPTY intersection stays `[]`, which the verifier reads as "public only"
 // (the tightest ceiling) — collapsing it to undefined would forge "no ceiling".
 const tightenCeiling = (
-  prior: unknown[] | undefined,
-  next: unknown[] | undefined,
-): unknown[] | undefined => {
+  prior: CfcConfClause[] | undefined,
+  next: CfcConfClause[] | undefined,
+): CfcConfClause[] | undefined => {
   if (prior === undefined) return next;
   if (next === undefined) return prior;
   return prior.filter((atom) => next.some((n) => deepEqual(n, atom)));
@@ -322,9 +324,9 @@ const tightenCeiling = (
 // Identical to `tightenCeiling` EXCEPT the prior-absent case yields undefined
 // (no prior trust to inherit) rather than adopting `next` wholesale.
 const clampIntegrity = (
-  prior: unknown[] | undefined,
-  next: unknown[] | undefined,
-): unknown[] | undefined => {
+  prior: CfcConfClause[] | undefined,
+  next: CfcConfClause[] | undefined,
+): CfcConfClause[] | undefined => {
   if (prior === undefined) return undefined;
   if (next === undefined) return prior;
   const kept = prior.filter((atom) => next.some((n) => deepEqual(n, atom)));
@@ -637,7 +639,7 @@ export function sqliteQuery(
       // CFC Phase 3: declared output ceiling + what to do when a row's label
       // exceeds it ("fail" default | "skip"). The typed alternative is
       // MaxConfidentiality<> on the Row schema (rowSchema.ifc).
-      maxConfidentiality?: unknown[];
+      maxConfidentiality?: CfcConfClause[];
       onExceed?: unknown;
       // CFC Phase 3.b: opt into read-time clearance — filter rows to those the
       // acting reader may read (a declared existence release). Requires the
@@ -771,7 +773,7 @@ export function sqliteQuery(
           // row, and decides fail/skip under the ceiling — every unresolvable
           // case refuses the query (fail closed), never under-labels.
           const rowSchemaCeiling = (inputs.rowSchema as {
-            ifc?: { maxConfidentiality?: unknown[] };
+            ifc?: { maxConfidentiality?: CfcConfClause[] };
           } | undefined)?.ifc?.maxConfidentiality;
           if (
             inputs.maxConfidentiality !== undefined &&
@@ -802,7 +804,9 @@ export function sqliteQuery(
             columns: res.columns,
             rows,
             owner: db.owner,
-            staticConfidentiality: staticConfidentialityOf(labelSchema),
+            staticConfidentiality: staticConfidentialityOf(
+              labelSchema,
+            ) as readonly CfcConfClause[] | undefined,
             ceiling,
             onExceed: inputs.onExceed,
             // Phase 3.b read-time clearance: the reader is the acting principal

--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -15,8 +15,10 @@ import {
   ruleInputFields,
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
-import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
+import type { CfcAtomObject } from "@commonfabric/api/cfc";
 import type { CfcConfClause } from "../../cfc/clause.ts";
+import type { CfcAtom } from "@commonfabric/api/cfc";
+import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
 import { clauseAlternatives } from "../../cfc/clause.ts";
 
@@ -28,8 +30,8 @@ interface ResultColumn {
 
 /** A row's per-row label, shaped as a schema `ifc` for the row-doc write. */
 export interface PerRowIfc {
-  confidentiality?: unknown[];
-  integrity?: unknown[];
+  confidentiality?: CfcConfClause[];
+  integrity?: CfcAtom[];
 }
 
 export interface RowLabelReadArgs {
@@ -43,9 +45,9 @@ export interface RowLabelReadArgs {
   owner?: string;
   /** Per-column (Phase 2) confidentiality atoms of the labeled projection —
    *  they ride every row, so they count against the ceiling too. */
-  staticConfidentiality?: readonly unknown[];
+  staticConfidentiality?: readonly CfcConfClause[];
   /** Declared output ceiling (placeholders already resolved). */
-  ceiling?: readonly unknown[];
+  ceiling?: readonly CfcConfClause[];
   /** What to do when a row's label exceeds the ceiling (default "fail"). */
   onExceed?: unknown;
   /** CFC Phase 3.b read-time clearance: when set, keep only rows the acting
@@ -126,7 +128,7 @@ function intersectCommonAlternatives(
 // (Caveat/Expires/material-risk marker) never admits a plain reader, so the row
 // is withheld — fail closed.
 function readerAdmitsLabel(
-  confidentiality: readonly unknown[],
+  confidentiality: readonly CfcConfClause[],
   reader: string,
 ): boolean {
   return confidentiality.every((clause) =>
@@ -231,7 +233,9 @@ export function computeRowLabelRead(
         const clause = common.atoms.length === 1
           ? common.atoms[0]
           : { anyOf: common.atoms };
-        labels = rows.map(() => ({ confidentiality: [clause] }));
+        labels = rows.map(() => ({
+          confidentiality: [clause as CfcConfClause],
+        }));
       }
       // kind === "unconstrained": no confidentiality on the aggregate — leave
       // labels undefined. Either way no per-row eval (no origins to attribute);
@@ -290,9 +294,11 @@ export function computeRowLabelRead(
           }
           const ifc: PerRowIfc = {};
           if (res.confidentiality.length > 0) {
-            ifc.confidentiality = res.confidentiality;
+            ifc.confidentiality = res.confidentiality as CfcConfClause[];
           }
-          if (res.integrity.length > 0) ifc.integrity = res.integrity;
+          if (res.integrity.length > 0) {
+            ifc.integrity = res.integrity as CfcAtom[];
+          }
           labels.push(
             ifc.confidentiality || ifc.integrity ? ifc : undefined,
           );
@@ -402,12 +408,14 @@ export function computeRowLabelRead(
  * closed — a ceiling that can't be pinned must not silently widen.
  */
 export function resolveCeilingPlaceholders(
-  ceiling: readonly unknown[],
+  ceiling: readonly CfcConfClause[],
   ctx: { actingPrincipal?: string; owner?: string },
-): { atoms: unknown[] } | { error: string } {
-  const atoms: unknown[] = [];
+): { atoms: CfcConfClause[] } | { error: string } {
+  const atoms: CfcConfClause[] = [];
   for (const atom of ceiling) {
-    if (isRecord(atom) && atom.__ctCurrentPrincipal === true) {
+    if (
+      isRecord(atom) && (atom as CfcAtomObject).__ctCurrentPrincipal === true
+    ) {
       if (ctx.actingPrincipal === undefined) {
         return {
           error: "sqlite: ceiling references the acting user but no acting " +
@@ -417,7 +425,7 @@ export function resolveCeilingPlaceholders(
       atoms.push(ctx.actingPrincipal);
       continue;
     }
-    if (isRecord(atom) && atom.__ctDbOwner === true) {
+    if (isRecord(atom) && (atom as CfcAtomObject).__ctDbOwner === true) {
       if (ctx.owner === undefined) {
         return {
           error: "sqlite: ceiling references the db owner but the db ref " +

--- a/packages/runner/src/builtins/sqlite/row-label-write.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-write.ts
@@ -27,6 +27,8 @@ import {
   ruleInputFields,
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
+import type { CfcConfClause } from "../../cfc/clause.ts";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
 import {
@@ -40,7 +42,7 @@ import {
  *  input (sink-request) before the commit. */
 export interface RowLabelWritePolicy {
   table: string;
-  label: { confidentiality: unknown[]; integrity: unknown[] };
+  label: { confidentiality: CfcConfClause[]; integrity: CfcAtom[] };
 }
 
 export interface RowLabelWriteArgs {
@@ -51,7 +53,7 @@ export interface RowLabelWriteArgs {
   /** The db's owner (db ref), resolving the rule's `dbOwner()` term. */
   owner?: string;
   /** The confidentiality atoms carried by a bound value ([] if unlabeled). */
-  confidentialityOf: (value: unknown) => readonly unknown[];
+  confidentialityOf: (value: unknown) => readonly CfcConfClause[];
   /** True iff the connected server advertised commit-time re-derivation
    *  (Phase 3.c) — the gate then admits the non-attributable shapes with
    *  unlabeled inputs instead of failing closed. Default false. */
@@ -282,7 +284,12 @@ export function checkSqliteRowLabelWrite(
             "ceiling); storing the value would launder its label; fail closed",
         };
       }
-      if (!cfcObservationFitsCeiling(conf, res.confidentiality)) {
+      if (
+        !cfcObservationFitsCeiling(
+          conf,
+          res.confidentiality as readonly CfcConfClause[],
+        )
+      ) {
         return {
           error: `sqlite: a value bound to rule-bearing table ` +
             `"${declaredKey}" carries confidentiality not captured by the ` +
@@ -293,7 +300,10 @@ export function checkSqliteRowLabelWrite(
     }
     policies.push({
       table: declaredKey,
-      label: { confidentiality: res.confidentiality, integrity: res.integrity },
+      label: {
+        confidentiality: res.confidentiality as CfcConfClause[],
+        integrity: res.integrity as CfcAtom[],
+      },
     });
   }
   return { policies };

--- a/packages/runner/src/builtins/sqlite/write-ceiling.ts
+++ b/packages/runner/src/builtins/sqlite/write-ceiling.ts
@@ -9,6 +9,7 @@
 // without a ceiling are unaffected (zero behavior change until `ifc` is used).
 
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
+import type { CfcConfClause } from "../../cfc/clause.ts";
 import {
   blankWriteSql,
   parseWriteParamColumns,
@@ -16,8 +17,8 @@ import {
 } from "@commonfabric/memory/sqlite/write-targets";
 
 interface ColumnIfc {
-  maxConfidentiality?: readonly unknown[];
-  confidentiality?: readonly unknown[];
+  maxConfidentiality?: readonly CfcConfClause[];
+  confidentiality?: readonly CfcConfClause[];
 }
 type Tables = Record<
   string,
@@ -108,7 +109,7 @@ export function checkSqliteWriteCeiling(
   params: ReadonlyArray<unknown> | Record<string, unknown> | undefined,
   tables: Tables | undefined,
   /** The confidentiality atoms carried by a bound value ([] if unlabeled). */
-  confidentialityOf: (value: unknown) => readonly unknown[],
+  confidentialityOf: (value: unknown) => readonly CfcConfClause[],
 ): string | undefined {
   if (!tables) return undefined;
   // Blank string-literals/comments once; both parsers read the same SQL.
@@ -145,7 +146,7 @@ export function checkSqliteWriteCeiling(
   // case; the declared property keys may differ in case from the SQL).
   const resolveCeiling = (
     col: string,
-  ): { found: boolean; ceiling?: readonly unknown[] } => {
+  ): { found: boolean; ceiling?: readonly CfcConfClause[] } => {
     if (table === undefined) return { found: false };
     const props = tables[table]?.properties;
     if (!props) return { found: false };
@@ -158,7 +159,7 @@ export function checkSqliteWriteCeiling(
   // Check one labeled value against its (named) target column. Fails closed when
   // the column can't be positively resolved.
   const checkLabeled = (
-    conf: readonly unknown[],
+    conf: readonly CfcConfClause[],
     col: string,
   ): string | undefined => {
     const r = resolveCeiling(col);

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -4,6 +4,7 @@ import {
   isObject,
   isRecord,
 } from "@commonfabric/utils/types";
+import type { CfcConfClause } from "./cfc/clause.ts";
 import {
   cloneIfNecessary,
   FabricInstance,
@@ -1172,7 +1173,7 @@ export class CellImpl<T extends FabricValue>
     // column's `ifc.maxConfidentiality`. The label rides the bound value (a Cell
     // or any carried-label value); fail closed when a labeled value's target
     // column can't be determined. No-op until a column declares `ifc`.
-    const confidentialityOf = (value: unknown): readonly unknown[] => {
+    const confidentialityOf = (value: unknown): readonly CfcConfClause[] => {
       const view = cfcLabelViewForCell(value);
       return view
         ? cfcConfidentialityForObservationNode({ labelView: view })
@@ -1182,7 +1183,9 @@ export class CellImpl<T extends FabricValue>
       sql,
       params,
       tables as Parameters<typeof checkSqliteWriteCeiling>[2],
-      confidentialityOf,
+      confidentialityOf as unknown as Parameters<
+        typeof checkSqliteWriteCeiling
+      >[3],
     );
     if (ceilingViolation) throw new TypeError(ceilingViolation);
 

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -1,4 +1,5 @@
 import { type ImmutableJSONValue, JSONSchemaObj } from "@commonfabric/api";
+import type { CfcConfClause } from "./cfc/clause.ts";
 import { isRecord } from "@commonfabric/utils/types";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
@@ -348,7 +349,7 @@ export class ContextualFlowControl {
   // Return a copy of the schema with joined confidentiality atoms.
   public schemaWithLub(
     schema: JSONSchema,
-    confidentiality: readonly unknown[],
+    confidentiality: readonly CfcConfClause[],
   ): JSONSchema {
     const joined = new Set<unknown>(confidentiality);
     if (isRecord(schema) && schema.ifc !== undefined) {

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -155,7 +155,7 @@ export type ExchangeEvalContext = {
    * integrity (boundary-minted facts, consumed-read integrity). The guard
    * pool is `label.integrity ∪ ctx.integrity`.
    */
-  readonly integrity?: readonly unknown[];
+  readonly integrity?: readonly CfcAtom[];
   /** Boundary-context atoms minted for this evaluation site (B5). */
   readonly boundary?: readonly unknown[];
   /** Trust closure for concept-valued integrity guards (B3). */

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -104,7 +104,7 @@ export type CfcGrantIdentity = {
 export type CfcGrant = CfcGrantIdentity & {
   readonly version: typeof CFC_GRANT_VERSION;
   /** Principal-like atoms (§3.1.8-validated) the release extends to. */
-  readonly audience: readonly unknown[];
+  readonly audience: readonly CfcAtom[];
   readonly grantedAt: number;
   readonly expiresAt?: number;
   /** §6 intent attribution once the intent substrate exists. */
@@ -130,7 +130,7 @@ export type CfcGrantWriteInput = {
   readonly kind: string;
   readonly owner: string;
   readonly resource: unknown;
-  readonly audience: readonly unknown[];
+  readonly audience: readonly CfcAtom[];
   /** Defaults to `owner` — the v1 governing-space posture (module doc). */
   readonly space?: string;
   /** Defaults to the runner clock at write time. */

--- a/packages/runner/src/cfc/label-introspection.ts
+++ b/packages/runner/src/cfc/label-introspection.ts
@@ -119,7 +119,7 @@ export const CONF_LABEL_NOT_AVAILABLE: InspectConfLabelResult = Object.freeze({
  */
 export type ConfLabelConsumedObservation = {
   path: readonly string[];
-  confidentiality: readonly unknown[];
+  confidentiality: readonly CfcConfClause[];
 };
 
 export type ConfLabelQueryEvaluation = {
@@ -131,7 +131,7 @@ export type ConfLabelQueryEvaluation = {
    * hidden arms are value-independent of protected fields (the response is
    * the shared constant), so nothing protected flowed to the caller.
    */
-  consumedConfidentiality: readonly unknown[];
+  consumedConfidentiality: readonly CfcConfClause[];
   /**
    * The same consumption, one record per consulted concrete metadata path
    * (paths are unique by construction — clause/alternative indices plus

--- a/packages/runner/src/cfc/label-representation.ts
+++ b/packages/runner/src/cfc/label-representation.ts
@@ -1,3 +1,5 @@
+import type { CfcConfClause } from "./clause.ts";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
@@ -203,10 +205,10 @@ export const transformCfcLabelForCrossSpacePersist = (
 ): IFCLabel => {
   const confidentiality = label.confidentiality === undefined
     ? undefined
-    : (transformValue(label.confidentiality, undefined, []) as unknown[]);
+    : (transformValue(label.confidentiality, undefined, []) as CfcConfClause[]);
   const integrity = label.integrity === undefined
     ? undefined
-    : (transformValue(label.integrity, undefined, []) as unknown[]);
+    : (transformValue(label.integrity, undefined, []) as CfcAtom[]);
   if (
     confidentiality === label.confidentiality && integrity === label.integrity
   ) {

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -1,12 +1,16 @@
 import { encodePointer } from "../../../memory/v2/path.ts";
 import type { CfcConfClause } from "./clause.ts";
-import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import {
+  CFC_ATOM_TYPE,
+  type CfcAtom,
+  type CfcAtomObject,
+} from "@commonfabric/api/cfc";
 import { uniqueCfcAtoms } from "./observation.ts";
 import { normalizeClause } from "./clause.ts";
 
 export type IFCLabel = {
-  confidentiality?: unknown[];
-  integrity?: unknown[];
+  confidentiality?: CfcConfClause[];
+  integrity?: CfcAtom[];
 };
 
 /**
@@ -102,16 +106,18 @@ export const hasCfcLabelValues = (label: IFCLabel): boolean =>
 // `PromptSlotBound.source` / `Caveat.by` are themselves `CfcAtom`s), so a Caveat
 // can appear at any depth; walk the whole structure and drop `source` from each
 // Caveat found, leaving its `kind`/`by`/`type` and all other atoms intact.
-const redactCaveatSourceAtom = (atom: unknown): unknown => {
+const redactCaveatSourceAtom = (atom: CfcAtom): CfcAtom => {
   if (Array.isArray(atom)) {
     return atom.map(redactCaveatSourceAtom);
   }
   if (atom === null || typeof atom !== "object") {
     return atom;
   }
-  const obj = atom as Record<string, unknown>;
+  // The array arm is handled above, but narrowing cannot drop a
+  // `ReadonlyArray` interface from the union, so name the object arm.
+  const obj = atom as CfcAtomObject;
   const dropSource = obj.type === CFC_ATOM_TYPE.Caveat;
-  const out: Record<string, unknown> = {};
+  const out: Record<string, CfcAtom> = {};
   for (const [key, value] of Object.entries(obj)) {
     if (dropSource && key === "source") {
       continue;

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -22,9 +22,9 @@ import {
   normalizeClause,
 } from "./clause.ts";
 
-export type CfcObservedConfidentiality = readonly unknown[];
+export type CfcObservedConfidentiality = readonly CfcConfClause[];
 export type CfcObservationMaxConfidentiality =
-  | readonly unknown[]
+  | readonly CfcConfClause[]
   | undefined;
 
 // Marker confidentiality atom injected when a cell's label could not be read
@@ -142,7 +142,7 @@ export const cfcConfidentialityForObservationNode = (
 };
 
 export const cfcObservationFitsCeiling = (
-  confidentiality: readonly unknown[],
+  confidentiality: readonly CfcConfClause[],
   observationMaxConfidentiality: CfcObservationMaxConfidentiality,
 ): boolean => {
   // undefined means no ceiling. A declared but empty ceiling means "public
@@ -248,7 +248,7 @@ const integrityAtomSatisfies = (
  * (concrete/pattern) floors.
  */
 export const cfcIntegritySatisfiesFloor = (
-  integrity: readonly unknown[],
+  integrity: readonly CfcAtom[],
   requiredIntegrity: readonly unknown[],
   trust?: CfcFloorTrustContext,
 ): boolean =>
@@ -356,7 +356,7 @@ export const cfcIntegritySatisfiesFloorCoherently = (
  * by construction.
  */
 export const atomsOutsideCeiling = (
-  confidentiality: readonly unknown[],
+  confidentiality: readonly CfcConfClause[],
   ceiling: CfcObservationMaxConfidentiality,
 ): ImmutableJSONValue[] => {
   if (ceiling === undefined) {
@@ -428,7 +428,7 @@ export const meetCfcObservationCeilings = (
 ): CfcObservationMaxConfidentiality => {
   if (a === undefined) return b;
   if (b === undefined) return a;
-  const met: unknown[] = [];
+  const met: CfcConfClause[] = [];
   for (const clauseA of a) {
     const alternativesA = clauseAlternatives(clauseA as CfcConfClause);
     if (alternativesA.length === 0) continue;

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4,6 +4,7 @@ import {
   type CfcAtom,
   cfcAtom,
 } from "@commonfabric/api/cfc";
+import type { CfcObservationMaxConfidentiality } from "./observation.ts";
 import {
   internSchema,
   internSchemaAsTaggedHashString,
@@ -1774,8 +1775,8 @@ export const deriveFlowJoin = (
     collectLabeledSpaces?: boolean;
   },
 ): {
-  confidentiality: unknown[];
-  integrity: unknown[];
+  confidentiality: CfcConfClause[];
+  integrity: CfcAtom[];
   labeledSpaces?: ReadonlySet<MemorySpace>;
 } => {
   const atoms: unknown[] = [];
@@ -1787,7 +1788,7 @@ export const deriveFlowJoin = (
   // uncertified. (In practice most transactions read some unlabeled doc,
   // so the meet is usually empty until inputs are universally certified —
   // staged conformance per SC-9, never over-claiming.)
-  let hereditaryMeet: unknown[] | undefined;
+  let hereditaryMeet: CfcAtom[] | undefined;
   const labeledSpaces = options?.collectLabeledSpaces === true
     ? new Set<MemorySpace>()
     : undefined;
@@ -1898,7 +1899,7 @@ export const deriveFlowJoin = (
     atoms.push(...observation.confidentiality);
   }
   const confidentiality = uniqueCfcAtoms(atoms);
-  const integrity: unknown[] = [...(hereditaryMeet ?? [])];
+  const integrity: CfcAtom[] = [...(hereditaryMeet ?? [])];
   // Derivation provenance (§8.9.3 TransformedBy, staged: identity binding
   // only — no per-input refs/witnesses yet). The flow join is one per-tx
   // label stamped on every written doc, so the identity must hold for the
@@ -2427,8 +2428,8 @@ const projectedSourceLabel = (
   claim: ProjectionClaim,
 ): IFCLabel => {
   const source = canonicalizeLogicalPath([...claim.source, ...claim.field]);
-  const confidentiality: unknown[] = [];
-  const integrity: unknown[] = [];
+  const confidentiality: CfcConfClause[] = [];
+  const integrity: CfcAtom[] = [];
   // Map insertion order is the schema-walk order (parents before children),
   // so contributions stay ordered ancestor-first along the source lineage.
   for (const [key, label] of sourceEntryLabels) {
@@ -3703,7 +3704,7 @@ const verifyInputRequirements = (
       // carries no markers, so the extra arm is byte-inert for it; the
       // containment pre-check keeps the dominant plaintext path a single
       // deepEqual per pair.
-      const fitsLegacy = (confidentiality: readonly unknown[]): boolean =>
+      const fitsLegacy = (confidentiality: readonly CfcConfClause[]): boolean =>
         confidentiality.every((value) =>
           maxConfidentiality.some((allowed) =>
             deepEqual(allowed, value) ||
@@ -4564,8 +4565,8 @@ export const loadSchemaDocument = (
 const collectConsumedLabel = (
   tx: IExtendedStorageTransaction,
 ): {
-  confidentiality: readonly unknown[];
-  integrity: readonly unknown[];
+  confidentiality: readonly CfcConfClause[];
+  integrity: readonly CfcAtom[];
   modulePolicySpaces: ReadonlyMap<string, ReadonlySet<MemorySpace>>;
 } => {
   const atoms: unknown[] = [];
@@ -4679,15 +4680,15 @@ const collectConsumedLabel = (
  */
 const evaluateGatedConfidentiality = (
   tx: IExtendedStorageTransaction,
-  confidentiality: readonly unknown[],
-  integrity: readonly unknown[],
+  confidentiality: readonly CfcConfClause[],
+  integrity: readonly CfcAtom[],
   boundary: readonly unknown[],
   consumption: CfcGrantConsumptionContext,
   destinationSpace?:
     | MemorySpace
     | ((reference: unknown) => MemorySpace | undefined),
 ): {
-  confidentiality: readonly unknown[];
+  confidentiality: readonly CfcConfClause[];
   exhausted: boolean;
   firings: number;
   resolutionFailures: readonly {
@@ -4844,10 +4845,13 @@ const verifySinkRequestCeilings = (
         );
         const rewrittenOffending = outcome.exhausted
           ? undefined
-          : atomsOutsideCeiling(outcome.confidentiality, ceiling);
+          : atomsOutsideCeiling(
+            outcome.confidentiality,
+            ceiling as CfcObservationMaxConfidentiality,
+          );
         const rawOffending = atomsOutsideCeiling(
           consumed.confidentiality,
-          ceiling,
+          ceiling as CfcObservationMaxConfidentiality,
         );
         if (outcome.exhausted) {
           tx.noteCfcDiagnostic(
@@ -4870,7 +4874,10 @@ const verifySinkRequestCeilings = (
     }
     // Same membership semantics as cfcObservationFitsCeiling (shared helper),
     // so the egress gate and the observation fits-test cannot drift.
-    const offending = atomsOutsideCeiling(effective, ceiling);
+    const offending = atomsOutsideCeiling(
+      effective,
+      ceiling as CfcObservationMaxConfidentiality,
+    );
     if (offending.length > 0) {
       // Name the offending atom(s) so an observe-mode diagnostic identifies the
       // exact (sink, atom) pair that needs a ceiling entry (review on #3993).
@@ -4958,7 +4965,7 @@ const verifyWriteFloor = (
     ) => ImplementationIdentity | undefined;
     linkWriteInputs: readonly LinkWritePolicyInput[];
     candidateSchemas: ReadonlyMap<string, JSONSchema>;
-    flowIntegrity: readonly unknown[];
+    flowIntegrity: readonly CfcAtom[];
   },
 ): string[] => {
   const failures: string[] = [];
@@ -5034,7 +5041,7 @@ const verifyWriteFloor = (
     // One contribution per link written at/under the floor path (each linked
     // value must individually carry the floor), plus one `value` contribution
     // when plain data was written (crediting the flow meet when available).
-    const contributions: (readonly unknown[])[] = [];
+    const contributions: (readonly CfcAtom[])[] = [];
     for (const input of linksHere) {
       const derived = derivePersistedLinkLabel(
         tx,
@@ -5670,7 +5677,7 @@ export const prepareBoundaryCommit = (
     // shape would re-smear the pointer/content split.
     const clearedExistence: Array<{
       path: readonly string[];
-      confidentiality: readonly unknown[];
+      confidentiality: readonly CfcConfClause[];
     }> = [];
     // Only pre-class LEGACY entries (no `observes`) pool: they conflated
     // existence with content/membership, and the one-time migration absorb
@@ -6093,14 +6100,14 @@ export const prepareBoundaryCommit = (
       // permuted forms of one clause would both survive — a doubled clause
       // list and one spurious envelope rewrite (the SC-11 churn class).
       // normalizeClause each clause first; non-clause atoms pass through.
-      const foldedUnique = (atoms: readonly unknown[]): unknown[] =>
+      const foldedUnique = (atoms: readonly CfcConfClause[]): CfcConfClause[] =>
         uniqueCfcAtoms(
           atoms.map((atom) => normalizeClause(atom as CfcConfClause)),
         );
       const frozenConfidentialityFor = (
         path: readonly string[],
-      ): unknown[] => {
-        const atoms: unknown[] = [...flowConfidentiality];
+      ): CfcConfClause[] => {
+        const atoms: CfcConfClause[] = [...flowConfidentiality];
         clearedExistence.forEach((cleared, index) => {
           if (isPrefix(path, cleared.path)) {
             attachedExistence.add(index);
@@ -6373,7 +6380,7 @@ export const prepareBoundaryCommit = (
       // shape entry so the existence history survives the migration.
       const leftoverByPath = new Map<
         string,
-        { path: readonly string[]; atoms: unknown[] }
+        { path: readonly string[]; atoms: CfcConfClause[] }
       >();
       clearedExistence.forEach((cleared, index) => {
         if (attachedExistence.has(index)) {

--- a/packages/runner/src/cfc/render-ceiling.ts
+++ b/packages/runner/src/cfc/render-ceiling.ts
@@ -145,7 +145,7 @@ export type RenderConfidentialityResolverConfig = {
  * per distinct space.
  */
 export const spaceAtomIdsInConfidentiality = (
-  confidentiality: readonly unknown[],
+  confidentiality: readonly CfcConfClause[],
 ): readonly string[] => {
   const ids: string[] = [];
   for (const clause of confidentiality) {
@@ -165,8 +165,8 @@ export const spaceAtomIdsInConfidentiality = (
 
 /** The label of the cell being rendered, as read at the display boundary. */
 export type RenderLabelInput = {
-  readonly confidentiality: readonly unknown[];
-  readonly integrity?: readonly unknown[];
+  readonly confidentiality: readonly CfcConfClause[];
+  readonly integrity?: readonly CfcAtom[];
 };
 
 /**

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -139,7 +139,7 @@ const normalizeMaterialRiskStringForms = (clause: unknown): unknown => {
 };
 
 export const dischargeMaterialRiskAtoms = (
-  atoms: readonly unknown[],
+  atoms: readonly CfcConfClause[],
 ): ImmutableJSONValue[] => {
   // Fuel budget scaled to the label (cubic P2 on #4567): the default 64 would
   // exhaust on a label with more than ~64 droppable alternatives, and the
@@ -156,7 +156,7 @@ export const dischargeMaterialRiskAtoms = (
     0,
   );
   const result = evaluateExchangeRules(
-    { confidentiality: normalized },
+    { confidentiality: normalized as CfcConfClause[] },
     MATERIAL_RISK_SNAPSHOT,
     { integrity: [INJECTION_SAFE_ATOM] },
     alternativeCount + DEFAULT_EXCHANGE_FUEL,
@@ -175,7 +175,7 @@ const mergeIfc = (
     observedConfidentiality,
     instructionInert,
   }: {
-    observedConfidentiality: readonly unknown[];
+    observedConfidentiality: readonly CfcConfClause[];
     instructionInert: boolean;
   },
 ): Record<string, unknown> => {
@@ -260,7 +260,7 @@ export const resolveSchemaForValidation = (
 
 const annotateSchema = (
   schema: JSONSchema,
-  observedConfidentiality: readonly unknown[],
+  observedConfidentiality: readonly CfcConfClause[],
   fullSchema: JSONSchema,
   visitedRef?: AnnotationRefVisit,
 ): AnnotationResult => {
@@ -439,7 +439,7 @@ const annotateSchema = (
 
 export const schemaWithInjectionSafeAnnotations = (
   schema: JSONSchema,
-  observedConfidentiality: readonly unknown[] = [],
+  observedConfidentiality: readonly CfcConfClause[] = [],
 ): JSONSchema => {
   const clone = cloneJson(schema);
   return stripRequiredFields(

--- a/packages/runner/src/cfc/sink-inventory.ts
+++ b/packages/runner/src/cfc/sink-inventory.ts
@@ -1,3 +1,4 @@
+import type { CfcConfClause } from "./clause.ts";
 export type InitialSinkName =
   | "fetchBinary"
   | "fetchText"
@@ -45,7 +46,7 @@ export const isInitialSinkInventoryName = (
  * recorded `sink-request` write-policy input.
  */
 export type SinkMaxConfidentiality = Readonly<
-  Record<string, readonly unknown[]>
+  Record<string, readonly CfcConfClause[]>
 >;
 
 /**

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -1,4 +1,5 @@
 import type { CellScope, JSONSchema } from "../builder/types.ts";
+import type { CfcConfClause } from "./clause.ts";
 import type { FabricValue } from "@commonfabric/api";
 import type { CfcModulePolicyRefAtom } from "@commonfabric/api/cfc";
 import type { MemorySpace } from "@commonfabric/memory/interface";
@@ -354,7 +355,7 @@ export type CfcDereferenceTrace = Immutable<{
 export type CfcLabelMetadataObservation = Immutable<{
   target: CfcAddress;
   observes: LabelMetadataObservationClass;
-  confidentiality: unknown[];
+  confidentiality: CfcConfClause[];
 }>;
 
 export type ImplementationIdentity =

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,4 +1,6 @@
 import { isObject, isRecord } from "@commonfabric/utils/types";
+import type { CfcConfClause } from "./cfc/clause.ts";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { forEachSubschema } from "./schema-walk.ts";
 import {
   fabricFromNativeValue,
@@ -140,8 +142,8 @@ const schemaPathsOverlap = (
 
 const labelHasValues = (
   label: {
-    confidentiality?: readonly unknown[];
-    integrity?: readonly unknown[];
+    confidentiality?: readonly CfcConfClause[];
+    integrity?: readonly CfcAtom[];
   },
 ): boolean =>
   (label.confidentiality?.length ?? 0) > 0 ||

--- a/packages/runner/test/cfc-clause-meet.test.ts
+++ b/packages/runner/test/cfc-clause-meet.test.ts
@@ -131,7 +131,7 @@ describe("CFC ceiling meet (pairwise alternative-set union)", () => {
     // atoms, OR-clauses (with an order-differing spelling), the malformed
     // empty clause, and the ungrantable read-failed marker (bare and
     // wrapped).
-    const ceilingClausePool: readonly unknown[] = [
+    const ceilingClausePool: readonly CfcConfClause[] = [
       A,
       B,
       C,
@@ -142,7 +142,7 @@ describe("CFC ceiling meet (pairwise alternative-set union)", () => {
       { anyOf: [] },
       CFC_LABEL_READ_FAILED_ATOM,
     ];
-    const labelClausePool: readonly unknown[] = [
+    const labelClausePool: readonly CfcConfClause[] = [
       A,
       B,
       C,
@@ -155,9 +155,9 @@ describe("CFC ceiling meet (pairwise alternative-set union)", () => {
     ];
 
     const subsetsUpToSize2 = (
-      pool: readonly unknown[],
-    ): readonly (readonly unknown[])[] => {
-      const subsets: (readonly unknown[])[] = [[]];
+      pool: readonly CfcConfClause[],
+    ): readonly (readonly CfcConfClause[])[] => {
+      const subsets: (readonly CfcConfClause[])[] = [[]];
       for (let i = 0; i < pool.length; i++) {
         subsets.push([pool[i]]);
         for (let j = i + 1; j < pool.length; j++) {
@@ -170,7 +170,7 @@ describe("CFC ceiling meet (pairwise alternative-set union)", () => {
     it("holds over every (C1, C2, L) triple in the universe", () => {
       const ceilings: readonly CfcObservationMaxConfidentiality[] = [
         undefined,
-        ...subsetsUpToSize2(ceilingClausePool),
+        ...subsetsUpToSize2(ceilingClausePool as CfcConfClause[]),
       ];
       const labels = subsetsUpToSize2(labelClausePool);
       let checked = 0;

--- a/packages/runner/test/cfc-clause.test.ts
+++ b/packages/runner/test/cfc-clause.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import {
@@ -159,7 +160,7 @@ describe("CFC clause kernel", () => {
   });
 
   describe("canonicalizeCfcMetadata clause interiors", () => {
-    const metadataWith = (confidentiality: unknown[]): CfcMetadata => ({
+    const metadataWith = (confidentiality: CfcConfClause[]): CfcMetadata => ({
       version: 1,
       schemaHash: "hash",
       labelMap: {
@@ -205,7 +206,9 @@ describe("CFC clause kernel", () => {
         path: [],
       }) as CfcAddress;
 
-    const linkWriteWith = (confidentiality: unknown[]): WritePolicyInput => ({
+    const linkWriteWith = (
+      confidentiality: CfcConfClause[],
+    ): WritePolicyInput => ({
       kind: "link-write",
       target: address("of:target"),
       source: address("of:source"),

--- a/packages/runner/test/cfc-exchange-eval.test.ts
+++ b/packages/runner/test/cfc-exchange-eval.test.ts
@@ -736,7 +736,7 @@ describe("CFC exchange-rule evaluation (B4)", () => {
       const evidencePool = [roleAliceX, roleAliceY, roleBobX];
 
       for (let round = 0; round < 200; round++) {
-        const clauses: unknown[] = [];
+        const clauses: CfcConfClause[] = [];
         const clauseCount = 1 + Math.floor(random() * 3);
         for (let i = 0; i < clauseCount; i++) {
           const alternativeCount = 1 + Math.floor(random() * 3);
@@ -746,8 +746,8 @@ describe("CFC exchange-rule evaluation (B4)", () => {
           );
           clauses.push(
             alternatives.length === 1
-              ? alternatives[0]
-              : { anyOf: alternatives },
+              ? alternatives[0] as CfcConfClause
+              : { anyOf: alternatives } as CfcOrClause,
           );
         }
         const rules: ExchangeRule[] = Array.from(
@@ -957,7 +957,7 @@ describe("CFC exchange-rule evaluation (B4)", () => {
       for (const ref of cases) {
         const result = evaluateExchangeRules(
           {
-            confidentiality: [{ anyOf: [spaceX, ref] }],
+            confidentiality: [{ anyOf: [spaceX, ref] } as CfcOrClause],
             integrity: [roleAliceX],
           },
           other,

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -416,7 +416,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
   const seedLabeledCell = async (
     runtime: Runtime,
     id: string,
-    label: { confidentiality: unknown[]; integrity?: unknown[] },
+    label: { confidentiality: CfcConfClause[]; integrity?: CfcAtom[] },
   ): Promise<void> => {
     const seed = runtime.edit();
     const target = runtime.getCell(signer.did(), id, undefined, seed);
@@ -623,7 +623,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
           kind: "builtin",
           builtinId: "cfc-grant-writer",
         });
-        const attempt = (audience: unknown[]) => () =>
+        const attempt = (audience: CfcAtom[]) => () =>
           tx.writeCfcGrant({
             kind: "ShareGrant",
             owner: signer.did(),

--- a/packages/runner/test/cfc-label-introspection.test.ts
+++ b/packages/runner/test/cfc-label-introspection.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import {
@@ -18,7 +19,7 @@ import type { CfcMetadata } from "../src/cfc/types.ts";
 const SOURCE_A = { space: "did:key:spacea", id: "of:origin-a", path: [] };
 const SOURCE_B = { space: "did:key:spaceb", id: "of:origin-b", path: [] };
 
-const caveatAtom = (source: unknown) => ({
+const caveatAtom = (source: CfcAtom) => ({
   type: CFC_ATOM_TYPE.Caveat,
   kind: "prompt-influence",
   source,
@@ -35,7 +36,7 @@ const metadataWith = (
 // A derived-component entry guarding /value/body with a source-bearing caveat
 // clause: the §4.6.4.2 interim fallback territory (the entry's own effective
 // confidentiality is a sound population label for its source fields).
-const derivedBodyEntry = (atom: unknown = caveatAtom(SOURCE_A)) => ({
+const derivedBodyEntry = (atom: CfcAtom = caveatAtom(SOURCE_A)) => ({
   path: ["body"],
   label: { confidentiality: ["secret", atom] },
   origin: "derived" as const,

--- a/packages/runner/test/cfc-label-metadata-persist.test.ts
+++ b/packages/runner/test/cfc-label-metadata-persist.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { CfcLabelView } from "../src/cfc/label-view-core.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
@@ -125,7 +126,7 @@ describe("CFC persist-seam link-label re-derivation (inv-12 Stage 0)", () => {
         id: sourceId,
         path: [],
       },
-      cfcLabelView,
+      cfcLabelView: cfcLabelView as CfcLabelView,
     });
     tx.prepareCfc();
     expect((await tx.commit()).ok).toBeDefined();

--- a/packages/runner/test/cfc-policy-of-label.test.ts
+++ b/packages/runner/test/cfc-policy-of-label.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
@@ -382,7 +383,7 @@ describe("PolicyOf label-time binding", () => {
       expect(reference).toBeDefined();
       const reader = "did:key:cold-compiled-reader";
       const evaluated = evaluateExchangeRules(
-        { confidentiality: [reference] },
+        { confidentiality: [reference as CfcConfClause] },
         undefined,
         {
           integrity: [cfcAtom.hasRole(reader, space, "reader")],
@@ -538,7 +539,7 @@ describe("PolicyOf label-time binding", () => {
         );
       expect(reference).toBeDefined();
       const evaluated = evaluateExchangeRules(
-        { confidentiality: [reference] },
+        { confidentiality: [reference as CfcConfClause] },
         undefined,
         {
           integrity: [{ type: "IntegrityEvidence" }],

--- a/packages/runner/test/cfc-standard-profile.test.ts
+++ b/packages/runner/test/cfc-standard-profile.test.ts
@@ -50,7 +50,7 @@ const isMaterialRisk = (atom: unknown): boolean => {
     typeof (atom as { kind?: unknown }).kind === "string" &&
     materialKinds.has((atom as { kind: string }).kind);
 };
-const legacyStrip = (atoms: readonly unknown[]): unknown[] =>
+const legacyStrip = (atoms: readonly CfcConfClause[]): CfcConfClause[] =>
   uniqueCfcAtoms(
     atoms
       .map((clause) => {
@@ -74,8 +74,9 @@ const legacyStrip = (atoms: readonly unknown[]): unknown[] =>
 // bare-InjectionSafe material-risk discharge). This calls the REAL sanitizer
 // entry point — including its legacy bare-string normalization — so the golden
 // guards the shipped code, not a reimplementation (codex P2 on #4567).
-const dischargeViaProfile = (atoms: readonly unknown[]): unknown[] =>
-  dischargeMaterialRiskAtoms(atoms);
+const dischargeViaProfile = (
+  atoms: readonly CfcConfClause[],
+): CfcConfClause[] => dischargeMaterialRiskAtoms(atoms);
 
 const clauseSetsEqual = (a: readonly unknown[], b: readonly unknown[]) =>
   a.length === b.length &&
@@ -162,8 +163,8 @@ describe("CFC standard prompt-caveat profile (B6)", () => {
 
     for (const [name, input] of scenarios) {
       it(name, () => {
-        const oracle = legacyStrip(input);
-        const ruled = dischargeViaProfile(input);
+        const oracle = legacyStrip(input as CfcConfClause[]);
+        const ruled = dischargeViaProfile(input as CfcConfClause[]);
         expect(clauseSetsEqual(ruled, oracle)).toBe(true);
       });
     }

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
@@ -40,7 +42,7 @@ type StoredEntry = {
 const SOURCE_A = { space: "did:key:remote-a", id: "of:origin-a", path: [] };
 const SOURCE_B = { space: "did:key:remote-b", id: "of:origin-b", path: [] };
 
-const caveatAtom = (source: unknown = SOURCE_A) => ({
+const caveatAtom = (source: CfcAtom = SOURCE_A) => ({
   type: CFC_ATOM_TYPE.Caveat,
   kind: "prompt-influence",
   source,
@@ -58,7 +60,7 @@ const metadataWith = (
 const templateEntry = (
   targetPath: string[],
   tail: string[],
-  confidentiality: unknown[],
+  confidentiality: CfcConfClause[],
 ): LabelMapEntry => ({
   path: [
     "cfc",
@@ -696,7 +698,9 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
 describe("CFC template metadata population (Stage B): evaluator resolution", () => {
   // A derived-component entry guarding /value/body with a source-bearing
   // caveat clause — the interim-rule shape.
-  const derivedBodyEntry = (atom: unknown = caveatAtom()): LabelMapEntry => ({
+  const derivedBodyEntry = (
+    atom: CfcAtom = caveatAtom(),
+  ): LabelMapEntry => ({
     path: ["body"],
     label: { confidentiality: ["secret", atom] },
     origin: "derived",
@@ -881,7 +885,9 @@ describe("CFC template metadata population (Stage B): evaluator resolution", () 
 });
 
 describe("CFC template metadata population (Stage B): derivation unit properties", () => {
-  const derivedEntry = (confidentiality: unknown[]): LabelMapEntry => ({
+  const derivedEntry = (
+    confidentiality: CfcConfClause[],
+  ): LabelMapEntry => ({
     path: ["body"],
     label: { confidentiality },
     origin: "derived",

--- a/packages/runner/test/sqlite-row-label-write.test.ts
+++ b/packages/runner/test/sqlite-row-label-write.test.ts
@@ -7,6 +7,7 @@
 // Spec: docs/specs/sqlite-builtin/06-cfc.md ("Write — the runner gate").
 
 import { describe, it } from "@std/testing/bdd";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { assert, assertEquals } from "@std/assert";
 import { checkSqliteRowLabelWrite } from "../src/builtins/sqlite/row-label-write.ts";
 import { table } from "@commonfabric/memory/sqlite/schema";
@@ -48,7 +49,7 @@ const tables = {
   notes: table({ id: "integer primary key", body: "text" }),
 };
 
-const unlabeled = (_v: unknown): readonly unknown[] => [];
+const unlabeled = (_v: unknown): readonly CfcConfClause[] => [];
 
 function expectError(
   res: ReturnType<typeof checkSqliteRowLabelWrite>,

--- a/packages/runner/test/sqlite-write-ceiling.test.ts
+++ b/packages/runner/test/sqlite-write-ceiling.test.ts
@@ -4,6 +4,7 @@
 // cfcLabelViewForCell, exercised end-to-end elsewhere).
 
 import { describe, it } from "@std/testing/bdd";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import { checkSqliteWriteCeiling } from "../src/builtins/sqlite/write-ceiling.ts";
 
@@ -19,8 +20,8 @@ const TABLES = {
 };
 
 // Fake label reader: a value's confidentiality is looked up by identity.
-const labels = new Map<unknown, readonly unknown[]>();
-const reader = (v: unknown) => labels.get(v) ?? [];
+const labels = new Map<unknown, readonly CfcConfClause[]>();
+const reader = (v: unknown): readonly CfcConfClause[] => labels.get(v) ?? [];
 const SECRET = { tag: "secret-value" }; // confidentiality {alice} (exceeds cap)
 const SUPPORTED = { tag: "supported-value" }; // confidentiality {support} (fits)
 labels.set(SECRET, ["alice"]);


### PR DESCRIPTION
Types the declarations that **carry** CFC clause and atom lists, completing the
vocabulary started in #5031 / #5033 / #5035. `IFCLabel`,
`CfcObservedConfidentiality`, `SinkMaxConfidentiality`, the ceiling / per-row /
exchange / introspection records, and the sqlite, llm, html, and cf-harness
label plumbing now say `CfcConfClause` / `CfcAtom` where they said `unknown[]`.

125 declarations retyped. The 29 remaining casts sit where a value genuinely
arrives untyped: cell reads, `transformValue` results, and the `CfcOrClause`
literals a test builds by hand.

No runtime change — annotations, casts, and imports only.

## Why this is one change

Every CFC atom list in the repo is a single type-connected component, so no
subset of it compiles on its own. That was measured, not assumed: typing the
carriers alongside the clause layer produced 122 errors reaching `api`,
`cell.ts`, `html`, and `runtime-client`, and typing successive waves of
declarations moved the count 115 → 118 → 76 → 85 rather than steadily down —
each wave pushed the frontier into whatever passes label data through. It
converged only once the work switched from *declaring* (which expands the
frontier) to *closing individual sites* (which terminates).

#5035 already established that the other obvious seam does not help: narrowing
producer return types is safe for consumers and therefore removes no
consumer-side error.

## A split that would work, for next time

`confidentiality` (63 declarations) and `integrity` (15) are near-disjoint
subsystems — clause machinery versus floor/trust machinery — sharing only the
`IFCLabel` container. Reverting just the integrity declarations from this branch
leaves **8 errors**, roughly half of them integrity-only locals that would not
exist in a confidentiality-only change. The genuine coupling is the key-generic
loops (`for (const key of LABEL_KEYS) label[key] = …` in `cloneCfcLabel`,
`redactCaveatSourcesForDisplay`, and one in `ui`), which would need a cast in
the first PR and shed it in the second.

Every earlier split attempt cut *across* the type graph and cost 40–120 sites or
bought nothing; this one cuts *along* it, separating two components that were
only ever adjacent in a struct. Not applied here — the split is lopsided and
costs casts — but it is the seam to use on the next label-typing job.

## Notes

- `cf-harness` type-checks inside its own `deno task test`, so a clean
  `deno task check` does **not** imply the repo type-checks. Its failure is the
  second commit here.
- Test helpers carried most of the churn: typing four of them —
  `clauseSetsEqual`, `caveatAtom`, `derivedBodyEntry`, `confidentialityOf` —
  cleared 56 errors at once.
- `packages/ui` also reads labels generically. It type-checks fine as-is and is
  untouched here, but the label vocabulary reaches one package further than a
  grep for `confidentiality:` finds.

## Test plan

- `deno task check` clean, `deno fmt --check` and `deno lint` exit 0.
- `packages/runner`: 1068 passed, 0 failed. `packages/cf-harness`: 500 passed.
- Full repo suite green on a clean, committed tree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed all containers that carry CFC clauses and atoms, replacing `unknown[]` with `CfcConfClause` and `CfcAtom` for end-to-end type safety. Impacts runner, HTML worker, SQLite and LLM builtins, and `cf-harness`; no runtime changes.

- **Refactors**
  - Typed `IFCLabel`, `CfcObservedConfidentiality`, `SinkMaxConfidentiality`, render policies, and exchange/introspection records to use `CfcConfClause`/`CfcAtom`.
  - Updated SQLite label read/write and write-ceiling, LLM dialog/generate flows, and the HTML worker reconciler to propagate typed atoms/clauses.
  - Fixed `cf-harness` model context to accumulate `CfcConfClause[]` for confidentiality.
  - Left a few casts where inputs are genuinely untyped (cell reads, `transformValue` outputs, specific test literals).

<sup>Written for commit cc40c6ece2c0f31855da26b8c822cce331e0e62c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

