### PR TITLE
feat(state-inspector,cli): `cf inspect churn` — write rate over time

### DIFF
--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -16,6 +16,8 @@ import {
   buildCrossSpaceLinkIndex,
   buildInspectorBundle,
   buildSpaceGraph,
+  commitChurn,
+  commitsPerMinute,
   contendedEntities,
   convergence,
   type ConvergenceResult,
@@ -666,6 +668,71 @@ export const inspect = new Command()
         for (const r of rows) {
           console.log(
             `${r.writes}\twrites\t${r.sessions} sessions\t${r.id}\t(${r.scope})`,
+          );
+        }
+      });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect churn */
+  .command(
+    "churn <space:string>",
+    "Write rate over time: commits/revisions per bucket, and what drove the " +
+      "busiest one. The storm-and-settle view `hot` cannot give.",
+  )
+  .option("--bucket <seconds:number>", "Bucket width in seconds.", {
+    default: 60,
+  })
+  .option("--since <time:string>", "Lower bound on commit time (inclusive).")
+  .option("--until <time:string>", "Upper bound on commit time (exclusive).")
+  .option("--top <n:number>", "Entities to attribute the peak bucket to.", {
+    default: 10,
+  })
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .action(async (options, space) => {
+    const s = await openByToken(space, options);
+    try {
+      const report = commitChurn(s, {
+        branch: options.branch,
+        bucketSeconds: options.bucket,
+        since: options.since,
+        until: options.until,
+        top: options.top,
+      });
+      out(!!options.json, report, () => {
+        if (report.peak === null) {
+          console.log("no timed commits in window");
+        } else {
+          const width = String(
+            Math.max(...report.buckets.map((b) => b.commits)),
+          ).length;
+          for (const b of report.buckets) {
+            const peak = b.startEpoch === report.peak.startEpoch
+              ? " ←peak"
+              : "";
+            console.log(
+              `${b.start}\t${String(b.commits).padStart(width)} commits\t` +
+                `${b.revisions} revisions${peak}`,
+            );
+          }
+          console.log(
+            `\n${report.totals.commits} commits / ${report.totals.revisions} ` +
+              `revisions over ${report.buckets.length} × ${report.bucketSeconds}s` +
+              `\npeak ${report.peak.start}: ${
+                commitsPerMinute(report.peak, report.bucketSeconds).toFixed(1)
+              } commits/min`,
+          );
+          for (const e of report.peakEntities) {
+            console.log(
+              `  ${e.writes}\twrites\t${e.sessions} sessions\t${e.id}\t(${e.scope})`,
+            );
+          }
+        }
+        if (report.untimedCommits > 0) {
+          console.log(
+            `\nnote: ${report.untimedCommits} commit(s) have unparseable ` +
+              `created_at and are absent from every bucket.`,
           );
         }
       });

--- a/packages/cli/test/inspect-churn.test.ts
+++ b/packages/cli/test/inspect-churn.test.ts
@@ -1,0 +1,164 @@
+// `cf inspect churn` through the real CLI process.
+//
+// The query's semantics are pinned in packages/state-inspector/test/churn.test.ts;
+// this suite covers the command surface — the rendered curve, the peak marker
+// and its attribution, --json, and the two notices a reader must not miss (a
+// window with no timed commits, and commits absent from every bucket).
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Database } from "@db/sqlite";
+import { cf } from "./utils.ts";
+
+/** `CliResult` streams are line arrays; join before substring assertions. */
+const text = (lines: string[]): string => lines.join("\n");
+
+const SESSION = "session:did%3Akey%3AzAlice:s1";
+
+interface Commit {
+  at: string;
+  entities: string[];
+}
+
+function seed(path: string, commits: Commit[]): void {
+  const db = new Database(path, { create: true });
+  db.exec(`
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);`);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution, created_at)
+     VALUES (?, ?, ?, '{}', '{"seq":0}', ?)`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, ?, 'set', '{}', ?)`,
+  );
+  commits.forEach((c, i) => {
+    const seq = i + 1;
+    commit.run(seq, SESSION, seq, c.at);
+    c.entities.forEach((id, op) => rev.run(id, seq, op, seq));
+  });
+  db.close();
+}
+
+/** A quiet minute, a storm minute, a settled minute — the July shape. */
+const STORM: Commit[] = [
+  { at: "2026-07-22 10:00:00", entities: ["of:topic-1"] },
+  ...Array.from({ length: 40 }, (_, i) => ({
+    at: "2026-07-22 10:01:00",
+    entities: i % 4 === 0 ? ["of:generated-0", "of:board"] : ["of:generated-0"],
+  })),
+  { at: "2026-07-22 10:02:00", entities: ["of:topic-2"] },
+];
+
+async function withStore(
+  commits: Commit[],
+  run: (path: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "cf-churn-test-" });
+  try {
+    const path = `${dir}/space.sqlite`;
+    seed(path, commits);
+    await run(path);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+describe("cf inspect churn", () => {
+  it("renders the curve, marks the peak, and blames its drivers", async () => {
+    await withStore(STORM, async (path) => {
+      const result = await cf(`inspect churn ${path}`);
+      expect(result.code).toBe(0);
+      const output = text(result.stdout);
+
+      // Every minute in the window appears, including the quiet ones.
+      expect(output).toContain("2026-07-22 10:00:00");
+      expect(output).toContain("2026-07-22 10:02:00");
+      // The busiest bucket is marked, and reported in the incident record's unit.
+      expect(output).toContain("←peak");
+      expect(output).toContain("peak 2026-07-22 10:01:00: 40.0 commits/min");
+      expect(output).toContain("42 commits / 52 revisions over 3 × 60s");
+      // ...and attributed to what actually drove it, ranked.
+      const generated = output.indexOf("of:generated-0");
+      const board = output.indexOf("of:board");
+      expect(generated).toBeGreaterThan(-1);
+      expect(board).toBeGreaterThan(generated);
+    });
+  });
+
+  it("bounds the window with --since/--until and widens with --bucket", async () => {
+    await withStore(STORM, async (path) => {
+      const zoomed = await cf(
+        `inspect churn ${path} --since 2026-07-22T10:01:00 --until 2026-07-22T10:02:00`,
+      );
+      expect(zoomed.code).toBe(0);
+      expect(text(zoomed.stdout)).toContain("40 commits / 50 revisions over 1");
+
+      const coarse = await cf(`inspect churn ${path} --bucket 3600`);
+      expect(coarse.code).toBe(0);
+      // Same totals, one bucket.
+      expect(text(coarse.stdout)).toContain("42 commits / 52 revisions over 1");
+    });
+  });
+
+  it("emits machine-readable JSON", async () => {
+    await withStore(STORM, async (path) => {
+      const result = await cf(`inspect churn ${path} --json --top 1`);
+      expect(result.code).toBe(0);
+      const report = JSON.parse(text(result.stdout));
+      expect(report.totals).toEqual({ commits: 42, revisions: 52 });
+      expect(report.buckets.map((b: { commits: number }) => b.commits))
+        .toEqual([1, 40, 1]);
+      expect(report.peak.start).toBe("2026-07-22 10:01:00");
+      expect(report.peakEntities).toHaveLength(1);
+      expect(report.peakEntities[0].id).toBe("of:generated-0");
+      expect(report.untimedCommits).toBe(0);
+    });
+  });
+
+  it("says so when the window holds no timed commits", async () => {
+    await withStore([], async (path) => {
+      const result = await cf(`inspect churn ${path}`);
+      expect(result.code).toBe(0);
+      expect(text(result.stdout)).toContain("no timed commits in window");
+    });
+  });
+
+  it("flags commits missing from every bucket rather than hiding them", async () => {
+    // A curve silently missing rows reads as a quiet period — the one way this
+    // command could actively mislead.
+    await withStore([
+      { at: "2026-07-22 10:00:00", entities: ["of:X"] },
+      { at: "not-a-timestamp", entities: ["of:Y"] },
+    ], async (path) => {
+      const result = await cf(`inspect churn ${path}`);
+      expect(result.code).toBe(0);
+      expect(text(result.stdout)).toContain(
+        "1 commit(s) have unparseable created_at",
+      );
+    });
+  });
+
+  it("refuses an over-wide span instead of truncating the curve", async () => {
+    await withStore([
+      { at: "2020-01-01 00:00:00", entities: ["of:X"] },
+      { at: "2026-07-22 10:00:00", entities: ["of:X"] },
+    ], async (path) => {
+      const result = await cf(`inspect churn ${path} --bucket 1`);
+      expect(result.code).not.toBe(0);
+      expect(text(result.stderr)).toContain("--bucket");
+    });
+  });
+});

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -115,6 +115,7 @@ deno task cf inspect summary  z6Mkqa41
 deno task cf inspect entities z6Mkqa41 [--kind piece]
 deno task cf inspect piece    z6Mkqa41 of:fid1:… [--code]   # pattern source, input, owned cells
 deno task cf inspect hot      z6Mkqa41 --limit 10
+deno task cf inspect churn    z6Mkqa41 [--bucket 60] [--since '2026-07-22 10:00:00'] [--top 10]
 deno task cf inspect history  z6Mkqa41 of:fid1:…
 deno task cf inspect value-at z6Mkqa41 of:fid1:… --path value/count [--seq N]
 

--- a/packages/state-inspector/churn.ts
+++ b/packages/state-inspector/churn.ts
@@ -1,0 +1,257 @@
+// Commit-rate churn over time — the retrospective, offline view of "is this
+// space writing more than it should be?".
+//
+// Why this exists as its own query (see docs/plans/space-clone-rehearsal.md):
+// `hotEntities` ranks entities by all-time write count, which cannot show a
+// storm STARTING or a settle COMPLETING — both are shapes in time, not totals.
+// The July 2026 Topics write storm (20 compiler-generated cells producing 96%
+// of all commits, peaking at ~1,598 commits/minute) is invisible to a total and
+// obvious in a rate curve.
+//
+// Two neighbours exist and neither fills this slot: the OTel commit telemetry
+// reports live rates, but only where a collector was attached when it mattered;
+// the workload diagnostics (labs#4950) instrument an orchestrated run of a live
+// runtime. This reads the durable store after the fact — any space, any window,
+// no instrumentation required at incident time.
+//
+// Deliberately threshold-free: it reports, it does not judge. What counts as
+// "settled" differs per space, and a wrong default would give false confidence
+// at exactly the moment a migration checklist is trusted most.
+
+import type { SpaceDb } from "./db.ts";
+
+/** One time bucket of write activity. */
+export interface ChurnBucket {
+  /** Bucket start, UTC, `YYYY-MM-DD HH:MM:SS` (the store's own clock format). */
+  start: string;
+  /** Unix seconds for the bucket start — for plotting without re-parsing. */
+  startEpoch: number;
+  commits: number;
+  revisions: number;
+}
+
+/** An entity ranked by writes within a single bucket. */
+export interface ChurnEntity {
+  id: string;
+  scope: string;
+  writes: number;
+  sessions: number;
+}
+
+export interface ChurnReport {
+  bucketSeconds: number;
+  branch: string;
+  /** First and last bucket start actually observed (null on an empty window). */
+  from: string | null;
+  to: string | null;
+  totals: { commits: number; revisions: number };
+  /** Contiguous, zero-filled from `from` to `to` so gaps read as quiet. */
+  buckets: ChurnBucket[];
+  /** The busiest bucket by commits, or null when the window is empty. */
+  peak: ChurnBucket | null;
+  /** Top writers inside `peak` — what to blame for the busiest minute. */
+  peakEntities: ChurnEntity[];
+  /**
+   * Commits whose `created_at` SQLite could not parse as a time, and which are
+   * therefore absent from every bucket. Nonzero means the curve is incomplete —
+   * surfaced rather than silently dropped.
+   */
+  untimedCommits: number;
+}
+
+export interface ChurnOptions {
+  branch?: string;
+  /** Bucket width in seconds. Default 60. */
+  bucketSeconds?: number;
+  /** Lower bound on `commit.created_at`, inclusive. `YYYY-MM-DD HH:MM:SS` or ISO. */
+  since?: string;
+  /** Upper bound on `commit.created_at`, exclusive. */
+  until?: string;
+  /** How many entities to attribute the peak bucket to. Default 10. */
+  top?: number;
+}
+
+/**
+ * Zero-filling is what makes a curve readable, but a year-long store bucketed
+ * by the second would materialize ~31M rows. Rather than silently truncate (and
+ * report a curve with holes as if it were complete), refuse and say what to do.
+ */
+const MAX_BUCKETS = 20_000;
+
+export function commitChurn(
+  space: SpaceDb,
+  options: ChurnOptions = {},
+): ChurnReport {
+  const branch = options.branch ?? "";
+  const bucketSeconds = options.bucketSeconds ?? 60;
+  const top = options.top ?? 10;
+  if (!Number.isInteger(bucketSeconds) || bucketSeconds <= 0) {
+    throw new Error("bucketSeconds must be a positive whole number of seconds");
+  }
+
+  const db = space.db;
+  // `strftime('%s', …)` yields NULL for a value it cannot parse as a time, which
+  // is how untimed rows are separated from real zero-activity buckets. It also
+  // yields TEXT, and SQLite sorts every INTEGER before every TEXT — so each
+  // comparison casts, or the bounds silently match everything (or nothing).
+  const window: string[] = [`c.branch = :branch`];
+  const params: Record<string, string | number> = { branch, b: bucketSeconds };
+  if (options.since !== undefined) {
+    window.push(
+      `CAST(strftime('%s', c.created_at) AS INTEGER) >= ` +
+        `CAST(strftime('%s', :since) AS INTEGER)`,
+    );
+    params.since = options.since;
+  }
+  if (options.until !== undefined) {
+    window.push(
+      `CAST(strftime('%s', c.created_at) AS INTEGER) < ` +
+        `CAST(strftime('%s', :until) AS INTEGER)`,
+    );
+    params.until = options.until;
+  }
+  const where = window.join(" AND ");
+
+  const untimed = db
+    .prepare(
+      `SELECT count(*) n FROM "commit" c
+       WHERE c.branch = :branch AND strftime('%s', c.created_at) IS NULL`,
+    )
+    .get<{ n: number }>({ branch })!.n;
+
+  // One row per bucket. LEFT JOIN so a commit that wrote no revisions still
+  // counts as a commit; count(DISTINCT c.seq) so the join fan-out cannot
+  // inflate the commit count.
+  const rows = db
+    .prepare(
+      `SELECT CAST(strftime('%s', c.created_at) / :b AS INTEGER) * :b AS bucket,
+              count(DISTINCT c.seq) commits,
+              count(r.commit_seq) revisions
+       FROM "commit" c
+       LEFT JOIN revision r ON r.commit_seq = c.seq
+       WHERE ${where} AND strftime('%s', c.created_at) IS NOT NULL
+       GROUP BY bucket
+       ORDER BY bucket`,
+    )
+    .all<{ bucket: number; commits: number; revisions: number }>(params);
+
+  if (rows.length === 0) {
+    return {
+      bucketSeconds,
+      branch,
+      from: null,
+      to: null,
+      totals: { commits: 0, revisions: 0 },
+      buckets: [],
+      peak: null,
+      peakEntities: [],
+      untimedCommits: untimed,
+    };
+  }
+
+  const first = rows[0].bucket;
+  const last = rows[rows.length - 1].bucket;
+  const span = (last - first) / bucketSeconds + 1;
+  if (span > MAX_BUCKETS) {
+    throw new Error(
+      `window spans ${Math.round(span)} buckets at ${bucketSeconds}s ` +
+        `(limit ${MAX_BUCKETS}); widen --bucket or narrow --since/--until.`,
+    );
+  }
+
+  const observed = new Map(rows.map((r) => [r.bucket, r]));
+  const buckets: ChurnBucket[] = [];
+  for (let t = first; t <= last; t += bucketSeconds) {
+    const hit = observed.get(t);
+    buckets.push({
+      start: epochToStoreTime(db, t),
+      startEpoch: t,
+      commits: hit?.commits ?? 0,
+      revisions: hit?.revisions ?? 0,
+    });
+  }
+
+  const totals = rows.reduce(
+    (acc, r) => ({
+      commits: acc.commits + r.commits,
+      revisions: acc.revisions + r.revisions,
+    }),
+    { commits: 0, revisions: 0 },
+  );
+
+  // Peak by commits; revisions break the tie, so a burst of fat commits ranks
+  // above the same number of trivial ones.
+  const peak = buckets.reduce((best, b) =>
+    b.commits > best.commits ||
+      (b.commits === best.commits && b.revisions > best.revisions)
+      ? b
+      : best
+  );
+
+  return {
+    bucketSeconds,
+    branch,
+    from: buckets[0].start,
+    to: buckets[buckets.length - 1].start,
+    totals,
+    buckets,
+    peak,
+    peakEntities: entitiesInWindow(space, {
+      branch,
+      fromEpoch: peak.startEpoch,
+      toEpoch: peak.startEpoch + bucketSeconds,
+      limit: top,
+    }),
+    untimedCommits: untimed,
+  };
+}
+
+/** Top entities by write count within a half-open epoch-second window. */
+function entitiesInWindow(
+  space: SpaceDb,
+  opts: {
+    branch: string;
+    fromEpoch: number;
+    toEpoch: number;
+    limit: number;
+  },
+): ChurnEntity[] {
+  return space.db
+    .prepare(
+      `SELECT r.id, r.scope_key, count(*) writes,
+              count(DISTINCT c.session_id) sessions
+       FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
+       WHERE c.branch = :branch
+         AND CAST(strftime('%s', c.created_at) AS INTEGER) >= :from
+         AND CAST(strftime('%s', c.created_at) AS INTEGER) < :to
+       GROUP BY r.id, r.scope_key
+       ORDER BY writes DESC, r.id
+       LIMIT :limit`,
+    )
+    .all<
+      { id: string; scope_key: string; writes: number; sessions: number }
+    >({
+      branch: opts.branch,
+      from: opts.fromEpoch,
+      to: opts.toEpoch,
+      limit: opts.limit,
+    })
+    .map((r) => ({
+      id: r.id,
+      scope: r.scope_key,
+      writes: r.writes,
+      sessions: r.sessions,
+    }));
+}
+
+/** Render an epoch second back into the store's own UTC text format. */
+function epochToStoreTime(db: SpaceDb["db"], epoch: number): string {
+  return db
+    .prepare(`SELECT datetime(:e, 'unixepoch') t`)
+    .get<{ t: string }>({ e: epoch })!.t;
+}
+
+/** Commits per minute for a bucket — the unit the incident record speaks in. */
+export function commitsPerMinute(bucket: ChurnBucket, seconds: number): number {
+  return (bucket.commits * 60) / seconds;
+}

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -18,6 +18,7 @@ export * from "./graph.ts";
 export * from "./timetravel.ts";
 export * from "./scopes.ts";
 export * from "./identity.ts";
+export * from "./churn.ts";
 export * from "./conflicts.ts";
 export * from "./detail.ts";
 export * from "./html.ts";

--- a/packages/state-inspector/test/churn.test.ts
+++ b/packages/state-inspector/test/churn.test.ts
@@ -1,0 +1,243 @@
+// Churn is the storm-and-settle view: `hot` ranks entities by all-time writes
+// and therefore cannot distinguish "1,000 writes spread over a week" from
+// "1,000 writes in one minute". These tests pin that distinction, the shape of
+// a storm that starts and then settles, and the honesty properties — zero-fill
+// so a quiet gap reads as quiet, untimed rows surfaced rather than dropped, and
+// a refusal instead of a silently truncated curve.
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import { openSpace } from "../db.ts";
+import { commitChurn, commitsPerMinute } from "../churn.ts";
+import { hotEntities } from "../queries.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+`;
+
+const SESSION = "session:did%3Akey%3AzAlice:s1";
+
+/** A fixture store whose commits carry explicit UTC times. */
+function build(
+  path: string,
+  seed: (
+    commit: (at: string, entities: string[], session?: string) => void,
+  ) => void,
+): void {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  let seq = 0;
+  const insertCommit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution, created_at)
+     VALUES (?, ?, ?, '{}', '{"seq":0}', ?)`,
+  );
+  const insertRevision = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, ?, 'set', '{}', ?)`,
+  );
+  seed((at, entities, session = SESSION) => {
+    const s = ++seq;
+    insertCommit.run(s, session, s, at);
+    entities.forEach((id, i) => insertRevision.run(id, s, i, s));
+  });
+  db.close();
+}
+
+function withStore(
+  seed: Parameters<typeof build>[1],
+  run: (space: ReturnType<typeof openSpace>) => void,
+): void {
+  const dir = Deno.makeTempDirSync({ prefix: "churn-test-" });
+  const path = `${dir}/space.sqlite`;
+  try {
+    build(path, seed);
+    const space = openSpace(path);
+    try {
+      run(space);
+    } finally {
+      space.close();
+    }
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
+  }
+}
+
+Deno.test("churn separates a burst from the same writes spread out", () => {
+  // Identical totals, opposite shapes. `hot` cannot tell these apart; that is
+  // the whole reason churn exists.
+  const burst: Parameters<typeof build>[1] = (commit) => {
+    for (let i = 0; i < 30; i++) commit("2026-07-22 10:00:00", ["of:X"]);
+  };
+  const spread: Parameters<typeof build>[1] = (commit) => {
+    for (let i = 0; i < 30; i++) {
+      commit(`2026-07-22 10:${String(i).padStart(2, "0")}:00`, ["of:X"]);
+    }
+  };
+
+  withStore(burst, (space) => {
+    const r = commitChurn(space, { bucketSeconds: 60 });
+    assertEquals(r.totals.commits, 30);
+    assertEquals(r.buckets.length, 1);
+    assertEquals(r.peak?.commits, 30);
+    assertEquals(commitsPerMinute(r.peak!, 60), 30);
+    assertEquals(hotEntities(space)[0].writes, 30);
+  });
+
+  withStore(spread, (space) => {
+    const r = commitChurn(space, { bucketSeconds: 60 });
+    // Guard the fixture itself: a malformed timestamp would land here as a
+    // missing commit rather than an error, quietly weakening the comparison.
+    assertEquals(r.untimedCommits, 0);
+    assertEquals(r.totals.commits, 30);
+    // Same total writes as the burst...
+    assertEquals(hotEntities(space)[0].writes, 30);
+    // ...but the peak minute holds exactly one of them.
+    assertEquals(r.peak?.commits, 1);
+    assertEquals(commitsPerMinute(r.peak!, 60), 1);
+  });
+});
+
+Deno.test("a storm that starts and settles is visible as a curve", () => {
+  // Shaped like the July Topics incident: quiet, then a generated cell storms,
+  // then it settles. The settle is the part a total can never show.
+  withStore((commit) => {
+    commit("2026-07-22 10:00:00", ["of:topic-1"]);
+    // The storm is driven by the generated cell; the board takes collateral
+    // writes, so the ranking has a real winner rather than a tie.
+    for (let i = 0; i < 200; i++) {
+      const entities = i % 10 === 0
+        ? ["of:generated-cell", "of:board"]
+        : ["of:generated-cell"];
+      commit("2026-07-22 10:02:00", entities);
+    }
+    commit("2026-07-22 10:05:00", ["of:topic-2"]);
+  }, (space) => {
+    const r = commitChurn(space, { bucketSeconds: 60, top: 2 });
+
+    // Zero-fill makes the quiet minutes explicit rather than absent.
+    assertEquals(r.buckets.length, 6);
+    assertEquals(r.buckets.map((b) => b.commits), [1, 0, 200, 0, 0, 1]);
+
+    assertEquals(r.peak?.start, "2026-07-22 10:02:00");
+    assertEquals(commitsPerMinute(r.peak!, 60), 200);
+
+    // The peak is attributed to its actual drivers, ranked by writes.
+    assertEquals(r.peakEntities[0].id, "of:generated-cell");
+    assertEquals(r.peakEntities[0].writes, 200);
+    assertEquals(r.peakEntities[0].sessions, 1);
+    assertEquals(r.peakEntities[1].id, "of:board");
+    assertEquals(r.peakEntities[1].writes, 20);
+
+    // Settled: activity returns to baseline and stays there.
+    assert(r.buckets.slice(3).every((b) => b.commits <= 1));
+  });
+});
+
+Deno.test("bucket width changes resolution, not totals", () => {
+  withStore((commit) => {
+    for (let i = 0; i < 10; i++) commit("2026-07-22 10:00:00", ["of:X"]);
+    for (let i = 0; i < 10; i++) commit("2026-07-22 10:01:00", ["of:X"]);
+  }, (space) => {
+    const fine = commitChurn(space, { bucketSeconds: 60 });
+    const coarse = commitChurn(space, { bucketSeconds: 300 });
+    assertEquals(fine.totals, coarse.totals);
+    assertEquals(fine.buckets.length, 2);
+    assertEquals(coarse.buckets.length, 1);
+    assertEquals(coarse.peak?.commits, 20);
+  });
+});
+
+Deno.test("--since / --until bound the window, inclusive/exclusive", () => {
+  withStore((commit) => {
+    commit("2026-07-22 09:59:00", ["of:early"]);
+    commit("2026-07-22 10:00:00", ["of:inside"]);
+    commit("2026-07-22 10:01:00", ["of:late"]);
+  }, (space) => {
+    const r = commitChurn(space, {
+      bucketSeconds: 60,
+      since: "2026-07-22 10:00:00",
+      until: "2026-07-22 10:01:00",
+    });
+    assertEquals(r.totals.commits, 1);
+    assertEquals(r.peakEntities[0].id, "of:inside");
+  });
+});
+
+Deno.test("a commit with no revisions still counts as a commit", () => {
+  // LEFT JOIN, not JOIN: an empty commit is real activity and a fan-out over
+  // revisions must not inflate the commit count either.
+  withStore((commit) => {
+    commit("2026-07-22 10:00:00", []);
+    commit("2026-07-22 10:00:00", ["of:A", "of:B", "of:C"]);
+  }, (space) => {
+    const r = commitChurn(space, { bucketSeconds: 60 });
+    assertEquals(r.totals.commits, 2);
+    assertEquals(r.totals.revisions, 3);
+  });
+});
+
+Deno.test("multiple writer sessions are counted per entity", () => {
+  withStore((commit) => {
+    commit("2026-07-22 10:00:00", ["of:X"], "session:did%3Akey%3AzAlice:s1");
+    commit("2026-07-22 10:00:00", ["of:X"], "session:did%3Akey%3AzBob:s2");
+  }, (space) => {
+    const r = commitChurn(space, { bucketSeconds: 60 });
+    assertEquals(r.peakEntities[0].sessions, 2);
+  });
+});
+
+Deno.test("an empty window reports nothing rather than failing", () => {
+  withStore(() => {}, (space) => {
+    const r = commitChurn(space, { bucketSeconds: 60 });
+    assertEquals(r.totals.commits, 0);
+    assertEquals(r.buckets, []);
+    assertEquals(r.peak, null);
+    assertEquals(r.from, null);
+    assertEquals(r.peakEntities, []);
+  });
+});
+
+Deno.test("untimed commits are surfaced, not silently dropped", () => {
+  // A curve missing rows must say so — otherwise it reads as a quiet period.
+  withStore((commit) => {
+    commit("2026-07-22 10:00:00", ["of:X"]);
+    commit("not-a-timestamp", ["of:Y"]);
+  }, (space) => {
+    const r = commitChurn(space, { bucketSeconds: 60 });
+    assertEquals(r.totals.commits, 1);
+    assertEquals(r.untimedCommits, 1);
+  });
+});
+
+Deno.test("an over-wide span refuses instead of truncating the curve", () => {
+  withStore((commit) => {
+    commit("2020-01-01 00:00:00", ["of:X"]);
+    commit("2026-07-22 10:00:00", ["of:X"]);
+  }, (space) => {
+    const err = assertThrows(
+      () => commitChurn(space, { bucketSeconds: 1 }),
+      Error,
+    );
+    assert(err.message.includes("--bucket"), "names the way out");
+  });
+});
+
+Deno.test("a non-positive bucket width is rejected", () => {
+  withStore(() => {}, (space) => {
+    assertThrows(() => commitChurn(space, { bucketSeconds: 0 }), Error);
+    assertThrows(() => commitChurn(space, { bucketSeconds: 1.5 }), Error);
+  });
+});

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -136,6 +136,14 @@ fixed recipe. The recurring debugging questions and where they resolve:
   who), `timeline <space> <id>` (value after each write),
   `diff <space> <id> --from --to` (what changed between two seqs),
   `value-at … --seq` (state at a point).
