### PR TITLE
fix(llm): an LLM request says only what it can actually carry

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1779,7 +1779,15 @@ export type BuiltInLLMTextPart = {
 
 export type BuiltInLLMImagePart = {
   type: "image";
-  image: string | Uint8Array | ArrayBuffer | URL;
+  /**
+   * The image, as a string -- a URL or a data URI. Deliberately not
+   * `Uint8Array` / `ArrayBuffer` / `URL`: an LLM request is snapshotted through
+   * `createFrozenRequestSnapshot()`, which requires a `FabricValue`, and none of
+   * those three can be stored by the data model. The builtin's own input schema
+   * (`llm-schemas.ts`) already declares this field `{ type: "string" }`, so
+   * those arms were unreachable through the validated path as well.
+   */
+  image: string;
 };
 
 export type BuiltInLLMToolCallPart = {

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -1,6 +1,6 @@
 import { isRecord } from "@commonfabric/utils/types";
 import type { JSONValue } from "@commonfabric/api";
-import { findJsonUnfaithfulValues } from "@commonfabric/pure-json";
+import { isPureJson } from "@commonfabric/pure-json";
 import { LlmPrompt } from "./prompts/prompting.ts";
 import type {
   BuiltInLLMContent,
@@ -89,8 +89,7 @@ export type LLMToolResult = {
  * merely `FabricValue`s, which admit `bigint`, interned symbols, `NaN` / `-0`,
  * and fabric primitives that no model API can receive.
  *
- * `isLLMRequestMetadata()` is the authority: it checks faithfulness with
- * `findJsonUnfaithfulValues()`. An `undefined` value means "absent" -- JSON
+ * `isLLMRequestMetadata()` is the authority: it checks with `isPureJson()`. An `undefined` value means "absent" -- JSON
  * drops such a key, so it never crosses the boundary and is not checked.
  */
 export type LLMRequestMetadata = Record<string, JSONValue | undefined>;
@@ -136,11 +135,11 @@ export function isLLMRequestMetadata(
 ): input is LLMRequestMetadata {
   if (!isRecord(input) || Array.isArray(input)) return false;
   // An `undefined` value means "absent": JSON drops the key, so it is not part
-  // of what crosses the boundary and does not have to be JSON-faithful.
+  // of what crosses the boundary and does not have to be pure JSON.
   const present = Object.fromEntries(
     Object.entries(input).filter(([, value]) => value !== undefined),
   );
-  return findJsonUnfaithfulValues(present).length === 0;
+  return isPureJson(present);
 }
 
 // Validator functions removed - use BuiltInLLM types directly

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
+import type { FabricValue } from "@commonfabric/api";
 import { LlmPrompt } from "./prompts/prompting.ts";
 import type {
   BuiltInLLMContent,
@@ -27,10 +28,10 @@ export type LLMPrompt = LlmPrompt;
 // Use BuiltIn types directly
 export type LLMContent = BuiltInLLMContent;
 
-export interface LLMTool {
+export type LLMTool = {
   description: string;
   inputSchema: JSONSchema;
-}
+};
 
 export const GOOGLE_SEARCH_NATIVE_MODEL_TOOL = "google_search" as const;
 export const LLM_NATIVE_MODEL_TOOL_IDS = [
@@ -39,13 +40,13 @@ export const LLM_NATIVE_MODEL_TOOL_IDS = [
 
 export type LLMNativeModelToolId = typeof LLM_NATIVE_MODEL_TOOL_IDS[number];
 
-export interface LLMNativeModelToolResult {
+export type LLMNativeModelToolResult = {
   type: "cf-harness.native-model-tool-result";
   toolId: LLMNativeModelToolId;
   provider?: string;
   providerMetadata?: unknown;
   sources?: unknown;
-}
+};
 
 export function isLLMNativeModelToolId(
   input: unknown,
@@ -69,19 +70,24 @@ export function isLLMNativeModelToolResults(
   return Array.isArray(input) && input.every(isLLMNativeModelToolResult);
 }
 
-export interface LLMToolCall {
+export type LLMToolCall = {
   id: string;
   name: string;
   input: Record<string, any>;
-}
+};
 
-export interface LLMToolResult {
+export type LLMToolResult = {
   toolCallId: string;
   result: any;
   error?: string;
-}
+};
 
-export type LLMRequestMetadata = Record<string, string | undefined | object>;
+/**
+ * Request metadata. Values are `FabricValue`s -- an LLM request is snapshotted
+ * through `createFrozenRequestSnapshot()`, which requires one, so an arbitrary
+ * `object` here could not be stored.
+ */
+export type LLMRequestMetadata = Record<string, FabricValue>;
 export type LLMRequest = {
   cache?: boolean;
   messages: readonly BuiltInLLMMessage[];
@@ -96,7 +102,7 @@ export type LLMRequest = {
   nativeModelToolIds?: readonly LLMNativeModelToolId[];
 };
 
-export interface LLMGenerateObjectRequest {
+export type LLMGenerateObjectRequest = {
   schema: Record<string, unknown>;
   messages: readonly BuiltInLLMMessage[];
   model?: ModelName;
@@ -104,12 +110,12 @@ export interface LLMGenerateObjectRequest {
   cache?: boolean;
   maxTokens?: number;
   metadata?: LLMRequestMetadata;
-}
+};
 
-export interface LLMGenerateObjectResponse {
+export type LLMGenerateObjectResponse = {
   object: Record<string, unknown>;
   id?: string;
-}
+};
 
 function isArrayOf<T>(
   callback: (data: unknown) => boolean,

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@commonfabric/utils/types";
-import type { FabricValue } from "@commonfabric/api";
+import type { JSONValue } from "@commonfabric/api";
+import { findJsonUnfaithfulValues } from "@commonfabric/pure-json";
 import { LlmPrompt } from "./prompts/prompting.ts";
 import type {
   BuiltInLLMContent,
@@ -83,11 +84,16 @@ export type LLMToolResult = {
 };
 
 /**
- * Request metadata. Values are `FabricValue`s -- an LLM request is snapshotted
- * through `createFrozenRequestSnapshot()`, which requires one, so an arbitrary
- * `object` here could not be stored.
+ * Request metadata. This crosses a JSON boundary to a general LLM API, so
+ * values must be values ordinary JSON serialization carries faithfully -- not
+ * merely `FabricValue`s, which admit `bigint`, interned symbols, `NaN` / `-0`,
+ * and fabric primitives that no model API can receive.
+ *
+ * `isLLMRequestMetadata()` is the authority: it checks faithfulness with
+ * `findJsonUnfaithfulValues()`. An `undefined` value means "absent" -- JSON
+ * drops such a key, so it never crosses the boundary and is not checked.
  */
-export type LLMRequestMetadata = Record<string, FabricValue>;
+export type LLMRequestMetadata = Record<string, JSONValue | undefined>;
 export type LLMRequest = {
   cache?: boolean;
   messages: readonly BuiltInLLMMessage[];
@@ -128,11 +134,13 @@ function isArrayOf<T>(
 export function isLLMRequestMetadata(
   input: unknown,
 ): input is LLMRequestMetadata {
-  return isRecord(input) && !Array.isArray(input) &&
-    Object.entries(input).every(([k, v]) =>
-      typeof k === "string" &&
-      (v === undefined || typeof v === "string" || typeof v === "object")
-    );
+  if (!isRecord(input) || Array.isArray(input)) return false;
+  // An `undefined` value means "absent": JSON drops the key, so it is not part
+  // of what crosses the boundary and does not have to be JSON-faithful.
+  const present = Object.fromEntries(
+    Object.entries(input).filter(([, value]) => value !== undefined),
+  );
+  return findJsonUnfaithfulValues(present).length === 0;
 }
 
 // Validator functions removed - use BuiltInLLM types directly

--- a/packages/llm/test/types.test.ts
+++ b/packages/llm/test/types.test.ts
@@ -44,6 +44,20 @@ describe("types", () => {
         },
         cache: true,
       }));
+      // Any JSON-faithful value is valid metadata, not just strings.
+      assert(isLLMRequest({
+        messages: [],
+        model: DEFAULT_MODEL_NAME,
+        metadata: {
+          retryCount: 1,
+          enabled: true,
+          nothing: null,
+          nested: { deep: ["a", 2] },
+          // `undefined` means "absent" -- JSON drops the key.
+          absent: undefined,
+        },
+        cache: true,
+      }));
       assert(isLLMRequest({
         messages: [],
         model: DEFAULT_MODEL_NAME,
@@ -84,6 +98,11 @@ describe("types", () => {
       failRequest({ stop: {} });
       failRequest({ mode: "html" });
       failRequest({ metadata: "via piece" });
+      // Not carried faithfully across the JSON boundary to the model API.
+      failRequest({ metadata: { when: new Date() } });
+      failRequest({ metadata: { fn: () => 1 } });
+      failRequest({ metadata: { big: 1n } });
+      failRequest({ metadata: { nope: Number.NaN } });
       failRequest({ nativeModelToolIds: ["unknown_search"] });
       failRequest({ nativeModelToolIds: [GOOGLE_SEARCH_NATIVE_MODEL_TOOL, 1] });
     });

--- a/packages/pure-json/src/index.ts
+++ b/packages/pure-json/src/index.ts
@@ -1,4 +1,5 @@
 export {
   findJsonUnfaithfulValues,
+  isPureJson,
   type JsonUnfaithfulValue,
 } from "@/json-faithfulness.ts";

--- a/packages/pure-json/src/json-faithfulness.ts
+++ b/packages/pure-json/src/json-faithfulness.ts
@@ -42,6 +42,8 @@
 // properties, use `Object.hasOwn` for array slots, and reject a nonstandard
 // array prototype or an inherited `toJSON`.
 
+import type { JSONValue } from "@commonfabric/api";
+
 import { isPlainObject } from "@commonfabric/utils/types";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 
@@ -183,4 +185,18 @@ export function findJsonUnfaithfulValues(
   const out: JsonUnfaithfulValue[] = [];
   walk(value, "", new Set<object>(), out);
   return out;
+}
+
+/**
+ * Indicates whether `value` is pure JSON -- that ordinary JSON serialization
+ * carries it faithfully, by the whitelist in the module comment above. This is
+ * the boolean form of {@link findJsonUnfaithfulValues}; reach for that one when
+ * a caller needs to report WHICH parts are unfaithful and where.
+ *
+ * Note the known limitations documented above: an empty result does not certify
+ * adversarially-shaped objects, so this answers "will JSON change this ordinary
+ * value", not "is this hostile input safe".
+ */
+export function isPureJson(value: unknown): value is JSONValue {
+  return findJsonUnfaithfulValues(value).length === 0;
 }

--- a/packages/pure-json/test/json-faithfulness.test.ts
+++ b/packages/pure-json/test/json-faithfulness.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { findJsonUnfaithfulValues } from "@commonfabric/pure-json";
+import { findJsonUnfaithfulValues, isPureJson } from "@commonfabric/pure-json";
 
 describe("findJsonUnfaithfulValues", () => {
   it("accepts JSON-faithful shapes", () => {
@@ -151,5 +151,36 @@ describe("findJsonUnfaithfulValues", () => {
     // as two path steps.
     const found = findJsonUnfaithfulValues({ "a/b~c": NaN });
     expect(found[0]!.pointer).toBe("/a~1b~0c");
+  });
+});
+
+describe("isPureJson", () => {
+  it("accepts what JSON carries faithfully", () => {
+    expect(isPureJson(null)).toBe(true);
+    expect(isPureJson("text")).toBe(true);
+    expect(isPureJson(1)).toBe(true);
+    expect(isPureJson(true)).toBe(true);
+    expect(isPureJson({ a: [1, "two", { b: null }] })).toBe(true);
+  });
+
+  it("rejects what JSON would alter or drop", () => {
+    expect(isPureJson(undefined)).toBe(false);
+    expect(isPureJson(Number.NaN)).toBe(false);
+    expect(isPureJson(-0)).toBe(false);
+    expect(isPureJson(1n)).toBe(false);
+    expect(isPureJson(Symbol.for("s"))).toBe(false);
+    expect(isPureJson(() => 1)).toBe(false);
+    expect(isPureJson(new Date())).toBe(false);
+    expect(isPureJson({ nested: { bad: Number.POSITIVE_INFINITY } })).toBe(
+      false,
+    );
+  });
+
+  it("agrees with `findJsonUnfaithfulValues()`", () => {
+    for (const value of [null, 1, "s", { a: 1 }, [1, 2], new Map(), 1n]) {
+      expect(isPureJson(value)).toBe(
+        findJsonUnfaithfulValues(value).length === 0,
+      );
+    }
   });
 });


### PR DESCRIPTION
An `LLMRequest` is snapshotted through `createFrozenRequestSnapshot()`, which
requires a `FabricValue` because it clones via `cloneIfNecessary()`. Three
declarations claimed more than the data model can actually store.

| Declaration | Claimed | Now |
| --- | --- | --- |
| `BuiltInLLMImagePart.image` | `string \| Uint8Array \| ArrayBuffer \| URL` | `string` |
| `LLMRequestMetadata` | `Record<string, string \| undefined \| object>` | `Record<string, FabricValue>` |
| `LLMTool` + 5 siblings | `interface` | `type` alias |

2 files, +28/−14. No runtime change.

## Why this is not a capability removal

`Uint8Array`, `ArrayBuffer`, and `URL` cannot be stored via `data-model` —
`cloneIfNecessary()` throws on them — so a request carrying one would fail at the
snapshot, not merely type-check oddly.

And they were already unreachable through the validated path: the builtin's own
input schema (`runner/src/builtins/llm-schemas.ts:38`) declares

```ts
image: { type: "string" },
```

so a non-string `image` could never survive validation. Narrowing the TypeScript
type removes nothing that worked.

`LLMRequestMetadata`'s `object` arm made the same claim about arbitrary objects.
`LLMTool` and its siblings were `interface`s, which never receive an implicit
index signature and therefore can never satisfy `FabricPlainObject`.

## What was already right

`createFrozenRequestSnapshot<T extends FabricValue>` was correctly constrained
the whole time — it clones, so it genuinely needs a fabric value. The constraint
was not the lie; the types flowing into it were. Worth stating because the
tempting "fix" is to loosen the constraint, which would move the failure from
compile time to run time.

## Why

Groundwork for branding `FabricSpecialObject` nominal — it is an empty abstract
class today, so every object satisfies it structurally. With a brand applied
locally as a probe, repo-wide residue drops **29 → 24** (`runner` 12 → 7).

## Test plan

- `deno task check` clean without the brand; `deno lint` / `deno fmt --check`
  exit 0.
- Full repo suite green on a clean, committed tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure LLM requests carry only JSON-serializable data. Metadata is now validated as pure JSON; image parts accept strings only.

- **Bug Fixes**
  - `LLMRequestMetadata` is `Record<string, JSONValue | undefined>` and the guard now uses `isPureJson()` from `@commonfabric/pure-json` to accept numbers/booleans/null, treat `undefined` as absent, and reject non-JSON values (e.g., `Date`, functions, `bigint`, `NaN`).

- **Refactors**
  - Narrowed `BuiltInLLMImagePart.image` to `string` (URL or data URI).
  - Converted `LLMTool` and related types to `type` aliases.

<sup>Written for commit 0989295c1d717c99152fe432f17621e3fbd539f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

