### PR TITLE
feat(cli): view unknown named files as plain text

### DIFF
--- a/docs/plans/cf-view-language-coverage.md
+++ b/docs/plans/cf-view-language-coverage.md
@@ -1,7 +1,8 @@
 # `cf view` language and syntax coverage plan
 
-Status: In progress. Python files with recognized extensions now have
-syntax highlighting. The order is provisional because recent activity was
+Status: In progress. Unknown named files now use plain text. Python files with
+recognized extensions now have syntax highlighting. The order is provisional
+because recent activity was
 measured in six of the 24 active organization repositories.
 
 This plan takes `cf view` from its current TypeScript and JavaScript, Markdown,
@@ -80,7 +81,7 @@ relative value. Record the reason in this plan.
 
 ## Stage 0: honest selection and implementation foundation
 
-- [ ] Add a plain-text language and select it for unknown named files.
+- [x] Add a plain-text language and select it for unknown named files.
 - [ ] Preserve the intentional TypeScript default only for transformed
   compiler output that has no filename.
 - [ ] Add `--language` and `--filename` overrides for piped input.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,9 +5,9 @@
 `cf view [file]` is an interactive pager for transformed TypeScript, source
 files, and unified diffs. Named Markdown, JSON, JSONC, YAML, and Python files
 use their own syntax highlighting. A piped input without a file name remains
-unless it is detected as a diff. A named file with unrecognized syntax is shown
-as plain text. Redirected output keeps the text verbatim and adds ANSI color
-only when the selected color mode permits it.
+TypeScript unless it is detected as a diff. A named file with unrecognized
+syntax is shown as plain text. Redirected output keeps the text verbatim and
+adds ANSI color only when the selected color mode permits it.
 
 ```bash
 cf check pattern.tsx --show-transformed --no-run | cf view

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,8 +5,9 @@
 `cf view [file]` is an interactive pager for transformed TypeScript, source
 files, and unified diffs. Named Markdown, JSON, JSONC, YAML, and Python files
 use their own syntax highlighting. A piped input without a file name remains
-TypeScript unless it is detected as a diff. Redirected output keeps the text
-verbatim and adds ANSI color only when the selected color mode permits it.
+unless it is detected as a diff. A named file with unrecognized syntax is shown
+as plain text. Redirected output keeps the text verbatim and adds ANSI color
+only when the selected color mode permits it.
 
 ```bash
 cf check pattern.tsx --show-transformed --no-run | cf view

--- a/packages/cli/commands/view.ts
+++ b/packages/cli/commands/view.ts
@@ -10,8 +10,8 @@ files. Transformed TypeScript is parsed with the same parser the transformer
 uses, so blocks, closures, schemas, type positions and Common Fabric builders
 (pattern/lift/handler/…) are coloured exactly as the compiler sees them.
 Markdown, JSON, JSONC, YAML and Python files use syntax highlighting selected
-their names. Named files with unrecognized syntax remain plain text. The text
-shown is verbatim — colour only.
+from their names. Named files with unrecognized syntax remain plain text. The
+text shown is verbatim — colour only.
 
 Unified diffs are detected automatically: piping 'git diff' in gives added and
 removed lines their tints, full syntax colour, a structure tree of the code

--- a/packages/cli/commands/view.ts
+++ b/packages/cli/commands/view.ts
@@ -10,7 +10,8 @@ files. Transformed TypeScript is parsed with the same parser the transformer
 uses, so blocks, closures, schemas, type positions and Common Fabric builders
 (pattern/lift/handler/…) are coloured exactly as the compiler sees them.
 Markdown, JSON, JSONC, YAML and Python files use syntax highlighting selected
-from their names. The text shown is verbatim — colour only.
+their names. Named files with unrecognized syntax remain plain text. The text
+shown is verbatim — colour only.
 
 Unified diffs are detected automatically: piping 'git diff' in gives added and
 removed lines their tints, full syntax colour, a structure tree of the code

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -2,10 +2,10 @@
  * The contract every source language plugs into so the `cf view` pager can
  * colour, navigate, edit and (optionally) reason about it, plus selecting the
  * right language for a file. A language is a stateless strategy object: one