+- _"Is this space writing more than it should be / has it settled?"_ →
+  `churn <space>` (commits + revisions per time bucket, and the entities driving
+  the busiest one). `hot` ranks by all-time writes and so cannot separate a
+  burst from the same writes spread over a week — churn is the shape-in-time
+  view: a storm starting, and a settle completing. Use it before and after a
+  `setsrc` on a populated space; `--bucket`/`--since`/`--until` frame the
+  window. It reports rates and never judges them — what counts as "settled" is
+  yours to decide.
 - _"Is this entity the same across spaces / did a replica drift?"_ →
   `converge <id>
   --all` / `converge-scan --all`, trusting the


### PR DESCRIPTION
## Why

First of three PRs implementing `docs/plans/space-clone-rehearsal.md` (merged in #5009). This is the piece the design doc identified as having **no existing substitute**, and it stands alone from the clone work.

Updating a deployed pattern on a populated space is a rehearsal-grade event, and the blessed checklist ends with "churn returns to baseline and *stays* there — a storm is a steady state, not a spike." Nothing in the tree could answer that. `hot` ranks entities by all-time write count, so it cannot distinguish 1,000 writes spread over a week from 1,000 writes in one minute — the July 2026 Topics incident (20 compiler-generated cells producing 96% of all commits, peaking at ~1,598 commits/minute) is invisible in a total and obvious in a rate curve.

Two neighbours exist and neither fills this slot: the OTel commit telemetry reports live rates, but only where a collector happened to be attached when it mattered; the workload diagnostics in #4950 instrument an orchestrated run of a live runtime. Churn reads the durable store after the fact — any space, any window, no instrumentation required at incident time. That retrospective-offline niche is the gap.

## What Changed

- **`packages/state-inspector/churn.ts`** — `commitChurn(space, {branch, bucketSeconds, since, until, top})` buckets commits and revisions over `commit.created_at`, and attributes the busiest bucket to the entities that drove it. `commitsPerMinute()` renders a bucket in the unit the incident record speaks.
- **`cf inspect churn <space>`** with `--bucket` / `--since` / `--until` / `--top` / `--branch`, composing with the existing `--remote` and `--json` machinery.
- Skill map entry (the symptom → command table) and README usage line.

Three honesty properties, each pinned by a test:

- **Zero-filled** between the first and last observed bucket, so a quiet gap reads as quiet rather than being absent from the series.
- **Untimed commits are reported**, not dropped. A commit whose `created_at` SQLite cannot parse is excluded from every bucket, and a curve missing rows would otherwise read as a quiet period.
- **An over-wide span refuses** rather than truncating. A year-long store bucketed by the second would materialize ~31M rows; the error names the way out (`--bucket` / `--since`).

Deliberately **threshold-free** — it reports rates and never judges them. Per the design doc's decision: what counts as "settled" differs per space, and a wrong default would give false confidence at exactly the moment a migration checklist is trusted most.

One subtlety worth flagging for review: `strftime('%s', …)` returns **TEXT**, and SQLite orders every INTEGER before every TEXT, so an uncast comparison against an epoch number silently matches everything or nothing. Every bound casts explicitly; the peak-attribution query was wrong before a test caught it.

## Test plan

- `packages/state-inspector/test/churn.test.ts` — 10 tests, all hermetic (fixture stores built in temp dirs, explicit timestamps, no clocks or sleeps). The load-bearing one builds the same 30 writes in two shapes — one burst vs spread over 30 minutes — asserts `hotEntities` reports 30 for **both**, and that churn's peak is 30 vs 1. That is the principle the query exists to guard. Others cover the storm→settle curve with peak attribution and ranking, bucket width changing resolution but not totals, `--since`/`--until` bounds, a commit with no revisions still counting (LEFT JOIN, no fan-out inflation), multi-session counting, the empty window, and the three honesty properties above.
- `packages/state-inspector` full suite — 48 passed.
- `cd packages/cli && deno task test` — 120 passed.
- `deno check`, `deno lint`, `deno fmt`, `deno task check-skill-facts` — clean.
- End-to-end against a seeded store (quiet · 3 storm minutes · settle):

```
2026-07-22 10:02:00	  1 commits	1 revisions
2026-07-22 10:03:00	400 commits	450 revisions ←peak
...
peak 2026-07-22 10:03:00: 400.0 commits/min
  400	writes	1 sessions	of:generated-0	(space)
   50	writes	1 sessions	of:board	(space)
```

### Acceptance against the real July store

Run against the 1.0 GB Estuary Topics snapshot (200,348 commits, 213,148 revisions, 765 sessions, 2026-07-09 → 07-22). Churn reproduced the incident record's headline figures **independently, from the durable store alone**:

| Incident record (Gideon, from the 2026-07-22 snapshot) | `cf inspect churn` |
| --- | --- |
| peak 1,598 commits/minute | **1,598.0 commits/min**, pinned to `2026-07-10 17:03` |
| 192,381 revisions in 20 generated cells = 90.3% of all revisions | **192,381 = 90.3%** (via `hot --limit 20`) |

The onset is the shape the query was built to show — and the reason a total cannot substitute:

```
2026-07-10 16:57:00	   3 commits
2026-07-10 17:00:00	   0 commits
2026-07-10 17:01:00	 890 commits
2026-07-10 17:02:00	1531 commits
2026-07-10 17:03:00	1598 commits ←peak
2026-07-10 17:04:00	1395 commits
   ... sustained ~1,300/min plateau ...
```

Silence, then a jump to a **sustained plateau** — the oscillator steady state the incident describes, not a spike. The blessed checklist's "churn returns to baseline and *stays* there" is exactly this distinction, and it is now checkable.

Also exercised on real data: `--bucket 3600` (311 hourly buckets, top 12 hours = 85.7% of all commits), `--since`/`--until` zoom, `untimedCommits: 0` across 200k commits, and the 18,609-bucket default-resolution run staying under the refusal limit. Read-only discipline verified — source mtime unchanged, no `-wal`/`-shm` companions created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cf inspect churn` to chart write rate over time and blame the busiest window on its top writers. Also adds CLI tests to cover the command output and safety notices.

- **New Features**
  - `cf inspect churn <space>` with `--bucket`, `--since`, `--until`, `--top`, `--branch` (works with existing `--remote`, `--json`).
  - `commitChurn()` in `packages/state-inspector` buckets by `commit.created_at`, zero-fills gaps, surfaces untimed commits, and rejects over-wide spans with a clear error.
  - Peak report shows commits/min and the top entities with write and session counts.
  - Docs: usage in `packages/state-inspector/README.md` and skill map entry in `skills/state-inspector/SKILL.md`.

- **Tests**
  - Added `packages/cli/test/inspect-churn.test.ts` to exercise the CLI: curve rendering, peak marker and attribution, JSON output, “no timed commits” notice, untimed-commit notice, and refusal on over-wide spans.

<sup>Written for commit ede47531753633148ffac379dc5aa1f8a1bb115c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

