### PR TITLE
fix(integration): settle CFC button interactions

### DIFF
--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -1,0 +1,194 @@
+import { Browser, type Page } from "@commonfabric/integration";
+import { assert, assertEquals } from "@std/assert";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import {
+  CLICK_TARGET_ATTR,
+  clickCfButton,
+  clickCfButtonsConcurrently,
+} from "./cfc-browser-helpers.ts";
+
+describe("CFC browser helpers", () => {
+  let browser: Browser;
+  let page: Page;
+
+  beforeAll(async () => {
+    browser = await Browser.launch({ headless: true });
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it("settles the view before clicking a rendered control", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const button = document.createElement("button");
+      button.id = "lp-guest-button";
+      button.textContent = "Continue as guest";
+      root.append(button);
+      document.body.append(host);
+
+      let settleCalls = 0;
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+        __settleCalls: () => number;
+      }).commonfabric = {
+        viewSettled: () => {
+          settleCalls++;
+          button.addEventListener("click", () => {
+            const input = document.createElement("input");
+            input.id = "lp-join-name";
+            document.body.append(input);
+          }, { once: true });
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __settleCalls: () => number;
+      }).__settleCalls = () => settleCalls;
+    });
+
+    await clickCfButton(page, "#lp-guest-button");
+
+    const result = await page.evaluate(() => ({
+      inputPresent: document.querySelector("#lp-join-name") !== null,
+      settleCalls: (globalThis as typeof globalThis & {
+        __settleCalls: () => number;
+      }).__settleCalls(),
+    }));
+    assert(
+      result.inputPresent,
+      'clicking "Continue as guest" did not reveal #lp-join-name',
+    );
+    assertEquals(result.settleCalls, 2);
+  });
+
+  it("settles the view after clicking so local effects render", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const button = document.createElement("button");
+      button.id = "post-settle-guest-button";
+      button.textContent = "Continue as guest";
+      root.append(button);
+      document.body.append(host);
+
+      let clicked = false;
+      let settleCalls = 0;
+      button.addEventListener("click", () => {
+        clicked = true;
+      }, { once: true });
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+        __postSettleCalls: () => number;
+      }).commonfabric = {
+        viewSettled: () => {
+          settleCalls++;
+          if (clicked) {
+            const input = document.createElement("input");
+            input.id = "post-settle-join-name";
+            document.body.append(input);
+          }
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __postSettleCalls: () => number;
+      }).__postSettleCalls = () => settleCalls;
+    });
+
+    await clickCfButton(page, "#post-settle-guest-button");
+
+    const result = await page.evaluate(() => ({
+      inputPresent: document.querySelector("#post-settle-join-name") !== null,
+      settleCalls: (globalThis as typeof globalThis & {
+        __postSettleCalls: () => number;
+      }).__postSettleCalls(),
+    }));
+    assert(
+      result.inputPresent,
+      "the click effect was not applied by a post-click view settle",
+    );
+    assertEquals(result.settleCalls, 2);
+  });
+
+  it("marks grouped targets between settlement barriers", async () => {
+    await page.evaluate((clickTargetAttr: string) => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      let settleCalls = 0;
+      const settleCallsAtClick: number[] = [];
+      const createButton = (id: string) => {
+        const button = document.createElement("button");
+        button.id = id;
+        button.textContent = id;
+        return button;
+      };
+      const firstButton = createButton("grouped-button-a");
+      const secondButton = createButton("grouped-button-b");
+      let secondTargetMarkedAtFirstClick = false;
+      firstButton.addEventListener("click", () => {
+        if (settleCallsAtClick.length === 0) {
+          secondTargetMarkedAtFirstClick = secondButton.hasAttribute(
+            clickTargetAttr,
+          );
+        }
+        settleCallsAtClick.push(settleCalls);
+      });
+      secondButton.addEventListener("click", () => {
+        settleCallsAtClick.push(settleCalls);
+      }, { once: true });
+      root.append(firstButton, secondButton);
+      document.body.append(host);
+
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+        __groupedClickResult: () => {
+          settleCalls: number;
+          settleCallsAtClick: number[];
+          secondTargetMarkedAtFirstClick: boolean;
+        };
+      }).commonfabric = {
+        viewSettled: () => {
+          settleCalls++;
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __groupedClickResult: () => {
+          settleCalls: number;
+          settleCallsAtClick: number[];
+          secondTargetMarkedAtFirstClick: boolean;
+        };
+      }).__groupedClickResult = () => ({
+        settleCalls,
+        settleCallsAtClick,
+        secondTargetMarkedAtFirstClick,
+      });
+    }, { args: [CLICK_TARGET_ATTR] });
+
+    await clickCfButtonsConcurrently([
+      { page, selector: "#grouped-button-a" },
+      { page, selector: "#grouped-button-b" },
+      { page, selector: "#grouped-button-a" },
+    ]);
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __groupedClickResult: () => {
+          settleCalls: number;
+          settleCallsAtClick: number[];
+          secondTargetMarkedAtFirstClick: boolean;
+        };
+      }).__groupedClickResult()
+    );
+    assertEquals(result.settleCallsAtClick, [1, 1, 1]);
+    assertEquals(result.settleCalls, 2);
+    assert(
+      result.secondTargetMarkedAtFirstClick,
+      `the second target did not carry ${CLICK_TARGET_ATTR} before dispatch`,
+    );
+  });
+});

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -11,10 +11,9 @@ import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
 const DEFAULT_CFC_BROWSER_TIMEOUT = 30_000;
 /**
  * Attribute a mark predicate stamps on the element it resolved, so the test can
- * then address exactly that element. What identifies a mark is the attribute's
- * value — a fresh unique token per click — so the predicates here and in
- * `note-button-helpers.ts` all stamp this one attribute name, and no helper
- * resolves or clears a mark another one made.
+ * then address exactly that element. Each mark is a unique whitespace-separated
+ * token in the attribute value. Grouped clicks can therefore mark the same
+ * element more than once without losing an earlier target.
  */
 export const CLICK_TARGET_ATTR = "data-cfc-click-target";
 
