### PR TITLE
ci(dashboard): publish the dashboard image only from main

### DIFF
--- a/.github/workflows/dashboard-image.yml
+++ b/.github/workflows/dashboard-image.yml
@@ -1,7 +1,7 @@
 name: Dashboard
 
 on:
-  workflow_call:
+  workflow_dispatch: {} # Publish a main commit the path filter below misses
   push:
     branches: [main]
     paths:
@@ -19,12 +19,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: dashboard-${{ github.event.pull_request.number || github.ref }}
+  group: dashboard-${{ github.ref }}
   cancel-in-progress: true
-
-env:
-  IMAGE: us-central1-docker.pkg.dev/commontools-core/containers/dev-dashboard
-  SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   tests:
@@ -32,11 +28,19 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
+      # A manual run can name any ref. Publishing moves the `latest` tag that
+      # the deployment follows, so a run on another ref stops here, before
+      # anything from that ref is checked out or run.
+      - name: Verify the run is on main
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          echo "The dashboard image publishes only from main; this run is on ${GITHUB_REF}." >&2
+          exit 1
+
       - name: Checkout source commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-          ref: ${{ env.SOURCE_SHA }}
 
       - name: Setup Deno
         uses: ./.github/actions/deno-setup
@@ -48,92 +52,21 @@ jobs:
         working-directory: packages/dashboard
         run: deno task test
 
-  build:
-    name: Image build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
-    steps:
-      - name: Checkout source commit
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
-          ref: ${{ env.SOURCE_SHA }}
-
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
-
-      - name: Build dashboard image
-        uses: useblacksmith/build-push-action@v2
-        with:
-          context: .
-          file: Dockerfile.dashboard
-          platforms: linux/amd64
-          push: false
-          tags: ${{ env.IMAGE }}:${{ env.SOURCE_SHA }}
-
-  publish_authorization:
-    name: Authorize publish
-    needs: [tests, build]
-    if: ${{ !cancelled() }}
-    outputs:
-      allowed: ${{ steps.decision.outputs.allowed }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
-    steps:
-      - name: Evaluate publish policy
-        id: decision
-        env:
-          ACTOR_ID: ${{ github.actor_id }}
-          BUILD_RESULT: ${{ needs.build.result }}
-          PUSH_BRANCH: ${{ vars.PUSH_BRANCH }}
-          PUBLISHER_ACTOR_IDS: ${{ vars.DASHBOARD_PUBLISHER_ACTOR_IDS }}
-          RUN_ATTEMPT: ${{ github.run_attempt }}
-          TEST_RESULT: ${{ needs.tests.result }}
-        shell: bash
-        run: |
-          allowed=false
-          member=false
-
-          if [[ ",${PUBLISHER_ACTOR_IDS}," == *",${ACTOR_ID},"* ]]; then
-            member=true
-          fi
-
-          if [[ "$BUILD_RESULT" == "success" ]]; then
-            if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" && "$TEST_RESULT" == "success" ]]; then
-              allowed=true
-            # PR-actor publishing is disabled (commented out, not removed):
-            # the GCP workload-identity provider's attribute condition
-            # rejects pull_request-context OIDC tokens, so this path could
-            # only ever fail the run at the Google auth step — every PR by
-            # an allow-listed actor went red on "Publish image" once CI
-            # started calling this workflow for all PRs (#4963). Publishing
-            # is main-only until the provider condition deliberately admits
-            # PR tokens; then this block (and the member/env plumbing
-            # above) can be restored as-is.
-            # elif [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$member" == "true" ]]; then
-            #   if [[ "$TEST_RESULT" == "success" || ("$PUSH_BRANCH" == "true" && "$RUN_ATTEMPT" -gt 1) ]]; then
-            #     allowed=true
-            #   fi
-            fi
-          fi
-
-          echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
-
   publish:
     name: Publish image
-    needs: [tests, build, publish_authorization]
-    if: ${{ !cancelled() && needs.publish_authorization.outputs.allowed == 'true' }}
+    needs: [tests]
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
+    env:
+      IMAGE: us-central1-docker.pkg.dev/commontools-core/containers/dev-dashboard
     steps:
       - name: Checkout source commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-          ref: ${{ env.SOURCE_SHA }}
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -165,7 +98,7 @@ jobs:
             --header "Authorization: Bearer ${ACCESS_TOKEN}" \
             --header 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
             --write-out '%header{docker-content-digest}\n%{http_code}' \
-            "https://us-central1-docker.pkg.dev/v2/commontools-core/containers/dev-dashboard/manifests/${SOURCE_SHA}")
+            "https://us-central1-docker.pkg.dev/v2/commontools-core/containers/dev-dashboard/manifests/${GITHUB_SHA}")
           digest=${result%%$'\n'*}
           status=${result##*$'\n'}
 
@@ -184,20 +117,6 @@ jobs:
               ;;
           esac
 
-      - name: Select image tags
-        id: image
-        shell: bash
-        run: |
-          tags="${IMAGE}:${SOURCE_SHA}"
-          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            tags="${tags}"$'\n'"${IMAGE}:latest"
-          fi
-          {
-            echo "tags<<EOF"
-            echo "$tags"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Build and push dashboard image
         id: build
         if: ${{ steps.existing.outputs.exists != 'true' }}
@@ -207,15 +126,12 @@ jobs:
           file: Dockerfile.dashboard
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.image.outputs.tags }}
+          tags: |
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
 
       - name: Promote existing image to latest
