### PR TITLE
refactor(cfc): label leaf consumers name their clauses

### DIFF
--- a/packages/cf-harness/src/contracts/cfc-model-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-model-context.ts
@@ -94,7 +94,7 @@ export const mergeConfidentialityOnlyLabels = (
         continue;
       }
       seen.add(key);
-      confidentiality.push(cloneJsonValue(value));
+      confidentiality.push(cloneJsonValue(value) as CfcConfClause);
     }
   }
   return confidentiality.length > 0 ? { confidentiality } : undefined;

--- a/packages/cf-harness/src/contracts/cfc-model-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-model-context.ts
@@ -1,4 +1,5 @@
 import type { CfcLabelView, IFCLabel } from "@commonfabric/runner/cfc";
+import type { CfcConfClause } from "@commonfabric/runner/cfc";
 import type { HarnessCfcInvocationInputLabelPath } from "./cfc-invocation-context.ts";
 import type { ToolOutputId } from "./tool-result.ts";
 
@@ -81,7 +82,7 @@ const labelValueKey = (value: unknown): string => {
 export const mergeConfidentialityOnlyLabels = (
   labels: readonly (IFCLabel | undefined)[],
 ): IFCLabel | undefined => {
-  const confidentiality: unknown[] = [];
+  const confidentiality: CfcConfClause[] = [];
   const seen = new Set<string>();
   for (const label of labels) {
     const confidentialityOnly = label === undefined

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -1067,7 +1067,7 @@ export class WorkerReconciler {
    * admit only bare atoms — an OR-clause never matches either, staying closed.
    */
   private resolvedConfidentialityRenderable(
-    confidentiality: readonly unknown[],
+    confidentiality: readonly CfcConfClause[],
     integrity: readonly CfcAtom[],
     policy: RenderPolicy,
   ): boolean {
@@ -1132,7 +1132,9 @@ export class WorkerReconciler {
     return this.canRenderConfidentialityAtom(atom, policy);
   }
 
-  private confidentialityLabels(labelView: CfcLabelView): readonly unknown[] {
+  private confidentialityLabels(
+    labelView: CfcLabelView,
+  ): readonly CfcConfClause[] {
     return ContextualFlowControl.uniqueAtoms(
       labelView.entries.flatMap((entry) => [
         ...(entry.label.confidentiality ?? []),

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -118,7 +118,7 @@ export interface RenderPolicy {
    * Confidentiality atoms this subtree may declassify before applying the max bound.
    * This is a temporary low-level capability hook for trusted UI experiments.
    */
-  declassifyConfidentiality: readonly unknown[];
+  declassifyConfidentiality: readonly CfcConfClause[];
 
   /**
    * Integrity required for user-visible text in this subtree.

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -160,16 +160,16 @@ function dbTablesResolved(
  *  admit them too. */
 function staticConfidentialityOf(
   labelSchema: Record<string, unknown> | undefined,
-): unknown[] {
+): CfcConfClause[] {
   const props = (labelSchema as {
     properties?: {
       result?: { items?: { properties?: Record<string, unknown> } };
     };
   })?.properties?.result?.items?.properties;
   if (!props) return [];
-  const out: unknown[] = [];
+  const out: CfcConfClause[] = [];
   for (const p of Object.values(props)) {
-    const conf = (p as { ifc?: { confidentiality?: unknown[] } })?.ifc
+    const conf = (p as { ifc?: { confidentiality?: CfcConfClause[] } })?.ifc
       ?.confidentiality;
     if (Array.isArray(conf)) out.push(...conf);
   }
@@ -285,16 +285,16 @@ function deriveNullOriginIfc(
 }
 
 type ColumnIfc = {
-  confidentiality?: unknown[];
+  confidentiality?: CfcConfClause[];
   integrity?: CfcAtom[];
   maxConfidentiality?: CfcConfClause[];
 };
 
 const unionAtoms = (
-  a: unknown[] | undefined,
-  b: unknown[] | undefined,
-): unknown[] | undefined => {
-  const out: unknown[] = [...(a ?? [])];
+  a: CfcConfClause[] | undefined,
+  b: CfcConfClause[] | undefined,
+): CfcConfClause[] | undefined => {
+  const out: CfcConfClause[] = [...(a ?? [])];
   for (const atom of b ?? []) {
     if (!out.some((existing) => deepEqual(existing, atom))) out.push(atom);
   }

--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -30,7 +30,7 @@ interface ResultColumn {
 
 /** A row's per-row label, shaped as a schema `ifc` for the row-doc write. */
 export interface PerRowIfc {
-  confidentiality?: unknown[];
+  confidentiality?: CfcConfClause[];
   integrity?: CfcAtom[];
 }
 
@@ -45,7 +45,7 @@ export interface RowLabelReadArgs {
   owner?: string;
   /** Per-column (Phase 2) confidentiality atoms of the labeled projection —
    *  they ride every row, so they count against the ceiling too. */
-  staticConfidentiality?: readonly unknown[];
+  staticConfidentiality?: readonly CfcConfClause[];
   /** Declared output ceiling (placeholders already resolved). */
   ceiling?: readonly CfcConfClause[];
   /** What to do when a row's label exceeds the ceiling (default "fail"). */
@@ -84,7 +84,7 @@ const isRecord = (x: unknown): x is Record<string, unknown> =>
 // intersection, so no principal is guaranteed to read every contributing row.
 type AggregateCommon =
   | { kind: "unconstrained" }
-  | { kind: "readers"; atoms: unknown[] }
+  | { kind: "readers"; atoms: CfcConfClause[] }
   | { kind: "refuse" };
 
 // Intersect the common alternatives of every CONFIDENTIALITY-BEARING
@@ -116,7 +116,10 @@ function intersectCommonAlternatives(
     if (acc.size === 0) return { kind: "refuse" }; // no shared reader
   }
   if (!anyConfidentiality) return { kind: "unconstrained" };
-  return { kind: "readers", atoms: acc === undefined ? [] : [...acc.values()] };
+  return {
+    kind: "readers",
+    atoms: acc === undefined ? [] : [...acc.values()] as CfcConfClause[],
+  };
 }
 
 // CFC Phase 3.b — whether the acting reader may read a row carrying this
@@ -128,7 +131,7 @@ function intersectCommonAlternatives(
 // (Caveat/Expires/material-risk marker) never admits a plain reader, so the row
 // is withheld — fail closed.
 function readerAdmitsLabel(
-  confidentiality: readonly unknown[],
+  confidentiality: readonly CfcConfClause[],
   reader: string,
 ): boolean {
   return confidentiality.every((clause) =>
@@ -292,7 +295,7 @@ export function computeRowLabelRead(
           }
           const ifc: PerRowIfc = {};
           if (res.confidentiality.length > 0) {
-            ifc.confidentiality = res.confidentiality;
+            ifc.confidentiality = res.confidentiality as CfcConfClause[];
           }
           if (res.integrity.length > 0) {
             ifc.integrity = res.integrity as CfcAtom[];

--- a/packages/runner/src/builtins/sqlite/row-label-write.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-write.ts
@@ -42,7 +42,7 @@ import {
  *  input (sink-request) before the commit. */
 export interface RowLabelWritePolicy {
   table: string;
-  label: { confidentiality: unknown[]; integrity: CfcAtom[] };
+  label: { confidentiality: CfcConfClause[]; integrity: CfcAtom[] };
 }
 
 export interface RowLabelWriteArgs {
@@ -301,7 +301,7 @@ export function checkSqliteRowLabelWrite(
     policies.push({
       table: declaredKey,
       label: {
-        confidentiality: res.confidentiality,
+        confidentiality: res.confidentiality as CfcConfClause[],
         integrity: res.integrity as CfcAtom[],
       },
     });

--- a/packages/runner/src/builtins/sqlite/write-ceiling.ts
+++ b/packages/runner/src/builtins/sqlite/write-ceiling.ts
@@ -18,7 +18,7 @@ import {
 
 interface ColumnIfc {
   maxConfidentiality?: readonly CfcConfClause[];
-  confidentiality?: readonly unknown[];
+  confidentiality?: readonly CfcConfClause[];
 }
 type Tables = Record<
   string,


### PR DESCRIPTION
Types the CFC confidentiality carriers in the **leaf consumers** as
`CfcConfClause[]`: the sqlite per-row / static label paths, the html worker's
label surface, and the cf-harness model context.

10 declarations, 6 fallout sites, 7 files. No runtime change — annotations,
casts, and imports only.

## Why this half is nearly free

These construct labels and assign them into `IFCLabel`, which is still
`unknown[]` here. **Narrow-into-wide is always assignable**, so narrowing the
leaves costs nothing on its own; the core half follows and narrows the
destination, at which point the two casts this adds go away.

Measured: with the core declarations reverted, this side leaves 4 errors, and 3
of those are artifacts of a pattern-based revert rather than real coupling.

## Splitting notes

This replaces the leaf portion of #5040 (27 files), which is being split into
this and a core half.

It does subdivide once more — sqlite (4 files) vs display surfaces (3 files), at
**2** coupling sites — but at 48 lines total that buys no reviewability for two
extra CI cycles, so it is left whole. Measured, not assumed; say the word if you
want it split.

## Test plan

- `deno task check` clean; `deno fmt --check` and `deno lint` exit 0.
- `packages/cf-harness`: 500 passed. It type-checks inside its OWN
  `deno task test`, so a clean root `check` does not cover it — that is how the
  one real defect here (a push into a now-typed array from an
  `IFCLabel`-sourced value) was caught.
- Full repo suite green on a clean, committed tree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Type the CFC confidentiality arrays in leaf consumers as `CfcConfClause[]` across SQLite label paths, the HTML worker label surface, and the `cf-harness` model context. No runtime changes; sets up the core follow-up that narrows `IFCLabel`.

- **Refactors**
  - SQLite: typed `confidentiality` in per-row/static labels, write ceiling, and helpers (`staticConfidentialityOf`, `unionAtoms`, row read/write types).
  - HTML worker: typed `RenderPolicy.declassifyConfidentiality`, reconciler checks, and label extraction.
  - `cf-harness`: accumulates `CfcConfClause[]` in the model context with a boundary cast while `IFCLabel` remains wide.

<sup>Written for commit 437e35878e06d621364c30aa7208218a8cc3b467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

