### PR TITLE
fix(runner): chunk compile-cache write-backs so an interrupted first-open settle survives (estuary outage)

### DIFF
--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -1378,11 +1378,28 @@ export const COMPILE_CACHE_WRITEBACK_CHUNK_MODULES = 4;
  *
  * Ordering makes every prefix of committed chunks a maximally useful partial
  * state: dependencies first (DFS post-order over the import graph), the
- * ENTRY module last. The closure loaders (`loadSourceClosure` /
- * `loadCompiledClosure`) start at the entry and fail closed on any missing
- * doc, so a partial prefix is never misread as a complete closure — it is
- * simply a cache miss whose already-durable docs make the next session's
+ * ENTRY module last.
+ *
+ * What the entry-last pin actually guarantees: an interrupted write-back
+ * never persists the entry doc of a namespace that did not already have one
+ * (a fresh compiled `compileCache:<version>/` namespace, or a fresh space's
+ * source set), and an ABSENT ENTRY is exactly the miss test of both load
+ * paths (`loadCompiledClosure` returns empty; `loadSourceClosure` resolves
+ * undefined). So every partial prefix this ordering can produce reads as a
+ * plain cache miss whose already-durable docs make the next session's
  * re-write cheaper (equal-value re-writes diff to nothing).
+ *
+ * The loaders are deliberately NOT fail-closed on missing DESCENDANTS:
+ * `loadCompiledClosure` drops an absent/unstamped child along with the edge
+ * to it (pinned by "skips compiled import links without integrity"), and the
+ * by-identity hit test is entry presence. Chunk interruption cannot create
+ * an entry-present/descendant-missing state, but should one arise out of
+ * band, it degrades to a clean RECOMPILE rather than a corrupt load: the
+ * source path rejects the partial graph in `loadVerifiedSourceClosure`
+ * (verifySourceDocs' missing-import check) and the compiled path fails
+ * cached-module evaluation, both funneling into the cold recompile fallback
+ * — pinned by the descendant-missing tests in
+ * compile-cache-incremental-writeback.test.ts.
  *
  * `extraRoots` is computed over the FULL module set and must be passed to
  * each chunk's write (the entry doc's synthetic root links enumerate every

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -441,8 +441,14 @@ export function buildSourceDocs(
   modules: readonly CacheableModule[],
   entryIdentity: string,
   moduleDelegations: ModuleDelegationMap = EMPTY_MODULE_DELEGATIONS,
+  extraRootsOverride?: readonly string[],
 ): Map<string, SourceDoc> {
-  const extraRoots = unreachedRoots(modules, entryIdentity);
+  // `extraRootsOverride` exists for chunked (incremental) write-backs: the
+  // synthetic root links on the ENTRY doc must be computed over the FULL
+  // emitted module set, while `modules` here may be just the chunk being
+  // written in this transaction (see planCompileCacheWriteChunks).
+  const extraRoots = extraRootsOverride ??
+    unreachedRoots(modules, entryIdentity);
   const out = new Map<string, SourceDoc>();
   for (const module of modules) {
     const delegatedModuleIdentities = validDelegatedModuleIdentities(
@@ -744,6 +750,7 @@ export function writeSourceDocs(
   entryIdentity: string,
   tx: IExtendedStorageTransaction,
   moduleDelegations: ModuleDelegationMap = EMPTY_MODULE_DELEGATIONS,
+  extraRootsOverride?: readonly string[],
 ): ModuleDelegationMap {
   assertNoUnpinnedFabricImports(modules);
   const effectiveModuleDelegations = effectiveModuleDelegationsForWrite(
@@ -758,6 +765,7 @@ export function writeSourceDocs(
     modules,
     entryIdentity,
     effectiveModuleDelegations,
+    extraRootsOverride,
   );
   withCompileCacheBuiltin(tx, () => {
     for (const [identity, doc] of docs) {
@@ -1211,6 +1219,8 @@ export function writeCompiledDocs(
   opts: {
     runtimeVersion: string;
     moduleDelegations?: ModuleDelegationMap;
+    /** See {@link buildSourceDocs}: full-set root links for chunked writes. */
+    extraRoots?: readonly string[];
   },
   tx: IExtendedStorageTransaction,
 ): ModuleDelegationMap {
@@ -1223,7 +1233,8 @@ export function writeCompiledDocs(
     opts.moduleDelegations ?? EMPTY_MODULE_DELEGATIONS,
     { compiledRuntimeVersion: opts.runtimeVersion },
   );
-  const extraRoots = unreachedRoots(modules, entryIdentity);
+  const extraRoots = opts.extraRoots ??
+    unreachedRoots(modules, entryIdentity);
   const schema = compiledDocWriteSchema();
   withCompileCacheBuiltin(tx, () => {
     for (const module of modules) {
@@ -1304,6 +1315,8 @@ export function writeSourceAndCompiledDocs(
   opts: {
     runtimeVersion: string;
     moduleDelegations?: ModuleDelegationMap;
+    /** See {@link buildSourceDocs}: full-set root links for chunked writes. */
+    extraRoots?: readonly string[];
   },
   tx: IExtendedStorageTransaction,
 ): ModuleDelegationMap {
@@ -1326,6 +1339,7 @@ export function writeSourceAndCompiledDocs(
     entryIdentity,
     tx,
     effectiveModuleDelegations,
+    opts.extraRoots,
   );
   writeCompiledDocs(
     runtime,
@@ -1336,6 +1350,96 @@ export function writeSourceAndCompiledDocs(
     tx,
   );
   return effectiveModuleDelegations;
+}
+
+/**
+ * How many modules a single compile-cache write-back transaction covers.
+ *
+ * Why not one transaction for the whole closure: the first client session
+ * over a space whose compiled refs went stale (a compiler/transformer output
+ * change, e.g. #4980) re-writes the ENTIRE closure. As one all-or-nothing
+ * commit, a session interrupted mid-write persists nothing, the next session
+ * redoes everything, and under aggressive client timeouts no session ever
+ * lands the write — the space retries forever (the estuary first-open
+ * outage). Chunked commits make that recovery durable and incremental:
+ * every committed chunk survives an interruption, re-runs re-write already
+ * durable docs as empty diffs, and a few interrupted sessions converge to
+ * the settled closure.
+ *
+ * 4 modules ≈ 8 docs per commit keeps each commit well under typical
+ * ws-message/commit-validation budgets while bounding the commit count for
+ * large closures. A closure of ≤4 modules still commits exactly once,
+ * identical to the pre-chunking behavior.
+ */
+export const COMPILE_CACHE_WRITEBACK_CHUNK_MODULES = 4;
+
+/**
+ * Plan the transaction chunks for an incremental compile-cache write-back.
+ *
+ * Ordering makes every prefix of committed chunks a maximally useful partial
+ * state: dependencies first (DFS post-order over the import graph), the
+ * ENTRY module last. The closure loaders (`loadSourceClosure` /
+ * `loadCompiledClosure`) start at the entry and fail closed on any missing
+ * doc, so a partial prefix is never misread as a complete closure — it is
+ * simply a cache miss whose already-durable docs make the next session's
+ * re-write cheaper (equal-value re-writes diff to nothing).
+ *
+ * `extraRoots` is computed over the FULL module set and must be passed to
+ * each chunk's write (the entry doc's synthetic root links enumerate every
+ * module unreachable through the natural import graph; computing it over a
+ * chunk would corrupt the entry doc's link set).
+ */
+export function planCompileCacheWriteChunks(
+  modules: readonly CacheableModule[],
+  entryIdentity: string,
+  chunkSize: number = COMPILE_CACHE_WRITEBACK_CHUNK_MODULES,
+): { chunks: CacheableModule[][]; extraRoots: readonly string[] } {
+  if (!Number.isInteger(chunkSize) || chunkSize < 1) {
+    throw new Error(`invalid compile-cache write chunk size: ${chunkSize}`);
+  }
+  const extraRoots = unreachedRoots(modules, entryIdentity);
+  const byId = new Map(modules.map((m) => [m.identity, m]));
+  const ordered: CacheableModule[] = [];
+  const visited = new Set<string>();
+  // Iterative DFS post-order (import cycles are legal in ES modules; the
+  // visited set breaks them — chunking is commit batching, not a semantic
+  // ordering requirement, so any cycle cut is fine).
+  const visit = (rootId: string): void => {
+    const stack: { id: string; expanded: boolean }[] = [
+      { id: rootId, expanded: false },
+    ];
+    while (stack.length > 0) {
+      const frame = stack.pop()!;
+      const module = byId.get(frame.id);
+      if (module === undefined) continue;
+      if (frame.expanded) {
+        ordered.push(module);
+        continue;
+      }
+      if (visited.has(frame.id)) continue;
+      visited.add(frame.id);
+      stack.push({ id: frame.id, expanded: true });
+      for (const imp of module.imports) {
+        if (!visited.has(imp.targetIdentity)) {
+          stack.push({ id: imp.targetIdentity, expanded: false });
+        }
+      }
+    }
+  };
+  // Every module is either reachable from the entry or listed in extraRoots
+  // (unreachedRoots returns ALL unreachable modules), so these walks cover
+  // the full set. The entry is pinned visited during the root walks (an
+  // unreachable module may import back INTO the entry) and walked last, so
+  // the entry doc is always in the final chunk.
+  visited.add(entryIdentity);
+  for (const rootIdentity of extraRoots) visit(rootIdentity);
+  visited.delete(entryIdentity);
+  visit(entryIdentity);
+  const chunks: CacheableModule[][] = [];
+  for (let i = 0; i < ordered.length; i += chunkSize) {
+    chunks.push(ordered.slice(i, i + chunkSize));
+  }
+  return { chunks, extraRoots };
 }
 
 /**

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1811,14 +1811,19 @@ export class PatternManager {
     // single commit, a session killed mid-write persisted NOTHING and every
     // retrying session redid the whole write — under aggressive client
     // timeouts no session ever landed it (the estuary first-open outage).
-    // Each committed chunk survives interruption: docs are content-addressed
-    // and the closure loaders fail closed on missing docs, so a partial
-    // prefix reads as a cache miss (never as a corrupt closure), and the next
-    // session's re-write diffs already-durable docs to nothing. Dependencies
-    // commit first and the entry doc last (see planCompileCacheWriteChunks).
-    // The `persistence` promise callers await still resolves only after ALL
-    // chunks are durable, so the "refs-only pattern JSON requires a durable
-    // closure" contract is unchanged.
+    // Each committed chunk survives interruption: docs are content-addressed,
+    // dependencies commit first and the ENTRY doc last, so an interrupted
+    // write-back never persists the entry of a namespace that lacked one —
+    // and an absent entry is exactly the load paths' miss test, so every
+    // producible partial prefix reads as a plain cache miss. (That is the
+    // precise guarantee; the loaders do NOT fail closed on missing
+    // descendants — see planCompileCacheWriteChunks for why the
+    // entry-present/descendant-missing state, not producible by this
+    // ordering, still degrades to a clean recompile.) The next session's
+    // re-write diffs already-durable docs to nothing. The `persistence`
+    // promise callers await still resolves only after ALL chunks are
+    // durable, so the "refs-only pattern JSON requires a durable closure"
+    // contract is unchanged.
     const { chunks, extraRoots } = planCompileCacheWriteChunks(
       modules,
       entryIdentity,
@@ -1843,8 +1848,18 @@ export class PatternManager {
       // conflicts — a conflict-free write-back still commits on the first
       // attempt — so the ceiling is only paid during recovery after a
       // compiler-version bump.
+      //
+      // The historical fixed floor (16) is NOT applied per chunk — that would
+      // multiply the minimum by chunk count (six low-edge chunks = 96 retries
+      // vs the old closure-wide 16; Codex review on #5094). A single-chunk
+      // write-back keeps the exact historical budget; a multi-chunk one gives
+      // each chunk its edge-proportional share plus one round of slack, so
+      // the aggregate stays >= 16 (8 * 2 chunks minimum) without the 16x
+      // chunk-count inflation.
       const importEdges = chunk.reduce((n, m) => n + m.imports.length, 0);
-      const writebackMaxRetries = Math.max(16, 2 * importEdges + 8);
+      const writebackMaxRetries = chunks.length === 1
+        ? Math.max(16, 2 * importEdges + 8)
+        : 2 * importEdges + 8;
       let chunkDelegations: ModuleDelegationMap = new Map();
       const { error } = await this.runtime.editWithRetry((tx) => {
         chunkDelegations = writeSourceAndCompiledDocs(

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -37,6 +37,7 @@ import {
   loadVerifiedSourceClosure,
   type ModuleDelegationMap,
   moduleDelegationsFromDocs,
+  planCompileCacheWriteChunks,
   ROOT_LINK_SPECIFIER,
   type SourceDoc,
   sourceDocKey,
@@ -1804,41 +1805,71 @@ export class PatternManager {
   ): Promise<void> {
     const writebackStart = performance.now();
     await this.syncCompileCacheWriteTargets(space, modules, opts);
-    // The write-back re-writes source docs whose values carry quote-cell
-    // indirections (one derived doc per import edge). On a cold replica those
-    // derived docs are unknown, and each commit attempt discovers exactly ONE
-    // of them: the engine rejects on the first stale read, editWithRetry
-    // pulls that doc, and only then does the next attempt's diff reach the
-    // following one (CT-1824, live-traced on the browser rig — the system-app
-    // closure re-write conflicts on ~24 pre-existing edge docs, one per
-    // round). Convergence therefore needs one retry per pre-existing derived
-    // doc; the general DEFAULT_MAX_RETRIES (5) exhausts long before that and
-    // the cache never heals, so every later cold boot recompiles. Budget by
-    // the write set's edge count (source + compiled edge docs) with slack.
-    // Rounds are bounded by actual conflicts — a conflict-free write-back
-    // still commits on the first attempt — so the ceiling is only paid during
-    // recovery after a compiler-version bump.
-    const importEdges = modules.reduce((n, m) => n + m.imports.length, 0);
-    const writebackMaxRetries = Math.max(16, 2 * importEdges + 8);
-    let committedModuleDelegations = moduleDelegations;
-    const { error } = await this.runtime.editWithRetry((tx) => {
-      committedModuleDelegations = writeSourceAndCompiledDocs(
-        this.runtime,
-        space,
-        modules,
-        entryIdentity,
-        { ...opts, moduleDelegations },
-        tx,
-      );
-    }, writebackMaxRetries);
-    logger.time(writebackStart, "compile-cache", "writeback");
-    if (error) {
-      logger.error("compile-cache-writeback-failed", () => [
-        `entry=${entryIdentity}`,
-        error.message,
-      ]);
-      throw throwableStorageError(error);
+    // The closure is committed in CHUNKS of bounded module count rather than
+    // one all-or-nothing transaction. A stale-refs recovery (compiler output
+    // change over a pre-existing space) re-writes the entire closure; as a
+    // single commit, a session killed mid-write persisted NOTHING and every
+    // retrying session redid the whole write — under aggressive client
+    // timeouts no session ever landed it (the estuary first-open outage).
+    // Each committed chunk survives interruption: docs are content-addressed
+    // and the closure loaders fail closed on missing docs, so a partial
+    // prefix reads as a cache miss (never as a corrupt closure), and the next
+    // session's re-write diffs already-durable docs to nothing. Dependencies
+    // commit first and the entry doc last (see planCompileCacheWriteChunks).
+    // The `persistence` promise callers await still resolves only after ALL
+    // chunks are durable, so the "refs-only pattern JSON requires a durable
+    // closure" contract is unchanged.
+    const { chunks, extraRoots } = planCompileCacheWriteChunks(
+      modules,
+      entryIdentity,
+    );
+    // Union of the per-chunk effective delegation maps. Chunks partition the
+    // module set and the effective map is keyed per module, so the union over
+    // all chunks equals the single-transaction effective map exactly.
+    const committedModuleDelegations = new Map<string, ReadonlySet<string>>();
+    for (const chunk of chunks) {
+      // The write-back re-writes source docs whose values carry quote-cell
+      // indirections (one derived doc per import edge). On a cold replica
+      // those derived docs are unknown, and each commit attempt discovers
+      // exactly ONE of them: the engine rejects on the first stale read,
+      // editWithRetry pulls that doc, and only then does the next attempt's
+      // diff reach the following one (CT-1824, live-traced on the browser
+      // rig — the system-app closure re-write conflicts on ~24 pre-existing
+      // edge docs, one per round). Convergence therefore needs one retry per
+      // pre-existing derived doc; the general DEFAULT_MAX_RETRIES (5)
+      // exhausts long before that and the cache never heals, so every later
+      // cold boot recompiles. Budget by the chunk's edge count (source +
+      // compiled edge docs) with slack. Rounds are bounded by actual
+      // conflicts — a conflict-free write-back still commits on the first
+      // attempt — so the ceiling is only paid during recovery after a
+      // compiler-version bump.
+      const importEdges = chunk.reduce((n, m) => n + m.imports.length, 0);
+      const writebackMaxRetries = Math.max(16, 2 * importEdges + 8);
+      let chunkDelegations: ModuleDelegationMap = new Map();
+      const { error } = await this.runtime.editWithRetry((tx) => {
+        chunkDelegations = writeSourceAndCompiledDocs(
+          this.runtime,
+          space,
+          chunk,
+          entryIdentity,
+          { ...opts, moduleDelegations, extraRoots },
+          tx,
+        );
+      }, writebackMaxRetries);
+      if (error) {
+        logger.time(writebackStart, "compile-cache", "writeback");
+        logger.error("compile-cache-writeback-failed", () => [
+          `entry=${entryIdentity}`,
+          `chunkModules=${chunk.length}/${modules.length}`,
+          error.message,
+        ]);
+        throw throwableStorageError(error);
+      }
+      for (const [identity, predecessors] of chunkDelegations) {
+        committedModuleDelegations.set(identity, predecessors);
+      }
     }
+    logger.time(writebackStart, "compile-cache", "writeback");
     this.runtime.registerModuleDelegations(space, committedModuleDelegations);
   }
 

--- a/packages/runner/test/compile-cache-incremental-writeback.test.ts
+++ b/packages/runner/test/compile-cache-incremental-writeback.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import {
+  computeModuleHashes,
+  resolveModuleImports,
+} from "../src/harness/module-identity.ts";
+import type { CacheableModule, RuntimeProgram } from "../src/harness/types.ts";
+import {
+  loadCompiledClosure,
+  loadSourceClosure,
+  loadVerifiedSourceClosure,
+  planCompileCacheWriteChunks,
+  verifySourceDocs,
+  writeSourceAndCompiledDocs,
+} from "../src/compilation-cache/cell-cache.ts";
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+
+// These tests drive the sync parse internals directly (below the async flow
+// boundaries that normally load the deferred compiler stack), so load it here.
+await ensureCompilerStack();
+
+const signer = await Identity.fromPassphrase("incremental writeback test");
+
+// A small multi-module program (same synthesis idiom as cell-cache.test.ts):
+// /main.tsx -> /util.ts -> (none), /main.tsx -> /types.ts.
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        `import { helper } from "./util.ts";`,
+        `import type { Thing } from "./types.ts";`,
+        `export const run = (t: Thing) => helper(t.n);`,
+      ].join("\n"),
+    },
+    {
+      name: "/util.ts",
+      contents: `export const helper = (n: number) => n + 1;`,
+    },
+    { name: "/types.ts", contents: `export interface Thing { n: number; }` },
+  ],
+};
+
+/** Synthesize the engine's `CacheableModule[]` from an authored program. */
+function toModules(
+  program: RuntimeProgram,
+): { modules: CacheableModule[]; entryIdentity: string } {
+  const ids = computeModuleHashes(program);
+  const edges = resolveModuleImports(program);
+  const modules = program.files.map((f) => ({
+    identity: ids.get(f.name)!,
+    filename: f.name,
+    source: f.contents,
+    js: `/* compiled */ ${f.name}`,
+    imports: (edges.get(f.name)?.internalDeps ?? []).map((d) => ({
+      specifier: d.specifier,
+      targetIdentity: ids.get(d.target)!,
+    })),
+  }));
+  return { modules, entryIdentity: ids.get(program.main)! };
+}
+
+/** A module no import edge reaches (the injected-helper shape). */
+function isolatedModule(): CacheableModule {
+  return {
+    identity: computeModuleHashes({
+      main: "/iso.ts",
+      files: [{ name: "/iso.ts", contents: "export const iso = 1;" }],
+    }).get("/iso.ts")!,
+    filename: "/iso.ts",
+    source: "export const iso = 1;",
+    js: "/* compiled */ /iso.ts",
+    imports: [],
+  };
+}
+
+describe("planCompileCacheWriteChunks", () => {
+  it("covers every module exactly once, bounded chunks, entry last", () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const { chunks, extraRoots } = planCompileCacheWriteChunks(
+      modules,
+      entryIdentity,
+      1,
+    );
+    expect(extraRoots).toEqual([]);
+    expect(chunks.length).toBe(3);
+    for (const chunk of chunks) expect(chunk.length).toBe(1);
+    const flat = chunks.flat();
+    expect(new Set(flat.map((m) => m.identity)).size).toBe(modules.length);
+    // Dependencies first, the entry module in the final chunk.
+    const last = chunks[chunks.length - 1]!;
+    expect(last[last.length - 1]!.identity).toBe(entryIdentity);
+  });
+
+  it("keeps a small closure in a single chunk (pre-chunking behavior)", () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const { chunks } = planCompileCacheWriteChunks(modules, entryIdentity, 8);
+    expect(chunks.length).toBe(1);
+    expect(chunks[0]!.length).toBe(modules.length);
+  });
+
+  it("computes extraRoots over the full set and orders them before the entry", () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const iso = isolatedModule();
+    const { chunks, extraRoots } = planCompileCacheWriteChunks(
+      [...modules, iso],
+      entryIdentity,
+      1,
+    );
+    expect(extraRoots).toEqual([iso.identity]);
+    const order = chunks.flat().map((m) => m.identity);
+    expect(order.length).toBe(modules.length + 1);
+    // The unreachable root is durable before the entry doc that links it.
+    expect(order.indexOf(iso.identity)).toBeLessThan(
+      order.indexOf(entryIdentity),
+    );
+    expect(order[order.length - 1]).toBe(entryIdentity);
+  });
+
+  it("rejects a non-positive chunk size", () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    expect(() => planCompileCacheWriteChunks(modules, entryIdentity, 0))
+      .toThrow();
+  });
+});
+
+describe("chunked compile-cache write-back (interruption survivability)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  const space = signer.did();
+  const RTVER = "rt-incremental-test-1";
+  const opts = () => ({ runtimeVersion: RTVER });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      trustSnapshotProvider: () => ({
+        id: "incremental-writeback-test",
+        actingPrincipal: signer.did(),
+      }),
+    });
+  });
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /** Commit one chunk in its own transaction (the write-back's unit). */
+  async function commitChunk(
+    chunk: CacheableModule[],
+    entryIdentity: string,
+    extraRoots: readonly string[],
+  ): Promise<void> {
+    const tx = runtime.edit();
+    writeSourceAndCompiledDocs(
+      runtime,
+      space,
+      chunk,
+      entryIdentity,
+      { ...opts(), extraRoots },
+      tx,
+    );
+    tx.prepareCfc();
+    const { error } = await tx.commit();
+    expect(error).toBeUndefined();
+  }
+
+  it("a committed chunk prefix is a cache miss, never a corrupt closure; a rerun converges", async () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const { chunks, extraRoots } = planCompileCacheWriteChunks(
+      modules,
+      entryIdentity,
+      1,
+    );
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // Session 1 dies after its first chunk committed: dependencies only,
+    // no entry doc.
+    await commitChunk(chunks[0]!, entryIdentity, extraRoots);
+
+    // Fail-closed on the partial prefix: both closure loaders treat it as a
+    // plain cache miss (no entry doc), not as a readable-but-wrong closure.
+    const missTx = runtime.edit();
+    const compiledMiss = await loadCompiledClosure(
+      runtime,
+      space,
+      entryIdentity,
+      opts(),
+      missTx,
+    );
+    expect(compiledMiss.size).toBe(0);
+    const sourceMiss = await loadVerifiedSourceClosure(
+      runtime,
+      space,
+      entryIdentity,
+      missTx,
+    );
+    expect(sourceMiss).toBeUndefined();
+    missTx.abort?.();
+
+    // Session 2 re-runs the full chunked write-back over the durable prefix
+    // (the already-written docs re-diff to their existing values).
+    for (const chunk of chunks) {
+      await commitChunk(chunk, entryIdentity, extraRoots);
+    }
+
+    // The closure is now complete, link-reachable, and self-verifying.
+    const tx = runtime.edit();
+    const compiled = await loadCompiledClosure(
+      runtime,
+      space,
+      entryIdentity,
+      opts(),
+      tx,
+    );
+    expect(compiled.size).toBe(modules.length);
+    for (const module of modules) {
+      expect(compiled.get(module.identity)?.code).toBe(module.js);
+    }
+    const source = (await loadSourceClosure(
+      runtime,
+      space,
+      entryIdentity,
+      tx,
+    ))!;
+    expect(source.size).toBe(modules.length);
+    expect(verifySourceDocs(entryIdentity, source).ok).toBe(true);
+    tx.abort?.();
+  });
+
+  it("chunked writes preserve the entry's synthetic root links to unreachable modules", async () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const iso = isolatedModule();
+    const all = [...modules, iso];
+    const { chunks, extraRoots } = planCompileCacheWriteChunks(
+      all,
+      entryIdentity,
+      1,
+    );
+    for (const chunk of chunks) {
+      await commitChunk(chunk, entryIdentity, extraRoots);
+    }
+
+    // The link-following loaders reach the isolated module through the entry
+    // doc's root link even though it was written in a different transaction
+    // than the entry.
+    const tx = runtime.edit();
+    const compiled = await loadCompiledClosure(
+      runtime,
+      space,
+      entryIdentity,
+      opts(),
+      tx,
+    );
+    expect(compiled.size).toBe(all.length);
+    expect(compiled.get(iso.identity)?.code).toBe(iso.js);
+    const source = (await loadSourceClosure(
+      runtime,
+      space,
+      entryIdentity,
+      tx,
+    ))!;
+    expect(source.has(iso.identity)).toBe(true);
+    tx.abort?.();
+  });
+});

--- a/packages/runner/test/compile-cache-incremental-writeback.test.ts
+++ b/packages/runner/test/compile-cache-incremental-writeback.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { StorageManager } from "../src/storage/cache.deno.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import {
   computeModuleHashes,
@@ -13,10 +16,14 @@ import {
   loadSourceClosure,
   loadVerifiedSourceClosure,
   planCompileCacheWriteChunks,
+  setCompileCacheRuntimeVersionForTesting,
   verifySourceDocs,
+  writeCompiledDocs,
   writeSourceAndCompiledDocs,
+  writeSourceDocs,
 } from "../src/compilation-cache/cell-cache.ts";
 import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 // These tests drive the sync parse internals directly (below the async flow
 // boundaries that normally load the deferred compiler stack), so load it here.
@@ -235,6 +242,54 @@ describe("chunked compile-cache write-back (interruption survivability)", () => 
     tx.abort?.();
   });
 
+  it("entry-present/descendant-missing (not producible by interruption) is a partial compiled read and a source-closure miss", async () => {
+    // Chunk interruption cannot create this state (the entry doc lands
+    // last), but out-of-band loss can. Pin the ACTUAL loader behavior the
+    // safety argument rests on: the compiled loader is NOT fail-closed on a
+    // missing descendant — it returns the entry plus the valid subset — while
+    // the verified source loader rejects the partial graph, so the system
+    // recovers via recompile-from-source (see the degradation test below).
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const { chunks, extraRoots } = planCompileCacheWriteChunks(
+      modules,
+      entryIdentity,
+      1,
+    );
+    const utilIdentity = modules.find((m) => m.filename === "/util.ts")!
+      .identity;
+    // Commit every chunk EXCEPT the /util.ts dependency — including the
+    // entry chunk.
+    for (const chunk of chunks) {
+      if (chunk.some((m) => m.identity === utilIdentity)) continue;
+      await commitChunk(chunk, entryIdentity, extraRoots);
+    }
+
+    const tx = runtime.edit();
+    // Compiled loader: entry present, missing child skipped along with its
+    // edge (same behavior "skips compiled import links without integrity"
+    // pins) — the result is a PARTIAL closure, not a miss.
+    const compiled = await loadCompiledClosure(
+      runtime,
+      space,
+      entryIdentity,
+      opts(),
+      tx,
+    );
+    expect(compiled.has(entryIdentity)).toBe(true);
+    expect(compiled.has(utilIdentity)).toBe(false);
+    expect(compiled.size).toBe(modules.length - 1);
+    // Verified source loader: fail-closed — the missing import target fails
+    // graph verification, so the caller degrades to a recompile.
+    const source = await loadVerifiedSourceClosure(
+      runtime,
+      space,
+      entryIdentity,
+      tx,
+    );
+    expect(source).toBeUndefined();
+    tx.abort?.();
+  });
+
   it("chunked writes preserve the entry's synthetic root links to unreachable modules", async () => {
     const { modules, entryIdentity } = toModules(PROGRAM);
     const iso = isolatedModule();
@@ -269,5 +324,160 @@ describe("chunked compile-cache write-back (interruption survivability)", () => 
     ))!;
     expect(source.has(iso.identity)).toBe(true);
     tx.abort?.();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// System-level degradation pin: the by-identity load's hit test is ENTRY
+// presence (`closure.has(entryIdentity)`), not closure completeness. Chunked
+// interruption cannot create an entry-present/descendant-missing compiled
+// namespace (the entry doc lands last), but the safety argument in
+// planCompileCacheWriteChunks leans on what happens if that state exists
+// anyway: cached-module evaluation fails on the missing module and the load
+// falls back to a clean recompile from the verified source closure — a
+// working pattern, never a corrupt load — and the recovery write-back heals
+// the compiled namespace.
+// ---------------------------------------------------------------------------
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager._sharedServer = server;
+    return manager;
+  }
+  private _sharedServer!: MemoryV2Server.Server;
+  protected override server(): MemoryV2Server.Server {
+    return this._sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+
+describe("descendant-missing compiled closure degrades to a clean recompile", () => {
+  it("loadPatternByIdentity recompiles from source and heals the compiled set", async () => {
+    const RTVER = "test-degrade-1";
+    const restoreVersion = setCompileCacheRuntimeVersionForTesting(RTVER);
+    const server = newSharedServer();
+    const space = signer.did();
+    const program = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            `import { bump } from "./util.ts";`,
+            `import { lift, pattern } from "commonfabric";`,
+            `const inc = lift((x: number) => bump(x));`,
+            `export default pattern<{ value: number }>(({ value }) => {`,
+            `  return { result: inc(value) };`,
+            `});`,
+          ].join("\n"),
+        },
+        {
+          name: "/util.ts",
+          contents: `export const bump = (n: number) => n + 1;`,
+        },
+      ],
+    };
+
+    const smA = SharedServerStorageManager.connectTo(server, { as: signer });
+    const runtimeA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: smA,
+    });
+    let smB: SharedServerStorageManager | undefined;
+    let runtimeB: Runtime | undefined;
+    try {
+      // Real compile for real module bodies, but persist BY HAND: the full
+      // source closure plus a compiled set that is missing /util.ts — the
+      // entry-present/descendant-missing state no chunk interruption can
+      // produce.
+      const { modules, entryIdentity } = await runtimeA.harness
+        .compileToRecordGraph(program, { fabricImports: { space } });
+      const utilModule = modules.find((m) => m.filename === "/util.ts");
+      expect(utilModule).toBeDefined();
+      const compiledSubset = modules.filter((m) => m !== utilModule);
+      const tx = runtimeA.edit();
+      writeSourceDocs(runtimeA, space, modules, entryIdentity, tx);
+      writeCompiledDocs(
+        runtimeA,
+        space,
+        compiledSubset,
+        entryIdentity,
+        { runtimeVersion: RTVER },
+        tx,
+      );
+      tx.prepareCfc();
+      expect((await tx.commit()).error).toBeUndefined();
+      await smA.synced();
+
+      // Cold replica: confirm the pre-state actually exercises the intended
+      // path — the compiled ENTRY is present (hit test passes) while the
+      // descendant is absent. Without this guard a mis-stamped write would
+      // silently turn the test into the ordinary absent-entry miss.
+      smB = SharedServerStorageManager.connectTo(server, { as: signer });
+      runtimeB = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: smB,
+      });
+      const preTx = runtimeB.edit();
+      const partial = await loadCompiledClosure(
+        runtimeB,
+        space,
+        entryIdentity,
+        { runtimeVersion: RTVER },
+        preTx,
+      );
+      preTx.abort?.();
+      expect(partial.has(entryIdentity)).toBe(true);
+      expect(partial.has(utilModule!.identity)).toBe(false);
+
+      // The by-identity load must degrade to a clean recompile: a WORKING
+      // pattern from the verified source closure, not a corrupt cached load.
+      const loaded = await runtimeB.patternManager.loadPatternByIdentity(
+        entryIdentity,
+        "default",
+        space,
+      );
+      expect(loaded).toBeDefined();
+      await runtimeB.patternManager.flushCompileCacheWrites();
+      await smB.synced();
+
+      // The recovery write-back healed the compiled namespace: the closure
+      // is complete again (recompile is identity-stable over the same
+      // source).
+      const healTx = runtimeB.edit();
+      const healed = await loadCompiledClosure(
+        runtimeB,
+        space,
+        entryIdentity,
+        { runtimeVersion: RTVER },
+        healTx,
+      );
+      healTx.abort?.();
+      expect(healed.has(entryIdentity)).toBe(true);
+      expect(healed.has(utilModule!.identity)).toBe(true);
+      expect(healed.size).toBe(modules.length);
+    } finally {
+      restoreVersion();
+      await runtimeB?.dispose();
+      await smB?.close();
+      await runtimeA.dispose();
+      await smA.close();
+      await server.close();
+    }
   });
 });


