### PR TITLE
fix(cf-harness): recover streamed output items on the Codex subscription path

### DIFF
--- a/docs/plans/cf-harness-codex-subscription-auth.md
+++ b/docs/plans/cf-harness-codex-subscription-auth.md
@@ -400,8 +400,13 @@ Expected files:
 
 - [x] Parse chunks incrementally across arbitrary byte boundaries.
 - [x] Normalize assistant text, function calls, response id, encrypted
-  reasoning, usage, and terminal status from the provider's terminal response
-  without exposing raw SSE events to the prompt loop.
+  reasoning, usage, and terminal status from the provider's terminal response,
+  falling back to the completed `response.output_item.done` items streamed
+  earlier when the terminal event carries no assembled output — an empty array
+  or `null`, as the ChatGPT Codex backend returns under `store: false`. A
+  populated terminal output always wins (no double-counting); `failed` and
+  `incomplete` statuses still fail. Raw SSE events are not exposed to the
+  prompt loop.
 - [x] Reject malformed JSON, conflicting duplicate call ids, incomplete
   arguments, and a stream that ends without a terminal response event.
 - [x] Abort the fetch and reader immediately when the run signal aborts.

--- a/packages/cf-harness/docs/OPENAI_CODEX_PROTOCOL.md
+++ b/packages/cf-harness/docs/OPENAI_CODEX_PROTOCOL.md
@@ -69,6 +69,16 @@ The response adapter accepts `response.completed`, `response.done`,
 the compared clients normalize those terminal forms. It persists encrypted
 reasoning output items only as provider-tagged opaque continuation state.
 
+Under `store: false` the ChatGPT Codex backend streams each completed item via
+`response.output_item.done` but returns **no assembled output** on the terminal
+event — an empty `output` array, or `null` — because it keeps no stored response
+to echo back. The adapter therefore accumulates the streamed `output_item.done`
+items and normalizes from them whenever the terminal output is empty/null; a
+populated terminal `output` (other providers, or stored responses) always wins,
+so the two representations never double-count, and `failed`/`incomplete`
+statuses still fail before normalization. Reading only the terminal `output`
+silently drops the model's message and tool calls.
+
 ## Product boundary
 
 The local filesystem credential adapter is keyed to a local owner. Loom must

--- a/packages/cf-harness/src/model/openai-codex-responses.ts
+++ b/packages/cf-harness/src/model/openai-codex-responses.ts
@@ -673,8 +673,17 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
     }
     await emitAttempt(request.onAttempt, baseAttempt);
     let terminal: Record<string, unknown> | undefined;
