### PR TITLE
fix(llm): a generate-object request's schema is a `JSONSchema`

### DIFF
--- a/docs/development/LLM_TESTING.md
+++ b/docs/development/LLM_TESTING.md
@@ -54,9 +54,11 @@ addMockResponse(
   { role: "assistant", content: "Hi!", id: "mock-1" },
 );
 
-// For generateObject (no tools path)
+// For generateObject (no tools path). `req.schema` is a `JSONSchema`, which
+// includes the boolean schemas `true` and `false`, so narrow before reading a
+// keyword off it.
 addMockObjectResponse(
-  (req) => req.schema.type === "object",
+  (req) => typeof req.schema === "object" && req.schema.type === "object",
   { object: { name: "Alice" }, id: "mock-2" },
 );
 ```

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -108,7 +108,7 @@ export type LLMRequest = {
 };
 
 export type LLMGenerateObjectRequest = {
-  schema: Record<string, unknown>;
+  schema: JSONSchema;
   messages: readonly BuiltInLLMMessage[];
   model?: ModelName;
   system?: string;

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -1765,7 +1765,7 @@ export function generateObject<T extends Record<string, unknown>>(
         maxTokens: maxTokens ?? 8192,
         schema: llmToolExecutionHelpers.prepareSchemaForLLM(
           toDeepFrozenSchema(schema),
-        ) as Record<string, unknown>,
+        ),
         model: model ?? DEFAULT_GENERATE_OBJECT_MODELS,
         metadata: {
           ...readyMetadata,

--- a/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
@@ -286,7 +286,7 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
       (req) =>
         req.messages.some((m) =>
           typeof m.content === "string" && m.content.includes(testPrompt)
-        ) && req.schema.type === "object",
+        ) && typeof req.schema === "object" && req.schema.type === "object",
       {
         object: { title: "Model Title", summary: "Model summary" },
         id: "d1b-go-direct-1",
@@ -402,7 +402,7 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
       (req) =>
         req.messages.some((m) =>
           typeof m.content === "string" && m.content.includes(testPrompt)
-        ) && req.schema.type === "object",
+        ) && typeof req.schema === "object" && req.schema.type === "object",
       {
         object: { items: [{ name: "alpha" }, { name: "beta" }] },
         id: "d1b-go-child-doc-1",
@@ -504,7 +504,7 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
       (req) =>
         req.messages.some((m) =>
           typeof m.content === "string" && m.content.includes(testPrompt)
-        ) && req.schema.type === "object",
+        ) && typeof req.schema === "object" && req.schema.type === "object",
       {
         object: {
           tagged: [{ a: "x" }, { b: 2 }],
@@ -633,7 +633,7 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
       (req) =>
         req.messages.some((m) =>
           typeof m.content === "string" && m.content.includes(testPrompt)
-        ) && req.schema.type === "object",
+        ) && typeof req.schema === "object" && req.schema.type === "object",
       { object: { verdict: "unstamped" }, id: "d1b-go-disabled-1" },
     );
 

--- a/packages/runner/test/generate-object-tools.test.ts
+++ b/packages/runner/test/generate-object-tools.test.ts
@@ -247,7 +247,7 @@ describe("generateObject with tools", () => {
       (req) =>
         req.messages.some((m) =>
           typeof m.content === "string" && m.content.includes(testPrompt)
-        ) && req.schema.type === "object",
+        ) && typeof req.schema === "object" && req.schema.type === "object",
       {
         object: {
           title: "Test Title",


### PR DESCRIPTION
`LLMGenerateObjectRequest.schema` was declared `Record<string, unknown>`, and
its sole producer cast a `JSONSchema` into that shape to satisfy it:

```ts
schema: llmToolExecutionHelpers.prepareSchemaForLLM(
  toDeepFrozenSchema(schema),
) as Record<string, unknown>,
```

`prepareSchemaForLLM` is declared `(schema: JSONSchema): JSONSchema`, so the
cast existed only to widen a value the producer already had in hand. Declaring
the field `JSONSchema` removes it.

## The narrowings are real, not ceremony

Five test matchers read `req.schema.type === "object"`. `JSONSchema` is
`JSONSchemaObj | boolean`, and `true` / `false` are valid schemas that carry no
`type`, so those reads now narrow with `typeof req.schema === "object"` first —
the idiom already used elsewhere in `runner` for this union. The old
`Record<string, unknown>` was hiding that the union has a second arm.

## What this deliberately does NOT do

It does not declare the field `JSONSchemaObj`, though a boolean schema is
arguably meaningless for structured object output. The producer hands over
whatever `prepareSchemaForLLM()` returns, which is `JSONSchema`; the narrower
declaration would move the cast to the producer rather than remove it, and
would assert something about that function's range that is not established
here.

## Why

This was the last site failing under a local experiment that gives
`FabricSpecialObject` a nominal brand — it is an empty abstract class today, so
structurally every object satisfies it. **With this change, `deno task check` is
clean with the brand applied**, which is what the brand needs in order to land.

The change stands on its own without the brand: `deno task check` was verified
green both with and without it, and the brand is not part of this PR.

## Test plan

- Full repo suite green (exit 0, 196.7s).
- `deno task check` green with AND without the brand experiment applied;
  `deno fmt --check` and `deno lint` green.
- `runner/test/cfc-llm-derived-stamp-builtins.test.ts` and
  `runner/test/generate-object-tools.test.ts` pass (3 tests, 30 steps).
- Type-only change; the sole runtime expression is unchanged apart from a
  deleted cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `LLMGenerateObjectRequest.schema` to `JSONSchema` instead of `Record<string, unknown>` to match `prepareSchemaForLLM` and remove an unnecessary cast. Updated tests and the LLM mock-matcher example in `docs/development/LLM_TESTING.md` to narrow `JSONSchema` with `typeof req.schema === "object"` before reading `type`; no runtime changes.

<sup>Written for commit 9ac200851719e8e7e8bcc4ed29920ad56006c0f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

