### PR TITLE
feat(cli): `piece setsrc --check` — compatibility preflight for a source swap

### DIFF
--- a/docs/common/workflows/development.md
+++ b/docs/common/workflows/development.md
@@ -10,6 +10,9 @@ deno task cf check pattern.tsx
 # Deploy
 deno task cf piece new ... pattern.tsx
 
+# Ask whether the update would be accepted, without applying it
+deno task cf piece setsrc ... --piece PIECE_ID --check pattern.tsx
+
 # Update existing (faster iteration)
 deno task cf piece setsrc ... --piece PIECE_ID pattern.tsx
 
@@ -65,4 +68,16 @@ deno task cf piece link ... editor-id/items viewer-id/items
   bypass compilation, normal value validation, or atomic stale-update checks.
   `piece new` accepts the same flag for deploy-script symmetry, but a fresh
   piece has no predecessor schema to compare.
+- `setsrc --check` answers all of the above ahead of time and applies nothing.
+  It runs the same rules the update enforces — the pattern-contract subset
+  proof, the CFC document merge against the schema the piece's documents
+  actually carry, and the retained-link proof — and reports which fields would
+  block the update and why, plus the migration work setup would perform (a new
+  handler stream's marker, for example). It exits `0` when the update would be
+  accepted and `3` when it would not, so a deploy script can gate on it.
+  `--json` (only valid with `--check`) emits the same verdict machine-readably.
+  The check never writes to the piece; compiling the candidate does persist the
+  pattern's content-addressed source, exactly as any compile does. A real
+  `setsrc` that is refused now reports the same field-level reasons instead of
+  a low-level rejection, and leaves the piece on its original pattern.
 - Test one feature at a time

--- a/docs/development/debugging/cli-debugging.md
+++ b/docs/development/debugging/cli-debugging.md
@@ -140,6 +140,12 @@ deno task cf piece get --piece <piece-id> brokenField -i "$CF_IDENTITY" -a URL -
 
 This keeps you working with the same piece instance, preserving any test data you've set up.
 
+If a `setsrc` is refused as incompatible, the error names the field and the rule
+that refused it, and the piece stays on its original pattern. To ask the same
+question before touching the piece, add `--check`: it applies nothing, reports
+which fields would block the update and why, and exits `3` when the update would
+not be possible (`0` when it would). Add `--json` for a machine-readable verdict.
+
 ## See Also
 
 - ./workflow.md - General debugging workflow

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -133,6 +133,12 @@ The supported output switches are:
   JSON stream.
 - `cf piece get` and `cf wish` always return JSON. Their `--json` options are
   accepted, documented no-ops for callers that select JSON explicitly.
+- `cf piece setsrc --check --json` serializes the compatibility verdict for a
+  source update that is not applied. `--json` requires `--check`, because the
+  verdict is the only thing `setsrc` has to serialize. The command exits `0`
+  when the update would be accepted and `3` when it would not; `3` is also the
+  exit code of a real `setsrc` refused as incompatible, so a caller can branch
+  on "incompatible" without parsing text.
 - `cf check --json` compiles without evaluating and prints one object with a
   `files` array. Each entry has the input `path` and the compiled module bodies
   in `output`.

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -366,6 +366,13 @@ const PIECE_REGISTRY_LINK_EXAMPLE = [
   ),
   `Link the well-known "pieceRegistry" list to a piece field.`,
 ] as const;
+const SETSRC_CHECK_EXAMPLE = [
+  cliText(`cf piece setsrc --check ${EX_ID} ${EX_COMP_PIECE} ./main.tsx`),
+  `Report whether ./main.tsx could be applied to "${RAW_EX_COMP
+    .piece!}", changing nothing. Exits ${SETSRC_INCOMPATIBLE_EXIT_CODE} if it could not.`,
+] as const;
+const SETSRC_CHECK_FLAG_DESCRIPTION =
+  `Report whether the source could be applied, without applying it. Exits ${SETSRC_INCOMPATIBLE_EXIT_CODE} when it could not.`;
 
 // Enhanced description with workflow tips
 function pieceEnvStatus(): string {
@@ -601,11 +608,7 @@ export const piece = new Command()
     cliText(`cf piece setsrc ${EX_ID} ${EX_URL} ./main.tsx`),
     `Update the source for "${RAW_EX_COMP.piece!}" with ./main.tsx`,
   )
-  .example(
-    cliText(`cf piece setsrc --check ${EX_ID} ${EX_COMP_PIECE} ./main.tsx`),
-    `Report whether ./main.tsx could be applied to "${RAW_EX_COMP
-      .piece!}", changing nothing. Exits ${SETSRC_INCOMPATIBLE_EXIT_CODE} if it could not.`,
-  )
+  .example(...SETSRC_CHECK_EXAMPLE)
   .option("-c,--piece <piece:string>", "The target piece ID.")
   .option(
     "--main-export <export:string>",
@@ -623,37 +626,10 @@ export const piece = new Command()
     "--dangerously-allow-incompatible-schema",
     "Replace the source even when pattern or retained-link schema compatibility cannot be proven.",
   )
-  .option(
-    "--check",
-    `Report whether the source could be applied, without applying it. Exits ${SETSRC_INCOMPATIBLE_EXIT_CODE} when it could not.`,
-  )
+  .option("--check", SETSRC_CHECK_FLAG_DESCRIPTION)
   .option("--json", "Output machine-readable JSON. Requires --check.")
   .arguments("<main:string>")
-  .action(async (options, mainPath) => {
-    setQuietMode(!!options.quiet);
-    assertSetSourceFlagCombination(options);
-    if (options.check) {
-      const report = await checkPieceSourceFromCommand(options, mainPath);
-      render(
-        options.json ? report : formatPatternUpdateCheckReport(report),
-        { json: !!options.json },
-      );
-      if (!report.compatible) Deno.exit(SETSRC_INCOMPATIBLE_EXIT_CODE);
-      return;
-    }
-    let pieceConfig: PieceConfig;
-    try {
-      pieceConfig = await setPieceSourceFromCommand(options, mainPath);
-    } catch (error) {
-      reportIncompatibleSetSource(error);
-      throw error;
-    }
-    render(`Updated source for piece ${pieceConfig.piece}`);
-    hint(cliText(`NEXT STEPS:
-  → Test in browser: ${pieceConfig.apiUrl}/${pieceConfig.space}/${pieceConfig.piece}
-  → Test a callable: cf piece call --piece ${pieceConfig.piece} <callableName> ...
-  → Check state:     cf piece inspect --piece ${pieceConfig.piece} ...`));
-  })
+  .action(runSetSourceCommand)
   /* piece inspect */
   .command("inspect", "Inspect detailed information about a piece")
   .usage(pieceUsage)
@@ -1377,6 +1353,70 @@ export async function setPieceSourceFromCommand(
     },
   );
   return pieceConfig;
+}
+
+/** Injectable seams for the `piece setsrc` action body. */
+export interface SetSourceCommandDependencies {
+  checkPieceSource?: typeof checkPieceSourceFromCommand;
+  setPieceSource?: typeof setPieceSourceFromCommand;
+  print?: (message: unknown, options?: { json?: boolean }) => void;
+  printError?: (message: string) => void;
+  printHint?: (message: string) => void;
+  exit?: (code: number) => never;
+}
+
+/**
+ * The whole of `cf piece setsrc`, including its `--check` preflight.
+ *
+ * Why it lives outside the command chain: the routing decisions here are the
+ * load-bearing part of the feature — a `--check` run must never reach the
+ * mutating call, and a refused update must exit
+ * {@link SETSRC_INCOMPATIBLE_EXIT_CODE} rather than the generic failure code.
+ * As a plain function with injectable seams those rules can be tested directly,
+ * which an inline `.action` callback (network, `Deno.exit`) cannot be.
+ */
+export async function runSetSourceCommand(
+  options: PieceCLIOptions & { quiet?: boolean },
+  mainPath: string,
+  deps: SetSourceCommandDependencies = {},
+): Promise<void> {
+  const print = deps.print ?? render;
+  const printHint = deps.printHint ?? hint;
+  setQuietMode(!!options.quiet);
+  assertSetSourceFlagCombination(options);
+  if (options.check) {
+    const report = await (deps.checkPieceSource ?? checkPieceSourceFromCommand)(
+      options,
+      mainPath,
+    );
+    print(
+      options.json ? report : formatPatternUpdateCheckReport(report),
+      { json: !!options.json },
+    );
+    if (!report.compatible) {
+      return (deps.exit ?? Deno.exit)(SETSRC_INCOMPATIBLE_EXIT_CODE);
+    }
+    return;
+  }
+  let pieceConfig: PieceConfig;
+  try {
+    pieceConfig = await (deps.setPieceSource ?? setPieceSourceFromCommand)(
+      options,
+      mainPath,
+    );
+  } catch (error) {
+    reportIncompatibleSetSource(error, {
+      ...(deps.printError ? { printError: deps.printError } : {}),
+      printHint,
+      ...(deps.exit ? { exit: deps.exit } : {}),
+    });
+    throw error;
+  }
+  print(`Updated source for piece ${pieceConfig.piece}`);
+  printHint(cliText(`NEXT STEPS:
+  → Test in browser: ${pieceConfig.apiUrl}/${pieceConfig.space}/${pieceConfig.piece}
+  → Test a callable: cf piece call --piece ${pieceConfig.piece} <callableName> ...
+  → Check state:     cf piece inspect --piece ${pieceConfig.piece} ...`));
 }
 
 /**

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2,6 +2,7 @@ import { Table } from "@cliffy/table";
 import { Command, ValidationError } from "@cliffy/command";
 import {
   applyPieceInput,
+  checkPiecePattern,
   type EntryConfig,
   executePieceCallable,
   formatViewTree,
@@ -39,8 +40,20 @@ import type { CellScope } from "@commonfabric/api";
 import { parseCellPath } from "@commonfabric/runner";
 import { UI } from "@commonfabric/runner";
 import ports from "@commonfabric/ports" with { type: "json" };
-import type { PiecePatternRef } from "@commonfabric/piece/ops";
+import {
+  type PatternUpdateCheckReport,
+  PatternUpdateIncompatibleError,
+  type PiecePatternRef,
+} from "@commonfabric/piece/ops";
 import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
+
+/**
+ * Exit code for `cf piece setsrc --check` when the update would NOT be
+ * possible, and for a real `setsrc` refused as incompatible. Distinct from 1
+ * (operational failure) and 2 (bad arguments) so a caller can branch on
+ * "incompatible" without parsing text.
+ */
+export const SETSRC_INCOMPATIBLE_EXIT_CODE = 3;
 
 // Hint system: print helpful next-step suggestions after operations
 let quietMode = false;
@@ -383,6 +396,7 @@ COMMON WORKFLOWS:
 ${pieceEnvStatus()}
 TIPS:
   • Use 'setsrc' for iteration, not repeated 'new' (avoids clutter)
+  • 'setsrc --check' reports whether an update would be accepted, changing nothing
   • After 'set', run 'step' to trigger computed value updates
   • Path format: forward slashes only (items/0/name, not items[0].name)
   • JSON values: strings need quotes: echo '"hello"' | cf piece set ...`);
@@ -587,6 +601,11 @@ export const piece = new Command()
     cliText(`cf piece setsrc ${EX_ID} ${EX_URL} ./main.tsx`),
     `Update the source for "${RAW_EX_COMP.piece!}" with ./main.tsx`,
   )
+  .example(
+    cliText(`cf piece setsrc --check ${EX_ID} ${EX_COMP_PIECE} ./main.tsx`),
+    `Report whether ./main.tsx could be applied to "${RAW_EX_COMP
+      .piece!}", changing nothing. Exits ${SETSRC_INCOMPATIBLE_EXIT_CODE} if it could not.`,
+  )
   .option("-c,--piece <piece:string>", "The target piece ID.")
   .option(
     "--main-export <export:string>",
@@ -604,10 +623,31 @@ export const piece = new Command()
     "--dangerously-allow-incompatible-schema",
     "Replace the source even when pattern or retained-link schema compatibility cannot be proven.",
   )
