### PR TITLE
feat(cli): cf piece call --invocation — settled Invocation JSON, transaction-local ack (WS-D/D2)

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -181,12 +181,19 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   ends in the stream link. The binding is a content hash over the caller's key
   plus the whole link, not a delimited join: the caller's half is opaque, so
   concatenation would let a chosen id shift the separator.
-- **cli:** `--invocation <id>` on `piece call` (UUID minted and printed by
+- ~~**cli:** `--invocation <id>` on `piece call` (UUID minted and printed by
   default, including when the wait times out); after commit, sync and read the
   receipt (a cold plain read returns `undefined` — sync first); reclassify
   `precondition: "receipt-exists"` as success-with-readback, exit 0. Output is
   the `Invocation` JSON — `status` and `id` from day one, `result` once WS-C
-  lands.
+  lands.~~ — **done (D2)**: `cf piece call` mints a UUID (or takes
+  `--invocation <id>`), prints `invocation: <id>` to stderr at dispatch —
+  before any network work — and re-prints it with the furthest phase on every
+  failure exit; the receipt reads back through `tx.handlingReceiptLink`
+  (pull = sync + read); `precondition: "receipt-exists"` settles as success
+  with the original outcome (`deduplicated: true`), exit 0; stdout is the
+  settled `Invocation` JSON (`invocation`, `status`, `result` when the
+  receipt carries a value).
 - **cli, pre-dispatch validation:** `piece call` validates the payload against
   the *deployed* verb schema before sending — an undeclared or malformed
   field is an immediate local rejection. This is the half that catches
@@ -196,16 +203,20 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
 - **cli, phase reporting:** every output — success, failure, timeout — carries
   the furthest observed `phase`
   (`initial_sync | dispatched | committed | readback`) beside the invocation
-  id; verbose output adds per-phase timings (initial sync / dispatch /
-  handler / commit / result sync / readback). With a caller-supplied id a
-  retry is safe in every phase, so phase is diagnosis; a derived `retrySafe`
-  convenience flag may ride along.
-- **Acknowledgement is transaction-local.** The call path awaits *this
+  id — **done (D2)** for the annotation (tracked through an `onPhase`
+  callback, printed on failure exits); verbose output adds per-phase timings
+  (initial sync / dispatch / handler / commit / result sync / readback) —
+  still open. With a caller-supplied id a retry is safe in every phase, so
+  phase is diagnosis; a derived `retrySafe` convenience flag may ride along.
+- ~~**Acknowledgement is transaction-local.** The call path awaits *this
   handling's* commit (D1's commit callback) plus receipt sync — never
   `runtime.idle()` / full-sync quiescence, which today holds a committed
   write hostage to downstream recomputation (60–80 s body writes observed
-  live while `crossrefs` re-derived). Acceptance test: a deliberately slow
-  derived recomputation cannot delay `addTopic` acknowledgement.
+  live while `crossrefs` re-derived).~~ — **done (D2)**: the handler send
+  path awaits only the commit callback and the receipt pull; a unit test
+  fails if the path ever awaits `runtime.idle()` or `manager.synced()`. The
+  live acceptance check — a deliberately slow derived recomputation cannot
+  delay `addTopic` acknowledgement — rides with D3's integration scenarios.
 - Integration tests (isolated toolshed, `isolated-test-processes`
   conventions), four timeout/retry scenarios: timeout before dispatch (retry
   re-executes; one topic); timeout after dispatch, before commit

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -30,7 +30,7 @@ import {
   SpaceConfig,
   stepPiece,
 } from "../lib/piece.ts";
-import type { InvocationPhase } from "../lib/callable.ts";
+import type { InvocationOutcome, InvocationPhase } from "../lib/callable.ts";
 import { renderPiece } from "../lib/piece-render.ts";
 import { parseSqliteSource } from "../lib/sqlite-source.ts";
 import { render, safeStringify } from "../lib/render.ts";
@@ -331,6 +331,49 @@ export function resolveInvocationId(
     throw new ValidationError("--invocation requires a non-blank id");
   }
   return raw;
