### PR TITLE
test(html): the render-policy seeds take real atoms

### DIFF
--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "@std/assert";
+import type { CfcAtom } from "@commonfabric/api/cfc";
 import { Identity } from "@commonfabric/identity";
 import {
   isCell as isRuntimeCell,
@@ -2983,7 +2984,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       "H3b resolver admits User/Space-via-HasRole and blocks the unresolvable",
       async () => {
         const seedTx = runtime.edit();
-        const seedLabeled = (id: string, value: string, atom: unknown) => {
+        const seedLabeled = (id: string, value: string, atom: CfcAtom) => {
           const cell = runtime.getCell<string>(
             signer.did(),
             id,
@@ -3093,7 +3094,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           },
         };
         const seedTx = runtime.edit();
-        const seed = (id: string, value: string, atom: unknown) => {
+        const seed = (id: string, value: string, atom: CfcAtom) => {
           const cell = runtime.getCell<string>(
             signer.did(),
             id,


### PR DESCRIPTION
Two `seed` / `seedLabeled` helpers in the render-policy test declared their
`atom` parameter as `unknown`, then placed it straight into a `labelMap` entry's
`confidentiality`, where it is a `CfcAtom`. Typed to match. 1 file, +5/−2.

## Why

Groundwork for branding `FabricSpecialObject` nominal. It is currently an empty
abstract class, so *every* object satisfies it structurally — which is how
unrelated values reach `FabricValue` slots. With a brand applied locally as a
probe, `packages/html` residue drops **2 → 0** (repo-wide 42 → 40).

## Note on scope

This was scoped as "the `html`/`toolshed` cluster", but the three sites turned
out not to be homogeneous. The single `toolshed` one
(`routes/storage/memory/memory.handlers.ts`) is not independently fixable: it is
the memory wire-protocol root again —

```
ServerMessage → SessionEffectMessage → .effect: SessionSync → …
```

— the same structural mismatch behind the 16 `memory` sites, where the protocol
type graph does not satisfy `FabricValue`. It will fall out of that work rather
than this PR, so `toolshed` stays at 1 for now.

## Test plan

- `deno task check` clean without the brand; `deno lint` / `deno fmt --check`
  exit 0.
- `packages/html`: 43 passed, 0 failed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed the render-policy test seed helpers to accept `CfcAtom` (from `@commonfabric/api/cfc`) instead of `unknown`. This aligns with the labelMap confidentiality field and prepares for nominal branding work, reducing type noise in `packages/html`.

<sup>Written for commit 6073cfba43b632810c069a2925cb9b542b774627. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

