### PR TITLE
fix(dashboard): derive the live shell version from its content

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2033,6 +2033,7 @@
       },
       "packages/dashboard": {
         "dependencies": [
+          "npm:@noble/hashes@^2.2.0",
           "npm:@resvg/resvg-js@2.6.2"
         ]
       },

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -76,8 +76,12 @@ snapshot for that source and shows the combined list in gray with the error.
 Each event connection receives the current tile snapshot before it waits for
 new collections. The browser reconciles that snapshot by tile ID, leaving
 unchanged elements, focus, and scroll positions in place. Routine data updates
-never navigate the page. A changed shell version reloads once so an unattended
-display picks up new CSS or client code after a dashboard deployment.
+never navigate the page. At startup the server hashes the shell renderer and
+wrapper together with fixed rendered HTML for every status. Changes to the
+shell markup, CSS, browser code, embedded assets, or actual refresh interval
+therefore change the version. An unattended display reloads when it reconnects
+to a server with a different version. Routine tile data changes leave the
+version unchanged.
 
 The tab favicon follows the most urgent visible tile. It is red when any tile is
 red, orange when there are no red tiles but at least one orange tile, and green

--- a/packages/dashboard/deno.jsonc
+++ b/packages/dashboard/deno.jsonc
@@ -1,6 +1,7 @@
 {
   "imports": {
     // Dependency guide: ../../docs/development/DEPENDENCIES.md
+    "@noble/hashes": "npm:@noble/hashes@^2.2.0",
     "@resvg/resvg-js": "npm:@resvg/resvg-js@2.6.2"
   },
   "tasks": {

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -1,13 +1,21 @@
 // Rendering tests: renderTile turns a TileView into markup, shell wraps the grid
 // in the page. Pure string work — no server, no network, no subprocess.
-import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertMatch,
+  assertNotEquals,
+  assertStringIncludes,
+} from "@std/assert";
 import type { Status, TileView } from "./types.ts";
 import {
   FAVICON_CRY_AFTER_MS,
   formatViewerTimes,
   renderTile,
   shell,
-  SHELL_VERSION,
+  shellFingerprint,
+  shellVersion,
+  shellVersionContent,
 } from "./render.ts";
 import { humanSpan } from "./lib.ts";
 import { REPO } from "./config.ts";
@@ -170,7 +178,6 @@ Deno.test("shell: the grid and the wide tiles land in their own slots", () => {
     `<div class="tile bad wide">w</div>`,
     3,
     30_000,
-    SHELL_VERSION,
     "bad",
   );
   assertStringIncludes(
@@ -193,10 +200,13 @@ Deno.test("shell: the grid and the wide tiles land in their own slots", () => {
 });
 
 Deno.test("shell: the freshness age and the refresh interval reach both the text and the script", () => {
-  const html = shell("", "", 7, 45_000, SHELL_VERSION, "good");
+  const html = shell("", "", 7, 45_000, "good");
   assertStringIncludes(html, `<span id="agotext">updated 7s ago</span>`);
   assertStringIncludes(html, "const REFRESH = 45000;");
-  assertStringIncludes(html, `const SHELL_VERSION = ${SHELL_VERSION};`);
+  assertStringIncludes(
+    html,
+    `const SHELL_VERSION = ${JSON.stringify(shellVersion(45_000))};`,
+  );
   assertStringIncludes(html, "let base = 7;");
   assertStringIncludes(html, `new EventSource('/events')`);
   assertStringIncludes(
@@ -220,6 +230,58 @@ Deno.test("shell: the freshness age and the refresh interval reach both the text
   assertStringIncludes(html, `link.dataset.focusKey === focusedKey`);
 });
 
+Deno.test("shell: static content has a SHA-256 fingerprint", () => {
+  const content = shellVersionContent(30_000);
+  const version = shellVersion(30_000);
+  assertStringIncludes(content, `"renderShell":"function renderShell(`);
+  assertStringIncludes(content, `"shell":"function shell(`);
+  assertMatch(version, /^sha256:[0-9a-f]{64}$/);
+  assertEquals(version, shellFingerprint(content));
+  const incompatibleChanges = [
+    [
+      `.evtxt{color:inherit;text-decoration:none`,
+      `.evtxt{color:#fff;text-decoration:none`,
+    ],
+    [
+      `if (update.shellVersion !== SHELL_VERSION)`,
+      `if (update.version !== SHELL_VERSION)`,
+    ],
+    ["dashboard-grid", "dashboard-grid-v2"],
+  ];
+  for (const [before, after] of incompatibleChanges) {
+    assertStringIncludes(content, before);
+    assertNotEquals(
+      shellFingerprint(content.replace(before, after)),
+      version,
+    );
+  }
+});
+
+Deno.test("shell: live data keeps the fingerprint; persistent configuration changes it", () => {
+  const first = shell(
+    `<div class="tile good">first</div>`,
+    "",
+    0,
+    30_000,
+    "good",
+  );
+  const second = shell(
+    `<div class="tile bad">second</div>`,
+    `<div class="tile warn wide">third</div>`,
+    999,
+    30_000,
+    "bad",
+    123,
+    456,
+  );
+  const differentRefresh = shell("", "", 0, 60_000, "good");
+  const embedded = (html: string): string =>
+    html.match(/const SHELL_VERSION = "([^"]+)";/)?.[1] ?? "";
+  assertEquals(embedded(first), shellVersion(30_000));
+  assertEquals(embedded(second), shellVersion(30_000));
+  assertNotEquals(embedded(differentRefresh), embedded(first));
+});
+
 Deno.test("formatViewerTimes: the viewer's formatter replaces the UTC fallback", () => {
   const time = { dateTime: "2024-01-02T17:05:00Z", textContent: "17:05 UTC" };
   const viewerTime = new Intl.DateTimeFormat("en-GB", {
@@ -233,7 +295,7 @@ Deno.test("formatViewerTimes: the viewer's formatter replaces the UTC fallback",
 });
 
 Deno.test("shell: the browser runs the viewer-time formatter", () => {
-  const html = shell("", "", 0, 30_000, SHELL_VERSION, "good");
+  const html = shell("", "", 0, 30_000, "good");
   const source = formatViewerTimes.toString();
   assertStringIncludes(source, `time[data-viewer-time][datetime]`);
   assert(
@@ -256,7 +318,7 @@ Deno.test("shell: the browser runs the viewer-time formatter", () => {
 });
 
 Deno.test("shell: server-measured red age changes the favicon after one hour", () => {
-  const html = shell("", "", 0, 1000, SHELL_VERSION, "good");
+  const html = shell("", "", 0, 1000, "good");
   assertStringIncludes(
     html,
     `const FAVICON_CRY_AFTER_MS = ${FAVICON_CRY_AFTER_MS}`,
@@ -268,7 +330,6 @@ Deno.test("shell: server-measured red age changes the favicon after one hour", (
     "",
     0,
     1000,
-    SHELL_VERSION,
     "bad",
     1_234,
     567,
@@ -319,7 +380,7 @@ Deno.test("shell: server-measured red age changes the favicon after one hour", (
 
 Deno.test("shell: the repo name in the header is escaped", () => {
   assertStringIncludes(
-    shell("", "", 0, 1000, SHELL_VERSION, "good"),
+    shell("", "", 0, 1000, "good"),
     `<span>${REPO.replace(/&/g, "&amp;")}</span>`,
   );
 });

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -1,5 +1,6 @@
 // Uniform rendering: every tile becomes the same markup from its TileView, and
 // the shell wraps the grid + wide tiles in the dark page with the SSE client.
+import { sha256 } from "@noble/hashes/sha2.js";
 import type { TileView } from "./types.ts";
 import { durationTag, escapeHtml, STATUS_DOT } from "./lib.ts";
 import { REPO } from "./config.ts";
@@ -13,12 +14,13 @@ const FAVICON_PNG_HREFS = JSON.stringify({
   "bad-crying": faviconHref("bad-crying"),
 });
 const PAINT_STATUS_FAVICON = paintStatusFavicon.toString();
+const FAVICON_STATUSES: Record<FaviconStatus, FaviconStatus> = {
+  good: "good",
+  warn: "warn",
+  bad: "bad",
+};
 
 export const FAVICON_CRY_AFTER_MS = 60 * 60 * 1000;
-
-// Open dashboards reload when this changes. Increment it with shell markup,
-// styles, client code, or the update payload shape.
-export const SHELL_VERSION = 4;
 
 type ViewerTimeElement = Pick<HTMLTimeElement, "dateTime" | "textContent">;
 
@@ -75,12 +77,12 @@ export function renderTile(v: TileView, id?: string, wide = false): string {
   }"${tgt}>${inner}</a>`;
 }
 
-export function shell(
+function renderShell(
   gridHtml: string,
   wideHtml: string,
   ago: number,
   refreshMs: number,
-  shellVersion: number,
+  shellVersion: string,
   status: FaviconStatus,
   serverRedSince: number | null = null,
   serverRedAgeMs: number | null = null,
@@ -143,7 +145,7 @@ ${faviconLink(status)}
   <div id="dashboard-wide">${wideHtml}</div>
 <script>
   const REFRESH = ${refreshMs};
-  const SHELL_VERSION = ${shellVersion};
+  const SHELL_VERSION = ${JSON.stringify(shellVersion)};
   const COL = { green: '#43c574', amber: '#e0a852', red: '#e2504a' };
   const FAVICONS = ${FAVICON_PNG_HREFS};
   const FAVICON_CRY_AFTER_MS = ${FAVICON_CRY_AFTER_MS};
@@ -235,4 +237,67 @@ ${faviconLink(status)}
   paint();
   setInterval(paint, 1000);
 </script></body></html>`;
+}
+
+export function shellFingerprint(content: string): string {
+  const digest = sha256(new TextEncoder().encode(content));
+  const hex = Array.from(
+    digest,
+    (byte) => byte.toString(16).padStart(2, "0"),
+  ).join("");
+  return `sha256:${hex}`;
+}
+
+// Function source covers every renderer branch and the production wrapper.
+// Fixed rendered examples add the output of called helpers and assets. Live
+// values use placeholders because updates replace them without reloading.
+export function shellVersionContent(refreshMs: number): string {
+  return JSON.stringify({
+    renderShell: renderShell.toString(),
+    shell: shell.toString(),
+    representatives: Object.values(FAVICON_STATUSES).map((status) =>
+      renderShell(
+        "<!-- live grid -->",
+        "<!-- live wide tiles -->",
+        123,
+        refreshMs,
+        "__shell_version__",
+        status,
+        456,
+        789,
+      )
+    ),
+  });
+}
+
+const SHELL_VERSIONS = new Map<number, string>();
+
+export function shellVersion(refreshMs: number): string {
+  let version = SHELL_VERSIONS.get(refreshMs);
+  if (!version) {
+    version = shellFingerprint(shellVersionContent(refreshMs));
+    SHELL_VERSIONS.set(refreshMs, version);
+  }
+  return version;
+}
+
+export function shell(
+  gridHtml: string,
+  wideHtml: string,
+  ago: number,
+  refreshMs: number,
+  status: FaviconStatus,
+  serverRedSince: number | null = null,
+  serverRedAgeMs: number | null = null,
+): string {
+  return renderShell(
+    gridHtml,
+    wideHtml,
+    ago,
+    refreshMs,
+    shellVersion(refreshMs),
+    status,
+    serverRedSince,
+    serverRedAgeMs,
+  );
 }

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -6,6 +6,7 @@
 import {
   assert,
   assertEquals,
+  assertMatch,
   assertRejects,
   assertStringIncludes,
 } from "@std/assert";
@@ -92,7 +93,7 @@ interface TestUpdate {
   gridHtml: string;
   wideHtml: string;
   ageSeconds: number;
-  shellVersion: number;
+  shellVersion: string;
   faviconStatus: "good" | "warn" | "bad";
   faviconRedSince: number | null;
   faviconRedAgeMs: number | null;
@@ -1087,7 +1088,7 @@ Deno.test("sse: /events opens a stream, tick pushes new tile markup, disconnect 
   assertEquals(await chunk(reader), ": connected\n\n");
   assertEquals(clients.size, 1);
   const initial = updateFromEvent(await chunk(reader));
-  assert(initial.shellVersion > 0);
+  assertMatch(initial.shellVersion, /^sha256:[0-9a-f]{64}$/);
   assert(initial.ageSeconds >= 0);
   assert(["good", "warn", "bad"].includes(initial.faviconStatus));
   assert(Object.hasOwn(initial, "faviconRedSince"));
@@ -1116,7 +1117,7 @@ Deno.test("broadcast: a client whose stream is gone is dropped rather than throw
     gridHtml: "",
     wideHtml: "",
     ageSeconds: 0,
-    shellVersion: 1,
+    shellVersion: "test-shell",
     faviconStatus: "good",
     faviconRedSince: null,
     faviconRedAgeMs: null,

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -26,7 +26,7 @@ import { makeCtx } from "./ctx.ts";
 import { friendlyError } from "./lib.ts";
 import { faviconPng, faviconStatus } from "./favicon.ts";
 import type { FaviconStatus } from "./favicon.ts";
-import { renderTile, shell, SHELL_VERSION } from "./render.ts";
+import { renderTile, shell, shellVersion } from "./render.ts";
 import type { Ctx, Run, RunSource, Tile, TileView } from "./types.ts";
 
 const ctx = makeCtx();
@@ -69,7 +69,7 @@ interface DashboardUpdate {
   gridHtml: string;
   wideHtml: string;
   ageSeconds: number;
-  shellVersion: number;
+  shellVersion: string;
   faviconStatus: FaviconStatus;
   faviconRedSince: number | null;
   faviconRedAgeMs: number | null;
@@ -398,6 +398,7 @@ const routes = TILES.flatMap((t) => t.routes ?? []);
 // the real cadence for the fastest tile is its interval plus a tick, not the bare
 // interval.
 const REFRESH_MS = Math.min(...TILES.map((t) => t.intervalMs)) + TICK_MS;
+const SHELL_VERSION = shellVersion(REFRESH_MS);
 
 export function page(currentViews: ReadonlyMap<string, TileView> = views): string {
   const update = dashboardUpdate(currentViews);
@@ -406,7 +407,6 @@ export function page(currentViews: ReadonlyMap<string, TileView> = views): strin
     update.wideHtml,
     update.ageSeconds,
     REFRESH_MS,
-    update.shellVersion,
     update.faviconStatus,
     update.faviconRedSince,
     update.faviconRedAgeMs,


### PR DESCRIPTION
Open dashboards retain their initial CSS and browser code while accepting updated tile markup over server-sent events. The manually maintained numeric version allowed a deployment to mix old shell styling with new markup when a shell change did not also bump the number.

Compute a SHA-256 fingerprint from the renderer and wrapper source, canonical rendered output for every status, and the actual refresh interval. Fixed placeholders keep routine tile state out of the version. Embed the same derived fingerprint in page HTML and update events so incompatible deployments reload without a human-maintained counter.

Add regression coverage for markup, CSS, client-contract, persistent-configuration, and live-data changes. Declare the hashing dependency within the dashboard package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the dashboard shell version from its content using a SHA-256 fingerprint and embeds it in HTML and SSE updates so incompatible deployments auto-reload. Prevents mixing old CSS/client code with new tile markup.

- **Bug Fixes**
  - Compute version from renderer + wrapper sources, fixed rendered HTML for each status, and the actual refresh interval.
  - Use placeholders so routine live data does not change the version.
  - Embed the derived version in the page and event payload; clients reload on mismatch.
  - Replace numeric `SHELL_VERSION` with `shellVersion(refreshMs)` and cache per refresh interval.
  - Add regression tests covering markup/CSS changes, client contract, persistent config, and live data behavior; update README.

- **Dependencies**
  - Add `@noble/hashes` for SHA-256 and declare it in `packages/dashboard`.

<sup>Written for commit e608b186697d5b0d90ea5181da763396992c6713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

