### PR TITLE
Constrain invocation payloads to Fabric values

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -279,6 +279,9 @@ export type FabricValue =
   | FabricPlainObject
   | undefined;
 
+/** A fabric value other than `null` or `undefined`. */
+export type NonNullableFabricValue = Exclude<FabricValue, null | undefined>;
+
 /** An array of fabric values. */
 export interface FabricArray extends ArrayLike<FabricValue> {}
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -280,7 +280,7 @@ export type FabricValue =
   | undefined;
 
 /** A fabric value other than `null` or `undefined`. */
-export type NonNullableFabricValue = Exclude<FabricValue, null | undefined>;
+export type NonNullableFabricValue = NonNullable<FabricValue>;
 
 /** An array of fabric values. */
 export interface FabricArray extends ArrayLike<FabricValue> {}

--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -10,6 +10,7 @@ export {
   FabricPrimitive,
   FabricSpecialObject,
   type FabricValue,
+  type NonNullableFabricValue,
   type FabricValueLayer,
 } from "./interface.ts";
 

--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -10,8 +10,8 @@ export {
   FabricPrimitive,
   FabricSpecialObject,
   type FabricValue,
-  type NonNullableFabricValue,
   type FabricValueLayer,
+  type NonNullableFabricValue,
 } from "./interface.ts";
 
 export {

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -171,7 +171,7 @@ export type FabricValue =
   | undefined;
 
 /** A fabric value other than `null` or `undefined`. */
-export type NonNullableFabricValue = Exclude<FabricValue, null | undefined>;
+export type NonNullableFabricValue = NonNullable<FabricValue>;
 
 /** Array of fabric values. */
 export interface FabricArray extends ArrayLike<FabricValue> {}

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -170,6 +170,9 @@ export type FabricValue =
   // -- undefined --
   | undefined;
 
+/** A fabric value other than `null` or `undefined`. */
+export type NonNullableFabricValue = Exclude<FabricValue, null | undefined>;
+
 /** Array of fabric values. */
 export interface FabricArray extends ArrayLike<FabricValue> {}
 

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -1,4 +1,9 @@
-import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
+import type {
+  FabricBytes,
+  FabricValue,
+  NonNullableFabricValue,
+  SchemaPathSelector,
+} from "@commonfabric/api";
 import type { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 
 /**
@@ -61,19 +66,19 @@ export interface AuthorizationError extends Error {
 export type Command<
   Ability extends string = The,
   Of extends DID = DID,
-  In extends NonNullable<unknown> = NonNullable<unknown>,
+  In extends NonNullableFabricValue = NonNullableFabricValue,
 > = {
   cmd: Ability;
   sub: Of;
   args: In;
   meta?: Meta;
-  nonce?: Uint8Array;
+  nonce?: FabricBytes;
 };
 
 export type Invocation<
   Ability extends string = The,
   Of extends DID = DID,
-  In extends NonNullable<unknown> = NonNullable<unknown>,
+  In extends NonNullableFabricValue = NonNullableFabricValue,
 > = {
   iss: DID;
   aud?: DID;
@@ -81,7 +86,7 @@ export type Invocation<
   sub: Of;
   args: In;
   meta?: Meta;
-  nonce?: Uint8Array;
+  nonce?: FabricBytes;
   exp?: UTCUnixTimestampInSeconds;
   iat?: UTCUnixTimestampInSeconds;
   prf: Delegation[];
@@ -158,7 +163,7 @@ export type InferProtoMethods<
   Prefix extends string = "",
 > = {
   [Name in keyof Methods & string]: Methods[Name] extends (
-    input: infer In extends NonNullable<unknown>,
+    input: infer In extends NonNullableFabricValue,
   ) => Task<infer Out extends NonNullable<unknown>, infer Effect> ?
       | {
         [The in `${Prefix}/${Name}`]: Method<
@@ -178,7 +183,9 @@ export type InferProtoMethods<
 export type Method<
   Protocol,
   Ability extends The,
-  In extends NonNullable<unknown>,
+  In extends NonNullableFabricValue,
+  // Method results may be in-process `Result` envelopes carrying raw `Error`s,
+  // so they are non-nullish but not necessarily `FabricValue`s.
   Out extends NonNullable<unknown>,
   Effect,
 > = {
@@ -195,7 +202,7 @@ export type Method<
     sub: MemorySpace;
     args: In;
     meta?: Meta;
-    nonce?: Uint8Array;
+    nonce?: FabricBytes;
   };
   ConsumerInvocation: Invocation<Ability, InferOf<Protocol>, In>;
   ProviderCommand: Receipt<


### PR DESCRIPTION
## Summary
- add NonNullableFabricValue, the non-nullish subset of FabricValue
- require invocation and command payloads to be non-nullable Fabric values
- represent embedded invocation nonces as immutable FabricBytes

Method outputs remain non-nullish unknown values because in-process Result envelopes can carry raw Error instances.

## Validation
- deno task check

## Coverage Check

This PR only edits type declarations, so the following accounts for spurious complaints:

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/memory uncovered lines = 1295 lines


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrain invocation and command payloads to non-nullable Fabric values and switch nonces to `FabricBytes` for stronger type safety. Introduce `NonNullableFabricValue` (using `NonNullable<FabricValue>`) in `@commonfabric/api` and re-export it from `@commonfabric/data-model`; use it for `Command`, `Invocation`, and method input generics, while outputs remain non-nullish `unknown`.

- **Migration**
  - Ensure all `args` are non-nullish `FabricValue` and update method input generics to `NonNullableFabricValue`.
  - Replace `nonce?: Uint8Array` with `nonce?: FabricBytes` across invocations, commands, and method command shapes.

<sup>Written for commit 203ea8f41883637eb18c815b35424952fdaa3b15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->