### PR TITLE
fix(shell): resolve a view's space before the view renders

### DIFF
--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -266,8 +266,10 @@ export class XRootView extends BaseView {
   // or no runtime); kept only so space.did attribution can track navigation.
   #telemetry: BrowserTelemetry | undefined;
 
-  // The name `space` was resolved from, while the view addresses its space by
-  // name. Navigating within that name keeps the space already resolved.
+  // The name the current lookup was started for, while the view addresses its
+  // space by name. Navigating within that name keeps the space already
+  // resolved, and keeps a lookup still in flight running. A lookup that fails
+  // clears this, so a later navigation to the same name tries again.
   #resolvedSpaceName: string | undefined;
   // Invalidates a resolution that a newer navigation has superseded.
   #resolveSpaceToken = 0;
@@ -287,7 +289,12 @@ export class XRootView extends BaseView {
     const identity = app?.identity;
     const view = app?.view;
     if (identity && view && "spaceName" in view) {
-      if (view.spaceName === this.#resolvedSpaceName && this.space) return;
+      // The name alone decides the space: a named space's key is derived from
+      // the name and a fixed passphrase, so every identity on one name
+      // addresses the same space. A change of identity leaves the answer
+      // alone. The home view below is the case that does turn on identity,
+      // and it recomputes on every change.
+      if (view.spaceName === this.#resolvedSpaceName) return;
       this.#resolveNamedSpace(identity, view.spaceName);
       return;
     }
@@ -315,6 +322,8 @@ export class XRootView extends BaseView {
       (space) => this.#setSpace(space, token),
       (error) => {
         console.error("[RootView] Failed to resolve space name:", error);
+        if (token !== this.#resolveSpaceToken) return;
+        this.#resolvedSpaceName = undefined;
         this.#setSpace(undefined, token);
       },
     );

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -5,12 +5,11 @@ import {
   AppUpdateEvent,
   clone,
   Command,
-  isAppViewEqual,
   isCommand,
   navigate,
 } from "../../shared/mod.ts";
 import { BaseView, createDefaultAppState, SHELL_COMMAND } from "./BaseView.ts";
-import { KeyStore } from "@commonfabric/identity";
+import { type Identity, KeyStore } from "@commonfabric/identity";
 import { property, state } from "lit/decorators.js";
 import { Task } from "@lit/task";
 import {
@@ -139,7 +138,7 @@ export class XRootView extends BaseView {
         // Browser OpenTelemetry (Phase 3): self-gated + lazy — returns null
         // (and imports no OTel SDK) unless telemetryEnabled is set. Attributes
         // use the identity's DID and the currently resolved space; the runtime
-        // (and this sink) outlives navigations, so #resolveViewSpace keeps the
+        // (and this sink) outlives navigations, so #syncViewSpace keeps the
         // sink's space.did current via setSpace.
         const userDid = app.identity.did();
         const telemetry = await initBrowserOtel({
@@ -184,7 +183,7 @@ export class XRootView extends BaseView {
         }
 
         // Update the provided runtime; `space` is view state, resolved
-        // from app.view in updated() independent of the runtime's life.
+        // from app.view in willUpdate() independent of the runtime's life.
         this.runtime = rt.runtime();
 
         // Expose the runtime and cell debug utilities for console use
@@ -234,6 +233,16 @@ export class XRootView extends BaseView {
     }
   };
 
+  // Point `space` at the space the new view addresses. This runs before
+  // render, not in updated(), so no render ever pairs a view with the space
+  // of the view it replaced. AppView reads the view and the space together
+  // and treats a space name that disagrees with a space DID as an error.
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has("app")) {
+      this.#syncViewSpace(this.app);
+    }
+  }
+
   protected override updated(changedProperties: PropertyValues<this>): void {
     if (!changedProperties.has("app")) {
       return;
@@ -251,41 +260,68 @@ export class XRootView extends BaseView {
     if (flipState || stateChanged) {
       this._rt.run([current]);
     }
-    if (
-      flipState || stateChanged ||
-      (previous && !isAppViewEqual(previous.view, current.view))
-    ) {
-      void this.#resolveViewSpace(current);
-    }
   }
 
   // The active browser telemetry sink (undefined when telemetry is disabled
   // or no runtime); kept only so space.did attribution can track navigation.
   #telemetry: BrowserTelemetry | undefined;
 
-  // Resolve the current view to a space DID — view state, independent of
-  // the runtime's lifecycle.
+  // The name `space` was resolved from, while the view addresses its space by
+  // name. Navigating within that name keeps the space already resolved.
+  #resolvedSpaceName: string | undefined;
+  // Invalidates a resolution that a newer navigation has superseded.
   #resolveSpaceToken = 0;
-  async #resolveViewSpace(app: AppState | undefined): Promise<void> {
-    const token = ++this.#resolveSpaceToken;
-    let space: DID | undefined;
+  #spaceResolution: Promise<void> | undefined;
+
+  // Resolves once the space the current view addresses is known. A view that
+  // names its space resolves that name asynchronously, and addresses no space
+  // until the name lands.
+  spaceResolved(): Promise<void> {
+    return this.#spaceResolution ?? Promise.resolve();
+  }
+
+  // Derive the view's space DID — view state, independent of the runtime's
+  // lifecycle. Every path assigns synchronously except a space named by the
+  // view, which has to be looked up.
+  #syncViewSpace(app: AppState | undefined): void {
     const identity = app?.identity;
     const view = app?.view;
+    if (identity && view && "spaceName" in view) {
+      if (view.spaceName === this.#resolvedSpaceName && this.space) return;
+      this.#resolveNamedSpace(identity, view.spaceName);
+      return;
+    }
+
+    this.#resolvedSpaceName = undefined;
+    this.#spaceResolution = undefined;
+    let space: DID | undefined;
     if (identity && view) {
       if ("builtin" in view) {
         space = view.builtin === "home" ? identity.did() : undefined;
       } else if ("spaceDid" in view) {
         space = view.spaceDid;
-      } else if ("spaceName" in view) {
-        try {
-          space = await resolveSpaceDid(identity, view.spaceName);
-        } catch (error) {
-          console.error("[RootView] Failed to resolve space name:", error);
-          space = undefined;
-        }
       }
     }
-    if (token !== this.#resolveSpaceToken) return;
+    this.#setSpace(space, ++this.#resolveSpaceToken);
+  }
+
+  #resolveNamedSpace(identity: Identity, spaceName: string): void {
+    const token = ++this.#resolveSpaceToken;
+    this.#resolvedSpaceName = spaceName;
+    // The lookup is asynchronous, so the view addresses no space until it
+    // completes. The space of the view being replaced is not it.
+    this.#setSpace(undefined, token);
+    this.#spaceResolution = resolveSpaceDid(identity, spaceName).then(
+      (space) => this.#setSpace(space, token),
+      (error) => {
+        console.error("[RootView] Failed to resolve space name:", error);
+        this.#setSpace(undefined, token);
+      },
+    );
+  }
+
+  #setSpace(space: DID | undefined, token: number): void {
+    if (token !== this.#resolveSpaceToken || space === this.space) return;
     this.space = space;
     // Keep browser OTel span attribution in sync with the resolved space —
     // the telemetry sink lives across navigations.

--- a/packages/shell/test/app-view-named-space.test.ts
+++ b/packages/shell/test/app-view-named-space.test.ts
@@ -91,4 +91,61 @@ describe("XAppView named-space preparation", () => {
       restore();
     }
   });
+
+  it("loads nothing while the view's space is still being resolved", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const space = "did:key:z6Mk-shell-app-view-second-space" as DID;
+      const names: string[] = [];
+      const root = { id: () => "root" };
+      const view = new XAppView();
+      // RootView hands the view and its space over together, so a view that
+      // names a space RootView has not resolved yet arrives with no space.
+      view.app = {
+        view: { spaceName: "atlas" },
+      } as never;
+      view.space = undefined;
+      view.rt = {
+        signal: new AbortController().signal,
+        resolveSpaceName: (name: string) => {
+          names.push(name);
+          return Promise.resolve(space);
+        },
+        getSpaceRootPattern: () => Promise.resolve(root),
+      } as never;
+
+      view._spaceRootPattern.run();
+      await view._spaceRootPattern.taskComplete;
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+
+      // No space, so no load and nothing to disagree about.
+      expect(view._spaceRootPattern.value).toBeUndefined();
+      expect(names).toEqual([]);
+
+      // Once the name resolves, the pair agrees and the root pattern loads.
+      view.space = space;
+      view._spaceRootPattern.run();
+      await view._spaceRootPattern.taskComplete;
+      expect(view._spaceRootPattern.value).toBe(root);
+      expect(names).toEqual(["atlas"]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("reports a name that resolves to a space other than the one given", async () => {
+    const { prepareNamedSpace } = await import("../src/lib/named-space.ts");
+    const atlas = "did:key:z6Mk-shell-named-space-atlas" as DID;
+    const notebook = "did:key:z6Mk-shell-named-space-notebook" as DID;
+
+    await expect(
+      prepareNamedSpace(
+        { view: { spaceName: "atlas" } } as never,
+        { resolveSpaceName: () => Promise.resolve(atlas) },
+        notebook,
+      ),
+    ).rejects.toThrow("resolved inconsistently");
+  });
 });

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -194,6 +194,63 @@ describe("XRootView", () => {
     }
   });
 
+  it("drops the previous space before a differently named view renders", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XRootView } = await import("../src/views/RootView.ts");
+      const { resolveSpaceDid } = await import("@commonfabric/lib-shell");
+      const view = new XRootView();
+      const identity = await Identity.fromPassphrase(
+        "root-view-named-space-transition-test",
+      );
+      // willUpdate runs before render, which is the point of the test: what
+      // it leaves behind is what the app view is handed.
+      const lifecycle = view as unknown as {
+        willUpdate(changed: Map<string, unknown>): void;
+      };
+      const appChanged = new Map<string, unknown>([["app", undefined]]);
+      const setView = (next: unknown) => {
+        view.app = {
+          ...view.app,
+          identity,
+          view: next as typeof view.app.view,
+        };
+        lifecycle.willUpdate(appChanged);
+      };
+
+      const atlas = await resolveSpaceDid(identity, "atlas");
+      const notebook = await resolveSpaceDid(identity, "notebook");
+      expect(atlas).not.toBe(notebook);
+
+      // A name is looked up asynchronously, so the view has no space yet.
+      setView({ spaceName: "atlas" });
+      expect(view.getRuntimeSpaceDID()).toBeUndefined();
+      await view.spaceResolved();
+      expect(view.getRuntimeSpaceDID()).toBe(atlas);
+
+      // Moving between pieces of one space keeps the space already resolved.
+      setView({ spaceName: "atlas", pieceId: "piece-1" });
+      expect(view.getRuntimeSpaceDID()).toBe(atlas);
+
+      // Naming a different space drops the old DID in the same step that
+      // adopts the new view, so the two are never rendered together.
+      setView({ spaceName: "notebook" });
+      expect(view.getRuntimeSpaceDID()).toBeUndefined();
+      await view.spaceResolved();
+      expect(view.getRuntimeSpaceDID()).toBe(notebook);
+
+      // A view addressing its space by DID needs no lookup at all.
+      setView({ spaceDid: atlas });
+      expect(view.getRuntimeSpaceDID()).toBe(atlas);
+
+      // The home view addresses the identity's own space.
+      setView({ builtin: "home" });
+      expect(view.getRuntimeSpaceDID()).toBe(identity.did());
+    } finally {
+      restore();
+    }
+  });
+
   it("guards a browser reload only while the runtime reports pending writes", async () => {
     const restore = installBrowserGlobals();
     try {

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -251,6 +251,67 @@ describe("XRootView", () => {
     }
   });
 
+  it("starts one lookup per name, whatever else changes in the app state", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XRootView } = await import("../src/views/RootView.ts");
+      const { resolveSpaceDid } = await import("@commonfabric/lib-shell");
+      const view = new XRootView();
+      const first = await Identity.fromPassphrase("root-view-one-lookup-first");
+      const second = await Identity.fromPassphrase(
+        "root-view-one-lookup-second",
+      );
+      const lifecycle = view as unknown as {
+        willUpdate(changed: Map<string, unknown>): void;
+      };
+      const appChanged = new Map<string, unknown>([["app", undefined]]);
+
+      // A named space is keyed off the name and a fixed passphrase, so it is
+      // the same space for everyone. Identity has no say in the answer.
+      const atlas = await resolveSpaceDid(first, "atlas");
+      expect(await resolveSpaceDid(second, "atlas")).toBe(atlas);
+      expect(first.did()).not.toBe(second.did());
+
+      view.app = {
+        ...view.app,
+        identity: first,
+        view: { spaceName: "atlas" } as typeof view.app.view,
+      };
+      lifecycle.willUpdate(appChanged);
+      // The promise handed back identifies the lookup now in flight.
+      const lookup = view.spaceResolved();
+
+      // An unrelated change while the lookup is still running leaves it be,
+      // rather than abandoning it and starting the same lookup over.
+      view.app = { ...view.app, config: { showDebuggerView: true } };
+      lifecycle.willUpdate(appChanged);
+      expect(view.spaceResolved()).toBe(lookup);
+
+      await lookup;
+      expect(view.getRuntimeSpaceDID()).toBe(atlas);
+
+      // Switching identity on the same name keeps the space, and asks again
+      // for nothing: the answer cannot have changed.
+      view.app = { ...view.app, identity: second };
+      lifecycle.willUpdate(appChanged);
+      expect(view.getRuntimeSpaceDID()).toBe(atlas);
+      expect(view.spaceResolved()).toBe(lookup);
+
+      // Logging out drops the space; logging back in looks it up afresh.
+      view.app = { ...view.app, identity: undefined };
+      lifecycle.willUpdate(appChanged);
+      expect(view.getRuntimeSpaceDID()).toBeUndefined();
+
+      view.app = { ...view.app, identity: second };
+      lifecycle.willUpdate(appChanged);
+      expect(view.spaceResolved()).not.toBe(lookup);
+      await view.spaceResolved();
+      expect(view.getRuntimeSpaceDID()).toBe(atlas);
+    } finally {
+      restore();
+    }
+  });
+
   it("guards a browser reload only while the runtime reports pending writes", async () => {
     const restore = installBrowserGlobals();
     try {


### PR DESCRIPTION
Navigating from one space to another by name — clicking a space chip in the home pattern's list, or any navigation that names a different space — logged an error twice and left AppView's space root pattern task in an error state for one update cycle:

  [AppView] Failed to load space root pattern: Error: Named space <name>
  resolved inconsistently: <newDid> != <oldDid>

RootView held the view and the space it addresses as two independently updated pieces of state. The app state, and with it the view, changes synchronously when a navigation command is applied, but turning a space name into a space DID is asynchronous, and RootView started that lookup from updated(), which runs after render. So a render in between handed AppView the new view paired with the DID of the space the user was leaving. AppView passes that pair to prepareNamedSpace, whose whole job is to reject a name and a DID that disagree, and it threw. The next update carried the resolved DID and the page recovered, so the effect was a pair of console errors and a flash of the "Failed to load piece" path on every cross-space navigation by name.

Move the derivation into willUpdate, so it runs before the render that consumes it, and make the space follow the view in one step. Every kind of view except a named one now resolves synchronously: the home view is the identity's own space, and a view addressing its space by DID already carries it. A named view drops the previous space in the same synchronous step that adopts the new view and fills in the DID when the lookup lands. Until then the view addresses no space at all, which the pattern tasks already handle by loading nothing — the same state as a first page load.

To keep that from costing anything on ordinary navigation, RootView remembers the name the current space was resolved from. Moving between pieces of one space keeps the space already resolved and starts no new lookup; only a change of name does.

prepareNamedSpace keeps its guard. It is now checking for a genuine disagreement rather than reporting a sequencing artifact.

Adds a RootView test walking a name-to-name navigation and asserting the space is dropped in the step that adopts the new view, plus AppView tests covering the window where the view has no space yet and the guard that still fires when a name really does resolve elsewhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross‑space navigation by name by resolving a view’s space before render, so `AppView` never sees a mismatched space name and DID. Also avoids restarting space‑name lookups on unrelated app state changes to prevent flicker and errors.

- **Bug Fixes**
  - Move space derivation from updated() to willUpdate() so the view and its space are in sync before render.
  - Named views: drop the previous space immediately; resolve the DID asynchronously; reuse by name and keep any in‑flight lookup; switching identity on the same name keeps the space; failed lookups clear the marker so retries work.
  - Home view resolves synchronously to the identity’s DID; DID‑addressed views remain synchronous.
  - Keep the prepareNamedSpace guard; it now only triggers on real mismatches.
  - Add tests for name‑to‑name navigation, the no‑space window while resolving, one‑lookup‑per‑name across unrelated state changes and identity switches, and the mismatch guard.

<sup>Written for commit 7977c8fbb98984e5d369f58b7d91275fb3809d4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

