### PR TITLE
feat(api,runner): make FabricRegExp and FabricError available to pattern code

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -159,6 +159,36 @@ export interface FabricBytesConstructor {
 export declare const FabricBytes: FabricBytesConstructor;
 
 /**
+ * An immutable regular expression. Extends `FabricPrimitive` -- treated like a
+ * primitive in the fabric type system (always frozen, passes through
+ * conversion unchanged).
+ *
+ * The pattern is held as a flavor / source / flags triple rather than as a
+ * native `RegExp`, so that flavors with no native representation can still be
+ * carried. `value` reconstitutes a native `RegExp` where one exists.
+ */
+export interface FabricRegExp extends FabricPrimitive {
+  readonly source: string;
+  readonly flags: string;
+  readonly flavor: string;
+
+  /**
+   * A fresh native `RegExp` equivalent to this value, returned anew on each
+   * call so the internal instance is never aliased out. Throws for a flavor
+   * with no native `RegExp` representation.
+   */
+  readonly value: RegExp;
+}
+
+export interface FabricRegExpConstructor {
+  new (regex: RegExp): FabricRegExp;
+  new (flavor: string, source: string, flags: string): FabricRegExp;
+  prototype: FabricRegExp;
+}
+
+export declare const FabricRegExp: FabricRegExpConstructor;
+
+/**
  * The full set of values that the fabric storage layer can represent.
  */
 export type FabricValue =

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -189,6 +189,68 @@ export interface FabricRegExpConstructor {
 export declare const FabricRegExp: FabricRegExpConstructor;
 
 /**
+ * Structured state for constructing a `FabricError`. The fixed-schema slots
+ * are `FabricValue`-typed; `extras` carries any custom enumerable properties,
+ * whose keys must not collide with the slot names.
+ */
+export type FabricErrorState = {
+  /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
+  readonly type: string;
+  /** The `.name` property. Omit to mean "same as `type`". */
+  readonly name?: string | null | undefined;
+  /** The `.message` property. */
+  readonly message: string;
+  /** The `.stack` property, or `undefined`. */
+  readonly stack: string | undefined;
+  /** The `.cause` value, in `FabricValue` form, or `undefined`. */
+  readonly cause: FabricValue | undefined;
+  /** Custom enumerable own properties, in `FabricValue` form. */
+  readonly extras?:
+    | Iterable<readonly [string, FabricValue]>
+    | Readonly<Record<string, FabricValue>>
+    | undefined;
+};
+
+/**
+ * An error carried as fabric data. Extends `FabricInstance` (not
+ * `FabricPrimitive`): it holds fixed-schema slots plus a bag of extras, and
+ * `cause` may be an arbitrary `FabricValue`, so it is a small object graph
+ * rather than a leaf.
+ *
+ * Like every `FabricInstance` it is mutable until frozen: the slots are plain
+ * writable properties, and `setExtra()` / `deleteExtra()` are gated on the
+ * frozen state.
+ */
+export interface FabricError extends FabricInstance {
+  type: string;
+  name: string;
+  message: string;
+  stack: string | undefined;
+  cause: FabricValue | undefined;
+
+  getExtra(key: string): FabricValue | undefined;
+  hasExtra(key: string): boolean;
+  setExtra(key: string, value: FabricValue): void;
+  deleteExtra(key: string): boolean;
+  readonly extraSize: number;
+  extraKeys(): IterableIterator<string>;
+  extraEntries(): IterableIterator<[string, FabricValue]>;
+}
+
+export interface FabricErrorConstructor {
+  new (state: FabricErrorState): FabricError;
+  fromNativeError(error: Error): FabricError;
+  prototype: FabricError;
+}
+
+export declare const FabricError: FabricErrorConstructor;
+
+// TODO(danfuzz): `FabricMap` and `FabricSet` are deliberately absent from the
+// declarations above. Both need substantial rework before they are useful, and
+// declaring them here would imply a utility they do not yet have. Their
+// absence is a decision, not an oversight; revisit once that rework lands.
+
+/**
  * The full set of values that the fabric storage layer can represent.
  */
 export type FabricValue =

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -418,6 +418,9 @@ export class FabricError extends FabricNativeWrapper<Error>
 }
 
 // Compile-time check that the exported `FabricError` constructor matches the
-// `FabricErrorConstructor` declared in `@commonfabric/api`. This catches drift
-// between the public type contract and this implementation.
+// `FabricErrorConstructor` declared in `@commonfabric/api`. This catches a
+// declared member that is missing here or has the wrong type. It does NOT
+// catch the other direction: `satisfies` is an assignability check, so a
+// public member on this class that the declaration omits passes silently.
+// Members added here need adding there by hand.
 FabricError satisfies ApiFabricErrorConstructor;

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -1,3 +1,8 @@
+import type {
+  FabricError as ApiFabricError,
+  FabricErrorConstructor as ApiFabricErrorConstructor,
+} from "@commonfabric/api";
+
 import type { FabricValue } from "@/interface.ts";
 import {
   DEEP_CLONE_CORE,
@@ -85,7 +90,8 @@ export type FabricErrorState = {
  * `[CODEC]`, which is the source of truth for the encoded form.
  * See Section 1.4.1 of the formal spec.
  */
-export class FabricError extends FabricNativeWrapper<Error> {
+export class FabricError extends FabricNativeWrapper<Error>
+  implements ApiFabricError {
   /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
   type: string;
   /** The `.name` property (always a concrete string). */
@@ -410,3 +416,8 @@ export class FabricError extends FabricNativeWrapper<Error> {
     return this.#codec;
   }
 }
+
+// Compile-time check that the exported `FabricError` constructor matches the
+// `FabricErrorConstructor` declared in `@commonfabric/api`. This catches drift
+// between the public type contract and this implementation.
+FabricError satisfies ApiFabricErrorConstructor;

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -202,6 +202,9 @@ function rejectExtraRegExpProperties(regex: RegExp): void {
 }
 
 // Compile-time check that the exported `FabricRegExp` constructor matches the
-// `FabricRegExpConstructor` declared in `@commonfabric/api`. This catches drift
-// between the public type contract and this implementation.
+// `FabricRegExpConstructor` declared in `@commonfabric/api`. This catches a
+// declared member that is missing here or has the wrong type. It does NOT
+// catch the other direction: `satisfies` is an assignability check, so a
+// public member on this class that the declaration omits passes silently.
+// Members added here need adding there by hand.
 FabricRegExp satisfies ApiFabricRegExpConstructor;

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -1,3 +1,8 @@
+import type {
+  FabricRegExp as ApiFabricRegExp,
+  FabricRegExpConstructor as ApiFabricRegExpConstructor,
+} from "@commonfabric/api";
+
 import type { FabricValue } from "@/interface.ts";
 import { BaseFabricPrimitive } from "./BaseFabricPrimitive.ts";
 import { BaseFabricCodec } from "@/codec-common/BaseFabricCodec.ts";
@@ -33,7 +38,8 @@ const DEFAULT_FLAVOR = "es2025";
  * other regex syntaxes in the future.
  * See Section 1.4.1 of the formal spec.
  */
-export class FabricRegExp extends BaseFabricPrimitive {
+export class FabricRegExp extends BaseFabricPrimitive
+  implements ApiFabricRegExp {
   /** The pattern source text. */
   readonly #source: string;
 
@@ -194,3 +200,8 @@ function rejectExtraRegExpProperties(regex: RegExp): void {
     );
   }
 }
+
+// Compile-time check that the exported `FabricRegExp` constructor matches the
+// `FabricRegExpConstructor` declared in `@commonfabric/api`. This catches drift
+// between the public type contract and this implementation.
+FabricRegExp satisfies ApiFabricRegExpConstructor;

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -86,7 +86,10 @@ import {
   FabricSpecialObject,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
-import { FabricLink } from "@commonfabric/data-model/fabric-instances";
+import {
+  FabricError,
+  FabricLink,
+} from "@commonfabric/data-model/fabric-instances";
 import {
   FabricBytes,
   FabricEpochDays,
@@ -307,6 +310,7 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     FabricLink,
     FabricBytes,
     FabricRegExp,
+    FabricError,
 
     // Debug stringifiers (helpers exposed for pattern code)
     toCompactDebugString,

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -92,6 +92,7 @@ import {
   FabricEpochDays,
   FabricEpochNsec,
   FabricHash,
+  FabricRegExp,
 } from "@commonfabric/data-model/fabric-primitives";
 import {
   toCompactDebugString,
@@ -305,6 +306,7 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     FabricHash,
     FabricLink,
     FabricBytes,
+    FabricRegExp,
 
     // Debug stringifiers (helpers exposed for pattern code)
     toCompactDebugString,

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -459,6 +459,8 @@ export interface BuilderFunctionsAndConstants {
     typeof import("@commonfabric/data-model/fabric-instances").FabricLink;
   FabricBytes:
     typeof import("@commonfabric/data-model/fabric-primitives").FabricBytes;
+  FabricRegExp:
+    typeof import("@commonfabric/data-model/fabric-primitives").FabricRegExp;
 
   // Debug stringifiers
   toCompactDebugString:

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -461,6 +461,8 @@ export interface BuilderFunctionsAndConstants {
     typeof import("@commonfabric/data-model/fabric-primitives").FabricBytes;
   FabricRegExp:
     typeof import("@commonfabric/data-model/fabric-primitives").FabricRegExp;
+  FabricError:
+    typeof import("@commonfabric/data-model/fabric-instances").FabricError;
 
   // Debug stringifiers
   toCompactDebugString:

--- a/packages/runner/test/builder-fabric-classes.test.ts
+++ b/packages/runner/test/builder-fabric-classes.test.ts
@@ -12,6 +12,7 @@ import {
   FabricEpochDays,
   FabricEpochNsec,
   FabricHash,
+  FabricRegExp,
 } from "@commonfabric/data-model/fabric-primitives";
 import { createBuilder } from "../src/builder/factory.ts";
 import { getRuntimeModuleExports } from "../src/sandbox/runtime-modules.ts";
@@ -35,8 +36,8 @@ const declaredClasses = [
 ].map((match) => match[1]);
 
 // The `data-model` class each binding is expected to be. This table is the
-// test's own knowledge of the eight classes, and the first assertion below
-// pins it against the derived list, so the two cannot drift apart silently.
+// test's own knowledge, and the first assertion below pins it against the
+// derived list, so the two cannot drift apart silently.
 const expectedBindings: Record<string, unknown> = {
   FabricSpecialObject,
   FabricInstance,
@@ -46,6 +47,7 @@ const expectedBindings: Record<string, unknown> = {
   FabricHash,
   FabricLink,
   FabricBytes,
+  FabricRegExp,
 };
 
 describe("commonfabric Fabric value classes", () => {
@@ -104,6 +106,31 @@ describe("commonfabric Fabric value classes", () => {
 
       expect(instance).toBeInstanceOf(FabricLink);
       expect(instance.payload).toEqual(payload);
+    });
+  });
+
+  describe("FabricRegExp", () => {
+    // Both declared constructor overloads, since the pattern-visible
+    // declaration offers both and only one of them is the obvious one.
+    it("constructs an instance from a native `RegExp`", () => {
+      const BoundFabricRegExp = commonfabric
+        .FabricRegExp as typeof FabricRegExp;
+      const instance = new BoundFabricRegExp(/ab+c/gi);
+
+      expect(instance).toBeInstanceOf(FabricRegExp);
+      expect(instance.source).toBe("ab+c");
+      expect(instance.flags).toBe("gi");
+      expect(instance.value).toEqual(/ab+c/gi);
+    });
+
+    it("constructs an instance from an explicit flavor, source and flags", () => {
+      const BoundFabricRegExp = commonfabric
+        .FabricRegExp as typeof FabricRegExp;
+      const instance = new BoundFabricRegExp("es2025", "a.c", "s");
+
+      expect(instance.flavor).toBe("es2025");
+      expect(instance.source).toBe("a.c");
+      expect(instance.flags).toBe("s");
     });
   });
 

--- a/packages/runner/test/builder-fabric-classes.test.ts
+++ b/packages/runner/test/builder-fabric-classes.test.ts
@@ -6,7 +6,10 @@ import {
   FabricPrimitive,
   FabricSpecialObject,
 } from "@commonfabric/data-model/fabric-value";
-import { FabricLink } from "@commonfabric/data-model/fabric-instances";
+import {
+  FabricError,
+  FabricLink,
+} from "@commonfabric/data-model/fabric-instances";
 import {
   FabricBytes,
   FabricEpochDays,
@@ -48,6 +51,7 @@ const expectedBindings: Record<string, unknown> = {
   FabricLink,
   FabricBytes,
   FabricRegExp,
+  FabricError,
 };
 
 describe("commonfabric Fabric value classes", () => {
@@ -131,6 +135,42 @@ describe("commonfabric Fabric value classes", () => {
       expect(instance.flavor).toBe("es2025");
       expect(instance.source).toBe("a.c");
       expect(instance.flags).toBe("s");
+    });
+  });
+
+  describe("FabricError", () => {
+    it("constructs an instance carrying its fixed-schema slots", () => {
+      const BoundFabricError = commonfabric.FabricError as typeof FabricError;
+      const instance = new BoundFabricError({
+        type: "TypeError",
+        message: "nope",
+        stack: undefined,
+        cause: undefined,
+      });
+
+      expect(instance).toBeInstanceOf(FabricError);
+      expect(instance.type).toBe("TypeError");
+      expect(instance.name).toBe("TypeError");
+      expect(instance.message).toBe("nope");
+    });
+
+    // Unlike the other exposed classes, this one is mutable until frozen, so
+    // pattern code can reach its extras bag. Pinned because exposing writable
+    // members is a choice rather than a side effect of exposing the class.
+    it("allows extras to be set and read back", () => {
+      const BoundFabricError = commonfabric.FabricError as typeof FabricError;
+      const instance = new BoundFabricError({
+        type: "Error",
+        message: "with extras",
+        stack: undefined,
+        cause: undefined,
+      });
+
+      instance.setExtra("code", 42);
+
+      expect(instance.getExtra("code")).toBe(42);
+      expect(instance.hasExtra("code")).toBe(true);
+      expect(instance.extraSize).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary

`FabricRegExp` and `FabricError` both exist in `data-model` and are fully built
— codecs, round-tripping, the lot — but neither was declared in
`packages/api/index.ts`, so pattern code could not name either one.

This declares both, binds both in the runner's builder, and pins each
declaration against its implementation.

## The failure mode is compile-time, not runtime

Worth stating explicitly, because a recent change in this area looked similar
and was not: `FabricBytes`, `FabricLink`, and `FabricSpecialObject` were
**declared but unbound**, so a pattern using them type-checked cleanly and then
failed at *execution*.

These two have the opposite shape. There was no declaration at all, so a pattern
naming them fails at *compile* time — visible immediately, with no
silently-wrong runtime behavior. Same area, different severity. The fix closes
both halves at once: each class gets its declaration *and* its binding, so
neither can land in the declared-but-unbound state.

## What changed

| File | Change |
|---|---|
| `packages/api/index.ts` | declarations for both classes, plus `FabricErrorState` |
| `packages/runner/src/builder/factory.ts` | runtime bindings |
| `packages/runner/src/builder/types.ts` | matching type entries |
| `packages/runner/test/builder-fabric-classes.test.ts` | table entries + construction tests |
| `data-model/src/fabric-primitives/FabricRegExp.ts` | `implements` + `satisfies` pins |
| `data-model/src/fabric-instances/FabricError.ts` | `implements` + `satisfies` pins |

The `FabricValue` union needs no edit — it keys on `FabricSpecialObject`, so
these are covered by inheritance. The declarations omit the static `[CODEC]`,
matching how the other classes are declared.

## ⚠️ Disclosure: `FabricError`'s declaration exposes mutators

`FabricRegExp` is an immutable leaf. **`FabricError` is not**, and its
pattern-visible surface says so: `type`, `name`, `message`, `stack`, and `cause`
are declared as **writable** properties, and `setExtra()` / `deleteExtra()` are
declared alongside the read-only accessors.

That is faithful to the implementation — a `FabricInstance` is mutable until
frozen, and the mutators are gated on frozen state rather than absent. But it
does mean this PR hands pattern code a **mutation surface** it did not have,
which is a larger step than making a value merely nameable. Declaring the class
read-only would have been the smaller change and the dishonest one; the
declaration matches what the object actually does.

## ⚠️ Disclosure: this touches two `data-model` files, outside the surface it is nominally about

Each class gains `implements ApiFabric<X>` and a trailing
`Fabric<X> satisfies ApiFabric<X>Constructor`.

**Why, given the PR is otherwise an api + runner change:** the api↔data-model
mirror is **hand-maintained with no enforcement**. This PR *authors* two
declarations by hand — one against a class with two constructor overloads and
four accessors, the other against a class with five schema slots, six extras
methods, a static, and its own state type. That is precisely the shape that
drifts quietly, because a mismatch produces no error anywhere until someone hits
it. #5010's missing `symbol` arm is the existing precedent.

This is **bringing files into line, not inventing a convention**:
`FabricEpochNsec`, `FabricEpochDays`, `FabricHash`, and `FabricLink` already
carry the same pins.

### What the pins do and do not catch

Verified in both directions, rather than assumed.

**They catch a mismatch.** Perturbing `readonly flavor: string` to `number`
makes `deno check` fail at the `satisfies` line; restored afterward. A pin that
cannot fail is worse than no pin, so it seemed worth actually breaking.

**They do not catch under-declaration**, and that limitation is worth stating
because it is the direction most likely to matter. `satisfies` and `implements`
are *assignability* checks: a class carrying **more** members than the interface
declares still satisfies it. So a member that exists on the class but is missing
from the api declaration — the case where pattern authors simply cannot reach
something that is there — passes both pins silently.

That is not hypothetical. `FabricHash` is in exactly that state today: the class
has `taggedHashString` and `copyInto()`, `api/index.ts`'s `FabricHash` interface
declares neither, and its pins pass. So "the `satisfies` pin passed first try"
is weaker evidence than it looks.

**The new declarations were therefore checked for completeness separately, by a
check with a positive control.** Run against `FabricHash` it returns
`"copyInto" | "taggedHashString"` — proving it fires when there is something to
find. Run against the new declarations it returns nothing. Without that control,
"no error" would have been indistinguishable from a check incapable of detecting
anything.

So the completeness claim rests on that check, not on the `satisfies` line. The
pins are worth having for the direction they do cover; they are simply not
evidence for this one.

The comments at both new pin sites say so explicitly rather than repeating the
existing sites' broader claim about catching "drift". That wording is inherited
from four pre-existing pins and overstates what the check does; those four are
left alone here rather than swept, but the two this PR adds do not propagate it.

## ⚠️ `FabricMap` and `FabricSet` are deliberately omitted

Recorded as a `TODO(danfuzz)` in `api/index.ts` beside the new declarations:
both need substantial rework before they are useful, and declaring them would
imply a utility they do not have. **Their absence is a decision, not an
oversight.**

Naming it in the source matters because the next person auditing which classes
are pattern-visible will find these two missing and, with no note, reasonably
conclude it was an omission and "fix" it.

## The regression test caught this class of bug live

The builder test derives its expected class list from `types/commonfabric.d.ts`
— the artifact the sandbox actually feeds a pattern — and asserts the derived
list matches its table of expected `data-model` classes **exactly**.

That exact-match assertion was added during review of an earlier PR, to close a
vacuity hole nobody had a live example of at the time. **It reproduced that hole
here, on a PR that did not exist when it was written.** At the intermediate step
where a class was declared but not yet bound:

```
binds `FabricRegExp` to the `data-model` class itself ... ok
```

Passing — on `undefined === undefined`, since the name was absent from both the
builder surface and the expectations table. The exact-match assertion was the
only thing that caught the gap.

That is also why this PR touches the test at all: a new declaration turns the
derived list red automatically, and it takes a table entry to turn it green
again. The test is doing exactly what it was hardened to do.

## Tests

`FabricRegExp` construction is exercised through **both** declared constructor
overloads — from a native `RegExp`, and from an explicit flavor/source/flags
triple — since the declaration offers both and only one is obvious.
`FabricError` is exercised through its state-object constructor and its
`fromNativeError()` static.

Three consuming suites, as this spans three packages: `data-model` 47 passed /
2123 steps, `api` green, `runner` green. `fmt` and `lint` clean.
