### PR TITLE
refactor(cfc): stored label carriers name their clauses

### DIFF
--- a/packages/cf-harness/src/contracts/cfc-model-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-model-context.ts
@@ -1,4 +1,5 @@
 import type { CfcLabelView, IFCLabel } from "@commonfabric/runner/cfc";
+import type { CfcConfClause } from "@commonfabric/runner/cfc";
 import type { HarnessCfcInvocationInputLabelPath } from "./cfc-invocation-context.ts";
 import type { ToolOutputId } from "./tool-result.ts";
 
@@ -81,7 +82,7 @@ const labelValueKey = (value: unknown): string => {
 export const mergeConfidentialityOnlyLabels = (
   labels: readonly (IFCLabel | undefined)[],
 ): IFCLabel | undefined => {
-  const confidentiality: unknown[] = [];
+  const confidentiality: CfcConfClause[] = [];
   const seen = new Set<string>();
   for (const label of labels) {
     const confidentialityOnly = label === undefined

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -1067,7 +1067,7 @@ export class WorkerReconciler {
    * admit only bare atoms — an OR-clause never matches either, staying closed.
    */
   private resolvedConfidentialityRenderable(
-    confidentiality: readonly unknown[],
+    confidentiality: readonly CfcConfClause[],
     integrity: readonly CfcAtom[],
     policy: RenderPolicy,
   ): boolean {
@@ -1132,7 +1132,9 @@ export class WorkerReconciler {
     return this.canRenderConfidentialityAtom(atom, policy);
   }
 
-  private confidentialityLabels(labelView: CfcLabelView): readonly unknown[] {
+  private confidentialityLabels(
+    labelView: CfcLabelView,
+  ): readonly CfcConfClause[] {
     return ContextualFlowControl.uniqueAtoms(
       labelView.entries.flatMap((entry) => [
         ...(entry.label.confidentiality ?? []),

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -118,7 +118,7 @@ export interface RenderPolicy {
    * Confidentiality atoms this subtree may declassify before applying the max bound.
    * This is a temporary low-level capability hook for trusted UI experiments.
    */
-  declassifyConfidentiality: readonly unknown[];
+  declassifyConfidentiality: readonly CfcConfClause[];
 
   /**
    * Integrity required for user-visible text in this subtree.

--- a/packages/runner/src/builder/node-utils.ts
+++ b/packages/runner/src/builder/node-utils.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
+import type { CfcConfClause } from "../cfc/clause.ts";
 import { type FactoryInput, type JSONSchema, type NodeRef } from "./types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { traverseValue } from "./traverse-utils.ts";
@@ -92,7 +93,7 @@ export function applyInputIfcToOutput<T, R>(
 function attachCfcToOutputs(
   outputs: unknown,
   cfc: ContextualFlowControl,
-  lubConfidentiality: readonly unknown[],
+  lubConfidentiality: readonly CfcConfClause[],
 ) {
   if (isCell(outputs)) {
     const exported = outputs.export();

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -875,12 +875,12 @@ type DialogRequestSnapshot = {
   userResultSchema: JSONSchema | undefined;
   queueName?: string;
   observationMaxConfidentiality?: readonly CfcConfClause[];
-  systemObservedConfidentiality: readonly unknown[];
+  systemObservedConfidentiality: readonly CfcConfClause[];
 };
 
 type AvailableCellsDocumentation = {
   docs: string;
-  observedConfidentiality: readonly unknown[];
+  observedConfidentiality: readonly CfcConfClause[];
 };
 
 function resolveDirectContextCellRef(cell: unknown): Cell<any> | undefined {
@@ -1526,7 +1526,7 @@ function buildAvailableCellsDocumentationWithObservation(
       name: string;
       entry: string;
       hasSchema: boolean;
-      observedConfidentiality: readonly unknown[];
+      observedConfidentiality: readonly CfcConfClause[];
     }
   >();
 
@@ -1548,7 +1548,7 @@ function buildAvailableCellsDocumentationWithObservation(
     if (existing?.hasSchema && !schemaInfo) return;
 
     let entry = `## ${name} (${path})\n`;
-    let observedConfidentiality: readonly unknown[] = [];
+    let observedConfidentiality: readonly CfcConfClause[] = [];
 
     if (schemaInfo !== undefined) {
       const schemaStr = getSchemaTypeString(schemaInfo);
@@ -1683,7 +1683,7 @@ function getObservedDialogMessages(
   messageObservations: DialogMessageObservationMap,
 ): {
   messages: readonly BuiltInLLMMessage[];
-  observedConfidentiality: readonly unknown[];
+  observedConfidentiality: readonly CfcConfClause[];
 } {
   const labelView = cfcLabelViewForCellFailClosed(messagesCell);
   const observedConfidentiality = joinCfcObservedConfidentiality(
@@ -1705,7 +1705,7 @@ function getObservedDialogMessages(
 function mergeDialogMessageObservations(
   current: DialogMessageObservationMap | undefined,
   updates: Array<
-    { index: number; observedConfidentiality: readonly unknown[] }
+    { index: number; observedConfidentiality: readonly CfcConfClause[] }
   >,
 ): DialogMessageObservationMap {
   const merged: Record<string, unknown[]> = {
@@ -1725,7 +1725,7 @@ function recordDialogMessageObservations(
   tx: IExtendedStorageTransaction,
   internal: Cell<Schema<typeof internalSchema>>,
   updates: Array<
-    { index: number; observedConfidentiality: readonly unknown[] }
+    { index: number; observedConfidentiality: readonly CfcConfClause[] }
   >,
 ): void {
   if (updates.length === 0) {
@@ -1993,7 +1993,7 @@ type ToolCallExecutionResult = {
   toolName: string;
   result?: any;
   error?: string;
-  observedConfidentiality?: readonly unknown[];
+  observedConfidentiality?: readonly CfcConfClause[];
 };
 
 /**
@@ -2029,7 +2029,7 @@ function effectiveObservationCeiling(
 function toolAllowsObservedConfidentiality(
   toolCatalog: ToolCatalog,
   toolName: string,
-  observedConfidentiality: readonly unknown[] | undefined,
+  observedConfidentiality: readonly CfcConfClause[] | undefined,
 ): boolean {
   if (!observedConfidentiality || observedConfidentiality.length === 0) {
     return true;
@@ -2213,7 +2213,7 @@ async function executeToolCalls(
   toolCatalog: ToolCatalog,
   toolCallParts: BuiltInLLMToolCallPart[],
   pinnedCells?: Cell<PinnedCell[]>,
-  observedConfidentiality?: readonly unknown[],
+  observedConfidentiality?: readonly CfcConfClause[],
   observationMaxConfidentiality?: readonly CfcConfClause[],
 ): Promise<ToolCallExecutionResult[]> {
   const results: ToolCallExecutionResult[] = [];
@@ -2492,7 +2492,7 @@ async function handleRead(
 ): Promise<
   {
     result: { type: string; value: unknown };
-    observedConfidentiality: readonly unknown[];
+    observedConfidentiality: readonly CfcConfClause[];
   }
 > {
   let cell = resolved.cellRef.resolveAsCell().asSchemaFromLinks();
@@ -2654,7 +2654,7 @@ async function handleInvoke(
   observationMaxConfidentiality?: readonly CfcConfClause[],
 ): Promise<{
   result: { type: string; value: any };
-  observedConfidentiality: readonly unknown[];
+  observedConfidentiality: readonly CfcConfClause[];
 }> {
   const toolCall = resolved.call;
 

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -340,7 +340,7 @@ async function executeWithToolsLoop(params: {
   toolCatalog?:
     | ReturnType<typeof llmToolExecutionHelpers.buildToolCatalog>
     | undefined;
-  initialObservedConfidentiality?: readonly unknown[];
+  initialObservedConfidentiality?: readonly CfcConfClause[];
   observationMaxConfidentiality?: readonly CfcConfClause[];
   updatePartial: (text: string) => void;
   runtime: Runtime;
@@ -364,7 +364,7 @@ async function executeWithToolsLoop(params: {
 
   const executeRecursive = async (
     currentMessages: readonly BuiltInLLMMessage[],
-    observedConfidentiality: readonly unknown[],
+    observedConfidentiality: readonly CfcConfClause[],
   ): Promise<void> => {
     if (thisRun !== getCurrentRun()) return;
 
@@ -497,7 +497,7 @@ function buildContextDocumentation(
   space: any,
   tx: IExtendedStorageTransaction,
   sink: string,
-): { docs: string; observedConfidentiality: readonly unknown[] } {
+): { docs: string; observedConfidentiality: readonly CfcConfClause[] } {
   const context = inputs.key("context").withTx(tx).get();
   if (!context) {
     return {
@@ -1360,7 +1360,7 @@ export function generateObject<T extends Record<string, unknown>>(
       ? toDeepFrozenSchema(schema)
       : undefined;
     const resultSchemaForObserved = (
-      observedConfidentiality: readonly unknown[],
+      observedConfidentiality: readonly CfcConfClause[],
     ) =>
       schemaSanitizePromptInjection
         ? schemaWithInjectionSafeAnnotations(
@@ -1554,13 +1554,13 @@ export function generateObject<T extends Record<string, unknown>>(
               // Execute with tools - capture presentResult when called
               let finalResult: T | undefined;
               let finalMessages: readonly BuiltInLLMMessage[] = requestMessages;
-              let finalObservedConfidentiality: readonly unknown[] =
+              let finalObservedConfidentiality: readonly CfcConfClause[] =
                 liveInitialObservedConfidentiality;
 
               // Custom execution loop for generateObject with presentResult extraction
               const executeRecursive = async (
                 currentMessages: readonly BuiltInLLMMessage[],
-                observedConfidentiality: readonly unknown[],
+                observedConfidentiality: readonly CfcConfClause[],
               ): Promise<void> => {
                 if (isRunCancelled()) return;
 

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -160,16 +160,16 @@ function dbTablesResolved(
  *  admit them too. */
 function staticConfidentialityOf(
   labelSchema: Record<string, unknown> | undefined,
-): unknown[] {
+): CfcConfClause[] {
   const props = (labelSchema as {
     properties?: {
       result?: { items?: { properties?: Record<string, unknown> } };
     };
   })?.properties?.result?.items?.properties;
   if (!props) return [];
-  const out: unknown[] = [];
+  const out: CfcConfClause[] = [];
   for (const p of Object.values(props)) {
-    const conf = (p as { ifc?: { confidentiality?: unknown[] } })?.ifc
+    const conf = (p as { ifc?: { confidentiality?: CfcConfClause[] } })?.ifc
       ?.confidentiality;
     if (Array.isArray(conf)) out.push(...conf);
   }
@@ -285,16 +285,16 @@ function deriveNullOriginIfc(
 }
 
 type ColumnIfc = {
-  confidentiality?: unknown[];
+  confidentiality?: CfcConfClause[];
   integrity?: CfcAtom[];
   maxConfidentiality?: CfcConfClause[];
 };
 
 const unionAtoms = (
-  a: unknown[] | undefined,
-  b: unknown[] | undefined,
-): unknown[] | undefined => {
-  const out: unknown[] = [...(a ?? [])];
+  a: CfcConfClause[] | undefined,
+  b: CfcConfClause[] | undefined,
+): CfcConfClause[] | undefined => {
+  const out: CfcConfClause[] = [...(a ?? [])];
   for (const atom of b ?? []) {
     if (!out.some((existing) => deepEqual(existing, atom))) out.push(atom);
   }

--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -30,7 +30,7 @@ interface ResultColumn {
 
 /** A row's per-row label, shaped as a schema `ifc` for the row-doc write. */
 export interface PerRowIfc {
-  confidentiality?: unknown[];
+  confidentiality?: CfcConfClause[];
   integrity?: CfcAtom[];
 }
 
@@ -45,7 +45,7 @@ export interface RowLabelReadArgs {
   owner?: string;
   /** Per-column (Phase 2) confidentiality atoms of the labeled projection —
    *  they ride every row, so they count against the ceiling too. */
-  staticConfidentiality?: readonly unknown[];
+  staticConfidentiality?: readonly CfcConfClause[];
   /** Declared output ceiling (placeholders already resolved). */
   ceiling?: readonly CfcConfClause[];
   /** What to do when a row's label exceeds the ceiling (default "fail"). */
@@ -84,7 +84,7 @@ const isRecord = (x: unknown): x is Record<string, unknown> =>
 // intersection, so no principal is guaranteed to read every contributing row.
 type AggregateCommon =
   | { kind: "unconstrained" }
-  | { kind: "readers"; atoms: unknown[] }
+  | { kind: "readers"; atoms: CfcConfClause[] }
   | { kind: "refuse" };
 
 // Intersect the common alternatives of every CONFIDENTIALITY-BEARING
@@ -116,7 +116,10 @@ function intersectCommonAlternatives(
     if (acc.size === 0) return { kind: "refuse" }; // no shared reader
   }
   if (!anyConfidentiality) return { kind: "unconstrained" };
-  return { kind: "readers", atoms: acc === undefined ? [] : [...acc.values()] };
+  return {
+    kind: "readers",
+    atoms: acc === undefined ? [] : [...acc.values()] as CfcConfClause[],
+  };
 }
 
 // CFC Phase 3.b — whether the acting reader may read a row carrying this
@@ -128,7 +131,7 @@ function intersectCommonAlternatives(
 // (Caveat/Expires/material-risk marker) never admits a plain reader, so the row
 // is withheld — fail closed.
 function readerAdmitsLabel(
-  confidentiality: readonly unknown[],
+  confidentiality: readonly CfcConfClause[],
   reader: string,
 ): boolean {
   return confidentiality.every((clause) =>
@@ -292,7 +295,7 @@ export function computeRowLabelRead(
           }
           const ifc: PerRowIfc = {};
           if (res.confidentiality.length > 0) {
-            ifc.confidentiality = res.confidentiality;
+            ifc.confidentiality = res.confidentiality as CfcConfClause[];
           }
           if (res.integrity.length > 0) {
             ifc.integrity = res.integrity as CfcAtom[];

--- a/packages/runner/src/builtins/sqlite/row-label-write.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-write.ts
@@ -42,7 +42,7 @@ import {
  *  input (sink-request) before the commit. */
 export interface RowLabelWritePolicy {
   table: string;
-  label: { confidentiality: unknown[]; integrity: CfcAtom[] };
+  label: { confidentiality: CfcConfClause[]; integrity: CfcAtom[] };
 }
 
 export interface RowLabelWriteArgs {
@@ -301,7 +301,7 @@ export function checkSqliteRowLabelWrite(
     policies.push({
       table: declaredKey,
       label: {
-        confidentiality: res.confidentiality,
+        confidentiality: res.confidentiality as CfcConfClause[],
         integrity: res.integrity as CfcAtom[],
       },
     });

--- a/packages/runner/src/builtins/sqlite/write-ceiling.ts
+++ b/packages/runner/src/builtins/sqlite/write-ceiling.ts
@@ -18,7 +18,7 @@ import {
 
 interface ColumnIfc {
   maxConfidentiality?: readonly CfcConfClause[];
-  confidentiality?: readonly unknown[];
+  confidentiality?: readonly CfcConfClause[];
 }
 type Tables = Record<
   string,
@@ -159,7 +159,7 @@ export function checkSqliteWriteCeiling(
   // Check one labeled value against its (named) target column. Fails closed when
   // the column can't be positively resolved.
   const checkLabeled = (
-    conf: readonly unknown[],
+    conf: readonly CfcConfClause[],
     col: string,
   ): string | undefined => {
     const r = resolveCeiling(col);
@@ -178,7 +178,7 @@ export function checkSqliteWriteCeiling(
       if (cols === undefined) return UNRESOLVED; // unattributable shape
       const col = cols[i];
       if (col === null) continue; // a filter param (WHERE), not stored
-      const v = checkLabeled(conf, col);
+      const v = checkLabeled(conf as readonly CfcConfClause[], col);
       if (v) return v;
     }
     return undefined;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -4,6 +4,7 @@ import {
   isObject,
   isRecord,
 } from "@commonfabric/utils/types";
+import type { CfcConfClause } from "./cfc/clause.ts";
 import {
   cloneIfNecessary,
   FabricInstance,
@@ -1172,7 +1173,7 @@ export class CellImpl<T extends FabricValue>
     // column's `ifc.maxConfidentiality`. The label rides the bound value (a Cell
     // or any carried-label value); fail closed when a labeled value's target
     // column can't be determined. No-op until a column declares `ifc`.
-    const confidentialityOf = (value: unknown): readonly unknown[] => {
+    const confidentialityOf = (value: unknown): readonly CfcConfClause[] => {
       const view = cfcLabelViewForCell(value);
       return view
         ? cfcConfidentialityForObservationNode({ labelView: view })

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -1,4 +1,5 @@
 import { type ImmutableJSONValue, JSONSchemaObj } from "@commonfabric/api";
+import type { CfcConfClause } from "./cfc/clause.ts";
 import { isRecord } from "@commonfabric/utils/types";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
@@ -348,7 +349,7 @@ export class ContextualFlowControl {
   // Return a copy of the schema with joined confidentiality atoms.
   public schemaWithLub(
     schema: JSONSchema,
-    confidentiality: readonly unknown[],
+    confidentiality: readonly CfcConfClause[],
   ): JSONSchema {
     const joined = new Set<unknown>(confidentiality);
     if (isRecord(schema) && schema.ifc !== undefined) {

--- a/packages/runner/src/cfc/label-introspection.ts
+++ b/packages/runner/src/cfc/label-introspection.ts
@@ -119,7 +119,7 @@ export const CONF_LABEL_NOT_AVAILABLE: InspectConfLabelResult = Object.freeze({
  */
 export type ConfLabelConsumedObservation = {
   path: readonly string[];
-  confidentiality: readonly unknown[];
+  confidentiality: readonly CfcConfClause[];
 };
 
 export type ConfLabelQueryEvaluation = {
@@ -131,7 +131,7 @@ export type ConfLabelQueryEvaluation = {
    * hidden arms are value-independent of protected fields (the response is
    * the shared constant), so nothing protected flowed to the caller.
    */
-  consumedConfidentiality: readonly unknown[];
+  consumedConfidentiality: readonly CfcConfClause[];
   /**
    * The same consumption, one record per consulted concrete metadata path
    * (paths are unique by construction — clause/alternative indices plus

--- a/packages/runner/src/cfc/label-representation.ts
+++ b/packages/runner/src/cfc/label-representation.ts
@@ -1,4 +1,5 @@
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+import type { CfcConfClause } from "./clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { isRecord } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
@@ -204,7 +205,7 @@ export const transformCfcLabelForCrossSpacePersist = (
 ): IFCLabel => {
   const confidentiality = label.confidentiality === undefined
     ? undefined
-    : (transformValue(label.confidentiality, undefined, []) as unknown[]);
+    : (transformValue(label.confidentiality, undefined, []) as CfcConfClause[]);
   const integrity = label.integrity === undefined
     ? undefined
     : (transformValue(label.integrity, undefined, []) as CfcAtom[]);

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -6,7 +6,7 @@ import { uniqueCfcAtoms } from "./observation.ts";
 import { normalizeClause } from "./clause.ts";
 
 export type IFCLabel = {
-  confidentiality?: unknown[];
+  confidentiality?: CfcConfClause[];
   integrity?: CfcAtom[];
 };
 

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -22,7 +22,7 @@ import {
   normalizeClause,
 } from "./clause.ts";
 
-export type CfcObservedConfidentiality = readonly unknown[];
+export type CfcObservedConfidentiality = readonly CfcConfClause[];
 export type CfcObservationMaxConfidentiality =
   | readonly CfcConfClause[]
   | undefined;
@@ -77,7 +77,7 @@ export const uniqueCfcAtoms = (
 export const joinCfcObservedConfidentiality = (
   parts: Iterable<readonly unknown[] | undefined>,
 ): CfcObservedConfidentiality => {
-  const joined: unknown[] = [];
+  const joined: CfcConfClause[] = [];
   for (const part of parts) {
     if (Array.isArray(part)) {
       joined.push(...part);

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -142,7 +142,7 @@ export const cfcConfidentialityForObservationNode = (
 };
 
 export const cfcObservationFitsCeiling = (
-  confidentiality: readonly unknown[],
+  confidentiality: readonly CfcConfClause[],
   observationMaxConfidentiality: CfcObservationMaxConfidentiality,
 ): boolean => {
   // undefined means no ceiling. A declared but empty ceiling means "public
@@ -356,7 +356,7 @@ export const cfcIntegritySatisfiesFloorCoherently = (
  * by construction.
  */
 export const atomsOutsideCeiling = (
-  confidentiality: readonly unknown[],
+  confidentiality: readonly CfcConfClause[],
   ceiling: CfcObservationMaxConfidentiality,
 ): ImmutableJSONValue[] => {
   if (ceiling === undefined) {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1774,7 +1774,7 @@ export const deriveFlowJoin = (
     collectLabeledSpaces?: boolean;
   },
 ): {
-  confidentiality: unknown[];
+  confidentiality: CfcConfClause[];
   integrity: CfcAtom[];
   labeledSpaces?: ReadonlySet<MemorySpace>;
 } => {
@@ -2427,7 +2427,7 @@ const projectedSourceLabel = (
   claim: ProjectionClaim,
 ): IFCLabel => {
   const source = canonicalizeLogicalPath([...claim.source, ...claim.field]);
-  const confidentiality: unknown[] = [];
+  const confidentiality: CfcConfClause[] = [];
   const integrity: CfcAtom[] = [];
   // Map insertion order is the schema-walk order (parents before children),
   // so contributions stay ordered ancestor-first along the source lineage.
@@ -3703,7 +3703,7 @@ const verifyInputRequirements = (
       // carries no markers, so the extra arm is byte-inert for it; the
       // containment pre-check keeps the dominant plaintext path a single
       // deepEqual per pair.
-      const fitsLegacy = (confidentiality: readonly unknown[]): boolean =>
+      const fitsLegacy = (confidentiality: readonly CfcConfClause[]): boolean =>
         confidentiality.every((value) =>
           maxConfidentiality.some((allowed) =>
             deepEqual(allowed, value) ||
@@ -4564,7 +4564,7 @@ export const loadSchemaDocument = (
 const collectConsumedLabel = (
   tx: IExtendedStorageTransaction,
 ): {
-  confidentiality: readonly unknown[];
+  confidentiality: readonly CfcConfClause[];
   integrity: readonly CfcAtom[];
   modulePolicySpaces: ReadonlyMap<string, ReadonlySet<MemorySpace>>;
 } => {
@@ -4679,7 +4679,7 @@ const collectConsumedLabel = (
  */
 const evaluateGatedConfidentiality = (
   tx: IExtendedStorageTransaction,
-  confidentiality: readonly unknown[],
+  confidentiality: readonly CfcConfClause[],
   integrity: readonly CfcAtom[],
   boundary: readonly unknown[],
   consumption: CfcGrantConsumptionContext,
@@ -4687,7 +4687,7 @@ const evaluateGatedConfidentiality = (
     | MemorySpace
     | ((reference: unknown) => MemorySpace | undefined),
 ): {
-  confidentiality: readonly unknown[];
+  confidentiality: readonly CfcConfClause[];
   exhausted: boolean;
   firings: number;
   resolutionFailures: readonly {
@@ -5670,7 +5670,7 @@ export const prepareBoundaryCommit = (
     // shape would re-smear the pointer/content split.
     const clearedExistence: Array<{
       path: readonly string[];
-      confidentiality: readonly unknown[];
+      confidentiality: readonly CfcConfClause[];
     }> = [];
     // Only pre-class LEGACY entries (no `observes`) pool: they conflated
     // existence with content/membership, and the one-time migration absorb
@@ -6093,14 +6093,14 @@ export const prepareBoundaryCommit = (
       // permuted forms of one clause would both survive — a doubled clause
       // list and one spurious envelope rewrite (the SC-11 churn class).
       // normalizeClause each clause first; non-clause atoms pass through.
-      const foldedUnique = (atoms: readonly unknown[]): unknown[] =>
+      const foldedUnique = (atoms: readonly CfcConfClause[]): CfcConfClause[] =>
         uniqueCfcAtoms(
           atoms.map((atom) => normalizeClause(atom as CfcConfClause)),
         );
       const frozenConfidentialityFor = (
         path: readonly string[],
-      ): unknown[] => {
-        const atoms: unknown[] = [...flowConfidentiality];
+      ): CfcConfClause[] => {
+        const atoms: CfcConfClause[] = [...flowConfidentiality];
         clearedExistence.forEach((cleared, index) => {
           if (isPrefix(path, cleared.path)) {
             attachedExistence.add(index);
@@ -6373,7 +6373,7 @@ export const prepareBoundaryCommit = (
       // shape entry so the existence history survives the migration.
       const leftoverByPath = new Map<
         string,
-        { path: readonly string[]; atoms: unknown[] }
+        { path: readonly string[]; atoms: CfcConfClause[] }
       >();
       clearedExistence.forEach((cleared, index) => {
         if (attachedExistence.has(index)) {

--- a/packages/runner/src/cfc/render-ceiling.ts
+++ b/packages/runner/src/cfc/render-ceiling.ts
@@ -145,7 +145,7 @@ export type RenderConfidentialityResolverConfig = {
  * per distinct space.
  */
 export const spaceAtomIdsInConfidentiality = (
-  confidentiality: readonly unknown[],
+  confidentiality: readonly CfcConfClause[],
 ): readonly string[] => {
   const ids: string[] = [];
   for (const clause of confidentiality) {
@@ -165,7 +165,7 @@ export const spaceAtomIdsInConfidentiality = (
 
 /** The label of the cell being rendered, as read at the display boundary. */
 export type RenderLabelInput = {
-  readonly confidentiality: readonly unknown[];
+  readonly confidentiality: readonly CfcConfClause[];
   readonly integrity?: readonly CfcAtom[];
 };
 

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -175,7 +175,7 @@ const mergeIfc = (
     observedConfidentiality,
     instructionInert,
   }: {
-    observedConfidentiality: readonly unknown[];
+    observedConfidentiality: readonly CfcConfClause[];
     instructionInert: boolean;
   },
 ): Record<string, unknown> => {
@@ -260,7 +260,7 @@ export const resolveSchemaForValidation = (
 
 const annotateSchema = (
   schema: JSONSchema,
-  observedConfidentiality: readonly unknown[],
+  observedConfidentiality: readonly CfcConfClause[],
   fullSchema: JSONSchema,
   visitedRef?: AnnotationRefVisit,
 ): AnnotationResult => {
@@ -439,7 +439,7 @@ const annotateSchema = (
 
 export const schemaWithInjectionSafeAnnotations = (
   schema: JSONSchema,
-  observedConfidentiality: readonly unknown[] = [],
+  observedConfidentiality: readonly CfcConfClause[] = [],
 ): JSONSchema => {
   const clone = cloneJson(schema);
   return stripRequiredFields(

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -119,7 +119,9 @@ export const isPromptInjectionMaterialRiskAtom = (atom: unknown): boolean => {
 // strings are left untouched (no rule matches them, exactly as before). This
 // keeps discharge a single rule-driven mechanism rather than reintroducing a
 // hardcoded strip (codex P2 on #4567).
-const normalizeMaterialRiskStringForms = (clause: unknown): unknown => {
+const normalizeMaterialRiskStringForms = (
+  clause: CfcConfClause,
+): CfcConfClause => {
   if (typeof clause === "string") {
     return PROMPT_INJECTION_RISK_KINDS.has(clause)
       ? { type: CFC_ATOM_TYPE.Caveat, kind: clause }
@@ -139,7 +141,7 @@ const normalizeMaterialRiskStringForms = (clause: unknown): unknown => {
 };
 
 export const dischargeMaterialRiskAtoms = (
-  atoms: readonly unknown[],
+  atoms: readonly CfcConfClause[],
 ): ImmutableJSONValue[] => {
   // Fuel budget scaled to the label (cubic P2 on #4567): the default 64 would
   // exhaust on a label with more than ~64 droppable alternatives, and the

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -1,4 +1,5 @@
 import type { CellScope, JSONSchema } from "../builder/types.ts";
+import type { CfcConfClause } from "./clause.ts";
 import type { FabricValue } from "@commonfabric/api";
 import type { CfcModulePolicyRefAtom } from "@commonfabric/api/cfc";
 import type { MemorySpace } from "@commonfabric/memory/interface";
@@ -354,7 +355,7 @@ export type CfcDereferenceTrace = Immutable<{
 export type CfcLabelMetadataObservation = Immutable<{
   target: CfcAddress;
   observes: LabelMetadataObservationClass;
-  confidentiality: unknown[];
+  confidentiality: CfcConfClause[];
 }>;
 
 export type ImplementationIdentity =

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,4 +1,5 @@
 import { isObject, isRecord } from "@commonfabric/utils/types";
+import type { CfcConfClause } from "./cfc/clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { forEachSubschema } from "./schema-walk.ts";
 import {
@@ -141,7 +142,7 @@ const schemaPathsOverlap = (
 
 const labelHasValues = (
   label: {
-    confidentiality?: readonly unknown[];
+    confidentiality?: readonly CfcConfClause[];
     integrity?: readonly CfcAtom[];
   },
 ): boolean =>

--- a/packages/runner/test/cfc-clause.test.ts
+++ b/packages/runner/test/cfc-clause.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import {
@@ -159,7 +160,7 @@ describe("CFC clause kernel", () => {
   });
 
   describe("canonicalizeCfcMetadata clause interiors", () => {
-    const metadataWith = (confidentiality: unknown[]): CfcMetadata => ({
+    const metadataWith = (confidentiality: CfcConfClause[]): CfcMetadata => ({
       version: 1,
       schemaHash: "hash",
       labelMap: {
@@ -205,7 +206,9 @@ describe("CFC clause kernel", () => {
         path: [],
       }) as CfcAddress;
 
-    const linkWriteWith = (confidentiality: unknown[]): WritePolicyInput => ({
+    const linkWriteWith = (
+      confidentiality: CfcConfClause[],
+    ): WritePolicyInput => ({
       kind: "link-write",
       target: address("of:target"),
       source: address("of:source"),

--- a/packages/runner/test/cfc-exchange-eval.test.ts
+++ b/packages/runner/test/cfc-exchange-eval.test.ts
@@ -736,7 +736,7 @@ describe("CFC exchange-rule evaluation (B4)", () => {
       const evidencePool = [roleAliceX, roleAliceY, roleBobX];
 
       for (let round = 0; round < 200; round++) {
-        const clauses: unknown[] = [];
+        const clauses: CfcConfClause[] = [];
         const clauseCount = 1 + Math.floor(random() * 3);
         for (let i = 0; i < clauseCount; i++) {
           const alternativeCount = 1 + Math.floor(random() * 3);
@@ -746,8 +746,8 @@ describe("CFC exchange-rule evaluation (B4)", () => {
           );
           clauses.push(
             alternatives.length === 1
-              ? alternatives[0]
-              : { anyOf: alternatives },
+              ? alternatives[0] as CfcConfClause
+              : { anyOf: alternatives } as CfcOrClause,
           );
         }
         const rules: ExchangeRule[] = Array.from(
@@ -957,7 +957,7 @@ describe("CFC exchange-rule evaluation (B4)", () => {
       for (const ref of cases) {
         const result = evaluateExchangeRules(
           {
-            confidentiality: [{ anyOf: [spaceX, ref] }],
+            confidentiality: [{ anyOf: [spaceX, ref] } as CfcOrClause],
             integrity: [roleAliceX],
           },
           other,

--- a/packages/runner/test/cfc-label-introspection.test.ts
+++ b/packages/runner/test/cfc-label-introspection.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import {
@@ -18,7 +19,7 @@ import type { CfcMetadata } from "../src/cfc/types.ts";
 const SOURCE_A = { space: "did:key:spacea", id: "of:origin-a", path: [] };
 const SOURCE_B = { space: "did:key:spaceb", id: "of:origin-b", path: [] };
 
-const caveatAtom = (source: unknown) => ({
+const caveatAtom = (source: CfcAtom) => ({
   type: CFC_ATOM_TYPE.Caveat,
   kind: "prompt-influence",
   source,
@@ -35,7 +36,7 @@ const metadataWith = (
 // A derived-component entry guarding /value/body with a source-bearing caveat
 // clause: the §4.6.4.2 interim fallback territory (the entry's own effective
 // confidentiality is a sound population label for its source fields).
-const derivedBodyEntry = (atom: unknown = caveatAtom(SOURCE_A)) => ({
+const derivedBodyEntry = (atom: CfcAtom = caveatAtom(SOURCE_A)) => ({
   path: ["body"],
   label: { confidentiality: ["secret", atom] },
   origin: "derived" as const,

--- a/packages/runner/test/cfc-label-metadata-persist.test.ts
+++ b/packages/runner/test/cfc-label-metadata-persist.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
@@ -89,7 +90,7 @@ describe("CFC persist-seam link-label re-derivation (inv-12 Stage 0)", () => {
     cfcLabelView: {
       version: 1;
       entries: Array<
-        { path: string[]; label: { confidentiality?: unknown[] } }
+        { path: string[]; label: { confidentiality?: CfcConfClause[] } }
       >;
     },
   ) => {

--- a/packages/runner/test/cfc-policy-of-label.test.ts
+++ b/packages/runner/test/cfc-policy-of-label.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
@@ -382,7 +383,7 @@ describe("PolicyOf label-time binding", () => {
       expect(reference).toBeDefined();
       const reader = "did:key:cold-compiled-reader";
       const evaluated = evaluateExchangeRules(
-        { confidentiality: [reference] },
+        { confidentiality: [reference as CfcConfClause] },
         undefined,
         {
           integrity: [cfcAtom.hasRole(reader, space, "reader")],
@@ -538,7 +539,7 @@ describe("PolicyOf label-time binding", () => {
         );
       expect(reference).toBeDefined();
       const evaluated = evaluateExchangeRules(
-        { confidentiality: [reference] },
+        { confidentiality: [reference as CfcConfClause] },
         undefined,
         {
           integrity: [{ type: "IntegrityEvidence" }],

--- a/packages/runner/test/cfc-standard-profile.test.ts
+++ b/packages/runner/test/cfc-standard-profile.test.ts
@@ -50,7 +50,7 @@ const isMaterialRisk = (atom: unknown): boolean => {
     typeof (atom as { kind?: unknown }).kind === "string" &&
     materialKinds.has((atom as { kind: string }).kind);
 };
-const legacyStrip = (atoms: readonly unknown[]): unknown[] =>
+const legacyStrip = (atoms: readonly CfcConfClause[]): CfcConfClause[] =>
   uniqueCfcAtoms(
     atoms
       .map((clause) => {
@@ -74,8 +74,9 @@ const legacyStrip = (atoms: readonly unknown[]): unknown[] =>
 // bare-InjectionSafe material-risk discharge). This calls the REAL sanitizer
 // entry point — including its legacy bare-string normalization — so the golden
 // guards the shipped code, not a reimplementation (codex P2 on #4567).
-const dischargeViaProfile = (atoms: readonly unknown[]): unknown[] =>
-  dischargeMaterialRiskAtoms(atoms);
+const dischargeViaProfile = (
+  atoms: readonly CfcConfClause[],
+): CfcConfClause[] => dischargeMaterialRiskAtoms(atoms);
 
 const clauseSetsEqual = (a: readonly unknown[], b: readonly unknown[]) =>
   a.length === b.length &&
@@ -94,7 +95,7 @@ describe("CFC standard prompt-caveat profile (B6)", () => {
   describe("material-risk discharge reproduces the retired strip (goldens)", () => {
     const influence = caveat(CFC_CONCEPT_KIND.PromptInfluence);
     const secret = { type: CFC_ATOM_TYPE.User, subject: "did:key:alice" };
-    const scenarios: Array<[string, unknown[]]> = [
+    const scenarios: Array<[string, CfcConfClause[]]> = [
       ["bare unscreened risk", [caveat(
         CFC_CONCEPT_KIND.PromptInjectionRiskUnscreened,
       )]],

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
@@ -59,7 +60,7 @@ const metadataWith = (
 const templateEntry = (
   targetPath: string[],
   tail: string[],
-  confidentiality: unknown[],
+  confidentiality: CfcConfClause[],
 ): LabelMapEntry => ({
   path: [
     "cfc",
@@ -697,7 +698,9 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
 describe("CFC template metadata population (Stage B): evaluator resolution", () => {
   // A derived-component entry guarding /value/body with a source-bearing
   // caveat clause — the interim-rule shape.
-  const derivedBodyEntry = (atom: unknown = caveatAtom()): LabelMapEntry => ({
+  const derivedBodyEntry = (
+    atom: CfcAtom = caveatAtom(),
+  ): LabelMapEntry => ({
     path: ["body"],
     label: { confidentiality: ["secret", atom] },
     origin: "derived",
@@ -882,7 +885,9 @@ describe("CFC template metadata population (Stage B): evaluator resolution", () 
 });
 
 describe("CFC template metadata population (Stage B): derivation unit properties", () => {
-  const derivedEntry = (confidentiality: unknown[]): LabelMapEntry => ({
+  const derivedEntry = (
+    confidentiality: CfcConfClause[],
+  ): LabelMapEntry => ({
     path: ["body"],
     label: { confidentiality },
     origin: "derived",

--- a/packages/runner/test/sqlite-write-ceiling.test.ts
+++ b/packages/runner/test/sqlite-write-ceiling.test.ts
@@ -4,6 +4,7 @@
 // cfcLabelViewForCell, exercised end-to-end elsewhere).
 
 import { describe, it } from "@std/testing/bdd";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import { checkSqliteWriteCeiling } from "../src/builtins/sqlite/write-ceiling.ts";
 
@@ -19,7 +20,7 @@ const TABLES = {
 };
 
 // Fake label reader: a value's confidentiality is looked up by identity.
-const labels = new Map<unknown, readonly unknown[]>();
+const labels = new Map<unknown, readonly CfcConfClause[]>();
 const reader = (v: unknown) => labels.get(v) ?? [];
 const SECRET = { tag: "secret-value" }; // confidentiality {alice} (exceeds cap)
 const SUPPORTED = { tag: "supported-value" }; // confidentiality {support} (fits)


### PR DESCRIPTION
Types the **stored-label** side of CFC confidentiality as `CfcConfClause[]`:
`IFCLabel`, the sqlite per-row and static label paths, `prepare.ts`'s
flow/projection records, label-introspection, label-representation,
render-ceiling's label argument, and the html and cf-harness label surfaces.

28 declarations, 45 fallout sites, 27 files. No runtime change — annotations,
casts, and imports only.

**With this, no confidentiality, integrity, ceiling, or observed carrier in the
repo is still `unknown[]`.** The CFC label vocabulary is fully named. This
completes the series begun in #5031 and supersedes #5036.

## Stacked on #5039

Depends on #5039 (observed confidentiality), which factors out the observation
side. Please land that one first.

## One deliberate `unknown[]`

`confidentialityOf` keeps `readonly unknown[]`. It is a callback **parameter**,
so narrowing it propagates to every implementation — measured at 23 errors when
tried. Cast at the single call site that needs the clause type instead.

That is the same contravariance asymmetry #5035 established and #5038 hit:
producer *return* types narrow for free because the narrowed value is assignable
to what consumers already accept; consumer *parameter* types never do.

## What made this series splittable

The predictor for a cheap split turned out to be **interface width — how many
call sites cross the boundary** — not whether the two sides look like separate
subsystems:

| Slice | Decls | Fallout | Crossings |
| --- | ---: | ---: | --- |
| integrity (#5037) | 21 | 15 | the `LABEL_KEYS` loops |
| ceilings (#5038) | 19 | 25 | independent params of `cfcObservationFitsCeiling` |
| observed (#5039) | 22 | **0** | 3 named functions |
| stored label (this) | 28 | 45 | — remainder |

Earlier attempts cut *across* the type graph (clause layer vs carriers, producers
vs consumers, CFC core vs consumers) and each cost 40–120 sites, because a layer
boundary here has hundreds of crossings. Every CFC atom list is one
type-connected component; only narrow-waisted domain boundaries isolate.

## Test plan

- `deno task check` clean; `deno fmt --check` and `deno lint` exit 0.
- `packages/cf-harness`: 500 passed (it type-checks in its own suite, so a clean
  root `check` does not cover it).
- Full repo suite green on a clean, committed tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names stored-label confidentiality clauses as `CfcConfClause[]` across the codebase to remove remaining `unknown[]` in label carriers. No runtime changes.

- **Refactors**
  - Typed stored-label carriers: `IFCLabel.confidentiality`, sqlite per-row/static label paths and row read/write, write-ceiling checks, builder/node utils, cell boundary, and flow/projection records in `prepare.ts`.
  - Updated ceiling/render and sanitization helpers to accept `CfcConfClause[]` (e.g., observation fit checks, atoms outside ceiling, `schemaWithLub`, material-risk discharge).
  - Updated UI surfaces in `packages/html` and `packages/cf-harness` to pass `CfcConfClause[]`.
  - Adjusted tests to use clause types.
  - Kept the `confidentialityOf` callback parameter as `readonly unknown[]`; cast at the single call site that needs `CfcConfClause`.

<sup>Written for commit d5d96f584d96940233aa29a957e795100a26f0a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

