### PR TITLE
feat(data-model): make `FabricSpecialObject` nominal

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -766,6 +766,21 @@ FabricSpecialObject (abstract root)
 a single `instanceof FabricSpecialObject` check wherever code needs to recognize
 any fabric-system value without caring which branch it belongs to.
 
+It is **nominal**, not structural: the `@fabric/special-object` member is a
+brand that exists only in the type system (`declare` emits no runtime member,
+and nothing reads the key). This matters for what `FabricValue` means as a
+static claim. TypeScript is structurally typed, so were the class empty, every
+object would satisfy `FabricSpecialObject` — and therefore satisfy
+`FabricValue`, since the union includes this type. Annotating a value
+`FabricValue` would then assert nothing at all. The brand is what makes the
+annotation carry information.
+
+The brand is a well-known string key rather than a `unique symbol` because
+`interface.ts` is deliberately free of runtime imports, and a `unique symbol`
+would have to be imported as a *value*. `packages/api/index.ts` declares the
+identical member; the two must agree exactly, since a value branded by one
+would otherwise not satisfy the other.
+
 ```typescript
 // file: packages/data-model/interface.ts
 
@@ -777,7 +792,9 @@ any fabric-system value without caring which branch it belongs to.
  * fabric-system value without caring which branch of the hierarchy it
  * belongs to.
  */
-export abstract class FabricSpecialObject {}
+export abstract class FabricSpecialObject {
+  declare readonly "@fabric/special-object": true;
+}
 ```
 
 **`FabricPrimitive`** is the abstract base class for non-`FabricInstance` types

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -766,7 +766,7 @@ FabricSpecialObject (abstract root)
 a single `instanceof FabricSpecialObject` check wherever code needs to recognize
 any fabric-system value without caring which branch it belongs to.
 
-It is **nominal**, not structural: the `@fabric/special-object` member is a
+It is **nominal**, not structural: the `@commonfabric/FabricSpecialObject` member is a
 brand that exists only in the type system (`declare` emits no runtime member,
 and nothing reads the key). This matters for what `FabricValue` means as a
 static claim. TypeScript is structurally typed, so were the class empty, every
@@ -793,7 +793,7 @@ would otherwise not satisfy the other.
  * belongs to.
  */
 export abstract class FabricSpecialObject {
-  declare readonly "@fabric/special-object": true;
+  declare readonly "@commonfabric/FabricSpecialObject": true;
 }
 ```
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -27,9 +27,15 @@ import type { Cfc, CurrentPrincipal, WriteAuthorizedBy } from "./cfc.ts";
 /**
  * Common base class for `FabricInstance` and `FabricPrimitive`. Enables a
  * single `instanceof` check for any fabric-system value type.
+ *
+ * The `@fabric/special-object` member is a nominal brand with no runtime
+ * existence — see the canonical declaration in
+ * `data-model/src/interface.ts` for why it is a well-known string key and not
+ * a `unique symbol`. The two declarations must agree exactly.
  */
-// deno-lint-ignore no-empty-interface
-export interface FabricSpecialObject {}
+export interface FabricSpecialObject {
+  readonly "@fabric/special-object": true;
+}
 
 export interface FabricSpecialObjectConstructor {
   prototype: FabricSpecialObject;

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -28,13 +28,13 @@ import type { Cfc, CurrentPrincipal, WriteAuthorizedBy } from "./cfc.ts";
  * Common base class for `FabricInstance` and `FabricPrimitive`. Enables a
  * single `instanceof` check for any fabric-system value type.
  *
- * The `@fabric/special-object` member is a nominal brand with no runtime
- * existence — see the canonical declaration in
+ * The `@commonfabric/FabricSpecialObject` member is a nominal brand with no
+ * runtime existence — see the canonical declaration in
  * `data-model/src/interface.ts` for why it is a well-known string key and not
  * a `unique symbol`. The two declarations must agree exactly.
  */
 export interface FabricSpecialObject {
-  readonly "@fabric/special-object": true;
+  readonly "@commonfabric/FabricSpecialObject": true;
 }
 
 export interface FabricSpecialObjectConstructor {

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -22,12 +22,12 @@
  * fabric-system value without caring which branch of the hierarchy it
  * belongs to.
  *
- * The `@fabric/special-object` member is a nominal brand, and exists only in
- * the type system: `declare` emits no runtime member, and nothing ever reads
- * the key. Without it the class is structurally empty, so *every* object
- * satisfies `FabricSpecialObject` — which in turn makes every object satisfy
- * `FabricValue`, since that union includes this type. The brand is what makes
- * `FabricValue` mean anything as a static claim.
+ * The `@commonfabric/FabricSpecialObject` member is a nominal brand, and
+ * exists only in the type system: `declare` emits no runtime member, and
+ * nothing ever reads the key. Without it the class is structurally empty, so
+ * *every* object satisfies `FabricSpecialObject` — which in turn makes every
+ * object satisfy `FabricValue`, since that union includes this type. The brand
+ * is what makes `FabricValue` mean anything as a static claim.
  *
  * It is a well-known string key rather than a `unique symbol` because that
  * would require importing a symbol *value*, and this file is deliberately free
@@ -36,7 +36,7 @@
  * will not satisfy the other.
  */
 export abstract class FabricSpecialObject {
-  declare readonly "@fabric/special-object": true;
+  declare readonly "@commonfabric/FabricSpecialObject": true;
 }
 
 //

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -21,8 +21,23 @@
  * `instanceof FabricSpecialObject` check wherever code needs to recognize any
  * fabric-system value without caring which branch of the hierarchy it
  * belongs to.
+ *
+ * The `@fabric/special-object` member is a nominal brand, and exists only in
+ * the type system: `declare` emits no runtime member, and nothing ever reads
+ * the key. Without it the class is structurally empty, so *every* object
+ * satisfies `FabricSpecialObject` — which in turn makes every object satisfy
+ * `FabricValue`, since that union includes this type. The brand is what makes
+ * `FabricValue` mean anything as a static claim.
+ *
+ * It is a well-known string key rather than a `unique symbol` because that
+ * would require importing a symbol *value*, and this file is deliberately free
+ * of runtime imports (see the file header). `packages/api/index.ts` declares
+ * the identical member; the two must agree exactly, or a value branded by one
+ * will not satisfy the other.
  */
-export abstract class FabricSpecialObject {}
+export abstract class FabricSpecialObject {
+  declare readonly "@fabric/special-object": true;
+}
 
 //
 // Fabric instance protocol


### PR DESCRIPTION
`FabricSpecialObject` was an empty abstract class, mirrored by an empty
interface in `api`:

```ts
export abstract class FabricSpecialObject {}
```

TypeScript is structurally typed, so **every object satisfied it** — and
therefore satisfied `FabricValue`, since the union includes this type.
Annotating a value `FabricValue` asserted nothing at all.

Both declarations now carry a brand:

```ts
// data-model/src/interface.ts
export abstract class FabricSpecialObject {
  declare readonly "@fabric/special-object": true;
}

