### PR TITLE
docs(topics): attach the Topic doc blocks to the type they describe

### DIFF
--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -209,8 +209,10 @@ interface TopicsInput {
   topics?: Writable<TopicPiece[] | Default<[]>>;
   myName?: PerUser<Writable<string | Default<"">>>;
 }
-// TopicInput additionally takes mentionable?: Writable<TopicPiece[]> — the
-// board's own list, wired at creation, for detail-page Connections.
+// TopicInput additionally takes mentionable?: Writable<TopicReference[]> —
+// the board's own list, wired at creation, for detail-page Connections.
+// TopicReference is TopicPiece minus its own crossrefs, so a Topic's schema
+// describes its siblings without recursing over the whole board.
 ```
 
 ### Output Schema

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -100,16 +100,10 @@ export interface TopicInput {
 }
 
 /**
- * A #topic — a durable unit of shared attention: a title, a living body
- * document, a flat chronological comment thread, and typed links out to other
- * core objects (PRs, agent sessions, other topics). Deliberately has no
- * status, labels, or assignees; what a topic grows next is part of the
- * experiment (CT-1878).
- */
-/**
- * The shared-safe projection stored in the tracker's list. Session-local UI
- * controls are intentionally excluded: a TopicPiece can be followed from a
- * shared list even when the viewer has no matching session-local cells.
+ * A sibling Topic as seen from another Topic: enough to render and navigate a
+ * crossref chip and to scan its prose for references, and deliberately not its
+ * own crossref graph. Keeping this projection non-recursive is what lets one
+ * Topic's schema describe its siblings without traversing the whole board.
  */
 export interface TopicReference {
   [NAME]: string;
@@ -133,9 +127,18 @@ export interface TopicReference {
 }
 
 /**
- * The board-facing Topic projection. Crossref targets deliberately use the
- * non-recursive TopicReference contract: a Topic needs enough sibling data to
- * render and navigate chips, not each sibling's entire crossref graph.
+ * A #topic — a durable unit of shared attention: a title, a living body
+ * document, a flat chronological comment thread, and typed links out to other
+ * core objects (PRs, agent sessions, other topics). Deliberately has no
+ * status, labels, or assignees; what a topic grows next is part of the
+ * experiment (CT-1878).
+ *
+ * This is the board-facing projection, and the one stored in the tracker's
+ * list. Session-local UI controls are intentionally excluded: a TopicPiece can
+ * be followed from a shared list even when the viewer has no matching
+ * session-local cells. Crossref targets deliberately use the non-recursive
+ * TopicReference contract: a Topic needs enough sibling data to render and
+ * navigate chips, not each sibling's entire crossref graph.
  */
 export interface TopicPiece extends TopicReference {
   /** This topic's own place in the board's prose graph, derived read-side


### PR DESCRIPTION
## Why

#4997 split `TopicPiece` into a non-recursive `TopicReference` base to stop
schema validation from traversing the whole board graph. That was the right
fix, but both of the interface's doc blocks stayed on the base type — so the
prose that defines a #topic, and the prose explaining the shared-safe list
projection, now sit above `TopicReference` while describing `TopicPiece`. One
of them even names `TopicPiece` in its body.

That is exactly the failure the docs guidance warns about: someone — human or
LLM — searching for "the shared-safe projection stored in the tracker's list"
lands on the wrong interface and concludes siblings are what the board stores.
The tracker's list holds `TopicPiece` (`main.tsx:51,90`); `TopicReference` is
what a Topic sees of its *siblings*.

`packages/patterns/index.md` has the same drift: it still advertises
`mentionable?: Writable<TopicPiece[]>`, which #4997 changed to
`TopicReference[]`.

Follow-up to #4997.

## What Changed

- `topic.tsx` — move the `#topic` block and the shared-safe-projection block
  onto `TopicPiece`, merged into one; give `TopicReference` its own summary
  saying what it is (a sibling as seen from another Topic) and why it is
  deliberately non-recursive.
- `packages/patterns/index.md` — correct `mentionable` to `TopicReference[]`
  and note in one line how the two types relate.

Comments and one markdown block only — no type, signature, or behavior change.

## Test plan

- `deno task cf test packages/patterns/topics/topics.test.tsx` — 39 passed
- `deno task cf test packages/patterns/topics/multi-user.test.tsx` — 7 passed
- `deno fmt --check` / `deno lint` on the touched files — clean
- Diffed `cf check packages/patterns/topics/main.tsx --show-transformed`
  against `main`: the only deltas are the source echo and its content hash.
  Interface-level JSDoc does not become a schema `description`, so the emitted
  schema is unchanged and there is no migration implication.

## Not included

Two other findings from reviewing #4997, left for the author to decide:

- `TopicCrossref` in `main.tsx:76-78` still uses `TopicPiece[]` for
  `refsOut`/`referencedBy`, so board crossref rows still carry each sibling's
  full piece including its own `crossrefs` — not a cycle, but a larger
  validated surface than the non-recursive contract #4997 just declared.
  `crossrefChipRow` already accepts `TopicReference[]`, so narrowing is
  type-only — but it touches the board's published schema, so it is not a
  drive-by.
- Neither of #4997's fixes has an automated guard; both rest on the manual
  Estuary rehearsal. I tried to reproduce the sibling-validation failure at the
  pattern-unit level (seeding a board's list with a legacy-shaped Topic) and it
  passes on both sides of #4997, so a guard would need to be integration-level
  or a direct acyclicity assertion over the emitted schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the Topic docs to the correct interfaces and corrected a stale type reference in the patterns catalog. Clarifies `TopicPiece` vs `TopicReference` without changing the schema or behavior.

- **Bug Fixes**
  - Moved the `#topic` and shared-safe projection docs from `TopicReference` to `TopicPiece`; added a clear summary for `TopicReference` as the non-recursive sibling view.
  - Updated `mentionable` in `packages/patterns/index.md` to `TopicReference[]` and noted how it relates to `TopicPiece`.

<sup>Written for commit 9dc3bfc3d71d38febfeba905beae868d74942a97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

