### PR TITLE
refactor(cfc): integrity carriers name the atoms they hold

### DIFF
--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -27,6 +27,7 @@ import {
   UI,
   useCancelGroup,
 } from "@commonfabric/runner";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import type { CellRef } from "@commonfabric/runtime-client";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -595,7 +596,7 @@ export class WorkerReconciler {
       textIntegrity: {
         requiredIntegrity: [
           ...(parentTextIntegrity?.requiredIntegrity ?? []),
-          ...requiredIntegrity,
+          ...(requiredIntegrity as readonly CfcAtom[]),
         ],
         allowLiteralText: (parentTextIntegrity?.allowLiteralText ?? true) &&
           allowLiteralText,
@@ -1066,7 +1067,7 @@ export class WorkerReconciler {
    */
   private resolvedConfidentialityRenderable(
     confidentiality: readonly unknown[],
-    integrity: readonly unknown[],
+    integrity: readonly CfcAtom[],
     policy: RenderPolicy,
   ): boolean {
     const resolved = this.resolveRenderConfidentiality!({
@@ -1378,7 +1379,7 @@ export class WorkerReconciler {
     );
   }
 
-  private integrityLabels(labelView: CfcLabelView): readonly unknown[] {
+  private integrityLabels(labelView: CfcLabelView): readonly CfcAtom[] {
     return ContextualFlowControl.uniqueAtoms(
       labelView.entries.flatMap((entry) =>
         entry.path.length === 0 ? [...(entry.label.integrity ?? [])] : []

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Cancel, Cell, JSONSchema } from "@commonfabric/runner";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import type {
   RenderConfidentialityResolver,
   SpaceMembershipProvider,
@@ -123,7 +124,7 @@ export interface RenderPolicy {
    * Undefined means descendant text is not integrity-gated.
    */
   textIntegrity?: {
-    requiredIntegrity: readonly unknown[];
+    requiredIntegrity: readonly CfcAtom[];
     allowLiteralText: boolean;
     /**
      * The enclosing text-integrity boundaries this policy applies to, innermost

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2,6 +2,7 @@ import {
   FabricPrimitive,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import {
   DEFAULT_MODEL_NAME,
   LLMClient,
@@ -2094,7 +2095,11 @@ function toolInputRequiredIntegrityFailure(
       // membership the commit-boundary gates use. `trust` carries the acting
       // principal's closure so a CONCEPT-valued floor accepts any concrete
       // atom above the concept (D5), consistently with the read/write gates.
-      const satisfied = cfcIntegritySatisfiesFloor(integrity, required, trust);
+      const satisfied = cfcIntegritySatisfiesFloor(
+        integrity as readonly CfcAtom[],
+        required,
+        trust,
+      );
       if (!satisfied) {
         return `field "${path || "(root)"}" requires integrity the ` +
           `model-supplied value does not carry (pass an integrity-bearing ` +

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -20,6 +20,7 @@
 // this read path.
 
 import { type Cell, createCell, encodeSqliteParams } from "../cell.ts";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { parseLink } from "../link-utils.ts";
 import {
   computeRowLabelRead,
@@ -284,7 +285,7 @@ function deriveNullOriginIfc(
 
 type ColumnIfc = {
   confidentiality?: unknown[];
-  integrity?: unknown[];
+  integrity?: CfcAtom[];
   maxConfidentiality?: unknown[];
 };
 
@@ -322,9 +323,9 @@ const tightenCeiling = (
 // Identical to `tightenCeiling` EXCEPT the prior-absent case yields undefined
 // (no prior trust to inherit) rather than adopting `next` wholesale.
 const clampIntegrity = (
-  prior: unknown[] | undefined,
-  next: unknown[] | undefined,
-): unknown[] | undefined => {
+  prior: CfcAtom[] | undefined,
+  next: CfcAtom[] | undefined,
+): CfcAtom[] | undefined => {
   if (prior === undefined) return undefined;
   if (next === undefined) return prior;
   const kept = prior.filter((atom) => next.some((n) => deepEqual(n, atom)));

--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -15,6 +15,7 @@ import {
   ruleInputFields,
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
 import type { CfcConfClause } from "../../cfc/clause.ts";
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
@@ -29,7 +30,7 @@ interface ResultColumn {
 /** A row's per-row label, shaped as a schema `ifc` for the row-doc write. */
 export interface PerRowIfc {
   confidentiality?: unknown[];
-  integrity?: unknown[];
+  integrity?: CfcAtom[];
 }
 
 export interface RowLabelReadArgs {
@@ -292,7 +293,9 @@ export function computeRowLabelRead(
           if (res.confidentiality.length > 0) {
             ifc.confidentiality = res.confidentiality;
           }
-          if (res.integrity.length > 0) ifc.integrity = res.integrity;
+          if (res.integrity.length > 0) {
+            ifc.integrity = res.integrity as CfcAtom[];
+          }
           labels.push(
             ifc.confidentiality || ifc.integrity ? ifc : undefined,
           );

--- a/packages/runner/src/builtins/sqlite/row-label-write.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-write.ts
@@ -27,6 +27,7 @@ import {
   ruleInputFields,
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
 import {
@@ -40,7 +41,7 @@ import {
  *  input (sink-request) before the commit. */
 export interface RowLabelWritePolicy {
   table: string;
-  label: { confidentiality: unknown[]; integrity: unknown[] };
+  label: { confidentiality: unknown[]; integrity: CfcAtom[] };
 }
 
 export interface RowLabelWriteArgs {
@@ -293,7 +294,10 @@ export function checkSqliteRowLabelWrite(
     }
     policies.push({
       table: declaredKey,
-      label: { confidentiality: res.confidentiality, integrity: res.integrity },
+      label: {
+        confidentiality: res.confidentiality,
+        integrity: res.integrity as CfcAtom[],
+      },
     });
   }
   return { policies };

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -155,7 +155,7 @@ export type ExchangeEvalContext = {
    * integrity (boundary-minted facts, consumed-read integrity). The guard
    * pool is `label.integrity ∪ ctx.integrity`.
    */
-  readonly integrity?: readonly unknown[];
+  readonly integrity?: readonly CfcAtom[];
   /** Boundary-context atoms minted for this evaluation site (B5). */
   readonly boundary?: readonly unknown[];
   /** Trust closure for concept-valued integrity guards (B3). */
@@ -581,7 +581,7 @@ const extendThroughGrantGuard = (
 const matchRule = (
   rule: ExchangeRule,
   confidentiality: readonly CfcConfClause[],
-  availableIntegrity: readonly unknown[],
+  availableIntegrity: readonly CfcAtom[],
   ctx: ExchangeEvalContext,
   homeClauses?: ReadonlySet<number>,
 ): RuleMatch[] => {

--- a/packages/runner/src/cfc/label-representation.ts
+++ b/packages/runner/src/cfc/label-representation.ts
@@ -1,4 +1,5 @@
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { isRecord } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import {
@@ -206,7 +207,7 @@ export const transformCfcLabelForCrossSpacePersist = (
     : (transformValue(label.confidentiality, undefined, []) as unknown[]);
   const integrity = label.integrity === undefined
     ? undefined
-    : (transformValue(label.integrity, undefined, []) as unknown[]);
+    : (transformValue(label.integrity, undefined, []) as CfcAtom[]);
   if (
     confidentiality === label.confidentiality && integrity === label.integrity
   ) {

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -1,4 +1,5 @@
 import { encodePointer } from "../../../memory/v2/path.ts";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import type { CfcConfClause } from "./clause.ts";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { uniqueCfcAtoms } from "./observation.ts";
@@ -6,7 +7,7 @@ import { normalizeClause } from "./clause.ts";
 
 export type IFCLabel = {
   confidentiality?: unknown[];
-  integrity?: unknown[];
+  integrity?: CfcAtom[];
 };
 
 /**
@@ -88,7 +89,9 @@ export const cloneCfcLabel = (label: IFCLabel): IFCLabel => {
   for (const key of LABEL_KEYS) {
     const value = label[key];
     if (Array.isArray(value) && value.length > 0) {
-      cloned[key] = [...value];
+      // TODO(danfuzz): drop the cast once `confidentiality` names its
+      // clause type too; this loop spans both label keys.
+      cloned[key] = [...value] as CfcAtom[];
     }
   }
   return cloned;
@@ -151,7 +154,9 @@ export const redactCaveatSourcesForDisplay = (
     for (const key of LABEL_KEYS) {
       const value = entry.label[key];
       if (Array.isArray(value) && value.length > 0) {
-        label[key] = value.map(redactCaveatSourceAtom);
+        // TODO(danfuzz): drop the cast once `confidentiality` names its
+        // clause type too; this loop spans both label keys.
+        label[key] = value.map(redactCaveatSourceAtom) as CfcAtom[];
       }
     }
     return {

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -226,7 +226,7 @@ const integrityAtomSatisfies = (
       trust?.trustResolver !== undefined &&
       trust.trustResolver.conceptSatisfied(
         concept.uri,
-        [actual],
+        [actual as CfcAtom],
         trust.actingPrincipal,
       );
   }
@@ -248,8 +248,8 @@ const integrityAtomSatisfies = (
  * (concrete/pattern) floors.
  */
 export const cfcIntegritySatisfiesFloor = (
-  integrity: readonly unknown[],
-  requiredIntegrity: readonly unknown[],
+  integrity: readonly CfcAtom[],
+  requiredIntegrity: readonly CfcAtom[],
   trust?: CfcFloorTrustContext,
 ): boolean =>
   requiredIntegrity.every((required) =>
@@ -308,7 +308,7 @@ export const cfcIntegrityWitnessKey = (
  */
 export const cfcIntegritySatisfiesFloorCoherently = (
   consumedIntegrity: readonly (readonly unknown[])[],
-  requiredIntegrity: readonly unknown[],
+  requiredIntegrity: readonly CfcAtom[],
   trust?: CfcFloorTrustContext,
 ): boolean =>
   requiredIntegrity.every((required) => {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1775,7 +1775,7 @@ export const deriveFlowJoin = (
   },
 ): {
   confidentiality: unknown[];
-  integrity: unknown[];
+  integrity: CfcAtom[];
   labeledSpaces?: ReadonlySet<MemorySpace>;
 } => {
   const atoms: unknown[] = [];
@@ -1787,7 +1787,7 @@ export const deriveFlowJoin = (
   // uncertified. (In practice most transactions read some unlabeled doc,
   // so the meet is usually empty until inputs are universally certified —
   // staged conformance per SC-9, never over-claiming.)
-  let hereditaryMeet: unknown[] | undefined;
+  let hereditaryMeet: CfcAtom[] | undefined;
   const labeledSpaces = options?.collectLabeledSpaces === true
     ? new Set<MemorySpace>()
     : undefined;
@@ -1898,7 +1898,7 @@ export const deriveFlowJoin = (
     atoms.push(...observation.confidentiality);
   }
   const confidentiality = uniqueCfcAtoms(atoms);
-  const integrity: unknown[] = [...(hereditaryMeet ?? [])];
+  const integrity: CfcAtom[] = [...(hereditaryMeet ?? [])];
   // Derivation provenance (§8.9.3 TransformedBy, staged: identity binding
   // only — no per-input refs/witnesses yet). The flow join is one per-tx
   // label stamped on every written doc, so the identity must hold for the
@@ -2428,7 +2428,7 @@ const projectedSourceLabel = (
 ): IFCLabel => {
   const source = canonicalizeLogicalPath([...claim.source, ...claim.field]);
   const confidentiality: unknown[] = [];
-  const integrity: unknown[] = [];
+  const integrity: CfcAtom[] = [];
   // Map insertion order is the schema-walk order (parents before children),
   // so contributions stay ordered ancestor-first along the source lineage.
   for (const [key, label] of sourceEntryLabels) {
@@ -4565,7 +4565,7 @@ const collectConsumedLabel = (
   tx: IExtendedStorageTransaction,
 ): {
   confidentiality: readonly unknown[];
-  integrity: readonly unknown[];
+  integrity: readonly CfcAtom[];
   modulePolicySpaces: ReadonlyMap<string, ReadonlySet<MemorySpace>>;
 } => {
   const atoms: unknown[] = [];
@@ -4575,7 +4575,7 @@ const collectConsumedLabel = (
   // transaction-global over-approximation as the confidentiality union —
   // rules bind kind/source structurally, so evidence still has to match the
   // clause it discharges.
-  const integrityAtoms: unknown[] = [];
+  const integrityAtoms: CfcAtom[] = [];
   for (
     const read of [
       ...(tx.getReadActivities?.() ?? []),
@@ -4680,7 +4680,7 @@ const collectConsumedLabel = (
 const evaluateGatedConfidentiality = (
   tx: IExtendedStorageTransaction,
   confidentiality: readonly unknown[],
-  integrity: readonly unknown[],
+  integrity: readonly CfcAtom[],
   boundary: readonly unknown[],
   consumption: CfcGrantConsumptionContext,
   destinationSpace?:
@@ -4958,7 +4958,7 @@ const verifyWriteFloor = (
     ) => ImplementationIdentity | undefined;
     linkWriteInputs: readonly LinkWritePolicyInput[];
     candidateSchemas: ReadonlyMap<string, JSONSchema>;
-    flowIntegrity: readonly unknown[];
+    flowIntegrity: readonly CfcAtom[];
   },
 ): string[] => {
   const failures: string[] = [];
@@ -5034,7 +5034,7 @@ const verifyWriteFloor = (
     // One contribution per link written at/under the floor path (each linked
     // value must individually carry the floor), plus one `value` contribution
     // when plain data was written (crediting the flow meet when available).
-    const contributions: (readonly unknown[])[] = [];
+    const contributions: (readonly CfcAtom[])[] = [];
     for (const input of linksHere) {
       const derived = derivePersistedLinkLabel(
         tx,

--- a/packages/runner/src/cfc/render-ceiling.ts
+++ b/packages/runner/src/cfc/render-ceiling.ts
@@ -166,7 +166,7 @@ export const spaceAtomIdsInConfidentiality = (
 /** The label of the cell being rendered, as read at the display boundary. */
 export type RenderLabelInput = {
   readonly confidentiality: readonly unknown[];
-  readonly integrity?: readonly unknown[];
+  readonly integrity?: readonly CfcAtom[];
 };
 
 /**

--- a/packages/runner/src/cfc/trust.ts
+++ b/packages/runner/src/cfc/trust.ts
@@ -243,7 +243,7 @@ export type TrustResolver = {
    */
   conceptSatisfied(
     concept: string,
-    integrityAtoms: readonly unknown[],
+    integrityAtoms: readonly CfcAtom[],
     actingPrincipal: string | undefined,
   ): boolean;
 };

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,4 +1,5 @@
 import { isObject, isRecord } from "@commonfabric/utils/types";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { forEachSubschema } from "./schema-walk.ts";
 import {
   fabricFromNativeValue,
@@ -141,7 +142,7 @@ const schemaPathsOverlap = (
 const labelHasValues = (
   label: {
     confidentiality?: readonly unknown[];
-    integrity?: readonly unknown[];
+    integrity?: readonly CfcAtom[];
   },
 ): boolean =>
   (label.confidentiality?.length ?? 0) > 0 ||

--- a/packages/runner/test/cfc-concept-floor.test.ts
+++ b/packages/runner/test/cfc-concept-floor.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { cfcAtom } from "@commonfabric/api/cfc";
@@ -220,7 +221,7 @@ describe("CFC concept-level integrity floors (D5)", () => {
       // against a concrete object never meets.
       expect(cfcIntegritySatisfiesFloor(
         [gps("X")],
-        [arrayGuard],
+        [arrayGuard as unknown as CfcAtom],
         trustCtx(signer.did()),
       )).toBe(false);
     });

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
@@ -40,7 +41,7 @@ type StoredEntry = {
 const SOURCE_A = { space: "did:key:remote-a", id: "of:origin-a", path: [] };
 const SOURCE_B = { space: "did:key:remote-b", id: "of:origin-b", path: [] };
 
-const caveatAtom = (source: unknown = SOURCE_A) => ({
+const caveatAtom = (source: CfcAtom = SOURCE_A) => ({
   type: CFC_ATOM_TYPE.Caveat,
   kind: "prompt-influence",
   source,

--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
@@ -1,4 +1,5 @@
 import { css, html } from "lit";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { BaseElement } from "../../core/base-element.ts";
 import type { CfcLabelView } from "@commonfabric/runtime-client";
 
@@ -90,7 +91,9 @@ const filteredLabel = (
     }
     const filtered = values.filter((value) => atomMatchesFilter(value, filter));
     if (filtered.length > 0) {
-      result[key] = filtered;
+      // TODO(danfuzz): drop the cast once `confidentiality` names its clause
+      // type too; this loop spans both label keys.
+      result[key] = filtered as CfcAtom[];
     }
   }
   return LABEL_KEYS.some((key) => Array.isArray(result[key]))


### PR DESCRIPTION
Types the declarations that carry CFC **integrity** atom lists as `CfcAtom[]`
instead of `unknown[]`: `IFCLabel.integrity`, the flow / consumed / contribution
records in `prepare.ts`, the trust and exchange guard pools, and the sqlite and
html integrity plumbing. Integrity carries no OR-clauses, so `CfcAtom` is the
right vocabulary throughout.

21 declarations, 15 fallout sites, 17 files. Confidentiality deliberately keeps
`unknown[]` here — it is the sibling PR.

No runtime change: annotations, casts, and imports only.

## Why this splits cleanly

Confidentiality and integrity are near-disjoint subsystems. Confidentiality
flows through the clause machinery (`clauseAlternatives`, `clauseSubsumes`,
ceilings, exchange rules); integrity flows through floors and trust closure
(`cfcIntegritySatisfiesFloor`, hereditary meet). They share only the `IFCLabel`
container, so each can be typed without the other.

The only coupling is the loops that span both label keys:

```ts
for (const key of LABEL_KEYS) {   // ["confidentiality", "integrity"]
  cloned[key] = [...value] as CfcAtom[];
}
```

Three of them — `cloneCfcLabel`, `redactCaveatSourcesForDisplay`, and the `ui`
label filter — each carrying a `TODO(danfuzz)` naming the condition that removes
the cast. The confidentiality PR satisfies it.

This is the seam that works. Earlier attempts in this series cut *across* the
type graph (clause layer vs carriers, producers vs consumers, CFC core vs
consumers) and cost 40–120 sites or bought nothing measurable — every CFC atom
list is one type-connected component. This cut runs *along* the graph, splitting
two subsystems that were only ever adjacent inside a struct. It replaces #5036,
which did both halves at once across 33 files.

## Test plan

- `deno task check` clean; `deno fmt --check` and `deno lint` exit 0.
- Full repo suite green on a clean, committed tree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch all CFC integrity carriers to `CfcAtom[]` for better type safety across labels, trust, and evaluation. No runtime behavior changes.

- **Refactors**
  - Core CFC: `IFCLabel.integrity`, flow/consumption/contribution records in `prepare.ts`, and integrity checks (e.g., `cfcIntegritySatisfiesFloor`) now use `readonly CfcAtom[]`.
  - Integrations: SQLite label plumbing (`row-label-*/sqlite-builtins`), HTML worker render policy, and UI label filter updated to carry integrity as `CfcAtom[]`. Confidentiality stays `unknown[]`; temporary casts remain in three cross-key loops with TODOs to remove when confidentiality is typed.

<sup>Written for commit 63cc1a7a0f6341bcbe3201c3a7e7eefc7a8321ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