// api/index.ts
export interface FabricSpecialObject {
  readonly "@fabric/special-object": true;
}
```

## Why a string key and not a `unique symbol`

`interface.ts` is deliberately free of runtime imports — its own header says so,
to avoid dependency cycles — and a `unique symbol` would have to be imported as
a *value*. A well-known string key declared identically on both sides is
type-only on both sides.

The two declarations must agree exactly; a value branded by one would otherwise
not satisfy the other. Both doc comments say so, and the canonical explanation
lives on the `data-model` declaration.

## No runtime existence

`declare` emits no member, and nothing reads the key. Verified rather than
assumed — had it mis-emitted a field, every fabric instance would gain a
property and serialization would shift:

```
own keys:       []
has brand key:  false
brand in obj:   false
encodes as:     fvj1:{"b":{"/Bytes@1":"AQID"}}
```

## Fallout

None left. This is the last step of an arc that began at **324** type errors
under the brand and cleared them across ~20 PRs, the immediately preceding ones
being #5053, #5054, #5055, and #5056. Three of those found real defects rather
than type-hygiene noise: `nativeFromFabricValue()` returning `[Error]` typed
`FabricValue`, `BuiltInLLMImagePart` admitting `ArrayBuffer | URL` across a
boundary that cannot carry them, and `SchedulerActionObservation` declared twice
with differing strictness. No test caught any of the three.

Also updates the formal spec's §1.4.6, which reproduces the declaration
verbatim, and now states why the type is nominal.

## Test plan

Both instruments that misled this arc are included:

- `deno task check` — green.
- **`packages/data-model`'s own check** — green. Root `deno task check` does not
  cover this package (it is absent from `tasks/check.sh`'s path list); it is
  checked by its own package task under `deno task test`.
- `deno task check-docs` — 518/518.
- `packages/runtime-client` and `packages/cf-harness` explicit checks — green.
  Both type-check outside the root task.
- `deno fmt --check`, `deno lint` — green.
- Full repo suite — green (exit 0, 206.0s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNgY3ooreGzww89dwayfst

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `FabricSpecialObject` nominal by adding a type-only `@commonfabric/FabricSpecialObject` brand so only branded values satisfy `FabricValue`. No runtime behavior changes; the spec is updated.

- **Bug Fixes**
  - Added `readonly "@commonfabric/FabricSpecialObject": true` to `FabricSpecialObject` in `packages/data-model/src/interface.ts` and `packages/api/index.ts`.
  - Updated the formal spec to document the brand, why it’s a string key (not a `unique symbol`), and to match the new `@commonfabric` namespacing.
  - Verified the brand is type-only (`declare`): no emitted members and no serialization changes.

<sup>Written for commit b5cb8d5f52bd7165ea5663ff8203a91b42b6f50b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

