### PR TITLE
dashboard: make benchmark history CPU-aware

### DIFF
--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -17,7 +17,11 @@ manual trigger measures a specific commit.
 
 The team ops dashboard charts benchmark trends on its `/bench` page, sampling
 one successful run per four-hour window from those artifacts. Each
-benchmark's series is identified by its origin file, group, and name.
+benchmark is identified by its origin file, group, and name. The report's CPU
+field divides that benchmark into one line per processor. The dashboard never
+connects measurements from different processors. A report without a CPU
+identity is unusable for trends because its measurements cannot be assigned to
+a processor.
 
 Benchmark numbers are not gated, and neither is CI wall time. The only per-PR
 gate is the coverage-debt ratchet (`tasks/coverage-check.ts`), which never

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -439,40 +439,45 @@ Notes:
   gray and shows `$???` for that source. The values from responding sources
   remain as a lower bound. A GitHub classic-plan setup still falls back to
   minutes when Blacksmith is not configured.
-- **`benchmarks`** trends a **scale-invariant index** of benchmark performance on the
-  `benchmarks.yml` runs on main over ~45 days. The job runs `deno bench --json` over
-  the runner, cache, and deep-equal benchmarks and uploads the report as a
-  `bench-results` artifact (90-day retention; there is no committed history). Each
-  run's index is the previous run's index times the **geometric mean of the
-  per-benchmark changes** between the two runs, so every benchmark weighs the same
-  regardless of size and **only a broad, across-the-board move shifts it** — a
-  regression in one benchmark, however slow, barely registers (that is the
-  drill-down's job; a summed total, by contrast, is dominated by the few slowest
-  benchmarks). The headline is the **trend** itself — the fractional change of the
-  index across the recent window — over a second line naming how many benchmarks the
-  latest run measured and, when a recent window is highlighted, how many days that
-  window spans. **Red** — the signal this tile is mainly here to
-  raise — is the **most recent run failing outright, or finishing green on CI with no
-  readable benchmark data** (it ran and made nothing usable, so it is as good as
-  failed); red reads the workflow-run list and the latest run's cached result, so it
-  fires even when the artifacts cannot be read. **Orange** is the index **trending
-  up** (past 5%). The trend reads a recent window only — the runs in the last
-  `BENCH_TREND_MAX_AGE_DAYS` or the newest `BENCH_TREND_MIN_RUNS`, whichever is more,
-  the same "larger of the two" idea as CI duration's median window — while the
-  sparkline still spans the full ~45 days with that window drawn brighter. Green
-  while flat or falling. `deno bench` samples
-  each benchmark to a fixed time budget, so the run's wall clock barely moves with
-  performance; the per-op times do, which is why the tile trends those rather than
-  the run's duration. Because the index comes from the artifacts, the tile grays when
-  no in-window run has readable data and the latest run is neither failed nor empty:
-  **collecting…** while a fetch is still in progress — shown from the moment a
-  collection starts, before the run list is even fetched, so a freshly loaded
-  dashboard is never blank — and **benchmark data unavailable** once a fetch has
-  finished and found none. Chaining the per-run ratios makes **adding or removing a benchmark
-  a non-event**: it is in only one run of the adjacent pair at that step, so it drops
-  out of the geometric mean and the index does not step — no reset needed. A large
-  rise reads as a fold multiplier (`▲44×`) once it passes 4x, rather
-  than a long percentage. The trend is a robust
+- **`benchmarks`** trends one **scale-invariant index per CPU** on the
+  `benchmarks.yml` runs on main over ~45 days. The job runs `deno bench --json`
+  over the runner, cache, and deep-equal benchmarks. It uploads the report as a
+  `bench-results` artifact with 90-day retention. There is no committed
+  history. Each CPU's index compares a run with the previous run on the same
+  CPU. It multiplies the previous index by the **geometric mean of the
+  per-benchmark changes**. Every benchmark weighs the same regardless of size.
+  **Only a broad, across-the-board move shifts an index.** A regression in one
+  benchmark barely registers, however slow that benchmark is. The drill-down
+  covers individual benchmarks. A summed total would instead be dominated by
+  the few slowest benchmarks. Each CPU has its own coloured line. The headline
+  shows the largest established CPU trend. A second line names how many
+  benchmarks the latest run measured and the highlighted window when applicable.
+  **Red** marks the **most recent run failing outright, or finishing green on CI
+  with no readable benchmark data**. A successful run with no usable output is
+  treated as failed. This
+  state reads the workflow-run list and the latest run's cached result. It
+  therefore fires when the artifacts cannot be read. **Orange** means at least
+  one CPU index is **trending up** past 5%. Each CPU trend uses the runs in the
+  last `BENCH_TREND_MAX_AGE_DAYS` or the newest `BENCH_TREND_MIN_RUNS`,
+  whichever set is larger. This matches the window rule used for the CI
+  duration median. The corresponding line still spans the full ~45 days. Its
+  trend window is brighter. Green means every established CPU is flat or
+  falling. `deno bench` samples each benchmark to a fixed time budget. The
+  run's wall clock therefore barely moves with performance. The per-operation
+  times do move, so the tile trends those values instead. Because the index
+  comes from artifacts, the tile turns gray when no in-window run has readable
+  data and the latest run is neither failed nor empty. It shows
+  **collecting…** while a fetch is in progress. This state appears before the
+  run list is fetched, so a newly loaded dashboard is never blank. It shows
+  **benchmark data unavailable** after an empty fetch finishes. Adding or
+  removing a benchmark does not move an index. The benchmark is absent from
+  one side of that adjacent comparison, so it drops out of the geometric mean.
+  A CPU change starts another line instead of connecting measurements from
+  unlike machines. A gap longer than one fifth of the chart width breaks a
+  CPU's line. Any sample isolated by those breaks appears as a point. A CPU
+  with one sample also appears as a point until another sample can form a line.
+  A large rise reads as a fold multiplier (`▲44×`) once it passes 4x. This
+  avoids a long percentage. The trend is a robust
   **daily-median Theil–Sen** fit: the sub-daily samples are first collapsed to one
   median per calendar day, then the trend is the median of the pairwise log-slopes
   between days, projected across the day span. The daily median absorbs within-day
@@ -484,16 +489,21 @@ Notes:
   The window is capped by the 90-day artifact retention, so it shows at most ~45
   days and only as far back as the job has run.
   - The tile drills through to the per-benchmark history behind `/bench`, which the
-    tile's collection keeps warm in the background. That collection lists benchmark
-    runs on main, samples one run per shortest-view bucket, downloads that artifact,
-    unzips it in-process, and reads each benchmark's timings. Each completed
-    artifact check is persisted before it is counted as finished, so only new runs
-    and new attempts are fetched after the first fill or a server restart. (The
-    shortest-view buckets are about 16 minutes wide, so the first cache fill can
-    download correspondingly more artifacts.)
-  - Its **runtime benchmarks** view at `/bench?view=runtime` shows a sparkline
-    for **every** benchmark on a shared calendar-time axis, so a late-starting
-    benchmark sits at the right and a stale one visibly ends short of it.
+    tile's collection keeps warm in the background. The collection lists
+    benchmark runs on main. It samples one run per shortest-view bucket,
+    downloads that artifact, and unzips it in the process. It then reads each
+    benchmark's timings and CPU. A report without a CPU identity is cached as
+    unusable instead of being pooled with measurements from unknown machines.
+    Cache entries written before CPU identity was stored are fetched again.
+    Each completed artifact check is persisted before it is counted as
+    finished. Only new runs and attempts are fetched after the first fill or a
+    server restart. The shortest-view buckets are about 16 minutes wide. The
+    first cache fill can therefore download more artifacts.
+  - Its **runtime benchmarks** view at `/bench?view=runtime` shows one coloured
+    line per CPU for **every** benchmark. The lines share a calendar-time axis.
+    A late-starting CPU line sits at the right. A single sample appears as a
+    point. A stale line visibly ends short of the current date. The dashboard
+    tile leaves out the CPU legend to keep the compact chart readable.
     Selectors choose which measurement to plot (a percentile ladder — **p0** =
     min, **p50** = the mean, **p75**, **p99**, **p99.5**, **p99.9**, **p100** =
     max) and whether to group by source **file** or sort by latest **duration**
@@ -503,11 +513,20 @@ Notes:
     the collected samples per day. Keyboard arrows adjust the window without
     moving focus. Enter applies the range immediately. Another selector carries
     the range into its own navigation, and leaving the controls applies it
-    directly. Each row is coloured by its own trend, and the page reads from the
+    directly. Each row shows one latest value and trend from the CPU with the
+    most benchmark samples in the selected window. A tie uses the CPU with the
+    newest sample, then its name for a stable result. That representative CPU
+    also sets the row colour and sorting. A numbered CPU key identifies the
+    representative series and links to its definition. The same key and a
+    colour swatch appear in one CPU legend after all benchmark graphs instead
+    of repeating processor names in every row. It includes the full processor
+    identity reported by the artifacts, the number of benchmark graphs and runs
+    shown for that CPU, and the observed date range. The page reads from the
     server cache so it re-renders instantly. Its progress panel stays visible as
-    Idle between collections. During collection it shows cached, queued, requested,
-    responded, outstanding, and failed artifact checks. Changing the range leaves
-    the server collection running and joins it from the new page.
+    Idle between
+    collections. During collection it shows cached, queued, requested,
+    responded, outstanding, and failed artifact checks. Changing the range
+    leaves the server collection running and joins it from the new page.
   - The **CI duration history** view at `/bench?view=ci` selects either labs
     `deno.yml` or loom `test-fast.yml`. It charts every job's start-to-finish
     duration on one calendar-time axis. An overall row measures the workflow

--- a/packages/dashboard/benchmark-history-cache.test.ts
+++ b/packages/dashboard/benchmark-history-cache.test.ts
@@ -28,18 +28,21 @@ Deno.test("runtime benchmark history persists usable and empty artifacts", async
       runId: 101,
       runAttempt: 1,
       at: now - DAY_MS,
+      cpu: "AMD EPYC 7763 64-Core Processor",
       metrics: new Map([["packages/a.bench.ts > works", stats(1_000)]]),
     });
     writer.set({
       runId: 101,
       runAttempt: 2,
       at: now - DAY_MS,
+      cpu: "INTEL(R) XEON(R) PLATINUM 8573C",
       metrics: new Map([["packages/a.bench.ts > works", stats(1_500)]]),
     });
     writer.set({
       runId: 102,
       runAttempt: 1,
       at: now,
+      cpu: "AMD EPYC 9V74 80-Core Processor",
       metrics: new Map(),
     });
     writer.markRefreshed(now - 1_000, writer.list());
@@ -53,7 +56,9 @@ Deno.test("runtime benchmark history persists usable and empty artifacts", async
       1_500,
     );
     assertEquals(reader.get(101)?.runAttempt, 2);
+    assertEquals(reader.get(101)?.cpu, "INTEL(R) XEON(R) PLATINUM 8573C");
     assertEquals(reader.get(102)?.metrics.size, 0);
