### PR TITLE
docs(debugging): make cli-debugging.md's $CF_IDENTITY usage self-contained

### DIFF
--- a/docs/development/debugging/cli-debugging.md
+++ b/docs/development/debugging/cli-debugging.md
@@ -15,15 +15,32 @@ deno task cf check pattern.tsx
 deno task cf check pattern.tsx --show-transformed
 ```
 
+## Identity for CLI Commands
+
+Every command below passes `-i "$CF_IDENTITY"`. Set it once per shell to the
+unique key you use for normal development — see
+[LOCAL_DEV_SERVERS.md](../LOCAL_DEV_SERVERS.md) for the full recipe:
+
+```bash
+mkdir -p .cf
+deno run -A packages/cli/mod.ts id new > .cf/shared-dev.key
+export CF_IDENTITY="$PWD/.cf/shared-dev.key"
+```
+
+Without it set, `-i "$CF_IDENTITY"` expands to an empty argument and the
+command fails immediately with `Missing value for option "--identity"`. Don't
+reach for `id derive "implicit trust"` here: that is the local server's own
+operator key, reserved for operator actions.
+
 ## Deploying a Test Piece
 
 ```bash
 # Deploy — returns a piece-id used by all commands below
-deno task cf piece new --identity key.json --api-url URL --space SPACE pattern.tsx
+deno task cf piece new -i "$CF_IDENTITY" --api-url URL --space SPACE pattern.tsx
 
 # Set test data
 echo '{"title": "Test", "done": false}' | \
-  deno task cf piece set --identity key.json --api-url URL --space SPACE --piece ID testItem
+  deno task cf piece set -i "$CF_IDENTITY" --api-url URL --space SPACE --piece ID testItem
 ```
 
 ## When to Use CLI vs Browser


### PR DESCRIPTION
## Why

#4971 swept `docs/development/debugging/cli-debugging.md` onto `-i "$CF_IDENTITY"` as part of moving guidance off the shared implicit-trust key. It left the page in a state where it can't be followed: the variable is used in every command from the "Quick Diagnostic Sequence" onward, but the page never tells the reader to set it, and "Deploying a Test Piece" was still on a stale `--identity key.json`.

A reader working straight down the page in a fresh shell hits this on every command:

```
Missing value for option "--identity".
```

(Verified against the real CLI with `-i ""` — it's an arg-parse failure, not a missing-keyfile error.)

This closes the one review thread left open when #4971 landed. **The reviewer's proposed remedy there was wrong and is deliberately not applied**: cubic suggested swapping `$CF_IDENTITY` for `$n`, claiming `CF_IDENTITY` is "undefined and undocumented". It isn't — `CF_IDENTITY` is registered as a global env option in `packages/cli/commands/piece.ts` and read via `Deno.env.get("CF_IDENTITY")` in `packages/cli/commands/main.ts`, while there is no `n` env var anywhere in `packages/`. Applying that suggestion would have broken working docs. The variable was right; the setup was missing.

## What Changed

- New "Identity for CLI Commands" section: mints the unique `.cf/shared-dev.key` via `id new`, exports `CF_IDENTITY`, and points at [LOCAL_DEV_SERVERS.md](../blob/main/docs/development/LOCAL_DEV_SERVERS.md) as the canonical recipe.
- Restates #4971's own policy inline — don't derive `"implicit trust"` here; that's the local server's operator key.
- "Deploying a Test Piece" moves from `--identity key.json` to `-i "$CF_IDENTITY"`, so the whole page is one coherent setup.

Docs-only; no code or behavior changes.

## Test plan

- Confirmed the failure mode with the real CLI: `deno run -A packages/cli/mod.ts piece get --piece bogus -i "" -a http://localhost:8000 -s testspace` → `Missing value for option "--identity".`
- Confirmed `CF_IDENTITY` is the actual env var (`piece.ts` `globalEnv` registration, `main.ts` read) and that `Deno.env.get("n")` does not appear in `packages/`.
- Gate coverage note: `deno fmt` excludes this file ("No target files found"), and `deno task check-docs` type-checks only TS/TSX blocks, so neither gate covers the changed bash. The CLI check above is the substantive verification.
- Existing inbound anchor links (`#stale-computed-values-after-piece-set`, referenced from `debugging/README.md` and `gotchas/browser-stale-ui.md`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the CLI debugging guide self-contained by adding `CF_IDENTITY` setup and updating examples to use it, preventing “Missing value for option "--identity"” errors. Clarifies not to use the implicit-trust operator key and links to LOCAL_DEV_SERVERS.md for the full setup.

- **Bug Fixes**
  - Added “Identity for CLI Commands” with steps to mint `.cf/shared-dev.key` (`id new`) and `export CF_IDENTITY=...`.
  - Updated “Deploying a Test Piece” examples from `--identity key.json` to `-i "$CF_IDENTITY"`.

<sup>Written for commit 6d8f21c4951a4643661bb3164154894e72d264b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

