### PR TITLE
feat(cli): add Python highlighting to cf view

### DIFF
--- a/docs/plans/cf-view-language-coverage.md
+++ b/docs/plans/cf-view-language-coverage.md
@@ -1,11 +1,13 @@
 # `cf view` language and syntax coverage plan
 
-Status: Not started. The order is provisional because recent activity was
+Status: In progress. Python files with recognized extensions now have
+syntax highlighting. The order is provisional because recent activity was
 measured in six of the 24 active organization repositories.
 
 This plan takes `cf view` from its current TypeScript and JavaScript, Markdown,
-JSON and JSONC, YAML, and diff support to honest handling of every textual
-syntax in the active `commontoolsinc` repositories.
+JSON and JSONC, YAML, extension-based Python highlighting, and diff support to
+honest handling of every textual syntax in the active `commontoolsinc`
+repositories.
 
 The frozen evidence is in the
 [July 2026 coverage survey](../history/packages/cli/cf-view-language-coverage-2026-07.md).
@@ -118,8 +120,9 @@ notebook selects JSON or line-oriented JSON without broad suffix guesses.
 
 ## Stage 2: Python
 
-- [ ] Highlight `.py` files and extensionless Python programs.
-- [ ] Recognize direct Python and `uv run` shebangs.
+- [x] Highlight `.py`, `.pyi`, and `.pyw` files.
+- [ ] Recognize extensionless programs from direct Python and `uv run`
+  shebangs.
 - [ ] Add class, function, async function, and decorated-definition structure.
 - [ ] Add representative Loom, Specs, Legibility, Raia, and gVisor fixtures.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,14 +3,15 @@
 ## View pager
 
 `cf view [file]` is an interactive pager for transformed TypeScript, source
-files, and unified diffs. Named Markdown, JSON, JSONC, and YAML files use their
-own syntax highlighting. A piped input without a file name remains TypeScript
-unless it is detected as a diff. Redirected output keeps the text verbatim and
-adds ANSI color only when the selected color mode permits it.
+files, and unified diffs. Named Markdown, JSON, JSONC, YAML, and Python files
+use their own syntax highlighting. A piped input without a file name remains
+TypeScript unless it is detected as a diff. Redirected output keeps the text
+verbatim and adds ANSI color only when the selected color mode permits it.
 
 ```bash
 cf check pattern.tsx --show-transformed --no-run | cf view
 cf view .github/workflows/deno.yml
+cf view scripts/analyse.py
 git diff upstream/main | cf view
 ```
 

--- a/packages/cli/commands/view.ts
+++ b/packages/cli/commands/view.ts
@@ -9,8 +9,8 @@ A less-like viewer for the dense output of '--show-transformed' and saved source
 files. Transformed TypeScript is parsed with the same parser the transformer
 uses, so blocks, closures, schemas, type positions and Common Fabric builders
 (pattern/lift/handler/…) are coloured exactly as the compiler sees them.
-Markdown, JSON, JSONC and YAML files use syntax highlighting selected from
-their names. The text shown is verbatim — colour only.
+Markdown, JSON, JSONC, YAML and Python files use syntax highlighting selected
+from their names. The text shown is verbatim — colour only.
 
 Unified diffs are detected automatically: piping 'git diff' in gives added and
 removed lines their tints, full syntax colour, a structure tree of the code

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -1341,34 +1341,19 @@ function applyCompleteNewFile(
     spliceStart(a.info) - spliceStart(b.info)
   );
   let delta = 0;
-  let groupStart = 0;
-  while (groupStart < ordered.length) {
-    const start = spliceStart(ordered[groupStart].info);
-    let groupEnd = groupStart + 1;
-    while (
-      groupEnd < ordered.length &&
-      spliceStart(ordered[groupEnd].info) === start
-    ) {
-      groupEnd++;
-    }
-    for (let index = groupStart; index < groupEnd; index++) {
-      const { hunk, fileName } = ordered[index];
-      applyCompleteHunkSide(
-        rawLines,
-        model,
-        lines,
-        hunk,
-        "new",
-        complete,
-        fileName,
-        start + delta - spliceStart(hunk),
-      );
-    }
-    for (let index = groupStart; index < groupEnd; index++) {
-      const { hunk, info } = ordered[index];
-      delta += hunk.newCount - info.newCount;
-    }
-    groupStart = groupEnd;
+  for (const { hunk, info, fileName } of ordered) {
+    const start = spliceStart(info);
+    applyCompleteHunkSide(
+      rawLines,
+      model,
+      lines,
+      hunk,
+      "new",
+      complete,
+      fileName,
+      start + delta - spliceStart(hunk),
+    );
+    delta += hunk.newCount - info.newCount;
   }
 }
 

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -93,6 +93,10 @@ export function diffSource(
     edit,
     hunkCommitOwners(edit.sourceText ?? "", git),
   );
+  const completeFiles: DiffHighlightFiles = {
+    fileText: expectedFiles,
+    hunks: saveHunks,
+  };
 
   // No file on disk backs this diff (nothing resolved or verified): read-only.
   // A deletion of an entire file has no new-side lines, but its empty workspace
