### PR TITLE
test(background-piece-service): run the suite under the fake clock

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -399,6 +399,52 @@ distinction it checks is decided by the rejection's error type rather than by
 elapsed time, so collapsing the backoff timing preserves the outcome each case
 asserts.
 
+## The background-piece-service suite: the same clock for a polling loop
+
+`packages/background-piece-service` loads the same shared harness — its
+`packages/background-piece-service/test/clock-preload.ts` calls
+`installFakeClock` in the `auto-advance` mode, wired through `--preload` on the
+package test task, with the controls exposed as a global `clock` typed in
+`test/clock.d.ts` — and follows the same rule for test sleeps. It needs the
+clock for the same reason the runner does: the service's own machinery is
+time-coupled, so freezing every positive-delay timer would deadlock a plain test
+on the service's own loop rather than on any sleep the test wrote.
+
+Three pieces of the service arm positive-delay timers. `SpaceManager.execLoop`
+parks on `sleep(pollingIntervalMs)` between polls of its task queue.
+`SpaceManager.stop` races a `setInterval` that watches for the active job to
+finish against a `sleep(deactivationTimeoutMs)` deadline. And
+`WorkerController.exec` arms a `setTimeout(timeoutMs)` that rejects a worker
+request the worker never answers. Each of these is scheduled from `src/`, so the
+clock reads it as a production timer. The poll and the deactivation deadline
+reach `setTimeout` indirectly, through the `sleep` helper in
+`@commonfabric/utils`; that does not change the classification, because the
+clock reads the immediate caller's frame, and `sleep`'s own frame is a `src/`
+frame too. They therefore auto-advance: the poll interval elapses instantly,
+and an unanswered worker request's timeout fires on its own.
+The auto-advance mechanism is the runner's, described just above.
+
+Each wait these tests need goes through the clock. A test that exercises one
+branch of the exec loop and then stops it starts the loop, calls
+`clock.settle()` to let it reach its parked `sleep`, clears `isRunning`, and
+calls `clock.tick(1)` to fire that parked sleep so the loop sees the flag and
+exits. A test that waits for a worker's initialize request to time out calls
+`clock.tick(1)` to fire the `timeoutMs` timer. A test that needs only the next
+reactive turn — a sink firing, a shutdown callback running — waits on
+`clock.settle()`.
+
+One file stays on the real clock, listed in the preload's `realClockFiles`:
+`otel.test.ts`. It exercises the real OpenTelemetry SDK against a real loopback
+OTLP receiver. The provider's `forceFlush` and `shutdown` guard each flush with
+their own `setTimeout`, armed inside the vendored SDK rather than from `src/`;
+under auto-advance that guard fires against the real HTTP round trip before it
+completes, and the flush reports that the span processor did not finish within
+its timeout. The SDK's periodic metric reader arms a repeating interval that is
+a production timer too. These tests carry no sleeps or deadlines to convert, so
+the fake clock would buy them no determinism; they keep real time, already opt
+out of the op sanitizer for those timers, and tear them down through
+`shutdownOpenTelemetry`.
+
 ## The runtime-client suite stays on the real clock
 
 `packages/runtime-client` keeps its unit tests on the real clock, and the

--- a/packages/background-piece-service/deno.jsonc
+++ b/packages/background-piece-service/deno.jsonc
@@ -5,7 +5,12 @@
     "help": "deno run -A src/main.ts --help",
     "add-admin-piece": "deno run -A cast-admin.ts --patternPath=bgAdmin.tsx",
     // --no-check: this package is type-checked by `deno task check` (tasks/check.sh).
-    "test": "deno test --no-check --allow-env --allow-ffi --allow-net=127.0.0.1 --allow-read --allow-run --allow-write --allow-sys test/*.test.ts",
+    // --preload runs test/clock-preload.ts before the test modules; it replaces
+    // the clock so the service's own polls and timeouts auto-advance and test
+    // sleeps freeze. See that file and docs/development/waiting-in-tests.md. The
+    // global `clock` type lives in test/clock.d.ts, which `deno task check` sees
+    // by type-checking the package as one program.
+    "test": "deno test --no-check --preload=test/clock-preload.ts --allow-env --allow-ffi --allow-net=127.0.0.1 --allow-read --allow-run --allow-write --allow-sys test/*.test.ts",
     "check": "deno check src/**/*.ts",
     "lint": "deno lint",
     "fmt": "deno fmt"

