### PR TITLE
test(utils): drive the sleep/timeout tests with a fake clock

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -440,6 +440,41 @@ builds would drive the clock to the runaway guard. Adopting the harness would
 mean excluding the very files that own timers, and no test in the suite observes
 a controllable time window a fake clock would help with.
 
+## The utils package: a fake clock the test imports
+
+The reconciler and runner harnesses above install their fake clock through a
+`--preload` that wraps every `Deno.test` in the package, so a test gets the
+frozen clock whether or not it asked for one. That default is deliberate there:
+it catches a wall-clock sleep written anywhere in a suite that is meant to wait
+on events instead. `packages/utils` does not want that default. It is a grab-bag
+of utilities; most of its tests are not about time at all, and some — the
+logger's timing tests, for one — busy-spin against the real `performance.now`,
+which a faked clock would leave spinning forever. Only the `sleep` and `timeout`
+tests want controlled time.
+
+So `packages/utils/test/sleep.test.ts` takes the opposite approach: instead of a
+preload forcing a clock on the whole package, the two suites that want one import
+it and open it themselves. They use `FakeTime` from `@std/testing/time`, opened
+with a `using` declaration so it restores the clock when the block ends:
+
+- `using time = new FakeTime()` freezes the real timer that `sleep` or `timeout`
+  arms, so nothing resolves until the test advances the clock.
+- `await time.tickAsync(ms)` advances the fake clock by `ms` and settles the
+  promises the fired timers resolve.
+- `Date.now()` reports the faked time, so a `sleep(5)` is observed as still
+  pending after `tickAsync(4)` and resolved after a further `tickAsync(1)`, with
+  the elapsed time reading exactly five milliseconds — an exact assertion with no
+  real waiting and no flake.
+
+Nothing global is installed for the package, so the other suites in the same file
+need no exception list: `yieldToEventLoop` and `unrefTimer` open no `FakeTime` and
+run on the real clock, which is what they need — `yieldToEventLoop`'s timer-turn
+budget is measured against the real `performance.now` and its test drives a real
+CPU-bound spin, and `unrefTimer` detaches a real Deno timer from the event loop's
+ref-count. This is the lighter tool: reach for the preload harness when a whole
+suite should be held to controlled time, and for a directly-imported `FakeTime`
+when only a test or two measures a delay.
+
 ## Proving a negative
 
 A test that asserts something never happens has no event of its own to wait for.

--- a/packages/utils/test/sleep.test.ts
+++ b/packages/utils/test/sleep.test.ts
@@ -1,11 +1,22 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { FakeTime } from "@std/testing/time";
 import {
   sleep,
   timeout,
   unrefTimer,
   yieldToEventLoop,
 } from "@commonfabric/utils/sleep";
+
+// `sleep` and `timeout` are delay utilities, so their tests want controlled
+// time rather than a padded real-time bound. Each opens a `FakeTime` (from
+// `@std/testing/time`) with `using`, which freezes the real timer `sleep` and
+// `timeout` arm and restores the clock when the block ends. `time.tickAsync(ms)`
+// advances the fake clock and settles the promises the fired timers resolve, and
+// `Date.now()` reports the faked time, so the timing assertions are exact and
+// cannot flake. The suites below that measure real elapsed time or touch real
+// Deno timers — `yieldToEventLoop` and `unrefTimer` — open no `FakeTime` and run
+// on the real clock.
 
 /** Hold the event loop synchronously for ~ms, like a CPU-bound compile step. */
 const busySpin = (ms: number) => {
@@ -16,17 +27,43 @@ const busySpin = (ms: number) => {
 };
 
 describe("sleep", () => {
-  it("resolves after the given timeout", async () => {
-    const start = performance.now();
-    await sleep(5);
-    // Timers never fire early; keep the bound loose so the test cannot flake.
-    expect(performance.now() - start).toBeGreaterThanOrEqual(4);
+  it("resolves once logical time reaches the delay, not before", async () => {
+    using time = new FakeTime();
+    const start = Date.now();
+    let resolved = false;
+    const done = sleep(5).then(() => {
+      resolved = true;
+    });
+
+    await time.tickAsync(4);
+    expect(resolved).toBe(false); // four of five milliseconds have elapsed
+
+    await time.tickAsync(1);
+    await done;
+    expect(resolved).toBe(true);
+    // The promise resolved after exactly five milliseconds of faked time.
+    expect(Date.now() - start).toBe(5);
   });
 });
 
 describe("timeout", () => {
-  it("rejects with the given message after the timeout", async () => {
-    await expect(timeout(1, "took too long")).rejects.toThrow("took too long");
+  it("rejects with the given message once the delay elapses, not before", async () => {
+    using time = new FakeTime();
+    let state: "pending" | "rejected" = "pending";
+    let caught: unknown;
+    const settled = timeout(3, "took too long").catch((error) => {
+      state = "rejected";
+      caught = error;
+    });
+
+    await time.tickAsync(2);
+    expect(state).toBe("pending"); // still one millisecond short of rejecting
+
+    await time.tickAsync(1);
+    await settled;
+    expect(state).toBe("rejected");
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe("took too long");
   });
 });
 


### PR DESCRIPTION
The sleep and timeout helpers are delay utilities, and their tests measured elapsed real time to check them: `sleep(5)` was asserted by reading `performance.now()` before and after and requiring the delta to clear a padded lower bound. That is the shape this repository is moving away from. A real-time bound puts a floor under how long the test takes and, worse, cannot distinguish a slow machine or a paused CI VM from a genuine hang, so it is both slow and a latent flake.

Testing a delay utility is the textbook fake-clock case. The two suites that measure a delay now open a `FakeTime` from `@std/testing/time` with a `using` declaration, which freezes the real timer the helper arms and restores the clock when the block ends. `time.tickAsync(ms)` advances the fake clock and settles the promises the fired timers resolve, and `Date.now()` reports the faked time. So a `sleep(5)` is observed as still pending after `tickAsync(4)` and resolved after a further `tickAsync(1)`, with the elapsed time reading exactly five milliseconds — an exact assertion with no real waiting and no flake. `timeout` is checked the same way, pending after `tickAsync(2)` and rejected after `tickAsync(1)`.

The clock is imported and opened by the tests that want it rather than installed for the whole package by a preload, because it is opt-in. A preload that wraps every `Deno.test` earns its keep by catching a stray wall-clock sleep anywhere in a suite that should wait on events, but this package is a grab-bag whose other timing tests — the logger's, for one — busy-spin against the real `performance.now` and must stay on the real clock. So only `sleep` and `timeout` open a `FakeTime`; `yieldToEventLoop` and `unrefTimer`, which measure real elapsed time and touch real Deno timers, run untouched in the same file.

docs/development/waiting-in-tests.md gains a section contrasting the two approaches: the preload harness when a whole suite should be held to controlled time, and a directly-imported `FakeTime` when only a test or two measures a delay.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace real-time waits in `utils` tests with a fake clock to make `sleep` and `timeout` fast and non-flaky. Document when to use a local fake clock vs a package-wide preload.

- **Refactors**
  - Drive `sleep` and `timeout` tests with `FakeTime` from `@std/testing/time` using `using` and `time.tickAsync(ms)`; assert exact elapsed time via `Date.now()` and verify rejection messages.
  - Keep `yieldToEventLoop` and `unrefTimer` on the real clock to exercise actual timers and CPU-bound spins.
  - Add guidance in `docs/development/waiting-in-tests.md` on opting into a per-test `FakeTime` in `packages/utils` vs using a preload suite-wide.

<sup>Written for commit a3560614a43f8985234d3e37ad15b94671600dba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

