### PR TITLE
feat(cli): highlight YAML in cf view

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,19 @@
 # @commonfabric/cli
 
+## View pager
+
+`cf view [file]` is an interactive pager for transformed TypeScript, source
+files, and unified diffs. Named Markdown, JSON, JSONC, and YAML files use their
+own syntax highlighting. A piped input without a file name remains TypeScript
+unless it is detected as a diff. Redirected output keeps the text verbatim and
+adds ANSI color only when the selected color mode permits it.
+
+```bash
+cf check pattern.tsx --show-transformed --no-run | cf view
+cf view .github/workflows/deno.yml
+git diff upstream/main | cf view
+```
+
 ## Piece data search
 
 `cf piece search <query>` reads every piece in the selected space and returns

--- a/packages/cli/commands/view.ts
+++ b/packages/cli/commands/view.ts
@@ -3,13 +3,14 @@ import { type ColorWhen, ViewError, viewMain } from "../lib/view/mod.ts";
 import { cliText } from "../lib/cli-name.ts";
 
 const description = cliText(
-  `Interactive, syntax-aware pager for transformed patterns and diffs.
+  `Interactive, syntax-aware pager for transformed patterns, source files and diffs.
 
-A less-like viewer for the dense output of '--show-transformed'. It parses the
-text with the same TypeScript parser the transformer uses, so blocks, closures,
-schemas, type positions and Common Fabric builders (pattern/lift/handler/…) are
-coloured exactly as the compiler sees them. The text shown is verbatim — colour
-only.
+A less-like viewer for the dense output of '--show-transformed' and saved source
+files. Transformed TypeScript is parsed with the same parser the transformer
+uses, so blocks, closures, schemas, type positions and Common Fabric builders
+(pattern/lift/handler/…) are coloured exactly as the compiler sees them.
+Markdown, JSON, JSONC and YAML files use syntax highlighting selected from
+their names. The text shown is verbatim — colour only.
 
 Unified diffs are detected automatically: piping 'git diff' in gives added and
 removed lines their tints, full syntax colour, a structure tree of the code

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -732,6 +732,13 @@ interface MutableLine {
   bg?: "add" | "del";
 }
 
+interface FragmentLine {
+  diffLine: number;
+  code: string;
+  /** Context can establish old-side state without replacing new-side colours. */
+  render?: boolean;
+}
+
 interface HunkCtx {
   rawLines: string[];
   modelLines: DiffModel["lines"];
@@ -815,8 +822,8 @@ function buildHunk(hunk: DiffHunk, ctx: HunkCtx): StructureNode {
   // Mapping of this hunk's visible new-file lines → diff lines, and lazily-
   // parsed fragments for lines the workspace cannot vouch for.
   const newToDiff = new Map<number, number>();
-  const newFragment: { diffLine: number; code: string }[] = [];
-  const oldFragment: { diffLine: number; code: string }[] = [];
+  const newFragment: FragmentLine[] = [];
+  const oldFragment: FragmentLine[] = [];
 
   for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
     const entry = modelLines[i];
@@ -835,13 +842,18 @@ function buildHunk(hunk: DiffHunk, ctx: HunkCtx): StructureNode {
     if (entry.kind === "add") lines[i].bg = "add";
     if (entry.kind === "del") lines[i].bg = "del";
 
+    if (entry.kind === "ctx") {
+      oldFragment.push({ diffLine: i, code, render: false });
+    }
     if (entry.kind === "del") {
+      const fragment = { diffLine: i, code, render: false };
+      oldFragment.push(fragment);
       const oldSpans = ctx.oldFileLines?.[entry.oldLine!]?.spans;
       const shifted = oldSpans ? shiftCompleteLineSpans(t, oldSpans) : null;
       if (shifted) {
         lines[i].spans = shifted;
       } else {
-        oldFragment.push({ diffLine: i, code });
+        fragment.render = true;
       }
       continue;
     }
@@ -875,13 +887,15 @@ function buildHunk(hunk: DiffHunk, ctx: HunkCtx): StructureNode {
     ctx.newLanguage,
     ctx.newFileName,
   );
-  applyFragmentSpans(
-    oldFragment,
-    lines,
-    rawLines,
-    ctx.oldLanguage,
-    ctx.oldFileName,
-  );
+  if (oldFragment.some((fragment) => fragment.render)) {
+    applyFragmentSpans(
+      oldFragment,
+      lines,
+      rawLines,
+      ctx.oldLanguage,
+      ctx.oldFileName,
+    );
+  }
 
   // --- structure ---------------------------------------------------------
   // Verified hunks remap the workspace file's own nodes (precise ranges, live
@@ -1002,7 +1016,7 @@ function shiftCompleteLineSpans(
  * fragment so its structure tree can be remapped too.
  */
 function applyFragmentSpans(
-  fragment: { diffLine: number; code: string }[],
+  fragment: FragmentLine[],
   lines: MutableLine[],
   rawLines: string[],
   language: Language,
@@ -1014,6 +1028,7 @@ function applyFragmentSpans(
     fileName,
   );
   for (let i = 0; i < fragment.length; i++) {
+    if (fragment[i].render === false) continue;
     const { diffLine } = fragment[i];
     const spans = parsed.lines[i]?.spans ?? [];
     lines[diffLine].spans = shiftSpans(markerSpan(rawLines[diffLine]), spans);

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -31,7 +31,7 @@ import {
   messageAt,
   sameCommit,
 } from "./commitmsg.ts";
-import type { Highlighter } from "./languages/language.ts";
+import type { Highlighter, Language } from "./languages/language.ts";
 import { languageForFile } from "./languages/language.ts";
 import type {
   EditableSource,
@@ -208,13 +208,16 @@ export function diffSource(
     editable: true,
     policy,
     parse: (text) => reparse(ws, text, cache),
-    // Live highlighting recolours only the lines an edit changes and reuses the
-    // seed (buildDiffDocument's colours, including the file/hunk headers and the
-    // workspace-file syntax highlighting) for the rest. Cost tracks the edit,
-    // not the whole diff, and the unchanged headers never flicker colour. The
-    // full parse on pause restores workspace-verified spans across the edit.
+    // Live highlighting recolours the lines an edit changes and reuses the seed
+    // (buildDiffDocument's colours, including the file/hunk headers and the
+    // workspace-file syntax highlighting) for the rest. Languages whose colour
+    // can cross lines re-highlight the complete file. The full parse on
+    // pause restores workspace-verified spans across the edit.
     createHighlighter: (text, seed) =>
-      createDiffHighlighter(text, seed, edit.oldFileLines),
+      createDiffHighlighter(text, seed, edit.oldFileLines, {
+        fileText: expectedFiles,
+        hunks: saveHunks,
+      }),
     dirtyLabels: (original, current) =>
       [
         ...collectFileOutputs(
@@ -974,13 +977,15 @@ function applyExpansion(
  * — the colours {@link buildDiffDocument} produced for the unedited text — for
  * every line the edit leaves alone. Edited removed lines use the complete old
  * file's spans. Other edited body lines use a marker-aware single-line parse.
- * The headers stay in the unchanged prefix or suffix. When no seed is given,
- * the highlighter renders every line itself.
+ * A language can ask to re-highlight complete files when its colours depend on
+ * preceding lines. The headers stay in the unchanged prefix or suffix. When no
+ * seed is given, the highlighter renders every line itself.
  */
 export function createDiffHighlighter(
   initialText: string,
   seed?: readonly Line[],
   oldFileLines?: readonly (readonly Line[] | null)[],
+  completeFiles?: DiffHighlightFiles,
 ): Highlighter {
   let text = initialText;
   const initialRaw = initialText.split("\n");
@@ -993,6 +998,17 @@ export function createDiffHighlighter(
         oldLineSpansAt(initialModel, index, oldFileLines),
       )
     )).slice();
+  if (!seed && initialModel) {
+    rehighlightTouchedHunks(
+      initialRaw,
+      initialModel,
+      lines,
+      0,
+      initialRaw.length,
+      oldFileLines,
+      completeFiles,
+    );
+  }
   return {
     get lines() {
       return lines;
@@ -1023,10 +1039,217 @@ export function createDiffHighlighter(
         recoloured,
         lines.slice(oldRaw.length - s),
       );
+      rehighlightTouchedHunks(
+        newRaw,
+        model,
+        lines,
+        p,
+        newRaw.length - s,
+        oldFileLines,
+        completeFiles,
+      );
       text = next;
       return lines;
     },
   };
+}
+
+interface DiffHighlightFiles {
+  readonly fileText: ReadonlyMap<string, string>;
+  readonly hunks: readonly MutableHunk[];
+}
+
+/** Re-highlight touched YAML sides with complete files when they are available.
+ * A fragment remains the fallback for an unverified hunk. */
+function rehighlightTouchedHunks(
+  rawLines: string[],
+  model: DiffModel | null,
+  lines: Line[],
+  changedStart: number,
+  changedEnd: number,
+  oldFileLines?: readonly (readonly Line[] | null)[],
+  completeFiles?: DiffHighlightFiles,
+): void {
+  if (!model) return;
+  const changedLast = Math.max(changedStart, changedEnd - 1);
+  let fullNewFiles: Map<string, string> | undefined;
+  const indexedHunks = model.files.flatMap((file, fileIndex) =>
+    file.hunks.map((hunk) => ({
+      fileIndex,
+      hunk,
+      newFileName: file.newPath ?? file.oldPath,
+    }))
+  ).map((entry, index) => ({
+    ...entry,
+    index,
+    info: completeFiles?.hunks[index],
+  }));
+  const completeLineDeltas = indexedHunks.map(({ info }) => {
+    const path = info?.absPath;
+    if (!path || !isWritable(info)) return 0;
+    return indexedHunks.reduce((delta, other) => {
+      const otherInfo = other.info;
+      return otherInfo?.absPath === path &&
+          isWritable(otherInfo) &&
+          spliceStart(otherInfo) < spliceStart(info)
+        ? delta + other.hunk.newCount - otherInfo.newCount
+        : delta;
+    }, 0);
+  });
+  for (const [fileIndex, file] of model.files.entries()) {
+    const oldFileName = file.oldPath ?? file.newPath;
+    const newFileName = file.newPath ?? file.oldPath;
+    const oldLanguage = languageForFile(oldFileName);
+    const newLanguage = languageForFile(newFileName);
+    const fileHunks = indexedHunks.filter((entry) =>
+      entry.fileIndex === fileIndex
+    );
+    const touched = fileHunks.filter(({ hunk }) =>
+      changedLast >= hunk.headerLine && changedStart <= hunk.endLine
+    );
+    if (touched.length === 0) continue;
+
+    if (oldLanguage.highlightFullFileOnDiffEdit) {
+      const completeOld = oldFileLines?.[fileIndex];
+      for (const { hunk } of touched) {
+        if (completeOld) {
+          applyCompleteHunkSide(
+            rawLines,
+            model,
+            lines,
+            hunk,
+            "old",
+            completeOld,
+            oldFileName,
+          );
+          continue;
+        }
+        rehighlightHunkSide(
+          rawLines,
+          model,
+          lines,
+          hunk,
+          "old",
+          oldLanguage,
+          oldFileName,
+        );
+      }
+    }
+
+    if (newLanguage.highlightFullFileOnDiffEdit) {
+      const writable = touched.find(({ info }) =>
+        info?.absPath && isWritable(info)
+      )?.info;
+      const path = writable?.absPath;
+      const completeText = path && completeFiles
+        ? (fullNewFiles ??= collectFileOutputs(
+          rawLines.join("\n"),
+          completeFiles.fileText,
+          completeFiles.hunks,
+        )).get(path)
+        : undefined;
+      if (completeText !== undefined && path) {
+        const completeNew = newLanguage.highlightLines(
+          completeText,
+          newFileName,
+        );
+        for (
+          const {
+            hunk,
+            info,
+            index,
+            newFileName: hunkFileName,
+          } of indexedHunks
+        ) {
+          if (info?.absPath !== path || !isWritable(info)) continue;
+          const lineOffset = spliceStart(info) +
+            (completeLineDeltas[index] ?? 0) -
+            spliceStart(hunk);
+          applyCompleteHunkSide(
+            rawLines,
+            model,
+            lines,
+            hunk,
+            "new",
+            completeNew,
+            hunkFileName,
+            lineOffset,
+          );
+        }
+      } else {
+        for (const { hunk } of touched) {
+          rehighlightHunkSide(
+            rawLines,
+            model,
+            lines,
+            hunk,
+            "new",
+            newLanguage,
+            newFileName,
+          );
+        }
+      }
+    }
+  }
+}
+
+function applyCompleteHunkSide(
+  rawLines: string[],
+  model: DiffModel,
+  lines: Line[],
+  hunk: DiffHunk,
+  side: "old" | "new",
+  complete: readonly Line[],
+  fileName: string | undefined,
+  lineOffset = 0,
+): void {
+  for (let line = hunk.headerLine + 1; line <= hunk.endLine; line++) {
+    const entry = model.lines[line];
+    const sourceLine = side === "old" ? entry?.oldLine : entry?.newLine;
+    const included = side === "old"
+      ? entry?.kind === "del"
+      : entry?.kind === "ctx" || entry?.kind === "add";
+    if (!included || sourceLine === undefined) continue;
+    lines[line] = diffLineRender(
+      rawLines[line],
+      fileName,
+      complete[sourceLine + lineOffset]?.spans,
+    );
+  }
+}
+
+function rehighlightHunkSide(
+  rawLines: string[],
+  model: DiffModel,
+  lines: Line[],
+  hunk: DiffHunk,
+  side: "old" | "new",
+  language: Language,
+  fileName: string | undefined,
+): void {
+  const fragment: { diffLine: number; code: string }[] = [];
+  for (let line = hunk.headerLine + 1; line <= hunk.endLine; line++) {
+    const kind = model.lines[line]?.kind;
+    const included = side === "old"
+      ? kind === "ctx" || kind === "del"
+      : kind === "ctx" || kind === "add";
+    if (included) {
+      fragment.push({ diffLine: line, code: rawLines[line].slice(1) });
+    }
+  }
+  const highlighted = language.highlightLines(
+    fragment.map((entry) => entry.code).join("\n"),
+    fileName,
+  );
+  for (let index = 0; index < fragment.length; index++) {
+    const { diffLine } = fragment[index];
+    if (side === "old" && model.lines[diffLine]?.kind === "ctx") continue;
+    lines[diffLine] = diffLineRender(
+      rawLines[diffLine],
+      fileName,
+      highlighted[index]?.spans,
+    );
+  }
 }
 
 /**

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -2,10 +2,10 @@
  * The contract every source language plugs into so the `cf view` pager can
  * colour, navigate, edit and (optionally) reason about it, plus selecting the
  * right language for a file. A language is a stateless strategy object: one
- * instance describes TypeScript, one Markdown, one JSON. The pager selects the
- * right one for a file ONCE (via {@link languageForFile}) and then dispatches
- * every operation through that object's methods — there is no per-operation
- * branch on the file extension.
+ * instance describes TypeScript, one Markdown, one JSON, and one YAML. The
+ * pager selects the right one for a file ONCE (via {@link languageForFile}) and
+ * then dispatches every operation through that object's methods — there is no
+ * per-operation branch on the file extension.
  *
  * Per-file mutable state (a warm incremental parse, a language service) is not
  * held on the language; the language is a factory for the small stateful
@@ -21,6 +21,7 @@ import type { DiffMaps } from "../diffdoc.ts";
 import { typeScriptLanguage } from "./typescript/language.ts";
 import { markdownLanguage } from "./markdown/language.ts";
 import { jsonLanguage } from "./json/language.ts";
+import { yamlLanguage } from "./yaml/language.ts";
 
 /**
  * Live syntax highlighting that re-highlights only the region an edit touches,
@@ -104,7 +105,8 @@ export interface HunkStructureContext {
  * language {@link matches} once per file; all later work is method dispatch.
  */
 export interface Language {
-  /** Stable identifier, e.g. `"typescript"`, `"markdown"`, `"json"`. */
+  /** Stable identifier, such as `"typescript"`, `"markdown"`, `"json"`, or
+   * `"yaml"`. */
   readonly id: string;
 
   /** Does this language claim `fileName`? Consulted in order by {@link
@@ -121,6 +123,10 @@ export interface Language {
    * non-interactive fast path and the diff fragment renderer. `fileName` is
    * advisory (a language may parse `.ts` and `.tsx` differently). */
   highlightLines(text: string, fileName?: string): Line[];
+
+  /** Whether live diff edits need complete-file highlighting because an earlier
+   * line can determine how later lines are coloured. */
+  readonly highlightFullFileOnDiffEdit?: boolean;
 
   /** An incremental highlighter seeded with `text`, for live editing.
    * `fileName` is advisory, as for {@link highlightLines}. */
@@ -163,7 +169,12 @@ export interface Language {
  */
 let languages: readonly Language[] | undefined;
 function allLanguages(): readonly Language[] {
-  return languages ??= [markdownLanguage, jsonLanguage, typeScriptLanguage];
+  return languages ??= [
+    markdownLanguage,
+    jsonLanguage,
+    yamlLanguage,
+    typeScriptLanguage,
+  ];
 }
 
 /** The language for `fileName` — the first that claims it. TypeScript is the
@@ -195,11 +206,11 @@ export function distinctLanguages(
  * The semantic service for a diff view, from the languages the diff touches. A
  * diff spans potentially many files of different languages; the service is the
  * first language present that offers one, scoped to just its own files (so a
- * TypeScript program is not seeded with the diff's Markdown or JSON files).
- * Only TypeScript offers one today, so this resolves to it whenever the diff
- * includes a TypeScript file and to nothing otherwise. When a second semantic
- * language appears this becomes a per-file composite; the per-language slot the
- * pager dispatches through is already here.
+ * TypeScript program is not seeded with the diff's Markdown, JSON, or YAML
+ * files). Only TypeScript offers one today, so this resolves to it whenever the
+ * diff includes a TypeScript file and to nothing otherwise. When a second
+ * semantic language appears this becomes a per-file composite; the per-language
+ * slot the pager dispatches through is already here.
  */
 export function diffSemanticsFor(
   languages: readonly Language[],

--- a/packages/cli/lib/view/languages/yaml/language.ts
+++ b/packages/cli/lib/view/languages/yaml/language.ts
@@ -1,0 +1,28 @@
+/**
+ * The YAML language for the pager. It provides syntax highlighting for direct
+ * files, diffs, and live edits. YAML does not provide structure navigation or
+ * a semantic layer.
+ */
+import type { Language } from "../language.ts";
+import {
+  createYamlHighlighter,
+  isYamlPath,
+  yamlDocument,
+  yamlHighlightLines,
+} from "./yaml.ts";
+
+export const yamlLanguage: Language = {
+  id: "yaml",
+
+  matches: (fileName) => isYamlPath(fileName),
+
+  parseDocument: (text) => yamlDocument(text),
+
+  highlightLines: (text) => yamlHighlightLines(text),
+
+  highlightFullFileOnDiffEdit: true,
+
+  createHighlighter: (text) => createYamlHighlighter(text),
+
+  hunkStructure: () => [],
+};

--- a/packages/cli/lib/view/languages/yaml/yaml.ts
+++ b/packages/cli/lib/view/languages/yaml/yaml.ts
@@ -1,0 +1,996 @@
+/**
+ * YAML syntax highlighting for the pager. The scanner recognizes block and
+ * flow collections, mapping keys, scalar types, comments, tags, anchors,
+ * aliases, quoted strings, and block scalars. It accepts incomplete input so
+ * files remain highlighted while they are being edited.
+ */
+import type { Document, Line, Span, TokenClass } from "../../model.ts";
+import { cpLen } from "../../ansi.ts";
+import type { Highlighter } from "../language.ts";
+
+/** Whether `fileName` names a YAML file. */
+export function isYamlPath(fileName: string | undefined): boolean {
+  return fileName !== undefined && /\.ya?ml$/i.test(fileName);
+}
+
+interface QuoteState {
+  readonly quote: "'" | '"';
+  readonly cls: TokenClass;
+}
+
+interface BlockScalarState {
+  readonly baseIndent: number;
+  readonly key?: boolean;
+  contentIndent?: number;
+}
+
+interface PlainScalarState {
+  readonly baseIndent: number;
+  readonly flowDepth?: number;
+  readonly key?: boolean;
+}
+
+interface ExplicitKeyState {
+  readonly indent: number;
+  readonly flowDepth: number;
+  expectsNode: boolean;
+  indentlessSequence: boolean;
+}
+
+interface HighlightState {
+  /** Logical indentation of each open flow collection. */
+  readonly flow: number[];
+  readonly explicitKeys: ExplicitKeyState[];
+  documentPrefix: boolean;
+  quote?: QuoteState;
+  block?: BlockScalarState;
+  plain?: PlainScalarState;
+  flowKeyCandidate?: {
+    readonly depth: number;
+    readonly indent: number;
+  };
+  pendingNodeIndent?: number;
+}
+
+/** Colour YAML text into rendered lines. */
+export function yamlHighlightLines(text: string): Line[] {
+  const rawLines = text.split("\n");
+  const state: HighlightState = {
+    flow: [],
+    explicitKeys: [],
+    documentPrefix: true,
+  };
+  return rawLines.map((line, index) =>
+    highlightLine(line, state, rawLines, index)
+  );
+}
+
+/** A full YAML document. YAML currently contributes syntax colour only. */
+export function yamlDocument(text: string): Document {
+  return {
+    text,
+    lines: yamlHighlightLines(text),
+    structure: [],
+    flatStructure: [],
+    definitions: new Map(),
+  };
+}
+
+/** A whole-document YAML highlighter. */
+export function createYamlHighlighter(initial: string): Highlighter {
+  let lines = yamlHighlightLines(initial);
+  return {
+    get lines() {
+      return lines;
+    },
+    update(next: string): readonly Line[] {
+      lines = yamlHighlightLines(next);
+      return lines;
+    },
+  };
+}
+
+function highlightLine(
+  line: string,
+  state: HighlightState,
+  rawLines: readonly string[],
+  lineIndex: number,
+): Line {
+  if (state.flowKeyCandidate?.depth === 0) {
+    state.flowKeyCandidate = undefined;
+  }
+  const blockLine = highlightBlockScalarLine(line, state);
+  if (blockLine) return blockLine;
+  const plainLine = highlightPlainScalarContinuationLine(line, state);
+  if (plainLine) return plainLine;
+
+  const spans: Span[] = [];
+  let col = 0;
+  const push = (
+    start: number,
+    end: number,
+    cls: TokenClass,
+    bracketDepth?: number,
+  ) => {
+    if (end <= start) return;
+    const segment = line.slice(start, end);
+    spans.push(
+      bracketDepth === undefined
+        ? { col, text: segment, cls }
+        : { col, text: segment, cls, bracketDepth },
+    );
+    col += cpLen(segment);
+  };
+
+  const markerAfterBom = line[0] === "\uFEFF" &&
+    isDocumentMarker(line, 1, "---");
+  const documentStart = !state.quote && line[0] === "\uFEFF" &&
+      (state.documentPrefix || markerAfterBom ||
+        bomStartsDocumentPrefix(rawLines, lineIndex))
+    ? 1
+    : 0;
+  let i = 0;
+  if (documentStart > 0) {
+    push(0, documentStart, "plain");
+    i = documentStart;
+  }
+  if (state.quote) {
+    const quoted = scanQuoted(line, i, state.quote.quote, true);
+    push(i, quoted.end, state.quote.cls);
+    i = quoted.end;
+    if (!quoted.closed) return { text: line, spans };
+    state.quote = undefined;
+    if (state.flow.length > 0) {
+      state.flowKeyCandidate = {
+        depth: state.flow.length,
+        indent: leadingIndent(line),
+      };
+    }
+  }
+
+  const firstContent = skipWhitespace(line, documentStart);
+  const firstIndent = firstContent - documentStart;
+  const substantive = firstContent < line.length &&
+    line[firstContent] !== "\r" &&
+    !(line[firstContent] === "#" &&
+      isLineCommentStart(line, firstContent, documentStart));
+  if (substantive) {
+    discardCompletedExplicitKeys(state, line, firstContent, firstIndent);
+  }
+  const pendingExplicitKey = substantive
+    ? state.explicitKeys.at(-1)
+    : undefined;
+  const pendingNodeIndent = substantive ? state.pendingNodeIndent : undefined;
+  const propertyOnly = substantive &&
+    isPropertyOnlyLine(line, firstContent);
+  const continuesExplicitKey = pendingExplicitKey?.expectsNode === true &&
+    !propertyOnly;
+  if (substantive) {
+    state.documentPrefix = false;
+    if (!propertyOnly) {
+      state.pendingNodeIndent = undefined;
+      if (pendingExplicitKey?.expectsNode) {
+        pendingExplicitKey.expectsNode = false;
+      }
+    }
+  }
+
+  const flowPlain = state.plain?.flowDepth === undefined
+    ? undefined
+    : state.plain;
+  if (flowPlain) {
+    if (firstContent >= line.length || line[firstContent] === "\r") {
+      if (firstContent > i) push(i, firstContent, "whitespace");
+      if (firstContent < line.length) {
+        push(firstContent, line.length, "whitespace");
+      }
+      return { text: line, spans };
+    }
+    if (
+      line[firstContent] === "#" &&
+      isCommentStart(line, firstContent)
+    ) {
+      state.plain = undefined;
+    } else {
+      if (firstContent > i) push(i, firstContent, "whitespace");
+      const end = scanPlainScalar(line, firstContent, state.flow.length);
+      if (end > firstContent) {
+        const scalarEnd = trimTrailingWhitespace(
+          line,
+          firstContent,
+          end,
+        );
+        emitPlainScalar(
+          line,
+          firstContent,
+          scalarEnd,
+          flowPlain.key === true,
+          push,
+          true,
+        );
+        i = scalarEnd;
+        const continues = end === line.length &&
+          flowPlainScalarContinues(rawLines, lineIndex, state.flow.length);
+        state.plain = continues ? flowPlain : undefined;
+      } else {
+        state.plain = undefined;
+      }
+    }
+  }
+
+  let explicitKey = continuesExplicitKey;
+  let mappingIndent: number | undefined;
+  let nodeStart = firstContent;
+  let nodeIndent = firstIndent;
+  let sequenceIndent: number | undefined;
+  while (i < line.length) {
+    if (isWhitespace(line[i])) {
+      const end = skipWhitespace(line, i);
+      push(i, end, "whitespace");
+      i = end;
+      continue;
+    }
+
+    if (
+      i === documentStart &&
+      (isDocumentMarker(line, i, "---") ||
+        isDocumentMarker(line, i, "..."))
+    ) {
+      state.flow.length = 0;
+      state.explicitKeys.length = 0;
+      state.flowKeyCandidate = undefined;
+      state.pendingNodeIndent = undefined;
+      push(i, i + 3, "sectionHeader");
+      state.documentPrefix = line.startsWith("...", i);
+      i += 3;
+      continue;
+    }
+
+    if (i === documentStart && line[i] === "%") {
+      const end = scanUntilSeparation(line, i + 1);
+      push(i, end, "keyword");
+      i = end;
+      while (i < line.length) {
+        if (isWhitespace(line[i])) {
+          const tokenEnd = skipWhitespace(line, i);
+          push(i, tokenEnd, "whitespace");
+          i = tokenEnd;
+          continue;
+        }
+        if (line[i] === "#" && isCommentStart(line, i)) {
+          push(i, line.length, "comment");
+          i = line.length;
+          break;
+        }
+        const tokenEnd = scanUntilSeparation(line, i);
+        push(i, tokenEnd, line[i] === "!" ? "keyword" : "string");
+        i = tokenEnd;
+      }
+      continue;
+    }
+
+    if (
+      line[i] === "#" &&
+      isLineCommentStart(line, i, documentStart)
+    ) {
+      push(i, line.length, "comment");
+      break;
+    }
+
+    if (line[i] === "'" || line[i] === '"') {
+      state.flowKeyCandidate = undefined;
+      const quote = line[i] as "'" | '"';
+      const quoted = scanQuoted(line, i, quote, false);
+      const after = skipWhitespace(line, quoted.end);
+      const key = explicitKey ||
+        (quoted.closed &&
+          isMappingColon(line, after, state.flow.length, true));
+      const cls: TokenClass = key ? "propertyName" : "string";
+      if (key) mappingIndent = nodeIndent;
+      if (quoted.closed && state.flow.length > 0) {
+        state.flowKeyCandidate = {
+          depth: state.flow.length,
+          indent: nodeIndent,
+        };
+      }
+      push(i, quoted.end, cls);
+      i = quoted.end;
+      explicitKey = false;
+      if (!quoted.closed) state.quote = { quote, cls };
+      continue;
+    }
+
+    const block = scanBlockScalarHeader(line, i);
+    if (block) {
+      state.flowKeyCandidate = undefined;
+      const blockKey = explicitKey;
+      explicitKey = false;
+      push(i, block.end, "punctuation");
+      const explicitBaseIndent = blockKey
+        ? state.explicitKeys.at(-1)?.indent
+        : undefined;
+      const baseIndent = explicitBaseIndent ?? mappingIndent ??
+        sequenceIndent ?? pendingNodeIndent ?? firstIndent;
+      state.block = {
+        baseIndent,
+        key: blockKey || undefined,
+        contentIndent: block.indent === undefined
+          ? undefined
+          : baseIndent + block.indent,
+      };
+      i = block.end;
+      continue;
+    }
+
+    const c = line[i];
+    if (c === "[" || c === "{") {
+      state.flowKeyCandidate = undefined;
+      explicitKey = false;
+      push(i, i + 1, "bracket", state.flow.length);
+      state.flow.push(nodeIndent);
+      i++;
+      continue;
+    }
+    if (c === "]" || c === "}") {
+      const closedIndent = state.flow.pop();
+      const closedFlow = closedIndent !== undefined;
+      const depth = state.flow.length;
+      push(i, i + 1, "bracket", depth);
+      explicitKey = false;
+      state.flowKeyCandidate = undefined;
+      while (
+        state.explicitKeys.at(-1)?.flowDepth !== undefined &&
+        state.explicitKeys.at(-1)!.flowDepth > state.flow.length
+      ) {
+        state.explicitKeys.pop();
+      }
+      if (closedFlow) {
+        state.flowKeyCandidate = {
+          depth: state.flow.length,
+          indent: closedIndent,
+        };
+      }
+      i++;
+      continue;
+    }
+    if (c === "," && state.flow.length > 0) {
+      state.flowKeyCandidate = undefined;
+      explicitKey = false;
+      while (
+        state.explicitKeys.at(-1)?.flowDepth === state.flow.length
+      ) {
+        state.explicitKeys.pop();
+      }
+      push(i, i + 1, "punctuation");
+      i++;
+      continue;
+    }
+    const flowKeyCandidate = state.flowKeyCandidate?.depth ===
+        state.flow.length
+      ? state.flowKeyCandidate
+      : undefined;
+    if (
+      c === ":" &&
+      isMappingColon(
+        line,
+        i,
+        state.flow.length,
+        flowKeyCandidate !== undefined,
+      )
+    ) {
+      const explicitKeyState = matchingExplicitKey(
+        state,
+        i,
+        firstContent,
+        firstIndent,
+      );
+      if (explicitKeyState) {
+        mappingIndent = explicitKeyState.indent;
+        state.explicitKeys.pop();
+      } else if (flowKeyCandidate) {
+        mappingIndent = flowKeyCandidate.indent;
+      }
+      state.flowKeyCandidate = undefined;
+      push(i, i + 1, "punctuation");
+      const after = skipWhitespace(line, i + 1);
+      const emptyKeyIndent = i === nodeStart ? nodeIndent : undefined;
+      mappingIndent ??= emptyKeyIndent;
+      if (explicitKey && i === nodeStart) {
+        explicitKey = false;
+      }
+      const valueIndent = mappingIndent ?? emptyKeyIndent ??
+        pendingNodeIndent;
+      if (
+        valueIndent !== undefined &&
+        (isEmptyNodeRemainder(line, after) ||
+          isPropertyOnlyLine(line, after))
+      ) {
+        state.pendingNodeIndent = valueIndent;
+      }
+      i++;
+      continue;
+    }
+    if (
+      (c === "-" || c === "?") &&
+      isCollectionIndicator(line, i, firstContent)
+    ) {
+      state.flowKeyCandidate = undefined;
+      push(i, i + 1, "punctuation");
+      explicitKey = c === "?";
+      if (c === "?") {
+        state.explicitKeys.push({
+          indent: nodeIndent,
+          flowDepth: state.flow.length,
+          expectsNode: isEmptyNodeRemainder(line, i + 1) ||
+            isPropertyOnlyLine(line, i + 1),
+          indentlessSequence: false,
+        });
+        nodeStart = skipWhitespace(line, i + 1);
+        nodeIndent = nodeStart - documentStart;
+      }
+      if (c === "-") {
+        if (
+          continuesExplicitKey &&
+          pendingExplicitKey?.flowDepth === state.flow.length &&
+          i - documentStart === pendingExplicitKey.indent
+        ) {
+          pendingExplicitKey.indentlessSequence = true;
+        }
+        sequenceIndent = i - documentStart;
+        nodeStart = skipWhitespace(line, i + 1);
+        nodeIndent = nodeStart - documentStart;
+        if (
+          isEmptyNodeRemainder(line, nodeStart) ||
+          isPropertyOnlyLine(line, nodeStart)
+        ) {
+          state.pendingNodeIndent = sequenceIndent;
+        }
+      }
+      i++;
+      continue;
+    }
+
+    if (c === "&" || c === "*" || c === "!") {
+      state.flowKeyCandidate = undefined;
+      const end = scanHandle(line, i);
+      const after = skipWhitespace(line, end);
+      if ((c === "&" || c === "!") && i === nodeStart) {
+        nodeStart = after;
+      }
+      if (isMappingColon(line, after, state.flow.length, false)) {
+        mappingIndent = nodeIndent;
+      }
+      if (c === "*" && explicitKey) {
+        mappingIndent = nodeIndent;
+        explicitKey = false;
+      }
+      push(i, end, "keyword");
+      i = end;
+      continue;
+    }
+
+    state.flowKeyCandidate = undefined;
+    const end = scanPlainScalar(line, i, state.flow.length);
+    if (end === i) {
+      const size = (line.codePointAt(i) ?? 0) > 0xffff ? 2 : 1;
+      push(i, i + size, "plain");
+      i += size;
+      continue;
+    }
+    const scalarEnd = trimTrailingWhitespace(line, i, end);
+    const after = skipWhitespace(line, scalarEnd);
+    const wasExplicitKey = explicitKey;
+    const key = wasExplicitKey ||
+      isMappingColon(line, after, state.flow.length, false);
+    if (key) mappingIndent = nodeIndent;
+    const explicitBaseIndent = wasExplicitKey
+      ? state.explicitKeys.at(-1)?.indent
+      : undefined;
+    const baseIndent = explicitBaseIndent ?? mappingIndent ?? sequenceIndent ??
+      pendingNodeIndent ?? firstIndent;
+    const multiline = (!key || wasExplicitKey) && end === line.length &&
+      (state.flow.length === 0
+        ? plainScalarContinues(rawLines, lineIndex, baseIndent)
+        : flowPlainScalarContinues(
+          rawLines,
+          lineIndex,
+          state.flow.length,
+        ));
+    emitPlainScalar(line, i, scalarEnd, key, push, multiline);
+    if (multiline) {
+      state.plain = {
+        baseIndent,
+        flowDepth: state.flow.length > 0 ? state.flow.length : undefined,
+        key: wasExplicitKey || undefined,
+      };
+    }
+    explicitKey = false;
+    i = scalarEnd;
+  }
+
+  return { text: line, spans };
+}
+
+function highlightPlainScalarContinuationLine(
+  line: string,
+  state: HighlightState,
+): Line | null {
+  const plain = state.plain;
+  if (!plain || plain.flowDepth !== undefined) return null;
+  if (line.trim().length === 0) {
+    return line.length === 0 ? { text: line, spans: [] } : {
+      text: line,
+      spans: [{ col: 0, text: line, cls: "whitespace" }],
+    };
+  }
+
+  const indent = leadingIndent(line);
+  const firstContent = skipWhitespace(line, 0);
+  if (indent <= plain.baseIndent || line[firstContent] === "#") {
+    state.plain = undefined;
+    return null;
+  }
+
+  let comment = line.length;
+  for (let i = firstContent; i < line.length; i++) {
+    if (line[i] === "#" && isCommentStart(line, i)) {
+      comment = i;
+      break;
+    }
+  }
+  const scalarEnd = trimTrailingWhitespace(
+    line,
+    firstContent,
+    comment,
+  );
+  const spans: Span[] = [];
+  if (firstContent > 0) {
+    spans.push({
+      col: 0,
+      text: line.slice(0, firstContent),
+      cls: "whitespace",
+    });
+  }
+  if (scalarEnd > firstContent) {
+    spans.push({
+      col: cpLen(line.slice(0, firstContent)),
+      text: line.slice(firstContent, scalarEnd),
+      cls: plain.key ? "propertyName" : "string",
+    });
+  }
+  if (comment > scalarEnd) {
+    spans.push({
+      col: cpLen(line.slice(0, scalarEnd)),
+      text: line.slice(scalarEnd, comment),
+      cls: "whitespace",
+    });
+  }
+  if (comment < line.length) {
+    spans.push({
+      col: cpLen(line.slice(0, comment)),
+      text: line.slice(comment),
+      cls: "comment",
+    });
+    state.plain = undefined;
+  }
+  return { text: line, spans };
+}
+
+function flowPlainScalarContinues(
+  rawLines: readonly string[],
+  lineIndex: number,
+  flowDepth: number,
+): boolean {
+  for (let index = lineIndex + 1; index < rawLines.length; index++) {
+    const line = rawLines[index];
+    if (line.trim().length === 0) continue;
+    const firstContent = skipWhitespace(line, 0);
+    if (
+      line[firstContent] === "#" ||
+      line[firstContent] === "," ||
+      line[firstContent] === "]" ||
+      line[firstContent] === "}"
+    ) {
+      return false;
+    }
+    return scanPlainScalar(line, firstContent, flowDepth) > firstContent;
+  }
+  return false;
+}
+
+function plainScalarContinues(
+  rawLines: readonly string[],
+  lineIndex: number,
+  baseIndent: number,
+): boolean {
+  for (let index = lineIndex + 1; index < rawLines.length; index++) {
+    const line = rawLines[index];
+    if (line.trim().length === 0) continue;
+    const firstContent = skipWhitespace(line, 0);
+    if (line[firstContent] === "#") return false;
+    return leadingIndent(line) > baseIndent;
+  }
+  return false;
+}
+
+function highlightBlockScalarLine(
+  line: string,
+  state: HighlightState,
+): Line | null {
+  const block = state.block;
+  if (!block) return null;
+  const indent = leadingIndent(line);
+  if (line.trim().length === 0) {
+    return line.length === 0 ? { text: line, spans: [] } : {
+      text: line,
+      spans: [{ col: 0, text: line, cls: "whitespace" }],
+    };
+  }
+
+  if (block.contentIndent === undefined) {
+    if (indent <= block.baseIndent) {
+      state.block = undefined;
+      return null;
+    }
+    block.contentIndent = indent;
+  } else if (indent < block.contentIndent) {
+    state.block = undefined;
+    return null;
+  }
+
+  const spans: Span[] = [];
+  if (indent > 0) {
+    spans.push({
+      col: 0,
+      text: line.slice(0, indent),
+      cls: "whitespace",
+    });
+  }
+  if (indent < line.length) {
+    spans.push({
+      col: cpLen(line.slice(0, indent)),
+      text: line.slice(indent),
+      cls: block.key ? "propertyName" : "string",
+    });
+  }
+  return { text: line, spans };
+}
+
+interface QuotedResult {
+  readonly end: number;
+  readonly closed: boolean;
+}
+
+function scanQuoted(
+  line: string,
+  start: number,
+  quote: "'" | '"',
+  continuation: boolean,
+): QuotedResult {
+  let i = continuation ? start : start + 1;
+  while (i < line.length) {
+    if (quote === '"' && line[i] === "\\") {
+      i = Math.min(line.length, i + 2);
+      continue;
+    }
+    if (line[i] === quote) {
+      if (quote === "'" && line[i + 1] === "'") {
+        i += 2;
+        continue;
+      }
+      return { end: i + 1, closed: true };
+    }
+    i++;
+  }
+  return { end: line.length, closed: false };
+}
+
+interface BlockHeader {
+  readonly end: number;
+  readonly indent?: number;
+}
+
+function scanBlockScalarHeader(
+  line: string,
+  start: number,
+): BlockHeader | null {
+  if (line[start] !== "|" && line[start] !== ">") return null;
+  let i = start + 1;
+  let indent: number | undefined;
+  let chomping = false;
+  for (let count = 0; count < 2 && i < line.length; count++) {
+    const c = line[i];
+    if (!chomping && (c === "+" || c === "-")) {
+      chomping = true;
+      i++;
+      continue;
+    }
+    if (indent === undefined && c >= "1" && c <= "9") {
+      indent = Number(c);
+      i++;
+      continue;
+    }
+    break;
+  }
+  const after = skipHorizontalWhitespace(line, i);
+  if (
+    after < line.length && line[after] !== "#" && line[after] !== "\r"
+  ) {
+    return null;
+  }
+  return { end: i, indent };
+}
+
+function scanPlainScalar(
+  line: string,
+  start: number,
+  flowDepth: number,
+): number {
+  let i = start;
+  while (i < line.length) {
+    const c = line[i];
+    if (c === "#" && isCommentStart(line, i)) break;
+    if (c === ":" && isMappingColon(line, i, flowDepth, false)) break;
+    if (
+      flowDepth > 0 &&
+      (c === "," || c === "[" || c === "]" || c === "{" || c === "}")
+    ) {
+      break;
+    }
+    i++;
+  }
+  return i;
+}
+
+function emitPlainScalar(
+  line: string,
+  start: number,
+  end: number,
+  key: boolean,
+  push: (
+    start: number,
+    end: number,
+    cls: TokenClass,
+    bracketDepth?: number,
+  ) => void,
+  forceString = false,
+): void {
+  const cls = key
+    ? "propertyName"
+    : forceString
+    ? "string"
+    : scalarClass(line.slice(start, end));
+  let i = start;
+  while (i < end) {
+    const whitespace = isWhitespace(line[i]);
+    let next = i + 1;
+    while (next < end && isWhitespace(line[next]) === whitespace) next++;
+    push(i, next, whitespace ? "whitespace" : cls);
+    i = next;
+  }
+}
+
+function scalarClass(raw: string): TokenClass {
+  const value = raw.trim();
+  if (/^(?:true|True|TRUE|false|False|FALSE)$/.test(value)) return "boolean";
+  if (/^(?:null|Null|NULL|~)$/.test(value)) return "keyword";
+  if (isYamlNumber(value)) return "number";
+  return "string";
+}
+
+function isYamlNumber(value: string): boolean {
+  if (/^[+-]?(?:\.inf|\.Inf|\.INF)$/.test(value)) return true;
+  if (/^(?:\.nan|\.NaN|\.NAN)$/.test(value)) return true;
+  if (/^0o[0-7]+$/.test(value)) return true;
+  if (/^0x[0-9a-fA-F]+$/.test(value)) return true;
+  return /^[+-]?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?)(?:[eE][+-]?[0-9]+)?$/
+    .test(value);
+}
+
+function bomStartsDocumentPrefix(
+  rawLines: readonly string[],
+  lineIndex: number,
+): boolean {
+  const line = rawLines[lineIndex];
+  if (line[0] !== "\uFEFF") return false;
+  const first = skipWhitespace(line, 1);
+  if (
+    first < line.length && line[first] !== "\r" &&
+    !(line[first] === "#" &&
+      (first === 1 || isCommentStart(line, first)))
+  ) {
+    return false;
+  }
+  for (let index = lineIndex + 1; index < rawLines.length; index++) {
+    const next = rawLines[index];
+    const start = next[0] === "\uFEFF" ? 1 : 0;
+    const content = skipWhitespace(next, start);
+    if (content >= next.length || next[content] === "\r") continue;
+    if (
+      next[content] === "#" &&
+      (content === start || isCommentStart(next, content))
+    ) {
+      continue;
+    }
+    return content === start && isDocumentMarker(next, start, "---");
+  }
+  return true;
+}
+
+function discardCompletedExplicitKeys(
+  state: HighlightState,
+  line: string,
+  firstContent: number,
+  firstIndent: number,
+): void {
+  while (state.flow.length === 0) {
+    const key = state.explicitKeys.at(-1);
+    if (!key || key.flowDepth !== 0 || firstIndent > key.indent) return;
+    if (firstIndent === key.indent && line[firstContent] === ":") return;
+    if (
+      firstIndent === key.indent &&
+      line[firstContent] === "-" &&
+      isCollectionIndicator(line, firstContent, firstContent) &&
+      (key.expectsNode || key.indentlessSequence)
+    ) {
+      return;
+    }
+    if (
+      key.expectsNode &&
+      firstIndent === key.indent &&
+      scanBlockScalarHeader(line, firstContent)
+    ) {
+      return;
+    }
+    state.explicitKeys.pop();
+  }
+}
+
+function matchingExplicitKey(
+  state: HighlightState,
+  index: number,
+  firstContent: number,
+  firstIndent: number,
+): ExplicitKeyState | undefined {
+  const key = state.explicitKeys.at(-1);
+  if (!key || key.flowDepth !== state.flow.length) return undefined;
+  if (key.flowDepth > 0) return key;
+  return index === firstContent && firstIndent === key.indent ? key : undefined;
+}
+
+function isDocumentMarker(
+  line: string,
+  start: number,
+  marker: "---" | "...",
+): boolean {
+  if (!line.startsWith(marker, start)) return false;
+  const next = line[start + marker.length];
+  return next === undefined || isWhitespace(next);
+}
+
+function isCollectionIndicator(
+  line: string,
+  index: number,
+  firstContent: number,
+): boolean {
+  const previous = line[index - 1];
+  const next = line[index + 1];
+  const separatedBefore = index === firstContent || isWhitespace(previous) ||
+    previous === "[" || previous === "{" || previous === ",";
+  return separatedBefore && (next === undefined || isWhitespace(next));
+}
+
+function isMappingColon(
+  line: string,
+  index: number,
+  flowDepth: number,
+  jsonStyleKey: boolean,
+): boolean {
+  if (line[index] !== ":") return false;
+  const next = line[index + 1];
+  if (next === undefined || isWhitespace(next)) {
+    return true;
+  }
+  if (
+    flowDepth > 0 &&
+    (next === "," || next === "]" || next === "}" ||
+      next === "[" || next === "{")
+  ) {
+    return true;
+  }
+  return flowDepth > 0 && jsonStyleKey;
+}
+
+function isCommentStart(line: string, index: number): boolean {
+  return index === 0 || isWhitespace(line[index - 1]);
+}
+
+function isLineCommentStart(
+  line: string,
+  index: number,
+  documentStart: number,
+): boolean {
+  return isCommentStart(line, index) ||
+    (documentStart > 0 && index === documentStart);
+}
+
+function scanHandle(line: string, start: number): number {
+  if (line[start] === "!" && line[start + 1] === "<") {
+    const close = line.indexOf(">", start + 2);
+    return close < 0 ? line.length : close + 1;
+  }
+  let i = start + 1;
+  while (i < line.length) {
+    const c = line[i];
+    if (
+      isWhitespace(c) || c === "," || c === "[" || c === "]" ||
+      c === "{" || c === "}" ||
+      (c === "#" && isCommentStart(line, i))
+    ) {
+      break;
+    }
+    i++;
+  }
+  return i;
+}
+
+function isPropertyOnlyLine(
+  line: string,
+  start: number,
+): boolean {
+  let i = start;
+  let found = false;
+  while (i < line.length) {
+    i = skipWhitespace(line, i);
+    if (i >= line.length || line[i] === "\r") return found;
+    if (line[i] === "#" && isCommentStart(line, i)) return found;
+    if (line[i] !== "!" && line[i] !== "&") return false;
+    found = true;
+    i = scanHandle(line, i);
+  }
+  return found;
+}
+
+function isEmptyNodeRemainder(line: string, start: number): boolean {
+  const first = skipWhitespace(line, start);
+  return first >= line.length || line[first] === "\r" ||
+    (line[first] === "#" && isCommentStart(line, first));
+}
+
+function scanUntilSeparation(line: string, start: number): number {
+  let i = start;
+  while (i < line.length && !isWhitespace(line[i])) i++;
+  return i;
+}
+
+function leadingIndent(line: string): number {
+  let i = 0;
+  while (i < line.length && (line[i] === " " || line[i] === "\t")) i++;
+  return i;
+}
+
+function skipHorizontalWhitespace(line: string, start: number): number {
+  let i = start;
+  while (i < line.length && (line[i] === " " || line[i] === "\t")) i++;
+  return i;
+}
+
+function skipWhitespace(line: string, start: number): number {
+  let i = start;
+  while (i < line.length && isWhitespace(line[i])) i++;
+  return i;
+}
+
+function trimTrailingWhitespace(
+  line: string,
+  start: number,
+  end: number,
+): number {
+  let i = end;
+  while (i > start && isWhitespace(line[i - 1])) i--;
+  return i;
+}
+
+function isWhitespace(c: string | undefined): boolean {
+  return c === " " || c === "\t" || c === "\r";
+}

--- a/packages/cli/lib/view/languages/yaml/yaml.ts
+++ b/packages/cli/lib/view/languages/yaml/yaml.ts
@@ -179,43 +179,29 @@ function highlightLine(
     ? undefined
     : state.plain;
   if (flowPlain) {
-    if (firstContent >= line.length || line[firstContent] === "\r") {
+    if (firstContent >= line.length) {
       if (firstContent > i) push(i, firstContent, "whitespace");
-      if (firstContent < line.length) {
-        push(firstContent, line.length, "whitespace");
-      }
       return { text: line, spans };
     }
-    if (
-      line[firstContent] === "#" &&
-      isCommentStart(line, firstContent)
-    ) {
-      state.plain = undefined;
-    } else {
-      if (firstContent > i) push(i, firstContent, "whitespace");
-      const end = scanPlainScalar(line, firstContent, state.flow.length);
-      if (end > firstContent) {
-        const scalarEnd = trimTrailingWhitespace(
-          line,
-          firstContent,
-          end,
-        );
-        emitPlainScalar(
-          line,
-          firstContent,
-          scalarEnd,
-          flowPlain.key === true,
-          push,
-          true,
-        );
-        i = scalarEnd;
-        const continues = end === line.length &&
-          flowPlainScalarContinues(rawLines, lineIndex, state.flow.length);
-        state.plain = continues ? flowPlain : undefined;
-      } else {
-        state.plain = undefined;
-      }
-    }
+    if (firstContent > i) push(i, firstContent, "whitespace");
+    const end = scanPlainScalar(line, firstContent, state.flow.length);
+    const scalarEnd = trimTrailingWhitespace(
+      line,
+      firstContent,
+      end,
+    );
+    emitPlainScalar(
+      line,
+      firstContent,
+      scalarEnd,
+      flowPlain.key === true,
+      push,
+      true,
+    );
+    i = scalarEnd;
+    const continues = end === line.length &&
+      flowPlainScalarContinues(rawLines, lineIndex, state.flow.length);
+    state.plain = continues ? flowPlain : undefined;
   }
 
   let explicitKey = continuesExplicitKey;
@@ -471,12 +457,6 @@ function highlightLine(
 
     state.flowKeyCandidate = undefined;
     const end = scanPlainScalar(line, i, state.flow.length);
-    if (end === i) {
-      const size = (line.codePointAt(i) ?? 0) > 0xffff ? 2 : 1;
-      push(i, i + size, "plain");
-      i += size;
-      continue;
-    }
     const scalarEnd = trimTrailingWhitespace(line, i, end);
     const after = skipWhitespace(line, scalarEnd);
     const wasExplicitKey = explicitKey;
@@ -792,7 +772,6 @@ function bomStartsDocumentPrefix(
   lineIndex: number,
 ): boolean {
   const line = rawLines[lineIndex];
-  if (line[0] !== "\uFEFF") return false;
   const first = skipWhitespace(line, 1);
   if (
     first < line.length && line[first] !== "\r" &&

--- a/packages/cli/test/view-language.test.ts
+++ b/packages/cli/test/view-language.test.ts
@@ -14,6 +14,7 @@ import {
 import { typeScriptLanguage } from "../lib/view/languages/typescript/language.ts";
 import { markdownLanguage } from "../lib/view/languages/markdown/language.ts";
 import { jsonLanguage } from "../lib/view/languages/json/language.ts";
+import { yamlLanguage } from "../lib/view/languages/yaml/language.ts";
 import {
   buildDiffDocument,
   type DiffMaps,
@@ -27,6 +28,7 @@ Deno.test("languageForFile: extensions resolve, and the rest backstops to TS", (
   }
   assertEquals(languageForFile("README.md").id, "markdown");
   assertEquals(languageForFile("deno.jsonc").id, "json");
+  assertEquals(languageForFile("workflow.yml").id, "yaml");
   // No language claims these, so the fallback (TypeScript) resolves them.
   assertEquals(languageForFile("notes.xyz").id, "typescript");
   assertEquals(languageForFile(undefined).id, "typescript");
@@ -38,9 +40,13 @@ Deno.test("distinctLanguages: dedupes in first-seen order", () => {
     "b.ts",
     "c.md",
     "d.json",
+    "e.yaml",
     undefined,
   ]);
-  assertEquals(languages.map((l) => l.id), ["typescript", "markdown", "json"]);
+  assertEquals(
+    languages.map((l) => l.id),
+    ["typescript", "markdown", "json", "yaml"],
+  );
 });
 
 const FILE_TEXT = `export function double(n: number): number {
@@ -102,9 +108,12 @@ Deno.test("diffSemanticsFor: TypeScript answers over its own files in the diff",
     // Languages without a semantic layer contribute none, so a diff of only
     // those resolves to no service.
     assertEquals(
-      diffSemanticsFor([markdownLanguage, jsonLanguage], DIFF, maps, {
-        cwd: root,
-      }),
+      diffSemanticsFor(
+        [markdownLanguage, jsonLanguage, yamlLanguage],
+        DIFF,
+        maps,
+        { cwd: root },
+      ),
       undefined,
     );
   } finally {

--- a/packages/cli/test/view-yaml.test.ts
+++ b/packages/cli/test/view-yaml.test.ts
@@ -1,0 +1,1083 @@
+/**
+ * The YAML language used by `cf view`. Tests cover direct files, diffs, live
+ * edits, common scalar forms, flow collections, and state that crosses lines.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import {
+  createYamlHighlighter,
+  isYamlPath,
+  yamlDocument,
+  yamlHighlightLines,
+} from "../lib/view/languages/yaml/yaml.ts";
+import { languageForFile } from "../lib/view/languages/language.ts";
+import type { Line, TokenClass } from "../lib/view/model.ts";
+import { parseDiff } from "../lib/view/diff.ts";
+import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
+import { createDiffHighlighter, diffSource } from "../lib/view/diffedit.ts";
+
+function verbatim(lines: readonly Line[]): string {
+  return lines.map((line) => line.spans.map((span) => span.text).join(""))
+    .join("\n");
+}
+
+function classesOf(lines: readonly Line[], token: string): Set<TokenClass> {
+  const classes = new Set<TokenClass>();
+  for (const line of lines) {
+    for (const span of line.spans) {
+      if (span.text === token) classes.add(span.cls);
+    }
+  }
+  return classes;
+}
+
+Deno.test("yaml: path matching recognizes yml and yaml", () => {
+  assert(isYamlPath("config.yaml"));
+  assert(isYamlPath("/repo/.github/workflows/check.yml"));
+  assert(isYamlPath("UPPER.YAML"));
+  assert(!isYamlPath("config.json"));
+  assert(!isYamlPath("yaml.ts"));
+  assert(!isYamlPath(undefined));
+  assertEquals(languageForFile("config.yaml").id, "yaml");
+  assertEquals(languageForFile("check.yml").id, "yaml");
+});
+
+Deno.test("yaml: keys and scalar types receive distinct classes", () => {
+  const lines = yamlHighlightLines([
+    "name: widget",
+    "count: 42",
+    "ratio: -2.5e-3",
+    "enabled: true",
+    "disabled: FALSE",
+    "missing: null",
+    "empty: ~",
+  ].join("\n"));
+
+  for (
+    const key of [
+      "name",
+      "count",
+      "ratio",
+      "enabled",
+      "disabled",
+      "missing",
+      "empty",
+    ]
+  ) {
+    assertEquals([...classesOf(lines, key)], ["propertyName"]);
+  }
+  assertEquals([...classesOf(lines, "widget")], ["string"]);
+  assertEquals([...classesOf(lines, "42")], ["number"]);
+  assertEquals([...classesOf(lines, "-2.5e-3")], ["number"]);
+  assertEquals([...classesOf(lines, "true")], ["boolean"]);
+  assertEquals([...classesOf(lines, "FALSE")], ["boolean"]);
+  assertEquals([...classesOf(lines, "null")], ["keyword"]);
+  assertEquals([...classesOf(lines, "~")], ["keyword"]);
+  assert(classesOf(lines, ":").has("punctuation"));
+});
+
+Deno.test("yaml: core scalar resolution uses exact YAML 1.2 spellings", () => {
+  const typed: [string, TokenClass][] = [
+    ["True", "boolean"],
+    ["FALSE", "boolean"],
+    ["Null", "keyword"],
+    ["NULL", "keyword"],
+    ["~", "keyword"],
+    ["01", "number"],
+    ["+01", "number"],
+    ["01.2", "number"],
+    [".5", "number"],
+    ["12e3", "number"],
+    ["0o17", "number"],
+    ["0x2A", "number"],
+    ["-.Inf", "number"],
+    [".NaN", "number"],
+  ];
+  const strings = [
+    "TrUe",
+    "NuLl",
+    "0b101",
+    "1_000",
+    "-.nan",
+    ".iNf",
+    "0XFF",
+    "0x_1",
+    "1_",
+    "1__2",
+    "+0xFF",
+    "+0o7",
+  ];
+  const lines = yamlHighlightLines([
+    ...typed.map(([value], index) => `typed_${index}: ${value}`),
+    ...strings.map((value, index) => `string_${index}: ${value}`),
+  ].join("\n"));
+
+  for (const [value, cls] of typed) {
+    assertEquals([...classesOf(lines, value)], [cls], value);
+  }
+  for (const value of strings) {
+    assertEquals([...classesOf(lines, value)], ["string"], value);
+  }
+});
+
+Deno.test("yaml: quoted keys and values keep escapes and doubled quotes", () => {
+  const source = [
+    `"quoted key": "a \\"value\\" # still a value"`,
+    "'single key': 'it''s # data'",
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+  assertEquals([...classesOf(lines, '"quoted key"')], ["propertyName"]);
+  assertEquals(
+    [...classesOf(lines, '"a \\"value\\" # still a value"')],
+    ["string"],
+  );
+  assertEquals([...classesOf(lines, "'single key'")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "'it''s # data'")], ["string"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: comments require separation and do not consume URLs", () => {
+  const source = [
+    "url: https://example.test/a#fragment",
+    "label: value # trailing comment",
+    "# whole-line comment",
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+  assertEquals(
+    [...classesOf(lines, "https://example.test/a#fragment")],
+    ["string"],
+  );
+  assertEquals([...classesOf(lines, "# trailing comment")], ["comment"]);
+  assertEquals([...classesOf(lines, "# whole-line comment")], ["comment"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: flow collections use punctuation and rainbow brackets", () => {
+  const lines = yamlHighlightLines(
+    `root: {items: [1, 0x2a, 0o17, 0b101], ready: false}`,
+  );
+  const brackets = lines[0].spans.filter((span) => span.cls === "bracket");
+  assertEquals(
+    brackets.map((span) => [span.text, span.bracketDepth]),
+    [["{", 0], ["[", 1], ["]", 1], ["}", 0]],
+  );
+  assertEquals([...classesOf(lines, "items")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "ready")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "0x2a")], ["number"]);
+  assertEquals([...classesOf(lines, "0o17")], ["number"]);
+  assertEquals([...classesOf(lines, "0b101")], ["string"]);
+  assertEquals([...classesOf(lines, "false")], ["boolean"]);
+  assert(classesOf(lines, ",").has("punctuation"));
+});
+
+Deno.test("yaml: flow delimiters only terminate plain scalars inside flow", () => {
+  const block = yamlHighlightLines("foo:[bar]");
+  assertEquals([...classesOf(block, "foo:[bar]")], ["string"]);
+  assert(!block[0].spans.some((span) => span.cls === "propertyName"));
+  assert(!block[0].spans.some((span) => span.cls === "bracket"));
+
+  const flow = yamlHighlightLines("{foo:[bar]}");
+  assertEquals([...classesOf(flow, "foo")], ["propertyName"]);
+  assertEquals([...classesOf(flow, "bar")], ["string"]);
+  assertEquals(
+    flow[0].spans.filter((span) => span.cls === "bracket").map((span) =>
+      span.text
+    ),
+    ["{", "[", "]", "}"],
+  );
+
+  const adjacent = yamlHighlightLines(
+    "{[a, b]:value, {a: b}:other}",
+  );
+  assertEquals([...classesOf(adjacent, "value")], ["string"]);
+  assertEquals([...classesOf(adjacent, "other")], ["string"]);
+  assert(!adjacent[0].spans.some((span) => span.text === ":value"));
+  assert(!adjacent[0].spans.some((span) => span.text === ":other"));
+});
+
+Deno.test("yaml: sequence markers, tags, anchors, and aliases are highlighted", () => {
+  const source = [
+    "---",
+    "defaults: &defaults",
+    "  image: !!str app:latest",
+    "services:",
+    "  - <<: *defaults",
+    "    custom: !include config.yml",
+    "tagged_value: !foo: value",
+    "source: &key name",
+    "*key : value",
+    "colon_anchor: &foo: value",
+    "colon_alias: *foo:",
+    "...",
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+  assertEquals([...classesOf(lines, "---")], ["sectionHeader"]);
+  assertEquals([...classesOf(lines, "...")], ["sectionHeader"]);
+  assertEquals([...classesOf(lines, "&defaults")], ["keyword"]);
+  assertEquals([...classesOf(lines, "&key")], ["keyword"]);
+  assertEquals([...classesOf(lines, "*key")], ["keyword"]);
+  assertEquals([...classesOf(lines, "&foo:")], ["keyword"]);
+  assertEquals([...classesOf(lines, "*foo:")], ["keyword"]);
+  assertEquals([...classesOf(lines, "*defaults")], ["keyword"]);
+  assertEquals([...classesOf(lines, "!!str")], ["keyword"]);
+  assertEquals([...classesOf(lines, "!include")], ["keyword"]);
+  assertEquals([...classesOf(lines, "!foo:")], ["keyword"]);
+  assert(
+    !lines.some((line) => line.spans.some((span) => span.text === "!foo")),
+  );
+  assertEquals([...classesOf(lines, "<<")], ["propertyName"]);
+  const aliasKey = lines.find((line) => line.text === "*key : value")!;
+  assert(
+    aliasKey.spans.some((span) =>
+      span.text === ":" && span.cls === "punctuation"
+    ),
+  );
+  assert(!aliasKey.spans.some((span) => span.text === "*key:"));
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: adjacent flow mapping values follow complete key tokens", () => {
+  const source = [
+    '[foo":bar]',
+    '{"foo" :bar}',
+    "{[a,b] :value}",
+    "[? !foo, true, false]",
+    "[[? !foo]: true]",
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+  assertEquals([...classesOf(lines, 'foo":bar')], ["string"]);
+  assertEquals([...classesOf(lines, '"foo"')], ["propertyName"]);
+  assertEquals([...classesOf(lines, "bar")], ["string"]);
+  assertEquals([...classesOf(lines, "value")], ["string"]);
+  assertEquals([...classesOf(lines, "true")], ["boolean"]);
+  assertEquals([...classesOf(lines, "false")], ["boolean"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: flow collection block keys retain their mapping indent", () => {
+  for (
+    const source of [
+      "[a, b]:\n  |2\n  child: inside\nnext: done",
+      "- [a, b]:\n    |2\n    child: inside\n- done",
+      "{? a: b}: |2\n  child: inside\nnext: done",
+      "{outer: {? inner: value}}: |2\n  child: inside\nnext: done",
+      "{? &anchor }: |2\n  child: inside\nnext: done",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    assertEquals([...classesOf(lines, "child: inside")], ["string"], source);
+    if (source.includes("next: done")) {
+      assertEquals([...classesOf(lines, "next")], ["propertyName"], source);
+    }
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: completed block flow nodes do not leak into later keys", () => {
+  for (
+    const source of [
+      'outer:\n  first: [a]\n"root":\n  |2\n  child: inside\nnext: done',
+      "outer:\n  first: [a]\n:\n  |2\n  child: inside\nnext: done",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    assertEquals([...classesOf(lines, "child: inside")], ["string"], source);
+    assertEquals([...classesOf(lines, "next")], ["propertyName"], source);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: empty block keys establish their own mapping indent", () => {
+  for (
+    const source of [
+      ":\n  |2\n  child: inside\nnext: done",
+      "outer:\n  :\n    |2\n    child: inside\n  next: done",
+      "- :\n    |2\n    child: inside\n- done",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    assertEquals([...classesOf(lines, "child: inside")], ["string"], source);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: document markers start at the stream's first column", () => {
+  const withBom = "\uFEFF---\nkey: value";
+  const bomLines = yamlHighlightLines(withBom);
+  assertEquals([...classesOf(bomLines, "---")], ["sectionHeader"]);
+  assertEquals(verbatim(bomLines), withBom);
+
+  const indented = yamlHighlightLines("  ---");
+  assertEquals([...classesOf(indented, "---")], ["string"]);
+  assertEquals(verbatim(indented), "  ---");
+
+  const stream = "--- one\n...\n\uFEFF--- two";
+  const streamLines = yamlHighlightLines(stream);
+  assertEquals([...classesOf([streamLines[2]], "---")], ["sectionHeader"]);
+  assertEquals(verbatim(streamLines), stream);
+
+  const prefixedComment = yamlHighlightLines("\uFEFF# prefix\n---");
+  assertEquals(
+    [...classesOf([prefixedComment[0]], "# prefix")],
+    ["comment"],
+  );
+
+  const laterPrefix = "a: b\n\uFEFF# next document\n\n---\nc: d";
+  const laterPrefixLines = yamlHighlightLines(laterPrefix);
+  assertEquals(
+    [...classesOf([laterPrefixLines[1]], "# next document")],
+    ["comment"],
+  );
+  assertEquals(verbatim(laterPrefixLines), laterPrefix);
+
+  const trailingPrefix = "a: b\n\uFEFF# trailing";
+  const trailingPrefixLines = yamlHighlightLines(trailingPrefix);
+  assertEquals(
+    [...classesOf([trailingPrefixLines[1]], "# trailing")],
+    ["comment"],
+  );
+  assertEquals(verbatim(trailingPrefixLines), trailingPrefix);
+
+  const directive = "%TAG !yaml! tag:yaml.org,2002: # primary\n---";
+  const directiveLines = yamlHighlightLines(directive);
+  assertEquals([...classesOf(directiveLines, "%TAG")], ["keyword"]);
+  assertEquals([...classesOf(directiveLines, "!yaml!")], ["keyword"]);
+  assertEquals(
+    [...classesOf(directiveLines, "tag:yaml.org,2002:")],
+    ["string"],
+  );
+  assertEquals([...classesOf(directiveLines, "# primary")], ["comment"]);
+  assertEquals(verbatim(directiveLines), directive);
+
+  const embeddedBom = yamlHighlightLines("key: foo\uFEFF#bar");
+  assertEquals([...classesOf(embeddedBom, "foo\uFEFF#bar")], ["string"]);
+});
+
+Deno.test("yaml: block scalar content stays string until it dedents", () => {
+  const source = [
+    "script: |2- # shell text",
+    "  echo '# not a YAML comment'",
+    "  key: still text",
+    "",
+    "next: >",
+    "  folded text",
+    "done: true",
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+  assertEquals([...classesOf(lines, "|2-")], ["punctuation"]);
+  assertEquals([...classesOf(lines, "# shell text")], ["comment"]);
+  assertEquals(
+    lines[1].spans.map((span) => span.cls),
+    ["whitespace", "string"],
+  );
+  assertEquals(
+    lines[2].spans.map((span) => span.cls),
+    ["whitespace", "string"],
+  );
+  assertEquals([...classesOf(lines, "folded text")], ["string"]);
+  assertEquals([...classesOf(lines, "done")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "true")], ["boolean"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: a stream BOM does not add logical indentation", () => {
+  const source = "\uFEFFscript: |1\n child: inside\nnext: true";
+  const lines = yamlHighlightLines(source);
+  assertEquals([...classesOf(lines, "child: inside")], ["string"]);
+  assertEquals([...classesOf(lines, "next")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "true")], ["boolean"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: explicit block indentation follows compact sequence mappings", () => {
+  const source = [
+    "outer:",
+    "  - key: |2",
+    "      first",
+    "    next: done",
+    "  - key: >2",
+    "      second",
+    "    final: true",
+    "!!str tagged: |2",
+    "  tagged content",
+    "after_tag: done",
+    "&anchor anchored: |2",
+    "  anchored content",
+    "after_anchor: done",
+    "separate:",
+    "  |2",
+    "  child: inside",
+    "after_separate: done",
+    "-",
+    "  |2",
+    "  sequence content",
+    "? explicit",
+    ":",
+    "  |2",
+    "  explicit content",
+    "after_explicit: done",
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+  assertEquals([...classesOf(lines, "first")], ["string"]);
+  assertEquals([...classesOf(lines, "second")], ["string"]);
+  assertEquals([...classesOf(lines, "next")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "final")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "tagged content")], ["string"]);
+  assertEquals([...classesOf(lines, "anchored content")], ["string"]);
+  assertEquals([...classesOf(lines, "child: inside")], ["string"]);
+  assertEquals([...classesOf(lines, "sequence content")], ["string"]);
+  assertEquals([...classesOf(lines, "explicit content")], ["string"]);
+  assertEquals([...classesOf(lines, "after_tag")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "after_anchor")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "after_separate")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "after_explicit")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "true")], ["boolean"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: node properties preserve a pending block scalar indent", () => {
+  for (
+    const source of [
+      "folded:\n   !foo\n  >1\n child: inside\nnext: done",
+      "folded: !foo\n  |2\n  child: inside\nnext: done",
+      "- !foo\n  |2\n  child: inside\n- done",
+      "!foo :\n  |2\n  child: inside\nnext: done",
+      "&anchor :\n  |2\n  child: inside\nnext: done",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    assertEquals([...classesOf(lines, "child: inside")], ["string"], source);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: a standalone explicit key carries state across lines", () => {
+  const source = [
+    "?",
+    "  key",
+    ":",
+    "  |2",
+    "  child: inside",
+    "next: done",
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+  assertEquals([...classesOf(lines, "key")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "child: inside")], ["string"]);
+  assertEquals([...classesOf(lines, "next")], ["propertyName"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: explicit flow collection keys carry state to their value", () => {
+  for (
+    const source of [
+      "?\n  [a, b]\n:\n  |2\n  child: inside\nnext: done",
+      "?\n  {a: b}\n:\n  |2\n  child: inside\nnext: done",
+      "?\n  [a,\n    {b: c}]\n:\n  |2\n  child: inside\nnext: done",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    assertEquals([...classesOf(lines, "child: inside")], ["string"], source);
+    assertEquals([...classesOf(lines, "next")], ["propertyName"], source);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: nested explicit keys retain their outer value scope", () => {
+  for (
+    const source of [
+      "?\n  {? [a, b]: c}\n:\n  |2\n  child: inside\nnext: done",
+      "?\n  - a\n  - b\n:\n  |2\n  child: inside\nnext: done",
+      "?\n- a\n- b\n:\n  |2\n  child: inside\nnext: done",
+      "?\n  a: one\n  b: two\n:\n  |2\n  child: inside\nnext: done",
+      "? !foo\n:\n  |2\n  child: inside\nnext: done",
+      "? |-\n  key\n:\n  |2\n  child: inside\nnext: done",
+      "?\n|-\n  key\n:\n  |2\n  child: inside\nnext: done",
+      '?\n  "quoted\n  key"\n:\n  |2\n  child: inside\nnext: done',
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    assertEquals([...classesOf(lines, "child: inside")], ["string"], source);
+    assertEquals([...classesOf(lines, "next")], ["propertyName"], source);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: compact mappings inside explicit keys use local indentation", () => {
+  for (
+    const source of [
+      "? : value\n: outer",
+      "? :\n    |2\n    child: inside\n: outer",
+      "? key:\n    |2\n    child: inside\n  next: value\n: outer",
+      "? : inner\n  : mid\n: outer",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    if (source.includes("value")) {
+      assertEquals([...classesOf(lines, "value")], ["string"], source);
+    }
+    if (source.includes("child: inside")) {
+      assertEquals([...classesOf(lines, "child: inside")], ["string"], source);
+    }
+    if (source.includes("next: value")) {
+      assertEquals([...classesOf(lines, "next")], ["propertyName"], source);
+    }
+    if (source.includes("mid")) {
+      assertEquals([...classesOf(lines, "inner")], ["string"], source);
+      assertEquals([...classesOf(lines, "mid")], ["string"], source);
+    }
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: explicit value colons consume pending empty keys", () => {
+  for (
+    const source of [
+      "?\n: |2\n  child: inside\nnext: done",
+      "?\n: plain\n  continuation\nnext: done",
+      '?\n: "value"\nnext: done',
+      "?\n!foo\n: value\nnext: done",
+      "? !foo : |2\n    child: inside\n  next: done\n: outer",
+      "? &anchor : true\n  next: done\n: outer",
+      "? !foo &anchor : value\n  next: done\n: outer",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    if (source.includes("child: inside")) {
+      assertEquals([...classesOf(lines, "child: inside")], ["string"], source);
+    }
+    if (source.includes("plain")) {
+      assertEquals([...classesOf(lines, "plain")], ["string"], source);
+      assertEquals([...classesOf(lines, "continuation")], ["string"], source);
+    }
+    if (source.includes('"value"')) {
+      assertEquals([...classesOf(lines, '"value"')], ["string"], source);
+    }
+    if (source.includes(": true")) {
+      assertEquals([...classesOf(lines, "true")], ["boolean"], source);
+    }
+    if (source.includes(": value") && !source.includes('"value"')) {
+      assertEquals([...classesOf(lines, "value")], ["string"], source);
+    }
+    assertEquals([...classesOf(lines, "next")], ["propertyName"], source);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: compact empty keys retain their mapping indentation", () => {
+  for (
+    const source of [
+      "- : true\n  next: done",
+      "- : |2\n    child: inside\n  next: done",
+      "outer:\n  - : true\n    next: done",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    if (source.includes("true")) {
+      assertEquals([...classesOf(lines, "true")], ["boolean"], source);
+    }
+    if (source.includes("child: inside")) {
+      assertEquals([...classesOf(lines, "child: inside")], ["string"], source);
+    }
+    assertEquals([...classesOf(lines, "next")], ["propertyName"], source);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: nested explicit keys accept indentless sequence nodes", () => {
+  const source = [
+    "outer:",
+    "  ?",
+    "  - a",
+    "  - b",
+    "  :",
+    "    |2",
+    "    child: inside",
+    "next: done",
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+  assertEquals([...classesOf(lines, "child: inside")], ["string"]);
+  assertEquals([...classesOf(lines, "next")], ["propertyName"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: explicit block scalar key content uses key styling", () => {
+  for (
+    const source of [
+      "? |-\n  key text\n: value",
+      "?\n|-\n  key text\n: value",
+      "?\n  |-\n  key text\n: value",
+      "?\n  |2\n  key text\n: value",
+      "outer:\n  ?\n    |2\n    key text\n  : value",
+      "- ? |2\n    key text\n  : value",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    assertEquals([...classesOf(lines, "key text")], ["propertyName"], source);
+    assertEquals([...classesOf(lines, "value")], ["string"], source);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: multiline plain explicit keys retain key styling", () => {
+  for (
+    const source of [
+      "? multi\n  line\n: value",
+      "?\n  multi\n  line\n: value",
+      "?\n  multi\n    line\n: value",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    assertEquals([...classesOf(lines, "multi")], ["propertyName"], source);
+    assertEquals([...classesOf(lines, "line")], ["propertyName"], source);
+    assertEquals([...classesOf(lines, "value")], ["string"], source);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: multiline plain scalars resolve as strings", () => {
+  const source = [
+    "boolean: true",
+    "  continued",
+    "number: 12",
+    "  units",
+    "nothing: null",
+    "",
+    "  continued",
+    "sequence:",
+    "  - FALSE",
+    "    continued",
+    "flow: [true",
+    "  continued, false]",
+    "done: true",
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+  assertEquals([...classesOf([lines[0]], "true")], ["string"]);
+  assertEquals([...classesOf([lines[2]], "12")], ["string"]);
+  assertEquals([...classesOf([lines[4]], "null")], ["string"]);
+  assertEquals([...classesOf([lines[8]], "FALSE")], ["string"]);
+  assertEquals([...classesOf([lines[10]], "true")], ["string"]);
+  assertEquals([...classesOf([lines[11]], "continued")], ["string"]);
+  assertEquals([...classesOf([lines[11]], "false")], ["boolean"]);
+  assertEquals([...classesOf([lines[12]], "true")], ["boolean"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: separate nodes retain multiline plain scalar state", () => {
+  for (
+    const source of [
+      "key:\n  true\n  continued\nnext: false",
+      "-\n  true\n  continued\n- false",
+      "key:\n  !foo\n  true\n  continued\nnext: false",
+      "key: !foo\n  true\n  continued\nnext: false",
+      "- !foo\n  true\n  continued\n- false",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    const typed = lines.find((line) => line.text.trim() === "true")!;
+    assertEquals([...classesOf([typed], "true")], ["string"], source);
+    assertEquals([...classesOf(lines, "continued")], ["string"], source);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
+Deno.test("yaml: multiline quoted strings resume normal syntax after closing", () => {
+  const source = [
+    'message: "first line',
+    '  second # data": value # comment',
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+  assertEquals(lines[0].spans.at(-1)?.cls, "string");
+  assertEquals(lines[1].spans[0].cls, "string");
+  assertEquals([...classesOf(lines, "value")], ["string"]);
+  assertEquals([...classesOf(lines, "# comment")], ["comment"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: document and incremental highlighting are lossless", () => {
+  const before = "emoji: 🎉\nready: false\n";
+  const after = "emoji: 🎉\nready: true\ncount: .inf\n";
+  const document = yamlDocument(before);
+  assertEquals(verbatim(document.lines), before);
+  assertEquals(document.structure, []);
+
+  const highlighter = createYamlHighlighter(before);
+  assertEquals(highlighter.lines, yamlHighlightLines(before));
+  assertEquals(highlighter.update(after), yamlHighlightLines(after));
+  assertEquals(verbatim(highlighter.lines), after);
+});
+
+Deno.test("yaml: incomplete syntax remains lossless", () => {
+  for (
+    const source of [
+      'key: "unterminated',
+      "key: 'unterminated",
+      "flow: {nested: [1, 2",
+      "script: |",
+      "  # block content",
+      "😀: value\r\nnext: true\r\n",
+    ]
+  ) {
+    assertEquals(verbatim(yamlHighlightLines(source)), source);
+  }
+});
+
+Deno.test("yaml: a YAML diff uses YAML highlighting on both sides", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const file = "name: gadget\ncount: 2\n";
+    Deno.writeTextFileSync(join(root, "config.yaml"), file);
+    const workspace: DiffWorkspace = {
+      resolve: (path) => join(root, path),
+      read: (path) => {
+        try {
+          return Deno.readTextFileSync(path);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const diff = `diff --git a/config.yaml b/config.yaml
+--- a/config.yaml
++++ b/config.yaml
+@@ -1,2 +1,2 @@
+-name: widget
++name: gadget
+ count: 2
+`;
+    const model = parseDiff(diff)!;
+    const { doc } = buildDiffDocument(diff, model, workspace);
+    const nameSpans = doc.lines.filter((line) => line.text.includes("name:"))
+      .flatMap((line) => line.spans);
+    assert(
+      nameSpans.some((span) =>
+        span.text === "name" && span.cls === "propertyName"
+      ),
+    );
+    assert(
+      nameSpans.some((span) => span.text === "widget" && span.cls === "string"),
+    );
+    assert(
+      nameSpans.some((span) => span.text === "gadget" && span.cls === "string"),
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("yaml: an unavailable old diff side carries context into deletions", () => {
+  const diff = [
+    "--- a/config.yml",
+    "+++ b/config.yml",
+    "@@ -1,2 +1 @@",
+    " script: |",
+    "-  child: old",
+    "",
+  ].join("\n");
+  const workspace: DiffWorkspace = {
+    resolve: () => null,
+    read: () => null,
+  };
+  const { doc } = buildDiffDocument(diff, parseDiff(diff)!, workspace);
+  const removed = doc.lines.find((line) => line.text.includes("child: old"))!;
+  assert(
+    removed.spans.some((span) =>
+      span.text === "child: old" && span.cls === "string"
+    ),
+  );
+  assert(!removed.spans.some((span) => span.cls === "propertyName"));
+});
+
+Deno.test("yaml: editing a YAML diff line re-applies YAML highlighting", () => {
+  const diff = [
+    "diff --git a/config.yml b/config.yml",
+    "--- a/config.yml",
+    "+++ b/config.yml",
+    "@@ -1 +1 @@",
+    " count: 1",
+    "",
+  ].join("\n");
+  const highlighter = createDiffHighlighter(diff);
+  const updated = highlighter.update(diff.replace("count: 1", "count: 42"));
+  const line = updated.find((candidate) => candidate.text.includes("count:"))!;
+  assert(
+    line.spans.some((span) =>
+      span.text === "count" && span.cls === "propertyName"
+    ),
+  );
+  assert(
+    line.spans.some((span) => span.text === "42" && span.cls === "number"),
+  );
+});
+
+Deno.test("yaml: live diff edits preserve and update cross-line state", () => {
+  const diff = [
+    "diff --git a/config.yml b/config.yml",
+    "--- a/config.yml",
+    "+++ b/config.yml",
+    "@@ -1,5 +1,5 @@",
+    " script: |",
+    "   child: old",
+    " next: true",
+    ' message: "first',
+    '   nested: old"',
+    "",
+  ].join("\n");
+  const highlighter = createDiffHighlighter(diff);
+
+  const insideBlock = diff.replace("child: old", "child: new");
+  let lines = highlighter.update(insideBlock);
+  let line = lines.find((candidate) => candidate.text.includes("child:"))!;
+  assert(
+    line.spans.some((span) =>
+      span.text === "child: new" && span.cls === "string"
+    ),
+  );
+  assert(!line.spans.some((span) => span.cls === "propertyName"));
+
+  const insideQuote = insideBlock.replace("nested: old", "nested: new");
+  lines = highlighter.update(insideQuote);
+  line = lines.find((candidate) => candidate.text.includes("nested:"))!;
+  assert(
+    line.spans.some((span) =>
+      span.text.includes("nested: new") && span.cls === "string"
+    ),
+  );
+  assert(!line.spans.some((span) => span.cls === "propertyName"));
+
+  const withoutBlock = insideQuote.replace("script: |", "script:");
+  lines = highlighter.update(withoutBlock);
+  line = lines.find((candidate) => candidate.text.includes("child:"))!;
+  assert(
+    line.spans.some((span) =>
+      span.text === "child" && span.cls === "propertyName"
+    ),
+  );
+
+  const withoutQuote = withoutBlock.replace(
+    'message: "first',
+    "message:",
+  );
+  lines = highlighter.update(withoutQuote);
+  line = lines.find((candidate) => candidate.text.includes("nested:"))!;
+  assert(
+    line.spans.some((span) =>
+      span.text === "nested" && span.cls === "propertyName"
+    ),
+  );
+});
+
+Deno.test("yaml: live diff edits retain state that begins above the hunk", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(
+      join(root, "config.yml"),
+      "script: |\n  intro\n  child: new\nnext: true\n",
+    );
+    const workspace: DiffWorkspace = {
+      resolve: (path) => join(root, path),
+      read: (path) => {
+        try {
+          return Deno.readTextFileSync(path);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const diff = [
+      "diff --git a/config.yml b/config.yml",
+      "--- a/config.yml",
+      "+++ b/config.yml",
+      "@@ -3 +3 @@",
+      "-  child: old",
+      "+  child: new",
+      "",
+    ].join("\n");
+    const { doc, edit } = buildDiffDocument(
+      diff,
+      parseDiff(diff)!,
+      workspace,
+    );
+    const source = diffSource(workspace, edit);
+    const highlighter = source.createHighlighter!(diff, doc.lines);
+    const updated = highlighter.update(
+      diff.replace("+  child: new", "+  child: newer"),
+    );
+    for (const value of ["child: old", "child: newer"]) {
+      const line = updated.find((candidate) => candidate.text.includes(value))!;
+      assert(
+        line.spans.some((span) => span.text === value && span.cls === "string"),
+      );
+      assert(!line.spans.some((span) => span.cls === "propertyName"));
+    }
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+function assertLiveDiffLineOffsets(
+  repeatedFileSection: boolean,
+  reverseFileSections = false,
+): void {
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(
+      join(root, "config.yml"),
+      [
+        "script: |",
+        "  intro",
+        "  middle one",
+        "  middle two",
+        "  target: new",
+        "next: true",
+        "",
+      ].join("\n"),
+    );
+    const workspace: DiffWorkspace = {
+      resolve: (path) => join(root, path),
+      read: (path) => {
+        try {
+          return Deno.readTextFileSync(path);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const header = [
+      "diff --git a/config.yml b/config.yml",
+      "--- a/config.yml",
+      "+++ b/config.yml",
+    ];
+    const introHunk = [
+      "@@ -2 +2 @@",
+      "-  old intro",
+      "+  intro",
+    ];
+    const targetHunk = [
+      "@@ -5 +5 @@",
+      "-  target: old",
+      "+  target: new",
+    ];
+    const body = !repeatedFileSection
+      ? [...header, ...introHunk, ...targetHunk]
+      : reverseFileSections
+      ? [...header, ...targetHunk, ...header, ...introHunk]
+      : [...header, ...introHunk, ...header, ...targetHunk];
+    const diff = [
+      ...body,
+      "",
+    ].join("\n");
+    const { doc, edit } = buildDiffDocument(
+      diff,
+      parseDiff(diff)!,
+      workspace,
+    );
+    const source = diffSource(workspace, edit);
+    const highlighter = source.createHighlighter!(
+      diff,
+      doc.lines,
+    );
+    const edited = diff
+      .replace("@@ -2 +2 @@", "@@ -2 +2,2 @@")
+      .replace("+  intro", "+  intro\n+  inserted");
+    const updated = highlighter.update(edited);
+    const target = updated.find((line) => line.text === "+  target: new")!;
+    assert(
+      target.spans.some((span) =>
+        span.text === "target: new" && span.cls === "string"
+      ),
+    );
+    assert(!target.spans.some((span) => span.cls === "propertyName"));
+
+    source.save(edited, diff);
+    const afterSave = highlighter.update(
+      edited.replace("+  target: new", "+  target: newer"),
+    );
+    const savedTarget = afterSave.find((line) =>
+      line.text === "+  target: newer"
+    )!;
+    assert(
+      savedTarget.spans.some((span) =>
+        span.text === "target: newer" && span.cls === "string"
+      ),
+    );
+    assert(!savedTarget.spans.some((span) => span.cls === "propertyName"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+}
+
+Deno.test("yaml: live diff line insertions shift later complete-file spans", () => {
+  assertLiveDiffLineOffsets(false);
+});
+
+Deno.test("yaml: live diff offsets cross repeated file sections", () => {
+  assertLiveDiffLineOffsets(true);
+});
+
+Deno.test("yaml: live diff offsets follow file coordinates", () => {
+  assertLiveDiffLineOffsets(true, true);
+});
+
+Deno.test("yaml: a touched path rehighlights every repeated section", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(
+      join(root, "config.yml"),
+      [
+        "script:",
+        "  intro",
+        "  middle one",
+        "  middle two",
+        "  target: new",
+        "next: true",
+        "",
+      ].join("\n"),
+    );
+    const workspace: DiffWorkspace = {
+      resolve: (path) => join(root, path),
+      read: (path) => {
+        try {
+          return Deno.readTextFileSync(path);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const diff = [
+      "diff --git a/config.yml b/config.yml",
+      "--- a/config.yml",
+      "+++ b/config.yml",
+      "@@ -1 +1 @@",
+      "-script: old",
+      "+script:",
+      "diff --git a/config.yml b/config.yml",
+      "--- a/config.yml",
+      "+++ b/config.yml",
+      "@@ -5 +5 @@",
+      "-  target: old",
+      "+  target: new",
+      "",
+    ].join("\n");
+    const { doc, edit } = buildDiffDocument(
+      diff,
+      parseDiff(diff)!,
+      workspace,
+    );
+    const highlighter = diffSource(workspace, edit).createHighlighter!(
+      diff,
+      doc.lines,
+    );
+    const updated = highlighter.update(
+      diff.replace("+script:", "+script: |"),
+    );
+    const target = updated.find((line) => line.text === "+  target: new")!;
+    assert(
+      target.spans.some((span) =>
+        span.text === "target: new" && span.cls === "string"
+      ),
+    );
+    assert(!target.spans.some((span) => span.cls === "propertyName"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});

--- a/packages/cli/test/view-yaml.test.ts
+++ b/packages/cli/test/view-yaml.test.ts
@@ -2,7 +2,7 @@
  * The YAML language used by `cf view`. Tests cover direct files, diffs, live
  * edits, common scalar forms, flow collections, and state that crosses lines.
  */
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertStrictEquals } from "@std/assert";
 import { join } from "@std/path";
 import {
   createYamlHighlighter,
@@ -136,6 +136,37 @@ Deno.test("yaml: quoted keys and values keep escapes and doubled quotes", () => 
   assertEquals(verbatim(lines), source);
 });
 
+Deno.test("yaml: explicit multiline quoted keys retain key styling", () => {
+  // YAML restricts implicit keys to one line, so multiline keys use `?`.
+  for (
+    const [source, fragments] of [
+      [
+        [
+          '? "multi',
+          "",
+          '  line"',
+          ": value",
+        ].join("\n"),
+        ['"multi', '  line"'],
+      ],
+      [
+        [
+          "mapping: { ? 'multi",
+          "  line' : value }",
+        ].join("\n"),
+        ["'multi", "  line'"],
+      ],
+    ] as const
+  ) {
+    const lines = yamlHighlightLines(source);
+    for (const fragment of fragments) {
+      assertEquals([...classesOf(lines, fragment)], ["propertyName"], source);
+    }
+    assertEquals([...classesOf(lines, "value")], ["string"], source);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
 Deno.test("yaml: comments require separation and do not consume URLs", () => {
   const source = [
     "url: https://example.test/a#fragment",
@@ -233,6 +264,40 @@ Deno.test("yaml: sequence markers, tags, anchors, and aliases are highlighted", 
     ),
   );
   assert(!aliasKey.spans.some((span) => span.text === "*key:"));
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: an alias can be an explicit mapping key", () => {
+  const source = "? *alias\n: value";
+  const lines = yamlHighlightLines(source);
+
+  assertEquals([...classesOf(lines, "*alias")], ["keyword"]);
+  assertEquals([...classesOf(lines, "value")], ["string"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: verbatim tags and property-only lines remain lossless", () => {
+  const source = [
+    "tagged: !<tag:example.org,2026:widget> value",
+    "unfinished: !<tag:example.org,2026:widget",
+    "first:",
+    "  !foo &anchor  ",
+    "  value",
+    "second:",
+    "  !bar &other # properties",
+    "  value",
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+
+  assertEquals(
+    [...classesOf(lines, "!<tag:example.org,2026:widget>")],
+    ["keyword"],
+  );
+  assertEquals(
+    [...classesOf(lines, "!<tag:example.org,2026:widget")],
+    ["keyword"],
+  );
+  assertEquals([...classesOf(lines, "# properties")], ["comment"]);
   assertEquals(verbatim(lines), source);
 });
 
@@ -353,6 +418,26 @@ Deno.test("yaml: document markers start at the stream's first column", () => {
   assertEquals([...classesOf(embeddedBom, "foo\uFEFF#bar")], ["string"]);
 });
 
+Deno.test("yaml: a BOM only starts a document prefix before a marker", () => {
+  const content = "first: value\n\uFEFFsecond: value";
+  assertEquals(verbatim(yamlHighlightLines(content)), content);
+
+  const prefix = [
+    "first: value",
+    "\uFEFF# next document",
+    "# another prefix comment",
+    "---",
+    "second: value",
+  ].join("\n");
+  const lines = yamlHighlightLines(prefix);
+  assertEquals(
+    [...classesOf(lines, "# another prefix comment")],
+    ["comment"],
+  );
+  assertEquals([...classesOf(lines, "---")], ["sectionHeader"]);
+  assertEquals(verbatim(lines), prefix);
+});
+
 Deno.test("yaml: block scalar content stays string until it dedents", () => {
   const source = [
     "script: |2- # shell text",
@@ -377,6 +462,25 @@ Deno.test("yaml: block scalar content stays string until it dedents", () => {
   assertEquals([...classesOf(lines, "folded text")], ["string"]);
   assertEquals([...classesOf(lines, "done")], ["propertyName"]);
   assertEquals([...classesOf(lines, "true")], ["boolean"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: block scalars accept blank content and reject bad headers", () => {
+  const source = [
+    "literal: |",
+    "  ",
+    "  text",
+    "empty: |",
+    "after: true",
+    "invalid: |x",
+  ].join("\n");
+  const lines = yamlHighlightLines(source);
+
+  assertEquals(lines[1].spans.map((span) => span.cls), ["whitespace"]);
+  assertEquals([...classesOf(lines, "text")], ["string"]);
+  assertEquals([...classesOf(lines, "after")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "true")], ["boolean"]);
+  assertEquals([...classesOf(lines, "|x")], ["string"]);
   assertEquals(verbatim(lines), source);
 });
 
@@ -660,6 +764,59 @@ Deno.test("yaml: multiline plain scalars resolve as strings", () => {
   assertEquals([...classesOf([lines[11]], "false")], ["boolean"]);
   assertEquals([...classesOf([lines[12]], "true")], ["boolean"]);
   assertEquals(verbatim(lines), source);
+});
+
+Deno.test("yaml: multiline plain scalars preserve whitespace and comments", () => {
+  const block = [
+    "message: first",
+    "  \t",
+    "  second   # trailing comment",
+    "next: true",
+  ].join("\n");
+  const blockLines = yamlHighlightLines(block);
+  assertEquals(
+    blockLines[1].spans.map((span) => span.cls),
+    ["whitespace"],
+  );
+  assertEquals([...classesOf(blockLines, "second")], ["string"]);
+  assertEquals(
+    [...classesOf(blockLines, "# trailing comment")],
+    ["comment"],
+  );
+  assertEquals([...classesOf(blockLines, "next")], ["propertyName"]);
+  assertEquals(verbatim(blockLines), block);
+
+  for (
+    const flow of [
+      [
+        "values: [first",
+        "  ",
+        "  second]",
+      ].join("\n"),
+      "values: [first\r\n\r\n  second]\r\n",
+    ]
+  ) {
+    const flowLines = yamlHighlightLines(flow);
+    assertEquals(flowLines[1].spans.map((span) => span.cls), ["whitespace"]);
+    assertEquals([...classesOf(flowLines, "second")], ["string"]);
+    assertEquals(verbatim(flowLines), flow);
+  }
+});
+
+Deno.test("yaml: structural lines end plain scalar continuation", () => {
+  for (
+    const source of [
+      "value: true\n  # separate comment",
+      "value: [true\n # comment",
+      "value: [true\n , false]",
+      "value: [true\n ]",
+      "value: {key: true\n }",
+    ]
+  ) {
+    const lines = yamlHighlightLines(source);
+    assertEquals([...classesOf(lines, "true")], ["boolean"], source);
+    assertEquals(verbatim(lines), source);
+  }
 });
 
 Deno.test("yaml: separate nodes retain multiline plain scalar state", () => {
@@ -1077,6 +1234,74 @@ Deno.test("yaml: a touched path rehighlights every repeated section", () => {
       ),
     );
     assert(!target.spans.some((span) => span.cls === "propertyName"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("yaml: live diff highlighting leaves other files unchanged", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(
+      join(root, "config.yml"),
+      "script:\n  child: new\n",
+    );
+    Deno.writeTextFileSync(
+      join(root, "other.yml"),
+      "enabled: true\n",
+    );
+    const workspace: DiffWorkspace = {
+      resolve: (path) => join(root, path),
+      read: (path) => {
+        try {
+          return Deno.readTextFileSync(path);
+        } catch {
+          return null;
+        }
+      },
+    };
+    const diff = [
+      "diff --git a/config.yml b/config.yml",
+      "--- a/config.yml",
+      "+++ b/config.yml",
+      "@@ -1 +1 @@",
+      "-script: old",
+      "+script:",
+      "diff --git a/other.yml b/other.yml",
+      "--- a/other.yml",
+      "+++ b/other.yml",
+      "@@ -1 +1 @@",
+      "-enabled: false",
+      "+enabled: true",
+      "",
+    ].join("\n");
+    const { doc, edit } = buildDiffDocument(
+      diff,
+      parseDiff(diff)!,
+      workspace,
+    );
+    const originalOther = doc.lines.find((line) =>
+      line.text === "+enabled: true"
+    )!;
+    const highlighter = diffSource(workspace, edit).createHighlighter!(
+      diff,
+      doc.lines,
+    );
+    const updated = highlighter.update(
+      diff.replace("+script:", "+script: |"),
+    );
+    const other = updated.find((line) => line.text === "+enabled: true")!;
+    assertStrictEquals(other, originalOther);
+    assert(
+      other.spans.some((span) =>
+        span.text === "enabled" && span.cls === "propertyName"
+      ),
+    );
+    assert(
+      other.spans.some((span) =>
+        span.text === "true" && span.cls === "boolean"
+      ),
+    );
   } finally {
     Deno.removeSync(root, { recursive: true });
   }


### PR DESCRIPTION
Add a lossless YAML scanner for .yaml and .yml files. It colours mapping keys, scalar values, collections, comments, node properties, quoted text, and block scalars in direct source and unified diff views.

Preserve complete-file YAML state during live diff edits. Include old-side context when the original file is unavailable. Register the language with the pager, update command documentation, and cover direct files, diffs, edits, and YAML 1.2 scalar forms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds YAML syntax highlighting to `cf view` for `.yaml`/`.yml` files in direct views and unified diffs, with correct cross-line state (block scalars, quotes, flow) during live edits. Live diffs now re-highlight complete YAML files when needed and handle repeated file sections without bleeding into other files.

- **New Features**
  - New `yaml` language with a lossless scanner; highlights mapping keys, scalar values, flow/blocked collections, comments, tags/anchors, quoted text, and block scalars.
  - YAML is auto-selected by file name; registered with the pager and documented (README updates and `view` command help in `@commonfabric/cli`).
  - Live diffs include old-side context even if the original file is unavailable.

- **Refactors**
  - Diff highlighter can re-highlight touched hunks using full file text when a language requests it; kicks in even without a seed.
  - Tracks per-hunk line offsets and repeated file sections so inserted lines shift complete-file spans correctly; unrelated files reuse existing lines unchanged.
  - Language API adds `highlightFullFileOnDiffEdit`; YAML opts in and the language registry now includes YAML.

<sup>Written for commit bcd3826a58492734420f76927ae9d34d545cc434. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