### PR DESCRIPTION
## Why

Deploying `a8c11e27e` to Estuary broke home-space loading for every existing
identity: cold-opening a space with real data took 29–61s — longer than client
timeouts — while fresh identities worked. Rolling the server back to
`80678fbbc` restored 0.5s opens. This PR fixes the actual cause, so main can be
deployed again.

**The cause is not what we first thought, and the investigation is part of the
record:**

1. First suspect was #4606 (pending-stack dependencies) — the timing fit and it
   touched the storage layer. We said so in team chat. **That was wrong.**
2. A local A/B harness (two worktrees serving the *same* seeded space store,
   identical timed probes) reproduced the behavior change and `git bisect run`
   across the 89-commit window landed on **#4980** (`a0f82ce3c`, sandbox
   type-library strip). #4606, which is later in the window, is exonerated.
3. Mechanism: #4980 changed the transformer's *output* (its own diff updates
   `.expected.jsx` fixtures). Authored pattern identity is deliberately stable
   (`entry-identity.ts` hashes authored source only), but compiled module refs
   (`cf:module/<hash>`) hash the compiled form — so every module's ref changed,
   every derived/`computed:` cell's cause changed, and the first client session
   over any pre-existing space recompiles the closure and rewrites its derived
   state ("the storm": ~3 commits, ~64 revisions, ~664KB locally).
