### PR TITLE
fix(topics): make navigation durable across cold loads

### DIFF
--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -3387,8 +3387,10 @@ interface CFScrollAttributes<T> extends CFHTMLAttributes<T> {
 
 interface CFCellLinkAttributes<T> extends CFHTMLAttributes<T> {
   "link"?: string;
-  "$cell": CellLike<any>;
+  "label"?: string;
+  "$cell"?: CellLike<any>;
   "spaceName"?: string;
+  "static"?: boolean;
 }
 
 interface CFSpaceLinkAttributes<T> extends CFHTMLAttributes<T> {

--- a/packages/patterns/integration/topics-navigation.test.ts
+++ b/packages/patterns/integration/topics-navigation.test.ts
@@ -1,0 +1,201 @@
+import { Identity } from "@commonfabric/identity";
+import { env, type Page, waitForCondition } from "@commonfabric/integration";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { assertEquals } from "@std/assert";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import {
+  CLICK_TARGET_ATTR,
+  clickMarked,
+  waitForRuntimeIdle,
+  waitForText,
+} from "./cfc-browser-helpers.ts";
+import {
+  initializePiecesController,
+  PieceController,
+  PiecesController,
+} from "./pieces-controller.ts";
+
+const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
+const TARGET_TITLE = "Navigation target";
+const SOURCE_TITLE = "Crossref source";
+
+describe("Topics durable navigation", () => {
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
+
+  let identity: Identity;
+  let cc: PiecesController;
+  let board: PieceController;
+  let boardSinkCancel: (() => void) | undefined;
+  let targetFid: string;
+  let sourceFid: string;
+
+  beforeAll(async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+    cc = await initializePiecesController({
+      spaceName: SPACE_NAME,
+      apiUrl: new URL(API_URL),
+      identity,
+    });
+    await cc.ensureDefaultPattern();
+
+    const sourcePath = join(import.meta.dirname!, "..", "topics", "main.tsx");
+    const rootPath = join(import.meta.dirname!, "..");
+    const program = await cc.manager().runtime.harness.resolve(
+      new FileSystemProgramResolver(sourcePath, rootPath),
+    );
+    board = await cc.create(program, { start: true });
+
+    const resultCell = cc.manager().getResult(board.getCell());
+    boardSinkCancel = resultCell.sink(() => {});
+
+    await board.result.set(
+      { title: TARGET_TITLE, agentName: "Topics navigation test" },
+      ["addTopic"],
+    );
+    const target = await topicAt(board, 0);
+    targetFid = target.id;
+
+    await board.result.set(
+      {
+        title: SOURCE_TITLE,
+        body: `This topic references ${targetFid}.`,
+        agentName: "Topics navigation test",
+      },
+      ["addTopic"],
+    );
+    const sourceReference = await topicAt(board, 1);
+    sourceFid = sourceReference.id;
+  });
+
+  afterAll(async () => {
+    boardSinkCancel?.();
+    await cc?.dispose();
+  });
+
+  it("opens topics and crossrefs after a cold browser load without scheduler handlers", async () => {
+    const page = shell.page();
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: SPACE_NAME, pieceId: board.id },
+      identity,
+    });
+    await waitForRuntimeIdle(page);
+    await Promise.all([
+      waitForText(page, "body", TARGET_TITLE),
+      waitForText(page, "body", SOURCE_TITLE),
+    ]);
+
+    // The browser worker has never run this board before. This is the exact
+    // cold-load boundary where pattern-owned click streams used to be present
+    // in persisted VDOM without a registered handler.
+    const openedPieceId = await clickCellLink(page, "Open");
+    const openedFid = openedPieceId.replace(/^of:/, "");
+    await waitForTopicView(page, openedPieceId);
+
+    const otherTitle = openedFid === targetFid ? SOURCE_TITLE : TARGET_TITLE;
+    const otherFid = openedFid === targetFid ? sourceFid : targetFid;
+    await waitForText(page, "body", otherTitle);
+
+    const crossrefPieceId = await clickCellLink(page, otherTitle);
+    assertEquals(crossrefPieceId, `of:${otherFid}`);
+    await waitForTopicView(page, crossrefPieceId);
+
+    const droppedEvents = await page.evaluate(() =>
+      ((globalThis as typeof globalThis & {
+        __cfConsoleTail?: Array<{ method: string; text: string }>;
+      }).__cfConsoleTail ?? []).filter((entry) =>
+        entry.text.includes("scheduler Event dropped: no handler registered")
+      )
+    );
+    assertEquals(droppedEvents, []);
+  });
+});
+
+async function topicAt(
+  board: PieceController,
+  index: number,
+): Promise<PieceController> {
+  const result = await board.result.getCell();
+  await result.pull();
+  return new PieceController(
+    board.manager(),
+    result.key("topics").key(index).resolveAsCell(),
+  );
+}
+
+/**
+ * Wait for a resolved cf-cell-link, mark its native button, then issue one
+ * trusted browser click. Returning the link's fid lets the test assert the
+ * shell selected exactly the destination represented by the rendered data.
+ */
+async function clickCellLink(page: Page, label: string): Promise<string> {
+  const token = `topics-cell-link-${crypto.randomUUID()}`;
+  await waitForCondition(
+    page,
+    (
+      probe,
+      targetLabel: string,
+      targetToken: string,
+      clickTargetAttribute: string,
+    ) => {
+      for (const element of probe.collect("cf-cell-link")) {
+        const link = element as HTMLElement & {
+          label?: string;
+          link?: string;
+          _resolvedCell?: unknown;
+        };
+        if (
+          link.label !== targetLabel || !link.link || !link._resolvedCell
+        ) {
+          continue;
+        }
+        const chip = link.shadowRoot?.querySelector("cf-chip");
+        const button = chip?.shadowRoot?.querySelector("button");
+        if (!button || !probe.isRendered(button)) continue;
+        link.setAttribute("data-topics-link-target", targetToken);
+        button.setAttribute(clickTargetAttribute, targetToken);
+        return true;
+      }
+      return false;
+    },
+    { args: [label, token, CLICK_TARGET_ATTR] },
+  );
+
+  const target = await page.evaluate((targetToken: string) => {
+    const stack: (Document | ShadowRoot)[] = [document];
+    while (stack.length > 0) {
+      const root = stack.pop()!;
+      const found = root.querySelector(
+        `[data-topics-link-target="${targetToken}"]`,
+      ) as (HTMLElement & { link?: string }) | null;
+      if (found?.link) return found.link;
+      for (const element of root.querySelectorAll("*")) {
+        if (element.shadowRoot) stack.push(element.shadowRoot);
+      }
+    }
+    return undefined;
+  }, { args: [token] });
+  if (!target?.startsWith("/of:")) {
+    throw new Error(`Topics link "${label}" had invalid target: ${target}`);
+  }
+
+  await clickMarked(page, token);
+  return target.slice(1);
+}
+
+async function waitForTopicView(page: Page, pieceId: string): Promise<void> {
+  await waitForCondition(
+    page,
+    (_probe, expectedSpaceName: string, expectedPieceId: string) => {
+      const state = globalThis.app?.serialize() as
+        | { view?: { spaceName?: string; pieceId?: string } }
+        | undefined;
+      return state?.view?.spaceName === expectedSpaceName &&
+        state.view.pieceId === expectedPieceId;
+    },
+    { args: [SPACE_NAME, pieceId] },
+  );
+}

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -17,16 +17,17 @@ import {
 
 import Topic, {
   asArray,
-  crossrefChipRow,
   crossrefJoin,
+  crossrefLinkRow,
   fidPayload,
-  openTopic,
   rejectMutation,
   snippet,
   topicAuthorFromAgent,
   topicAuthorFromPerson,
   topicAuthorLabel,
+  topicCellLink,
   topicCorpus,
+  type TopicNavigationLink,
   type TopicPiece,
   TOPICS_THEME,
   whenLabel,
@@ -43,6 +44,7 @@ export type {
   TopicInput,
   TopicLink,
   TopicLinkKind,
+  TopicNavigationLink,
   TopicOutput,
   TopicPiece,
   TopicReference,
@@ -84,6 +86,13 @@ export interface TopicCrossref {
   referencedBy: TopicPiece[];
 }
 
+/** Private UI projection. Public consumers retain TopicCrossref's deployed
+ * piece-valued schema; navigation uses durable fid/title snapshots. */
+interface TopicCrossrefView extends TopicCrossref {
+  refsOutLinks: TopicNavigationLink[];
+  referencedByLinks: TopicNavigationLink[];
+}
+
 /**
  * Topics — a tracker over #topic pieces: durable units of shared attention
  * (CT-1878). Deliberately minimal: no statuses, labels, or assignees; topics
@@ -112,10 +121,9 @@ export interface TopicsOutput {
   submitTopic: Stream<void>;
 }
 
-// Navigation + chip-row live with the other shared pieces in topic.tsx (the
-// detail page renders the same chips); re-exported here so embedders and
-// tests keep importing them from the tracker.
-export { crossrefChipRow, openTopic } from "./topic.tsx";
+// Navigation helpers live with the shared Topic UI because the board and
+// detail page render the same durable links.
+export { crossrefLinkRow, topicCellLink } from "./topic.tsx";
 
 /** Browser composer submit. Profile wishes are resolved by the pattern and
  * bound into this handler as plain snapshot values, which keeps the mutation
@@ -220,12 +228,10 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
   // any board change (O(topics × text) — trivial at board scale; the growth
   // path is per-topic memoization). Identity is each entry's resolved
   // result-doc fid, so the existing corpus lights up with zero authoring
-  // changes and nothing derived is persisted. Rows carry their pieces
-  // directly: the UI binds navigation handlers to the row pieces (safe since
-  // #4714's path-scoped wildcard fix — before it, a handler bound to a piece
-  // nested inside a derived wrapper object silently kept the consuming UI
-  // computed from ever running, which forced the earlier index-plumbed shape).
-  const crossrefs = computed(() => {
+  // changes and nothing derived is persisted. The private view also carries
+  // fid/title snapshots so rendered navigation is durable across cold loads;
+  // the public result below retains its deployed piece-valued schema.
+  const crossrefView = computed(() => {
     const list = asArray(topics.get());
     // Each entry's own fid payload ("" while unresolved, e.g. mid-sync — such
     // entries simply hold no edges this render). resolveAsCell/entityId are
@@ -240,7 +246,7 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
       list.map((t) => topicCorpus(t)),
       payloads,
     );
-    const rows: TopicCrossref[] = [];
+    const rows: TopicCrossrefView[] = [];
     list.forEach((t, i) => {
       if (!t) return;
       rows.push({
@@ -248,10 +254,27 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
         topic: t,
         refsOut: refsOut[i].map((j) => list[j]),
         referencedBy: referencedBy[i].map((j) => list[j]),
+        refsOutLinks: refsOut[i].map((j) => ({
+          fid: payloads[j] ? `fid1:${payloads[j]}` : "",
+          title: list[j]?.title ?? "",
+        })),
+        referencedByLinks: referencedBy[i].map((j) => ({
+          fid: payloads[j] ? `fid1:${payloads[j]}` : "",
+          title: list[j]?.title ?? "",
+        })),
       });
     });
     return rows;
   });
+
+  const crossrefs = computed(() =>
+    crossrefView.map((row) => ({
+      fid: row.fid,
+      topic: row.topic,
+      refsOut: row.refsOut,
+      referencedBy: row.referencedBy,
+    }))
+  );
 
   const hasNoTopics = computed(() =>
     asArray(topics.get()).filter((t) => t).length === 0
@@ -287,11 +310,9 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
 
           <cf-vstack gap="2" padding="4">
             {computed(() => {
-              // Iterate the piece-valued crossref rows directly (one per
-              // non-null topic); each row carries its topic and the sibling
-              // pieces it links, so the card binds navigation to row pieces
-              // with no index indirection.
-              const rows = crossrefs;
+              // Iterate the private rows directly so card and crossref links
+              // persist ordinary fid data instead of scheduler event streams.
+              const rows = crossrefView;
               const order = rows
                 .map((_, i) => i)
                 .filter((i) => rows[i]?.topic)
@@ -317,24 +338,21 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
                           )
                           : null}
                         <cf-text variant="caption" tone="muted">
-                          {t.commentCount} comments · by{" "}
+                          {t.commentCount ?? 0} comments · by{" "}
                           {topicAuthorLabel(t.createdBy, t.createdByName)} ·
                           {" "}
-                          {whenLabel(t.lastActivityAt)}
+                          {whenLabel(t.lastActivityAt ?? 0)}
                         </cf-text>
-                        {crossrefChipRow("references →", false, row.refsOut)}
-                        {crossrefChipRow(
+                        {crossrefLinkRow(
+                          "references →",
+                          row.refsOutLinks,
+                        )}
+                        {crossrefLinkRow(
                           "← referenced by",
-                          true,
-                          row.referencedBy,
+                          row.referencedByLinks,
                         )}
                       </cf-vstack>
-                      <cf-button
-                        variant="secondary"
-                        onClick={openTopic({ topic: t })}
-                      >
-                        Open
-                      </cf-button>
+                      {topicCellLink(row.fid, "Open")}
                     </cf-hstack>
                   </cf-card>
                 );

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -6,11 +6,9 @@ import {
   equals,
   handler,
   NAME,
-  navigateTo,
   pattern,
   type PerSession,
   type PerUser,
-  SELF,
   Stream,
   UI,
   type VNode,
@@ -112,21 +110,32 @@ export interface TopicInput {
  * shared list even when the viewer has no matching session-local cells.
  */
 export interface TopicReference {
-  [NAME]: string;
+  /** Like the other derived display fields, a cold retained sibling may not
+   * have produced this path yet. Its persisted title remains authoritative. */
+  [NAME]: string | Default<""> | undefined;
   title: string;
   body: string;
   comments: TopicComment[];
   links: TopicLink[];
   createdAt: number;
-  createdBy?: TopicAuthor;
+  /** Mixed-version list projections can resolve an older sibling's absent
+   * path as undefined. Fabric shapes that absence to this inert legacy
+   * sentinel at the list boundary; newly computed non-empty authorship remains
+   * a structured TopicAuthor. */
+  createdBy?:
+    | TopicAuthor
+    | Default<{ kind: "person"; name: "" }>
+    | undefined;
   /** @deprecated Compatibility shadow for consumers of the previous result
    * schema. New callers must use `createdBy`; the pattern mirrors this field. */
   createdByName: string;
-  bodyUpdatedBy?: TopicAuthor;
-  bodyUpdatedAt?: number;
-  commentCount: number;
+  bodyUpdatedBy?: TopicAuthor | undefined;
+  bodyUpdatedAt?: number | undefined;
+  /** Cold mixed-version references can expose an unresolved computed path as
+   * explicit undefined. Shape it to zero until the sibling starts. */
+  commentCount: number | Default<0> | undefined;
   /** Max of creation, comments, body saves, and link additions. */
-  lastActivityAt: number;
+  lastActivityAt: number | Default<0> | undefined;
   addComment: Stream<AddCommentEvent>;
   addLink: Stream<AddLinkEvent>;
   setBody: Stream<SetBodyEvent>;
@@ -170,6 +179,14 @@ export interface TopicOutput extends TopicPiece {
   saveBody: Stream<void>;
   cancelEditBody: Stream<void>;
   submitLink: Stream<void>;
+}
+
+/** The durable, non-reactive information a rendered link needs. Keeping this
+ * separate from TopicReference avoids persisting a scheduler-backed click
+ * stream in VDOM: the shell resolves the fid and owns navigation. */
+export interface TopicNavigationLink {
+  fid: string;
+  title: string;
 }
 
 // ===== Shared theme (calm editorial light) =====
@@ -354,43 +371,39 @@ export const crossrefJoin = (
   return { refsOut, referencedBy };
 };
 
-/** Row navigation, bound per topic card and per crossref chip. Module-scope
- * handler (not an inline closure) so embedders and tests can bind and drive
- * it directly. */
-export const openTopic = handler<void, { topic: TopicReference }>(
-  (_, { topic }) => {
-    navigateTo(topic);
-  },
-);
+/** A Topic destination rendered as data, not as a pattern-owned handler.
+ * `cf-cell-link` resolves the fid in the active space and delegates ordinary
+ * and Cmd/Ctrl-click navigation to the shell. This remains usable after a
+ * cold load because the persisted VDOM contains no ephemeral event stream. */
+export const topicCellLink = (fid: string, label: string) =>
+  fid
+    ? (
+      <cf-cell-link
+        link={`/of:${fid}`}
+        label={label}
+        static
+      />
+    )
+    : null;
 
-/** One row of crossref chips ("references →" / "← referenced by"): each chip
- * names a sibling topic and navigates to it. Takes the sibling pieces
- * directly and binds navigation to each — #4714's path-scoped wildcard fix
- * makes binding a piece reached through a derived crossref row safe (before
- * it, such a bind silently kept the consuming UI computed from ever running,
- * which forced the earlier index-plumbed shape). Module-scope and pure so the
- * single-runtime suite can also drive the exact markup directly (pinning the
- * no-edges → null branch) alongside the real card path it renders via
- * continuous UI demand. */
-export const crossrefChipRow = (
+/** One row of crossref links ("references →" / "← referenced by"). The view
+ * carries only durable fid/title snapshots; the public crossref result keeps
+ * its existing piece-valued contract. */
+export const crossrefLinkRow = (
   caption: string,
-  accent: boolean,
-  pieces: TopicReference[],
+  links: TopicNavigationLink[],
 ) =>
-  pieces.length === 0
+  links.length === 0
     ? null
     : (
       <cf-hstack gap="1" align="center" style="flex-wrap: wrap;">
         <cf-text variant="caption" tone="muted">{caption}</cf-text>
-        {pieces.map((p) => (
-          <cf-chip
-            label={snippet(p?.title || "(untitled topic)", 40)}
-            size="xs"
-            color={accent ? "accent" : "neutral"}
-            interactive
-            oncf-click={openTopic({ topic: p })}
-          />
-        ))}
+        {links.map((link) =>
+          topicCellLink(
+            link.fid,
+            snippet(link.title || "(untitled topic)", 40),
+          )
+        )}
       </cf-hstack>
     );
 
@@ -505,7 +518,6 @@ export default pattern<TopicInput, TopicOutput>(
       bodyUpdatedBy,
       bodyUpdatedAt,
       mentionable,
-      [SELF]: self,
     },
   ) => {
     // Session-local UI state (new-tab test: none of this should carry over).
@@ -534,11 +546,11 @@ export default pattern<TopicInput, TopicOutput>(
     // optional input path; sibling Topic schemas can then validate the piece.
     const createdByView = computed(() => {
       const name = (createdBy?.name ?? "").trim();
-      if (name) return createdBy;
+      if (name && createdBy) return createdBy;
       const legacyName = (createdByName ?? "").trim();
       return legacyName
         ? { kind: "person" as const, name: legacyName }
-        : undefined;
+        : { kind: "person" as const, name: "" as const };
     });
 
     // --- Streams (external API; also usable headlessly via CLI) ---
@@ -661,9 +673,16 @@ export default pattern<TopicInput, TopicOutput>(
     // from the mentionable siblings — the same join the board's cards use,
     // reduced to this piece's row (identified via SELF). Nothing persisted;
     // pre-rev pieces without `mentionable` simply derive empty sets.
-    const crossrefs = computed(() => {
+    const crossrefView = computed(() => {
       const sibs = asArray(mentionable.get());
-      if (sibs.length === 0) return { refsOut: [], referencedBy: [] };
+      if (sibs.length === 0) {
+        return {
+          refsOut: [],
+          referencedBy: [],
+          refsOutLinks: [],
+          referencedByLinks: [],
+        };
+      }
       // Each sibling's own fid payload ("" while unresolved — such entries
       // hold no edges this render). Cell-runtime surface cast, as in notes'
       // appendLink.
@@ -673,15 +692,40 @@ export default pattern<TopicInput, TopicOutput>(
         return ref ? fidPayload(entityRefToString(ref)) : "";
       });
       const joined = crossrefJoin(sibs.map((t) => topicCorpus(t)), payloads);
-      // Self-identification via SELF + equals: needs #4714's path-scoped
-      // wildcard fix — before it, the resolveAsCell chain above silently
-      // erased self's comparable marking and this computed never ran.
-      const me = sibs.findIndex((t) => t && equals(t, self));
-      return me < 0 ? { refsOut: [], referencedBy: [] } : {
-        refsOut: joined.refsOut[me].map((j) => sibs[j]),
-        referencedBy: joined.referencedBy[me].map((j) => sibs[j]),
-      };
+      // Select this Topic by a durable field-link identity. Its result title is
+      // a write-through link to its unique argument title cell, so following a
+      // retained sibling's title through any wrapper/result aliases meets the
+      // current input title without relying on the materialized object's
+      // comparable marker (which some derived wrappers lose).
+      const me = sibs.findIndex((t, i) =>
+        t && equals(mentionable.key(i).key("title"), title)
+      );
+      return me < 0
+        ? {
+          refsOut: [],
+          referencedBy: [],
+          refsOutLinks: [],
+          referencedByLinks: [],
+        }
+        : {
+          refsOut: joined.refsOut[me].map((j) => sibs[j]),
+          referencedBy: joined.referencedBy[me].map((j) => sibs[j]),
+          refsOutLinks: joined.refsOut[me].map((j) => ({
+            fid: payloads[j] ? `fid1:${payloads[j]}` : "",
+            title: sibs[j]?.title ?? "",
+          })),
+          referencedByLinks: joined.referencedBy[me].map((j) => ({
+            fid: payloads[j] ? `fid1:${payloads[j]}` : "",
+            title: sibs[j]?.title ?? "",
+          })),
+        };
     });
+    // Preserve the deployed public result schema. Navigation-only fid/title
+    // snapshots stay private to the rendered view.
+    const crossrefs = computed(() => ({
+      refsOut: crossrefView.refsOut,
+      referencedBy: crossrefView.referencedBy,
+    }));
 
     const hasLinks = computed(() => linksView.length > 0);
     const hasComments = computed(() => commentsView.length > 0);
@@ -860,15 +904,19 @@ export default pattern<TopicInput, TopicOutput>(
 
               {/* ── Connections (derived crossrefs; nothing persisted) ── */}
               {computed(() => {
-                const { refsOut, referencedBy } = crossrefs;
-                return refsOut.length === 0 && referencedBy.length === 0
+                const { refsOutLinks, referencedByLinks } = crossrefView;
+                return refsOutLinks.length === 0 &&
+                    referencedByLinks.length === 0
                   ? null
                   : (
                     <cf-card>
                       <cf-vstack gap="2">
                         <cf-heading level={5}>Connections</cf-heading>
-                        {crossrefChipRow("references →", false, refsOut)}
-                        {crossrefChipRow("← referenced by", true, referencedBy)}
+                        {crossrefLinkRow("references →", refsOutLinks)}
+                        {crossrefLinkRow(
+                          "← referenced by",
+                          referencedByLinks,
+                        )}
                       </cf-vstack>
                     </cf-card>
                   );

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -13,10 +13,11 @@
 import { action, assert, Default, NAME, UI, Writable } from "commonfabric";
 import { pattern } from "commonfabric";
 import Topics, {
-  crossrefChipRow,
-  openTopic,
+  crossrefLinkRow,
   submitProfileTopic,
+  topicCellLink,
   type TopicPiece,
+  type TopicReference,
 } from "./main.tsx";
 import Topic, {
   crossrefJoin,
@@ -36,6 +37,68 @@ import Topic, {
   whenLabel,
 } from "./topic.tsx";
 
+interface TestVNode {
+  type: "vnode";
+  name: string;
+  // deno-lint-ignore no-explicit-any
+  props: Record<string, any>;
+  children: unknown[];
+}
+
+const isVNode = (node: unknown): node is TestVNode =>
+  typeof node === "object" && node !== null &&
+  (node as { type?: unknown }).type === "vnode";
+
+function findAllByTag(
+  node: unknown,
+  tag: string,
+  found: TestVNode[] = [],
+): TestVNode[] {
+  if (Array.isArray(node)) {
+    node.forEach((child) => findAllByTag(child, tag, found));
+    return found;
+  }
+  if (!isVNode(node)) return found;
+  if (node.name === tag) found.push(node);
+  for (const child of node.children ?? []) findAllByTag(child, tag, found);
+  return found;
+}
+
+// Compiled JSX props can be cell-backed even when the source expression was
+// a plain string or boolean.
+// deno-lint-ignore no-explicit-any
+const propValue = (value: any): unknown =>
+  value && typeof value.get === "function" ? value.get() : value;
+
+// A faithful pre-authorship Topic projection: the legacy schema has no
+// `createdBy` path at all. Pushing one into a current Topic's retained
+// mentionable list exercises the mixed-version boundary that production
+// migration must preserve.
+const LegacyUnsignedTopic = pattern(() => {
+  const addComment = action((_event: { body: string }) => {});
+  const addLink = action(
+    (_event: { kind: TopicLinkKind; url: string; label: string }) => {},
+  );
+  const setBody = action((_event: { body: string }) => {});
+  return {
+    [NAME]: undefined,
+    title: "Legacy unsigned sibling",
+    body: "",
+    comments: [],
+    links: [],
+    createdAt: 1,
+    // The retained mixed-version link materializes the legacy missing path as
+    // a present undefined value, which must survive current list validation.
+    createdBy: undefined,
+    createdByName: "Legacy Person",
+    commentCount: undefined,
+    lastActivityAt: undefined,
+    addComment,
+    addLink,
+    setBody,
+  };
+});
+
 export default pattern(() => {
   const board = Topics({});
   // The board stores only TopicPiece's shared-safe projection. Exercise the
@@ -44,6 +107,17 @@ export default pattern(() => {
   const directTopic = Topic({
     title: "Direct topic",
     body: "line one\nline two",
+  });
+  // A retained mixed-version list link can project the absent optional
+  // createdBy path as an explicit undefined. Keep that sibling in a live
+  // mentionable universe: the consumer must validate and derive crossrefs
+  // without weakening non-empty authorship away from TopicAuthor.
+  const mixedMentionable = new Writable<
+    TopicReference[] | Default<[]>
+  >([]);
+  const mixedMentionConsumer = Topic({
+    title: "Mixed mention consumer",
+    mentionable: mixedMentionable,
   });
 
   // Branch pin for the detail derive: a piece with no `mentionable` wired
@@ -139,6 +213,11 @@ export default pattern(() => {
       agentName: "Sol",
     });
   });
+  const action_link_unsigned_mixed_version_sibling = action(() => {
+    mixedMentionable.push(
+      LegacyUnsignedTopic({}) as TopicReference,
+    );
+  });
 
   // The previous deployed event shapes remain operational while callers
   // migrate. They use the hidden legacy name cell; new callers always send an
@@ -227,22 +306,23 @@ export default pattern(() => {
     directTopic.linkUrlDraft.set("   ");
     directTopic.submitLink.send();
   });
-  // Bound at pattern-body level (binding inside an action is an illegal
-  // position); the reactive reference resolves at send time, by which point
-  // the first topic exists.
-  const boundOpenFirst = openTopic({
-    topic: board.topics[0] as TopicPiece,
-  });
-  const action_open_topic = action(() => {
-    boundOpenFirst.send();
-  });
-
   // --- assertions ---
 
   const assert_initial = assert(() =>
     board.topicCount === 0 &&
     (board.topics ?? []).length === 0 &&
     (board.mentionable ?? []).length === 0
+  );
+  const assert_explicit_undefined_author_projection = assert(() =>
+    mixedMentionable.get().length === 1 &&
+    // The explicit undefined was accepted, then shaped through the declared
+    // compatibility default for downstream readers.
+    mixedMentionable.get()[0]?.createdBy?.name === "" &&
+    mixedMentionable.get()[0]?.commentCount === 0 &&
+    mixedMentionable.get()[0]?.lastActivityAt === 0 &&
+    mixedMentionable.get()[0]?.[NAME] === "" &&
+    (mixedMentionConsumer.crossrefs?.refsOut ?? []).length === 0 &&
+    (mixedMentionConsumer.crossrefs?.referencedBy ?? []).length === 0
   );
 
   const assert_first_topic = assert(() =>
@@ -484,17 +564,31 @@ export default pattern(() => {
       (lone.crossrefs?.referencedBy ?? []).length === 0;
   });
 
-  // Drives the exact chip markup the card map emits, independent of UI
-  // demand timing: a populated row yields the hstack vnode — navigation
-  // binds included — and an edgeless row collapses to null so the card
-  // renders nothing for it. The real in-card path renders too: this suite
-  // exports [UI], so the harness demands the vdom continuously (#4715).
-  const assert_chip_row_markup = assert(() => {
-    const list = (board.topics ?? []) as TopicPiece[];
-    if (list.length < 2) return false;
-    const row = crossrefChipRow("references →", false, [list[0], list[1]]);
+  // Pin the persisted navigation contract directly. A cold renderer must see
+  // ordinary cf-cell-link destinations, never pattern-owned handler streams.
+  const assert_cell_link_markup = assert(() => {
+    const rows = board.crossrefs ?? [];
+    if (rows.length < 2 || !rows[0]?.fid || !rows[1]?.fid) return false;
+    const row = crossrefLinkRow("references →", [
+      { fid: rows[0].fid, title: rows[0].topic.title },
+      { fid: rows[1].fid, title: rows[1].topic.title },
+    ]);
+    const open = topicCellLink(rows[0].fid, "Open");
+    const rowLinks = findAllByTag(row, "cf-cell-link");
+    const openLinks = findAllByTag(open, "cf-cell-link");
     return row !== null &&
-      crossrefChipRow("← referenced by", true, []) === null;
+      open !== null &&
+      rowLinks.length === 2 &&
+      openLinks.length === 1 &&
+      propValue(rowLinks[0].props.link) === `/of:${rows[0].fid}` &&
+      propValue(rowLinks[1].props.link) === `/of:${rows[1].fid}` &&
+      propValue(openLinks[0].props.link) === `/of:${rows[0].fid}` &&
+      propValue(openLinks[0].props.label) === "Open" &&
+      propValue(openLinks[0].props.static) === true &&
+      openLinks[0].props.onClick === undefined &&
+      openLinks[0].props["oncf-click"] === undefined &&
+      crossrefLinkRow("← referenced by", []) === null &&
+      topicCellLink("", "Open") === null;
   });
 
   // A share link in a comment counts too — its colon is percent-encoded.
@@ -616,6 +710,8 @@ export default pattern(() => {
     [UI]: board[UI],
     tests: [
       { assertion: assert_initial },
+      { action: action_link_unsigned_mixed_version_sibling },
+      { assertion: assert_explicit_undefined_author_projection },
       { action: action_submit_profile_topic },
       { assertion: assert_profile_topic_submitted },
       { action: action_submit_profile_comment },
@@ -656,7 +752,7 @@ export default pattern(() => {
       { render: board[UI] },
       { assertion: assert_detail_edges },
       { assertion: assert_lone_edgeless },
-      { assertion: assert_chip_row_markup },
+      { assertion: assert_cell_link_markup },
       { render: board[UI] },
       { action: action_comment_first_again },
       { action: action_add_third_topic },
@@ -673,7 +769,6 @@ export default pattern(() => {
       { render: directTopic[UI] },
       { render: legacy[UI] },
       { assertion: assert_legacy_fields_load },
-      { action: action_open_topic },
       { assertion: assert_pure_helpers },
       { action: action_comment_ref_encoded },
       { assertion: assert_comment_edge },


### PR DESCRIPTION
## Summary

Fix Topics navigation so board links and detail cross-references continue to work when their VDOM is recomputed in a fresh browser worker.

The failure was caused by persisting scheduler-owned event streams in computed VDOM. A cold worker could render the stored stream identifier, but it had no ephemeral handler registered for that identifier, so clicks were dropped. This replaces those handlers with durable `cf-cell-link` data carrying the target piece FID; the shell owns same-tab and Cmd/Ctrl-click navigation.

This also:

- preserves the public cross-reference result schema while deriving a private FID/title navigation view
- keeps legacy/mixed-version Topic projections loadable
- uses title field-link identity for detail self-selection
- corrects the JSX declaration for `cf-cell-link` runtime attributes
- adds a cold-browser integration regression covering board Open, detail cross-reference navigation, and absence of scheduler dropped-event warnings

The branch is rebased onto latest `main` and includes the behavior from #4991 (body-at-create and thrown mutation rejections). It is independent of #4992.

## Validation

- `deno fmt --check` on changed files
- `deno check` on changed files
- `deno task cf check main.tsx topic.tsx --no-run`
- Topics unit tests: 33/33
- Topics rejection tests: 10 assertions
- Multi-user Topics tests: 7/7
- `deno task integration patterns topics-navigation`: 1/1
- manual cold-browser verification of board Open, board/detail cross-references, and Cmd-click, with no dropped-event warning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Topics navigation durable across cold browser loads by replacing ephemeral click handlers with `cf-cell-link` links that encode target FIDs. Board “Open” and cross-reference links now work after a fresh worker start and support Cmd/Ctrl-click, with no dropped-event warnings.

- **Bug Fixes**
  - Replaced pattern-owned click streams with durable `cf-cell-link` (shell owns navigation).
  - Fixed JSX typings for `cf-cell-link` by adding `label`, `static`, and making `$cell` optional.
  - Added a cold-browser integration test covering board open, cross-ref navigation, and absence of scheduler dropped-event warnings; updated unit tests.

- **Refactors**
  - Introduced a private cross-reference view with `TopicNavigationLink` (fid/title) while preserving the public `TopicCrossref` schema.
  - Switched detail self-selection to title field-link identity for resilience across wrappers.
  - Kept legacy/mixed-version Topic projections loadable by shaping `createdBy`, `commentCount`, and `lastActivityAt` defaults.

<sup>Written for commit 297846687acbe0091d0ce7181d65c619be5fdb66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

