### PR TITLE
fix(dashboard): use Git commits for live versioning

### DIFF
--- a/.github/workflows/dashboard-image.yml
+++ b/.github/workflows/dashboard-image.yml
@@ -126,6 +126,8 @@ jobs:
           file: Dockerfile.dashboard
           platforms: linux/amd64
           push: true
+          build-args: |
+            DASHBOARD_GIT_COMMIT=${{ github.sha }}
           tags: |
             ${{ env.IMAGE }}:${{ github.sha }}
             ${{ env.IMAGE }}:latest

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -11,12 +11,17 @@
 # it on any host — an Apple-Silicon Mac emulates amd64 through QEMU:
 #
 #   docker build --platform=linux/amd64 -f Dockerfile.dashboard \
+#     --build-arg DASHBOARD_GIT_COMMIT=$(git rev-parse HEAD) \
 #     -t us-central1-docker.pkg.dev/commontools-core/containers/dev-dashboard:$(git rev-parse HEAD) .
 
 FROM --platform=linux/amd64 denoland/deno:2.8.1
 
 WORKDIR /app
 COPY . .
+
+ARG DASHBOARD_GIT_COMMIT
+ENV DASHBOARD_GIT_COMMIT=${DASHBOARD_GIT_COMMIT}
+RUN printf '%s\n' "${DASHBOARD_GIT_COMMIT}" | grep -Eq '^[0-9a-f]{40}$'
 
 # Pre-fetch the dashboard's and the Gantt drill-down's dependencies, and make the
 # cache writable by the non-root runtime user (Deno and resvg write to it).

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -57,7 +57,7 @@
     "initialize-db": "deno run --allow-env --allow-read --allow-write --allow-ffi --allow-net=github.com,release-assets.githubusercontent.com,jsr.io packages/memory/scripts/initialize-db.ts",
     "integration": "./tasks/integration.ts",
     "demo": "./tasks/demo.ts",
-    "dashboard": "deno run --allow-net --allow-run=deno --allow-read --allow-write --allow-env packages/dashboard/server.ts",
+    "dashboard": "deno run --allow-net --allow-run=deno,git --allow-read --allow-write --allow-env packages/dashboard/server.ts",
     "profile": "./scripts/restart-local-dev.sh --inspect-brk",
     "cf-profile": "ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && deno run -A \"$ROOT/packages/cli/support/profiling/cf-profile.ts\"",
     "cf-inspect-brk": "bash -lc 'ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && CF_CLI_NAME=cf deno run --inspect-brk --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\" \"$@\"' --",

--- a/deno.lock
+++ b/deno.lock
@@ -2033,7 +2033,6 @@
       },
       "packages/dashboard": {
         "dependencies": [
-          "npm:@noble/hashes@^2.2.0",
           "npm:@resvg/resvg-js@2.6.2"
         ]
       },

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -37,6 +37,7 @@ dashboard/
   favicon.ts    runtime status priority and access to generated PNG favicon copies
   favicon-png.generated.ts  generated runtime PNG favicon copies
   favicon-artwork.ts  build/test-only SVG source for those favicon copies
+  version.ts    Git commit used as the browser/server compatibility version
   render.ts     renderTile(view) + the page shell/CSS
   server.ts     generic runtime: scheduler, SSE, route mounting, page assembly
   registry.ts   THE ONE REGISTRATION POINT — the array of tiles
@@ -76,12 +77,11 @@ snapshot for that source and shows the combined list in gray with the error.
 Each event connection receives the current tile snapshot before it waits for
 new collections. The browser reconciles that snapshot by tile ID, leaving
 unchanged elements, focus, and scroll positions in place. Routine data updates
