### PR TITLE
refactor(memory): move the scheduler wire types to the wire module

### DIFF
--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -596,6 +596,84 @@ export type SchedulerActionSnapshotQuery = {
  * principal and session components use the same encoding as resolved memory
  * scope keys; clients must never construct one to select another context.
  */
+export type SchedulerActionKind =
+  | "computation"
+  | "effect"
+  | "event-handler";
+
+export type SchedulerObservationTransactionKind =
+  | "dependency-collection"
+  | "action-run"
+  | "event-preflight";
+
+export type SchedulerObservationAddress = {
+  space: string;
+  id: EntityId;
+  scope?: CellScope;
+  path: readonly string[];
+};
+
+export type CompleteActionScopeSummary = {
+  version: 1;
+  complete: true;
+  implementationFingerprint: string;
+  runtimeFingerprint: string;
+  piece: SchedulerObservationAddress;
+  reads: SchedulerObservationAddress[];
+  writes: SchedulerObservationAddress[];
+  materializerWriteEnvelopes: SchedulerObservationAddress[];
+  directOutputs: SchedulerObservationAddress[];
+};
+
+/**
+ * A scheduler action observation as it is stored and carried across the memory
+ * boundary.
+ *
+ * A parallel declaration of the same concept lives in the runner, at
+ * `runner/src/scheduler/persistent-observation.ts`. The two are not the same
+ * type and differ in strictness:
+ *
+ * - addresses here are {@link SchedulerObservationAddress} (`space: string`);
+ *   the runner uses `IMemorySpaceAddress` (`space: MemorySpace`)
+ * - `branch` here is `BranchName`; the runner declares it `string`
+ *
+ * The runner produces observations and this side stores them, so this one is
+ * deliberately the wider of the pair. Nothing checks that they agree: the wire
+ * fields that carry an observation (`CommitData.schedulerObservation` and
+ * `SchedulerActionSnapshotResult.observation`) are declared `unknown`, so a
+ * change to either declaration will not surface at the seam. Keep them in sync
+ * by hand until one of them owns the shape.
+ */
+export type SchedulerActionObservation = {
+  version: 1 | 2;
+  ownerSpace?: string;
+  branch: BranchName;
+  pieceId: string;
+  processGeneration: number;
+  actionId: string;
+  actionKind: SchedulerActionKind;
+  implementationFingerprint: string;
+  runtimeFingerprint: string;
+  completeActionScopeSummary?: CompleteActionScopeSummary;
+  observedAtSeq: number;
+  observedAtLocalSeq?: number;
+  transactionKind: SchedulerObservationTransactionKind;
+  reads: SchedulerObservationAddress[];
+  shallowReads: SchedulerObservationAddress[];
+  actualChangedWrites: SchedulerObservationAddress[];
+  currentKnownWrites: SchedulerObservationAddress[];
+  declaredWrites?: SchedulerObservationAddress[];
+  materializerWriteEnvelopes: SchedulerObservationAddress[];
+  ignoredSchedulingWrites?: SchedulerObservationAddress[];
+  actionOptions?: {
+    debounceMs?: number;
+    noDebounce?: boolean;
+    throttleMs?: number;
+  };
+  status: "success" | "failed";
+  errorFingerprint?: string;
+};
+
 export type SchedulerExecutionContextKey =
   | "space"
   | `user:${string}`

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -17,6 +17,7 @@ import {
   type CellScope,
   type ClientCommit,
   commitPreconditionValueHash,
+  type CompleteActionScopeSummary,
   decodeMemoryBoundary,
   DEFAULT_BRANCH,
   encodeMemoryBoundary,
@@ -26,14 +27,23 @@ import {
   type Operation,
   type PatchOp,
   type Reference,
+  type SchedulerActionObservation,
   type SchedulerActionSnapshotCursor,
   type SchedulerExecutionContextKey,
+  type SchedulerObservationAddress,
   type SessionId,
   type SqliteOperation,
   tableDeclaresRowLabel,
 } from "../v2.ts";
 
-export type { SchedulerExecutionContextKey } from "../v2.ts";
+export type {
+  CompleteActionScopeSummary,
+  SchedulerActionKind,
+  SchedulerActionObservation,
+  SchedulerExecutionContextKey,
+  SchedulerObservationAddress,
+  SchedulerObservationTransactionKind,
+} from "../v2.ts";
 
 const DEFAULT_SCOPE: CellScope = "space";
 const DEFAULT_SCOPE_KEY = "space" as const;
@@ -861,23 +871,6 @@ export type AppliedCommit = {
   schedulerDirtiedReaders?: SchedulerReaderIndexEntry[];
 };
 
-export type SchedulerActionKind =
-  | "computation"
-  | "effect"
-  | "event-handler";
-
-export type SchedulerObservationTransactionKind =
-  | "dependency-collection"
-  | "action-run"
-  | "event-preflight";
-
-export type SchedulerObservationAddress = {
-  space: string;
-  id: EntityId;
-  scope?: CellScope;
-  path: readonly string[];
-};
-
 export interface ResolvedSchedulerObservationAddress
   extends SchedulerObservationAddress {
   scopeKey: string;
@@ -885,48 +878,6 @@ export interface ResolvedSchedulerObservationAddress
 
 type SchedulerWriteAddress = SchedulerObservationAddress & {
   scopeKey?: string;
-};
-
-export type CompleteActionScopeSummary = {
-  version: 1;
-  complete: true;
-  implementationFingerprint: string;
-  runtimeFingerprint: string;
-  piece: SchedulerObservationAddress;
-  reads: SchedulerObservationAddress[];
-  writes: SchedulerObservationAddress[];
-  materializerWriteEnvelopes: SchedulerObservationAddress[];
-  directOutputs: SchedulerObservationAddress[];
-};
-
-export type SchedulerActionObservation = {
-  version: 1 | 2;
-  ownerSpace?: string;
-  branch: BranchName;
-  pieceId: string;
-  processGeneration: number;
-  actionId: string;
-  actionKind: SchedulerActionKind;
-  implementationFingerprint: string;
-  runtimeFingerprint: string;
-  completeActionScopeSummary?: CompleteActionScopeSummary;
-  observedAtSeq: number;
-  observedAtLocalSeq?: number;
-  transactionKind: SchedulerObservationTransactionKind;
-  reads: SchedulerObservationAddress[];
-  shallowReads: SchedulerObservationAddress[];
-  actualChangedWrites: SchedulerObservationAddress[];
-  currentKnownWrites: SchedulerObservationAddress[];
-  declaredWrites?: SchedulerObservationAddress[];
-  materializerWriteEnvelopes: SchedulerObservationAddress[];
-  ignoredSchedulingWrites?: SchedulerObservationAddress[];
-  actionOptions?: {
-    debounceMs?: number;
-    noDebounce?: boolean;
-    throttleMs?: number;
-  };
-  status: "success" | "failed";
-  errorFingerprint?: string;
 };
 
 const isSchedulerRecord = (

--- a/packages/runner/src/scheduler/persistent-observation.ts
+++ b/packages/runner/src/scheduler/persistent-observation.ts
@@ -45,6 +45,22 @@ export type CompleteActionScopeSummaryInput = Omit<
   "implementationFingerprint" | "runtimeFingerprint"
 >;
 
+/**
+ * A scheduler action observation as the runner produces it.
+ *
+ * A parallel declaration of the same concept lives in memory, at
+ * `memory/v2.ts`. The two are not the same type and differ in strictness:
+ *
+ * - addresses here are `IMemorySpaceAddress` (`space: MemorySpace`); memory
+ *   uses `SchedulerObservationAddress` (`space: string`)
+ * - `branch` here is `string`; memory declares it `BranchName`
+ *
+ * This side produces observations and memory stores them, so memory's is
+ * deliberately the wider of the pair. Nothing checks that they agree: the wire
+ * fields that carry an observation are declared `unknown` on the memory side,
+ * so a change to either declaration will not surface at the seam. Keep them in
+ * sync by hand until one of them owns the shape.
+ */
 export type SchedulerActionObservation = {
   version: 1 | 2;
   ownerSpace?: string;


### PR DESCRIPTION
Moves five scheduler **wire** types from `v2/engine.ts` into `v2.ts`, where the
other wire types live: `SchedulerActionKind`,
`SchedulerObservationTransactionKind`, `SchedulerObservationAddress`,
`CompleteActionScopeSummary`, and `SchedulerActionObservation`.

`engine.ts` re-exports all five, alongside the `SchedulerExecutionContextKey`
re-export it already had — so no consumer import changes. 2 files, no runtime
change.

`ResolvedSchedulerObservationAddress` and `SchedulerWriteAddress` stay in
`engine.ts`: they are engine-internal, not wire shapes.

## Why

`v2.ts` is the base module — `engine.ts` imports *from* it and nothing flows the
other way. So a wire type in `v2.ts` cannot reference one that lives downstream
in `engine.ts` without creating an import cycle, which this package is
particularly sensitive to.

These five ride on commits and snapshot results across the memory boundary, so
they belong on the wire side regardless. This is a prerequisite for typing
`schedulerObservation` / `observation`, which are currently `unknown`.

## What this deliberately does NOT do

It does not type those `unknown` fields. Attempting that surfaced a real problem:
**`SchedulerActionObservation` is defined twice.**

| | `packages/memory` (this one) | `runner/src/scheduler/persistent-observation.ts` |
| --- | --- | --- |
| addresses | `SchedulerObservationAddress` — `space: string` | `IMemorySpaceAddress` — `space: MemorySpace` |
| `branch` | `BranchName` | `string` |

Two structurally-parallel declarations of one wire concept, differing in
strictness. `observation: unknown` is what has been hiding the divergence —
nothing forced them to agree. Typing the field makes the seam fail: the memory
type yields the reads, the runner type is what test helpers accept, and they do
not unify.

Both declarations now carry a comment naming the other's location, the two
differences, and the reason drift goes unnoticed — the wire fields carrying an
observation are `unknown`, so neither declaration constrains the other.

Resolving it is a question about which side owns the shape (memory being wider
is arguably right for storage, or the strict definition should win everywhere),
so it is left for a follow-up rather than decided here.

Also measured and rejected: tightening `SchedulerObservationAddress.space` to
`MemorySpace` cascades to **127** errors, 118 of them in one test file that uses
plain strings for spaces.

## Test plan

- `deno task check` clean; `deno lint` / `deno fmt --check` exit 0.
- Full repo suite green on a clean, committed tree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move five scheduler wire types from `packages/memory/v2/engine.ts` to `packages/memory/v2.ts` so wire shapes live in the wire module and to avoid import cycles. `engine.ts` re-exports them; no consumer import changes and no runtime change.

- **Refactors**
  - Moved `SchedulerActionKind`, `SchedulerObservationTransactionKind`, `SchedulerObservationAddress`, `CompleteActionScopeSummary`, `SchedulerActionObservation` into `v2.ts`; re-exported from `v2/engine.ts`.
  - Kept engine-internal `ResolvedSchedulerObservationAddress` and `SchedulerWriteAddress` in `v2/engine.ts`.
  - Documented the parallel `SchedulerActionObservation` in `packages/runner/src/scheduler/persistent-observation.ts` and its differences; left `schedulerObservation` / `observation` fields as `unknown` for now to unblock follow-up typing.

<sup>Written for commit 8f852a5166a3a921bd50eccc5eb5ea3ad244e355. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

