### PR TITLE
docs: retire three `TODO(danfuzz)` comments that no longer say the right thing

### DIFF
--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -50,11 +50,12 @@ function isInDeepFrozenCache(obj: object): boolean {
  * `true`, and a frozen graph reaching a function reads as deep-frozen, even
  * though the function's internals -- its `prototype` object and closure state --
  * remain mutable. This is deliberate, so general-purpose callers that freeze
- * objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`) keep working; the
- * honest fix is a strict `FabricValue`-only `deepFreeze()` migration (tracked as
- * TASK-0086).
+ * objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`) keep working.
  *
- * TODO(danfuzz): Fix the problem.
+ * TODO(danfuzz): Migrate `deepFreeze()` to accept `FabricValue` only. A
+ * function is not a `FabricValue`, so a strict signature removes the case
+ * rather than special-casing it; the blocker is the general-purpose callers
+ * above, which must stop passing objects-with-methods first.
  */
 function isNecessarilyFrozenValue(value: unknown): boolean {
   if (typeof value === "object") {

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -230,15 +230,17 @@ function analyzeType(value: any, state: AnalyzeTypeState): JSONSchema {
       // Shouldn't happen: We have a cell link but its link doesn't correspond
       // to a cell.
 
-      // TODO(danfuzz): I think the `TODO(seefeld)` below reflects the old state
-      // of `createJsonSchema()` which was defined to return a
-      // `JSONSchemaObjMutable` (which had to be an `object`) and not a
-      // `JSONSchema` (which includes `boolean`), and not some other problem
-      // with returning `true`. That said, maybe it's more appropriate to
-      // `throw` in this case? Figure out what's what, and take action as
-      // appropriate.
-
-      // TODO(seefeld): Should be `true`.
+      // Returning `true` (the JSON Schema "accept anything" literal) is now
+      // type-legal here: `analyzeType()` returns `JSONSchema`, which is
+      // `JSONSchemaObj | boolean`. The obstacle is no longer the type, it is
+      // schema IDENTITY -- `analyzeType()` results are interned, so `{}` and
+      // `true` are distinct interned schemas with distinct hashes. Swapping
+      // them changes generated schemas that reach storage, which makes it a
+      // migration rather than a cleanup.
+      //
+      // TODO(danfuzz): Decide whether this branch should `throw` instead. It is
+      // reached only when a cell link resolves to no cell, which is a
+      // "shouldn't happen" -- returning an accept-anything schema hides it.
       return emptySchemaObject();
     }
 
@@ -272,10 +274,9 @@ function analyzeType(value: any, state: AnalyzeTypeState): JSONSchema {
 
   const basicSchema = schemaForValueType(value);
   if (basicSchema === undefined) {
-    // TODO(danfuzz): I think it's safe to return `true` here. (See longer
-    // related comment above.)
-
-    // Unrecognized type. Treat it as "any."
+    // Unrecognized type. Treat it as "any." (`true` would say the same thing
+    // and is type-legal; see the interning note above for why it is not a
+    // drop-in swap.)
     return finishResult(emptySchemaObject());
   }
 
@@ -320,9 +321,9 @@ function itemsSchemaFromArray(
   // No need for any fanciness for empty or single-element arrays.
   switch (value.length) {
     case 0: {
-      // TODO(danfuzz): I think it's safe to return `true` here. (See longer
-      // related comment above.)
-      // TODO(seefeld): should be `true` in this case.
+      // An empty array constrains nothing, so `items` accepts anything. (`true`
+      // would say the same thing and is type-legal; see the interning note above
+      // for why it is not a drop-in swap.)
       return emptySchemaObject();
     }
     case 1: {

--- a/packages/utils/src/deep-equal.ts
+++ b/packages/utils/src/deep-equal.ts
@@ -12,13 +12,16 @@ import { isRecord } from "./types.ts";
  * @param b - Second value to compare
  * @returns True if the values are deeply equal
  *
- * TODO(danfuzz): This function is only suitable for non-class-instance data
- * beyond plain objects and arrays. It compares class instances by enumerable
- * own-props, so two same-class `FabricPrimitive` values (state in private
- * `#fields`, zero own-props) compare equal regardless of value, and
+ * **Not for `FabricValue`s.** This function compares class instances by
+ * enumerable own-props, so two same-class `FabricPrimitive` values (state in
+ * private `#fields`, zero own-props) compare equal regardless of value, and
  * `FabricInstance` values compare by internal slots rather than logical
- * contents. Use the `data-model`-aware `valueEqual()` for any `FabricValue`
- * comparison.
+ * contents. Use `data-model`'s `valueEqual()` for any `FabricValue` comparison.
+ *
+ * This is a property of the function, not a defect awaiting repair: `utils` sits
+ * below `data-model` and cannot reach the codecs that decide fabric equality, and
+ * a second implementation here would duplicate `valueEqual()` rather than extend
+ * it. The scope is the fix.
  */
 export function deepEqual(a: any, b: any): boolean {
   if (Object.is(a, b)) return true;


### PR DESCRIPTION
Comments only, no behavior change. From a sweep of all 50 `TODO(danfuzz)` markers
in `packages/`, these are the ones that were **defunct or answerable now**. Each
either asked a question that has since been answered, or prescribed work that
should not happen.

## `data-model/src/deep-freeze.ts`

The comment spent a paragraph explaining why treating functions as immutable
leaves is **deliberate** — then ended with a bare `TODO(danfuzz): Fix the
problem.`, which reads as contradicting everything above it.

It now names the actual fix (a `FabricValue`-only `deepFreeze()` signature — a
function is not a `FabricValue`, so a strict signature *removes* the case rather
than special-casing it) and the actual blocker (general-purpose callers that pass
objects-with-methods must stop first).

Also drops the `TASK-0086` reference. A private-tracker id has no referent for
anyone reading the source; it was the only one left in `packages/` or `docs/`.

## `runner/src/builder/json-utils.ts`

The comment hypothesized that the two neighbouring `TODO(seefeld): should be
\`true\`` markers reflected an **old return type** rather than a real problem with
`true`, and asked to "figure out what's what, and take action as appropriate".

**Figured out — the hypothesis is correct.** `analyzeType()` returns
`JSONSchema`, which is `JSONSchemaObj | boolean` (`api/index.ts:1579`), so `true`
is type-legal here today. The type-level obstacle is gone.

**It is still not a drop-in swap, for a reason the comment did not know about.**
`analyzeType()` results are passed through `internSchema()`, so `{}` and `true`
are distinct interned schemas with distinct hashes — and the current `{}` output
is pinned by `json-utils.test.ts` (`items: {}`, `toEqual({})`). Swapping them
changes generated schemas that reach storage. That is a migration, not a cleanup,
so I did not do it; I recorded it where the next person will look.

⚠️ **This resolves two `TODO(seefeld)` markers**, since answering them is exactly
what the enclosing `TODO(danfuzz)` asked for — flagging that explicitly, as they
are someone else's markers. The information in them is preserved and sharpened,
not dropped. A third, unrelated `TODO(seefeld)` in the same file (about `$ref`
creation) is untouched.

One genuinely open question survives as a TODO, narrowed to what is actually
undecided: whether the no-cell-for-this-link branch should `throw` rather than
return an accept-anything schema that hides a "shouldn't happen".

## `utils/src/deep-equal.ts`

A `TODO` implying `deepEqual()` should learn about fabric values. It should not,
and the marker invited exactly the wrong change:

- `utils` sits **below** `data-model` — 22 `data-model` files import `utils`, and
  nothing goes the other way (verified, not assumed). It cannot reach the codecs
  that decide fabric equality without a cycle.
- A second implementation here would **duplicate** `valueEqual()` rather than
  extend it.

Demoted to a note stating that the scope *is* the fix, keeping the existing
pointer to `valueEqual()`.

## What I deliberately left alone

The other 44 markers are real pending work, not cleanup. Two clusters dominate:

| cluster | count | why it stays |
|---|---:|---|
| `isRecord`-gated walks with no `FabricSpecialObject` guard | ~15 | The class #5001 is fixing; each needs its own analysis |
| "Latent — schemas don't admit `Fabric*` values on this path" | ~9 | Deliberate advance markers, per #5001's follow-up note |

Individually notable, and **not** addressed here because none is a drive-by:

- `runner.ts:1100` (the `deepEqual` result-projection gate) — **#5001 fixes this
  one**; it will be defunct when that merges.
- `llm-dialog.ts:1430` and `:3407` — a duplicated TODO naming its own fix
  (`asSchemaOrThrow`). No such guard exists yet, and how deep the validation
  should go is a design call, not a cleanup.
- `cell.ts:3381` — `Cell.of(new Date())` throws under the strict codec. A real,
  precisely-described bug worth its own PR.

## Testing

`deno task check`, `check-docs` (518 blocks), `fmt --check`, `lint` clean.
Suites: utils 91, data-model (green), runner 1070 — 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112UHG8bqH6cRMqZtRwBwcA


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retired three defunct TODO comments and replaced them with clear notes and next steps. No code changes or behavior impact.

- **Refactors**
  - `data-model/src/deep-freeze.ts`: Clarified why functions are treated as immutable leaves; replaced TODO with a plan to migrate `deepFreeze()` to a `FabricValue`-only signature; removed a private tracker reference.
  - `runner/src/builder/json-utils.ts`: Resolved TODOs about using `true` vs `{}` by documenting the interning/hash implications; kept a focused TODO on possibly `throw`ing when a link resolves to no cell.
  - `utils/src/deep-equal.ts`: Replaced a TODO with a note that this is not for `FabricValue`s; pointed to `valueEqual()` and explained layering to avoid duplication.

<sup>Written for commit cd47071034fbc617f288e3bb4dcb6357c367b89a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