+}
+
+/**
+ * Build the phase observer for a handler invocation. Its whole job is to put
+ * the invocation id on stderr at the moment the event is about to dispatch —
+ * BEFORE any network work — so a caller whose process dies past that line
+ * still holds the exact id to retry with, and the retry deduplicates instead
+ * of executing a second time. Announcing once matters: a caller scraping
+ * stderr for its id should not have to decide which of several to trust.
+ */
+export function invocationPhaseReporter(
+  invocationId: string,
+  onAdvance: (phase: InvocationPhase) => void,
+  announce: (message: string) => void = console.error,
+): (phase: InvocationPhase) => void {
+  let announced = false;
+  return (next) => {
+    if (next === "dispatched" && !announced) {
+      announced = true;
+      announce(`invocation: ${invocationId}`);
+    }
+    onAdvance(next);
+  };
+}
+
+/**
+ * Shape a settled handler invocation for stdout. This is the wire contract an
+ * agent parses, so the optional keys are load-bearing: `deduplicated` appears
+ * only when the call collided on an existing receipt, and `result` only when
+ * the receipt carried one — a value-less verb omits it rather than reporting
+ * `null`, which would be indistinguishable from a verb that returned null.
+ */
+export function invocationJson(
+  outcome: InvocationOutcome,
+): Record<string, unknown> {
+  return {
+    invocation: outcome.id,
+    status: outcome.status,
+    ...(outcome.deduplicated ? { deduplicated: true } : {}),
+    ...("result" in outcome && outcome.result !== undefined
+      ? { result: outcome.result }
+      : {}),
+  };
 }
 
 export function writePieceRenderStatus(
@@ -1159,16 +1202,10 @@ after --. Handlers interpret piped input when no input argument is present.`,
         invocation.rawArgs,
         {
           invocationId,
-          onPhase: (next) => {
-            // The id goes to stderr the moment the event is about to
-            // dispatch, BEFORE any network work: if this process dies past
-            // this line, the caller holds the exact id to retry with, and
-            // the retry deduplicates instead of double-executing.
-            if (next === "dispatched" && phase === "initial_sync") {
-              console.error(`invocation: ${invocationId}`);
-            }
-            phase = next;
-          },
+          onPhase: invocationPhaseReporter(
+            invocationId,
+            (next) => phase = next,
+          ),
         },
       );
       if (result.helpText) {
@@ -1194,18 +1231,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
       if (result.invocation) {
         // The machine surface for a handler invocation: stdout carries the
         // settled Invocation JSON, prose stays on stderr via hint().
-        render(JSON.stringify(
-          {
-            invocation: result.invocation.id,
-            status: result.invocation.status,
-            ...(result.invocation.deduplicated ? { deduplicated: true } : {}),
-            ...("result" in result.invocation
-              ? { result: result.invocation.result }
-              : {}),
-          },
-          null,
-          2,
-        ));
+        render(JSON.stringify(invocationJson(result.invocation), null, 2));
         hint(cliText(`NEXT STEPS:
   → Verify state:  cf piece get --piece ${pieceConfig.piece} <path> ...
   → Full inspect:  cf piece inspect --piece ${pieceConfig.piece} ...`));

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1115,9 +1115,10 @@ after --. Handlers interpret piped input when no input argument is present.`,
   .option("-c,--piece <piece:string>", "The target piece ID.")
   .option(
     "--invocation <id:string>",
-    "Idempotency key for a handler call (before the callable name). " +
-      "Retrying with the same id settles on the original outcome instead " +
-      "of executing again. Minted automatically when omitted.",
+    "Idempotency key for a handler call (before the callable name). A " +
+      "same-id retry cannot commit twice — it settles on the original " +
+      "outcome — but the handler body does re-run, so effects outside the " +
+      "transaction repeat. Minted automatically when omitted.",
   )
   .stopEarly()
   .arguments("<callable:string> [tail...:string]")

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -30,6 +30,7 @@ import {
   SpaceConfig,
   stepPiece,
 } from "../lib/piece.ts";
+import type { InvocationPhase } from "../lib/callable.ts";
 import { renderPiece } from "../lib/piece-render.ts";
 import { parseSqliteSource } from "../lib/sqlite-source.ts";
 import { render, safeStringify } from "../lib/render.ts";
@@ -1112,9 +1113,17 @@ after --. Handlers interpret piped input when no input argument is present.`,
     `Run the "search" tool using schema-derived flags after "--".`,
   )
   .option("-c,--piece <piece:string>", "The target piece ID.")
+  .option(
+    "--invocation <id:string>",
+    "Idempotency key for a handler call (before the callable name). " +
+      "Retrying with the same id settles on the original outcome instead " +
+      "of executing again. Minted automatically when omitted.",
+  )
   .stopEarly()
   .arguments("<callable:string> [tail...:string]")
   .action(async function (options, callableName, ...tail) {
+    const invocationId = options.invocation ?? crypto.randomUUID();
+    let phase: InvocationPhase = "initial_sync";
     try {
       setQuietMode(!!options.quiet);
       const invocation = pieceCallInvocation(
@@ -1129,6 +1138,19 @@ after --. Handlers interpret piped input when no input argument is present.`,
         pieceConfig,
         callableName,
         invocation.rawArgs,
+        {
+          invocationId,
+          onPhase: (next) => {
+            // The id goes to stderr the moment the event is about to
+            // dispatch, BEFORE any network work: if this process dies past
+            // this line, the caller holds the exact id to retry with, and
+            // the retry deduplicates instead of double-executing.
+            if (next === "dispatched" && phase === "initial_sync") {
+              console.error(`invocation: ${invocationId}`);
+            }
+            phase = next;
+          },
+        },
       );
       if (result.helpText) {
         render(result.helpText);
@@ -1150,6 +1172,26 @@ after --. Handlers interpret piped input when no input argument is present.`,
         }
         return;
       }
+      if (result.invocation) {
+        // The machine surface for a handler invocation: stdout carries the
+        // settled Invocation JSON, prose stays on stderr via hint().
+        render(JSON.stringify(
+          {
+            invocation: result.invocation.id,
+            status: result.invocation.status,
+            ...(result.invocation.deduplicated ? { deduplicated: true } : {}),
+            ...("result" in result.invocation
+              ? { result: result.invocation.result }
+              : {}),
+          },
+          null,
+          2,
+        ));
+        hint(cliText(`NEXT STEPS:
+  → Verify state:  cf piece get --piece ${pieceConfig.piece} <path> ...
+  → Full inspect:  cf piece inspect --piece ${pieceConfig.piece} ...`));
+        return;
+      }
       const confirmation =
         `Called handler "${callableName}" on piece ${pieceConfig.piece}`;
       if (result.parsed.usedJsonInput) {
@@ -1166,6 +1208,10 @@ after --. Handlers interpret piped input when no input argument is present.`,
       }
       const message = error instanceof Error ? error.message : String(error);
       console.error(message);
