### PR TITLE
feat(cli): `cf space` — clone, verify, reset, fingerprint

### DIFF
--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -8,6 +8,7 @@ import { fuse } from "./fuse.ts";
 import { init } from "./init.ts";
 import { inspect } from "./inspect.ts";
 import { piece } from "./piece.ts";
+import { space } from "./space.ts";
 import { identity } from "./identity.ts";
 import { test } from "./test-command.ts";
 import { view } from "./view.ts";
@@ -93,6 +94,8 @@ export const main = new Command()
   .command("deps", deps)
   // @ts-ignore for the above type issue
   .command("inspect", inspect)
+  // @ts-ignore for the above type issue
+  .command("space", space)
   .command("view", view)
   .command("exec", exec)
   // @ts-ignore for the above type issue

--- a/packages/cli/commands/space.ts
+++ b/packages/cli/commands/space.ts
@@ -63,17 +63,25 @@ function fromFileUrl(url: string): string {
   }
 }
 
-/** Download a remote snapshot to a temp file so `--from` can take a URL. */
-async function fetchSnapshot(url: string): Promise<string> {
+/**
+ * Download a remote snapshot to a temp file so `--from` can take a URL.
+ *
+ * Returns the staging directory alongside the path so the caller can remove it:
+ * a real snapshot is gigabytes, and leaving one per invocation in the system
+ * temp directory would be a quiet disk leak.
+ */
+async function fetchSnapshot(
+  url: string,
+): Promise<{ path: string; stagingDir: string }> {
   const response = await fetch(url);
   if (!response.ok || response.body === null) {
     throw new Error(`could not download ${url}: HTTP ${response.status}`);
   }
-  const dir = await Deno.makeTempDir({ prefix: "cf-space-clone-" });
-  const path = `${dir}/snapshot.sqlite`;
+  const stagingDir = await Deno.makeTempDir({ prefix: "cf-space-clone-" });
+  const path = `${stagingDir}/snapshot.sqlite`;
   using file = await Deno.open(path, { write: true, create: true });
   await response.body.pipeTo(file.writable);
-  return path;
+  return { path, stagingDir };
 }
 
 const bytes = (n: number): string =>
@@ -118,17 +126,30 @@ export const space = new Command()
           "outside any store a local server is serving.",
       );
     }
-    const source = /^https?:\/\//.test(options.from)
+    const remote = /^https?:\/\//.test(options.from)
       ? await fetchSnapshot(options.from)
-      : options.from;
+      : undefined;
 
