### PR TITLE
refactor(memory): add `encodeMemoryBoundaryUnprovenFabricValue()`

### DIFF
--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -6,6 +6,7 @@ import { Server, SessionRegistry } from "../v2/server.ts";
 import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,
+  encodeMemoryBoundaryUnprovenFabricValue,
   type EntitySnapshot,
   getMemoryProtocolFlags,
   MEMORY_PROTOCOL,
@@ -65,7 +66,7 @@ const handshakeTransport = (
         return Promise.resolve();
       }
       if (message.type === "session.open") {
-        receiver(encodeMemoryBoundary({
+        receiver(encodeMemoryBoundaryUnprovenFabricValue({
           type: "response",
           requestId: message.requestId!,
           ok: {

--- a/packages/memory/test/v2-restore-flush-test.ts
+++ b/packages/memory/test/v2-restore-flush-test.ts
@@ -2,7 +2,10 @@ import { assert, assertEquals } from "@std/assert";
 import { defer } from "@commonfabric/utils/defer";
 import { Server } from "../v2/server.ts";
 import { connect, type Transport } from "../v2/client.ts";
-import { decodeMemoryBoundary, encodeMemoryBoundary } from "../v2.ts";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundaryUnprovenFabricValue,
+} from "../v2.ts";
 import {
   testSessionOpenAuthFactory,
   testSessionOpenServerOptions,
@@ -116,7 +119,7 @@ class ReconnectableTransport implements Transport {
         const localSeq = typeof requestId === "string"
           ? this.#transactRequestLocalSeqById.get(requestId)
           : undefined;
-        const payload = encodeMemoryBoundary(message);
+        const payload = encodeMemoryBoundaryUnprovenFabricValue(message);
         if (
           this.#delayTransacts &&
           typeof requestId === "string" &&

--- a/packages/memory/test/v2-server-acl-test.ts
+++ b/packages/memory/test/v2-server-acl-test.ts
@@ -4,6 +4,7 @@ import { Database } from "@db/sqlite";
 import { Server } from "../v2/server.ts";
 import {
   encodeMemoryBoundary,
+  encodeMemoryBoundaryUnprovenFabricValue,
   getMemoryProtocolFlags,
   type GraphQueryResult,
   type HelloOkMessage,
@@ -112,7 +113,7 @@ const transactOperation = async (
   operation: Record<string, unknown>,
   localSeq: number,
 ): Promise<ResponseMessage<{ seq: number }>> => {
-  await connection.receive(encodeMemoryBoundary({
+  await connection.receive(encodeMemoryBoundaryUnprovenFabricValue({
     type: "transact",
     requestId: nextRequestId("tx"),
     space,

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -18,6 +18,7 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { JSONSchema } from "@commonfabric/api";
 import {
   encodeMemoryBoundary,
+  encodeMemoryBoundaryUnprovenFabricValue,
   type EntityDocument,
   getMemoryProtocolFlags,
   type HelloOkMessage,
@@ -48,7 +49,7 @@ import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
 const textEncoder = new TextEncoder();
 
 const encodedBytes = (value: ServerMessage): number =>
-  textEncoder.encode(encodeMemoryBoundary(value)).byteLength;
+  textEncoder.encode(encodeMemoryBoundaryUnprovenFabricValue(value)).byteLength;
 
 const largeSchema = (): JSONSchema => ({
   type: "object",
@@ -146,12 +147,13 @@ Deno.test("sync schema table experiment captures repeated schema savings", () =>
   const message = syncEffect(sync);
   const bytes = encodedBytes(message);
   const schemaMarkerCount =
-    encodeMemoryBoundary(message).split("$defs").length -
+    encodeMemoryBoundaryUnprovenFabricValue(message).split("$defs").length -
     1;
   const compressed = compressServerMessageSchemas(message);
   const compressedBytes = encodedBytes(compressed);
-  const compressedSchemaMarkerCount = encodeMemoryBoundary(compressed)
-    .split("$defs").length - 1;
+  const compressedSchemaMarkerCount =
+    encodeMemoryBoundaryUnprovenFabricValue(compressed)
+      .split("$defs").length - 1;
   const expanded = expandServerMessageSchemas(compressed);
 
   assertEquals(expanded, message);

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -981,6 +981,38 @@ export const wireMemoryProtocolFlags = (
 export const encodeMemoryBoundary = (value: FabricValue): string =>
   jsonFromValue(value);
 
+/**
+ * Encodes a wire payload that the type system cannot yet prove is a
+ * `FabricValue`. Identical to `encodeMemoryBoundary()` in every respect but the
+ * declared parameter type; prefer that one wherever it type-checks.
+ *
+ * The memory protocol's own message types are the callers here. They are
+ * fabric values in fact — they cross this boundary on every request and
+ * response, and would fail loudly if they were not — but they cannot be
+ * *stated* as such, because several of their fields are declared `unknown`
+ * (notably `SchedulerActionSnapshotResult.observation`, and `SqliteDbRef`'s
+ * `tables`, whose `TableSchema` carries a `[key: string]: unknown` catch-all).
+ * A type containing an `unknown` field is not assignable to `FabricValue`, so
+ * the whole enclosing message is rejected however sound its actual contents.
+ *
+ * What is given up is narrower than it looks: the encoding *verifies*. A value
+ * that no codec can represent throws — at any depth, naming the offending
+ * subvalue ("Cannot encode new ArrayBuffer(...): no applicable codec"). So this
+ * trades a compile-time guarantee for a runtime one that already ran, rather
+ * than for no guarantee at all. What it does lose is the early, local report:
+ * a bad value is caught at the encode, not at the assignment that introduced
+ * it.
+ *
+ * Every use marks a declaration that has not been tightened yet, which is why
+ * the name is what it is — the count of callers is the size of the remaining
+ * job, and `grep` measures it. As those `unknown` fields acquire real types,
+ * move the corresponding calls back to `encodeMemoryBoundary()`; when the last
+ * one moves, delete this.
+ */
+export const encodeMemoryBoundaryUnprovenFabricValue = (
+  value: unknown,
+): string => jsonFromValue(value as FabricValue);
+
 export const commitPreconditionValueHash = (value: FabricValue): string =>
   hashStringOf(encodeMemoryBoundary(value));
 

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -3,6 +3,7 @@ import {
   compatibleMemoryProtocolFlags,
   decodeMemoryBoundary,
   encodeMemoryBoundary,
+  encodeMemoryBoundaryUnprovenFabricValue,
   type EntitySnapshot,
   getMemoryProtocolFlags,
   getPersistentSchedulerStateConfig,
@@ -190,7 +191,7 @@ export class Client {
     const requestId = message.requestId as string;
     const pending = Promise.withResolvers<unknown>();
     this.#pending.set(requestId, pending);
-    await this.transport.send(encodeMemoryBoundary(message));
+    await this.transport.send(encodeMemoryBoundaryUnprovenFabricValue(message));
     const result = await pending.promise as ResponseMessage<Result>;
     if (result.error) {
       const error = new Error(result.error.message);
@@ -1477,7 +1478,7 @@ export const connect = Client.connect;
 export const loopback = (server: Server): Transport => {
   let receiver = (_payload: string) => {};
   const connection = server.connect((message) => {
-    receiver(encodeMemoryBoundary(message));
+    receiver(encodeMemoryBoundaryUnprovenFabricValue(message));
   });
   return {
     async send(payload: string) {

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -21,6 +21,7 @@ import {
   decodeMemoryBoundary,
   DEFAULT_BRANCH,
   encodeMemoryBoundary,
+  encodeMemoryBoundaryUnprovenFabricValue,
   type EntityDocument,
   type EntityId,
   isEntityDocument,
@@ -4965,7 +4966,7 @@ const applyCommitTransaction = (
   const authorizationRef = engine.legacyCommitMetadataRefsRequired
     ? LEGACY_EMPTY_AUTHORIZATION_REF
     : null;
-  const original = encodeMemoryBoundary(commit);
+  const original = encodeMemoryBoundaryUnprovenFabricValue(commit);
   const resolution = encodeMemoryBoundary(
     resolvedPendingReads.length > 0 ? { seq, resolvedPendingReads } : { seq },
   );
@@ -4981,7 +4982,9 @@ const applyCommitTransaction = (
       aud: LEGACY_EMPTY_INVOCATION.aud ?? null,
       cmd: LEGACY_EMPTY_INVOCATION.cmd,
       sub: LEGACY_EMPTY_INVOCATION.sub,
-      invocation: encodeMemoryBoundary(LEGACY_EMPTY_INVOCATION),
+      invocation: encodeMemoryBoundaryUnprovenFabricValue(
+        LEGACY_EMPTY_INVOCATION,
+      ),
     });
   }
   engine.statements.insertCommit.run({
@@ -6400,7 +6403,7 @@ const sameStoredOriginal = (
   stored: string,
   incoming: ClientCommit,
 ): boolean => {
-  return stored === encodeMemoryBoundary(incoming);
+  return stored === encodeMemoryBoundaryUnprovenFabricValue(incoming);
 };
 
 const revisionKey = (

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -8,6 +8,7 @@ import {
   dbNeedsColumnProvenance,
   decodeMemoryBoundary,
   encodeMemoryBoundary,
+  encodeMemoryBoundaryUnprovenFabricValue,
   type EntityDocument,
   getPersistentSchedulerStateConfig,
   type GraphQuery,
@@ -3213,7 +3214,9 @@ export class Server {
     if (parsed?.type === "hello") {
       const response = respondToHello(parsed);
       if (response.type !== "hello.ok") {
-        return Promise.resolve(encodeMemoryBoundary(response));
+        return Promise.resolve(
+          encodeMemoryBoundaryUnprovenFabricValue(response),
+        );
       }
       return Promise.resolve(encodeMemoryBoundary({
         type: "response",

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -12,7 +12,7 @@
  * bundles.
  */
 
-import { encodeMemoryBoundary } from "../v2.ts";
+import { encodeMemoryBoundaryUnprovenFabricValue } from "../v2.ts";
 import * as MemoryServer from "./server.ts";
 import { verifySessionOpenAuthorization } from "./session-open-auth.ts";
 import { Identity } from "@commonfabric/identity";
@@ -72,7 +72,7 @@ export class StandaloneMemoryServer {
       const connectionTag = nextConnectionTag++;
       const connection = memory.connect((message) => {
         if (socket.readyState === WebSocket.OPEN) {
-          socket.send(encodeMemoryBoundary(message));
+          socket.send(encodeMemoryBoundaryUnprovenFabricValue(message));
         }
       });
       const debugWrites = Deno.env.get("CF_DEBUG_MEMORY_WRITES") === "1";

--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -4,7 +4,7 @@ import { defer } from "@commonfabric/utils/defer";
 import type { MIME, URI } from "@commonfabric/memory/interface";
 import {
   decodeMemoryBoundary,
-  encodeMemoryBoundary,
+  encodeMemoryBoundaryUnprovenFabricValue,
   type EntityDocument,
 } from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
@@ -113,7 +113,7 @@ class SabotagedReconnectTransport implements MemoryV2Client.Transport {
       this.onConnectionCount?.(this.connectionCount);
       this.#connection = this.server.connect((message) => {
         if (!this.#dropResponses) {
-          this.#receiver(encodeMemoryBoundary(message));
+          this.#receiver(encodeMemoryBoundaryUnprovenFabricValue(message));
         }
       });
     }

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -1,5 +1,5 @@
 import type { AppRouteHandler } from "@/lib/types.ts";
-import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
+import { encodeMemoryBoundaryUnprovenFabricValue } from "@commonfabric/memory/v2";
 import * as MemoryServer from "@commonfabric/memory/v2/server";
 import type * as Routes from "./memory.routes.ts";
 import { memoryServer } from "../memory.ts";
@@ -166,7 +166,7 @@ const attachMemorySocketPipeline = (
     if (socket.readyState !== WebSocket.OPEN) {
       return;
     }
-    socket.send(encodeMemoryBoundary(message));
+    socket.send(encodeMemoryBoundaryUnprovenFabricValue(message));
   });
   const closeConnection = () => {
     connection.close();


### PR DESCRIPTION
Adds a companion to `encodeMemoryBoundary()` that takes `unknown` rather than
`FabricValue`, and moves to it the call sites whose arguments cannot be
statically shown to be fabric values. No runtime change: both functions call
`jsonFromValue()` on the same value.

**15 of 255 call sites move.** The other 240 keep the checked contract.

## Why

The memory protocol's own message types are the callers that move. They are
fabric values in fact — they cross this boundary on every request and response,
and would fail loudly otherwise — but they cannot be *stated* as such, because
several of their fields are declared `unknown`: notably
`SchedulerActionSnapshotResult.observation`, and `SqliteDbRef`'s `tables`, whose
`TableSchema` carries a `[key: string]: unknown` catch-all. A type containing an
`unknown` field is not assignable to `FabricValue`, so the whole enclosing
message is rejected however sound its actual contents.

This surfaced under a local experiment that gives `FabricSpecialObject` a
nominal brand — an empty abstract class today, so structurally every object
satisfies it. Branding it is the goal of the wider arc; these 15 sites were the
largest remaining group of fallout. **This change stands on its own without the
brand** (`deno task check` is green either way); the brand is not part of it.

## Why a companion rather than retyping the parameter

Retyping `encodeMemoryBoundary`'s parameter to `unknown` was measured first. It
reaches the same end state, but discards static checking on all 255 calls to
accommodate 15.

A companion localizes that. The deliberately unlovely name is the point: every
use marks a declaration that has not been tightened yet, so the caller count is
the size of the remaining job and `grep` reports it. When the last call migrates
back, the function is deleted.

## What is given up

Narrower than it looks. The encoding *verifies*: a value no codec can represent
throws, at any depth, naming the offending subvalue.

```
URL          -> THROW Cannot encode "https://x.example/": no applicable codec.
ArrayBuffer  -> THROW Cannot encode new ArrayBuffer(...): no applicable codec.
nested URL   -> THROW Cannot encode "https://x.example/": no applicable codec.
plain ok     -> OK   fvj1:{"a":1,"b":[true,null,"s"]}
```

So this trades a compile-time guarantee for a runtime one that already ran,
rather than for no guarantee at all. What it does lose is the early, local
report: a bad value is caught at the encode, not at the assignment that
introduced it. The doc comment says so.

One of the moved sites is `test/v2-server-acl-test.ts`, which passes
`[operation as unknown as Operation]` under a comment noting the suite
deliberately feeds the server payloads it must reject — a call site that is
supposed to carry an unproven value.

## Test plan

- Full repo suite green (exit 0, 200.6s), `memory` 439/439.
- `deno task check`, `deno fmt --check`, `deno lint` all green.
- Both functions delegate to `jsonFromValue()` with no other difference, so
  encoded output is unchanged at every moved site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `encodeMemoryBoundaryUnprovenFabricValue()` to handle memory protocol messages the type system can’t yet prove are `FabricValue`. Moved 15 call sites to it; runtime behavior is unchanged since both encoders delegate to `jsonFromValue()`.

- **Refactors**
  - Keep `encodeMemoryBoundary()` typed to `FabricValue` for the other 240 call sites.
  - Use the new API in `@commonfabric/memory/v2` client, server, engine, standalone WebSocket, tests, and the Toolshed route bridge.
  - Reason: some message fields are `unknown` (e.g., `SchedulerActionSnapshotResult.observation`, `SqliteDbRef.tables`), so these payloads can’t be statically typed as `FabricValue` yet. This change isolates those cases for future tightening.

<sup>Written for commit 4761192a7931d6cfafa9e94b4de321f163074196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Coverage

`packages/memory` rises by 2 uncovered lines. Both are `deno fmt` rewrapping an
**already-uncovered** call site, because the new identifier is longer:

```ts
// before — one line, uncovered
return Promise.resolve(encodeMemoryBoundary(response));

// after — three lines, same uncovered branch
return Promise.resolve(
  encodeMemoryBoundaryUnprovenFabricValue(response),
);
```

That is `v2/server.ts` (the non-`hello.ok` branch) and `v2/engine.ts` (the
`legacyCommitMetadataRefsRequired` branch). Verified by running the memory
suite under coverage on this branch and on `main` and diffing per file: 958 →
960, +1 in each of those two files, with no other file changing. No code became
unreachable and no branch lost a test.

Accepting rather than reshaping the code to match a line count.

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/memory uncovered lines = 1304 lines
