### PR TITLE
refactor(cfc): observed confidentiality names its clauses

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -875,12 +875,12 @@ type DialogRequestSnapshot = {
   userResultSchema: JSONSchema | undefined;
   queueName?: string;
   observationMaxConfidentiality?: readonly CfcConfClause[];
-  systemObservedConfidentiality: readonly unknown[];
+  systemObservedConfidentiality: readonly CfcConfClause[];
 };
 
 type AvailableCellsDocumentation = {
   docs: string;
-  observedConfidentiality: readonly unknown[];
+  observedConfidentiality: readonly CfcConfClause[];
 };
 
 function resolveDirectContextCellRef(cell: unknown): Cell<any> | undefined {
@@ -1526,7 +1526,7 @@ function buildAvailableCellsDocumentationWithObservation(
       name: string;
       entry: string;
       hasSchema: boolean;
-      observedConfidentiality: readonly unknown[];
+      observedConfidentiality: readonly CfcConfClause[];
     }
   >();
 
@@ -1548,7 +1548,7 @@ function buildAvailableCellsDocumentationWithObservation(
     if (existing?.hasSchema && !schemaInfo) return;
 
     let entry = `## ${name} (${path})\n`;
-    let observedConfidentiality: readonly unknown[] = [];
+    let observedConfidentiality: readonly CfcConfClause[] = [];
 
     if (schemaInfo !== undefined) {
       const schemaStr = getSchemaTypeString(schemaInfo);
@@ -1683,7 +1683,7 @@ function getObservedDialogMessages(
   messageObservations: DialogMessageObservationMap,
 ): {
   messages: readonly BuiltInLLMMessage[];
-  observedConfidentiality: readonly unknown[];
+  observedConfidentiality: readonly CfcConfClause[];
 } {
   const labelView = cfcLabelViewForCellFailClosed(messagesCell);
   const observedConfidentiality = joinCfcObservedConfidentiality(
@@ -1705,7 +1705,7 @@ function getObservedDialogMessages(
 function mergeDialogMessageObservations(
   current: DialogMessageObservationMap | undefined,
   updates: Array<
-    { index: number; observedConfidentiality: readonly unknown[] }
+    { index: number; observedConfidentiality: readonly CfcConfClause[] }
   >,
 ): DialogMessageObservationMap {
   const merged: Record<string, unknown[]> = {
@@ -1725,7 +1725,7 @@ function recordDialogMessageObservations(
   tx: IExtendedStorageTransaction,
   internal: Cell<Schema<typeof internalSchema>>,
   updates: Array<
-    { index: number; observedConfidentiality: readonly unknown[] }
+    { index: number; observedConfidentiality: readonly CfcConfClause[] }
   >,
 ): void {
   if (updates.length === 0) {
@@ -1993,7 +1993,7 @@ type ToolCallExecutionResult = {
   toolName: string;
   result?: any;
   error?: string;
-  observedConfidentiality?: readonly unknown[];
+  observedConfidentiality?: readonly CfcConfClause[];
 };
 
 /**
@@ -2029,7 +2029,7 @@ function effectiveObservationCeiling(
 function toolAllowsObservedConfidentiality(
   toolCatalog: ToolCatalog,
   toolName: string,
-  observedConfidentiality: readonly unknown[] | undefined,
+  observedConfidentiality: readonly CfcConfClause[] | undefined,
 ): boolean {
   if (!observedConfidentiality || observedConfidentiality.length === 0) {
     return true;
@@ -2213,7 +2213,7 @@ async function executeToolCalls(
   toolCatalog: ToolCatalog,
   toolCallParts: BuiltInLLMToolCallPart[],
   pinnedCells?: Cell<PinnedCell[]>,
-  observedConfidentiality?: readonly unknown[],
+  observedConfidentiality?: readonly CfcConfClause[],
   observationMaxConfidentiality?: readonly CfcConfClause[],
 ): Promise<ToolCallExecutionResult[]> {
   const results: ToolCallExecutionResult[] = [];
@@ -2492,7 +2492,7 @@ async function handleRead(
 ): Promise<
   {
     result: { type: string; value: unknown };
-    observedConfidentiality: readonly unknown[];
+    observedConfidentiality: readonly CfcConfClause[];
   }
 > {
   let cell = resolved.cellRef.resolveAsCell().asSchemaFromLinks();
@@ -2654,7 +2654,7 @@ async function handleInvoke(
   observationMaxConfidentiality?: readonly CfcConfClause[],
 ): Promise<{
   result: { type: string; value: any };
-  observedConfidentiality: readonly unknown[];
+  observedConfidentiality: readonly CfcConfClause[];
 }> {
   const toolCall = resolved.call;
 

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -340,7 +340,7 @@ async function executeWithToolsLoop(params: {
   toolCatalog?:
     | ReturnType<typeof llmToolExecutionHelpers.buildToolCatalog>
     | undefined;
-  initialObservedConfidentiality?: readonly unknown[];
+  initialObservedConfidentiality?: readonly CfcConfClause[];
   observationMaxConfidentiality?: readonly CfcConfClause[];
   updatePartial: (text: string) => void;
   runtime: Runtime;
@@ -364,7 +364,7 @@ async function executeWithToolsLoop(params: {
 
   const executeRecursive = async (
     currentMessages: readonly BuiltInLLMMessage[],
-    observedConfidentiality: readonly unknown[],
+    observedConfidentiality: readonly CfcConfClause[],
   ): Promise<void> => {
     if (thisRun !== getCurrentRun()) return;
 
@@ -497,7 +497,7 @@ function buildContextDocumentation(
   space: any,
   tx: IExtendedStorageTransaction,
   sink: string,
-): { docs: string; observedConfidentiality: readonly unknown[] } {
+): { docs: string; observedConfidentiality: readonly CfcConfClause[] } {
   const context = inputs.key("context").withTx(tx).get();
   if (!context) {
     return {
@@ -1360,7 +1360,7 @@ export function generateObject<T extends Record<string, unknown>>(
       ? toDeepFrozenSchema(schema)
       : undefined;
     const resultSchemaForObserved = (
-      observedConfidentiality: readonly unknown[],
+      observedConfidentiality: readonly CfcConfClause[],
     ) =>
       schemaSanitizePromptInjection
         ? schemaWithInjectionSafeAnnotations(
@@ -1554,13 +1554,13 @@ export function generateObject<T extends Record<string, unknown>>(
               // Execute with tools - capture presentResult when called
               let finalResult: T | undefined;
               let finalMessages: readonly BuiltInLLMMessage[] = requestMessages;
-              let finalObservedConfidentiality: readonly unknown[] =
+              let finalObservedConfidentiality: readonly CfcConfClause[] =
                 liveInitialObservedConfidentiality;
 
               // Custom execution loop for generateObject with presentResult extraction
               const executeRecursive = async (
                 currentMessages: readonly BuiltInLLMMessage[],
-                observedConfidentiality: readonly unknown[],
+                observedConfidentiality: readonly CfcConfClause[],
               ): Promise<void> => {
                 if (isRunCancelled()) return;
 

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -22,7 +22,7 @@ import {
   normalizeClause,
 } from "./clause.ts";
 
-export type CfcObservedConfidentiality = readonly unknown[];
+export type CfcObservedConfidentiality = readonly CfcConfClause[];
 export type CfcObservationMaxConfidentiality =
   | readonly CfcConfClause[]
   | undefined;
@@ -77,7 +77,7 @@ export const uniqueCfcAtoms = (
 export const joinCfcObservedConfidentiality = (
   parts: Iterable<readonly unknown[] | undefined>,
 ): CfcObservedConfidentiality => {
-  const joined: unknown[] = [];
+  const joined: CfcConfClause[] = [];
   for (const part of parts) {
     if (Array.isArray(part)) {
       joined.push(...part);

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -175,7 +175,7 @@ const mergeIfc = (
     observedConfidentiality,
     instructionInert,
   }: {
-    observedConfidentiality: readonly unknown[];
+    observedConfidentiality: readonly CfcConfClause[];
     instructionInert: boolean;
   },
 ): Record<string, unknown> => {
@@ -260,7 +260,7 @@ export const resolveSchemaForValidation = (
 
 const annotateSchema = (
   schema: JSONSchema,
-  observedConfidentiality: readonly unknown[],
+  observedConfidentiality: readonly CfcConfClause[],
   fullSchema: JSONSchema,
   visitedRef?: AnnotationRefVisit,
 ): AnnotationResult => {
@@ -439,7 +439,7 @@ const annotateSchema = (
 
 export const schemaWithInjectionSafeAnnotations = (
   schema: JSONSchema,
-  observedConfidentiality: readonly unknown[] = [],
+  observedConfidentiality: readonly CfcConfClause[] = [],
 ): JSONSchema => {
   const clone = cloneJson(schema);
   return stripRequiredFields(


### PR DESCRIPTION
Types the **observation / flow** side of CFC confidentiality as
`CfcConfClause[]`: the `CfcObservedConfidentiality` alias itself, and the
`observedConfidentiality` plumbing through `llm`, `llm-dialog`, and
`schema-sanitization`.

**22 declarations, zero fallout sites, 4 files.** No runtime change — annotations
and imports only.

## Why it is free

The observed side reaches the rest of CFC through only three named functions —
`cfcConfidentialityForObservationNode()`, `cfcObservationFitsCeiling()`, and
`dischargeMaterialRiskAtoms()` — and those already speak the clause vocabulary
after #5033/#5038. So narrowing the observation declarations disturbs nothing at
all.

That is the property worth naming for the next slice of this kind: what predicts
a cheap split is **interface width — how many call sites cross the boundary** —
not whether the two sides look like separate subsystems. The label/ceiling seam
(#5038) worked because the two meet as independent parameters of one function;
this one works because the crossing count is three. The layer-shaped cuts earlier
in this series failed because a layer boundary here has hundreds of crossings.

## Note for future sweeps

`CfcObservedConfidentiality` is a type **alias**, not a field, so a `name: type`
grep does not find it — yet it is the single upstream behind most of the
observation plumbing. Same shape as `RenderConfidentialityCeiling.atoms` in
#5038. Worth grepping `= readonly unknown\[\]` alongside `: unknown\[\]`.

Remaining after this: the stored-label carriers (27 declarations, 8 coupling
sites), which is the last of #5036.

## Test plan

- `deno task check` clean; `deno fmt --check` and `deno lint` exit 0.
- Full repo suite green on a clean, committed tree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed the observed-confidentiality path as `CfcConfClause[]` end to end, replacing `unknown[]` across CFC observation/flow and related LLM code. No runtime changes.

- **Refactors**
  - Set `CfcObservedConfidentiality = readonly CfcConfClause[]` and typed `joinCfcObservedConfidentiality` accordingly.
  - Updated signatures and fields in `llm`, `llm-dialog`, and `schema-sanitization` to use clause-typed arrays.
  - Aligned with existing clause-based APIs: `cfcConfidentialityForObservationNode()`, `cfcObservationFitsCeiling()`, `dischargeMaterialRiskAtoms()`.

<sup>Written for commit 6fa0d64fccb3dbae30676e41b1b7252d0a9da109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