+  .option(
+    "--check",
+    `Report whether the source could be applied, without applying it. Exits ${SETSRC_INCOMPATIBLE_EXIT_CODE} when it could not.`,
+  )
+  .option("--json", "Output machine-readable JSON. Requires --check.")
   .arguments("<main:string>")
   .action(async (options, mainPath) => {
     setQuietMode(!!options.quiet);
-    const pieceConfig = await setPieceSourceFromCommand(options, mainPath);
+    assertSetSourceFlagCombination(options);
+    if (options.check) {
+      const report = await checkPieceSourceFromCommand(options, mainPath);
+      render(
+        options.json ? report : formatPatternUpdateCheckReport(report),
+        { json: !!options.json },
+      );
+      if (!report.compatible) Deno.exit(SETSRC_INCOMPATIBLE_EXIT_CODE);
+      return;
+    }
+    let pieceConfig: PieceConfig;
+    try {
+      pieceConfig = await setPieceSourceFromCommand(options, mainPath);
+    } catch (error) {
+      reportIncompatibleSetSource(error);
+      throw error;
+    }
     render(`Updated source for piece ${pieceConfig.piece}`);
     hint(cliText(`NEXT STEPS:
   → Test in browser: ${pieceConfig.apiUrl}/${pieceConfig.space}/${pieceConfig.piece}
@@ -1276,6 +1316,7 @@ export interface PieceCLIOptions {
   repository?: string;
   root?: string;
   dangerouslyAllowIncompatibleSchema?: boolean;
+  check?: boolean;
   json?: boolean;
 }
 
@@ -1336,6 +1377,128 @@ export async function setPieceSourceFromCommand(
     },
   );
   return pieceConfig;
+}
+
+/**
+ * Reject `setsrc` flag combinations that cannot mean anything coherent.
+ *
+ * `--json` shapes the check's verdict, so it needs a verdict to shape. And the
+ * dangerous override exists to SKIP the compatibility proof, which is the only
+ * thing `--check` computes — combining them would print a verdict the caller
+ * has already declared they intend to ignore.
+ */
+export function assertSetSourceFlagCombination(
+  options: Pick<
+    PieceCLIOptions,
+    "check" | "json" | "dangerouslyAllowIncompatibleSchema"
+  >,
+): void {
+  if (options.json && !options.check) {
+    throw new ValidationError('"--json" is only available with "--check".', {
+      exitCode: 1,
+    });
+  }
+  if (options.check && options.dangerouslyAllowIncompatibleSchema) {
+    throw new ValidationError(
+      '"--check" cannot be combined with "--dangerously-allow-incompatible-schema": the check reports the compatibility the override skips.',
+      { exitCode: 1 },
+    );
+  }
+}
+
+/** Injectable dependencies for testing the `piece setsrc --check` boundary. */
+export interface CheckPieceSourceCommandDependencies {
+  checkPiecePattern?: typeof checkPiecePattern;
+}
+
+/** Run the `piece setsrc --check` preflight and return its verdict. */
+export async function checkPieceSourceFromCommand(
+  options: PieceCLIOptions,
+  mainPath: string,
+  deps: CheckPieceSourceCommandDependencies = {},
+): Promise<PatternUpdateCheckReport> {
+  const pieceConfig = parsePieceOptions(options);
+  return await (deps.checkPiecePattern ?? checkPiecePattern)(
+    pieceConfig,
+    localPatternEntry(mainPath, options),
+  );
+}
+
+const CHECK_STATUS_MARK = {
+  pass: "ok  ",
+  fail: "FAIL",
+  "not-applicable": "n/a ",
+} as const;
+
+/**
+ * Human-readable `--check` report. Every line answers one of: what was proved,
+ * what was refused and why, and what setup will migrate on the way through.
+ */
+export function formatPatternUpdateCheckReport(
+  report: PatternUpdateCheckReport,
+): string {
+  const lines: string[] = [];
+  lines.push(
+    report.compatible
+      ? `COMPATIBLE — the pattern source can be applied to piece ${report.piece}.`
+      : `INCOMPATIBLE — the pattern source cannot be applied to piece ${report.piece}.`,
+  );
+  lines.push("");
+  lines.push("Checks:");
+  for (const step of report.steps) {
+    lines.push(
+      `  [${CHECK_STATUS_MARK[step.status]}] ${step.name}${
+        step.note ? ` — ${step.note}` : ""
+      }`,
+    );
+  }
+  if (report.blockers.length > 0) {
+    lines.push("");
+    lines.push("Blockers:");
+    for (const blocker of report.blockers) {
+      lines.push(`  • [${blocker.class}] ${blocker.message}`);
+    }
+  }
+  if (report.advisories.length > 0) {
+    lines.push("");
+    lines.push("Would migrate on update:");
+    for (const advisory of report.advisories) {
+      lines.push(`  • ${advisory.message}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Report a refused `setsrc` the way `--check` would, then exit with the
+ * incompatibility code. Returns null when the error is something else (the
+ * caller rethrows). The `deps` seam lets tests observe the wiring without a
+ * real process exit.
+ */
+export function reportIncompatibleSetSource(
+  error: unknown,
+  deps?: {
+    printError?: (message: string) => void;
+    printHint?: (message: string) => void;
+    exit?: (code: number) => never;
+  },
+): never | null {
+  if (!(error instanceof PatternUpdateIncompatibleError)) return null;
+  const printError = deps?.printError ?? console.error;
+  const printHint = deps?.printHint ?? hint;
+  const exit = deps?.exit ?? Deno.exit;
+  printError(
+    `Pattern source cannot be applied to piece ${error.piece}. The piece was NOT modified.`,
+  );
+  for (const blocker of error.blockers) {
+    printError(`  • [${blocker.class}] ${blocker.message}`);
+  }
+  printHint(cliText(
+    `TIP: Run the same evaluation without attempting the update:
+  cf piece setsrc --check --piece ${error.piece} <main> ...
+Add --dangerously-allow-incompatible-schema only if you accept losing the guarantees above.`,
+  ));
+  return exit(SETSRC_INCOMPATIBLE_EXIT_CODE);
 }
 
 const CELL_SCOPE_VALUES = new Set(["space", "user", "session"]);

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -211,14 +211,67 @@ run_piece_values() {
       jq -r '.patternRef.identity'
   )
 
-  if cf piece setsrc $SPACE_ARGS --piece "$schema_piece_id" \
+  # The preflight answers the same question without touching the piece: exit 3
+  # for "would not be possible", and a report naming the offending field.
+  local check_status check_json
+  set +e
+  cf piece setsrc --check $SPACE_ARGS --piece "$schema_piece_id" \
+    "$SCHEMA_INCOMPATIBLE_PATTERN_SRC" \
+    >"$WORK_DIR/incompatible-check.out" \
+    2>"$WORK_DIR/incompatible-check.err"
+  check_status=$?
+  set -e
+  if [ "$check_status" -ne 3 ]; then
+    error "setsrc --check should exit 3 for an incompatible source (got $check_status)."
+  fi
+  if ! grep -q "INCOMPATIBLE" "$WORK_DIR/incompatible-check.out"; then
+    error "setsrc --check did not report the verdict."
+  fi
+  if ! grep -q "result.value" "$WORK_DIR/incompatible-check.out"; then
+    error "setsrc --check did not name the offending field."
+  fi
+  # The check applies nothing.
+  if [ "$(
+    cf piece inspect --json $SPACE_ARGS --piece "$schema_piece_id" |
+      jq -r '.patternRef.identity'
+  )" != "$schema_identity_before" ]; then
+    error "setsrc --check changed the piece source."
+  fi
+  check_json=$(
+    cf piece setsrc --check --json $SPACE_ARGS --piece "$schema_piece_id" \
+      "$SCHEMA_INCOMPATIBLE_PATTERN_SRC" || true
+  )
+  if [ "$(printf '%s' "$check_json" | jq -r '.compatible')" != "false" ]; then
+    error "setsrc --check --json did not report an incompatible verdict."
+  fi
+  if [ "$(printf '%s' "$check_json" | jq -r '.blockers[0].field')" != "value" ]; then
+    error "setsrc --check --json did not name the offending field."
+  fi
+  # A compatible source passes the same preflight.
+  cf piece setsrc --check $SPACE_ARGS --piece "$schema_piece_id" \
+    "$SCHEMA_COMPATIBLE_PATTERN_SRC" >/dev/null
+
+  local setsrc_status
+  set +e
+  cf piece setsrc $SPACE_ARGS --piece "$schema_piece_id" \
     "$SCHEMA_INCOMPATIBLE_PATTERN_SRC" \
     >"$WORK_DIR/incompatible-setsrc.out" \
-    2>"$WORK_DIR/incompatible-setsrc.err"; then
-    error "Incompatible setsrc should fail without the dangerous override."
+    2>"$WORK_DIR/incompatible-setsrc.err"
+  setsrc_status=$?
+  set -e
+  if [ "$setsrc_status" -ne 3 ]; then
+    error "Incompatible setsrc should fail with exit 3 (got $setsrc_status)."
   fi
-  if ! grep -q "not backward compatible" "$WORK_DIR/incompatible-setsrc.err"; then
-    error "Incompatible setsrc failed for an unexpected reason."
+  # The refusal names the field and the rule, not a low-level rejection, and
+  # points at the preflight that reports the same thing without mutating.
+  if ! grep -q "result.value" "$WORK_DIR/incompatible-setsrc.err"; then
+    error "Incompatible setsrc did not name the offending field."
+  fi
+  if ! grep -q "pattern-contract" "$WORK_DIR/incompatible-setsrc.err"; then
+    error "Incompatible setsrc did not name the rule that refused it."
+  fi
+  if ! grep -q -- "--check" "$WORK_DIR/incompatible-setsrc.err"; then
+    error "Incompatible setsrc did not point at the --check preflight."
   fi
   schema_identity_after_rejection=$(
     cf piece inspect --json $SPACE_ARGS --piece "$schema_piece_id" |

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -34,6 +34,7 @@ import {
   SlugResolutionError,
 } from "@commonfabric/piece";
 import {
+  type PatternUpdateCheckReport,
   type PiecePatternRef,
   PiecesController,
 } from "@commonfabric/piece/ops";
@@ -1227,6 +1228,37 @@ export async function setPiecePattern(
         ? { dangerouslyAllowIncompatibleSchema: true }
         : {}),
     },
+  );
+}
+
+/**
+ * Dry-run the pattern swap `setPiecePattern` would perform and return the
+ * verdict. Never mutates the piece.
+ */
+export async function checkPiecePattern(
+  config: PieceConfig,
+  entry: EntryConfig,
+  deps: PieceOperationDependencies = {},
+): Promise<PatternUpdateCheckReport> {
+  const manager = await (deps.loadManager ?? loadManager)(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(
+    config,
+    manager,
+    deps.resolvePieceAddress,
+  );
+  const pieces = deps.createController?.(manager) ??
+    new PiecesController(manager);
+  const piece = await pieces.get(
+    resolvedConfig.piece,
+    false,
+    undefined,
+    resolvedConfig.pieceScope,
+  );
+  return await piece.checkPattern(
+    await (deps.getPinnedProgramFromFile ?? getPinnedProgramFromFile)(
+      manager,
+      entry,
+    ),
   );
 }
 

--- a/packages/cli/test/piece-setsrc-check.test.ts
+++ b/packages/cli/test/piece-setsrc-check.test.ts
@@ -14,15 +14,20 @@ import {
   type PatternUpdateCheckReport,
   PatternUpdateIncompatibleError,
 } from "@commonfabric/piece/ops";
+import type { PieceManager } from "@commonfabric/piece";
+import type { PiecesController } from "@commonfabric/piece/ops";
 import {
   assertSetSourceFlagCombination,
   checkPieceSourceFromCommand,
   formatPatternUpdateCheckReport,
   piece,
   reportIncompatibleSetSource,
+  runSetSourceCommand,
   setPieceSourceFromCommand,
+  type SetSourceCommandDependencies,
   SETSRC_INCOMPATIBLE_EXIT_CODE,
 } from "../commands/piece.ts";
+import { checkPiecePattern } from "../lib/piece.ts";
 
 const API_URL = "https://cf.dev";
 const SPACE = "common-knowledge";
@@ -222,5 +227,282 @@ describe("cli piece setsrc --check", () => {
     });
     expect(result).toBe(null);
     expect(exited).toBe(false);
+  });
+});
+
+describe("cli piece setsrc — the action body", () => {
+  // `runSetSourceCommand` IS the command: the chain only forwards to it. These
+  // pin the routing, the rendering choice, and the process exit status, which
+  // is what a script calling `setsrc` actually depends on.
+  const baseOptions = {
+    apiUrl: API_URL,
+    space: SPACE,
+    identity: "/tmp/test.key",
+    piece: PIECE,
+  };
+
+  interface Recorded {
+    printed: { message: unknown; json?: boolean }[];
+    errors: string[];
+    hints: string[];
+    exits: number[];
+  }
+
+  const recorder = (): Recorded & { deps: SetSourceCommandDependencies } => {
+    const recorded: Recorded = {
+      printed: [],
+      errors: [],
+      hints: [],
+      exits: [],
+    };
+    return {
+      ...recorded,
+      deps: {
+        print: (message, options) =>
+          recorded.printed.push({ message, json: options?.json }),
+        printError: (message) => recorded.errors.push(message),
+        printHint: (message) => recorded.hints.push(message),
+        exit: (code: number) => {
+          recorded.exits.push(code);
+          return undefined as never;
+        },
+      },
+    };
+  };
+
+  it("renders a compatible check as text and never touches the piece", async () => {
+    const recorded = recorder();
+    let mutated = false;
+
+    await runSetSourceCommand(
+      { ...baseOptions, check: true },
+      "/repo/pattern.tsx",
+      {
+        ...recorded.deps,
+        checkPieceSource: () => Promise.resolve(compatibleReport),
+        setPieceSource: () => {
+          mutated = true;
+          return Promise.resolve(baseOptions);
+        },
+      },
+    );
+
+    expect(mutated).toBe(false);
+    expect(recorded.exits).toEqual([]);
+    expect(recorded.printed.length).toBe(1);
+    expect(recorded.printed[0].json).toBe(false);
+    expect(String(recorded.printed[0].message)).toContain("COMPATIBLE");
+  });
+
+  it("hands --json the report itself, not the rendered text", async () => {
+    const recorded = recorder();
+
+    await runSetSourceCommand(
+      { ...baseOptions, check: true, json: true },
+      "/repo/pattern.tsx",
+      {
+        ...recorded.deps,
+        checkPieceSource: () => Promise.resolve(compatibleReport),
+      },
+    );
+
+    expect(recorded.printed[0].json).toBe(true);
+    expect(recorded.printed[0].message).toBe(compatibleReport);
+  });
+
+  it("exits 3 after reporting an incompatible check", async () => {
+    const recorded = recorder();
+
+    await runSetSourceCommand(
+      { ...baseOptions, check: true },
+      "/repo/pattern.tsx",
+      {
+        ...recorded.deps,
+        checkPieceSource: () => Promise.resolve(incompatibleReport),
+      },
+    );
+
+    // The verdict is printed BEFORE the exit: a caller reading stdout still
+    // learns why, and a caller branching on status gets a distinct code.
+    expect(String(recorded.printed[0].message)).toContain("INCOMPATIBLE");
+    expect(recorded.exits).toEqual([SETSRC_INCOMPATIBLE_EXIT_CODE]);
+  });
+
+  it("refuses --json without --check before doing any work", async () => {
+    const recorded = recorder();
+    let checked = false;
+
+    await expect(
+      runSetSourceCommand({ ...baseOptions, json: true }, "/repo/pattern.tsx", {
+        ...recorded.deps,
+        checkPieceSource: () => {
+          checked = true;
+          return Promise.resolve(compatibleReport);
+        },
+      }),
+    ).rejects.toThrow('"--json" is only available with "--check"');
+    expect(checked).toBe(false);
+  });
+
+  it("applies the source and points at the next steps", async () => {
+    const recorded = recorder();
+    let applied: unknown;
+
+    await runSetSourceCommand(baseOptions, "/repo/pattern.tsx", {
+      ...recorded.deps,
+      setPieceSource: (options, mainPath) => {
+        applied = { piece: options.piece, mainPath };
+        return Promise.resolve(baseOptions);
+      },
+    });
+
+    expect(applied).toEqual({ piece: PIECE, mainPath: "/repo/pattern.tsx" });
+    expect(String(recorded.printed[0].message)).toContain(
+      `Updated source for piece ${PIECE}`,
+    );
+    expect(recorded.hints.join("\n")).toContain("NEXT STEPS");
+    expect(recorded.exits).toEqual([]);
+  });
+
+  it("reports a refused update with exit 3 and rethrows", async () => {
+    const recorded = recorder();
+    const refusal = new PatternUpdateIncompatibleError(
+      PIECE,
+      incompatibleReport.blockers,
+    );
+
+    await expect(
+      runSetSourceCommand(baseOptions, "/repo/pattern.tsx", {
+        ...recorded.deps,
+        setPieceSource: () => Promise.reject(refusal),
+      }),
+    ).rejects.toBe(refusal);
+
+    expect(recorded.exits).toEqual([SETSRC_INCOMPATIBLE_EXIT_CODE]);
+    expect(recorded.errors.join("\n")).toContain("The piece was NOT modified.");
+    expect(recorded.errors.join("\n")).toContain("favorites");
+  });
+
+  it("lets an unrelated failure surface unchanged", async () => {
+    const recorded = recorder();
+    const failure = new Error("network down");
+
+    await expect(
+      runSetSourceCommand(baseOptions, "/repo/pattern.tsx", {
+        ...recorded.deps,
+        setPieceSource: () => Promise.reject(failure),
+      }),
+    ).rejects.toBe(failure);
+
+    // Nothing dressed it up as an incompatibility, and no status was claimed.
+    expect(recorded.errors).toEqual([]);
+    expect(recorded.exits).toEqual([]);
+  });
+});
+
+describe("cli piece setsrc --check — the library boundary", () => {
+  // `checkPiecePattern` is the read-only twin of `setPiecePattern`: it resolves
+  // the same piece address the same way and asks the controller for a verdict,
+  // without ever reaching a mutating call.
+  const config = {
+    apiUrl: API_URL,
+    space: SPACE,
+    identity: "/tmp/test.key",
+    piece: "my-slug",
+  };
+
+  it("resolves the piece address and asks the controller for a verdict", async () => {
+    const manager = { id: "manager" } as unknown as PieceManager;
+    const calls: Record<string, unknown> = {};
+    const controller = {
+      checkPattern: (program: unknown) => {
+        calls.checkedProgram = program;
+        return Promise.resolve(compatibleReport);
+      },
+      setPattern: () => {
+        throw new Error("a check must never mutate the piece");
+      },
+    };
+
+    const report = await checkPiecePattern(
+      config,
+      { mainPath: "/repo/pattern.tsx", rootPath: "/repo" },
+      {
+        loadManager: (loaded) => {
+          calls.loadedConfig = loaded;
+          return Promise.resolve(manager);
+        },
+        resolvePieceAddress: (resolvingManager, token) => {
+          calls.resolved = { sameManager: resolvingManager === manager, token };
+          return Promise.resolve(PIECE);
+        },
+        createController: (controllerManager) => {
+          calls.controllerManager = controllerManager;
+          return {
+            get: (
+              id: string,
+              start: boolean,
+              _tx: unknown,
+              scope: unknown,
+            ) => {
+              calls.got = { id, start, scope };
+              return Promise.resolve(controller);
+            },
+          } as unknown as PiecesController;
+        },
+        getPinnedProgramFromFile: (programManager, entry) => {
+          calls.pinned = { sameManager: programManager === manager, entry };
+          return Promise.resolve({ main: "/repo/pattern.tsx", files: [] });
+        },
+      },
+    );
+
+    expect(report).toBe(compatibleReport);
+    expect(calls.loadedConfig).toBe(config);
+    expect(calls.resolved).toEqual({ sameManager: true, token: "my-slug" });
+    expect(calls.controllerManager).toBe(manager);
+    // The resolved address is what gets looked up, and the piece is fetched
+    // WITHOUT starting it — a preflight must not run the pattern.
+    expect(calls.got).toEqual({ id: PIECE, start: false, scope: undefined });
+    expect(calls.pinned).toEqual({
+      sameManager: true,
+      entry: { mainPath: "/repo/pattern.tsx", rootPath: "/repo" },
+    });
+    expect(calls.checkedProgram).toEqual({
+      main: "/repo/pattern.tsx",
+      files: [],
+    });
+  });
+
+  it("carries the piece scope through to the lookup", async () => {
+    const manager = {} as unknown as PieceManager;
+    let scope: unknown = "unset";
+
+    await checkPiecePattern(
+      { ...config, pieceScope: "user" },
+      { mainPath: "/repo/pattern.tsx" },
+      {
+        loadManager: () => Promise.resolve(manager),
+        resolvePieceAddress: () => Promise.resolve(PIECE),
+        createController: () =>
+          ({
+            get: (
+              _id: string,
+              _start: boolean,
+              _tx: unknown,
+              cellScope: unknown,
+            ) => {
+              scope = cellScope;
+              return Promise.resolve({
+                checkPattern: () => Promise.resolve(incompatibleReport),
+              });
+            },
+          }) as unknown as PiecesController,
+        getPinnedProgramFromFile: () =>
+          Promise.resolve({ main: "/repo/pattern.tsx", files: [] }),
+      },
+    );
+
+    expect(scope).toBe("user");
   });
 });

