### PR TITLE
docs(plans): verb contract — record review context (llm-dialog precedent, #5059 preflight, deferred get flags)

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -14,6 +14,12 @@ post-merge review amendments (decisions 5–7: attribution via CFC provenance,
 patterns return references while clients render identity, `@name` deferred);
 index and fixture wording follows the references model.
 
+**Amended 2026-07-28**, context only — no scope or decision changed: Risks
+names #5059 (`cf piece setsrc --check`) as the candidate preflight for the
+write-storm gate, and the design doc records the llm-dialog invocation
+precedent (Prior art) and two deferred `cf piece get` read-control flags
+(Discovery).
+
 ## Governing decisions
 
 Made 2026-07-24, shaping everything below:
@@ -327,6 +333,13 @@ change that alters them.
   #4956, merged 2026-07-24 — is the candidate fix; confirm before the first
   Phase 1 deploy). Until the gate clears, a "live-board acceptance pass"
   degrades to a scratch board and must say so rather than pass silently.
+  **#5059 (`cf piece setsrc --check`) is the candidate preflight for this
+  gate:** it answers whether a source can be applied to a given piece before
+  attempting it, driving the real rules in dry-run — the schema subset proof,
+  the CFC envelope merge, the retained-link validator — rather than a second
+  copy of them. It does not measure commit rates, so the rehearsal above
+  stands; what it removes is discovering an incompatibility by attempting the
+  swap on the live board.
 - **WS-E's gates may stall it** (OQ1, CFC review, collection unknown, trusted
   ingress mint and propagation): it is last and severable; everything through
   Phase 4 delivers without it, and `topics.agentName` remains the safe interim.

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -20,6 +20,12 @@ not a parallel invocation field; patterns return child references while clients
 render their ids and paths; and client-local `@name` bindings are deferred
 because they overlap confusingly with fabric-side slugs.
 
+**Context added (2026-07-28)**, from a further review pass — additive only, no
+decision changed: a second in-tree precedent for the invocation protocol, the
+llm-dialog builtin (Prior art); `cf piece setsrc --check` (#5059) named as the
+candidate preflight for the implementation plan's write-storm gate; and two
+deferred `cf piece get` read-control flags recorded under Discovery.
+
 ## Goal
 
 Any pattern drivable by an agent, with no pattern-specific CLI code. Filing one
@@ -298,6 +304,16 @@ broad form proves too noisy. Both are projections of existing references, not
 fields every pattern must maintain. Acceptance for an index: its serialization
 contains no expanded piece, action, or runtime values, and a full-board read
 stays bounded.
+
+Two client affordances surfaced in review (2026-07-28) and are deferred,
+blocking nothing: `cf piece get` could grow flags that let an agent control
+how much data a read returns when exploring the fabric interactively — a
+`--schema` override that reads through a narrower schema (the runtime's
+`asSchema`; the CLI already narrows its own internal reads this way, e.g.
+`packages/cli/lib/piece-render.ts`), and a limit on the number of records
+returned from a large array. Adjacent CLI work for when board scale demands
+it, recorded here so the deferral is deliberate; neither is an ask on any
+workstream in the implementation plan.
 
 Discovery is the parent's job; the child's own verbs are the child's. A comment
 is addressed to the topic, not routed through the board — **but that depends on
@@ -687,6 +703,17 @@ fixed-timeout sync failures, roughly six minutes of mutation waits, and one
 field silently discarded by a stale deployed schema. Each failure maps to a
 section above, and the session's three-topic scenario is adopted as the
 end-to-end acceptance fixture in the implementation plan.
+
+Closer to home, the llm-dialog builtin already runs the invocation protocol in
+miniature: each tool call mints its result cell at a **caller-supplied id**
+(`toolCall.id`), hands it to the handler as `result` — its own comment reads
+"doesn't HAVE to be used, but can be" — and resolves off the commit callback
+(`packages/runner/src/builtins/llm-dialog.ts`, the tool-invocation path around
+`runtime.run(tx, pattern, invocationArgs, result)`). The scheduler receipt
+remains the right substrate for the reasons given in Part 2 — the create-only
+exactly-once collision is what a client retry needs — but llm-dialog is
+in-production evidence that the caller-supplied-id → durable-result-cell
+ergonomics this design exposes already work.
 
 ## Open questions
 


### PR DESCRIPTION
## Why

Folds the review context posted on #4968 ([comment](https://github.com/commontoolsinc/labs/pull/4968#issuecomment-5098604859)) into the plan of record, per the plan's own convention ("keep current as work proceeds"; #5006 is the precedent). Additive only — no decision, scope, or workstream changes. A comment thread doesn't survive as context for future readers of the plan; these three notes are worth having in place.

## What Changed

- **Design doc, Prior art:** the llm-dialog builtin recorded as a second in-tree precedent for the invocation protocol — it already mints the result cell at a caller-supplied id (`toolCall.id`), hands it to the handler as `result`, and resolves off the commit callback. The scheduler receipt stays the chosen substrate for the reasons Part 2 gives; llm-dialog is in-production evidence the ergonomics work.
- **Design doc, Discovery:** two deferred `cf piece get` read-control flags recorded — a `--schema` override (the runtime's `asSchema`, which the CLI already uses to narrow its own internal reads, e.g. `piece-render.ts`) and a record limit on large arrays — so the deferral reads as deliberate. Explicitly not asks on any workstream.
- **Implementation doc, Risks:** #5059 (`cf piece setsrc --check`) named as the candidate preflight for the write-storm gate — dry-run of the real rules (schema subset proof, CFC envelope merge, retained-link validator), no second copy. It doesn't measure commit rates, so the rehearsal step stands.
- Both docs get a dated one-paragraph amendment note per house style.

## Test plan

- `deno task check-docs plans` — passes.
- `docs/` is fmt-excluded; prose hand-wrapped at 80 columns (verified no added line exceeds it).
- Citations checked against source: `toolCall.id` result-cell mint and the `result` comment in `packages/runner/src/builtins/llm-dialog.ts`; `asSchema` on `Cell` (`packages/runner/src/cell.ts:310`); internal narrowing at `packages/cli/lib/piece-render.ts:41`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds review context to the verb contract docs so future readers have the in-tree precedents and deferrals in one place. Records the `llm-dialog` invocation precedent, names `cf piece setsrc --check` (#5059) as the write-storm preflight, and documents two deferred `cf piece get` read controls (`--schema` via `asSchema`, and a record limit).

<sup>Written for commit 585fe619bd873beb22101b21d7d2f74fd3d17ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