4. **The production killer is the amplifier, not the storm**: the storm's
   dominant transaction was all-or-nothing. A session killed mid-settle
   persisted **zero rows** (measured), so a space whose storm outruns client
   timeouts retries forever and never settles. Estuary was in exactly that
   loop; a *completed* settle makes a space permanently fast again.
5. Cross-version tests pin it to the client: OLD server × NEW client is slow
   and writes the storm; NEW server × OLD client is fast and clean.
   (`engine.open()` on a 60MB space db: 3.5ms old, 3.8ms new — the server was
   innocent. The estuary "server rollback fixed it" observation was because
   estuary serves the shell, so the server rollback rolled the *client* back
   too.)

Storms of this kind will happen again — any commit that changes transform
output re-keys derived state for every space. This PR does not stop the storm;
it makes it **survivable**.

## What Changed

Traced storm anatomy: (1) a single 664KB `writeBackCompileCache` transaction —
286 write attempts, the entire module closure — ~95% of the bytes; (2) the
per-piece `instantiatePattern` transaction (28 writes); (3) a second small
write-back. The closure write-back had equated "a refs-only pattern needs a
durable closure" with "one transaction", which the loaders do not require.

- `compilation-cache/cell-cache.ts`: `planCompileCacheWriteChunks` — orders the
  closure dependencies-first (iterative DFS post-order), **pins the entry
  module to the last chunk**, slices at 4 modules/transaction; threads the
  entry's `extraRoots` so chunked writes cannot corrupt the entry's link set.