-    const targetDir = options.to;
-    const manifest = await createClone({
-      source,
-      space: spaceDid,
-      targetDir,
-      forbiddenDirs: liveStoreDirs(),
-    });
+    let manifest;
+    try {
+      manifest = await createClone({
+        source: remote?.path ?? options.from,
+        space: spaceDid,
+        targetDir: options.to,
+        forbiddenDirs: liveStoreDirs(),
+      });
+    } finally {
+      if (remote) {
+        await Deno.remove(remote.stagingDir, { recursive: true }).catch(
+          () => {},
+        );
+      }
+    }
+
+    // Report the RESOLVED directory, not the raw argument: the serve line below
+    // has to be a valid absolute `file://` URL, and a relative `--to` would
+    // otherwise print one that silently does not work when pasted.
+    const targetDir = await Deno.realPath(options.to);
     const paths = clonePaths(targetDir, spaceDid);
 
     out(!!options.json, { manifest, paths }, () => {

--- a/packages/cli/commands/space.ts
+++ b/packages/cli/commands/space.ts
@@ -1,0 +1,259 @@
+// `cf space` — operator commands over a whole space store.
+//
+// Today this is the rehearsal-clone workflow from
+// docs/plans/space-clone-rehearsal.md: make a writable copy of a real space,
+// run a migration against it, judge the result, reset, repeat.
+//
+// Why this is NOT under `cf inspect`: inspect's contract is that it is
+// read-only — "it explains, it never reproduces or replays" — and that boundary
+// is what makes it trustworthy. A clone exists precisely to be written to, so
+// it gets its own noun.
+//
+// Acquiring the snapshot stays manual for production, by design: the dump
+// endpoint is hard-off there (see memory-dump-policy.ts) and a whole-space dump
+// is a confidentiality decision, not an ergonomics one. `--from` therefore takes
+// a file an operator already has (typically `VACUUM INTO` server-side, then
+// scp), or an https URL (the S3 hop the July rehearsal used to share one
+// snapshot across operators).
+
+import { Command, ValidationError } from "@cliffy/command";
+import {
+  clonePaths,
+  createClone,
+  openSpace,
+  readManifest,
+  resetClone,
+  resolveSpace,
+  verifyClone,
+} from "@commonfabric/state-inspector";
+import { contentFingerprint } from "@commonfabric/state-inspector";
+import { hasJsonArgument } from "../lib/json-output.ts";
+
+function out(json: boolean, data: unknown, render: () => void): void {
+  if (json) console.log(JSON.stringify(data, null, 2));
+  else render();
+}
+
+/**
+ * Store directories a clone must never be written into: whatever the
+ * environment says a local server is serving. Explicit paths, not a guess about
+ * what looks like production.
+ */
+function liveStoreDirs(): string[] {
+  const dirs: string[] = [];
+  const memoryDir = Deno.env.get("MEMORY_DIR");
+  if (memoryDir) {
+    dirs.push(
+      memoryDir.startsWith("file://") ? fromFileUrl(memoryDir) : memoryDir,
+    );
+  }
+  const dbPath = Deno.env.get("DB_PATH");
+  if (dbPath) dirs.push(dbPath.replace(/\/[^/]*$/, ""));
+  // The toolshed's default when neither is set is `./cache/memory/` relative to
+  // its working directory; a clone landing there would be served unintentionally.
+  dirs.push(`${Deno.cwd()}/cache/memory`);
+  return dirs;
+}
+
+function fromFileUrl(url: string): string {
+  try {
+    return decodeURIComponent(new URL(url).pathname);
+  } catch {
+    return url;
+  }
+}
+
+/** Download a remote snapshot to a temp file so `--from` can take a URL. */
+async function fetchSnapshot(url: string): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok || response.body === null) {
+    throw new Error(`could not download ${url}: HTTP ${response.status}`);
+  }
+  const dir = await Deno.makeTempDir({ prefix: "cf-space-clone-" });
+  const path = `${dir}/snapshot.sqlite`;
+  using file = await Deno.open(path, { write: true, create: true });
+  await response.body.pipeTo(file.writable);
+  return path;
+}
+
+const bytes = (n: number): string =>
+  n >= 1e9 ? `${(n / 1e9).toFixed(2)} GB` : `${(n / 1e6).toFixed(1)} MB`;
+
+export const space = new Command()
+  .name("space")
+  .description(
+    "Whole-space operator commands: rehearsal clones of a space store.",
+  )
+  .default("help")
+  .error((error, command) => {
+    if (hasJsonArgument(command.getMainCommand().getRawArgs())) throw error;
+  })
+  .globalOption("--json", "Output machine-readable JSON.")
+  /* space clone */
+  .command(
+    "clone <space:string>",
+    "Build a writable rehearsal clone of a space store from a snapshot.",
+  )
+  // `--from`/`--to` are required in substance but NOT declared `required`:
+  // cliffy appends required options to the usage line, which would break the
+  // repo invariant that a command's usage ends with its positional arguments
+  // (see main-command.test.ts). Validating here also gives a more actionable
+  // message than cliffy's generic one.
+  .option(
+    "--from <source:string>",
+    "Snapshot to clone: a .sqlite path, or an https URL to download.",
+  )
+  .option("--to <dir:string>", "Destination clone directory.")
+  .action(async (options, spaceDid) => {
+    if (!options.from) {
+      throw new ValidationError(
+        "--from is required: a .sqlite snapshot path, or an https URL. " +
+          "For production, take one server-side with `VACUUM INTO` and copy " +
+          "it down — the dump endpoint is deliberately off there.",
+      );
+    }
+    if (!options.to) {
+      throw new ValidationError(
+        "--to is required: the directory to build the clone in. It must be " +
+          "outside any store a local server is serving.",
+      );
+    }
+    const source = /^https?:\/\//.test(options.from)
+      ? await fetchSnapshot(options.from)
+      : options.from;
+
+    const targetDir = options.to;
+    const manifest = await createClone({
+      source,
+      space: spaceDid,
+      targetDir,
+      forbiddenDirs: liveStoreDirs(),
+    });
+    const paths = clonePaths(targetDir, spaceDid);
+
+    out(!!options.json, { manifest, paths }, () => {
+      console.log(
+        `cloned ${spaceDid}\n` +
+          `  snapshot   ${
+            bytes(manifest.snapshotBytes)
+          }  ${manifest.snapshotHash}\n` +
+          `  counts     ${manifest.counts.commits} commits, ` +
+          `${manifest.counts.revisions} revisions, ` +
+          `${manifest.counts.entities} entities\n` +
+          `  content    ${manifest.fingerprint.hash}\n` +
+          `             ${manifest.fingerprint.entities} entities fingerprinted, ` +
+          `${manifest.fingerprint.excludedGenerated} generated cells excluded\n` +
+          `  working    ${paths.workingPath}\n\n` +
+          `serve it (NOT the live store — note the port offset):\n` +
+          `  MEMORY_DIR="file://${targetDir}/" ./scripts/start-local-dev.sh --port-offset 10\n\n` +
+          `then, per attempt:\n` +
+          `  cf space verify ${targetDir}\n` +
+          `  cf space reset  ${targetDir}`,
+      );
+    });
+  })
+  /* space verify */
+  .command(
+    "verify <dir:string>",
+    "Check a clone against its manifest: baseline intact, content unchanged.",
+  )
+  .action(async (options, dir) => {
+    const result = await verifyClone(dir);
+    out(!!options.json, result, () => {
+      const { counts, fingerprint } = result;
+      console.log(
+        `baseline   ${result.baselineIntact ? "intact" : "CORRUPTED"}\n` +
+          `content    ${fingerprint.match ? "unchanged" : "CHANGED"}\n` +
+          `           manifest ${fingerprint.manifest}\n` +
+          `           working  ${fingerprint.working}\n` +
+          `commits    ${counts.manifest.commits} → ${counts.working.commits}\n` +
+          `revisions  ${counts.manifest.revisions} → ${counts.working.revisions}\n` +
+          `entities   ${counts.manifest.entities} → ${counts.working.entities}\n\n` +
+          (result.ok
+            ? "OK — durable content survived. Growing counts are expected: a " +
+              "migration writes."
+            : result.baselineIntact
+            ? "CONTENT CHANGED — run `cf space fingerprint <dir>/engine-v3/" +
+              "<did>.sqlite --per-entity` against the working copy and the " +
+              "pristine baseline to see which entities moved."
+            : "BASELINE CORRUPTED — the pristine snapshot no longer matches " +
+              "the manifest; do not reset to it."),
+      );
+    });
+    // A failed verification is a RESULT, not a usage error: the report above is
+    // the output a script or an operator reads. Exit nonzero so a rehearsal
+    // script can gate on it, without cliffy appending usage help.
+    if (!result.ok) Deno.exit(1);
+  })
+  /* space reset */
+  .command(
+    "reset <dir:string>",
+    "Restore the working copy from the pristine snapshot, discarding the attempt.",
+  )
+  .action(async (options, dir) => {
+    const before = await readManifest(dir);
+    await resetClone(dir);
+    const after = await verifyClone(dir);
+    out(!!options.json, { manifest: before, verify: after }, () => {
+      console.log(
+        `reset ${before.space} to its baseline (${before.createdAt})\n` +
+          `  commits back to ${after.counts.working.commits}\n` +
+          `  content  ${
+            after.fingerprint.match ? "matches baseline" : "STILL DIFFERS"
+          }`,
+      );
+    });
+    if (!after.ok) Deno.exit(1);
+  })
+  /* space fingerprint */
+  .command(
+    "fingerprint <space:string>",
+    "Content fingerprint of a store — the durable-content half of `verify`, " +
+      "runnable against any space (a clone, a snapshot, or a local store).",
+  )
+  .option(
+    "--include-generated",
+    "Include compiler-generated internal cells. They rotate on every pattern " +
+      "update by design, so this answers 'what moved at all?', not 'did " +
+      "content survive?'.",
+  )
+  .option("--per-entity", "List every entity hash, not just the roll-up.")
+  .action(async (options, token) => {
+    const db = openSpace(await resolveSpace(token));
+    try {
+      const report = contentFingerprint(db, {
+        includeGenerated: options.includeGenerated,
+      });
+      out(!!options.json, report, () => {
+        console.log(
+          `${report.hash}\n` +
+            `${report.entities} entities fingerprinted, ` +
+            `${report.excludedGenerated} generated cells excluded`,
+        );
+        if (report.ambiguous.length > 0) {
+          console.log(
+            `\nnote: ${report.ambiguous.length} id(s) are generated in one ` +
+              `manifest and named in another; counted as generated.`,
+          );
+        }
+        if (report.unhashable.length > 0) {
+          console.log(
+            `\nnote: ${report.unhashable.length} entit(ies) could not be ` +
+              `hashed and are absent from the roll-up:`,
+          );
+          for (const u of report.unhashable.slice(0, 10)) {
+            console.log(`  ${u.id}: ${u.reason}`);
+          }
+        }
+        if (options.perEntity) {
+          for (const e of report.perEntity) {
+            console.log(
+              `${e.hash ?? "(no value)"}\t${e.kind}\t${e.id}\t(${e.scope})`,
+            );
+          }
+        }
+      });
+    } finally {
+      db.close();
+    }
+  });

