### PR TITLE
fix(cli): dispatch fallback-resolved handlers through the proven stream cell

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1348,18 +1348,30 @@ async function tryResolvePieceHandler(
     },
     required: [callableName],
   });
-  if (!isHandlerCell(streamRoot.key(callableName))) {
+  const streamCell = streamRoot.key(callableName);
+  if (!isHandlerCell(streamCell)) {
     return null;
   }
 
+  // Dispatch through the cell whose stream-ness this path just proved, not a
+  // second cell built by reading the schema back from links. Both address the
+  // same target — `getResult` is the identity on the piece cell — so they
+  // differ only in schema, and a link-derived schema is exactly what defeated
+  // the ordinary detection paths above. Sending on that cell takes `.set()`'s
+  // non-stream branch (`packages/runner/src/cell.ts:1316`) and fails with
+  // "Transaction required for .set()" instead of queueing the event, so a verb
+  // this path lists is a verb that could not be called.
   const rootCell = await piece.result.getCell();
-  const callableCell = rootCell.key(callableName).asSchemaFromLinks();
+  const linkDerivedCell = rootCell.key(callableName).asSchemaFromLinks();
   return {
-    callableCell,
+    callableCell: streamCell,
     callableKind: "handler",
     cellKey: callableName,
     cellProp: "result",
-    commandSpec: callableCommandSpec(callableCell, "handler"),
+    // The link-derived cell still carries whatever payload schema the piece
+    // does publish, which the forced stream cast does not; keep using it for
+    // the command spec so `--help` and input validation are unaffected.
+    commandSpec: callableCommandSpec(linkDerivedCell, "handler"),
     manager,
     piece,
     space,

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -914,6 +914,164 @@ function getChildSchema(
   return properties[key] as JSONSchema | undefined;
 }
 
+describe("forced-stream fallback dispatch", () => {
+  /** A verb that defeats ordinary detection — plain object value, no `$stream`
+   * marker, no stream schema — but that the forced stream cast proves is a
+   * handler. This is the only case `tryResolvePieceHandler` exists for, and
+   * the one where the cell that passed detection and the cell built by reading
+   * the schema back from links are not interchangeable. */
+  function createFallbackHarness() {
+    const sends: unknown[] = [];
+    const dataWrites: unknown[] = [];
+
+    // The cell the forced cast proves. Only this one dispatches.
+    const streamCell = {
+      isStream: () => true,
+      send: (value: unknown, onCommit?: (tx: unknown) => void) => {
+        sends.push(value);
+        onCommit?.({ status: () => ({ status: "done" }) });
+      },
+    };
+
+    // What `rootCell.key(name).asSchemaFromLinks()` yields: carries the
+    // published payload schema, but nothing marking it a stream. A real cell
+    // here has a `send` that routes to `.set()`'s non-stream branch and
+    // throws "Transaction required for .set()".
+    // `key()` must yield nothing for "pattern"/"extraParams", or
+    // detectCallableKind's tool probe classifies this as a tool and the
+    // fallback path under test is never reached.
+    const emptyChild = {
+      get: () => undefined,
+      getRaw: () => undefined,
+    };
+    const linkDerivedCell = {
+      schema: {
+        type: "object",
+        properties: { note: { type: "string" } },
+      } as JSONSchema,
+      get: () => ({}),
+      getRaw: () => ({}),
+      asSchemaFromLinks: () => linkDerivedCell,
+      key: () => emptyChild,
+    };
+
+    const rootValue = { hiddenPing: {} };
+    const rootCell = {
+      schema: {
+        type: "object",
+        properties: { hiddenPing: { type: "object" } },
+      } as JSONSchema,
+      get: () => rootValue,
+      getRaw: () => rootValue,
+      asSchemaFromLinks: () => rootCell,
+      key: (name: string) => name === "hiddenPing" ? linkDerivedCell : absent,
+    };
+    // The input root offers nothing, so resolution falls past both ordinary
+    // paths to the forced cast.
+    const absent: {
+      schema?: JSONSchema;
+      get: () => unknown;
+      getRaw: () => unknown;
+      asSchemaFromLinks: () => unknown;
+      key: () => unknown;
+    } = {
+      get: () => undefined,
+      getRaw: () => undefined,
+      asSchemaFromLinks: () => absent,
+      key: () => emptyChild,
+    };
+    const emptyCell = {
+      schema: { type: "object" } as JSONSchema,
+      get: () => ({}),
+      getRaw: () => ({}),
+      asSchemaFromLinks: () => emptyCell,
+      key: () => absent,
+    };
+
+    const piece = {
+      getCell: () => ({
+        get: () => rootValue,
+        asSchema: () => ({ key: () => streamCell }),
+      }),
+      input: {
+        getCell: () => Promise.resolve(emptyCell),
+        set: (value: unknown) => {
+          dataWrites.push(value);
+          return Promise.resolve();
+        },
+      },
+      result: {
+        getCell: () => Promise.resolve(rootCell),
+        set: (value: unknown) => {
+          dataWrites.push(value);
+          return Promise.resolve();
+        },
+      },
+    };
+
+    const manager = {
+      getSpace: () => "home",
+      synced: async () => {},
+      runtime: {
+        [CF_RUNTIME_ERROR_LOG]: [] as Array<{ message: string }>,
+        idle: async () => {},
+      },
+    };
+
+    return { sends, dataWrites, piece, manager, linkDerivedCell, streamCell };
+  }
+
+  const config = {
+    apiUrl: "http://localhost:8000",
+    identity: "/tmp/test-identity.pem",
+    piece: "fid1:piece-123",
+    space: "home",
+  };
+
+  it("sends through the cell whose stream-ness was proven, not a link-derived one", async () => {
+    const harness = createFallbackHarness();
+
+    const result = await executePieceCallable(
+      config,
+      "hiddenPing",
+      ["--note", "hi"],
+      {
+        loadManager: () => Promise.resolve(harness.manager as never),
+        loadPiece: () => Promise.resolve(harness.piece as never),
+        isStdinTerminal: () => true,
+      },
+    );
+
+    expect(result.resolved.callableKind).toBe("handler");
+    // Dispatched as an event through the proven cell. Resolving to the
+    // link-derived cell instead leaves a cell that `.set()` treats as data.
+    expect(result.resolved.callableCell).toBe(harness.streamCell);
+    expect(harness.sends).toEqual([{ note: "hi" }]);
+    expect(harness.dataWrites).toEqual([]);
+  });
+
+  it("keeps the published payload schema for the command spec", async () => {
+    const harness = createFallbackHarness();
+
+    const result = await executePieceCallable(
+      config,
+      "hiddenPing",
+      ["--note", "hi"],
+      {
+        loadManager: () => Promise.resolve(harness.manager as never),
+        loadPiece: () => Promise.resolve(harness.piece as never),
+        isStdinTerminal: () => true,
+      },
+    );
+
+    // The forced cast's own schema is just the stream marker; `--help` and
+    // input validation must still see what the piece publishes.
+    expect(result.resolved.commandSpec.inputSchema).toEqual(
+      harness.linkDerivedCell.schema,
+    );
+  });
+});
+
 describe("piece call stdin payloads", () => {
   it("identifies JSON output without treating delimited fields as selectors", () => {
     expect(


### PR DESCRIPTION
## Why

`cf piece call` resolves a callable through three paths in order: result cell,
input cell, then `tryResolvePieceHandler` — a fallback for handlers whose schema
lost the stream marker. Its own sibling in `listPieceCallables` states the
reason: *"a handler whose schema lost the stream marker still dispatches via the
forced stream cast … so a callable-by-name verb can never be absent from the
listing."*

That fallback detects a handler by imposing `asCell: ["stream"]` on the piece
cell and asking whether the result is a handler cell — and then **discards that
cell**, returning one built by `rootCell.key(name).asSchemaFromLinks()` instead.
Reading the schema back from links is exactly what defeated the two ordinary
detection paths before it.

Both cells address the same target — `getResult` is the identity on the piece
cell (`packages/piece/src/manager.ts:784-788`) — so they differ only in schema.
But `.send()` delegates to `.set()` (`packages/runner/src/cell.ts:1398`), which
branches on `isStream()`: stream → `scheduler.queueEvent`, otherwise a plain
data write requiring a transaction. The link-derived cell fails that test, so it
takes the non-stream branch and throws `Transaction required for .set()`
(`cell.ts:1316`) rather than queueing the event.

Net effect: **a verb this path lists is a verb that cannot be called.** It
appears in `cf piece verbs`, and `cf piece call` fails on it with an error that
describes a data write the caller never asked for.

Found while verifying an unrelated claim about that same error message for the
verb-contract plan (#5102, #5104); it is a real defect independent of that work.

## What Changed

`tryResolvePieceHandler` now dispatches through the cell whose stream-ness it
proved.

The command spec deliberately keeps using the link-derived cell. That cell
carries whatever payload schema the piece does publish, while the forced cast
carries only the stream marker — so swapping it too would silently empty
`--help` and pre-dispatch input validation. The second test below pins that,
since it is the obvious way to get this wrong.

`listPieceCallables` needs no change: its fallback computes a spec but never
dispatches, so it was already reading from the correct cell.

## Test plan

Two tests in `packages/cli/test/piece-call.test.ts`, over a piece whose verb
defeats ordinary detection (plain object value, no `$stream` marker, no stream
schema) but passes the forced cast:

- **dispatch** — asserts the resolved cell is the proven stream cell and that
  the payload arrives via `send`, with no data write. Verified to fail without
  the fix (`git stash` on the lib change → 1 failed step).
- **command spec** — asserts the published payload schema still reaches
  `commandSpec.inputSchema`, guarding the naive fix that swaps both cells.

Suite state:

- `deno task test` in `packages/cli` — 123 passed, 0 failed.
- `deno fmt --check` and `deno check` clean on both changed files.

## Not covered

Both tests use cell doubles, like the rest of this file — they pin the
resolution wiring, not real runtime dispatch. What remains unverified is which
real pattern reaches the CLI in the unmarked state this path exists for. That
question is recorded separately in #5104 as a check to settle before WS-C's C3,
because it also determines whether schema-generator's result-schema emission
would skip the same verbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cf piece call` so fallback-resolved handlers dispatch through the proven stream cell, preventing "Transaction required for .set()" and making listed verbs callable again. The command spec still reads from the link-derived schema to keep `--help` and input validation intact.

- **Bug Fixes**
  - `tryResolvePieceHandler` now sends via the verified stream cell instead of a link-derived cell, avoiding the non-stream `.set()` path.
  - Command spec continues to use the link-derived cell so published payload schemas are preserved.

<sup>Written for commit 06d8496a23a04361f47a664c0660e76b2e999926. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