-never navigate the page. At startup the server hashes the shell renderer and
-wrapper together with fixed rendered HTML for every status. Changes to the
-shell markup, CSS, browser code, embedded assets, or actual refresh interval
-therefore change the version. An unattended display reloads when it reconnects
-to a server with a different version. Routine tile data changes leave the
-version unchanged.
+never navigate the page. The server uses the current Git commit as its
+compatibility version. Local development reads the checked-out commit from Git.
+A deployed image receives the commit that its publishing workflow checked out.
+An unattended display reloads when it reconnects to a server running a
+different commit.
 
 The tab favicon follows the most urgent visible tile. It is red when any tile is
 red, orange when there are no red tiles but at least one orange tile, and green
@@ -711,7 +711,9 @@ some other commit, build and push it by hand:
 ```bash
 SHA=$(git rev-parse HEAD)
 IMG=us-central1-docker.pkg.dev/commontools-core/containers/dev-dashboard
-docker build --platform=linux/amd64 -f Dockerfile.dashboard -t "$IMG:$SHA" .
+docker build --platform=linux/amd64 \
+  --build-arg DASHBOARD_GIT_COMMIT="$SHA" \
+  -f Dockerfile.dashboard -t "$IMG:$SHA" .
 docker push "$IMG:$SHA"
 ```
 