--- a/packages/cli/test/piece-setsrc-check.test.ts
+++ b/packages/cli/test/piece-setsrc-check.test.ts
@@ -1,0 +1,226 @@
+/**
+ * `cf piece setsrc --check` — the command boundary.
+ *
+ * Why: the preflight only earns its keep if it is genuinely read-only and if
+ * its exit status is machine-usable. These tests pin the routing (a `--check`
+ * run must never reach the mutating library call), the flag validation, the
+ * exit code, and the human/JSON report shapes. The rules themselves are pinned
+ * in `packages/piece/test/pattern-update-check.test.ts`.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  type PatternUpdateCheckReport,
+  PatternUpdateIncompatibleError,
+} from "@commonfabric/piece/ops";
+import {
+  assertSetSourceFlagCombination,
+  checkPieceSourceFromCommand,
+  formatPatternUpdateCheckReport,
+  piece,
+  reportIncompatibleSetSource,
+  setPieceSourceFromCommand,
+  SETSRC_INCOMPATIBLE_EXIT_CODE,
+} from "../commands/piece.ts";
+
+const API_URL = "https://cf.dev";
+const SPACE = "common-knowledge";
+const PIECE = "abcdefghijklmnopqrstuvwxyz";
+
+const compatibleReport: PatternUpdateCheckReport = {
+  piece: PIECE,
+  compatible: true,
+  steps: [
+    { name: "pattern contract", status: "pass", note: "contracts still hold" },
+    {
+      name: "CFC document migration (argument)",
+      status: "not-applicable",
+      note: "no stored envelope",
+    },
+    { name: "retained argument links", status: "pass" },
+  ],
+  blockers: [],
+  advisories: [
+    {
+      class: "setup-migration",
+      role: "result",
+      field: "addFavorite",
+      message: "`addFavorite` is a new handler stream; setup materializes it.",
+    },
+  ],
+};
+
+const incompatibleReport: PatternUpdateCheckReport = {
+  piece: PIECE,
+  compatible: false,
+  steps: [{ name: "pattern contract", status: "fail" }],
+  blockers: [
+    {
+      class: "cfc-schema-migration",
+      role: "result",
+      field: "favorites",
+      reason:
+        "required field favorites needs a default to preserve old documents",
+      message:
+        "field `favorites` would become required but has no default — an existing document predating it could not be read.",
+    },
+  ],
+  advisories: [],
+};
+
+describe("cli piece setsrc --check", () => {
+  it("registers the preflight flags on setsrc", () => {
+    const flags = piece.getCommand("setsrc")!.getOptions().flatMap((option) =>
+      option.flags
+    );
+    expect(flags).toContain("--check");
+    expect(flags).toContain("--json");
+  });
+
+  it("routes a check to the read-only library call, never the mutating one", async () => {
+    let checked: unknown;
+    const report = await checkPieceSourceFromCommand(
+      {
+        apiUrl: API_URL,
+        space: SPACE,
+        identity: "/tmp/test.key",
+        piece: PIECE,
+        root: "/repo",
+        check: true,
+      },
+      "/repo/pattern.tsx",
+      {
+        checkPiecePattern: (config, entry) => {
+          checked = { config, entry };
+          return Promise.resolve(compatibleReport);
+        },
+      },
+    );
+
+    expect(report).toBe(compatibleReport);
+    expect(checked).toEqual({
+      config: {
+        apiUrl: API_URL,
+        space: SPACE,
+        identity: "/tmp/test.key",
+        piece: PIECE,
+      },
+      entry: { mainPath: "/repo/pattern.tsx", rootPath: "/repo" },
+    });
+  });
+
+  it("does not call setPiecePattern for a check run", async () => {
+    // The mutating boundary is a separate function; a check run reaches the
+    // other one. Proven by wiring a setPiecePattern that would fail the test
+    // if it were ever invoked.
+    let mutated = false;
+    await checkPieceSourceFromCommand(
+      {
+        apiUrl: API_URL,
+        space: SPACE,
+        identity: "/tmp/test.key",
+        piece: PIECE,
+        check: true,
+      },
+      "/repo/pattern.tsx",
+      { checkPiecePattern: () => Promise.resolve(compatibleReport) },
+    );
+    await setPieceSourceFromCommand(
+      {
+        apiUrl: API_URL,
+        space: SPACE,
+        identity: "/tmp/test.key",
+        piece: PIECE,
+      },
+      "/repo/pattern.tsx",
+      {
+        setPiecePattern: () => {
+          mutated = true;
+          return Promise.resolve();
+        },
+      },
+    );
+    expect(mutated).toBe(true);
+  });
+
+  it("rejects --json without --check", () => {
+    expect(() => assertSetSourceFlagCombination({ json: true })).toThrow(
+      '"--json" is only available with "--check"',
+    );
+    expect(() => assertSetSourceFlagCombination({ json: true, check: true }))
+      .not.toThrow();
+  });
+
+  it("rejects --check combined with the dangerous override", () => {
+    expect(() =>
+      assertSetSourceFlagCombination({
+        check: true,
+        dangerouslyAllowIncompatibleSchema: true,
+      })
+    ).toThrow('"--check" cannot be combined');
+    expect(() =>
+      assertSetSourceFlagCombination({
+        dangerouslyAllowIncompatibleSchema: true,
+      })
+    ).not.toThrow();
+  });
+
+  it("renders a compatible verdict with its proved steps and migration work", () => {
+    const output = formatPatternUpdateCheckReport(compatibleReport);
+    expect(output).toContain("COMPATIBLE");
+    expect(output).toContain("pattern contract");
+    expect(output).toContain("n/a");
+    expect(output).toContain("Would migrate on update:");
+    expect(output).toContain("addFavorite");
+    expect(output).not.toContain("Blockers:");
+  });
+
+  it("renders an incompatible verdict naming the field and the rule", () => {
+    const output = formatPatternUpdateCheckReport(incompatibleReport);
+    expect(output).toContain("INCOMPATIBLE");
+    expect(output).toContain("Blockers:");
+    expect(output).toContain("[cfc-schema-migration]");
+    expect(output).toContain("favorites");
+    expect(output).toContain("could not be read");
+  });
+
+  it("reports a refused setsrc with the check's reasons and exit 3", () => {
+    const errors: string[] = [];
+    const hints: string[] = [];
+    let exited: number | undefined;
+    const error = new PatternUpdateIncompatibleError(
+      PIECE,
+      incompatibleReport.blockers,
+    );
+
+    reportIncompatibleSetSource(error, {
+      printError: (message) => errors.push(message),
+      printHint: (message) => hints.push(message),
+      exit: (code: number) => {
+        exited = code;
+        return undefined as never;
+      },
+    });
+
+    expect(exited).toBe(SETSRC_INCOMPATIBLE_EXIT_CODE);
+    expect(errors[0]).toContain("The piece was NOT modified.");
+    expect(errors.join("\n")).toContain("favorites");
+    expect(errors.join("\n")).toContain("[cfc-schema-migration]");
+    expect(hints.join("\n")).toContain("setsrc --check");
+  });
+
+  it("leaves an unrelated failure alone", () => {
+    let exited = false;
+    const result = reportIncompatibleSetSource(new Error("network down"), {
+      printError: () => {},
+      printHint: () => {},
+      exit: () => {
+        exited = true;
+        return undefined as never;
+      },
+    });
+    expect(result).toBe(null);
+    expect(exited).toBe(false);
+  });
+});

--- a/packages/piece/src/ops/mod.ts
+++ b/packages/piece/src/ops/mod.ts
@@ -5,3 +5,13 @@ export {
   type PiecePatternRef,
   type PiecePatternSourceRef,
 } from "./piece-controller.ts";
+export {
+  checkPatternUpdate,
+  type PatternUpdateAdvisory,
+  type PatternUpdateBlocker,
+  type PatternUpdateBlockerClass,
+  type PatternUpdateCheckReport,
+  type PatternUpdateCheckStep,
+  PatternUpdateIncompatibleError,
+  type PatternUpdateRole,
+} from "../pattern-update-check.ts";

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -44,6 +44,7 @@ import {
 } from "../schema-compatibility.ts";
 import {
   checkPatternUpdate,
+  type PatternUpdateCheckInput,
   type PatternUpdateCheckReport,
   PatternUpdateIncompatibleError,
   type PatternUpdateRole,
@@ -2645,6 +2646,152 @@ class PiecePropIo implements PieceCellIo {
   }
 }
 
+/**
+ * Outcome of running the retained-link validator ahead of a pattern update.
+ * `ran: false` means the proof could not be evaluated at all, which the report
+ * shows as not-applicable rather than as a silent pass.
+ */
+export interface RetainedLinkVerdict {
+  ran: boolean;
+  issue?: string;
+  note?: string;
+}
+
+/**
+ * A piece's argument cell, or `undefined` when the piece has none.
+ *
+ * Why swallow the throw: `getArgument` raises for a piece whose result cell
+ * carries no argument metadata link. To the update check that is a piece with
+ * nothing to validate, not an error — every rule that needs the argument
+ * reports itself not-applicable instead.
+ *
+ * Exported for direct testing: the callers are private methods, and the
+ * absent-argument branch is otherwise only reachable through a malformed
+ * piece.
+ */
+export function pieceArgumentCellOrUndefined(
+  manager: PieceManager,
+  pieceCell: Cell<unknown>,
+): Cell<unknown> | undefined {
+  try {
+    return manager.getArgument(pieceCell);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The CFC schema envelopes at rest for the given role/cell pairs — the
+ * `existing` side of the merge the next setup commit would perform. Read
+ * through `runtime.readTx()`, which cannot write.
+ *
+ * A role is absent when its cell is absent, when its document carries no
+ * stored CFC metadata, or when that metadata cannot be read back. That is not
+ * a gap in the check: the merge only runs against a stored envelope, so with
+ * none there is nothing for it to reject.
+ */
+export function storedCfcEnvelopes(
+  manager: PieceManager,
+  cells: readonly (readonly [
+    PatternUpdateRole,
+    Cell<unknown> | undefined,
+  ])[],
+): Partial<Record<PatternUpdateRole, JSONSchema>> {
+  const tx = manager.runtime.readTx();
+  const envelopes: Partial<Record<PatternUpdateRole, JSONSchema>> = {};
+  for (const [role, cell] of cells) {
+    if (cell === undefined) continue;
+    try {
+      const link = cell.getAsNormalizedFullLink();
+      const metadata = readStoredCfcMetadata(tx, {
+        space: link.space,
+        id: link.id,
+        scope: link.scope,
+      });
+      if (metadata?.schemaHash === undefined) continue;
+      envelopes[role] = loadSchemaDocument(
+        tx,
+        link.space,
+        metadata.schemaHash,
+      );
+    } catch {
+      // An unreadable envelope is reported as "not applicable" rather than
+      // guessed at; the caller sees the role missing.
+      continue;
+    }
+  }
+  return envelopes;
+}
+
+/**
+ * Run the retained-link validator `setPattern` installs, over the argument
+ * links already committed for a piece. Read-only: it inspects `getRaw()` and
+ * the candidate's argument schema, and never writes.
+ */
+export function retainedLinkVerdict(
+  manager: PieceManager,
+  argumentCell: Cell<unknown> | undefined,
+  previousPattern: Pattern,
+  candidate: Pattern,
+): RetainedLinkVerdict {
+  if (argumentCell === undefined) {
+    return { ran: false, note: "this piece has no argument cell" };
+  }
+  try {
+    assertSuppliedLinkSchemasCompatible(
+      suppliedLinks(argumentCell.getRaw()),
+      candidate.argumentSchema,
+      argumentCell,
+      manager,
+      {
+        priorArgumentSchema: previousPattern.argumentSchema,
+        linksPreservedVerbatim: true,
+      },
+    );
+    return { ran: true };
+  } catch (error) {
+    return {
+      ran: true,
+      issue: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Re-describe a failed update in the same terms `checkPattern` would, so the
+ * user is told WHICH field broke WHICH rule instead of whichever low-level
+ * message surfaced first (a raw CFC commit rejection, most painfully).
+ *
+ * `verdict` is a thunk rather than a value because gathering it re-reads
+ * storage: the two early returns below must not pay for a verdict they are
+ * going to discard. It never retries and never writes — the setup transaction
+ * has already aborted, so the state it re-reads is the untouched pre-update
+ * state and the piece is not half-updated. When the verdict finds no blocker —
+ * a transport failure, a compile error, a genuine bug — the original error is
+ * returned unchanged rather than being dressed up as an incompatibility.
+ */
+export function explainUpdateFailure(
+  piece: string,
+  error: unknown,
+  options: { dangerouslyAllowIncompatibleSchema?: boolean },
+  verdict: () => PatternUpdateCheckReport,
+): unknown {
+  // The override deliberately ran the update without the compatibility
+  // gates; reporting gate findings for its failure would misattribute it.
+  if (options.dangerouslyAllowIncompatibleSchema) return error;
+  if (error instanceof PatternUpdateIncompatibleError) return error;
+  let report: PatternUpdateCheckReport;
+  try {
+    report = verdict();
+  } catch {
+    return error;
+  }
+  if (report.blockers.length === 0) return error;
+  return new PatternUpdateIncompatibleError(piece, report.blockers, {
+    cause: error,
+  });
+}
+
 export class PieceController<T = unknown> {
   #cell: Cell<T>;
   #manager: PieceManager;
@@ -2874,97 +3021,41 @@ export class PieceController<T = unknown> {
     // The retained-link proof reads the argument document's RAW value, so that
     // document has to be loaded first. `setPattern` gets this for free — setup
     // loads the argument before validating it — but the preflight must ask.
-    await this.#argumentCellOrUndefined()?.sync();
+    await pieceArgumentCellOrUndefined(this.#manager, this.#cell)?.sync();
 
-    return checkPatternUpdate({
+    return checkPatternUpdate(
+      this.#updateCheckInput(previousPattern, candidate),
+    );
+  }
+
+  /**
+   * Everything {@link checkPatternUpdate} needs about this piece, gathered
+   * read-only. Shared by the preflight and by the explanation an enforced
+   * update produces when it is refused, so the two cannot disagree.
+   */
+  #updateCheckInput(
+    previousPattern: Pattern,
+    candidate: Pattern,
+  ): PatternUpdateCheckInput {
+    const argumentCell = pieceArgumentCellOrUndefined(
+      this.#manager,
+      this.#cell,
+    );
+    return {
       piece: this.id,
       previous: previousPattern,
       candidate,
-      storedCfcEnvelopes: this.#storedCfcEnvelopes(),
-      retainedLinks: this.#retainedLinkVerdict(previousPattern, candidate),
-    });
-  }
-
-  /**
-   * The CFC schema envelopes at rest for this piece's argument and result
-   * documents — the `existing` side of the merge the next setup commit would
-   * perform. Read through `runtime.readTx()`, which cannot write.
-   *
-   * A role is absent when its document carries no stored CFC metadata. That is
-   * not a gap in the check: the merge only runs against a stored envelope, so
-   * with none there is nothing for it to reject.
-   */
-  #storedCfcEnvelopes(): Partial<Record<PatternUpdateRole, JSONSchema>> {
-    const runtime = this.#manager.runtime;
-    const tx = runtime.readTx();
-    const envelopes: Partial<Record<PatternUpdateRole, JSONSchema>> = {};
-    const cells: [PatternUpdateRole, Cell<unknown> | undefined][] = [
-      ["result", this.#cell],
-      ["argument", this.#argumentCellOrUndefined()],
-    ];
-    for (const [role, cell] of cells) {
-      if (cell === undefined) continue;
-      try {
-        const link = cell.getAsNormalizedFullLink();
-        const metadata = readStoredCfcMetadata(tx, {
-          space: link.space,
-          id: link.id,
-          scope: link.scope,
-        });
-        if (metadata?.schemaHash === undefined) continue;
-        envelopes[role] = loadSchemaDocument(
-          tx,
-          link.space,
-          metadata.schemaHash,
-        );
-      } catch {
-        // An unreadable envelope is reported as "not applicable" rather than
-        // guessed at; the caller sees the role missing.
-        continue;
-      }
-    }
-    return envelopes;
-  }
-
-  #argumentCellOrUndefined(): Cell<unknown> | undefined {
-    try {
-      return this.#manager.getArgument(this.#cell);
-    } catch {
-      return undefined;
-    }
-  }
-
-  /**
-   * Run the retained-link validator `setPattern` installs, over the argument
-   * links already committed for this piece. Read-only: it inspects
-   * `getRaw()` and the candidate's argument schema, and never writes.
-   */
-  #retainedLinkVerdict(
-    previousPattern: Pattern,
-    candidate: Pattern,
-  ): { ran: boolean; issue?: string; note?: string } {
-    const argumentCell = this.#argumentCellOrUndefined();
-    if (argumentCell === undefined) {
-      return { ran: false, note: "this piece has no argument cell" };
-    }
-    try {
-      assertSuppliedLinkSchemasCompatible(
-        suppliedLinks(argumentCell.getRaw()),
-        candidate.argumentSchema,
-        argumentCell,
+      storedCfcEnvelopes: storedCfcEnvelopes(this.#manager, [
+        ["result", this.#cell],
+        ["argument", argumentCell],
+      ]),
+      retainedLinks: retainedLinkVerdict(
         this.#manager,
-        {
-          priorArgumentSchema: previousPattern.argumentSchema,
-          linksPreservedVerbatim: true,
-        },
-      );
-      return { ran: true };
-    } catch (error) {
-      return {
-        ran: true,
-        issue: error instanceof Error ? error.message : String(error),
-      };
-    }
+        argumentCell,
+        previousPattern,
+        candidate,
+      ),
+    };
   }
 
   async setPattern(
@@ -3012,50 +3103,19 @@ export class PieceController<T = unknown> {
           repository: options?.repository,
         }) as Cell<T>;
       } catch (error) {
-        throw this.#explainUpdateFailure(previousPattern, pattern, error, {
-          dangerouslyAllowIncompatibleSchema: options
-            ?.dangerouslyAllowIncompatibleSchema,
-        });
+        throw explainUpdateFailure(
+          this.id,
+          error,
+          {
+            dangerouslyAllowIncompatibleSchema: options
+              ?.dangerouslyAllowIncompatibleSchema,
+          },
+          () =>
+            checkPatternUpdate(
+              this.#updateCheckInput(previousPattern, pattern),
+            ),
+        );
       }
-    });
-  }
-
-  /**
-   * Re-describe a failed update in the same terms `checkPattern` would, so the
-   * user is told WHICH field broke WHICH rule instead of whichever low-level
-   * message surfaced first (a raw CFC commit rejection, most painfully).
-   *
-   * This never retries and never writes: the setup transaction has already
-   * aborted, so the state it re-reads is the untouched pre-update state and the
-   * piece is not half-updated. When the verdict finds no blocker — a transport
-   * failure, a compile error, a genuine bug — the original error is returned
-   * unchanged rather than being dressed up as an incompatibility.
-   */
-  #explainUpdateFailure(
-    previousPattern: Pattern,
-    candidate: Pattern,
-    error: unknown,
-    options: { dangerouslyAllowIncompatibleSchema?: boolean },
-  ): unknown {
-    // The override deliberately ran the update without the compatibility
-    // gates; reporting gate findings for its failure would misattribute it.
-    if (options.dangerouslyAllowIncompatibleSchema) return error;
-    if (error instanceof PatternUpdateIncompatibleError) return error;
-    let report: PatternUpdateCheckReport;
-    try {
-      report = checkPatternUpdate({
-        piece: this.id,
-        previous: previousPattern,
-        candidate,
-        storedCfcEnvelopes: this.#storedCfcEnvelopes(),
-        retainedLinks: this.#retainedLinkVerdict(previousPattern, candidate),
-      });
-    } catch {
-      return error;
-    }
-    if (report.blockers.length === 0) return error;
-    return new PatternUpdateIncompatibleError(this.id, report.blockers, {
-      cause: error,
     });
   }
 

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -29,10 +29,10 @@ import {
 import type { CellKind, LinkScope } from "@commonfabric/api";
 import {
   cfcSchemaChildRoot,
-  loadSchemaDocument,
-  readStoredCfcMetadata,
+  loadStoredCfcEnvelope,
   resolveCfcSchemaRefRoot,
   resolveCfcSchemaRefs,
+  type StoredCfcEnvelope,
   validateSchemaValue,
 } from "@commonfabric/runner/cfc";
 import { pieceId, PieceManager } from "../manager.ts";
@@ -2681,14 +2681,17 @@ export function pieceArgumentCellOrUndefined(
 }
 
 /**
- * The CFC schema envelopes at rest for the given role/cell pairs — the
- * `existing` side of the merge the next setup commit would perform. Read
- * through `runtime.readTx()`, which cannot write.
+ * What is at rest for the given role/cell pairs — the `existing` side of the
+ * merge the next setup commit would perform. Read through
+ * `runtime.readTx()`, which cannot write.
  *
- * A role is absent when its cell is absent, when its document carries no
- * stored CFC metadata, or when that metadata cannot be read back. That is not
- * a gap in the check: the merge only runs against a stored envelope, so with
- * none there is nothing for it to reject.
+ * This deliberately contains NO error handling of its own: each document is
+ * resolved by `loadStoredCfcEnvelope`, the SAME gatherer the real commit path
+ * runs, so what counts as "nothing stored" versus "stored but unreadable" is
+ * decided once, by one function, for both the preflight and the enforced
+ * update. An unreadable envelope therefore reaches the verdict as a blocker
+ * (the commit path rejects that state), and only a role with no cell at all
+ * is absent from the result.
  */
 export function storedCfcEnvelopes(
   manager: PieceManager,
@@ -2696,29 +2699,17 @@ export function storedCfcEnvelopes(
     PatternUpdateRole,
     Cell<unknown> | undefined,
   ])[],
-): Partial<Record<PatternUpdateRole, JSONSchema>> {
+): Partial<Record<PatternUpdateRole, StoredCfcEnvelope>> {
   const tx = manager.runtime.readTx();
-  const envelopes: Partial<Record<PatternUpdateRole, JSONSchema>> = {};
+  const envelopes: Partial<Record<PatternUpdateRole, StoredCfcEnvelope>> = {};
   for (const [role, cell] of cells) {
     if (cell === undefined) continue;
-    try {
-      const link = cell.getAsNormalizedFullLink();
-      const metadata = readStoredCfcMetadata(tx, {
-        space: link.space,
-        id: link.id,
-        scope: link.scope,
-      });
-      if (metadata?.schemaHash === undefined) continue;
-      envelopes[role] = loadSchemaDocument(
-        tx,
-        link.space,
-        metadata.schemaHash,
-      );
-    } catch {
-      // An unreadable envelope is reported as "not applicable" rather than
-      // guessed at; the caller sees the role missing.
-      continue;
-    }
+    const link = cell.getAsNormalizedFullLink();
+    envelopes[role] = loadStoredCfcEnvelope(tx, {
+      space: link.space,
+      id: link.id,
+      scope: link.scope,
+    });
   }
   return envelopes;
 }

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -29,6 +29,8 @@ import {
 import type { CellKind, LinkScope } from "@commonfabric/api";
 import {
   cfcSchemaChildRoot,
+  loadSchemaDocument,
+  readStoredCfcMetadata,
   resolveCfcSchemaRefRoot,
   resolveCfcSchemaRefs,
   validateSchemaValue,
@@ -40,6 +42,12 @@ import {
   assertPatternSchemasBackwardCompatible,
   assertSchemaSubset,
 } from "../schema-compatibility.ts";
+import {
+  checkPatternUpdate,
+  type PatternUpdateCheckReport,
+  PatternUpdateIncompatibleError,
+  type PatternUpdateRole,
+} from "../pattern-update-check.ts";
 
 interface PieceCellIo {
   get(path?: CellPath): Promise<unknown>;
@@ -2839,6 +2847,126 @@ export class PieceController<T = unknown> {
     return (await this.getPatternSourceProgram())?.files;
   }
 
+  /**
+   * Would {@link setPattern} accept `program`? Answers without mutating the
+   * piece: no setup runs, no transaction commits, and the piece's pattern
+   * identity is untouched whatever the verdict.
+   *
+   * Every rule is the real one. The pattern-contract proof is the same function
+   * `setPattern` asserts with; the CFC verdict drives the real envelope merge
+   * over the schema currently at rest for this piece's documents; the
+   * retained-link proof is the same validator `setPattern` installs as
+   * `validateArgumentLinks`, run against committed state.
+   *
+   * Compiling the candidate is not free of side effects — like any compile it
+   * content-addresses the pattern's source and module closure into the space —
+   * but those documents are immutable and keyed by content, and the piece
+   * itself is never written.
+   */
+  async checkPattern(
+    program: RuntimeProgram,
+  ): Promise<PatternUpdateCheckReport> {
+    const { pattern: previousPattern, ref: previousRef } = await this
+      .#loadCurrentPattern();
+    const candidate = await compileProgram(this.#manager, program, {
+      previousEntryIdentity: previousRef.identity,
+    });
+    // The retained-link proof reads the argument document's RAW value, so that
+    // document has to be loaded first. `setPattern` gets this for free — setup
+    // loads the argument before validating it — but the preflight must ask.
+    await this.#argumentCellOrUndefined()?.sync();
+
+    return checkPatternUpdate({
+      piece: this.id,
+      previous: previousPattern,
+      candidate,
+      storedCfcEnvelopes: this.#storedCfcEnvelopes(),
+      retainedLinks: this.#retainedLinkVerdict(previousPattern, candidate),
+    });
+  }
+
+  /**
+   * The CFC schema envelopes at rest for this piece's argument and result
+   * documents — the `existing` side of the merge the next setup commit would
+   * perform. Read through `runtime.readTx()`, which cannot write.
+   *
+   * A role is absent when its document carries no stored CFC metadata. That is
+   * not a gap in the check: the merge only runs against a stored envelope, so
+   * with none there is nothing for it to reject.
+   */
+  #storedCfcEnvelopes(): Partial<Record<PatternUpdateRole, JSONSchema>> {
+    const runtime = this.#manager.runtime;
+    const tx = runtime.readTx();
+    const envelopes: Partial<Record<PatternUpdateRole, JSONSchema>> = {};
+    const cells: [PatternUpdateRole, Cell<unknown> | undefined][] = [
+      ["result", this.#cell],
+      ["argument", this.#argumentCellOrUndefined()],
+    ];
+    for (const [role, cell] of cells) {
+      if (cell === undefined) continue;
+      try {
+        const link = cell.getAsNormalizedFullLink();
+        const metadata = readStoredCfcMetadata(tx, {
+          space: link.space,
+          id: link.id,
+          scope: link.scope,
+        });
+        if (metadata?.schemaHash === undefined) continue;
+        envelopes[role] = loadSchemaDocument(
+          tx,
+          link.space,
+          metadata.schemaHash,
+        );
+      } catch {
+        // An unreadable envelope is reported as "not applicable" rather than
+        // guessed at; the caller sees the role missing.
+        continue;
+      }
+    }
+    return envelopes;
+  }
+
+  #argumentCellOrUndefined(): Cell<unknown> | undefined {
+    try {
+      return this.#manager.getArgument(this.#cell);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Run the retained-link validator `setPattern` installs, over the argument
+   * links already committed for this piece. Read-only: it inspects
+   * `getRaw()` and the candidate's argument schema, and never writes.
+   */
+  #retainedLinkVerdict(
+    previousPattern: Pattern,
+    candidate: Pattern,
+  ): { ran: boolean; issue?: string; note?: string } {
+    const argumentCell = this.#argumentCellOrUndefined();
+    if (argumentCell === undefined) {
+      return { ran: false, note: "this piece has no argument cell" };
+    }
+    try {
+      assertSuppliedLinkSchemasCompatible(
+        suppliedLinks(argumentCell.getRaw()),
+        candidate.argumentSchema,
+        argumentCell,
+        this.#manager,
+        {
+          priorArgumentSchema: previousPattern.argumentSchema,
+          linksPreservedVerbatim: true,
+        },
+      );
+      return { ran: true };
+    } catch (error) {
+      return {
+        ran: true,
+        issue: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
   async setPattern(
     program: RuntimeProgram,
     options?: {
@@ -2853,35 +2981,81 @@ export class PieceController<T = unknown> {
       const pattern = await compileProgram(this.#manager, program, {
         previousEntryIdentity: previousRef.identity,
       });
-      if (!options?.dangerouslyAllowIncompatibleSchema) {
-        assertPatternSchemasBackwardCompatible(previousPattern, pattern);
+      try {
+        if (!options?.dangerouslyAllowIncompatibleSchema) {
+          assertPatternSchemasBackwardCompatible(previousPattern, pattern);
+        }
+        return await execute(this.#manager, this.id, pattern, undefined, {
+          start: true,
+          expectedPatternIdentity: previousRef,
+          validateArgumentLinks: options?.dangerouslyAllowIncompatibleSchema
+            ? undefined
+            : (argumentCell, argumentSchema) =>
+              assertSuppliedLinkSchemasCompatible(
+                suppliedLinks(argumentCell.getRaw()),
+                argumentSchema,
+                argumentCell,
+                this.#manager,
+                {
+                  priorArgumentSchema: previousPattern.argumentSchema,
+                  // `applySetupState` rewrites the argument from `getRaw()`, so
+                  // every retained link's envelope is written back unchanged and
+                  // nothing here is rebuilt as an alias. The validator verifies
+                  // that per link against committed state rather than taking
+                  // this declaration on trust — anything the setup staged that
+                  // is NOT already committed (e.g. a link-shaped schema
+                  // default from the incoming pattern) still faces the full
+                  // rebuild rules.
+                  linksPreservedVerbatim: true,
+                },
+              ),
+          repository: options?.repository,
+        }) as Cell<T>;
+      } catch (error) {
+        throw this.#explainUpdateFailure(previousPattern, pattern, error, {
+          dangerouslyAllowIncompatibleSchema: options
+            ?.dangerouslyAllowIncompatibleSchema,
+        });
       }
-      return await execute(this.#manager, this.id, pattern, undefined, {
-        start: true,
-        expectedPatternIdentity: previousRef,
-        validateArgumentLinks: options?.dangerouslyAllowIncompatibleSchema
-          ? undefined
-          : (argumentCell, argumentSchema) =>
-            assertSuppliedLinkSchemasCompatible(
-              suppliedLinks(argumentCell.getRaw()),
-              argumentSchema,
-              argumentCell,
-              this.#manager,
-              {
-                priorArgumentSchema: previousPattern.argumentSchema,
-                // `applySetupState` rewrites the argument from `getRaw()`, so
-                // every retained link's envelope is written back unchanged and
-                // nothing here is rebuilt as an alias. The validator verifies
-                // that per link against committed state rather than taking
-                // this declaration on trust — anything the setup staged that
-                // is NOT already committed (e.g. a link-shaped schema
-                // default from the incoming pattern) still faces the full
-                // rebuild rules.
-                linksPreservedVerbatim: true,
-              },
-            ),
-        repository: options?.repository,
-      }) as Cell<T>;
+    });
+  }
+
+  /**
+   * Re-describe a failed update in the same terms `checkPattern` would, so the
+   * user is told WHICH field broke WHICH rule instead of whichever low-level
+   * message surfaced first (a raw CFC commit rejection, most painfully).
+   *
+   * This never retries and never writes: the setup transaction has already
+   * aborted, so the state it re-reads is the untouched pre-update state and the
+   * piece is not half-updated. When the verdict finds no blocker — a transport
+   * failure, a compile error, a genuine bug — the original error is returned
+   * unchanged rather than being dressed up as an incompatibility.
+   */
+  #explainUpdateFailure(
+    previousPattern: Pattern,
+    candidate: Pattern,
+    error: unknown,
+    options: { dangerouslyAllowIncompatibleSchema?: boolean },
+  ): unknown {
+    // The override deliberately ran the update without the compatibility
+    // gates; reporting gate findings for its failure would misattribute it.
+    if (options.dangerouslyAllowIncompatibleSchema) return error;
+    if (error instanceof PatternUpdateIncompatibleError) return error;
+    let report: PatternUpdateCheckReport;
+    try {
+      report = checkPatternUpdate({
+        piece: this.id,
+        previous: previousPattern,
+        candidate,
+        storedCfcEnvelopes: this.#storedCfcEnvelopes(),
+        retainedLinks: this.#retainedLinkVerdict(previousPattern, candidate),
+      });
+    } catch {
+      return error;
+    }
+    if (report.blockers.length === 0) return error;
+    return new PatternUpdateIncompatibleError(this.id, report.blockers, {
+      cause: error,
     });
   }
 

--- a/packages/piece/src/pattern-update-check.ts
+++ b/packages/piece/src/pattern-update-check.ts
@@ -1,0 +1,376 @@
+/**
+ * Ahead-of-time compatibility verdict for `cf piece setsrc`.
+ *
+ * Why: replacing a piece's pattern source can be refused for several distinct
+ * reasons, and until now the only way to learn which one applied was to attempt
+ * the update and read a low-level rejection out of the commit path. That cost a
+ * production incident on the hosted Estuary deployment: home roots and profile
+ * pieces were pinned to patterns that could not migrate their existing
+ * documents, and the failure only surfaced as a CFC commit rejection deep inside
+ * setup.
+ *
+ * This module assembles the verdict from the SAME rule implementations the real
+ * update runs — `patternSchemaCompatibilityIssues` (the pattern-contract
+ * subset proof), `cfcSchemaMergeIssue` (the CFC document merge), and the caller's
+ * run of `assertSuppliedLinkSchemasCompatible` — so the preflight cannot drift
+ * away from what the update actually enforces. Nothing here reads or writes
+ * storage; the caller gathers the stored envelopes read-only and hands them in.
+ */
+
+import type { JSONSchema, Pattern } from "@commonfabric/runner";
+import { cfcSchemaMergeIssue, isStreamSlot } from "@commonfabric/runner/cfc";
+import { patternSchemaCompatibilityIssues } from "./schema-compatibility.ts";
+
+/** Which side of the pattern's contract a finding concerns. */
+export type PatternUpdateRole = "argument" | "result";
+
+export type PatternUpdateBlockerClass =
+  /** The candidate pattern's declared contract is not an evolution of the
+   * running pattern's (field removed, type mutated, bound narrowed, a newly
+   * required field with no default). Enforced by
+   * `assertPatternSchemasBackwardCompatible`. */
+  | "pattern-contract"
+  /** The stored document cannot be migrated onto the candidate's schema
+   * because a now-required field carries no default. Enforced by the CFC
+   * schema merge at commit time. */
+  | "cfc-schema-migration"
+  /** Any other CFC envelope merge rejection (an incompatible type change, an
+   * IFC claim that cannot be weakened). Also enforced at commit time. */
+  | "cfc-schema-merge"
+  /** A durable link already supplied into an argument slot would no longer
+   * satisfy the candidate's schema for that slot. */
+  | "retained-link";
+
+export interface PatternUpdateBlocker {
+  class: PatternUpdateBlockerClass;
+  /** `argument` = the pattern's INPUT contract; `result` = its OUTPUT. */
+  role?: PatternUpdateRole;
+  /** Dotted schema path the rule reported, when it named one. */
+  path?: string;
+  /** The single field the rule named, when it named one. */
+  field?: string;
+  /**
+   * The named field is a handler stream on the candidate's contract — a
+   * runtime-materialized capability marker, not stored document data. The CFC
+   * document merge exempts such a slot from its additive-required rule
+   * (labs#4977); the pattern-contract proof does not. A blocker carrying this
+   * flag is therefore refused by the contract layer alone, and the two layers
+   * disagree about it.
+   */
+  streamSlot?: true;
+  /** The rule's own reason, verbatim. */
+  reason: string;
+  /** A full sentence suitable for printing on its own. */
+  message: string;
+}
+
+export interface PatternUpdateAdvisory {
+  /** Not a blocker: the update succeeds, but setup has migration work to do. */
+  class: "setup-migration";
+  role: PatternUpdateRole;
+  field: string;
+  message: string;
+}
+
+export type PatternUpdateCheckStatus = "pass" | "fail" | "not-applicable";
+
+export interface PatternUpdateCheckStep {
+  name: string;
+  status: PatternUpdateCheckStatus;
+  /** Why a step was skipped, or what it proved. */
+  note?: string;
+}
+
+export interface PatternUpdateCheckReport {
+  piece: string;
+  /** True when every applicable rule accepted the update. */
+  compatible: boolean;
+  steps: PatternUpdateCheckStep[];
+  blockers: PatternUpdateBlocker[];
+  advisories: PatternUpdateAdvisory[];
+}
+
+/**
+ * A pattern update was refused because the candidate is not compatible with the
+ * piece as it stands.
+ *
+ * Why a dedicated class: the underlying rejections arrive in several shapes —
+ * a schema-subset assertion, a CFC commit rejection re-wrapped as a plain
+ * `Error` at the runner's setup boundary, a retained-link proof failure — and
+ * the useful part (WHICH field, and under WHICH rule) was previously buried in
+ * whichever low-level message happened to surface first. Carrying the same
+ * {@link PatternUpdateBlocker} list the `--check` preflight reports means the
+ * enforced path and the preflight can never disagree about the reason.
+ */
+export class PatternUpdateIncompatibleError extends Error {
+  readonly piece: string;
+  readonly blockers: readonly PatternUpdateBlocker[];
+
+  constructor(
+    piece: string,
+    blockers: readonly PatternUpdateBlocker[],
+    options?: { cause?: unknown },
+  ) {
+    // The actionable reasons lead. The originating message is kept as a
+    // subordinate trailing line rather than dropped: a CLI renders only the
+    // blockers (see `reportIncompatibleSetSource`), but a library consumer
+    // reading `.message` or a stack trace still gets the low-level detail.
+    const underlying = options?.cause instanceof Error
+      ? options.cause.message
+      : undefined;
+    super(
+      `Pattern source cannot be applied to piece ${piece}:\n${
+        blockers.map((blocker) => `- ${blocker.message}`).join("\n")
+      }${underlying === undefined ? "" : `\nCaused by: ${underlying}`}`,
+      options?.cause === undefined ? undefined : { cause: options.cause },
+    );
+    this.name = "PatternUpdateIncompatibleError";
+    this.piece = piece;
+    this.blockers = blockers;
+  }
+}
+
+/** Everything the verdict needs, gathered read-only by the caller. */
+export interface PatternUpdateCheckInput {
+  piece: string;
+  previous: Pattern;
+  candidate: Pattern;
+  /**
+   * The CFC schema envelopes currently at rest for the piece's argument and
+   * result documents. `undefined` for a role means that document carries no
+   * stored CFC envelope, in which case the CFC merge never runs for it at
+   * commit time and the class genuinely cannot fail.
+   */
+  storedCfcEnvelopes: Partial<Record<PatternUpdateRole, JSONSchema>>;
+  /**
+   * Outcome of the caller's run of the real retained-link validator. `ran:
+   * false` means the caller could not evaluate it (no argument cell), which is
+   * reported as not-applicable rather than silently passing.
+   */
+  retainedLinks: { ran: boolean; issue?: string; note?: string };
+}
+
+const ROLE_LABEL: Record<PatternUpdateRole, string> = {
+  argument: "input (argument)",
+  result: "output (result)",
+};
+
+/**
+ * Split `"argument.favorites: newly required argument field has no default"`
+ * into its path, its leaf field, and the bare reason. The path's first segment
+ * is the role, which is how the report tells an INPUT finding from an OUTPUT
+ * one.
+ */
+export function parseContractIssue(issue: string): PatternUpdateBlocker {
+  const separator = issue.indexOf(": ");
+  const path = separator === -1 ? undefined : issue.slice(0, separator);
+  const reason = separator === -1 ? issue : issue.slice(separator + 2);
+  const segments = path?.split(".") ?? [];
+  const role = segments[0] === "argument"
+    ? "argument"
+    : segments[0] === "result"
+    ? "result"
+    : undefined;
+  const field = segments.length > 1 ? segments[segments.length - 1] : undefined;
+  return {
+    class: "pattern-contract",
+    ...(role ? { role } : {}),
+    ...(path ? { path } : {}),
+    ...(field ? { field } : {}),
+    reason,
+    message: field
+      ? `${path} — ${reason}. This is the pattern's ${
+        ROLE_LABEL[role ?? "argument"]
+      } contract.`
+      : `${path ?? "pattern"} — ${reason}.`,
+  };
+}
+
+/**
+ * Mark a contract blocker whose field is a handler stream, and say so in the
+ * message.
+ *
+ * Why it matters: the two layers that gate a source swap disagree about this
+ * case. The CFC document merge exempts a stream slot from its
+ * additive-required rule — a stream marker is re-materialized by setup on
+ * every run, so an old document that lacks one has no value to preserve and no
+ * meaningful default to declare. The pattern-contract subset proof has no such
+ * exemption, so it still refuses the update. Reporting the refusal truthfully
+ * (rather than suppressing it to match the CFC layer) is what keeps the
+ * preflight's verdict equal to what `setsrc` will actually do; naming the
+ * disagreement is what makes the refusal actionable.
+ */
+function annotateStreamSlot(
+  blocker: PatternUpdateBlocker,
+  candidate: Pattern,
+): PatternUpdateBlocker {
+  if (blocker.field === undefined || blocker.role === undefined) return blocker;
+  const properties = schemaProperties(
+    blocker.role === "argument"
+      ? candidate.argumentSchema
+      : candidate.resultSchema,
+  );
+  if (!isStreamSlot(properties[blocker.field])) return blocker;
+  return {
+    ...blocker,
+    streamSlot: true,
+    message:
+      `${blocker.message} \`${blocker.field}\` is a handler stream: it ` +
+      `holds no stored document data, and the CFC document layer already ` +
+      `exempts such a slot — only the pattern-contract proof refuses it. ` +
+      `Declaring the field optional on the pattern's contract clears this.`,
+  };
+}
+
+/** `"required field favorites needs a default …"` -> `favorites`. */
+function cfcNamedField(message: string): string | undefined {
+  return /^required field (\S+) needs a default/.exec(message)?.[1];
+}
+
+/**
+ * Named slots the candidate declares as streams that the running pattern did
+ * not. These are handler streams; setup materializes their `{ "$stream": true }`
+ * marker over the existing document, so they are migration WORK rather than an
+ * incompatibility — the CFC merge exempts a stream slot from the
+ * additive-required default rule precisely because it holds no preservable
+ * document data.
+ */
+function streamSlotAdvisories(
+  previous: Pattern,
+  candidate: Pattern,
+): PatternUpdateAdvisory[] {
+  const advisories: PatternUpdateAdvisory[] = [];
+  for (const role of ["argument", "result"] as const) {
+    const before = schemaProperties(
+      role === "argument" ? previous.argumentSchema : previous.resultSchema,
+    );
+    const after = schemaProperties(
+      role === "argument" ? candidate.argumentSchema : candidate.resultSchema,
+    );
+    for (const [field, schema] of Object.entries(after)) {
+      if (!isStreamSlot(schema)) continue;
+      if (isStreamSlot(before[field])) continue;
+      advisories.push({
+        class: "setup-migration",
+        role,
+        field,
+        message:
+          `\`${field}\` is a new handler stream on the ${ROLE_LABEL[role]} ` +
+          `contract. Setup will materialize its stream marker on the existing ` +
+          `document; no stored value is lost.`,
+      });
+    }
+  }
+  return advisories;
+}
+
+function schemaProperties(
+  schema: JSONSchema | undefined,
+): Record<string, JSONSchema> {
+  if (typeof schema !== "object" || schema === null) return {};
+  return schema.properties ?? {};
+}
+
+/**
+ * Decide whether `candidate` can replace `previous` on this piece, and say why
+ * not when it cannot. Pure: every rule is driven over values the caller already
+ * gathered.
+ */
+export function checkPatternUpdate(
+  input: PatternUpdateCheckInput,
+): PatternUpdateCheckReport {
+  const blockers: PatternUpdateBlocker[] = [];
+  const steps: PatternUpdateCheckStep[] = [];
+
+  const contractIssues = patternSchemaCompatibilityIssues(
+    input.previous,
+    input.candidate,
+  );
+  blockers.push(
+    ...contractIssues
+      .map(parseContractIssue)
+      .map((blocker) => annotateStreamSlot(blocker, input.candidate)),
+  );
+  steps.push({
+    name: "pattern contract",
+    status: contractIssues.length === 0 ? "pass" : "fail",
+    note: contractIssues.length === 0
+      ? "the candidate's argument and result contracts accept everything the running pattern's did"
+      : undefined,
+  });
+
+  for (const role of ["argument", "result"] as const) {
+    const stored = input.storedCfcEnvelopes[role];
+    if (stored === undefined) {
+      steps.push({
+        name: `CFC document migration (${role})`,
+        status: "not-applicable",
+        note:
+          `the ${role} document carries no stored CFC schema envelope, so the ` +
+          `CFC merge does not run for it`,
+      });
+      continue;
+    }
+    const candidateSchema = role === "argument"
+      ? input.candidate.argumentSchema
+      : input.candidate.resultSchema;
+    const issue = cfcSchemaMergeIssue(stored, candidateSchema);
+    if (issue === undefined) {
+      steps.push({
+        name: `CFC document migration (${role})`,
+        status: "pass",
+        note: "the stored document merges onto the candidate schema",
+      });
+      continue;
+    }
+    const field = cfcNamedField(issue.message);
+    blockers.push({
+      class: issue.migration ? "cfc-schema-migration" : "cfc-schema-merge",
+      role,
+      ...(field ? { field } : {}),
+      reason: issue.message,
+      message: field
+        ? `field \`${field}\` would become required but has no default — the ` +
+          `existing ${role} document predates it and could not be read. ` +
+          `Give it a \`Default<>\`, or make it optional.`
+        : `${ROLE_LABEL[role]} document cannot be migrated: ${issue.message}.`,
+    });
+    steps.push({
+      name: `CFC document migration (${role})`,
+      status: "fail",
+    });
+  }
+
+  if (!input.retainedLinks.ran) {
+    steps.push({
+      name: "retained argument links",
+      status: "not-applicable",
+      ...(input.retainedLinks.note ? { note: input.retainedLinks.note } : {}),
+    });
+  } else if (input.retainedLinks.issue === undefined) {
+    steps.push({
+      name: "retained argument links",
+      status: "pass",
+      note: "every durable link already supplied into an argument slot still " +
+        "satisfies the candidate's schema for that slot",
+    });
+  } else {
+    blockers.push({
+      class: "retained-link",
+      role: "argument",
+      reason: input.retainedLinks.issue,
+      message:
+        `a durable link already supplied into an argument slot would no longer ` +
+        `satisfy the candidate schema: ${input.retainedLinks.issue}.`,
+    });
+    steps.push({ name: "retained argument links", status: "fail" });
+  }
+
+  return {
+    piece: input.piece,
+    compatible: blockers.length === 0,
+    steps,
+    blockers,
+    advisories: streamSlotAdvisories(input.previous, input.candidate),
+  };
+}

--- a/packages/piece/src/pattern-update-check.ts
+++ b/packages/piece/src/pattern-update-check.ts
@@ -37,6 +37,11 @@ export type PatternUpdateBlockerClass =
   /** Any other CFC envelope merge rejection (an incompatible type change, an
    * IFC claim that cannot be weakened). Also enforced at commit time. */
   | "cfc-schema-merge"
+  /** The document's stored CFC metadata names a schema envelope that cannot
+   * be loaded (missing cid document, content-hash mismatch). The commit path
+   * records this load failure as a rejection reason and refuses the update,
+   * so the preflight refuses too — never "not applicable". */
+  | "cfc-envelope-unreadable"
   /** A durable link already supplied into an argument slot would no longer
    * satisfy the candidate's schema for that slot. */
   | "retained-link";
@@ -130,18 +135,33 @@ export class PatternUpdateIncompatibleError extends Error {
   }
 }
 
