### PR TITLE
docs(plans): verb contract — settle the verb-marking predicate before C3

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -130,6 +130,21 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
   ignored — design rule 1): emit `additionalProperties: false` for event
   payloads, confirm the runner enforces it at dispatch, and record the rule
   in the mapping spec.
+- **Settle before C3 — which signal marks a verb?** "Stream/handler
+  properties" is not a single predicate today. `isStream()` accepts three
+  independent signals, any one of which suffices: the cell's construction kind,
+  `asCell: ["stream"]` in the schema, and a stored `{$stream: true}` value
+  (`packages/runner/src/cell.ts:924-946`). If C3 keys emission off the schema
+  marker alone, a verb carrying only the stored marker gets no result schema
+  and rule 3 silently does not apply to it — and the WS-C exit below would not
+  catch that, since it exercises one CTS pattern that does carry the marker.
+  That the signals diverge in practice is not hypothetical: the CLI has two
+  runtime workarounds for handlers whose schema lost the marker
+  (`tryResolvePieceHandler`, and the forced-stream probe in
+  `listPieceCallables`, whose comment says so). What is *not* yet established
+  is whether any pattern reaches schema-generator in that state. Determine that
+  first; if it can, C3 needs a predicate that agrees with dispatch, and the
+  exit criterion needs a second fixture that lacks the schema marker.
 - ~~**runner:** plain-return projection~~ — **done (C4)**:
   `plainResultReceipts`, default-off, env-reachable
   (`EXPERIMENTAL_PLAIN_RESULT_RECEIPTS`); registry entry in


### PR DESCRIPTION
## Why

WS-C's schema-generator step says to "emit a result schema for stream/handler
properties." That reads as one predicate, and it is not one.

`isStream()` accepts **three independent signals**, any one of which suffices
(`packages/runner/src/cell.ts:924-946`): the cell's construction kind,
`asCell: ["stream"]` in the schema, and a stored `{$stream: true}` value. If C3
keys emission off the schema marker alone, a verb carrying only the stored
marker gets no result schema — rule 3 silently does not apply to it — and WS-C's
exit criterion would not catch it, because it exercises one CTS pattern that
does carry the marker.

That the signals diverge is not hypothetical. The CLI carries two runtime
workarounds for handlers whose schema lost the marker: `tryResolvePieceHandler`,
and the forced-stream probe in `listPieceCallables`, whose comment states the
reason outright — "a handler whose schema lost the stream marker still
dispatches via the forced stream cast … so a callable-by-name verb can never be
absent from the listing."

What is deliberately *not* claimed here: that any pattern actually reaches
schema-generator in that state. The CLI compensating implies it happens
somewhere, but I did not trace where or why. So this lands as a check to settle
before C3, not as a stated defect — the bullet says so explicitly.

Cheaper to answer before C3 than to discover once result schemas are landing.

## What Changed

One bullet in WS-C: the three signals, the failure mode if C3 picks the wrong
one, the existing evidence that they diverge, the explicit gap in that evidence,
and what to do in each case — if a pattern can reach the generator unmarked, C3
needs a predicate that agrees with dispatch, and the exit criterion needs a
second fixture lacking the schema marker.

## Relationship to other PRs

- Independent of #5102 (review context). Different sections of the same file, no
  textual conflict; either can merge first. Held out of #5102 deliberately
  because that PR asserts "context only — no scope or decision changed," and
  adding a gating check to a workstream is not that.
- The `tryResolvePieceHandler` workaround cited above has its own defect, fixed
  separately — it detects through a forced-stream view and then returns a cell
  built without the cast.

## Test plan

- `deno task check-docs plans` — passes.
- `docs/` is fmt-excluded; prose hand-wrapped at 80 columns (verified no added
  line exceeds it).
- Citations checked at the cited lines: the three branches of `isStream()`
  (`cell.ts:924-946`), and both CLI workarounds in `packages/cli/lib/piece.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the WS-C plan to decide how stream verbs are marked before C3 so result schema emission matches runtime dispatch. Documents the three `isStream()` signals and directs C3 to use a matching predicate, adding an exit fixture without the schema marker if needed.

<sup>Written for commit 80548305552c4af66b0c85e4b405a40d5ef1085e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

