### PR TITLE
feat(runner): caller-supplied event ids + receipt link exposure (verb contract WS-D/D1)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -15,6 +15,7 @@
     "jsr:@deno/loader@~0.3.10": "0.3.14",
     "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@denosaurs/plug@^1.1.0": "1.1.0",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/async@1": "1.5.0",
     "jsr:@std/async@^1.4.0": "1.5.0",
@@ -264,7 +265,7 @@
     "@std/expect@1.0.20": {
       "integrity": "ffc4f3c33f732417e3e9acf3d995818c89984313c37d933b9ebbb4571d2887e9",
       "dependencies": [
-        "jsr:@std/assert",
+        "jsr:@std/assert@^1.0.19",
         "jsr:@std/internal@^1.0.14",
         "jsr:@std/path@^1.1.6"
       ]
@@ -338,7 +339,7 @@
     "@std/testing@1.0.19": {
       "integrity": "f4236172365b216728dc3cc8b5e80a9f4c33083d1e4ede7613d5b25b4014898e",
       "dependencies": [
-        "jsr:@std/assert",
+        "jsr:@std/assert@^1.0.19",
         "jsr:@std/async@^1.4.0",
         "jsr:@std/data-structures@^1.1.0",
         "jsr:@std/fs@^1.0.24",

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -166,13 +166,13 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
 Size M (~1 week). Idempotency portion has no dependencies; result readback
 joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
 
-- **runner:** thread a caller-supplied `eventId` from `cell.send()` to
-  `queueEvent` (the parameter exists — `facade.ts:1308`; the send path passes
-  none — `cell.ts:1276`). Expose the receipt cell's link **structurally
-  through the dispatch path**: the commit callback on success, a structured
-  field on the `receipt-exists` rejection on collision. Both branches already
-  know the cell; nobody parses error prose, and the CLI never reconstructs
-  `{ $ctx, $event }` client-side.
+- ~~**runner:** thread a caller-supplied `eventId`; expose the receipt link
+  structurally~~ — **done (D1)**: `cell.send(event, onCommit, { eventId })`
+  internal options thread to `queueEvent`, and `tx.handlingReceiptLink`
+  (mirroring `dispatchedEventId`) carries the receipt address to the sender's
+  commit callback on success AND on `receipt-exists` collision — the loser
+  receives the winner's outcome address; nobody parses error prose or
+  reconstructs `{ $ctx, $event }` client-side.
 - **cli:** `--invocation <id>` on `piece call` (UUID minted and printed by
   default, including when the wait times out); after commit, sync and read the
   receipt (a cold plain read returns `undefined` — sync first); reclassify

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -175,10 +175,12 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   reconstructs `{ $ctx, $event }` client-side. The caller's key is bound to
   its stream on the way in (`scopeCallerEventId`): a receipt derives from the
   handler's input bindings plus the event id, and bindings alone do not
-  identify the verb, so an unscoped key let one id reused across two verbs of
-  a piece collide — the second call reported as an already-settled success it
-  never made. Scoping restores what minted ids had, since every minted id
-  ends in the stream link.
+  identify the verb, so an unscoped key lets one id reused across two verbs of
+  a piece collide — the second call is reported as an already-settled success
+  it never made. Scoping restores what minted ids had, since every minted id
+  ends in the stream link. The binding is a content hash over the caller's key
+  plus the whole link, not a delimited join: the caller's half is opaque, so
+  concatenation would let a chosen id shift the separator.
 - **cli:** `--invocation <id>` on `piece call` (UUID minted and printed by
   default, including when the wait times out); after commit, sync and read the
   receipt (a cold plain read returns `undefined` — sync first); reclassify

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -172,7 +172,13 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   (mirroring `dispatchedEventId`) carries the receipt address to the sender's
   commit callback on success AND on `receipt-exists` collision — the loser
   receives the winner's outcome address; nobody parses error prose or
-  reconstructs `{ $ctx, $event }` client-side.
+  reconstructs `{ $ctx, $event }` client-side. The caller's key is bound to
+  its stream on the way in (`scopeCallerEventId`): a receipt derives from the
+  handler's input bindings plus the event id, and bindings alone do not
+  identify the verb, so an unscoped key let one id reused across two verbs of
+  a piece collide — the second call reported as an already-settled success it
+  never made. Scoping restores what minted ids had, since every minted id
+  ends in the stream link.
 - **cli:** `--invocation <id>` on `piece call` (UUID minted and printed by
   default, including when the wait times out); after commit, sync and read the
   receipt (a cold plain read returns `undefined` — sync first); reclassify

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -34,6 +34,7 @@ import { encodeCellToSigilString } from "./builtins/sqlite/cf-link-codec.ts";
 import { sqliteQueryNodeFactory } from "./builtins/sqlite/query-node.ts";
 import { checkSqliteWriteCeiling } from "./builtins/sqlite/write-ceiling.ts";
 import { checkSqliteRowLabelWrite } from "./builtins/sqlite/row-label-write.ts";
+import { scopeCallerEventId } from "./scheduler/event-identity.ts";
 import { recordSinkRequestPolicyInput } from "./cfc/sink-request.ts";
 import { cfcLabelViewForCell } from "./cfc/label-view.ts";
 import { cfcConfidentialityForObservationNode } from "./cfc/observation.ts";
@@ -1324,7 +1325,12 @@ export class CellImpl<T extends FabricValue>
         onCommit,
         false,
         {
-          eventId: sendOptions?.eventId,
+          // The caller's key is opaque and unscoped; queueEvent expects a
+          // durable delivery id. Binding it to this stream is what keeps two
+          // verbs that share input bindings from colliding on one receipt.
+          eventId: sendOptions?.eventId === undefined
+            ? undefined
+            : scopeCallerEventId(sendOptions.eventId, resolvedToValueLink),
           originTx: this.tx ?? undefined,
         },
       );

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1284,9 +1284,11 @@ export class CellImpl<T extends FabricValue>
      * Internal-only stream-send options. `eventId` supplies the durable event
      * id (spec §7.5) instead of minting one: an ingress caller that owns a
      * delivery id passes it through so a retry of the same id collides on the
-     * handling's create-only receipt instead of re-executing (verb contract
-     * WS-D, docs/plans/pattern-verb-contract-implementation.md). Ignored on
-     * the plain-cell write path.
+     * handling's create-only receipt (verb contract WS-D,
+     * docs/plans/pattern-verb-contract-implementation.md). The receipt is a
+     * COMMIT witness, not an execution witness — the redelivered event still
+     * runs the handler body and then loses the race, so effects outside the
+     * transaction repeat. Ignored on the plain-cell write path.
      */
     sendOptions?: { eventId?: string },
   ): Cell<T> {
@@ -1425,8 +1427,9 @@ export class CellImpl<T extends FabricValue>
         /**
          * Internal-only stream-send options: `eventId` passes a
          * caller-supplied durable event id through to the scheduler, so a
-         * same-id retry collides on the handling's create-only receipt
-         * instead of re-executing (verb contract WS-D).
+         * same-id retry collides on the handling's create-only receipt and
+         * cannot commit twice — though the body does re-run (verb contract
+         * WS-D).
          */
         { eventId?: string },
       ]

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -283,22 +283,32 @@ declare module "@commonfabric/api" {
     set(
       value: AnyCellWrapping<T> | T,
       onCommit?: (tx: IExtendedStorageTransaction) => void,
+      sendOptions?: { eventId?: string },
     ): C;
   }
 
   /**
-   * Augment Streamable to add onCommit callback support.
-   * Event is optional only when T is void (matching public API).
+   * Augment Streamable to add onCommit callback and internal send-options
+   * support (`eventId` — caller-supplied durable event id, verb contract
+   * WS-D). Event is optional only when T is void (matching public API).
    */
   interface IStreamable<T> {
     send(
       ...args: T extends void ? [] | [AnyCellWrapping<T> | T] | [
           AnyCellWrapping<T> | T,
           (tx: IExtendedStorageTransaction) => void,
+        ] | [
+          AnyCellWrapping<T> | T,
+          ((tx: IExtendedStorageTransaction) => void) | undefined,
+          { eventId?: string },
         ]
         : [AnyCellWrapping<T> | T] | [
           AnyCellWrapping<T> | T,
           (tx: IExtendedStorageTransaction) => void,
+        ] | [
+          AnyCellWrapping<T> | T,
+          ((tx: IExtendedStorageTransaction) => void) | undefined,
+          { eventId?: string },
         ]
     ): void;
   }