- * instance describes TypeScript, one Markdown, one JSON, one YAML, and one
- * Python. The pager selects the right one for a file ONCE (via
- * {@link languageForFile}), then dispatches every operation through that
- * object's methods — there is no per-operation branch on the file extension.
+ * instance describes each supported syntax, and plain text handles unknown
+ * named files. The pager selects the right one for a file ONCE (via {@link
+ * languageForFile}) and then dispatches every operation through that object's
+ * methods — there is no per-operation branch on the file extension.
  *
  * Per-file mutable state (a warm incremental parse, a language service) is not
  * held on the language; the language is a factory for the small stateful
@@ -23,6 +23,7 @@ import { markdownLanguage } from "./markdown/language.ts";
 import { jsonLanguage } from "./json/language.ts";
 import { yamlLanguage } from "./yaml/language.ts";
 import { pythonLanguage } from "./python/language.ts";
+import { plainTextLanguage } from "./plain-text/language.ts";
 
 /**
  * Live syntax highlighting that re-highlights only the region an edit touches,
@@ -107,12 +108,11 @@ export interface HunkStructureContext {
  */
 export interface Language {
   /** Stable identifier, such as `"typescript"`, `"markdown"`, `"json"`,
-   * `"yaml"`, or `"python"`. */
+   * `"yaml"`, `"python"`, or `"plain-text"`. */
   readonly id: string;
 
   /** Does this language claim `fileName`? Consulted in order by {@link
-   * languageForFile}; TypeScript claims its own family and also backstops
-   * anything unclaimed. */
+   * languageForFile}. */
   matches(fileName: string | undefined): boolean;
 
   /** Parse `text` into the full document model: coloured lines, a structure
@@ -163,8 +163,9 @@ export interface Language {
 
 /**
  * Every language the pager knows, most specific first, built on first use.
- * TypeScript comes last: it claims the TypeScript family and is also the
- * fallback (below) for anything unclaimed.
+ * Plain text comes last because it claims every named file left after the
+ * syntax-specific languages. An input with no filename is handled by the
+ * fallback below.
  *
  * The list is lazy so this module's top level never reads the concrete language
  * singletons: they and this module form an import cycle (a language's semantic
@@ -180,11 +181,13 @@ function allLanguages(): readonly Language[] {
     yamlLanguage,
     pythonLanguage,
     typeScriptLanguage,
+    plainTextLanguage,
   ];
 }
 
-/** The language for `fileName` — the first that claims it. TypeScript is the
- * fallback, so a pipe (no name) or an unrecognised extension resolves to it. */
+/** The language for `fileName` — the first that claims it. Plain text claims
+ * otherwise unknown named files. TypeScript remains the fallback for an
+ * unnamed pipe of transformed compiler output. */
 export function languageForFile(fileName: string | undefined): Language {
   for (const language of allLanguages()) {
     if (language.matches(fileName)) return language;
@@ -212,11 +215,11 @@ export function distinctLanguages(
  * The semantic service for a diff view, from the languages the diff touches. A
  * diff spans potentially many files of different languages; the service is the
  * first language present that offers one, scoped to just its own files (so a
- * TypeScript program is not seeded with the diff's Markdown, JSON, YAML, or
- * Python files). Only TypeScript offers one today, so this resolves to it
- * whenever the diff includes a TypeScript file and to nothing otherwise. When
- * a second semantic language appears this becomes a per-file composite; the
- * per-language slot the pager dispatches through is already here.
+ * TypeScript program is not seeded with the diff's non-TypeScript files). Only
+ * TypeScript offers one today, so this resolves to it whenever the diff includes
+ * a TypeScript file and to nothing otherwise. When a second semantic language
+ * appears this becomes a per-file composite; the per-language slot the pager
+ * dispatches through is already here.
  */
 export function diffSemanticsFor(
   languages: readonly Language[],

--- a/packages/cli/lib/view/languages/plain-text/language.ts
+++ b/packages/cli/lib/view/languages/plain-text/language.ts
@@ -1,0 +1,25 @@
+/**
+ * The plain-text language for named files whose syntax `cf view` does not
+ * recognize. It must remain last in the language registry because it claims
+ * every filename left after the syntax-specific languages.
+ */
+import type { Language } from "../language.ts";
+import {
+  createPlainTextHighlighter,
+  plainTextDocument,
+  plainTextLines,
+} from "./plain-text.ts";
+
+export const plainTextLanguage: Language = {
+  id: "plain-text",
+
+  matches: (fileName) => fileName !== undefined,
+
+  parseDocument: (text) => plainTextDocument(text),
+
+  highlightLines: (text) => plainTextLines(text),
+
+  createHighlighter: (text) => createPlainTextHighlighter(text),
+
+  hunkStructure: () => [],
+};

--- a/packages/cli/lib/view/languages/plain-text/plain-text.ts
+++ b/packages/cli/lib/view/languages/plain-text/plain-text.ts
@@ -1,0 +1,45 @@
+/**
+ * Plain-text documents for files whose syntax `cf view` does not recognize.
+ * Every non-empty line is one plain span. The document has no structure or
+ * definitions.
+ */
+import type { Document, Line } from "../../model.ts";
+import type { Highlighter } from "../language.ts";
+
+/** Render every source line as one plain span. */
+export function plainTextLines(text: string): Line[] {
+  return text.split("\n").map((line) => ({
+    text: line,
+    spans: line.length === 0
+      ? []
+      : [{ col: 0, text: line, cls: "plain" as const }],
+  }));
+}
+
+/** Build a document with plain lines and no source-language structure. */
+export function plainTextDocument(text: string): Document {
+  return {
+    text,
+    lines: plainTextLines(text),
+    structure: [],
+    flatStructure: [],
+    definitions: new Map(),
+  };
+}
+
+/** Rebuild the inexpensive plain lines after each edit. */
+export function createPlainTextHighlighter(initial: string): Highlighter {
+  let text = initial;
+  let lines = plainTextLines(initial);
+  return {
+    get lines() {
+      return lines;
+    },
+    update(next: string): readonly Line[] {
+      if (next === text) return lines;
+      text = next;
+      lines = plainTextLines(next);
+      return lines;
+    },
+  };
+}

--- a/packages/cli/lib/view/languages/typescript/language.ts
+++ b/packages/cli/lib/view/languages/typescript/language.ts
@@ -1,10 +1,9 @@
 /**
- * The TypeScript (and TSX/JS) language for the pager. It is the catch-all: any
- * file no more specific language claims is coloured and navigated as
- * TypeScript, which is also right for the transformed-pattern blobs the pager is
- * most often handed. Highlighting, structure, incremental editing and the
- * semantic layer all live in the neighbouring {@link ./parse.ts} and {@link
- * ./semantics.ts}; this module only adapts them to the {@link Language}
+ * The TypeScript (and TSX/JS) language for the pager. It handles named files in
+ * that language family. It is also the intentional default for unnamed
+ * transformed-pattern output. Highlighting, structure, incremental editing and
+ * the semantic layer all live in the neighbouring {@link ./parse.ts} and
+ * {@link ./semantics.ts}; this module only adapts them to the {@link Language}
  * contract.
  */
 import type { Language } from "../language.ts";
@@ -21,9 +20,8 @@ export const typeScriptLanguage: Language = {
   id: "typescript",
 
   // Claims the TypeScript / JavaScript family (`.ts`, `.tsx`, `.mts`, `.cts`,
-  // `.js`, `.jsx`, `.mjs`, `.cjs`). It is also the fallback in `languageForFile`
-  // for anything unclaimed — a pipe of transformed output, an unknown extension
-  // — so those resolve here too, just via that fallback rather than this test.
+  // `.js`, `.jsx`, `.mjs`, `.cjs`). `languageForFile` also selects it for an
+  // unnamed pipe of transformed compiler output.
   matches: (fileName) =>
     fileName !== undefined && /\.[cm]?[jt]sx?$/i.test(fileName),
 

--- a/packages/cli/lib/view/languages/typescript/parse.ts
+++ b/packages/cli/lib/view/languages/typescript/parse.ts
@@ -33,6 +33,7 @@ import { flattenStructure } from "../../model.ts";
 import { cpLen } from "../../ansi.ts";
 import { computeLineStarts, lineIndexOf } from "../../lines.ts";
 import type { Highlighter } from "../language.ts";
+import { plainTextDocument, plainTextLines } from "../plain-text/plain-text.ts";
 import {
   describeSynthetic,
   isBuilderName,
@@ -151,7 +152,7 @@ export function parseDocument(
   try {
     return parseTypeScriptDocument(text, fileName);
   } catch {
-    return plainDocument(text);
+    return plainTextDocument(text);
   }
 }
 
@@ -215,7 +216,7 @@ export function highlightDocument(
       collectSchemaObjects(sf),
     );
   } catch {
-    return plainLines(text);
+    return plainTextLines(text);
   }
 }
 
@@ -236,25 +237,6 @@ function scriptKindFor(fileName: string): ts.ScriptKind {
   // Inputs without a TypeScript extension can still be transformed output
   // containing JSX.
   return ts.ScriptKind.TSX;
-}
-
-function plainLines(text: string): Line[] {
-  return text.split("\n").map((line) => ({
-    text: line,
-    spans: line.length === 0
-      ? []
-      : [{ col: 0, text: line, cls: "plain" as const }],
-  }));
-}
-
-function plainDocument(text: string): Document {
-  return {
-    text,
-    lines: plainLines(text),
-    structure: [],
-    flatStructure: [],
-    definitions: new Map(),
-  };
 }
 
 /**
@@ -364,7 +346,7 @@ export function createHighlighter(
 ): Highlighter {
   let text = initial;
   let highlighter = tryCreateTypeScriptHighlighter(initial, fileName);
-  let lines: readonly Line[] = highlighter?.lines ?? plainLines(initial);
+  let lines: readonly Line[] = highlighter?.lines ?? plainTextLines(initial);
 
   return {
     get lines() {
@@ -382,7 +364,7 @@ export function createHighlighter(
         }
       }
       highlighter = tryCreateTypeScriptHighlighter(next, fileName);
-      lines = highlighter?.lines ?? plainLines(next);
+      lines = highlighter?.lines ?? plainTextLines(next);
       return lines;
     },
   };

--- a/packages/cli/lib/view/mod.ts
+++ b/packages/cli/lib/view/mod.ts
@@ -1,9 +1,10 @@
 /**
  * Entry point for `cf view`. Reads the input (a file argument or piped stdin),
- * parses it once — as a unified diff when it reads as one, else as transformed
- * TypeScript — then either launches the interactive pager (when stdout is a
- * TTY) or prints the colourised text and exits, mirroring how `less`/`bat`
- * behave when their output is redirected.
+ * parses it once — as a unified diff when it reads as one, otherwise with the
+ * language selected from its filename — then either launches the interactive
+ * pager (when stdout is a TTY) or prints the colourised text and exits,
+ * mirroring how `less`/`bat` behave when their output is redirected. An unnamed
+ * pipe remains transformed TypeScript.
  */
 import { renderLineColored } from "./highlight.ts";
 import { runPager } from "./pager.ts";

--- a/packages/cli/lib/view/model.ts
+++ b/packages/cli/lib/view/model.ts
@@ -1,10 +1,10 @@
 /**
  * Shared data model for the `cf view` pager.
  *
- * The pipeline is: raw text -> {@link parseDocument} (TypeScript parser) ->
- * {@link Document} -> {@link renderFrame}. Everything downstream of the parser
- * operates on these structures, never on the TypeScript AST directly, which
- * keeps the renderer pure and testable.
+ * The pipeline is: raw text -> selected language parser -> {@link Document} ->
+ * {@link renderFrame}. Everything downstream of the parser operates on these
+ * structures, never on a language-specific syntax tree directly, which keeps
+ * the renderer pure and testable.
  */
 
 /**

--- a/packages/cli/lib/view/pager.ts
+++ b/packages/cli/lib/view/pager.ts
@@ -16,7 +16,6 @@ import { cursorScreenPos, renderFrame, type ViewState } from "./render.ts";
 import { Session, type SessionOptions } from "./session.ts";
 import { ui } from "./theme.ts";
 import type { Semantics } from "./languages/language.ts";
-import { languageForFile } from "./languages/language.ts";
 import type { EditableSource } from "./editsource.ts";
 import { realFileGateway } from "./filegateway.ts";
 import { ViewError } from "./errors.ts";
@@ -91,7 +90,7 @@ export function realPagerDeps(): PagerDeps {
 export async function runPager(
   doc: Document,
   options: PagerOptions,
-  semanticsIn?: Semantics,
+  semantics: Semantics | undefined,
   editSource?: EditableSource,
   deps: PagerDeps = realPagerDeps(),
 ): Promise<void> {
@@ -105,17 +104,6 @@ export async function runPager(
       }). Pipe through a real terminal, or use --plain.`,
     );
   }
-
-  // A best-effort semantic service for inferred types / cross-file definitions.
-  // Construction is cheap (the program is built lazily on first use) and every
-  // query degrades to nothing, so this never blocks startup or fails the pager
-  // when the text is not a resolvable module graph. The caller picks the right
-  // service for the input (transformed blob vs diff); fall back to the catch-all
-  // language's whole-document service.
-  const semantics = semanticsIn ??
-    languageForFile(undefined).createSemantics?.(doc.text, {
-      cwd: Deno.cwd(),
-    });
 
   // The terminal fills the area outside the character grid (the sub-cell padding
   // below the last row) with its default background. Set that to the status

--- a/packages/cli/test/view-json.test.ts
+++ b/packages/cli/test/view-json.test.ts
@@ -46,7 +46,7 @@ Deno.test("json: isJsonPath recognises json extensions", () => {
 Deno.test("json: the registry selects JSON for .json and .jsonc", () => {
   assertEquals(languageForFile("deno.json").id, "json");
   assertEquals(languageForFile("cfg.jsonc").id, "json");
-  // Anything else falls through to the TypeScript catch-all.
+  // Other registered selections remain unchanged.
   assertEquals(languageForFile("main.ts").id, "typescript");
   assertEquals(languageForFile("notes.md").id, "markdown");
   assertEquals(languageForFile(undefined).id, "typescript");

--- a/packages/cli/test/view-language.test.ts
+++ b/packages/cli/test/view-language.test.ts
@@ -1,8 +1,9 @@
 /**
- * Language selection: `languageForFile` picks a language by extension (and
- * backstops to TypeScript for pipes and unknown files), `distinctLanguages`
- * dedupes the languages a diff touches, and `diffSemanticsFor` composes the diff
- * view's semantic layer from the languages present, scoped to each one's files.
+ * Language selection: `languageForFile` picks a language by extension, uses
+ * plain text for unknown named files, and keeps TypeScript for unnamed pipes.
+ * `distinctLanguages` dedupes the languages a diff touches, and
+ * `diffSemanticsFor` composes the diff view's semantic layer from the languages
+ * present, scoped to each one's files.
  */
 import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
@@ -16,6 +17,7 @@ import { markdownLanguage } from "../lib/view/languages/markdown/language.ts";
 import { jsonLanguage } from "../lib/view/languages/json/language.ts";
 import { yamlLanguage } from "../lib/view/languages/yaml/language.ts";
 import { pythonLanguage } from "../lib/view/languages/python/language.ts";
+import { plainTextLanguage } from "../lib/view/languages/plain-text/language.ts";
 import {
   buildDiffDocument,
   type DiffMaps,
@@ -23,7 +25,7 @@ import {
 } from "../lib/view/diffdoc.ts";
 import { parseDiff } from "../lib/view/diff.ts";
 
-Deno.test("languageForFile: extensions resolve, and the rest backstops to TS", () => {
+Deno.test("languageForFile: named files resolve and unnamed input defaults to TypeScript", () => {
   for (const ts of ["a.ts", "a.tsx", "a.mts", "a.cts", "a.js", "a.jsx"]) {
     assertEquals(languageForFile(ts).id, "typescript", ts);
   }
@@ -31,8 +33,8 @@ Deno.test("languageForFile: extensions resolve, and the rest backstops to TS", (
   assertEquals(languageForFile("deno.jsonc").id, "json");
   assertEquals(languageForFile("workflow.yml").id, "yaml");
   assertEquals(languageForFile("script.py").id, "python");
-  // No language claims these, so the fallback (TypeScript) resolves them.
-  assertEquals(languageForFile("notes.xyz").id, "typescript");
+  assertEquals(languageForFile("notes.xyz").id, "plain-text");
+  assertEquals(languageForFile("LICENSE").id, "plain-text");
   assertEquals(languageForFile(undefined).id, "typescript");
 });
 
@@ -44,11 +46,12 @@ Deno.test("distinctLanguages: dedupes in first-seen order", () => {
     "d.json",
     "e.yaml",
     "f.py",
+    "LICENSE",
     undefined,
   ]);
   assertEquals(
     languages.map((l) => l.id),
-    ["typescript", "markdown", "json", "yaml", "python"],
+    ["typescript", "markdown", "json", "yaml", "python", "plain-text"],
   );
 });
 
@@ -112,7 +115,13 @@ Deno.test("diffSemanticsFor: TypeScript answers over its own files in the diff",
     // those resolves to no service.
     assertEquals(
       diffSemanticsFor(
-        [markdownLanguage, jsonLanguage, yamlLanguage, pythonLanguage],
+        [
+          markdownLanguage,
+          jsonLanguage,
+          yamlLanguage,
+          pythonLanguage,
+          plainTextLanguage,
+        ],
         DIFF,
         maps,
         { cwd: root },

--- a/packages/cli/test/view-language.test.ts
+++ b/packages/cli/test/view-language.test.ts
@@ -38,6 +38,13 @@ Deno.test("languageForFile: named files resolve and unnamed input defaults to Ty
   assertEquals(languageForFile(undefined).id, "typescript");
 });
 
+Deno.test("languageForFile: named JavaScript uses the TypeScript-family parser", () => {
+  const source = "export const answer = 42;\n";
+  const doc = languageForFile("answer.js").parseDocument(source, "answer.js");
+  assertEquals(doc.text, source);
+  assert(doc.lines[0].spans.some((span) => span.cls === "storageKeyword"));
+});
+
 Deno.test("distinctLanguages: dedupes in first-seen order", () => {
   const languages = distinctLanguages([
     "a.ts",

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -22,6 +22,7 @@ import { diffSource } from "../lib/view/diffedit.ts";
 import { ViewError } from "../lib/view/errors.ts";
 import { term } from "../lib/view/ansi.ts";
 import { ui } from "../lib/view/theme.ts";
+import { buildView } from "../lib/view/mod.ts";
 
 const OPTS = { color: false, showLineNumbers: false };
 const DOC = parseDocument("export const x = 1;\nconst y = x;\n");
@@ -140,6 +141,15 @@ Deno.test("pager: draws the document and quits on q", async () => {
   // The alt screen is entered on start and left on cleanup.
   assert(writes.some((w) => w.includes("\x1b[?1049h")), "entered alt screen");
   assert(writes.some((w) => w.includes("\x1b[?1049l")), "left alt screen");
+});
+
+Deno.test("pager: unknown named files schedule no semantic work", async () => {
+  const view = buildView("const incomplete = `plain\n", "LICENSE");
+  const semantics = view.semantics();
+  assertEquals(semantics, undefined);
+  const { deps, timers } = makeFake({ steps: [{ bytes: enc("q") }] });
+  await runPager(view.doc, OPTS, semantics, view.editSource, deps);
+  assertEquals(timers.size, 0);
 });
 
 Deno.test("pager: with colour, matches the terminal background to the status bar and restores it", async () => {

--- a/packages/cli/test/view-plain-text.test.ts
+++ b/packages/cli/test/view-plain-text.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Plain-text handling for named files whose syntax `cf view` does not
+ * recognize. Direct documents, diffs, and live diff edits must preserve the
+ * complete input without TypeScript coloring or structure.
+ */
+import { assertEquals } from "@std/assert";
+import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
+import { parseDiff } from "../lib/view/diff.ts";
+import { createDiffHighlighter } from "../lib/view/diffedit.ts";
+import { languageForFile } from "../lib/view/languages/language.ts";
+import { buildView } from "../lib/view/mod.ts";
+import type { Line } from "../lib/view/model.ts";
+
+const NO_WS: DiffWorkspace = { resolve: () => null, read: () => null };
+
+function verbatim(lines: readonly Line[]): string {
+  return lines.map((line) => line.spans.map((span) => span.text).join(""))
+    .join("\n");
+}
+
+Deno.test("plain text: unknown named files select plain text while unnamed input stays TypeScript", () => {
+  assertEquals(languageForFile("LICENSE").id, "plain-text");
+  assertEquals(languageForFile("checksums.sha256").id, "plain-text");
+  assertEquals(languageForFile(undefined).id, "typescript");
+});
+
+Deno.test("plain text: direct documents preserve source without structure", () => {
+  const text = 'const rights = "reserved";\r\n\nunfinished ${value 🎉\n';
+  const language = languageForFile("LICENSE");
+  const lines = language.highlightLines(text, "LICENSE");
+  assertEquals(verbatim(lines), text);
+  assertEquals(
+    lines.flatMap((line) => line.spans.map((span) => span.cls)),
+    ["plain", "plain"],
+  );
+
+  const view = buildView(text, "LICENSE");
+  const doc = view.doc;
+  assertEquals(doc.text, text);
+  assertEquals(doc.lines, lines);
+  assertEquals(doc.structure, []);
+  assertEquals(doc.flatStructure, []);
+  assertEquals([...doc.definitions], []);
+  assertEquals(view.semantics(), undefined);
+  assertEquals(view.editSource.editable, true);
+  assertEquals(view.editSource.parse(text), doc);
+});
+
+Deno.test("plain text: live edits remain lossless and plain", () => {
+  const initial = "terms and conditions";
+  const next = "const incomplete = `terms\n🎉";
+  const highlighter = languageForFile("LICENSE").createHighlighter(
+    initial,
+    "LICENSE",
+  );
+  assertEquals(verbatim(highlighter.lines), initial);
+  const updated = highlighter.update(next);
+  assertEquals(verbatim(updated), next);
+  assertEquals(
+    updated.flatMap((line) => line.spans.map((span) => span.cls)),
+    ["plain", "plain"],
+  );
+  assertEquals(highlighter.update(next), updated);
+});
+
+Deno.test("plain text: unknown-file diffs keep source content plain", () => {
+  const diff = `diff --git a/LICENSE b/LICENSE
+--- a/LICENSE
++++ b/LICENSE
+@@ -1 +1 @@
+-const old = 1;
++const next = 2;
+`;
+  const model = parseDiff(diff)!;
+  const { doc } = buildDiffDocument(diff, model, NO_WS);
+  const contentSpans = doc.lines.slice(4, 6).flatMap((line) =>
+    line.spans.filter((span) => span.col > 0)
+  );
+  assertEquals(
+    contentSpans.map((span) => span.cls),
+    ["plain", "plain"],
+  );
+  assertEquals(
+    doc.flatStructure.map((node) => node.kind),
+    ["section", "hunk"],
+  );
+  assertEquals(verbatim(doc.lines), diff);
+});
+
+Deno.test("plain text: editing an unknown-file diff reapplies plain coloring", () => {
+  const diff = `diff --git a/LICENSE b/LICENSE
+--- a/LICENSE
++++ b/LICENSE
+@@ -1 +1 @@
+-old terms
++new terms
+`;
+  const updatedText = diff.replace("new terms", "export const terms = 1;");
+  const lines = createDiffHighlighter(diff).update(updatedText);
+  const edited = lines[5].spans.filter((span) => span.col > 0);
+  assertEquals(edited.map((span) => span.cls), ["plain"]);
+  assertEquals(verbatim(lines), updatedText);
+});


### PR DESCRIPTION
cf view previously sent every unrecognized filename through the TypeScript parser. That produced misleading syntax colors, structure, and semantic work for prose and unsupported languages.

Add a plain-text language as the final named-file fallback. Keep TypeScript as the intentional default for unnamed transformed compiler output. Reuse the lossless renderer for TypeScript parser failures, and cover direct files, diffs, live edits, and the interactive pager.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unknown named files in `cf view` now render as plain text to avoid misleading TypeScript colors and structure. Unnamed piped input still defaults to TypeScript; TypeScript parse failures fall back to lossless plain text.

- **New Features**
  - Introduced a `plain-text` language for unknown named files and reused it on TypeScript parse failures; applied to direct files, diffs, and live edits with an incremental highlighter.
  - Kept TypeScript as the default for unnamed input; plain‑text files and non‑TypeScript diffs schedule no semantic work; added tests for selection, JS file parsing, pager semantics, and plain‑text edits.

- **Bug Fixes**
  - Restored README and command help wording so filename-based selection and the unnamed TypeScript fallback are described correctly.

<sup>Written for commit 86a92362ca04110344d782843224834070739495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

