### PR TITLE
test(ui): replace a real sleep in the form-field async-flush test

### DIFF
--- a/packages/ui/src/v2/core/form-field-controller.test.ts
+++ b/packages/ui/src/v2/core/form-field-controller.test.ts
@@ -383,8 +383,12 @@ describe("FormFieldController registration behavior", () => {
     let flushCount = 0;
 
     const mockCell = {
+      // The write lands on a macrotask, not a wall-clock delay. That boundary
+      // is what gives the test teeth: a flush that failed to await set() would
+      // run its assertions on the microtask that follows, before the write, and
+      // observe the pre-write value.
       set: async (value: string) => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await new Promise((resolve) => setTimeout(resolve, 0));
         cellValue = value;
         flushCount++;
       },


### PR DESCRIPTION
The "should handle async flush" test in form-field-controller mocked a cell whose set() awaited `new Promise((resolve) => setTimeout(resolve, 10))` before recording the write, to model network latency. That is a real wall-clock sleep: it puts a floor under the test's runtime and, being timing-based, is the kind of wait that flakes when the machine is loaded or paused.

The delay is not what the test checks. The test checks that flush() awaits set() to completion — that after `await registration.flush()` the write has landed. What makes that assertion have teeth is only that the write happens on a later turn than flush()'s caller resumes: a flush that forgot to await set() would run its own assertions first and observe the pre-write value.

A macrotask boundary provides that ordering without a wall-clock delay. Replace the ten-millisecond timer with a zero-delay one, which fires on the next event loop turn: the write still lands a macrotask after a non-awaiting flush's assertions would have run, so the test still fails when flush() drops its await, but it no longer sleeps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the 10ms delay in the async flush test with a 0ms timeout to keep the write on the next tick without sleeping. This removes timing-based flakes and speeds up the test while still failing if flush() does not await set().

<sup>Written for commit 33d6cddd29f9e38e965608b7e3de82f7269fc6f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

