### PR TITLE
docs(plans): verb contract — discovery is read depth, naming is slugs

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -14,6 +14,12 @@ post-merge review amendments (decisions 5–7: attribution via CFC provenance,
 patterns return references while clients render identity, `@name` deferred);
 index and fixture wording follows the references model.
 
+**Amended 2026-07-27** by a second review pass, extending decision 6 to
+discovery and naming (decisions 8–9). A2's pattern-authored index is retired in
+favour of a generic client read-depth control (F4), and `--slug` on
+`piece call` becomes the naming affordance (F5). Risks names #5059 as the
+`setsrc` preflight the write-storm gate wants.
+
 ## Governing decisions
 
 Made 2026-07-24, shaping everything below:
@@ -33,12 +39,24 @@ Made 2026-07-24, shaping everything below:
    parallel `actor` field. `topics.agentName` stays as an interim atomic
    argument until trusted `cf` ingress can mint and propagate general
    `AgentActor` provenance.
-6. **Patterns return references; clients render identity.** Discovery indexes
-   carry stable child references and summaries. Fid/path annotation belongs to
-   the CLI, which can see backing cell identities.
+6. **Patterns return references; clients render identity.** Fid/path
+   annotation belongs to the CLI, which can see backing cell identities.
 7. **Client-local `@name` bindings are deferred.** Their overlap with
    fabric-side slugs needs a separate naming design and is not required by this
    plan.
+
+Added 2026-07-27, extending decision 6 to the two surfaces it had not yet
+reached:
+
+8. **Discovery is a client read-depth control, not a pattern-authored index.**
+   The parent already links its children; the 300k-token board read was a
+   reader expanding every reference it crossed. Fixing depth once in the client
+   gives every pattern bounded discovery with nothing to author or keep in
+   step. A2 is retired and replaced by F4.
+9. **Naming is slugs, assigned by the client.** `--slug` on `piece call` names
+   the reference a verb returned, generalizing `piece new --slug` (F5). No verb
+   mints, stores, or returns a name; pattern-side assignment is a CFC
+   namespace-authorization question, out of scope here.
 
 ## Non-goals
 
@@ -51,6 +69,8 @@ Named so their absence reads as intent, not oversight:
   delegated agent, but does not deliver delegation.
 - **Client-local aliases** — `@name` / `cf bind` are deferred pending a
   separate comparison with existing slugs and configured host/space addressing.
+  Naming itself is *not* deferred: slugs already work, and F5 applies them to
+  returned references. What is deferred is a *second* naming system.
 - **Cross-space effect atomicity** — the spec's I11 gap stands; the guarantee
   is same-space, which covers `topics`.
 - **Batch / session mode** for the CLI — orthogonal call-cost work, linked
@@ -64,7 +84,8 @@ Named so their absence reads as intent, not oversight:
 
 ### WS-A — `topics` Part 1 finish
 
-Size S–M (~2–4 days). No dependencies. `packages/patterns/topics`.
+Size S (~1–2 days, down from S–M when A2 was retired). No dependencies.
+`packages/patterns/topics`.
 
 - `AddTopicEvent` gains optional `body` — argument widening, compat-checker
   clean — and `addTopic` creates the child with it, making `setBody` an
@@ -73,23 +94,20 @@ Size S–M (~2–4 days). No dependencies. `packages/patterns/topics`.
   `agentName`, empty comment body, invalid link URL. UI composer wrappers
   (`submitTopic`, `submitComment`, `saveBody`, …) keep their silent guards —
   an empty draft is a non-event in a composer, a defect headlessly.
