### PR TITLE
refactor(memory,runner): the SQLite wire types say `FabricValue`

### DIFF
--- a/packages/memory/test/v2-sqlite-commit-eval-test.ts
+++ b/packages/memory/test/v2-sqlite-commit-eval-test.ts
@@ -18,6 +18,7 @@ import {
   runQuery,
 } from "../v2/sqlite/exec.ts";
 import { table } from "../v2/sqlite/schema.ts";
+import type { SqliteDbRef, SqliteParamsWire } from "../v2.ts";
 import {
   all,
   authoredBy,
@@ -132,7 +133,7 @@ async function withAttached(
   }
 }
 
-const sqliteOp = (sql: string, params?: unknown[]): Operation => ({
+const sqliteOp = (sql: string, params?: SqliteParamsWire): Operation => ({
   op: "sqlite",
   db: { id: DB_ID, tables: TABLES, owner: OWNER },
   sql,
@@ -462,8 +463,8 @@ function bareDb(): Database {
 
 const bareOp = (
   sql: string,
-  params?: unknown[],
-  tables: Record<string, unknown> = TABLES,
+  params?: SqliteParamsWire,
+  tables: SqliteDbRef["tables"] = TABLES,
 ) => ({
   op: "sqlite" as const,
   db: { id: DB_ID, tables, owner: OWNER },

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -446,7 +446,9 @@ export type GraphQueryRequest = {
 // --- SQLite builtins (docs/specs/sqlite-builtin) ---
 
 /** Wire form of SQLite bind parameters. */
-export type SqliteParamsWire = ReadonlyArray<unknown> | Record<string, unknown>;
+export type SqliteParamsWire =
+  | ReadonlyArray<FabricValue>
+  | Record<string, FabricValue>;
 
 /** Reference to a cell-derived SQLite database: an opaque id (the handle cell's
  *  entity id) plus the declared table schemas (for additive create/migrate).
@@ -457,7 +459,7 @@ export type SqliteParamsWire = ReadonlyArray<unknown> | Record<string, unknown>;
  *  `space` (or absent) keeps the original unqualified name. */
 export type SqliteDbRef = {
   id: string;
-  tables?: Record<string, unknown>;
+  tables?: Record<string, FabricValue>;
   scope?: CellScope;
   /** The db's owner — the principal that created the SqliteDb cell. Resolves
    *  the per-row label rule's `dbOwner()` term (CFC Phase 3); a FIXED db
@@ -1000,12 +1002,9 @@ export const encodeMemoryBoundary = (value: FabricValue): string =>
  * containing an `unknown` field is not assignable to `FabricValue`, so the
  * whole enclosing message is rejected however sound its actual contents.
  *
- * Every remaining caller is blocked by the same root: `SqliteDbRef.tables` is
- * `Record<string, unknown>`, which reaches `SqliteOperation` → `Operation` →
- * `ClientCommit`, and from there every message that carries a commit. Its
- * natural element type, `TableSchema`, carries a `[key: string]: unknown`
- * catch-all, so tightening `tables` means tightening that too, plus the
- * runner's own copy of the `SqliteDbRef` shape.
+ * Every remaining caller is blocked by the same root: `ClientCommit`'s
+ * `schedulerObservation` is `unknown`, which reaches every message that carries
+ * a commit.
  *
  * What is given up is narrower than it looks: the encoding *verifies*. A value
  * that no codec can represent throws — at any depth, naming the offending

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -18,6 +18,8 @@
 //
 // Pure module: no FFI, no engine imports — safe for client-side import.
 
+import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
+
 /** A reference to a declared column, handed to the rule as `f.<col>`. */
 export type FieldRef = {
   field: string;
@@ -33,8 +35,8 @@ export type MatchOpts = {
 /** Serialized rule, attached to the table schema as `rowLabel`. */
 export type RowLabelSpec = {
   version: 1;
-  confidentiality?: unknown;
-  integrity?: unknown;
+  confidentiality?: FabricValue;
+  integrity?: FabricValue;
 };
 
 /** Field handles passed to the rule: one accessor per declared column. */
@@ -44,7 +46,7 @@ export type RowFieldHandles<C extends Record<string, unknown>> =
 
 export type RowLabelRule<C extends Record<string, unknown>> = (
   f: RowFieldHandles<C>,
-) => { confidentiality?: unknown; integrity?: unknown };
+) => { confidentiality?: FabricValue; integrity?: FabricValue };
 
 const isRecord = (x: unknown): x is Record<string, unknown> =>
   typeof x === "object" && x !== null && !Array.isArray(x);
@@ -67,11 +69,11 @@ export function match(
   field: FieldRef,
   re: RegExp,
   opts: MatchOpts = {},
-): { match: Record<string, unknown> } {
+): { match: FabricPlainObject } {
   assertField(field, "match()");
   assertRegExp(re, "match()");
   const flags = re.flags.includes("g") ? re.flags : re.flags + "g";
-  const node: Record<string, unknown> = {
+  const node: FabricPlainObject = {
     field: field.field,
     source: re.source,
     flags,
@@ -91,8 +93,8 @@ export function match(
 export function whenMatches(
   field: FieldRef,
   re: RegExp,
-  then: unknown,
-): { when: unknown; then: unknown } {
+  then: FabricValue,
+): { when: FabricValue; then: FabricValue } {
   assertField(field, "whenMatches()");
   assertRegExp(re, "whenMatches()");
   return {
@@ -112,8 +114,8 @@ export function whenMatches(
  *  did:key untouched (base58 is case-sensitive), unknown protocols identity. */
 export function principal(
   protocol: string,
-  of: { match: Record<string, unknown> },
-): { principal: Record<string, unknown> } {
+  of: { match: FabricPlainObject },
+): { principal: FabricPlainObject } {
   if (typeof protocol !== "string" || !/^[a-z][a-z0-9.+-]*$/.test(protocol)) {
     throw new TypeError(
       `principal(): invalid DID protocol ${JSON.stringify(protocol)}`,
@@ -132,26 +134,28 @@ export function dbOwner(): { dbOwner: true } {
 }
 
 /** A literal atom (escape hatch). (Named `constant` — `const` is reserved.) */
-export function constant(atom: unknown): { constant: unknown } {
+export function constant(atom: FabricValue): { constant: FabricValue } {
   return { constant: atom };
 }
 
 /** Separate conjunctive clauses, one per atom — today's only confidentiality
  *  combinator (every principal an independent requirement). */
-export function all(...terms: unknown[]): { allOf: unknown[] } {
+export function all(...terms: FabricValue[]): { allOf: FabricValue[] } {
   return { allOf: terms };
 }
 
 /** ONE authored OR-clause: any alternative satisfies it (CFC spec §3.1.8).
  *  Serializes, but `table()` REJECTS it until the runtime ships the
  *  clause-aware label profile — never silently lowered to all-of. */
-export function any(...terms: unknown[]): { anyOf: unknown[] } {
+export function any(...terms: FabricValue[]): { anyOf: FabricValue[] } {
   return { anyOf: terms };
 }
 
 /** Set-intersection over integrity atom sets (the trust-floor meet).
  *  Integrity only — confidentiality combines by all()/any(). */
-export function intersect(...terms: unknown[]): { intersect: unknown[] } {
+export function intersect(
+  ...terms: FabricValue[]
+): { intersect: FabricValue[] } {
   return { intersect: terms };
 }
 
@@ -160,8 +164,8 @@ export function intersect(...terms: unknown[]): { intersect: unknown[] } {
  *  is forgeable by the row's writer, so it never lowers to the trusted
  *  `AuthoredBy` family directly (see 06-cfc.md; upgrade via provider trust). */
 export function authoredBy(
-  p: { principal: Record<string, unknown> },
-): { authoredBy: unknown } {
+  p: { principal: FabricPlainObject },
+): { authoredBy: FabricValue } {
   assertPrincipal(p, "authoredBy()");
   return { authoredBy: p };
 }
@@ -169,8 +173,8 @@ export function authoredBy(
 /** Integrity claim: endorsed by the extracted principal (same downgrade rule
  *  as `authoredBy`). */
 export function endorsedBy(
-  p: { principal: Record<string, unknown> },
-): { endorsedBy: unknown } {
+  p: { principal: FabricPlainObject },
+): { endorsedBy: FabricValue } {
   assertPrincipal(p, "endorsedBy()");
   return { endorsedBy: p };
 }

--- a/packages/memory/v2/sqlite/schema.ts
+++ b/packages/memory/v2/sqlite/schema.ts
@@ -7,6 +7,7 @@
 // These helpers compile to plain data; the transformer/runtime do not special-
 // case them.
 
+import type { FabricValue } from "@commonfabric/api";
 import { CF_LINK_SUFFIX, isCfLinkColumn } from "./columns.ts";
 import { buildRowLabelSpec, type RowLabelRule } from "./row-label.ts";
 
@@ -16,14 +17,14 @@ export type ColumnSchema = {
   sqlType: string;
   /** Marks a `_cf_link` column (stored TEXT, surfaced as a Cell). */
   cfLink?: true;
-  [key: string]: unknown;
+  [key: string]: FabricValue;
 };
 
 export type TableSchema = {
   type: "object";
   properties: Record<string, ColumnSchema>;
   required: string[];
-  [key: string]: unknown;
+  [key: string]: FabricValue;
 };
 
 /** Column spec: a shorthand SQL type string, or an explicit column schema. */

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -44,28 +44,24 @@ import {
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
 import { stripEntityUriScheme } from "../entity-kind.ts";
-import { columnDeclaresIfc } from "@commonfabric/memory/v2";
+import {
+  columnDeclaresIfc,
+  type SqliteDbRef as WireSqliteDbRef,
+  type SqliteParamsWire,
+} from "@commonfabric/memory/v2";
 import { validateRowLabelSpec } from "@commonfabric/memory/sqlite/row-label";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 
-type SqliteDbRef = {
-  id: string;
-  tables?: Record<string, unknown>;
-  // The author-declared scope of the SqliteDb cell (space/user/session). The
-  // server folds this into the on-disk filename so user/session-scoped dbs get
-  // a per-user / per-session file. Absent ⇒ "space" (the default, unqualified).
-  scope?: CellScope;
-  // The db's owner — the principal that created the SqliteDb cell, captured
-  // once at handle creation (CFC Phase 3: resolves the row rule's dbOwner()
-  // and the ceiling's __ctDbOwner placeholder; never the acting reader).
-  owner?: string;
+// The wire shape (`id`, `tables`, `scope`, `owner`) is the memory protocol's
+// own `SqliteDbRef`; only `rev` is added here.
+type SqliteDbRef = WireSqliteDbRef & {
   // db.exec's optimistic-concurrency revision (bumped per write, cell.ts). A
   // handle re-derivation must carry it forward: deleting it changes the handle
   // value, which every consumer hashing the handle (e.g. sqliteQuery's
   // reactOn) sees as "new inputs".
   rev?: number;
 };
-type WireParams = readonly unknown[] | Record<string, unknown> | undefined;
+type WireParams = SqliteParamsWire | undefined;
 
 const errMsg = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
@@ -117,7 +113,7 @@ function readDbRef(value: unknown): SqliteDbRef {
         ? cloneIfNecessary(
           ref.tables as Parameters<typeof cloneIfNecessary>[0],
           { frozen: false },
-        ) as Record<string, unknown>
+        ) as SqliteDbRef["tables"]
         : undefined,
       // Validate at the boundary: an invalid scope value must not flow into
       // query execution / on-disk filename derivation.
@@ -140,7 +136,7 @@ function readDbRef(value: unknown): SqliteDbRef {
  * probe: a resolved rule always validates; a null-riddled one never does.
  */
 function dbTablesResolved(
-  tables: Record<string, unknown> | undefined,
+  tables: SqliteDbRef["tables"],
 ): boolean {
   if (tables === undefined) return true;
   for (const t of Object.values(tables)) {
@@ -527,7 +523,7 @@ export function sqliteDatabase(
         scope,
       );
       const options = inputsCell.withTx(tx).get() as
-        | { tables?: Record<string, unknown> }
+        | { tables?: SqliteDbRef["tables"] }
         | undefined;
       // `handle` is a builtin RESULT cell (makeResultCell), and result cells
       // are always `of:`-schemed — the computed kind applies only to derived
@@ -568,7 +564,7 @@ export function sqliteDatabase(
         ? cloneIfNecessary(
           merged as Parameters<typeof cloneIfNecessary>[0],
           { frozen: false },
-        ) as Record<string, unknown>
+        ) as SqliteDbRef["tables"]
         : undefined;
       // Fail closed on an UNRESOLVED materialization (this runtime loaded the
       // pattern but not every linked doc under `tables`): writing it would

--- a/packages/runner/src/builtins/sqlite/row-label-write.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-write.ts
@@ -29,7 +29,10 @@ import {
 } from "@commonfabric/memory/sqlite/row-label";
 import type { CfcConfClause } from "../../cfc/clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
-import { tableDeclaresRowLabel } from "@commonfabric/memory/v2";
+import {
+  type SqliteDbRef,
+  tableDeclaresRowLabel,
+} from "@commonfabric/memory/v2";
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
 import {
   blankWriteSql,
@@ -47,9 +50,12 @@ export interface RowLabelWritePolicy {
 
 export interface RowLabelWriteArgs {
   sql: string;
+  /** Bind values as `.exec()` received them — NOT `SqliteParamsWire`. The
+   *  gate runs before encoding, so a value here may still be a `Cell`
+   *  (that is what `confidentialityOf` reads a label off). */
   params: ReadonlyArray<unknown> | Record<string, unknown> | undefined;
   /** Declared table schemas (`db.tables`, wire-supplied — re-validated). */
-  tables: Record<string, unknown> | undefined;
+  tables: SqliteDbRef["tables"];
   /** The db's owner (db ref), resolving the rule's `dbOwner()` term. */
   owner?: string;
   /** The confidentiality atoms carried by a bound value ([] if unlabeled). */

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -27,7 +27,7 @@ import {
 } from "@commonfabric/data-model/schema-hash";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import type { ReadonlyCell } from "@commonfabric/api";
-import type { SqliteParamsWire } from "@commonfabric/memory/v2";
+import type { SqliteDbRef, SqliteParamsWire } from "@commonfabric/memory/v2";
 import { isCfLinkColumn } from "@commonfabric/memory/sqlite/columns";
 import { encodeCellToSigilString } from "./builtins/sqlite/cf-link-codec.ts";
 import { sqliteQueryNodeFactory } from "./builtins/sqlite/query-node.ts";
@@ -1166,8 +1166,10 @@ export class CellImpl<T extends FabricValue>
       ? cloneIfNecessary(
         materialized.tables as Parameters<typeof cloneIfNecessary>[0],
         { frozen: false },
-      ) as Record<string, unknown>
-      : handle.tables as Record<string, unknown> | undefined;
+      ) as SqliteDbRef["tables"]
+      // `handle` is a raw, unvalidated read (see above), so this states the
+      // wire shape rather than proving it.
+      : handle.tables as SqliteDbRef["tables"];
     // CFC write-ceiling (Phase 2): a value bound to a labeled column must fit the
     // column's `ifc.maxConfidentiality`. The label rides the bound value (a Cell
     // or any carried-label value); fail closed when a labeled value's target

--- a/packages/runner/test/sqlite-cf-link-decode.test.ts
+++ b/packages/runner/test/sqlite-cf-link-decode.test.ts
@@ -17,7 +17,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { table } from "@commonfabric/memory/sqlite/schema";
-import type { SqliteDbRef } from "@commonfabric/memory/v2";
+import type { SqliteDbRef, SqliteParamsWire } from "@commonfabric/memory/v2";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import {
@@ -54,7 +54,7 @@ describe("sqlite query result _cf_link behavior", () => {
   const seedSqlite = async (
     db: SqliteDbRef,
     sql: string,
-    params?: readonly unknown[],
+    params?: SqliteParamsWire,
   ): Promise<void> => {
     const seedTx = runtime.edit();
     seedTx.recordSqliteWrite!(space, { op: "sqlite", db, sql, params });

--- a/packages/runner/test/sqlite-cf-link-roundtrip.test.ts
+++ b/packages/runner/test/sqlite-cf-link-roundtrip.test.ts
@@ -9,7 +9,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { table } from "@commonfabric/memory/sqlite/schema";
-import type { SqliteDbRef } from "@commonfabric/memory/v2";
+import type { SqliteDbRef, SqliteParamsWire } from "@commonfabric/memory/v2";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { areNormalizedLinksSame } from "../src/link-utils.ts";
@@ -43,7 +43,7 @@ describe("_cf_link round-trip through SQLite storage", () => {
   const seedSqlite = async (
     db: SqliteDbRef,
     sql: string,
-    params?: readonly unknown[],
+    params?: SqliteParamsWire,
   ): Promise<void> => {
     const seedTx = runtime.edit();
     seedTx.recordSqliteWrite!(space, { op: "sqlite", db, sql, params });

--- a/packages/runner/test/sqlite-query-rowschema-decode.test.ts
+++ b/packages/runner/test/sqlite-query-rowschema-decode.test.ts
@@ -14,7 +14,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { table } from "@commonfabric/memory/sqlite/schema";
-import type { SqliteDbRef } from "@commonfabric/memory/v2";
+import type { SqliteDbRef, SqliteParamsWire } from "@commonfabric/memory/v2";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -59,7 +59,7 @@ describe("sqliteQuery rowSchema-driven _cf_link decode (Piece A runtime)", () =>
   const seedSqlite = async (
     db: SqliteDbRef,
     sql: string,
-    params?: readonly unknown[],
+    params?: SqliteParamsWire,
   ): Promise<void> => {
     const seedTx = runtime.edit();
     seedTx.recordSqliteWrite!(space, { op: "sqlite", db, sql, params });

--- a/packages/runner/test/sqlite-read-labeling.test.ts
+++ b/packages/runner/test/sqlite-read-labeling.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import type { SqliteDbRef } from "@commonfabric/memory/v2";
+import type { SqliteDbRef, SqliteParamsWire } from "@commonfabric/memory/v2";
 import { Runtime } from "../src/runtime.ts";
 import { labelResultSchema } from "../src/builtins/sqlite-builtins.ts";
 import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
@@ -195,7 +195,11 @@ describe({
     await storageManager?.close();
   });
 
-  const seed = async (db: SqliteDbRef, sql: string, params?: unknown[]) => {
+  const seed = async (
+    db: SqliteDbRef,
+    sql: string,
+    params?: SqliteParamsWire,
+  ) => {
     const tx = runtime.edit();
     tx.recordSqliteWrite!(space, { op: "sqlite", db, sql, params });
     return await tx.commit();

--- a/packages/runner/test/sqlite-storage.test.ts
+++ b/packages/runner/test/sqlite-storage.test.ts
@@ -10,7 +10,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { cfLink, table } from "@commonfabric/memory/sqlite/schema";
-import type { SqliteDbRef } from "@commonfabric/memory/v2";
+import type { SqliteDbRef, SqliteParamsWire } from "@commonfabric/memory/v2";
 import { Runtime } from "../src/runtime.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -42,7 +42,7 @@ describe("storage provider sqlite passthrough (emulated server)", () => {
   const seedSqlite = async (
     db: SqliteDbRef,
     sql: string,
-    params?: readonly unknown[],
+    params?: SqliteParamsWire,
   ) => {
     const tx = runtime.edit();
     tx.recordSqliteWrite!(space, { op: "sqlite", db, sql, params });


### PR DESCRIPTION
**Prep, no behavior change.** First of three; the stack ends by deleting
`encodeMemoryBoundaryUnprovenFabricValue()`.

Every SQLite type that crosses the memory boundary declared its payload
`unknown`, so no message containing one could be *stated* as a `FabricValue`
however sound its contents. These are wire types — their values are serialized on
every request, which is exactly what `FabricValue` means.

| Declaration | Before | After |
|---|---|---|
| `ColumnSchema` / `TableSchema` catch-alls | `[key: string]: unknown` | `FabricValue` |
| `RowLabelSpec` + the AST builders producing it | `unknown` | `FabricValue` / `FabricPlainObject` |
| `SqliteDbRef.tables` | `Record<string, unknown>` | `Record<string, FabricValue>` |
| `SqliteParamsWire` | both arms `unknown` | both arms `FabricValue` |

The row-label builders were worth checking rather than assuming: they accept a
`RegExp`, which is **not** a fabric value. They decompose it into `source` +
`flags` strings before it reaches a node, so nothing unserializable is ever
embedded — and the file header already claimed as much ("the builders below
return plain-JSON AST nodes"). The types now say it too.

## One field deliberately stays `unknown`

`RowLabelWriteArgs.params` does **not** move. That gate runs *before* encoding,
so a value there may still be a `Cell` — that is precisely what
`confidentialityOf` reads a label off. `unknown` is correct, and the field now
carries a comment saying why it is not `SqliteParamsWire`.

## Two duplicated shapes, deduped

The fix for the type and the fix for the duplication turned out to be the same
edit:

- `packages/runner/src/builtins/sqlite-builtins.ts` kept a **private copy** of the
  `SqliteDbRef` shape. It is now `WireSqliteDbRef & { rev?: number }` — `rev` is
  the only field the runner genuinely adds, and the wire fields can no longer
  drift from the protocol's.
- `RowLabelWriteArgs.tables` re-spelled `Record<string, unknown>` inline; it now
  says `SqliteDbRef["tables"]`.

## What this does not do

The `as Record<string, unknown>` assertions around `cloneIfNecessary` are
pre-existing and are not removed — they now name the type they are actually
asserting. The underlying `cloneIfNecessary` typing is a separate problem.

## Testing

`deno task check`, `check-docs` (518 blocks), `fmt --check`, `lint` clean
repo-wide. Suites: memory 439 passed, runner 1070 passed. `deno.lock` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112UHG8bqH6cRMqZtRwBwcA


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened SQLite wire types to use Fabric values across `@commonfabric/memory/v2` and the runner, improving type safety and keeping the runtime aligned with the wire protocol. No behavior change.

- **Refactors**
  - `SqliteParamsWire` now accepts arrays/objects of `FabricValue`.
  - `SqliteDbRef.tables` is `Record<string, FabricValue>`; runner uses the wire `SqliteDbRef` from `@commonfabric/memory/v2` and adds `rev?: number`.
  - Row label spec and builders typed to `FabricValue`/`FabricPlainObject`; `RegExp` inputs are decomposed to strings.
  - `ColumnSchema`/`TableSchema` catch-alls set to `FabricValue`.
  - `RowLabelWriteArgs.params` stays `unknown` (pre-encoding gate); `tables` uses `SqliteDbRef["tables"]`.
  - Test helpers now accept the new wire types.

<sup>Written for commit a998e69ff26f334b68db743d8f95712d9b6e3f68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