--- a/packages/background-piece-service/test/clock-preload.ts
+++ b/packages/background-piece-service/test/clock-preload.ts
@@ -1,0 +1,31 @@
+// Runs before every test module in this package (wired in through `--preload`
+// on the package's test task). It installs the shared fake clock in
+// "auto-advance" mode: the service's own positive-delay timers (armed from
+// `src/` — `SpaceManager.execLoop`'s poll interval, `SpaceManager.stop`'s
+// deactivation deadline, and `WorkerController.exec`'s request timeout, all
+// reached through the `sleep` helper in `@commonfabric/utils`) advance logical
+// time on their own, so a poll elapses instantly and an unanswered worker
+// request times out without real sleeping, while a wall-clock sleep armed from a
+// `test/` file freezes and its waiter deadlocks. The controls are a global
+// `clock` (settle/tick/reset), typed in `test/clock.d.ts`. See the shared
+// harness at `packages/test-support/test/clock-preload.ts` and
+// `docs/development/waiting-in-tests.md`.
+
+import { installFakeClock } from "@commonfabric/test-support/clock-preload";
+
+installFakeClock({
+  mode: "auto-advance",
+  realClockFiles: [
+    // otel.test.ts exercises the real OpenTelemetry SDK against a real loopback
+    // OTLP receiver. The provider's forceFlush and shutdown guard each flush
+    // with their own setTimeout, armed inside the vendored SDK rather than from
+    // `src/`; under auto-advance that guard fires against the real HTTP round
+    // trip before it completes, and the flush reports that the span processor
+    // did not finish within its timeout. The SDK's periodic metric reader arms a
+    // repeating interval that is a production timer too. These tests carry no
+    // sleeps or deadlines to convert, so the fake clock buys them no
+    // determinism; they keep real time, already opt out of the op sanitizer for
+    // those timers, and tear them down through shutdownOpenTelemetry.
+    "otel",
+  ],
+});

--- a/packages/background-piece-service/test/clock.d.ts
+++ b/packages/background-piece-service/test/clock.d.ts
@@ -1,10 +1,10 @@
 // Ambient types for the clock preload (`clock-preload.ts`). `deno check` sees
-// this because it type-checks the package directory as one program; test files
-// reference `clock` with no import. Declared with `var` rather than `const` so
-// it merges with the identical global that `packages/background-piece-service`
-// declares for its own copy of this harness: `deno task check` compiles every
-// workspace package as one program, and two block-scoped `const clock` bindings
-// there collide (TS2451), while two `var` bindings of the same type merge.
+// this because it type-checks the package as one program (`deno task check`);
+// test files reference `clock` with no import. Declared with `var` rather than
+// `const` so it merges with the identical global that `packages/runner` declares
+// for its own copy of this harness: `deno task check` compiles every workspace
+// package as one program, and two block-scoped `const clock` bindings there
+// collide (TS2451), while two `var` bindings of the same type merge.
 // deno-lint-ignore no-var
 declare var clock: {
   // Drain reactive (zero-delay) work to a fixpoint without moving the clock.

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, describe, it } from "@std/testing/bdd";
 import {
   assert,
   assertEquals,
@@ -486,7 +486,7 @@ describe("BackgroundPieceService", () => {
     assertEquals(piecesCell.schemaSyncCount, 1);
 
     piecesCell.emit([]);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await clock.settle();
     assertEquals(stopped, [TEST_DID]);
     await service.stop();
   });
@@ -533,7 +533,7 @@ describe("BackgroundPieceService", () => {
         pieceId: OTHER_PIECE_ID,
       })),
     ]);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await clock.settle();
 
     assertEquals(started, [TEST_DID]);
     assertEquals(stopped, [TEST_DID]);
