### PR TITLE
refactor(memory): name the validated `session.open` authorization

### DIFF
--- a/packages/memory/test/session-open-auth-test.ts
+++ b/packages/memory/test/session-open-auth-test.ts
@@ -4,7 +4,10 @@ import { alice, bob, mallory, space } from "./principal.ts";
 import { MEMORY_PROTOCOL } from "../v2.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { verifySessionOpenAuthorization } from "../v2/session-open-auth.ts";
+import {
+  verifySessionOpenAuthorization,
+  wireAuthorizationOf,
+} from "../v2/session-open-auth.ts";
 
 const now = 1_000_000;
 const audience = bob.did();
@@ -56,6 +59,29 @@ const buildOpen = async (
     authorization: { signature: new FabricBytes(signature.ok) },
   };
 };
+
+describe("wireAuthorizationOf", () => {
+  it("narrows an authorization carrying a `FabricBytes` signature", () => {
+    const signature = new FabricBytes(new Uint8Array([1, 2, 3]));
+    assertEquals(wireAuthorizationOf({ signature }), { signature });
+  });
+
+  it("rejects a non-record authorization", () => {
+    assertEquals(wireAuthorizationOf(undefined), undefined);
+    assertEquals(wireAuthorizationOf("signed"), undefined);
+    assertEquals(wireAuthorizationOf(null), undefined);
+  });
+
+  it("rejects a signature that is not `FabricBytes`", () => {
+    // Raw bytes are what the in-process `Signature<T>` looks like; the wire
+    // form must be the fabric primitive, so this must not narrow.
+    assertEquals(
+      wireAuthorizationOf({ signature: new Uint8Array([1, 2, 3]) }),
+      undefined,
+    );
+    assertEquals(wireAuthorizationOf({}), undefined);
+  });
+});
 
 describe("verifySessionOpenAuthorization", () => {
   it("accepts a valid signed open and returns the issuer principal", async () => {

--- a/packages/memory/v2/session-open-auth.ts
+++ b/packages/memory/v2/session-open-auth.ts
@@ -65,6 +65,33 @@ export type SessionOpenMessage = {
   authorization?: unknown;
 };
 
+/**
+ * The `session.open` authorization AFTER validation. Deliberately not the
+ * declared type of `SessionOpenMessage.authorization`: that field is whatever
+ * the peer sent, so it stays `unknown` and only
+ * {@link wireAuthorizationOf} may produce this type.
+ *
+ * The signature crosses the wire as a `FabricBytes` -- the canonical binary
+ * fabric value -- not as the `Uint8Array`-derived `Signature<T>` used
+ * in-process.
+ */
+export type WireSessionOpenAuthorization = {
+  signature: FabricBytes;
+};
+
+/**
+ * Narrow a peer-supplied `authorization` to {@link WireSessionOpenAuthorization},
+ * or `undefined` if it is not one. This is the only sanctioned way to go from
+ * the untrusted field to the named shape.
+ */
+export const wireAuthorizationOf = (
+  authorization: unknown,
+): WireSessionOpenAuthorization | undefined => {
+  if (!isRecord(authorization)) return undefined;
+  const { signature } = authorization;
+  return signature instanceof FabricBytes ? { signature } : undefined;
+};
+
 export type VerifySessionOpenOptions = {
   /** This server's own audience identity. */
   audience: string;
@@ -86,12 +113,8 @@ export const verifySessionOpenAuthorization = async (
   message: SessionOpenMessage,
   options: VerifySessionOpenOptions,
 ): Promise<string> => {
-  const rawSignature = isRecord(message.authorization)
-    ? message.authorization.signature
-    : undefined;
-  const signature = rawSignature instanceof FabricBytes
-    ? rawSignature.slice()
-    : null;
+  const wireAuthorization = wireAuthorizationOf(message.authorization);
+  const signature = wireAuthorization?.signature.slice() ?? null;
   if (!isRecord(message.invocation) || signature === null) {
     throw authorizationError("memory session.open requires authorization");
   }


### PR DESCRIPTION
The `session.open` authorization was reached by poking at an untyped value:
`isRecord(message.authorization)` → `.signature` → `instanceof FabricBytes`. The
shape those checks establish had no name, so a load-bearing fact was discoverable
only by reading them: **a signature crosses the wire as a `FabricBytes`** — the
canonical binary fabric value — **not as the `Uint8Array`-derived `Signature<T>`
used in-process.**

Names the post-validation shape and gives it one sanctioned entry point:

```ts
export type WireSessionOpenAuthorization = { signature: FabricBytes };

export const wireAuthorizationOf = (
  authorization: unknown,
): WireSessionOpenAuthorization | undefined => { … };
```

The call site goes from three inline steps to two lines. 1 file, same runtime
behavior — identical checks, identical order, now behind a single narrowing
point.

## What this deliberately does NOT do

It does **not** retype `SessionOpenMessage.authorization` or
`SessionOpenRequest.authorization`. Those fields hold whatever the peer sent, so
declaring them as the validated shape would assert something the *sender*
controls. The `unknown` there is load-bearing, and the name belongs on the output
of validation rather than its input.

That distinction is the whole point of the change: previously there was no way to
tell, from types alone, which side of the trust boundary a value was on.

## Context

Found while tracing whether the memory wire path carries `Authorization` — it
does, and this explains why the ten `interface … extends Uint8Array` / `extends
Error` declarations never appear in the `FabricSpecialObject` brand residue: the
wire form uses `FabricBytes`, which is a genuine `FabricValue`, so nothing on
that path ever demands the `Uint8Array`-derived types be fabric values.

Independent of the brand arc — this is boundary legibility, not residue.

## Test plan

- `deno task check` clean; `deno lint` / `deno fmt --check` exit 0.
- `packages/memory`: 438 passed, 0 failed.
- Full repo suite green on a clean, committed tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes and names the validated `session.open` authorization to make the trust boundary explicit, with no behavior changes. Adds tests to cover the wire-authorization narrowing.

- **Refactors**
  - Define `WireSessionOpenAuthorization` as `{ signature: FabricBytes }` (wire form).
  - Add `wireAuthorizationOf(authorization: unknown)` to narrow untrusted input and use it in verification.
  - Add tests for `wireAuthorizationOf()`: narrows `FabricBytes`; rejects non-record authorization; rejects `Uint8Array` signatures.

<sup>Written for commit 1d5fd2ec0e48dd7e521046ea1c123c76fb319bfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