+    assertEquals(reader.get(102)?.cpu, "AMD EPYC 9V74 80-Core Processor");
     assertEquals(reader.refreshedAt, now - 1_000);
     assertEquals(
       reader.refreshedRuns()?.map((run) => [run.runId, run.runAttempt]),
@@ -65,6 +70,45 @@ Deno.test("runtime benchmark history persists usable and empty artifacts", async
         () => false,
       ),
       false,
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("runtime benchmark history replaces CPU-less data", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
+  const file = `${directory}/history.json`;
+  const now = Date.now();
+  try {
+    const legacy = new BenchmarkHistoryStore(file);
+    await legacy.load();
+    legacy.set({
+      runId: 125,
+      runAttempt: 1,
+      at: now,
+      metrics: new Map([["packages/a.bench.ts > works", stats(1_000)]]),
+    });
+    await legacy.save(now);
+
+    const migrated = new BenchmarkHistoryStore(file);
+    await migrated.load();
+    assertEquals(migrated.get(125)?.cpu, undefined);
+    migrated.set({
+      runId: 125,
+      runAttempt: 1,
+      at: now,
+      cpu: "AMD EPYC 7763 64-Core Processor",
+      metrics: new Map([["packages/a.bench.ts > works", stats(2_000)]]),
+    });
+    await migrated.save(now);
+
+    const reader = new BenchmarkHistoryStore(file);
+    await reader.load();
+    assertEquals(reader.get(125)?.cpu, "AMD EPYC 7763 64-Core Processor");
+    assertEquals(
+      reader.get(125)?.metrics.get("packages/a.bench.ts > works")?.p99,
+      2_000,
     );
   } finally {
     await Deno.remove(directory, { recursive: true });

--- a/packages/dashboard/benchmark-history-cache.ts
+++ b/packages/dashboard/benchmark-history-cache.ts
@@ -22,6 +22,8 @@ export interface CachedBenchmarkRun {
   runId: number;
   runAttempt: number;
   at: number;
+  // Entries written before processor-specific charts are fetched again.
+  cpu?: string;
   metrics: Map<string, BenchmarkStats>;
 }
 
@@ -29,6 +31,7 @@ interface StoredBenchmarkRun {
   runId: number;
   runAttempt: number;
   at: number;
+  cpu?: string;
   metrics: Record<string, BenchmarkStats>;
 }
 
@@ -85,7 +88,10 @@ const isStoredRun = (value: unknown): value is StoredBenchmarkRun => {
   const run = value as StoredBenchmarkRun;
   return Number.isInteger(run.runId) && run.runId > 0 &&
     Number.isInteger(run.runAttempt) && run.runAttempt > 0 &&
-    Number.isFinite(run.at) && typeof run.metrics === "object" &&
+    Number.isFinite(run.at) &&
+    (run.cpu === undefined ||
+      (typeof run.cpu === "string" && run.cpu.trim().length > 0)) &&
+    typeof run.metrics === "object" &&
     run.metrics !== null && !Array.isArray(run.metrics) &&
     Object.values(run.metrics).every(isStats);
 };
@@ -195,6 +201,7 @@ export class BenchmarkHistoryStore {
         runId: run.runId,
         runAttempt: run.runAttempt,
         at: run.at,
+        cpu: run.cpu,
         metrics: new Map(Object.entries(run.metrics)),
       });
     }
@@ -243,7 +250,10 @@ export class BenchmarkHistoryStore {
   #merge(contents: BenchmarkHistoryContents): void {
     for (const run of contents.runs) {
       const key = runKey(run.runId, run.runAttempt);
-      if (!this.#runs.has(key)) this.#runs.set(key, run);
+      const current = this.#runs.get(key);
+      if (!current || (current.cpu === undefined && run.cpu !== undefined)) {
+        this.#runs.set(key, run);
+      }
     }
     this.#invalidatedAt = Math.max(
       this.#invalidatedAt,
@@ -401,11 +411,14 @@ export class BenchmarkHistoryStore {
   set(run: CachedBenchmarkRun): CachedBenchmarkRun {
     const key = runKey(run.runId, run.runAttempt);
     const current = this.#runs.get(key);
-    if (current) return current;
+    if (current && (current.cpu !== undefined || run.cpu === undefined)) {
+      return current;
+    }
     const stored = {
       runId: run.runId,
       runAttempt: run.runAttempt,
       at: run.at,
+      cpu: run.cpu,
       metrics: new Map(run.metrics),
     };
     this.#runs.set(key, stored);
@@ -457,6 +470,7 @@ export class BenchmarkHistoryStore {
             runId: run.runId,
             runAttempt: run.runAttempt,
             at: run.at,
+            cpu: run.cpu,
             metrics: Object.fromEntries(run.metrics),
           })),
         };

--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -261,6 +261,10 @@ Deno.test("a slice covering the whole series leaves the line in its own color", 
   );
   assertEquals([...whole.matchAll(/<polyline/g)].length, 1, "base only, no tint over it");
   assert(!whole.includes(lighten("#10a37f")), "the line keeps its own color");
+  assert(
+    whole.includes('<stop offset="0" stop-color="#10a37f"'),
+    "the line uses its own color from the left edge",
+  );
   // Same for a count past the end of the series.
   const over = multiSparkline([{ vals: [1, 2, 3, 4], color: "#10a37f" }], { highlight: { count: 9 } });
   assertEquals([...over.matchAll(/<polyline/g)].length, 1);
@@ -279,6 +283,111 @@ Deno.test("multiSparkline: every base is drawn before any tint", () => {
   ], { highlight: { count: 2 } });
   const strokes = [...svg.matchAll(/<polyline[^>]*stroke="([^"]*)"/g)].map((m) => m[1]);
   assertEquals(strokes, ["#10a37f", "#d97757", lighten("#10a37f"), lighten("#d97757")]);
+});
+
+Deno.test("multiSparkline: shared axes and per-line highlights", () => {
+  const svg = multiSparkline([
+    {
+      vals: [1, 2, 3],
+      color: "#10a37f",
+      xs: [0, 0.2, 0.4],
+      highlightCount: 2,
+    },
+    {
+      vals: [4, 5, 6],
+      color: "#d97757",
+      xs: [0.6, 0.8, 1],
+      highlightCount: 0,
+    },
+  ], { fadeFrom: "#111111" });
+  const lines = [
+    ...svg.matchAll(
+      /<polyline points="([^"]*)"[^>]*stroke="([^"]*)"/g,
+    ),
+  ].map((match) => ({
+    points: match[1].split(" "),
+    stroke: match[2],
+  }));
+  assertEquals(lines.length, 3);
+  assertEquals(
+    lines[0].points.map((point) => Number(point.split(",")[0])),
+    [0, 44, 88],
+  );
+  assertEquals(
+    lines[1].points.map((point) => Number(point.split(",")[0])),
+    [132, 176, 220],
+  );
+  assertEquals(lines[2].stroke, lighten("#10a37f"));
+  assertEquals(
+    lines[2].points.map((point) => Number(point.split(",")[0])),
+    [44, 88],
+  );
+  assert(!svg.includes("<mask"));
+  assert(svg.includes('<stop offset="0.2" stop-color="#10a37f"'));
+  assert(svg.includes('<stop offset="0.5" stop-color="#d97757"'));
+});
+
+Deno.test("multiSparkline: one-point markers are explicit", () => {
+  const svg = multiSparkline([
+    {
+      vals: [5],
+      color: "#d97757",
+      xs: [0.75],
+      showSinglePoint: true,
+    },
+  ]);
+  assert(
+    svg.includes(
+      '<circle cx="165.0" cy="31.0" r="1.0" fill="#d97757"/>',
+    ),
+  );
+  assertEquals([...svg.matchAll(/<polyline/g)].length, 0);
+});
+
+Deno.test("multiSparkline: large horizontal gaps split paths without losing points", () => {
+  const svg = multiSparkline([{
+    vals: [1, 2, 3, 4, 5],
+    color: "#d97757",
+    xs: [0, 0.2, 0.41, 0.5, 0.8],
+    highlightCount: 4,
+    maxXGap: 0.2,
+    showSinglePoint: true,
+  }]);
+  const paths = [
+    ...svg.matchAll(/<polyline points="([^"]+)"[^>]*stroke="([^"]+)"/g),
+  ].map((match) => ({
+    points: match[1].split(" "),
+    stroke: match[2],
+  }));
+  assertEquals(paths, [
+    {
+      points: ["0.0,31.0", "44.0,24.0"],
+      stroke: "#d97757",
+    },
+    {
+      points: ["90.2,17.0", "110.0,10.0"],
+      stroke: "#d97757",
+    },
+    {
+      points: ["90.2,17.0", "110.0,10.0"],
+      stroke: lighten("#d97757"),
+    },
+  ]);
+  assert(
+    svg.includes(
+      '<circle cx="176.0" cy="3.0" r="1.0" fill="#d97757"/>',
+    ),
+  );
+
+  const offsetBoundary = multiSparkline([{
+    vals: [1, 2],
+    color: "#d97757",
+    xs: [0.6, 0.8],
+    maxXGap: 0.2,
+    showSinglePoint: true,
+  }]);
+  assertEquals([...offsetBoundary.matchAll(/<polyline/g)].length, 1);
+  assertEquals([...offsetBoundary.matchAll(/<circle/g)].length, 0);
 });
 
 Deno.test("sparkline: xs place points on a shared axis", () => {

--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -375,7 +375,9 @@ Deno.test("multiSparkline: large horizontal gaps split paths without losing poin
   ]);
   assert(
     svg.includes(
-      '<circle cx="176.0" cy="3.0" r="1.0" fill="#d97757"/>',
+      `<circle cx="176.0" cy="3.0" r="1.0" fill="${
+        lighten("#d97757")
+      }"/>`,
     ),
   );
 
@@ -388,6 +390,22 @@ Deno.test("multiSparkline: large horizontal gaps split paths without losing poin
   }]);
   assertEquals([...offsetBoundary.matchAll(/<polyline/g)].length, 1);
   assertEquals([...offsetBoundary.matchAll(/<circle/g)].length, 0);