+    // The ChatGPT Codex backend streams each completed output item via a
+    // `response.output_item.done` event, but with `store: false` it returns an
+    // EMPTY `output` array on the terminal `response.completed` event (it does
+    // not assemble a stored response to echo back). Accumulate the streamed
+    // items so the model's message and tool calls are not silently dropped.
+    const streamedItems: unknown[] = [];
     for await (const event of parseSse(response, request.signal)) {
       const type = event.type;
+      if (type === "response.output_item.done" && event.item !== undefined) {
+        streamedItems.push(event.item);
+      }
       if (type === "error") {
         throw new Error(
           "OpenAI Codex Responses stream returned an error event",
@@ -700,6 +709,18 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
       throw new Error(
         "Codex Responses stream ended without a terminal response event",
       );
+    }
+    // With `store: false` the ChatGPT Codex backend returns no assembled output
+    // on the terminal event — an empty array, or (also observed on this
+    // backend) `null` — even though it streamed the items. Fall back to what we
+    // accumulated so downstream parsing sees the model's message and tool
+    // calls. A POPULATED terminal output always wins (no double-counting); any
+    // other malformed shape is left for normalizeTerminalResponse to reject.
+    const terminalOutputEmpty = terminal.output === null ||
+      terminal.output === undefined ||
+      (Array.isArray(terminal.output) && terminal.output.length === 0);
+    if (terminalOutputEmpty && streamedItems.length > 0) {
+      terminal = { ...terminal, output: streamedItems };
     }
     const usage = typeof terminal.usage === "object" &&
         terminal.usage !== null && !Array.isArray(terminal.usage)

--- a/packages/cf-harness/test/openai-codex-responses.test.ts
+++ b/packages/cf-harness/test/openai-codex-responses.test.ts
@@ -184,6 +184,90 @@ Deno.test("Codex Responses client bounds stable run affinity identifiers", async
   assertEquals(requestIds[0] === requestIds[1], false);
 });
 
+Deno.test("Codex Responses client recovers streamed output items when store:false empties the terminal output", async () => {
+  // The ChatGPT Codex backend streams each completed item via
+  // `response.output_item.done` but, with `store: false`, returns an EMPTY
+  // `output` array on `response.completed`. The client must fall back to the
+  // streamed items or it silently drops the model's message and tool calls
+  // (observed live: agents did nothing, 0 tool calls, empty final text).
+  const client = new OpenAICodexResponsesClient({
+    credentialResolver: { resolve: () => Promise.resolve(credential) },
+    fetchFn: () =>
+      Promise.resolve(sse(
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_1",
+            role: "assistant",
+            content: [{ type: "output_text", text: "on it" }],
+          },
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "bash",
+            arguments: '{"command":"uname -a"}',
+          },
+        },
+        {
+          type: "response.completed",
+          response: { id: "resp_stream", status: "completed", output: [] },
+        },
+      )),
+  });
+
+  const result = await client.complete({
+    model: "gpt-5.4",
+    transcript: [{ role: "user", content: "explore" }],
+    tools: [],
+    nativeModelToolIds: [],
+    runId: "run-stream",
+  });
+
+  assertEquals(result.assistant.content, "on it");
+  assertEquals(result.assistant.toolCalls?.[0]?.id, "call_1");
+  assertEquals(result.assistant.toolCalls?.[0]?.function.name, "bash");
+});
+
+Deno.test("Codex Responses client recovers streamed output items when the terminal output is null", async () => {
+  // The same backend has also been observed returning `output: null` (not just
+  // an empty array) with valid streamed items. Treat null like empty.
+  const client = new OpenAICodexResponsesClient({
+    credentialResolver: { resolve: () => Promise.resolve(credential) },
+    fetchFn: () =>
+      Promise.resolve(sse(
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "bash",
+            arguments: '{"command":"whoami"}',
+          },
+        },
+        {
+          type: "response.completed",
+          response: { id: "resp_null", status: "completed", output: null },
+        },
+      )),
+  });
+
+  const result = await client.complete({
+    model: "gpt-5.4",
+    transcript: [{ role: "user", content: "who" }],
+    tools: [],
+    nativeModelToolIds: [],
+    runId: "run-null",
+  });
+
+  assertEquals(result.assistant.toolCalls?.[0]?.function.name, "bash");
+});
+
 Deno.test("Codex Responses client normalizes tool calls and preserves encrypted continuation", async () => {
   const requestBodies: Array<Record<string, unknown>> = [];
   const client = new OpenAICodexResponsesClient({


### PR DESCRIPTION
## Why

Every cf-harness tool-run on the **`openai-codex`** (ChatGPT/Codex subscription) provider came back **empty** — the agent produced no message and made no tool calls, so `--model-provider openai-codex` runs did nothing. Auth and transport were fine (`HTTP 200`, owner-bound OAuth, real `chatgpt.com/backend-api/codex/responses` endpoint); the model's output was being silently dropped.

**Root cause:** the request sends `store: false`, and with that the ChatGPT Codex backend streams each completed item via `response.output_item.done` events but returns an **empty `output` array** on the terminal `response.completed` event (it doesn't assemble a stored response to echo back). The client read only `terminal.output`, so it discarded the streamed message and function calls.

A live run made it unambiguous — the event stream was:
`response.created → output_item.added → function_call_arguments.delta×N → function_call_arguments.done → output_item.done → response.completed`
with `usage.output_tokens: 31`, yet the terminal `output` was `[]`.

## What changed

`packages/cf-harness/src/model/openai-codex-responses.ts`: accumulate items from `response.output_item.done` as the stream is read, and fall back to them **only when** the terminal event's `output` is empty. When the terminal output is populated (other providers / stored responses) behavior is unchanged — nothing double-counts.

This is the codex-Responses counterpart to the Chat-Completions tool-run fix in #4998 (`openai-compatible-gateway.ts`); the gap was in the subscription path landed in #4931.

## Test plan

- **Regression test** (`openai-codex-responses.test.ts`): a stream of `response.output_item.done` items (a message + a `function_call`) followed by `response.completed` with `output: []` — asserts the client recovers both the content and the tool call. (Fails without the fix: empty terminal output → empty content, no tool calls.)
- **Verified live** against a ChatGPT/Codex subscription: an agent now runs bash in the runsc-cfc sandbox and answers (`uname -a` → sandbox kernel; `whoami` → root) — 2 model turns, 2 tool calls, no gateway. Before this fix the same run produced 0 tool calls and empty text.
- Full codex responses suite: **23 passed**; `deno fmt --check` / `deno lint` / `deno check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty outputs on the Codex subscription path by capturing streamed `response.output_item.done` items and using them when the terminal `output` is empty or `null`. Tool runs and messages now work again with `--model-provider openai-codex`.

- **Bug Fixes**
  - Accumulate streamed items and fall back only when terminal `output` is empty or `null` (with `store:false`); populated terminal output still wins, no double-counting.
  - Added tests for empty `[]` and `null` terminal outputs; updated docs to explain the `store:false` behavior and the fallback.

<sup>Written for commit c9ecedc839383a5af3692a9b48f1ea3953f15b0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