@@ -542,6 +542,15 @@ describe("BackgroundPieceService", () => {
 });
 
 describe("SpaceManager", () => {
+  // One freezeAround wraps this whole describe, so its timer map and logical
+  // clock persist across cases. Several cases leave a fire-and-forget
+  // WorkerController.shutdown() (from setupWorkerController) parked on a worker
+  // that never answers, so its cleanup timeout lingers in the map. Dropping
+  // every pending timer after each case keeps a leftover from firing in a later
+  // case — here or in a following describe once this one's trailing
+  // auto-advance runs.
+  afterEach(() => clock.reset());
+
   it("schedules, runs, retries, disables, and removes pieces", async () => {
     await withMockWorker(async () => {
       const entry = new FakeEntryCell(pieceEntry());
@@ -629,8 +638,12 @@ describe("SpaceManager", () => {
 
       manager.start();
       manager.start();
-      await new Promise((resolve) => setTimeout(resolve, 2));
+      // execLoop parks on sleep(pollingIntervalMs) each pass; let it reach the
+      // first park, stop it, then fire the parked sleep so the loop observes
+      // isRunning === false and exits.
+      await clock.settle();
       await manager.stop();
+      await clock.tick(1);
       assertEquals(
         (manager as never as { isRunning: boolean }).isRunning,
         false,
@@ -701,10 +714,14 @@ describe("SpaceManager", () => {
         shutdown: () => Promise.resolve(),
       };
       (manager as never as { isRunning: boolean }).isRunning = true;
-      setTimeout(() => {
-        (manager as never as { isRunning: boolean }).isRunning = false;
-      }, 2);
-      await (manager as never as { execLoop: () => Promise<void> }).execLoop();
+      // isReady() === false: the loop parks on sleep(pollingIntervalMs). Let it
+      // reach the park, clear isRunning, then fire the parked sleep so it exits.
+      const idleLoop = (manager as never as { execLoop: () => Promise<void> })
+        .execLoop();
+      await clock.settle();
+      (manager as never as { isRunning: boolean }).isRunning = false;
+      await clock.tick(1);
+      await idleLoop;
 
       (manager as never as { workerController: unknown }).workerController = {
         isReady: () => true,
@@ -713,12 +730,16 @@ describe("SpaceManager", () => {
       (manager as never as { activePiece: FakeEntryCell | null }).activePiece =
         entry;
       (manager as never as { isRunning: boolean }).isRunning = true;
-      setTimeout(() => {
-        (manager as never as { activePiece: FakeEntryCell | null })
-          .activePiece = null;
-        (manager as never as { isRunning: boolean }).isRunning = false;
-      }, 2);
-      await (manager as never as { execLoop: () => Promise<void> }).execLoop();
+      // isReady() === true with an active piece: the loop parks until the active
+      // piece clears.
+      const activeLoop = (manager as never as { execLoop: () => Promise<void> })
+        .execLoop();
+      await clock.settle();
+      (manager as never as { activePiece: FakeEntryCell | null }).activePiece =
+        null;
+      (manager as never as { isRunning: boolean }).isRunning = false;
+      await clock.tick(1);
+      await activeLoop;
 
       (manager as never as { pendingTasks: unknown[] }).pendingTasks = [{
         pieceId: PIECE_ID,
@@ -726,10 +747,14 @@ describe("SpaceManager", () => {
         timestamp: Date.now() + 10,
       }];
       (manager as never as { isRunning: boolean }).isRunning = true;
-      setTimeout(() => {
-        (manager as never as { isRunning: boolean }).isRunning = false;
-      }, 2);
-      await (manager as never as { execLoop: () => Promise<void> }).execLoop();
+      // The only pending task is scheduled in the future: the loop parks until
+      // it comes due.
+      const futureLoop = (manager as never as { execLoop: () => Promise<void> })
+        .execLoop();
+      await clock.settle();
+      (manager as never as { isRunning: boolean }).isRunning = false;
+      await clock.tick(1);
+      await futureLoop;
 
       const calls: string[] = [];
       (manager as never as { workerController: unknown }).workerController = {
@@ -775,9 +800,12 @@ describe("SpaceManager", () => {
       });
 
       manager.watch([entry as never]);
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      // Let the initial worker finish initializing before injecting the error.
+      await clock.settle();
       MockWorker.instances.at(-1)!.error("terminal failure");
-      await new Promise((resolve) => setTimeout(resolve, 5));
+      // The terminal error disables the space and starts a replacement worker,
+      // which initializes on the same reactive turn.
+      await clock.settle();
 
       assert(entry.value.disabledAt > 0);
       assertStringIncludes(entry.value.status, "TerminalError");
@@ -788,6 +816,10 @@ describe("SpaceManager", () => {
 
   it("disables pieces when worker initialization fails", async () => {
     await withMockWorker(async () => {
+      // The first worker never answers, so its initialize request times out and
+      // the space is disabled. Every worker built after it answers, so the
+      // replacement the failure path starts initializes and the recreation loop
+      // stops rather than spinning.
       MockWorker.respondByDefault = false;
       const entry = new FakeEntryCell(pieceEntry());
       const manager = new SpaceManager({
@@ -798,11 +830,11 @@ describe("SpaceManager", () => {
         deactivationTimeoutMs: 1,
         timeoutMs: 1,
       });
+      MockWorker.respondByDefault = true;
       manager.watch([entry as never]);
-      setTimeout(() => {
-        MockWorker.respondByDefault = true;
-      }, 0);
-      await new Promise((resolve) => setTimeout(resolve, 8));
+      // Advance past the first worker's initialize timeout (timeoutMs: 1); the
+      // rejection disables the space and starts a replacement that answers.
+      await clock.tick(1);
 
       assert(entry.value.disabledAt > 0);
       assertStringIncludes(entry.value.status, "Failed to initialize worker");
@@ -830,7 +862,7 @@ describe("SpaceManager", () => {
       await (manager as never as {
         setupWorkerController: () => Promise<void>;
       }).setupWorkerController();
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await clock.settle();
 
       assertEquals(removed, true);
       await manager.stop();
@@ -1203,7 +1235,7 @@ describe("background piece service entry point", () => {
 
     try {
       signals.SIGINT();
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await clock.settle();
     } catch (_error) {
       // The fake exit throws so the test can observe it.
     }
@@ -1269,7 +1301,7 @@ describe("background piece service entry point", () => {
     );
     try {
       callback();
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await clock.settle();
     } catch (_error) {
       // The fake exit throws so the test can observe it.
     }


### PR DESCRIPTION
The service's own machinery is time-coupled. SpaceManager.execLoop parks on sleep(pollingIntervalMs) between polls of its task queue, SpaceManager.stop races a setInterval that watches for the active job to finish against a sleep(deactivationTimeoutMs) deadline, and WorkerController.exec arms a setTimeout(timeoutMs) that rejects a worker request the worker never answers. The tests waited on that behavior with real-time sleeps and Date.now/performance.now deadlines, which is the case a fake clock is meant to fix: a sleep puts a floor under the suite's wall time, and a deadline puts a ceiling on what a loaded or paused machine can still observe.

Adopt the shared fake-clock harness. Add test/clock-preload.ts as a thin wrapper that calls installFakeClock (from @commonfabric/test-support) in auto-advance mode, wired through --preload on the package test task, plus test/clock.d.ts for the global clock type. In that mode a positive-delay timer scheduled from src/ auto-advances (the poll interval elapses instantly and an unanswered worker request's timeout fires on its own) while a positive-delay timer scheduled from a test file freezes, so a leftover sleep deadlocks and Deno's async-op sanitizer reports it rather than letting it pass by luck. The service polls through the sleep helper in @commonfabric/utils, whose own frame is a src/ frame, so those polls are read as production timers and auto-advance.

Convert the SpaceManager and WorkerController tests. A test that runs a branch of the exec loop and then stops it starts the loop, settles to let it reach its parked sleep, clears isRunning, and ticks once to fire that sleep so the loop exits. A test that waits for a worker's initialize request to time out ticks the timeoutMs timer directly. Settle-waits that need only the next reactive turn use clock.settle().

Declare the global clock with var rather than const, and carry a scoped deno-lint-ignore no-var on it, in both this package's test/clock.d.ts and the runner's: deno task check compiles every workspace package as one program, and two block-scoped const clock bindings across the two packages collide (TS2451), while two var bindings of the same type merge. Checking a package directory on its own never sees the other's declaration, so the collision surfaces only in the repo-wide check.

One freezeAround wraps a whole describe, so its timer map persists across the describe's cases. A fire-and-forget WorkerController.shutdown(), started by setupWorkerController when it replaces a worker, leaves a cleanup request parked on a worker that never answers, and the describe's trailing auto-advance would fire that leftover after the describe ends, inside the next describe. Reset the clock after each SpaceManager case so no leftover survives.

otel.test.ts stays on the real clock, listed in the preload's realClockFiles: it exercises the real OpenTelemetry SDK against a real loopback OTLP receiver, and the provider's forceFlush/shutdown guard each flush with their own setTimeout armed inside the vendored SDK. Under auto-advance that guard fires against the real HTTP round trip before it completes, so the flush reports that the span processor did not finish within its timeout. The tests carry no sleeps or deadlines to convert, so the fake clock would buy them no determinism.

The package runs under the generic workspace "Test" CI job, which invokes the package's own deno task test, so wiring the preload into that task is all CI needs and no workflow change is required.

Document the harness in docs/development/waiting-in-tests.md alongside the runner section.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `background-piece-service` tests under a shared fake clock to remove real-time sleeps and make polling/timeouts deterministic. This speeds up the suite and reduces flakiness with no CI changes.

- **Refactors**
  - Add `test/clock-preload.ts` to install `installFakeClock` from `@commonfabric/test-support` in auto-advance; wire via `--preload` in `deno.jsonc`.
  - Declare global `var clock` in `test/clock.d.ts`; switch the runner’s clock declaration to `var` to avoid TS2451 during workspace `deno task check`.
  - Update service tests to use `clock.settle()`/`clock.tick()`; add `afterEach(clock.reset)` in the `SpaceManager` suite to clear leftover timers.
  - Keep `otel.test.ts` on real time via `realClockFiles` because of OpenTelemetry SDK timers.
  - Expand docs in `docs/development/waiting-in-tests.md` with a `background-piece-service` section.

<sup>Written for commit a315ce5db31214c7f9ba09dcee3386d13155c1fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

