### PR TITLE
docs(plans): verb contract — fold in review context and structural findings

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -202,10 +202,11 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
   properties" is not a single predicate today. `isStream()` accepts three
   independent signals, any one of which suffices: the cell's construction kind,
   `asCell: ["stream"]` in the schema, and a stored `{$stream: true}` value
-  (`packages/runner/src/cell.ts:924-946`). If C3 keys emission off the schema
-  marker alone, a verb carrying only the stored marker gets no result schema
-  and rule 3 silently does not apply to it — and the WS-C exit below would not
-  catch that, since it exercises one CTS pattern that does carry the marker.
+  (`Cell.isStream`, `packages/runner/src/cell.ts:936-958`). If C3 keys emission
+  off the schema marker alone, a verb carrying only the stored marker gets no
+  result schema and rule 3 silently does not apply to it — and the WS-C exit
+  below would not catch that, since it exercises one CTS pattern that does
+  carry the marker.
   That the signals diverge in practice is not hypothetical: the CLI has two
   runtime workarounds for handlers whose schema lost the marker
   (`tryResolvePieceHandler`, and the forced-stream probe in

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -4,6 +4,13 @@
 [`pattern-verb-contract.md`](pattern-verb-contract.md) (PR #4968). Keep current
 as work proceeds: check off exit criteria, record scope changes.
 
+**Amended 2026-07-28**, context only — no scope or decision changed: Risks
+names #5059 (`cf piece setsrc --check`) as the candidate preflight for the
+write-storm gate, and WS-F gains a read-path guard so `cf piece get` on a verb
+redirects to `cf piece call`. The design doc carries the same pass's larger
+share: the llm-dialog handler-branch precedent, tools restated as deferred
+rather than rejected, and the structural-interface property.
+
 **Amended 2026-07-24** from the first live headless session (a three-topic
 graph, ~24 CLI operations): compact discovery index (A2), closed-world inputs
 (C5), transaction-local acknowledgement as a WS-D exit criterion, phase
@@ -348,6 +355,12 @@ Size M, mostly parallel. `packages/cli`, `skills/cf`.
   backing identity changes; evaluate a narrower path-selected form if broad
   output is too noisy. Patterns return child references and never manufacture
   their own fid fields for this purpose.
+- **Read-path guard:** `cf piece get` on a path that resolves to a verb returns
+  the stream's serialization rather than redirecting. The llm-dialog `read`
+  tool already rejects this case with the right message — "Path resolves to a
+  handler; use invoke() instead" — and the CLI read path
+  (`packages/cli/lib/piece.ts`, `getCellValue`) has no equivalent check. Cheap,
+  and it saves an agent a wasted turn.
 - `--await` / `--no-wait` and the caller-controlled wait bound — with WS-D.
 - Skill updates ride each surface (`skills/cf`, `skills/topics`): the handle
   lookup and verification read leave the documented workflow when Phase 4
@@ -427,6 +440,13 @@ change that alters them.
   #4956, merged 2026-07-24 — is the candidate fix; confirm before the first
   Phase 1 deploy). Until the gate clears, a "live-board acceptance pass"
   degrades to a scratch board and must say so rather than pass silently.
+  **#5059 (`cf piece setsrc --check`) is the candidate preflight for this
+  gate:** it answers whether a source can be applied to a given piece before
+  attempting it, driving the real rules in dry-run — the schema subset proof,
+  the CFC envelope merge, the retained-link validator — rather than a second
+  copy of them. It does not measure commit rates, so the rehearsal above
+  stands; what it removes is discovering an incompatibility by attempting the
+  swap on the live board.
 - **WS-E's gates may stall it** (OQ1, CFC review, collection unknown, trusted
   ingress mint and propagation): it is last and severable; everything through
   Phase 4 delivers without it, and `topics.agentName` remains the safe interim.

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -6,10 +6,12 @@ as work proceeds: check off exit criteria, record scope changes.
 
 **Amended 2026-07-28**, context only — no scope or decision changed: Risks
 names #5059 (`cf piece setsrc --check`) as the candidate preflight for the
