### PR TITLE
test(cfc): the label seed helpers use `IFCLabel`

### DIFF
--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { Identity } from "@commonfabric/identity";
@@ -2263,7 +2264,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       }) as { cfc?: { labelMap?: { entries?: unknown[] } } };
       const entries = stored.cfc?.labelMap?.entries as Array<{
         path: string[];
-        label: { confidentiality?: unknown[]; integrity?: unknown[] };
+        label: IFCLabel;
       }>;
       expect(entries).toEqual(
         expect.arrayContaining([
@@ -2328,7 +2329,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       }) as { cfc?: { labelMap?: { entries?: unknown[] } } };
       const entries = stored.cfc?.labelMap?.entries as Array<{
         path: string[];
-        label: { confidentiality?: unknown[]; integrity?: unknown[] };
+        label: IFCLabel;
       }>;
       expect(entries).toEqual(
         expect.arrayContaining([
@@ -2474,7 +2475,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       }) as { cfc?: { labelMap?: { entries?: unknown[] } } };
       const entries = stored.cfc?.labelMap?.entries as Array<{
         path: string[];
-        label: { confidentiality?: unknown[]; integrity?: unknown[] };
+        label: IFCLabel;
       }>;
       expect(entries).toEqual(
         expect.arrayContaining([
@@ -3268,7 +3269,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       }) as { cfc?: { labelMap?: { entries?: unknown[] } } };
       const entries = stored.cfc?.labelMap?.entries as Array<{
         path: string[];
-        label: { confidentiality?: unknown[]; integrity?: unknown[] };
+        label: IFCLabel;
       }>;
       expect(entries).toEqual(
         expect.arrayContaining([

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { type CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
@@ -50,7 +51,7 @@ const spaceB = (await Identity.fromPassphrase("cfc-cross-space-integrity B"))
 
 type LabelMapEntry = {
   path: string[];
-  label: { confidentiality?: unknown[]; integrity?: unknown[] };
+  label: IFCLabel;
   origin?: string;
 };
 type PersistedDoc = {

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
@@ -15,7 +16,7 @@ const space = signer.did();
 
 type StoredEntry = {
   path: string[];
-  label: { confidentiality?: string[]; integrity?: unknown[] };
+  label: IFCLabel;
   origin?: string;
   observes?: string;
 };

--- a/packages/runner/test/cfc-external-ingest.test.ts
+++ b/packages/runner/test/cfc-external-ingest.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
@@ -13,7 +14,7 @@ const space = signer.did();
 
 type StoredEntry = {
   path: string[];
-  label: { confidentiality?: unknown[]; integrity?: unknown[] };
+  label: IFCLabel;
   origin?: string;
 };
 

--- a/packages/runner/test/cfc-flow-integrity.test.ts
+++ b/packages/runner/test/cfc-flow-integrity.test.ts
@@ -1,4 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
+import type { CfcAtom } from "@commonfabric/api/cfc";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
@@ -13,7 +15,7 @@ const space = signer.did();
 
 type StoredEntry = {
   path: string[];
-  label: { confidentiality?: unknown[]; integrity?: unknown[] };
+  label: IFCLabel;
   origin?: string;
 };
 
@@ -41,7 +43,7 @@ describe("CFC flow labels: integrity propagation (phase C)", () => {
   const seedDoc = async (
     runtime: Runtime,
     cause: string,
-    integrity: unknown[],
+    integrity: CfcAtom[],
   ): Promise<string> => {
     const seed = runtime.edit();
     const cell = runtime.getCell(space, cause, undefined, seed);

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { type CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
@@ -416,7 +417,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
   const seedLabeledCell = async (
     runtime: Runtime,
     id: string,
-    label: { confidentiality: unknown[]; integrity?: unknown[] },
+    label: IFCLabel,
   ): Promise<void> => {
     const seed = runtime.edit();
     const target = runtime.getCell(signer.did(), id, undefined, seed);

--- a/packages/runner/test/cfc-policy-boundary.test.ts
+++ b/packages/runner/test/cfc-policy-boundary.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
@@ -91,7 +92,7 @@ const SECRET_SCHEMA = internSchema(
 const seedSpaceLabeledCell = async (
   runtime: Runtime,
   id: string,
-  label: { confidentiality: unknown[]; integrity?: unknown[] },
+  label: IFCLabel,
 ): Promise<void> => {
   const seed = runtime.edit();
   const target = runtime.getCell(signer.did(), id, undefined, seed);

--- a/packages/runner/test/cfc-prefix-provenance-stats.test.ts
+++ b/packages/runner/test/cfc-prefix-provenance-stats.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
@@ -59,7 +60,7 @@ const seedLabeledDoc = async (
   runtime: Runtime,
   id: string,
   value: FabricValue,
-  label: { integrity?: unknown[]; confidentiality?: unknown[] },
+  label: IFCLabel,
 ): Promise<void> => {
   const seed = runtime.edit();
   const cell = runtime.getCell(signer.did(), id, undefined, seed);

--- a/packages/runner/test/cfc-required-integrity-provenance.test.ts
+++ b/packages/runner/test/cfc-required-integrity-provenance.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
@@ -38,7 +39,7 @@ const seedLabeledDoc = async (
   runtime: Runtime,
   id: string,
   value: FabricValue,
-  label: { integrity?: unknown[]; confidentiality?: unknown[] },
+  label: IFCLabel,
 ): Promise<void> => {
   const seed = runtime.edit();
   const cell = runtime.getCell(signer.did(), id, undefined, seed);

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
@@ -196,7 +197,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
   const seedLabeledCell = async (
     runtime: Runtime,
     id: string,
-    label: { confidentiality: unknown[]; integrity?: unknown[] },
+    label: IFCLabel,
   ): Promise<void> => {
     const seed = runtime.edit();
     const target = runtime.getCell(signer.did(), id, undefined, seed);

--- a/packages/runner/test/cfc-sink-ceiling.test.ts
+++ b/packages/runner/test/cfc-sink-ceiling.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
@@ -49,7 +50,7 @@ const seedConfidentialCell = async (
   runtime: Runtime,
   id: string,
   schema = CONFIDENTIAL_SCHEMA,
-  atoms: readonly unknown[] = ["medical"],
+  atoms: readonly CfcConfClause[] = ["medical"],
 ): Promise<void> => {
   const seed = runtime.edit();
   const target = runtime.getCell(signer.did(), id, undefined, seed);

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import type { CfcConfClause } from "../src/cfc/clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
@@ -34,7 +35,7 @@ const foreignSpace = foreignSigner.did();
 
 type StoredEntry = {
   path: string[];
-  label: { confidentiality?: unknown[]; integrity?: unknown[] };
+  label: IFCLabel;
   origin?: string;
   observes?: string;
 };

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
@@ -27,7 +28,7 @@ const foreignSpace = foreignSigner.did();
 
 type StoredEntry = {
   path: string[];
-  label: { confidentiality?: unknown[]; integrity?: unknown[] };
+  label: IFCLabel;
   origin?: string;
   observes?: string;
 };

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
@@ -67,7 +68,7 @@ const seedLabeledDoc = async (
   runtime: Runtime,
   id: string,
   value: FabricValue,
-  label: { integrity?: unknown[]; confidentiality?: unknown[] },
+  label: IFCLabel,
   path: string[] = [],
 ): Promise<void> => {
   const seed = runtime.edit();

--- a/packages/runner/test/cfc-write-prefix-provenance.test.ts
+++ b/packages/runner/test/cfc-write-prefix-provenance.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
@@ -93,7 +94,7 @@ const seedLabeledDoc = async (
   runtime: Runtime,
   id: string,
   value: FabricValue,
-  label: { integrity?: unknown[]; confidentiality?: unknown[] },
+  label: IFCLabel,
 ): Promise<void> => {
   const seed = runtime.edit();
   const cell = runtime.getCell(signer.did(), id, undefined, seed);


### PR DESCRIPTION
Sixteen CFC test helpers re-declared `IFCLabel` inline —
`{ confidentiality?: unknown[]; integrity?: unknown[] }` and permutations —
rather than importing it. They now use the real type, which is itself correctly
typed as of #5042, so the seeds are right by construction instead of by
coincidence.

Three test-local declarations typed alongside: `cfc-flow-integrity`'s
`integrity`, `cfc-sink-ceiling`'s `atoms`, and `cfc-existence-channel`'s inline
label shape.

15 files, +35/−19. No runtime change.

## Why

Groundwork for branding `FabricSpecialObject` nominal. It is an empty abstract
class today, so *every* object satisfies it structurally, which is how unrelated
values reach `FabricValue` slots. With a brand applied locally as a probe,
repo-wide residue drops **42 → 32**.

## On the file count

There is no seam here because there is no coupling: each test file declares its
own helper, so these are 16 independent single-file edits and any subset
compiles. It splits *anywhere* at zero cost, which is exactly why splitting would
be arbitrary rather than meaningful. The file count reflects how far the
duplication had spread, not review burden — one mechanical transformation, about
two lines per file.

## What is left in `runner`, and why it is not here

Two roots remain, both needing a decision rather than a cleanup:

- **`LLMRequest` (6 sites).** `BuiltInLLMImagePart.image` is
  `string | Uint8Array | ArrayBuffer | URL`. `ArrayBuffer` and `URL` are not
  `FabricValue`s and do not survive `jsonFromValue()`, yet `LLMRequest` is passed
  to `FabricValue`-typed APIs. That is a latent hole, not a missing annotation,
  so it should not be papered over with a cast.
- **`isRecord`-narrowed `unknown` (differential, result-utils, prepare).**
  `isRecord()` narrows to `Record<string | number | symbol, unknown>`, which is
  not a `FabricValue`. Fixing these needs the
  `isFabricValue(x) && isFabricPlainObject(x)` idiom and a call about each
  function's contract.

Plus one `memory`-protocol site (`memory-v2-reconnect-race.test.ts`) that belongs
to that cluster.

## Test plan

- `deno task check` clean without the brand; `deno lint` / `deno fmt --check`
  exit 0.
- `packages/runner`: 1068 passed, 0 failed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced inline CFC label shapes in test helpers with the canonical `IFCLabel`. Tightened a few helper parameter types. No runtime changes.

- **Refactors**
  - Import and use `IFCLabel` across CFC tests instead of `{ confidentiality?: unknown[]; integrity?: unknown[] }` and variants.
  - Narrowed helper params: `integrity: CfcAtom[]` in `cfc-flow-integrity`, `atoms: readonly CfcConfClause[]` in `cfc-sink-ceiling`, and unified stored entry labels to `IFCLabel`; improves type safety and prepares for nominal branding of `FabricSpecialObject`.

<sup>Written for commit 2a7b63d010236cfc5f8290e8f735bb5f8fe0f91b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

