### PR TITLE
ci: type-check top-level TypeScript scripts

### DIFF
--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -120,6 +120,7 @@ FILES_TO_CHECK+=("${DIRS[@]}")
 
 # Glob patterns - bash expands these with nullglob set
 FILES_TO_CHECK+=(tasks/*.ts)
+FILES_TO_CHECK+=(scripts/*.ts)
 FILES_TO_CHECK+=(packages/ui/src/v2/components/*[!outliner]/*.ts*)
 FILES_TO_CHECK+=(packages/cli/*.ts)
 FILES_TO_CHECK+=(packages/static/*.ts)


### PR DESCRIPTION
The Check job relies on tasks/check.sh as the complete list of code paths that receive a standalone type check. The top-level scripts workspace was omitted, so scripts could remain valid enough to format and lint while carrying unchecked TypeScript errors.

Add the scripts/*.ts entry points to that list. This keeps existing scripts and future top-level scripts under the same CI type-safety gate as tasks/*.ts.

Verified with deno task check, deno fmt --check, and deno lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `scripts/*.ts` to the CI type-check list in `tasks/check.sh` so top-level scripts get the same standalone type check as `tasks/*.ts`. This closes a gap where scripts could pass lint/format but still carry unchecked TypeScript errors.

<sup>Written for commit 781d19d8fe66db1b37bb20b2230a6907a900adfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