-write-storm gate, and WS-F gains a read-path guard so `cf piece get` on a verb
-redirects to `cf piece call`. The design doc carries the same pass's larger
-share: the llm-dialog handler-branch precedent, tools restated as deferred
-rather than rejected, and the structural-interface property.
+write-storm gate, WS-F gains a read-path guard so `cf piece get` on a verb
+redirects to `cf piece call`, and Non-goals records that constraining
+`cf piece set` is out of scope pending a decision this plan does not make. The
+design doc carries the same pass's larger share: the llm-dialog handler-branch
+precedent, tools restated as deferred rather than rejected, and the
+structural-interface property.
 
 **Amended 2026-07-24** from the first live headless session (a three-topic
 graph, ~24 CLI operations): compact discovery index (A2), closed-world inputs
@@ -60,6 +62,15 @@ Named so their absence reads as intent, not oversight:
   separate comparison with existing slugs and configured host/space addressing.
 - **Cross-space effect atomicity** — the spec's I11 gap stands; the guarantee
   is same-space, which covers `topics`.
+- **Constraining direct data writes.** `cf piece set` writes a result field
+  directly, past every rule in Part 1 — no declared payload, no atomic unit,
+  no typed rejection. The LLM tool surface has no equivalent (it can only
+  mutate through verbs), so the CLI is the outlier. Whether this stays a
+  sanctioned escape hatch depends on a declarative notion of pattern-managed
+  state that does not exist yet (the `readonly`/opt-in-writability question),
+  and `set` is also an authoring and debugging tool whose non-agent uses this
+  contract does not touch. Until that decision is made, the contract governs
+  verbs and says nothing about `set`.
 - **Batch / session mode** for the CLI — orthogonal call-cost work, linked
   rather than orphaned: even perfect verbs leave a fresh runtime paying boot
   and sync per call (20–80 s per mutation observed live), so this gets its

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -25,9 +25,10 @@ decision changed. Prior art records the llm-dialog builtin as a second in-tree
 precedent for the invocation protocol. The "no third callable kind" decision is
 restated as a deferral rather than a rejection, with the two properties that
 keep a create verb additive later. Discovery records two deferred `cf piece
-get` read-control flags, and the property that makes verb sets structural
-interfaces for free. Rule 6 and the schema-evolution section each gain the
-second reason they are load-bearing.
+get` read-control flags, and the machinery that would make verb sets structural
+interfaces — along with the unsettled question of how a verb is identified,
+which that machinery depends on. Rule 6 and the schema-evolution section each
+gain the second reason they are load-bearing.
 
 ## Goal
 
@@ -245,7 +246,8 @@ Rule 6 is also what keeps a set of verbs an *interface* rather than a
 members may depend on call order is a session type: conformance to it cannot be
 decided from the schema alone, because the schema cannot express "only after
 A". With rule 6 held, conformance is a plain structural question — the subset
-check the repo already runs. See Discovery for what that buys.
+check the repo already runs. See Discovery for what that buys, and for the
+premise it still rests on.
 
 ### Attribution: principal and execution provenance
 
@@ -318,7 +320,8 @@ stays bounded.
 Discovery is the parent's job; the child's own verbs are the child's. A comment
 is addressed to the topic, not routed through the board — **but that depends on
 the CLI dispatching a nested piece's streams, which today fails with
-`Transaction required for .set()`** (`packages/runner/src/cell.ts:1316`; its own
+`Transaction required for .set()`** (the non-stream branch of `Cell.set`,
+`packages/runner/src/cell.ts:1347`; its own
 board topic). Until that lands, board-level routing
 (`addComment {topicFid, body}`) is the documented workaround — pragmatic, not
 the target shape.
@@ -327,27 +330,40 @@ Two client affordances surfaced in review (2026-07-28) and are deferred,
 blocking nothing: `cf piece get` could grow flags that let an agent control
 how much data a read returns when exploring the fabric interactively — a
 `--schema` override reading through a narrower schema (the runtime's
-`asSchema`; the
-CLI already narrows its own internal reads this way, e.g.
+`asSchema`; the CLI already narrows its own internal reads this way, e.g.
 `packages/cli/lib/piece-render.ts:41`), and a limit on the number of records
 returned from a large array. Adjacent CLI work for when board scale demands it,
 recorded here so the deferral is deliberate; neither is an ask on any
 workstream in the implementation plan.
 
-**A set of verbs is already a structural interface, and that is free.** Schemas
-are the type system, so a verb set is a schema fragment and conformance is a
-subset check the repo already computes (`schemaSubsetIssue`). Its variance is
-already correct for the purpose: an implementer must accept at least the
-declared payload and return at most the declared result, which is exactly the
-argument/result direction pair above. Interface conformance and schema
-evolution are the same rule — evolution is conformance to one's past self.
-Nothing needs to be built, so any explicit interface mechanism (nominal
-declaration, discovery *by* interface) is deferred until a concrete need
-appears. The one precondition worth stating, because a future change could
-silently cost it: **verbs must stay in the piece's own schema.** Moving the
-verb list into a separate index cell — a plausible response to the read-size
-pressure this section describes — would end the property without any error
-appearing.
+**A set of verbs wants to be a structural interface, and the machinery for that
+already exists.** Schemas are the type system, so a verb set is a schema
+fragment and conformance is a subset check the repo already computes
+(`schemaSubsetIssue`). Its variance is already correct for the purpose: an
+implementer must accept at least the declared payload and return at most the
+declared result, which is exactly the argument/result direction pair above.
+Interface conformance and schema evolution are the same rule — evolution is
+conformance to one's past self. So no type machinery needs building, and any
+explicit interface mechanism (nominal declaration, discovery *by* interface) is
+deferred until a concrete need appears.
+
+What is **not** yet true is the premise all of that rests on: that a piece's
+verbs can be identified from its schema. Verb-ness has three independent
+encodings — the cell's construction kind, `asCell: ["stream"]` in the schema,
+and a stored `{$stream: true}` value — and `Cell.isStream` accepts any one of
+them (`packages/runner/src/cell.ts:936-958`). A conformance check filtering on
+the
+schema marker therefore misses verbs carried only by the stored one, and those
+exist in practice: the CLI keeps a forced-stream fallback specifically to
+dispatch them. Settling which signal is authoritative is already a prerequisite
+for the implementation plan's C3 (result-schema emission keys off the same
+question), and it is the same prerequisite here. Until it is settled, treat
+structural conformance as available in principle rather than in hand.
+
+One further precondition, cheap to hold and easy to lose: **verbs must stay in
+the piece's own schema.** Moving the verb list into a separate index cell — a
+plausible response to the read-size pressure this section describes — would
+end the property without any error appearing.
 
 ### Composition: the atomic-unit rule
 
@@ -763,11 +779,12 @@ sink rather than a commit. And llm-dialog bounds its caller-side wait with a
 120-second `TOOL_CALL_TIMEOUT` (`:126`), whose sibling `REQUEST_TIMEOUT` drops
 a user's message outright when one is pending (`:3053-3062`) — the fixed-wait
 failure class this document's own live-session evidence names one paragraph
-above. So the precedent is precise: the caller-supplied-id → durable-result-
-cell ergonomics are proven, and the bounded wait wrapped around them is exactly
-what returning an address and letting the client decide whether to wait
-removes. The scheduler receipt remains the right substrate for the reasons Part
-2 gives — the create-only exactly-once collision is what a client retry needs.
+above. So the precedent is precise: the ergonomics of a caller-supplied id
+resolving to a durable result cell are proven, and the bounded wait wrapped
+around them is exactly what returning an address and letting the client decide
+whether to wait removes. The scheduler receipt remains the right substrate for
+the reasons Part 2 gives — the create-only exactly-once collision is what a
+client retry needs.
 
 ## Open questions
 
@@ -824,8 +841,9 @@ removes. The scheduler receipt remains the right substrate for the reasons Part
   statement of why, from the 2026-07-28 pass: a "tool" is not a distinct kind
   of callable at all. Both branches of the runtime's tool path do the same
   thing — send an invocation, get a durable result cell at a caller-supplied
-  id — and the pattern branch merely instantiates first, leaving a running
-  instance behind that nothing collects. So instantiation is *a verb whose
+  id — and the pattern branch merely instantiates first, leaving behind a
+  running instance that this path does not collect. So instantiation is *a verb
+  whose
   result is a child reference*, which rule 5 and the child-reference decision
   already cover; it is out of scope here because its extra machinery (pattern
   resolution through `$patternRef`, the CFC observation flag and frozen request
@@ -834,8 +852,9 @@ removes. The scheduler receipt remains the right substrate for the reasons Part
   now: the result envelope must be able to carry a reference (already true —
   patterns return child references), and the payload model must be able to
   express a *declared but not caller-suppliable* field. The second already
-  exists at the type layer as `FrameworkProvided<T>`
-  (`packages/api/index.ts:2252-2270`, used for the bash tool's `sandboxId`);
+  exists at the type layer as `FrameworkProvided<T>` and
+  `FrameworkProvidedKeys<>` (`packages/api/index.ts:2264-2282`, used for the
+  bash tool's `sandboxId`);
   only the runtime's strip list is hardcoded. Rule 1 should be worded so a
   declared field may be framework-owned rather than caller-supplied.
 - **Failures are returned, not recorded.** The receipt's

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -352,13 +352,12 @@ verbs can be identified from its schema. Verb-ness has three independent
 encodings — the cell's construction kind, `asCell: ["stream"]` in the schema,
 and a stored `{$stream: true}` value — and `Cell.isStream` accepts any one of
 them (`packages/runner/src/cell.ts:936-958`). A conformance check filtering on
-the
-schema marker therefore misses verbs carried only by the stored one, and those
-exist in practice: the CLI keeps a forced-stream fallback specifically to
-dispatch them. Settling which signal is authoritative is already a prerequisite
-for the implementation plan's C3 (result-schema emission keys off the same
-question), and it is the same prerequisite here. Until it is settled, treat
-structural conformance as available in principle rather than in hand.
+the schema marker therefore misses verbs carried only by the stored one, and
+those exist in practice: the CLI keeps a forced-stream fallback specifically to
+dispatch them. The same question gates result-schema emission in the
+implementation plan, so settling which signal is authoritative serves both.
+Until it is settled, treat structural conformance as available in principle
+rather than in hand.
 
 One further precondition, cheap to hold and easy to lose: **verbs must stay in
 the piece's own schema.** Moving the verb list into a separate index cell — a

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -604,7 +604,7 @@ Every top-level name published is permanent; a value nested under one key
 leaves only that key permanent and everything beneath it free to narrow. The
 llm-dialog tool path already returns exactly this shape from both of its
 branches — an `@resultLocation` link, the value, and its schema together
-(`packages/runner/src/builtins/llm-dialog.ts:2789-2797` and `:2818-2826`).
+(`packages/runner/src/builtins/llm-dialog.ts:2841-2847` and `:2869-2875`).
 
 ### Authoring
 
@@ -769,14 +769,15 @@ miniature. Its **handler** path mints a result cell at a *caller-supplied* id
 (`toolCall.id`), hands that cell to the handler as `result` — the code's own
 comment reads "doesn't HAVE to be used, but can be" — and resolves off the
 commit callback: `handler.withTx(tx).send({...input, result}, (completedTx) =>
-…)` (`packages/runner/src/builtins/llm-dialog.ts:2730-2735`). That is this
-design's shape, already in production. Two qualifications keep the citation
-honest. It is specifically the handler branch that is the precedent; the
-sibling `runtime.run(tx, pattern, invocationArgs, result)` branch (`:2728`) is
-the tool-as-bound-sub-pattern path this document defers, and it resolves off a
-sink rather than a commit. And llm-dialog bounds its caller-side wait with a
-120-second `TOOL_CALL_TIMEOUT` (`:126`), whose sibling `REQUEST_TIMEOUT` drops
-a user's message outright when one is pending (`:3053-3062`) — the fixed-wait
+…)` (`handleInvoke`, `packages/runner/src/builtins/llm-dialog.ts:2756-2761`).
+That is this design's shape, already in production. Two qualifications keep the
+citation honest. It is specifically the handler branch that is the precedent;
+the sibling `runtime.run(tx, pattern, invocationArgs, result)` branch (`:2754`)
+is the tool-as-bound-sub-pattern path this document defers, and it resolves off
+a sink rather than a commit. And llm-dialog bounds its caller-side wait with a
+120-second `TOOL_CALL_TIMEOUT` (`:131`), whose sibling `REQUEST_TIMEOUT` drops
+a user's message outright when one is pending (the `addMessage` guard,
+`:3105-3111`) — the fixed-wait
 failure class this document's own live-session evidence names one paragraph
 above. So the precedent is precise: the ergonomics of a caller-supplied id
 resolving to a durable result cell are proven, and the bounded wait wrapped

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -20,6 +20,15 @@ not a parallel invocation field; patterns return child references while clients
 render their ids and paths; and client-local `@name` bindings are deferred
 because they overlap confusingly with fabric-side slugs.
 