@@ -207,17 +211,14 @@ export function diffSource(
     isDiff: true,
     editable: true,
     policy,
-    parse: (text) => reparse(ws, text, cache),
+    parse: (text) => reparse(ws, text, cache, completeFiles),
     // Live highlighting recolours the lines an edit changes and reuses the seed
     // (buildDiffDocument's colours, including the file/hunk headers and the
     // workspace-file syntax highlighting) for the rest. Languages whose colour
     // can cross lines re-highlight the complete file. The full parse on
     // pause restores workspace-verified spans across the edit.
     createHighlighter: (text, seed) =>
-      createDiffHighlighter(text, seed, edit.oldFileLines, {
-        fileText: expectedFiles,
-        hunks: saveHunks,
-      }),
+      createDiffHighlighter(text, seed, edit.oldFileLines, completeFiles),
     dirtyLabels: (original, current) =>
       [
         ...collectFileOutputs(
@@ -988,6 +989,7 @@ export function createDiffHighlighter(
   completeFiles?: DiffHighlightFiles,
 ): Highlighter {
   let text = initialText;
+  const completeHighlighters = new Map<string, Highlighter>();
   const initialRaw = initialText.split("\n");
   const initialModel = seed ? null : parseDiff(initialText);
   let lines: Line[] = (seed ??
@@ -1007,6 +1009,7 @@ export function createDiffHighlighter(
       initialRaw.length,
       oldFileLines,
       completeFiles,
+      completeHighlighters,
     );
   }
   return {
@@ -1017,6 +1020,7 @@ export function createDiffHighlighter(
       if (next === text) return lines;
       const oldRaw = text.split("\n");
       const newRaw = next.split("\n");
+      const oldHighlighted = lines;
       const minLen = Math.min(oldRaw.length, newRaw.length);
       let p = 0;
       while (p < minLen && oldRaw[p] === newRaw[p]) p++;
@@ -1027,6 +1031,13 @@ export function createDiffHighlighter(
       ) {
         s++;
       }
+      const localEdit = localDiffLineEdit(
+        oldRaw,
+        newRaw,
+        oldHighlighted,
+        p,
+        s,
+      );
       const model = parseDiff(next);
       const recoloured = newRaw.slice(p, newRaw.length - s).map((l, i) =>
         diffLineRender(
@@ -1047,6 +1058,8 @@ export function createDiffHighlighter(
         newRaw.length - s,
         oldFileLines,
         completeFiles,
+        completeHighlighters,
+        localEdit,
       );
       text = next;
       return lines;
@@ -1059,8 +1072,88 @@ interface DiffHighlightFiles {
   readonly hunks: readonly MutableHunk[];
 }
 
-/** Re-highlight touched YAML sides with complete files when they are available.
- * A fragment remains the fallback for an unverified hunk. */
+interface TouchedHunk {
+  readonly hunk: DiffHunk;
+  readonly info: MutableHunk | undefined;
+}
+
+interface CompleteHunk {
+  readonly hunk: DiffHunk;
+  readonly info: MutableHunk;
+  readonly fileName: string | undefined;
+}
+
+interface LocalDiffLineEdit {
+  readonly newDiffLine: number;
+  readonly before: Line;
+  readonly after: string;
+}
+
+function localDiffLineEdit(
+  oldRaw: readonly string[],
+  newRaw: readonly string[],
+  oldHighlighted: readonly Line[],
+  changedStart: number,
+  commonSuffix: number,
+): LocalDiffLineEdit | undefined {
+  const oldChanged = oldRaw.slice(
+    changedStart,
+    oldRaw.length - commonSuffix,
+  );
+  const newChanged = newRaw.slice(
+    changedStart,
+    newRaw.length - commonSuffix,
+  );
+  let beforeLine: number;
+  let afterLine: number;
+  if (
+    oldChanged.length === 1 && newChanged.length === 1 &&
+    (oldChanged[0][0] === "+" || oldChanged[0][0] === " ") &&
+    oldChanged[0][0] === newChanged[0][0]
+  ) {
+    beforeLine = changedStart;
+    afterLine = changedStart;
+  } else if (
+    oldChanged.length === 1 && newChanged.length === 2 &&
+    oldChanged[0][0] === " " &&
+    newChanged[0] === `-${oldChanged[0].slice(1)}` &&
+    newChanged[1][0] === "+"
+  ) {
+    beforeLine = changedStart;
+    afterLine = changedStart + 1;
+  } else {
+    return undefined;
+  }
+
+  const highlighted = oldHighlighted[beforeLine];
+  const raw = oldRaw[beforeLine];
+  if (!highlighted || !raw || raw.length === 0) return undefined;
+  const marker = raw[0];
+  const markerSpan = highlighted.spans[0];
+  if (
+    markerSpan?.col !== 0 || markerSpan.text !== marker ||
+    markerSpan.text.length !== 1
+  ) {
+    return undefined;
+  }
+  return {
+    newDiffLine: afterLine,
+    before: {
+      text: raw.slice(1),
+      spans: highlighted.spans.slice(1).map((span) => ({
+        ...span,
+        col: span.col - 1,
+      })),
+    },
+    after: newRaw[afterLine].slice(1),
+  };
+}
+
+/**
+ * Re-highlight touched sides with complete files when the language carries
+ * lexical state across lines. A fragment remains the fallback for an unverified
+ * hunk.
+ */
 function rehighlightTouchedHunks(
   rawLines: string[],
   model: DiffModel | null,
@@ -1069,46 +1162,61 @@ function rehighlightTouchedHunks(
   changedEnd: number,
   oldFileLines?: readonly (readonly Line[] | null)[],
   completeFiles?: DiffHighlightFiles,
+  completeHighlighters?: Map<string, Highlighter>,
+  localEdit?: LocalDiffLineEdit,
 ): void {
   if (!model) return;
   const changedLast = Math.max(changedStart, changedEnd - 1);
-  let fullNewFiles: Map<string, string> | undefined;
-  const indexedHunks = model.files.flatMap((file, fileIndex) =>
-    file.hunks.map((hunk) => ({
-      fileIndex,
-      hunk,
-      newFileName: file.newPath ?? file.oldPath,
-    }))
-  ).map((entry, index) => ({
-    ...entry,
-    index,
-    info: completeFiles?.hunks[index],
-  }));
-  const completeLineDeltas = indexedHunks.map(({ info }) => {
-    const path = info?.absPath;
-    if (!path || !isWritable(info)) return 0;
-    return indexedHunks.reduce((delta, other) => {
-      const otherInfo = other.info;
-      return otherInfo?.absPath === path &&
-          isWritable(otherInfo) &&
-          spliceStart(otherInfo) < spliceStart(info)
-        ? delta + other.hunk.newCount - otherInfo.newCount
-        : delta;
-    }, 0);
-  });
+  const statefulFiles: {
+    fileIndex: number;
+    oldFileName: string | undefined;
+    newFileName: string | undefined;
+    oldLanguage: Language;
+    newLanguage: Language;
+    touched: TouchedHunk[];
+  }[] = [];
+  let hunkIndex = 0;
   for (const [fileIndex, file] of model.files.entries()) {
     const oldFileName = file.oldPath ?? file.newPath;
     const newFileName = file.newPath ?? file.oldPath;
     const oldLanguage = languageForFile(oldFileName);
     const newLanguage = languageForFile(newFileName);
-    const fileHunks = indexedHunks.filter((entry) =>
-      entry.fileIndex === fileIndex
-    );
-    const touched = fileHunks.filter(({ hunk }) =>
-      changedLast >= hunk.headerLine && changedStart <= hunk.endLine
-    );
-    if (touched.length === 0) continue;
+    const touched: TouchedHunk[] = [];
+    for (const hunk of file.hunks) {
+      if (
+        (oldLanguage.highlightFullFileOnDiffEdit ||
+          newLanguage.highlightFullFileOnDiffEdit) &&
+        changedLast >= hunk.headerLine && changedStart <= hunk.endLine
+      ) {
+        touched.push({ hunk, info: completeFiles?.hunks[hunkIndex] });
+      }
+      hunkIndex++;
+    }
+    if (touched.length > 0) {
+      statefulFiles.push({
+        fileIndex,
+        oldFileName,
+        newFileName,
+        oldLanguage,
+        newLanguage,
+        touched,
+      });
+    }
+  }
+  if (statefulFiles.length === 0) return;
 
+  let fullNewFiles: Map<string, string> | undefined;
+  let completeHunksByPath: Map<string, CompleteHunk[]> | undefined;
+  const appliedNewPaths = new Set<string>();
+  for (const stateful of statefulFiles) {
+    const {
+      fileIndex,
+      oldFileName,
+      newFileName,
+      oldLanguage,
+      newLanguage,
+      touched,
+    } = stateful;
     if (oldLanguage.highlightFullFileOnDiffEdit) {
       const completeOld = oldFileLines?.[fileIndex];
       for (const { hunk } of touched) {
@@ -1137,10 +1245,25 @@ function rehighlightTouchedHunks(
     }
 
     if (newLanguage.highlightFullFileOnDiffEdit) {
-      const writable = touched.find(({ info }) =>
-        info?.absPath && isWritable(info)
-      )?.info;
-      const path = writable?.absPath;
+      const locallyHighlighted = localEdit !== undefined &&
+        touched.some(({ hunk }) =>
+          localEdit.newDiffLine > hunk.headerLine &&
+          localEdit.newDiffLine <= hunk.endLine
+        ) &&
+        newLanguage.highlightDiffLineEditLocally?.(
+          localEdit.before,
+          localEdit.after,
+        );
+      if (locallyHighlighted && localEdit) {
+        lines[localEdit.newDiffLine] = diffLineRender(
+          rawLines[localEdit.newDiffLine],
+          newFileName,
+          locallyHighlighted.spans,
+        );
+        continue;
+      }
+      const path = touched.find(({ info }) => info?.absPath && isWritable(info))
+        ?.info?.absPath;
       const completeText = path && completeFiles
         ? (fullNewFiles ??= collectFileOutputs(
           rawLines.join("\n"),
@@ -1148,34 +1271,29 @@ function rehighlightTouchedHunks(
           completeFiles.hunks,
         )).get(path)
         : undefined;
-      if (completeText !== undefined && path) {
-        const completeNew = newLanguage.highlightLines(
-          completeText,
-          newFileName,
-        );
-        for (
-          const {
-            hunk,
-            info,
-            index,
-            newFileName: hunkFileName,
-          } of indexedHunks
-        ) {
-          if (info?.absPath !== path || !isWritable(info)) continue;
-          const lineOffset = spliceStart(info) +
-            (completeLineDeltas[index] ?? 0) -
-            spliceStart(hunk);
-          applyCompleteHunkSide(
-            rawLines,
-            model,
-            lines,
-            hunk,
-            "new",
-            completeNew,
-            hunkFileName,
-            lineOffset,
+      if (completeText !== undefined && path && completeFiles) {
+        if (appliedNewPaths.has(path)) continue;
+        appliedNewPaths.add(path);
+        let completeHighlighter = completeHighlighters?.get(path);
+        let completeNew: readonly Line[];
+        if (!completeHighlighter) {
+          completeHighlighter = newLanguage.createHighlighter(
+            completeText,
+            newFileName,
           );
+          completeHighlighters?.set(path, completeHighlighter);
+          completeNew = completeHighlighter.lines;
+        } else {
+          completeNew = completeHighlighter.update(completeText);
         }
+        completeHunksByPath ??= indexCompleteHunks(model, completeFiles);
+        applyCompleteNewFile(
+          rawLines,
+          model,
+          lines,
+          completeNew,
+          completeHunksByPath.get(path) ?? [],
+        );
       } else {
         for (const { hunk } of touched) {
           rehighlightHunkSide(
@@ -1190,6 +1308,67 @@ function rehighlightTouchedHunks(
         }
       }
     }
+  }
+}
+
+function indexCompleteHunks(
+  model: DiffModel,
+  completeFiles: DiffHighlightFiles,
+): Map<string, CompleteHunk[]> {
+  const byPath = new Map<string, CompleteHunk[]>();
+  let index = 0;
+  for (const file of model.files) {
+    const fileName = file.newPath ?? file.oldPath;
+    for (const hunk of file.hunks) {
+      const info = completeFiles.hunks[index++];
+      if (!info?.absPath || !isWritable(info)) continue;
+      const entries = byPath.get(info.absPath) ?? [];
+      entries.push({ hunk, info, fileName });
+      byPath.set(info.absPath, entries);
+    }
+  }
+  return byPath;
+}
+
+function applyCompleteNewFile(
+  rawLines: string[],
+  model: DiffModel,
+  lines: Line[],
+  complete: readonly Line[],
+  entries: readonly CompleteHunk[],
+): void {
+  const ordered = [...entries].sort((a, b) =>
+    spliceStart(a.info) - spliceStart(b.info)
+  );
+  let delta = 0;
+  let groupStart = 0;
+  while (groupStart < ordered.length) {
+    const start = spliceStart(ordered[groupStart].info);
+    let groupEnd = groupStart + 1;
+    while (
+      groupEnd < ordered.length &&
+      spliceStart(ordered[groupEnd].info) === start
+    ) {
+      groupEnd++;
+    }
+    for (let index = groupStart; index < groupEnd; index++) {
+      const { hunk, fileName } = ordered[index];
+      applyCompleteHunkSide(
+        rawLines,
+        model,
+        lines,
+        hunk,
+        "new",
+        complete,
+        fileName,
+        start + delta - spliceStart(hunk),
+      );
+    }
+    for (let index = groupStart; index < groupEnd; index++) {
+      const { hunk, info } = ordered[index];
+      delta += hunk.newCount - info.newCount;
+    }
+    groupStart = groupEnd;
   }
 }
 
@@ -1408,20 +1587,78 @@ export const _internal = {
   dropHeaderBetween,
   joinAdjacent,
   oldLineSpansAt,
+  changedStatefulFileOutputs,
 };
 
 function reparse(
   ws: DiffWorkspace,
   text: string,
   cache?: WorkspaceCache,
+  completeFiles?: DiffHighlightFiles,
 ): Document {
   const model = parseDiff(text);
   // An edit keeps every line's marker, so the text still parses as a diff; if a
   // pathological edit breaks that, fall back to a plain parse so highlighting
   // still updates.
-  return model
-    ? buildDiffDocument(text, model, ws, cache).doc
-    : languageForFile(undefined).parseDocument(text);
+  if (!model) return languageForFile(undefined).parseDocument(text);
+  if (!completeFiles) return buildDiffDocument(text, model, ws, cache).doc;
+  const editedFiles = collectFileOutputs(
+    text,
+    completeFiles.fileText,
+    completeFiles.hunks,
+  );
+  const statefulPaths = new Set<string>();
+  let hunkIndex = 0;
+  for (const file of model.files) {
+    const oldLanguage = languageForFile(file.oldPath ?? file.newPath);
+    const newLanguage = languageForFile(file.newPath ?? file.oldPath);
+    const needsCompleteFile = oldLanguage.highlightFullFileOnDiffEdit ||
+      newLanguage.highlightFullFileOnDiffEdit;
+    for (const _hunk of file.hunks) {
+      const path = completeFiles.hunks[hunkIndex++]?.absPath;
+      if (needsCompleteFile && path) statefulPaths.add(path);
+    }
+  }
+  const statefulEdits = changedStatefulFileOutputs(
+    editedFiles,
+    completeFiles.fileText,
+    statefulPaths,
+  );
+  if (statefulEdits.size === 0) {
+    return buildDiffDocument(text, model, ws, cache).doc;
+  }
+  // Reconstructed files make the edited new side the complete source used for
+  // syntax highlighting and diff verification.
+  const editedWorkspace: DiffWorkspace = {
+    resolve: (path) => ws.resolve(path),
+    read: (path) => {
+      const edited = statefulEdits.get(path);
+      return edited === undefined ? ws.read(path) : edited;
+    },
+    ...(ws.readBlob
+      ? { readBlob: (object: string) => ws.readBlob!(object) }
+      : {}),
+    ...(ws.readBlobs
+      ? {
+        readBlobs: (objects: readonly string[]) => ws.readBlobs!(objects),
+      }
+      : {}),
+  };
+  const editedCache: WorkspaceCache = new Map(cache);
+  for (const path of statefulEdits.keys()) editedCache.delete(path);
+  return buildDiffDocument(text, model, editedWorkspace, editedCache).doc;
+}
+
+function changedStatefulFileOutputs(
+  editedFiles: ReadonlyMap<string, string>,
+  baselines: ReadonlyMap<string, string>,
+  statefulPaths: ReadonlySet<string>,
+): Map<string, string> {
+  return new Map(
+    [...editedFiles].filter(([path, edited]) =>
+      statefulPaths.has(path) && edited !== baselines.get(path)
+    ),
+  );
 }
 
 interface FileSplice {

--- a/packages/cli/lib/view/languages/json/language.ts
+++ b/packages/cli/lib/view/languages/json/language.ts
@@ -25,6 +25,8 @@ export const jsonLanguage: Language = {
 
   highlightLines: (text) => jsonHighlightLines(text),
 
+  highlightFullFileOnDiffEdit: true,
+
   createHighlighter: (text) => createJsonHighlighter(text),
 
   hunkStructure: (ctx) => remapStructure(ctx),

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -2,10 +2,10 @@
  * The contract every source language plugs into so the `cf view` pager can
  * colour, navigate, edit and (optionally) reason about it, plus selecting the
  * right language for a file. A language is a stateless strategy object: one
- * instance describes TypeScript, one Markdown, one JSON, and one YAML. The
- * pager selects the right one for a file ONCE (via {@link languageForFile}) and
- * then dispatches every operation through that object's methods — there is no
- * per-operation branch on the file extension.
+ * instance describes TypeScript, one Markdown, one JSON, one YAML, and one
+ * Python. The pager selects the right one for a file ONCE (via
+ * {@link languageForFile}), then dispatches every operation through that
+ * object's methods — there is no per-operation branch on the file extension.
  *
  * Per-file mutable state (a warm incremental parse, a language service) is not
  * held on the language; the language is a factory for the small stateful
@@ -22,6 +22,7 @@ import { typeScriptLanguage } from "./typescript/language.ts";
 import { markdownLanguage } from "./markdown/language.ts";
 import { jsonLanguage } from "./json/language.ts";
 import { yamlLanguage } from "./yaml/language.ts";
+import { pythonLanguage } from "./python/language.ts";
 
 /**
  * Live syntax highlighting that re-highlights only the region an edit touches,
@@ -105,8 +106,8 @@ export interface HunkStructureContext {
  * language {@link matches} once per file; all later work is method dispatch.
  */
 export interface Language {
-  /** Stable identifier, such as `"typescript"`, `"markdown"`, `"json"`, or
-   * `"yaml"`. */
+  /** Stable identifier, such as `"typescript"`, `"markdown"`, `"json"`,
+   * `"yaml"`, or `"python"`. */
   readonly id: string;
 
   /** Does this language claim `fileName`? Consulted in order by {@link
@@ -124,9 +125,13 @@ export interface Language {
    * advisory (a language may parse `.ts` and `.tsx` differently). */
   highlightLines(text: string, fileName?: string): Line[];
 
-  /** Whether live diff edits need complete-file highlighting because an earlier
-   * line can determine how later lines are coloured. */
+  /** Whether diff edits need complete-file highlighting because an earlier line
+   * can determine how later lines are coloured. */
   readonly highlightFullFileOnDiffEdit?: boolean;
+
+  /** Highlight one source-line edit from its previous complete-file colours, or
+   * return null when the edit can affect syntax outside one token. */
+  highlightDiffLineEditLocally?(before: Line, after: string): Line | null;
 
   /** An incremental highlighter seeded with `text`, for live editing.
    * `fileName` is advisory, as for {@link highlightLines}. */
@@ -173,6 +178,7 @@ function allLanguages(): readonly Language[] {
     markdownLanguage,
     jsonLanguage,
     yamlLanguage,
+    pythonLanguage,
     typeScriptLanguage,
   ];
 }
@@ -206,11 +212,11 @@ export function distinctLanguages(
  * The semantic service for a diff view, from the languages the diff touches. A
  * diff spans potentially many files of different languages; the service is the
  * first language present that offers one, scoped to just its own files (so a
- * TypeScript program is not seeded with the diff's Markdown, JSON, or YAML
- * files). Only TypeScript offers one today, so this resolves to it whenever the
- * diff includes a TypeScript file and to nothing otherwise. When a second
- * semantic language appears this becomes a per-file composite; the per-language
- * slot the pager dispatches through is already here.
+ * TypeScript program is not seeded with the diff's Markdown, JSON, YAML, or
+ * Python files). Only TypeScript offers one today, so this resolves to it
+ * whenever the diff includes a TypeScript file and to nothing otherwise. When
+ * a second semantic language appears this becomes a per-file composite; the
+ * per-language slot the pager dispatches through is already here.
  */
 export function diffSemanticsFor(
   languages: readonly Language[],

--- a/packages/cli/lib/view/languages/markdown/language.ts
+++ b/packages/cli/lib/view/languages/markdown/language.ts
@@ -25,6 +25,8 @@ export const markdownLanguage: Language = {
 
   highlightLines: (text) => highlightMarkdownLines(text),
 
+  highlightFullFileOnDiffEdit: true,
+
   createHighlighter: (text) => createMarkdownHighlighter(text),
 
   hunkStructure(ctx: HunkStructureContext): StructureNode[] {

--- a/packages/cli/lib/view/languages/python/language.ts
+++ b/packages/cli/lib/view/languages/python/language.ts
@@ -1,0 +1,28 @@
+/**
+ * The Python language for the pager. It provides lossless syntax highlighting
+ * for direct files, diffs, and live edits. Python does not provide structure
+ * navigation or a semantic layer.
+ */
+import type { Language } from "../language.ts";
+import {
+  createPythonHighlighter,
+  isPythonPath,
+  pythonDocument,
+  pythonHighlightLines,
+} from "./python.ts";
+
+export const pythonLanguage: Language = {
+  id: "python",
+
+  matches: (fileName) => isPythonPath(fileName),
+
+  parseDocument: (text) => pythonDocument(text),
+
+  highlightLines: (text) => pythonHighlightLines(text),
+
+  highlightFullFileOnDiffEdit: true,
+
+  createHighlighter: (text) => createPythonHighlighter(text),
+
+  hunkStructure: () => [],
+};

--- a/packages/cli/lib/view/languages/python/python.ts
+++ b/packages/cli/lib/view/languages/python/python.ts
@@ -1,0 +1,867 @@
+/**
+ * A lossless Python highlighter for the pager. The scanner follows Python's
+ * lexical tokens while remaining lenient enough to colour a file during an
+ * incomplete edit. It recognises current string prefixes, multiline strings,
+ * identifiers, keywords, numeric forms, comments, operators, and delimiters.
+ *
+ * The scanner consumes the complete document because a triple-quoted string can
+ * determine the colour of later lines. It does not execute Python or require a
+ * Python installation.
+ */
+import type { Document, Line, Span, TokenClass } from "../../model.ts";
+import { cpLen } from "../../ansi.ts";
+import { computeLineStarts, lineIndexOf } from "../../lines.ts";
+import type { Highlighter } from "../language.ts";
+
+/** Whether `fileName` names a Python source or stub file. */
+export function isPythonPath(fileName: string | undefined): boolean {
+  return fileName !== undefined && /\.(py|pyi|pyw)$/i.test(fileName);
+}
+
+interface Token {
+  readonly start: number;
+  readonly end: number;
+  readonly cls: TokenClass;
+  readonly bracketDepth?: number;
+  readonly text?: string;
+}
+
+interface StringStart {
+  readonly quoteStart: number;
+  readonly quote: "'" | '"';
+  readonly triple: boolean;
+  readonly formatted: boolean;
+}
+
+const STRING_PREFIXES = new Set([
+  "b",
+  "f",
+  "r",
+  "t",
+  "u",
+  "br",
+  "fr",
+  "rb",
+  "rf",
+  "rt",
+  "tr",
+]);
+
+const BOOLEAN_WORDS = new Set(["False", "True"]);
+const OPERATOR_WORDS = new Set(["and", "in", "is", "not", "or"]);
+const CONTROL_WORDS = new Set([
+  "break",
+  "continue",
+  "elif",
+  "else",
+  "except",
+  "finally",
+  "for",
+  "if",
+  "pass",
+  "raise",
+  "return",
+  "try",
+  "while",
+  "with",
+  "yield",
+]);
+const STORAGE_WORDS = new Set([
+  "class",
+  "def",
+  "del",
+  "global",
+  "lambda",
+  "nonlocal",
+]);
+const KEYWORDS = new Set([
+  "None",
+  "as",
+  "assert",
+  "async",
+  "await",
+  "from",
+  "import",
+]);
+
+const OPERATORS = [
+  "**=",
+  "//=",
+  "<<=",
+  ">>=",
+  ":=",
+  "!=",
+  "%=",
+  "&=",
+  "**",
+  "*=",
+  "+=",
+  "-=",
+  "->",
+  "//",
+  "/=",
+  "<<",
+  "<=",
+  "==",
+  ">=",
+  ">>",
+  "@=",
+  "^=",
+  "|=",
+  "%",
+  "&",
+  "*",
+  "+",
+  "-",
+  "/",
+  "<",
+  "=",
+  ">",
+  "@",
+  "^",
+  "|",
+  "~",
+] as const;
+
+const ASSIGNMENT_OPERATORS = [
+  "**=",
+  "//=",
+  "<<=",
+  ">>=",
+  "%=",
+  "&=",
+  "*=",
+  "+=",
+  "-=",
+  "/=",
+  "=",
+  "@=",
+  "^=",
+  "|=",
+] as const;
+
+const OPEN_TO_CLOSE = new Map([
+  ["(", ")"],
+  ["[", "]"],
+  ["{", "}"],
+]);
+const CLOSE_TO_OPEN = new Map([
+  [")", "("],
+  ["]", "["],
+  ["}", "{"],
+]);
+
+const ID_START = /^\p{ID_Start}$/u;
+const ID_CONTINUE = /^\p{ID_Continue}$/u;
+
+/** Tokenise `text` into a gapless sequence that covers every source character. */
+function tokenize(text: string): Token[] {
+  const tokens: Token[] = [];
+  const brackets: string[] = [];
+  let declaration: "class" | "function" | undefined;
+  let previous: Token | undefined;
+  let i = 0;
+
+  const add = (
+    start: number,
+    end: number,
+    cls: TokenClass,
+    bracketDepth?: number,
+    tokenText?: string,
+  ): Token => {
+    const token = bracketDepth === undefined
+      ? { start, end, cls, text: tokenText }
+      : { start, end, cls, bracketDepth, text: tokenText };
+    tokens.push(token);
+    return token;
+  };
+
+  while (i < text.length) {
+    const c = text[i];
+    if (isWhitespace(c)) {
+      let end = i + 1;
+      while (end < text.length && isWhitespace(text[end])) end++;
+      add(i, end, "whitespace");
+      i = end;
+      continue;
+    }
+
+    if (c === "#") {
+      let end = i + 1;
+      while (end < text.length && text[end] !== "\n") end++;
+      add(i, end, "comment");
+      i = end;
+      continue;
+    }
+
+    const string = stringStartAt(text, i);
+    if (string) {
+      const end = scanString(text, string);
+      const token = add(
+        i,
+        end,
+        string.formatted ? "template" : "string",
+      );
+      previous = token;
+      declaration = undefined;
+      i = end;
+      continue;
+    }
+
+    if (isDigit(c) || (c === "." && isDigit(text[i + 1]))) {
+      const end = scanNumber(text, i);
+      const token = add(i, end, "number");
+      previous = token;
+      declaration = undefined;
+      i = end;
+      continue;
+    }
+
+    if (isIdentifierStart(text, i)) {
+      const end = scanIdentifier(text, i);
+      const word = text.slice(i, end);
+      let cls: TokenClass;
+      if (declaration !== undefined) {
+        cls = declaration === "function" ? "functionName" : "interfaceName";
+        declaration = undefined;
+      } else {
+        cls = identifierClass(text, i, end, word, previous, brackets.length);
+      }
+      const token = add(i, end, cls, undefined, word);
+      previous = token;
+      if (word === "def") declaration = "function";
+      else if (word === "class") declaration = "class";
+      i = end;
+      continue;
+    }
+
+    if (OPEN_TO_CLOSE.has(c)) {
+      const token = add(i, i + 1, "bracket", brackets.length, c);
+      brackets.push(c);
+      previous = token;
+      declaration = undefined;
+      i++;
+      continue;
+    }
+
+    const expectedOpen = CLOSE_TO_OPEN.get(c);
+    if (expectedOpen !== undefined) {
+      if (brackets.at(-1) === expectedOpen) brackets.pop();
+      const token = add(i, i + 1, "bracket", brackets.length, c);
+      previous = token;
+      declaration = undefined;
+      i++;
+      continue;
+    }
+
+    if (text.startsWith("...", i)) {
+      const token = add(i, i + 3, "keyword", undefined, "...");
+      previous = token;
+      declaration = undefined;
+      i += 3;
+      continue;
+    }
+
+    const operator = OPERATORS.find((candidate) =>
+      text.startsWith(candidate, i)
+    );
+    if (operator !== undefined) {
+      const token = add(
+        i,
+        i + operator.length,
+        "operator",
+        undefined,
+        operator,
+      );
+      previous = token;
+      declaration = undefined;
+      i += operator.length;
+      continue;
+    }
+
+    if (c === "," || c === ":" || c === "." || c === ";" || c === "\\") {
+      const token = add(i, i + 1, "punctuation", undefined, c);
+      previous = token;
+      declaration = undefined;
+      i++;
+      continue;
+    }
+
+    const size = codePointSize(text, i);
+    const token = add(i, i + size, "plain");
+    previous = token;
+    declaration = undefined;
+    i += size;
+  }
+  return tokens;
+}
+
+function identifierClass(
+  text: string,
+  start: number,
+  end: number,
+  word: string,
+  previous: Token | undefined,
+  bracketDepth: number,
+): TokenClass {
+  if (BOOLEAN_WORDS.has(word)) return "boolean";
+  if (OPERATOR_WORDS.has(word)) return "operator";
+  if (CONTROL_WORDS.has(word)) return "controlKeyword";
+  if (STORAGE_WORDS.has(word)) return "storageKeyword";
+  if (KEYWORDS.has(word)) return "keyword";
+  if (softKeywordAt(text, start, end, word, bracketDepth)) {
+    return word === "type" ? "storageKeyword" : "controlKeyword";
+  }
+  if (previous?.text === ".") return "propertyName";
+  const next = skipHorizontalWhitespace(text, end);
+  if (text[next] === "(" || previous?.text === "@") return "callName";
+  return "identifier";
+}
+
+/**
+ * `match`, `case`, and `type` are soft keywords. They retain identifier colour
+ * in assignments and calls, while their statement forms receive keyword colour.
+ */
+function softKeywordAt(
+  text: string,
+  start: number,
+  end: number,
+  word: string,
+  bracketDepth: number,
+): boolean {
+  if (word !== "match" && word !== "case" && word !== "type") {
+    return false;
+  }
+  if (word === "type") {
+    if (!firstTokenInSimpleStatement(text, start)) return false;
+    const next = skipHorizontalWhitespaceAndLineJoins(text, end);
+    if (!isIdentifierStart(text, next)) return false;
+    const afterName = skipHorizontalWhitespaceAndLineJoins(
+      text,
+      scanIdentifier(text, next),
+    );
+    return text[afterName] === "=" ||
+      (text[afterName] === "[" && typeParameterListEndsAtEquals(
+        text,
+        afterName,
+      ));
+  }
+  const next = skipHorizontalWhitespace(text, end);
+  if (bracketDepth > 0) return false;
+  if (!firstTokenOnPhysicalLine(text, start)) return false;
+  if (next === end && (text[end] === "." || text[end] === "[")) {
+    return false;
+  }
+  return statementColonAfter(text, end);
+}
+
+function typeParameterListEndsAtEquals(text: string, start: number): boolean {
+  const brackets = ["["];
+  let i = start + 1;
+  while (i < text.length && brackets.length > 0) {
+    const c = text[i];
+    if (c === "#") {
+      while (i < text.length && text[i] !== "\n") i++;
+      continue;
+    }
+    const string = stringStartAt(text, i);
+    if (string) {
+      i = scanString(text, string);
+      continue;
+    }
+    if (OPEN_TO_CLOSE.has(c)) {
+      brackets.push(c);
+      i++;
+      continue;
+    }
+    const expectedOpen = CLOSE_TO_OPEN.get(c);
+    if (expectedOpen !== undefined && brackets.at(-1) === expectedOpen) {
+      brackets.pop();
+      i++;
+      continue;
+    }
+    i += codePointSize(text, i);
+  }
+  return brackets.length === 0 &&
+    text[skipHorizontalWhitespaceAndLineJoins(text, i)] === "=";
+}
+
+function statementColonAfter(text: string, start: number): boolean {
+  const brackets: string[] = [];
+  let lambdaParameters = 0;
+  let content = false;
+  let i = start;
+  while (i < text.length) {
+    const c = text[i];
+    if (c === "\n" || c === "\r") {
+      if (brackets.length === 0) return false;
+      i++;
+      continue;
+    }
+    if (isHorizontalWhitespace(c)) {
+      i++;
+      continue;
+    }
+    if (c === "#") {
+      if (brackets.length === 0) return false;
+      while (i < text.length && text[i] !== "\n") i++;
+      continue;
+    }
+    if (
+      c === "\\" &&
+      (text[i + 1] === "\n" ||
+        (text[i + 1] === "\r" && text[i + 2] === "\n"))
+    ) {
+      i += text[i + 1] === "\r" ? 3 : 2;
+      continue;
+    }
+    const string = stringStartAt(text, i);
+    if (string) {
+      content = true;
+      i = scanString(text, string);
+      continue;
+    }
+    if (brackets.length === 0 && isIdentifierStart(text, i)) {
+      const end = scanIdentifier(text, i);
+      if (text.slice(i, end) === "lambda") lambdaParameters++;
+      content = true;
+      i = end;
+      continue;
+    }
+    if (OPEN_TO_CLOSE.has(c)) {
+      brackets.push(c);
+      content = true;
+      i++;
+      continue;
+    }
+    const expectedOpen = CLOSE_TO_OPEN.get(c);
+    if (expectedOpen !== undefined) {
+      if (brackets.at(-1) === expectedOpen) brackets.pop();
+      content = true;
+      i++;
+      continue;
+    }
+    if (c === ":" && brackets.length === 0) {
+      if (text[i + 1] === "=") {
+        content = true;
+        i += 2;
+        continue;
+      }
+      if (lambdaParameters > 0) {
+        lambdaParameters--;
+        content = true;
+        i++;
+        continue;
+      }
+      return content;
+    }
+    const assignment = brackets.length === 0
+      ? assignmentOperatorAt(text, i)
+      : undefined;
+    if (assignment !== undefined) {
+      if (lambdaParameters === 0 || assignment !== "=") return false;
+      content = true;
+      i += assignment.length;
+      continue;
+    }
+    content = true;
+    i += codePointSize(text, i);
+  }
+  return false;
+}
+
+function assignmentOperatorAt(
+  text: string,
+  start: number,
+): string | undefined {
+  if (
+    text[start] === "=" &&
+    (text[start + 1] === "=" ||
+      text[start - 1] === "<" ||
+      text[start - 1] === ">" ||
+      text[start - 1] === "!" ||
+      text[start - 1] === "=")
+  ) {
+    return undefined;
+  }
+  return ASSIGNMENT_OPERATORS.find((operator) =>
+    text.startsWith(operator, start)
+  );
+}
+
+function firstTokenOnPhysicalLine(text: string, start: number): boolean {
+  const lineStart = text.lastIndexOf("\n", start - 1) + 1;
+  for (let i = lineStart; i < start; i++) {
+    if (!isHorizontalWhitespace(text[i])) return false;
+  }
+  return true;
+}
+
+function firstTokenInSimpleStatement(text: string, start: number): boolean {
+  const lineStart = text.lastIndexOf("\n", start - 1) + 1;
+  let i = start - 1;
+  while (i >= lineStart && isHorizontalWhitespace(text[i])) i--;
+  if (i < lineStart || text[i] === ";") return true;
+  if (text[i] !== ":") return false;
+  const firstWord = /^[ \t\f\v]*([A-Za-z]+)/.exec(
+    text.slice(lineStart, i),
+  )?.[1];
+  return firstWord !== undefined && INLINE_SUITE_WORDS.has(firstWord);
+}
+
+const INLINE_SUITE_WORDS = new Set([
+  "async",
+  "case",
+  "class",
+  "def",
+  "elif",
+  "else",
+  "except",
+  "finally",
+  "for",
+  "if",
+  "match",
+  "try",
+  "while",
+  "with",
+]);
+
+function stringStartAt(text: string, start: number): StringStart | null {
+  let quoteStart = start;
+  let prefix = "";
+  if (text[start] !== "'" && text[start] !== '"') {
+    for (const length of [2, 1]) {
+      const candidate = text.slice(start, start + length).toLowerCase();
+      const quote = text[start + length];
+      if (
+        STRING_PREFIXES.has(candidate) && (quote === "'" || quote === '"')
+      ) {
+        prefix = candidate;
+        quoteStart = start + length;
+        break;
+      }
+    }
+  }
+  const quote = text[quoteStart];
+  if (quote !== "'" && quote !== '"') return null;
+  return {
+    quoteStart,
+    quote,
+    triple: text.startsWith(quote.repeat(3), quoteStart),
+    formatted: prefix.includes("f") || prefix.includes("t"),
+  };
+}
+
+function scanString(text: string, string: StringStart): number {
+  const width = string.triple ? 3 : 1;
+  const delimiter = string.quote.repeat(width);
+  let i = string.quoteStart + width;
+  while (i < text.length) {
+    if (text.startsWith(delimiter, i)) return i + width;
+    const c = text[i];
+    if (!string.triple && (c === "\n" || c === "\r")) return i;
+    if (c === "\\") {
+      if (
+        string.formatted &&
+        (text[i + 1] === "{" || text[i + 1] === "}")
+      ) {
+        i++;
+      } else {
+        i = scanEscape(text, i);
+      }
+      continue;
+    }
+    if (string.formatted && c === "{") {
+      if (text[i + 1] === "{") {
+        i += 2;
+      } else {
+        i = scanReplacementField(text, i + 1, string.triple);
+      }
+      continue;
+    }
+    i += codePointSize(text, i);
+  }
+  return text.length;
+}
+
+/**
+ * Find the end of one formatted-string replacement field. Nested collections
+ * and nested strings shield their braces, including Python 3.12's same-quote
+ * f-string expressions.
+ */
+function scanReplacementField(
+  text: string,
+  start: number,
+  outerMultiline: boolean,
+): number {
+  const brackets: string[] = [];
+  let formatSpec = false;
+  let firstLineBreak: number | undefined;
+  let i = start;
+  while (i < text.length) {
+    const c = text[i];
+    if (
+      !outerMultiline && firstLineBreak === undefined &&
+      (c === "\n" || c === "\r")
+    ) {
+      firstLineBreak = i;
+    }
+    if (formatSpec) {
+      if (c === "{") {
+        if (text[i + 1] === "{") {
+          i += 2;
+        } else {
+          i = scanReplacementField(text, i + 1, outerMultiline);
+        }
+        continue;
+      }
+      if (c === "}") return i + 1;
+      i += codePointSize(text, i);
+      continue;
+    }
+    if (c === "#") {
+      while (i < text.length && text[i] !== "\n") i++;
+      continue;
+    }
+    const nested = stringStartAt(text, i);
+    if (nested) {
+      i = scanString(text, nested);
+      continue;
+    }
+    if (OPEN_TO_CLOSE.has(c)) {
+      brackets.push(c);
+      i++;
+      continue;
+    }
+    const expectedOpen = CLOSE_TO_OPEN.get(c);
+    if (expectedOpen !== undefined) {
+      if (c === "}" && brackets.length === 0) return i + 1;
+      if (brackets.at(-1) === expectedOpen) brackets.pop();
+      i++;
+      continue;
+    }
+    if (c === ":" && brackets.length === 0 && text[i + 1] !== "=") {
+      formatSpec = true;
+      i++;
+      continue;
+    }
+    if (c === "\\") {
+      i = scanEscape(text, i);
+      continue;
+    }
+    i += codePointSize(text, i);
+  }
+  return firstLineBreak ?? text.length;
+}
+
+function scanEscape(text: string, start: number): number {
+  return text[start + 1] === "\r" && text[start + 2] === "\n"
+    ? start + 3
+    : Math.min(text.length, start + 2);
+}
+
+function scanNumber(text: string, start: number): number {
+  let i = start;
+  if (text[i] === ".") {
+    i = scanDigitPart(text, i + 1, isDigit);
+  } else if (
+    text[i] === "0" &&
+    (text[i + 1] === "b" || text[i + 1] === "B")
+  ) {
+    i = scanBasedInteger(text, i + 2, (c) => c === "0" || c === "1");
+    return i;
+  } else if (
+    text[i] === "0" &&
+    (text[i + 1] === "o" || text[i + 1] === "O")
+  ) {
+    i = scanBasedInteger(text, i + 2, (c) => c >= "0" && c <= "7");
+    return i;
+  } else if (
+    text[i] === "0" &&
+    (text[i + 1] === "x" || text[i + 1] === "X")
+  ) {
+    i = scanBasedInteger(text, i + 2, isHexDigit);
+    return i;
+  } else {
+    i = scanDigitPart(text, i, isDigit);
+    if (text[i] === ".") {
+      i = scanDigitPart(text, i + 1, isDigit);
+    }
+  }
+  if (text[i] === "e" || text[i] === "E") {
+    let exponent = i + 1;
+    if (text[exponent] === "+" || text[exponent] === "-") exponent++;
+    if (isDigit(text[exponent])) i = scanDigitPart(text, exponent, isDigit);
+  }
+  return scanImaginarySuffix(text, i);
+}
+
+function scanBasedInteger(
+  text: string,
+  start: number,
+  digit: (value: string) => boolean,
+): number {
+  let i = start;
+  if (text[i] === "_" && digit(text[i + 1])) i++;
+  return scanDigitPart(text, i, digit);
+}
+
+function scanDigitPart(
+  text: string,
+  start: number,
+  digit: (value: string) => boolean,
+): number {
+  let i = start;
+  while (
+    digit(text[i]) ||
+    (text[i] === "_" && digit(text[i - 1]) && digit(text[i + 1]))
+  ) {
+    i++;
+  }
+  return i;
+}
+
+function scanImaginarySuffix(text: string, end: number): number {
+  return text[end] === "j" || text[end] === "J" ? end + 1 : end;
+}
+
+function scanIdentifier(text: string, start: number): number {
+  let i = start + codePointSize(text, start);
+  while (isIdentifierContinue(text, i)) i += codePointSize(text, i);
+  return i;
+}
+
+function isIdentifierStart(text: string, offset: number): boolean {
+  const value = codePointAt(text, offset);
+  return value === "_" || (value !== undefined && ID_START.test(value));
+}
+
+function isIdentifierContinue(text: string, offset: number): boolean {
+  const value = codePointAt(text, offset);
+  return value === "_" || (value !== undefined && ID_CONTINUE.test(value));
+}
+
+function codePointAt(text: string, offset: number): string | undefined {
+  const point = text.codePointAt(offset);
+  return point === undefined ? undefined : String.fromCodePoint(point);
+}
+
+function codePointSize(text: string, offset: number): number {
+  return (text.codePointAt(offset) ?? 0) > 0xffff ? 2 : 1;
+}
+
+function isDigit(value: string | undefined): boolean {
+  return value !== undefined && value >= "0" && value <= "9";
+}
+
+function isHexDigit(value: string): boolean {
+  return isDigit(value) ||
+    (value >= "a" && value <= "f") ||
+    (value >= "A" && value <= "F");
+}
+
+function isWhitespace(value: string): boolean {
+  return isHorizontalWhitespace(value) || value === "\n" || value === "\r";
+}
+
+function isHorizontalWhitespace(value: string): boolean {
+  return value === " " || value === "\t" || value === "\f" || value === "\v";
+}
+
+function skipHorizontalWhitespace(text: string, start: number): number {
+  let i = start;
+  while (i < text.length && isHorizontalWhitespace(text[i])) i++;
+  return i;
+}
+
+function skipHorizontalWhitespaceAndLineJoins(
+  text: string,
+  start: number,
+): number {
+  let i = start;
+  while (i < text.length) {
+    i = skipHorizontalWhitespace(text, i);
+    if (text[i] !== "\\") return i;
+    if (text[i + 1] === "\n") {
+      i += 2;
+      continue;
+    }
+    if (text[i + 1] === "\r" && text[i + 2] === "\n") {
+      i += 3;
+      continue;
+    }
+    return i;
+  }
+  return i;
+}
+
+/** Split whole-document tokens across physical lines and compute span columns. */
+export function pythonHighlightLines(text: string): Line[] {
+  const lineStarts = computeLineStarts(text);
+  const rawLines = text.split("\n");
+  const spans: Span[][] = rawLines.map(() => []);
+  const columns = rawLines.map(() => 0);
+  for (const token of tokenize(text)) {
+    let position = token.start;
+    let line = lineIndexOf(lineStarts, position);
+    while (position < token.end && line < rawLines.length) {
+      const lineEnd = line + 1 < lineStarts.length
+        ? lineStarts[line + 1] - 1
+        : text.length;
+      const segmentEnd = Math.min(token.end, lineEnd);
+      if (segmentEnd > position) {
+        const segment = text.slice(position, segmentEnd);
+        spans[line].push(
+          token.bracketDepth === undefined
+            ? {
+              col: columns[line],
+              text: segment,
+              cls: token.cls,
+            }
+            : {
+              col: columns[line],
+              text: segment,
+              cls: token.cls,
+              bracketDepth: token.bracketDepth,
+            },
+        );
+        columns[line] += cpLen(segment);
+      }
+      if (segmentEnd < token.end) {
+        line++;
+        position = lineStarts[line] ?? token.end;
+      } else {
+        position = segmentEnd;
+      }
+    }
+  }
+  return rawLines.map((line, index) => ({
+    text: line,
+    spans: spans[index],
+  }));
+}
+
+/** A full Python document with syntax colouring and no semantic structure. */
+export function pythonDocument(text: string): Document {
+  return {
+    text,
+    lines: pythonHighlightLines(text),
+    structure: [],
+    flatStructure: [],
+    definitions: new Map(),
+  };
+}
+
+/** Whole-document highlighting preserves multiline-string state after edits. */
+export function createPythonHighlighter(initial: string): Highlighter {
+  let lines = pythonHighlightLines(initial);
+  return {
+    get lines() {
+      return lines;
+    },
+    update(text: string): readonly Line[] {
+      lines = pythonHighlightLines(text);
+      return lines;
+    },
+  };
+}

--- a/packages/cli/lib/view/languages/typescript/language.ts
+++ b/packages/cli/lib/view/languages/typescript/language.ts
@@ -12,6 +12,7 @@ import { remapStructure } from "../../diffremap.ts";
 import {
   createHighlighter,
   highlightDocument,
+  highlightLineEditLocally,
   parseDocument,
 } from "./parse.ts";
 import { createDiffSemantics, createSemantics } from "./semantics.ts";
@@ -29,6 +30,10 @@ export const typeScriptLanguage: Language = {
   parseDocument: (text, fileName) => parseDocument(text, fileName),
 
   highlightLines: (text, fileName) => highlightDocument(text, fileName),
+
+  highlightFullFileOnDiffEdit: true,
+
+  highlightDiffLineEditLocally: highlightLineEditLocally,
 
   createHighlighter: (text, fileName) => createHighlighter(text, fileName),
 

--- a/packages/cli/lib/view/languages/typescript/parse.ts
+++ b/packages/cli/lib/view/languages/typescript/parse.ts
@@ -257,6 +257,83 @@ function plainDocument(text: string): Document {
   };
 }
 
+/**
+ * A conventional quoted string remains one token when an edit changes only its
+ * unescaped contents. Replacing only that span preserves the complete-file
+ * colours and bracket depths of every other token on the line.
+ */
+export function highlightLineEditLocally(
+  before: Line,
+  after: string,
+): Line | null {
+  const oldText = before.text;
+  if (oldText === after) return before;
+  const minLength = Math.min(oldText.length, after.length);
+  let prefix = 0;
+  while (
+    prefix < minLength &&
+    oldText.charCodeAt(prefix) === after.charCodeAt(prefix)
+  ) {
+    prefix++;
+  }
+  let suffix = 0;
+  while (
+    suffix < minLength - prefix &&
+    oldText.charCodeAt(oldText.length - 1 - suffix) ===
+      after.charCodeAt(after.length - 1 - suffix)
+  ) {
+    suffix++;
+  }
+  const oldEnd = oldText.length - suffix;
+  const newEnd = after.length - suffix;
+
+  let spanStart = 0;
+  for (const [spanIndex, span] of before.spans.entries()) {
+    const spanEnd = spanStart + span.text.length;
+    if (span.cls === "string") {
+      const quote = span.text[0];
+      const quoted = (quote === "'" || quote === '"') &&
+        span.text.length >= 2 && span.text.at(-1) === quote;
+      const content = span.text.slice(1, -1);
+      const contentStart = spanStart + 1;
+      const contentEnd = spanEnd - 1;
+      if (
+        quoted &&
+        !content.includes("\\") &&
+        prefix >= contentStart &&
+        oldEnd <= contentEnd &&
+        prefix <= oldEnd
+      ) {
+        const inserted = after.slice(prefix, newEnd);
+        if (
+          inserted.includes("\\") || inserted.includes(quote) ||
+          /[\r\n\u2028\u2029]/u.test(inserted)
+        ) {
+          return null;
+        }
+        const relativeStart = prefix - spanStart;
+        const relativeEnd = oldEnd - spanStart;
+        const newSpanText = span.text.slice(0, relativeStart) +
+          inserted +
+          span.text.slice(relativeEnd);
+        const columnDelta = cpLen(newSpanText) - cpLen(span.text);
+        return {
+          text: after,
+          spans: before.spans.map((current, index) =>
+            index === spanIndex
+              ? { ...current, text: newSpanText }
+              : index > spanIndex
+              ? { ...current, col: current.col + columnDelta }
+              : current
+          ),
+        };
+      }
+    }
+    spanStart = spanEnd;
+  }
+  return null;
+}
+
 function highlightFromSourceFile(
   sf: ts.SourceFile,
   text: string,

--- a/packages/cli/test/view-diffedit-cov.test.ts
+++ b/packages/cli/test/view-diffedit-cov.test.ts
@@ -21,6 +21,7 @@ import {
   createDiffHighlighter,
   diffSource,
 } from "../lib/view/diffedit.ts";
+import { typeScriptLanguage } from "../lib/view/languages/typescript/language.ts";
 
 /** A workspace backed by a real temp dir. */
 function tempWs(
@@ -529,6 +530,23 @@ Deno.test("diffedit cov: the highlighter's lines getter returns the seeded lines
   }
 });
 
+Deno.test("diffedit cov: a partial seed falls back to rendering the edited line", () => {
+  const bodyLine = DIFF.split("\n").indexOf("+const y = 2;");
+  const partialSeed = createDiffHighlighter(DIFF).lines.slice(0, bodyLine);
+  const highlighter = createDiffHighlighter(
+    DIFF,
+    partialSeed,
+  );
+  const edited = DIFF.replace("+const y = 2;", "+const y = 20;");
+  const changed = highlighter.update(edited)[bodyLine];
+  assertEquals(changed.text, "+const y = 20;");
+  assertEquals(changed.spans[0].cls, "diffAdd");
+  assertEquals(
+    changed.spans.find((span) => span.text === "20")?.cls,
+    "number",
+  );
+});
+
 Deno.test("diffedit cov: deferred parsing selects only changed stateful files", () => {
   const baselines = new Map([
     ["/workspace/changed.ts", "const changed = 1;\n"],
@@ -551,6 +569,129 @@ Deno.test("diffedit cov: deferred parsing selects only changed stateful files", 
     )],
     [["/workspace/changed.ts", "const changed = 2;\n"]],
   );
+});
+
+Deno.test("diffedit cov: repeated non-overlapping file sections are highlighted once", () => {
+  const file = [
+    "const value = `",
+    "first",
+    "middle",
+    "second",
+    "`;",
+    "",
+  ].join("\n");
+  const firstSection = [
+    "diff --git a/template.ts b/template.ts",
+    "--- a/template.ts",
+    "+++ b/template.ts",
+    "@@ -2 +2 @@",
+    "-old first",
+    "+first",
+  ].join("\n");
+  const secondSection = [
+    "diff --git a/template.ts b/template.ts",
+    "--- a/template.ts",
+    "+++ b/template.ts",
+    "@@ -4 +4 @@",
+    "-old second",
+    "+second",
+  ].join("\n");
+  const diff = `${firstSection}\n${secondSection}\n`;
+  const { ws, done } = tempWs({ "template.ts": file });
+  const language = typeScriptLanguage as {
+    createHighlighter: typeof typeScriptLanguage.createHighlighter;
+  };
+  const createHighlighter = language.createHighlighter;
+  let completeCreates = 0;
+  let completeUpdates = 0;
+  language.createHighlighter = (text, fileName) => {
+    completeCreates++;
+    const highlighter = createHighlighter(text, fileName);
+    return {
+      get lines() {
+        return highlighter.lines;
+      },
+      update: (next) => {
+        completeUpdates++;
+        return highlighter.update(next);
+      },
+    };
+  };
+  try {
+    const built = buildDiffDocument(diff, parseDiff(diff)!, ws);
+    const highlighter = diffSource(ws, built.edit).createHighlighter!(
+      diff,
+      built.doc.lines,
+    );
+    const editedText = diff
+      .replace("+first", "+first changed")
+      .replace("+second", "+second changed");
+    const highlighted = highlighter.update(editedText);
+    for (const text of ["first changed", "second changed"]) {
+      const changed = highlighted.find((line) => line.text === `+${text}`);
+      assertEquals(
+        changed?.spans.find((span) => span.text === text)?.cls,
+        "template",
+      );
+    }
+    assertEquals(completeCreates, 1);
+    assertEquals(completeUpdates, 0);
+  } finally {
+    language.createHighlighter = createHighlighter;
+    done();
+  }
+});
+
+Deno.test("diffedit cov: deferred parsing preserves optional blob readers", () => {
+  const file = ["const value = `", "before", "`;", ""].join("\n");
+  const diff = [
+    "diff --git a/template.ts b/template.ts",
+    "index 1111111..2222222 100644",
+    "--- a/template.ts",
+    "+++ b/template.ts",
+    "@@ -2 +2 @@",
+    "-old",
+    "+before",
+    "",
+  ].join("\n");
+  const { root, done } = tempWs({ "template.ts": file });
+  try {
+    for (const reader of ["readBlob", "readBlobs"] as const) {
+      let calls = 0;
+      const optionalReader: Pick<DiffWorkspace, typeof reader> =
+        reader === "readBlob"
+          ? {
+            readBlob: () => {
+              calls++;
+              return null;
+            },
+          }
+          : {
+            readBlobs: () => {
+              calls++;
+              return new Map();
+            },
+          };
+      const ws: DiffWorkspace = {
+        resolve: (path) => join(root, path),
+        read: (path) => Deno.readTextFileSync(path),
+        ...optionalReader,
+      };
+      const built = buildDiffDocument(diff, parseDiff(diff)!, ws);
+      const source = diffSource(ws, built.edit);
+      calls = 0;
+      const editedText = diff.replace("+before", "+after");
+      const reparsed = source.parse(editedText);
+      assert(calls > 0, `${reader} was forwarded to the deferred parse`);
+      const changed = reparsed.lines.find((line) => line.text === "+after");
+      assertEquals(
+        changed?.spans.find((span) => span.text === "after")?.cls,
+        "template",
+      );
+    }
+  } finally {
+    done();
+  }
 });
 
 Deno.test("diffedit cov: the highlighter recolours a Markdown body line via the +++ header scan", () => {
@@ -690,6 +831,13 @@ Deno.test("diffedit cov: a diff matching no file on disk yields a read-only sour
   assertEquals(
     src.save("any text"),
     "Nothing to save — this diff matches no file on disk.",
+  );
+  const parsed = src.parse(DIFF);
+  assertEquals(parsed.text, DIFF);
+  assert(
+    parsed.lines.some((line) =>
+      line.spans.some((span) => span.cls === "diffHunk")
+    ),
   );
 });
 

--- a/packages/cli/test/view-diffedit-cov.test.ts
+++ b/packages/cli/test/view-diffedit-cov.test.ts
@@ -529,6 +529,30 @@ Deno.test("diffedit cov: the highlighter's lines getter returns the seeded lines
   }
 });
 
+Deno.test("diffedit cov: deferred parsing selects only changed stateful files", () => {
+  const baselines = new Map([
+    ["/workspace/changed.ts", "const changed = 1;\n"],
+    ["/workspace/untouched.ts", "const untouched = 1;\n"],
+    ["/workspace/plain.txt", "plain\n"],
+  ]);
+  const edited = new Map([
+    ["/workspace/changed.ts", "const changed = 2;\n"],
+    ["/workspace/untouched.ts", "const untouched = 1;\n"],
+    ["/workspace/plain.txt", "changed plain\n"],
+  ]);
+  assertEquals(
+    [..._de.changedStatefulFileOutputs(
+      edited,
+      baselines,
+      new Set([
+        "/workspace/changed.ts",
+        "/workspace/untouched.ts",
+      ]),
+    )],
+    [["/workspace/changed.ts", "const changed = 2;\n"]],
+  );
+});
+
 Deno.test("diffedit cov: the highlighter recolours a Markdown body line via the +++ header scan", () => {
   // Seed-less so the highlighter renders every line itself, then edit a body
   // line whose nearest preceding header is `+++ b/doc.md` — exercising the

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -327,6 +327,222 @@ export const shown = 2;
   }
 });
 
+Deno.test("diffedit: stateful languages keep complete-file colours after edits", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const cases = [
+      {
+        path: "notes.md",
+        file: ["```python", "before", "```", ""].join("\n"),
+        cls: "string",
+      },
+      {
+        path: "config.jsonc",
+        file: ["/* opening", "before", "*/", ""].join("\n"),
+        cls: "comment",
+      },
+      {
+        path: "template.ts",
+        file: ["const value = `", "before", "`;", ""].join("\n"),
+        cls: "template",
+      },
+    ] as const;
+    const ws: DiffWorkspace = {
+      resolve: (path) => join(root, path),
+      read: (path) => {
+        try {
+          return Deno.readTextFileSync(path);
+        } catch {
+          return null;
+        }
+      },
+    };
+
+    for (const testCase of cases) {
+      Deno.writeTextFileSync(join(root, testCase.path), testCase.file);
+      const diff = [
+        `diff --git a/${testCase.path} b/${testCase.path}`,
+        `--- a/${testCase.path}`,
+        `+++ b/${testCase.path}`,
+        "@@ -2 +2 @@",
+        "-old",
+        "+before",
+        "",
+      ].join("\n");
+      const built = buildDiffDocument(diff, parseDiff(diff)!, ws);
+      const source = diffSource(ws, built.edit);
+      const highlighter = source.createHighlighter!(diff, built.doc.lines);
+      const editedText = diff.replace("+before", "+after");
+      const edited = highlighter.update(editedText);
+      const editedLine = edited[editedText.split("\n").indexOf("+after")];
+      assertEquals(
+        editedLine.spans.find((span) => span.text === "after")?.cls,
+        testCase.cls,
+        `${testCase.path} live colour`,
+      );
+
+      const editedAgainText = editedText.replace("+after", "+again");
+      const editedAgain = highlighter.update(editedAgainText);
+      const editedAgainLine = editedAgain[
+        editedAgainText.split("\n").indexOf("+again")
+      ];
+      assertEquals(
+        editedAgainLine.spans.find((span) => span.text === "again")?.cls,
+        testCase.cls,
+        `${testCase.path} repeated live colour`,
+      );
+
+      const reparsed = source.parse(editedAgainText);
+      const parsedLine = reparsed.lines[
+        editedAgainText.split("\n").indexOf("+again")
+      ];
+      assertEquals(
+        parsedLine.spans.find((span) => span.text === "again")?.cls,
+        testCase.cls,
+        `${testCase.path} deferred colour`,
+      );
+    }
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: a local string edit leaves surrounding template state intact", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const file = [
+      "const value = `head ${",
+      '  "AAHED"',
+      "} tail`;",
+      "",
+    ].join("\n");
+    const path = join(root, "template.ts");
+    Deno.writeTextFileSync(path, file);
+    const diff = [
+      "diff --git a/template.ts b/template.ts",
+      "--- a/template.ts",
+      "+++ b/template.ts",
+      "@@ -2,2 +2,2 @@",
+      '-  "AAHE"',
+      '+  "AAHED"',
+      " } tail`;",
+      "",
+    ].join("\n");
+    const ws: DiffWorkspace = {
+      resolve: () => path,
+      read: () => file,
+    };
+    const built = buildDiffDocument(diff, parseDiff(diff)!, ws);
+    const highlighter = diffSource(ws, built.edit).createHighlighter!(
+      diff,
+      built.doc.lines,
+    );
+    const editedText = diff.replace('"AAHED"', '"AAHEDS"');
+    const edited = highlighter.update(editedText);
+    const raw = editedText.split("\n");
+    const stringLine = edited[raw.indexOf('+  "AAHEDS"')];
+    assertEquals(
+      stringLine.spans.find((span) => span.text === '"AAHEDS"')?.cls,
+      "string",
+    );
+    const tailLine = edited[raw.indexOf(" } tail`;")];
+    assertEquals(
+      tailLine.spans.find((span) => span.text.includes(" tail`"))?.cls,
+      "template",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: a local string edit retains same-line contextual colours", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const file = [
+      "const obj = {",
+      '  label: "AAHED",',
+      "};",
+      "",
+    ].join("\n");
+    const path = join(root, "object.ts");
+    Deno.writeTextFileSync(path, file);
+    const diff = [
+      "diff --git a/object.ts b/object.ts",
+      "--- a/object.ts",
+      "+++ b/object.ts",
+      "@@ -2 +2 @@",
+      '-  label: "AAHE",',
+      '+  label: "AAHED",',
+      "",
+    ].join("\n");
+    const ws: DiffWorkspace = {
+      resolve: () => path,
+      read: () => file,
+    };
+    const built = buildDiffDocument(diff, parseDiff(diff)!, ws);
+    const highlighter = diffSource(ws, built.edit).createHighlighter!(
+      diff,
+      built.doc.lines,
+    );
+    const editedText = diff.replace('"AAHED"', '"AAHEDS"');
+    const highlighted = highlighter.update(editedText);
+    const line = highlighted[
+      editedText.split("\n").indexOf('+  label: "AAHEDS",')
+    ];
+    assertEquals(
+      line.spans.find((span) => span.text === "label")?.cls,
+      "propertyName",
+    );
+    assertEquals(
+      line.spans.find((span) => span.text === '"AAHEDS"')?.cls,
+      "string",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("diffedit: an edit beside a string escape updates later hunks", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const first = 'const v = "a\\"b"; // \\';
+    const editedFirst = 'const v = "a\\x"b"; // \\';
+    const file = `${first}\nNEXT token\n`;
+    const path = join(root, "state.ts");
+    Deno.writeTextFileSync(path, file);
+    const diff = [
+      "diff --git a/state.ts b/state.ts",
+      "--- a/state.ts",
+      "+++ b/state.ts",
+      "@@ -1 +1 @@",
+      "-old first",
+      `+${first}`,
+      "@@ -2 +2 @@",
+      "-old next",
+      "+NEXT token",
+      "",
+    ].join("\n");
+    const ws: DiffWorkspace = {
+      resolve: () => path,
+      read: () => file,
+    };
+    const built = buildDiffDocument(diff, parseDiff(diff)!, ws);
+    const highlighter = diffSource(ws, built.edit).createHighlighter!(
+      diff,
+      built.doc.lines,
+    );
+    const editedText = diff.replace(`+${first}`, `+${editedFirst}`);
+    const highlighted = highlighter.update(editedText);
+    const nextLine = highlighted[editedText.split("\n").indexOf("+NEXT token")];
+    assertEquals(
+      nextLine.spans.find((span) => span.text === "NEXT token")?.cls,
+      "string",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
 Deno.test("diffedit: editing a context line shows it as a removed/added pair", () => {
   const { root, ws, done } = tempWorkspace();
   try {

--- a/packages/cli/test/view-language.test.ts
+++ b/packages/cli/test/view-language.test.ts
@@ -15,6 +15,7 @@ import { typeScriptLanguage } from "../lib/view/languages/typescript/language.ts
 import { markdownLanguage } from "../lib/view/languages/markdown/language.ts";
 import { jsonLanguage } from "../lib/view/languages/json/language.ts";
 import { yamlLanguage } from "../lib/view/languages/yaml/language.ts";
+import { pythonLanguage } from "../lib/view/languages/python/language.ts";
 import {
   buildDiffDocument,
   type DiffMaps,
@@ -29,6 +30,7 @@ Deno.test("languageForFile: extensions resolve, and the rest backstops to TS", (
   assertEquals(languageForFile("README.md").id, "markdown");
   assertEquals(languageForFile("deno.jsonc").id, "json");
   assertEquals(languageForFile("workflow.yml").id, "yaml");
+  assertEquals(languageForFile("script.py").id, "python");
   // No language claims these, so the fallback (TypeScript) resolves them.
   assertEquals(languageForFile("notes.xyz").id, "typescript");
   assertEquals(languageForFile(undefined).id, "typescript");
@@ -41,11 +43,12 @@ Deno.test("distinctLanguages: dedupes in first-seen order", () => {
     "c.md",
     "d.json",
     "e.yaml",
+    "f.py",
     undefined,
   ]);
   assertEquals(
     languages.map((l) => l.id),
-    ["typescript", "markdown", "json", "yaml"],
+    ["typescript", "markdown", "json", "yaml", "python"],
   );
 });
 
@@ -109,7 +112,7 @@ Deno.test("diffSemanticsFor: TypeScript answers over its own files in the diff",
     // those resolves to no service.
     assertEquals(
       diffSemanticsFor(
-        [markdownLanguage, jsonLanguage, yamlLanguage],
+        [markdownLanguage, jsonLanguage, yamlLanguage, pythonLanguage],
         DIFF,
         maps,
         { cwd: root },
@@ -140,6 +143,59 @@ Deno.test("typeScriptLanguage exposes both semantic services", () => {
   } finally {
     done();
   }
+});
+
+Deno.test("typeScriptLanguage identifies edits confined to quoted string contents", () => {
+  const highlightLocally = typeScriptLanguage.highlightDiffLineEditLocally!;
+  const stringLine = typeScriptLanguage.highlightLines(
+    '  "AAHED",',
+    "words.ts",
+  )[0];
+  assert(
+    highlightLocally(stringLine, '  "AAHEDS",'),
+    "an insertion before the unchanged closing quote stays within one string",
+  );
+  const contextualBefore = [
+    "const value = {",
+    '  label: "A", nested: [true],',
+    "};",
+  ].join("\n");
+  const contextualAfter = contextualBefore.replace('"A"', '"A😀"');
+  assertEquals(
+    highlightLocally(
+      typeScriptLanguage.highlightLines(contextualBefore, "object.ts")[1],
+      '  label: "A😀", nested: [true],',
+    ),
+    typeScriptLanguage.highlightLines(contextualAfter, "object.ts")[1],
+    "other token classes, bracket depths, and Unicode columns stay unchanged",
+  );
+  assertEquals(
+    highlightLocally(stringLine, '  "AAHED\\S",'),
+    null,
+    "an escape change can alter how the rest of the line is tokenised",
+  );
+  const escapedLine = typeScriptLanguage.highlightLines(
+    String.raw`const value = "a\"b";`,
+    "escaped.ts",
+  )[0];
+  assertEquals(
+    highlightLocally(
+      escapedLine,
+      String.raw`const value = "ax\"b";`,
+    ),
+    null,
+    "an existing escape can interact with an adjacent edit",
+  );
+
+  const templateLine = typeScriptLanguage.highlightLines(
+    "const value = `\nbefore\n`;\n",
+    "template.ts",
+  )[1];
+  assertEquals(
+    highlightLocally(templateLine, "after"),
+    null,
+    "template contents retain state from an earlier line",
+  );
 });
 
 Deno.test("diffSemanticsFor: a language with no matching files is skipped", () => {

--- a/packages/cli/test/view-parse-cov.test.ts
+++ b/packages/cli/test/view-parse-cov.test.ts
@@ -31,6 +31,7 @@ import { assert, assertEquals } from "@std/assert";
 import {
   createHighlighter,
   highlightDocument,
+  highlightLineEditLocally,
   parseDocument,
 } from "../lib/view/languages/typescript/parse.ts";
 import { languageForFile } from "../lib/view/languages/language.ts";
@@ -97,6 +98,11 @@ Deno.test("createHighlighter: update with identical text returns the same lines"
   // diffRange returns null for identical text, so update short-circuits and
   // hands back the exact same array reference.
   assertEquals(after, before);
+});
+
+Deno.test("highlightLineEditLocally: unchanged text returns the original line", () => {
+  const before = createHighlighter('const value = "same";', "m.ts").lines[0];
+  assert(highlightLineEditLocally(before, before.text) === before);
 });
 
 // --- safeStartLine walk-back past a multi-line token (lines 459, 460) --------

--- a/packages/cli/test/view-python.test.ts
+++ b/packages/cli/test/view-python.test.ts
@@ -1,0 +1,643 @@
+/**
+ * Python highlighting for direct files, diffs, and live edits. The scanner is
+ * lenient and lossless, including while multiline strings are incomplete.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import {
+  createPythonHighlighter,
+  isPythonPath,
+  pythonDocument,
+  pythonHighlightLines,
+} from "../lib/view/languages/python/python.ts";
+import { languageForFile } from "../lib/view/languages/language.ts";
+import type { Line, TokenClass } from "../lib/view/model.ts";
+import { parseDiff } from "../lib/view/diff.ts";
+import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
+import { createDiffHighlighter, diffSource } from "../lib/view/diffedit.ts";
+
+function verbatim(lines: readonly Line[]): string {
+  return lines.map((line) => line.spans.map((span) => span.text).join(""))
+    .join("\n");
+}
+
+function classesOf(lines: readonly Line[], text: string): Set<TokenClass> {
+  const classes = new Set<TokenClass>();
+  for (const line of lines) {
+    for (const span of line.spans) {
+      if (span.text === text) classes.add(span.cls);
+    }
+  }
+  return classes;
+}
+
+function classOnLine(
+  lines: readonly Line[],
+  lineText: string,
+  token: string,
+): TokenClass | undefined {
+  return lines.find((line) => line.text === lineText)?.spans.find((span) =>
+    span.text === token
+  )?.cls;
+}
+
+function tempWorkspace(root: string): DiffWorkspace {
+  return {
+    resolve: (path) => join(root, path),
+    read: (path) => {
+      try {
+        return Deno.readTextFileSync(path);
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+Deno.test("python: path matching recognises source, stub, and windowed files", () => {
+  for (const path of ["main.py", "types.pyi", "app.pyw", "/tmp/UPPER.PY"]) {
+    assert(isPythonPath(path), path);
+  }
+  for (const path of ["module.pyc", "archive.pyz", "notes.md", undefined]) {
+    assert(!isPythonPath(path), String(path));
+  }
+});
+
+Deno.test("python: the language registry selects Python extensions", () => {
+  const python = languageForFile("main.py");
+  assertEquals(python.id, "python");
+  assertEquals(languageForFile("types.pyi").id, "python");
+  assertEquals(languageForFile("app.pyw").id, "python");
+  assertEquals(languageForFile("main.ts").id, "typescript");
+  assertEquals(languageForFile(undefined).id, "typescript");
+  assertEquals(
+    verbatim(python.createHighlighter("answer = True").lines),
+    "answer = True",
+  );
+});
+
+Deno.test("python: declarations, keywords, calls, properties, and comments colour", () => {
+  const source = [
+    "#!/usr/bin/env python3",
+    "@decorator",
+    'async def greet(name: str = "world") -> str:',
+    "    if name is None or not name:",
+    "        raise ValueError(name)",
+    "    return name.upper()  # ready",
+    "",
+    "class Greeter:",
+    "    pass",
+  ].join("\n");
+  const lines = pythonHighlightLines(source);
+
+  assertEquals([...classesOf(lines, "#!/usr/bin/env python3")], ["comment"]);
+  assertEquals([...classesOf(lines, "@")], ["operator"]);
+  assertEquals([...classesOf(lines, "decorator")], ["callName"]);
+  assertEquals([...classesOf(lines, "async")], ["keyword"]);
+  assertEquals([...classesOf(lines, "def")], ["storageKeyword"]);
+  assertEquals([...classesOf(lines, "greet")], ["functionName"]);
+  assertEquals([...classesOf(lines, "if")], ["controlKeyword"]);
+  assertEquals([...classesOf(lines, "is")], ["operator"]);
+  assertEquals([...classesOf(lines, "None")], ["keyword"]);
+  assertEquals([...classesOf(lines, "ValueError")], ["callName"]);
+  assertEquals([...classesOf(lines, "upper")], ["propertyName"]);
+  assertEquals([...classesOf(lines, "# ready")], ["comment"]);
+  assertEquals([...classesOf(lines, "class")], ["storageKeyword"]);
+  assertEquals([...classesOf(lines, "Greeter")], ["interfaceName"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("python: current string prefixes and escapes remain single tokens", () => {
+  const source = [
+    String.raw`plain = "a\"b\\c"`,
+    String.raw`raw = r"\w+\s"`,
+    String.raw`bytes_value = br"\x00"`,
+    `formatted = f"{value!r}"`,
+    `template = tr"{value}"`,
+    `legacy = u"text"`,
+  ].join("\n");
+  const lines = pythonHighlightLines(source);
+
+  assertEquals([...classesOf(lines, String.raw`"a\"b\\c"`)], ["string"]);
+  assertEquals([...classesOf(lines, String.raw`r"\w+\s"`)], ["string"]);
+  assertEquals([...classesOf(lines, String.raw`br"\x00"`)], ["string"]);
+  assertEquals([...classesOf(lines, `f"{value!r}"`)], ["template"]);
+  assertEquals([...classesOf(lines, `tr"{value}"`)], ["template"]);
+  assertEquals([...classesOf(lines, `u"text"`)], ["string"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("python: multiline strings carry state across blank lines", () => {
+  const source = [
+    'message = """first',
+    "",
+    "second # text, not a comment",
+    'third"""',
+    "answer = 42",
+  ].join("\n");
+  const lines = pythonHighlightLines(source);
+
+  assertEquals(lines[1], { text: "", spans: [] });
+  assertEquals(
+    [...classesOf(lines, "second # text, not a comment")],
+    ["string"],
+  );
+  assertEquals([...classesOf(lines, "answer")], ["identifier"]);
+  assertEquals([...classesOf(lines, "42")], ["number"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("python: CRLF backslash continuations stay inside strings", () => {
+  const continuation = "\\\r\n";
+  const source = `plain = "left${continuation}right"\r\n` +
+    `formatted = f"{1${continuation}+ 2}"`;
+  const lines = pythonHighlightLines(source);
+
+  assertEquals([...classesOf(lines, 'right"')], ["string"]);
+  assertEquals([...classesOf(lines, '+ 2}"')], ["template"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("python: formatted strings accept nested same-quote expressions", () => {
+  const source = [
+    'value = f"{items["key"]!r:>{width}}"',
+    `nested = f"{f'{value=}'}"`,
+    'filled = f"{value:[<10}"',
+    String.raw`escaped = f"\{items["key"]}"`,
+  ].join("\n");
+  const lines = pythonHighlightLines(source);
+
+  assertEquals(
+    [...classesOf(lines, 'f"{items["key"]!r:>{width}}"')],
+    ["template"],
+  );
+  assertEquals(
+    [...classesOf(lines, `f"{f'{value=}'}"`)],
+    ["template"],
+  );
+  assertEquals([...classesOf(lines, 'f"{value:[<10}"')], ["template"]);
+  assertEquals(
+    [...classesOf(lines, String.raw`f"\{items["key"]}"`)],
+    ["template"],
+  );
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("python: formatted replacement fields can cross physical lines", () => {
+  const source = [
+    'value = f"{',
+    "    first +  # comment",
+    "    second",
+    '}"',
+    "answer = True",
+  ].join("\n");
+  const lines = pythonHighlightLines(source);
+
+  assertEquals([...classesOf(lines, "    first +  # comment")], ["template"]);
+  assertEquals([...classesOf(lines, "    second")], ["template"]);
+  assertEquals([...classesOf(lines, '}"')], ["template"]);
+  assertEquals([...classesOf(lines, "True")], ["boolean"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("python: numeric forms and ellipsis use literal classes", () => {
+  const source =
+    "values = (0, 1_000, 0b_1010, 0o755, 0xCA_FE, .5, 1., 1.5e-2, 3j, ...)";
+  const lines = pythonHighlightLines(source);
+
+  for (
+    const number of [
+      "0",
+      "1_000",
+      "0b_1010",
+      "0o755",
+      "0xCA_FE",
+      ".5",
+      "1.",
+      "1.5e-2",
+      "3j",
+    ]
+  ) {
+    assertEquals([...classesOf(lines, number)], ["number"], number);
+  }
+  assertEquals([...classesOf(lines, "...")], ["keyword"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("python: brackets retain rainbow depth and Unicode columns", () => {
+  const source = 'π = call([{"😀": value}])';
+  const [line] = pythonHighlightLines(source);
+  const brackets = line.spans.filter((span) => span.cls === "bracket");
+
+  assertEquals(
+    brackets.map((span) => [span.text, span.bracketDepth]),
+    [
+      ["(", 0],
+      ["[", 1],
+      ["{", 2],
+      ["}", 2],
+      ["]", 1],
+      [")", 0],
+    ],
+  );
+  const value = line.spans.find((span) => span.text === "value")!;
+  assertEquals(value.col, [...source.slice(0, source.indexOf("value"))].length);
+  assertEquals(verbatim([line]), source);
+});
+
+Deno.test("python: soft keywords remain identifiers outside statements", () => {
+  const source = [
+    "match subject:",
+    "    case Point(x, y):",
+    "        pass",
+    "type Pair[T] = tuple[T, T]",
+    "match = 1",
+    "match = lambda x: x",
+    "match  \\",
+    "    = lambda x: x",
+    "match, other = lambda: 1",
+    "match, \\",
+    "    other = lambda: 1",
+    "match.subject",
+    "match + 1",
+    "match: object",
+    "match()",
+    "match(subject):",
+    "    case Point():",
+    "match lambda x=1: x:",
+    "    case 1:",
+    "        pass",
+    "match value if flag else lambda arg=1: arg:",
+    "    case _: pass",
+    "match value, lambda arg=1: arg:",
+    "    case _: pass",
+    "match lambda outer=lambda inner=1: inner: outer:",
+    "    case _: pass",
+    "match x := 1:",
+    "    case 1: pass",
+    "match left == right:",
+    "    case True: pass",
+    "match call(x=1):",
+    "    case _: pass",
+    "match (",
+    "    subject",
+    "):",
+    "    case Point(",
+    "        x,",
+    "    ):",
+    "        pass",
+    "match \\",
+    "    subject:",
+    "    case (  # grouped pattern",
+    "        Point()",
+    "    ):",
+    "        pass",
+    "case()",
+    "case: int",
+    "case += 1",
+    "case = lambda x: x",
+    "match.subject: int",
+    "case[index]: str",
+    "{",
+    "    match + 1: value,",
+    "}",
+    "type(value)",
+    "type[index]",
+    "type \\",
+    "    Explicit = int",
+    "type Continued \\",
+    "    = str",
+    "type Generic[T] \\",
+    "    = list[T]",
+    "value = 1; type Result = int",
+    "if True: type Inline = str",
+  ].join("\n");
+  const lines = pythonHighlightLines(source);
+
+  assert(classesOf(lines, "match").has("controlKeyword"));
+  assert(classesOf(lines, "match").has("identifier"));
+  assert(classesOf(lines, "match").has("callName"));
+  assert(classesOf(lines, "case").has("controlKeyword"));
+  assert(classesOf(lines, "case").has("callName"));
+  assert(classesOf(lines, "type").has("storageKeyword"));
+  assert(classesOf(lines, "type").has("callName"));
+  assert(classesOf(lines, "type").has("identifier"));
+  assertEquals(classOnLine(lines, "match.subject", "match"), "identifier");
+  assertEquals(classOnLine(lines, "match + 1", "match"), "identifier");
+  assertEquals(
+    classOnLine(lines, "match = lambda x: x", "match"),
+    "identifier",
+  );
+  assertEquals(classOnLine(lines, "match  \\", "match"), "identifier");
+  assertEquals(
+    classOnLine(lines, "match, other = lambda: 1", "match"),
+    "identifier",
+  );
+  assertEquals(classOnLine(lines, "match, \\", "match"), "identifier");
+  assertEquals(classOnLine(lines, "match: object", "match"), "identifier");
+  assertEquals(classOnLine(lines, "case: int", "case"), "identifier");
+  assertEquals(classOnLine(lines, "case += 1", "case"), "identifier");
+  assertEquals(
+    classOnLine(lines, "case = lambda x: x", "case"),
+    "identifier",
+  );
+  assertEquals(
+    classOnLine(lines, "match.subject: int", "match"),
+    "identifier",
+  );
+  assertEquals(classOnLine(lines, "case[index]: str", "case"), "identifier");
+  assertEquals(
+    classOnLine(lines, "    match + 1: value,", "match"),
+    "identifier",
+  );
+  assertEquals(classOnLine(lines, "match (", "match"), "controlKeyword");
+  assertEquals(
+    classOnLine(lines, "match lambda x=1: x:", "match"),
+    "controlKeyword",
+  );
+  assertEquals(
+    classOnLine(
+      lines,
+      "match value if flag else lambda arg=1: arg:",
+      "match",
+    ),
+    "controlKeyword",
+  );
+  assertEquals(
+    classOnLine(lines, "match value, lambda arg=1: arg:", "match"),
+    "controlKeyword",
+  );
+  assertEquals(
+    classOnLine(
+      lines,
+      "match lambda outer=lambda inner=1: inner: outer:",
+      "match",
+    ),
+    "controlKeyword",
+  );
+  assertEquals(classOnLine(lines, "match x := 1:", "match"), "controlKeyword");
+  assertEquals(
+    classOnLine(lines, "match left == right:", "match"),
+    "controlKeyword",
+  );
+  assertEquals(
+    classOnLine(lines, "match call(x=1):", "match"),
+    "controlKeyword",
+  );
+  assertEquals(
+    classOnLine(lines, "    case Point(", "case"),
+    "controlKeyword",
+  );
+  assertEquals(classOnLine(lines, "match \\", "match"), "controlKeyword");
+  assertEquals(
+    classOnLine(lines, "    case (  # grouped pattern", "case"),
+    "controlKeyword",
+  );
+  assertEquals(classOnLine(lines, "type[index]", "type"), "identifier");
+  assertEquals(classOnLine(lines, "type \\", "type"), "storageKeyword");
+  assertEquals(
+    classOnLine(lines, "type Continued \\", "type"),
+    "storageKeyword",
+  );
+  assertEquals(
+    classOnLine(lines, "type Generic[T] \\", "type"),
+    "storageKeyword",
+  );
+  assertEquals(
+    classOnLine(lines, "value = 1; type Result = int", "type"),
+    "storageKeyword",
+  );
+  assertEquals(
+    classOnLine(lines, "if True: type Inline = str", "type"),
+    "storageKeyword",
+  );
+  const crlfAssignment = pythonHighlightLines(
+    "match, \\\r\n    other = lambda: 1",
+  );
+  assertEquals(
+    classOnLine(crlfAssignment, "match, \\\r", "match"),
+    "identifier",
+  );
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("python: malformed and incomplete input stays lossless", () => {
+  for (
+    const source of [
+      "value = 'unterminated\nnext = True",
+      'value = """unterminated\nstill text',
+      "f'{unclosed'",
+      "0x 1e+ @@@",
+      "\ud800",
+      "",
+      " \t\f",
+    ]
+  ) {
+    const document = pythonDocument(source);
+    assertEquals(verbatim(document.lines), source);
+    assertEquals(document.structure, []);
+  }
+});
+
+Deno.test("python: incomplete formatted fields recover without dropping text", () => {
+  const source = [
+    "value = match",
+    'escaped = f"{{literal}}"',
+    'line_break = f"{value',
+    "next = True",
+    'commented = f"""{value  # field comment',
+    '}"""',
+    String.raw`backslash = f"{value\}}"`,
+    "lower_hex = 0xdead_beef",
+    "bare = 😀",
+  ].join("\n");
+  const lines = pythonHighlightLines(source);
+
+  assert(classesOf(lines, "match").has("identifier"));
+  assertEquals([...classesOf(lines, 'f"{{literal}}"')], ["template"]);
+  assertEquals([...classesOf(lines, "True")], ["boolean"]);
+  assertEquals([...classesOf(lines, "0xdead_beef")], ["number"]);
+  assertEquals(verbatim(lines), source);
+});
+
+Deno.test("python: live file highlighting re-baselines multiline state", () => {
+  const before = 'value = """first\nsecond\n"""\n';
+  const after = 'value = "first"\nsecond = True\n';
+  const highlighter = createPythonHighlighter(before);
+
+  assertEquals([...classesOf(highlighter.lines, "second")], ["string"]);
+  const updated = highlighter.update(after);
+  assertEquals([...classesOf(updated, "second")], ["identifier"]);
+  assertEquals([...classesOf(updated, "True")], ["boolean"]);
+  assertEquals(verbatim(updated), after);
+});
+
+Deno.test("python: unavailable diff files use context for multiline strings", () => {
+  const diff = [
+    "diff --git a/example.py b/example.py",
+    "--- a/example.py",
+    "+++ b/example.py",
+    "@@ -1,3 +1,3 @@",
+    ' value = """',
+    "-old text",
+    "+new text",
+    ' """',
+    "",
+  ].join("\n");
+  const model = parseDiff(diff)!;
+  const workspace: DiffWorkspace = {
+    resolve: () => null,
+    read: () => null,
+  };
+  const { doc } = buildDiffDocument(diff, model, workspace);
+
+  assertEquals([...classesOf(doc.lines, "old text")], ["string"]);
+  assertEquals([...classesOf(doc.lines, "new text")], ["string"]);
+  assertEquals(verbatim(doc.lines), diff);
+});
+
+Deno.test("python: a seedless diff highlighter joins both hunk sides", () => {
+  const diff = [
+    "diff --git a/example.py b/example.py",
+    "--- a/example.py",
+    "+++ b/example.py",
+    "@@ -1,3 +1,3 @@",
+    ' value = """',
+    "-old text",
+    "+new text",
+    ' """',
+    "",
+  ].join("\n");
+  const highlighter = createDiffHighlighter(diff);
+
+  assertEquals([...classesOf(highlighter.lines, "old text")], ["string"]);
+  assertEquals([...classesOf(highlighter.lines, "new text")], ["string"]);
+  assertEquals(verbatim(highlighter.lines), diff);
+
+  const renamedHeader = diff.replace(
+    "diff --git a/example.py b/example.py",
+    "diff --git a/renamed.py b/renamed.py",
+  );
+  assertEquals(verbatim(highlighter.update(renamedHeader)), renamedHeader);
+  assertEquals(verbatim(highlighter.update("not a diff")), "not a diff");
+});
+
+Deno.test("python: live diff edits retain complete-file multiline state", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const file = ['value = """', "new text", '"""', ""].join("\n");
+    Deno.writeTextFileSync(join(root, "example.py"), file);
+    const diff = [
+      "diff --git a/example.py b/example.py",
+      "--- a/example.py",
+      "+++ b/example.py",
+      "@@ -2 +2 @@",
+      "-old text",
+      "+new text",
+      "",
+    ].join("\n");
+    const model = parseDiff(diff)!;
+    const workspace = tempWorkspace(root);
+    const { doc, edit } = buildDiffDocument(diff, model, workspace);
+    const source = diffSource(workspace, edit);
+    const highlighter = source.createHighlighter!(diff, doc.lines);
+
+    const editedText = diff.replace("+new text", "+newer text");
+    const edited = highlighter.update(editedText);
+    assertEquals([...classesOf(edited, "newer text")], ["string"]);
+    assertEquals(verbatim(edited), editedText);
+
+    const reparsed = source.parse(editedText);
+    assertEquals([...classesOf(reparsed.lines, "newer text")], ["string"]);
+    assertEquals(verbatim(reparsed.lines), editedText);
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("python: deferred diff parsing keeps old state across a rename", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const file = ['value = """', "new text", '"""', ""].join("\n");
+    Deno.writeTextFileSync(join(root, "example.txt"), file);
+    const diff = [
+      "diff --git a/example.py b/example.txt",
+      "--- a/example.py",
+      "+++ b/example.txt",
+      "@@ -2 +2 @@",
+      "-old text",
+      "+new text",
+      "",
+    ].join("\n");
+    const model = parseDiff(diff)!;
+    const workspace = tempWorkspace(root);
+    const { doc, edit } = buildDiffDocument(diff, model, workspace);
+    const source = diffSource(workspace, edit);
+    const highlighter = source.createHighlighter!(diff, doc.lines);
+
+    assertEquals([...classesOf(doc.lines, "old text")], ["string"]);
+    const editedText = diff.replace("+new text", "+newer text");
+    const edited = highlighter.update(editedText);
+    assertEquals([...classesOf(edited, "old text")], ["string"]);
+
+    const reparsed = source.parse(editedText);
+    assertEquals([...classesOf(reparsed.lines, "old text")], ["string"]);
+    assertEquals(verbatim(reparsed.lines), editedText);
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("python: live edits account for line shifts across later hunks", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const file = [
+      'value = """',
+      "first",
+      "middle",
+      "last",
+      '"""',
+      "",
+    ].join("\n");
+    Deno.writeTextFileSync(join(root, "example.py"), file);
+    const diff = [
+      "diff --git a/example.py b/example.py",
+      "--- a/example.py",
+      "+++ b/example.py",
+      "@@ -2 +2 @@",
+      "-old first",
+      "+first",
+      "@@ -4 +4 @@",
+      "-old last",
+      "+last",
+      "",
+    ].join("\n");
+    const model = parseDiff(diff)!;
+    const workspace = tempWorkspace(root);
+    const { doc, edit } = buildDiffDocument(diff, model, workspace);
+    const highlighter = diffSource(workspace, edit).createHighlighter!(
+      diff,
+      doc.lines,
+    );
+    const edited = [
+      "diff --git a/example.py b/example.py",
+      "--- a/example.py",
+      "+++ b/example.py",
+      "@@ -2 +2,2 @@",
+      "-old first",
+      "+first",
+      "+inserted",
+      "@@ -4 +5 @@",
+      "-old last",
+      "+last",
+      "",
+    ].join("\n");
+    const lines = highlighter.update(edited);
+
+    assertEquals([...classesOf(lines, "inserted")], ["string"]);
+    assertEquals([...classesOf(lines, "last")], ["string"]);
+    assertEquals(verbatim(lines), edited);
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});

--- a/packages/cli/test/view-python.test.ts
+++ b/packages/cli/test/view-python.test.ts
@@ -421,6 +421,49 @@ Deno.test("python: soft keywords remain identifiers outside statements", () => {
   assertEquals(verbatim(lines), source);
 });
 
+Deno.test("python: soft-keyword scanners handle nested and incomplete forms", () => {
+  const misplacedType = pythonHighlightLines("value type Alias = int");
+  assertEquals([...classesOf(misplacedType, "type")], ["identifier"]);
+
+  const genericAlias = [
+    "type Alias[",
+    '    T: tuple[str, "]"],',
+    "    # punctuation in this comment does not close the parameters: ]",
+    "] = list[T]",
+  ].join("\n");
+  const genericLines = pythonHighlightLines(genericAlias);
+  assertEquals([...classesOf(genericLines, "type")], ["storageKeyword"]);
+  assertEquals(verbatim(genericLines), genericAlias);
+
+  const commentedMatch = pythonHighlightLines(
+    "match subject # fake suite colon:",
+  );
+  assertEquals([...classesOf(commentedMatch, "match")], ["identifier"]);
+
+  const stringMatch = pythonHighlightLines('match "fake:"');
+  assertEquals([...classesOf(stringMatch, "match")], ["identifier"]);
+
+  const incompleteMatch = pythonHighlightLines("match subject");
+  assertEquals([...classesOf(incompleteMatch, "match")], ["identifier"]);
+
+  const escapedFormatSpec = 'value = f"{item:{{x}" + after';
+  const formatLines = pythonHighlightLines(escapedFormatSpec);
+  assertEquals([...classesOf(formatLines, "after")], ["identifier"]);
+  assertEquals(verbatim(formatLines), escapedFormatSpec);
+
+  const crlfAlias = "type Alias \\\r\n    = int";
+  assertEquals(
+    [...classesOf(pythonHighlightLines(crlfAlias), "type")],
+    ["storageKeyword"],
+  );
+
+  for (const source of [String.raw`type \ Alias = int`, "type"]) {
+    const lines = pythonHighlightLines(source);
+    assertEquals([...classesOf(lines, "type")], ["identifier"]);
+    assertEquals(verbatim(lines), source);
+  }
+});
+
 Deno.test("python: malformed and incomplete input stays lossless", () => {
   for (
     const source of [


### PR DESCRIPTION
Add filename-based Python language selection for .py, .pyi, and .pyw files, and implement syntax highlighting for Python tokens, strings, numbers, comments, definitions, imports, and decorators. Add focused language and pager fixtures and document the new coverage.

Preserve syntax context when diffs are edited by highlighting each changed file from its complete contents. Cache TypeScript parse results, reuse safe local string edits, and fall back to complete-file highlighting around escapes or context-sensitive constructs. Group hunks and invalidate only affected cached files so unchanged hunks retain their colours without redundant complete-file parsing.

Update the live coverage plan to record extension-based Python support while leaving shebang detection and structural navigation as future work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Python syntax highlighting to `cf view` and tightens live diff highlighting to preserve context for stateful languages, reducing flicker and redundant work during edits.

- **New Features**
  - Python highlighting in `cf view` for `.py`, `.pyi`, and `.pyw` (tokens, strings incl. f-strings, numbers, comments, imports, decorators).
  - README and coverage plan updated to note extension-based Python support.

- **Refactors**
  - Diff edits rehighlight only touched files from complete contents; unchanged hunks keep their colours, and repeated file sections reuse a cached per-file highlighter.
  - Added language APIs for stateful diff edits: full-file-on-edit and optional single-line local edit; TypeScript implements safe local string edits and parse-result caching, with deferred parsing limited to changed stateful files and support for optional blob readers.

<sup>Written for commit 8e5bb5818c385da1ba6d3681d89e0072137ff1be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