- `pattern-manager.ts`: `writeBackCompileCache` commits the chunks sequentially
  through the unchanged `editWithRetry` + CFC-prepare path (per-edge retry
  budget now per chunk). The awaited persistence promise still resolves only
  after all chunks are durable, so the `$patternRef` contract is unchanged.
- **Consistency:** the entry module is pinned to the LAST chunk, and an absent
  entry is exactly both load paths' miss test — so an interruption never
  persists the entry of a namespace that lacked one, and a committed *prefix*
  reads as a plain cache miss. The loaders are deliberately **not** fail-closed
  on missing *descendants*: a partial compiled closure degrades to
  recompile-from-source (and the recovery write-back heals the namespace),
  which the new entry-present/descendant-missing tests pin at both the loader
  and system level.
- The instantiation transaction stays atomic on purpose: it is already
  per-piece (the natural boundary), small, and its atomicity is load-bearing
  for the cold-start repair path.

## Test plan (measured on the harness's 50k-doc dataset, all runs real)

- **Unfixed baseline:** storm = +3 commits/+64 revisions; kill at 1.2s → 0 rows
  persisted (reconfirmed).
- **Fixed, uninterrupted:** +6 commits/+64 revisions, 2.82s vs 2.83s — no
  latency regression; settled states mutually accepted by both clients with
  zero writes in both directions.
