### PR TITLE
test(data-model): type five sites as what they actually hold

### DIFF
--- a/docs/specs/memory-v2/01-data-model.md
+++ b/docs/specs/memory-v2/01-data-model.md
@@ -49,7 +49,7 @@ Entity values are stored in an **envelope** with well-known top-level keys:
 
 ```typescript
 // Shown at module scope.
-interface SigilLink {
+type SigilLink = {
   "/": {
     "link@1": {
       id?: `of:${string}` | `cid:${string}`;
@@ -57,12 +57,12 @@ interface SigilLink {
       space?: string;
     };
   };
-}
+};
 
-interface InternalManifestEntry {
+type InternalManifestEntry = {
   partialCause: FabricValue;
   link: SigilLink;
-}
+};
 
 interface EntityDocument {
   value?: FabricValue; // The cell's data when present.

--- a/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
@@ -967,7 +967,7 @@ describe("JsonEncodingContext", () => {
     it("throws on `FabricInstance` whose state references itself", () => {
       const { context } = makeTestContext();
       // Create an instance with a circular reference in its state.
-      const state = { eek: [] as unknown[] };
+      const state = { eek: [] as FabricValue[] };
       state.eek.push(state);
 
       const us = new UnknownValue("Test@1", state);

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { FabricInstance, type FabricValue } from "@/interface.ts";
+import {
+  FabricInstance,
+  type FabricOrConvertibleNativeValue,
+  type FabricValue,
+} from "@/interface.ts";
 import { CODEC } from "@/codec-common/interface.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
@@ -35,7 +39,7 @@ import { DummyReconstructionContext } from "./fabric-instances/fixtures.ts";
  * `fabricFromNativeValue()` and decodes it back to native form via
  * `nativeFromFabricValue()`.
  */
-function roundTrip(value: FabricValue): FabricValue {
+function roundTrip(value: FabricValue): FabricOrConvertibleNativeValue {
   return nativeFromFabricValue(fabricFromNativeValue(value));
 }
 

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -33,8 +33,12 @@ function hex(hash: Uint8Array): string {
   return Array.from(hash).map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-/** Extract the raw hash bytes from `hashOf()` for comparison. */
-function hashBytesOf(value: FabricValue): Uint8Array {
+/**
+ * Extract the raw hash bytes from `hashOf()` for comparison. Takes `unknown`,
+ * as `hashOf()` itself does: the native-instance cases below hash a native
+ * `Date` / `RegExp` / `Uint8Array`, none of which is a `FabricValue`.
+ */
+function hashBytesOf(value: unknown): Uint8Array {
   return hashOf(value).bytes;
 }
 

--- a/packages/data-model/test/valueEquals.test.ts
+++ b/packages/data-model/test/valueEquals.test.ts
@@ -250,7 +250,7 @@ describe("valueEqual()", () => {
     const equalShape = () => ({ a: 1, b: [2, 3] });
     const unequalShape = () => ({ a: 1, b: [2, 4] });
 
-    const states: Record<"DF" | "F" | "U", (v: object) => object> = {
+    const states: Record<"DF" | "F" | "U", (v: FabricValue) => FabricValue> = {
       DF: (v) => deepFreeze(v),
       F: (v) => Object.freeze(v),
       U: (v) => v,


### PR DESCRIPTION
Five annotations claimed less — or more — than the values they describe. All are
correct independently of anything else, and none changes runtime behavior.

| File | Was | Actually |
| --- | --- | --- |
| `test/value-hash.test.ts` | local `hashBytesOf(value: FabricValue)` | wraps `hashOf()`, which takes `unknown` |
| `test/native-conversion.test.ts` | `roundTrip(): FabricValue` | returns `FabricOrConvertibleNativeValue` |
| `test/valueEquals.test.ts` | `(v: object) => object` | holds fabric values |
| `test/codec-json/JsonEncodingContext.test.ts` | circular state as `unknown[]` | `FabricValue[]` at every level |

The `hashBytesOf()` one is the substantive one. It is a test-local helper that
narrows `hashOf(value: unknown)` down to `FabricValue` — and the
`hashOf() native instances` cases directly below it deliberately hash a native
`Date`, `RegExp`, and `Uint8Array`, asserting each matches its fabric
equivalent. None of those is a `FabricValue`. So the helper contradicted both
the function it calls and the tests that call it; it now mirrors `hashOf()`.

`roundTrip()` is similar in spirit: it ends in `nativeFromFabricValue()`, and
the entire point of the round trip is that the value comes back in *native*
form, which is what `FabricOrConvertibleNativeValue` names.

## Docs

`docs/specs/memory-v2/01-data-model.md` declared its illustrative `SigilLink`
and `InternalManifestEntry` as `interface`s. An interface never gets an
implicit index signature, so neither could satisfy the
`[key: string]: FabricValue` on the `EntityDocument` they sit under — the block
only type-checked because `FabricValue` currently admits every object. The real
declarations in `memory/v2.ts` are type aliases; the doc now matches them.

## Why

Preparation for making `FabricSpecialObject` nominal, which is what surfaced
these. That change is a separate PR; nothing here depends on it, and this lands
as a no-op on `main`.

Worth recording for whoever measures this next: `packages/data-model` is **not**
in `tasks/check.sh`'s path list, so a root `deno task check` does not cover it.
It is type-checked by its own package task, which runs as a dependency of
`deno task test`.

## Test plan

- `deno task check`, `deno task check-docs`, `deno fmt --check`, `deno lint`
  all green.
- `packages/data-model` check + tests: 47 passed, 2123 steps.
- Full repo suite running; will confirm before merge.
- Type-only edits throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mismatched type annotations in `packages/data-model` tests so they match the actual values. No runtime changes.

- **Refactors**
  - `value-hash.test.ts`: `hashBytesOf` now accepts `unknown` to mirror `hashOf()` and allow native `Date`/`RegExp`/`Uint8Array`.
  - `native-conversion.test.ts`: `roundTrip` returns `FabricOrConvertibleNativeValue` (native after round trip).
  - `valueEquals.test.ts`: frozen-state helpers typed as `(v: FabricValue) => FabricValue`.
  - `codec-json/JsonEncodingContext.test.ts`: circular state array typed as `FabricValue[]`.
  - Docs: switch `SigilLink` and `InternalManifestEntry` to type aliases in `docs/specs/memory-v2/01-data-model.md` to match `memory/v2.ts` and the index signature.

<sup>Written for commit 5338a474328677619fdeb1666c0de854c55c3c04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