--- a/packages/dashboard/deno.jsonc
+++ b/packages/dashboard/deno.jsonc
@@ -1,11 +1,10 @@
 {
   "imports": {
     // Dependency guide: ../../docs/development/DEPENDENCIES.md
-    "@noble/hashes": "npm:@noble/hashes@^2.2.0",
     "@resvg/resvg-js": "npm:@resvg/resvg-js@2.6.2"
   },
   "tasks": {
-    "watch": "deno run --watch --allow-net --allow-run=deno --allow-read --allow-write --allow-env server.ts",
+    "watch": "deno run --watch --allow-net --allow-run=deno,git --allow-read --allow-write --allow-env server.ts",
     "test": "deno run --allow-env --allow-read --allow-write --allow-run test/runner.ts",
     // Resvg's Linux loader checks the C library through Node's process report,
     // which reads CPU, network-interface, and hostname information.

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -1,25 +1,18 @@
 // Rendering tests: renderTile turns a TileView into markup, shell wraps the grid
 // in the page. Pure string work — no server, no network, no subprocess.
-import {
-  assert,
-  assertEquals,
-  assertMatch,
-  assertNotEquals,
-  assertStringIncludes,
-} from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Status, TileView } from "./types.ts";
 import {
   FAVICON_CRY_AFTER_MS,
   formatViewerTimes,
   renderTile,
   shell,
-  shellFingerprint,
-  shellVersion,
-  shellVersionContent,
 } from "./render.ts";
 import { humanSpan } from "./lib.ts";
 import { REPO } from "./config.ts";
 import { FAVICON_VERSION } from "./favicon.ts";
+
+const TEST_VERSION = "1".repeat(40);
 
 function view(over: Partial<TileView> = {}): TileView {
   return { label: "labs ci", status: "good", ...over };
@@ -178,6 +171,7 @@ Deno.test("shell: the grid and the wide tiles land in their own slots", () => {
     `<div class="tile bad wide">w</div>`,
     3,
     30_000,
+    TEST_VERSION,
     "bad",
   );
   assertStringIncludes(
@@ -200,12 +194,12 @@ Deno.test("shell: the grid and the wide tiles land in their own slots", () => {
 });
 
 Deno.test("shell: the freshness age and the refresh interval reach both the text and the script", () => {
-  const html = shell("", "", 7, 45_000, "good");
+  const html = shell("", "", 7, 45_000, TEST_VERSION, "good");
   assertStringIncludes(html, `<span id="agotext">updated 7s ago</span>`);
   assertStringIncludes(html, "const REFRESH = 45000;");
   assertStringIncludes(
     html,
-    `const SHELL_VERSION = ${JSON.stringify(shellVersion(45_000))};`,
+    `const SHELL_VERSION = ${JSON.stringify(TEST_VERSION)};`,
   );
   assertStringIncludes(html, "let base = 7;");
   assertStringIncludes(html, `new EventSource('/events')`);
@@ -230,39 +224,13 @@ Deno.test("shell: the freshness age and the refresh interval reach both the text
   assertStringIncludes(html, `link.dataset.focusKey === focusedKey`);
 });
 
-Deno.test("shell: static content has a SHA-256 fingerprint", () => {
-  const content = shellVersionContent(30_000);
-  const version = shellVersion(30_000);
-  assertStringIncludes(content, `"renderShell":"function renderShell(`);
-  assertStringIncludes(content, `"shell":"function shell(`);
-  assertMatch(version, /^sha256:[0-9a-f]{64}$/);
-  assertEquals(version, shellFingerprint(content));
-  const incompatibleChanges = [
-    [
-      `.evtxt{color:inherit;text-decoration:none`,
-      `.evtxt{color:#fff;text-decoration:none`,
-    ],
-    [
-      `if (update.shellVersion !== SHELL_VERSION)`,
-      `if (update.version !== SHELL_VERSION)`,
-    ],
-    ["dashboard-grid", "dashboard-grid-v2"],
-  ];
-  for (const [before, after] of incompatibleChanges) {
-    assertStringIncludes(content, before);
-    assertNotEquals(
-      shellFingerprint(content.replace(before, after)),
-      version,
-    );
-  }
-});
-
-Deno.test("shell: live data keeps the fingerprint; persistent configuration changes it", () => {
+Deno.test("shell: live data and runtime settings keep the Git commit version", () => {
   const first = shell(
     `<div class="tile good">first</div>`,
     "",
     0,
     30_000,
+    TEST_VERSION,
     "good",
   );
   const second = shell(
@@ -270,16 +238,24 @@ Deno.test("shell: live data keeps the fingerprint; persistent configuration chan
     `<div class="tile warn wide">third</div>`,
     999,
     30_000,
+    TEST_VERSION,
     "bad",
     123,
     456,
   );
-  const differentRefresh = shell("", "", 0, 60_000, "good");
+  const differentRefresh = shell(
+    "",
+    "",
+    0,
+    60_000,
+    TEST_VERSION,
+    "good",
+  );
   const embedded = (html: string): string =>
     html.match(/const SHELL_VERSION = "([^"]+)";/)?.[1] ?? "";
-  assertEquals(embedded(first), shellVersion(30_000));
-  assertEquals(embedded(second), shellVersion(30_000));
-  assertNotEquals(embedded(differentRefresh), embedded(first));
+  assertEquals(embedded(first), TEST_VERSION);
+  assertEquals(embedded(second), TEST_VERSION);
+  assertEquals(embedded(differentRefresh), TEST_VERSION);
 });
 
 Deno.test("formatViewerTimes: the viewer's formatter replaces the UTC fallback", () => {
@@ -295,7 +271,7 @@ Deno.test("formatViewerTimes: the viewer's formatter replaces the UTC fallback",
 });
 
 Deno.test("shell: the browser runs the viewer-time formatter", () => {
-  const html = shell("", "", 0, 30_000, "good");
+  const html = shell("", "", 0, 30_000, TEST_VERSION, "good");
   const source = formatViewerTimes.toString();
   assertStringIncludes(source, `time[data-viewer-time][datetime]`);
   assert(
@@ -318,7 +294,7 @@ Deno.test("shell: the browser runs the viewer-time formatter", () => {
 });
 
 Deno.test("shell: server-measured red age changes the favicon after one hour", () => {
-  const html = shell("", "", 0, 1000, "good");
+  const html = shell("", "", 0, 1000, TEST_VERSION, "good");
   assertStringIncludes(
     html,
     `const FAVICON_CRY_AFTER_MS = ${FAVICON_CRY_AFTER_MS}`,
@@ -330,6 +306,7 @@ Deno.test("shell: server-measured red age changes the favicon after one hour", (
     "",
     0,
     1000,
+    TEST_VERSION,
     "bad",
     1_234,
     567,
@@ -380,7 +357,7 @@ Deno.test("shell: server-measured red age changes the favicon after one hour", (
 
 Deno.test("shell: the repo name in the header is escaped", () => {
   assertStringIncludes(
-    shell("", "", 0, 1000, "good"),
+    shell("", "", 0, 1000, TEST_VERSION, "good"),
     `<span>${REPO.replace(/&/g, "&amp;")}</span>`,
   );
 });

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -1,6 +1,5 @@
 // Uniform rendering: every tile becomes the same markup from its TileView, and
 // the shell wraps the grid + wide tiles in the dark page with the SSE client.
-import { sha256 } from "@noble/hashes/sha2.js";
 import type { TileView } from "./types.ts";
 import { durationTag, escapeHtml, STATUS_DOT } from "./lib.ts";
 import { REPO } from "./config.ts";
@@ -14,11 +13,6 @@ const FAVICON_PNG_HREFS = JSON.stringify({
   "bad-crying": faviconHref("bad-crying"),
 });
 const PAINT_STATUS_FAVICON = paintStatusFavicon.toString();
-const FAVICON_STATUSES: Record<FaviconStatus, FaviconStatus> = {
-  good: "good",
-  warn: "warn",
-  bad: "bad",
-};
 
 export const FAVICON_CRY_AFTER_MS = 60 * 60 * 1000;
 
@@ -239,53 +233,12 @@ ${faviconLink(status)}
 </script></body></html>`;
 }
 
-export function shellFingerprint(content: string): string {
-  const digest = sha256(new TextEncoder().encode(content));
-  const hex = Array.from(
-    digest,
-    (byte) => byte.toString(16).padStart(2, "0"),
-  ).join("");
-  return `sha256:${hex}`;
-}
-
-// Function source covers every renderer branch and the production wrapper.
-// Fixed rendered examples add the output of called helpers and assets. Live
-// values use placeholders because updates replace them without reloading.
-export function shellVersionContent(refreshMs: number): string {
-  return JSON.stringify({
-    renderShell: renderShell.toString(),
-    shell: shell.toString(),
-    representatives: Object.values(FAVICON_STATUSES).map((status) =>
-      renderShell(
-        "<!-- live grid -->",
-        "<!-- live wide tiles -->",
-        123,
-        refreshMs,
-        "__shell_version__",
-        status,
-        456,
-        789,
-      )
-    ),
-  });
-}
-
-const SHELL_VERSIONS = new Map<number, string>();
-
-export function shellVersion(refreshMs: number): string {
-  let version = SHELL_VERSIONS.get(refreshMs);
-  if (!version) {
-    version = shellFingerprint(shellVersionContent(refreshMs));
-    SHELL_VERSIONS.set(refreshMs, version);
-  }
-  return version;
-}
-
 export function shell(
   gridHtml: string,
   wideHtml: string,
   ago: number,
   refreshMs: number,
+  shellVersion: string,
   status: FaviconStatus,
   serverRedSince: number | null = null,
   serverRedAgeMs: number | null = null,
@@ -295,7 +248,7 @@ export function shell(
     wideHtml,
     ago,
     refreshMs,
-    shellVersion(refreshMs),
+    shellVersion,
     status,
     serverRedSince,
     serverRedAgeMs,

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -1088,7 +1088,7 @@ Deno.test("sse: /events opens a stream, tick pushes new tile markup, disconnect 
   assertEquals(await chunk(reader), ": connected\n\n");
   assertEquals(clients.size, 1);
   const initial = updateFromEvent(await chunk(reader));
-  assertMatch(initial.shellVersion, /^sha256:[0-9a-f]{64}$/);
+  assertMatch(initial.shellVersion, /^[0-9a-f]{40}$/);
   assert(initial.ageSeconds >= 0);
   assert(["good", "warn", "bad"].includes(initial.faviconStatus));
   assert(Object.hasOwn(initial, "faviconRedSince"));

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-net --allow-run=deno --allow-read --allow-write --allow-env
+#!/usr/bin/env -S deno run --allow-net --allow-run=deno,git --allow-read --allow-write --allow-env
 // Fabric wall — modular live dashboard.
 //
 // Each tile lives in tiles/ and is registered once in registry.ts. This file is
@@ -7,7 +7,7 @@
 // drill-down routes a tile declares. It knows nothing about individual tiles.
 //
 //   cd <repo root>
-//   deno run --allow-net --allow-run=deno --allow-read --allow-write --allow-env \
+//   deno run --allow-net --allow-run=deno,git --allow-read --allow-write --allow-env \
 //     packages/dashboard/server.ts
 //   open http://localhost:8731
 //
@@ -26,8 +26,9 @@ import { makeCtx } from "./ctx.ts";
 import { friendlyError } from "./lib.ts";
 import { faviconPng, faviconStatus } from "./favicon.ts";
 import type { FaviconStatus } from "./favicon.ts";
-import { renderTile, shell, shellVersion } from "./render.ts";
+import { renderTile, shell } from "./render.ts";
 import type { Ctx, Run, RunSource, Tile, TileView } from "./types.ts";
+import { dashboardVersion } from "./version.ts";
 
 const ctx = makeCtx();
 const views = new Map<string, TileView>();
@@ -398,7 +399,7 @@ const routes = TILES.flatMap((t) => t.routes ?? []);
 // the real cadence for the fastest tile is its interval plus a tick, not the bare
 // interval.
 const REFRESH_MS = Math.min(...TILES.map((t) => t.intervalMs)) + TICK_MS;
-const SHELL_VERSION = shellVersion(REFRESH_MS);
+const SHELL_VERSION = dashboardVersion();
 
 export function page(currentViews: ReadonlyMap<string, TileView> = views): string {
   const update = dashboardUpdate(currentViews);
@@ -407,6 +408,7 @@ export function page(currentViews: ReadonlyMap<string, TileView> = views): strin
     update.wideHtml,
     update.ageSeconds,
     REFRESH_MS,
+    SHELL_VERSION,
     update.faviconStatus,
     update.faviconRedSince,
     update.faviconRedAgeMs,

--- a/packages/dashboard/test/runner.ts
+++ b/packages/dashboard/test/runner.ts
@@ -8,7 +8,7 @@ export const TEST_COMMANDS = [
     "--allow-env",
     "--allow-read",
     "--allow-write",
-    `--allow-run=${Deno.execPath()}`,
+    `--allow-run=${Deno.execPath()},git`,
     "--ignore=favicon-client.browser.test.ts",
     "--ignore=favicon-raster.test.ts",
     "--ignore=regenerate-favicons.test.ts",

--- a/packages/dashboard/version.test.ts
+++ b/packages/dashboard/version.test.ts
@@ -1,0 +1,70 @@
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import { dashboardVersion } from "./version.ts";
+
+const FIRST_COMMIT = "1".repeat(40);
+const SECOND_COMMIT = "a".repeat(40);
+
+Deno.test("dashboard version uses the deployed image commit", () => {
+  assertEquals(
+    dashboardVersion(
+      (name) => name === "DASHBOARD_GIT_COMMIT" ? FIRST_COMMIT : undefined,
+      () => {
+        throw new Error("Git must not run for a deployed image");
+      },
+    ),
+    FIRST_COMMIT,
+  );
+});
+
+Deno.test("dashboard version reads the current commit for local development", () => {
+  assertEquals(
+    dashboardVersion(() => undefined, () => SECOND_COMMIT),
+    SECOND_COMMIT,
+  );
+});
+
+Deno.test("dashboard version rejects missing or abbreviated commits", () => {
+  for (const version of ["", "abc123", "g".repeat(40)]) {
+    assertThrows(
+      () => dashboardVersion(() => version, () => FIRST_COMMIT),
+      Error,
+      "Dashboard Git commit must be a full 40-character lowercase hash.",
+    );
+  }
+});
+
+Deno.test("local dashboard version matches the checked-out commit", () => {
+  const result = new Deno.Command("git", {
+    args: ["rev-parse", "--verify", "HEAD^{commit}"],
+    cwd: new URL("../../", import.meta.url),
+    stdout: "piped",
+  }).outputSync();
+  assertEquals(result.success, true);
+  assertEquals(
+    dashboardVersion(() => undefined),
+    new TextDecoder().decode(result.stdout).trim(),
+  );
+});
+
+Deno.test("dashboard image requires the publishing workflow commit", async () => {
+  const dockerfile = await Deno.readTextFile(
+    new URL("../../Dockerfile.dashboard", import.meta.url),
+  );
+  assertStringIncludes(dockerfile, "ARG DASHBOARD_GIT_COMMIT");
+  assertStringIncludes(
+    dockerfile,
+    "ENV DASHBOARD_GIT_COMMIT=${DASHBOARD_GIT_COMMIT}",
+  );
+  assertStringIncludes(
+    dockerfile,
+    "grep -Eq '^[0-9a-f]{40}$'",
+  );
+
+  const readme = await Deno.readTextFile(
+    new URL("./README.md", import.meta.url),
+  );
+  assertStringIncludes(
+    readme,
+    '--build-arg DASHBOARD_GIT_COMMIT="$SHA"',
+  );
+});

--- a/packages/dashboard/version.test.ts
+++ b/packages/dashboard/version.test.ts
@@ -1,8 +1,9 @@
 import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
-import { dashboardVersion } from "./version.ts";
+import { currentGitCommit, dashboardVersion } from "./version.ts";
 
 const FIRST_COMMIT = "1".repeat(40);
 const SECOND_COMMIT = "a".repeat(40);
+const encoder = new TextEncoder();
 
 Deno.test("dashboard version uses the deployed image commit", () => {
   assertEquals(
@@ -44,6 +45,29 @@ Deno.test("local dashboard version matches the checked-out commit", () => {
     dashboardVersion(() => undefined),
     new TextDecoder().decode(result.stdout).trim(),
   );
+});
+
+Deno.test("dashboard version reports Git command failures", () => {
+  for (
+    const [stderr, message] of [
+      [
+        "fatal: not a git repository",
+        "Could not read the dashboard Git commit: fatal: not a git repository",
+      ],
+      ["", "Could not read the dashboard Git commit."],
+    ]
+  ) {
+    assertThrows(
+      () =>
+        currentGitCommit(() => ({
+          success: false,
+          stdout: new Uint8Array(),
+          stderr: encoder.encode(stderr),
+        })),
+      Error,
+      message,
+    );
+  }
 });
 
 Deno.test("dashboard image requires the publishing workflow commit", async () => {

--- a/packages/dashboard/version.ts
+++ b/packages/dashboard/version.ts
@@ -1,17 +1,26 @@
 type Environment = (name: string) => string | undefined;
 type ReadGitCommit = () => string;
+interface GitCommandOutput {
+  success: boolean;
+  stdout: Uint8Array;
+  stderr: Uint8Array;
+}
+type RunGitCommand = () => GitCommandOutput;
 
 const decoder = new TextDecoder();
 const REPOSITORY_ROOT = new URL("../../", import.meta.url);
 const GIT_COMMIT_PATTERN = /^[0-9a-f]{40}$/;
 
-function currentGitCommit(): string {
-  const result = new Deno.Command("git", {
-    args: ["rev-parse", "--verify", "HEAD^{commit}"],
-    cwd: REPOSITORY_ROOT,
-    stdout: "piped",
-    stderr: "piped",
-  }).outputSync();
+export function currentGitCommit(
+  runGit: RunGitCommand = () =>
+    new Deno.Command("git", {
+      args: ["rev-parse", "--verify", "HEAD^{commit}"],
+      cwd: REPOSITORY_ROOT,
+      stdout: "piped",
+      stderr: "piped",
+    }).outputSync(),
+): string {
+  const result = runGit();
   if (!result.success) {
     const detail = decoder.decode(result.stderr).trim();
     throw new Error(

--- a/packages/dashboard/version.ts
+++ b/packages/dashboard/version.ts
@@ -1,0 +1,39 @@
+type Environment = (name: string) => string | undefined;
+type ReadGitCommit = () => string;
+
+const decoder = new TextDecoder();
+const REPOSITORY_ROOT = new URL("../../", import.meta.url);
+const GIT_COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+
+function currentGitCommit(): string {
+  const result = new Deno.Command("git", {
+    args: ["rev-parse", "--verify", "HEAD^{commit}"],
+    cwd: REPOSITORY_ROOT,
+    stdout: "piped",
+    stderr: "piped",
+  }).outputSync();
+  if (!result.success) {
+    const detail = decoder.decode(result.stderr).trim();
+    throw new Error(
+      `Could not read the dashboard Git commit${detail ? `: ${detail}` : "."}`,
+    );
+  }
+  return decoder.decode(result.stdout).trim();
+}
+
+function validGitCommit(value: string): string {
+  if (!GIT_COMMIT_PATTERN.test(value)) {
+    throw new Error(
+      "Dashboard Git commit must be a full 40-character lowercase hash.",
+    );
+  }
+  return value;
+}
+
+export function dashboardVersion(
+  env: Environment = Deno.env.get,
+  readGitCommit: ReadGitCommit = currentGitCommit,
+): string {
+  const deployedCommit = env("DASHBOARD_GIT_COMMIT");
+  return validGitCommit(deployedCommit ?? readGitCommit());
+}

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -152,6 +152,11 @@ Deno.test("Dashboard publishes only from main, never from a pull request", async
   assertStringIncludes(build, "\n          push: true\n");
   assertStringIncludes(
     build,
+    "\n          build-args: |\n" +
+      "            DASHBOARD_GIT_COMMIT=${{ github.sha }}\n",
+  );
+  assertStringIncludes(
+    build,
     "\n          tags: |\n" +
       "            ${{ env.IMAGE }}:${{ github.sha }}\n" +
       "            ${{ env.IMAGE }}:latest\n",


### PR DESCRIPTION
The dashboard needs one compatibility value shared by the initial page and server-sent updates so browsers reload after a deployment changes their code or markup. Deriving that value from renderer source made the reload contract difficult to follow and required a dashboard-only hashing dependency.

Resolve the version once when the server starts. Local runs read the full checked-out commit from Git. Published images receive the workflow's checked-out commit as a validated Docker build argument. Pass that value into both the rendered page and server-sent updates, and remove the renderer hashing machinery and direct hashing dependency.

Update local permissions and manual build instructions for Git commit resolution. Add tests for local and deployed resolution, commit validation, Docker and workflow wiring, and version stability across live data. The complete dashboard test task, workflow tests, repository formatting, and repository lint checks pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the current Git commit as the dashboard’s compatibility version, resolved once at server start and shared with SSE updates. This replaces hashing-based versioning, simplifies the reload contract, and removes a dashboard-only hashing dependency.

- **Refactors**
  - Local dev reads the checked-out commit via `git rev-parse`; deployed images receive a validated `DASHBOARD_GIT_COMMIT` build arg.
  - Inject the commit into the HTML shell and `/events` payload so the browser reloads only when deployments change.
  - Drop shell fingerprinting logic and pass the version into `shell(...)`; simplify render/tests accordingly.
  - Allow running `git` in Deno tasks; wire commit through `Dockerfile.dashboard` and the dashboard image workflow.
  - Make Git command execution injectable in `version.ts`; add tests for Git lookup failures and error paths to keep coverage stable.

- **Dependencies**
  - Remove `@noble/hashes`.
  - Add the `DASHBOARD_GIT_COMMIT` Docker build arg with 40-char lowercase SHA validation.

<sup>Written for commit 8a056d25c54b11fe45ff7667bc9bc0a6d06a2ee1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