+**Context added (2026-07-28)**, from a further review pass — additive, no
+decision changed. Prior art records the llm-dialog builtin as a second in-tree
+precedent for the invocation protocol. The "no third callable kind" decision is
+restated as a deferral rather than a rejection, with the two properties that
+keep a create verb additive later. Discovery records two deferred `cf piece
+get` read-control flags, and the property that makes verb sets structural
+interfaces for free. Rule 6 and the schema-evolution section each gain the
+second reason they are load-bearing.
+
 ## Goal
 
 Any pattern drivable by an agent, with no pattern-specific CLI code. Filing one
@@ -231,6 +240,13 @@ relies on. Closing them is safe; what it costs is two commitments:
 Rule 6 has teeth: any "call A, then call B" sequence where A configures B is a
 race under concurrency. Its canonical instance is attribution.
 
+Rule 6 is also what keeps a set of verbs an *interface* rather than a
+*protocol*, which is why it is not merely an ergonomics rule. A verb set whose
+members may depend on call order is a session type: conformance to it cannot be
+decided from the schema alone, because the schema cannot express "only after
+A". With rule 6 held, conformance is a plain structural question — the subset
+check the repo already runs. See Discovery for what that buys.
+
 ### Attribution: principal and execution provenance
 
 A write carries two attributions — who authorized it and who performed it.