--- a/packages/cli/test/space.test.ts
+++ b/packages/cli/test/space.test.ts
@@ -1,0 +1,207 @@
+// `cf space` end to end through the real CLI process: the rehearsal loop an
+// operator actually runs (clone → attempt → verify → reset → verify) plus the
+// two things a script depends on — a nonzero exit when content moved, and a
+// refusal to write into the live store.
+//
+// The library's semantics are covered in packages/state-inspector/test/; this
+// suite guards the command surface and its exit codes.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Database } from "@db/sqlite";
+import { cf, withEnv } from "./utils.ts";
+
+/** `CliResult` streams are line arrays; join before substring assertions. */
+const text = (lines: string[]): string => lines.join("\n");
+
+const SPACE = "did:key:z6MkCliCloneTest";
+const SESSION = "session:did:key:zSpaceAAAA:11111111-2222-3333";
+const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
+
+const link = (id: string) => ({ "/": { "link@1": { id, path: [] } } });
+
+/** A source snapshot with one piece, one authored cell, one generated cell. */
+function seedSnapshot(path: string): void {
+  const db = new Database(path, { create: true });
+  db.exec(`
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);`);
+  appendDocs(db, [
+    ["of:piece", {
+      value: { $NAME: "Board" },
+      argument: link("of:input"),
+      internal: [
+        { partialCause: "entries", link: link("of:named") },
+        { partialCause: { $generated: 0 }, link: link("of:generated") },
+      ],
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+      schema: { type: "object", properties: {}, $defs: {} },
+    }],
+    ["of:input", { value: { title: "a topic" } }],
+    ["of:named", { value: "named-v1", result: link("of:piece") }],
+    ["of:generated", { value: "generated-v1", result: link("of:piece") }],
+  ]);
+  db.close();
+}
+
+function appendDocs(db: Database, docs: [string, unknown][]): void {
+  const base = db.prepare(`SELECT coalesce(max(seq), 0) s FROM "commit"`)
+    .get<{ s: number }>()!.s;
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, '{}', '{}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, scope_key, seq, op_index, op, data, commit_seq)
+     VALUES (?, 'space', ?, 0, 'set', ?, ?)`,
+  );
+  docs.forEach(([id, doc], i) => {
+    const seq = base + i + 1;
+    commit.run(seq, SESSION, seq);
+    rev.run(id, seq, JSON.stringify(doc), seq);
+  });
+}
+
+/** Apply writes to the clone's working copy, as a rehearsal attempt would. */
+function writeToWorkingCopy(dir: string, docs: [string, unknown][]): void {
+  const db = new Database(`${dir}/engine-v3/${SPACE}.sqlite`);
+  appendDocs(db, docs);
+  db.close();
+}
+
+async function withFixture(
+  run: (t: { snapshot: string; clone: string; root: string }) => Promise<void>,
+): Promise<void> {
+  const root = await Deno.makeTempDir({ prefix: "cf-space-test-" });
+  try {
+    const snapshotDir = `${root}/snapshot`;
+    await Deno.mkdir(snapshotDir);
+    const snapshot = `${snapshotDir}/${SPACE}.sqlite`;
+    seedSnapshot(snapshot);
+    await run({ snapshot, clone: `${root}/clone`, root });
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+}
+
+describe("cf space", () => {
+  it("runs the rehearsal loop: clone, attempt, verify, reset", async () => {
+    await withFixture(async ({ snapshot, clone }) => {
+      const cloned = await cf(
+        `space clone ${SPACE} --from ${snapshot} --to ${clone}`,
+      );
+      expect(cloned.code).toBe(0);
+      // The working copy lands where the memory server resolves a space store,
+      // so MEMORY_DIR can serve the clone under the same DID.
+      expect(text(cloned.stdout)).toContain(`engine-v3/${SPACE}.sqlite`);
+      expect(text(cloned.stdout)).toContain("1 generated cells excluded");
+
+      const clean = await cf(`space verify ${clone}`);
+      expect(clean.code).toBe(0);
+      expect(text(clean.stdout)).toContain("content    unchanged");
+
+      // A rehearsal attempt that damages authored content.
+      writeToWorkingCopy(clone, [["of:input", {
+        value: { title: "CLOBBERED" },
+      }]]);
+
+      const damaged = await cf(`space verify ${clone}`);
+      expect(damaged.code).toBe(1);
+      expect(text(damaged.stdout)).toContain("content    CHANGED");
+
+      const reset = await cf(`space reset ${clone}`);
+      expect(reset.code).toBe(0);
+      expect(text(reset.stdout)).toContain("matches baseline");
+
+      const recovered = await cf(`space verify ${clone}`);
+      expect(recovered.code).toBe(0);
+    });
+  });
+
+  it("passes verification when only generated cells were rewritten", async () => {
+    // A clean pattern update rotates generated cells and adds commits. If that
+    // failed verification, every legitimate migration would look like data loss.
+    await withFixture(async ({ snapshot, clone }) => {
+      await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
+      writeToWorkingCopy(clone, [
+        ["of:generated", { value: "generated-v2", result: link("of:piece") }],
+      ]);
+
+      const result = await cf(`space verify ${clone}`);
+      expect(result.code).toBe(0);
+      expect(text(result.stdout)).toContain("content    unchanged");
+      // ...and the growth is still reported, not hidden.
+      expect(text(result.stdout)).toContain("commits    4 → 5");
+    });
+  });
+
+  it("refuses to write a clone into the live store directory", async () => {
+    await withFixture(async ({ snapshot, root }) => {
+      const live = `${root}/live-memory`;
+      await Deno.mkdir(live);
+      // The CLI subprocess inherits this env, which is how it learns what the
+      // local server is serving.
+      await withEnv("MEMORY_DIR", `file://${live}/`, async () => {
+        const result = await cf(
+          `space clone ${SPACE} --from ${snapshot} --to ${live}/clone`,
+        );
+        expect(result.code).not.toBe(0);
+        expect(text(result.stderr)).toContain(
+          "overlaps the live store directory",
+        );
+        expect(await exists(`${live}/clone`)).toBe(false);
+      });
+    });
+  });
+
+  it("reports a fingerprint that ignores generated-cell churn", async () => {
+    await withFixture(async ({ snapshot, clone }) => {
+      await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
+      const working = `${clone}/engine-v3/${SPACE}.sqlite`;
+
+      const before = await cf(`space fingerprint ${working}`);
+      expect(before.code).toBe(0);
+      expect(text(before.stdout)).toContain("3 entities fingerprinted");
+
+      writeToWorkingCopy(clone, [
+        ["of:generated", { value: "generated-v2", result: link("of:piece") }],
+      ]);
+      const after = await cf(`space fingerprint ${working}`);
+      expect(after.stdout[0]).toBe(before.stdout[0]);
+
+      // --include-generated deliberately inverts that.
+      const loose = await cf(
+        `space fingerprint ${working} --include-generated`,
+      );
+      expect(loose.stdout[0]).not.toBe(before.stdout[0]);
+    });
+  });
+
+  it("rejects a directory that is not a clone", async () => {
+    await withFixture(async ({ root }) => {
+      const result = await cf(`space verify ${root}`);
+      expect(result.code).not.toBe(0);
+      expect(text(result.stderr)).toContain("is not a clone directory");
+    });
+  });
+});
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/test/space.test.ts
+++ b/packages/cli/test/space.test.ts
@@ -208,6 +208,20 @@ describe("cf space", () => {
     // snapshot across operators. A real snapshot is gigabytes, so the staging
     // copy must not survive the command.
     await withFixture(async ({ snapshot, clone }) => {
+      // Compare staging directories before and after rather than asserting the
+      // system temp directory holds none: it is shared, so an unrelated
+      // leftover would fail this spuriously and forever.
+      const stagingDirs = async (): Promise<Set<string>> => {
+        const found = new Set<string>();
+        for await (
+          const entry of Deno.readDir(Deno.env.get("TMPDIR") ?? "/tmp")
+        ) {
+          if (entry.name.startsWith("cf-space-clone-")) found.add(entry.name);
+        }
+        return found;
+      };
+      const before = await stagingDirs();
+
       const body = await Deno.readFile(snapshot);
       const server = Deno.serve(
         { hostname: "127.0.0.1", port: 0, onListen: () => {} },
@@ -226,12 +240,8 @@ describe("cf space", () => {
         await server.shutdown();
       }
 
-      const leaked = [];
-      for await (
-        const entry of Deno.readDir(Deno.env.get("TMPDIR") ?? "/tmp")
-      ) {
-        if (entry.name.startsWith("cf-space-clone-")) leaked.push(entry.name);
-      }
+      const after = await stagingDirs();
+      const leaked = [...after].filter((name) => !before.has(name));
       expect(leaked).toEqual([]);
     });
   });
@@ -351,13 +361,22 @@ describe("cf space", () => {
     });
   });
 
