### PR TITLE
test(piece): pin the cold-start setup repair at the flag-off posture

### DIFF
--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -1619,6 +1619,70 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(afterEvent.key("count").get()).toBe(1);
   });
 
+  it("cold start heals an already-moved identity with the update flag off", async () => {
+    // The same durable state as the test above, at the posture every deployment
+    // that does not set the flag actually runs: systemPatternAutoUpdate OFF.
+    // That is the runtime default — `Runtime`'s experimental defaults omit the
+    // flag entirely, so it is `undefined` unless a host passes it (the shell
+    // does; an embedding host need not).
+    //
+    // The split this pins: RECONCILING to a newer official pattern is flag-gated
+    // (checkAndUpdateDefaultPattern → "skipped-disabled"), but REPAIRING a doc
+    // onto its own already-pinned identity must NOT be. They are different
+    // operations — the repair changes no identity, rolls nothing forward, and
+    // writes no user data. Gate it too and an aged root has no recovery path at
+    // all on the deployments most likely to be carrying aged roots.
+    await setupHome({ systemPatternAutoUpdate: false });
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    await manager.stopPiece(root);
+
+    stub.setSource(SOURCE_V3_HANDLER);
+    // Model the refresh CLI faithfully: it compiles the replacement INTO the
+    // space (so the identity cold-loads — its probeLoad verified exactly that)
+    // and then writes patternIdentity meta only, never running setup. With the
+    // flag off nothing else compiles it, so without this the doc would point at
+    // an unloadable identity — a different failure than the one under test.
+    const targetPattern = await runtime.patternManager.compilePattern(
+      {
+        main: HOME_PATTERN_URL,
+        files: [{ name: HOME_PATTERN_URL, contents: SOURCE_V3_HANDLER }],
+      },
+      { space: manager.getSpace() },
+    );
+    const targetRef = runtime.patternManager.getArtifactEntryRef(
+      targetPattern,
+    )!;
+    const targetId = await identityForSource(
+      SOURCE_V3_HANDLER,
+      {},
+      HOME_PATTERN_URL,
+    );
+    expect(targetRef.identity).toBe(targetId);
+    const { error } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).setMetaRaw("patternIdentity", targetRef);
+    });
+    expect(error).toBeUndefined();
+    expect(runtime.cfcEnforcementMode).not.toBe("disabled");
+
+    await controller.ensureDefaultPattern();
+    await runtime.idle();
+
+    const after = (await manager.getDefaultPattern(false))!;
+    expect(getPatternIdentityRef(after)?.identity).toBe(targetId);
+    expect(after.key("count").get()).toBe(0);
+    (after.key("bump") as unknown as { send: (e: unknown) => void }).send({});
+    await runtime.idle();
+    await (after as unknown as { pull: () => Promise<unknown> }).pull();
+    const afterEvent = (await manager.getDefaultPattern(false))!;
+    expect(afterEvent.key("count").get()).toBe(1);
+  });
+
   it("heals a root whose pinned pattern fails CFC migration by rolling forward to official", async () => {
     // The estuary brick, faithfully: a home root pinned to an OLD home.tsx
     // whose required `favorites` predates its `Default<>`. The doc was


### PR DESCRIPTION
Adds one test to `check-update-default-pattern.test.ts` covering the default-root cold-start setup repair with `systemPatternAutoUpdate` **off**.

### Why

Every existing case in that file runs with the flag on. But the flag is `undefined` — falsy — unless a host sets it explicitly: `Runtime`'s experimental defaults omit it entirely (`runtime.ts:889-896`; only `computedCellIds` gets a `??=` normalization). The shell passes `flagValue(...) ?? true` (`shell/src/lib/env.ts:74`); an embedding host need not. So the posture most likely to be carrying aged roots is the one with no coverage.

### What it pins

The two operations behind that flag are not the same thing:

- **Reconciling** a root to a newer official pattern *is* flag-gated — `checkAndUpdateDefaultPattern` returns `"skipped-disabled"` (`pieces-controller.ts:955`).
- **Repairing** a doc onto its own already-pinned identity is *not*, and shouldn't become so. The repair changes no identity, rolls nothing forward, and writes no user data.

Without this test, gating the repair alongside the reconcile would leave an aged root with no recovery path on every deployment that doesn't set the flag, and nothing would fail.

The test mirrors the existing "cold start heals a doc whose identity already moved without setup" at `systemPatternAutoUpdate: false`, asserts CFC enforcement is live (not `disabled`), and pins the heal functionally end-to-end: identity preserved, `count` materialized, and `bump.send({})` driving `count` 0 → 1 through the once-missing stream marker.

### One scaffolding note

The replacement is compiled **into the space** before the meta-only `patternIdentity` swap, mirroring what an operator refresh CLI does. With the flag off nothing else compiles it, and an unloadable identity fails as `Could not load pattern` — a different failure than the missing-`$stream`-marker brick under test. Loadable and runnable are provisioned separately here.

### Gate

`deno fmt --check` + `deno lint` clean; workspace `deno task check` clean; full `piece` package suite 23 passed / 281 steps / 0 failed.

Test-only — no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a test that verifies cold-start repair of the default root works with `systemPatternAutoUpdate` off, while `checkAndUpdateDefaultPattern` reconcile remains gated. This pins the recovery path so aged roots still heal when hosts don’t set the flag.

<sup>Written for commit ad8128a19280bdcc3d6a67c99186364d36d798a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

