### PR TITLE
refactor(cfc): ceilings name the clauses they admit

### DIFF
--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -172,9 +172,7 @@ export class WorkerReconciler {
     );
     this.rootRenderPolicy = ceiling === undefined ? DEFAULT_RENDER_POLICY : {
       declassifyConfidentiality: [],
-      maxConfidentiality: [
-        ...(ceiling.atoms ?? []),
-      ] as readonly CfcConfClause[],
+      maxConfidentiality: [...(ceiling.atoms ?? [])],
       caveatKindAllow: [...(ceiling.caveatKinds ?? [])],
     };
   }

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -27,6 +27,7 @@ import {
   UI,
   useCancelGroup,
 } from "@commonfabric/runner";
+import type { CfcConfClause } from "@commonfabric/runner/cfc";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import type { CellRef } from "@commonfabric/runtime-client";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
@@ -171,7 +172,9 @@ export class WorkerReconciler {
     );
     this.rootRenderPolicy = ceiling === undefined ? DEFAULT_RENDER_POLICY : {
       declassifyConfidentiality: [],
-      maxConfidentiality: [...(ceiling.atoms ?? [])],
+      maxConfidentiality: [
+        ...(ceiling.atoms ?? []),
+      ] as readonly CfcConfClause[],
       caveatKindAllow: [...(ceiling.caveatKinds ?? [])],
     };
   }