+/**
+ * What the shared gatherer (`loadStoredCfcEnvelope` in the runner's CFC
+ * layer — the SAME function the commit path calls) found at rest for one
+ * document. Declared structurally here so this module stays pure; the
+ * runner's `StoredCfcEnvelope` is assignable to it.
+ */
+export type StoredEnvelopeState =
+  /** No stored CFC metadata: the merge never runs for this document. */
+  | { readonly status: "none" }
+  /** A verified envelope is at rest; the merge runs against `schema`. */
+  | { readonly status: "loaded"; readonly schema: JSONSchema }
+  /** Metadata names an envelope that cannot be loaded. The commit path
+   * rejects this state, so it is a blocker — never "not applicable". */
+  | { readonly status: "unreadable"; readonly reason: string };
+
 /** Everything the verdict needs, gathered read-only by the caller. */
 export interface PatternUpdateCheckInput {
   piece: string;
   previous: Pattern;
   candidate: Pattern;
   /**
-   * The CFC schema envelopes currently at rest for the piece's argument and
-   * result documents. `undefined` for a role means that document carries no
-   * stored CFC envelope, in which case the CFC merge never runs for it at
-   * commit time and the class genuinely cannot fail.
+   * What the shared gatherer found for the piece's argument and result
+   * documents. `undefined` for a role means the piece has no such document
+   * (e.g. no argument cell), which — like `none` — leaves the CFC merge with
+   * nothing to run against.
    */
-  storedCfcEnvelopes: Partial<Record<PatternUpdateRole, JSONSchema>>;
+  storedCfcEnvelopes: Partial<Record<PatternUpdateRole, StoredEnvelopeState>>;
   /**
    * Outcome of the caller's run of the real retained-link validator. `ran:
    * false` means the caller could not evaluate it (no argument cell), which is
@@ -301,7 +321,7 @@ export function checkPatternUpdate(
 
   for (const role of ["argument", "result"] as const) {
     const stored = input.storedCfcEnvelopes[role];
-    if (stored === undefined) {
+    if (stored === undefined || stored.status === "none") {
       steps.push({
         name: `CFC document migration (${role})`,
         status: "not-applicable",
@@ -311,10 +331,30 @@ export function checkPatternUpdate(
       });
       continue;
     }
+    if (stored.status === "unreadable") {
+      // The commit path records this exact load failure as a rejection
+      // reason, so the real update WOULD be refused. Reporting it as
+      // "not applicable" is how a preflight green-lights a doomed swap.
+      blockers.push({
+        class: "cfc-envelope-unreadable",
+        role,
+        reason: stored.reason,
+        message:
+          `the stored CFC schema envelope for the ${role} document could ` +
+          `not be read (${stored.reason}) — a real update would be rejected ` +
+          `over the same failure. Repair the stored envelope before ` +
+          `retrying.`,
+      });
+      steps.push({
+        name: `CFC document migration (${role})`,
+        status: "fail",
+      });
+      continue;
+    }
     const candidateSchema = role === "argument"
       ? input.candidate.argumentSchema
       : input.candidate.resultSchema;
-    const issue = cfcSchemaMergeIssue(stored, candidateSchema);
+    const issue = cfcSchemaMergeIssue(stored.schema, candidateSchema);
     if (issue === undefined) {
       steps.push({
         name: `CFC document migration (${role})`,

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -126,6 +126,42 @@ export function assertPatternSchemasBackwardCompatible(
   previous: Pattern,
   candidate: Pattern,
 ): void {
+  const issues = patternSchemaCompatibilityIssues(previous, candidate);
+  if (issues.length > 0) {
+    throw new Error(patternSchemaIncompatibilityMessage(issues));
+  }
+}
+
+/** The message {@link assertPatternSchemasBackwardCompatible} throws. */
+export function patternSchemaIncompatibilityMessage(
+  issues: readonly string[],
+): string {
+  return `Pattern schemas are not backward compatible:\n${
+    issues.map((issue) => `- ${issue}`).join("\n")
+  }`;
+}
+
+/**
+ * Every reason `candidate` would be refused as an evolution of `previous`, as
+ * the human-readable strings {@link assertPatternSchemasBackwardCompatible}
+ * reports. Empty means the update is contract-compatible.
+ *
+ * Why this exists separately from the assert: `cf piece setsrc --check` needs
+ * the SAME verdict without a throw, so the preflight and the enforced update
+ * share one rule implementation. Callers that just want the gate should keep
+ * using the assert.
+ *
+ * Each issue is `"<path>: <reason>"`, where the path's first segment is the
+ * role — `argument` for the pattern's INPUT contract, `result` for its OUTPUT
+ * contract. That distinction is load-bearing for readers: a newly-required
+ * INPUT field genuinely needs a default (the pattern reads it, and an existing
+ * caller never supplied it), whereas the result rules govern what downstream
+ * readers were promised.
+ */
+export function patternSchemaCompatibilityIssues(
+  previous: Pattern,
+  candidate: Pattern,
+): string[] {
   const issues: string[] = [];
   for (
     const [label, schema] of [
@@ -140,13 +176,9 @@ export function assertPatternSchemasBackwardCompatible(
       issues.push(`${label} has an invalid schema: ${issue}`);
     }
   }
-  if (issues.length > 0) {
-    throw new Error(
-      `Pattern schemas are not backward compatible:\n${
-        issues.map((issue) => `- ${issue}`).join("\n")
-      }`,
-    );
-  }
+  // An invalid schema definition short-circuits: the subset proof below is only
+  // meaningful over well-formed schemas.
+  if (issues.length > 0) return issues;
 
   const argumentIssue = schemaSubsetIssue(
     previous.argumentSchema,
@@ -182,13 +214,7 @@ export function assertPatternSchemasBackwardCompatible(
   );
   if (resultIssue) issues.push(resultIssue);
 
-  if (issues.length > 0) {
-    throw new Error(
-      `Pattern schemas are not backward compatible:\n${
-        issues.map((issue) => `- ${issue}`).join("\n")
-      }`,
-    );
-  }
+  return issues;
 }
 
 /**

--- a/packages/piece/test/pattern-update-check.test.ts
+++ b/packages/piece/test/pattern-update-check.test.ts
@@ -1,0 +1,419 @@
+/**
+ * `PieceController.checkPattern` — the ahead-of-time verdict behind
+ * `cf piece setsrc --check` — and the structured failure the enforced update
+ * now reports.
+ *
+ * Why: the Estuary incident was a piece pinned to a pattern that could not
+ * migrate its stored document, discovered only by attempting the swap and
+ * reading a low-level rejection. These tests pin both halves of the fix: the
+ * preflight answers the question without mutating anything, and a refused
+ * update names the same reason the preflight would.
+ *
+ * CFC enforcement is ON (`enforce-explicit`) throughout, because the CFC
+ * document-merge rules only run under an enforcing mode.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import {
+  getPatternIdentityRef,
+  type JSONSchema,
+  type Pattern,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { PieceManager } from "../src/manager.ts";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
+import {
+  checkPatternUpdate,
+  PatternUpdateIncompatibleError,
+} from "../src/pattern-update-check.ts";
+
+const signer = await Identity.fromPassphrase("pattern update check");
+
+const program = (contents: string): RuntimeProgram => ({
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents }],
+});
+
+/** The running pattern: one optional input, one result field. */
+const BASE = program(`/// <cts-enable />
+import { Writable, pattern } from "commonfabric";
+
+export default pattern<{ seed?: string }>(() => {
+  const title = new Writable<string>("hi").for("title");
+  return { title };
+});
+`);
+
+/** Compatible evolution: a new OPTIONAL input the old caller never supplied. */
+const ADDS_OPTIONAL_INPUT = program(`/// <cts-enable />
+import { Writable, pattern } from "commonfabric";
+
+export default pattern<{ seed?: string; nickname?: string }>(() => {
+  const title = new Writable<string>("hi").for("title");
+  return { title };
+});
+`);
+
+/** Incompatible: a newly REQUIRED input field with no default. */
+const ADDS_REQUIRED_INPUT = program(`/// <cts-enable />
+import { Writable, pattern } from "commonfabric";
+
+export default pattern<{ seed?: string; nickname: string }>(() => {
+  const title = new Writable<string>("hi").for("title");
+  return { title };
+});
+`);
+
+/** Incompatible: an existing input field's type mutated. */
+const MUTATES_INPUT_TYPE = program(`/// <cts-enable />
+import { Writable, pattern } from "commonfabric";
+
+export default pattern<{ seed?: number }>(() => {
+  const title = new Writable<string>("hi").for("title");
+  return { title };
+});
+`);
+
+/** Compatible: adds a handler stream the old document has no marker for. */
+const ADDS_HANDLER_STREAM = program(`/// <cts-enable />
+import { handler, pattern, Writable } from "commonfabric";
+
+const rename = handler<{ title: string }, { title: Writable<string> }>(
+  (event, state) => {
+    state.title.set(event.title);
+  },
+);
+
+export default pattern<{ seed?: string }>(() => {
+  const title = new Writable<string>("hi").for("title");
+  return { title, rename: rename({ title }) };
+});
+`);
+
+function patternOf(
+  argumentSchema: JSONSchema,
+  resultSchema: JSONSchema,
+): Pattern {
+  return {
+    argumentSchema,
+    resultSchema,
+    derivedInternalCells: [],
+    result: {},
+    nodes: [],
+  };
+}
+
+describe("pattern update check", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "pattern-update-check-" + crypto.randomUUID(),
+    });
+    manager = new PieceManager(session, runtime);
+    await manager.synced();
+    pieces = new PiecesController(manager);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("accepts a compatible source and proves each rule it ran", async () => {
+    const piece = await pieces.create(BASE, { input: {} });
+    const report = await piece.checkPattern(ADDS_OPTIONAL_INPUT);
+
+    expect(report.compatible).toBe(true);
+    expect(report.blockers).toEqual([]);
+    expect(report.piece).toBe(piece.id);
+    expect(report.steps.map((step) => step.name)).toContain("pattern contract");
+    expect(report.steps.map((step) => step.name)).toContain(
+      "retained argument links",
+    );
+    // Every applicable step passed; none silently failed.
+    expect(report.steps.some((step) => step.status === "fail")).toBe(false);
+  });
+
+  it("refuses a newly required INPUT field with no default, naming it", async () => {
+    const piece = await pieces.create(BASE, { input: {} });
+    const report = await piece.checkPattern(ADDS_REQUIRED_INPUT);
+
+    expect(report.compatible).toBe(false);
+    const blocker = report.blockers.find((entry) =>
+      entry.class === "pattern-contract"
+    );
+    expect(blocker).toBeDefined();
+    expect(blocker!.role).toBe("argument");
+    expect(blocker!.field).toBe("nickname");
+    expect(blocker!.reason).toContain("newly required argument field");
+    // Berni's framing: an added required INPUT genuinely needs a default,
+    // because the pattern reads it and an existing caller never supplied it.
+    expect(blocker!.message).toContain("input (argument)");
+  });
+
+  it("refuses an incompatible type mutation on an existing field", async () => {
+    const piece = await pieces.create(BASE, { input: {} });
+    const report = await piece.checkPattern(MUTATES_INPUT_TYPE);
+
+    expect(report.compatible).toBe(false);
+    expect(report.blockers[0].class).toBe("pattern-contract");
+    expect(report.blockers[0].field).toBe("seed");
+    expect(report.blockers[0].reason).toMatch(/type|no longer accepts/);
+  });
+
+  it("reports a new handler stream as setup migration work", async () => {
+    const piece = await pieces.create(BASE, { input: {} });
+    const report = await piece.checkPattern(ADDS_HANDLER_STREAM);
+
+    const advisory = report.advisories.find((entry) =>
+      entry.field === "rename"
+    );
+    expect(advisory).toBeDefined();
+    expect(advisory!.class).toBe("setup-migration");
+    expect(advisory!.message).toContain("stream marker");
+    // The CFC document layer exempts a stream slot from its additive-required
+    // rule (labs#4977), so nothing here is a CFC blocker.
+    expect(
+      report.blockers.filter((entry) => entry.class.startsWith("cfc-schema")),
+    ).toEqual([]);
+  });
+
+  it("names the layer disagreement when a stream slot is refused", async () => {
+    // Truthfulness over convenience: the pattern-contract proof has no stream
+    // exemption, so `setsrc` DOES refuse a pattern that merely adds a handler.
+    // The check reports what will happen and says which layer refused.
+    const piece = await pieces.create(BASE, { input: {} });
+    const report = await piece.checkPattern(ADDS_HANDLER_STREAM);
+
+    expect(report.compatible).toBe(false);
+    const blocker = report.blockers.find((entry) => entry.field === "rename");
+    expect(blocker).toBeDefined();
+    expect(blocker!.class).toBe("pattern-contract");
+    expect(blocker!.streamSlot).toBe(true);
+    expect(blocker!.message).toContain("only the pattern-contract proof");
+
+    // And the enforced path agrees with the preflight, field for field.
+    const error = await piece.setPattern(ADDS_HANDLER_STREAM).then(
+      () => undefined,
+      (thrown: unknown) => thrown,
+    );
+    expect(error).toBeInstanceOf(PatternUpdateIncompatibleError);
+    expect(
+      (error as PatternUpdateIncompatibleError).blockers.map((entry) => ({
+        class: entry.class,
+        field: entry.field,
+      })),
+    ).toEqual(report.blockers.map((entry) => ({
+      class: entry.class,
+      field: entry.field,
+    })));
+  });
+
+  it("mutates nothing, whatever the verdict", async () => {
+    const piece = await pieces.create(BASE, { input: {} });
+    await manager.synced();
+    const before = getPatternIdentityRef(piece.getCell());
+    const beforeTitle = await piece.result.get(["title"]);
+
+    expect((await piece.checkPattern(ADDS_OPTIONAL_INPUT)).compatible).toBe(
+      true,
+    );
+    expect((await piece.checkPattern(ADDS_REQUIRED_INPUT)).compatible).toBe(
+      false,
+    );
+    await runtime.idle();
+    await manager.synced();
+
+    expect(getPatternIdentityRef(piece.getCell())).toEqual(before);
+    expect(await piece.result.get(["title"])).toEqual(beforeTitle);
+  });
+
+  it("refuses the real update with the same reason, leaving the piece intact", async () => {
+    const piece = await pieces.create(BASE, { input: {} });
+    await manager.synced();
+    const before = getPatternIdentityRef(piece.getCell());
+
+    const error = await piece.setPattern(ADDS_REQUIRED_INPUT).then(
+      () => undefined,
+      (thrown: unknown) => thrown,
+    );
+
+    expect(error).toBeInstanceOf(PatternUpdateIncompatibleError);
+    const incompatible = error as PatternUpdateIncompatibleError;
+    expect(incompatible.piece).toBe(piece.id);
+    expect(
+      incompatible.blockers.some((blocker) =>
+        blocker.field === "nickname" && blocker.role === "argument"
+      ),
+    ).toBe(true);
+    // The raw low-level assertion is still available as the cause, but the
+    // message a user sees names the field and the rule.
+    expect(incompatible.message).toContain("nickname");
+
+    // Fail closed: the piece still runs its original pattern.
+    await manager.synced();
+    expect(getPatternIdentityRef(piece.getCell())).toEqual(before);
+  });
+
+  it("still applies a compatible source", async () => {
+    const piece = await pieces.create(BASE, { input: {} });
+    await manager.synced();
+    const before = getPatternIdentityRef(piece.getCell());
+
+    await piece.setPattern(ADDS_OPTIONAL_INPUT);
+    await manager.synced();
+
+    expect(getPatternIdentityRef(piece.getCell())).not.toEqual(before);
+  });
+});
+
+describe("pattern update check — CFC document migration", () => {
+  // The Estuary class, pinned at the layer that decides it. The stored envelope
+  // is what the piece's document actually carries; the candidate is what the
+  // incoming pattern would write. `checkPatternUpdate` drives the REAL CFC
+  // merge over that pair, so this cannot drift from what a commit would do.
+  const stored: JSONSchema = {
+    type: "object",
+    properties: { owner: { type: "string" } },
+    required: ["owner"],
+  };
+
+  const previous = patternOf({ type: "object" }, stored);
+
+  it("refuses a stored document that predates a now-required field", () => {
+    const candidate = patternOf({ type: "object" }, {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        favorites: { type: "array", items: { type: "string" } },
+      },
+      required: ["owner", "favorites"],
+    });
+
+    const report = checkPatternUpdate({
+      piece: "of:test",
+      previous,
+      candidate,
+      storedCfcEnvelopes: { result: stored },
+      retainedLinks: { ran: false },
+    });
+
+    expect(report.compatible).toBe(false);
+    const blocker = report.blockers.find((entry) =>
+      entry.class === "cfc-schema-migration"
+    );
+    expect(blocker).toBeDefined();
+    expect(blocker!.field).toBe("favorites");
+    expect(blocker!.reason).toContain(
+      "required field favorites needs a default",
+    );
+    expect(blocker!.message).toContain("could not be read");
+  });
+
+  it("accepts the same field once it declares a default", () => {
+    const candidate = patternOf({ type: "object" }, {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        favorites: { type: "array", items: { type: "string" }, default: [] },
+      },
+      required: ["owner", "favorites"],
+    });
+
+    const report = checkPatternUpdate({
+      piece: "of:test",
+      previous,
+      candidate,
+      storedCfcEnvelopes: { result: stored },
+      retainedLinks: { ran: false },
+    });
+
+    expect(
+      report.blockers.filter((entry) => entry.class === "cfc-schema-migration"),
+    ).toEqual([]);
+  });
+
+  it("exempts a newly required handler stream slot", () => {
+    const candidate = patternOf({ type: "object" }, {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        addFavorite: {
+          type: "object",
+          properties: {},
+          asCell: ["stream"],
+        },
+      },
+      required: ["owner", "addFavorite"],
+    });
+
+    const report = checkPatternUpdate({
+      piece: "of:test",
+      previous,
+      candidate,
+      storedCfcEnvelopes: { result: stored },
+      retainedLinks: { ran: false },
+    });
+
+    expect(
+      report.blockers.filter((entry) => entry.class.startsWith("cfc-schema")),
+    ).toEqual([]);
+    expect(report.advisories.some((entry) => entry.field === "addFavorite"))
+      .toBe(true);
+  });
+
+  it("reports a non-migration merge rejection as its own class", () => {
+    const candidate = patternOf({ type: "object" }, {
+      type: "object",
+      properties: { owner: { type: "number" } },
+      required: ["owner"],
+    });
+
+    const report = checkPatternUpdate({
+      piece: "of:test",
+      previous,
+      candidate,
+      storedCfcEnvelopes: { result: stored },
+      retainedLinks: { ran: false },
+    });
+
+    expect(report.compatible).toBe(false);
+    expect(
+      report.blockers.some((entry) => entry.class === "cfc-schema-merge"),
+    ).toBe(true);
+  });
+
+  it("marks the CFC step not-applicable when no envelope is stored", () => {
+    const report = checkPatternUpdate({
+      piece: "of:test",
+      previous,
+      candidate: previous,
+      storedCfcEnvelopes: {},
+      retainedLinks: { ran: false, note: "no argument cell" },
+    });
+
+    expect(report.compatible).toBe(true);
+    const cfcSteps = report.steps.filter((step) =>
+      step.name.startsWith("CFC document migration")
+    );
+    expect(cfcSteps.length).toBe(2);
+    expect(cfcSteps.every((step) => step.status === "not-applicable")).toBe(
+      true,
+    );
+  });
+});

