### PR TITLE
fix(data-model): narrow the native-conversion boundaries honestly

### DIFF
--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -5,6 +5,7 @@ export {
   type FabricArray,
   FabricInstance,
   type FabricNativeObject,
+  type FabricOrConvertibleNativeValue,
   type FabricPlainObject,
   FabricPrimitive,
   FabricSpecialObject,

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -197,6 +197,15 @@ export type FabricValueLayer =
  * Note: `bigint` is NOT included here -- it is a primitive (like `undefined`)
  * and belongs directly in `FabricValue` without wrapping.
  */
+export type FabricNativeObject =
+  | Error
+  | Map<unknown, unknown>
+  | Set<unknown>
+  | Date
+  | RegExp
+  | Uint8Array
+  | { toJSON(): unknown };
+
 /**
  * A value produced by converting fabric data back to native JS form. Unlike
  * `FabricValue`, its containers may hold `FabricNativeObject`s: converting a
@@ -208,12 +217,3 @@ export type FabricNativeValue =
   | FabricNativeObject
   | readonly FabricNativeValue[]
   | { readonly [key: string]: FabricNativeValue };
-
-export type FabricNativeObject =
-  | Error
-  | Map<unknown, unknown>
-  | Set<unknown>
-  | Date
-  | RegExp
-  | Uint8Array
-  | { toJSON(): unknown };

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -207,13 +207,17 @@ export type FabricNativeObject =
   | { toJSON(): unknown };
 
 /**
- * A value produced by converting fabric data back to native JS form. Unlike
- * `FabricValue`, its containers may hold `FabricNativeObject`s: converting a
- * `FabricError` yields an `Error`, so an array of them is an array of natives
- * with no `FabricValue` name.
+ * A `FabricValue`, a `FabricNativeObject`, or a deep tree thereof -- the values
+ * that convert to and from fabric form. This is the precondition of
+ * `fabricFromNativeValue()` (which fails on anything else), the result of
+ * `nativeFromFabricValue()`, and what `isFabricCompatible()` tests for.
+ *
+ * Distinct from `FabricValue`: containers here may hold `FabricNativeObject`s.
+ * Converting a `FabricError` yields an `Error`, so an array of them is an array
+ * of natives, which has no `FabricValue` name.
  */
-export type FabricNativeValue =
+export type FabricOrConvertibleNativeValue =
   | FabricValue
   | FabricNativeObject
-  | readonly FabricNativeValue[]
-  | { readonly [key: string]: FabricNativeValue };
+  | readonly FabricOrConvertibleNativeValue[]
+  | { readonly [key: string]: FabricOrConvertibleNativeValue };

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -197,6 +197,18 @@ export type FabricValueLayer =
  * Note: `bigint` is NOT included here -- it is a primitive (like `undefined`)
  * and belongs directly in `FabricValue` without wrapping.
  */
+/**
+ * A value produced by converting fabric data back to native JS form. Unlike
+ * `FabricValue`, its containers may hold `FabricNativeObject`s: converting a
+ * `FabricError` yields an `Error`, so an array of them is an array of natives
+ * with no `FabricValue` name.
+ */
+export type FabricNativeValue =
+  | FabricValue
+  | FabricNativeObject
+  | readonly FabricNativeValue[]
+  | { readonly [key: string]: FabricNativeValue };
+
 export type FabricNativeObject =
   | Error
   | Map<unknown, unknown>

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -7,6 +7,7 @@ import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
 
 import {
   type FabricNativeObject,
+  type FabricNativeValue,
   FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
@@ -584,7 +585,7 @@ function isFabricCompatibleInternal(
 export function nativeFromFabricValue(
   value: FabricValue,
   frozen = true,
-): FabricValue | FabricNativeObject {
+): FabricNativeValue {
   if (value instanceof FabricError) {
     return deepUnwrapFabricError(value, frozen);
   }
@@ -602,7 +603,7 @@ export function nativeFromFabricValue(
   }
 
   if (Array.isArray(value)) {
-    const result: (FabricValue | FabricNativeObject)[] = [];
+    const result: FabricNativeValue[] = [];
     for (let i = 0; i < value.length; i++) {
       if (!(i in value)) {
         result.length = i + 1;
@@ -614,21 +615,17 @@ export function nativeFromFabricValue(
       }
     }
     if (frozen) Object.freeze(result);
-    // TODO(danfuzz): the declared return type cannot describe a nested native
-    // container -- `FabricNativeObject` has no plain-array or plain-object arm,
-    // so an array holding an unwrapped `Error` has no name here. Widen the
-    // return to a recursive native-value type and drop these two casts.
-    return result as FabricValue;
+    return result;
   }
 
-  const result: Record<string, FabricValue | FabricNativeObject> = {};
+  const result: Record<string, FabricNativeValue> = {};
   for (const [key, val] of Object.entries(value)) {
     if (!isUnsafeObjectKey(key)) {
       result[key] = nativeFromFabricValue(val, frozen);
     }
   }
   if (frozen) Object.freeze(result);
-  return result as FabricValue;
+  return result;
 }
 
 function deepUnwrapFabricError(fe: FabricError, frozen: boolean): Error {

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -6,8 +6,7 @@ import {
 import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
 
 import {
-  type FabricNativeObject,
-  type FabricNativeValue,
+  type FabricOrConvertibleNativeValue,
   FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
@@ -284,7 +283,10 @@ const PROCESSING = Symbol("PROCESSING");
  * is already a deep-frozen `FabricValue`, returns it as-is (identity
  * optimization).
  *
- * @param value - The value to convert.
+ * @param value - The value to convert. Declared `unknown` for caller
+ *   convenience, but the call THROWS unless it is in fact a
+ *   `FabricOrConvertibleNativeValue`; `isFabricCompatible()` reports in
+ *   advance whether it is.
  * @param freeze - When `true` (default), deep-freezes the result tree.
  *   When `false`, wrapping and validation still occur but the result is
  *   left mutable.
@@ -474,11 +476,13 @@ function rebuildFabricErrorDeep(
  * checks recursively, so all nested values in arrays and objects must also be
  * fabric-compatible or convertible.
  *
- * This function is a TypeScript type guard for `FabricValue | FabricNativeObject`.
+ * This function is a TypeScript type guard for
+ * `FabricOrConvertibleNativeValue`, which names the recursive shape described
+ * above.
  */
 export function isFabricCompatible(
   value: unknown,
-): value is FabricValue | FabricNativeObject {
+): value is FabricOrConvertibleNativeValue {
   return isFabricCompatibleInternal(value, new Set());
 }
 
@@ -585,7 +589,7 @@ function isFabricCompatibleInternal(
 export function nativeFromFabricValue(
   value: FabricValue,
   frozen = true,
-): FabricNativeValue {
+): FabricOrConvertibleNativeValue {
   if (value instanceof FabricError) {
     return deepUnwrapFabricError(value, frozen);
   }
@@ -603,7 +607,7 @@ export function nativeFromFabricValue(
   }
 
   if (Array.isArray(value)) {
-    const result: FabricNativeValue[] = [];
+    const result: FabricOrConvertibleNativeValue[] = [];
     for (let i = 0; i < value.length; i++) {
       if (!(i in value)) {
         result.length = i + 1;
@@ -618,7 +622,7 @@ export function nativeFromFabricValue(
     return result;
   }
 
-  const result: Record<string, FabricNativeValue> = {};
+  const result: Record<string, FabricOrConvertibleNativeValue> = {};
   for (const [key, val] of Object.entries(value)) {
     if (!isUnsafeObjectKey(key)) {
       result[key] = nativeFromFabricValue(val, frozen);

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -341,7 +341,10 @@ function fabricFromNativeValueInternal(
   }
 
   // Primitives, `null`, and `undefined` don't need recursion or freezing.
-  if (!isRecord(value)) {
+  // Spelled as a `typeof` test rather than `!isRecord()` so the non-object
+  // arms of `FabricValueLayer` narrow: every non-object layer value is
+  // already a `FabricValue`.
+  if (typeof value !== "object" || value === null) {
     if (isOriginalRecord) {
       converted.set(original, value);
     }
@@ -599,7 +602,7 @@ export function nativeFromFabricValue(
   }
 
   if (Array.isArray(value)) {
-    const result: unknown[] = [];
+    const result: (FabricValue | FabricNativeObject)[] = [];
     for (let i = 0; i < value.length; i++) {
       if (!(i in value)) {
         result.length = i + 1;
@@ -611,17 +614,21 @@ export function nativeFromFabricValue(
       }
     }
     if (frozen) Object.freeze(result);
-    return result;
+    // TODO(danfuzz): the declared return type cannot describe a nested native
+    // container -- `FabricNativeObject` has no plain-array or plain-object arm,
+    // so an array holding an unwrapped `Error` has no name here. Widen the
+    // return to a recursive native-value type and drop these two casts.
+    return result as FabricValue;
   }
 
-  const result: Record<string, unknown> = {};
+  const result: Record<string, FabricValue | FabricNativeObject> = {};
   for (const [key, val] of Object.entries(value)) {
     if (!isUnsafeObjectKey(key)) {
       result[key] = nativeFromFabricValue(val, frozen);
     }
   }
   if (frozen) Object.freeze(result);
-  return result;
+  return result as FabricValue;
 }
 
 function deepUnwrapFabricError(fe: FabricError, frozen: boolean): Error {


### PR DESCRIPTION
Two spots in `native-conversion.ts` where the code could not state what its
values provably are. 1 file, +12/−5, no runtime change.

**`fabricFromNativeValueInternal`** guarded the primitive path with
`!isRecord(value)`. `isRecord` is `typeof === "object" && !== null`, so it is
true for arrays, and its negation does not clear the `unknown[]` arm of
`FabricValueLayer` — the compiler could not see what the comment already
asserted ("primitives, `null`, and `undefined`"). Spelled as an explicit
`typeof` test, which narrows properly. No cast.

**`nativeFromFabricValue`** accumulated into `unknown[]` and
`Record<string, unknown>`. Those are now typed to what they actually hold, with
a `TODO(danfuzz)` on the two returns naming the real gap: `FabricNativeObject`
has no plain-array or plain-object arm, so an array holding an unwrapped `Error`
has no expressible type in the declared return. Widening that to a recursive
native-value type is the proper fix and is bigger than this change.

## Why

Groundwork for branding `FabricSpecialObject` nominal. It is currently an empty
abstract class, so *every* object satisfies it structurally — which is how
unrelated values slip into `FabricValue` slots. With a brand applied locally as
a probe, repo-wide residue drops **46 → 42**.

The framing that matters for the rest of that arc: if `jsonFromValue(x)` can
serialize `x`, then `x` *is* a `FabricValue` de facto. So where the type system
disagrees, the declaration understates what the value provably is — these are
type bugs to fix, not call sites to cast.

## Test plan

- `deno task check` clean without the brand; `deno lint` and `deno fmt --check`
  exit 0.
- Full repo suite green on a clean, committed tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens native conversion type boundaries with the recursive `FabricOrConvertibleNativeValue` and correct object/primitive narrowing; re-exports the type on `fabric-value` for consumers. No runtime change; clearer contracts and groundwork for branding `FabricSpecialObject`.

- **Refactors**
  - In `fabricFromNativeValueInternal`, use a `typeof`/null check instead of `!isRecord(value)` to correctly narrow non-object values.
  - Add `FabricOrConvertibleNativeValue` in `interface.ts`; use it as the return of `nativeFromFabricValue`, the type guard of `isFabricCompatible`, and the documented precondition for `fabricFromNativeValue`; type array/object accumulators accordingly and remove casts; re-export it from `fabric-value`.
  - Place `FabricOrConvertibleNativeValue` after `FabricNativeObject` to fix docs and improve reading order.

<sup>Written for commit 27ebfe2bcf48bb797a0ae7fea529dbc57f11f0cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