+      // Where the invocation stopped decides retry semantics: anything at or
+      // past "dispatched" retries SAFELY ONLY with this same id (same-id
+      // retries deduplicate; a fresh id would re-execute).
+      console.error(`invocation: ${invocationId} phase: ${phase}`);
       Deno.exit(1);
     }
   })

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -315,6 +315,24 @@ export function pieceCallInvocation(
   return { rawArgs, jsonOutput };
 }
 
+/**
+ * Resolve the invocation id for a handler call: the caller's own id, or a
+ * freshly minted one. A blank id is rejected rather than passed down — it
+ * would read as "the caller supplied one" while carrying nothing that can
+ * distinguish one delivery from another, so the retry it promises to make
+ * safe would not be (verb contract WS-D).
+ */
+export function resolveInvocationId(
+  raw: string | undefined,
+  mint: () => string = () => crypto.randomUUID(),
+): string {
+  if (raw === undefined) return mint();
+  if (!raw.trim()) {
+    throw new ValidationError("--invocation requires a non-blank id");
+  }
+  return raw;
+}
+
 export function writePieceRenderStatus(
   message: string,
   jsonOutput: boolean,
@@ -1123,7 +1141,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
   .stopEarly()
   .arguments("<callable:string> [tail...:string]")
   .action(async function (options, callableName, ...tail) {
-    const invocationId = options.invocation ?? crypto.randomUUID();
+    const invocationId = resolveInvocationId(options.invocation);
     let phase: InvocationPhase = "initial_sync";
     try {
       setQuietMode(!!options.quiet);

--- a/packages/cli/lib/callable-command.ts
+++ b/packages/cli/lib/callable-command.ts
@@ -3,6 +3,7 @@ import {
   type CallableResolution,
   type CallableResultRef,
   executeResolvedCallable,
+  type InvocationOutcome,
 } from "./callable.ts";
 import {
   type ExecCommandSpec,
@@ -15,6 +16,8 @@ import {
 export interface CallableCommandExecutionResult<TResolved> {
   helpText?: string;
   outputText?: string;
+  /** Handler invocation outcome, passed through from ExecutedCallable. */
+  invocation?: InvocationOutcome;
   /** Tool result cell address, passed through from ExecutedCallable. */
   resultRef?: CallableResultRef;
   parsed: ParsedExecArgs;
@@ -111,6 +114,7 @@ export async function executeCallableCommand<
 
   return {
     outputText: executed.outputText,
+    invocation: executed.invocation,
     resultRef: executed.resultRef,
     parsed,
     resolved,

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -24,6 +24,15 @@ export interface CallableTransactionStatus {
 export interface CallableTransactionLike {
   status?: () => CallableTransactionStatus;
   commit?: () => Promise<unknown>;
+  /** The handling's receipt address (runner: tx.handlingReceiptLink) — on
+   * success this handling's outcome, on a receipt-exists collision the
+   * winner's original (verb contract WS-D). */
+  handlingReceiptLink?: {
+    id: string;
+    space: string;
+    scope?: CellScope;
+    path?: readonly (string | number)[];
+  };
 }
 
 export interface CallableCellLike {
@@ -41,6 +50,7 @@ export interface CallableCellLike {
   send?: (
     value: unknown,
     onCommit?: (tx: CallableTransactionLike) => void,
+    sendOptions?: { eventId?: string },
   ) => void;
 }
 
@@ -73,6 +83,12 @@ export interface CallableRuntimeLike {
     resultCell: CallableCellLike,
   ) => { sink?: (fn: (value: unknown) => void) => (() => void) | void } | void;
   prepareTxForCommit?: (tx: CallableTransactionLike) => void;
+  /** Open a cell at a normalized link — the receipt readback path. */
+  getCellFromLink?: (
+    link: NonNullable<CallableTransactionLike["handlingReceiptLink"]>,
+    schema?: JSONSchema,
+    tx?: CallableTransactionLike,
+  ) => CallableCellLike;
 }
 
 export interface CallableManagerLike {
@@ -97,8 +113,37 @@ export interface CallableResolution {
   space: string;
 }
 
+/** The phases a handler invocation passes through, reported on early exit so
+ * a caller knows whether a retry is pre- or post-dispatch (both are safe with
+ * a caller-supplied id; the phase is diagnosis, not a safety gate). */
+export type InvocationPhase =
+  | "initial_sync"
+  | "dispatched"
+  | "committed"
+  | "readback";
+
 export interface CallableExecutionDeps {
   uuid?: () => string;
+  /** Caller-supplied idempotency key for handler sends: threads through as
+   * the durable event id, so a retry of the same id collides on the
+   * handling's create-only receipt and reads the original outcome back
+   * instead of re-executing (verb contract WS-D). */
+  invocationId?: string;
+  /** Phase observer for early-exit reporting. */
+  onPhase?: (phase: InvocationPhase) => void;
+}
+
+/** The outcome of a handler invocation made with a caller-supplied id. */
+export interface InvocationOutcome {
+  id: string;
+  status: "settled";
+  /** The verb's result read back from the handling's receipt, when the
+   * receipt carried one (a reactive-bearing return, or a plain return under
+   * the plainResultReceipts flag). Absent for value-less verbs. */
+  result?: unknown;
+  /** True when this call collided on the create-only receipt: the handling
+   * did not commit again, and `result` is the ORIGINAL outcome. */
+  deduplicated?: boolean;
 }
 
 /** Durable address of a tool's per-invocation result cell. The scope is part
@@ -112,6 +157,8 @@ export interface CallableResultRef {
 
 export interface ExecutedCallable {
   outputText?: string;
+  /** Present for handler sends carrying a caller-supplied invocation id. */
+  invocation?: InvocationOutcome;
   /** The tool result cell's address, when the runtime exposes it — the handle
    * a caller can revisit later instead of re-running the tool (verb contract
    * Part 2, docs/plans/pattern-verb-contract.md). Handlers gain their
@@ -295,20 +342,36 @@ export async function executeResolvedCallable(
     if (typeof send === "function") {
       const runtimeErrors = runtimeErrorLog(resolved.manager.runtime);
       const errorCountBefore = runtimeErrors.length;
+      const invocationId = deps.invocationId;
+      deps.onPhase?.("dispatched");
       const tx = await new Promise<CallableTransactionLike>(
         (resolve, reject) => {
           try {
-            send.call(resolved.callableCell, input, resolve);
+            send.call(
+              resolved.callableCell,
+              input,
+              resolve,
+              invocationId !== undefined
+                ? { eventId: invocationId }
+                : undefined,
+            );
           } catch (error) {
             reject(error);
           }
         },
       );
-      await resolved.manager.runtime.idle();
-      await resolved.manager.synced();
+      // Acknowledgment is transaction-local (verb contract, Settlement): the
+      // commit callback above fires on THIS handling's final commit. Awaiting
+      // runtime.idle()/manager.synced() here instead would hold an
+      // already-committed write hostage to every derived recomputation it
+      // triggered elsewhere in the graph.
+      deps.onPhase?.("committed");
 
       const txStatus = tx?.status?.();
-      if (txStatus?.status === "error") {
+      const deduplicated = txStatus?.status === "error" &&
+        (txStatus.error as { precondition?: string } | undefined)
+            ?.precondition === "receipt-exists";
+      if (txStatus?.status === "error" && !deduplicated) {
         const latestRuntimeError = runtimeErrors.slice(errorCountBefore).at(-1)
           ?.message;
         throw new Error(
@@ -318,7 +381,37 @@ export async function executeResolvedCallable(
         );
       }
 
-      return {};
+      if (invocationId === undefined) return {};
+
+      // Read the handling's outcome back off its receipt. On a receipt-exists
+      // collision this is the ORIGINAL handling's receipt — same id, same
+      // outcome, no re-execution — so a retry settles as a success.
+      deps.onPhase?.("readback");
+      let result: unknown;
+      const link = tx?.handlingReceiptLink;
+      const getCellFromLink = resolved.manager.runtime.getCellFromLink;
+      if (link && typeof getCellFromLink === "function") {
+        const receipt = getCellFromLink.call(resolved.manager.runtime, link);
+        const value = typeof receipt.pull === "function"
+          ? await receipt.pull()
+          : receipt.get();
+        // A value-less verb's receipt is an empty record — existence-only.
+        if (
+          value !== undefined &&
+          !(isRecord(value) && Object.keys(value).length === 0)
+        ) {
+          result = value;
+        }
+      }
+
+      return {
+        invocation: {
+          id: invocationId,
+          status: "settled",
+          ...(deduplicated ? { deduplicated: true } : {}),
+          ...(result !== undefined ? { result } : {}),
+        },
+      };
     }
 
     await resolved.piece[resolved.cellProp].set(input, [resolved.cellKey]);

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -127,7 +127,11 @@ export interface CallableExecutionDeps {
   /** Caller-supplied idempotency key for handler sends: threads through as
    * the durable event id, so a retry of the same id collides on the
    * handling's create-only receipt and reads the original outcome back
-   * instead of re-executing (verb contract WS-D). */
+   * (verb contract WS-D). The guarantee is at-most-once *commit*, not
+   * at-most-once *execution* — a redelivered event re-runs the handler body
+   * and loses the race for the receipt, so a verb whose body has effects
+   * outside its transaction (an LLM call, a fetch) repeats those effects on
+   * retry even though nothing commits twice. */
   invocationId?: string;
   /** Phase observer for early-exit reporting. */
   onPhase?: (phase: InvocationPhase) => void;

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -59,6 +59,7 @@ import {
   type CliRuntimeErrorRecord,
   detectCallableKind,
   executeResolvedCallable,
+  type InvocationOutcome,
   runtimeErrorLog,
 } from "./callable.ts";
 import { executeCallableCommand } from "./callable-command.ts";
@@ -167,6 +168,8 @@ export interface PieceCallableDependencies extends CallableExecutionDeps {
 export interface ExecutedPieceCallable {
   helpText?: string;
   outputText?: string;
+  /** Handler invocation outcome, passed through from ExecutedCallable. */
+  invocation?: InvocationOutcome;
   /** Tool result cell address, passed through from ExecutedCallable. */
   resultRef?: CallableResultRef;
   parsed: ParsedExecArgs;

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -13,6 +13,7 @@ import {
   pieceCallRawArgs,
   pieceGetDataErrorReport,
   pieceLinkDataErrorReport,
+  resolveInvocationId,
 } from "../commands/piece.ts";
 import { LinkValidationError } from "../lib/piece.ts";
 
@@ -1127,6 +1128,16 @@ describe("piece call stdin payloads", () => {
       rawArgs: ["invoke", "--query", "--json"],
       jsonOutput: false,
     });
+  });
+
+  it("mints an invocation id when none is given and rejects a blank one", () => {
+    expect(resolveInvocationId(undefined, () => "minted-1")).toBe("minted-1");
+    expect(resolveInvocationId("caller-supplied")).toBe("caller-supplied");
+    // A blank id would claim caller-supplied idempotency while carrying
+    // nothing that distinguishes deliveries — the retry it promises would
+    // not be safe.
+    expect(() => resolveInvocationId("")).toThrow(/non-blank id/);
+    expect(() => resolveInvocationId("   ")).toThrow(/non-blank id/);
   });
 
   it('maps a bare "-" payload onto the --json-file stdin path', () => {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -8,6 +8,8 @@ import {
 } from "../lib/piece.ts";
 import {
   exitWithDataError,
+  invocationJson,
+  invocationPhaseReporter,
   isPieceGetDataError,
   pieceCallInvocation,
   pieceCallRawArgs,
@@ -1138,6 +1140,71 @@ describe("piece call stdin payloads", () => {
     // not be safe.
     expect(() => resolveInvocationId("")).toThrow(/non-blank id/);
     expect(() => resolveInvocationId("   ")).toThrow(/non-blank id/);
+  });
+
+  it("announces the invocation id once, at dispatch", () => {
+    const announced: string[] = [];
+    const seen: string[] = [];
+    const report = invocationPhaseReporter(
+      "inv-9",
+      (p) => seen.push(p),
+      (m) => announced.push(m),
+    );
+    // Nothing is announced before dispatch: until the event is on its way
+    // there is nothing a retry would deduplicate against.
+    report("initial_sync");
+    expect(announced).toEqual([]);
+    report("dispatched");
+    expect(announced).toEqual(["invocation: inv-9"]);
+    // Later phases, and a second dispatch, must not re-announce — a caller
+    // scraping stderr should not have to pick among several ids.
+    report("committed");
+    report("dispatched");
+    report("readback");
+    expect(announced).toEqual(["invocation: inv-9"]);
+    expect(seen).toEqual([
+      "initial_sync",
+      "dispatched",
+      "committed",
+      "dispatched",
+      "readback",
+    ]);
+  });
+
+  it("shapes the settled Invocation JSON an agent parses", () => {
+    expect(invocationJson({ id: "inv-1", status: "settled" })).toEqual({
+      invocation: "inv-1",
+      status: "settled",
+    });
+    expect(
+      invocationJson({ id: "inv-1", status: "settled", deduplicated: true }),
+    ).toEqual({
+      invocation: "inv-1",
+      status: "settled",
+      deduplicated: true,
+    });
+    expect(
+      invocationJson({
+        id: "inv-1",
+        status: "settled",
+        result: { commentId: "c-1" },
+      }),
+    ).toEqual({
+      invocation: "inv-1",
+      status: "settled",
+      result: { commentId: "c-1" },
+    });
+    // deduplicated: false is never emitted — its absence is the signal.
+    expect(
+      invocationJson({ id: "inv-1", status: "settled", deduplicated: false }),
+    ).not.toHaveProperty("deduplicated");
+    // A verb that genuinely returned null keeps it; a value-less verb omits
+    // the key entirely, so the two stay distinguishable on the wire.
+    expect(invocationJson({ id: "inv-1", status: "settled", result: null }))
+      .toEqual({ invocation: "inv-1", status: "settled", result: null });
+    expect(
+      invocationJson({ id: "inv-1", status: "settled", result: undefined }),
+    ).not.toHaveProperty("result");
   });
 
   it('maps a bare "-" payload onto the --json-file stdin path', () => {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -679,6 +679,148 @@ describe("executePieceCallable", () => {
       ),
     ).rejects.toThrow(/Handler "recordMessage" failed: Bad message payload/);
   });
+
+  it("threads the invocation id to send and settles with receipt readback, without awaiting graph quiescence", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "addComment",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+      receiptValue: { commentId: "c-1" },
+    });
+    const phases: string[] = [];
+
+    const result = await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "addComment",
+      ["--message", "milk"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocationId: "inv-123",
+        onPhase: (phase) => phases.push(phase),
+      },
+    );
+
+    expect(harness.tracker.sendOptions).toEqual([{ eventId: "inv-123" }]);
+    expect(result.invocation).toEqual({
+      id: "inv-123",
+      status: "settled",
+      result: { commentId: "c-1" },
+    });
+    expect(phases).toEqual(["dispatched", "committed", "readback"]);
+    expect(harness.tracker.receiptLinkRequested?.id).toBe("of:receipt-1");
+    // Transaction-local acknowledgment: the settled result must come straight
+    // off this handling's commit — never from draining the whole graph.
+    expect(harness.tracker.idleCalls).toBe(0);
+    expect(harness.tracker.syncedCalls).toBe(0);
+  });
+
+  it("reclassifies a receipt-exists collision as the original settled outcome", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "addComment",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+      receiptExists: true,
+      receiptValue: { commentId: "c-original" },
+    });
+
+    const result = await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "addComment",
+      ["--message", "milk"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocationId: "inv-dup",
+      },
+    );
+
+    expect(result.invocation).toEqual({
+      id: "inv-dup",
+      status: "settled",
+      deduplicated: true,
+      result: { commentId: "c-original" },
+    });
+  });
+
+  it("settles a value-less verb with no result key (existence-only receipt)", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "refresh",
+      inputSchema: { type: "object", properties: {} },
+      receiptValue: {},
+    });
+
+    const result = await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "refresh",
+      [],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => true,
+        invocationId: "inv-empty",
+      },
+    );
+
+    expect(result.invocation).toEqual({ id: "inv-empty", status: "settled" });
+  });
+
+  it("sends without options and returns no invocation when no id is supplied", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "refresh",
+      inputSchema: { type: "object", properties: {} },
+      receiptValue: { ignored: true },
+    });
+
+    const result = await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "refresh",
+      [],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => true,
+      },
+    );
+
+    expect(harness.tracker.sendOptions).toEqual([undefined]);
+    expect(result.invocation).toBeUndefined();
+    expect(harness.tracker.receiptLinkRequested).toBeUndefined();
+  });
 });
 
 function createPieceCallableHarness(options: {
@@ -693,6 +835,12 @@ function createPieceCallableHarness(options: {
   toolResult?: unknown;
   handlerFailureMessage?: string;
   callableScope?: "space" | "user" | "session";
+  /** Value the handling's receipt cell reads back ({} = value-less verb). */
+  receiptValue?: unknown;
+  /** Simulate the create-only receipt collision: commit fails with
+   * precondition "receipt-exists" while the link addresses the winner's
+   * original receipt. */
+  receiptExists?: boolean;
 }) {
   const tracker = {
     handlerWrites: [] as Array<{
@@ -700,6 +848,10 @@ function createPieceCallableHarness(options: {
       path: (string | number)[] | undefined;
       value: unknown;
     }>,
+    sendOptions: [] as Array<{ eventId?: string } | undefined>,
+    receiptLinkRequested: undefined as { id?: string } | undefined,
+    idleCalls: 0,
+    syncedCalls: 0,
     toolRunPattern: undefined as unknown,
     toolRunInput: undefined as unknown,
     toolResultScope: undefined as string | undefined,
@@ -737,14 +889,19 @@ function createPieceCallableHarness(options: {
           send: (
             value: unknown,
             onCommit?: (
-              tx: { status: () => { status: string; error?: Error } },
+              tx: {
+                status: () => { status: string; error?: Error };
+                handlingReceiptLink?: { id: string; space: string };
+              },
             ) => void,
+            sendOptions?: { eventId?: string },
           ) => {
             tracker.handlerWrites.push({
               cellProp: "result",
               path: [options.cellKey],
               value,
             });
+            tracker.sendOptions.push(sendOptions);
             if (options.handlerFailureMessage) {
               runtimeErrors.push({ message: options.handlerFailureMessage });
             }
@@ -755,7 +912,19 @@ function createPieceCallableHarness(options: {
                     status: "error",
                     error: new Error(options.handlerFailureMessage),
                   }
+                  : options.receiptExists
+                  ? {
+                    status: "error",
+                    error: Object.assign(
+                      new Error("Result receipt already exists"),
+                      { precondition: "receipt-exists" },
+                    ),
+                  }
                   : { status: "done" },
+              handlingReceiptLink: {
+                id: "of:receipt-1",
+                space: "did:key:test-home",
+              },
             });
           },
         }
@@ -814,11 +983,24 @@ function createPieceCallableHarness(options: {
     },
   };
 
+  const receiptCell = {
+    get: () => options.receiptValue,
+    pull: () => Promise.resolve(options.receiptValue),
+    key: (_key: string) => receiptCell,
+  };
+
   const manager = {
     getSpace: () => "home",
-    synced: async () => {},
+    synced: () => {
+      tracker.syncedCalls++;
+      return Promise.resolve();
+    },
     runtime: {
       [CF_RUNTIME_ERROR_LOG]: runtimeErrors,
+      getCellFromLink: (link: { id?: string }) => {
+        tracker.receiptLinkRequested = link;
+        return receiptCell;
+      },
       storageManager: {
         synced: async () => {},
       },
@@ -848,7 +1030,10 @@ function createPieceCallableHarness(options: {
           sink: () => () => {},
         };
       },
-      idle: async () => {},
+      idle: () => {
+        tracker.idleCalls++;
+        return Promise.resolve();
+      },
     },
   };
 


### PR DESCRIPTION
## Why

Two of the sharpest failures observed on the live topics board were CLI-inflicted:

1. **The duplicate-on-retry bug.** A `cf piece call` that timed out after dispatch left the caller with nothing to retry safely — a second call re-executed the handler and duplicated the mutation. The runner has had durable event ids and create-only receipts all along (spec scheduler-v2 §7.5/§7.6); the CLI just never used them.
2. **The 60–80 s acknowledgment.** After a handler's transaction committed, the CLI awaited `runtime.idle()` + full storage sync — holding an already-committed write hostage to every derived recomputation it triggered (`crossrefs` re-derives were the observed offender).

This is D2 of the verb-contract plan (docs/plans/pattern-verb-contract-implementation.md, WS-D), the CLI half of the invocation plumbing. D1 (#5087, now merged) exposed the runner side: `cell.send(event, onCommit, { eventId })`, `tx.handlingReceiptLink`, and `scopeCallerEventId`, which binds a caller's key to its stream so one invocation id reused across two verbs cannot collide on a single receipt.

## What Changed

- `cf piece call` gains `--invocation <id>` (before the callable name); a UUID is minted when omitted. The id is printed to stderr at dispatch — before any network work — so a caller that times out holds the exact key that makes its retry safe.
- The id threads through as the durable event id. A same-id retry collides on the handling's create-only receipt: `precondition: "receipt-exists"` is reclassified as settled success, the winner's original outcome is read back through `tx.handlingReceiptLink`, and the call exits 0 with `deduplicated: true`.
- **Transaction-local acknowledgment**: the handler send path now awaits only this handling's commit callback plus the receipt pull. The post-commit `idle()`/`synced()` pair is gone; a unit test fails if either returns to the path.
- stdout for handler invocations is the settled `Invocation` JSON — `{invocation, status, deduplicated?, result?}` (`result` appears when the receipt carries a value: reactive-bearing returns, or plain returns under the `plainResultReceipts` flag from #4994). Failure exits annotate stderr with `invocation: <id> phase: <phase>` (`initial_sync|dispatched|committed|readback`).
- Plan doc: D2 bullets checked off; still open from the WS-D list: pre-dispatch payload validation (coupled to C5's closed-world schemas) and per-phase timings under verbose output.

## Coverage

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/cli uncovered lines = 3884 lines

Accepted deliberately, and only after cutting it down. The ratchet first flagged +23 uncovered lines, all in `commands/piece.ts`. Diffing per-file lcov against a main run showed which ones, and two of the blocks were not really untestable — they were contracts hiding in the Cliffy action body:

- `invocationJson` — what an agent parses off stdout. Its optional keys carry meaning (`deduplicated` only on a receipt collision, `result` only when the receipt held one), so a value-less verb must stay distinguishable from a verb that returned `null`.
- `invocationPhaseReporter` — announces the id exactly once, at dispatch, before any network work. That announcement is the crash-safety guarantee: a caller that dies past it holds the id its retry needs.

Both are now exported and unit-tested, following the seam this file already uses for `pieceGetDataErrorReport` and `exitWithDataError`. That took the delta from +23 to +7, with 48 of the added lines covered.

The remaining 7 are the action-body wiring that calls them — `if (result.invocation)`, the `render`, the `hint` text, the `return`. Extracting further would relocate the wiring without adding assurance; the action body has to call something, and what it calls is tested. This is the repo's standing never-unit-covered class (same acceptance as #4992 and #4993), and raising the baseline by 7 is correct here because the lines are genuinely new code — unlike #5087, where the flagged lines belonged to a file that PR never touched and I declined the override.


## Test plan

- New unit tests in `packages/cli/test/piece-call.test.ts`: id threading into `send` options + settled readback + zero quiescence calls; receipt-exists collision settling as the original outcome; value-less (existence-only) receipts omitting `result`; the no-id path (cf exec) unchanged.
- Full `packages/cli` suite green locally (120 tests / 145 steps).
- The live acceptance check — a deliberately slow derived recomputation cannot delay `addTopic` acknowledgment — lands with D3's four timeout/retry integration scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--invocation <id>` to `cf piece call` to return settled Invocation JSON with at‑most‑once commit and transaction‑local acknowledgment, enabling safe retries without duplicate commits or slow post‑commit waits.

- **New Features**
  - Durable invocation id: threaded as `send(..., { eventId })`. UUID minted when omitted; stderr announces the id once at dispatch (before any network work). Failures also print `invocation` and furthest `phase` (`initial_sync|dispatched|committed|readback`). Same‑id retries deduplicate via the create‑only receipt; stdout returns `{ invocation, status, deduplicated?, result? }` read via `tx.handlingReceiptLink` (value‑less receipts omit `result`). No `runtime.idle()` or `manager.synced()` waits.

- **Bug Fixes**
  - Reject a blank `--invocation` to avoid unsafe “idempotency”.
  - Clarified help text and docs: the guarantee is at‑most‑once commit, not execution.

<sup>Written for commit a9517ad8818e910d8be7bfd6aab33fb7f32dc57c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


