### PR TITLE
fix(runner): make slow-traverse report coverage independent of machine speed

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -617,6 +617,18 @@ function prepareAnyOf(
 }
 
 /**
+ * Wall time (ms) above which a traversal reports its stats. The threshold and
+ * the report body live in `maybeReportSlowTraverse()` rather than inline at
+ * the call site: a threshold on real elapsed time decided whether ~40 lines
+ * ran, so leaving it inline made their coverage a function of how fast the
+ * machine happened to be. That swung the `packages/runner` coverage-debt
+ * metric by 39 lines between otherwise identical CI runs, and the ratchet in
+ * `docs/development/COVERAGE.md` then failed whichever pull requests landed on
+ * the fast side of a baseline recorded on the slow side.
+ */
+const SLOW_TRAVERSE_MS = 100;
+
+/**
  * Per-call doc-visit/unique-path diagnostics in `traverseWithSchema` build a
  * string and touch a Map+Set on EVERY schema visit — measurable in tail
  * traversals (thousands of visits each). They only feed the slow-traverse
@@ -2992,38 +3004,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     const rv = this.traverseWithSelector(doc, this.selector, link);
     const { error } = rv;
     const elapsed = logger.timeEnd("traverse") ?? 0;
-    if (elapsed > 100) {
-      // Find top visited docs
-      const topDocs = [...this.docVisits.entries()]
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, 5)
-        .map(([id, count]) => `${id.slice(0, 20)}..=${count}`)
-        .join(" ");
-      logger.warn("slow-traverse", () => [
-        `${elapsed.toFixed(0)}ms`,
-        `doc=${doc.address.id}/${doc.address.type}`,
-        `trackerKeys=${this.schemaTracker.size}`,
-        `trackerVals=${this.schemaTracker.totalValues}`,
-        `traverseSchema=${this.traverseWithSchemaCalls}`,
-        `traversePtr=${this.traversePointerCalls}`,
-        `traverseArr=${this.traverseArrayCalls}`,
-        `traverseObj=${this.traverseObjectCalls}`,
-        `traverseDAG=${this.traverseDAGCalls}`,
-        `anyOfBranches=${this.anyOfBranches}`,
-        `anyOfFastRejects=${this.anyOfFastRejects}`,
-        `anyOfPropertyMerges=${this.anyOfPropertyMerges}`,
-        `getDocAtPath=${this.getDocAtPathCalls}`,
-        `dagMemo=${this.dagMemo.size}`,
-        `uniqueDocs=${this.docVisits.size}`,
-        `uniquePaths=${this.uniquePaths.size}`,
-        `maxDepth=${this.maxDepth}`,
-        `schemaMemo=${this.activeMemo.size}`,
-        `schemaMemoHits=${this.schemaMemoHits}`,
-        TRAVERSE_DIAGNOSTICS
-          ? `topDocs=${topDocs}`
-          : "topDocs=n/a (set CF_TRAVERSE_DIAGNOSTICS=1)",
-      ]);
-    }
+    this.maybeReportSlowTraverse(elapsed, doc);
     if (error !== undefined) {
       // This helps track down mismatched schemas, but may be fine
       logger.debug("traverse", () => [
@@ -3034,6 +3015,54 @@ export class SchemaObjectTraverser<V extends FabricValue>
       ]);
     }
     return rv;
+  }
+
+  /**
+   * Logs the stats of a traversal that ran longer than `SLOW_TRAVERSE_MS`.
+   *
+   * The threshold is tested here rather than at the call site, and the call
+   * site invokes this unconditionally, so that every line in the traversal
+   * path runs on every traversal regardless of how long it took. A test then
+   * reaches the report body by passing an `elapsed` over the threshold — see
+   * `SLOW_TRAVERSE_MS` for why that matters. `topDocs` reports real counts
+   * only under `CF_TRAVERSE_DIAGNOSTICS=1`, which is what populates
+   * `docVisits`.
+   */
+  maybeReportSlowTraverse(
+    elapsed: number,
+    doc: IMemorySpaceValueAttestation,
+  ): void {
+    if (elapsed <= SLOW_TRAVERSE_MS) return;
+    // Find top visited docs
+    const topDocs = [...this.docVisits.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([id, count]) => `${id.slice(0, 20)}..=${count}`)
+      .join(" ");
+    logger.warn("slow-traverse", () => [
+      `${elapsed.toFixed(0)}ms`,
+      `doc=${doc.address.id}/${doc.address.type}`,
+      `trackerKeys=${this.schemaTracker.size}`,
+      `trackerVals=${this.schemaTracker.totalValues}`,
+      `traverseSchema=${this.traverseWithSchemaCalls}`,
+      `traversePtr=${this.traversePointerCalls}`,
+      `traverseArr=${this.traverseArrayCalls}`,
+      `traverseObj=${this.traverseObjectCalls}`,
+      `traverseDAG=${this.traverseDAGCalls}`,
+      `anyOfBranches=${this.anyOfBranches}`,
+      `anyOfFastRejects=${this.anyOfFastRejects}`,
+      `anyOfPropertyMerges=${this.anyOfPropertyMerges}`,
+      `getDocAtPath=${this.getDocAtPathCalls}`,
+      `dagMemo=${this.dagMemo.size}`,
+      `uniqueDocs=${this.docVisits.size}`,
+      `uniquePaths=${this.uniquePaths.size}`,
+      `maxDepth=${this.maxDepth}`,
+      `schemaMemo=${this.activeMemo.size}`,
+      `schemaMemoHits=${this.schemaMemoHits}`,
+      TRAVERSE_DIAGNOSTICS
+        ? `topDocs=${topDocs}`
+        : "topDocs=n/a (set CF_TRAVERSE_DIAGNOSTICS=1)",
+    ]);
   }
 
   /**

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -4199,3 +4199,143 @@ describe("canBranchMatch NaN and Infinity type handling", () => {
     expect(canBranchMatch({ type: "string" }, 42)).toBe(false);
   });
 });
+
+describe("MapSet size and totalValues", () => {
+  // Both getters exist only to fill in the slow-traverse report, so nothing
+  // else in the runtime reads them. Covering them here keeps them off the
+  // machine-speed-dependent path that report used to sit on.
+  it("counts keys and values in the reference-equality mode", () => {
+    const mapSet = new MapSet<string, string>();
+    expect(mapSet.size).toBe(0);
+    expect(mapSet.totalValues).toBe(0);
+
+    mapSet.add("a", "one");
+    mapSet.add("a", "two");
+    mapSet.add("b", "three");
+    // "two" is already present under "a" by reference, so it does not add.
+    mapSet.add("a", "two");
+
+    expect(mapSet.size).toBe(2);
+    expect(mapSet.totalValues).toBe(3);
+  });
+
+  it("counts keys and values in the hash-dedup mode", () => {
+    const mapSet = new MapSet<string, { n: number }>((value) => `${value.n}`);
+    expect(mapSet.size).toBe(0);
+    expect(mapSet.totalValues).toBe(0);
+
+    mapSet.add("a", { n: 1 });
+    mapSet.add("a", { n: 2 });
+    mapSet.add("b", { n: 3 });
+    // A distinct object that hashes the same is a duplicate here, unlike in
+    // the reference-equality mode above.
+    mapSet.add("a", { n: 2 });
+
+    expect(mapSet.size).toBe(2);
+    expect(mapSet.totalValues).toBe(3);
+  });
+});
+
+describe("SchemaObjectTraverser.maybeReportSlowTraverse", () => {
+  // Captures what the logger writes while `run` executes. The report has to
+  // actually be emitted for these tests to mean anything, so the logger is
+  // left enabled and its output intercepted rather than silenced.
+  function captureWarnings(run: () => void): string[] {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map((arg) => String(arg)).join(" "));
+    };
+    try {
+      run();
+    } finally {
+      console.warn = originalWarn;
+    }
+    return warnings;
+  }
+
+  it("reports the traversal's stats", () => {
+    const store = new Map<string, Revision<State>>();
+    const type = "application/json" as const;
+    const docUri = "of:slow-traverse-doc" as URI;
+    const docValue = { employees: [{ name: "Bob" }] };
+
+    const revision: Revision<State> = {
+      the: type,
+      of: docUri as Entity,
+      is: { value: docValue },
+      cause: hashOf({ the: type, of: docUri as Entity }),
+      since: 1,
+    };
+    store.set(`${revision.of}/${revision.the}`, revision);
+
+    const traverser = getTraverser(store, { path: ["value"], schema: true });
+    const doc: IMemorySpaceValueAttestation = {
+      address: {
+        space: "did:null:null",
+        id: docUri,
+        type,
+        path: ["value"],
+      },
+      value: docValue,
+    };
+    traverser.traverse(doc);
+
+    // In production this body is reached only when a traversal exceeds
+    // SLOW_TRAVERSE_MS of real elapsed time. Passing the elapsed time in is
+    // the point: it is what makes the report's coverage independent of
+    // machine speed, which is why the threshold lives in the method.
+    const warnings = captureWarnings(() =>
+      traverser.maybeReportSlowTraverse(150.4, doc)
+    );
+
+    expect(warnings.length).toBe(1);
+    const report = warnings[0];
+    expect(report).toContain("slow-traverse");
+    expect(report).toContain("150ms");
+    expect(report).toContain(`doc=${docUri}/${type}`);
+    // The traversal above ran, so the tracker counters are populated rather
+    // than reporting a zeroed-out traverser.
+    expect(report).toContain("trackerKeys=1");
+    expect(report).toContain("trackerVals=1");
+    expect(report).toContain("traverseSchema=");
+    expect(report).toContain("maxDepth=");
+    // docVisits is populated only under CF_TRAVERSE_DIAGNOSTICS=1.
+    expect(report).toContain("topDocs=n/a (set CF_TRAVERSE_DIAGNOSTICS=1)");
+  });
+
+  it("stays quiet for a traversal at or under the threshold", () => {
+    const store = new Map<string, Revision<State>>();
+    const type = "application/json" as const;
+    const docUri = "of:fast-traverse-doc" as URI;
+    const docValue = { employees: [{ name: "Bob" }] };
+
+    store.set(`${docUri}/${type}`, {
+      the: type,
+      of: docUri as Entity,
+      is: { value: docValue },
+      cause: hashOf({ the: type, of: docUri as Entity }),
+      since: 1,
+    });
+
+    const traverser = getTraverser(store, { path: ["value"], schema: true });
+    const doc: IMemorySpaceValueAttestation = {
+      address: {
+        space: "did:null:null",
+        id: docUri,
+        type,
+        path: ["value"],
+      },
+      value: docValue,
+    };
+
+    // 100ms is the threshold itself, and the guard is exclusive, so this is
+    // the boundary case that must not report.
+    const warnings = captureWarnings(() => {
+      traverser.traverse(doc);
+      traverser.maybeReportSlowTraverse(100, doc);
+    });
+
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -4236,106 +4236,122 @@ describe("MapSet size and totalValues", () => {
   });
 });
 
-describe("SchemaObjectTraverser.maybeReportSlowTraverse", () => {
-  // Captures what the logger writes while `run` executes. The report has to
-  // actually be emitted for these tests to mean anything, so the logger is
-  // left enabled and its output intercepted rather than silenced.
-  function captureWarnings(run: () => void): string[] {
-    const warnings: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (...args: unknown[]) => {
-      warnings.push(args.map((arg) => String(arg)).join(" "));
-    };
-    try {
-      run();
-    } finally {
-      console.warn = originalWarn;
+describe("SchemaObjectTraverser slow-traverse reporting", () => {
+  const type = "application/json" as const;
+
+  // A store that advances the traversal's clock the first time it is read.
+  // `traverse()` is synchronous, so a test cannot step the clock from outside
+  // while a traversal is in flight; loading a linked doc is the hook that runs
+  // during one. If the traversal never reads the store, `advanceMs` never
+  // lands and the assertions fail rather than passing vacuously — which is
+  // what `readStore` is asserted on.
+  class ClockAdvancingStore extends Map<string, Revision<State>> {
+    advanced = false;
+    constructor(private readonly onFirstRead: () => void) {
+      super();
     }
-    return warnings;
+    override get(key: string): Revision<State> | undefined {
+      if (!this.advanced) {
+        this.advanced = true;
+        this.onFirstRead();
+      }
+      return super.get(key);
+    }
   }
 
-  it("reports the traversal's stats", () => {
-    const store = new Map<string, Revision<State>>();
-    const type = "application/json" as const;
+  // Runs one real traversal with `elapsed` pinned to `advanceMs`, and returns
+  // whatever the logger wrote. `performance.now` is what `logger.timeStart` /
+  // `timeEnd` read, so overriding it is what decides the elapsed time the gate
+  // sees — no sleeping, and no dependence on how fast this machine is. The
+  // package's fake clock has already replaced `performance.now` with its own
+  // stub, so the property is saved and put back rather than assumed native.
+  function traverseWithElapsed(
+    advanceMs: number,
+  ): { warnings: string[]; readStore: boolean } {
+    const targetUri = "of:slow-traverse-target" as URI;
     const docUri = "of:slow-traverse-doc" as URI;
-    const docValue = { employees: [{ name: "Bob" }] };
-
-    const revision: Revision<State> = {
-      the: type,
-      of: docUri as Entity,
-      is: { value: docValue },
-      cause: hashOf({ the: type, of: docUri as Entity }),
-      since: 1,
-    };
-    store.set(`${revision.of}/${revision.the}`, revision);
-
-    const traverser = getTraverser(store, { path: ["value"], schema: true });
-    const doc: IMemorySpaceValueAttestation = {
-      address: {
-        space: "did:null:null",
-        id: docUri,
-        type,
-        path: ["value"],
+    // The container links into the target, so resolving it makes the traversal
+    // load the target out of the store — the moment the clock advances.
+    const docValue = {
+      employeeName: {
+        "/": {
+          [LINK_V1_TAG]: { id: targetUri, path: ["employees", "0", "name"] },
+        },
       },
-      value: docValue,
     };
-    traverser.traverse(doc);
 
-    // In production this body is reached only when a traversal exceeds
-    // SLOW_TRAVERSE_MS of real elapsed time. Passing the elapsed time in is
-    // the point: it is what makes the report's coverage independent of
-    // machine speed, which is why the threshold lives in the method.
-    const warnings = captureWarnings(() =>
-      traverser.maybeReportSlowTraverse(150.4, doc)
-    );
-
-    expect(warnings.length).toBe(1);
-    const report = warnings[0];
-    expect(report).toContain("slow-traverse");
-    expect(report).toContain("150ms");
-    expect(report).toContain(`doc=${docUri}/${type}`);
-    // The traversal above ran, so the tracker counters are populated rather
-    // than reporting a zeroed-out traverser.
-    expect(report).toContain("trackerKeys=1");
-    expect(report).toContain("trackerVals=1");
-    expect(report).toContain("traverseSchema=");
-    expect(report).toContain("maxDepth=");
-    // docVisits is populated only under CF_TRAVERSE_DIAGNOSTICS=1.
-    expect(report).toContain("topDocs=n/a (set CF_TRAVERSE_DIAGNOSTICS=1)");
-  });
-
-  it("stays quiet for a traversal at or under the threshold", () => {
-    const store = new Map<string, Revision<State>>();
-    const type = "application/json" as const;
-    const docUri = "of:fast-traverse-doc" as URI;
-    const docValue = { employees: [{ name: "Bob" }] };
-
+    let now = 1000;
+    const store = new ClockAdvancingStore(() => {
+      now += advanceMs;
+    });
+    store.set(`${targetUri}/${type}`, {
+      the: type,
+      of: targetUri as Entity,
+      is: { value: { employees: [{ name: "Bob" }] } },
+      cause: hashOf({ the: type, of: targetUri as Entity }),
+      since: 1,
+    });
     store.set(`${docUri}/${type}`, {
       the: type,
       of: docUri as Entity,
       is: { value: docValue },
       cause: hashOf({ the: type, of: docUri as Entity }),
-      since: 1,
+      since: 2,
     });
 
     const traverser = getTraverser(store, { path: ["value"], schema: true });
     const doc: IMemorySpaceValueAttestation = {
-      address: {
-        space: "did:null:null",
-        id: docUri,
-        type,
-        path: ["value"],
-      },
+      address: { space: "did:null:null", id: docUri, type, path: ["value"] },
       value: docValue,
     };
 
-    // 100ms is the threshold itself, and the guard is exclusive, so this is
-    // the boundary case that must not report.
-    const warnings = captureWarnings(() => {
+    const warnings: string[] = [];
+    const savedWarn = console.warn;
+    const savedNow = performance.now;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map((arg) => String(arg)).join(" "));
+    };
+    Reflect.set(performance, "now", () => now);
+    try {
       traverser.traverse(doc);
-      traverser.maybeReportSlowTraverse(100, doc);
-    });
+    } finally {
+      Reflect.set(performance, "now", savedNow);
+      console.warn = savedWarn;
+    }
+    return { warnings, readStore: store.advanced };
+  }
 
+  it("reports a traversal that crosses the threshold", () => {
+    const { warnings, readStore } = traverseWithElapsed(150);
+
+    expect(readStore).toBe(true);
+    expect(warnings.length).toBe(1);
+    const report = warnings[0];
+    expect(report).toContain("slow-traverse");
+    expect(report).toContain("150ms");
+    expect(report).toContain("doc=of:slow-traverse-doc/application/json");
+    // The container and the doc it links into were both tracked, so the report
+    // is reading live traversal state rather than a zeroed-out traverser.
+    expect(report).toContain("trackerKeys=2");
+    expect(report).toContain("trackerVals=2");
+    expect(report).toContain("traverseSchema=1");
+    expect(report).toContain("maxDepth=1");
+    // docVisits is populated only under CF_TRAVERSE_DIAGNOSTICS=1.
+    expect(report).toContain("topDocs=n/a (set CF_TRAVERSE_DIAGNOSTICS=1)");
+  });
+
+  it("stays quiet for a traversal well under the threshold", () => {
+    const { warnings, readStore } = traverseWithElapsed(5);
+
+    expect(readStore).toBe(true);
     expect(warnings).toEqual([]);
+  });
+
+  it("stays quiet at the threshold exactly, and reports one ms past it", () => {
+    // The gate is `elapsed > SLOW_TRAVERSE_MS`, so 100 is silent and 101 is
+    // not. Pinning both sides keeps a later edit from turning it into `>=`
+    // without a test noticing.
+    expect(traverseWithElapsed(100).warnings).toEqual([]);
+    expect(traverseWithElapsed(101).warnings.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Why

The `coverage-debt: packages/runner uncovered lines` metric is bimodal. It reads
either **6909** or **6948** on `main` — a swing of exactly 39 lines — depending
on nothing but how fast the CI machine happened to be.

Those 39 lines are the `elapsed > 100` slow-traverse diagnostic in
`traverse.ts`, plus the two `MapSet` getters that only that block calls. They
run only when a single traversal exceeds 100 ms of real wall time. In one `main`
run the block was hit **exactly once**, in the `pattern-integration-4` shard
alone; in the next run, never. Diffing the raw LCOV between those two runs,
`traverse.ts` is the *only* file in the package whose count differs — every one
of the other 250 files is identical.

That makes the ratchet in `docs/development/COVERAGE.md` a coin flip. The
baseline is the latest non-cold `main` run, so when `main` lands on the lucky-low
6909, every subsequent pull request whose traversals all stay under 100 ms comes
in at 6948 and fails `+39` with no code cause. #5074 is a clean example:
`OVER 6913 6952 +39 (+0.6%)` on a change that removed no tests.

This is the failure mode `AGENTS.md` warns about for timeouts and sleeps —
behavior that depends on unpredictable timings aligning — applied to coverage
instead of to a test.

## What Changed

- Named the threshold `SLOW_TRAVERSE_MS`, and moved both it and the report body
  into `SchemaObjectTraverser.maybeReportSlowTraverse()`. The call site invokes
  it unconditionally, so every line on the traversal path runs on every
  traversal regardless of elapsed time.
- Tests reach the report by passing an `elapsed` over the threshold, rather than
  by hoping a machine is slow. There is no sleep, poll, or timing assumption.
- `MapSet.size` / `totalValues` exist only to fill in that report, so they rode
  the same coin flip. They now have direct tests in both the reference-equality
  and hash-dedup modes.

Production behavior is unchanged: same 100 ms threshold, same lazy `logger.warn`
thunk, same payload, same `CF_TRAVERSE_DIAGNOSTICS` gating of `topDocs`.

Note this deterministically *lowers* `packages/runner` debt, re-seeding the
ratchet at the stricter of the two values instead of leaving it to chance. It
does not retroactively fix #5074 or #5096 — those need a rebase once this lands.

## Test plan

- `deno task test` in `packages/runner`: **1075 passed, 0 failed** (4m54s).
- `deno check`, `deno fmt --check`, `deno lint` clean on both touched files;
  `deno.lock` untouched.
- Local `DENO_COVERAGE_DIR` run over `traverse.test.ts` confirms the previously
  flaky lines are now covered on every run:

  | lines | before | after |
  |---|---|---|
  | `MapSet.size` / `totalValues` | flaky | 12/12 covered |
  | call site | flaky | covered |
  | report body | flaky | 35/35 covered |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make slow-traverse diagnostics deterministic by moving the threshold and report into `SchemaObjectTraverser.maybeReportSlowTraverse()`, called on every traversal. This stabilizes `packages/runner` coverage by removing machine-speed variance without changing production behavior.

- **Bug Fixes**
  - Added `SLOW_TRAVERSE_MS` (100 ms) and call `maybeReportSlowTraverse(elapsed, doc)` unconditionally from `traverse()`.
  - Tests drive a real `traverse()` with `performance.now` overridden and a clock-advancing store; verify 150ms reports, 5ms is silent, and the boundary is exact (100 silent, 101 reports).
  - Added direct tests for `MapSet.size` and `totalValues` in reference-equality and hash-dedup modes.
  - Same lazy `logger.warn` payload and `CF_TRAVERSE_DIAGNOSTICS` gating; coverage for `packages/runner` is now stable.

<sup>Written for commit f403e10d1aedc5c7113ca91b4adb5d07ee08cf16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