--- a/packages/piece/test/pattern-update-check.test.ts
+++ b/packages/piece/test/pattern-update-check.test.ts
@@ -17,6 +17,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { loadStoredCfcEnvelope } from "@commonfabric/runner/cfc";
 import {
   type Cell,
   getPatternIdentityRef,
@@ -291,6 +292,154 @@ describe("pattern update check", () => {
 
     expect(getPatternIdentityRef(piece.getCell())).not.toEqual(before);
   });
+
+  it("reports an unreadable stored envelope on a live piece as a blocker", async () => {
+    // The reviewed false-COMPATIBLE bug, at the controller: a piece whose
+    // argument document's stored CFC metadata names an envelope that cannot
+    // be loaded must FAIL the preflight, not sail through as not-applicable.
+    const piece = await pieces.create(BASE, { input: {} });
+    await manager.synced();
+
+    // Corrupt the argument document the way the runner's cfc-boundary
+    // "missing or unreadable" test does: stored CFC metadata naming a schema
+    // envelope that does not exist. The raw seed transaction bypasses CFC
+    // preparation, exactly like a partially-replicated or damaged store.
+    const link = pieceArgumentCellOrUndefined(manager, piece.getCell())!
+      .getAsNormalizedFullLink();
+    const seed = runtime.edit();
+    const record = seed.readOrThrow({
+      space: link.space,
+      id: link.id,
+      scope: link.scope,
+      type: "application/json",
+      path: [],
+    });
+    seed.writeOrThrow({
+      space: link.space,
+      id: link.id,
+      scope: link.scope,
+      type: "application/json",
+      path: [],
+    }, {
+      ...(record as Record<string, unknown>),
+      cfc: {
+        version: 1,
+        schemaHash: "missing-hash",
+        labelMap: {
+          version: 1,
+          entries: [{ path: [], label: { confidentiality: [] } }],
+        },
+      },
+    });
+    const seedResult = await seed.commit();
+    expect(seedResult.ok).toBeDefined();
+    await manager.synced();
+
+    // The preflight refuses: unreadable is a blocker, never not-applicable.
+    const report = await piece.checkPattern(ADDS_OPTIONAL_INPUT);
+    expect(report.compatible).toBe(false);
+    const blocker = report.blockers.find((entry) =>
+      entry.class === "cfc-envelope-unreadable"
+    );
+    expect(blocker).toBeDefined();
+    expect(blocker!.role).toBe("argument");
+    expect(blocker!.reason).toContain("missing or unreadable");
+    expect(
+      report.steps.find((step) =>
+        step.name === "CFC document migration (argument)"
+      )!.status,
+    ).toBe("fail");
+  });
+
+  it("agrees with the enforced commit about an unreadable envelope, through the shared gatherer", async () => {
+    // ONE corrupted document, BOTH consumers of `loadStoredCfcEnvelope`:
+    // the real commit machinery (`prepareCfc`, which every setsrc setup
+    // commit runs when its writes are CFC-relevant) and the preflight
+    // verdict. The agreement is literal — the commit's rejection reason is
+    // the very string the check reports as the blocker's reason.
+    //
+    // The commit side writes the corrupted document directly (the runner's
+    // cfc-boundary recipe) rather than driving a full `setPattern`: whether
+    // a given source swap's setup produces a CFC-recorded write to a given
+    // document depends on which values actually change, so a direct labeled
+    // write is the deterministic way to pin what the commit does when it
+    // DOES touch the document.
+    const ifcSchema = {
+      type: "object",
+      properties: {
+        secret: { type: "string", ifc: { confidentiality: ["secret"] } },
+      },
+      required: ["secret"],
+    } as const;
+    const docCell = runtime.getCell(
+      manager.getSpace(),
+      "shared-gatherer-agreement-doc",
+      { type: "object", properties: { secret: { type: "string" } } },
+    );
+    const docId = docCell.getAsNormalizedFullLink().id;
+
+    const seed = runtime.edit();
+    seed.writeOrThrow({
+      space: manager.getSpace(),
+      scope: "space",
+      id: docId,
+      type: "application/json",
+      path: [],
+    }, {
+      value: { secret: "seed" },
+      cfc: {
+        version: 1,
+        schemaHash: "missing-hash",
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: ["secret"],
+            label: { confidentiality: ["secret"] },
+          }],
+        },
+      },
+    });
+    const seedResult = await seed.commit();
+    expect(seedResult.ok).toBeDefined();
+
+    // The check's side of the agreement: the shared gatherer calls the state
+    // unreadable, and the verdict turns that into a blocker.
+    const stored = loadStoredCfcEnvelope(runtime.readTx(), {
+      space: manager.getSpace(),
+      id: docId,
+      scope: "space",
+    });
+    expect(stored.status).toBe("unreadable");
+    const reason = (stored as { reason: string }).reason;
+    expect(reason).toContain("missing or unreadable");
+
+    const pattern = patternOf({ type: "object" }, { type: "object" });
+    const report = checkPatternUpdate({
+      piece: "of:test",
+      previous: pattern,
+      candidate: pattern,
+      storedCfcEnvelopes: { result: stored },
+      retainedLinks: { ran: false },
+    });
+    expect(report.compatible).toBe(false);
+    expect(report.blockers[0].class).toBe("cfc-envelope-unreadable");
+    expect(report.blockers[0].reason).toBe(reason);
+
+    // The commit's side: a labeled write to the same document runs the same
+    // gatherer inside `prepareCfc` and rejects with the same reason.
+    const tx = runtime.edit();
+    const writer = runtime.getCell(
+      manager.getSpace(),
+      "shared-gatherer-agreement-doc",
+      ifcSchema,
+      tx,
+    );
+    writer.set({ secret: "updated" });
+    tx.prepareCfc();
+    const result = await tx.commit();
+    expect(result.error).toBeDefined();
+    expect(result.error!.message).toContain(reason);
+  });
 });
 
 describe("pattern update check — CFC document migration", () => {
@@ -320,7 +469,7 @@ describe("pattern update check — CFC document migration", () => {
       piece: "of:test",
       previous,
       candidate,
-      storedCfcEnvelopes: { result: stored },
+      storedCfcEnvelopes: { result: { status: "loaded", schema: stored } },
       retainedLinks: { ran: false },
     });
 
@@ -350,7 +499,7 @@ describe("pattern update check — CFC document migration", () => {
       piece: "of:test",
       previous,
       candidate,
-      storedCfcEnvelopes: { result: stored },
+      storedCfcEnvelopes: { result: { status: "loaded", schema: stored } },
       retainedLinks: { ran: false },
     });
 
@@ -377,7 +526,7 @@ describe("pattern update check — CFC document migration", () => {
       piece: "of:test",
       previous,
       candidate,
-      storedCfcEnvelopes: { result: stored },
+      storedCfcEnvelopes: { result: { status: "loaded", schema: stored } },
       retainedLinks: { ran: false },
     });
 
@@ -399,7 +548,7 @@ describe("pattern update check — CFC document migration", () => {
       piece: "of:test",
       previous,
       candidate,
-      storedCfcEnvelopes: { result: stored },
+      storedCfcEnvelopes: { result: { status: "loaded", schema: stored } },
       retainedLinks: { ran: false },
     });
 
@@ -407,6 +556,40 @@ describe("pattern update check — CFC document migration", () => {
     expect(
       report.blockers.some((entry) => entry.class === "cfc-schema-merge"),
     ).toBe(true);
+  });
+
+  it("refuses an unreadable stored envelope, as the commit would", () => {
+    // The false-COMPATIBLE trap this class exists for: metadata names an
+    // envelope that cannot be loaded. The commit path records that load
+    // failure as a rejection reason, so the real update is refused — the
+    // preflight must say so, not shrug it off as "not applicable".
+    const report = checkPatternUpdate({
+      piece: "of:test",
+      previous,
+      candidate: previous,
+      storedCfcEnvelopes: {
+        result: {
+          status: "unreadable",
+          reason: "stored schemaHash missing-hash is missing or unreadable",
+        },
+      },
+      retainedLinks: { ran: false },
+    });
+
+    expect(report.compatible).toBe(false);
+    const blocker = report.blockers.find((entry) =>
+      entry.class === "cfc-envelope-unreadable"
+    );
+    expect(blocker).toBeDefined();
+    expect(blocker!.role).toBe("result");
+    expect(blocker!.reason).toContain("missing or unreadable");
+    expect(blocker!.message).toContain("could not be read");
+    expect(blocker!.message).toContain("would be rejected");
+    expect(
+      report.steps.find((step) =>
+        step.name === "CFC document migration (result)"
+      )!.status,
+    ).toBe("fail");
   });
 
   it("marks the CFC step not-applicable when no envelope is stored", () => {
@@ -590,28 +773,21 @@ describe("pattern update check — gathering the piece's side of the verdict", (
     expect(storedCfcEnvelopes(manager, [["argument", undefined]])).toEqual({});
   });
 
-  it("skips a role whose envelope cannot be read", () => {
-    const unreadable = {
-      getAsNormalizedFullLink() {
-        throw new Error("document unavailable");
-      },
-    } as unknown as Cell<unknown>;
-
-    expect(storedCfcEnvelopes(manager, [["result", unreadable]])).toEqual({});
-  });
-
-  it("skips a live document that stores no schema envelope", async () => {
+  it("reports a live document that stores no schema envelope as none", async () => {
     const piece = await pieces.create(BASE, { input: {} });
     await manager.synced();
 
     // No envelope at rest means the CFC merge never runs for that role at
-    // commit time, so the role is simply absent rather than guessed at.
+    // commit time — `none`, not a guess and not a failure.
     expect(
       storedCfcEnvelopes(manager, [
         ["result", piece.getCell()],
         ["argument", pieceArgumentCellOrUndefined(manager, piece.getCell())],
       ]),
-    ).toEqual({});
+    ).toEqual({
+      result: { status: "none" },
+      argument: { status: "none" },
+    });
   });
 
   it("loads the envelope a document's stored metadata names", () => {
@@ -627,9 +803,11 @@ describe("pattern update check — gathering the piece's side of the verdict", (
         readTx: () => ({
           readOrThrow: (target: { id: string }) =>
             target.id.startsWith("cid:") ? { value: schema } : {
-              version: 1,
-              labelMap: { entries: [] },
-              schemaHash: taggedHashString,
+              cfc: {
+                version: 1,
+                labelMap: { entries: [] },
+                schemaHash: taggedHashString,
+              },
             },
         }),
       },
@@ -642,9 +820,45 @@ describe("pattern update check — gathering the piece's side of the verdict", (
       }),
     } as unknown as Cell<unknown>;
 
-    expect(storedCfcEnvelopes(stubbedManager, [["result", cell]])).toEqual({
-      result: schema,
-    });
+    const result = storedCfcEnvelopes(stubbedManager, [["result", cell]])
+      .result!;
+    expect(result.status).toBe("loaded");
+    expect((result as { schema: unknown }).schema).toEqual(schema);
+  });
+
+  it("reports metadata whose envelope cannot be loaded as unreadable", () => {
+    // Stored metadata names a schema hash, but the content-addressed schema
+    // document is gone. The commit path records exactly this as a rejection
+    // reason (see the cfc-boundary "missing or unreadable" test), so the
+    // gatherer must surface it — not skip the role.
+    const stubbedManager = {
+      runtime: {
+        readTx: () => ({
+          readOrThrow: (target: { id: string }) =>
+            target.id.startsWith("cid:") ? undefined : {
+              cfc: {
+                version: 1,
+                labelMap: { entries: [] },
+                schemaHash: "missing-hash",
+              },
+            },
+        }),
+      },
+    } as unknown as PieceManager;
+    const cell = {
+      getAsNormalizedFullLink: () => ({
+        space: "did:key:envelope-test",
+        id: "of:piece",
+        scope: undefined,
+      }),
+    } as unknown as Cell<unknown>;
+
+    const result = storedCfcEnvelopes(stubbedManager, [["result", cell]])
+      .result!;
+    expect(result.status).toBe("unreadable");
+    expect((result as { reason: string }).reason).toContain(
+      "missing or unreadable",
+    );
   });
 
   it("marks the retained-link proof not-applicable with no argument cell", () => {

--- a/packages/piece/test/pattern-update-check.test.ts
+++ b/packages/piece/test/pattern-update-check.test.ts
@@ -16,7 +16,9 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
+  type Cell,
   getPatternIdentityRef,
   type JSONSchema,
   type Pattern,
@@ -27,7 +29,16 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { PieceManager } from "../src/manager.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 import {
+  explainUpdateFailure,
+  pieceArgumentCellOrUndefined,
+  retainedLinkVerdict,
+  storedCfcEnvelopes,
+} from "../src/ops/piece-controller.ts";
+import {
   checkPatternUpdate,
+  parseContractIssue,
+  type PatternUpdateBlocker,
+  type PatternUpdateCheckReport,
   PatternUpdateIncompatibleError,
 } from "../src/pattern-update-check.ts";
 
@@ -415,5 +426,363 @@ describe("pattern update check — CFC document migration", () => {
     expect(cfcSteps.every((step) => step.status === "not-applicable")).toBe(
       true,
     );
+  });
+});
+
+describe("pattern update check — findings that name no field", () => {
+  // A contract issue does not always come with a `role.field` path: a schema
+  // that cannot even be validated is reported against the pattern as a whole.
+  // Such a blocker must still read as a full sentence, and must not be run
+  // through the stream-slot annotation (there is no field to look up).
+  const wellFormed = patternOf({ type: "object" }, { type: "object" });
+
+  it("reports an unvalidatable schema against the pattern, not a field", () => {
+    const candidate = patternOf(
+      {
+        type: "object",
+        properties: { seed: { $ref: "#/definitions/absent" } },
+      },
+      { type: "object" },
+    );
+
+    const report = checkPatternUpdate({
+      piece: "of:test",
+      previous: wellFormed,
+      candidate,
+      storedCfcEnvelopes: {},
+      retainedLinks: { ran: false },
+    });
+
+    expect(report.compatible).toBe(false);
+    const blocker = report.blockers[0];
+    expect(blocker.class).toBe("pattern-contract");
+    expect(blocker.field).toBeUndefined();
+    expect(blocker.role).toBeUndefined();
+    // No field means no stream-slot lookup, so the annotation must not fire.
+    expect(blocker.streamSlot).toBeUndefined();
+    expect(blocker.message).toContain("invalid schema");
+    // Still a full sentence a CLI can print on its own line.
+    expect(blocker.message).toMatch(/ — .+\.$/);
+  });
+
+  it("parses a bare reason that carries no path at all", () => {
+    const blocker = parseContractIssue("something went sideways");
+
+    expect(blocker.class).toBe("pattern-contract");
+    expect(blocker.path).toBeUndefined();
+    expect(blocker.field).toBeUndefined();
+    expect(blocker.reason).toBe("something went sideways");
+    expect(blocker.message).toBe("pattern — something went sideways.");
+  });
+
+  it("survives a pattern that declares no schemas at all", () => {
+    // `argumentSchema`/`resultSchema` are optional on a compiled pattern, and
+    // the advisory scan must not assume an object is there to read properties
+    // off. Whatever the verdict, producing one must not throw.
+    const bare = {
+      derivedInternalCells: [],
+      result: {},
+      nodes: [],
+    } as unknown as Pattern;
+
+    const report = checkPatternUpdate({
+      piece: "of:test",
+      previous: bare,
+      candidate: bare,
+      storedCfcEnvelopes: {},
+      retainedLinks: { ran: false },
+    });
+
+    expect(report.piece).toBe("of:test");
+    expect(report.advisories).toEqual([]);
+  });
+});
+
+describe("pattern update check — stream slot advisories", () => {
+  const stream: JSONSchema = {
+    type: "object",
+    properties: {},
+    asCell: ["stream"],
+  };
+
+  it("reports a stream slot the running pattern did not declare", () => {
+    const report = checkPatternUpdate({
+      piece: "of:test",
+      previous: patternOf({ type: "object" }, { type: "object" }),
+      candidate: patternOf({ type: "object" }, {
+        type: "object",
+        properties: { rename: stream },
+      }),
+      storedCfcEnvelopes: {},
+      retainedLinks: { ran: false },
+    });
+
+    expect(report.advisories.map((entry) => entry.field)).toEqual(["rename"]);
+    expect(report.advisories[0].role).toBe("result");
+  });
+
+  it("stays quiet about a stream slot that was already there", () => {
+    // Setup materializes a stream marker on every run, so a slot the running
+    // pattern already declares is not migration work worth reporting.
+    const withStream = patternOf({ type: "object" }, {
+      type: "object",
+      properties: { rename: stream },
+    });
+
+    const report = checkPatternUpdate({
+      piece: "of:test",
+      previous: withStream,
+      candidate: withStream,
+      storedCfcEnvelopes: {},
+      retainedLinks: { ran: false },
+    });
+
+    expect(report.advisories).toEqual([]);
+  });
+});
+
+describe("pattern update check — gathering the piece's side of the verdict", () => {
+  // The three read-only gatherers behind `checkPattern`. Their absent /
+  // unreadable branches decide whether a rule reports "not applicable" or a
+  // blocker, so each is driven here against real cells rather than inferred.
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "pattern-update-gather-" + crypto.randomUUID(),
+    });
+    manager = new PieceManager(session, runtime);
+    await manager.synced();
+    pieces = new PiecesController(manager);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("resolves a piece's argument cell", async () => {
+    const piece = await pieces.create(BASE, { input: {} });
+    expect(pieceArgumentCellOrUndefined(manager, piece.getCell()))
+      .toBeDefined();
+  });
+
+  it("reports no argument cell for a document that has none", async () => {
+    const piece = await pieces.create(BASE, { input: {} });
+    // The argument document itself carries no `argument` metadata link, so it
+    // stands in for a piece that has none: `getArgument` throws, and the
+    // gatherer must answer "absent" rather than propagate.
+    const argument = pieceArgumentCellOrUndefined(manager, piece.getCell())!;
+    expect(pieceArgumentCellOrUndefined(manager, argument)).toBeUndefined();
+  });
+
+  it("skips a role whose cell is absent", () => {
+    expect(storedCfcEnvelopes(manager, [["argument", undefined]])).toEqual({});
+  });
+
+  it("skips a role whose envelope cannot be read", () => {
+    const unreadable = {
+      getAsNormalizedFullLink() {
+        throw new Error("document unavailable");
+      },
+    } as unknown as Cell<unknown>;
+
+    expect(storedCfcEnvelopes(manager, [["result", unreadable]])).toEqual({});
+  });
+
+  it("skips a live document that stores no schema envelope", async () => {
+    const piece = await pieces.create(BASE, { input: {} });
+    await manager.synced();
+
+    // No envelope at rest means the CFC merge never runs for that role at
+    // commit time, so the role is simply absent rather than guessed at.
+    expect(
+      storedCfcEnvelopes(manager, [
+        ["result", piece.getCell()],
+        ["argument", pieceArgumentCellOrUndefined(manager, piece.getCell())],
+      ]),
+    ).toEqual({});
+  });
+
+  it("loads the envelope a document's stored metadata names", () => {
+    const { schema, taggedHashString } = internSchema(
+      { type: "object", properties: { owner: { type: "string" } } },
+      true,
+    );
+    // The read side of a document that HAS a committed envelope: `cfc`
+    // metadata naming a schema hash, and the content-addressed schema document
+    // that hash resolves to.
+    const stubbedManager = {
+      runtime: {
+        readTx: () => ({
+          readOrThrow: (target: { id: string }) =>
+            target.id.startsWith("cid:") ? { value: schema } : {
+              version: 1,
+              labelMap: { entries: [] },
+              schemaHash: taggedHashString,
+            },
+        }),
+      },
+    } as unknown as PieceManager;
+    const cell = {
+      getAsNormalizedFullLink: () => ({
+        space: "did:key:envelope-test",
+        id: "of:piece",
+        scope: undefined,
+      }),
+    } as unknown as Cell<unknown>;
+
+    expect(storedCfcEnvelopes(stubbedManager, [["result", cell]])).toEqual({
+      result: schema,
+    });
+  });
+
+  it("marks the retained-link proof not-applicable with no argument cell", () => {
+    const pattern = patternOf({ type: "object" }, { type: "object" });
+    expect(retainedLinkVerdict(manager, undefined, pattern, pattern)).toEqual({
+      ran: false,
+      note: "this piece has no argument cell",
+    });
+  });
+
+  it("runs the retained-link proof over a real argument cell", async () => {
+    const piece = await pieces.create(BASE, { input: {} });
+    await manager.synced();
+    const argument = pieceArgumentCellOrUndefined(manager, piece.getCell());
+
+    const verdict = retainedLinkVerdict(
+      manager,
+      argument,
+      patternOf({ type: "object" }, { type: "object" }),
+      patternOf({ type: "object" }, { type: "object" }),
+    );
+
+    expect(verdict.ran).toBe(true);
+    expect(verdict.issue).toBeUndefined();
+  });
+
+  it("reports a retained-link proof that could not complete as an issue", () => {
+    const broken = {
+      getRaw() {
+        throw new Error("argument document unavailable");
+      },
+    } as unknown as Cell<unknown>;
+    const pattern = patternOf({ type: "object" }, { type: "object" });
+
+    const verdict = retainedLinkVerdict(manager, broken, pattern, pattern);
+
+    expect(verdict.ran).toBe(true);
+    expect(verdict.issue).toContain("argument document unavailable");
+  });
+
+  it("stringifies a non-Error retained-link failure", () => {
+    const broken = {
+      getRaw() {
+        throw "argument document vanished";
+      },
+    } as unknown as Cell<unknown>;
+    const pattern = patternOf({ type: "object" }, { type: "object" });
+
+    expect(retainedLinkVerdict(manager, broken, pattern, pattern).issue).toBe(
+      "argument document vanished",
+    );
+  });
+});
+
+describe("pattern update check — explaining a refused update", () => {
+  const blocker: PatternUpdateBlocker = {
+    class: "cfc-schema-migration",
+    role: "result",
+    field: "favorites",
+    reason: "required field favorites needs a default",
+    message: "field `favorites` would become required but has no default.",
+  };
+
+  const reportWith = (
+    blockers: PatternUpdateBlocker[],
+  ): PatternUpdateCheckReport => ({
+    piece: "of:test",
+    compatible: blockers.length === 0,
+    steps: [],
+    blockers,
+    advisories: [],
+  });
+
+  it("re-describes the failure with the blockers the check would report", () => {
+    const cause = new Error("commit rejected");
+    const explained = explainUpdateFailure(
+      "of:test",
+      cause,
+      {},
+      () => reportWith([blocker]),
+    );
+
+    expect(explained).toBeInstanceOf(PatternUpdateIncompatibleError);
+    const incompatible = explained as PatternUpdateIncompatibleError;
+    expect(incompatible.piece).toBe("of:test");
+    expect(incompatible.blockers).toEqual([blocker]);
+    expect(incompatible.cause).toBe(cause);
+    // The low-level detail survives as a trailing line rather than being lost.
+    expect(incompatible.message).toContain("commit rejected");
+  });
+
+  it("leaves the failure alone when the override skipped the gates", () => {
+    const cause = new Error("commit rejected");
+    let gathered = false;
+
+    const explained = explainUpdateFailure(
+      "of:test",
+      cause,
+      { dangerouslyAllowIncompatibleSchema: true },
+      () => {
+        gathered = true;
+        return reportWith([blocker]);
+      },
+    );
+
+    expect(explained).toBe(cause);
+    // Attributing gate findings to a run that skipped the gates would be a
+    // lie, and re-reading storage to produce them would be wasted work.
+    expect(gathered).toBe(false);
+  });
+
+  it("does not re-wrap a failure that already names its blockers", () => {
+    const cause = new PatternUpdateIncompatibleError("of:test", [blocker]);
+    let gathered = false;
+
+    const explained = explainUpdateFailure("of:test", cause, {}, () => {
+      gathered = true;
+      return reportWith([blocker]);
+    });
+
+    expect(explained).toBe(cause);
+    expect(gathered).toBe(false);
+  });
+
+  it("keeps the original failure when the verdict itself cannot be gathered", () => {
+    const cause = new Error("transport failure");
+
+    const explained = explainUpdateFailure("of:test", cause, {}, () => {
+      throw new Error("storage unavailable");
+    });
+
+    expect(explained).toBe(cause);
+  });
+
+  it("keeps the original failure when no rule was actually broken", () => {
+    const cause = new Error("something else went wrong");
+
+    expect(explainUpdateFailure("of:test", cause, {}, () => reportWith([])))
+      .toBe(cause);
   });
 });

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -90,6 +90,14 @@ export {
   CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON,
   CfcSchemaMigrationError,
 } from "./migration-reason.ts";
+export {
+  cfcSchemaMergeIssue,
+  isStreamSlot,
+  mergeCfcSchemaEnvelopes,
+} from "./schema-merge.ts";
+export type { CfcSchemaMergeIssue } from "./schema-merge.ts";
+export { readStoredCfcMetadata } from "./metadata.ts";
+export { loadSchemaDocument } from "./prepare.ts";
 export { LABEL_METADATA_OBSERVATION } from "./observation-classes.ts";
 export type { LabelMetadataObservationClass } from "./observation-classes.ts";
 export {

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -97,7 +97,8 @@ export {
 } from "./schema-merge.ts";
 export type { CfcSchemaMergeIssue } from "./schema-merge.ts";
 export { readStoredCfcMetadata } from "./metadata.ts";
-export { loadSchemaDocument } from "./prepare.ts";
+export { loadSchemaDocument, loadStoredCfcEnvelope } from "./prepare.ts";
+export type { StoredCfcEnvelope } from "./prepare.ts";
 export { LABEL_METADATA_OBSERVATION } from "./observation-classes.ts";
 export type { LabelMetadataObservationClass } from "./observation-classes.ts";
 export {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4555,6 +4555,72 @@ export const loadSchemaDocument = (
   return schema;
 };
 
+/**
+ * The stored CFC schema envelope at rest for one document, as the commit path
+ * sees it.
+ *
+ * Why one function: this is the gatherer BOTH the real commit path (the merge
+ * loop in `prepareCfc` below) and the `cf piece setsrc --check` preflight
+ * call, so the two cannot disagree about what a document carries or about
+ * what counts as a failure. The failure taxonomy is part of the contract:
+ *
+ * - `none` — the document stores no CFC metadata, so the envelope merge never
+ *   runs for it at commit time and there is genuinely nothing to reject.
+ * - `loaded` — the metadata's `schemaHash` resolved to a verified schema
+ *   document; `metadata` rides along for callers (the commit path) that also
+ *   need the stored label map.
+ * - `unreadable` — metadata EXISTS but its envelope cannot be loaded (missing
+ *   cid document, content-hash mismatch). The commit path records `reason`
+ *   and rejects the write in enforcing modes; a preflight must therefore
+ *   report it as a blocker, never as "not applicable" — treating it as absent
+ *   is how a check green-lights an update the real commit then refuses.
+ *
+ * A metadata READ failure (the transaction itself erroring) still propagates:
+ * that is an operational failure of the caller's transaction, not a property
+ * of the document, and both paths fail loudly on it today.
+ */
+export type StoredCfcEnvelope =
+  | { readonly status: "none" }
+  | {
+    readonly status: "loaded";
+    readonly schema: JSONSchema;
+    readonly metadata: CfcMetadata;
+  }
+  | { readonly status: "unreadable"; readonly reason: string };
+
+export const loadStoredCfcEnvelope = (
+  tx: IExtendedStorageTransaction,
+  target: {
+    space: MemorySpace;
+    id: string;
+    scope?: Parameters<typeof normalizeCellScope>[0];
+  },
+  type: MediaType = "application/json",
+): StoredCfcEnvelope => {
+  const metadata = storedMetadataFor(
+    tx,
+    target.space,
+    target.id as URI,
+    normalizeCellScope(target.scope),
+    type,
+  );
+  if (metadata === undefined) return { status: "none" };
+  try {
+    return {
+      status: "loaded",
+      schema: loadSchemaDocument(tx, target.space, metadata.schemaHash),
+      metadata,
+    };
+  } catch (error) {
+    return {
+      status: "unreadable",
+      reason: error instanceof Error
+        ? error.message
+        : `schema load failed for ${target.id}`,
+    };
+  }
+};
+
 // Union of confidentiality (and integrity) atoms across every non-internal labeled read in the
 // transaction, resolved from stored labels the same way verifyInputRequirements
 // resolves them. Transaction-global by design — deliberately NOT scoped to a
@@ -5361,30 +5427,25 @@ export const prepareBoundaryCommit = (
       if (flowJoinIsCrossSpace) crossSpaceEligible?.add(entry);
       return entry;
     };
-    const existing = storedMetadataFor(
-      tx,
-      space,
-      id,
-      scope,
-      "application/json",
-    );
+    // ONE gatherer decides what this document stores — the same function the
+    // `setsrc --check` preflight calls — so the commit path and the preflight
+    // cannot disagree about an unreadable envelope. `unreadable` records the
+    // load failure as a rejection reason exactly as the inline catch here
+    // always did.
+    const stored = loadStoredCfcEnvelope(tx, { space, id, scope });
+    if (stored.status === "unreadable") {
+      reasons.push(stored.reason);
+      continue;
+    }
+    const existing = stored.status === "loaded" ? stored.metadata : undefined;
     let storedSchema: JSONSchema | undefined;
     let mergedSchema = schema;
-    if (existing !== undefined && undefinedCandidate) {
+    if (stored.status === "loaded" && undefinedCandidate) {
+      storedSchema = stored.schema;
+      mergedSchema = storedSchema;
+    } else if (stored.status === "loaded") {
       try {
-        storedSchema = loadSchemaDocument(tx, space, existing.schemaHash);
-        mergedSchema = storedSchema;
-      } catch (error) {
-        reasons.push(
-          error instanceof Error
-            ? error.message
-            : `schema load failed for ${id}`,
-        );
-        continue;
-      }
-    } else if (existing !== undefined) {
-      try {
-        storedSchema = loadSchemaDocument(tx, space, existing.schemaHash);
+        storedSchema = stored.schema;
         mergedSchema = schemasEqualIgnoringWriterStamp(storedSchema, schema) ||
             storedSchemaCoversCandidateEnvelope(storedSchema, schema)
           ? storedSchema
@@ -5394,8 +5455,9 @@ export const prepareBoundaryCommit = (
         // token so the default-root runnability backstop can key on THIS class
         // (recoverable by rolling forward) and leave every other CFC rejection
         // fail-closed. Only the recorded reason is tagged; the human-readable
-        // message is preserved verbatim after the token. A plain schema-load or
-        // other merge failure records its bare message as before.
+        // message is preserved verbatim after the token. Schema-LOAD failures
+        // are handled above by the shared gatherer and record their bare
+        // message as before.
         reasons.push(
           error instanceof CfcSchemaMigrationError
             ? `${CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON}: ${error.message}`

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -365,7 +365,7 @@ const assertNoDivergentIfcBranches = (
 // preservable data — and it missed the scoped-descriptor dialect
 // (`[{ kind: "stream", scope: … }]`), which is a string only under the legacy
 // form. `getAsCellKind` normalizes both dialects.
-const isStreamSlot = (schema: JSONSchema | undefined): boolean =>
+export const isStreamSlot = (schema: JSONSchema | undefined): boolean =>
   ContextualFlowControl.getAsCellKind(
     ContextualFlowControl.getAsCellValues(schema).at(0),
   ) === "stream";
@@ -575,4 +575,46 @@ export const mergeCfcSchemaEnvelopes = (
   assertNoDivergentIfcBranches(existing);
   assertNoDivergentIfcBranches(candidate);
   return internSchema(mergeSchemaNode(existing, candidate));
+};
+
+/** Why a stored envelope and a candidate envelope cannot be merged. */
+export interface CfcSchemaMergeIssue {
+  /** The merge's own human-readable reason, verbatim. */
+  message: string;
+  /**
+   * True when the rejection is the additive-required migration class — an old
+   * document predating a now-required field that declares no default. This is
+   * the class the runnability backstop rolls forward on
+   * (see {@link CfcSchemaMigrationError}); everything else is a hard
+   * incompatibility.
+   */
+  migration: boolean;
+}
+
+/**
+ * Would {@link mergeCfcSchemaEnvelopes} accept this candidate over this stored
+ * envelope? `undefined` means yes.
+ *
+ * Why: `cf piece setsrc` used to discover an unmergeable schema only by
+ * attempting the update and taking a low-level commit rejection. This is the
+ * dry-run seam its `--check` preflight drives, so the preflight and the real
+ * commit share ONE implementation of the rules rather than drifting copies.
+ * It is pure — no transaction, no writes — because the merge itself is.
+ */
+export const cfcSchemaMergeIssue = (
+  existing: JSONSchema,
+  candidate: JSONSchema,
+): CfcSchemaMergeIssue | undefined => {
+  try {
+    mergeCfcSchemaEnvelopes(existing, candidate);
+    return undefined;
+  } catch (error) {
+    if (error instanceof CfcSchemaMigrationError) {
+      return { message: error.message, migration: true };
+    }
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      migration: false,
+    };
+  }
 };

--- a/packages/runner/test/cfc-stored-envelope.test.ts
+++ b/packages/runner/test/cfc-stored-envelope.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { loadStoredCfcEnvelope } from "../src/cfc/prepare.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+// `loadStoredCfcEnvelope` is the ONE gatherer of a document's stored CFC
+// schema envelope: the commit path's merge loop in `prepareCfc` and the
+// `cf piece setsrc --check` preflight both call it, so its three outcomes ARE
+// the shared failure taxonomy. In particular `unreadable` (metadata exists,
+// envelope cannot be loaded) must stay a distinct, surfaced state: the commit
+// records it as a rejection reason, and a preflight that mistook it for "no
+// envelope" would green-light an update the real commit then refuses — the
+// false-COMPATIBLE class this function exists to prevent.
+
+const space = "did:key:stored-envelope" as const;
+
+const fakeTx = (
+  documents: Record<string, unknown>,
+): IExtendedStorageTransaction =>
+  ({
+    readOrThrow: (target: { id: string }) => documents[target.id],
+  }) as unknown as IExtendedStorageTransaction;
+
+const target = { space, id: "of:doc", scope: "space" } as const;
+
+const metadataNaming = (schemaHash: string) => ({
+  cfc: {
+    version: 1,
+    schemaHash,
+    labelMap: { version: 1, entries: [] },
+  },
+});
+
+describe("loadStoredCfcEnvelope", () => {
+  it("reports a document with no stored metadata as none", () => {
+    expect(loadStoredCfcEnvelope(fakeTx({ "of:doc": { value: 1 } }), target))
+      .toEqual({ status: "none" });
+  });
+
+  it("loads and verifies the envelope the metadata names", () => {
+    const { schema, taggedHashString } = internSchema(
+      { type: "object", properties: { a: { type: "string" } } } as JSONSchema,
+      true,
+    );
+    const result = loadStoredCfcEnvelope(
+      fakeTx({
+        "of:doc": metadataNaming(taggedHashString),
+        [`cid:${taggedHashString}`]: { value: schema },
+      }),
+      target,
+    );
+
+    expect(result.status).toBe("loaded");
+    if (result.status === "loaded") {
+      expect(result.schema).toEqual(schema);
+      // The metadata rides along for the commit path, which also needs the
+      // stored label map.
+      expect(result.metadata.schemaHash).toBe(taggedHashString);
+    }
+  });
+
+  it("reports a missing envelope document as unreadable, not as none", () => {
+    const result = loadStoredCfcEnvelope(
+      fakeTx({ "of:doc": metadataNaming("missing-hash") }),
+      target,
+    );
+
+    expect(result.status).toBe("unreadable");
+    if (result.status === "unreadable") {
+      expect(result.reason).toContain("missing or unreadable");
+    }
+  });
+
+  it("reports a poisoned envelope document as unreadable", () => {
+    const { taggedHashString } = internSchema(
+      { type: "object", properties: { a: { type: "string" } } } as JSONSchema,
+      true,
+    );
+    // A different schema served at the claimed cid: address (audit S5).
+    const poisoned = internSchema(
+      { type: "string", ifc: { confidentiality: [] } } as JSONSchema,
+      true,
+    ).schema;
+    const result = loadStoredCfcEnvelope(
+      fakeTx({
+        "of:doc": metadataNaming(taggedHashString),
+        [`cid:${taggedHashString}`]: { value: poisoned },
+      }),
+      target,
+    );
+
+    expect(result.status).toBe("unreadable");
+    if (result.status === "unreadable") {
+      expect(result.reason).toContain("hash mismatch");
+    }
+  });
+});


### PR DESCRIPTION
## Why

`cf piece setsrc <main>` replaces the pattern source of a live piece. Until now
it just attempted the swap. When the new pattern could not be applied, the user
found out by attempting it, and what came back was whichever low-level rejection
happened to surface first — a schema-subset assertion, a retained-link proof
failure, or (worst) a raw CFC commit rejection re-wrapped as a plain `Error` at
the runner's setup-commit boundary. None of those tell you *which field* broke
*which rule*.

That cost a production incident on the hosted Estuary deployment over the last
few days: home roots and profile pieces pinned to patterns that could not
migrate their existing documents. #4967 and #4977 added runtime **repairs** for
that class. The lesson those PRs left on the table is the one this PR picks up:
you should be able to know **ahead of time** whether a given source can actually
be applied to a given piece.

So: a `--check` preflight that answers the question and applies nothing, and a
refused real `setsrc` that names the same reason the preflight would.

The design constraint that shaped everything here is **no second copy of the
rules**. A preflight that reimplements compatibility drifts from the enforcement
path and becomes a liar. Every verdict below is produced by driving the real
rule implementation in dry-run.

## What Changed

### The verdict (`packages/piece/src/pattern-update-check.ts`, new)

`checkPatternUpdate()` is pure — no transaction, no writes — and assembles the
verdict from three real rules:

| class | rule driven | source |
|---|---|---|
| `pattern-contract` | the argument/result subset proof `setPattern` asserts with | `patternSchemaCompatibilityIssues` (extracted below) |
| `cfc-schema-migration` / `cfc-schema-merge` | the real CFC envelope merge | `cfcSchemaMergeIssue` → `mergeCfcSchemaEnvelopes` |
| `retained-link` | the same validator `setPattern` installs as `validateArgumentLinks` | `assertSuppliedLinkSchemasCompatible` |

Blockers carry `role` (`argument` = INPUT, `result` = OUTPUT), `path`, `field`,
the rule's verbatim `reason`, and a printable `message`. Advisories carry
non-blocking setup migration work (a new handler stream's marker).

### Exposing the rules for dry-run, without duplicating them

- `packages/runner/src/cfc/schema-merge.ts` gains **`cfcSchemaMergeIssue`** — a
  small pure "would this merge succeed?" helper that runs the real
  `mergeCfcSchemaEnvelopes` and reports the failure, discriminating the
  additive-required migration class via the existing `CfcSchemaMigrationError`.
  `isStreamSlot` is exported so the stream nuance has one definition.
- `packages/piece/src/schema-compatibility.ts` gains
  **`patternSchemaCompatibilityIssues`** — the collector behind
  `assertPatternSchemasBackwardCompatible`, which is now a two-line wrapper
  over it. Thrown message is byte-identical; the early return on invalid
  schema definitions preserves the old early throw.
- `packages/runner/src/cfc/mod.ts` re-exports `readStoredCfcMetadata` and
  `loadSchemaDocument` so the piece layer can read a stored envelope.

### Read-only gathering (`PieceController.checkPattern`)

Reads the CFC schema envelopes at rest for the piece's argument and result
documents through **`runtime.readTx()`**, which physically cannot write (it
throws `ReadOnlyTransactionError` on `abort()`, let alone a write). A role with
no stored CFC metadata is reported `not-applicable` rather than guessed at —
correctly, since the merge only runs against a stored envelope, so with none the
class genuinely cannot fail.

### The CLI (`cf piece setsrc --check [--json]`)

- Exits **0** compatible / **3** incompatible. `3` is documented, distinct from
  1 (operational) and 2 (bad args), and is also the exit code of a real
  `setsrc` refused as incompatible — so a deploy script can branch on
  "incompatible" without parsing text.
- `--json` (only valid with `--check`) emits the verdict via the repo's existing
  `render(value, { json: true })` convention; `reservesStdoutForCommandOutput`
  already keeps stdout clean for it.
- `--check` + `--dangerously-allow-incompatible-schema` is rejected: the
  override exists to skip the proof `--check` computes.

### Better errors without `--check` (task item 3)

`PieceController.setPattern` now wraps both the assertion and the setup commit.
On failure it **re-derives the verdict from the already-compiled candidate** and
throws `PatternUpdateIncompatibleError` carrying the same `blockers` list
`--check` reports. No message sniffing anywhere — the two paths cannot disagree
about the reason, and a test pins them field-for-field.

- Fail-closed is preserved: the setup transaction has already aborted when the
  verdict is re-derived, so the state it re-reads is the untouched pre-update
  state. Tests assert the piece's pattern identity ref is unchanged after a
  refusal.
- A failure with **no** blockers (transport, compile, a genuine bug) is
  rethrown unchanged rather than dressed up as an incompatibility.
- `--dangerously-allow-incompatible-schema` failures are rethrown unchanged:
  that run deliberately skipped the gates, so reporting gate findings would
  misattribute it.
- The originating message is kept as a subordinate `Caused by:` line on
  `.message` (library consumers and stack traces keep the detail); the CLI
  prints only the blockers plus a `--check` pointer.

## What the check actually validates — and what it does not

**Validated:**

1. **Pattern contract**, both roles. Removed fields, incompatible type
   mutations, narrowed bounds/enums, changed `asCell`, and newly-required
   fields with no default. Berni's input/output distinction **is** available at
   this layer — the rule already reports `newly required argument field has no
   default` separately from `newly required result field has no default` — so
   the report labels findings `input (argument)` / `output (result)` from real
   data, not a guess.
2. **CFC document migration**, driving the real merge over the envelope the
   piece's documents actually carry. Verified empirically that a real piece root
   doc does carry `cfc.schemaHash`, and that its stored envelope equals the
   pattern's result schema — i.e. this reconstructs exactly the `(existing,
   candidate)` pair the next setup commit would hand the merge.
3. **Retained argument links**, via the same validator, over committed state.
4. **Handler stream markers**, reported as an advisory ("setup will materialize
   its stream marker; no stored value is lost"), never as a CFC blocker.

**Stated honestly, not faked:**

- **Only the piece's own argument and result documents are enumerated.**
  Derived internal cells and linked child docs are not. Enumerating every
  `(target doc, candidate schema)` pair a setup will record is only knowable by
  running setup, which cannot be done read-only. The check does not pretend
  otherwise: each role reports `pass` / `fail` / `not-applicable` explicitly.
- **`--check` is read-only with respect to the piece, not to the space.**
  Compiling the candidate content-addresses the pattern's source and module
  closure, as any compile does. Those documents are immutable and keyed by
  content, and are exactly what a subsequent real `setsrc` would write. The
  piece is never written; a test asserts the pattern ref and result value are
  unchanged after both a passing and a failing check. Documented on the method
  and in the docs.

## Finding worth a decision (surfaced, not silently fixed)

**The two gate layers disagree about handler streams.** The CFC document merge
exempts a stream slot from its additive-required rule (#4977's fix — a stream
marker is re-materialized by setup, so an old doc lacking one has no value to
preserve and no meaningful `Default<>` to declare). **The pattern-contract
subset proof has no such exemption.** Empirically, adding a handler to a pattern
and running `setsrc` today is refused with
`result.rename: newly required result field has no default`.

This is exactly Berni's framing arriving as a live bug: a newly-required field
on an **output** cell is inherently compatible, because the pattern creates it
fresh — yet the contract layer refuses it.

I did **not** change that rule. Loosening a schema-subset proof is a real
semantic change to a security-adjacent gate and does not belong in a preflight
PR. Instead the check stays truthful: it reports the blocker (because that is
what `setsrc` will do), flags it `streamSlot: true`, and says in the message
that only the pattern-contract proof refuses it and that the CFC layer already
exempts it. A test pins this behaviour and the preflight/enforcement agreement.

Worth a follow-up decision on whether the contract layer should gain the same
stream exemption, or the same output-cell reasoning more broadly.

## Test plan

New:
- `packages/piece/test/pattern-update-check.test.ts` — 13 cases, real runtime,
  real compiles, **CFC enforcement ON** (`enforce-explicit`). Covers:
  compatible-passes; newly-required INPUT with no default (names the field and
  the role); incompatible type mutation; handler-stream advisory; the layer
  disagreement above plus preflight/enforcement agreement field-for-field;
  `--check` mutates nothing (pattern ref and result value unchanged after both
  verdicts); the improved non-check error with the piece left intact; a
  compatible source still applies. Plus five cases driving the real CFC merge
  for the Estuary class: refused without a default, accepted with one, stream
  slot exempt, non-migration merge rejection classified separately, and
  not-applicable when no envelope is stored.
- `packages/cli/test/piece-setsrc-check.test.ts` — 9 cases at the command
  boundary, using the repo's dependency-injection convention: flag
  registration, `--check` routes to the read-only library call, flag-combination
  validation, human report rendering (compatible and incompatible), and
  `reportIncompatibleSetSource` (exit 3, blockers on stderr, `--check` hint,
  and returning null for an unrelated error).

Results — all run, all green:

| suite | result |
|---|---|
| `packages/piece` full (`deno task test`) | 25 passed (293 steps), 0 failed |
| `packages/cli` full (`deno task test`) | 120 passed (144 steps), 0 failed |
| `packages/runner` full (`deno task test`) | 1070 passed (5562 steps), 0 failed |
| `deno check` on all touched files | clean |
| `deno lint` on all touched files | clean (10 files) |
| `deno fmt` | applied |

Two pre-existing `pull-materialization` tests assert on the rejection message
shape; they pass unchanged because the improved error keeps the originating
message as a trailing `Caused by:` line.

The CLI **integration** suite (`integration/integration.sh`, section
`piece-values`) asserted the old raw text `not backward compatible`, which the
improved refusal deliberately no longer prints — CI caught this. Second commit
replaces that with the new contract (exit 3, the offending field, the rule that
refused it, the `--check` pointer) and adds live coverage of the preflight
itself: exit 3 with a named field, the `--json` verdict, that the check mutates
nothing, and that a compatible source passes it. Run locally against a real
toolshed: `Successfully ran CLI piece values integration tests`.

Manual smoke against the same live toolshed, for the record:

```
$ cf piece setsrc --check ... schema-incompatible.tsx ; echo $?
INCOMPATIBLE — the pattern source cannot be applied to piece fid1:5goBVQ….

Checks:
  [FAIL] pattern contract
  [n/a ] CFC document migration (argument) — the argument document carries no stored CFC schema envelope, so the CFC merge does not run for it
  [n/a ] CFC document migration (result) — …
  [ok  ] retained argument links — every durable link already supplied into an argument slot still satisfies the candidate's schema for that slot

Blockers:
  • [pattern-contract] result.value — a schema alternative accepted previously is not accepted by the candidate. This is the pattern's output (result) contract.
3

$ cf piece setsrc ... schema-incompatible.tsx        # no --check
Pattern source cannot be applied to piece fid1:5goBVQ…. The piece was NOT modified.
  • [pattern-contract] result.value — a schema alternative accepted previously is not accepted by the candidate. This is the pattern's output (result) contract.

TIP: Run the same evaluation without attempting the update:
  cf piece setsrc --check --piece fid1:5goBVQ… <main> ...
Add --dangerously-allow-incompatible-schema only if you accept losing the guarantees above.
```

Docs updated in the same change (live-doc rule): `docs/common/workflows/development.md`,
`docs/development/debugging/cli-debugging.md`, `packages/cli/README.md` (JSON
command contract + exit code), and the in-CLI help/examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
