### PR TITLE
refactor(cfc): retire the clause-typing casts and their TODOs

### DIFF
--- a/packages/runner/src/cfc/clause.ts
+++ b/packages/runner/src/cfc/clause.ts
@@ -27,10 +27,6 @@ export type CfcOrClause = { readonly anyOf: readonly CfcAtom[] };
 /** A confidentiality clause: a bare atom, or an OR of atoms. */
 export type CfcConfClause = CfcAtom | CfcOrClause;
 
-// TODO(danfuzz): The label and ceiling types that carry clause lists still
-// declare them as `unknown[]`, so callers cast on the way in. Drop those casts
-// once those types name clauses.
-
 export const isOrClause = (value: unknown): value is CfcOrClause =>
   isRecord(value) &&
   Array.isArray((value as { anyOf?: unknown }).anyOf) &&

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -157,7 +157,7 @@ export type ExchangeEvalContext = {
    */
   readonly integrity?: readonly CfcAtom[];
   /** Boundary-context atoms minted for this evaluation site (B5). */
-  readonly boundary?: readonly unknown[];
+  readonly boundary?: readonly CfcAtom[];
   /** Trust closure for concept-valued integrity guards (B3). */
   readonly trustResolver?: TrustResolver;
   readonly actingPrincipal?: string;
@@ -208,12 +208,10 @@ export type ExchangeEvalResult = {
 const extendThroughPattern = (
   environments: readonly AtomPatternBindings[],
   pattern: unknown,
-  pool: readonly unknown[],
+  pool: readonly CfcAtom[],
 ): AtomPatternBindings[] => {
   const next: AtomPatternBindings[] = [];
-  // TODO(danfuzz): drop the cast once the integrity guard pool is typed as
-  // `CfcAtom`.
-  const atoms = pool as readonly CfcAtom[];
+  const atoms = pool;
   for (const environment of environments) {
     for (
       const extended of matchAtomPatternAgainstAtoms(

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -89,9 +89,7 @@ export const cloneCfcLabel = (label: IFCLabel): IFCLabel => {
   for (const key of LABEL_KEYS) {
     const value = label[key];
     if (Array.isArray(value) && value.length > 0) {
-      // TODO(danfuzz): drop the cast once `confidentiality` names its
-      // clause type too; this loop spans both label keys.
-      cloned[key] = [...value] as CfcAtom[];
+      cloned[key] = [...value];
     }
   }
   return cloned;
@@ -154,8 +152,8 @@ export const redactCaveatSourcesForDisplay = (
     for (const key of LABEL_KEYS) {
       const value = entry.label[key];
       if (Array.isArray(value) && value.length > 0) {
-        // TODO(danfuzz): drop the cast once `confidentiality` names its
-        // clause type too; this loop spans both label keys.
+        // `value` is the union of both label-key array types, so `.map()`
+        // widens its callback parameter and loses the element type.
         label[key] = value.map(redactCaveatSourceAtom) as CfcAtom[];
       }
     }

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -206,7 +206,7 @@ export type CfcFloorTrustContext = {
  */
 const integrityAtomSatisfies = (
   required: unknown,
-  actual: unknown,
+  actual: CfcAtom,
   trust?: CfcFloorTrustContext,
 ): boolean => {
   const concept = conceptGuard(required);
@@ -230,9 +230,7 @@ const integrityAtomSatisfies = (
         trust.actingPrincipal,
       );
   }
-  // TODO(danfuzz): drop the cast once integrity atom lists are typed as
-  // `CfcAtom`.
-  return matchAtomPattern(required, actual as CfcAtom) !== null ||
+  return matchAtomPattern(required, actual) !== null ||
     atomEntails(actual, required);
 };
 
@@ -276,7 +274,7 @@ export const cfcIntegritySatisfiesFloor = (
  */
 export const cfcIntegrityWitnessKey = (
   required: unknown,
-  actual: unknown,
+  actual: CfcAtom,
   trust?: CfcFloorTrustContext,
 ): string | null => {
   if (!integrityAtomSatisfies(required, actual, trust)) return null;
@@ -307,7 +305,7 @@ export const cfcIntegrityWitnessKey = (
  * incoherent, exactly as two different concrete screening atoms would be.
  */
 export const cfcIntegritySatisfiesFloorCoherently = (
-  consumedIntegrity: readonly (readonly unknown[])[],
+  consumedIntegrity: readonly (readonly CfcAtom[])[],
   requiredIntegrity: readonly CfcAtom[],
   trust?: CfcFloorTrustContext,
 ): boolean =>

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4681,7 +4681,7 @@ const evaluateGatedConfidentiality = (
   tx: IExtendedStorageTransaction,
   confidentiality: readonly CfcConfClause[],
   integrity: readonly CfcAtom[],
-  boundary: readonly unknown[],
+  boundary: readonly CfcAtom[],
   consumption: CfcGrantConsumptionContext,
   destinationSpace?:
     | MemorySpace

--- a/packages/runner/src/cfc/trust.ts
+++ b/packages/runner/src/cfc/trust.ts
@@ -279,11 +279,9 @@ export const createTrustResolver = (
     const reached = new Set<string>();
     for (const statement of admissible) {
       if (reached.has(statement.implements)) continue;
-      // TODO(danfuzz): drop the cast once integrity atom lists are typed as
-      // `CfcAtom`.
       if (
         integrityAtoms.some((atom) =>
-          matchAtomPattern(statement.concrete, atom as CfcAtom) !== null
+          matchAtomPattern(statement.concrete, atom) !== null
         )
       ) {
         reached.add(statement.implements);

--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
@@ -1,5 +1,4 @@
 import { css, html } from "lit";
-import type { CfcAtom } from "@commonfabric/api/cfc";
 import { BaseElement } from "../../core/base-element.ts";
 import type { CfcLabelView } from "@commonfabric/runtime-client";
 
@@ -91,9 +90,7 @@ const filteredLabel = (
     }
     const filtered = values.filter((value) => atomMatchesFilter(value, filter));
     if (filtered.length > 0) {
-      // TODO(danfuzz): drop the cast once `confidentiality` names its clause
-      // type too; this loop spans both label keys.
-      result[key] = filtered as CfcAtom[];
+      result[key] = filtered;
     }
   }
   return LABEL_KEYS.some((key) => Array.isArray(result[key]))


### PR DESCRIPTION
Sweep of the `TODO(danfuzz)` markers the clause/carrier typing series
(#5031–#5042) left behind, now that every CFC confidentiality, integrity,
ceiling, and observed carrier names its type.

7 files, **+13/−28** — a net removal. No runtime change.

## What the sweep actually found

Removing them was only half the story; each TODO is a claim about the system, and
they had rotted differently:

- **Three were satisfied.** Casts gone: `cloneCfcLabel`, the `ui` label filter,
  and `trust.ts`'s guard-pool match.
- **Three claimed to be satisfied but were not** — removing their casts failed.
  Rather than reword them, this types what actually blocked them:
  `extendThroughPattern`'s `pool`, `integrityAtomSatisfies` /
  `cfcIntegrityWitnessKey`'s `actual`, `ctx.boundary`, `consumedIntegrity`, and
  `prepare.ts`'s `boundary` — five declarations still sitting at `unknown`.
- **One was stale.** `clause.ts` asserted that the label and ceiling types "still
  declare them as `unknown[]`", which stopped being true when #5042 landed. A
  TODO stating something false about the current system is worse than none: it
  sends the next reader looking for work already done.
- **One keeps its cast, with corrected reasoning.** `label-view-core.ts` is not
  blocked on the label types at all — `value` is the union of both label-key
  array types, so `.map()` widens its callback parameter and loses the element
  type. The comment now names that, instead of promising a removal that will
  never come.

Two of eight were actively misleading within a day of being written, which is
the argument for sweeping these while the context is still fresh.

## Test plan

- `deno task check` clean; `deno lint` and `deno fmt --check` exit 0.
- Full repo suite green on a clean, committed tree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires stale clause-typing casts and TODOs across CFC and tightens types for integrity atoms, boundary contexts, and guard pools. Comment-only and annotation updates with no runtime changes.

- **Refactors**
  - Typed `CfcAtom` usage: `ExchangeEvalContext.boundary`, `prepare.evaluateGatedConfidentiality.boundary`, `extendThroughPattern.pool`, `integrityAtomSatisfies`/`cfcIntegrityWitnessKey.actual`, and `consumedIntegrity`.
  - Removed casts in `cloneCfcLabel`, the UI label filter (`cf-cfc-label.ts`), and trust resolver pool matching.
  - Deleted a stale TODO in `clause.ts`; kept a cast in `label-view-core.ts` with corrected reasoning (array union widens `.map()` callback param).

<sup>Written for commit 641904313da0ac64d4a1f38cbf1fb9ec7cd864e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

