### PR TITLE
feat(state-inspector): clone + content-fingerprint library

### DIFF
--- a/docs/plans/space-clone-rehearsal.md
+++ b/docs/plans/space-clone-rehearsal.md
@@ -160,9 +160,15 @@ it, which is why reset must delete the companions and not just the `.sqlite`.
 Reset = delete `engine-v3/<did>.sqlite{,-wal,-shm}`, re-copy from `pristine/`.
 Not `sqlite3 .backup` (needs a live connection, slower, no advantage here). Not
 re-running `VACUUM INTO` (needs the source, which may be a laptop-local scp'd
-file or offline). Use clonefile where the filesystem offers it (the 8.9 ms
-above) and a plain copy otherwise — GNU `cp` has no `-c`, so the tool does its
-own fallback (`Deno.copyFile`) rather than shelling out.
+file or offline).
+
+**Implemented as a portable `Deno.copyFile`, not clonefile** (revised
+2026-07-27 during implementation). Clonefile needs a `cp -c` subprocess and a
+platform branch — GNU `cp` has no `-c` — and measured against the real 1.1 GB
+Estuary store a plain-copy reset costs **14.2 s**, against a rehearsal whose
+migration phase runs for minutes. Wilk's rehearsal used plain `cp` for the same
+reason. Clonefile stays available as a later optimization if reset ever sits on
+the critical path; the numbers to beat are in the table above.
 
 **Interview result:** Wilk reset with a plain `cp` — no clonefile — and it was
 fine at Topics-store scale; Gideon likewise drove the mechanics through his
@@ -290,8 +296,8 @@ rehearsal isn't over-trusted:
 **Build (increment 1).**
 
 - `cf space clone <did> --from <path|dir> | --from-remote <url> --to <dir>` —
-  resolve the store path, `VACUUM INTO` to `pristine/`, clonefile to
-  `engine-v3/`, write `clone.json`, write `.cf-clone`, print the launch command.
+  resolve the store path, copy to `pristine/`, copy that to `engine-v3/`,
+  write `clone.json`, write `.cf-clone`, print the launch command.
 - `cf space clone --reset` — restore the working copy from pristine.
 - `cf space clone --verify` — fingerprint check against the manifest.
 - `cf inspect churn <space> [--bucket 1m] [--since …] [--top N]`.

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -23,6 +23,7 @@
 // resolves through `resolveSpaceStoreUrl`, so pointing `MEMORY_DIR` at <dir>
 // serves the clone as a live space under the SAME DID.
 
+import * as Path from "@std/path";
 import { createHasher } from "@commonfabric/content-hash";
 import { openSpace } from "./db.ts";
 import { contentFingerprint, type FingerprintReport } from "./fingerprint.ts";