-- A compact discovery `index` result on the board — one reference-plus-summary
-  row per topic: the child reference plus scalar summaries (`title`,
-  `createdAt`, `createdBy`, `commentCount`, `lastActivityAt`) and reference
-  edges as sibling references — never expanded pieces, and no pattern-authored
-  fid fields (identity rendering is the CLI's job — decision 6, F2).
-  `crossrefs` stays as the UI's reference graph; it is not compact — each row
-  expands to full pieces, and a live full-board read through it exceeded 300k
-  tokens — and stops being the documented survey surface.
-- Tests: `topics.test.tsx` / `multi-user.test.tsx` cover body-at-create,
-  each thrown rejection (asserting no write happened), and the index
-  (asserting no expanded piece/action/runtime values serialize).
+- **No discovery index** (decision 8, amended 2026-07-27). The board authors
+  nothing for discovery: `crossrefs` stays the UI's reference graph and simply
+  stops being the documented survey surface, and bounded surveying arrives
+  generically in F4. The retired A2 would have had the board hand-maintain a
+  reference-plus-summary row per topic — a second interface over children it
+  already links, and no help for any read that is not the index.
+- Tests: `topics.test.tsx` / `multi-user.test.tsx` cover body-at-create and
+  each thrown rejection (asserting no write happened).
 - Docs riding the change: `packages/patterns/topics/README.md`,
   `skills/topics/SKILL.md` (`addTopic` example gains `body`;
   `deno task check-skill-facts` gates the citations).
 - **Exit:** filing-with-body is five CLI calls; a blank `agentName` fails with
-  a nonzero exit; a full-board survey is one bounded read of `index`; live
-  board updated via `setsrc` (gated — see Risks).
+  a nonzero exit; live board updated via `setsrc` (gated — see Risks). The
+  bounded-survey criterion moves to F4, where the capability now lives.
 
 ### WS-B — CLI settlement hygiene
 
@@ -241,6 +259,21 @@ Size M, mostly parallel. `packages/cli`, `skills/cf`.
   backing identity changes; evaluate a narrower path-selected form if broad
   output is too noisy. Patterns return child references and never manufacture
   their own fid fields for this purpose.
+- **Read-depth control for reads (F4, decision 8).** A read that stops at a
+  reference instead of expanding what it points at, so one read of a parent
+  surveys its children. This is what makes discovery bounded for every pattern,
+  and it is where WS-A's retired index criterion now lives. Pairs with
+  `--include-ids`: depth bounds the read, annotation makes the references
+  addressable. **Exit:** a full-board `topics` read is one call whose
+  serialization contains no expanded piece, action, or runtime value, and whose
+  size scales with the number of topics rather than their contents — measured
+  against the same live board that produced the 300k-token read.
+- **`--slug <name>` on `piece call` (F5, decision 9).** Assigns a fabric-side
+  slug to the reference the verb returned, reusing `assignSlug`
+  (`packages/piece/src/slugs.ts:15`) exactly as `piece new --slug` already does
+  (`packages/cli/commands/piece.ts:472`). No runtime and no pattern change;
+  depends only on verbs returning a reference (Phase 4). **Exit:** a create
+  names its child in one call, and the slug resolves to the canonical child.
 - `--await` / `--no-wait` and the caller-controlled wait bound — with WS-D.
 - Skill updates ride each surface (`skills/cf`, `skills/topics`): the handle
   lookup and verification read leave the documented workflow when Phase 4
@@ -250,7 +283,7 @@ Size M, mostly parallel. `packages/cli`, `skills/cf`.
 
 ```text
 Phase 1 (parallel, now): WS-A, WS-B, WS-F verb listing + identity
-                         annotation; WS-C starts
+                         annotation + read depth; WS-C starts
 Phase 2: WS-D idempotency-only  → duplicate bug dead on the live board
 Phase 3: WS-C lands             → topics verbs return values; flag still off
 Phase 4: WS-C + WS-D join       → full Invocation JSON; --await; flag flips
@@ -292,10 +325,11 @@ change that alters them.
     canonical child, not an intermediate wrapper;
   - attribution persists in `createdBy` / `bodyUpdatedBy`;
   - an undeclared field fails with a nonzero exit;
-  - a full-board discovery read stays bounded;
+  - a full-board discovery read stays bounded (via read depth, F4 — nothing
+    board-authored);
   - commit acknowledgement does not wait on cross-reference recomputation;
-  - update rehearsal and commit-rate monitoring pass before any live
-    `setsrc` (Risks — the write-storm gate).
+  - `setsrc --check` (#5059) passes, then update rehearsal and commit-rate
+    monitoring, before any live `setsrc` (Risks — the write-storm gate).
 - **Doc gates:** `deno task check-docs`, `deno task check-skill-facts` on
   every change touching docs or skills.
 
@@ -320,6 +354,14 @@ change that alters them.
   #4956, merged 2026-07-24 — is the candidate fix; confirm before the first
   Phase 1 deploy). Until the gate clears, a "live-board acceptance pass"
   degrades to a scratch board and must say so rather than pass silently.
+  **#5059 (`cf piece setsrc --check`) is the preflight half of this gate**: it
+  answers whether a given source can be applied to a given piece *before*
+  attempting it, driving the real rules in dry-run — the pattern-contract
+  subset proof, the CFC envelope merge, and the retained-link validator —
+  rather than reimplementing them. It does not measure commit rates, so the
+  rehearsal stands; what it removes is discovering an incompatibility by
+  attempting the swap on the live board. Adopt it as the first step of every
+  phase's deploy checklist once it lands.
 - **WS-E's gates may stall it** (OQ1, CFC review, collection unknown, trusted
   ingress mint and propagation): it is last and severable; everything through
   Phase 4 delivers without it, and `topics.agentName` remains the safe interim.
@@ -331,7 +373,7 @@ Importable one-to-one into the tracker; `blocks →` names the dependency edge.
 | id | title | size | depends on |
 | --- | --- | --- | --- |
 | A1 | topics: body at create + thrown rejections | S | — |
-| A2 | topics: reference-plus-summary discovery index | S | — |
+| ~~A2~~ | ~~topics: reference-plus-summary discovery index~~ — retired 2026-07-27 (decision 8); replaced by F4 | — | — |
 | B1 | cli: sink-based settlement, result cell address | S | — |
 | C1 | api: action return types, `Stream<T, R>`, VerbError | M | — |
 | C2 | ts-transformers: value-returning action lowering + CTS spec | M | C1 |
@@ -349,3 +391,5 @@ Importable one-to-one into the tracker; `blocks →` names the dependency edge.
 | F1 | cli: `cf piece verbs --json` | S | — (result schemas after C3) |
 | F2 | cli: generic identity/path annotation | M | — |
 | F3 | cli: `--await` / `--no-wait`, caller-controlled bound | S | D2 |
+| F4 | cli: read-depth control — bounded discovery for every pattern | M | — |
+| F5 | cli: `--slug` on `piece call`, naming a returned reference | S | C1–C3, D2 |

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -20,6 +20,14 @@ not a parallel invocation field; patterns return child references while clients
 render their ids and paths; and client-local `@name` bindings are deferred
 because they overlap confusingly with fabric-side slugs.
 
+**Review update (2026-07-27).** A second pass extended that same boundary —
+patterns expose their data and verbs; clients project them — to discovery and
+naming. Discovery becomes a client read-depth control rather than a
+pattern-authored index: a parent already links its children, and the unbounded
+read that motivated an index is a reader expanding every reference it crosses.
+Naming becomes fabric-side slugs assigned by the client to a returned
+reference, so no verb mints, stores, or returns a name.
+
 ## Goal
 
 Any pattern drivable by an agent, with no pattern-specific CLI code. Filing one
@@ -275,37 +283,48 @@ required, but is not a prerequisite for runtime-attested execution provenance
 ### Discovery
 
 A client holding only a board URL must reach the board's children without an
-O(children) sweep of per-child reads. So a parent exposes a **compact index** on
-its result — one row per child carrying a stable child reference and the summary
-fields a survey needs (name, author, timestamps, counts) — making the whole
-board one read. The pattern owns the reference and summary; the client, which
-can inspect the backing cells, owns rendering the reference as a fid or full
-path.
+O(children) sweep of per-child reads, and without dragging the whole graph back
+with them. Both halves are properties of the **read**, not of the pattern: a
+parent already links its children, so every reference a survey needs is in the
+durable data. What is missing is a reader that can cross a reference without
+expanding what it points at.
 
-`topics.crossrefs` already carries each `topic` reference, but it is the
-cross-reference graph, not a compact index: each row's `topic`, `refsOut`, and
+`topics.crossrefs` shows this precisely. It already carries each `topic`
+reference — the survey data is there — but each row's `topic`, `refsOut`, and
 `referencedBy` expand to full pieces on read
 (`packages/patterns/topics/main.tsx:70-78`), and a headless survey of the live
-board through it produced over 300k tokens of output. Its explicit `fid` field
-is not the general model either: it is derived indirectly from runtime-only
-cell surface, reads `""` while unresolved, and a pattern cannot reliably see
-its own runtime address. The index is therefore a separate result — one
-reference-plus-summary row per child, reference edges as sibling references,
-never expanded pieces — and generic clients render identity on top: a coarse
-exploration mode such as `--include-ids` can annotate every point where the
-backing identity changes, with a narrower path-selected form to follow if the
-broad form proves too noisy. Both are projections of existing references, not
-fields every pattern must maintain. Acceptance for an index: its serialization
-contains no expanded piece, action, or runtime values, and a full-board read
-stays bounded.
+board through it produced over 300k tokens of output. The defect is expansion
+depth, not an absent index.
 
-Discovery is the parent's job; the child's own verbs are the child's. A comment
-is addressed to the topic, not routed through the board — **but that depends on
-the CLI dispatching a nested piece's streams, which today fails with
-`Transaction required for .set()`** (`packages/runner/src/cell.ts:1294`; its own
-board topic). Until that lands, board-level routing
-(`addComment {topicFid, body}`) is the documented workaround — pragmatic, not
-the target shape.
+Discovery is therefore a **generic client capability**: a read-depth control
+that stops at references instead of expanding them, composed with the identity
+annotation that renders those references as fids or paths (`--include-ids`,
+coarse first, with a narrower path-selected form if the broad one proves too
+noisy). One bounded read of the parent then surveys the board, and every
+pattern gets it without authoring anything — the same relation `cf piece verbs`
+has to handlers, where the listing is derived from the durable schema rather
+than from a list the pattern maintains (Verb discovery).
+
+A **pattern-authored compact index** was the earlier proposal here and is
+rejected. It is a second interface over data the pattern already exposes: it
+must be kept in step with the children by hand, every pattern pays the
+authoring cost again, and it leaves the unbounded read in place for everything
+that is not the index. An explicit `fid` field is not the model either — it is
+derived indirectly from runtime-only cell surface, reads `""` while unresolved,
+and a pattern cannot reliably see its own runtime address. `crossrefs` stays
+what it is, the UI's reference graph, and stops being the documented survey
+surface.
+
+Acceptance for discovery: a full-board survey is one read whose serialization
+contains no expanded piece, action, or runtime value, and whose size is bounded
+by the number of children rather than by their contents.
+
+Verbs stay where their subject is: a comment is addressed to the topic, not
+routed through the board — **but that depends on the CLI dispatching a nested
+piece's streams, which today fails with `Transaction required for .set()`**
+(`packages/runner/src/cell.ts:1294`; its own board topic). Until that lands,
+board-level routing (`addComment {topicFid, body}`) is the documented
+workaround — pragmatic, not the target shape.
 
 ### Composition: the atomic-unit rule
 
@@ -617,12 +636,6 @@ $ cf piece invocation --url "$TOPICS_BOARD_URL" inv_9c1b --await
   "result": { "summary": "..." } }
 ```
 
-Client-local `@name` bindings are deferred. They can encode host + space +
-piece, while slugs (`cf piece set-slug`) are fabric-side names within a space,
-but two overlapping naming systems are too easy to confuse and aliases are not
-required for agent-drivable verbs. Revisit them separately only after concrete
-usage shows that full URLs, configured host/space, and slugs are insufficient.
-
 On any early exit — a timed-out wait, a lost connection — the client reports
 the furthest phase it observed as a structured field beside the invocation id
 it printed before network work began:
@@ -631,6 +644,41 @@ safety gate: with a caller-supplied id, a retry of that id is safe in every
 phase — before dispatch nothing committed; after it, the retry collides on the
 receipt and reads the original back. A `retrySafe` flag is derivable
 client-side sugar, not protocol.
+
+### Naming
+
+The returned reference is identity; a **slug** is the name — and the naming
+layer already exists. A slug is a document at an address derived
+deterministically from `(space, slug)` holding a write-redirect link to its
+target (`packages/runner/src/slugs.ts`), and `cf piece new --slug` already
+assigns one at creation time (`packages/cli/commands/piece.ts:472`). The same
+affordance belongs on `piece call`, applied to whatever reference the verb
+returned:
+
+```text
+$ cf piece call --url "$TOPICS_BOARD_URL" addTopic \
+    --title "Verb contract" --body @body.md --slug verb-contract
+{ "invocation": "inv_7f3a", "status": "settled",
+  "result": { "topic": "fid1:abc" } }
+→ slug "verb-contract" → fid1:abc
+```
+
+A create then yields a human-readable route without any verb minting, storing,
+or returning a name — the same division as identity rendering, one layer up.
+
+Assignment stays client-side deliberately. `setSlugLink` is a client flow
+(`packages/piece/src/slugs.ts:23`), the pattern-facing API exposes no entity-id
+addressing at all, and letting a pattern write a computable space-global
+address would make slug namespaces squattable by any pattern in the space —
+a CFC question, not a plumbing gap. Should pattern-side naming ever be wanted,
+that authorization question is the design, not the missing API.
+
+Client-local `@name` bindings remain deferred, for the reason they were
+deferred before: they can encode host + space + piece where slugs are
+fabric-side names within a space, but two overlapping naming systems are too
+easy to confuse, and aliases are not required for agent-drivable verbs.
+Revisit them only after concrete usage shows that full URLs, configured
+host/space, and slugs are insufficient.
 
 ## Defects and unknowns in the current machinery
 
@@ -668,10 +716,13 @@ that made it drivable. Its topics-board incarnation — the board topic *"Give
 the topics board an agent handle"* (Ben + Claude, 2026-07-22) — asks for five
 things: atomic `addTopic {title, body?}` returning the new topic reference,
 idempotency on create, a board index cell, board-level
-`addComment {topicFid}`, and an identity guard on mutating verbs. Every ask maps to a section above — the
+`addComment {topicFid}`, and an identity guard on mutating verbs. Every ask
+maps to a section above, two of them answered more generically than asked: the
 identity guard is the interim required `agentName` on every mutating event,
-pending general CFC ingress provenance. This document is their pattern-agnostic
-generalization. Deeper detail lives in the arc's defect register and
+pending general CFC ingress provenance, and the board index cell is answered by
+a client read-depth control that needs no cell (Discovery). This document is
+their pattern-agnostic generalization. Deeper detail lives in the arc's defect
+register and
 `docs/development/projects/fuse-fabric-access/topics-agent-ergonomics.md` on
 the loom PR.
 
@@ -754,10 +805,18 @@ end-to-end acceptance fixture in the implementation plan.
 - **Execution attribution is CFC provenance, not an invocation payload field.**
   `topics.agentName` remains an atomic interim argument until trusted `cf`
   ingress can mint and propagate the general provenance.
-- **Patterns return references; clients render identities.** A compact index
-  carries stable child references and summaries. Generic `--include-ids`
-  annotation belongs to the CLI because the pattern cannot reliably author its
-  own fid.
+- **Patterns return references; clients render identities.** Generic
+  `--include-ids` annotation belongs to the CLI because the pattern cannot
+  reliably author its own fid.
+- **Discovery is a read-depth control, not a pattern-authored index.** The
+  parent already links its children; the unbounded read is a reader expanding
+  every reference it crosses. Fixing it once in the client gives every pattern
+  bounded discovery with nothing to author or keep in step — the relation
+  `cf piece verbs` already has to handlers.
+- **Naming is slugs, assigned by the client.** `--slug` on `piece call` names
+  the reference a verb returned, generalizing `piece new --slug`. No verb
+  mints, stores, or returns a name. Pattern-side assignment is a CFC
+  namespace-authorization question, not a missing API.
 - **Client-local `@name` bindings are deferred.** Their distinction from slugs
   is real but confusing, and they are unnecessary for the core contract.
 
@@ -770,11 +829,11 @@ the steps below are the design-level order.
 1. Agree this document — particularly the open questions.
 2. Finish the Part 1 rework of `topics` / `topic` — the attribution rules
    already hold. Remaining, with no runtime change: a body argument on
-   `addTopic`, thrown rejections in place of silent early-returns — empty
-   titles and blank agent names both drop without a trace today — and the
-   reference-plus-summary discovery index (Discovery). (A thrown handler
-   error already surfaces as a nonzero CLI exit; stable codes arrive with the
-   protocol.)
+   `addTopic`, and thrown rejections in place of silent early-returns — empty
+   titles and blank agent names both drop without a trace today. (A thrown
+   handler error already surfaces as a nonzero CLI exit; stable codes arrive
+   with the protocol.) Discovery no longer appears in this step: it left the
+   pattern entirely and is client work, in step 6.
 3. Replace the tool-result poll with sink-based settlement and return the
    result cell's address to the caller. Standing fix, useful regardless.
 4. Plumb the id and the readback: pass a caller-supplied `eventId` from
@@ -789,7 +848,8 @@ the steps below are the design-level order.
    `AgentActor` propagation, metadata protection, and extraction. Retire
    per-event `agentName` fields only after that path is proven end to end.
 6. Add the client surface around invocation ids (mint-and-print,
-   `--invocation`, `--await` / `--no-wait`), verb listing, and generic
-   identity annotation for returned references and discovery indexes.
+   `--invocation`, `--await` / `--no-wait`), verb listing, generic identity
+   annotation for returned references, the read-depth control that makes
+   discovery bounded, and `--slug` assignment on a returned reference.
 
 Steps 2 and 3 stand on their own regardless of how the open questions land.