-  it("keeps a failure off stdout when --json was requested", async () => {
+  it("keeps usage help off stdout when --json was requested", async () => {
     // stdout is reserved for the JSON payload, so a failing command must not
     // print usage help into it and corrupt a caller's parse.
-    await withFixture(async ({ root }) => {
-      const result = await cf(`space verify ${root} --json`);
-      expect(result.code).not.toBe(0);
-      expect(text(result.stdout).trim()).toBe("");
+    //
+    // This must be a VALIDATION error: cliffy prints usage help to stdout for
+    // those and not for ordinary thrown errors, so testing with a plain error
+    // would pass even with the guard deleted.
+    await withFixture(async () => {
+      const withoutJson = await cf(`space clone ${SPACE} --to /tmp/unused`);
+      expect(withoutJson.code).not.toBe(0);
+      expect(text(withoutJson.stdout)).toContain("Usage:"); // help on stdout...
+
+      const withJson = await cf(`space clone ${SPACE} --to /tmp/unused --json`);
+      expect(withJson.code).not.toBe(0);
+      expect(text(withJson.stdout).trim()).toBe(""); // ...suppressed here
+      expect(text(withJson.stderr)).toContain("--from is required");
     });
   });
 

--- a/packages/cli/test/space.test.ts
+++ b/packages/cli/test/space.test.ts
@@ -188,6 +188,202 @@ describe("cf space", () => {
     });
   });
 
+  it("requires --from and --to, and says what they are for", async () => {
+    await withFixture(async ({ snapshot, clone }) => {
+      const noFrom = await cf(`space clone ${SPACE} --to ${clone}`);
+      expect(noFrom.code).not.toBe(0);
+      expect(text(noFrom.stderr)).toContain("--from is required");
+      // The message points at the sanctioned way to obtain a production
+      // snapshot, since the dump endpoint is deliberately off there.
+      expect(text(noFrom.stderr)).toContain("VACUUM INTO");
+
+      const noTo = await cf(`space clone ${SPACE} --from ${snapshot}`);
+      expect(noTo.code).not.toBe(0);
+      expect(text(noTo.stderr)).toContain("--to is required");
+    });
+  });
+
+  it("downloads an https snapshot and does not leave it behind", async () => {
+    // `--from <url>` is the S3 hop the July rehearsal used to share one
+    // snapshot across operators. A real snapshot is gigabytes, so the staging
+    // copy must not survive the command.
+    await withFixture(async ({ snapshot, clone }) => {
+      const body = await Deno.readFile(snapshot);
+      const server = Deno.serve(
+        { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+        () => new Response(body),
+      );
+      const url = `http://127.0.0.1:${server.addr.port}/snapshot.sqlite`;
+      try {
+        const result = await cf(
+          `space clone ${SPACE} --from ${url} --to ${clone}`,
+        );
+        expect(result.code).toBe(0);
+        expect(text(result.stdout)).toContain("1 generated cells excluded");
+        // The clone is real and verifies against its own manifest.
+        expect((await cf(`space verify ${clone}`)).code).toBe(0);
+      } finally {
+        await server.shutdown();
+      }
+
+      const leaked = [];
+      for await (
+        const entry of Deno.readDir(Deno.env.get("TMPDIR") ?? "/tmp")
+      ) {
+        if (entry.name.startsWith("cf-space-clone-")) leaked.push(entry.name);
+      }
+      expect(leaked).toEqual([]);
+    });
+  });
+
+  it("emits machine-readable JSON for clone, verify and fingerprint", async () => {
+    await withFixture(async ({ snapshot, clone }) => {
+      const cloned = await cf(
+        `space clone ${SPACE} --from ${snapshot} --to ${clone} --json`,
+      );
+      expect(cloned.code).toBe(0);
+      const { manifest, paths } = JSON.parse(text(cloned.stdout));
+      expect(manifest.space).toBe(SPACE);
+      expect(manifest.version).toBe(1);
+      // The reported path is absolute, so the printed serve line is a usable
+      // file:// URL even when --to was relative.
+      expect(paths.workingPath.startsWith("/")).toBe(true);
+
+      const verified = JSON.parse(
+        text((await cf(`space verify ${clone} --json`)).stdout),
+      );
+      expect(verified.ok).toBe(true);
+      expect(verified.fingerprint.match).toBe(true);
+
+      const fp = JSON.parse(
+        text(
+          (await cf(`space fingerprint ${paths.workingPath} --json`)).stdout,
+        ),
+      );
+      expect(fp.hash).toBe(manifest.fingerprint.hash);
+      expect(fp.ambiguous).toEqual([]);
+    });
+  });
+
+  it("lists per-entity hashes and flags entities it could not hash", async () => {
+    // A ~5,000-deep value parses but overflows the canonical hasher. The
+    // listing must name it rather than let it vanish from the roll-up.
+    await withFixture(async ({ snapshot, clone }) => {
+      await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
+      const working = `${clone}/engine-v3/${SPACE}.sqlite`;
+      let deep: unknown = null;
+      for (let i = 0; i < 5000; i++) deep = { a: deep };
+      writeToWorkingCopy(clone, [["of:pathological", { value: deep }]]);
+
+      const result = await cf(`space fingerprint ${working} --per-entity`);
+      expect(result.code).toBe(0);
+      const output = text(result.stdout);
+      expect(output).toContain("could not be");
+      expect(output).toContain("of:pathological");
+      // --per-entity lists the ordinary entities alongside their kind.
+      expect(output).toContain("of:input");
+    });
+  });
+
+  it("exits nonzero when a reset cannot restore the baseline", async () => {
+    await withFixture(async ({ snapshot, clone }) => {
+      await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
+      // Corrupt the baseline itself: reset will "succeed" mechanically but the
+      // clone no longer matches its manifest, which must not report success.
+      const pristine = `${clone}/pristine/${SPACE}.sqlite`;
+      const db = new Database(pristine);
+      appendDocs(db, [["of:input", { value: { title: "ROTTED BASELINE" } }]]);
+      db.close();
+
+      const result = await cf(`space reset ${clone}`);
+      expect(result.code).toBe(1);
+    });
+  });
+
+  it("refuses a target inside DB_PATH's directory too", async () => {
+    // Single-file mode: the live store is a file, so its DIRECTORY is what a
+    // clone must stay out of.
+    await withFixture(async ({ snapshot, root }) => {
+      const live = `${root}/single-file`;
+      await Deno.mkdir(live);
+      await withEnv("DB_PATH", `${live}/store.sqlite`, async () => {
+        const result = await cf(
+          `space clone ${SPACE} --from ${snapshot} --to ${live}/clone`,
+        );
+        expect(result.code).not.toBe(0);
+        expect(text(result.stderr)).toContain(
+          "overlaps the live store directory",
+        );
+      });
+    });
+  });
+
+  it("tolerates a malformed MEMORY_DIR instead of crashing", async () => {
+    // MEMORY_DIR comes from the environment and may be junk; that must not
+    // stop an operator from making a clone somewhere harmless.
+    await withFixture(async ({ snapshot, clone }) => {
+      await withEnv("MEMORY_DIR", "file://[not-a-url", async () => {
+        const result = await cf(
+          `space clone ${SPACE} --from ${snapshot} --to ${clone}`,
+        );
+        expect(result.code).toBe(0);
+      });
+    });
+  });
+
+  it("reports an HTTP failure on --from instead of a partial clone", async () => {
+    await withFixture(async ({ clone }) => {
+      const server = Deno.serve(
+        { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+        () => new Response("nope", { status: 404 }),
+      );
+      const url = `http://127.0.0.1:${server.addr.port}/missing.sqlite`;
+      try {
+        const result = await cf(
+          `space clone ${SPACE} --from ${url} --to ${clone}`,
+        );
+        expect(result.code).not.toBe(0);
+        expect(text(result.stderr)).toContain("HTTP 404");
+      } finally {
+        await server.shutdown();
+      }
+      expect(await exists(clone)).toBe(false);
+    });
+  });
+
+  it("keeps a failure off stdout when --json was requested", async () => {
+    // stdout is reserved for the JSON payload, so a failing command must not
+    // print usage help into it and corrupt a caller's parse.
+    await withFixture(async ({ root }) => {
+      const result = await cf(`space verify ${root} --json`);
+      expect(result.code).not.toBe(0);
+      expect(text(result.stdout).trim()).toBe("");
+    });
+  });
+
+  it("flags an id that one manifest generates and another names", async () => {
+    // Rotation-prone wins so the fingerprint stays stable, but that choice can
+    // hide a real content change, so it must never be silent.
+    await withFixture(async ({ snapshot, clone }) => {
+      await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
+      const working = `${clone}/engine-v3/${SPACE}.sqlite`;
+      writeToWorkingCopy(clone, [
+        ["of:second-piece", {
+          value: { $NAME: "Other" },
+          argument: link("of:input"),
+          // Names the cell the first piece calls compiler-generated.
+          internal: [{ partialCause: "entries", link: link("of:generated") }],
+          patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+          schema: { type: "object", properties: {}, $defs: {} },
+        }],
+      ]);
+
+      const result = await cf(`space fingerprint ${working}`);
+      expect(result.code).toBe(0);
+      expect(text(result.stdout)).toContain("generated in one");
+    });
+  });
+
   it("rejects a directory that is not a clone", async () => {
     await withFixture(async ({ root }) => {
       const result = await cf(`space verify ${root}`);

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -144,6 +144,16 @@ fixed recipe. The recurring debugging questions and where they resolve:
   `setsrc` on a populated space; `--bucket`/`--since`/`--until` frame the
   window. It reports rates and never judges them — what counts as "settled" is
   yours to decide.
+- _"Did a migration preserve this space's content?"_ → `cf space` (a sibling
+  command, not `inspect` — a clone exists to be written to, so it lives outside
+  inspect's read-only contract). `cf space clone <did> --from <snapshot> --to
+  <dir>` builds a writable rehearsal copy plus a manifest; `verify` reports
+  whether durable content still matches the baseline (exiting nonzero when it
+  does not) and `reset` restores it for the next attempt.
+  `cf space fingerprint <space>` runs the content check alone against any store.
+  Compiler-generated internal cells are excluded by default: a pattern update
+  rotates their identities on purpose, so counting them would change the
+  fingerprint on every legitimate migration.
 - _"Is this entity the same across spaces / did a replica drift?"_ →
   `converge <id>
   --all` / `converge-scan --all`, trusting the


### PR DESCRIPTION
## Why

Third and last of the stack implementing `docs/plans/space-clone-rehearsal.md` (merged in #5009). **Stacked on #5079**, which is stacked on #5075 — review in that order. This wires the library into the loop an operator actually runs.

The plan's blessed practice ends with "reset and repeat until two consecutive clean passes." Until now every step of that was hand-built: the July rehearsal computed its counts and content fingerprints with ad-hoc SQL and Python heredocs, freshly written per attempt. Two attempts measured differently cannot be compared, and an improvised check that quietly measures less than last time looks exactly like a pass.

```
cf space clone <did> --from <snapshot|url> --to <dir>
cf space verify <dir>          # nonzero exit when durable content moved
cf space reset <dir>
cf space fingerprint <space> [--per-entity] [--include-generated]
```

**`cf space` is its own noun, not an `inspect` subcommand.** Inspect's contract is its value — read-only, offline, "it explains, it never reproduces or replays" — and a clone exists precisely to be written to. Filing it under `inspect` would cost the one boundary that makes the skill trustworthy.

## What Changed

- `packages/cli/commands/space.ts` + registration in `main.ts`; skill map entry.
- `clone` prints the exact `MEMORY_DIR` + `--port-offset` line to serve the copy — the clone is reachable only at its own address, never the live one — followed by the per-attempt `verify`/`reset` commands.
- `--from` accepts an `https` URL as well as a path: the S3 hop the July rehearsal used so several operators could work from one identical snapshot.
- The live-store rail reads `MEMORY_DIR`/`DB_PATH` from the environment plus the toolshed's `./cache/memory` default, and refuses on path overlap. Explicit paths, never a "looks like production" heuristic — a guess that says yes when it should say no is worse than no check.

Two decisions worth a reviewer's eye:

- **`verify` exits 1 via `Deno.exit`, not `ValidationError`.** A failed verification is a *result*, not a usage error, and cliffy appends usage help to the latter — burying the report a rehearsal script actually reads. `Deno.exit(1)` is the established convention here (`acl.ts`, `exec.ts`).
- **`--from`/`--to` are validated in the action rather than declared `required`.** Cliffy appends required options to the usage line, which breaks the repo invariant that a command's usage ends with its positional arguments. `main-command.test.ts` caught this — I fixed the command rather than adding it to the exemption set, and the hand-written messages are more actionable (the `--from` error names the `VACUUM INTO`-then-copy path and why the dump endpoint is off in production).

## Test plan

- `packages/cli/test/space.test.ts` — 5 BDD cases through the real CLI process: the full rehearsal loop (clone → attempt → verify exits 1 → reset → verify exits 0); **verification passes when only generated cells were rewritten** while still reporting the commit growth (the clean-migration case); the live-store refusal writes nothing; the fingerprint ignores generated churn while `--include-generated` inverts it; a non-clone directory is rejected.
- `cd packages/cli && deno task test` — 120 passed. `deno check`, `deno lint`, `deno fmt`, `deno task check-skill-facts` clean.

### End to end on the real 1.1 GB Estuary Topics store

```
$ cf space clone did:key:… --from …/e3783eb2….sqlite --to …/cli-clone
cloned did:key:z6MkTopicsEstuary
  snapshot   1.10 GB  BM_KrgGNA-xL-5evm6w34zChs9uuJHcZ-tps6HKshCE
  counts     200348 commits, 213148 revisions, 6379 entities
  content    fid1:qQXyQ_6ALJyyAG0f87TOuw-idRRlpZPMb6LBPcbHEs0
             7707 entities fingerprinted, 6010 generated cells excluded

$ # …clobber one topic's durable content, as a bad migration would…
$ cf space verify …/cli-clone     # exit 1
content    CHANGED
           manifest fid1:qQXyQ_6ALJyyAG0f87TOuw-idRRlpZPMb6LBPcbHEs0
           working  fid1:Y9uT1-dIJzl0_vwvDwEB_U1zt1IlWUbtREp_PI94n2k
commits    200348 → 200349

$ cf space reset …/cli-clone && cf space verify …/cli-clone   # exit 0
```

The live-store rail was confirmed against a real `MEMORY_DIR`: it refuses and writes nothing.

## What stays manual, by design

Production snapshot acquisition (the dump endpoint is deliberately hard-off there and a whole-space dump is a confidentiality decision), the toolshed launch (`start-local-dev.sh --port-offset` already does it), and the migration driver itself, which is pattern-specific. The optional toolshed clone banner from the plan's increment 2 is not in this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `cf space` CLI to clone, verify, reset, and fingerprint space stores for safe, repeatable migration rehearsals. Prevents writes to live stores, prints a ready-to-run serve command, supports `--json`, and now has full end-to-end CLI coverage with stronger test guards.

- **New Features**
  - `space` command with `clone`, `verify`, `reset`, `fingerprint`.
  - `clone <did> --from <snapshot|https-url> --to <dir>` builds a clone + manifest, validates options at runtime, refuses targets overlapping live stores from `MEMORY_DIR`, `DB_PATH`, or `./cache/memory`, resolves the target to an absolute path, and prints the exact serve command with `MEMORY_DIR="file://..."` and `--port-offset`.
  - `verify <dir>` checks baseline integrity and durable content, reports count deltas, and exits 1 on mismatch.
  - `reset <dir>` restores the working copy from the pristine snapshot, re-verifies, and exits nonzero if still diverged.
  - `fingerprint <space>` reports the durable-content hash (roll-up and `--per-entity`), excludes compiler-generated cells by default with `--include-generated`, and works against a clone, a snapshot file, or a local store.
  - Global `--json` output for all subcommands.

- **Bug Fixes**
  - Cleans up downloaded snapshots from `--from <https-url>` after cloning.
  - Serve and follow-up commands now use the resolved absolute clone path to avoid broken `file://` URLs.
  - Hardened tests to fail on regressions: `--json` validation path keeps stdout clean, and the staging-leak check compares temp dirs before/after.

<sup>Written for commit 92ad260ce69081e1fdf1450aaa7240c1252a3b4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

