### PR TITLE
fix(ci): recover from partial Deno toolchain cache restores

### DIFF
--- a/.github/actions/deno-install/action.yml
+++ b/.github/actions/deno-install/action.yml
@@ -1,7 +1,7 @@
 name: "Cached Deno install"
 description: >
   Install Deno project dependencies from the restored cache when it is complete.
-  Fetch dependencies with retries when the cache is incomplete.
+  Fetch dependencies when the cache is incomplete.
 inputs:
   frozen:
     description: "Pass --frozen to deno install."
@@ -33,13 +33,4 @@ runs:
         fi
 
         echo "Deno cache is incomplete; fetching dependencies."
-        delays=(10 30 60)
-        for delay in "${delays[@]}"; do
-          if deno install "${frozen_arg[@]}"; then
-            exit 0
-          fi
-          echo "::warning::deno install failed; retrying in ${delay}s."
-          sleep "$delay"
-        done
-
         deno install "${frozen_arg[@]}"

--- a/.github/actions/deno-setup/action.yml
+++ b/.github/actions/deno-setup/action.yml
@@ -57,13 +57,19 @@ runs:
     # it to PATH is enough to run Deno. This is independent of the `cache` input
     # below (which gates the module/dependency cache) so jobs that pass
     # `cache: false` are covered too.
-    # Cache version: bump the `deno-bin-v1` token to invalidate all toolchain caches.
     - name: 💾 Restore Deno toolchain ${{ steps.resolve.outputs.version }}
       id: deno-toolchain-cache
       uses: actions/cache@v6
       with:
         path: ${{ runner.tool_cache }}/deno/${{ steps.resolve.outputs.version }}
-        key: deno-bin-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}
+        key: deno-bin-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}
+
+    - name: 🧹 Clear Deno toolchain after cache miss
+      if: steps.deno-toolchain-cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        TOOLCHAIN_DIR: ${{ runner.tool_cache }}/deno/${{ steps.resolve.outputs.version }}
+      run: rm -rf -- "${TOOLCHAIN_DIR:?}"
 
     - name: 🦕 Download Deno ${{ steps.resolve.outputs.version }}
       # Cache miss: download the toolchain from upstream. setup-deno installs it

--- a/tasks/deno-setup-action.test.ts
+++ b/tasks/deno-setup-action.test.ts
@@ -1,0 +1,92 @@
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+import { dirname, fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+const ACTION_PATH = join(
+  REPO_ROOT,
+  ".github",
+  "actions",
+  "deno-setup",
+  "action.yml",
+);
+const CACHE_MISS_STEP = "    - name: 🧹 Clear Deno toolchain after cache miss";
+
+function cacheMissStep(action: string): string {
+  const start = action.indexOf(CACHE_MISS_STEP);
+  assert(start >= 0, "cache-miss cleanup step not found");
+  const next = action.indexOf("\n    - name:", start + CACHE_MISS_STEP.length);
+  return action.slice(start, next < 0 ? action.length : next);
+}
+
+function shellScript(step: string): string {
+  const marker = "      run: ";
+  const start = step.indexOf(marker);
+  assert(start >= 0, "cache-miss cleanup shell script not found");
+  return step.slice(start + marker.length).split("\n", 1)[0];
+}
+
+Deno.test(
+  "Deno setup removes a partial toolchain after cache extraction fails",
+  async () => {
+    const root = await Deno.makeTempDir({
+      prefix: "deno-toolchain-cache-test-",
+    });
+    try {
+      const toolchainDir = join(root, "toolcache", "deno", "2.8.1");
+      const binDir = join(toolchainDir, "x64");
+      const bin = join(binDir, "deno");
+      await Deno.mkdir(binDir, { recursive: true });
+      await Deno.writeTextFile(
+        bin,
+        "#!/usr/bin/env bash\n" +
+          'echo "Bus error (core dumped)" >&2\n' +
+          "exit 135\n",
+      );
+      await Deno.chmod(bin, 0o755);
+
+      const action = await Deno.readTextFile(ACTION_PATH);
+      assertStringIncludes(
+        action,
+        "key: deno-bin-${{ runner.os }}-${{ runner.arch }}-" +
+          "${{ steps.resolve.outputs.version }}",
+      );
+      const step = cacheMissStep(action);
+      assertStringIncludes(
+        step,
+        "if: steps.deno-toolchain-cache.outputs.cache-hit != 'true'",
+      );
+      const output = await new Deno.Command("bash", {
+        args: [
+          "--noprofile",
+          "--norc",
+          "-e",
+          "-o",
+          "pipefail",
+          "-c",
+          shellScript(step),
+        ],
+        env: {
+          TOOLCHAIN_DIR: toolchainDir,
+        },
+      }).output();
+      const stderr = new TextDecoder().decode(output.stderr);
+
+      assertEquals(
+        output.code,
+        0,
+        `cached Deno recovery exited ${output.code}:\n${stderr}`,
+      );
+      await assertRejects(
+        () => Deno.stat(toolchainDir),
+        Deno.errors.NotFound,
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+);


### PR DESCRIPTION
A failed actions/cache extraction can leave part of the Deno toolchain under the runner tool cache while reporting no exact hit. setup-deno accepts that existing version directory, so later dependency installation executes the truncated binary and crashes with a bus error.

Use one fixed deno-bin key containing the runner operating system, architecture, and exact Deno version. It intentionally does not reuse the prior generation-labelled keys, so the first run starts cold. Future deliberate invalidation changes the key shape or removes the cache rather than carrying migration logic in the action.

When restoration reports anything other than an exact hit, remove the exact toolchain directory before the existing setup-deno download step. Exact hits continue through the existing cached-binary path.

Replace the dependency installation retry loop with one cache-only attempt followed by one online attempt. Add a focused regression that verifies the key, miss condition, and removal of a partially extracted toolchain.

Verification: repository-wide deno fmt --check and deno lint; focused Deno setup and version-pin tests; aggregate type checking; composite-action YAML parsing; shellcheck; forward and reverse adversarial reviews.

deflaked by Hixie's agent

Agent: Codex

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI flakiness caused by partial `actions/cache` restores of the Deno toolchain. We now use a stable cache key and wipe broken toolchains on cache miss so `setup-deno` always downloads a clean binary.

- **Bug Fixes**
  - Use a single key: `deno-bin-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}` (drops the old generation token; first run starts cold).
  - On any non-exact cache hit, remove `${{ runner.tool_cache }}/deno/${{ steps.resolve.outputs.version }}` before `setup-deno` downloads, avoiding truncated binaries.
  - Simplify `deno-install`: remove retry loop; perform one fetch when the cache is incomplete.
  - Add a regression test to verify the key shape and that cache-miss cleanup fully removes a partial toolchain.

<sup>Written for commit 9e1fa7e98c5fcfd19e5e7bf75c5b00c6e6a30963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