### PR DESCRIPTION
## Why

The verb-contract plan is explicitly a plan of record — "keep current as work
proceeds: check off exit criteria, record scope changes" — and #5006 already
amended it post-merge. This is a second review pass, and it lands one
principle in two places the plan had not yet applied it:

**A pattern exposes its data and its verbs. Everything else is a client
projection.**

The plan already holds this for identity (decision 6: patterns return
references, clients render fids and paths) and for verb discovery, where
`cf piece verbs` (#4993) derives the listing from the durable schema through
the same classification `cf piece call` resolves through — nothing authored,
and the listing and the dispatcher cannot disagree. Two surfaces were still
on the other side of that line.

**Discovery.** A2 asks the board to author and maintain a
reference-plus-summary row per topic. But the 300k-token live-board read that
motivated it was not caused by a missing index — `crossrefs` already carries
every `topic` reference; the survey data is there. It was caused by a reader
that expands every reference it crosses
(`packages/patterns/topics/main.tsx:70-78`). That is a read-depth defect, and
an index does not fix it — it routes around it for one blessed path while
every other read stays unbounded. It also costs every pattern the authoring
work separately, and has to be kept in step with the children by hand.

**Naming.** The plan deferred `@name` bindings because they overlap with
slugs (decision 7), which is right — but it left naming looking deferred
wholesale. Slugs already work: a doc at an address derived deterministically
from `(space, slug)` holding a write-redirect link
(`packages/runner/src/slugs.ts`), and `cf piece new --slug` already assigns
one at creation (`packages/cli/commands/piece.ts:472`). Applying the same
affordance to the reference a verb returned is a small CLI change that needs
no runtime and no pattern change, and it means no verb ever mints, stores, or
returns a name.

Also names #5059 in the write-storm gate, which currently says decision 3 is
"not yet satisfiable" and asks for a rehearsal before any live `setsrc`.

## What Changed

Docs only; no code.

**`pattern-verb-contract.md`**

- Discovery rewritten: the unbounded read is diagnosed as expansion depth,
  discovery becomes a generic client read-depth control composed with
  `--include-ids`, and the pattern-authored index is explicitly rejected with
  its reasons. Acceptance restated in terms of the read, not the index.
- New **Naming** subsection under Client surface: `--slug` on `piece call`,
  why assignment stays client-side (`setSlugLink` is a client flow,
  `packages/piece/src/slugs.ts:23`; the pattern-facing API exposes no
  entity-id addressing; a pattern writing a computable space-global address
  makes slug namespaces squattable — a CFC question, not a plumbing gap), and
  `@name` still deferred for its original reason.
- Two decisions added to "worth recording", staging steps 2 and 6 updated,
  Prior art notes the board-index ask is answered more generically than asked.

**`pattern-verb-contract-implementation.md`**

- Governing decisions 8 and 9; A2 struck from the issue table and replaced by
  F4 (read-depth control), plus F5 (`--slug` on `piece call`).
- WS-A loses the index bullet and its test, drops S–M → S, and hands the
  bounded-survey exit criterion to F4. WS-F gains F4 and F5 with exit
  criteria.
- Non-goals clarified: naming is not deferred, a *second* naming system is.
- Risks: #5059 named as the preflight half of the write-storm gate — it
  answers whether a source can be applied before attempting it, driving the
  real rules in dry-run rather than reimplementing them; it does not measure
  commit rates, so the rehearsal stands.

## Test plan

- `deno task check-docs plans` — passes (1 typed block in scope).
- `docs/` is excluded from `deno fmt`; prose hand-wrapped at 80 columns.
- Citations verified against source at these revisions: `assignSlug`
  (`packages/piece/src/slugs.ts:15`), `setSlugLink` (`:23`), `--slug` on
  `piece new` (`packages/cli/commands/piece.ts:472`), slug address derivation
  (`packages/runner/src/slugs.ts`), `crossrefs` expansion
  (`packages/patterns/topics/main.tsx:70-78`).

## Open to argument

- **F4's shape is unspecified on purpose.** "Stop at references instead of
  expanding them" is the requirement; whether that is a depth integer, a
  no-expand flag, or path-selected is a CLI design question I have not
  prejudged. If it turns out materially harder than the authored index, that
  is the strongest argument for keeping A2 and worth hearing.
- **F5 assumes slug assignment can follow a returned reference in the same
  invocation.** It depends on Phase 4 and nothing else, but if the reference
  is not resolvable to a cell at that point client-side, the sequencing needs
  another look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the verb-contract docs to make discovery a client read-depth control and naming a client-assigned slug, so patterns only return references and never author indexes or names. Retires the board-authored index (A2), introduces F4 (read depth) and F5 (`--slug` on `piece call`), and names `#5059` as the `setsrc` preflight in the write-storm gate.

- **Refactors**
  - Discovery: replace the pattern-authored index with a generic read-depth control (F4); `crossrefs` remains the UI graph; acceptance is one bounded read.
  - Naming: add `--slug` on `piece call` (F5) to name the returned reference; pattern-side naming stays out; `@name` remains deferred.
  - Plan updates: add decisions 8–9; retire A2; move the survey exit criterion from WS-A to F4; tighten WS-A scope and clarify non-goals.
  - Risks: include `#5059` (`cf piece setsrc --check`) as the preflight for the write-storm gate.

<sup>Written for commit 004195a36c5f21b888d2e74606abd54add5ae026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