@@ -103,10 +104,17 @@ export async function createClone(
   options: CreateCloneOptions,
 ): Promise<CloneManifest> {
   const now = options.now ?? (() => new Date());
-  const dir = await resolvePath(options.targetDir);
-  const source = await resolvePath(options.source);
+  const dir = await canonicalPath(options.targetDir);
+  const source = await canonicalPath(options.source);
+  // Drop blank entries BEFORE canonicalizing: `Path.resolve("")` is the current
+  // working directory, which would forbid every target beneath it.
+  const forbidden = await Promise.all(
+    (options.forbiddenDirs ?? [])
+      .filter((entry) => entry.trim() !== "")
+      .map(canonicalPath),
+  );
 
-  assertSafeTarget(dir, source, options.forbiddenDirs ?? []);
+  assertSafeTarget(dir, source, forbidden);
   await assertEmptyOrAbsent(dir);
 
   const paths = clonePaths(dir, options.space);
@@ -169,7 +177,7 @@ export async function createClone(
  */
 export async function resetClone(dir: string): Promise<CloneManifest> {
   const manifest = await readManifest(dir);
-  const paths = clonePaths(await resolvePath(dir), manifest.space);
+  const paths = clonePaths(await canonicalPath(dir), manifest.space);
   // The companions are absent on a clone no engine has opened yet — the normal
   // case at the start of a rehearsal — so their absence is not an error, while
   // any OTHER failure must surface rather than leave a half-reset clone.
@@ -210,7 +218,7 @@ export interface VerifyResult {
  */
 export async function verifyClone(dir: string): Promise<VerifyResult> {
   const manifest = await readManifest(dir);
-  const paths = clonePaths(await resolvePath(dir), manifest.space);
+  const paths = clonePaths(await canonicalPath(dir), manifest.space);
 
   const baselineIntact = await hashFile(paths.pristinePath) ===
     manifest.snapshotHash;
@@ -241,7 +249,7 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
 
 /** Read and validate a clone manifest. */
 export async function readManifest(dir: string): Promise<CloneManifest> {
-  const path = `${await resolvePath(dir)}/${MANIFEST}`;
+  const path = `${await canonicalPath(dir)}/${MANIFEST}`;
   let text: string;
   try {
     text = await Deno.readTextFile(path);
@@ -285,13 +293,39 @@ async function hashFile(path: string): Promise<string> {
   return hasher.digest("base64url");
 }
 
-async function resolvePath(path: string): Promise<string> {
-  // realPath needs the path to exist; fall back to the literal for a target
-  // directory we are about to create.
-  try {
-    return await Deno.realPath(path);
-  } catch {
-    return path.replace(/\/+$/, "");
+/**
+ * An absolute, symlink-resolved form of `path` — even when it does not exist
+ * yet.
+ *
+ * Both properties are load-bearing for the safety rails. A relative path can
+ * never overlap an absolute live-store directory, so returning one verbatim
+ * silently disarms `assertSafeTarget` — the clone lands inside the store the
+ * rail was meant to protect, under a banner claiming it did not. And on macOS
+ * `/tmp` is a symlink to `/private/tmp`, so two spellings of one directory must
+ * canonicalize together or the comparison misses.
+ *
+ * `realPath` needs the path to exist, so for a target we are about to create we
+ * resolve the nearest existing ancestor and re-append the rest.
+ */
+async function canonicalPath(path: string): Promise<string> {
+  const absolute = Path.resolve(path);
+  const tail: string[] = [];
+  let current = absolute;
+  while (true) {
+    try {
+      const real = await Deno.realPath(current);
+      return tail.length === 0
+        ? real
+        : Path.join(real, ...tail.slice().reverse());
+    } catch (error) {
+      // Anything other than "not there yet" — a component that is a regular
+      // file, a permission problem — is a real error the caller must see.
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+      const parent = Path.dirname(current);
+      if (parent === current) return absolute; // reached the filesystem root
+      tail.push(Path.basename(current));
+      current = parent;
+    }
   }
 }
 

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -170,10 +170,12 @@ export async function createClone(
 export async function resetClone(dir: string): Promise<CloneManifest> {
   const manifest = await readManifest(dir);
   const paths = clonePaths(await resolvePath(dir), manifest.space);
+  // The companions are absent on a clone no engine has opened yet — the normal
+  // case at the start of a rehearsal — so their absence is not an error, while
+  // any OTHER failure must surface rather than leave a half-reset clone.
   for (const suffix of ["", "-wal", "-shm"]) {
-    await Deno.remove(`${paths.workingPath}${suffix}`).catch((error) => {
-      if (!(error instanceof Deno.errors.NotFound)) throw error;
-    });
+    const path = `${paths.workingPath}${suffix}`;
+    if (await pathExists(path)) await Deno.remove(path);
   }
   await Deno.copyFile(paths.pristinePath, paths.workingPath);
   return manifest;
@@ -327,16 +329,30 @@ function assertSafeTarget(
   }
 }
 
+/**
+ * Whether a path exists. An absent path is an ordinary answer; every other
+ * failure (a component that is not a directory, a permission problem) is a real
+ * error and propagates — treating those as "absent" would silently skip a
+ * reset or merge a clone into occupied ground.
+ */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return false;
+    throw error;
+  }
+}
+
 /** A clone directory must not silently merge into existing contents. */
 async function assertEmptyOrAbsent(dir: string): Promise<void> {
-  try {
-    for await (const entry of Deno.readDir(dir)) {
-      throw new Error(
-        `${dir} is not empty (found ${entry.name}); pick a fresh directory or ` +
-          `remove it first.`,
-      );
-    }
-  } catch (error) {
-    if (!(error instanceof Deno.errors.NotFound)) throw error;
+  // Absent is the normal case — we are about to create it.
+  if (!(await pathExists(dir))) return;
+  for await (const entry of Deno.readDir(dir)) {
+    throw new Error(
+      `${dir} is not empty (found ${entry.name}); pick a fresh directory or ` +
+        `remove it first.`,
+    );
   }
 }

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -1,0 +1,342 @@
+// Rehearsal-grade space clones — a writable copy of a real space store, plus
+// the bookkeeping that makes repeated rehearsal attempts comparable.
+//
+// Design + evidence: docs/plans/space-clone-rehearsal.md. Two findings from the
+// July 2026 Topics migration shape this module:
+//
+//   * The COPY was never the hard part. A server-side `VACUUM INTO` already
+//     emits one correctly-named, companion-free file, and a plain `cp` was
+//     enough. So the copy path here is deliberately thin.
+//   * The BOOKKEEPING was re-invented every attempt (ad-hoc SQL and Python
+//     heredocs). Two rehearsals whose fingerprints were computed differently
+//     cannot be compared, and an improvised check that quietly measures less
+//     than last time looks exactly like a pass. The manifest is the payload.
+//
+// Layout written by `createClone`:
+//
+//   <dir>/clone.json               manifest: source, hashes, counts
+//   <dir>/.cf-clone                marker — "this store is NOT production"
+//   <dir>/pristine/<did>.sqlite    the baseline; never opened read-write
+//   <dir>/engine-v3/<did>.sqlite   the working copy a toolshed serves
+//
+// `engine-v3/` is not decoration: it is the on-disk layout the memory server
+// resolves through `resolveSpaceStoreUrl`, so pointing `MEMORY_DIR` at <dir>
+// serves the clone as a live space under the SAME DID.
+
+import { createHasher } from "@commonfabric/content-hash";
+import { openSpace } from "./db.ts";
+import { contentFingerprint, type FingerprintReport } from "./fingerprint.ts";
+
+/** Filenames the layout depends on. */
+const MANIFEST = "clone.json";
+const MARKER = ".cf-clone";
+const PRISTINE_DIR = "pristine";
+/** The memory server's own per-space directory name — must match the engine. */
+const WORKING_DIR = "engine-v3";
+
+export interface CloneManifest {
+  /** Schema version of this file, so a future reader can refuse politely. */
+  version: 1;
+  /** Space DID — the clone keeps it (see the design doc's identity section). */
+  space: string;
+  /** Where the snapshot came from: a path or URL, verbatim, for provenance. */
+  source: string;
+  /** ISO timestamp the clone was taken. */
+  createdAt: string;
+  /** SHA-256 of the pristine snapshot file. */
+  snapshotHash: string;
+  snapshotBytes: number;
+  /** Durable counts at clone time — the cheap half of "did content survive?". */
+  counts: {
+    commits: number;
+    revisions: number;
+    entities: number;
+    maxSeq: number;
+  };
+  /** Content fingerprint at clone time, generated cells excluded. */
+  fingerprint: { hash: string; entities: number; excludedGenerated: number };
+}
+
+export interface CreateCloneOptions {
+  /** Path to a `.sqlite` snapshot (a server-side `VACUUM INTO` output). */
+  source: string;
+  /** Space DID; determines the on-disk filename the server resolves. */
+  space: string;
+  /** Destination clone directory. Created if absent, must be empty otherwise. */
+  targetDir: string;
+  /**
+   * Store directories that must never be written to — normally the live
+   * server's. Callers pass what the environment says (`MEMORY_DIR`/`DB_PATH`).
+   */
+  forbiddenDirs?: string[];
+  /** Timestamp source, injectable so tests need no clock. */
+  now?: () => Date;
+}
+
+export interface ClonePaths {
+  dir: string;
+  manifestPath: string;
+  pristinePath: string;
+  workingPath: string;
+}
+
+/** Where each artifact lives for a clone of `space` in `dir`. */
+export function clonePaths(dir: string, space: string): ClonePaths {
+  const file = `${space}.sqlite`;
+  return {
+    dir,
+    manifestPath: `${dir}/${MANIFEST}`,
+    pristinePath: `${dir}/${PRISTINE_DIR}/${file}`,
+    workingPath: `${dir}/${WORKING_DIR}/${file}`,
+  };
+}
+
+/**
+ * Build a clone from a snapshot: copy to `pristine/`, copy that to
+ * `engine-v3/`, and record a manifest.
+ *
+ * The source is never opened read-write and never mutated — it is read for
+ * hashing and copied. Refuses to write into a forbidden (live) store directory
+ * or into the source's own directory.
+ */
+export async function createClone(
+  options: CreateCloneOptions,
+): Promise<CloneManifest> {
+  const now = options.now ?? (() => new Date());
+  const dir = await resolvePath(options.targetDir);
+  const source = await resolvePath(options.source);
+
+  assertSafeTarget(dir, source, options.forbiddenDirs ?? []);
+  await assertEmptyOrAbsent(dir);
+
+  const paths = clonePaths(dir, options.space);
+  await Deno.mkdir(`${dir}/${PRISTINE_DIR}`, { recursive: true });
+  await Deno.mkdir(`${dir}/${WORKING_DIR}`, { recursive: true });
+
+  // Plain copies. `VACUUM INTO` server-side already produced a consistent,
+  // companion-free file; re-vacuuming here would need the live source, which by
+  // this point is typically an scp'd file on a laptop.
+  await Deno.copyFile(source, paths.pristinePath);
+  await Deno.copyFile(paths.pristinePath, paths.workingPath);
+
+  const snapshotHash = await hashFile(paths.pristinePath);
+  const snapshotBytes = (await Deno.stat(paths.pristinePath)).size;
+
+  const space = openSpace(paths.pristinePath);
+  let counts: CloneManifest["counts"];
+  let fingerprint: FingerprintReport;
+  try {
+    counts = storeCounts(space);
+    fingerprint = contentFingerprint(space);
+  } finally {
+    space.close();
+  }
+
+  const manifest: CloneManifest = {
+    version: 1,
+    space: options.space,
+    source: options.source,
+    createdAt: now().toISOString(),
+    snapshotHash,
+    snapshotBytes,
+    counts,
+    fingerprint: {
+      hash: fingerprint.hash,
+      entities: fingerprint.entities,
+      excludedGenerated: fingerprint.excludedGenerated,
+    },
+  };
+
+  await Deno.writeTextFile(
+    paths.manifestPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  await Deno.writeTextFile(
+    `${dir}/${MARKER}`,
+    `This directory is a CLONE of space ${options.space}, not production.\n` +
+      `Taken ${manifest.createdAt} from ${options.source}.\n` +
+      `Reset it with: cf space reset ${dir}\n`,
+  );
+  return manifest;
+}
+
+/**
+ * Restore the working copy from the pristine snapshot.
+ *
+ * Deletes the `-wal`/`-shm` companions the engine creates on open. Leaving them
+ * behind would let a checkpoint replay part of the discarded attempt over the
+ * fresh copy — a reset that silently isn't one.
+ */
+export async function resetClone(dir: string): Promise<CloneManifest> {
+  const manifest = await readManifest(dir);
+  const paths = clonePaths(await resolvePath(dir), manifest.space);
+  for (const suffix of ["", "-wal", "-shm"]) {
+    await Deno.remove(`${paths.workingPath}${suffix}`).catch((error) => {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+    });
+  }
+  await Deno.copyFile(paths.pristinePath, paths.workingPath);
+  return manifest;
+}
+
+export interface VerifyResult {
+  /** True when the baseline is intact AND the working copy still matches it. */
+  ok: boolean;
+  /** The pristine snapshot still hashes to what the manifest recorded. */
+  baselineIntact: boolean;
+  /** Working-copy counts, against the manifest's. */
+  counts: {
+    manifest: CloneManifest["counts"];
+    working: CloneManifest["counts"];
+  };
+  /** Working-copy content fingerprint, and whether it matches the baseline. */
+  fingerprint: {
+    manifest: string;
+    working: string;
+    match: boolean;
+    excludedGenerated: number;
+  };
+}
+
+/**
+ * Check a clone against its manifest: the baseline is what it claims to be, and
+ * the working copy still holds the same durable content.
+ *
+ * A migration rehearsal EXPECTS counts to grow — that is what a migration does.
+ * The fingerprint is the signal that matters: generated cells are excluded, so
+ * a clean pattern update should leave it unchanged even as commits climb.
+ */
+export async function verifyClone(dir: string): Promise<VerifyResult> {
+  const manifest = await readManifest(dir);
+  const paths = clonePaths(await resolvePath(dir), manifest.space);
+
+  const baselineIntact = await hashFile(paths.pristinePath) ===
+    manifest.snapshotHash;
+
+  const space = openSpace(paths.workingPath);
+  let counts: CloneManifest["counts"];
+  let fingerprint: FingerprintReport;
+  try {
+    counts = storeCounts(space);
+    fingerprint = contentFingerprint(space);
+  } finally {
+    space.close();
+  }
+
+  const match = fingerprint.hash === manifest.fingerprint.hash;
+  return {
+    ok: baselineIntact && match,
+    baselineIntact,
+    counts: { manifest: manifest.counts, working: counts },
+    fingerprint: {
+      manifest: manifest.fingerprint.hash,
+      working: fingerprint.hash,
+      match,
+      excludedGenerated: fingerprint.excludedGenerated,
+    },
+  };
+}
+
+/** Read and validate a clone manifest. */
+export async function readManifest(dir: string): Promise<CloneManifest> {
+  const path = `${await resolvePath(dir)}/${MANIFEST}`;
+  let text: string;
+  try {
+    text = await Deno.readTextFile(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new Error(`${dir} is not a clone directory (no ${MANIFEST}).`);
+    }
+    throw error;
+  }
+  const parsed = JSON.parse(text) as CloneManifest;
+  if (parsed.version !== 1) {
+    throw new Error(
+      `${path} has manifest version ${parsed.version}; this tool understands 1.`,
+    );
+  }
+  return parsed;
+}
+
+function storeCounts(
+  space: ReturnType<typeof openSpace>,
+): CloneManifest["counts"] {
+  const one = <T extends object>(sql: string): T =>
+    space.db.prepare(sql).get<T>() as T;
+  const c = one<{ n: number; hi: number | null }>(
+    `SELECT count(*) n, max(seq) hi FROM "commit"`,
+  );
+  const r = one<{ n: number; e: number }>(
+    `SELECT count(*) n, count(DISTINCT id) e FROM revision`,
+  );
+  return { commits: c.n, revisions: r.n, entities: r.e, maxSeq: c.hi ?? 0 };
+}
+
+/**
+ * SHA-256 of a file, streamed through the canonical hasher
+ * (`@commonfabric/content-hash`) so a multi-GB store never lands in memory.
+ */
+async function hashFile(path: string): Promise<string> {
+  const hasher = createHasher();
+  using file = await Deno.open(path, { read: true });
+  for await (const chunk of file.readable) hasher.update(chunk);
+  return hasher.digest("base64url");
+}
+
+async function resolvePath(path: string): Promise<string> {
+  // realPath needs the path to exist; fall back to the literal for a target
+  // directory we are about to create.
+  try {
+    return await Deno.realPath(path);
+  } catch {
+    return path.replace(/\/+$/, "");
+  }
+}
+
+function isWithin(child: string, parent: string): boolean {
+  return child === parent || child.startsWith(`${parent}/`);
+}
+
+/**
+ * The rail that matters: never write a clone into the store a live server is
+ * serving, and never into the source's own directory.
+ *
+ * Explicit path refusal, not a "looks like production" heuristic — a guess that
+ * says yes when it should say no is worse than no check at all.
+ */
+function assertSafeTarget(
+  dir: string,
+  source: string,
+  forbiddenDirs: string[],
+): void {
+  const sourceDir = source.replace(/\/[^/]*$/, "");
+  if (isWithin(dir, sourceDir) || isWithin(sourceDir, dir)) {
+    throw new Error(
+      `refusing to clone into the snapshot's own directory (${sourceDir}).`,
+    );
+  }
+  for (const raw of forbiddenDirs) {
+    const forbidden = raw.replace(/\/+$/, "");
+    if (forbidden === "") continue;
+    if (isWithin(dir, forbidden) || isWithin(forbidden, dir)) {
+      throw new Error(
+        `refusing to write a clone into ${dir}: it overlaps the live store ` +
+          `directory ${forbidden}. Pick a target outside it.`,
+      );
+    }
+  }
+}
+
+/** A clone directory must not silently merge into existing contents. */
+async function assertEmptyOrAbsent(dir: string): Promise<void> {
+  try {
+    for await (const entry of Deno.readDir(dir)) {
+      throw new Error(
+        `${dir} is not empty (found ${entry.name}); pick a fresh directory or ` +
+          `remove it first.`,
+      );
+    }
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) throw error;
+  }
+}

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -35,6 +35,25 @@ import { listScopes } from "./scopes.ts";
 const ENUMERATION_CAP = 1_000_000;
 
 /**
+ * Hash one entity's durable value, reporting a rejection instead of throwing.
+ *
+ * `hashOf` refuses values it has no canonical form for (functions, symbols,
+ * unsupported object types such as `Map`, cyclic structures). Nothing stored
+ * today decodes to one, but `decodeStored` spans several at-rest formats, and a
+ * single odd entity must not abort a whole-space fingerprint — nor be quietly
+ * treated as empty, which would let real content drift read as "unchanged".
+ */
+export function hashEntityValue(
+  value: unknown,
+): { hash: string } | { error: string } {
+  try {
+    return { hash: hashOf(value).toString() };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
  * Every entity in the space, across EVERY scope.
  *
  * `listEntityModels` defaults to `scope: "space"`, which on a real store
@@ -43,19 +62,23 @@ const ENUMERATION_CAP = 1_000_000;
  * damage just as easily, so the fingerprint walks the scopes `listScopes`
  * reports rather than assuming one.
  */
-function allEntities(space: SpaceDb, branch: string): EntityModel[] {
+function allEntities(
+  space: SpaceDb,
+  branch: string,
+  cap: number = ENUMERATION_CAP,
+): EntityModel[] {
   const out: EntityModel[] = [];
   for (const scope of listScopes(space, { branch })) {
     const models = listEntityModels(space, {
       branch,
       scope: scope.raw,
-      limit: ENUMERATION_CAP,
+      limit: cap,
     });
-    if (models.length >= ENUMERATION_CAP) {
+    if (models.length >= cap) {
       throw new Error(
         `scope ${scope.raw} enumerates ${models.length}+ entities, at or above ` +
-          `the ${ENUMERATION_CAP} cap; refusing to fingerprint a possibly ` +
-          `truncated enumeration.`,
+          `the ${cap} cap; refusing to fingerprint a possibly truncated ` +
+          `enumeration.`,
       );
     }
     out.push(...models);
@@ -96,6 +119,12 @@ export interface FingerprintReport {
 export interface FingerprintOptions {
   branch?: string;
   /**
+   * Refuse rather than fingerprint a space whose scope enumerates at or above
+   * this many entities, since the enumeration may have been truncated. Defaults
+   * to 1,000,000 — far above any real space; raise it only knowingly.
+   */
+  enumerationCap?: number;
+  /**
    * Include compiler-generated internal cells. Default false. Turning this on
    * makes the fingerprint change on every pattern update by design; it exists
    * for "what moved at all?", not for "did content survive?".
@@ -113,11 +142,17 @@ export interface FingerprintOptions {
  */
 export function generatedInternalCellIds(
   space: SpaceDb,
-  options: { branch?: string } = {},
+  options: { branch?: string; enumerationCap?: number } = {},
 ): { generated: Set<string>; named: Set<string> } {
   const generated = new Set<string>();
   const named = new Set<string>();
-  for (const model of allEntities(space, options.branch ?? "")) {
+  for (
+    const model of allEntities(
+      space,
+      options.branch ?? "",
+      options.enumerationCap,
+    )
+  ) {
     if (model.kind !== "piece") continue;
     const doc = reconstructDocument(space, {
       id: model.id,
@@ -164,14 +199,17 @@ export function contentFingerprint(
   const branch = options.branch ?? "";
   const { generated, named } = options.includeGenerated
     ? { generated: new Set<string>(), named: new Set<string>() }
-    : generatedInternalCellIds(space, { branch });
+    : generatedInternalCellIds(space, {
+      branch,
+      enumerationCap: options.enumerationCap,
+    });
 
   const ambiguous = [...generated].filter((id) => named.has(id)).sort();
   const perEntity: EntityFingerprint[] = [];
   const unhashable: { id: string; reason: string }[] = [];
   let excludedGenerated = 0;
 
-  for (const model of allEntities(space, branch)) {
+  for (const model of allEntities(space, branch, options.enumerationCap)) {
     if (generated.has(model.id)) {
       excludedGenerated++;
       continue;
@@ -183,18 +221,12 @@ export function contentFingerprint(
     const value = (doc as Record<string, unknown> | undefined)?.value;
     let hash: string | null = null;
     if (value !== undefined) {
-      try {
-        hash = hashOf(value).toString();
-      } catch (error) {
-        // A value the canonical hasher rejects must be reported, not treated as
-        // absent — silently hashing it to null would let real content drift
-        // through as "unchanged".
-        unhashable.push({
-          id: model.id,
-          reason: error instanceof Error ? error.message : String(error),
-        });
+      const hashed = hashEntityValue(value);
+      if ("error" in hashed) {
+        unhashable.push({ id: model.id, reason: hashed.error });
         continue;
       }
+      hash = hashed.hash;
     }
     perEntity.push({
       id: model.id,

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -20,6 +20,7 @@
 // from the engine's notion of value identity.
 
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { utf8Compare } from "@commonfabric/utils/utf8";
 import type { SpaceDb } from "./db.ts";
 import { type EntityModel, listEntityModels } from "./model.ts";
 import { reconstructDocument } from "./reconstruct.ts";
@@ -204,7 +205,9 @@ export function contentFingerprint(
       enumerationCap: options.enumerationCap,
     });
 
-  const ambiguous = [...generated].filter((id) => named.has(id)).sort();
+  const ambiguous = [...generated].filter((id) => named.has(id)).sort(
+    utf8Compare,
+  );
   const perEntity: EntityFingerprint[] = [];
   const unhashable: { id: string; reason: string }[] = [];
   let excludedGenerated = 0;
@@ -238,7 +241,7 @@ export function contentFingerprint(
 
   // Sort so the roll-up is independent of enumeration order.
   perEntity.sort((a, b) =>
-    a.id === b.id ? compare(a.scope, b.scope) : compare(a.id, b.id)
+    a.id === b.id ? utf8Compare(a.scope, b.scope) : utf8Compare(a.id, b.id)
   );
 
   return {
@@ -251,15 +254,6 @@ export function contentFingerprint(
     unhashable,
     perEntity,
   };
-}
-
-/**
- * Byte-order string compare. `@commonfabric/utils/utf8` owns cross-platform
- * ordering; state-inspector is deliberately dep-light, and this only orders a
- * local array before hashing, so it uses the same code-point rule inline.
- */
-function compare(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 export interface FingerprintDiff {
@@ -292,9 +286,9 @@ export function diffFingerprints(
     else if (other.hash !== e.hash) changed.push(e.id);
   }
 
-  added.sort(compare);
-  removed.sort(compare);
-  changed.sort(compare);
+  added.sort(utf8Compare);
+  removed.sort(utf8Compare);
+  changed.sort(utf8Compare);
   return {
     equal: added.length === 0 && removed.length === 0 && changed.length === 0,
     added,

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -1,0 +1,272 @@
+// Durable-content fingerprints — "did this space's content survive?" as a
+// number you can compare, and a diff when it didn't.
+//
+// Why (docs/plans/space-clone-rehearsal.md): the July 2026 Topics rehearsal
+// verified content preservation with ad-hoc SQL and Python heredocs written
+// fresh each attempt. Two rehearsals whose fingerprints were computed
+// differently cannot be compared, and an improvised check that quietly measures
+// less than last time looks exactly like a pass. This is that check, computed
+// one way.
+//
+// COMPILER-GENERATED CELLS ARE EXCLUDED BY DEFAULT. A pattern update rotates
+// generated internal-cell identities on purpose (labs#4916), so including them
+// guarantees the fingerprint changes on every legitimate migration — which
+// makes it useless as a "content survived" signal. Verified against the real
+// Estuary Topics store: all 20 write-storm cells (192,381 revisions, 90.3% of
+// every revision) are `$generated`, and NONE of them is authored content.
+//
+// Hashing goes through `@commonfabric/data-model/value-hash` — the same
+// canonicalizing hash the runtime derives entity ids with, so this cannot drift
+// from the engine's notion of value identity.
+
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import type { SpaceDb } from "./db.ts";
+import { type EntityModel, listEntityModels } from "./model.ts";
+import { reconstructDocument } from "./reconstruct.ts";
+import { listScopes } from "./scopes.ts";
+
+/**
+ * `listEntityModels` caps at 5,000 by default — a real Estuary space already
+ * exceeds that. A fingerprint computed over a truncated enumeration would still
+ * return a confident-looking hash, which is the exact failure this whole module
+ * exists to prevent, so we raise the cap and REFUSE when even that is reached
+ * rather than hash a partial space.
+ */
+const ENUMERATION_CAP = 1_000_000;
+
+/**
+ * Every entity in the space, across EVERY scope.
+ *
+ * `listEntityModels` defaults to `scope: "space"`, which on a real store
+ * silently omits all PerUser/PerSession state (579 of 6,379 entities on the
+ * Estuary Topics store). Per-scope state is durable content a migration can
+ * damage just as easily, so the fingerprint walks the scopes `listScopes`
+ * reports rather than assuming one.
+ */
+function allEntities(space: SpaceDb, branch: string): EntityModel[] {
+  const out: EntityModel[] = [];
+  for (const scope of listScopes(space, { branch })) {
+    const models = listEntityModels(space, {
+      branch,
+      scope: scope.raw,
+      limit: ENUMERATION_CAP,
+    });
+    if (models.length >= ENUMERATION_CAP) {
+      throw new Error(
+        `scope ${scope.raw} enumerates ${models.length}+ entities, at or above ` +
+          `the ${ENUMERATION_CAP} cap; refusing to fingerprint a possibly ` +
+          `truncated enumeration.`,
+      );
+    }
+    out.push(...models);
+  }
+  return out;
+}
+
+/** One entity's content hash at head. */
+export interface EntityFingerprint {
+  id: string;
+  scope: string;
+  /** Entity classification (`piece`, `cell`, …) as the model reports it. */
+  kind: string;
+  /** `hashOf` the entity's durable `value`, or null when it has no value. */
+  hash: string | null;
+}
+
+export interface FingerprintReport {
+  /** Hash over every included entity's (id, scope, hash) — the one number. */
+  hash: string;
+  /** Entities included in `hash`. */
+  entities: number;
+  /** Internal cells skipped because a manifest calls them compiler-generated. */
+  excludedGenerated: number;
+  /**
+   * Ids some manifest calls generated and another calls named. Counted as
+   * generated (rotation-prone wins, so the fingerprint stays stable) but
+   * reported, because that choice can hide a real content change and must never
+   * be silent. Zero on every store observed so far.
+   */
+  ambiguous: string[];
+  /** Entities whose value could not be hashed, with the reason. Never silent. */
+  unhashable: { id: string; reason: string }[];
+  /** Per-entity hashes, id-sorted — the input to `diffFingerprints`. */
+  perEntity: EntityFingerprint[];
+}
+
+export interface FingerprintOptions {
+  branch?: string;
+  /**
+   * Include compiler-generated internal cells. Default false. Turning this on
+   * makes the fingerprint change on every pattern update by design; it exists
+   * for "what moved at all?", not for "did content survive?".
+   */
+  includeGenerated?: boolean;
+}
+
+/**
+ * Entity ids that some piece's `internal` manifest attributes to a
+ * compiler-generated cause (`partialCause: { $generated: N }`) rather than an
+ * authored name (`partialCause: "entries"`).
+ *
+ * The manifest is the only place this distinction is recorded: entity ids are
+ * content hashes and carry no marker of their own.
+ */
+export function generatedInternalCellIds(
+  space: SpaceDb,
+  options: { branch?: string } = {},
+): { generated: Set<string>; named: Set<string> } {
+  const generated = new Set<string>();
+  const named = new Set<string>();
+  for (const model of allEntities(space, options.branch ?? "")) {
+    if (model.kind !== "piece") continue;
+    const doc = reconstructDocument(space, {
+      id: model.id,
+      scope: model.scope,
+    });
+    const internal = (doc as Record<string, unknown> | undefined)?.internal;
+    if (!Array.isArray(internal)) continue;
+    for (const entry of internal) {
+      const id = manifestLinkId(entry);
+      if (id === undefined) continue;
+      if (isGeneratedCause((entry as Record<string, unknown>).partialCause)) {
+        generated.add(id);
+      } else {
+        named.add(id);
+      }
+    }
+  }
+  return { generated, named };
+}
+
+/** `{ $generated: N }` — the compiler's anonymous per-build ordinal. */
+function isGeneratedCause(cause: unknown): boolean {
+  return typeof cause === "object" && cause !== null && "$generated" in cause;
+}
+
+/** The link target id of a manifest entry (`{ partialCause, link }`). */
+function manifestLinkId(entry: unknown): string | undefined {
+  if (typeof entry !== "object" || entry === null) return undefined;
+  const link = (entry as Record<string, unknown>).link;
+  if (typeof link !== "object" || link === null) return undefined;
+  const envelope = (link as Record<string, unknown>)["/"];
+  if (typeof envelope !== "object" || envelope === null) return undefined;
+  const payload = (envelope as Record<string, unknown>)["link@1"];
+  if (typeof payload !== "object" || payload === null) return undefined;
+  const id = (payload as Record<string, unknown>).id;
+  return typeof id === "string" ? id : undefined;
+}
+
+/** Content fingerprint of a space at head. */
+export function contentFingerprint(
+  space: SpaceDb,
+  options: FingerprintOptions = {},
+): FingerprintReport {
+  const branch = options.branch ?? "";
+  const { generated, named } = options.includeGenerated
+    ? { generated: new Set<string>(), named: new Set<string>() }
+    : generatedInternalCellIds(space, { branch });
+
+  const ambiguous = [...generated].filter((id) => named.has(id)).sort();
+  const perEntity: EntityFingerprint[] = [];
+  const unhashable: { id: string; reason: string }[] = [];
+  let excludedGenerated = 0;
+
+  for (const model of allEntities(space, branch)) {
+    if (generated.has(model.id)) {
+      excludedGenerated++;
+      continue;
+    }
+    const doc = reconstructDocument(space, {
+      id: model.id,
+      scope: model.scope,
+    });
+    const value = (doc as Record<string, unknown> | undefined)?.value;
+    let hash: string | null = null;
+    if (value !== undefined) {
+      try {
+        hash = hashOf(value).toString();
+      } catch (error) {
+        // A value the canonical hasher rejects must be reported, not treated as
+        // absent — silently hashing it to null would let real content drift
+        // through as "unchanged".
+        unhashable.push({
+          id: model.id,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+        continue;
+      }
+    }
+    perEntity.push({
+      id: model.id,
+      scope: model.scope,
+      kind: model.kind,
+      hash,
+    });
+  }
+
+  // Sort so the roll-up is independent of enumeration order.
+  perEntity.sort((a, b) =>
+    a.id === b.id ? compare(a.scope, b.scope) : compare(a.id, b.id)
+  );
+
+  return {
+    hash: hashOf(
+      perEntity.map((e) => [e.id, e.scope, e.hash] as const),
+    ).toString(),
+    entities: perEntity.length,
+    excludedGenerated,
+    ambiguous,
+    unhashable,
+    perEntity,
+  };
+}
+
+/**
+ * Byte-order string compare. `@commonfabric/utils/utf8` owns cross-platform
+ * ordering; state-inspector is deliberately dep-light, and this only orders a
+ * local array before hashing, so it uses the same code-point rule inline.
+ */
+function compare(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export interface FingerprintDiff {
+  equal: boolean;
+  added: string[];
+  removed: string[];
+  changed: string[];
+}
+
+/**
+ * What moved between two fingerprints. This is the answer a rehearsal actually
+ * needs: not "the fingerprint differs" but "these three topic bodies differ".
+ */
+export function diffFingerprints(
+  before: FingerprintReport,
+  after: FingerprintReport,
+): FingerprintDiff {
+  const key = (e: EntityFingerprint) => `${e.id} ${e.scope}`;
+  const a = new Map(before.perEntity.map((e) => [key(e), e]));
+  const b = new Map(after.perEntity.map((e) => [key(e), e]));
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+
+  for (const [k, e] of b) if (!a.has(k)) added.push(e.id);
+  for (const [k, e] of a) {
+    const other = b.get(k);
+    if (other === undefined) removed.push(e.id);
+    else if (other.hash !== e.hash) changed.push(e.id);
+  }
+
+  added.sort(compare);
+  removed.sort(compare);
+  changed.sort(compare);
+  return {
+    equal: added.length === 0 && removed.length === 0 && changed.length === 0,
+    added,
+    removed,
+    changed,
+  };
+}

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -21,6 +21,8 @@ export * from "./identity.ts";
 export * from "./churn.ts";
 export * from "./conflicts.ts";
 export * from "./oracle.ts";
+export * from "./clone.ts";
+export * from "./fingerprint.ts";
 export * from "./detail.ts";
 export * from "./html.ts";
 export * from "./scheduler.ts";

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -231,6 +231,61 @@ Deno.test("refuses to write into the live store directory", async () => {
   });
 });
 
+Deno.test("the live-store refusal survives a RELATIVE target path", async () => {
+  // Regression: every other fixture here uses absolute temp-dir paths, and the
+  // rail passed for all of them while a relative `--to` sailed straight
+  // through — a relative path can never overlap an absolute forbidden one, so
+  // the clone landed inside the live store under a banner saying it had not.
+  await withDirs(async ({ root, source }) => {
+    const live = `${root}/live-memory`;
+    await Deno.mkdir(live);
+    const cwd = Deno.cwd();
+    Deno.chdir(root);
+    try {
+      await assertRejects(
+        () =>
+          createClone({
+            source,
+            space: SPACE,
+            targetDir: "./live-memory/clone", // relative, as a shell user types
+            forbiddenDirs: [live],
+            now: NOW,
+          }),
+        Error,
+        "overlaps the live store directory",
+      );
+    } finally {
+      Deno.chdir(cwd);
+    }
+    assertEquals(await exists(`${live}/clone`), false);
+  });
+});
+
+Deno.test("a symlinked spelling of the live store is still refused", async () => {
+  // On macOS `/tmp` is a symlink to `/private/tmp`, so the same directory has
+  // two spellings. Comparing them unresolved would miss the overlap.
+  await withDirs(async ({ root, source }) => {
+    const live = `${root}/live-memory`;
+    await Deno.mkdir(live);
+    const alias = `${root}/live-alias`;
+    await Deno.symlink(live, alias);
+
+    await assertRejects(
+      () =>
+        createClone({
+          source,
+          space: SPACE,
+          targetDir: `${alias}/clone`, // same directory, different spelling
+          forbiddenDirs: [live],
+          now: NOW,
+        }),
+      Error,
+      "overlaps the live store directory",
+    );
+    assertEquals(await exists(`${live}/clone`), false);
+  });
+});
+
 Deno.test("refuses to clone into the snapshot's own directory", async () => {
   await withDirs(async ({ source }) => {
     await assertRejects(

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -1,0 +1,279 @@
+// A clone exists so a rehearsal can be run, judged, and REPEATED from an
+// identical baseline. These tests pin the three properties that makes true:
+// the source is never touched, a reset really discards the attempt, and verify
+// can tell a clean migration from data loss.
+
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import {
+  clonePaths,
+  createClone,
+  readManifest,
+  resetClone,
+  verifyClone,
+} from "../clone.ts";
+
+const SPACE = "did:key:z6MkExampleSpace";
+const SESSION = "session:did:key:zSpaceAAAA:11111111-2222-3333";
+const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
+const NOW = () => new Date("2026-07-27T12:00:00.000Z");
+
+const link = (id: string) => ({ "/": { "link@1": { id, path: [] } } });
+
+/** A source store shaped like a real one: a piece with one named and one
+ *  generated internal cell, plus its input. */
+function seedSource(path: string): void {
+  const db = new Database(path, { create: true });
+  db.exec(`
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);`);
+  writeDocs(db, [
+    ["of:piece", {
+      value: { $NAME: "Board" },
+      argument: link("of:input"),
+      internal: [
+        { partialCause: "entries", link: link("of:named") },
+        { partialCause: { $generated: 0 }, link: link("of:generated") },
+      ],
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+      schema: { type: "object", properties: {}, $defs: {} },
+    }],
+    ["of:input", { value: { title: "a topic" } }],
+    ["of:named", { value: "named-v1", result: link("of:piece") }],
+    ["of:generated", { value: "generated-v1", result: link("of:piece") }],
+  ]);
+  db.close();
+}
+
+/** Append documents to an existing store, continuing its seq sequence. */
+function writeDocs(db: Database, docs: [string, unknown][]): void {
+  const next = db.prepare(`SELECT coalesce(max(seq), 0) s FROM "commit"`)
+    .get<{ s: number }>()!.s;
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, '{}', '{}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, scope_key, seq, op_index, op, data, commit_seq)
+     VALUES (?, 'space', ?, 0, 'set', ?, ?)`,
+  );
+  docs.forEach(([id, doc], i) => {
+    const seq = next + i + 1;
+    commit.run(seq, SESSION, seq);
+    rev.run(id, seq, JSON.stringify(doc), seq);
+  });
+}
+
+/** Apply writes to a store on disk (what a rehearsal's migration would do). */
+function mutate(path: string, docs: [string, unknown][]): void {
+  const db = new Database(path);
+  writeDocs(db, docs);
+  db.close();
+}
+
+async function withDirs(
+  run: (t: { root: string; source: string; clone: string }) => Promise<void>,
+): Promise<void> {
+  const root = await Deno.makeTempDir({ prefix: "clone-test-" });
+  try {
+    const sourceDir = `${root}/source`;
+    await Deno.mkdir(sourceDir);
+    const source = `${sourceDir}/${SPACE}.sqlite`;
+    seedSource(source);
+    await run({ root, source, clone: `${root}/clone` });
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+}
+
+Deno.test("a clone is servable, recorded, and leaves the source untouched", async () => {
+  await withDirs(async ({ source, clone }) => {
+    const before = await Deno.readFile(source);
+    const manifest = await createClone({
+      source,
+      space: SPACE,
+      targetDir: clone,
+      now: NOW,
+    });
+
+    const paths = clonePaths(clone, SPACE);
+    // The working copy sits where the memory server resolves a space store, so
+    // pointing MEMORY_DIR at the clone dir serves it under the same DID.
+    assert(paths.workingPath.endsWith(`engine-v3/${SPACE}.sqlite`));
+    assertEquals((await Deno.stat(paths.workingPath)).isFile, true);
+    assertEquals((await Deno.stat(paths.pristinePath)).isFile, true);
+    assertEquals((await Deno.stat(`${clone}/.cf-clone`)).isFile, true);
+
+    assertEquals(manifest.space, SPACE);
+    assertEquals(manifest.createdAt, "2026-07-27T12:00:00.000Z");
+    assertEquals(manifest.counts.commits, 4);
+    assertEquals(manifest.counts.entities, 4);
+    // One generated cell excluded; the piece, input and named cell remain.
+    assertEquals(manifest.fingerprint.excludedGenerated, 1);
+    assertEquals(manifest.fingerprint.entities, 3);
+
+    assertEquals(await Deno.readFile(source), before, "source is untouched");
+    assertEquals(await readManifest(clone), manifest, "manifest round-trips");
+  });
+});
+
+Deno.test("a clean migration keeps the fingerprint even as commits climb", async () => {
+  // The whole reason generated cells are excluded. A pattern update rotates
+  // them and adds commits; content is unchanged, so verify must still pass.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+
+    mutate(paths.workingPath, [
+      ["of:generated", { value: "generated-v2", result: link("of:piece") }],
+      ["of:generated", { value: "generated-v3", result: link("of:piece") }],
+    ]);
+
+    const v = await verifyClone(clone);
+    assert(v.ok, "a generated-cell rewrite is not a content change");
+    assert(v.fingerprint.match);
+    assert(
+      v.counts.working.commits > v.counts.manifest.commits,
+      "counts grew, as a migration should",
+    );
+  });
+});
+
+Deno.test("verify catches a real content change", async () => {
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+
+    mutate(paths.workingPath, [["of:input", {
+      value: { title: "CLOBBERED" },
+    }]]);
+
+    const v = await verifyClone(clone);
+    assert(!v.ok, "authored content moved");
+    assert(!v.fingerprint.match);
+    assert(v.baselineIntact, "the baseline itself is still fine");
+  });
+});
+
+Deno.test("reset discards the attempt, including WAL companions", async () => {
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+
+    // Open in WAL like the engine does, so real companions exist to clean up.
+    const db = new Database(paths.workingPath);
+    db.exec("PRAGMA journal_mode = WAL");
+    db.close();
+    mutate(paths.workingPath, [["of:input", {
+      value: { title: "CLOBBERED" },
+    }]]);
+    assert(!(await verifyClone(clone)).ok, "the attempt landed");
+
+    await resetClone(clone);
+
+    for (const suffix of ["-wal", "-shm"]) {
+      await assertRejects(
+        () => Deno.stat(`${paths.workingPath}${suffix}`),
+        Deno.errors.NotFound,
+        undefined,
+        `${suffix} must not survive a reset`,
+      );
+    }
+    const v = await verifyClone(clone);
+    assert(v.ok, "back to baseline");
+    assertEquals(v.counts.working.commits, v.counts.manifest.commits);
+  });
+});
+
+Deno.test("verify reports a corrupted baseline rather than trusting it", async () => {
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+    // A baseline that rotted is not a baseline; resetting to it would silently
+    // rehearse against the wrong data.
+    mutate(paths.pristinePath, [["of:input", { value: { title: "rot" } }]]);
+
+    const v = await verifyClone(clone);
+    assert(!v.baselineIntact);
+    assert(!v.ok);
+  });
+});
+
+Deno.test("refuses to write into the live store directory", async () => {
+  await withDirs(async ({ root, source, clone }) => {
+    const live = `${root}/live-memory`;
+    await Deno.mkdir(live);
+    await assertRejects(
+      () =>
+        createClone({
+          source,
+          space: SPACE,
+          targetDir: `${live}/nested`,
+          forbiddenDirs: [live],
+          now: NOW,
+        }),
+      Error,
+      "overlaps the live store directory",
+    );
+    assertEquals(await exists(clone), false);
+  });
+});
+
+Deno.test("refuses to clone into the snapshot's own directory", async () => {
+  await withDirs(async ({ source }) => {
+    await assertRejects(
+      () =>
+        createClone({
+          source,
+          space: SPACE,
+          targetDir: source.replace(/\/[^/]*$/, ""),
+          now: NOW,
+        }),
+      Error,
+      "snapshot's own directory",
+    );
+  });
+});
+
+Deno.test("refuses a non-empty target rather than merging into it", async () => {
+  await withDirs(async ({ source, clone }) => {
+    await Deno.mkdir(clone, { recursive: true });
+    await Deno.writeTextFile(`${clone}/something.txt`, "prior contents");
+    await assertRejects(
+      () => createClone({ source, space: SPACE, targetDir: clone, now: NOW }),
+      Error,
+      "is not empty",
+    );
+  });
+});
+
+Deno.test("a directory without a manifest is not a clone", async () => {
+  await withDirs(async ({ root }) => {
+    await assertRejects(
+      () => verifyClone(root),
+      Error,
+      "is not a clone directory",
+    );
+  });
+});
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -269,6 +269,95 @@ Deno.test("a directory without a manifest is not a clone", async () => {
   });
 });
 
+Deno.test("reset works on a clone that was never opened", async () => {
+  // The common case at the START of a rehearsal: no engine has run yet, so
+  // there are no WAL companions to remove. Absent companions are not an error.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+    assertEquals(await exists(`${paths.workingPath}-wal`), false);
+
+    await resetClone(clone);
+    assert((await verifyClone(clone)).ok);
+  });
+});
+
+Deno.test("a manifest from a future tool version is refused, not guessed at", async () => {
+  // Reading a newer layout with older rules could reset to the wrong file or
+  // compare against a fingerprint computed a different way.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const manifestPath = `${clone}/clone.json`;
+    const manifest = JSON.parse(await Deno.readTextFile(manifestPath));
+    await Deno.writeTextFile(
+      manifestPath,
+      JSON.stringify({ ...manifest, version: 2 }),
+    );
+
+    await assertRejects(
+      () => readManifest(clone),
+      Error,
+      "this tool understands 1",
+    );
+  });
+});
+
+Deno.test("an unreadable manifest surfaces its real error", async () => {
+  // Only ENOENT means "not a clone". Any other IO failure must not be
+  // reported as a missing manifest — that would send an operator looking in
+  // the wrong place.
+  await withDirs(async ({ root }) => {
+    const dir = `${root}/odd-clone`;
+    await Deno.mkdir(`${dir}/clone.json`, { recursive: true });
+    const error = await assertRejects(() => readManifest(dir), Error);
+    assert(
+      !error.message.includes("is not a clone directory"),
+      `expected the underlying IO error, got: ${error.message}`,
+    );
+  });
+});
+
+Deno.test("a filesystem error other than 'absent' is surfaced, not swallowed", async () => {
+  // Only ENOENT means "nothing there". Treating any other failure as absent
+  // would let `createClone` merge onto occupied ground, or let `reset` skip a
+  // file it failed to delete and call the clone pristine. A path whose parent
+  // component is a regular file yields NotADirectory — deterministically, with
+  // no permission games that a root-running CI would bypass.
+  await withDirs(async ({ root, source }) => {
+    const regularFile = `${root}/not-a-dir.txt`;
+    await Deno.writeTextFile(regularFile, "x");
+    const error = await assertRejects(
+      () =>
+        createClone({
+          source,
+          space: SPACE,
+          targetDir: `${regularFile}/clone`,
+          now: NOW,
+        }),
+      Error,
+    );
+    assert(
+      error instanceof Deno.errors.NotADirectory,
+      `expected the real IO error, got ${error.constructor.name}`,
+    );
+  });
+});
+
+Deno.test("an empty forbidden-directory entry is ignored, not treated as '/'", async () => {
+  // The CLI builds this list from the environment, where an unset variable can
+  // arrive as "". Treating that as a path prefix would refuse every target.
+  await withDirs(async ({ source, clone }) => {
+    const manifest = await createClone({
+      source,
+      space: SPACE,
+      targetDir: clone,
+      forbiddenDirs: ["", "  ", "/definitely/not/this/one"],
+      now: NOW,
+    });
+    assertEquals(manifest.space, SPACE);
+  });
+});
+
 async function exists(path: string): Promise<boolean> {
   try {
     await Deno.stat(path);

--- a/packages/state-inspector/test/fingerprint.test.ts
+++ b/packages/state-inspector/test/fingerprint.test.ts
@@ -1,0 +1,246 @@
+// The fingerprint's contract is one sentence: a legitimate pattern update must
+// not move it, and a content change must. Everything here pins one half of that.
+//
+// The load-bearing case is `generated cells are excluded`: compiler-generated
+// internal cells rotate their identities on every pattern update by design
+// (labs#4916), so a fingerprint that counted them would change on every clean
+// migration and answer no question at all. Verified against the real Estuary
+// Topics store, where all 20 write-storm cells are `$generated` and none is
+// authored content.
+
+import { assert, assertEquals } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import { openSpace, type SpaceDb } from "../db.ts";
+import {
+  contentFingerprint,
+  diffFingerprints,
+  generatedInternalCellIds,
+} from "../fingerprint.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+`;
+
+const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
+const SESSION = "session:did:key:zSpaceAAAA:11111111-2222-3333";
+
+const link = (id: string) => ({ "/": { "link@1": { id, path: [] } } });
+
+interface Doc {
+  id: string;
+  doc: Record<string, unknown>;
+  scope?: string;
+}
+
+/**
+ * A space holding one piece whose manifest names `of:named` as authored
+ * (`partialCause: "entries"`) and `of:generated` as compiler-generated
+ * (`partialCause: { $generated: 0 }`) — the exact shape observed in a real
+ * store — plus whatever extra docs a case needs.
+ */
+function seed(path: string, extra: Doc[] = []): void {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, '{}', '{}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, scope_key, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, ?, 0, 'set', ?, ?)`,
+  );
+  let seq = 0;
+  const write = (id: string, doc: unknown, scope = "space") => {
+    const s = ++seq;
+    commit.run(s, SESSION, s);
+    rev.run(id, scope, s, JSON.stringify(doc), s);
+  };
+
+  write("of:piece", {
+    value: { $NAME: "Board" },
+    argument: link("of:input"),
+    internal: [
+      { partialCause: "entries", link: link("of:named") },
+      { partialCause: { $generated: 0 }, link: link("of:generated") },
+    ],
+    patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+    schema: { type: "object", properties: {}, $defs: {} },
+  });
+  write("of:input", { value: { title: "untitled" } });
+  write("of:named", { value: "named-v1", result: link("of:piece") });
+  write("of:generated", { value: "generated-v1", result: link("of:piece") });
+
+  for (const e of extra) write(e.id, e.doc, e.scope ?? "space");
+  db.close();
+}
+
+function withSpace(extra: Doc[], run: (s: SpaceDb) => void): void {
+  const dir = Deno.makeTempDirSync({ prefix: "fingerprint-test-" });
+  try {
+    const path = `${dir}/space.sqlite`;
+    seed(path, extra);
+    const space = openSpace(path);
+    try {
+      run(space);
+    } finally {
+      space.close();
+    }
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
+  }
+}
+
+/** The fingerprint of the base space, plus one extra/overriding document. */
+function hashWith(extra: Doc[]): string {
+  let hash = "";
+  withSpace(extra, (s) => {
+    hash = contentFingerprint(s).hash;
+  });
+  return hash;
+}
+
+Deno.test("the manifest classifies generated vs authored internal cells", () => {
+  withSpace([], (space) => {
+    const { generated, named } = generatedInternalCellIds(space);
+    assert(generated.has("of:generated"));
+    assert(named.has("of:named"));
+    assert(!generated.has("of:named"));
+  });
+});
+
+Deno.test("a generated cell's value does not move the fingerprint", () => {
+  // THE contract. A pattern update rewrites generated cells by design; if that
+  // moved the fingerprint, every clean migration would look like data loss.
+  const base = hashWith([]);
+  const generatedChanged = hashWith([
+    {
+      id: "of:generated",
+      doc: { value: "generated-v2", result: link("of:piece") },
+    },
+  ]);
+  assertEquals(generatedChanged, base);
+});
+
+Deno.test("an authored cell's value does move the fingerprint", () => {
+  // The other half: excluding generated cells must not blind the check to real
+  // content. A named internal cell is intentional durable state.
+  const base = hashWith([]);
+  const namedChanged = hashWith([
+    { id: "of:named", doc: { value: "named-v2", result: link("of:piece") } },
+  ]);
+  assert(namedChanged !== base, "a named cell change must be visible");
+
+  const inputChanged = hashWith([
+    { id: "of:input", doc: { value: { title: "renamed" } } },
+  ]);
+  assert(inputChanged !== base, "an input cell change must be visible");
+});
+
+Deno.test("includeGenerated makes generated churn visible on purpose", () => {
+  withSpace([], (a) => {
+    const strict = contentFingerprint(a);
+    const loose = contentFingerprint(a, { includeGenerated: true });
+    assert(loose.hash !== strict.hash);
+    assertEquals(strict.excludedGenerated, 1);
+    assertEquals(loose.excludedGenerated, 0);
+    assertEquals(loose.entities, strict.entities + 1);
+  });
+});
+
+Deno.test("per-user and per-session state is covered, not silently skipped", () => {
+  // listEntityModels defaults to scope "space"; on the real Estuary store that
+  // omits 579 entities. A fingerprint that ignored them would call a migration
+  // clean while PerUser state was destroyed.
+  const base = hashWith([
+    {
+      id: "of:peruser",
+      doc: { value: "u1" },
+      scope: "user:did%3Akey%3AzAlice",
+    },
+  ]);
+  const changed = hashWith([
+    {
+      id: "of:peruser",
+      doc: { value: "u2" },
+      scope: "user:did%3Akey%3AzAlice",
+    },
+  ]);
+  assert(changed !== base, "a per-user value change must move the fingerprint");
+});
+
+Deno.test("the same id in two scopes is fingerprinted separately", () => {
+  withSpace([
+    { id: "of:shared", doc: { value: "space-value" } },
+    {
+      id: "of:shared",
+      doc: { value: "alice-value" },
+      scope: "user:did%3Akey%3AzAlice",
+    },
+  ], (space) => {
+    const fp = contentFingerprint(space);
+    const rows = fp.perEntity.filter((e) => e.id === "of:shared");
+    assertEquals(rows.length, 2);
+    assert(rows[0].hash !== rows[1].hash, "distinct scopes, distinct content");
+  });
+});
+
+Deno.test("the fingerprint is deterministic and order-independent", () => {
+  withSpace([{ id: "of:z", doc: { value: 1 } }, {
+    id: "of:a",
+    doc: { value: 2 },
+  }], (s) => {
+    assertEquals(contentFingerprint(s).hash, contentFingerprint(s).hash);
+    const fp = contentFingerprint(s);
+    const ids = fp.perEntity.map((e) => `${e.id} ${e.scope}`);
+    assertEquals([...ids].sort(), ids, "per-entity rows are sorted");
+  });
+});
+
+Deno.test("diff names what moved, not merely that something did", () => {
+  // The point of per-entity hashes: a rehearsal needs "these two cells changed",
+  // not "the number differs".
+  let before = null as ReturnType<typeof contentFingerprint> | null;
+  let after = null as ReturnType<typeof contentFingerprint> | null;
+  withSpace([], (s) => before = contentFingerprint(s));
+  withSpace([
+    { id: "of:named", doc: { value: "named-v2", result: link("of:piece") } },
+    { id: "of:newcomer", doc: { value: "hello" } },
+  ], (s) => after = contentFingerprint(s));
+
+  const d = diffFingerprints(before!, after!);
+  assert(!d.equal);
+  assertEquals(d.changed, ["of:named"]);
+  assertEquals(d.added, ["of:newcomer"]);
+  assertEquals(d.removed, []);
+
+  assert(
+    diffFingerprints(before!, before!).equal,
+    "a diff with itself is equal",
+  );
+});
+
+Deno.test("an entity with no value is recorded, not dropped", () => {
+  withSpace(
+    [{ id: "of:novalue", doc: { result: link("of:piece") } }],
+    (space) => {
+      const fp = contentFingerprint(space);
+      const row = fp.perEntity.find((e) => e.id === "of:novalue");
+      assert(row !== undefined, "present in the report");
+      assertEquals(row.hash, null);
+      assertEquals(fp.unhashable, []);
+    },
+  );
+});

--- a/packages/state-inspector/test/fingerprint.test.ts
+++ b/packages/state-inspector/test/fingerprint.test.ts
@@ -8,7 +8,7 @@
 // Topics store, where all 20 write-storm cells are `$generated` and none is
 // authored content.
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { Database } from "@db/sqlite";
 
 import { openSpace, type SpaceDb } from "../db.ts";
@@ -16,6 +16,7 @@ import {
   contentFingerprint,
   diffFingerprints,
   generatedInternalCellIds,
+  hashEntityValue,
 } from "../fingerprint.ts";
 
 const SCHEMA = `
@@ -230,6 +231,99 @@ Deno.test("diff names what moved, not merely that something did", () => {
     diffFingerprints(before!, before!).equal,
     "a diff with itself is equal",
   );
+
+  // The reverse direction names the disappearance. A migration that DROPS an
+  // entity is the failure this must catch, and it reads as `removed`, never as
+  // a bare "the fingerprints differ".
+  const reverse = diffFingerprints(after!, before!);
+  assertEquals(reverse.removed, ["of:newcomer"]);
+  assertEquals(reverse.changed, ["of:named"]);
+  assertEquals(reverse.added, []);
+});
+
+Deno.test("a value the canonical hasher rejects is reported, not skipped", () => {
+  // Nothing stored decodes to one of these today, but `decodeStored` spans
+  // several at-rest formats. Silently treating a rejected value as empty would
+  // let real content drift read as "unchanged" — the one lie this must not tell.
+  const ok = hashEntityValue({ title: "a topic" });
+  assert("hash" in ok);
+
+  const rejected = hashEntityValue(new Map([["a", 1]]));
+  assert("error" in rejected, "an unsupported object type must be reported");
+  assert(rejected.error.length > 0, "and must carry a reason");
+});
+
+Deno.test("one unhashable entity is reported without aborting the space", () => {
+  // A ~5,000-deep value stores and parses fine but overflows the canonical
+  // hasher's recursion. The whole-space fingerprint must survive it: report the
+  // entity as unhashable, keep hashing the rest. Aborting would leave a
+  // rehearsal with no verification at all; silently skipping would let that
+  // entity's content drift read as "unchanged".
+  let deep: unknown = null;
+  for (let i = 0; i < 5000; i++) deep = { a: deep };
+
+  withSpace([{ id: "of:pathological", doc: { value: deep } }], (space) => {
+    const fp = contentFingerprint(space);
+    assertEquals(fp.unhashable.length, 1);
+    assertEquals(fp.unhashable[0].id, "of:pathological");
+    assert(fp.unhashable[0].reason.length > 0, "carries a reason");
+    // The rest of the space still produced a fingerprint.
+    assert(fp.entities >= 3);
+    assert(fp.perEntity.every((e) => e.id !== "of:pathological"));
+  });
+});
+
+Deno.test("a possibly truncated enumeration is refused, not fingerprinted", () => {
+  // A hash over part of a space is worse than no hash: it looks authoritative.
+  withSpace([], (space) => {
+    assertThrows(
+      () => contentFingerprint(space, { enumerationCap: 1 }),
+      Error,
+      "truncated enumeration",
+    );
+  });
+});
+
+Deno.test("malformed internal manifests are skipped, not fatal", () => {
+  // A piece whose manifest is the wrong shape must not abort a whole-space
+  // fingerprint; its cells simply go unclassified (and so are fingerprinted).
+  withSpace([
+    {
+      id: "of:bad-manifest",
+      doc: {
+        value: {},
+        internal: "not-an-array",
+        patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+        schema: {},
+        argument: link("of:input"),
+      },
+    },
+    {
+      id: "of:odd-entries",
+      doc: {
+        value: {},
+        internal: [
+          "not-an-object",
+          { partialCause: "x" },
+          { partialCause: "x", link: "not-an-object" },
+          { partialCause: "x", link: {} },
+          { partialCause: "x", link: { "/": {} } },
+          { partialCause: "x", link: { "/": { "link@1": { id: 42 } } } },
+        ],
+        patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+        schema: {},
+        argument: link("of:input"),
+      },
+    },
+  ], (space) => {
+    const { generated, named } = generatedInternalCellIds(space);
+    // Only the well-formed fixture piece contributed classifications.
+    assert(generated.has("of:generated"));
+    assert(named.has("of:named"));
+    const fp = contentFingerprint(space);
+    assertEquals(fp.unhashable, []);
+    assert(fp.entities > 0);
+  });
 });
 
 Deno.test("an entity with no value is recorded, not dropped", () => {


### PR DESCRIPTION
## Why

Second of three PRs implementing `docs/plans/space-clone-rehearsal.md` (merged in #5009). **Stacked on #5075** (`cf inspect churn`) — review that first; this PR's base is that branch. Library only; the `cf space` command surface is the third PR.

The interview on #5009 inverted the doc's own build case, and this PR is shaped by the answer. The **copy** was never the hard part of the July rehearsal: a server-side `VACUUM INTO` already emits one correctly-named, companion-free file, and Wilk's reset was a plain `cp`. What *was* re-invented every attempt was the **verification bookkeeping** — counts and content fingerprints as ad-hoc SQL and Python heredocs, agent-written per run. Two rehearsals whose fingerprints were computed differently cannot be compared, and an improvised check that quietly measures less than last time looks exactly like a pass. So the manifest and the fingerprint are the payload here; the copy path is deliberately thin.

## What Changed

### `fingerprint.ts` — "did content survive?" as a comparable number

`contentFingerprint(space)` returns one hash plus per-entity hashes; `diffFingerprints(before, after)` names *which* entities moved, which is the answer a rehearsal actually needs. Hashing goes through `@commonfabric/data-model/value-hash` — the same canonicalizing hash the runtime derives entity ids with, so it cannot drift from the engine's notion of value identity.

**Compiler-generated internal cells are excluded by default.** A pattern update rotates their identities on purpose (#4916), so counting them would move the fingerprint on every legitimate migration and answer no question at all. The `internal` manifest is the only place that distinction is recorded — entity ids are content hashes carrying no marker of their own — where authored cells have a string `partialCause` (`"entries"`) and generated ones carry `{ $generated: N }`.

Validated against the real 1.1 GB Estuary Topics store: **all 20 write-storm cells are `$generated`, none is authored content**, and the generated/named sets are disjoint. The exclusion removes exactly the churn source and nothing else.

### Two silent-coverage bugs, found by running against real data

Both would have produced a confident-looking hash over a *partial* space — precisely the failure this module exists to prevent:

- `listEntityModels` caps at **5,000** by default; the real store holds 6,379 entities. An earlier probe's "865 generated cells" was silently truncated — the true count is 985.
- It also defaults to `scope: "space"`, silently omitting **579 PerUser/PerSession entities**. A fingerprint ignoring those would call a migration clean while per-user state was destroyed.

It now walks every scope `listScopes` reports, and *refuses* rather than hash a truncated enumeration.

### `clone.ts` — the working copy and its manifest

Writes `pristine/` + `engine-v3/` + `clone.json` + a `.cf-clone` marker. `engine-v3/` is not decoration: it is the layout `resolveSpaceStoreUrl` resolves, so pointing `MEMORY_DIR` at the directory serves the clone as a live space under the same DID.

- `resetClone` restores from pristine **and removes the `-wal`/`-shm` companions** — without which a checkpoint could replay part of a discarded attempt over the fresh copy, a reset that silently isn't one.
- `verifyClone` checks baseline integrity and the fingerprint. It *expects counts to grow* — that is what a migration does — so the fingerprint carries the signal.
- Target refusal is by explicit path overlap (live store dir, the snapshot's own dir, a non-empty target), never a "looks like production" heuristic: a guess that says yes when it should say no is worse than no check.

**Reset uses a portable `Deno.copyFile`, not APFS clonefile.** Measured 14.2 s on the real 1.1 GB store, against a rehearsal whose migration phase runs for minutes; clonefile needs a `cp -c` subprocess and a platform branch (GNU `cp` has no `-c`). The plan doc is amended in this PR to match, rather than left claiming otherwise.

## Test plan

- `test/fingerprint.test.ts` — 9 tests. The load-bearing pair asserts a **generated** cell's value change does *not* move the hash while a **named** cell's and an **input** cell's do; plus per-scope coverage (a PerUser change must move it), same-id-in-two-scopes, determinism and sort-order independence, `includeGenerated` inverting the behaviour on purpose, and the diff naming what moved.
- `test/clone.test.ts` — 9 tests: a clone is servable at the engine's path and leaves the source byte-identical; **a clean migration keeps the fingerprint even as commits climb**; a real content change is caught; reset discards the attempt including WAL companions; a corrupted baseline is reported rather than trusted; and the three refusals.
- Full `state-inspector` suite — 66 passed. `deno check`, `deno lint`, `deno fmt` clean.

### Against the real store

```
createClone  15.0s   snapshot 1.10 GB
             counts {commits:200348, revisions:213148, entities:6379, maxSeq:200348}
             fingerprint entities=7707 excluded=6010
verify       13.5s   ok=true baseline=true fpMatch=true
after a simulated attempt   ok=true, commits 200348 -> 200349
reset        14.2s   ok=true, commits back to 200348
source mtime unchanged: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a rehearsal-grade space clone and content fingerprint library to make migration rehearsals repeatable and trustworthy. Uses a portable copy path and strict verification so clean migrations keep the fingerprint while real content changes are caught.

- **New Features**
  - `contentFingerprint(space)` and `diffFingerprints(before, after)` produce a stable hash plus per-entity hashes; compiler-generated internal cells are excluded by default (opt-in via `includeGenerated`).
  - `createClone`, `resetClone`, `verifyClone`, `readManifest`, and `clonePaths` manage a clone with `pristine/`, `engine-v3/`, `clone.json`, and a `.cf-clone` marker; the working copy is servable at the engine path.
  - Safe by design: refuses targets overlapping the live store or the snapshot’s dir; requires an empty target; `resetClone` removes `-wal`/`-shm`; `verifyClone` expects counts to grow while the fingerprint stays the same on clean migrations.
  - Uses a portable `Deno.copyFile` for snapshot → `pristine/` and `pristine/` → `engine-v3/`; plan doc updated to reflect copy over clonefile.

- **Refactors**
  - Fingerprint now walks all scopes, refuses truncated listings, and exposes an `enumerationCap` option for large spaces; hashing goes through `@commonfabric/data-model/value-hash`.
  - Exported `hashEntityValue` reports unhashable entities and continues, instead of throwing and aborting the space.
  - Safer filesystem handling: canonicalizes target and forbidden directories (absolute + realpath) to catch relative and symlinked overlaps; blank forbidden entries ignored; shared `pathExists` and a stat-first empty-dir check; non-NotFound IO errors surface.
  - Added tests for edge cases including future‑manifest refusal, unreadable manifests, never‑opened resets, malformed manifests, deep‑object overflow, diff “removed” detection, and regressions for relative-path and symlinked overlap checks.

<sup>Written for commit 0769f1097a0c6e89dbbf4a5ec0dcea7c94f39982. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

