### PR TITLE
test(memory): type three wire fixtures as what they hold

### DIFF
--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -1262,8 +1262,8 @@ class ReconnectableLoopbackTransport implements Transport {
       if (this.connectionCount >= 2) {
         this.#reconnected.resolve();
       }
-      this.#connection = this.server.connect((message: FabricValue) => {
-        this.#receiver(encodeMemoryBoundary(message));
+      this.#connection = this.server.connect((message) => {
+        this.#receiver(encodeMemoryBoundaryUnprovenFabricValue(message));
       });
     }
     return this.#connection;

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -13,7 +13,10 @@ import {
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type {
+  FabricPlainObject,
+  FabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { JSONSchema } from "@commonfabric/api";
 import {
@@ -182,10 +185,9 @@ Deno.test("sync schema table reports each repeated schema once", () => {
 });
 
 Deno.test("sync schema table preserves own __proto__ fields", () => {
-  const value = JSON.parse('{"__proto__":{"safe":true}}') as Record<
-    string,
-    unknown
-  >;
+  const value = JSON.parse(
+    '{"__proto__":{"safe":true}}',
+  ) as FabricPlainObject;
   value.ref = linkRefFrom({
     id: "of:target",
     path: [],
@@ -682,7 +684,7 @@ Deno.test("sync schema table rejects refs without a populated table", () => {
 
 Deno.test("sync schema table validates dangling refs without recursive traversal", () => {
   const danglingRef = "schema-ref@2:sha256:missing";
-  let deeplyNested: unknown = {
+  let deeplyNested: FabricValue = {
     $alias: {
       id: "of:deep-target",
       path: [],


### PR DESCRIPTION
Three test-local annotations understated the values they held. All three are
accepted today only because `FabricSpecialObject` is an empty abstract class, so
structurally every object satisfies it.

| File | Was | Now |
| --- | --- | --- |
| `test/v2-client-test.ts` | callback annotated `(message: FabricValue)` | annotation dropped |
| `test/v2-sync-schema-table-test.ts` | `JSON.parse(...) as Record<string, unknown>` | `as FabricPlainObject` |
| `test/v2-sync-schema-table-test.ts` | `let deeplyNested: unknown` | `let deeplyNested: FabricValue` |

The first is the substantive one. The callback is handed to `Server.connect()`,
whose parameter is `Send = (message: ServerMessage) => void` — so the annotation
was asserting something narrower than, and in conflict with, the function it was
being passed to. Dropping it takes `ServerMessage` contextually, which is what
was always being received. The body then encodes through
`encodeMemoryBoundaryUnprovenFabricValue()`, as its sibling call sites in the
same file already do.

The other two are fixtures. The parsed-JSON object is a `FabricPlainObject`,
which is still mutable (`extends Record<string, FabricValue>`), so the test
builds it up in place exactly as before. The 20k-deep nest is a `FabricValue` at
every level.

## Why

These were the last three test-side sites failing under a local experiment that
gives `FabricSpecialObject` a nominal brand — the goal of the wider arc. With
this, one site remains repo-wide: `runner/src/builtins/llm.ts:1785`, which
blocks on `LLMGenerateObjectRequest.schema: Record<string, unknown>` and is
being handled separately.

**This change stands on its own without the brand** — `deno task check` is green
either way, and the brand is not part of it.

## Test plan

- Full repo suite green (exit 0, 190.8s), `memory` 439/439.
- `deno task check`, `deno fmt --check`, `deno lint` green.
- Type-only edits; no runtime change at any of the three sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened three test-only type annotations in `packages/memory` to reflect actual wire types and avoid relying on `FabricSpecialObject` being structurally empty. Type-only change; behavior unchanged and unblocks future branding work.

- **Refactors**
  - `v2-client-test.ts`: drop `(message: FabricValue)` from `Server.connect()` callback so it infers `ServerMessage`; encode via `encodeMemoryBoundaryUnprovenFabricValue()`.
  - `v2-sync-schema-table-test.ts`: cast parsed JSON to `FabricPlainObject` instead of `Record<string, unknown>`.
  - `v2-sync-schema-table-test.ts`: type `deeplyNested` as `FabricValue` instead of `unknown`.

<sup>Written for commit b245aeef514c358ddc3bd5682fd860259b7f5bb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