@@ -302,10 +318,36 @@ stays bounded.
 Discovery is the parent's job; the child's own verbs are the child's. A comment
 is addressed to the topic, not routed through the board — **but that depends on
 the CLI dispatching a nested piece's streams, which today fails with
-`Transaction required for .set()`** (`packages/runner/src/cell.ts:1294`; its own
+`Transaction required for .set()`** (`packages/runner/src/cell.ts:1316`; its own
 board topic). Until that lands, board-level routing
 (`addComment {topicFid, body}`) is the documented workaround — pragmatic, not
 the target shape.
+
+Two client affordances surfaced in review (2026-07-28) and are deferred,
+blocking nothing: `cf piece get` could grow flags that let an agent control
+how much data a read returns when exploring the fabric interactively — a
+`--schema` override reading through a narrower schema (the runtime's
+`asSchema`; the
+CLI already narrows its own internal reads this way, e.g.
+`packages/cli/lib/piece-render.ts:41`), and a limit on the number of records
+returned from a large array. Adjacent CLI work for when board scale demands it,
+recorded here so the deferral is deliberate; neither is an ask on any
+workstream in the implementation plan.
+
+**A set of verbs is already a structural interface, and that is free.** Schemas
+are the type system, so a verb set is a schema fragment and conformance is a
+subset check the repo already computes (`schemaSubsetIssue`). Its variance is
+already correct for the purpose: an implementer must accept at least the
+declared payload and return at most the declared result, which is exactly the
+argument/result direction pair above. Interface conformance and schema
+evolution are the same rule — evolution is conformance to one's past self.
+Nothing needs to be built, so any explicit interface mechanism (nominal
+declaration, discovery *by* interface) is deferred until a concrete need
+appears. The one precondition worth stating, because a future change could
+silently cost it: **verbs must stay in the piece's own schema.** Moving the
+verb list into a separate index cell — a plausible response to the read-size
+pressure this section describes — would end the property without any error
+appearing.
 
 ### Composition: the atomic-unit rule
 
@@ -530,6 +572,25 @@ open-world. The `Invocation` shape is the first schema this applies to — it
 must be authored open-world so protocol fields such as a payload digest or
 retention metadata can be added later.
 
+"Results may narrow freely" governs *values*, not *named fields*. Removing a
+named property is rejected outright in either direction — `objectSubsetIssue`
+returns "existing result field was removed" whenever the comparison is an
+evolution, on the stated principle that "pattern evolution preserves named
+fields as part of the public contract, even when the candidate object is
+otherwise open" (`packages/piece/src/schema-compatibility.ts:437-444`). A
+verb's `asCell` marker is pinned the same way: it is a semantic extension key
+compared for exact equality (`:100-106`, `:329-333`), so a field cannot change
+between data and verb across a deploy. Verb names and their verb-ness are
+therefore already a contract with teeth, before this document adds any rule.
+
+The practical consequence for verb results: return the value inside an
+envelope under a single key rather than spreading it across top-level fields.
+Every top-level name published is permanent; a value nested under one key
+leaves only that key permanent and everything beneath it free to narrow. The
+llm-dialog tool path already returns exactly this shape from both of its
+branches — an `@resultLocation` link, the value, and its schema together
+(`packages/runner/src/builtins/llm-dialog.ts:2789-2797` and `:2818-2826`).
+
 ### Authoring
 
 ```tsx
@@ -688,6 +749,26 @@ field silently discarded by a stale deployed schema. Each failure maps to a
 section above, and the session's three-topic scenario is adopted as the
 end-to-end acceptance fixture in the implementation plan.
 
+Closer to home, the llm-dialog builtin already runs this invocation protocol in
+miniature. Its **handler** path mints a result cell at a *caller-supplied* id
+(`toolCall.id`), hands that cell to the handler as `result` — the code's own
+comment reads "doesn't HAVE to be used, but can be" — and resolves off the
+commit callback: `handler.withTx(tx).send({...input, result}, (completedTx) =>
+…)` (`packages/runner/src/builtins/llm-dialog.ts:2730-2735`). That is this
+design's shape, already in production. Two qualifications keep the citation
+honest. It is specifically the handler branch that is the precedent; the
+sibling `runtime.run(tx, pattern, invocationArgs, result)` branch (`:2728`) is
+the tool-as-bound-sub-pattern path this document defers, and it resolves off a
+sink rather than a commit. And llm-dialog bounds its caller-side wait with a
+120-second `TOOL_CALL_TIMEOUT` (`:126`), whose sibling `REQUEST_TIMEOUT` drops
+a user's message outright when one is pending (`:3053-3062`) — the fixed-wait
+failure class this document's own live-session evidence names one paragraph
+above. So the precedent is precise: the caller-supplied-id → durable-result-
+cell ergonomics are proven, and the bounded wait wrapped around them is exactly
+what returning an address and letting the client decide whether to wait
+removes. The scheduler receipt remains the right substrate for the reasons Part
+2 gives — the create-only exactly-once collision is what a client retry needs.
+
 ## Open questions
 
 1. **What is the right default retention window**, given that it bounds the
@@ -737,10 +818,26 @@ end-to-end acceptance fixture in the implementation plan.
 - **No `cf topic` command.** `packages/cli` is a layer-4 package (Operation) and
   patterns are layer 7 (End-User Programs); a pattern-specific command inverts
   that dependency and has no principled stopping point once the first one lands.
-- **No third callable kind.** Tools are bound sub-patterns — external logic,
-  the wrong fit for verbs that mutate their host piece — and handlers already
-  have per-invocation result cells at the runtime level. The protocol exposes
-  the handler path rather than inventing beside it.
+- **No third callable kind — tools are deferred, not rejected.** The protocol
+  exposes the handler path rather than inventing beside it, because handlers
+  already have per-invocation result cells at the runtime level. The sharper
+  statement of why, from the 2026-07-28 pass: a "tool" is not a distinct kind
+  of callable at all. Both branches of the runtime's tool path do the same
+  thing — send an invocation, get a durable result cell at a caller-supplied
+  id — and the pattern branch merely instantiates first, leaving a running
+  instance behind that nothing collects. So instantiation is *a verb whose
+  result is a child reference*, which rule 5 and the child-reference decision
+  already cover; it is out of scope here because its extra machinery (pattern
+  resolution through `$patternRef`, the CFC observation flag and frozen request
+  snapshot, and instance lifetime) is real and unrelated to the call protocol.
+  Two properties keep a create verb additive later, and both are cheap to hold
+  now: the result envelope must be able to carry a reference (already true —
+  patterns return child references), and the payload model must be able to
+  express a *declared but not caller-suppliable* field. The second already
+  exists at the type layer as `FrameworkProvided<T>`
+  (`packages/api/index.ts:2252-2270`, used for the bash tool's `sandboxId`);
+  only the runtime's strip list is hardcoded. Rule 1 should be worded so a
+  declared field may be framework-owned rather than caller-supplied.
 - **Failures are returned, not recorded.** The receipt's
   at-most-once-*success* semantics stand as built: no receipt commits on
   failure, the same id safely re-executes, and failure observability is the


### PR DESCRIPTION
## Why

Two threads of context were sitting outside the plan of record and would not
have survived there: Ben's review comment on #4968
([link](https://github.com/commontoolsinc/labs/pull/4968#issuecomment-5098604859)),
and a follow-up reading pass over `llm-dialog`, the schema-compatibility
checker, and the CLI callable surface.

This supersedes the draft #5091, which folded in the comment alone. Two of its
three notes are carried here with corrections; the rest is new. Additive only —
no decision, scope, or workstream changed. Precedent for amending in place:
#5006.

The corrections matter enough to be the reason this is a separate PR rather
than a review on #5091:

- #5091 cites the llm-dialog precedent at `runtime.run(tx, pattern, …)`. That
  is the **tool-as-bound-sub-pattern** branch — the path this document rules
  out by name — and it resolves off a sink, not the commit callback the
  sentence describes. The precedent is the **handler** branch two lines below.
  As written, a reader following the anchor lands on the rejected callable kind
  and can read it as the doc softening its own decision.
- #5091 presents llm-dialog as unqualified evidence "the ergonomics work."
  llm-dialog bounds its caller-side wait with a 120s `TOOL_CALL_TIMEOUT`, and
  its sibling `REQUEST_TIMEOUT` silently drops a user's message when a request
  is pending. Three paragraphs above the insertion point, this same document
  cites "four fixed-timeout sync failures" as motivating evidence. Naming the
  timeout makes llm-dialog the strongest evidence in the section instead of an
  analogy that weakens the moment someone opens the file.

## What Changed

**Design doc**

- **Prior art:** the llm-dialog handler branch recorded as a second in-tree
  precedent, with both qualifications above stated inline.
- **Decisions:** "No third callable kind" restated as *tools are deferred, not
  rejected*. A tool is not a distinct callable kind — both branches of the
  runtime's tool path send an invocation and get a durable result cell at a
  caller-supplied id; the pattern branch merely instantiates first. Records the
  two properties that keep a create verb additive later, one of which
  (`FrameworkProvided<T>`) already exists at the type layer.
- **Discovery:** the two deferred `cf piece get` read-control flags; and the
  property that a verb set is *already* a structural interface, because schemas
  are the type system and the argument/result variance directions already
  match. Explicit interfaces deferred, with the one precondition that would
  silently cost the property — verbs must stay in the piece's own schema, not
  move to a side index.
- **Rule 6:** the second reason it is load-bearing. It is what keeps a verb set
  an interface rather than a session type, so conformance stays decidable from
  the schema.
- **Results and schema evolution:** "results may narrow freely" governs values,
  not named fields — removing a named property is rejected outright, and
  `asCell` is pinned by exact equality. Verb names and verb-ness are already a
  contract with teeth. Practical consequence: return results inside an envelope
  so only one key is permanent.
- Stale citation fixed: the `Transaction required for .set()` error is at
  `cell.ts:1316`, not `:1294`.

**Implementation doc**

- **Risks:** #5059 (`cf piece setsrc --check`) named as the candidate preflight
  for the write-storm gate. It does not measure commit rates, so the rehearsal
  step stands.
- **WS-F:** a read-path guard — `cf piece get` on a verb path returns the
  stream's serialization instead of redirecting; llm-dialog's `read` tool
  already rejects this with the right message.
- **Non-goals:** constraining direct data writes. `cf piece set` writes a result
  field past every rule in Part 1, and the LLM tool surface has no equivalent —
  it can only mutate through verbs — so the CLI is the outlier. Recorded as a
  non-goal rather than addressed: constraining it needs a declarative notion of
  pattern-managed state that this plan does not decide, and `set` has authoring
  and debugging uses this contract does not touch. Named so the absence reads
  as intent, which is what that section is for.

Both docs carry a dated amendment note per house style.

## Deliberately not included

- A reframing of the nested-stream blocker as a stream *misclassification* bug.
  The mechanism checks out — `send()` delegates to `set()`, which throws that
  error only in the non-stream branch — but `resolvePieceCallable` resolves a
  flat callable name with no path traversal, so the nested case fails earlier
  with "Callable not found". The reframe does not hold and stays out.
- Any behavior change to `cf piece set` — only the non-goal entry above, which
  states the gap without taking a position on closing it.

## Test plan

- `deno task check-docs plans` — passes.
- `docs/` is fmt-excluded; prose hand-wrapped at 80 columns (verified no added
  line exceeds it).
- Every citation checked against source at the cited lines: the handler-branch
  mint and `result` handoff (`llm-dialog.ts:2730-2735`), the `runtime.run`
  sibling (`:2728`), both timeouts (`:126`, `:3053-3062`), the result envelope
  in both branches (`:2789-2797`, `:2818-2826`), named-field removal and the
  `asCell` equality check (`schema-compatibility.ts:437-444`, `:100-106`,
  `:329-333`), `FrameworkProvided` (`api/index.ts:2252-2270`), the CLI's own
  narrowing (`piece-render.ts:41`), and `cell.ts:1316`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds review context to the verb contract docs, clarifies the call protocol, and sharpens the structural-interface stance. Records the `llm-dialog` handler precedent, defers tools, adds a read-path guard for `cf piece get`, leaves direct `cf piece set` writes out of scope, and states the result-schema prerequisite directly.

- **Refactors**
  - Design: recorded `llm-dialog` handler-branch precedent; restated tools as deferred with two guardrails (result envelope can carry a reference; payloads may include `FrameworkProvided<>` fields).
  - Structure: captured that interface machinery exists but verb identification is unsettled (three verb-ness encodings; CLI forced-stream fallback); clarified Rule 6’s role; advised returning results in an envelope and treating named fields as permanent.
  - Implementation: added a read-path guard so `cf piece get` on a verb returns the stream serialization; named `#5059` (`cf piece setsrc --check`) as the write-storm preflight; recorded direct `cf piece set` writes as out of scope.

- **Bug Fixes**
  - Repointed drifted citations and added symbol anchors for stability (e.g., `handleInvoke`, `Cell.isStream`, `addMessage`); refreshed line references (e.g., `cell.ts:1347`, `api/index.ts:2264-2282`), fixed hyphenation, tightened claims around collection/timeouts, and rewrapped a ragged paragraph.

<sup>Written for commit cb65a497c25bc1178d9089a448e142308f1f40e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