@@ -252,7 +251,11 @@ const markForClick = (
     | HTMLElement
     | null) ?? target;
   if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
-  clickTarget.setAttribute(attr, token);
+  const tokens = new Set(
+    (clickTarget.getAttribute(attr) ?? "").split(/\s+/).filter(Boolean),
+  );
+  tokens.add(token);
+  clickTarget.setAttribute(attr, [...tokens].join(" "));
   return true;
 };
 
@@ -622,15 +625,15 @@ export async function waitForDisabled(
   }
 }
 
-export async function clickCfButton(
+async function markRenderedCfButton(
   page: Page,
   selector: string,
-) {
+): Promise<string> {
   const token = `cf-button-${crypto.randomUUID()}`;
   try {
-    // Wait until the button is rendered, then mark its inner click target
-    // exactly once; the mark is the predicate, so the re-check on each DOM
-    // mutation retries finding the button without re-clicking anything.
+    // Mark the rendered button exactly once. The mark is the predicate, so the
+    // re-check on each DOM mutation retries finding the button without
+    // re-clicking anything.
     await waitForCondition(page, markForClick, {
       args: [selector, token, CLICK_TARGET_ATTR],
     });
@@ -646,7 +649,87 @@ export async function clickCfButton(
       { cause },
     );
   }
+  return token;
+}
+
+async function clickRenderedCfButton(
+  page: Page,
+  selector: string,
+) {
+  const token = await markRenderedCfButton(page, selector);
   await clickMarked(page, token);
+}
+
+export async function clickCfButton(
+  page: Page,
+  selector: string,
+) {
+  await settleView(page);
+  await clickRenderedCfButton(page, selector);
+  await settleView(page);
+}
+
+/**
+ * Settle every target page before dispatch. Mark every target before the first
+ * click. Dispatch every click without an intervening view settle. Settle every
+ * target page after dispatch.
+ */
+export async function clickCfButtonsConcurrently(
+  targets: readonly { page: Page; selector: string }[],
+): Promise<void> {
+  const pages = [...new Set(targets.map(({ page }) => page))];
+  await Promise.all(pages.map((page) => settleView(page)));
+
+  const markedByPage = pages.map((page) => ({
+    page,
+    tokens: [] as string[],
+  }));
+  const markResults = await Promise.allSettled(
+    markedByPage.map(async ({ page, tokens }) => {
+      for (
+        const { selector } of targets.filter((target) => target.page === page)
+      ) {
+        tokens.push(await markRenderedCfButton(page, selector));
+      }
+    }),
+  );
+  const clearMarks = () =>
+    Promise.all(
+      markedByPage.flatMap(({ page, tokens }) =>
+        tokens.map((token) => clearClickMark(page, token).catch(() => {}))
+      ),
+    );
+  const markFailure = markResults.find((result) =>
+    result.status === "rejected"
+  );
+  if (markFailure) {
+    await clearMarks();
+    throw markFailure.reason;
+  }
+
+  const clickResults = await Promise.allSettled(
+    markedByPage.map(async ({ page, tokens }) => {
+      for (const token of tokens) {
+        await clickMarked(page, token);
+      }
+    }),
+  );
+  await clearMarks();
+  const clickFailure = clickResults.find((result) =>
+    result.status === "rejected"
+  );
+  const settleResults = await Promise.allSettled(
+    pages.map((page) => settleView(page)),
+  );
+  if (clickFailure) {
+    throw clickFailure.reason;
+  }
+  const settleFailure = settleResults.find((result) =>
+    result.status === "rejected"
+  );
+  if (settleFailure) {
+    throw settleFailure.reason;
+  }
 }
 
 /**
@@ -681,7 +764,8 @@ export async function clickNthCfButton(
 }
 
 /**
- * Resolve the element tagged with `token` and click it, then clear the tag.
+ * Resolve the element whose click marks contain `token` and click it, then
+ * clear that mark.
  * Shared by `clickCfButton`, `clickNthCfButton`, and the text-matching click
  * helpers in `note-button-helpers.ts`: each one marks its target through its
  * own predicate, and the resolve/click/untag tail is the same for all of them.
@@ -692,7 +776,7 @@ export async function clickMarked(
 ): Promise<void> {
   try {
     const clickTarget = await page.waitForSelector(
-      `[${CLICK_TARGET_ATTR}="${token}"]`,
+      `[${CLICK_TARGET_ATTR}~="${token}"]`,
       {
         strategy: "pierce",
       },
@@ -717,15 +801,9 @@ export async function clickCfButtonAndWaitForText(
     return;
   }
 
-  // Settle the view BEFORE clicking, then click exactly ONCE. settleView
-  // resolves only once the worker is idle, the vdom batch has been applied to
-  // the main thread, and Lit updates have drained — i.e. the button's handler
-  // is actually bound. A single settled click is delivered to a live handler,
-  // so we never re-click: re-clicking a freshly-rendered control is racy (it
-  // can double-fire, and against a dismissable overlay the repeat clicks
-  // dismiss it). See docs/development/UI_TESTING.md.
+  // clickCfButton settles the view before and after delivering one click to the
+  // bound handler.
   try {
-    await settleView(page);
     await clickCfButton(page, buttonSelector);
   } catch (cause) {
     textProbe = await readTextProbe(page, textSelector).catch(() => undefined);
@@ -1666,18 +1744,21 @@ async function readDisabledProbe(
   }, { args: [selector] });
 }
 
-/** Remove the click tag carrying `token` from wherever it landed. */
+/** Remove the click mark carrying `token` from wherever it landed. */
 async function clearClickMark(
   page: Page,
   token: string,
 ): Promise<void> {
   await page.evaluate((targetToken, targetAttr) => {
+    const markTokens = (element: Element): string[] =>
+      (element.getAttribute(targetAttr) ?? "").split(/\s+/).filter(Boolean);
+
     function collect(
       root: Document | ShadowRoot,
       result: Element[],
     ): void {
       for (const element of root.querySelectorAll("*")) {
-        if (element.getAttribute(targetAttr) === targetToken) {
+        if (markTokens(element).includes(targetToken)) {
           result.push(element);
         }
         if (element.shadowRoot) {
@@ -1689,7 +1770,14 @@ async function clearClickMark(
     const matches: Element[] = [];
     collect(document, matches);
     for (const element of matches) {
-      element.removeAttribute(targetAttr);
+      const remaining = markTokens(element).filter((mark) =>
+        mark !== targetToken
+      );
+      if (remaining.length === 0) {
+        element.removeAttribute(targetAttr);
+      } else {
+        element.setAttribute(targetAttr, remaining.join(" "));
+      }
     }
   }, { args: [token, CLICK_TARGET_ATTR] });
 }

--- a/packages/patterns/integration/lunch-poll-vote.test.ts
+++ b/packages/patterns/integration/lunch-poll-vote.test.ts
@@ -31,6 +31,7 @@ import {
 } from "./pieces-controller.ts";
 import {
   clickCfButton,
+  clickCfButtonsConcurrently,
   collectBrowserLoadSummary,
   fillCfInput,
   logBrowserLoadSummary,
@@ -210,18 +211,25 @@ describe("lunch poll: two users vote on a shared option", () => {
           ]),
       );
 
-      // Both users vote green on the SAME option CONCURRENTLY: both clicks are
-      // dispatched before either browser settles, so the second voter is not
-      // guaranteed to have seen the first vote. The votes are distinct entities
-      // (keyed per voter), so both must survive and the tally reaches "2 love
-      // it" on BOTH browsers. A clobbering whole-list write against a base that
-      // missed the other vote would leave it at "1 love it".
+      // Both users vote green on the SAME option CONCURRENTLY. Both page views
+      // settle before the pair is dispatched. Neither page settles again until
+      // both clicks have been delivered. The second voter is not guaranteed to
+      // have seen the first vote. The votes are distinct entities, keyed per
+      // voter. Both must survive, and the tally reaches "2 love it" on BOTH
+      // browsers. A clobbering whole-list write against a base that missed the
+      // other vote would leave it at "1 love it".
       await timer.run(
         "both cast green concurrently",
         () =>
-          Promise.all([
-            clickCfButton(hostPage, voteButton(OPTION_A, "green")),
-            clickCfButton(guestPage, voteButton(OPTION_A, "green")),
+          clickCfButtonsConcurrently([
+            {
+              page: hostPage,
+              selector: voteButton(OPTION_A, "green"),
+            },
+            {
+              page: guestPage,
+              selector: voteButton(OPTION_A, "green"),
+            },
           ]),
       );
       await timer.run(

--- a/tasks/select-pattern-integration-files.test.ts
+++ b/tasks/select-pattern-integration-files.test.ts
@@ -131,25 +131,36 @@ Deno.test("pattern integration shard rejects unsafe integer values", () => {
   }
 });
 
-Deno.test("pattern integration profile separates the round-robin shard-one collision", async () => {
-  const files = (await listPatternIntegrationTests()).filter((name) =>
-    !INTERNALLY_SHARDED_FILE_NAMES.has(name)
-  );
+Deno.test("pattern integration profile separates a fixed round-robin collision", () => {
+  const cfCodeEditor = "cf-code-editor.test.ts";
+  const convergenceStorm = "convergence-storm.test.ts";
+  const files = [
+    "a-round-robin-control.test.ts",
+    cfCodeEditor,
+    "cfc-round-robin-control-a.test.ts",
+    "cfc-round-robin-control-b.test.ts",
+    "cfc-round-robin-control-c.test.ts",
+    convergenceStorm,
+  ];
   const roundRobin = new Map(
     files.toSorted().map((name, index) => [name, index % TOTAL_SHARDS + 1]),
   );
   const assignment = assignPatternIntegrationShards(files, TOTAL_SHARDS);
-  const cfCodeEditor = "cf-code-editor.test.ts";
-  const convergenceStorm = "convergence-storm.test.ts";
 
   assertEquals(
-    roundRobin.get(cfCodeEditor),
-    roundRobin.get(convergenceStorm),
-    "the sorted round-robin control should reproduce the profiled collision",
+    {
+      cfCodeEditor: roundRobin.get(cfCodeEditor),
+      convergenceStorm: roundRobin.get(convergenceStorm),
+    },
+    { cfCodeEditor: 2, convergenceStorm: 2 },
+    "the fixed round-robin control should reproduce the collision",
   );
   assertEquals(
-    assignment.get(cfCodeEditor) === assignment.get(convergenceStorm),
-    false,
+    {
+      cfCodeEditor: assignment.get(cfCodeEditor),
+      convergenceStorm: assignment.get(convergenceStorm),
+    },
+    { cfCodeEditor: 1, convergenceStorm: 3 },
     "the profiled assignment should separate the two expensive files",
   );
 });


### PR DESCRIPTION
The two-browser lunch-poll test could wait five minutes for the guest name input after clicking Continue as guest. Runtime idle covers worker reactivity only. A rendered button can still lack its bound handler, and a delivered click can leave its per-session state change unapplied to the DOM until the view settles again.

Settle ordinary button interactions before and after their single click. Add a grouped helper that settles every page, marks every target, dispatches all clicks without an intervening view settle, and then settles every page again. Preserve separate marks for repeated targets and clean up every mark on failure.

Add deterministic browser coverage for pre-click readiness, post-click rendering, grouped target readiness, and repeated targets. Use the grouped helper for simultaneous lunch-poll votes so the merge smoke test still begins from settled pre-vote views.

deflaked by Hixie's agent

Agent: Codex

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make CFC button clicks deterministic by settling the view before and after each click, and add a grouped helper for concurrent clicks across pages. This deflakes the lunch-poll flow, adds focused tests for pre/post-click readiness and grouped interactions, and stabilizes the sharding profile test.

- **Bug Fixes**
  - `clickCfButton` settles before and after one click so the handler is bound and effects render; `clickCfButtonAndWaitForText` uses it.
  - Click marks now support multiple tokens per element. Selectors updated to `[data-cfc-click-target~="…"]`, and cleanup removes only the specific token.
  - Sharding profile test now uses a fixed round-robin control and verifies shard assignments for `cf-code-editor.test.ts` and `convergence-storm.test.ts`, staying stable as filenames change.

- **New Features**
  - Added `clickCfButtonsConcurrently`: settle all involved pages, mark targets, dispatch all clicks together, then settle again. Cleans marks on failure and is used for simultaneous lunch-poll votes.
  - Added `cfc-browser-helpers.test.ts` covering pre-click readiness, post-click rendering, grouped target readiness, and repeated targets. `lunch-poll-vote.test.ts` now uses the grouped helper.

<sup>Written for commit 4a77632e8d56f49ff6b1859d5f2d283cdc518866. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

