### PR TITLE
fix(runner): narrow fabric values without discarding their type

### DIFF
--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -27,6 +27,7 @@ export {
 } from "./value-clone.ts";
 
 export {
+  isFabricObjectOrArray,
   isFabricPlainObject,
   isFabricValue,
   isFabricValueLayer,

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -11,8 +11,9 @@ import { BaseFabricInstance } from "./fabric-instances/BaseFabricInstance.ts";
 import { BaseFabricPrimitive } from "./fabric-primitives/BaseFabricPrimitive.ts";
 
 /**
- * Indicates whether the value is a fabric value, accepting `FabricInstance`
- * values, `undefined`, and arrays with `undefined` elements or sparse holes
+ * Indicates whether the value is a fabric value, accepting
+ * `FabricSpecialObject`s (both `FabricInstance` and `FabricPrimitive`),
+ * `undefined`, and arrays with `undefined` elements or sparse holes
  * -- in addition to the base fabric types (`null`, `boolean`, `number`,
  * `string`, plain objects, dense arrays).
  *
@@ -44,7 +45,7 @@ export function isFabricValueLayer(
         return isArrayWithOnlyIndexProperties(value);
       }
       // Plain objects are accepted; class instances are not (except
-      // `FabricInstance`, handled above).
+      // `FabricSpecialObject`, handled above).
       const proto = Object.getPrototypeOf(value);
       return proto === null || proto === Object.prototype;
     }
@@ -152,6 +153,32 @@ export function isFabricValue(value: unknown): value is FabricValue {
   };
 
   return check(value);
+}
+
+/**
+ * Indicates whether a fabric value is a plain object, an array, or a
+ * `FabricSpecialObject` -- everything a `typeof value === "object"` test
+ * accepts, minus `null`. The name spells out the array case because "object"
+ * alone reads as excluding it, and treating arrays as excluded here is a real
+ * hazard: the array arm carries the per-index walk in change detection.
+ *
+ * The runtime behavior matches a bare `isRecord()` exactly. The difference is
+ * static: `isRecord()` narrows to `Record<string | number | symbol, unknown>`,
+ * which discards the fact that the value is a `FabricValue` -- so a guarded
+ * value can no longer be handed to a `FabricValue` API. This keeps that half.
+ *
+ * Contrast `isFabricPlainObject()`, which is strictly narrower at RUNTIME: it
+ * accepts only plain objects, rejecting arrays and `FabricSpecialObject`s. The
+ * two are not interchangeable.
+ */
+export function isFabricObjectOrArray(
+  value: FabricValue,
+): value is FabricValue & object;
+export function isFabricObjectOrArray(
+  value: Immutable<FabricValue>,
+): value is Immutable<FabricValue> & object;
+export function isFabricObjectOrArray(value: unknown): boolean {
+  return typeof value === "object" && value !== null;
 }
 
 /**

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -159,8 +159,7 @@ export function isFabricValue(value: unknown): value is FabricValue {
  * Indicates whether a fabric value is a plain object, an array, or a
  * `FabricSpecialObject` -- everything a `typeof value === "object"` test
  * accepts, minus `null`. The name spells out the array case because "object"
- * alone reads as excluding it, and treating arrays as excluded here is a real
- * hazard: the array arm carries the per-index walk in change detection.
+ * alone reads as excluding it.
  *
  * The runtime behavior matches a bare `isRecord()` exactly. The difference is
  * static: `isRecord()` narrows to `Record<string | number | symbol, unknown>`,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -9,6 +9,7 @@ import {
   internSchemaAsTaggedHashString,
 } from "@commonfabric/data-model/schema-hash";
 import { emptySchemaObject } from "@commonfabric/data-model/schema-utils";
+import { isFabricObjectOrArray } from "@commonfabric/data-model/fabric-value";
 import {
   cloneForMutation,
   type CloneForMutationResult,
@@ -2639,7 +2640,7 @@ export const writeDetailValueForTarget = (
     return baseValue;
   }
 
-  if (!(isRecord(baseValue) || Array.isArray(baseValue))) {
+  if (!(isFabricObjectOrArray(baseValue) || Array.isArray(baseValue))) {
     // Base isn't a container yet deeper writes exist (rare/incoherent): build a
     // fresh container and overlay onto it (it's freshly mutable -- no COW).
     const result: Record<PropertyKey, unknown> | unknown[] =

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2640,7 +2640,7 @@ export const writeDetailValueForTarget = (
     return baseValue;
   }
 
-  if (!(isFabricObjectOrArray(baseValue) || Array.isArray(baseValue))) {
+  if (!isFabricObjectOrArray(baseValue)) {
     // Base isn't a container yet deeper writes exist (rare/incoherent): build a
     // fresh container and overlay onto it (it's freshly mutable -- no COW).
     const result: Record<PropertyKey, unknown> | unknown[] =

--- a/packages/runner/src/storage/differential.ts
+++ b/packages/runner/src/storage/differential.ts
@@ -1,9 +1,11 @@
 import { unclaimed } from "@commonfabric/memory/fact";
+import type { FabricPlainObject } from "@commonfabric/api";
+import { isFabricObjectOrArray } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/api";
 import {
   FabricSpecialObject,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
-import { isRecord } from "@commonfabric/utils/types";
 import type {
   IMemoryAddress,
   IMemoryChange,
@@ -59,8 +61,8 @@ const pushChangedPath = (
 };
 
 const collectChangedPaths = (
-  before: unknown,
-  after: unknown,
+  before: FabricValue,
+  after: FabricValue,
   currentPath: string[],
   depth: number,
   paths: string[][],
@@ -74,7 +76,7 @@ const collectChangedPaths = (
     return;
   }
 
-  if (isRecord(before) && isRecord(after)) {
+  if (isFabricObjectOrArray(before) && isFabricObjectOrArray(after)) {
     if (valueEqual(before, after)) {
       return;
     }
@@ -142,8 +144,12 @@ const collectChangedPaths = (
       return;
     }
 
-    const beforeKeys = Object.keys(before);
-    const afterKeys = Object.keys(after);
+    // Both are plain objects here: `FabricSpecialObject`s and arrays returned
+    // above. Narrowing does not carry those exclusions forward, so name it.
+    const beforeObject = before as FabricPlainObject;
+    const afterObject = after as FabricPlainObject;
+    const beforeKeys = Object.keys(beforeObject);
+    const afterKeys = Object.keys(afterObject);
 
     if (beforeKeys.length === afterKeys.length) {
       let sameKeys = true;
@@ -158,8 +164,8 @@ const collectChangedPaths = (
         for (const key of beforeKeys) {
           currentPath[depth] = key;
           collectChangedPaths(
-            before[key],
-            after[key],
+            beforeObject[key],
+            afterObject[key],
             currentPath,
             depth + 1,
             paths,
@@ -177,8 +183,8 @@ const collectChangedPaths = (
       currentPath[depth] = key;
       if (afterHas) {
         collectChangedPaths(
-          before[key],
-          after[key],
+          beforeObject[key],
+          afterObject[key],
           currentPath,
           depth + 1,
           paths,

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
+import type { FabricPlainObject } from "@commonfabric/api";
 import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
@@ -100,7 +101,7 @@ describe("CFC existence channel (SC-4, freeze-at-creation)", () => {
     rt: Runtime,
     sourceId: string | undefined,
     outCause: string,
-    value: Record<string, unknown>,
+    value: FabricPlainObject,
     writePath: string[] = [],
   ): Promise<string> => {
     const tx = rt.edit();
@@ -996,7 +997,7 @@ describe("CFC existence channel (SC-4, freeze-at-creation)", () => {
       copied: true,
     });
 
-    const overwrite = async (value: Record<string, unknown>) => {
+    const overwrite = async (value: FabricPlainObject) => {
       const tx = rt.edit();
       tx.writeOrThrow(
         { space, scope: "space", id: uri(outId), path: ["value"] },


### PR DESCRIPTION
Adds `isFabricObjectOrArray()` to `data-model` and uses it where a `FabricValue`
needs an object-or-array guard. 5 files, +46/−12.

```ts
export function isFabricObjectOrArray(
  value: FabricValue,
): value is FabricValue & object;
```

`isRecord()` narrows to `Record<string | number | symbol, unknown>`, which throws
away the fact that the value is a `FabricValue` — so a guarded value can no
longer be passed to a `FabricValue` API. The new predicate keeps that half. Its
runtime behavior is the *same expression*
(`typeof value === "object" && value !== null`), so what enters a guarded block
does not change.

## Why not `isFabricPlainObject()`

Because it is **not** a substitute — it is strictly narrower at runtime
(`isPlainObject`, i.e. plain objects only, rejecting arrays and
`FabricSpecialObject`s).

Swapping it in was tried earlier in this arc (#5047) and made two paths in
`differential.ts` unreachable: the `instanceof FabricSpecialObject` leaf case and
the entire array-diffing walk. Change detection fell through to a trailing
`valueEqual()`, emitting one change at the parent path instead of per-index
paths. **The full suite stayed green** — the failure mode was notification
granularity, not correctness — and only the coverage gate caught it (+41
uncovered lines against 1 attributable added line).

Both contrasts are now documented at the definition, since that is where the
mistake was available to be made.

## On the name

"object" alone reads as excluding arrays — that ambiguity is what produced the
bug above, so the name spells the array case out. Here the array arm is
load-bearing: it carries the per-index walk in change detection.

## Sites

- `storage/differential.ts` — `collectChangedPaths`'s `before`/`after` are now
  `FabricValue`, which is what callers were already passing (`addStateChange`
  hands the same values to `valueEqual`). The key-walk takes one named cast:
  narrowing cannot carry "not a special object, not an array" forward from the
  earlier returns.
- `cfc/prepare.ts` — same guard, same reasoning.
- `test/cfc-existence-channel.test.ts` — two test locals typed
  `FabricPlainObject`.

Also corrects two comments in `isFabricValueLayer()` that said `FabricInstance`
where the check is `instanceof FabricSpecialObject` — they understated it by
excluding `FabricPrimitive`.

## Why

Groundwork for branding `FabricSpecialObject` nominal. With a brand applied
locally as a probe, residue drops **29 → 24** on this branch, and to 18 once
#5051 lands.

## Test plan

- `deno task check` clean without the brand; `deno lint` / `deno fmt --check`
  exit 0.
- Full repo suite green, including the rename. The only later edits are the two
  `isFabricValueLayer()` doc comments.