@@ -625,7 +628,7 @@ export class WorkerReconciler {
   private staticPropAsAtomList(
     props: WorkerProps | null | undefined,
     key: string,
-  ): readonly unknown[] | undefined {
+  ): readonly CfcConfClause[] | undefined {
     if (!props || typeof props !== "object" || !(key in props)) {
       return undefined;
     }
@@ -637,9 +640,9 @@ export class WorkerReconciler {
       return undefined;
     }
     if (Array.isArray(value)) {
-      return value;
+      return value as readonly CfcConfClause[];
     }
-    return [value];
+    return [value as CfcConfClause];
   }
 
   private nodePropForRenderPolicy(
@@ -695,7 +698,7 @@ export class WorkerReconciler {
   private nodePropAsAtomList(
     node: WorkerVNode,
     keys: readonly string[],
-  ): readonly unknown[] | undefined {
+  ): readonly CfcConfClause[] | undefined {
     for (const key of keys) {
       const value = this.nodePropForRenderPolicy(node, key);
       if (typeof value === "function") {
@@ -707,14 +710,16 @@ export class WorkerReconciler {
       if (resolved === undefined) {
         continue;
       }
-      return Array.isArray(resolved) ? resolved : [resolved];
+      return (Array.isArray(resolved)
+        ? resolved
+        : [resolved]) as readonly CfcConfClause[];
     }
     return undefined;
   }
 
   private requiredAuthorshipIntegrityFromAuthor(
     node: WorkerVNode,
-  ): readonly unknown[] | undefined {
+  ): readonly CfcConfClause[] | undefined {
     const author = this.nodePropForRenderPolicy(node, "author") ??
       this.nodePropForRenderPolicy(node, "$author");
     if (!isCell(author)) {
@@ -913,7 +918,7 @@ export class WorkerReconciler {
 
   private normalizeAtomBound(
     labels: readonly unknown[] | undefined,
-  ): readonly unknown[] | undefined {
+  ): readonly CfcConfClause[] | undefined {
     if (labels === undefined) {
       return undefined;
     }
@@ -921,9 +926,9 @@ export class WorkerReconciler {
   }
 
   private narrowMaxConfidentiality(
-    parentMax: readonly unknown[] | undefined,
-    localMax: readonly unknown[] | undefined,
-  ): readonly unknown[] | undefined {
+    parentMax: readonly CfcConfClause[] | undefined,
+    localMax: readonly CfcConfClause[] | undefined,
+  ): readonly CfcConfClause[] | undefined {
     if (parentMax === undefined) {
       return localMax;
     }

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -599,7 +599,7 @@ export class WorkerReconciler {
       textIntegrity: {
         requiredIntegrity: [
           ...(parentTextIntegrity?.requiredIntegrity ?? []),
-          ...(requiredIntegrity as readonly CfcAtom[]),
+          ...requiredIntegrity,
         ],
         allowLiteralText: (parentTextIntegrity?.allowLiteralText ?? true) &&
           allowLiteralText,
@@ -698,7 +698,7 @@ export class WorkerReconciler {
   private nodePropAsAtomList(
     node: WorkerVNode,
     keys: readonly string[],
-  ): readonly CfcConfClause[] | undefined {
+  ): readonly CfcAtom[] | undefined {
     for (const key of keys) {
       const value = this.nodePropForRenderPolicy(node, key);
       if (typeof value === "function") {
@@ -710,16 +710,14 @@ export class WorkerReconciler {
       if (resolved === undefined) {
         continue;
       }
-      return (Array.isArray(resolved)
-        ? resolved
-        : [resolved]) as readonly CfcConfClause[];
+      return (Array.isArray(resolved) ? resolved : [resolved]) as CfcAtom[];
     }
     return undefined;
   }
 
   private requiredAuthorshipIntegrityFromAuthor(
     node: WorkerVNode,
-  ): readonly CfcConfClause[] | undefined {
+  ): readonly CfcAtom[] | undefined {
     const author = this.nodePropForRenderPolicy(node, "author") ??
       this.nodePropForRenderPolicy(node, "$author");
     if (!isCell(author)) {

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -299,7 +299,7 @@ export function normalizeRenderDeclassificationPolicy(
  * new release judgment.
  */
 export interface RenderConfidentialityCeiling {
-  atoms?: readonly unknown[];
+  atoms?: readonly CfcConfClause[];
   caveatKinds?: readonly string[];
 }
 
@@ -323,7 +323,7 @@ export function normalizeRenderConfidentialityCeiling(
     caveatKinds?: unknown;
   };
   return {
-    atoms: Array.isArray(atoms) ? atoms : [],
+    atoms: Array.isArray(atoms) ? atoms as readonly CfcConfClause[] : [],
     caveatKinds: Array.isArray(caveatKinds)
       ? caveatKinds.filter((kind): kind is string => typeof kind === "string")
       : [],

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Cancel, Cell, JSONSchema } from "@commonfabric/runner";
+import type { CfcConfClause } from "@commonfabric/runner/cfc";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import type {
   RenderConfidentialityResolver,
@@ -102,7 +103,7 @@ export interface RenderPolicy {
    * Confidentiality atoms allowed to render in this subtree.
    * Undefined means no render-time confidentiality bound is active.
    */
-  maxConfidentiality?: readonly unknown[];
+  maxConfidentiality?: readonly CfcConfClause[];
 
   /**
    * Caveat kinds admitted by the host's default render ceiling (spec

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2,6 +2,7 @@ import {
   FabricPrimitive,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
+import type { CfcConfClause } from "../cfc/clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import {
   DEFAULT_MODEL_NAME,
@@ -165,7 +166,7 @@ type SerializeForLLMObservationParams = {
   logicalPath?: readonly string[];
   rootLink?: NormalizedFullLink;
   labelView?: CfcLabelView;
-  observationMaxConfidentiality?: readonly unknown[];
+  observationMaxConfidentiality?: readonly CfcConfClause[];
 };
 
 function normalizeInputSchema(schemaLike: unknown): JSONSchema {
@@ -873,7 +874,7 @@ type DialogRequestSnapshot = {
   toolCatalog: ToolCatalog;
   userResultSchema: JSONSchema | undefined;
   queueName?: string;
-  observationMaxConfidentiality?: readonly unknown[];
+  observationMaxConfidentiality?: readonly CfcConfClause[];
   systemObservedConfidentiality: readonly unknown[];
 };
 
@@ -1418,7 +1419,7 @@ function materializeDialogRequestSnapshot(
     runtime,
     "llmDialog",
     inputs.key("observationMaxConfidentiality").withTx(tx).get() as
-      | readonly unknown[]
+      | readonly CfcConfClause[]
       | undefined,
   );
   const toolsCell = inputs.key("tools").withTx(tx) as Cell<
@@ -1514,7 +1515,7 @@ function buildAvailableCellsDocumentationWithObservation(
   space: MemorySpace,
   context: Record<string, unknown> | undefined,
   pinnedCells: Cell<PinnedCell[]>,
-  observationMaxConfidentiality?: readonly unknown[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ): AvailableCellsDocumentation {
   // Collect all cell entries, deduplicating by resolved path.
   // When the same cell appears multiple times (e.g., from context AND pinned),
@@ -1665,7 +1666,7 @@ function buildAvailableCellsDocumentation(
   space: MemorySpace,
   context: Record<string, unknown> | undefined,
   pinnedCells: Cell<PinnedCell[]>,
-  observationMaxConfidentiality?: readonly unknown[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ): string {
   return buildAvailableCellsDocumentationWithObservation(
     runtime,
@@ -2013,8 +2014,8 @@ type ToolCallExecutionResult = {
 function effectiveObservationCeiling(
   runtime: Runtime,
   sink: string,
-  patternBound: readonly unknown[] | undefined,
-): readonly unknown[] | undefined {
+  patternBound: readonly CfcConfClause[] | undefined,
+): readonly CfcConfClause[] | undefined {
   const ceilings = runtime.cfcSinkMaxConfidentiality;
   // Object.hasOwn guard: the sink name is a runner-controlled literal today, but
   // a name colliding with an Object.prototype member must resolve to "no
@@ -2213,7 +2214,7 @@ async function executeToolCalls(
   toolCallParts: BuiltInLLMToolCallPart[],
   pinnedCells?: Cell<PinnedCell[]>,
   observedConfidentiality?: readonly unknown[],
-  observationMaxConfidentiality?: readonly unknown[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ): Promise<ToolCallExecutionResult[]> {
   const results: ToolCallExecutionResult[] = [];
   for (const part of toolCallParts) {
@@ -2487,7 +2488,7 @@ function handleSchema(
 async function handleRead(
   resolved: ResolvedToolCall & { type: "read" },
   space: MemorySpace,
-  observationMaxConfidentiality?: readonly unknown[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ): Promise<
   {
     result: { type: string; value: unknown };
@@ -2650,7 +2651,7 @@ async function handleInvoke(
   runtime: Runtime,
   space: MemorySpace,
   resolved: ResolvedToolCall,
-  observationMaxConfidentiality?: readonly unknown[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ): Promise<{
   result: { type: string; value: any };
   observedConfidentiality: readonly unknown[];
@@ -2852,7 +2853,7 @@ async function invokeToolCall(
   resolved: ResolvedToolCall,
   _catalog?: ToolCatalog,
   pinnedCells?: Cell<PinnedCell[]>,
-  observationMaxConfidentiality?: readonly unknown[],
+  observationMaxConfidentiality?: readonly CfcConfClause[],
 ) {
   // Handle pinned cell tools
   if (resolved.type === "pin") {
@@ -3297,7 +3298,7 @@ async function startRequest(
       runtime,
       "llmDialog",
       inputs.key("observationMaxConfidentiality").get() as
-        | readonly unknown[]
+        | readonly CfcConfClause[]
         | undefined,
     );
   const builtinTools = inputs.key("builtinTools").get() !== false;
@@ -3320,7 +3321,7 @@ async function startRequest(
     messages: Schema<typeof LLMMessageSchema>[],
   ) => {
     const startIndex = (messagesCell.withTx(tx).get() as
-      | readonly unknown[]
+      | readonly CfcConfClause[]
       | undefined)?.length ?? 0;
     messagesCell.withTx(tx).push(...messages);
     if (runtime.cfcEnforcementMode === "disabled") {

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -1,4 +1,5 @@
 import { getLogger } from "@commonfabric/utils/logger";
+import type { CfcConfClause } from "../cfc/clause.ts";
 import {
   DEFAULT_GENERATE_OBJECT_MODELS,
   DEFAULT_MODEL_NAME,
@@ -340,7 +341,7 @@ async function executeWithToolsLoop(params: {
     | ReturnType<typeof llmToolExecutionHelpers.buildToolCatalog>
     | undefined;
   initialObservedConfidentiality?: readonly unknown[];
-  observationMaxConfidentiality?: readonly unknown[];
+  observationMaxConfidentiality?: readonly CfcConfClause[];
   updatePartial: (text: string) => void;
   runtime: Runtime;
   space: any;
@@ -537,7 +538,7 @@ function buildContextDocumentation(
         runtime,
         sink,
         inputs.key("observationMaxConfidentiality").withTx(tx).get() as
-          | readonly unknown[]
+          | readonly CfcConfClause[]
           | undefined,
       ),
     );
@@ -782,7 +783,7 @@ export function llm(
                     runtime,
                     "llm",
                     inputs.key("observationMaxConfidentiality").get() as
-                      | readonly unknown[]
+                      | readonly CfcConfClause[]
                       | undefined,
                   ),
                 updatePartial,
@@ -1125,7 +1126,7 @@ export function generateText(
                     runtime,
                     "generateText",
                     inputs.key("observationMaxConfidentiality").get() as
-                      | readonly unknown[]
+                      | readonly CfcConfClause[]
                       | undefined,
                   ),
                 updatePartial,
@@ -1272,7 +1273,7 @@ export function generateObject<T extends Record<string, unknown>>(
         runtime,
         "generateObject",
         inputs.key("observationMaxConfidentiality").withTx(tx).get() as
-          | readonly unknown[]
+          | readonly CfcConfClause[]
           | undefined,
       );
     const outputScope = tx.getNarrowestReadScope();

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -20,6 +20,7 @@
 // this read path.
 
 import { type Cell, createCell, encodeSqliteParams } from "../cell.ts";
+import type { CfcConfClause } from "../cfc/clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { parseLink } from "../link-utils.ts";
 import {
@@ -286,7 +287,7 @@ function deriveNullOriginIfc(
 type ColumnIfc = {
   confidentiality?: unknown[];
   integrity?: CfcAtom[];
-  maxConfidentiality?: unknown[];
+  maxConfidentiality?: CfcConfClause[];
 };
 
 const unionAtoms = (
@@ -306,9 +307,9 @@ const unionAtoms = (
 // An EMPTY intersection stays `[]`, which the verifier reads as "public only"
 // (the tightest ceiling) — collapsing it to undefined would forge "no ceiling".
 const tightenCeiling = (
-  prior: unknown[] | undefined,
-  next: unknown[] | undefined,
-): unknown[] | undefined => {
+  prior: CfcConfClause[] | undefined,
+  next: CfcConfClause[] | undefined,
+): CfcConfClause[] | undefined => {
   if (prior === undefined) return next;
   if (next === undefined) return prior;
   return prior.filter((atom) => next.some((n) => deepEqual(n, atom)));
@@ -638,7 +639,7 @@ export function sqliteQuery(
       // CFC Phase 3: declared output ceiling + what to do when a row's label
       // exceeds it ("fail" default | "skip"). The typed alternative is
       // MaxConfidentiality<> on the Row schema (rowSchema.ifc).
-      maxConfidentiality?: unknown[];
+      maxConfidentiality?: CfcConfClause[];
       onExceed?: unknown;
       // CFC Phase 3.b: opt into read-time clearance — filter rows to those the
       // acting reader may read (a declared existence release). Requires the
@@ -772,7 +773,7 @@ export function sqliteQuery(
           // row, and decides fail/skip under the ceiling — every unresolvable
           // case refuses the query (fail closed), never under-labels.
           const rowSchemaCeiling = (inputs.rowSchema as {
-            ifc?: { maxConfidentiality?: unknown[] };
+            ifc?: { maxConfidentiality?: CfcConfClause[] };
           } | undefined)?.ifc?.maxConfidentiality;
           if (
             inputs.maxConfidentiality !== undefined &&

--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -15,6 +15,7 @@ import {
   ruleInputFields,
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
+import type { CfcAtomObject } from "@commonfabric/api/cfc";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
 import type { CfcConfClause } from "../../cfc/clause.ts";
@@ -46,7 +47,7 @@ export interface RowLabelReadArgs {
    *  they ride every row, so they count against the ceiling too. */
   staticConfidentiality?: readonly unknown[];
   /** Declared output ceiling (placeholders already resolved). */
-  ceiling?: readonly unknown[];
+  ceiling?: readonly CfcConfClause[];
   /** What to do when a row's label exceeds the ceiling (default "fail"). */
   onExceed?: unknown;
   /** CFC Phase 3.b read-time clearance: when set, keep only rows the acting
@@ -405,12 +406,14 @@ export function computeRowLabelRead(
  * closed — a ceiling that can't be pinned must not silently widen.
  */
 export function resolveCeilingPlaceholders(
-  ceiling: readonly unknown[],
+  ceiling: readonly CfcConfClause[],
   ctx: { actingPrincipal?: string; owner?: string },
-): { atoms: unknown[] } | { error: string } {
-  const atoms: unknown[] = [];
+): { atoms: CfcConfClause[] } | { error: string } {
+  const atoms: CfcConfClause[] = [];
   for (const atom of ceiling) {
-    if (isRecord(atom) && atom.__ctCurrentPrincipal === true) {
+    if (
+      isRecord(atom) && (atom as CfcAtomObject).__ctCurrentPrincipal === true
+    ) {
       if (ctx.actingPrincipal === undefined) {
         return {
           error: "sqlite: ceiling references the acting user but no acting " +
@@ -420,7 +423,7 @@ export function resolveCeilingPlaceholders(
       atoms.push(ctx.actingPrincipal);
       continue;
     }
-    if (isRecord(atom) && atom.__ctDbOwner === true) {
+    if (isRecord(atom) && (atom as CfcAtomObject).__ctDbOwner === true) {
       if (ctx.owner === undefined) {
         return {
           error: "sqlite: ceiling references the db owner but the db ref " +

--- a/packages/runner/src/builtins/sqlite/row-label-write.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-write.ts
@@ -27,6 +27,7 @@ import {
   ruleInputFields,
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
+import type { CfcConfClause } from "../../cfc/clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
@@ -283,7 +284,12 @@ export function checkSqliteRowLabelWrite(
             "ceiling); storing the value would launder its label; fail closed",
         };
       }
-      if (!cfcObservationFitsCeiling(conf, res.confidentiality)) {
+      if (
+        !cfcObservationFitsCeiling(
+          conf as readonly CfcConfClause[],
+          res.confidentiality as readonly CfcConfClause[],
+        )
+      ) {
         return {
           error: `sqlite: a value bound to rule-bearing table ` +
             `"${declaredKey}" carries confidentiality not captured by the ` +

--- a/packages/runner/src/builtins/sqlite/write-ceiling.ts
+++ b/packages/runner/src/builtins/sqlite/write-ceiling.ts
@@ -9,6 +9,7 @@
 // without a ceiling are unaffected (zero behavior change until `ifc` is used).
 
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
+import type { CfcConfClause } from "../../cfc/clause.ts";
 import {
   blankWriteSql,
   parseWriteParamColumns,
@@ -16,7 +17,7 @@ import {
 } from "@commonfabric/memory/sqlite/write-targets";
 
 interface ColumnIfc {
-  maxConfidentiality?: readonly unknown[];
+  maxConfidentiality?: readonly CfcConfClause[];
   confidentiality?: readonly unknown[];
 }
 type Tables = Record<
@@ -145,7 +146,7 @@ export function checkSqliteWriteCeiling(
   // case; the declared property keys may differ in case from the SQL).
   const resolveCeiling = (
     col: string,
-  ): { found: boolean; ceiling?: readonly unknown[] } => {
+  ): { found: boolean; ceiling?: readonly CfcConfClause[] } => {
     if (table === undefined) return { found: false };
     const props = tables[table]?.properties;
     if (!props) return { found: false };

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -24,7 +24,7 @@ import {
 
 export type CfcObservedConfidentiality = readonly unknown[];
 export type CfcObservationMaxConfidentiality =
-  | readonly unknown[]
+  | readonly CfcConfClause[]
   | undefined;
 
 // Marker confidentiality atom injected when a cell's label could not be read
@@ -428,7 +428,7 @@ export const meetCfcObservationCeilings = (
 ): CfcObservationMaxConfidentiality => {
   if (a === undefined) return b;
   if (b === undefined) return a;
-  const met: unknown[] = [];
+  const met: CfcConfClause[] = [];
   for (const clauseA of a) {
     const alternativesA = clauseAlternatives(clauseA as CfcConfClause);
     if (alternativesA.length === 0) continue;

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4767,7 +4767,7 @@ const verifySinkRequestCeilings = (
   const state = tx.getCfcState();
   const ceilings = state.sinkMaxConfidentiality;
   if (ceilings === undefined) return [];
-  const gatedSinks = new Map<string, readonly unknown[]>();
+  const gatedSinks = new Map<string, readonly CfcConfClause[]>();
   for (const input of state.writePolicyInputs) {
     if (input.kind !== "sink-request") continue;
     // Own-property lookup only: a sink named like an Object.prototype member
@@ -6192,7 +6192,7 @@ export const prepareBoundaryCommit = (
               ?.confidentiality ?? [];
           const offending = atomsOutsideCeiling(
             flowConfidentiality,
-            declaredCeiling,
+            declaredCeiling as readonly CfcConfClause[],
           );
           if (offending.length > 0) {
             // SC-18c error contract: a stable reason naming the rule id and

--- a/packages/runner/src/cfc/sink-inventory.ts
+++ b/packages/runner/src/cfc/sink-inventory.ts
@@ -1,3 +1,4 @@
+import type { CfcConfClause } from "./clause.ts";
 export type InitialSinkName =
   | "fetchBinary"
   | "fetchText"
@@ -45,7 +46,7 @@ export const isInitialSinkInventoryName = (
  * recorded `sink-request` write-policy input.
  */
 export type SinkMaxConfidentiality = Readonly<
-  Record<string, readonly unknown[]>
+  Record<string, readonly CfcConfClause[]>
 >;
 
 /**

--- a/packages/runner/test/cfc-clause-meet.test.ts
+++ b/packages/runner/test/cfc-clause-meet.test.ts
@@ -131,7 +131,7 @@ describe("CFC ceiling meet (pairwise alternative-set union)", () => {
     // atoms, OR-clauses (with an order-differing spelling), the malformed
     // empty clause, and the ungrantable read-failed marker (bare and
     // wrapped).
-    const ceilingClausePool: readonly unknown[] = [
+    const ceilingClausePool: readonly CfcConfClause[] = [
       A,
       B,
       C,
@@ -142,7 +142,7 @@ describe("CFC ceiling meet (pairwise alternative-set union)", () => {
       { anyOf: [] },
       CFC_LABEL_READ_FAILED_ATOM,
     ];
-    const labelClausePool: readonly unknown[] = [
+    const labelClausePool: readonly CfcConfClause[] = [
       A,
       B,
       C,
@@ -155,9 +155,9 @@ describe("CFC ceiling meet (pairwise alternative-set union)", () => {
     ];
 
     const subsetsUpToSize2 = (
-      pool: readonly unknown[],
-    ): readonly (readonly unknown[])[] => {
-      const subsets: (readonly unknown[])[] = [[]];
+      pool: readonly CfcConfClause[],
+    ): readonly (readonly CfcConfClause[])[] => {
+      const subsets: (readonly CfcConfClause[])[] = [[]];
       for (let i = 0; i < pool.length; i++) {
         subsets.push([pool[i]]);
         for (let j = i + 1; j < pool.length; j++) {


### PR DESCRIPTION
Types the CFC **ceiling / allow-list** declarations as `CfcConfClause[]` instead
of `unknown[]`: `SinkMaxConfidentiality`, `CfcObservationMaxConfidentiality`, the
`observationMaxConfidentiality` plumbing through `llm` and `llm-dialog`, the
sqlite write-ceiling and per-row ceiling, and the html render-policy ceiling
props.

19 declarations, 25 fallout sites, 12 files. No runtime change — annotations,
casts, and imports only.

## Why this splits cleanly

A ceiling and the label it bounds are separate subsystems. They meet only as the
two **independent parameters** of `cfcObservationFitsCeiling(confidentiality,
ceiling)`, `atomsOutsideCeiling()`, and `clauseSubsumes(allowed, clause)` — so
typing the ceiling side leaves the label side untouched. Where a label reaches a
ceiling API it takes a cast, which the remaining label-carrier change removes.

This continues the seam that worked in #5037 (integrity, 21 declarations → 15
sites). Both cut *along* the type graph, between subsystems that meet at a narrow
interface. Earlier attempts in this series cut *across* it — clause layer vs
carriers, producers vs consumers, CFC core vs consumers — and each cost 40–120
sites or bought nothing, because every CFC atom list is one type-connected
component.

Remaining after this: the observed/flow and label-carrier declarations (~44),
which is what is left of #5036.

## One thing worth a look

`checkLabeled()` in `write-ceiling.ts` deliberately keeps `readonly unknown[]`.
Its argument comes from `confidentialityOf()`, which is label-side, not
ceiling-side — typing that parameter would have pulled the whole label half into
this PR, since narrowing a parameter propagates to every caller. Cast at the call
instead. (Same contravariance trap #5035 measured: producer returns narrow for
free, consumer parameters do not.)

## Test plan

- `deno task check` clean; `deno fmt --check` and `deno lint` exit 0.
- Full repo suite green on a clean, committed tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed all CFC ceilings/allow-lists as `CfcConfClause[]` across runner, sqlite, LLM, and HTML render policy; fixed HTML integrity readers to use `CfcAtom[]`. No runtime changes.

- **Refactors**
  - Replace ceiling types with `CfcConfClause[]` for `SinkMaxConfidentiality`, `CfcObservationMaxConfidentiality`, `llm`/`llmDialog` `observationMaxConfidentiality`, sqlite read/write ceilings, HTML render policy `maxConfidentiality`, and `RenderConfidentialityCeiling.atoms`.
  - Update helpers where ceilings are computed or passed; add narrow casts at label→ceiling boundaries; keep `checkLabeled()` in `sqlite/write-ceiling.ts` as `readonly unknown[]`.
  - HTML reconciler: integrity readers (`nodePropAsAtomList`, `requiredAuthorshipIntegrityFromAuthor`) return `CfcAtom[]`; `staticPropAsAtomList()` returns `CfcConfClause[]`.

- **Migration**
  - If you pass ceilings, use `readonly CfcConfClause[]` (render policy `maxConfidentiality`, `RenderConfidentialityCeiling.atoms`, sqlite `maxConfidentiality` and `rowSchema.ifc.maxConfidentiality`).
  - In `llm` and `llmDialog`, `observationMaxConfidentiality` is now `readonly CfcConfClause[] | undefined`.

<sup>Written for commit 4ed7a05e6e2ff2adaa4f35f73ecf7dd2d8dc153e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