-        if: >-
-          ${{
-            github.event_name == 'push' &&
-            github.ref == 'refs/heads/main' &&
-            steps.existing.outputs.exists == 'true'
-          }}
+        if: ${{ steps.existing.outputs.exists == 'true' }}
         env:
           EXISTING_DIGEST: ${{ steps.existing.outputs.digest }}
         run: docker buildx imagetools create --tag "${IMAGE}:latest" "${IMAGE}@${EXISTING_DIGEST}"
@@ -238,51 +154,6 @@ jobs:
           {
             echo "### Dashboard image published"
             echo
-            echo "- Tag: \`${IMAGE}:${SOURCE_SHA}\`"
+            echo "- Tag: \`${IMAGE}:${GITHUB_SHA}\`"
             echo "- Digest: \`${IMAGE}@${DIGEST}\`"
           } >> "$GITHUB_STEP_SUMMARY"
-
-  status:
-    name: Status
-    needs:
-      - tests
-      - build
-      - publish_authorization
-      - publish
-    if: ${{ always() }}
-    permissions: {}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - name: 🔎 Verify dashboard jobs
-        env:
-          AUTHORIZATION_RESULT: ${{ needs.publish_authorization.result }}
-          BUILD_RESULT: ${{ needs.build.result }}
-          PUBLISH_ALLOWED: ${{ needs.publish_authorization.outputs.allowed }}
-          PUBLISH_RESULT: ${{ needs.publish.result }}
-          TEST_RESULT: ${{ needs.tests.result }}
-        shell: bash
-        run: |
-          failures=()
-
-          [[ "$TEST_RESULT" == "success" ]] ||
-            failures+=("tests: ${TEST_RESULT}")
-          [[ "$BUILD_RESULT" == "success" ]] ||
-            failures+=("build: ${BUILD_RESULT}")
-          [[ "$AUTHORIZATION_RESULT" == "success" ]] ||
-            failures+=("publish_authorization: ${AUTHORIZATION_RESULT}")
-
-          if [[ "$PUBLISH_ALLOWED" == "true" ]]; then
-            [[ "$PUBLISH_RESULT" == "success" ]] ||
-              failures+=("publish: ${PUBLISH_RESULT}")
-          elif [[ "$PUBLISH_ALLOWED" == "false" ]]; then
-            [[ "$PUBLISH_RESULT" == "skipped" ]] ||
-              failures+=("publish: ${PUBLISH_RESULT}")
-          else
-            failures+=("publish_authorization output: ${PUBLISH_ALLOWED:-missing}")
-          fi
-
-          if (( ${#failures[@]} > 0 )); then
-            printf 'Unsuccessful dashboard jobs:\n'
-            printf '%s\n' "${failures[@]}"
-            exit 1
-          fi

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -20,14 +20,6 @@ jobs:
   # ---------------------------------------------------------------------------
   # Tier 0 – These jobs all start immediately with no dependencies
   # ---------------------------------------------------------------------------
-  dashboard:
-    name: "Dashboard"
-    if: ${{ github.event_name == 'pull_request' }}
-    uses: ./.github/workflows/dashboard-image.yml
-    permissions:
-      contents: read
-      id-token: write
-
   check:
     name: "Check"
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -987,7 +979,6 @@ jobs:
     name: "Status"
     if: ${{ always() && github.event_name == 'pull_request' }}
     needs:
-      - dashboard
       - check
       - cfcheck
       - test

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -26,15 +26,7 @@ merge protection stores and matches the job's name on its own.
 
 `Status` runs after every pull request validation job in `deno.yml`. It runs
 after failed and skipped dependencies. It fails unless every dependency
-succeeded. Add each new pull request validation job to its `needs` list. Its
-dependencies include the reusable Dashboard workflow.
-
-The Dashboard workflow's internal `Status` job waits for the dashboard tests,
-image build, publish authorization, and any authorized publish. The reusable
-workflow reports that result to the CI workflow's `Status`. GitHub names a
-check from a called workflow by joining the calling job's name to the called
-job's name, so that one is called `Dashboard / Status` and does not collide
-with the check to require. Do not require it separately in merge protection.
+succeeded. Add each new pull request validation job to its `needs` list.
 
 Keep pull request path filters out of workflows that provide required checks.
 GitHub leaves a required check pending when a path filter prevents its workflow

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -671,29 +671,38 @@ its embedded tsnet).
 
 **Build, push, deploy**
 
-On pull requests, the CI workflow calls
-`.github/workflows/dashboard-image.yml` as a reusable workflow. Every pull
-request runs the dashboard tests and an amd64 image build without cloud
-credentials. The internal `Status` job verifies the dashboard workflow, and the
-CI workflow's required `Status` job waits for that result. Main-branch pushes
-start the Dashboard workflow directly only when the dashboard image,
-dashboard package, Gantt drill-down, Deno dependency metadata, or the workflow
-itself changes.
+`.github/workflows/dashboard-image.yml` publishes the image, and it publishes
+only from `main`. A push to `main` starts it when the dashboard image, the
+dashboard package, the Gantt drill-down, the Deno dependency metadata, or the
+workflow itself changes. You can also start it by hand from the repository's
+Actions tab, which is how to publish a `main` commit whose files fall outside
+that path list. A manual run can name any branch or tag, so the workflow's
+first step fails a run that is not on `main`: publishing moves the `latest` tag
+the stage deployment follows. That step runs before anything from the named ref
+is checked out.
 
-For organization-member pull requests, a passing dashboard test and image build
-publish the source commit as `dev-dashboard:<full-sha>`. A controlled rerun may
-override a failed dashboard test by temporarily setting the repository Actions
-variable `PUSH_BRANCH=true`; the image build must still pass, the rerun must have
-`github.run_attempt > 1`, and GCP independently verifies the actor's numeric org
-membership ID. Reset `PUSH_BRANCH=false` immediately after testing. Main-branch
-pushes publish both the immutable SHA tag and `latest`. Once a SHA tag exists,
-reruns reuse its digest instead of rebuilding or moving the tag.
+The workflow runs the dashboard tests, then builds the amd64 image and pushes
+it under both the immutable `dev-dashboard:<full-sha>` tag and `latest`. Once a
+SHA tag exists, a rerun of that commit reuses its digest: it moves `latest` onto
+the image already there rather than rebuilding it or repushing the immutable
+tag.
+
+The same tests also run in CI, on pull requests and on main alike, because the
+dashboard is a workspace package and CI's `Test` job runs each package's test
+task. The publish workflow runs them again rather than leaning on that. The two
+workflows are independent — neither waits for the other, and this one cannot
+read CI's verdict — so its own test job is the only thing standing between a
+dashboard that fails its tests and the `latest` tag. Leave it in place even
+though it looks redundant.
+
+No image is built or published for a pull request.
 
 The publish job authenticates with GitHub OIDC and GCP Workload Identity
 Federation. It emits the immutable `sha256:` image reference in the workflow
 summary; no service-account JSON key is used.
 
-Manual build fallback:
+The manual trigger publishes whatever `main` currently points at. To publish
+some other commit, build and push it by hand:
 
 ```bash
 SHA=$(git rev-parse HEAD)
@@ -702,8 +711,9 @@ docker build --platform=linux/amd64 -f Dockerfile.dashboard -t "$IMG:$SHA" .
 docker push "$IMG:$SHA"
 ```
 
-Copy the published digest from the workflow summary into the infra stage
-overlay's `images[].digest`, commit that immutable pin, then run
+Copy the published digest — from the workflow summary, or from `docker push`'s
+output for a hand build — into the infra stage overlay's `images[].digest`,
+commit that immutable pin, then run
 `make apply-dev-dashboard-stage` from `infra/k8s`. The node then appears in the
 Tailscale console as `tag:dashboard`; open
 `https://dashboard.<tailnet>.ts.net/`. (The sidecar image is already pinned by

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -26,6 +26,17 @@ function jobIds(workflow: string): string[] {
   ].map((match) => match[1]);
 }
 
+function stepBlock(job: string, stepName: string): string {
+  const header = `      - name: ${stepName}\n`;
+  const start = job.indexOf(header);
+  assert(start >= 0, `${stepName} step not found`);
+
+  const bodyStart = start + header.length;
+  const nextStepOffset = job.slice(bodyStart).search(/^ {6}- name: /m);
+  const end = nextStepOffset < 0 ? job.length : bodyStart + nextStepOffset;
+  return job.slice(start, end);
+}
+
 function neededJobIds(job: string): string[] {
   const marker = "\n    needs:\n";
   const needsStart = job.indexOf(marker);
@@ -77,50 +88,12 @@ Deno.test("Status waits for every pull request validation job", async () => {
   assertStringIncludes(gate, "JOB_RESULTS: ${{ toJSON(needs) }}");
   assertStringIncludes(gate, 'select(.value.result != "success")');
   assertStringIncludes(gate, "permissions: {}");
-});
 
-Deno.test("Status calls reusable dashboard validation", async () => {
-  const deno = await workflow("deno.yml");
-  const dashboard = await workflow("dashboard-image.yml");
-  const caller = jobBlock(deno, "dashboard");
-
-  assertStringIncludes(caller, 'name: "Dashboard"');
-  assertStringIncludes(
-    caller,
-    "if: ${{ github.event_name == 'pull_request' }}",
-  );
-  assertStringIncludes(
-    caller,
-    "uses: ./.github/workflows/dashboard-image.yml",
-  );
-  assertStringIncludes(
-    caller,
-    "permissions:\n      contents: read\n      id-token: write",
-  );
-  assertStringIncludes(
-    dashboard,
-    "\npermissions:\n  contents: read\n\nconcurrency:\n",
-  );
-  assertEquals(
-    neededJobIds(jobBlock(deno, "status")).includes("dashboard"),
-    true,
-  );
-
-  const denoTriggers = workflowTriggers(deno);
-  assertStringIncludes(denoTriggers, "  pull_request:\n");
-  assertEquals(denoTriggers.includes("\n    paths:"), false);
-
-  const dashboardTriggers = workflowTriggers(dashboard);
-  assertStringIncludes(dashboardTriggers, "  workflow_call:\n");
-  assertStringIncludes(
-    dashboardTriggers,
-    "  push:\n    branches: [main]\n    paths:\n",
-  );
-  assertEquals(dashboardTriggers.includes("  pull_request:\n"), false);
-  assertStringIncludes(
-    dashboard,
-    "group: dashboard-${{ github.event.pull_request.number || github.ref }}",
-  );
+  // A path filter would leave the required check pending on a pull request
+  // that touches none of the listed paths.
+  const triggers = workflowTriggers(contents);
+  assertStringIncludes(triggers, "  pull_request:\n");
+  assertEquals(triggers.includes("\n    paths:"), false);
 });
 
 Deno.test("Coverage Comment follows the CI workflow by name", async () => {
@@ -132,87 +105,55 @@ Deno.test("Coverage Comment follows the CI workflow by name", async () => {
   assertStringIncludes(comment, `    workflows: ["${name[1]}"]\n`);
 });
 
-Deno.test("Dashboard Status verifies every reusable workflow job", async () => {
-  const contents = await workflow("dashboard-image.yml");
-  assertStringIncludes(contents, "name: Dashboard\n");
-  assertEquals(jobIds(contents).includes("dashboard_scope"), false);
+Deno.test("Dashboard publishes only from main, never from a pull request", async () => {
+  const deno = await workflow("deno.yml");
+  const dashboard = await workflow("dashboard-image.yml");
 
-  const gate = jobBlock(contents, "status");
-  const expected = jobIds(contents).filter((jobId) => jobId !== "status")
-    .sort();
-  assertEquals(neededJobIds(gate).sort(), expected);
-  for (const jobId of expected) {
-    assertStringIncludes(gate, `needs.${jobId}.result`);
-  }
-  assertStringIncludes(gate, "name: Status");
-  assertStringIncludes(gate, "if: ${{ always() }}");
-  assertStringIncludes(
-    gate,
-    "needs.publish_authorization.outputs.allowed",
-  );
-  assertStringIncludes(gate, 'TEST_RESULT" == "success"');
-  assertStringIncludes(gate, 'BUILD_RESULT" == "success"');
-  assertStringIncludes(gate, 'AUTHORIZATION_RESULT" == "success"');
-  assertStringIncludes(gate, 'PUBLISH_ALLOWED" == "true"');
-  assertStringIncludes(gate, 'PUBLISH_ALLOWED" == "false"');
-  assertStringIncludes(gate, "permissions: {}");
-});
+  assertEquals(deno.includes("dashboard-image.yml"), false);
+  assertEquals(jobIds(deno).includes("dashboard"), false);
 
-Deno.test("called dashboard validation always runs", async () => {
-  const contents = await workflow("dashboard-image.yml");
+  assertStringIncludes(dashboard, "name: Dashboard\n");
+  const triggers = workflowTriggers(dashboard);
+  assertStringIncludes(triggers, "  workflow_dispatch: {}");
+  assertStringIncludes(
+    triggers,
+    "  push:\n    branches: [main]\n    paths:\n",
+  );
+  assertEquals(triggers.includes("  pull_request:"), false);
+  assertEquals(triggers.includes("  workflow_call:"), false);
+  assertStringIncludes(
+    dashboard,
+    "\npermissions:\n  contents: read\n\nconcurrency:\n",
+  );
+  assertStringIncludes(dashboard, "group: dashboard-${{ github.ref }}");
+  assertEquals(jobIds(dashboard).sort(), ["publish", "tests"]);
 
-  for (const jobId of ["tests", "build"]) {
-    const validation = jobBlock(contents, jobId);
-    assertEquals(validation.includes("\n    needs:"), false);
-    assertEquals(validation.includes("\n    if:"), false);
-  }
+  // A manual run can name any ref, so the tests job refuses anything but main
+  // before the publish job it gates gets a credential. The guard has to fail
+  // the run, not just report: a guard that only warns lets a dispatch from any
+  // branch move the `latest` tag.
+  const tests = jobBlock(dashboard, "tests");
+  assertEquals(tests.includes("id-token: write"), false);
+  const guard = stepBlock(tests, "Verify the run is on main");
+  assertStringIncludes(guard, "if: ${{ github.ref != 'refs/heads/main' }}");
+  assertStringIncludes(guard, "\n          exit 1\n");
 
-  const authorization = jobBlock(contents, "publish_authorization");
-  assertStringIncludes(
-    authorization,
-    "needs: [tests, build]",
-  );
-  assertStringIncludes(authorization, "if: ${{ !cancelled() }}");
-  assertStringIncludes(authorization, "ACTOR_ID: ${{ github.actor_id }}");
-  assertStringIncludes(
-    authorization,
-    'if [[ ",${PUBLISHER_ACTOR_IDS}," == *",${ACTOR_ID},"* ]]; then',
-  );
-  assertStringIncludes(
-    authorization,
-    'if [[ "$BUILD_RESULT" == "success" ]]; then',
-  );
-  assertStringIncludes(
-    authorization,
-    'elif [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$member" == "true" ]]; then',
-  );
-  assertStringIncludes(
-    authorization,
-    'if [[ "$TEST_RESULT" == "success" || ("$PUSH_BRANCH" == "true" && "$RUN_ATTEMPT" -gt 1) ]]; then',
-  );
-
-  const publish = jobBlock(contents, "publish");
-  assertStringIncludes(
-    publish,
-    "needs: [tests, build, publish_authorization]",
-  );
-  assertStringIncludes(
-    publish,
-    "!cancelled() && needs.publish_authorization.outputs.allowed == 'true'",
-  );
+  const publish = jobBlock(dashboard, "publish");
+  assertStringIncludes(publish, "needs: [tests]");
+  assertEquals(publish.includes("\n    if:"), false);
   assertStringIncludes(
     publish,
     "permissions:\n      contents: read\n      id-token: write",
   );
 
-  for (
-    const jobId of [
-      "tests",
-      "build",
-      "publish_authorization",
-      "status",
-    ]
-  ) {
-    assertEquals(jobBlock(contents, jobId).includes("id-token: write"), false);
-  }
+  // Both tags go up in the one push: the immutable commit tag the infra
+  // overlay pins, and the `latest` the deployment follows.
+  const build = stepBlock(publish, "Build and push dashboard image");
+  assertStringIncludes(build, "\n          push: true\n");
+  assertStringIncludes(
+    build,
+    "\n          tags: |\n" +
+      "            ${{ env.IMAGE }}:${{ github.sha }}\n" +
+      "            ${{ env.IMAGE }}:latest\n",
+  );
 });


### PR DESCRIPTION
The dashboard image workflow carried a publish path for pull requests that could never work. The Google Cloud workload-identity provider rejects OIDC tokens minted in a pull-request context, so a pull request from an allow-listed actor always went red at the Google authentication step. That path was commented out rather than deleted, and everything built to serve it was left standing: an actor allow list, a rerun override switch, a job whose whole purpose was deciding whether publishing was permitted, and a second aggregating status job to report all of it back to the calling CI workflow.

We do not need to build dashboard images from pull requests at all, so remove the path and everything that existed only to support it.

The CI workflow no longer calls the dashboard workflow, which is what dragged it onto every pull request in the first place. The dashboard workflow is now standalone and main-only. It keeps its push trigger with the existing path filter and gains a manual trigger, so a main commit the path filter does not match can still be published by hand. A manual run can name any ref, so the first step fails a run that is not on main, before anything from that ref is checked out. Publishing moves the tag the stage deployment follows, and failing at the first step says that far more clearly than failing at authentication.

Removing the pull-request path collapses the rest of the workflow:

- The separate credential-free build job existed to prove the image builds on a pull request without granting it a token. On main the publish job built the same image again, so every main push that touched the dashboard built it twice. The two are now one job, gated on the tests.
- The authorization job computed a single boolean from actor identity, event name, ref, and a rerun override. With only main pushes and manual runs left that boolean is always true, so the job is gone and publishing simply needs the tests to pass. Two conditions inside the publish job that re-checked the event and ref go with it, having been unreachable when false.
- The internal status job aggregated job results so a called workflow could report a single check to its caller. Nothing calls this workflow now, so the run's own conclusion is the result.
- A variable held the pull request head commit so the checkouts could pin it over the merge commit. Outside a pull request the default checkout is already that commit, so the variable and the pins are gone.
- The image tag list was computed in a shell step because a pull request build had to omit the moving tag. Every publish is now a main publish, so both tags are written inline.
- Pull requests no longer receive a token-minting permission for a job that could not run there.

The PUSH_BRANCH and DASHBOARD_PUBLISHER_ACTOR_IDS repository variables were read only by the deleted authorization job and can be removed from the repository settings.

The workflow tests are rewritten around the properties that now matter: the dashboard workflow is unreachable from a pull request, and it publishes only from main. The previous tests asserted on lines that existed solely inside comments, so they passed whether or not the behavior was live and failed if the dead comment was deleted. The new assertions are scoped to individual steps through a helper alongside the existing job-level one, which matters rather than being tidiness: an unscoped search for the guard's failure would also match an unrelated error branch in the registry lookup and pass for the wrong reason. Each assertion was checked by mutation — removing the guard's failure, turning the push off, dropping the immutable tag, and neutering the guard condition each fail the suite.

The assertion that CI itself carries no path filter, which keeps the required status check from staying pending, moves into the test about that check rather than disappearing with the dashboard test that happened to host it.

Documentation follows the code. The dashboard README described the pull-request publish path and told operators to flip a repository variable that does nothing, and it claimed reruns do not move the moving tag when the workflow does exactly that. Neither the README nor the workflow now claims the Google credential is issued only to main; the evidence only ever covered pull-request-context tokens, which says nothing about a push from a branch, and a comment asserting a second layer of enforcement invites someone to weaken the guard that is actually doing the work.

The README also now records why the publish workflow runs the dashboard tests when CI already runs the same task on the same commit. The dashboard is a workspace package, so CI covers it on pull requests and on main alike, and the publish workflow's own test job looks like pure duplication. It has to stay: the two workflows are independent, neither waits for the other, and this one cannot read CI's verdict, so its test job is the only thing between a dashboard that fails its tests and the tag the deployment follows.

Dashboard tests still run on every pull request through the workspace test job. What a pull request loses is the image build, which now first runs after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish the dashboard image only from `main` and remove the unused pull-request publish path. The dashboard workflow is now standalone, simpler, and triggered by `main` pushes or manual dispatch with a guard.

- **Refactors**
  - `dashboard-image.yml` is `main`-only: keeps the push path filter and adds `workflow_dispatch`. The first step fails any run not on `main`.
  - Merged the build into the publish job gated by tests. Removed authorization and internal status jobs, PR-only variables, and PR token permissions. Tags are now inline: immutable `:<sha>` and `:latest`, with reruns promoting existing digests.
  - `deno.yml` no longer calls the reusable dashboard workflow or waits on it in `Status`. CI keeps no path filter to avoid pending required checks.
  - Tests assert the workflow is unreachable from PRs, publishes only from `main`, and validate the guard step and tag push. Added a helper for step-scoped assertions.
  - Documentation now reflects `main`-only publishing, why the publish workflow runs tests, manual dispatch behavior, and manual build/push steps. Pull requests do not build or publish the image.

- **Migration**
  - Remove repository variables `PUSH_BRANCH` and `DASHBOARD_PUBLISHER_ACTOR_IDS`.

<sup>Written for commit b2e9d66af9fa9cb41e579d182ad6bed49192268d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