+});
+
+Deno.test("multiSparkline: isolated markers use the tint only inside the highlighted tail", () => {
+  const color = "#d97757";
+  const svg = multiSparkline([{
+    vals: [1, 2, 3, 4, 5, 6],
+    color,
+    xs: [0, 0.25, 0.4, 0.5, 0.7, 0.95],
+    highlightCount: 2,
+    maxXGap: 0.2,
+    showSinglePoint: true,
+  }]);
+  const fills = [
+    ...svg.matchAll(/<circle[^>]*fill="([^"]+)"/g),
+  ].map((match) => match[1]);
+  assertEquals(fills, [color, lighten(color)]);
 });
 
 Deno.test("sparkline: xs place points on a shared axis", () => {

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -324,13 +324,13 @@ export function sparkline(
 // color, reaching full color by the midpoint (or by the start of the highlight,
 // if that comes sooner) — like the ci-duration sparkline. A series' `xs`
 // places its points on a shared horizontal axis. Its `highlightCount` redraws
-// its trailing points in a lighter tint. `opts.highlight` supplies the count
-// for series that do not set one. `maxXGap` breaks a path when adjacent
-// horizontal positions are farther apart than that fraction of the chart.
-// `showSinglePoint` draws explicit markers for a one-sample series and for
-// points isolated by those breaks. All overlays are HTML or gradients, so
-// preserveAspectRatio="none" cannot distort them. The span it covers is drawn
-// separately by a tile's `duration` slot.
+// its trailing points, including explicit markers, in a lighter tint.
+// `opts.highlight` supplies the count for series that do not set one. `maxXGap`
+// breaks a path when adjacent horizontal positions are farther apart than that
+// fraction of the chart. `showSinglePoint` draws explicit markers for a
+// one-sample series and for points isolated by those breaks. All overlays are
+// HTML or gradients, so preserveAspectRatio="none" cannot distort them. The
+// span it covers is drawn separately by a tile's `duration` slot.
 export function multiSparkline(
   series: {
     vals: number[];
@@ -385,7 +385,14 @@ export function multiSparkline(
     }
     return `url(#${id})`;
   };
-  type SparkPoint = { x: number; px: number; py: number };
+  const highlightStartIndex = (
+    line: (typeof series)[number],
+    pointCount: number,
+  ): number | undefined => {
+    const count = Math.min(highlightCount(line), pointCount);
+    return count >= 2 && count < pointCount ? pointCount - count : undefined;
+  };
+  type SparkPoint = { index: number; x: number; px: number; py: number };
   const splitPoints = (
     points: SparkPoint[],
     maxXGap: number | undefined,
@@ -428,7 +435,7 @@ export function multiSparkline(
       const x = s.xs?.length === s.vals.length
         ? s.xs[i]
         : i / (s.vals.length - 1);
-      return { x, px: x * w, py: yv(v) };
+      return { index: i, x, px: x * w, py: yv(v) };
     });
     return {
       s,
@@ -447,26 +454,33 @@ export function multiSparkline(
   // The trailing slice, redrawn in a lighter tint of each line's own color. A
   // slice covering the whole line marks nothing off, so it is left alone.
   const tints = drawn.map(({ s, points }) => {
-    const n = Math.min(highlightCount(s), points.length);
-    if (n < 2 || n >= points.length) return "";
-    const start = points.length - n;
+    const start = highlightStartIndex(s, points.length);
+    if (start === undefined) return "";
     return splitPoints(points.slice(start), s.maxXGap)
       .filter((segment) => segment.length >= 2)
       .map((segment) => poly(segment.map(svgPoint), lighten(s.color)))
       .join("");
   }).join("");
-  const isolatedMarkers = drawn.map(({ s, segments }) => {
+  const isolatedMarkers = drawn.map(({ s, points, segments }) => {
     if (!s.showSinglePoint) return "";
+    const highlightStart = highlightStartIndex(s, points.length);
     return segments
       .filter((segment) => segment.length === 1)
-      .map((segment) => marker(segment[0], s.color))
+      .map((segment) => {
+        const point = segment[0];
+        const color = highlightStart !== undefined &&
+            point.index >= highlightStart
+          ? lighten(s.color)
+          : s.color;
+        return marker(point, color);
+      })
       .join("");
   }).join("");
   const singleSeriesMarkers = drawable
     .filter((s) => s.vals.length === 1)
     .map((s) => {
       const x = s.xs?.length === 1 ? s.xs[0] : 0.5;
-      return marker({ x, px: x * w, py: yv(s.vals[0]) }, s.color);
+      return marker({ index: 0, x, px: x * w, py: yv(s.vals[0]) }, s.color);
     })
     .join("");
   const lines = bases + tints + isolatedMarkers + singleSeriesMarkers;

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -322,20 +322,33 @@ export function sparkline(
 // right-hand gutter at the line's end height, in the line color. With
 // `opts.fadeFrom`, each line fades from that color on the far left up to its own
 // color, reaching full color by the midpoint (or by the start of the highlight,
-// if that comes sooner) — like the ci-duration sparkline. `opts.highlight`
-// redraws the trailing `count` points of every line in a lighter tint of that
-// line's own color, picking out the slice that feeds the headline while keeping
-// each line identifiable. All overlays are HTML/gradient, so the
-// preserveAspectRatio="none" stretch can't distort them. Returns "" until there
-// are at least two points to plot. The span it covers is drawn separately by a
-// tile's `duration` slot.
+// if that comes sooner) — like the ci-duration sparkline. A series' `xs`
+// places its points on a shared horizontal axis. Its `highlightCount` redraws
+// its trailing points in a lighter tint. `opts.highlight` supplies the count
+// for series that do not set one. `maxXGap` breaks a path when adjacent
+// horizontal positions are farther apart than that fraction of the chart.
+// `showSinglePoint` draws explicit markers for a one-sample series and for
+// points isolated by those breaks. All overlays are HTML or gradients, so
+// preserveAspectRatio="none" cannot distort them. The span it covers is drawn
+// separately by a tile's `duration` slot.
 export function multiSparkline(
-  series: { vals: number[]; color: string; label?: string }[],
+  series: {
+    vals: number[];
+    color: string;
+    label?: string;
+    xs?: number[];
+    highlightCount?: number;
+    maxXGap?: number;
+    showSinglePoint?: boolean;
+  }[],
   opts: { fadeFrom?: string; highlight?: { count: number } } = {},
 ): string {
-  const all = series.flatMap((s) => s.vals);
-  const points = Math.max(0, ...series.map((s) => s.vals.length));
-  if (points < 2 || all.length === 0) return "";
+  const drawable = series.filter((line) =>
+    line.vals.length >= 2 ||
+    (line.showSinglePoint === true && line.vals.length === 1)
+  );
+  const all = drawable.flatMap((line) => line.vals);
+  if (!all.length) return "";
   const w = 220, h = 34, min = Math.min(...all), max = Math.max(...all), rng = (max - min) || 1;
   const yv = (v: number) => h - 3 - ((v - min) / rng) * (h - 6);
 
@@ -344,14 +357,24 @@ export function multiSparkline(
   // that comes sooner (so the base is solid before the handoff). userSpaceOnUse
   // keeps the transition at the same screen x for every line and avoids the
   // zero-bbox quirk when a line is flat.
-  const edge = opts.highlight && points > 1
-    ? Math.max(0, Math.min(1, (points - opts.highlight.count) / (points - 1)))
-    : 1;
-  const tf = Math.min(0.5, edge);
-  const off = String(+tf.toFixed(3));
   const defs: string[] = [];
-  const strokeFor = (color: string): string => {
+  const highlightCount = (
+    line: (typeof series)[number],
+  ): number => line.highlightCount ?? opts.highlight?.count ?? 0;
+  const highlightEdge = (line: (typeof series)[number]): number => {
+    const count = highlightCount(line);
+    if (count < 2) return 1;
+    if (count >= line.vals.length) return 0;
+    const index = line.vals.length - count;
+    return line.xs?.length === line.vals.length
+      ? line.xs[index]
+      : index / (line.vals.length - 1);
+  };
+  const strokeFor = (line: (typeof series)[number]): string => {
+    const color = line.color;
     if (!opts.fadeFrom) return color;
+    const tf = Math.min(0.5, Math.max(0, highlightEdge(line)));
+    const off = String(+tf.toFixed(3));
     const id = `mspk-${opts.fadeFrom.replace(/[^0-9a-fA-F]/g, "")}-${color.replace(/[^0-9a-fA-F]/g, "")}-${Math.round(tf * 100)}`;
     if (!defs.some((d) => d.includes(`"${id}"`))) {
       defs.push(
@@ -362,25 +385,94 @@ export function multiSparkline(
     }
     return `url(#${id})`;
   };
-  const hl = opts.highlight;
-  const poly = (pts: string[], stroke: string) => `<polyline points="${pts.join(" ")}" fill="none" stroke="${stroke}" stroke-width="2"/>`;
-  const drawn = series.filter((s) => s.vals.length >= 2).map((s) => ({
-    s,
-    pts: s.vals.map((v, i) => `${(i / (s.vals.length - 1) * w).toFixed(1)},${yv(v).toFixed(1)}`),
-  }));
+  type SparkPoint = { x: number; px: number; py: number };
+  const splitPoints = (
+    points: SparkPoint[],
+    maxXGap: number | undefined,
+  ): SparkPoint[][] => {
+    const segments: SparkPoint[][] = [];
+    for (const point of points) {
+      const current = segments[segments.length - 1];
+      const previous = current?.[current.length - 1];
+      const tolerance = maxXGap === undefined || previous === undefined
+        ? 0
+        : Number.EPSILON * 4 *
+          Math.max(
+            1,
+            Math.abs(point.x),
+            Math.abs(previous.x),
+            Math.abs(maxXGap),
+          );
+      if (
+        previous === undefined ||
+        (maxXGap !== undefined &&
+          Math.abs(point.x - previous.x) > maxXGap + tolerance)
+      ) {
+        segments.push([point]);
+      } else {
+        current.push(point);
+      }
+    }
+    return segments;
+  };
+  const svgPoint = (point: SparkPoint) =>
+    `${point.px.toFixed(1)},${point.py.toFixed(1)}`;
+  const poly = (pts: string[], stroke: string) =>
+    `<polyline points="${pts.join(" ")}" fill="none" stroke="${stroke}" stroke-width="2"/>`;
+  const marker = (point: SparkPoint, color: string) =>
+    `<circle cx="${point.px.toFixed(1)}" cy="${
+      point.py.toFixed(1)
+    }" r="1.0" fill="${escapeHtml(color)}"/>`;
+  const drawn = drawable.filter((s) => s.vals.length >= 2).map((s) => {
+    const points = s.vals.map((v, i) => {
+      const x = s.xs?.length === s.vals.length
+        ? s.xs[i]
+        : i / (s.vals.length - 1);
+      return { x, px: x * w, py: yv(v) };
+    });
+    return {
+      s,
+      points,
+      segments: splitPoints(points, s.maxXGap),
+    };
+  });
   // Every base first, then every tint, so a line drawn later cannot paint over an
   // earlier line's tint where the two cross inside the highlighted slice.
-  const bases = drawn.map(({ s, pts }) => poly(pts, strokeFor(s.color))).join("");
+  const bases = drawn.map(({ s, segments }) => {
+    const paths = segments.filter((segment) => segment.length >= 2);
+    if (!paths.length) return "";
+    const stroke = strokeFor(s);
+    return paths.map((path) => poly(path.map(svgPoint), stroke)).join("");
+  }).join("");
   // The trailing slice, redrawn in a lighter tint of each line's own color. A
   // slice covering the whole line marks nothing off, so it is left alone.
-  const tints = drawn.map(({ s, pts }) => {
-    const n = hl ? Math.min(hl.count, pts.length) : 0;
-    return n >= 2 && n < pts.length ? poly(pts.slice(pts.length - n), lighten(s.color)) : "";
+  const tints = drawn.map(({ s, points }) => {
+    const n = Math.min(highlightCount(s), points.length);
+    if (n < 2 || n >= points.length) return "";
+    const start = points.length - n;
+    return splitPoints(points.slice(start), s.maxXGap)
+      .filter((segment) => segment.length >= 2)
+      .map((segment) => poly(segment.map(svgPoint), lighten(s.color)))
+      .join("");
   }).join("");
-  const lines = bases + tints;
+  const isolatedMarkers = drawn.map(({ s, segments }) => {
+    if (!s.showSinglePoint) return "";
+    return segments
+      .filter((segment) => segment.length === 1)
+      .map((segment) => marker(segment[0], s.color))
+      .join("");
+  }).join("");
+  const singleSeriesMarkers = drawable
+    .filter((s) => s.vals.length === 1)
+    .map((s) => {
+      const x = s.xs?.length === 1 ? s.xs[0] : 0.5;
+      return marker({ x, px: x * w, py: yv(s.vals[0]) }, s.color);
+    })
+    .join("");
+  const lines = bases + tints + isolatedMarkers + singleSeriesMarkers;
   const defsBlock = defs.length ? `<defs>${defs.join("")}</defs>` : "";
 
-  const labeled = series.filter((s) => s.label !== undefined && s.vals.length >= 2);
+  const labeled = drawable.filter((s) => s.label !== undefined);
   if (labeled.length === 0) {
     return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="32" preserveAspectRatio="none" style="margin-top:9px">${defsBlock}${lines}</svg>`;
   }

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -21,6 +21,7 @@ import {
   formatNs,
   jsonFromZip,
   pointsForWindow,
+  representativeBenchmarkCpu,
   sampleBenchmarkRuns,
   trendPct,
   trendStatus,
@@ -281,14 +282,32 @@ const bench = (
   results: [ok ? { ok } : {}],
 });
 
+const TEST_CPU = "AMD EPYC 7763 64-Core Processor";
+
+function contrastRatio(foreground: string, background: string): number {
+  const luminance = (color: string): number => {
+    const channels = [1, 3, 5].map((offset) =>
+      Number.parseInt(color.slice(offset, offset + 2), 16) / 255
+    ).map((channel) =>
+      channel <= 0.04045
+        ? channel / 12.92
+        : ((channel + 0.055) / 1.055) ** 2.4
+    );
+    return 0.2126 * channels[0] + 0.7152 * channels[1] +
+      0.0722 * channels[2];
+  };
+  const foregroundLuminance = luminance(foreground);
+  const backgroundLuminance = luminance(background);
+  return (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05);
+}
+
 // The deno bench report. `noise` stands in for a benchmark's own console output
 // landing on stdout ahead of the JSON.
-const report = (benches: unknown[], noise = "") =>
-  noise + JSON.stringify({ version: 1, runtime: "deno", benches });
+const report = (benches: unknown[], noise = "", cpu = TEST_CPU) =>
+  noise + JSON.stringify({ version: 1, runtime: "deno", cpu, benches });
 
-// The tile sums each benchmark's average per-op time, so most tile tests only need
-// to control that sum. A bench-results artifact carrying one benchmark whose avg is
-// `avgNs` gives a run total of exactly `avgNs`.
+// Most tile tests use one benchmark whose average per-op time is `avgNs`.
 const totalZip = (avgNs: number): Promise<Uint8Array<ArrayBuffer>> =>
   benchZip(
     report([bench("packages/a/x.bench.ts", null, "b", { avg: avgNs } as Timings)]),
@@ -658,7 +677,7 @@ Deno.test("/bench?view=runtime serves the runtime history page", async () => {
   );
   const fragment = await fragmentResponse.text();
   assert(fragment.startsWith('<div id="range-content">'));
-  assertStringIncludes(fragment, "selected 7-day trend");
+  assertStringIncludes(fragment, "selected 7-day window");
   assert(!fragment.includes("<!doctype html>"));
   assert(!fragment.includes('<form class="controls"'));
 });
@@ -981,7 +1000,10 @@ Deno.test("benchmark: the trend reads the recent window only, not the whole hist
     assertEquals(v.duration, 39 * DAY); // the sparkline still spans the full history
     // The count line names the highlighted window's span: the newest 20 daily runs
     // (the run floor beats the 14-day age here) reach back 19 days.
-    assertStringIncludes(v.extra ?? "", "1 benchmark · last 19 days");
+    assertStringIncludes(
+      v.extra ?? "",
+      ">1 benchmark · last 19 days</div>",
+    );
   });
 });
 
@@ -1006,8 +1028,20 @@ Deno.test("benchmark: the tile paints its headline from cache before the backfil
   const seed = new BenchmarkHistoryStore();
   await seed.load();
   const cachedRuns = [
-    { runId: 84_001, runAttempt: 1, at: BASE - 2 * DAY, metrics: new Map([[key, stats]]) },
-    { runId: 84_002, runAttempt: 1, at: BASE - DAY, metrics: new Map([[key, stats]]) },
+    {
+      runId: 84_001,
+      runAttempt: 1,
+      at: BASE - 2 * DAY,
+      cpu: TEST_CPU,
+      metrics: new Map([[key, stats]]),
+    },
+    {
+      runId: 84_002,
+      runAttempt: 1,
+      at: BASE - DAY,
+      cpu: TEST_CPU,
+      metrics: new Map([[key, stats]]),
+    },
   ];
   for (const cachedRun of cachedRuns) seed.set(cachedRun);
   seed.markRefreshed(BASE - DAY, cachedRuns);
@@ -1486,14 +1520,20 @@ Deno.test("benchmark: the tile sums the totals, and one artifact per bucket is k
     // No "version" key here: the report is parsed whole when there is no console
     // output to skip past.
     zips[id * 10] = await benchZip(
-      JSON.stringify({ benches: [bench(key, null, "tick", timings(1_000))] }),
+      JSON.stringify({
+        cpu: TEST_CPU,
+        benches: [bench(key, null, "tick", timings(1_000))],
+      }),
     );
   }
   // The stale twin, listed before its window's winner so the newer one displaces it.
   runs.push(ghRun(599, at(11) - COLLECTION_BUCKET / 2));
   artifacts[599] = [{ id: 5_990, name: "bench-results", expired: false }];
   zips[5_990] = await benchZip(
-    JSON.stringify({ benches: [bench(key, null, "tick", timings(9_999_999))] }),
+    JSON.stringify({
+      cpu: TEST_CPU,
+      benches: [bench(key, null, "tick", timings(9_999_999))],
+    }),
   );
 
   await withApi({
@@ -1659,7 +1699,7 @@ async function fillVaried(): Promise<Api> {
 // Pull the rendered rows out of the drill-down html.
 function rows(html: string) {
   return [...html.matchAll(
-    /<div class="brow (\w+)">[\s\S]*?<span class="bname">([^<]*)<\/span><span class="bval">([^<]*)<span class="btrend">([^<]*)<\/span>/g,
+    /<div class="brow (\w+)">[\s\S]*?<span class="bname">([^<]*)<\/span><span class="bval"[^>]*><a class="cpu-id" [^>]*>CPU \d+<\/a>([^<]*)<span class="btrend">([^<]*)<\/span>/g,
   )].map((m) => ({ status: m[1], name: m[2], value: m[3], trend: m[4] }));
 }
 
@@ -1680,9 +1720,408 @@ Deno.test("benchmark: the tile indexes every benchmark equally; the drill-down k
     assertEquals(v.duration, 11 * DAY);
     assertStringIncludes(v.value ?? "", "▲"); // the rising trend is the headline
     assertStringIncludes(v.extra ?? "", "6 benchmarks"); // the count line
+    assert(!v.extra?.includes('class="swatch"'));
+    assert(!v.extra?.includes(TEST_CPU));
     // The per-benchmark history the drill-down reads is still assembled.
     assert(!v.extra?.includes("hot/steep"));
   });
+});
+
+Deno.test("benchmark: CPU lines split across large gaps and use distinct colors", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-cpus-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const cpus = [
+    "AMD EPYC 7763 64-Core Processor",
+    "Apple M2 Processor",
+    "ARM Neoverse V1 Processor",
+    ...Array.from(
+      { length: 13 },
+      (_, index) => `A Test CPU ${String(index).padStart(2, "0")}`,
+    ),
+    // These hashes produce the same initial generated color.
+    "CPU-03098",
+    "CPU-06084",
+  ].sort((a, b) => a.localeCompare(b));
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  const samples: {
+    cpuIndex: number;
+    at: number;
+    avg?: number;
+    day?: number;
+  }[] = [];
+  for (let day = 0; day < 8; day++) {
+    samples.push({
+      cpuIndex: 0,
+      at: BASE - (8 - day) * DAY,
+      day,
+    });
+    if (day === 0) {
+      samples.push({
+        cpuIndex: 0,
+        at: BASE - 8 * DAY + COLLECTION_BUCKET,
+        day,
+      });
+    }
+    samples.push({
+      cpuIndex: 1,
+      at: BASE - (8 - day) * DAY + 2 * COLLECTION_BUCKET,
+      avg: 1_000_000 * Math.pow(2, day / 7),
+      day,
+    });
+  }
+  for (let cpuIndex = 2; cpuIndex < 9; cpuIndex++) {
+    const offset = (cpuIndex + 2) * COLLECTION_BUCKET;
+    samples.push({
+      cpuIndex,
+      at: BASE - (cpuIndex === 2 ? 20 : 2) * DAY + offset,
+    });
+    samples.push({ cpuIndex, at: BASE - DAY + offset });
+  }
+  for (let cpuIndex = 9; cpuIndex < cpus.length; cpuIndex++) {
+    samples.push({
+      cpuIndex,
+      at: BASE - (cpuIndex + 2) * COLLECTION_BUCKET,
+    });
+  }
+  for (
+    const [sample, { cpuIndex, at, avg: sampleAvg, day }] of samples.entries()
+  ) {
+    const id = 90_000 + sample;
+    const cpu = cpus[cpuIndex];
+    const avg = sampleAvg ?? (cpuIndex === 0 ? 1_000 : cpuIndex * 1_000_000);
+    const benches = [
+      bench("packages/a/cpu.bench.ts", null, "flat", { avg } as Timings),
+    ];
+    if (day !== undefined && cpuIndex < 2) {
+      const representativeAvg = cpuIndex === 0
+        ? 1_000 * Math.pow(1.5, day / 7)
+        : 500_000;
+      benches.push(
+        bench(
+          "packages/a/cpu.bench.ts",
+          null,
+          "representative",
+          { avg: representativeAvg } as Timings,
+        ),
+      );
+    }
+    runs.push(ghRun(id, at));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    zips[id * 10] = await benchZip(
+      report(benches, "", cpu),
+    );
+  }
+  runs.sort((a, b) =>
+    Date.parse(b.created_at) - Date.parse(a.created_at)
+  );
+  try {
+    await withApi({
+      pages: { 1: runs },
+      artifacts,
+      zips,
+    }, async () => {
+      const isolated = await import(
+        `./benchmark.ts?cpus=${crypto.randomUUID()}`
+      );
+      const tile = await isolated.benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertEquals(tile.status, "warn");
+      assertStringIncludes(tile.value ?? "", "▲");
+      assertStringIncludes(tile.extra ?? "", ">1 benchmark</div>");
+      assert(!/\bCPUs?\b/.test(tile.extra ?? ""));
+      assert(!(tile.extra ?? "").includes('class="swatch"'));
+      assert(!(tile.extra ?? "").includes("AMD EPYC 7763"));
+      assert(!(tile.extra ?? "").includes("Apple M2"));
+      assert(!(tile.extra ?? "").includes("ARM Neoverse V1"));
+      const tileLines = [
+        ...(tile.extra ?? "").matchAll(
+          /<polyline points="([^"]+)"[^>]*stroke="([^"]+)"/g,
+        ),
+      ].map((match) => ({
+        pointCount: match[1].split(" ").length,
+        stroke: match[2],
+      }));
+      assertEquals(
+        tileLines.map((line) => line.pointCount).sort((a, b) => a - b),
+        [2, 2, 2, 2, 2, 2, 8, 9],
+      );
+      assertEquals(new Set(tileLines.map((line) => line.stroke)).size, 8);
+      const tileMarkerColors = [
+        ...(tile.extra ?? "").matchAll(/<circle[^>]*fill="([^"]+)"/g),
+      ].map((match) => match[1]);
+      assertEquals(tileMarkerColors.length, 11);
+      assertEquals(new Set(tileMarkerColors).size, 10);
+      assert(!(tile.extra ?? "").includes("<mask"));
+
+      const html = isolated.benchPage("p99", "file", 45, BASE);
+      assertEquals(rows(html), [
+        {
+          status: "good",
+          name: "flat",
+          value: "1.0µs",
+          trend: "flat",
+        },
+        {
+          status: "bad",
+          name: "representative",
+          value: "1.5µs",
+          trend: "▲50%",
+        },
+      ]);
+      assertEquals([...html.matchAll(/<div class="brow /g)].length, 2);
+      const pageLines = [
+        ...html.matchAll(
+          /<polyline points="([^"]+)"[^>]*stroke="([^"]+)"/g,
+        ),
+      ].map((match) => ({
+        pointCount: match[1].split(" ").length,
+        stroke: match[2],
+      }));
+      assertEquals(
+        pageLines.map((line) => line.pointCount).sort((a, b) => a - b),
+        [2, 2, 2, 2, 2, 2, 8, 8, 8, 8],
+      );
+      assertEquals(new Set(pageLines.map((line) => line.stroke)).size, 10);
+      const pageMarkerColors = [
+        ...html.matchAll(/<circle[^>]*fill="([^"]+)"/g),
+      ].map((match) => match[1]);
+      assertEquals(pageMarkerColors.length, 11);
+      assertEquals(new Set(pageMarkerColors).size, 10);
+      assert(!html.includes("<mask"));
+      assertEquals([...html.matchAll(/class="bcpu"/g)].length, 0);
+      assertEquals([...html.matchAll(/class="cpu-key"/g)].length, 18);
+      const legendColors = [
+        ...html.matchAll(
+          /class="cpu-key"[^>]*><span class="swatch" style="background:([^"]+)"/g,
+        ),
+      ].map((match) => match[1]);
+      assertEquals(legendColors.length, 18);
+      assertEquals(new Set(legendColors).size, 18);
+      for (const color of legendColors) {
+        assert(
+          contrastRatio(color, "#16181d") >= 3,
+          `${color} does not contrast with the CPU legend background`,
+        );
+      }
+      const rowCpuIds = [
+        ...html.matchAll(/class="bval" data-cpu-id="([^"]+)"/g),
+      ].map((match) => match[1]);
+      const legendCpuIds = [
+        ...html.matchAll(/class="cpu-key"[^>]*data-cpu-id="([^"]+)"/g),
+      ].map((match) => match[1]);
+      const legendTargets = new Map(
+        [
+          ...html.matchAll(
+            /class="cpu-key" id="([^"]+)" data-cpu-id="([^"]+)"/g,
+          ),
+        ].map((match) => [match[1], match[2]]),
+      );
+      const rowCpuLinks = [
+        ...html.matchAll(
+          /<a class="cpu-id" href="#([^"]+)"[^>]*>(CPU \d+)<\/a>/g,
+        ),
+      ].map((match) => ({ target: match[1], cpuId: match[2] }));
+      assertEquals(rowCpuIds, ["CPU 1", "CPU 1"]);
+      assertEquals(new Set(legendCpuIds).size, 18);
+      assertEquals(legendTargets.size, 18);
+      assertEquals(rowCpuLinks, [
+        { target: "cpu-type-1", cpuId: "CPU 1" },
+        { target: "cpu-type-1", cpuId: "CPU 1" },
+      ]);
+      for (const link of rowCpuLinks) {
+        assertEquals(legendTargets.get(link.target), link.cpuId);
+      }
+      assertStringIncludes(html, 'data-sample-count="9"');
+      assertStringIncludes(
+        html,
+        'aria-label="Representative CPU A Test CPU 00: 1.0µs, flat; 9 samples in the selected window"',
+      );
+      assertStringIncludes(
+        html,
+        'aria-label="Representative CPU A Test CPU 00: 1.5µs, ▲50%; 9 samples in the selected window"',
+      );
+      assertStringIncludes(
+        html,
+        'aria-label="CPU 1: A Test CPU 00; jump to CPU types legend"',
+      );
+      assertStringIncludes(html, "AMD EPYC 7763 64-Core Processor");
+      assertStringIncludes(html, "CPU-03098");
+      assertStringIncludes(html, "CPU-06084");
+      assertStringIncludes(
+        html,
+        '<span class="cpu-detail">2 benchmarks · 8 runs · observed ',
+      );
+      assertStringIncludes(
+        html,
+        '<span class="cpu-detail">1 benchmark · 1 run · observed ',
+      );
+      assert(
+        html.indexOf('class="cpu-legend"') >
+          html.lastIndexOf('class="brow '),
+      );
+      assert(!html.includes("1.0ms"));
+      assert(!html.includes("17ms"));
+      // The other CPU's latest values and trends put these benchmarks in the
+      // opposite order.
+      assertEquals(
+        rows(isolated.benchPage("p99", "duration", 45, BASE)).map((row) =>
+          row.name
+        ),
+        [
+          "packages/a/cpu.bench.ts &gt; representative",
+          "packages/a/cpu.bench.ts &gt; flat",
+        ],
+      );
+      assertEquals(
+        rows(isolated.benchPage("p99", "trend", 45, BASE)).map((row) =>
+          row.name
+        ),
+        [
+          "packages/a/cpu.bench.ts &gt; representative",
+          "packages/a/cpu.bench.ts &gt; flat",
+        ],
+      );
+    });
+  } finally {
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: CPU-less reports are not pooled", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "benchmark-no-cpu-",
+  });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const runs = [
+    ghRun(90_102, BASE),
+    ghRun(90_101, BASE - DAY),
+  ];
+  const artifacts: Api["artifacts"] = {
+    90_101: [{ id: 901_010, name: "bench-results", expired: false }],
+    90_102: [{ id: 901_020, name: "bench-results", expired: false }],
+  };
+  const noCpuReport = (avg: number) =>
+    report(
+      [bench("packages/a/cpu.bench.ts", null, "flat", {
+        avg,
+      } as Timings)],
+      "",
+      "",
+    );
+  const zips: Api["zips"] = {
+    901_010: await benchZip(noCpuReport(1_000)),
+    901_020: await benchZip(noCpuReport(1_000_000)),
+  };
+  try {
+    await withApi(
+      { pages: { 1: runs }, artifacts, zips },
+      async (calls) => {
+        const isolated = await import(
+          `./benchmark.ts?no-cpu=${crypto.randomUUID()}`
+        );
+        const tile = await isolated.benchmark.collect(
+          ctx({ GH_TOKEN: "t" }),
+        );
+        assertEquals(tile.status, "bad");
+        assertEquals(tile.sub, "no benchmark data");
+        assert(!(tile.extra ?? "").includes("Unknown CPU"));
+        assertEquals(artifactCalls(calls).length, 4);
+
+        await isolated.benchmark.collect(ctx({ GH_TOKEN: "t" }));
+        assertEquals(artifactCalls(calls).length, 4);
+        assert(
+          !isolated.benchPage("p99", "file", 45, BASE).includes(
+            'class="cpu-key"',
+          ),
+        );
+      },
+    );
+  } finally {
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: CPU-less cached runs are fetched again", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "benchmark-cpu-migration-",
+  });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const key = "packages/a/cpu.bench.ts > flat";
+  const legacyStats = {
+    min: 1_000,
+    avg: 1_000,
+    max: 1_000,
+    p75: 1_000,
+    p99: 1_000,
+    p995: 1_000,
+    p999: 1_000,
+  };
+  const legacy = new BenchmarkHistoryStore();
+  await legacy.load();
+  const legacyRuns = [
+    {
+      runId: 91_001,
+      runAttempt: 1,
+      at: BASE - DAY,
+      metrics: new Map([[key, legacyStats]]),
+    },
+    {
+      runId: 91_002,
+      runAttempt: 1,
+      at: BASE,
+      metrics: new Map([[key, legacyStats]]),
+    },
+  ];
+  for (const run of legacyRuns) legacy.set(run);
+  legacy.markRefreshed(Date.now(), legacyRuns);
+  await legacy.save();
+
+  const runs = [
+    ghRun(91_002, BASE),
+    ghRun(91_001, BASE - DAY),
+  ];
+  const artifacts: Api["artifacts"] = {
+    91_001: [{ id: 910_010, name: "bench-results", expired: false }],
+    91_002: [{ id: 910_020, name: "bench-results", expired: false }],
+  };
+  const zips: Api["zips"] = {
+    910_010: await totalZip(1_000),
+    910_020: await totalZip(1_000),
+  };
+  try {
+    await withApi({ pages: { 1: runs }, artifacts, zips }, async (calls) => {
+      const isolated = await import(
+        `./benchmark.ts?cpu-migration=${crypto.randomUUID()}`
+      );
+      const tile = await isolated.benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertEquals(artifactCalls(calls).length, 4);
+      assert(!(tile.extra ?? "").includes(TEST_CPU));
+      assert(!(tile.extra ?? "").includes("Unknown CPU"));
+      const html = isolated.benchPage("p99", "file", 45, BASE);
+      assertStringIncludes(html, TEST_CPU);
+      assertEquals([...html.matchAll(/class="cpu-key"/g)].length, 1);
+
+      const migrated = new BenchmarkHistoryStore();
+      await migrated.load();
+      assertEquals(migrated.get(91_001)?.cpu, TEST_CPU);
+      assertEquals(migrated.get(91_002)?.cpu, TEST_CPU);
+    });
+  } finally {
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
 });
 
 Deno.test("/bench: grouped by source file, each benchmark coloured by its own trend", async () => {
@@ -1694,6 +2133,10 @@ Deno.test("/bench: grouped by source file, each benchmark coloured by its own tr
       "packages/memory/query.bench.ts",
       "packages/runner/scheduler-persistent-state.bench.ts",
     ],
+  );
+  assertEquals(
+    [...html.matchAll(/<section class="benchmark-group">/g)].length,
+    3,
   );
   assertEquals(rows(html), [
     { status: "good", name: "easing", value: "900ns", trend: "▼10%" },
@@ -1759,6 +2202,15 @@ Deno.test("/bench: grouped by source file, each benchmark coloured by its own tr
   );
   assertStringIncludes(html, "rangeRequest.abort()");
   assertStringIncludes(html, "refreshRangeWhenIdle()");
+  assertStringIncludes(html, "const isSameDocumentFragment = (link) => {");
+  assertStringIncludes(
+    html,
+    'url.search === location.search &&\n      url.hash !== ""',
+  );
+  assertStringIncludes(
+    html,
+    "link && isSameTabLink(event, link) && !isSameDocumentFragment(link)",
+  );
   assert(!html.includes("location.reload()"));
   assert(!html.includes("benchRestoreDaysFocus"));
   assertStringIncludes(html, "setInterval(checkForUpdates, 60000)");
@@ -1776,6 +2228,45 @@ Deno.test("/bench: grouped by source file, each benchmark coloured by its own tr
     html,
     '<div class="axisrow"><div class="timeaxis"><span>',
   );
+  assertEquals([...html.matchAll(/class="bcpu"/g)].length, 0);
+  assertEquals([...html.matchAll(/class="cpu-key"/g)].length, 1);
+  assertStringIncludes(html, TEST_CPU);
+  assertStringIncludes(
+    html,
+    '<span class="cpu-detail">6 benchmarks · 12 runs · observed ',
+  );
+  assertEquals(
+    [...html.matchAll(/class="bval" data-cpu-id="CPU 1"/g)].length,
+    6,
+  );
+  assertEquals(
+    [
+      ...html.matchAll(
+        /<a class="cpu-id" href="#cpu-type-1"[^>]*>CPU 1<\/a>/g,
+      ),
+    ].length,
+    6,
+  );
+  assertStringIncludes(
+    html,
+    `aria-label="Representative CPU ${TEST_CPU}: 2.5ms, flat;`,
+  );
+  assertStringIncludes(
+    html,
+    'class="cpu-key" id="cpu-type-1" data-cpu-id="CPU 1"',
+  );
+  assertStringIncludes(html, ".bval a.cpu-id{text-decoration:none}");
+  assert(!html.includes("text-underline-offset"));
+  assert(!html.includes("Its numbered CPU key maps to the legend below."));
+  assert(
+    html.indexOf('class="cpu-legend"') >
+      html.lastIndexOf('class="brow '),
+  );
+  assertStringIncludes(
+    html,
+    "body.hide-green .benchmark-group:not(:has(.brow:not(.good)))",
+  );
+  assert(!html.includes("body.hide-green section:not("));
 });
 
 Deno.test("/bench?sort=trend: a flat list, biggest rise first, showing the full key", async () => {
@@ -1789,14 +2280,17 @@ Deno.test("/bench?sort=trend: a flat list, biggest rise first, showing the full 
     "packages/html/render.bench.ts &gt; easing",
     "packages/memory/query.bench.ts &gt; quarter",
   ]);
-  assert(!html.includes("<h2>"), "a flat list has no file headings");
+  assert(
+    !html.includes('<section class="benchmark-group">'),
+    "a flat list has no file groups",
+  );
   assertStringIncludes(
     html,
     `<a class="stat on" href="/bench?view=runtime&amp;repo=labs&amp;days=45&amp;sort=trend&amp;stat=p99" aria-current="true">trend</a>`,
   );
 });
 
-Deno.test("/bench?sort=duration lists the longest current benchmark first", async () => {
+Deno.test("/bench?sort=duration lists the longest displayed benchmark first", async () => {
   const html = await page("?stat=p99&sort=duration");
   assertEquals(rows(html).map((row) => row.name).slice(0, 3), [
     "packages/memory/query.bench.ts &gt; quarter",
@@ -1825,6 +2319,36 @@ Deno.test("/bench history windows keep about the same chart point count", () => 
 
   assert(full.length >= 89 && full.length <= 91);
   assert(short.length >= 89 && short.length <= 91);
+});
+
+Deno.test("representative benchmark CPU prefers coverage, recency, then name", () => {
+  const series = (cpu: string, sampleCount: number, points: number[]) => ({
+    cpu,
+    sampleCount,
+    points: points.map((at) => ({ at })),
+  });
+  assertEquals(
+    representativeBenchmarkCpu([
+      series("more recent", 100, [1, 4]),
+      series("more covered", 1_000, [1, 3]),
+    ])?.cpu,
+    "more covered",
+  );
+  assertEquals(
+    representativeBenchmarkCpu([
+      series("older", 100, [1, 3]),
+      series("newer", 100, [1, 4]),
+    ])?.cpu,
+    "newer",
+  );
+  assertEquals(
+    representativeBenchmarkCpu([
+      series("z CPU", 100, [1, 4]),
+      series("a CPU", 100, [1, 4]),
+    ])?.cpu,
+    "a CPU",
+  );
+  assertEquals(representativeBenchmarkCpu([]), undefined);
 });
 
 Deno.test("benchmark collection retains enough runs for the shortest history window", () => {
@@ -1883,7 +2407,7 @@ Deno.test("/bench: the history slider selects and clamps the displayed days", as
     short,
     'id="days" name="days" min="1" max="45" step="1" value="1"',
   );
-  assertStringIncludes(short, "selected 1-day trend");
+  assertStringIncludes(short, "selected 1-day window");
   assertStringIncludes(
     await page("?days=7"),
     '<div class="axisrow"><div class="timeaxis"><span>',
@@ -2122,10 +2646,9 @@ Deno.test("benchmark: an early-paint publish that throws is caught, and the coll
   }
 });
 
-Deno.test("benchmark: the tile totals a run even when no benchmark has a drawable series", async () => {
-  // Two runs, each reporting a different benchmark: no benchmark has two points,
-  // so the per-benchmark drill-down has nothing to plot. The tile still totals the
-  // latest run's benchmark(s) — here the set even changed, so it resets to run 802.
+Deno.test("benchmark: the drill-down keeps one-sample benchmarks", async () => {
+  // Each run reports a different benchmark. The tile still indexes both runs.
+  // The drill-down shows each benchmark's one sample as a point.
   const runs = [ghRun(801, BASE - DAY), ghRun(802, BASE)];
   await withApi({
     pages: { 1: runs },
@@ -2148,10 +2671,10 @@ Deno.test("benchmark: the tile totals a run even when no benchmark has a drawabl
     assertEquals(v.sub, undefined);
     assertStringIncludes(v.extra ?? "", "1 benchmark"); // the count line
     assertEquals(v.href, "/bench?view=runtime&repo=labs");
-    // Neither single-point benchmark reaches the drill-down: it needs >= 2 points.
     const drill = await page("");
-    assert(!drill.includes("one.bench.ts"));
-    assert(!drill.includes("two.bench.ts"));
+    assertStringIncludes(drill, "one.bench.ts");
+    assertStringIncludes(drill, "two.bench.ts");
+    assertEquals([...drill.matchAll(/<circle/g)].length, 2);
   });
 });
 
@@ -2395,12 +2918,14 @@ Deno.test("runtime history reconstructs unmanifested cache data before asking fo
       runId: 81_001,
       runAttempt: 1,
       at: BASE - DAY,
+      cpu: TEST_CPU,
       metrics: new Map([["packages/a/cache.bench.ts > cached", stats]]),
     });
     store.set({
       runId: 81_002,
       runAttempt: 1,
       at: BASE,
+      cpu: TEST_CPU,
       metrics: new Map([["packages/a/cache.bench.ts > cached", stats]]),
     });
     await store.save(BASE);

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -7,11 +7,17 @@
 // snapshot for the drill-down page. The dashboard test runner gives this module
 // a temporary server-data directory. These tests share that state, use distinct
 // run ids, and read snapshots after the collection that filled them.
-import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import type { Ctx, TileView } from "../types.ts";
 import { REPO } from "../config.ts";
 import { BenchmarkHistoryStore } from "../benchmark-history-cache.ts";
 import {
+  availableGeneratedCpuColor,
   benchmark,
   type BenchmarkFetchProgress,
   benchmarkHistoryCheckResponse,
@@ -1990,6 +1996,19 @@ Deno.test("benchmark: CPU lines split across large gaps and use distinct colors"
     } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
     await Deno.remove(directory, { recursive: true });
   }
+});
+
+Deno.test("generated CPU colors fail when no candidate is available", () => {
+  assertThrows(
+    () =>
+      availableGeneratedCpuColor(
+        0,
+        new Set(["#707070"]),
+        () => "#707070",
+      ),
+    Error,
+    "Could not assign a distinct CPU color.",
+  );
 });
 
 Deno.test("benchmark: CPU-less reports are not pooled", async () => {

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -748,18 +748,19 @@ function generatedCpuColor(hash: number): string {
   )}`;
 }
 
-function availableGeneratedCpuColor(
+export function availableGeneratedCpuColor(
   hash: number,
   usedColors: Set<string>,
+  generateColor: (hash: number) => string = generatedCpuColor,
 ): string {
-  // The color uses the low 21 hash bits. Adding an odd number visits each
-  // possible low-bit value once, so one of the first usedColors.size + 1
-  // candidates must be available.
-  for (let salt = 0;; salt++) {
+  // The color uses the low 21 hash bits. Adding an odd number visits every
+  // possible low-bit value before repeating.
+  for (let salt = 0; salt <= usedColors.size; salt++) {
     const mixed = (hash + Math.imul(salt, 0x9e3779b9)) >>> 0;
-    const candidate = generatedCpuColor(mixed);
+    const candidate = generateColor(mixed);
     if (!usedColors.has(candidate)) return candidate;
   }
+  throw new Error("Could not assign a distinct CPU color.");
 }
 
 function cpuColors(cpus: Iterable<string>): Map<string, string> {

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -1,42 +1,36 @@
-// benchmark: trends a scale-invariant index of benchmark performance on main. Each
-// run's index is the run-before's index times the geometric mean of the
-// per-benchmark changes between the two runs, so every benchmark weighs the same
-// regardless of size and only a broad, across-the-board move shifts it — a
-// regression in one benchmark, however slow, barely registers (that is the
-// drill-down's job). The colour follows the trend over a recent window only (the
-// runs in the last BENCH_TREND_MAX_AGE_DAYS or the newest BENCH_TREND_MIN_RUNS,
-// whichever is more, like ci duration's median window), while the sparkline still
-// spans the whole ~45 days with that window brighter. Red — the signal this tile is
-// mainly here to raise — when the
-// most recent run failed outright, or finished green on CI but produced no readable
-// benchmark data (it ran and made nothing usable, so it is as good as failed).
-// Orange when the index trends up (broad slowdown). Green while flat or falling.
-// deno bench samples each benchmark to a fixed time budget, so the run's wall clock
-// barely moves with performance; the per-op times do, which is why the tile trends
-// those rather than the run's duration.
+// benchmark: trends one scale-invariant index of benchmark performance per
+// processor on main. Each index changes by the geometric mean of the benchmark
+// changes between consecutive runs on that processor. Every benchmark has the
+// same weight regardless of size. Only a broad move shifts an index. One slow
+// benchmark barely registers. The drill-down shows individual benchmarks.
+// Each processor has its own coloured line. The headline shows the largest
+// established trend. Orange means at least one processor trends up. Green means
+// every established processor stays flat or falls. Red means the most recent
+// run failed, or finished successfully without readable benchmark data. Deno
+// bench samples each benchmark to a fixed time budget. Performance changes the
+// per-operation times without materially changing the run's wall-clock time.
 //
-// Chaining per-run ratios makes a benchmark added or removed a non-event: it is in
-// only one of the two runs at that step, so it drops out of the geometric mean and
-// the index does not step. The failed state reads the workflow-run list and the
-// latest run's cached result, so it fires even when the artifacts cannot be read;
-// the index needs the artifacts, so with none in the window (and no failure) the
-// tile grays — "collecting…" while a fetch is still in progress (shown from the
-// moment a collection starts, before the run list is even fetched), "benchmark data
-// unavailable" once a fetch has finished and found none. A fetch that fails outright
-// — offline, say — keeps the last-known trend grayed with the reason rather than
-// blanking. The headline is the
-// window's trend — the fractional change of the index across the recent window —
-// over a second line naming how many benchmarks the latest run measured and, when a
-// recent window is highlighted, how long that window spans.
+// A benchmark added or removed is absent from one side of an adjacent
+// comparison, so it does not move the index. A processor change starts another
+// line instead of connecting unlike machines. Each line's recent window
+// contains the runs in the last BENCH_TREND_MAX_AGE_DAYS or the newest
+// BENCH_TREND_MIN_RUNS, whichever is larger. The full line spans about 45 days.
+// The failed state reads the workflow-run list and the latest run's cached
+// result. It therefore works when artifacts cannot be read. Without usable
+// data, the tile reads "collecting…" during a fetch. It reads "benchmark data
+// unavailable" after an empty fetch. A failed fetch keeps the last-known
+// processor lines gray and names the reason.
 //
 // The /bench drill-down keeps the deeper picture. The benchmarks.yml job runs
-// `deno bench --json` and uploads the output as a `bench-results` artifact (90-day
-// retention); there is no committed history, so the drill-down lists recent runs
-// on main, keeps one artifact per shortest-view time bucket, unzips it in-process,
-// and reads every benchmark's timings. Results per run attempt are immutable and
-// persisted, so only new runs and attempts are fetched later. That per-benchmark
-// history, plus the CI duration and Gantt views, live behind /bench; the tile's
-// collection keeps them warm in the background.
+// `deno bench --json` and uploads the output as a `bench-results` artifact with
+// 90-day retention. There is no committed history. The drill-down lists recent
+// main runs and keeps one artifact per shortest-view time bucket. It unzips
+// each artifact in the process and reads every benchmark's timings and
+// processor identity. Results for a run attempt are immutable and persisted.
+// Later collections fetch only new runs and attempts. The drill-down overlays
+// one coloured line per processor for each benchmark. The CI duration and
+// Gantt views also live behind /bench. The tile's collection keeps this
+// history warm.
 import type { Ctx, Route, Status, Tile, TileView } from "../types.ts";
 import {
   BenchmarkHistoryStore,
@@ -64,10 +58,10 @@ import {
   github,
   githubDownload,
   humanSpan,
+  multiSparkline,
   performanceGithub,
   performanceGithubDownload,
   SPARK_FADE,
-  sparkline,
 } from "../lib.ts";
 import {
   BENCH_TREND_MAX_AGE_DAYS,
@@ -157,10 +151,20 @@ interface Bench {
 
 const benchmarkStore = new BenchmarkHistoryStore();
 // Assembled by collect() for the /bench drill-down: each benchmark key with its
-// timings over the covered days (oldest -> newest).
+// processor-specific timings over the covered days (oldest -> newest).
+interface BenchmarkCpuSeries {
+  cpu: string;
+  points: {
+    runId: number;
+    runAttempt: number;
+    at: number;
+    stats: Stats;
+  }[];
+}
+
 interface BenchmarkSeries {
   key: string;
-  points: { at: number; stats: Stats }[];
+  cpus: BenchmarkCpuSeries[];
 }
 
 let snapshot: BenchmarkSeries[] = [];
@@ -334,6 +338,8 @@ const benchKey = (b: Bench): string =>
     b.group ? b.group + "/" : ""
   }${b.name}`;
 
+const UNKNOWN_CPU = "Unknown CPU";
+
 // Wall-clock span of a series (first to last point), in milliseconds.
 const spanMs = (points: { at: number }[]): number =>
   points.length < 2 ? 0 : points[points.length - 1].at - points[0].at;
@@ -347,13 +353,20 @@ export function formatNs(ns: number): string {
   return `${(ns / 1e9).toFixed(2)}s`;
 }
 
-// deno bench --json -> { benchmark key -> timings }. A benchmark's own console
-// output can precede the JSON report on stdout, so parse from the report object.
-function benchMetrics(json: string): Map<string, Stats> {
+// deno bench --json -> processor identity plus benchmark timings. A benchmark's
+// own console output can precede the JSON report on stdout, so parse from the
+// report object.
+function parseBenchmarkReport(
+  json: string,
+): { cpu?: string; metrics: Map<string, Stats> } {
   const at = json.match(/\{\s*"version"\s*:/);
   const data = JSON.parse(at ? json.slice(at.index) : json) as {
+    cpu?: unknown;
     benches?: Bench[];
   };
+  const cpu = typeof data.cpu === "string" && data.cpu.trim().length > 0
+    ? data.cpu.trim()
+    : undefined;
   const m = new Map<string, Stats>();
   for (const b of data.benches ?? []) {
     const ok = b.results?.[0]?.ok;
@@ -370,7 +383,7 @@ function benchMetrics(json: string): Map<string, Stats> {
       p999: n(ok.p999, ok.avg),
     });
   }
-  return m;
+  return { cpu, metrics: m };
 }
 
 // Inflate raw-deflate bytes (the compression zip uses) to their decompressed form.
@@ -474,6 +487,7 @@ async function loadRun(
   token: string,
   github: BenchmarkGitHub,
 ): Promise<{ cached: boolean; error?: unknown }> {
+  let cpu = UNKNOWN_CPU;
   let metrics = new Map<string, Stats>();
   try {
     const arts = await github.json<{ artifacts?: Artifact[] }>(
@@ -485,7 +499,13 @@ async function loadRun(
     );
     if (art) {
       const json = await jsonFromZip(await fetchZip(art.id, token, github));
-      if (json) metrics = benchMetrics(json);
+      if (json) {
+        const report = parseBenchmarkReport(json);
+        if (report.cpu !== undefined) {
+          cpu = report.cpu;
+          metrics = report.metrics;
+        }
+      }
     }
   } catch (error) {
     // The read failed, so whether this run has usable results is still unknown.
@@ -499,57 +519,88 @@ async function loadRun(
     runId: run.id,
     runAttempt: run.run_attempt ?? 1,
     at: Date.parse(run.created_at),
+    cpu,
     metrics,
   });
   await benchmarkStore.save();
   return { cached: true };
 }
 
-// The stats series (oldest -> newest) for one benchmark key across the given runs.
-function seriesFor(key: string, runs: Run[]): { at: number; stats: Stats }[] {
-  const out: { at: number; stats: Stats }[] = [];
-  for (const r of runs) {
-    const s = currentRunMetrics(r)?.get(key);
-    if (s) out.push({ at: Date.parse(r.created_at), stats: s });
-  }
-  return out;
-}
-
-function currentRunMetrics(run: Run): Map<string, Stats> | undefined {
+function currentBenchmarkRun(run: Run): CachedBenchmarkRun | undefined {
   const cached = benchmarkStore.get(run.id);
   return cached && cached.runAttempt >= (run.run_attempt ?? 1)
-    ? cached.metrics
+    ? cached
     : undefined;
 }
 
-function assembleBenchmarkSnapshot(runs: Run[]): BenchmarkSeries[] {
-  const withData = runs.filter((run) =>
-    (currentRunMetrics(run)?.size ?? 0) > 0
-  );
-  const keys = new Set<string>();
-  for (const run of withData) {
-    for (const key of currentRunMetrics(run)!.keys()) keys.add(key);
+function currentRunMetrics(run: Run): Map<string, Stats> | undefined {
+  const cached = currentBenchmarkRun(run);
+  return cached?.cpu === undefined ? undefined : cached.metrics;
+}
+
+function assembleBenchmarkSeries(
+  runs: CachedBenchmarkRun[],
+): BenchmarkSeries[] {
+  const byKey = new Map<
+    string,
+    Map<
+      string,
+      {
+        runId: number;
+        runAttempt: number;
+        at: number;
+        stats: Stats;
+      }[]
+    >
+  >();
+  for (const run of [...runs].sort((a, b) => a.at - b.at)) {
+    if (run.cpu === undefined) continue;
+    for (const [key, stats] of run.metrics) {
+      let byCpu = byKey.get(key);
+      if (!byCpu) {
+        byCpu = new Map();
+        byKey.set(key, byCpu);
+      }
+      let points = byCpu.get(run.cpu);
+      if (!points) {
+        points = [];
+        byCpu.set(run.cpu, points);
+      }
+      points.push({
+        runId: run.runId,
+        runAttempt: run.runAttempt,
+        at: run.at,
+        stats,
+      });
+    }
   }
-  return [...keys]
-    .map((key) => ({ key, points: seriesFor(key, withData) }))
-    .filter((series) => series.points.length >= 2)
+  return [...byKey]
+    .map(([key, byCpu]) => ({
+      key,
+      cpus: [...byCpu]
+        .map(([cpu, points]) => ({ cpu, points }))
+        .filter((series) => series.points.length > 0)
+        .sort((a, b) => a.cpu.localeCompare(b.cpu)),
+    }))
+    .filter((series) => series.cpus.length > 0)
     .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function assembleBenchmarkSnapshot(runs: Run[]): BenchmarkSeries[] {
+  return assembleBenchmarkSeries(
+    runs.flatMap((run) => {
+      const cached = currentBenchmarkRun(run);
+      return cached?.cpu !== undefined && cached.metrics.size > 0
+        ? [cached]
+        : [];
+    }),
+  );
 }
 
 function assembleCachedBenchmarkSnapshot(
   runs: CachedBenchmarkRun[],
 ): BenchmarkSeries[] {
-  const keys = new Set(runs.flatMap((run) => [...run.metrics.keys()]));
-  return [...keys]
-    .map((key) => ({
-      key,
-      points: runs.flatMap((run) => {
-        const stats = run.metrics.get(key);
-        return stats ? [{ at: run.at, stats }] : [];
-      }),
-    }))
-    .filter((series) => series.points.length >= 2)
-    .sort((a, b) => a.key.localeCompare(b.key));
+  return assembleBenchmarkSeries(runs);
 }
 
 async function loadCachedBenchmarkSnapshot(now = Date.now()): Promise<void> {
@@ -557,10 +608,14 @@ async function loadCachedBenchmarkSnapshot(now = Date.now()): Promise<void> {
   if (benchmarkStore.quarantineFuture(now)) {
     await benchmarkStore.save(now);
   }
-  benchmarkRefreshedAt = benchmarkStore.refreshedAt;
   const cutoff = now - SPARK_DAYS * 86_400_000;
   const refreshedRuns = benchmarkStore.refreshedRuns();
   const cachedRuns = refreshedRuns ?? benchmarkStore.list(cutoff);
+  if (cachedRuns.some((run) => run.cpu === undefined)) {
+    benchmarkStore.invalidateRefresh(now);
+    await benchmarkStore.save(now);
+  }
+  benchmarkRefreshedAt = benchmarkStore.refreshedAt;
   if (refreshedRuns === null) {
     const available = cachedRuns.map((run) => ({
       id: run.runId,
@@ -633,11 +688,12 @@ function benchmarkUnavailable(sub: string): TileView {
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
-// The geometric mean of the per-benchmark ratios between two runs, over the
-// benchmarks they share (each with a positive average). Geometric, not arithmetic,
-// so a benchmark that doubles and one that halves cancel to no change. A benchmark
-// in only one of the two runs is not in the ratio, so adding or removing one is not
-// a change. 1 when the runs share nothing.
+// The geometric mean of the per-benchmark ratios between two runs on the same
+// processor, over the benchmarks they share (each with a positive average).
+// Geometric, not arithmetic, so a benchmark that doubles and one that halves
+// cancel to no change. A benchmark in only one of the two runs is not in the
+// ratio, so adding or removing one is not a change. 1 when the runs share
+// nothing.
 function benchmarkStepRatio(
   previous: CachedBenchmarkRun,
   current: CachedBenchmarkRun,
@@ -653,19 +709,151 @@ function benchmarkStepRatio(
   return count ? Math.exp(logSum / count) : 1;
 }
 
-// The grid tile: a scale-invariant index of benchmark performance, trended over ~45
-// days. Each run's index is the previous run's index times the geometric mean of
-// the per-benchmark changes between them, so every benchmark weighs the same and
-// only a broad, across-the-board move shifts it — a regression in one benchmark,
-// however slow, barely registers (that is the drill-down's job). Orange when the
-// index trends up (broad slowdown), red when the most recent run failed outright or
-// produced no readable data — the failure is what this tile is mainly here to
-// catch. Red reads the workflow-run list and the latest run's cached result, so it
-// fires even when the artifacts cannot be read; the index needs the artifacts, so
-// with none in the window (and no failure) the tile grays. The headline is the
-// window's trend. `offline` names a fetch failure: the tile then keeps its
-// last-known trend grayed (never a stale red or green), or shows a bare gray dash
-// when nothing is cached.
+const CPU_COLORS = [
+  "#6ea8fe",
+  "#d97757",
+  "#10a37f",
+  "#b58cf6",
+  "#e0a852",
+  "#56b6c2",
+  "#e06c9f",
+  "#9fb36b",
+  "#ff9da7",
+  "#8cd17d",
+  "#b6992d",
+  "#499894",
+  "#d37295",
+  "#fabfd2",
+  "#b07aa1",
+  "#86bcb6",
+];
+const CPU_LINE_MAX_X_GAP = 0.2;
+
+function cpuHash(cpu: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < cpu.length; index++) {
+    hash ^= cpu.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function generatedCpuColor(hash: number): string {
+  const red = 112 + (hash & 0x7f);
+  const green = 112 + ((hash >>> 7) & 0x7f);
+  const blue = 112 + ((hash >>> 14) & 0x7f);
+  return `#${((red << 16) | (green << 8) | blue).toString(16).padStart(
+    6,
+    "0",
+  )}`;
+}
+
+function availableGeneratedCpuColor(
+  hash: number,
+  usedColors: Set<string>,
+): string {
+  // The color uses the low 21 hash bits. Adding an odd number visits each
+  // possible low-bit value once, so one of the first usedColors.size + 1
+  // candidates must be available.
+  for (let salt = 0; salt <= usedColors.size; salt++) {
+    const mixed = (hash + Math.imul(salt, 0x9e3779b9)) >>> 0;
+    const candidate = generatedCpuColor(mixed);
+    if (!usedColors.has(candidate)) return candidate;
+  }
+  throw new Error("Could not assign a distinct CPU color.");
+}
+
+function cpuColors(cpus: Iterable<string>): Map<string, string> {
+  const colors = new Map<string, string>();
+  const usedPaletteIndexes = new Set<number>();
+  const usedColors = new Set<string>();
+  const sorted = [...new Set(cpus)].sort((a, b) => a.localeCompare(b));
+  for (const [ordinal, cpu] of sorted.entries()) {
+    const hash = cpuHash(cpu);
+    let color: string;
+    if (ordinal < CPU_COLORS.length) {
+      const start = hash % CPU_COLORS.length;
+      let index = start;
+      for (let offset = 0; offset < CPU_COLORS.length; offset++) {
+        const candidate = (start + offset) % CPU_COLORS.length;
+        if (!usedPaletteIndexes.has(candidate)) {
+          index = candidate;
+          break;
+        }
+      }
+      usedPaletteIndexes.add(index);
+      color = CPU_COLORS[index];
+    } else {
+      color = availableGeneratedCpuColor(hash, usedColors);
+    }
+    usedColors.add(color);
+    colors.set(cpu, color);
+  }
+  return colors;
+}
+
+interface BenchmarkCpuIndex {
+  cpu: string;
+  color: string;
+  points: { at: number; index: number }[];
+  windowCount: number;
+  windowPoints: { at: number; index: number }[];
+  trend: ReturnType<typeof benchmarkTrend>;
+}
+
+function benchmarkCpuIndices(
+  cached: CachedBenchmarkRun[],
+  now: number,
+): BenchmarkCpuIndex[] {
+  const byCpu = new Map<string, CachedBenchmarkRun[]>();
+  for (const run of cached) {
+    if (run.cpu === undefined) continue;
+    const runs = byCpu.get(run.cpu);
+    if (runs) runs.push(run);
+    else byCpu.set(run.cpu, [run]);
+  }
+  const windowCutoff = now - BENCH_TREND_MAX_AGE_DAYS * 86_400_000;
+  const colors = cpuColors(byCpu.keys());
+  return [...byCpu]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([cpu, runs]) => {
+      runs.sort((a, b) => a.at - b.at);
+      const points: { at: number; index: number }[] = [];
+      let index = 1;
+      for (let run = 0; run < runs.length; run++) {
+        if (run > 0) index *= benchmarkStepRatio(runs[run - 1], runs[run]);
+        points.push({ at: runs[run].at, index });
+      }
+      const inWindow = points.filter((point) =>
+        point.at >= windowCutoff
+      ).length;
+      const windowCount = Math.min(
+        points.length,
+        Math.max(inWindow, BENCH_TREND_MIN_RUNS),
+      );
+      const windowPoints = points.slice(points.length - windowCount);
+      return {
+        cpu,
+        color: colors.get(cpu)!,
+        points,
+        windowCount,
+        windowPoints,
+        trend: benchmarkTrend(
+          windowPoints.map((point) => point.at),
+          windowPoints.map((point) => point.index),
+        ),
+      };
+    });
+}
+
+// The grid tile trends a scale-invariant benchmark index over about 45 days.
+// Each processor has its own index and line. Every index starts at one and
+// changes only between runs on that processor. Hardware changes therefore
+// never become benchmark changes. The headline shows the largest established
+// trend. Orange means any processor trends up. Red means the most recent run
+// failed or produced no readable data. `offline` names a fetch failure. The
+// tile then keeps its last-known trends gray, or shows a gray dash when no
+// history is cached.
 function benchmarkIndexView(
   runs: Run[],
   now: number,
@@ -693,20 +881,15 @@ function benchmarkIndexView(
   const noData = latestResult !== undefined && latestResult.metrics.size === 0;
   const failed = failedCi || noData;
   const failSub = failedCi ? "last run failed" : "no benchmark data";
-  // The successful runs with readable artifacts in the window, oldest -> newest.
+  // The successful runs with processor identities and readable artifacts in the
+  // window, oldest -> newest.
   const cached = (benchmarkStore.refreshedRuns() ?? benchmarkStore.list(cutoff))
-    .filter((run) => run.at >= cutoff && run.metrics.size > 0)
+    .filter((run) =>
+      run.at >= cutoff && run.cpu !== undefined && run.metrics.size > 0
+    )
     .sort((a, b) => a.at - b.at);
-  // Chain each run's geometric-mean change against the run before it into a single
-  // scale-invariant index. It starts at 1 for the oldest run; a benchmark added or
-  // removed drops out of that step's ratio, so a set change never steps the index.
-  const points: { at: number; index: number }[] = [];
-  let index = 1;
-  for (let i = 0; i < cached.length; i++) {
-    if (i > 0) index *= benchmarkStepRatio(cached[i - 1], cached[i]);
-    points.push({ at: cached[i].at, index });
-  }
-  if (!points.length) {
+  const indices = benchmarkCpuIndices(cached, now);
+  if (!indices.length) {
     // A fetch failure with nothing cached to stand on: a gray dash and the reason.
     if (offline) return benchmarkUnavailable(offline);
     if (failed) {
@@ -726,22 +909,14 @@ function benchmarkIndexView(
       runs.length ? "benchmark data unavailable" : "no benchmark runs",
     );
   }
-  const values = points.map((point) => point.index);
-  // Trend over a recent window only, like ci duration's median window: the runs in
-  // the last BENCH_TREND_MAX_AGE_DAYS, or the newest BENCH_TREND_MIN_RUNS — whichever
-  // is more. The sparkline still spans the whole series, with that window brighter.
-  const windowCutoff = now - BENCH_TREND_MAX_AGE_DAYS * 86_400_000;
-  const inWindow = points.filter((point) => point.at >= windowCutoff).length;
-  const windowCount = Math.min(
-    points.length,
-    Math.max(inWindow, BENCH_TREND_MIN_RUNS),
+  const established = indices.filter((series) => series.trend.label !== "new");
+  const headline = (established.length ? established : indices).reduce((
+    worst,
+    series,
+  ) => series.trend.pct > worst.trend.pct ? series : worst);
+  const rising = indices.some((series) =>
+    series.trend.status === "warn" || series.trend.status === "bad"
   );
-  const windowPoints = points.slice(points.length - windowCount);
-  const trend = benchmarkTrend(
-    windowPoints.map((point) => point.at),
-    windowPoints.map((point) => point.index),
-  );
-  const rising = trend.status === "warn" || trend.status === "bad";
   // An offline collection keeps the trend but grays it: the run list it would need
   // to judge failed or rising could not be fetched, so it never asserts red or green.
   const status: Status = offline
@@ -752,36 +927,44 @@ function benchmarkIndexView(
     ? "warn"
     : "good";
   // Headline: the window's trend.
-  const value = escapeHtml(trend.label);
-  const count = cached[cached.length - 1].metrics.size;
+  const value = escapeHtml(headline.trend.label);
+  const latest = cached[cached.length - 1];
+  const count = latest.metrics.size;
   // Name the highlighted window's span beside the count, like CI duration names its
   // median window — in days (via humanSpan), not "runs", so it does not read as the
   // main-CI run count. Only when a window is actually highlighted; otherwise the
   // whole sparkline is the window and its span already sits in the corner.
-  const windowLabel = windowCount < values.length
-    ? ` · last ${humanSpan(spanMs(windowPoints))}`
+  const windowLabel = headline.windowCount < headline.points.length
+    ? ` · last ${humanSpan(spanMs(headline.windowPoints))}`
     : "";
-  const line =
+  const countLine =
     `<div style="font-size:13px;color:#9aa0ab;margin:5px 0 0">${count} benchmark${
       count === 1 ? "" : "s"
     }${windowLabel}</div>`;
+  const allPoints = indices.flatMap((series) => series.points);
+  const chartStart = Math.min(...allPoints.map((point) => point.at));
+  const chartEnd = Math.max(...allPoints.map((point) => point.at));
+  const chartSpan = chartEnd - chartStart;
+  const chartAxis = chartSpan || 1;
+  const chart = multiSparkline(
+    indices.map((series) => ({
+      vals: series.points.map((point) => point.index),
+      color: series.color,
+      xs: series.points.map((point) => (point.at - chartStart) / chartAxis),
+      highlightCount: series.windowCount,
+      maxXGap: CPU_LINE_MAX_X_GAP,
+      showSinglePoint: true,
+    })),
+    { fadeFrom: SPARK_FADE[status] },
+  );
   return {
     ...benchmarkDrill,
     label: "benchmarks",
     status,
     value,
     sub: offline ?? (failed ? failSub : undefined),
-    extra: `${line}${
-      sparkline(
-        values,
-        "#727882",
-        windowCount < values.length
-          ? { count: windowCount, color: "#c7ccd4" }
-          : undefined,
-        SPARK_FADE[status],
-      )
-    }`,
-    duration: spanMs(points),
+    extra: `${countLine}${chart}`,
+    duration: chartSpan,
   };
 }
 
@@ -1267,14 +1450,39 @@ export function pointsForWindow<T extends { at: number }>(
   return [...buckets.values()].sort((a, b) => a.at - b.at);
 }
 
+export function representativeBenchmarkCpu<
+  T extends { cpu: string; sampleCount: number; points: { at: number }[] },
+>(series: T[]): T | undefined {
+  let representative: T | undefined;
+  for (const candidate of series) {
+    if (!representative) {
+      representative = candidate;
+      continue;
+    }
+    const candidateLatest = candidate.points.at(-1)?.at ?? -Infinity;
+    const representativeLatest = representative.points.at(-1)?.at ?? -Infinity;
+    if (
+      candidate.sampleCount > representative.sampleCount ||
+      (candidate.sampleCount === representative.sampleCount &&
+        candidateLatest > representativeLatest) ||
+      (candidate.sampleCount === representative.sampleCount &&
+        candidateLatest === representativeLatest &&
+        candidate.cpu.localeCompare(representative.cpu) < 0)
+    ) {
+      representative = candidate;
+    }
+  }
+  return representative;
+}
+
 const dateLabel = (at: number): string =>
   new Date(at).toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
   });
 
-// The /bench drill-down: every benchmark's sparkline for the chosen measurement,
-// grouped by source file, each coloured by its own trend.
+// The /bench drill-down: every benchmark's processor-specific lines for the
+// chosen measurement, grouped by source file.
 interface BenchmarkPageOptions {
   progress?: BenchmarkFetchProgress;
   refreshError?: string;
@@ -1360,6 +1568,7 @@ export function benchPage(
     : "";
 
   let body: string;
+  let cpuLegend = "";
   if (!snapshot.length) {
     body = progress && !progressIdle ? "" : `<p class="empty">${
       escapeHtml(
@@ -1372,37 +1581,155 @@ export function benchPage(
     const axisStart = axisEnd - days * 86_400_000;
     const axisSpan = axisEnd - axisStart || 1;
     const bucketMs = ciHistoryBucketMs(days);
+    const colors = cpuColors(
+      snapshot.flatMap((series) => series.cpus.map((cpu) => cpu.cpu)),
+    );
+    const cpuKeys = new Map(
+      [...colors.keys()].map((cpu, index) => [
+        cpu,
+        { label: `CPU ${index + 1}`, anchor: `cpu-type-${index + 1}` },
+      ]),
+    );
     const rows = snapshot.flatMap((s) => {
-      const points = pointsForWindow(s.points, axisStart, bucketMs, axisEnd);
-      if (points.length < 2) return [];
-      const pts = points.map((p) => p.stats[stat.field]);
-      const trend = benchmarkTrend(points.map((p) => p.at), pts);
-      const xs = points.map((p) => (p.at - axisStart) / axisSpan);
-      const spark = sparkline(
-        pts,
-        "#727882",
-        undefined,
-        SPARK_FADE[trend.status],
-        xs,
+      const visibleCpus = s.cpus.flatMap((series) => {
+        const sourcePoints = series.points.filter((point) =>
+          point.at >= axisStart && point.at <= axisEnd
+        );
+        const points = pointsForWindow(
+          sourcePoints,
+          axisStart,
+          bucketMs,
+          axisEnd,
+        );
+        if (!points.length) return [];
+        const values = points.map((point) => point.stats[stat.field]);
+        const trend = benchmarkTrend(
+          points.map((point) => point.at),
+          values,
+        );
+        return [{
+          cpu: series.cpu,
+          color: colors.get(series.cpu)!,
+          sampleCount: sourcePoints.length,
+          points,
+          values,
+          pct: trend.pct,
+          status: trend.status,
+          trend: trend.label,
+          latest: values[values.length - 1],
+        }];
+      });
+      if (!visibleCpus.length) return [];
+      const cpus = visibleCpus;
+      const representative = representativeBenchmarkCpu(cpus)!;
+      const status = representative.status;
+      const pct = representative.pct;
+      const allPoints = cpus.flatMap((series) => series.points);
+      const firstAt = Math.min(...allPoints.map((point) => point.at));
+      const lastAt = Math.max(...allPoints.map((point) => point.at));
+      const spark = multiSparkline(
+        cpus.map((series) => ({
+          vals: series.values,
+          color: series.color,
+          xs: series.points.map((point) => (point.at - axisStart) / axisSpan),
+          maxXGap: CPU_LINE_MAX_X_GAP,
+          showSinglePoint: true,
+        })),
+        { fadeFrom: SPARK_FADE[status] },
       );
       return [{
         key: s.key,
         file: s.key.split(" > ")[0],
-        pct: trend.pct,
-        st: trend.status,
-        trend: trend.label,
+        pct,
+        st: status,
         spark,
-        dur: durationTag(spanMs(points)),
-        latest: pts[pts.length - 1],
+        dur: lastAt > firstAt ? durationTag(lastAt - firstAt) : "",
+        latest: representative.latest,
+        representative,
+        cpus,
       }];
     });
-    const rowHtml = (r: (typeof rows)[number], label: string) =>
-      `<div class="brow ${r.st}"><div class="bspark">${r.spark}${r.dur}</div><div class="bmeta">` +
-      `<span class="bname">${escapeHtml(label)}</span>` +
-      `<span class="bval">${formatNs(r.latest)}<span class="btrend">${
-        escapeHtml(r.trend)
-      }</span></span>` +
-      `</div></div>`;
+    const cpuDetails = new Map<string, {
+      color: string;
+      benchmarks: number;
+      runs: Set<string>;
+      firstAt: number;
+      lastAt: number;
+    }>();
+    for (const row of rows) {
+      for (const series of row.cpus) {
+        let detail = cpuDetails.get(series.cpu);
+        if (!detail) {
+          detail = {
+            color: series.color,
+            benchmarks: 0,
+            runs: new Set(),
+            firstAt: series.points[0].at,
+            lastAt: series.points[series.points.length - 1].at,
+          };
+          cpuDetails.set(series.cpu, detail);
+        }
+        detail.benchmarks++;
+        for (const point of series.points) {
+          detail.runs.add(`${point.runId}:${point.runAttempt}`);
+          detail.firstAt = Math.min(detail.firstAt, point.at);
+          detail.lastAt = Math.max(detail.lastAt, point.at);
+        }
+      }
+    }
+    if (cpuDetails.size) {
+      cpuLegend =
+        `<section class="cpu-legend" aria-labelledby="cpu-legend-title"><h2 class="cpu-legend-title" id="cpu-legend-title">CPU types</h2><div class="cpu-keys">${
+          [...cpuDetails]
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([cpu, detail]) => {
+              const benchmarks = `${detail.benchmarks} benchmark${
+                detail.benchmarks === 1 ? "" : "s"
+              }`;
+              const runs = `${detail.runs.size} run${
+                detail.runs.size === 1 ? "" : "s"
+              }`;
+              const observed = detail.firstAt === detail.lastAt
+                ? `observed ${dateLabel(detail.firstAt)}`
+                : `observed ${dateLabel(detail.firstAt)}–${
+                  dateLabel(detail.lastAt)
+                }`;
+              const { label: cpuId, anchor } = cpuKeys.get(cpu)!;
+              return `<div class="cpu-key" id="${anchor}" data-cpu-id="${cpuId}"><span class="swatch" style="background:${
+                escapeHtml(detail.color)
+              }"></span><span class="cpu-id" style="--cpu-color:${
+                escapeHtml(detail.color)
+              }">${cpuId}</span><span class="cpu-description"><span class="cpu-name">${
+                escapeHtml(cpu)
+              }</span><span class="cpu-detail">${benchmarks} · ${runs} · ${observed}</span></span></div>`;
+            }).join("")
+        }</div></section>`;
+    }
+    const rowHtml = (r: (typeof rows)[number], label: string) => {
+      const series = r.representative;
+      const { label: cpuId, anchor } = cpuKeys.get(series.cpu)!;
+      const latest = formatNs(series.latest);
+      const sampleCount = series.sampleCount;
+      const samples = `${sampleCount} sample${
+        sampleCount === 1 ? "" : "s"
+      } in the selected window`;
+      return `<div class="brow ${r.st}"><div class="bspark">${r.spark}${r.dur}</div><div class="bmeta">` +
+        `<span class="bname">${escapeHtml(label)}</span>` +
+        `<span class="bval" data-cpu-id="${cpuId}" data-sample-count="${sampleCount}" style="--cpu-color:${
+          escapeHtml(series.color)
+        }" title="${
+          escapeHtml(`${series.cpu} · ${samples}`)
+        }" aria-label="${
+          escapeHtml(
+            `Representative CPU ${series.cpu}: ${latest}, ${series.trend}; ${samples}`,
+          )
+        }"><a class="cpu-id" href="#${anchor}" aria-label="${
+          escapeHtml(`${cpuId}: ${series.cpu}; jump to CPU types legend`)
+        }">${cpuId}</a>${latest}<span class="btrend">${
+          escapeHtml(series.trend)
+        }</span></span>` +
+        `</div></div>`;
+    };
     const axis = `<div class="axisrow"><div class="timeaxis"><span>${
       dateLabel(axisStart)
     }</span><span>${dateLabel(axisEnd)}</span></div></div>`;
@@ -1429,7 +1756,7 @@ export function benchPage(
       }
       body = axis +
         [...groups.entries()].map(([file, rs]) =>
-          `<section><h2>${escapeHtml(file)}</h2><div class="blist">${
+          `<section class="benchmark-group"><h2>${escapeHtml(file)}</h2><div class="blist">${
             rs.map((r) =>
               rowHtml(r, r.key.split(" > ").slice(1).join(" > ") || r.key)
             ).join("")
@@ -1440,8 +1767,9 @@ export function benchPage(
 
   const rangeContent = `<div id="range-content">
     ${progressHtml}${refreshNotice}
-    <p class="legend">Percentile of per-op time across a run's samples — p0 = min, p50 = mean, p100 = max. Lower is faster. Coloured by the selected ${days}-day trend; fewer than seven distinct days are marked new. Duration sort uses the latest sample.</p>
+    <p class="legend">Percentile of per-op time across a run's samples — p0 = min, p50 = mean, p100 = max. Lower is faster. Each CPU has its own coloured line. The value, trend, and row colour use the CPU with the most benchmark samples in the selected ${days}-day window; a tie uses the CPU with the newest sample. Fewer than seven distinct days are marked new. Duration and trend sorting use the displayed value and trend.</p>
     ${body}
+    ${cpuLegend}
     <p class="note">Successful main runs come from the <a href="https://github.com/${REPO}/actions/workflows/${WORKFLOW}" target="_blank" rel="noopener">${WORKFLOW} runs ↗</a> (deno bench artifacts). Collection keeps enough samples for the shortest window, and charts reduce longer windows to about ${CI_HISTORY_POINT_TARGET} evenly spaced points.</p>
   </div>`;
   if (options.fragment) return rangeContent;
@@ -1481,16 +1809,29 @@ export function benchPage(
   .brow.bad{border-color:rgba(226,80,74,.5);background:rgba(226,80,74,.09)}
   .bmeta{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:2px}
   .bname{font-size:13px;color:#c7ccd4;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-  .bval{font-size:18px;font-weight:600;font-variant-numeric:tabular-nums}
+  .bval{font-size:18px;font-weight:600;font-variant-numeric:tabular-nums;display:flex;align-items:baseline;min-width:0}
+  .bval .cpu-id{margin-right:7px;align-self:center}
+  .bval a.cpu-id{text-decoration:none}
+  .bval a.cpu-id:hover{border-color:#6ea8fe;color:#fff}
+  .bval a.cpu-id:focus-visible{outline:2px solid #6ea8fe;outline-offset:2px}
   .btrend{font-size:12px;font-weight:400;color:#9aa0ab;margin-left:8px}
+  .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;flex:none;box-shadow:0 0 0 1px rgba(255,255,255,.42)}
+  .cpu-id{display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--cpu-color,#454b56);border-radius:4px;padding:1px 4px;font-size:9px;line-height:1.2;font-weight:500;color:#c7ccd4;white-space:nowrap}
   .bspark{flex:0 0 42%;min-width:0;position:relative}
   .bspark>div,.bspark>svg{margin-top:0!important}
+  .cpu-legend{margin-top:22px}.cpu-legend-title{margin:0 0 8px}
+  .cpu-keys{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:7px}
+  .cpu-key{display:flex;align-items:flex-start;gap:8px;background:#16181d;border:1px solid #23262d;border-radius:8px;padding:8px 10px}
+  .cpu-key:target{border-color:#6ea8fe;box-shadow:0 0 0 1px rgba(110,168,254,.24);scroll-margin-top:16px}
+  .cpu-key>.swatch,.cpu-key>.cpu-id{margin-top:3px}.cpu-description{min-width:0}
+  .cpu-name{display:block;font-size:12px;color:#c7ccd4;overflow-wrap:anywhere}
+  .cpu-detail{display:block;font-size:10px;color:#878d97;margin-top:2px}
   .empty,.refresh-error{color:#9aa0ab;font-size:14px}.refresh-error{color:#e0a852}
   .note{font-size:11px;color:#666c76;margin-top:22px}
   .note a{color:#6ea8fe;text-decoration:none}
   label.chk{font-size:13px;color:#c7ccd4;display:inline-flex;align-items:center;gap:6px;margin-left:auto;cursor:pointer;user-select:none}
   body.hide-green .brow.good{display:none}
-  body.hide-green section:not(:has(.brow:not(.good))){display:none}
+  body.hide-green .benchmark-group:not(:has(.brow:not(.good))){display:none}
   @media(max-width:640px){.timeaxis{flex:1}.brow{align-items:stretch;gap:7px;flex-wrap:wrap}.bspark{flex:1 0 100%}.controls .field,.controls .choice-group{flex:1 1 100%}.controls input[type=range]{flex:1;width:auto}.controls label.chk{margin-left:0}}
 </style></head><body data-snapshot-version="${escapeHtml(version)}">
   <div class="top"><a class="back" href="/">← dashboard</a><b>Performance history</b><span>${
@@ -1545,9 +1886,18 @@ export function benchPage(
   const isSameTabLink = (event, link) =>
     link.target !== "_blank" && event.button === 0 && !event.metaKey &&
     !event.ctrlKey && !event.shiftKey && !event.altKey;
+  const isSameDocumentFragment = (link) => {
+    const url = new URL(link.href);
+    return url.origin === location.origin &&
+      url.pathname === location.pathname &&
+      url.search === location.search &&
+      url.hash !== "";
+  };
   document.addEventListener("click", (event) => {
     const link = event.target.closest?.("a[href]");
-    if (link && isSameTabLink(event, link)) navigating = true;
+    if (
+      link && isSameTabLink(event, link) && !isSameDocumentFragment(link)
+    ) navigating = true;
   }, true);
   controls.addEventListener("submit", () => navigating = true);
   window.addEventListener("pagehide", () => {

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -755,12 +755,11 @@ function availableGeneratedCpuColor(
   // The color uses the low 21 hash bits. Adding an odd number visits each
   // possible low-bit value once, so one of the first usedColors.size + 1
   // candidates must be available.
-  for (let salt = 0; salt <= usedColors.size; salt++) {
+  for (let salt = 0;; salt++) {
     const mixed = (hash + Math.imul(salt, 0x9e3779b9)) >>> 0;
     const candidate = generatedCpuColor(mixed);
     if (!usedColors.has(candidate)) return candidate;
   }
-  throw new Error("Could not assign a distinct CPU color.");
 }
 
 function cpuColors(cpus: Iterable<string>): Map<string, string> {
@@ -801,13 +800,14 @@ interface BenchmarkCpuIndex {
   trend: ReturnType<typeof benchmarkTrend>;
 }
 
+type CpuBenchmarkRun = CachedBenchmarkRun & { cpu: string };
+
 function benchmarkCpuIndices(
-  cached: CachedBenchmarkRun[],
+  cached: CpuBenchmarkRun[],
   now: number,
 ): BenchmarkCpuIndex[] {
   const byCpu = new Map<string, CachedBenchmarkRun[]>();
   for (const run of cached) {
-    if (run.cpu === undefined) continue;
     const runs = byCpu.get(run.cpu);
     if (runs) runs.push(run);
     else byCpu.set(run.cpu, [run]);
@@ -884,7 +884,7 @@ function benchmarkIndexView(
   // The successful runs with processor identities and readable artifacts in the
   // window, oldest -> newest.
   const cached = (benchmarkStore.refreshedRuns() ?? benchmarkStore.list(cutoff))
-    .filter((run) =>
+    .filter((run): run is CpuBenchmarkRun =>
       run.at >= cutoff && run.cpu !== undefined && run.metrics.size > 0
     )
     .sort((a, b) => a.at - b.at);


### PR DESCRIPTION
Benchmark history previously compared adjacent workflow runs without considering which CPU produced each result. A runner hardware change could therefore appear as a software regression, and chart lines joined measurements that were not comparable.

Store the reported CPU with each cached artifact and refetch older entries that lack it. Build a separate normalized benchmark index for each CPU so the dashboard trend does not compare raw timings across processors.

Draw a distinct line for each CPU on the dashboard tile and benchmark history page. Split a line when adjacent points are more than one fifth of the chart width apart, and preserve isolated samples. Keep the dashboard tile compact by omitting its CPU legend and CPU count.

On the benchmark history page, choose the CPU with the most raw samples as each benchmark's representative value. Use that CPU for the row status and sorting. Break ties by the newest sample and then the CPU name.

Place numbered CPU definitions after the graphs and include each processor's full identity, coverage, run count, and observation dates. Link each row's CPU badge to its definition. Remove the normal link underline while preserving hover and keyboard focus styles.

Cover cache migration, processor separation, chart gaps, colors and contrast, representative selection, sorting, legend links, client navigation, badge styling, and the compact dashboard presentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make benchmark trends CPU-aware to avoid mixing processors and misreading hardware swaps as regressions. The dashboard now draws separate per‑CPU lines and uses the most‑sampled CPU per benchmark row.

- **New Features**
  - Store each report’s CPU in cache; build a per‑CPU normalized index and draw per‑CPU lines on the tile and `/bench`.
  - Tile: headline uses the largest established CPU trend; orange if any CPU trends up; shared x‑axis; split lines on large gaps; show isolated samples and one‑point series as markers; per‑CPU highlight windows; deterministic palette plus generated colors with contrast and collision handling.
  - `/bench`: one line per CPU for each benchmark; pick the CPU with the most samples as the row’s value/trend (tie‑break by newest sample, then CPU name); color and sort by that CPU; add a numbered CPU legend with full identity, coverage, run count, and observed dates; each row’s CPU badge links to its legend entry; compact tile omits a CPU legend.
  - Treat reports without a CPU identity as unusable; do not pool measurements from unknown machines; replace cached CPU‑less entries when a CPU is found; older CPU‑less runs are refetched automatically.

- **Bug Fixes**
  - Preserve highlight tint for isolated markers within the recent window when lines are split across large gaps.

<sup>Written for commit 17d24ae4862c132c53d280563647662cad33a875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