@@ -1270,6 +1280,15 @@ export class CellImpl<T extends FabricValue>
      * after success.
      */
     onCommit?: (tx: IExtendedStorageTransaction) => void,
+    /**
+     * Internal-only stream-send options. `eventId` supplies the durable event
+     * id (spec §7.5) instead of minting one: an ingress caller that owns a
+     * delivery id passes it through so a retry of the same id collides on the
+     * handling's create-only receipt instead of re-executing (verb contract
+     * WS-D, docs/plans/pattern-verb-contract-implementation.md). Ignored on
+     * the plain-cell write path.
+     */
+    sendOptions?: { eventId?: string },
   ): Cell<T> {
     const resolvedToValueLink = resolveLink(
       this.runtime,
@@ -1302,7 +1321,10 @@ export class CellImpl<T extends FabricValue>
         undefined,
         onCommit,
         false,
-        { originTx: this.tx ?? undefined },
+        {
+          eventId: sendOptions?.eventId,
+          originTx: this.tx ?? undefined,
+        },
       );
 
       this.cleanup?.();
@@ -1383,6 +1405,10 @@ export class CellImpl<T extends FabricValue>
          * after success.
          */
         (tx: IExtendedStorageTransaction) => void,
+      ] | [
+        AnyCellWrapping<T>,
+        ((tx: IExtendedStorageTransaction) => void) | undefined,
+        { eventId?: string },
       ]
       : [AnyCellWrapping<T>] | [
         AnyCellWrapping<T>,
@@ -1393,10 +1419,20 @@ export class CellImpl<T extends FabricValue>
          * after success.
          */
         (tx: IExtendedStorageTransaction) => void,
+      ] | [
+        AnyCellWrapping<T>,
+        ((tx: IExtendedStorageTransaction) => void) | undefined,
+        /**
+         * Internal-only stream-send options: `eventId` passes a
+         * caller-supplied durable event id through to the scheduler, so a
+         * same-id retry collides on the handling's create-only receipt
+         * instead of re-executing (verb contract WS-D).
+         */
+        { eventId?: string },
       ]
   ): void {
-    const [event, onCommit] = args;
-    this.set(event as AnyCellWrapping<T>, onCommit);
+    const [event, onCommit, sendOptions] = args;
+    this.set(event as AnyCellWrapping<T>, onCommit, sendOptions);
   }
 
   update<V extends (Partial<T> | AnyCellWrapping<Partial<T>>)>(

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -4135,6 +4135,12 @@ export class Runner {
       undefined,
       tx,
     );
+    // Expose the handling's receipt address on the transaction, where the
+    // sender's commit callback can read it (verb contract WS-D). Stashed
+    // before the branches so BOTH outcomes carry it: a committed handling
+    // hands back its own receipt, and a create-only collision loser hands
+    // back the same address — which is the winner's original outcome.
+    tx.handlingReceiptLink = receiptCell.getAsNormalizedFullLink();
     const receiptsEnabled =
       this.runtime.experimental.commitPreconditions === true;
     if (!resultHasReactives && frame.reactives.size === 0) {

--- a/packages/runner/src/scheduler/event-identity.ts
+++ b/packages/runner/src/scheduler/event-identity.ts
@@ -1,3 +1,4 @@
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import type { NormalizedFullLink } from "../link-utils.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 
@@ -50,10 +51,34 @@ export function mintEventId(
  * Scoping keeps the property the protocol actually wants: the same id sent to
  * the same stream is the same invocation (retries deduplicate), while the same
  * id sent elsewhere is a different one.
+ *
+ * The binding is a content hash of a structured value rather than delimited
+ * concatenation, because the caller's half is opaque: with `a:b` joined by
+ * `:`, the pair (`x`, `y:z`) and the pair (`x:y`, `z`) render identically, and
+ * a caller choosing its own id chooses which side of that ambiguity to sit on.
+ * Hashing also lets the whole link identify the stream — id, path, and space —
+ * so this does not quietly depend on stream links always being whole documents
+ * at the empty path, which is true today and is not a stated invariant.
+ * `hashOf` is type-tagged and length-prefixed, so no component can impersonate
+ * another, and it is deterministic across processes: a retry from a fresh CLI
+ * invocation derives the same id.
+ *
+ * The result deliberately does not carry the caller's id in the clear. That
+ * costs some greppability — an operator correlating a CLI invocation id with a
+ * scheduler log line has to re-derive it — but the id is caller-controlled
+ * text that would otherwise reach logs and telemetry verbatim. Do not append
+ * the raw id back for convenience.
  */
 export function scopeCallerEventId(
   callerEventId: string,
   eventLink: NormalizedFullLink,
 ): string {
-  return `evt:caller:${callerEventId}:${eventLink.id}`;
+  return `evt:caller:${
+    hashStringOf({
+      caller: callerEventId,
+      id: eventLink.id,
+      path: [...eventLink.path],
+      space: eventLink.space,
+    })
+  }`;
 }

--- a/packages/runner/src/scheduler/event-identity.ts
+++ b/packages/runner/src/scheduler/event-identity.ts
@@ -19,7 +19,8 @@ function originStateFor(tx: object): { key: string; counter: number } {
 
 /**
  * Mints the durable id for an event at send time (spec §7.5). Ingress
- * callers that already own a durable delivery id pass it through instead.
+ * callers that already own a durable delivery id pass it through
+ * {@link scopeCallerEventId} instead.
  */
 export function mintEventId(
   eventLink: NormalizedFullLink,
@@ -31,4 +32,28 @@ export function mintEventId(
     return `evt:${state.key}:${seq}:${eventLink.id}`;
   }
   return `evt:${crypto.randomUUID()}:${eventLink.id}`;
+}
+
+/**
+ * Binds a caller-supplied delivery id to the stream it was sent to.
+ *
+ * Every minted id above ends in `eventLink.id`, and that is load-bearing: the
+ * handling's receipt derives from the handler's input bindings plus the event
+ * id (`runner.ts`, `cause.$event`), and the bindings alone do not identify the
+ * verb — two handlers on one piece that close over the same state have
+ * byte-identical bindings. The stream component is what keeps their receipts
+ * apart. A raw caller id carries no such component, so without this an agent
+ * reusing one invocation id across two verbs would have its second call
+ * collide on the first's receipt and be reported as an already-settled
+ * success it never made.
+ *
+ * Scoping keeps the property the protocol actually wants: the same id sent to
+ * the same stream is the same invocation (retries deduplicate), while the same
+ * id sent elsewhere is a different one.
+ */
+export function scopeCallerEventId(
+  callerEventId: string,
+  eventLink: NormalizedFullLink,
+): string {
+  return `evt:caller:${callerEventId}:${eventLink.id}`;
 }

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -257,6 +257,9 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
   readonly originTx?: IExtendedStorageTransaction;
   readonly time?: number;
 }): void {
+  // `eventId` here is an already-durable delivery id, used verbatim — an
+  // ingress caller's opaque idempotency key is bound to its stream earlier,
+  // at the send surface (cell.ts), via scopeCallerEventId.
   const id = args.eventId ?? mintEventId(args.eventLink, args.originTx);
   const handler = findEventHandler(state.eventHandlers, args.eventLink);
 

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1047,6 +1047,17 @@ export interface IExtendedStorageTransaction
   dispatchedEventId?: string;
 
   /**
+   * The durable address of this handling's result/receipt cell (spec §7.6:
+   * "the receipt is the handling's result cell"). Set by the runner when a
+   * handler's outcome is written; consumed by a sender's commit callback to
+   * hand the caller a readable handle — on success AND on a create-only
+   * receipt collision, where it addresses the winner's original outcome
+   * (verb contract WS-D). Structural exposure so no caller ever reconstructs
+   * the `{ $ctx, $event }` cause or parses error prose.
+   */
+  handlingReceiptLink?: NormalizedFullLink;
+
+  /**
    * The wall-clock instant (ms) of the event whose dispatch opened this
    * transaction. Set by the scheduler's event dispatch; consumed by the runner
    * to freeze the handler frame's ambient clock (see Frame.eventTime). Carried

--- a/packages/runner/test/scheduler-event-identity.test.ts
+++ b/packages/runner/test/scheduler-event-identity.test.ts
@@ -6,7 +6,10 @@ import {
   it,
   space,
 } from "./scheduler-test-utils.ts";
-import { mintEventId } from "../src/scheduler/event-identity.ts";
+import {
+  mintEventId,
+  scopeCallerEventId,
+} from "../src/scheduler/event-identity.ts";
 import {
   dropQueuedEvent,
   queueSchedulerEvent,
@@ -54,6 +57,56 @@ describe("scheduler event identity", () => {
     expect(first).toMatch(/^evt:[^:]+:of:event-stream$/);
     expect(second).toMatch(/^evt:[^:]+:of:event-stream$/);
     expect(first).not.toBe(second);
+  });
+
+  it("scopes a caller id deterministically, so a retry re-derives it", () => {
+    // A retry may come from a fresh CLI process; same inputs must give the
+    // same durable id or the receipt collision never happens.
+    expect(scopeCallerEventId("inv-1", eventLink)).toBe(
+      scopeCallerEventId("inv-1", eventLink),
+    );
+    expect(scopeCallerEventId("inv-1", eventLink)).not.toBe(
+      scopeCallerEventId("inv-2", eventLink),
+    );
+  });
+
+  it("separates one caller id sent to different streams", () => {
+    // The defect the helper exists for: an invocation id reused across two
+    // verbs of a piece must not make the second collide on the first's
+    // receipt and report as an already-settled success.
+    const other: NormalizedFullLink = { ...eventLink, id: "of:other-stream" };
+    expect(scopeCallerEventId("inv-1", eventLink)).not.toBe(
+      scopeCallerEventId("inv-1", other),
+    );
+  });
+
+  it("distinguishes streams differing only by path or space", () => {
+    // Stream links are whole documents at the empty path today; covering
+    // path and space keeps the helper from depending on that quietly.
+    const atA: NormalizedFullLink = { ...eventLink, path: ["a"] };
+    const atB: NormalizedFullLink = { ...eventLink, path: ["b"] };
+    expect(scopeCallerEventId("inv-1", atA)).not.toBe(
+      scopeCallerEventId("inv-1", atB),
+    );
+    const elsewhere: NormalizedFullLink = {
+      ...eventLink,
+      space: "did:key:z6MkOtherEventIdentity" as MemorySpace,
+    };
+    expect(scopeCallerEventId("inv-1", eventLink)).not.toBe(
+      scopeCallerEventId("inv-1", elsewhere),
+    );
+  });
+
+  it("cannot be confused by a caller id that mimics a delimiter", () => {
+    // The caller's half is opaque and caller-chosen. Under delimited
+    // concatenation these pairs render identically; hashing keeps them apart.
+    // A link id is a URI, so it always carries a colon of its own — the
+    // separator is not distinguishable from the payload by inspection.
+    const ofYZ: NormalizedFullLink = { ...eventLink, id: "of:y:z" };
+    const yZ: NormalizedFullLink = { ...eventLink, id: "y:z" };
+    expect(scopeCallerEventId("x", ofYZ)).not.toBe(
+      scopeCallerEventId("x:of", yZ),
+    );
   });
 
   it("threads explicit event ids into queued events", () => {

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -951,6 +951,78 @@ describe("scheduler event receipts", () => {
     }
   });
 
+  it("cell.send carries a caller-supplied eventId and exposes the receipt link", async () => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { handler, pattern } = commonfabric;
+    let handlerInvocations = 0;
+    const noLaunch = handler<unknown, Record<string, never>>(
+      () => {
+        handlerInvocations++;
+      },
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => {
+      return { stream: noLaunch({}) };
+    });
+    const rootCell = runtime.getCell<{ stream: unknown }>(
+      space,
+      "receipts cell-send caller id root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    // Ingress-caller path (verb contract WS-D): the id rides cell.send's
+    // internal options instead of queueEvent directly — the CLI's route.
+    const eventId = "evt:receipt-cell-send:0:caller-id-root";
+    const outcomes: Array<{
+      status: string;
+      precondition?: string;
+      receiptLink?: ReturnType<Cell<unknown>["getAsNormalizedFullLink"]>;
+    }> = [];
+    const record = (t: IExtendedStorageTransaction) => {
+      const status = t.status();
+      outcomes.push({
+        status: status.status,
+        precondition: (status as { error?: { precondition?: string } }).error
+          ?.precondition,
+        receiptLink: t.handlingReceiptLink,
+      });
+    };
+    const streamCell = root.key("stream") as Cell<unknown>;
+    streamCell.send({}, record, { eventId });
+    await waitForSchedulerCondition(
+      runtime,
+      () => handlerInvocations === 1 && outcomes.length === 1,
+      "cell-send event did not settle",
+    );
+    // Same id again: the body re-runs (exactly-once is per commit) but the
+    // create-only receipt collides, and the loser's callback still carries
+    // the SAME receipt address — the winner's original outcome.
+    streamCell.send({}, record, { eventId });
+    await waitForSchedulerCondition(
+      runtime,
+      () => handlerInvocations === 2 && outcomes.length === 2,
+      "cell-send redelivery did not settle",
+    );
+    await runtime.scheduler.idleWithPendingCommits();
+
+    const expectedLink = receiptCellForEvent<Record<string, never>>(
+      runtime,
+      eventId,
+    ).getAsNormalizedFullLink();
+
+    expect(outcomes[0].status).toBe("done");
+    expect(outcomes[0].receiptLink?.id).toBe(expectedLink.id);
+    expect(outcomes[0].receiptLink?.space).toBe(expectedLink.space);
+    expect(outcomes[1].status).toBe("error");
+    expect(outcomes[1].precondition).toBe("receipt-exists");
+    expect(outcomes[1].receiptLink?.id).toBe(expectedLink.id);
+  });
+
   it("creates a receipt document for handlers that launch nothing", async () => {
     const { commonfabric } = createTrustedBuilder(runtime);
     const { handler, pattern } = commonfabric;

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -19,6 +19,7 @@ import type {
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { resolveLink } from "../src/link-resolution.ts";
 import { dispatchQueuedEvent } from "../src/scheduler/events.ts";
+import { scopeCallerEventId } from "../src/scheduler/event-identity.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 
@@ -1010,9 +1011,11 @@ describe("scheduler event receipts", () => {
     );
     await runtime.scheduler.idleWithPendingCommits();
 
+    // The caller's id is scoped to the stream before it becomes the durable
+    // event id, so the receipt address derives from the scoped form.
     const expectedLink = receiptCellForEvent<Record<string, never>>(
       runtime,
-      eventId,
+      scopeCallerEventId(eventId, resolvedStreamLink(streamCell, runtime)),
     ).getAsNormalizedFullLink();
 
     expect(outcomes[0].status).toBe("done");
@@ -1021,6 +1024,65 @@ describe("scheduler event receipts", () => {
     expect(outcomes[1].status).toBe("error");
     expect(outcomes[1].precondition).toBe("receipt-exists");
     expect(outcomes[1].receiptLink?.id).toBe(expectedLink.id);
+  });
+
+  it("two verbs sharing one caller-supplied id do not collide", async () => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { handler, pattern } = commonfabric;
+    let incremented = 0;
+    let decremented = 0;
+    // Two distinct verbs with IDENTICAL input bindings (both bound {}) — the
+    // shape the receipt cause cannot tell apart once $event is overwritten by
+    // a caller-supplied id. A minted id embeds the stream link and keeps them
+    // apart; a caller-supplied one must not lose that.
+    const increment = handler<unknown, Record<string, never>>(() => {
+      incremented++;
+    }, { proxy: true });
+    const decrement = handler<unknown, Record<string, never>>(() => {
+      decremented++;
+    }, { proxy: true });
+    const rootPattern = pattern(() => ({
+      increment: increment({}),
+      decrement: decrement({}),
+    }));
+    const rootCell = runtime.getCell<
+      { increment: unknown; decrement: unknown }
+    >(space, "receipts cross-verb caller id root", undefined, tx);
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const outcomes: Array<{ status: string; precondition?: string }> = [];
+    const record = (t: IExtendedStorageTransaction) => {
+      const status = t.status();
+      outcomes.push({
+        status: status.status,
+        precondition: (status as { error?: { precondition?: string } }).error
+          ?.precondition,
+      });
+    };
+    // The SAME caller id addressed at two different verbs. Each is a distinct
+    // invocation of a distinct verb; neither may deduplicate onto the other.
+    const eventId = "caller-shared-id";
+    (root.key("increment") as Cell<unknown>).send({}, record, { eventId });
+    await waitForSchedulerCondition(
+      runtime,
+      () => incremented === 1 && outcomes.length === 1,
+      "increment did not settle",
+    );
+    (root.key("decrement") as Cell<unknown>).send({}, record, { eventId });
+    await waitForSchedulerCondition(
+      runtime,
+      () => outcomes.length === 2,
+      "decrement did not settle",
+    );
+    await runtime.scheduler.idleWithPendingCommits();
+
+    expect(outcomes[0].status).toBe("done");
+    expect(outcomes[1].precondition).toBeUndefined();
+    expect(outcomes[1].status).toBe("done");
+    expect(decremented).toBe(1);
   });
 
   it("creates a receipt document for handlers that launch nothing", async () => {


### PR DESCRIPTION
## Why

Phase 2 of the verb-contract implementation plan (#4968), and the arc's most empirically motivated slice: three times in one evening on the live topics board we hit a timed-out mutation with unknowable commit state and no safe retry — the exact duplicate-minting failure the design documents. The scheduler already has the machinery (durable event ids, create-only receipts, I11); what was missing is the plumbing that lets a caller use it.

## What Changed

- **`cell.send(event, onCommit, { eventId })`**: internal-only send options thread a caller-supplied durable event id to `queueEvent`'s existing `opts.eventId`. Same internal tier as the existing `onCommit` parameter — the pattern-facing `IStreamable` in `packages/api` is untouched; only the runner's module augmentation widens.
- **`scopeCallerEventId`**: the caller's key is bound to its stream before it becomes the durable event id. This is load-bearing, not decoration. A handling's receipt derives from the handler's input bindings plus the event id, and the bindings alone do not identify the verb — two handlers on one piece that close over the same state have byte-identical bindings. Every minted id ends in the stream link, which is what kept their receipts apart; a raw caller id has no such component. Without scoping, `--invocation X increment` followed by `--invocation X decrement` made the second collide on the first's receipt and report as an already-settled success it never made. Applied at the send surface; `queueEvent`'s own `eventId` keeps its existing meaning of an already-durable id used verbatim, so its callers and tests are unchanged.
- **`tx.handlingReceiptLink`** (mirroring `dispatchedEventId`'s pattern): the runner stashes the handling's receipt address on the transaction before the outcome branches, so the sender's commit callback receives it **structurally** in both cases — success (this handling's outcome) and `receipt-exists` collision (the winner's original outcome). No caller reconstructs `{ $ctx, $event }`; no error-prose parsing.
- **Docs corrected**: the JSDoc claimed a same-id retry collides "instead of re-executing", which this PR's own test disproves (`handlerInvocations === 2` after redelivery). The receipt is a **commit** witness, not an execution witness — the body re-runs and then loses the race, so a verb whose body reaches outside its transaction repeats those effects on retry. Nothing commits twice; that is the whole guarantee, and the docs now say only that.
- Implementation plan: D1 checked off, including the scoping rule.

**Next (D2, #5089):** `cf piece call --invocation`, receipt readback via this link, `receipt-exists` reclassified as success-with-readback, phase reporting, and transaction-local acknowledgment.

## Test plan

- `packages/runner` full suite: 1073 passed, 5614 steps, 0 failed.
- `scheduler-event-receipts.test.ts` — 14 steps green, including two new cases: the cell-send contract end to end (caller id in, body re-runs on redelivery, receipt at the id-derived address, link exposed on success and on the collision), and a regression test that sends one id to two zero-arg verbs and fails if either deduplicates onto the other.
- `deno check` on runner sources; `deno fmt --check`; lint — clean.

## Coverage note (no debt accepted)

The `packages/runner` coverage metric is nondeterministic on this branch: identical code measured 6948 uncovered lines on two runs and 6909 on a third. The entire 39-line swing is in `packages/runner/src/traverse.ts`, which this PR does not touch — every other runner file sits at zero delta. Located by diffing per-file lcov between a PR run and a main run:

- `traverse.ts:2997-3026` — the body of `if (elapsed > 100)`, a slow-traverse diagnostic that runs only when a single traversal exceeds 100ms of wall clock.
- `traverse.ts:699-713` — the `size` and `totalValues` getters, whose only caller is that warning block.

Coverage of those lines tracks CI machine load, not the diff. The same nondeterminism shows elsewhere in the same runs: `packages/toolshed` moved +3 in one and -3 in the next with no toolshed change in either the PR or main.

**If this check goes red on a re-run, re-run it — do not add ACCEPT_COVERAGE_DEBT.** A merged override is applied to future baselines (`tasks/coverage-check.ts`, `applyBaselineOverrides`), so accepting 6948 here would permanently loosen the runner ratchet by 39 lines and hide that much real regression in every later PR.

Worth fixing separately: a ratchet that gates on wall-clock-triggered diagnostic branches will keep failing unrelated PRs that touch `packages/runner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds caller-supplied durable event IDs to `cell.send` and exposes the handling’s receipt link on the transaction, with ids scoped to the target stream via a content hash to prevent cross-verb collisions (WS-D/D1). Callers get a stable receipt handle, and retries don’t double-commit.

- **New Features**
  - `cell.send(event, onCommit, { eventId })` threads a caller `eventId` to `queueEvent` (internal-only; public API unchanged).
  - Runner sets `tx.handlingReceiptLink` before branching so commit callbacks get the receipt link on success and on `receipt-exists`.
  - Docs/JSDoc clarified the receipt is a commit witness; plan updated to mark D1 done.

- **Bug Fixes**
  - `scopeCallerEventId` binds a caller id to its stream by hashing the id with the full stream link (id, path, space), not concatenation, preventing cross-verb and delimiter-trick collisions; applied at the send surface.
  - Tests cover deterministic scoping, path/space differences, delimiter spoofing, the full `cell.send` path with receipt link exposure, and a regression where two verbs sharing one caller id must not collide.

<sup>Written for commit e87e75038a8be3acf54ea673d0db9d9ab18f69b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