- **Fixed, killed repeatedly mid-settle:** session 1 persists +4/+60, session 2
  +1/+4, session 3 opens clean — **monotonic progress, converged after 2
  interrupted sessions**, final cold open 1.1s / zero writes.
- **Fast path:** already-settled space — times and zero-write behavior
  identical to baseline.
- Suites: runner 1075 passed / 0 failed; piece 28 / 0; new
  `compile-cache-incremental-writeback.test.ts` (6 steps) green; check/lint/fmt
  clean.

## Known limits (stated, not hidden)

- The compile phase itself cannot be made durable — its durability *is* this
  write-back. A session killed before the write window still persists nothing.
  Chunking guarantees progress once writing starts; production convergence
  therefore depends on sessions surviving compile, which long-lived browser
  workers do even when individual UI requests time out.
- Chunked layout mints different (link-isomorphic) ids for derived import-edge
  docs than the monolith did; both settled states are accepted by both clients
  (verified bidirectionally).
- `writeBackSourceCache` (source-only path) remains single-tx — not on the
  storm path; conscious scope.
- The deeper issue — transform-output changes re-keying derived state for every
  existing space, with no migration story — is real and bigger than this PR;
  this makes the re-settle survivable rather than preventing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make compile-cache write-backs incremental so first-open resettles survive interruptions and spaces converge instead of looping on timeouts. Small closures still commit once; large closures persist progress across sessions.

- **Bug Fixes**
  - Added `planCompileCacheWriteChunks` to order modules dependencies-first, pin the entry last, and split write-backs into 4-module transactions (`COMPILE_CACHE_WRITEBACK_CHUNK_MODULES`).
  - Updated `writeBackCompileCache` to commit chunks sequentially via `editWithRetry`; callers still await until all chunks are durable; per-chunk retries scale with edge count, keeping the single-chunk floor and avoiding multiplying the fixed floor across chunks.
  - Threaded full-set `extraRoots` through `writeSourceDocs`/`writeCompiledDocs`/`writeSourceAndCompiledDocs` so the entry’s synthetic root links stay correct across chunked writes.
  - Guaranteed safe partials: the entry doc lands last, so an interrupted write never persists an entry; an absent entry is a cache miss. If an entry-present/descendant-missing state exists out of band, the compiled loader returns entry + valid subset and the system degrades to a clean recompile from verified source.
  - Added tests for chunk ordering, root-link integrity, interruption survivability, compiled-loader behavior on missing descendants, and system-level degrade-to-recompile that heals the compiled set.

<sup>Written for commit d1ce24310490d84070f4594c2ae01c4e79acd289. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


