### PR TITLE
feat(cli): guide diff context expansion in the pager

### DIFF
--- a/packages/cli/lib/view/actions.ts
+++ b/packages/cli/lib/view/actions.ts
@@ -24,6 +24,15 @@ export function maxPagerTop(lineCount: number, height: number): number {
   return Math.max(0, lineCount - visibleDocumentRows);
 }
 
+/** Number of rows occupied by diff content. The empty logical line after a
+ * final line break begins the padded area. */
+export function diffContentRowCount(
+  rowCount: number,
+  hasTrailingEmptyLine: boolean,
+): number {
+  return Math.max(0, rowCount - (hasTrailingEmptyLine ? 1 : 0));
+}
+
 /** All occurrences of `query`, document-ordered. Smartcase: lower-case query
  * matches case-insensitively, any upper-case forces case-sensitivity. */
 export function findMatches(doc: Document, query: string): Match[] {

--- a/packages/cli/lib/view/actions.ts
+++ b/packages/cli/lib/view/actions.ts
@@ -17,6 +17,13 @@ export function maxTop(lineCount: number, height: number): number {
   return Math.max(0, lineCount - contentRows);
 }
 
+/** Largest pager `top`, with the last line at the end of the top quarter. */
+export function maxPagerTop(lineCount: number, height: number): number {
+  const contentRows = Math.max(1, height - 1);
+  const visibleDocumentRows = Math.max(1, Math.ceil(contentRows / 4));
+  return Math.max(0, lineCount - visibleDocumentRows);
+}
+
 /** All occurrences of `query`, document-ordered. Smartcase: lower-case query
  * matches case-insensitively, any upper-case forces case-sensitivity. */
 export function findMatches(doc: Document, query: string): Match[] {
@@ -237,7 +244,7 @@ export function frameTop(
   const top = nodeHeight <= rows
     ? startLine - Math.floor((rows - nodeHeight) / 2)
     : startLine - Math.floor(rows / 10);
-  return clamp(top, 0, maxTop(lineCount, height));
+  return clamp(top, 0, maxPagerTop(lineCount, height));
 }
 
 /**
@@ -259,7 +266,7 @@ export function scrollToAnchor(
   const target = anchorLine < top
     ? anchorLine - margin
     : anchorLine - rows + 1 + margin;
-  return clamp(target, 0, maxTop(lineCount, height));
+  return clamp(target, 0, maxPagerTop(lineCount, height));
 }
 
 /**

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -66,8 +66,8 @@ export interface SaveOptions {
 export interface EditableSource {
   /** A short label for the editable target (the filename), or null. */
   readonly label: string | null;
-  /** True for a diff view (whether or not it is editable), so the pager offers
-   * file folding. Absent/false for a plain file or a non-diff pipe. */
+  /** True for a diff view, whether or not it is editable. Absent or false for a
+   * plain file or a non-diff pipe. */
   readonly isDiff?: boolean;
   /** False when there is no underlying file to edit. `reason` is shown when a
    * cursor move is attempted on a non-editable view. */

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -101,9 +101,9 @@ export function labeledDiffMetadataLine(
   );
   if (!downward || metadata.line !== downward.line + 1) return metadata.line;
   const line = lines[downward.line];
-  if (!line) return metadata.line;
   const firstWidth = diffAnnotationDecoration("expandDown", width).firstWidth;
-  return displayWidth(line, mode) > Math.max(1, width) - firstWidth
+  return line &&
+      displayWidth(line, mode) > Math.max(1, width) - firstWidth
     ? null
     : metadata.line;
 }
@@ -660,8 +660,8 @@ function selectionRowBounds(
   const firstCell = Math.min(lo, display.length - 1);
   const lastCell = Math.max(firstCell, hi - 1);
   return {
-    first: wrappedRowForPosition(plan, line, firstCell)?.offset ?? 0,
-    last: wrappedRowForPosition(plan, line, lastCell)?.offset ?? 0,
+    first: wrappedRowForPosition(plan, line, firstCell)!.offset,
+    last: wrappedRowForPosition(plan, line, lastCell)!.offset,
   };
 }
 

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -406,7 +406,7 @@ export function renderFrame(doc: Document, view: ViewState): string[] {
       buildWrapPlan(doc.lines, view.displayMode, contentWidth, decorations)
     : null;
   const documentRowCount = wrapPlan?.rowCount ?? doc.lines.length;
-  const hasTrailingEmptyLine = view.expandMargin &&
+  const hasTrailingEmptyLine = view.isDiff === true &&
     doc.lines.at(-1)?.text.length === 0;
   const diffEndRow = Math.max(
     0,

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -877,8 +877,16 @@ function renderStatus(
       ? paint(padTo(view.inputLine, view.width), ui.statusBar)
       : padTo(view.inputLine, view.width);
   }
-  const total = doc.lines.length;
-  const rowCount = wrapPlan?.rowCount ?? total;
+  const hasTrailingEmptyDiffRow = view.isDiff === true && !view.cursor &&
+    doc.lines.at(-1)?.text.length === 0;
+  const total = diffContentRowCount(
+    doc.lines.length,
+    hasTrailingEmptyDiffRow,
+  );
+  const rowCount = diffContentRowCount(
+    wrapPlan?.rowCount ?? doc.lines.length,
+    hasTrailingEmptyDiffRow,
+  );
   const lastRow = Math.min(
     Math.max(0, rowCount - 1),
     view.top + view.height - 2,
@@ -898,13 +906,7 @@ function renderStatus(
     : Math.round((view.top / (rowCount - 1)) * 100);
   const endTop = view.cursor || view.isDiff !== true
     ? maxTop(rowCount, view.height)
-    : maxPagerTop(
-      diffContentRowCount(
-        rowCount,
-        doc.lines.at(-1)?.text.length === 0,
-      ),
-      view.height,
-    );
+    : maxPagerTop(rowCount, view.height);
   const atEnd = view.top >= endTop;
 
   // The left of the bar is either a message / selected-node label (plain text)

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -9,23 +9,104 @@
  * then run-length encoded into ANSI. Horizontal scrolling, the line-number
  * gutter and the structure guide bar are all column maths over that grid.
  */
+import { maxPagerTop, maxTop } from "./actions.ts";
 import { cpLen, paint, RESET, type Style } from "./ansi.ts";
 import type { Document, Line, StructureNode, ViewMode } from "./model.ts";
 import {
   type DisplayCell,
   displayLine,
   type DisplayMode,
+  displayWidth,
   glyphFor,
 } from "./display.ts";
 import { overlaySpanStyle, spanStyle } from "./highlight.ts";
 import { lineBg, ui } from "./theme.ts";
 import {
   buildWrapPlan,
-  fitWrapChrome,
+  fitViewLayout,
+  type WrapDecoration,
   type WrappedRow,
   wrappedRowAt,
+  wrappedRowForPosition,
   type WrapPlan,
 } from "./wrap.ts";
+
+/** Maximum columns used by the Ctrl-L label and its diff-edge marker. */
+export const DIFF_MARGIN_WIDTH = 3;
+
+/** Downward-pointing fleuron end marks for wide, compact, and narrow areas. */
+const END_MARK_ROWS = {
+  wide: ["☙   ❦   ❧", "☙   ❧", "❦"],
+  compact: ["☙ ❦ ❧", "☙ ❧", "❦"],
+  narrow: ["❦"],
+} as const;
+
+function endMarkRows(width: number, availableRows: number): readonly string[] {
+  if (availableRows >= 3 && width >= 9) return END_MARK_ROWS.wide;
+  if (availableRows >= 3 && width >= 5) return END_MARK_ROWS.compact;
+  if (availableRows >= 2 && width >= 9) return END_MARK_ROWS.wide.slice(1);
+  if (availableRows >= 2 && width >= 5) return END_MARK_ROWS.compact.slice(1);
+  if (width >= 9) return [END_MARK_ROWS.wide[0]];
+  if (width >= 5) return [END_MARK_ROWS.compact[0]];
+  return END_MARK_ROWS.narrow;
+}
+
+export type DiffAnnotationKind =
+  | "expandUp"
+  | "expandDown"
+  | "diffMetadata";
+
+export interface DiffAnnotation {
+  /** Folded logical line carrying the annotation. */
+  readonly line: number;
+  readonly kind: DiffAnnotationKind;
+}
+
+/** Wrapped source widths reserved by one diff annotation. */
+export function diffAnnotationDecoration(
+  kind: DiffAnnotationKind,
+  width: number,
+  labelMetadata = true,
+): WrapDecoration {
+  const available = Math.max(0, width - 1);
+  return {
+    firstWidth: Math.min(
+      kind === "diffMetadata" && labelMetadata ? 3 : 1,
+      available,
+    ),
+    firstContinuationWidth: Math.min(
+      kind === "expandDown" ? 3 : kind === "expandUp" ? 0 : 1,
+      available,
+    ),
+    continuationWidth: Math.min(
+      kind === "expandUp" ? 0 : 1,
+      available,
+    ),
+  };
+}
+
+/** The metadata line that carries the Ctrl-L label in this wrapped layout. */
+export function labeledDiffMetadataLine(
+  lines: readonly Line[],
+  mode: DisplayMode,
+  width: number,
+  annotations: readonly DiffAnnotation[],
+): number | null {
+  const metadata = annotations.find((annotation) =>
+    annotation.kind === "diffMetadata"
+  );
+  if (!metadata) return null;
+  const downward = annotations.find((annotation) =>
+    annotation.kind === "expandDown"
+  );
+  if (!downward || metadata.line !== downward.line + 1) return metadata.line;
+  const line = lines[downward.line];
+  if (!line) return metadata.line;
+  const firstWidth = diffAnnotationDecoration("expandDown", width).firstWidth;
+  return displayWidth(line, mode) > Math.max(1, width) - firstWidth
+    ? null
+    : metadata.line;
+}
 
 /** A key suggestion for the status line: the key (already capitalised for
  * display, e.g. `Q`, `^X^S`, `WASD`) and what it does. Drawn Turbo-Pascal style,
@@ -41,6 +122,8 @@ export interface ViewState {
   width: number;
   height: number;
   color: boolean;
+  /** Whether the source is a diff. */
+  isDiff?: boolean;
   showLineNumbers: boolean;
   /** Whether long logical lines continue on later screen rows. */
   wrapLines: boolean;
@@ -76,6 +159,16 @@ export interface ViewState {
   /** Whether Ctrl-L can reveal more context here (a diff), so the navigation
    * help advertises it. */
   canExpand?: boolean;
+  /** Whether this pager can draw diff annotations. */
+  expandMargin?: boolean;
+  /** Per-line annotations drawn against the right edge. */
+  diffAnnotations?: readonly DiffAnnotation[];
+  /** Absolute display row of the diff edge the next Ctrl-L will expand. */
+  expandRow?: number | null;
+  /** Whether the marked edge expands upward. False means downward. */
+  expandUp?: boolean | null;
+  /** Absolute display rows occupied by metadata adjacent to the expansion edge. */
+  diffMetadataRows?: readonly number[];
   /** Whether the view is editable, so the navigation help advertises `e`. */
   canEdit?: boolean;
   /** Whether this source offers an alternate rendered representation. */
@@ -109,14 +202,23 @@ function gutterWidth(doc: Document, view: ViewState): number {
 function layout(
   doc: Document,
   view: ViewState,
-): { gutterWidth: number; guideWidth: number } {
-  const requested = {
-    gutterWidth: gutterWidth(doc, view),
-    guideWidth: view.selected ? 1 : 0,
+): {
+  gutterWidth: number;
+  guideWidth: number;
+  contentWidth: number;
+} {
+  const fitted = fitViewLayout(
+    view.width,
+    gutterWidth(doc, view),
+    view.selected ? 1 : 0,
+    view.expandMargin ? DIFF_MARGIN_WIDTH : 0,
+    view.wrapLines,
+  );
+  return {
+    gutterWidth: fitted.gutterWidth,
+    guideWidth: fitted.guideWidth,
+    contentWidth: fitted.contentWidth + fitted.marginWidth,
   };
-  return view.wrapLines
-    ? fitWrapChrome(view.width, requested.gutterWidth, requested.guideWidth)
-    : requested;
 }
 
 /**
@@ -132,18 +234,15 @@ export function cursorScreenPos(
   if (!view.cursor || view.overlay || view.dialog) return null;
   const { line, col } = view.cursor;
   if (line < 0 || line >= doc.lines.length) return null;
-  const { gutterWidth, guideWidth } = layout(doc, view);
-  const contentWidth = Math.max(1, view.width - gutterWidth - guideWidth);
+  const { gutterWidth, guideWidth, contentWidth } = layout(doc, view);
   let screenLine = line;
   let contentCol = col - view.left;
   if (view.wrapLines) {
     const plan = view.wrapPlan ??
       buildWrapPlan(doc.lines, view.displayMode, contentWidth);
-    const first = plan.firstRow[line];
-    const last = plan.lastRow[line];
-    screenLine = Math.min(first + Math.floor(col / plan.rowStride), last);
-    const rowOffset = (screenLine - first) * plan.rowStride;
-    contentCol = col - rowOffset;
+    const row = wrappedRowForPosition(plan, line, col);
+    screenLine = row?.row ?? plan.firstRow[line];
+    contentCol = col - (row?.offset ?? 0);
   }
   const contentHeight = view.height - 1;
   const r = screenLine - view.top;
@@ -207,6 +306,34 @@ interface LineMatches {
   blockPrefixMaxEnd?: Float64Array;
 }
 
+type MarginMarker =
+  | "expandUp"
+  | "expandDown"
+  | "diffMetadata"
+  | "diffEnd"
+  | null;
+
+function marginAnnotation(marker: MarginMarker, width: number): string {
+  if (marker === null) return "";
+  const text = marker === "expandUp"
+    ? "◥"
+    : marker === "expandDown"
+    ? "◢"
+    : "█";
+  return clipAnnotation(text, width);
+}
+
+/** Keep at least one source cell when an annotation meets a narrow view. */
+function clipAnnotation(text: string, width: number): string {
+  const capacity = Math.max(0, width - 1);
+  return capacity === 0 ? "" : [...text].slice(-capacity).join("");
+}
+
+function clipConnectorAnnotation(text: string, width: number): string {
+  const capacity = Math.max(0, width);
+  return capacity === 0 ? "" : [...text].slice(-capacity).join("");
+}
+
 const MATCH_BLOCK_SIZE = 64;
 
 /** The contiguous slice of document-ordered matches on one visible line. */
@@ -242,12 +369,71 @@ function matchesOnLine(
 export function renderFrame(doc: Document, view: ViewState): string[] {
   const rows: string[] = [];
   const contentHeight = view.height - 1;
-  const { gutterWidth: gw, guideWidth } = layout(doc, view);
-  const contentWidth = Math.max(1, view.width - gw - guideWidth);
+  const {
+    gutterWidth: gw,
+    guideWidth,
+    contentWidth,
+  } = layout(doc, view);
+  const annotations = new Map(
+    (view.diffAnnotations ?? []).map((annotation) => [
+      annotation.line,
+      annotation.kind,
+    ]),
+  );
+  const metadataLabelLine = view.wrapLines
+    ? labeledDiffMetadataLine(
+      doc.lines,
+      view.displayMode,
+      contentWidth,
+      view.diffAnnotations ?? [],
+    )
+    : view.diffAnnotations?.find((annotation) =>
+      annotation.kind === "diffMetadata"
+    )?.line ?? null;
+  const decorations = new Map<number, WrapDecoration>();
+  for (const [line, kind] of annotations) {
+    decorations.set(
+      line,
+      diffAnnotationDecoration(
+        kind,
+        contentWidth,
+        kind !== "diffMetadata" || line === metadataLabelLine,
+      ),
+    );
+  }
   const wrapPlan = view.wrapLines
-    ? view.wrapPlan ?? buildWrapPlan(doc.lines, view.displayMode, contentWidth)
+    ? view.wrapPlan ??
+      buildWrapPlan(doc.lines, view.displayMode, contentWidth, decorations)
     : null;
-  const rowStride = wrapPlan?.rowStride ?? contentWidth;
+  const documentRowCount = wrapPlan?.rowCount ?? doc.lines.length;
+  const hasTrailingEmptyLine = view.expandMargin &&
+    doc.lines.at(-1)?.text.length === 0;
+  const diffEndRow = Math.max(
+    0,
+    hasTrailingEmptyLine ? documentRowCount - 1 : documentRowCount,
+  );
+  const lastDiffLine = doc.lines.length - (hasTrailingEmptyLine ? 2 : 1);
+  const finalTriangleRow = annotations.get(lastDiffLine) === "expandDown"
+    ? wrapPlan?.firstRow[lastDiffLine] ?? lastDiffLine
+    : null;
+  const hasDiffEndConnector = view.isDiff === true &&
+    view.expandMargin === true &&
+    finalTriangleRow !== null;
+  const labelDiffEnd = finalTriangleRow !== null &&
+    finalTriangleRow + 1 === diffEndRow;
+  const diffEndSuffix = (width: number) =>
+    clipConnectorAnnotation(labelDiffEnd ? "^L█" : "█", width);
+  let endMarkStart = diffEndRow + (hasDiffEndConnector ? 1 : 0);
+  const availableEndRows = contentHeight - Math.max(0, endMarkStart - view.top);
+  const showEndMark = view.isDiff === true && !view.cursor;
+  let endRows = showEndMark ? endMarkRows(view.width, availableEndRows) : [];
+  if (
+    showEndMark && hasDiffEndConnector && availableEndRows <= 0 &&
+    diffEndRow >= view.top && diffEndRow < view.top + contentHeight
+  ) {
+    endMarkStart = diffEndRow;
+    endRows = END_MARK_ROWS.narrow;
+  }
   let displayedLine = -1;
   let displayedCells: readonly DisplayCell[] | undefined;
   let displayedSelection: SelectionSpan | null = null;
@@ -255,27 +441,75 @@ export function renderFrame(doc: Document, view: ViewState): string[] {
 
   for (let r = 0; r < contentHeight; r++) {
     const rowIdx = view.top + r;
+    const endMark = endRows[rowIdx - endMarkStart] ?? null;
+    if (endMark !== null) {
+      const suffix = hasDiffEndConnector && rowIdx === diffEndRow
+        ? diffEndSuffix(view.width)
+        : "";
+      rows.push(
+        composeContent(
+          undefined,
+          view,
+          0,
+          Math.max(1, view.width),
+          Math.max(1, view.width),
+          false,
+          null,
+          undefined,
+          null,
+          endMark,
+          suffix,
+        ),
+      );
+      continue;
+    }
     const wrappedRow: WrappedRow | undefined = wrapPlan
       ? wrappedRowAt(wrapPlan, rowIdx)
-      : { line: rowIdx, offset: view.left, lastOffset: view.left };
+      : undefined;
+    const lineIdx = wrappedRow?.line ?? rowIdx;
     const firstOfLine = !wrapPlan || wrappedRow === undefined ||
       wrapPlan.firstRow[wrappedRow.line] === rowIdx;
-    if (wrappedRow && wrappedRow.line !== displayedLine) {
-      displayedLine = wrappedRow.line;
+    if (lineIdx < doc.lines.length && lineIdx !== displayedLine) {
+      displayedLine = lineIdx;
       const line = doc.lines[displayedLine];
       displayedCells = line ? displayLine(line, view.displayMode) : undefined;
       displayedSelection = selectionSpan(view, displayedLine, line);
       displayedMatches = view.color ? matchesOnLine(view, displayedLine) : null;
-    } else if (!wrappedRow) {
+    } else if (lineIdx >= doc.lines.length) {
       displayedCells = undefined;
       displayedSelection = null;
       displayedMatches = null;
     }
+    const annotation = annotations.get(lineIdx);
+    const labelsWrappedExpansion = annotation === "expandDown" &&
+      wrapPlan !== null &&
+      wrappedRow !== undefined &&
+      rowIdx === wrapPlan.firstRow[lineIdx] + 1;
+    const marginMarker: MarginMarker = firstOfLine && annotation
+      ? annotation
+      : wrappedRow && wrappedRow.suffixWidth > 0
+      ? "diffMetadata"
+      : hasDiffEndConnector && rowIdx === diffEndRow
+      ? "diffEnd"
+      : null;
+    const suffix = firstOfLine && annotation === "diffMetadata" &&
+        lineIdx === metadataLabelLine
+      ? clipAnnotation("^L█", contentWidth)
+      : labelsWrappedExpansion
+      ? clipAnnotation("^L█", contentWidth)
+      : hasDiffEndConnector && rowIdx === diffEndRow
+      ? diffEndSuffix(contentWidth)
+      : marginAnnotation(marginMarker, contentWidth);
+    const sourceWidth = wrappedRow?.sourceWidth ??
+      Math.max(1, contentWidth - suffix.length);
     rows.push(
       renderContentRow(
         doc,
         view,
-        wrappedRow,
+        lineIdx,
+        wrappedRow?.offset ?? view.left,
+        sourceWidth,
+        wrappedRow?.wrapMarker ?? false,
         displayedCells,
         displayedSelection,
         displayedMatches,
@@ -283,7 +517,8 @@ export function renderFrame(doc: Document, view: ViewState): string[] {
         gw,
         guideWidth,
         contentWidth,
-        rowStride,
+        wrapPlan,
+        suffix,
       ),
     );
   }
@@ -308,7 +543,10 @@ export function renderFrame(doc: Document, view: ViewState): string[] {
 function renderContentRow(
   doc: Document,
   view: ViewState,
-  row: WrappedRow | undefined,
+  lineIdx: number,
+  offset: number,
+  sourceWidth: number,
+  wrapMarker: boolean,
   display: readonly DisplayCell[] | undefined,
   selection: SelectionSpan | null,
   matches: LineMatches | null,
@@ -316,9 +554,9 @@ function renderContentRow(
   gutterWidth: number,
   guideWidth: number,
   contentWidth: number,
-  rowStride: number,
+  wrapPlan: WrapPlan | null,
+  suffix: string,
 ): string {
-  const lineIdx = row?.line ?? -1;
   const line: Line | undefined = doc.lines[lineIdx];
   const inSelRange = !!view.selected &&
     lineIdx >= view.selected.startLine && lineIdx <= view.selected.endLine;
@@ -344,9 +582,8 @@ function renderContentRow(
           view.selected!,
           lineIdx,
           line,
-          row?.offset ?? 0,
-          rowStride,
-          row?.lastOffset ?? 0,
+          offset,
+          wrapPlan!,
           selection,
           display,
         )
@@ -359,12 +596,15 @@ function renderContentRow(
   const content = composeContent(
     line,
     view,
-    row?.offset ?? 0,
+    offset,
     contentWidth,
+    sourceWidth,
+    wrapMarker,
     selection,
     display,
     matches,
-    row !== undefined && row.offset < row.lastOffset,
+    null,
+    suffix,
   );
   return gutter + guide + content;
 }
@@ -386,8 +626,7 @@ function wrappedGuideChar(
   lineIdx: number,
   line: Line | undefined,
   offset: number,
-  stride: number,
-  lastOffset: number,
+  plan: WrapPlan,
   span: SelectionSpan | null,
   display: readonly DisplayCell[] | undefined,
 ): string {
@@ -397,8 +636,8 @@ function wrappedGuideChar(
   const bounds = selectionRowBounds(
     span,
     display ?? [],
-    stride,
-    lastOffset,
+    plan,
+    lineIdx,
   );
   if (offset < bounds.first || offset > bounds.last) return " ";
   const first = lineIdx === selected.startLine && offset === bounds.first;
@@ -412,8 +651,8 @@ function wrappedGuideChar(
 function selectionRowBounds(
   span: SelectionSpan | null,
   display: readonly DisplayCell[],
-  stride: number,
-  lastOffset: number,
+  plan: WrapPlan,
+  line: number,
 ): { first: number; last: number } {
   if (display.length === 0) return { first: 0, last: 0 };
   const lo = span ? displayIndexAtOrAfter(display, span.lo) : 0;
@@ -421,8 +660,8 @@ function selectionRowBounds(
   const firstCell = Math.min(lo, display.length - 1);
   const lastCell = Math.max(firstCell, hi - 1);
   return {
-    first: Math.min(Math.floor(firstCell / stride) * stride, lastOffset),
-    last: Math.min(Math.floor(lastCell / stride) * stride, lastOffset),
+    first: wrappedRowForPosition(plan, line, firstCell)?.offset ?? 0,
+    last: wrappedRowForPosition(plan, line, lastCell)?.offset ?? 0,
   };
 }
 
@@ -497,10 +736,13 @@ function composeContent(
   view: ViewState,
   offset: number,
   width: number,
+  sourceWidth: number,
+  showWrapMarker: boolean,
   sel: SelectionSpan | null,
   display: readonly DisplayCell[] | undefined,
   lineMatches: LineMatches | null,
-  continues: boolean,
+  endMark: string | null,
+  suffix: string,
 ): string {
   const { color } = view;
   // Every content cell sits on the blue editor background; a diff line carries a
@@ -510,10 +752,9 @@ function composeContent(
     ? { bg: line?.bg ? lineBg(line.bg) : ui.editorBg }
     : EMPTY_STYLE;
   const cells: Cell[] = new Array(width);
-  for (let i = 0; i < width; i++) cells[i] = { ch: " ", style: rowBg };
-  const showWrapMarker = continues && width > 1;
-  const sourceWidth = showWrapMarker ? width - 1 : width;
-
+  for (let i = 0; i < cells.length; i++) {
+    cells[i] = { ch: " ", style: rowBg };
+  }
   if (line && display) {
     // The display list may hold fewer cells than the line has code points —
     // ANSI sequences are hidden and runs of control codes collapse — so cells
@@ -542,10 +783,36 @@ function composeContent(
   }
 
   if (showWrapMarker) {
-    cells[width - 1] = {
+    cells[sourceWidth] = {
       ch: "\\",
       style: color ? mergeBg(ui.wrapMarker, rowBg) : EMPTY_STYLE,
     };
+  }
+  const suffixCells = [...suffix];
+  if (endMark !== null) {
+    const ornament = [...endMark];
+    const centeredStart = Math.floor((width - ornament.length) / 2);
+    const suffixStart = cells.length - suffixCells.length;
+    const start = centeredStart + ornament.length <= suffixStart
+      ? centeredStart
+      : Math.floor((suffixStart - ornament.length) / 2);
+    if (start >= 0) {
+      for (let i = 0; i < ornament.length; i++) {
+        cells[start + i] = {
+          ch: ornament[i],
+          style: color ? mergeBg(ui.endMark, rowBg) : EMPTY_STYLE,
+        };
+      }
+    }
+  }
+  if (suffixCells.length > 0) {
+    const start = cells.length - suffixCells.length;
+    for (let i = 0; i < suffixCells.length; i++) {
+      cells[start + i] = {
+        ch: suffixCells[i],
+        style: color ? mergeBg(ui.wrapMarker, rowBg) : EMPTY_STYLE,
+      };
+    }
   }
 
   return cellsToAnsi(cells, color);
@@ -629,7 +896,10 @@ function renderStatus(
   const pct = rowCount <= 1
     ? 100
     : Math.round((view.top / (rowCount - 1)) * 100);
-  const atEnd = view.top + view.height - 1 >= rowCount;
+  const endTop = view.cursor || view.isDiff !== true
+    ? maxTop(rowCount, view.height)
+    : maxPagerTop(rowCount, view.height);
+  const atEnd = view.top >= endTop;
 
   // The left of the bar is either a message / selected-node label (plain text)
   // or a row of key hints (keys highlighted, Turbo Pascal style).

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -101,9 +101,9 @@ export function labeledDiffMetadataLine(
   );
   if (!downward || metadata.line !== downward.line + 1) return metadata.line;
   const line = lines[downward.line];
+  if (!line) return metadata.line;
   const firstWidth = diffAnnotationDecoration("expandDown", width).firstWidth;
-  return line &&
-      displayWidth(line, mode) > Math.max(1, width) - firstWidth
+  return displayWidth(line, mode) > Math.max(1, width) - firstWidth
     ? null
     : metadata.line;
 }
@@ -660,8 +660,8 @@ function selectionRowBounds(
   const firstCell = Math.min(lo, display.length - 1);
   const lastCell = Math.max(firstCell, hi - 1);
   return {
-    first: wrappedRowForPosition(plan, line, firstCell)!.offset,
-    last: wrappedRowForPosition(plan, line, lastCell)!.offset,
+    first: wrappedRowForPosition(plan, line, firstCell)?.offset ?? 0,
+    last: wrappedRowForPosition(plan, line, lastCell)?.offset ?? 0,
   };
 }
 

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -9,7 +9,7 @@
  * then run-length encoded into ANSI. Horizontal scrolling, the line-number
  * gutter and the structure guide bar are all column maths over that grid.
  */
-import { maxPagerTop, maxTop } from "./actions.ts";
+import { diffContentRowCount, maxPagerTop, maxTop } from "./actions.ts";
 import { cpLen, paint, RESET, type Style } from "./ansi.ts";
 import type { Document, Line, StructureNode, ViewMode } from "./model.ts";
 import {
@@ -408,9 +408,9 @@ export function renderFrame(doc: Document, view: ViewState): string[] {
   const documentRowCount = wrapPlan?.rowCount ?? doc.lines.length;
   const hasTrailingEmptyLine = view.isDiff === true &&
     doc.lines.at(-1)?.text.length === 0;
-  const diffEndRow = Math.max(
-    0,
-    hasTrailingEmptyLine ? documentRowCount - 1 : documentRowCount,
+  const diffEndRow = diffContentRowCount(
+    documentRowCount,
+    hasTrailingEmptyLine,
   );
   const lastDiffLine = doc.lines.length - (hasTrailingEmptyLine ? 2 : 1);
   const finalTriangleRow = annotations.get(lastDiffLine) === "expandDown"
@@ -898,7 +898,13 @@ function renderStatus(
     : Math.round((view.top / (rowCount - 1)) * 100);
   const endTop = view.cursor || view.isDiff !== true
     ? maxTop(rowCount, view.height)
-    : maxPagerTop(rowCount, view.height);
+    : maxPagerTop(
+      diffContentRowCount(
+        rowCount,
+        doc.lines.at(-1)?.text.length === 0,
+      ),
+      view.height,
+    );
   const atEnd = view.top >= endTop;
 
   // The left of the bar is either a message / selected-node label (plain text)

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -4263,7 +4263,7 @@ export function helpOverlay(): {
     ["  A / D", "parent / first child"],
     ["  Tab / ⇧Tab", "next / previous node (depth-first)"],
     ["  Z", "centre selected node"],
-    ["  ^L", "diff: reveal more of the file one quarter down the view"],
+    ["  ^L", "diff: reveal more context at the marked edge"],
     ["  Esc", "clear selection / search"],
     ["", ""],
     ["Editing (a file or a diff)", ""],

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -545,6 +545,7 @@ export class Session {
         if (annotation.line < from || annotation.line >= to) {
           return [{ ...annotation, line: back(annotation.line) }];
         }
+        if (annotation.kind === "diffMetadata") return [];
         return [{
           ...annotation,
           line: rev.up ? from : Math.max(0, from - 1),
@@ -2781,17 +2782,16 @@ export class Session {
     const lines = this.foldPlan().displayLines;
     for (const annotation of annotations) {
       const line = lines[annotation.line];
-      if (line) {
-        width = Math.max(
-          width,
-          displayWidth(line, this.displayMode) -
-            this.lineContentWidth(
-              annotation.line,
-              annotations,
-              contentWidth,
-            ),
-        );
-      }
+      if (!line) continue;
+      width = Math.max(
+        width,
+        displayWidth(line, this.displayMode) -
+          this.lineContentWidth(
+            annotation.line,
+            annotations,
+            contentWidth,
+          ),
+      );
     }
     return Math.max(0, width);
   }
@@ -3505,6 +3505,9 @@ export class Session {
   ): readonly number[] {
     const line = this.adjacentDiffMetadataLine(expand);
     if (line === null) return [];
+    const fold = this.foldPlan();
+    const folded = fold.docToDisplay(line);
+    if (fold.displayLines[folded] !== this.currentDoc.lines[line]) return [];
     const first = this.toDisplay(line);
     const last = this.toDisplayEnd(line);
     const rows: number[] = [];
@@ -3525,6 +3528,11 @@ export class Session {
     }
     const fold = this.foldPlan();
     const marker = fold.docToDisplay(expand.markerLine);
+    if (
+      fold.displayLines[marker] !== this.currentDoc.lines[expand.markerLine]
+    ) {
+      return [];
+    }
     const annotations: DiffAnnotation[] = [{
       line: marker,
       kind: expand.up ? "expandUp" : "expandDown",

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -18,7 +18,11 @@ import { cpLen } from "./ansi.ts";
 import {
   type DialogButton,
   type DialogState,
+  DIFF_MARGIN_WIDTH,
+  type DiffAnnotation,
+  diffAnnotationDecoration,
   type KeyHint,
+  labeledDiffMetadataLine,
   type Match,
   overlayBox,
   type OverlayState,
@@ -28,6 +32,7 @@ import {
   clamp,
   findMatches,
   frameTop,
+  maxPagerTop,
   maxTop,
   nextMatchIndex,
   nodeAtLine,
@@ -46,6 +51,7 @@ import {
   displayLine,
   type DisplayMode,
   displayModeLabel,
+  displayWidth,
   hasNonPrintable,
   sourceColumnOf,
 } from "./display.ts";
@@ -74,8 +80,10 @@ import type {
 import type { DirEntry, FileGateway } from "./filegateway.ts";
 import {
   buildWrapPlan,
-  fitWrapChrome,
+  fitViewLayout,
+  type WrapDecoration,
   wrappedRowAt,
+  wrappedRowForPosition,
   type WrapPlan,
 } from "./wrap.ts";
 
@@ -142,6 +150,28 @@ interface ViewportAnchor {
   readonly displayCol: number;
 }
 
+interface ExpansionLayoutCache {
+  readonly decoratedPlan: WrapPlan;
+  readonly decoratedTop: number;
+  readonly basePlan: WrapPlan;
+  readonly baseTop: number;
+}
+
+interface ExpandOffer {
+  /** Screen row in the undecorated layout. */
+  readonly row: number | null;
+  /** Document line carrying the expansion triangle. */
+  readonly markerLine: number | null;
+  /** Document line passed to the context expander. */
+  readonly line: number;
+  readonly up: boolean;
+}
+
+interface ExpandEdge extends ExpandOffer {
+  readonly aimRow: number;
+  readonly room: HunkRoom;
+}
+
 interface FoldAnchor {
   readonly docLine: number;
   readonly sourceCol: number;
@@ -186,15 +216,32 @@ export class Session {
     lines: readonly Line[];
     mode: DisplayMode;
     width: number;
+    decorations: string;
     plan: WrapPlan;
   };
+  private baseWrapPlanCache?: {
+    lines: readonly Line[];
+    mode: DisplayMode;
+    width: number;
+    plan: WrapPlan;
+  };
+  private expansionLayoutCache?: ExpansionLayoutCache;
+  private wrapDecorations = new Map<number, WrapDecoration>();
+  private wrapDecorationKey = "";
   private displayColumnCache?: {
     doc: Document;
     mode: DisplayMode;
     columns: Map<number, Uint32Array>;
   };
+  private maxDisplayWidthCache?: {
+    lines: readonly Line[];
+    mode: DisplayMode;
+    width: number;
+  };
   private nonPrintCache?: { doc: Document; value: boolean };
   private fileLineCache?: { doc: Document; value: (number | null)[] | null };
+  /** Diff metadata lines, cached against the parsed document. */
+  private diffMetadataCache?: { doc: Document; lines: readonly number[] };
 
   width: number;
   height: number;
@@ -422,16 +469,42 @@ export class Session {
     if (
       this.wrapPlanCache?.lines !== lines ||
       this.wrapPlanCache.mode !== this.displayMode ||
-      this.wrapPlanCache.width !== width
+      this.wrapPlanCache.width !== width ||
+      this.wrapPlanCache.decorations !== this.wrapDecorationKey
     ) {
       this.wrapPlanCache = {
+        lines,
+        mode: this.displayMode,
+        width,
+        decorations: this.wrapDecorationKey,
+        plan: buildWrapPlan(
+          lines,
+          this.displayMode,
+          width,
+          this.wrapDecorations,
+        ),
+      };
+    }
+    return this.wrapPlanCache.plan;
+  }
+
+  /** Wrapped text layout without transient right-edge annotations. */
+  private baseWrapPlan(): WrapPlan {
+    const lines = this.foldPlan().displayLines;
+    const width = this.contentWidth();
+    if (
+      this.baseWrapPlanCache?.lines !== lines ||
+      this.baseWrapPlanCache.mode !== this.displayMode ||
+      this.baseWrapPlanCache.width !== width
+    ) {
+      this.baseWrapPlanCache = {
         lines,
         mode: this.displayMode,
         width,
         plan: buildWrapPlan(lines, this.displayMode, width),
       };
     }
-    return this.wrapPlanCache.plan;
+    return this.baseWrapPlanCache.plan;
   }
 
   /** Number of screen rows after file folding and optional line wrapping. */
@@ -465,6 +538,28 @@ export class Session {
     const doc = this.displayDoc();
     const view = this.view();
     const sel = view.selected;
+    const expandRow = view.expandRow;
+    const diffAnnotations = view.diffAnnotations;
+    const projectedAnnotations = diffAnnotations?.flatMap(
+      (annotation): DiffAnnotation[] => {
+        if (annotation.line < from || annotation.line >= to) {
+          return [{ ...annotation, line: back(annotation.line) }];
+        }
+        if (annotation.kind === "diffMetadata") return [];
+        return [{
+          ...annotation,
+          line: rev.up ? from : Math.max(0, from - 1),
+        }];
+      },
+    );
+    const projectedTriangle = projectedAnnotations?.find((annotation) =>
+      annotation.kind !== "diffMetadata"
+    );
+    const frameAnnotations = projectedAnnotations?.filter((annotation) =>
+      annotation.kind !== "diffMetadata" ||
+      (projectedTriangle !== undefined &&
+        Math.abs(annotation.line - projectedTriangle.line) === 1)
+    );
     return {
       doc: { ...doc, lines: drop(doc.lines) },
       view: {
@@ -485,6 +580,21 @@ export class Session {
           ? view.matches.filter((m) => m.line < from || m.line >= to)
             .map((m) => ({ ...m, line: back(m.line) }))
           : null,
+        // A downward reveal's next edge can sit among the lines still to land.
+        // Until they arrive, mark the hunk-side row that currently bounds them.
+        expandRow: expandRow === null || expandRow === undefined
+          ? expandRow
+          : expandRow < from
+          ? expandRow
+          : expandRow >= to
+          ? expandRow - waiting
+          : rev.up
+          ? from
+          : Math.max(0, from - 1),
+        diffMetadataRows: frameAnnotations
+          ?.filter((annotation) => annotation.kind === "diffMetadata")
+          .map((annotation) => annotation.line),
+        diffAnnotations: frameAnnotations,
       },
     };
   }
@@ -497,31 +607,62 @@ export class Session {
   /** A document position to its screen row. A hidden line maps to its file's
    * summary, and a wrapped line maps to the segment containing `displayCol`. */
   private toDisplay(docLine: number, displayCol = 0): number {
+    return this.toDisplayWithPlan(
+      docLine,
+      displayCol,
+      this.wrapLines ? this.wrapPlan() : null,
+    );
+  }
+
+  /** Map a document position through a specific wrapped layout. */
+  private toDisplayWithPlan(
+    docLine: number,
+    displayCol: number,
+    plan: WrapPlan | null,
+  ): number {
     const fold = this.foldPlan();
     const folded = fold.docToDisplay(docLine);
     const col = fold.displayLines[folded] === this.currentDoc.lines[docLine]
       ? displayCol
       : 0;
-    return this.foldedPositionToDisplay(folded, col);
+    return this.foldedPositionToDisplayWithPlan(folded, col, plan);
   }
 
   /** A folded logical line and display column to its screen row. */
   private foldedPositionToDisplay(folded: number, displayCol = 0): number {
-    if (!this.wrapLines) return folded;
-    const plan = this.wrapPlan();
-    const first = plan.firstRow[folded] ?? 0;
-    const last = plan.lastRow[folded] ?? first;
-    return clamp(
-      first + Math.floor(Math.max(0, displayCol) / plan.rowStride),
-      first,
-      last,
+    return this.foldedPositionToDisplayWithPlan(
+      folded,
+      displayCol,
+      this.wrapLines ? this.wrapPlan() : null,
     );
+  }
+
+  /** Map a folded position through a specific wrapped layout. */
+  private foldedPositionToDisplayWithPlan(
+    folded: number,
+    displayCol: number,
+    plan: WrapPlan | null,
+  ): number {
+    if (!plan) return folded;
+    return wrappedRowForPosition(plan, folded, displayCol)?.row ??
+      plan.firstRow[folded] ?? 0;
   }
 
   /** The last screen row occupied by a document line. */
   private toDisplayEnd(docLine: number): number {
+    return this.toDisplayEndWithPlan(
+      docLine,
+      this.wrapLines ? this.wrapPlan() : null,
+    );
+  }
+
+  /** Last screen row for a document line in a specific wrapped layout. */
+  private toDisplayEndWithPlan(
+    docLine: number,
+    plan: WrapPlan | null,
+  ): number {
     const folded = this.toFolded(docLine);
-    return this.wrapLines ? this.wrapPlan().lastRow[folded] ?? 0 : folded;
+    return plan ? plan.lastRow[folded] ?? 0 : folded;
   }
 
   /** A screen row to the document line it stands for. */
@@ -651,13 +792,7 @@ export class Session {
       0,
       Math.max(0, plan.firstRow.length - 1),
     );
-    const first = plan.firstRow[line] ?? 0;
-    const last = plan.lastRow[line] ?? first;
-    this.top = clamp(
-      first + Math.floor(anchor.displayCol / plan.rowStride),
-      first,
-      last,
-    );
+    this.top = wrappedRowForPosition(plan, line, anchor.displayCol)?.row ?? 0;
     this.clampScroll();
   }
 
@@ -677,6 +812,23 @@ export class Session {
 
   view(): ViewState {
     const o = this.overlay;
+    const expand = this.mode === "normal" && !this.overlay &&
+        !this.cursorOn && this.chord === null && this.source?.expandContext
+      ? this.expandOffer()
+      : null;
+    const offeredExpand = expand && !("blocked" in expand) ? expand : null;
+    const diffMargin = this.hasDiffMargin();
+    let diffAnnotations = diffMargin
+      ? this.displayDiffAnnotations(offeredExpand)
+      : [];
+    diffAnnotations = this.syncWrapDecorations(diffAnnotations);
+    if (!this.wrapLines) {
+      this.left = clamp(this.left, 0, this.maxLeft(diffAnnotations));
+    }
+    const expandRow = offeredExpand?.markerLine === null ||
+        offeredExpand?.markerLine === undefined
+      ? null
+      : this.toDisplay(offeredExpand.markerLine);
     const ov: OverlayState | null = this.mode === "filePicker"
       ? this.pickerOverlay()
       : this.mode === "jumpList"
@@ -702,6 +854,7 @@ export class Session {
       width: this.width,
       height: this.height,
       color: this.color,
+      isDiff: this.source?.isDiff === true,
       showLineNumbers: this.lineNumberMode !== "off",
       wrapLines: this.wrapLines,
       wrapPlan: this.wrapLines ? this.wrapPlan() : null,
@@ -726,7 +879,14 @@ export class Session {
         ? { line: this.toFolded(this.buffer.row), col: this.buffer.col }
         : null,
       editHint: this.cursorOn ? this.editHint() : null,
-      canExpand: this.canExpand(),
+      canExpand: offeredExpand !== null,
+      expandMargin: diffMargin,
+      diffAnnotations,
+      expandRow,
+      expandUp: offeredExpand?.up ?? null,
+      diffMetadataRows: diffMargin
+        ? this.displayAdjacentDiffMetadataRows(offeredExpand)
+        : [],
       canEdit: !this.cursorOn && !!this.source?.editable,
       canRender: !!this.source?.render,
       viewMode: this.viewMode,
@@ -894,8 +1054,22 @@ export class Session {
   }
 
   private clampScroll(): void {
-    this.top = clamp(this.top, 0, maxTop(this.displayCount(), this.height));
-    this.left = this.wrapLines ? 0 : clamp(this.left, 0, this.maxLineLen);
+    this.top = clamp(this.top, 0, this.lastTop());
+    this.left = this.wrapLines ? 0 : clamp(this.left, 0, this.maxLeft());
+  }
+
+  /** Furthest vertical position for the current pager or editor mode. */
+  private lastTop(): number {
+    return this.cursorOn
+      ? maxTop(this.doc.lines.length, this.height)
+      : this.pagerLastTop(this.displayCount());
+  }
+
+  /** Furthest vertical position for a pager layout with `rowCount` rows. */
+  private pagerLastTop(rowCount: number): number {
+    return this.source?.isDiff
+      ? maxPagerTop(rowCount, this.height)
+      : maxTop(rowCount, this.height);
   }
 
   private selectedNode(): StructureNode | null {
@@ -911,28 +1085,52 @@ export class Session {
 
   /** Screen row containing the first character of a structure node. */
   private nodeStartRow(node: StructureNode): number {
+    return this.nodeStartRowWithPlan(
+      node,
+      this.wrapLines ? this.wrapPlan() : null,
+    );
+  }
+
+  /** First row of a structure node in a specific wrapped layout. */
+  private nodeStartRowWithPlan(
+    node: StructureNode,
+    plan: WrapPlan | null,
+  ): number {
     const col = this.renderedLineChangesColumns(node.startLine)
       ? 0
       : node.startCol;
-    return this.toDisplay(
+    return this.toDisplayWithPlan(
       node.startLine,
       this.displayCol(node.startLine, col),
+      plan,
     );
   }
 
   /** Screen row containing the last character of a structure node. */
   private nodeEndRow(node: StructureNode): number {
+    return this.nodeEndRowWithPlan(
+      node,
+      this.wrapLines ? this.wrapPlan() : null,
+    );
+  }
+
+  /** Last row of a structure node in a specific wrapped layout. */
+  private nodeEndRowWithPlan(
+    node: StructureNode,
+    plan: WrapPlan | null,
+  ): number {
     const fold = this.foldPlan();
     const folded = fold.docToDisplay(node.endLine);
     if (fold.displayLines[folded] !== this.currentDoc.lines[node.endLine]) {
-      return this.wrapLines ? this.wrapPlan().lastRow[folded] ?? 0 : folded;
+      return plan ? plan.lastRow[folded] ?? 0 : folded;
     }
     const endCol = this.renderedLineChangesColumns(node.endLine)
       ? codePointLength(this.currentDoc.lines[node.endLine]?.text ?? "")
       : node.endCol;
-    return this.toDisplay(
+    return this.toDisplayWithPlan(
       node.endLine,
       this.displayCol(node.endLine, Math.max(0, endCol - 1)),
+      plan,
     );
   }
 
@@ -946,11 +1144,15 @@ export class Session {
     // line, where the block opens) would otherwise be off screen. Horizontal
     // scroll is left untouched for the same reason. Anchors are in display rows,
     // since a collapsed file's lines share its summary row.
-    this.top = scrollToAnchor(
-      this.nodeStartRow(node),
-      this.top,
-      this.height,
-      this.displayCount(),
+    this.top = clamp(
+      scrollToAnchor(
+        this.nodeStartRow(node),
+        this.top,
+        this.height,
+        this.displayCount(),
+      ),
+      0,
+      this.lastTop(),
     );
     this.message = "";
   }
@@ -1154,18 +1356,17 @@ export class Session {
         end = destRow;
       }
     }
-    this.top = frameTop(
-      start,
-      end,
-      this.height,
-      this.displayCount(),
+    this.top = clamp(
+      frameTop(
+        start,
+        end,
+        this.height,
+        this.displayCount(),
+      ),
+      0,
+      this.lastTop(),
     );
-    if (
-      !this.wrapLines &&
-      (destCol < this.left || destCol >= this.left + this.width)
-    ) {
-      this.left = clamp(destCol - 4, 0, this.maxLineLen);
-    }
+    this.revealColumn(target.destLine, destCol);
     this.message = `→ line ${target.destLine + 1}`;
   }
 
@@ -1287,15 +1488,10 @@ export class Session {
       this.top = clamp(
         row - Math.floor(this.contentRows() / 2),
         0,
-        maxTop(this.displayCount(), this.height),
+        this.lastTop(),
       );
     }
-    if (
-      !this.wrapLines &&
-      (col < this.left || col >= this.left + this.width)
-    ) {
-      this.left = clamp(col - 4, 0, this.maxLineLen);
-    }
+    this.revealColumn(m.line, col);
     this.message = "";
   }
 
@@ -1513,7 +1709,7 @@ export class Session {
     }
 
     const rows = this.contentRows();
-    const lastTop = maxTop(this.displayCount(), this.height);
+    const lastTop = this.lastTop();
     switch (key.name) {
       case "q":
       case "Q":
@@ -1559,13 +1755,13 @@ export class Session {
       case "H":
         this.left = this.wrapLines
           ? 0
-          : clamp(this.left - HORIZONTAL_STEP, 0, this.maxLineLen);
+          : clamp(this.left - this.horizontalStep(), 0, this.maxLeft());
         return;
       case "l":
       case "L":
         this.left = this.wrapLines
           ? 0
-          : clamp(this.left + HORIZONTAL_STEP, 0, this.maxLineLen);
+          : clamp(this.left + this.horizontalStep(), 0, this.maxLeft());
         return;
       case "space":
       case "pagedown":
@@ -1631,11 +1827,15 @@ export class Session {
       case "Z": {
         const node = this.selectedNode();
         if (node) {
-          this.top = frameTop(
-            this.nodeStartRow(node),
-            this.nodeEndRow(node),
-            this.height,
-            this.displayCount(),
+          this.top = clamp(
+            frameTop(
+              this.nodeStartRow(node),
+              this.nodeEndRow(node),
+              this.height,
+              this.displayCount(),
+            ),
+            0,
+            this.lastTop(),
           );
         }
         return;
@@ -1672,6 +1872,7 @@ export class Session {
         this.matches = [];
         this.message = "";
         if (anchor) this.restoreWrappedAnchor(anchor);
+        else this.clampScroll();
         return;
       }
     }
@@ -1700,6 +1901,7 @@ export class Session {
   private toggleLineWrapping(): void {
     const anchor = this.viewportAnchor();
     this.wrapLines = !this.wrapLines;
+    this.expansionLayoutCache = undefined;
     if (this.wrapLines) {
       this.left = 0;
       this.restoreWrappedAnchor(anchor);
@@ -1772,8 +1974,9 @@ export class Session {
     this.top = clamp(
       row,
       0,
-      maxTop(this.displayCount(), this.height),
+      this.lastTop(),
     );
+    this.clampScroll();
   }
 
   /** Toggle the file the viewport (or selection) is on between shown and hidden. */
@@ -1839,17 +2042,17 @@ export class Session {
   // --- editing ---------------------------------------------------------------
 
   private scrollOrPan(name: string): void {
-    const lastTop = maxTop(this.displayCount(), this.height);
+    const lastTop = this.lastTop();
     if (name === "up") this.top = clamp(this.top - 1, 0, lastTop);
     else if (name === "down") this.top = clamp(this.top + 1, 0, lastTop);
     else if (name === "left") {
       this.left = this.wrapLines
         ? 0
-        : clamp(this.left - HORIZONTAL_STEP, 0, this.maxLineLen);
+        : clamp(this.left - this.horizontalStep(), 0, this.maxLeft());
     } else if (name === "right") {
       this.left = this.wrapLines
         ? 0
-        : clamp(this.left + HORIZONTAL_STEP, 0, this.maxLineLen);
+        : clamp(this.left + this.horizontalStep(), 0, this.maxLeft());
     }
   }
 
@@ -2020,6 +2223,7 @@ export class Session {
       case "escape":
         this.cursorOn = false;
         this.reparse(); // refresh structure before returning to navigation
+        this.ensureCursorVisible();
         return;
       case "ctrl-s":
         this.enterEditSearch();
@@ -2512,16 +2716,112 @@ export class Session {
     const cw = this.contentWidth();
     if (b.col < this.left) this.left = b.col;
     else if (b.col >= this.left + cw) this.left = b.col - cw + 1;
-    this.left = clamp(this.left, 0, this.maxLineLen);
+    this.left = clamp(this.left, 0, this.maxLeft());
   }
 
   private contentWidth(): number {
-    const gutterWidth = this.gutterWidth();
-    const guideWidth = this.selectedNode() ? 1 : 0;
-    const fitted = this.wrapLines
-      ? fitWrapChrome(this.width, gutterWidth, guideWidth)
-      : { gutterWidth, guideWidth };
-    return Math.max(1, this.width - fitted.gutterWidth - fitted.guideWidth);
+    const fitted = fitViewLayout(
+      this.width,
+      this.gutterWidth(),
+      this.selectedNode() ? 1 : 0,
+      this.hasDiffMargin() ? DIFF_MARGIN_WIDTH : 0,
+      this.wrapLines,
+    );
+    return fitted.contentWidth + fitted.marginWidth;
+  }
+
+  /** Pager annotations currently visible beside logical document lines. */
+  private activeDiffAnnotations(): readonly DiffAnnotation[] {
+    if (
+      this.mode !== "normal" || this.overlay || this.cursorOn ||
+      this.chord !== null || !this.source?.expandContext
+    ) {
+      return [];
+    }
+    const expand = this.expandOffer();
+    return expand && !("blocked" in expand)
+      ? this.displayDiffAnnotations(expand)
+      : [];
+  }
+
+  /** Widest folded line under the active non-printable display mode. */
+  private maxDisplayWidth(): number {
+    const lines = this.foldPlan().displayLines;
+    if (
+      this.maxDisplayWidthCache?.lines !== lines ||
+      this.maxDisplayWidthCache.mode !== this.displayMode
+    ) {
+      let width = 0;
+      for (const line of lines) {
+        width = Math.max(width, displayWidth(line, this.displayMode));
+      }
+      this.maxDisplayWidthCache = { lines, mode: this.displayMode, width };
+    }
+    return this.maxDisplayWidthCache.width;
+  }
+
+  /** Source cells available on one folded line after its annotation. */
+  private lineContentWidth(
+    foldedLine: number,
+    annotations = this.activeDiffAnnotations(),
+    contentWidth = this.contentWidth(),
+  ): number {
+    const annotation = annotations.find((item) => item.line === foldedLine);
+    if (!annotation) return contentWidth;
+    const decoration = diffAnnotationDecoration(annotation.kind, contentWidth);
+    return Math.max(1, contentWidth - decoration.firstWidth);
+  }
+
+  /** Furthest horizontal offset needed by any line under its own annotation. */
+  private maxLeft(
+    annotations: readonly DiffAnnotation[] = this.activeDiffAnnotations(),
+  ): number {
+    if (!this.hasDiffMargin()) return this.maxLineLen;
+    const contentWidth = this.contentWidth();
+    let width = this.maxDisplayWidth() - contentWidth;
+    const lines = this.foldPlan().displayLines;
+    for (const annotation of annotations) {
+      const line = lines[annotation.line];
+      if (!line) continue;
+      width = Math.max(
+        width,
+        displayWidth(line, this.displayMode) -
+          this.lineContentWidth(
+            annotation.line,
+            annotations,
+            contentWidth,
+          ),
+      );
+    }
+    return Math.max(0, width);
+  }
+
+  /** Horizontal pan distance for the current content width. */
+  private horizontalStep(): number {
+    if (!this.hasDiffMargin()) return HORIZONTAL_STEP;
+    const annotations = this.activeDiffAnnotations();
+    let width = this.contentWidth();
+    for (const annotation of annotations) {
+      width = Math.min(
+        width,
+        this.lineContentWidth(annotation.line, annotations),
+      );
+    }
+    return Math.max(1, Math.min(HORIZONTAL_STEP, width));
+  }
+
+  /** Bring one display column into an unwrapped viewport. */
+  private revealColumn(docLine: number, col: number): void {
+    if (this.wrapLines) return;
+    const width = this.lineContentWidth(this.toFolded(docLine));
+    if (col >= this.left && col < this.left + width) return;
+    const leading = Math.min(4, width - 1);
+    this.left = clamp(col - leading, 0, this.maxLeft());
+  }
+
+  /** Whether this pager can draw diff annotations. */
+  private hasDiffMargin(): boolean {
+    return !this.cursorOn && !!this.source?.expandContext;
   }
 
   /** Cycle the line-number gutter: off → input position → file/message line. */
@@ -2531,6 +2831,7 @@ export class Session {
     this.lineNumberMode =
       order[(order.indexOf(this.lineNumberMode) + 1) % order.length];
     if (anchor) this.restoreWrappedAnchor(anchor);
+    else this.clampScroll();
     const label = this.lineNumberMode === "off"
       ? "off"
       : this.lineNumberMode === "input"
@@ -2921,10 +3222,10 @@ export class Session {
 
   /** Reveal more of the underlying file around a hunk (Ctrl-L). When the text
    * cursor is active the hunk is the one it sits in and the view follows the
-   * cursor; in pager mode it is the hunk at the middle of the screen, and the
-   * view holds the far edge of that hunk still so the revealed lines open a gap
-   * in front of the user. The extra context is applied to the baseline too, so
-   * it does not count as an unsaved edit. */
+   * cursor; in pager mode it is the hunk nearest one quarter down the visible
+   * content, and the view holds the far edge of that hunk still so the revealed
+   * lines open a gap in front of the user. The extra context is applied to the
+   * baseline too, so it does not count as an unsaved edit. */
   private performExpand(): void {
     if (!this.source?.expandContext || !this.buffer) {
       this.message = "Expanding context isn't available here.";
@@ -2955,6 +3256,9 @@ export class Session {
       }
       refLine = offer.line;
       up = offer.up;
+      if (this.wrapLines) {
+        this.syncWrapDecorations(this.displayDiffAnnotations(offer));
+      }
     }
     const r = this.source.expandContext(
       this.buffer.text(),
@@ -2990,6 +3294,10 @@ export class Session {
     this.splitRow = null;
     this.setSourceDocument(this.source.parse(r.text));
     this.needsReparse = false;
+    this.wrapDecorations = new Map();
+    this.wrapDecorationKey = "";
+    this.wrapPlanCache = undefined;
+    this.expansionLayoutCache = undefined;
     if (this.cursorOn) {
       this.seedHighlighter();
       this.clampScroll();
@@ -3000,7 +3308,57 @@ export class Session {
     // Pager mode: re-point the selection at the same node (its line moved), and
     // put the pinned line back on the row it was on.
     this.reselectAfterExpand(selected, moved);
-    this.top = this.toDisplay(moved(pinDoc)) - pinRow;
+    const movedPin = moved(pinDoc);
+    if (this.wrapLines) {
+      const basePlan = this.baseWrapPlan();
+      const basePin = this.toDisplayWithPlan(movedPin, 0, basePlan);
+      const baseTop = clamp(
+        basePin - pinRow,
+        0,
+        this.pagerLastTop(basePlan.rowCount),
+      );
+      this.top = baseTop;
+      const next = this.expandOffer();
+      const nextOffer = next && !("blocked" in next) ? next : null;
+      let nextAnnotations = this.displayDiffAnnotations(nextOffer);
+      let state = this.wrapDecorationState(nextAnnotations);
+      this.wrapDecorations = state.decorations;
+      this.wrapDecorationKey = state.key;
+      this.wrapPlanCache = undefined;
+      let decoratedPlan = this.wrapPlan();
+      let decoratedTop = clamp(
+        this.toDisplayWithPlan(movedPin, 0, decoratedPlan) - pinRow,
+        0,
+        this.pagerLastTop(decoratedPlan.rowCount),
+      );
+      const visible = this.metadataWithVisibleTriangle(
+        nextAnnotations,
+        decoratedPlan,
+        decoratedTop,
+      );
+      if (visible.length !== nextAnnotations.length) {
+        nextAnnotations = visible;
+        state = this.wrapDecorationState(nextAnnotations);
+        this.wrapDecorations = state.decorations;
+        this.wrapDecorationKey = state.key;
+        this.wrapPlanCache = undefined;
+        decoratedPlan = this.wrapPlan();
+        decoratedTop = clamp(
+          this.toDisplayWithPlan(movedPin, 0, decoratedPlan) - pinRow,
+          0,
+          this.pagerLastTop(decoratedPlan.rowCount),
+        );
+      }
+      this.top = decoratedTop;
+      this.expansionLayoutCache = {
+        decoratedPlan,
+        decoratedTop: this.top,
+        basePlan,
+        baseTop,
+      };
+    } else {
+      this.top = this.toDisplay(movedPin) - pinRow;
+    }
     this.clampScroll();
     // The revealed lines fill the gap the insertion point opened, so the driver
     // can walk them in from the held edge. A join is drawn in one step instead:
@@ -3050,28 +3408,57 @@ export class Session {
     this.selectedIndex = idx >= 0 ? idx : null;
   }
 
-  /** Whether a node is on screen: its display rows overlap the viewport, and it
-   * is not inside a collapsed file. A collapsed file's inner lines all map to
-   * its summary row, which overlaps the viewport whenever that row is shown, so
-   * the hidden range is excluded by its document extent instead. */
-  private nodeOnScreen(node: StructureNode): boolean {
+  /** Whether a node overlaps one viewport under a specific wrapped layout.
+   * Nodes inside a collapsed file are excluded because their hidden lines map
+   * to the visible file summary. */
+  private nodeOnScreenWithLayout(
+    node: StructureNode,
+    plan: WrapPlan | null,
+    top: number,
+  ): boolean {
     const inHiddenFile = this.foldFiles().some((f) =>
       this.collapsed.has(f.index) &&
       node.startLine > f.headerLine && node.startLine <= f.endLine
     );
     if (inHiddenFile) return false;
-    return this.nodeEndRow(node) >= this.top &&
-      this.nodeStartRow(node) < this.top + this.contentRows();
+    return this.nodeEndRowWithPlan(node, plan) >= top &&
+      this.nodeStartRowWithPlan(node, plan) < top + this.contentRows();
   }
 
-  /** The middle of the content on screen, as a display row. The rows the
-   * content occupies, rather than the rows the terminal has: a document shorter
-   * than the screen ends part-way down it, and the rows past its end are not
-   * somewhere the user is looking. */
-  private middleRow(): number {
-    const last = Math.min(this.top + this.contentRows(), this.displayCount()) -
-      1;
-    return Math.floor((this.top + last) / 2);
+  /** The row one quarter down the content on screen. This uses the rows that
+   * hold content rather than blank terminal rows below a short document. */
+  private expansionTargetRow(plan: WrapPlan | null, top: number): number {
+    const count = plan?.rowCount ?? this.foldPlan().displayLines.length;
+    const last = Math.min(top + this.contentRows(), count) - 1;
+    return top + Math.floor((last - top) / 4);
+  }
+
+  /** Expansion layout without the annotations that the chosen edge produces. */
+  private expansionLayout(): { plan: WrapPlan | null; top: number } {
+    if (!this.wrapLines) return { plan: null, top: this.top };
+    const decorated = this.wrapPlan();
+    const base = this.baseWrapPlan();
+    if (
+      this.expansionLayoutCache?.decoratedPlan === decorated &&
+      this.expansionLayoutCache.basePlan === base &&
+      this.expansionLayoutCache.decoratedTop === this.top
+    ) {
+      return { plan: base, top: this.expansionLayoutCache.baseTop };
+    }
+    const topRow = wrappedRowAt(
+      decorated,
+      clamp(this.top, 0, Math.max(0, decorated.rowCount - 1)),
+    );
+    const baseTop = topRow
+      ? wrappedRowForPosition(base, topRow.line, topRow.offset)?.row ?? 0
+      : 0;
+    this.expansionLayoutCache = {
+      decoratedPlan: decorated,
+      decoratedTop: this.top,
+      basePlan: base,
+      baseTop,
+    };
+    return { plan: base, top: baseTop };
   }
 
   /** How much context each hunk can still reveal, keyed by its header line.
@@ -3086,49 +3473,242 @@ export class Session {
     return this.roomCache.room;
   }
 
-  /** Every hunk edge the user can see: the row it sits on, the line to expand
-   * from, which way that grows, and what the file offers there. A hunk with
-   * neither edge on screen offers nothing to aim at — its boundaries are off in
-   * the dark, and growing one would happen where it could not be watched. */
-  private visibleEdges(): {
-    row: number;
-    line: number;
-    up: boolean;
-    room: HunkRoom;
-  }[] {
+  /** Lines classified as file or hunk metadata by the diff parser. */
+  private diffMetadataLines(): readonly number[] {
+    if (this.diffMetadataCache?.doc === this.currentDoc) {
+      return this.diffMetadataCache.lines;
+    }
+    const lines: number[] = [];
+    const model = parseDiff(this.currentDoc.text);
+    if (model) {
+      for (let line = 0; line < model.lines.length; line++) {
+        const kind = model.lines[line].kind;
+        if (kind === "meta" || kind === "hunk") {
+          lines.push(line);
+        }
+      }
+    }
+    this.diffMetadataCache = { doc: this.currentDoc, lines };
+    return lines;
+  }
+
+  /** Metadata line directly beyond the marked expansion edge. */
+  private adjacentDiffMetadataLine(expand: ExpandOffer | null): number | null {
+    if (!expand || expand.markerLine === null) return null;
+    const line = expand.up ? expand.line : expand.line + 1;
+    return this.diffMetadataLines().includes(line) ? line : null;
+  }
+
+  /** Screen rows of metadata directly beyond the marked expansion edge. */
+  private displayAdjacentDiffMetadataRows(
+    expand: ExpandOffer | null,
+  ): readonly number[] {
+    const line = this.adjacentDiffMetadataLine(expand);
+    if (line === null) return [];
+    const fold = this.foldPlan();
+    const folded = fold.docToDisplay(line);
+    if (fold.displayLines[folded] !== this.currentDoc.lines[line]) return [];
+    const first = this.toDisplay(line);
+    const last = this.toDisplayEnd(line);
+    const rows: number[] = [];
+    for (let row = first; row <= last; row++) rows.push(row);
+    return rows;
+  }
+
+  /** Annotations for an expansion triangle visible in the base layout. */
+  private displayDiffAnnotations(
+    expand: ExpandOffer | null,
+  ): DiffAnnotation[] {
+    const { top } = this.expansionLayout();
+    if (
+      !expand || expand.markerLine === null || expand.row === null ||
+      expand.row < top || expand.row >= top + this.contentRows()
+    ) {
+      return [];
+    }
+    const fold = this.foldPlan();
+    const marker = fold.docToDisplay(expand.markerLine);
+    if (
+      fold.displayLines[marker] !== this.currentDoc.lines[expand.markerLine]
+    ) {
+      return [];
+    }
+    const annotations: DiffAnnotation[] = [{
+      line: marker,
+      kind: expand.up ? "expandUp" : "expandDown",
+    }];
+    const metadataLine = this.adjacentDiffMetadataLine(expand);
+    if (metadataLine !== null) {
+      const metadata = fold.docToDisplay(metadataLine);
+      if (
+        fold.displayLines[metadata] === this.currentDoc.lines[metadataLine]
+      ) {
+        annotations.push({ line: metadata, kind: "diffMetadata" });
+      }
+    }
+    return annotations;
+  }
+
+  /** Apply line-specific wrap widths while keeping the viewport's source
+   * position fixed. */
+  private syncWrapDecorations(
+    annotations: readonly DiffAnnotation[],
+  ): DiffAnnotation[] {
+    let visible = [...annotations];
+    const baseTop = this.wrapLines ? this.expansionLayout().top : 0;
+    const anchor = this.wrapLines ? this.viewportAnchor() : null;
+    if (anchor) {
+      const tentative = this.wrapDecorationState(visible);
+      const plan = buildWrapPlan(
+        this.foldPlan().displayLines,
+        this.displayMode,
+        this.contentWidth(),
+        tentative.decorations,
+      );
+      const top = this.wrappedTopForAnchor(anchor, plan);
+      visible = this.metadataWithVisibleTriangle(visible, plan, top);
+    }
+    const state = this.wrapDecorationState(visible);
+    if (state.key === this.wrapDecorationKey) return visible;
+    this.wrapDecorations = state.decorations;
+    this.wrapDecorationKey = state.key;
+    this.wrapPlanCache = undefined;
+    if (anchor) {
+      this.restoreWrappedAnchor(anchor);
+      this.expansionLayoutCache = {
+        decoratedPlan: this.wrapPlan(),
+        decoratedTop: this.top,
+        basePlan: this.baseWrapPlan(),
+        baseTop,
+      };
+    }
+    return visible;
+  }
+
+  /** Top row produced by restoring one source position in a wrapped plan. */
+  private wrappedTopForAnchor(anchor: ViewportAnchor, plan: WrapPlan): number {
+    const line = clamp(
+      anchor.foldedLine,
+      0,
+      Math.max(0, plan.firstRow.length - 1),
+    );
+    const row = wrappedRowForPosition(plan, line, anchor.displayCol)?.row ?? 0;
+    return clamp(row, 0, this.pagerLastTop(plan.rowCount));
+  }
+
+  /** Hide a metadata label when its reflow pushes the triangle off-screen. */
+  private metadataWithVisibleTriangle(
+    annotations: readonly DiffAnnotation[],
+    plan: WrapPlan,
+    top: number,
+  ): DiffAnnotation[] {
+    const triangle = annotations.find((annotation) =>
+      annotation.kind !== "diffMetadata"
+    );
+    if (
+      !triangle ||
+      !annotations.some((annotation) => annotation.kind === "diffMetadata")
+    ) {
+      return [...annotations];
+    }
+    const row = plan.firstRow[triangle.line];
+    if (row >= top && row < top + this.contentRows()) {
+      return [...annotations];
+    }
+    return annotations.filter((annotation) =>
+      annotation.kind !== "diffMetadata"
+    );
+  }
+
+  /** Wrap widths and cache identity for one set of diff annotations. */
+  private wrapDecorationState(
+    annotations: readonly DiffAnnotation[],
+  ): { decorations: Map<number, WrapDecoration>; key: string } {
+    const decorations = new Map<number, WrapDecoration>();
+    const contentWidth = this.contentWidth();
+    const metadataLabelLine = this.wrapLines
+      ? labeledDiffMetadataLine(
+        this.foldPlan().displayLines,
+        this.displayMode,
+        contentWidth,
+        annotations,
+      )
+      : null;
+    if (this.wrapLines) {
+      for (const annotation of annotations) {
+        decorations.set(
+          annotation.line,
+          diffAnnotationDecoration(
+            annotation.kind,
+            contentWidth,
+            annotation.kind !== "diffMetadata" ||
+              annotation.line === metadataLabelLine,
+          ),
+        );
+      }
+    }
+    const key = this.wrapLines
+      ? `${contentWidth}|${this.displayMode}|${metadataLabelLine ?? "-"}|${
+        annotations.map((annotation) => `${annotation.line}:${annotation.kind}`)
+          .join(",")
+      }`
+      : "";
+    return { decorations, key };
+  }
+
+  /** Every hunk boundary visible at its expansion row. `markerLine` names the
+   * first or last body line and is null when the hunk has no body. */
+  private visibleEdges(
+    plan: WrapPlan | null,
+    top: number,
+  ): ExpandEdge[] {
     const room = this.expandRoom();
     const rows = this.contentRows();
-    const onScreen = (row: number) => row >= this.top && row < this.top + rows;
-    const out = [];
+    const onScreen = (row: number) => row >= top && row < top + rows;
+    const out: ExpandEdge[] = [];
     for (const h of this.doc.flatStructure) {
-      if (h.kind !== "hunk" || !this.nodeOnScreen(h)) continue;
+      if (
+        h.kind !== "hunk" || !this.nodeOnScreenWithLayout(h, plan, top)
+      ) {
+        continue;
+      }
       const r = room.get(h.startLine);
       if (!r) continue;
-      // The top edge is the header the revealed lines land under; the bottom is
-      // the last body line they land after.
+      const firstBodyLine = h.startLine + 1;
+      const hasBody = firstBodyLine <= h.endLine;
+      // Expansion visibility stays on the hunk boundary. A separate body-line
+      // row places the marker without moving which edge Ctrl-L targets.
       for (
-        const [line, up] of [[h.startLine, true], [h.endLine, false]] as const
+        const [line, markerLine, up] of [
+          [h.startLine, hasBody ? firstBodyLine : null, true],
+          [h.endLine, hasBody ? h.endLine : null, false],
+        ] as const
       ) {
-        const row = up ? this.toDisplay(line) : this.toDisplayEnd(line);
-        if (onScreen(row)) out.push({ row, line, up, room: r });
+        const aimRow = this.toDisplayEndWithPlan(line, plan);
+        const row = markerLine === null
+          ? null
+          : this.toDisplayWithPlan(markerLine, 0, plan);
+        if (onScreen(aimRow)) {
+          out.push({ row, markerLine, aimRow, line, up, room: r });
+        }
       }
     }
     return out;
   }
 
   /** The hunk edge Ctrl-L acts on in pager mode: the visible one nearest the
-   * middle of the screen, or nearest a selected node when one sits in a hunk.
-   * Null when no edge is on screen. The edge is returned whether or not it has
-   * room, so that the offer of Ctrl-L and what Ctrl-L does agree. */
-  private expandEdge():
-    | { line: number; up: boolean; room: HunkRoom }
-    | null {
-    const edges = this.visibleEdges();
+   * row one quarter down the visible content, or nearest a selected node when
+   * one sits in a hunk. Null when no edge is on screen. The edge is returned
+   * whether or not it has room, so that the offer of Ctrl-L and what Ctrl-L
+   * does agree. */
+  private expandEdge(): ExpandEdge | null {
+    const { plan, top } = this.expansionLayout();
+    const edges = this.visibleEdges(plan, top);
     if (edges.length === 0) return null;
     // A selected node sitting in a hunk aims at that hunk, and its own row is
     // what the edges are measured from: the user picked a place to look.
     const sel = this.selectedNode();
-    const own = sel && this.nodeOnScreen(sel)
+    const own = sel && this.nodeOnScreenWithLayout(sel, plan, top)
       ? edges.filter((e) =>
         this.doc.flatStructure.some((h) =>
           h.kind === "hunk" && h.startLine <= e.line && e.line <= h.endLine &&
@@ -3136,36 +3716,46 @@ export class Session {
         )
       )
       : [];
-    const from = own.length > 0 ? this.nodeStartRow(sel!) : this.middleRow();
+    const from = own.length > 0
+      ? this.nodeStartRowWithPlan(sel!, plan)
+      : this.expansionTargetRow(plan, top);
     const pool = own.length > 0 ? own : edges;
     // Distance in display rows: a collapsed file stands on one row, and the
     // lines it hides are not distance the eye travels.
     let best = pool[0];
     for (const e of pool) {
-      if (Math.abs(e.row - from) < Math.abs(best.row - from)) best = e;
+      const distance = Math.abs(e.aimRow - from);
+      const bestDistance = Math.abs(best.aimRow - from);
+      const available = e.up ? e.room.up : e.room.down;
+      const bestAvailable = best.up ? best.room.up : best.room.down;
+      // A hunk with no body has coincident boundaries. Prefer the direction
+      // with context when the other direction has none.
+      if (
+        distance < bestDistance ||
+        (e.aimRow === best.aimRow && available > 0 && bestAvailable === 0)
+      ) {
+        best = e;
+      }
     }
-    return { line: best.line, up: best.up, room: best.room };
-  }
-
-  /** Whether Ctrl-L would reveal anything from where the user is looking, which
-   * is what the status bar offers it on. Edit mode aims with the cursor rather
-   * than the screen, and keeps its own offer. */
-  private canExpand(): boolean {
-    if (this.cursorOn || !this.source?.expandContext) return false;
-    const offer = this.expandOffer();
-    return offer !== null && !("blocked" in offer);
+    return best;
   }
 
   /** Whether Ctrl-L would reveal anything, and what stops it when it would not.
-   * Drives both the status bar's offer of Ctrl-L and the key itself. */
+   * Drives the edge marker, the status bar's offer of Ctrl-L, and the key
+   * itself. */
   private expandOffer():
-    | { line: number; up: boolean }
+    | ExpandOffer
     | { blocked: "top" | "bottom" | "hunk" }
     | null {
     const edge = this.expandEdge();
     if (!edge) return null;
     if ((edge.up ? edge.room.up : edge.room.down) > 0) {
-      return { line: edge.line, up: edge.up };
+      return {
+        row: edge.row,
+        markerLine: edge.markerLine,
+        line: edge.line,
+        up: edge.up,
+      };
     }
     if (edge.up) return { blocked: edge.room.atFileTop ? "top" : "hunk" };
     return { blocked: edge.room.atFileBottom ? "bottom" : "hunk" };
@@ -3178,11 +3768,14 @@ export class Session {
       this.message = "Opening files isn't available here.";
       return;
     }
+    const wasCursorOn = this.cursorOn;
     this.cursorOn = false;
     // Opening the picker drops the text cursor, and cancelling it returns to
     // navigation, which reads the structure tree. Refresh it here as leaving
     // edit mode by Esc does, so that return lands on a current tree.
     this.reparse();
+    if (wasCursorOn) this.ensureCursorVisible();
+    else this.clampScroll();
     this.overlay = null;
     this.overlayStack = [];
     this.pickerDir = this.pickerStartDir();
@@ -3511,7 +4104,7 @@ export class Session {
     this.top = clamp(
       this.toDisplay(docLine),
       0,
-      maxTop(this.displayCount(), this.height),
+      this.lastTop(),
     );
     this.left = 0;
   }
@@ -3670,7 +4263,7 @@ export function helpOverlay(): {
     ["  A / D", "parent / first child"],
     ["  Tab / ⇧Tab", "next / previous node (depth-first)"],
     ["  Z", "centre selected node"],
-    ["  ^L", "diff: reveal more of the file at the middle of the view"],
+    ["  ^L", "diff: reveal more of the file one quarter down the view"],
     ["  Esc", "clear selection / search"],
     ["", ""],
     ["Editing (a file or a diff)", ""],

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -545,7 +545,6 @@ export class Session {
         if (annotation.line < from || annotation.line >= to) {
           return [{ ...annotation, line: back(annotation.line) }];
         }
-        if (annotation.kind === "diffMetadata") return [];
         return [{
           ...annotation,
           line: rev.up ? from : Math.max(0, from - 1),
@@ -2782,16 +2781,17 @@ export class Session {
     const lines = this.foldPlan().displayLines;
     for (const annotation of annotations) {
       const line = lines[annotation.line];
-      if (!line) continue;
-      width = Math.max(
-        width,
-        displayWidth(line, this.displayMode) -
-          this.lineContentWidth(
-            annotation.line,
-            annotations,
-            contentWidth,
-          ),
-      );
+      if (line) {
+        width = Math.max(
+          width,
+          displayWidth(line, this.displayMode) -
+            this.lineContentWidth(
+              annotation.line,
+              annotations,
+              contentWidth,
+            ),
+        );
+      }
     }
     return Math.max(0, width);
   }
@@ -3505,9 +3505,6 @@ export class Session {
   ): readonly number[] {
     const line = this.adjacentDiffMetadataLine(expand);
     if (line === null) return [];
-    const fold = this.foldPlan();
-    const folded = fold.docToDisplay(line);
-    if (fold.displayLines[folded] !== this.currentDoc.lines[line]) return [];
     const first = this.toDisplay(line);
     const last = this.toDisplayEnd(line);
     const rows: number[] = [];
@@ -3528,11 +3525,6 @@ export class Session {
     }
     const fold = this.foldPlan();
     const marker = fold.docToDisplay(expand.markerLine);
-    if (
-      fold.displayLines[marker] !== this.currentDoc.lines[expand.markerLine]
-    ) {
-      return [];
-    }
     const annotations: DiffAnnotation[] = [{
       line: marker,
       kind: expand.up ? "expandUp" : "expandDown",

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -30,6 +30,7 @@ import {
 } from "./render.ts";
 import {
   clamp,
+  diffContentRowCount,
   findMatches,
   frameTop,
   maxPagerTop,
@@ -1067,8 +1068,14 @@ export class Session {
 
   /** Furthest vertical position for a pager layout with `rowCount` rows. */
   private pagerLastTop(rowCount: number): number {
-    return this.source?.isDiff
-      ? maxPagerTop(rowCount, this.height)
+    const isDiff = this.source?.isDiff === true;
+    const hasTrailingEmptyLine = isDiff &&
+      this.foldPlan().displayLines.at(-1)?.text.length === 0;
+    return isDiff
+      ? maxPagerTop(
+        diffContentRowCount(rowCount, hasTrailingEmptyLine),
+        this.height,
+      )
       : maxTop(rowCount, this.height);
   }
 
@@ -3425,12 +3432,9 @@ export class Session {
       this.nodeStartRowWithPlan(node, plan) < top + this.contentRows();
   }
 
-  /** The row one quarter down the content on screen. This uses the rows that
-   * hold content rather than blank terminal rows below a short document. */
-  private expansionTargetRow(plan: WrapPlan | null, top: number): number {
-    const count = plan?.rowCount ?? this.foldPlan().displayLines.length;
-    const last = Math.min(top + this.contentRows(), count) - 1;
-    return top + Math.floor((last - top) / 4);
+  /** The row one quarter down the screen's content area. */
+  private expansionTargetRow(top: number): number {
+    return top + Math.floor((this.contentRows() - 1) / 4);
   }
 
   /** Expansion layout without the annotations that the chosen edge produces. */
@@ -3718,7 +3722,7 @@ export class Session {
       : [];
     const from = own.length > 0
       ? this.nodeStartRowWithPlan(sel!, plan)
-      : this.expansionTargetRow(plan, top);
+      : this.expansionTargetRow(top);
     const pool = own.length > 0 ? own : edges;
     // Distance in display rows: a collapsed file stands on one row, and the
     // lines it hides are not distance the eye travels.

--- a/packages/cli/lib/view/theme.ts
+++ b/packages/cli/lib/view/theme.ts
@@ -136,9 +136,11 @@ export const ui = {
   selectionBg: C.selectionBg,
   /** The vertical guide bar drawn beside a selected node. */
   guide: { fg: C.cyan, bold: true, bg: C.editorBg } as Style,
-  /** The marker in the final column of a row whose content continues. The
-   * renderer supplies the content row's editor or diff background. */
+  /** Continuation and diff-margin markers. The renderer supplies the content
+   * row's editor or diff background. */
   wrapMarker: { fg: C.yellow, bold: true } as Style,
+  /** End-of-document ornament. */
+  endMark: { fg: C.fgDim } as Style,
   statusBar: { fg: C.fg, bg: C.panel } as Style,
   statusKey: { fg: C.red, bg: C.panel, bold: true } as Style,
   /** The current file name on the status bar. */

--- a/packages/cli/lib/view/wrap.ts
+++ b/packages/cli/lib/view/wrap.ts
@@ -6,12 +6,31 @@ import { type DisplayMode, displayWidth } from "./display.ts";
 import type { Line } from "./model.ts";
 
 export interface WrappedRow {
+  /** Absolute screen row in the complete wrapped document. */
+  readonly row: number;
   /** Index of the logical line in the displayed document. */
   readonly line: number;
   /** Display-column offset where this screen row starts. */
   readonly offset: number;
   /** Display-column offset where this logical line's final screen row starts. */
   readonly lastOffset: number;
+  /** Source cells available on this row. */
+  readonly sourceWidth: number;
+  /** Whether source content continues on the following row. */
+  readonly continues: boolean;
+  /** Whether this row has room for a continuation marker. */
+  readonly wrapMarker: boolean;
+  /** Cells reserved at the right edge for a line annotation. */
+  readonly suffixWidth: number;
+}
+
+export interface WrapDecoration {
+  /** Cells reserved on the logical line's first screen row. */
+  readonly firstWidth: number;
+  /** Cells reserved on the first screen row after the logical line wraps. */
+  readonly firstContinuationWidth?: number;
+  /** Cells reserved on later screen rows of the logical line. */
+  readonly continuationWidth: number;
 }
 
 export interface WrapPlan {
@@ -24,6 +43,51 @@ export interface WrapPlan {
   readonly firstRow: readonly number[];
   /** Last screen row occupied by each logical line. */
   readonly lastRow: readonly number[];
+  /** Source cells consumed by a continued first row. */
+  readonly firstSourceWidth: readonly number[];
+  /** Source cells consumed by each continued row after the first. */
+  readonly continuationStride: readonly number[];
+  /** Source cells consumed by the first continuation when it wraps again. */
+  readonly firstContinuationStride: readonly number[];
+  /** Annotation width on each logical line's first row. */
+  readonly firstSuffixWidth: readonly number[];
+  /** Annotation width on each logical line's first continuation row. */
+  readonly firstContinuationSuffixWidth: readonly number[];
+  /** Annotation width on later rows of each logical line. */
+  readonly continuationSuffixWidth: readonly number[];
+}
+
+export interface ViewLayout {
+  readonly gutterWidth: number;
+  readonly guideWidth: number;
+  readonly contentWidth: number;
+  readonly marginWidth: number;
+}
+
+/** Fit pager chrome around at least one source cell. Wrapped rows retain a
+ * second content cell for their continuation marker when the terminal has room.
+ * The expansion margin is kept ahead of optional left-side chrome. */
+export function fitViewLayout(
+  totalWidth: number,
+  gutterWidth: number,
+  guideWidth: number,
+  marginWidth: number,
+  wrapLines: boolean,
+): ViewLayout {
+  const width = Math.max(1, totalWidth);
+  const margin = Math.min(Math.max(0, marginWidth), width - 1);
+  const availableWidth = width - margin;
+  const minContentWidth = wrapLines && availableWidth > 1 ? 2 : 1;
+  let gutter = Math.max(0, gutterWidth);
+  let guide = Math.max(0, guideWidth);
+  if (availableWidth - gutter - guide < minContentWidth) gutter = 0;
+  if (availableWidth - gutter - guide < minContentWidth) guide = 0;
+  return {
+    gutterWidth: gutter,
+    guideWidth: guide,
+    contentWidth: availableWidth - gutter - guide,
+    marginWidth: margin,
+  };
 }
 
 /** Fit optional left-side chrome while retaining two content columns whenever
@@ -33,11 +97,13 @@ export function fitWrapChrome(
   gutterWidth: number,
   guideWidth: number,
 ): { gutterWidth: number; guideWidth: number } {
-  const minContentWidth = totalWidth > 1 ? 2 : 1;
-  let gutter = Math.max(0, gutterWidth);
-  let guide = Math.max(0, guideWidth);
-  if (totalWidth - gutter - guide < minContentWidth) gutter = 0;
-  if (totalWidth - gutter - guide < minContentWidth) guide = 0;
+  const { gutterWidth: gutter, guideWidth: guide } = fitViewLayout(
+    totalWidth,
+    gutterWidth,
+    guideWidth,
+    0,
+    true,
+  );
   return { gutterWidth: gutter, guideWidth: guide };
 }
 
@@ -55,11 +121,67 @@ export function wrappedRowAt(
     if (plan.firstRow[mid] <= row) lo = mid;
     else hi = mid - 1;
   }
+  const within = row - plan.firstRow[lo];
+  const lastWithin = plan.lastRow[lo] - plan.firstRow[lo];
+  const firstSource = plan.firstSourceWidth[lo];
+  const firstContinuationStride = plan.firstContinuationStride[lo];
+  const stride = plan.continuationStride[lo];
+  const offset = within === 0
+    ? 0
+    : within === 1
+    ? firstSource
+    : firstSource + firstContinuationStride + (within - 2) * stride;
+  const lastOffset = lastWithin === 0
+    ? 0
+    : lastWithin === 1
+    ? firstSource
+    : firstSource + firstContinuationStride + (lastWithin - 2) * stride;
+  const suffixWidth = within === 0
+    ? plan.firstSuffixWidth[lo]
+    : within === 1
+    ? plan.firstContinuationSuffixWidth[lo]
+    : plan.continuationSuffixWidth[lo];
+  const continues = within < lastWithin;
+  const available = plan.rowWidth - suffixWidth;
   return {
+    row,
     line: lo,
-    offset: (row - plan.firstRow[lo]) * plan.rowStride,
-    lastOffset: (plan.lastRow[lo] - plan.firstRow[lo]) * plan.rowStride,
+    offset,
+    lastOffset,
+    sourceWidth: continues
+      ? available > 1 ? available - 1 : available
+      : available,
+    continues,
+    wrapMarker: continues && available > 1,
+    suffixWidth,
   };
+}
+
+/** Resolve the wrapped row containing a display column on one logical line. */
+export function wrappedRowForPosition(
+  plan: WrapPlan,
+  line: number,
+  displayCol: number,
+): WrappedRow | undefined {
+  if (line < 0 || line >= plan.firstRow.length) return undefined;
+  const first = plan.firstRow[line];
+  const last = plan.lastRow[line];
+  const col = Math.max(0, displayCol);
+  let row = first;
+  const firstSource = plan.firstSourceWidth[line];
+  if (first < last && col >= firstSource) {
+    const firstContinuationStride = plan.firstContinuationStride[line];
+    const afterFirst = col - firstSource;
+    row = first + 1;
+    if (first + 1 < last && afterFirst >= firstContinuationStride) {
+      row = first + 2 +
+        Math.floor(
+          (afterFirst - firstContinuationStride) /
+            plan.continuationStride[line],
+        );
+    }
+  }
+  return wrappedRowAt(plan, Math.min(row, last));
 }
 
 /** Lay logical lines out as fixed-width screen rows. Rows whose content
@@ -69,20 +191,86 @@ export function buildWrapPlan(
   lines: readonly Line[],
   mode: DisplayMode,
   width: number,
+  decorations: ReadonlyMap<number, WrapDecoration> = new Map(),
 ): WrapPlan {
   const rowWidth = Math.max(1, width);
   const rowStride = Math.max(1, rowWidth - 1);
   let rowCount = 0;
   const firstRow: number[] = new Array(lines.length);
   const lastRow: number[] = new Array(lines.length);
+  const firstSourceWidth: number[] = new Array(lines.length);
+  const continuationStride: number[] = new Array(lines.length);
+  const firstContinuationStride: number[] = new Array(lines.length);
+  const firstSuffixWidth: number[] = new Array(lines.length);
+  const firstContinuationSuffixWidth: number[] = new Array(lines.length);
+  const continuationSuffixWidth: number[] = new Array(lines.length);
   for (let line = 0; line < lines.length; line++) {
     firstRow[line] = rowCount;
-    const width = displayWidth(lines[line], mode);
-    const count = width <= rowWidth
-      ? 1
-      : 1 + Math.ceil((width - rowWidth) / rowStride);
+    const decoration = decorations.get(line);
+    const firstSuffix = Math.min(
+      Math.max(0, decoration?.firstWidth ?? 0),
+      rowWidth - 1,
+    );
+    const continuationSuffix = Math.min(
+      Math.max(0, decoration?.continuationWidth ?? 0),
+      rowWidth - 1,
+    );
+    const firstContinuationSuffix = Math.min(
+      Math.max(
+        0,
+        decoration?.firstContinuationWidth ?? continuationSuffix,
+      ),
+      rowWidth - 1,
+    );
+    const firstAvailable = rowWidth - firstSuffix;
+    const firstContinuationAvailable = rowWidth - firstContinuationSuffix;
+    const continuationAvailable = rowWidth - continuationSuffix;
+    const firstStride = firstAvailable > 1
+      ? firstAvailable - 1
+      : firstAvailable;
+    const nextStride = firstContinuationAvailable > 1
+      ? firstContinuationAvailable - 1
+      : firstContinuationAvailable;
+    const laterStride = continuationAvailable > 1
+      ? continuationAvailable - 1
+      : continuationAvailable;
+    const lineWidth = displayWidth(lines[line], mode);
+    let count = 1;
+    if (lineWidth > firstAvailable) {
+      const afterFirst = lineWidth - firstStride;
+      if (afterFirst <= firstContinuationAvailable) {
+        count = 2;
+      } else {
+        const afterNext = afterFirst - nextStride;
+        const middle = Math.max(
+          0,
+          Math.ceil(
+            (afterNext - continuationAvailable) / laterStride,
+          ),
+        );
+        count = 3 + middle;
+      }
+    }
     rowCount += count;
     lastRow[line] = rowCount - 1;
+    firstSourceWidth[line] = count === 1 ? firstAvailable : firstStride;
+    firstContinuationStride[line] = nextStride;
+    continuationStride[line] = laterStride;
+    firstSuffixWidth[line] = firstSuffix;
+    firstContinuationSuffixWidth[line] = firstContinuationSuffix;
+    continuationSuffixWidth[line] = continuationSuffix;
   }
-  return { rowCount, rowWidth, rowStride, firstRow, lastRow };
+  return {
+    rowCount,
+    rowWidth,
+    rowStride,
+    firstRow,
+    lastRow,
+    firstSourceWidth,
+    continuationStride,
+    firstContinuationStride,
+    firstSuffixWidth,
+    firstContinuationSuffixWidth,
+    continuationSuffixWidth,
+  };
 }

--- a/packages/cli/test/alias.test.ts
+++ b/packages/cli/test/alias.test.ts
@@ -36,4 +36,8 @@ describe("CLI naming", () => {
     expect(cliName({ envName: "$(touch /tmp/pwned)" })).toBe("cf");
     expect(cliName({ envName: "`touch /tmp/pwned`" })).toBe("cf");
   });
+
+  it("recognizes the executable name when the environment gives no name", () => {
+    expect(cliName({ envName: "", execPath: "/usr/local/bin/cf" })).toBe("cf");
+  });
 });

--- a/packages/cli/test/alias.test.ts
+++ b/packages/cli/test/alias.test.ts
@@ -36,8 +36,4 @@ describe("CLI naming", () => {
     expect(cliName({ envName: "$(touch /tmp/pwned)" })).toBe("cf");
     expect(cliName({ envName: "`touch /tmp/pwned`" })).toBe("cf");
   });
-
-  it("recognizes the executable name when the environment gives no name", () => {
-    expect(cliName({ envName: "", execPath: "/usr/local/bin/cf" })).toBe("cf");
-  });
 });

--- a/packages/cli/test/trusted-test-event.test.ts
+++ b/packages/cli/test/trusted-test-event.test.ts
@@ -1,0 +1,21 @@
+import { assertEquals } from "@std/assert";
+import { buildActionEvent } from "../lib/trusted-test-event.ts";
+
+Deno.test("trusted UI action without a payload synthesizes a click event", () => {
+  const event = buildActionEvent(undefined, {
+    surface: "pattern-id",
+    action: "save",
+  });
+  assertEquals(event, {
+    type: "click",
+    provenance: {
+      origin: "dom",
+      trusted: true,
+      ui: {
+        pattern: "pattern-id",
+        eventIntegrity: ["pattern-id"],
+        uiContractDataset: { uiAction: "save" },
+      },
+    },
+  });
+});

--- a/packages/cli/test/trusted-test-event.test.ts
+++ b/packages/cli/test/trusted-test-event.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "@std/assert";
+import { isRendererTrustedEvent } from "../../runner/src/cfc/ui-contract.ts";
 import { buildActionEvent } from "../lib/trusted-test-event.ts";
 
 Deno.test("trusted UI action without a payload synthesizes a click event", () => {
@@ -18,4 +19,5 @@ Deno.test("trusted UI action without a payload synthesizes a click event", () =>
       },
     },
   });
+  assertEquals(isRendererTrustedEvent(event), true);
 });

--- a/packages/cli/test/utils.test.ts
+++ b/packages/cli/test/utils.test.ts
@@ -1,8 +1,12 @@
 import { assertEquals, assertStrictEquals, assertThrows } from "@std/assert";
 import type { MemorySpace } from "@commonfabric/runner";
-import { throwOnSpaceAuthorizationError } from "../lib/utils.ts";
+import { absPath, throwOnSpaceAuthorizationError } from "../lib/utils.ts";
 
 const SPACE = "did:key:z6Mk-cli-utils-authz-space" as MemorySpace;
+
+Deno.test("absPath resolves a relative path against the supplied directory", () => {
+  assertEquals(absPath("nested/file.ts", "/work"), "/work/nested/file.ts");
+});
 
 Deno.test("throwOnSpaceAuthorizationError rethrows the recorded denial", () => {
   const denial = Object.assign(new Error("Principal lacks READ on space"), {

--- a/packages/cli/test/view-actions.test.ts
+++ b/packages/cli/test/view-actions.test.ts
@@ -5,6 +5,7 @@ import {
   clamp,
   findMatches,
   frameTop,
+  maxPagerTop,
   maxTop,
   nextMatchIndex,
   nodeAtLine,
@@ -41,6 +42,14 @@ Deno.test("clamp / maxTop", () => {
   // 100 lines, height 24 -> content rows 23 -> maxTop 77
   assertEquals(maxTop(100, 24), 77);
   assertEquals(maxTop(5, 24), 0);
+});
+
+Deno.test("maxPagerTop leaves the bottom three quarters below the last line", () => {
+  // Height 21 has 20 content rows. The last line occupies the fifth row, with
+  // 15 rows below it.
+  assertEquals(maxPagerTop(100, 21), 95);
+  assertEquals(maxPagerTop(5, 21), 0, "a short document already fits");
+  assertEquals(maxPagerTop(100, 2), 99, "one content row still shows text");
 });
 
 Deno.test("findMatches: smartcase", () => {
@@ -228,10 +237,11 @@ Deno.test("frameTop: puts a too-tall node's top line ~1/10 down", () => {
   assert(top < 100, "node start is below the top of the screen");
 });
 
-Deno.test("frameTop: clamps at document bounds", () => {
+Deno.test("frameTop: respects document bounds", () => {
   assertEquals(frameTop(0, 2, 40, 1000), 0, "cannot scroll above the start");
   const t = frameTop(999, 999, 40, 1000);
-  assertEquals(t, maxTop(1000, 40), "clamped to the last page");
+  assertEquals(t, 980, "the padded end lets the final line be centered");
+  assert(t <= maxPagerTop(1000, 40));
 });
 
 Deno.test("scrollToAnchor: no scroll when the anchor is already visible", () => {
@@ -252,11 +262,12 @@ Deno.test("scrollToAnchor: minimal scroll when the anchor is off screen", () => 
   assert(60 >= down && 60 <= down + 10, "anchor now visible");
 });
 
-Deno.test("scrollToAnchor: clamps at document bounds", () => {
+Deno.test("scrollToAnchor: respects document bounds", () => {
   assertEquals(scrollToAnchor(0, 50, 12, 1000), 0); // can't scroll past the top
-  // near the end: top clamps to maxTop while keeping the anchor visible
+  // The padded end leaves room for the normal lower margin around the anchor.
   const t = scrollToAnchor(999, 0, 12, 1000);
-  assertEquals(t, maxTop(1000, 12));
+  assertEquals(t, 991);
+  assert(t <= maxPagerTop(1000, 12));
   assert(999 >= t && 999 <= t + 10, "last-line anchor visible");
 });
 

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -1273,6 +1273,8 @@ Deno.test("diffedit: Ctrl-L reveals more of the file above the hunk", () => {
 Deno.test("diffedit: Ctrl-L expands context in pager mode (no text cursor)", () => {
   const { s, done } = expandSession();
   try {
+    // A twelve-row content area puts its quarter-screen target above the hunk.
+    s.resize(80, 13);
     // No arrow press, so the text cursor is never revealed: we are in the pager.
     const view = s.view();
     assertEquals(view.cursor, null, "no text cursor");
@@ -1314,6 +1316,8 @@ Deno.test("diffedit: Ctrl-L expands context in pager mode (no text cursor)", () 
 Deno.test("diffedit: the expansion marker appears only in pager navigation", () => {
   const { s, done } = expandSession();
   try {
+    // A twelve-row content area puts its quarter-screen target above the hunk.
+    s.resize(80, 13);
     assertEquals(s.view().expandRow, 5, "navigation marks the chosen edge");
     assertEquals(s.view().diffMetadataRows, [4]);
     press(s, "/");
@@ -1489,6 +1493,8 @@ Deno.test("diffedit: in pager mode Ctrl-L expands the selected hunk", () => {
 Deno.test("diffedit: pager Ctrl-L keeps the hunk header in view when expanding up from the top", () => {
   const { s, done } = expandSession();
   try {
+    // A twelve-row content area puts its quarter-screen target above the hunk.
+    s.resize(80, 13);
     assertEquals(s.view().top, 0, "starts at the top, pager mode");
     s.handleKey({ name: "ctrl-l" }); // expands up (reveals alpha/beta)
     // The header and preamble sit above the insertion point, so they do not
@@ -1596,16 +1602,24 @@ Deno.test("diffedit: a whole-file selection uses the quarter-screen expansion ta
     assertEquals(
       s.view().expandUp,
       true,
-      "the quarter-screen target chooses the first hunk's top edge",
+      "the quarter-screen target chooses an upward edge",
+    );
+    assertEquals(
+      s.view().expandRow,
+      10,
+      "the second hunk's top edge wins the equal-distance choice",
     );
     s.handleKey({ name: "ctrl-l" });
-    // The whole diff is on screen, and the quarter-screen target is nearest the
-    // first hunk's top edge.
+    // The target is equally far from the first hunk's bottom and the second
+    // hunk's top. The second edge has more context available.
     assert(s.view().message.startsWith("Showing line"), s.view().message);
-    assert(s.doc.text.includes("@@ -1,6 +1,6 @@"), s.doc.text);
     assert(
-      s.doc.text.includes("@@ -30,3 +30,3 @@"),
-      "the other hunk is untouched",
+      s.doc.text.includes("@@ -4,3 +4,3 @@"),
+      "the first hunk is untouched",
+    );
+    assert(
+      s.doc.text.includes("@@ -20,13 +20,13 @@"),
+      "the second hunk expanded upward",
     );
   } finally {
     Deno.removeSync(root, { recursive: true });

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -14,7 +14,9 @@ import {
 } from "../lib/view/diffdoc.ts";
 import { createDiffHighlighter, diffSource } from "../lib/view/diffedit.ts";
 import { type GitRunner, realGit } from "../lib/view/commitmsg.ts";
+import { renderFrame } from "../lib/view/render.ts";
 import { Session } from "../lib/view/session.ts";
+import { stripAnsi } from "../lib/view/ansi.ts";
 import { promptText } from "./view-helpers.ts";
 
 function press(s: Session, ...names: string[]): void {
@@ -1272,8 +1274,28 @@ Deno.test("diffedit: Ctrl-L expands context in pager mode (no text cursor)", () 
   const { s, done } = expandSession();
   try {
     // No arrow press, so the text cursor is never revealed: we are in the pager.
-    assertEquals(s.view().cursor, null, "no text cursor");
-    assert(s.view().canExpand, "the status line advertises expand");
+    const view = s.view();
+    assertEquals(view.cursor, null, "no text cursor");
+    assert(view.canExpand, "the status line advertises expand");
+    assertEquals(view.expandRow, 5, "the first hunk body line is marked");
+    assertEquals(
+      view.diffMetadataRows,
+      [4],
+      "only the adjacent header is marked",
+    );
+    assertEquals(view.diffAnnotations, [
+      { line: 5, kind: "expandUp" },
+      { line: 4, kind: "diffMetadata" },
+    ]);
+    const rows = renderFrame(s.displayDoc(), view).map(stripAnsi);
+    for (let row = 0; row < 4; row++) {
+      assertEquals(rows[row].at(-1), " ", "earlier metadata is not marked");
+    }
+    assert(
+      rows[4].endsWith("^L█"),
+      "the hunk header labels the available expansion",
+    );
+    assertEquals(rows[5].at(-1), "◥", "the marker points upward");
     s.handleKey({ name: "ctrl-l" });
     const lines = s.doc.text.split("\n");
     // The hunk on screen expanded; with nothing selected it grows upward first.
@@ -1284,6 +1306,118 @@ Deno.test("diffedit: Ctrl-L expands context in pager mode (no text cursor)", () 
     // Revealing context is not an edit: a clean quit needs no save prompt.
     press(s, "q");
     assert(s.quit, "quit without a save prompt");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: the expansion marker appears only in pager navigation", () => {
+  const { s, done } = expandSession();
+  try {
+    assertEquals(s.view().expandRow, 5, "navigation marks the chosen edge");
+    assertEquals(s.view().diffMetadataRows, [4]);
+    press(s, "/");
+    assertEquals(s.view().expandRow, null, "search owns the next key");
+    assertEquals(
+      s.view().diffMetadataRows,
+      [],
+      "search hides its neighboring block",
+    );
+    press(s, "escape", "?");
+    assert(s.view().overlay !== null, "help is open");
+    assertEquals(s.view().expandRow, null, "an overlay owns the next key");
+    assertEquals(s.view().diffMetadataRows, [], "an overlay hides the block");
+    press(s, "escape");
+    assertEquals(s.view().expandRow, 5, "leaving help restores the marker");
+    press(s, "ctrl-x");
+    assertEquals(s.view().expandRow, null, "a chord owns the next key");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: a wrapped hunk header keeps the expansion triangle on the body", () => {
+  const { s, done } = expandSession();
+  try {
+    s.resize(9, 30);
+    press(s, "\\");
+    const view = s.view();
+    const headerFirstRow = view.wrapPlan!.firstRow[4];
+    const headerLastRow = view.wrapPlan!.lastRow[4];
+    const firstBodyFirstRow = view.wrapPlan!.firstRow[5];
+    assertEquals(view.expandRow, firstBodyFirstRow);
+    const rows = renderFrame(s.displayDoc(), view).map(stripAnsi);
+    for (let row = headerFirstRow; row <= headerLastRow; row++) {
+      const rendered = rows[row - view.top];
+      assertEquals(
+        rendered.at(-1),
+        "█",
+        "every wrapped hunk-header row is marked as metadata",
+      );
+      assertEquals(
+        rendered.endsWith("^L█"),
+        row === headerFirstRow,
+        "the first wrapped row carries the line's Ctrl-L label",
+      );
+    }
+    assertEquals(
+      rows[firstBodyFirstRow - view.top].at(-1),
+      "◥",
+      "the marker sits on the first body line",
+    );
+    s.handleKey({ name: "ctrl-l" });
+    assertEquals(
+      s.doc.text.split("\n")[4],
+      "@@ -1,5 +1,5 @@",
+      "Ctrl-L expands the marked top edge",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: adjacent metadata waits until its triangle is visible", () => {
+  const { s, done } = expandSession();
+  try {
+    s.resize(80, 6);
+    const view = s.view();
+    assertEquals(view.top, 0);
+    assertEquals(view.expandRow, 5, "the body marker sits below the viewport");
+    assertEquals(view.diffMetadataRows, [4], "the neighboring header is known");
+    assertEquals(view.diffAnnotations, []);
+    const rows = renderFrame(s.displayDoc(), view).map(stripAnsi);
+    assertEquals(
+      rows[4].at(-1),
+      " ",
+      "the visible header has no block without its triangle",
+    );
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffedit: wrapped metadata does not reflow its triangle off-screen", () => {
+  const { s, done } = expandSession();
+  try {
+    s.resize(15, 9);
+    press(s, "\\");
+    const first = s.view();
+    const firstRows = renderFrame(s.displayDoc(), first).map(stripAnsi);
+    assertEquals(first.top, 0);
+    assertEquals(first.diffAnnotations, [{ line: 5, kind: "expandUp" }]);
+    assert(
+      firstRows.some((row) => row.endsWith("◥")),
+      "the expansion triangle remains visible",
+    );
+    assert(
+      firstRows.every((row) => !row.includes("^L") && !row.endsWith("█")),
+      "metadata is hidden when its extra wrapping would hide the triangle",
+    );
+
+    const second = s.view();
+    assertEquals(second.top, first.top);
+    assertEquals(second.diffAnnotations, first.diffAnnotations);
+    assertEquals(renderFrame(s.displayDoc(), second).map(stripAnsi), firstRows);
   } finally {
     done();
   }
@@ -1318,7 +1452,8 @@ Deno.test("diffedit: in pager mode Ctrl-L expands the selected hunk", () => {
     );
     // Select the second hunk via the structure tree (no text cursor), then
     // expand: the choice of hunk must follow the selection, not a stale buffer.
-    // Left alone the middle of the screen would reach down from the first.
+    // The quarter-screen target reaches up from the first hunk. Selecting the
+    // second hunk makes the selection govern the expansion instead.
     let guard = 0;
     while ((s.view().selected?.startLine ?? -1) !== 9 && guard++ < 200) {
       s.handleKey({ name: "tab" });
@@ -1404,8 +1539,19 @@ Deno.test("diffedit: pager Ctrl-L fills a short screen from the held edge", () =
     );
     // Scroll down so the hunk body is at the top and the header is off screen.
     for (let i = 0; i < 6; i++) s.handleKey({ name: "j" });
+    const view = s.view();
+    assertEquals(view.expandRow, 7, "the last hunk body line is marked");
+    assertEquals(s.displayDoc().lines[view.expandRow!].text, " line22");
+    assertEquals(
+      renderFrame(s.displayDoc(), view).map(
+        stripAnsi,
+      )[view.expandRow! - view.top]
+        .at(-1),
+      "◢",
+      "the marker points down from the last body line",
+    );
     s.handleKey({ name: "ctrl-l" });
-    // The middle of the screen sits in the hunk's lower half, so the lines come
+    // The quarter-screen target is in the hunk's lower half, so the lines come
     // from below it and what follows the hunk is held still. Ten lines land on
     // a five-row screen, so they fill it from that held edge: the last of them
     // is on screen and the hunk has been pushed off the top.
@@ -1417,7 +1563,7 @@ Deno.test("diffedit: pager Ctrl-L fills a short screen from the held edge", () =
   }
 });
 
-Deno.test("diffedit: in pager mode Ctrl-L with the whole-file node selected still expands a hunk", () => {
+Deno.test("diffedit: a whole-file selection uses the quarter-screen expansion target", () => {
   const root = Deno.makeTempDirSync();
   try {
     // Long enough to back FAR_DIFF's second hunk, which sits at line 30.
@@ -1447,12 +1593,16 @@ Deno.test("diffedit: in pager mode Ctrl-L with the whole-file node selected stil
     s.handleKey({ name: "tab" }); // selects the whole-file node, whose start line
     // is the "diff --git" header — in no hunk.
     assertEquals(s.view().selected?.label, "▸ m.ts");
+    assertEquals(
+      s.view().expandUp,
+      true,
+      "the quarter-screen target chooses the first hunk's top edge",
+    );
     s.handleKey({ name: "ctrl-l" });
-    // It must resolve to a hunk, not report nothing. The whole diff is on
-    // screen, so the middle of the content is nearest the first hunk's bottom
-    // edge and that is the one that grows.
+    // The whole diff is on screen, and the quarter-screen target is nearest the
+    // first hunk's top edge.
     assert(s.view().message.startsWith("Showing line"), s.view().message);
-    assert(s.doc.text.includes("@@ -4,13 +4,13 @@"), s.doc.text);
+    assert(s.doc.text.includes("@@ -1,6 +1,6 @@"), s.doc.text);
     assert(
       s.doc.text.includes("@@ -30,3 +30,3 @@"),
       "the other hunk is untouched",

--- a/packages/cli/test/view-editbuffer.test.ts
+++ b/packages/cli/test/view-editbuffer.test.ts
@@ -79,6 +79,20 @@ Deno.test("editbuffer: dirty tracks against the original", () => {
   assert(!b.dirty(), "back to original content is clean again");
 });
 
+Deno.test("editbuffer: commitSaved makes the current text clean", () => {
+  const b = new EditBuffer("before");
+  b.moveLineEnd();
+  b.insert(" after");
+  assert(b.dirty(), "the edit starts dirty");
+
+  b.commitSaved();
+  assertEquals(b.baseline(), "before after");
+  assert(!b.dirty(), "the saved text is the new clean baseline");
+
+  b.insert(" again");
+  assert(b.dirty(), "a later edit is measured against the saved text");
+});
+
 // --- kill / yank ------------------------------------------------------------
 
 Deno.test("editbuffer: kill-line then yank round-trips", () => {

--- a/packages/cli/test/view-filepicker.test.ts
+++ b/packages/cli/test/view-filepicker.test.ts
@@ -167,6 +167,24 @@ Deno.test("filepicker: escape cancels and leaves the buffer untouched", () => {
   assertEquals(s.doc.text, FILES["/work/a.ts"]);
 });
 
+Deno.test("filepicker: opening from pager mode preserves the viewport", () => {
+  const path = "/work/a.ts";
+  const text = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join("\n");
+  const s = new Session(
+    parseDocument(text, path),
+    { color: false, showLineNumbers: false },
+    { width: 60, height: 5 },
+    undefined,
+    fakeSource(path),
+    gateway(),
+  );
+  for (let i = 0; i < 8; i++) press(s, "down");
+  assertEquals(s.view().top, 8);
+  openPicker(s);
+  press(s, "escape");
+  assertEquals(s.view().top, 8);
+});
+
 Deno.test("filepicker: refuses to open with unsaved edits", () => {
   const s = session();
   press(s, "e"); // reveal cursor

--- a/packages/cli/test/view-fold.test.ts
+++ b/packages/cli/test/view-fold.test.ts
@@ -244,6 +244,55 @@ Deno.test("fold: f hides the file the viewport is on, f again shows it", () => {
   assertEquals(s.displayDoc().lines.length, full, "showing again restores it");
 });
 
+Deno.test("fold: a summary omits markers for a hidden expansion edge", () => {
+  const ws: DiffWorkspace = {
+    resolve: (path) => path,
+    read: (path) =>
+      path.endsWith("app.test.ts") ? "x\nadded\nafter" : "keep\nnew\nafter",
+  };
+  const model = parseDiff(TWO_FILES)!;
+  const { doc, edit } = buildDiffDocument(TWO_FILES, model, ws);
+  const s = new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 80, height: 30 },
+    undefined,
+    diffSource(ws, edit),
+  );
+  press(s, "f");
+  const view = s.view();
+  assertEquals(view.canExpand, true);
+  assertEquals(view.expandRow, 7);
+  assertEquals(view.expandUp, false);
+  assertEquals(view.diffAnnotations, [{ line: 7, kind: "expandDown" }]);
+  const rendered = renderFrame(s.displayDoc(), view);
+  assertEquals(rendered[0].trimEnd(), "▸ src/app.ts  +1 −1");
+  assertEquals(rendered[7].at(-1), "◢");
+
+  const internals = s as unknown as {
+    displayDiffAnnotations(expand: {
+      row: number;
+      markerLine: number;
+      line: number;
+      up: boolean;
+    }): readonly unknown[];
+    displayAdjacentDiffMetadataRows(expand: {
+      row: number;
+      markerLine: number;
+      line: number;
+      up: boolean;
+    }): readonly number[];
+  };
+  const hiddenEdge = {
+    row: 5,
+    markerLine: 5,
+    line: 4,
+    up: true,
+  };
+  assertEquals(internals.displayDiffAnnotations(hiddenEdge), []);
+  assertEquals(internals.displayAdjacentDiffMetadataRows(hiddenEdge), []);
+});
+
 Deno.test("fold: a smaller file-number gutter clamps horizontal panning", () => {
   const root = Deno.makeTempDirSync();
   try {

--- a/packages/cli/test/view-fold.test.ts
+++ b/packages/cli/test/view-fold.test.ts
@@ -244,6 +244,68 @@ Deno.test("fold: f hides the file the viewport is on, f again shows it", () => {
   assertEquals(s.displayDoc().lines.length, full, "showing again restores it");
 });
 
+Deno.test("fold: a smaller file-number gutter clamps horizontal panning", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const longLine = "x".repeat(40);
+    const diff = [
+      "diff --git a/large.ts b/large.ts",
+      "--- a/large.ts",
+      "+++ b/large.ts",
+      "@@ -1000,3 +1000,3 @@",
+      ` ${longLine}`,
+      "-old",
+      "+new",
+      " tail",
+      "diff --git a/small.ts b/small.ts",
+      "--- a/small.ts",
+      "+++ b/small.ts",
+      "@@ -1,2 +1,2 @@",
+      ` ${longLine}`,
+      "-before",
+      "+after",
+      "",
+    ].join("\n");
+    const largeFile = [
+      ...Array.from({ length: 999 }, (_, i) => `line ${i + 1}`),
+      longLine,
+      "new",
+      "tail",
+      "",
+    ].join("\n");
+    Deno.writeTextFileSync(join(root, "large.ts"), largeFile);
+    Deno.writeTextFileSync(join(root, "small.ts"), `${longLine}\nafter\n`);
+    const ws: DiffWorkspace = {
+      resolve: (path) => join(root, path),
+      read: (path) => Deno.readTextFileSync(path),
+    };
+    const model = parseDiff(diff)!;
+    const { doc, edit } = buildDiffDocument(diff, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 20, height: 20 },
+      undefined,
+      diffSource(ws, edit),
+    );
+    assert(s.view().expandMargin, "the diff reserves its expansion margin");
+    press(s, "#", "#");
+    for (let i = 0; i < 20; i++) press(s, "l");
+    const withLargeFileNumbers = s.view().left;
+
+    press(s, "f");
+    assert(
+      s.view().left < withLargeFileNumbers,
+      "the smaller gutter clamps the right edge",
+    );
+    const atRightEdge = s.view().left;
+    press(s, "l");
+    assertEquals(s.view().left, atRightEdge, "right does not move left");
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
 Deno.test("fold: F hides all files, E shows all files", () => {
   const s = foldSession(TWO_FILES);
   const full = s.displayDoc().lines.length;
@@ -364,24 +426,23 @@ Deno.test("fold: a selected file spans every wrapped summary row", () => {
     "+y",
     "",
   ].join("\n");
-  const height = 6;
+  const height = 7;
   const s = foldSession(diff, height, 20);
   press(s, "\\", "F");
   const summaryLine = s.displayDoc().lines.findIndex((line) =>
     line.text.startsWith(`▸ ${longPath}`)
   );
   assert(summaryLine >= 0, "the long file is collapsed to a summary");
-  const plan = s.view().wrapPlan!;
-  const first = plan.firstRow[summaryLine];
-  const last = plan.lastRow[summaryLine];
-  assert(last > first, "the summary occupies continuation rows");
-
   for (let i = 0; i < 500; i++) {
     if (s.view().selected?.label.includes(longPath)) break;
     press(s, "tab");
   }
   assert(s.view().selected?.label.includes(longPath), "the file is selected");
   press(s, "enter", "z");
+  const plan = s.view().wrapPlan!;
+  const first = plan.firstRow[summaryLine];
+  const last = plan.lastRow[summaryLine];
+  assert(last > first, "the revealed summary occupies continuation rows");
   assertEquals(
     s.view().top,
     frameTop(first, last, height, plan.rowCount),

--- a/packages/cli/test/view-render.test.ts
+++ b/packages/cli/test/view-render.test.ts
@@ -521,6 +521,19 @@ Deno.test("renderFrame: a trailing diff newline omits an orphan end connector", 
   ]);
 });
 
+Deno.test("renderFrame: a read-only trailing diff newline precedes its end mark", () => {
+  const rows = renderFrame(
+    parseDocument("done\n"),
+    diffView({ width: 9, height: 5, color: false }),
+  );
+  assertEquals(rows.slice(0, 4), [
+    "done     ",
+    "☙   ❦   ❧",
+    "  ☙   ❧  ",
+    "    ❦    ",
+  ]);
+});
+
 Deno.test("renderFrame: a final downward triangle labels the diff connector", () => {
   for (const text of ["done", "done\n"]) {
     const doc = parseDocument(text);

--- a/packages/cli/test/view-render.test.ts
+++ b/packages/cli/test/view-render.test.ts
@@ -26,6 +26,10 @@ function baseView(over: Partial<ViewState> = {}): ViewState {
   };
 }
 
+function diffView(over: Partial<ViewState> = {}): ViewState {
+  return baseView({ isDiff: true, ...over });
+}
+
 /** The editor background sits behind every cell, so a "highlighted" cell is one
  * whose background is some OTHER colour (a selection tint, a search match, a
  * diff row). */
@@ -80,6 +84,30 @@ function bgAtColumn(row: string, target: number): string | null {
   return null;
 }
 
+/** Foreground colour active at one visible column, as an RGB tuple string. */
+function fgAtColumn(row: string, target: number): string | null {
+  let fg: string | null = null;
+  let col = 0;
+  let i = 0;
+  while (i < row.length) {
+    if (row[i] === "\x1b") {
+      // deno-lint-ignore no-control-regex
+      const sgr = row.slice(i).match(/^\x1b\[([0-9;]*)m/);
+      if (sgr) {
+        if (sgr[1] === "0" || sgr[1] === "") fg = null;
+        const rgb = sgr[1].match(/(?:^|;)38;2;(\d+);(\d+);(\d+)(?:;|$)/);
+        if (rgb) fg = `${rgb[1]},${rgb[2]},${rgb[3]}`;
+        i += sgr[0].length;
+        continue;
+      }
+    }
+    if (col === target) return fg;
+    col += 1;
+    i += 1;
+  }
+  return null;
+}
+
 Deno.test("renderFrame: node highlight covers the whole statement, not the padding", () => {
   const doc = parseDocument("const x = 1;\nconst y = 2;\n");
   // A structure node now spans the whole statement `const x = 1;` (12 columns),
@@ -118,6 +146,134 @@ Deno.test("renderFrame: emits exactly `height` rows", () => {
   const doc = parseDocument(SAMPLE);
   const rows = renderFrame(doc, baseView({ height: 12 }));
   assertEquals(rows.length, 12);
+});
+
+Deno.test("renderFrame: draws a centered gray cul-de-lampe after the document", () => {
+  const doc = parseDocument("last");
+  const rows = renderFrame(doc, diffView({ width: 15, height: 5 }));
+  assertEquals(stripAnsi(rows[0]), "last           ");
+  assertEquals(stripAnsi(rows[1]), "   ☙   ❦   ❧   ");
+  assertEquals(stripAnsi(rows[2]), "     ☙   ❧     ");
+  assertEquals(stripAnsi(rows[3]), "       ❦       ");
+  const endMarkColor = ui.endMark.fg!.join(",");
+  assertEquals(fgAtColumn(rows[1], 3), endMarkColor);
+  assertEquals(fgAtColumn(rows[2], 5), endMarkColor);
+  assertEquals(fgAtColumn(rows[3], 7), endMarkColor);
+});
+
+Deno.test("renderFrame: the end mark is centered across the line-number gutter", () => {
+  const doc = parseDocument("last");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 15,
+      height: 5,
+      color: false,
+      showLineNumbers: true,
+    }),
+  );
+  assertEquals(rows.slice(1, 4), [
+    "   ☙   ❦   ❧   ",
+    "     ☙   ❧     ",
+    "       ❦       ",
+  ]);
+});
+
+Deno.test("renderFrame: the end mark follows the final wrapped row", () => {
+  const doc = parseDocument("abcdefghijklmnopqrst");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 15,
+      height: 6,
+      color: false,
+      wrapLines: true,
+    }),
+  );
+  assertEquals(rows.slice(0, 5), [
+    "abcdefghijklmn\\",
+    "opqrst         ",
+    "   ☙   ❦   ❧   ",
+    "     ☙   ❧     ",
+    "       ❦       ",
+  ]);
+});
+
+Deno.test("renderFrame: a compact cul-de-lampe retains its triangle", () => {
+  const rows = renderFrame(
+    parseDocument("last"),
+    diffView({ width: 7, height: 5, color: false }),
+  );
+  assertEquals(rows.slice(1, 4), [
+    " ☙ ❦ ❧ ",
+    "  ☙ ❧  ",
+    "   ❦   ",
+  ]);
+});
+
+Deno.test("renderFrame: a two-row cul-de-lampe retains its point", () => {
+  const cases = [
+    {
+      width: 15,
+      expected: ["     ☙   ❧     ", "       ❦       "],
+    },
+    {
+      width: 7,
+      expected: ["  ☙ ❧  ", "   ❦   "],
+    },
+  ];
+  for (const { width, expected } of cases) {
+    const rows = renderFrame(
+      parseDocument("last"),
+      diffView({ width, height: 4, color: false }),
+    );
+    assertEquals(rows.slice(1, 3), expected);
+  }
+});
+
+Deno.test("renderFrame: narrow end-mark rows retain a centered fleuron", () => {
+  const doc = parseDocument("last");
+  for (const width of [1, 2, 3, 4]) {
+    const rows = renderFrame(
+      doc,
+      diffView({ width, height: 5, color: false }),
+    );
+    assertEquals(rows[1].length, width);
+    assertEquals(
+      rows[1].indexOf("❦"),
+      Math.floor((width - 1) / 2),
+      `width ${width} rendered ${JSON.stringify(rows[1])}`,
+    );
+    assertEquals(rows[2], " ".repeat(width));
+    assertEquals(rows[3], " ".repeat(width));
+  }
+});
+
+Deno.test("renderFrame: ordinary documents leave rows after the document blank", () => {
+  const doc = parseDocument("last");
+  const rows = renderFrame(
+    doc,
+    baseView({
+      width: 15,
+      height: 3,
+      color: false,
+    }),
+  );
+  assertEquals(rows[1], " ".repeat(15));
+});
+
+Deno.test("renderFrame: edit mode leaves rows after the document blank", () => {
+  const doc = parseDocument("last");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 15,
+      height: 3,
+      color: false,
+      cursor: { line: 0, col: 0 },
+    }),
+  );
+  assertEquals(rows[1], " ".repeat(15));
 });
 
 Deno.test("renderFrame: content rows are verbatim under the colour", () => {
@@ -163,6 +319,321 @@ Deno.test("renderFrame: styles wrapped continuation markers", () => {
   assert(!rows[2].includes(fgCode(ui.wrapMarker.fg!)));
 });
 
+Deno.test("renderFrame: annotates only the lines that carry diff markers", () => {
+  const doc = parseDocument("1234567\nabcdefghij");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 7,
+      height: 5,
+      expandMargin: true,
+      diffAnnotations: [{ line: 1, kind: "expandDown" }],
+      wrapLines: true,
+    }),
+  );
+  assertEquals(stripAnsi(rows[0]), "1234567");
+  assertEquals(stripAnsi(rows[1]), "abcde\\◢");
+  assertEquals(stripAnsi(rows[2]), "fgh\\^L█");
+  assertEquals(stripAnsi(rows[3]), "ij    █");
+  assert(rows[1].includes(fgCode(ui.wrapMarker.fg!)));
+  assert(rows[2].includes(fgCode(ui.wrapMarker.fg!)));
+  assert(rows[3].includes(fgCode(ui.wrapMarker.fg!)));
+  assertEquals(bgAtColumn(rows[1], 6), ui.editorBg.join(","));
+});
+
+Deno.test("renderFrame: a wrapped edge labels only its closest connector", () => {
+  const doc = parseDocument("abcdefghij\nmeta");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 7,
+      height: 6,
+      color: false,
+      expandMargin: true,
+      diffAnnotations: [
+        { line: 0, kind: "expandDown" },
+        { line: 1, kind: "diffMetadata" },
+      ],
+      wrapLines: true,
+    }),
+  );
+  assertEquals(rows.slice(0, 5), [
+    "abcde\\◢",
+    "fgh\\^L█",
+    "ij    █",
+    "meta  █",
+    " ☙ ❦ ❧ ",
+  ]);
+
+  const fittingRows = renderFrame(
+    parseDocument("abc\nmeta"),
+    diffView({
+      width: 7,
+      height: 4,
+      color: false,
+      expandMargin: true,
+      diffAnnotations: [
+        { line: 0, kind: "expandDown" },
+        { line: 1, kind: "diffMetadata" },
+      ],
+      wrapLines: true,
+    }),
+  );
+  assertEquals(fittingRows.slice(0, 2), [
+    "abc   ◢",
+    "meta^L█",
+  ]);
+});
+
+Deno.test("renderFrame: the expansion margin preserves an exact-width line", () => {
+  const doc = parseDocument("abcd");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 7,
+      height: 2,
+      color: false,
+      expandMargin: true,
+      diffAnnotations: [{ line: 0, kind: "expandUp" }],
+    }),
+  );
+  assertEquals(rows[0], "abcd  ◥");
+});
+
+Deno.test("renderFrame: the closest metadata row labels Ctrl-L before the block", () => {
+  const doc = parseDocument("abc\ndef\nghi");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 6,
+      height: 4,
+      expandMargin: true,
+      diffAnnotations: [
+        { line: 0, kind: "expandDown" },
+        { line: 1, kind: "diffMetadata" },
+      ],
+    }),
+  );
+  assertEquals(stripAnsi(rows[0]), "abc  ◢");
+  assertEquals(stripAnsi(rows[1]), "def^L█");
+  assertEquals(stripAnsi(rows[2]), "ghi   ");
+  const markerColor = ui.wrapMarker.fg!.join(",");
+  assertEquals(fgAtColumn(rows[1], 3), markerColor);
+  assertEquals(fgAtColumn(rows[1], 4), markerColor);
+  assertEquals(fgAtColumn(rows[1], 5), markerColor);
+  assertEquals(bgAtColumn(rows[1], 5), ui.editorBg.join(","));
+});
+
+Deno.test("renderFrame: a narrow expansion annotation preserves the block", () => {
+  const doc = parseDocument("a\nb");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 2,
+      height: 3,
+      color: false,
+      expandMargin: true,
+      diffAnnotations: [
+        { line: 0, kind: "expandDown" },
+        { line: 1, kind: "diffMetadata" },
+      ],
+    }),
+  );
+  assertEquals(rows.slice(0, 2), ["a◢", "b█"]);
+});
+
+Deno.test("renderFrame: wrapped metadata keeps its label beside the backslash", () => {
+  const doc = parseDocument("edge\nabcdefghij");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 7,
+      height: 6,
+      color: false,
+      expandMargin: true,
+      diffAnnotations: [
+        { line: 0, kind: "expandDown" },
+        { line: 1, kind: "diffMetadata" },
+      ],
+      wrapLines: true,
+    }),
+  );
+  assertEquals(rows.slice(0, 5), [
+    "edge  ◢",
+    "abc\\^L█",
+    "defgh\\█",
+    "ij    █",
+    " ☙ ❦ ❧ ",
+  ]);
+});
+
+Deno.test("renderFrame: a diff without a final triangle omits the end connector", () => {
+  const doc = parseDocument("done");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 9,
+      height: 5,
+      color: false,
+      expandMargin: true,
+    }),
+  );
+  assertEquals(rows.slice(0, 4), [
+    "done     ",
+    "☙   ❦   ❧",
+    "  ☙   ❧  ",
+    "    ❦    ",
+  ]);
+});
+
+Deno.test("renderFrame: a trailing diff newline omits an orphan end connector", () => {
+  const doc = parseDocument("done\n");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 9,
+      height: 5,
+      color: false,
+      expandMargin: true,
+    }),
+  );
+  assertEquals(rows.slice(0, 4), [
+    "done     ",
+    "☙   ❦   ❧",
+    "  ☙   ❧  ",
+    "    ❦    ",
+  ]);
+});
+
+Deno.test("renderFrame: a final downward triangle labels the diff connector", () => {
+  for (const text of ["done", "done\n"]) {
+    const doc = parseDocument(text);
+    const rows = renderFrame(
+      doc,
+      diffView({
+        width: 9,
+        height: 5,
+        color: false,
+        expandMargin: true,
+        diffAnnotations: [{ line: 0, kind: "expandDown" }],
+      }),
+    );
+    assertEquals(rows[0], "done    ◢");
+    assertEquals(rows[1], "      ^L█");
+  }
+
+  const shortRows = renderFrame(
+    parseDocument("done"),
+    diffView({
+      width: 9,
+      height: 3,
+      color: false,
+      expandMargin: true,
+      diffAnnotations: [{ line: 0, kind: "expandDown" }],
+    }),
+  );
+  assertEquals(shortRows.slice(0, 2), [
+    "done    ◢",
+    "    ❦ ^L█",
+  ]);
+});
+
+Deno.test("renderFrame: a wrapped final triangle connects below the diff", () => {
+  const rows = renderFrame(
+    parseDocument("abcdefghij"),
+    diffView({
+      width: 7,
+      height: 6,
+      color: false,
+      expandMargin: true,
+      diffAnnotations: [{ line: 0, kind: "expandDown" }],
+      wrapLines: true,
+    }),
+  );
+  assertEquals(rows.slice(0, 5), [
+    "abcde\\◢",
+    "fgh\\^L█",
+    "ij    █",
+    "      █",
+    " ☙ ❦ ❧ ",
+  ]);
+});
+
+Deno.test("renderFrame: a narrow final connector keeps its functional glyphs", () => {
+  const cases: readonly { width: number; expected: string[] }[] = [
+    { width: 1, expected: ["a", "█"] },
+    { width: 2, expected: ["a◢", "L█"] },
+    { width: 3, expected: ["a ◢", "^L█"] },
+    { width: 4, expected: ["a  ◢", "❦^L█"] },
+    { width: 5, expected: ["a   ◢", "❦ ^L█"] },
+  ];
+  for (const { width, expected } of cases) {
+    const rows = renderFrame(
+      parseDocument("a"),
+      diffView({
+        width,
+        height: 3,
+        color: false,
+        expandMargin: true,
+        diffAnnotations: [{ line: 0, kind: "expandDown" }],
+      }),
+    );
+    assertEquals(rows.slice(0, 2), expected);
+  }
+});
+
+Deno.test("renderFrame: a short diff uses the available row for its end mark", () => {
+  const doc = parseDocument("done");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 9,
+      height: 3,
+      color: false,
+      expandMargin: true,
+    }),
+  );
+  assertEquals(rows.slice(0, 2), [
+    "done     ",
+    "☙   ❦   ❧",
+  ]);
+});
+
+Deno.test("renderFrame: a narrow expansion margin reclaims the gutter", () => {
+  const doc = parseDocument("a");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 5,
+      height: 2,
+      color: false,
+      showLineNumbers: true,
+      expandMargin: true,
+      diffAnnotations: [{ line: 0, kind: "expandDown" }],
+    }),
+  );
+  assertEquals(rows[0], "a   ◢");
+  assertEquals(visibleWidth(rows[0]), 5);
+});
+
+Deno.test("renderFrame: a narrow expansion margin reclaims the guide", () => {
+  const doc = parseDocument("const x = 1;");
+  const node = doc.flatStructure.find((n) => n.name === "x")!;
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 2,
+      height: 2,
+      color: false,
+      selected: node,
+      expandMargin: true,
+      diffAnnotations: [{ line: 0, kind: "expandUp" }],
+    }),
+  );
+  assertEquals(rows[0], "c◥");
+  assertEquals(visibleWidth(rows[0]), 2);
+});
+
 Deno.test("renderFrame: a wrapped marker keeps each diff-row background", () => {
   const parsed = parseDocument("abcdefgh");
   for (const bg of ["add", "del"] as const) {
@@ -192,7 +663,14 @@ Deno.test("renderFrame: a physically one-column view preserves source text", () 
   const doc = parseDocument("ab");
   const rows = renderFrame(
     doc,
-    baseView({ width: 1, height: 3, color: false, wrapLines: true }),
+    diffView({
+      width: 1,
+      height: 3,
+      color: false,
+      expandMargin: true,
+      diffAnnotations: [{ line: 0, kind: "diffMetadata" }],
+      wrapLines: true,
+    }),
   );
   assertEquals(rows.slice(0, 2), ["a", "b"]);
 });
@@ -568,6 +1046,41 @@ Deno.test("renderFrame: status line reports position", () => {
   const rows = renderFrame(doc, baseView({ height: 8 }));
   const status = stripAnsi(rows[rows.length - 1]);
   assert(status.includes("/"), `status shows position: "${status}"`);
+});
+
+Deno.test("renderFrame: END means the mode-specific scroll limit", () => {
+  const doc = parseDocument(
+    Array.from({ length: 12 }, (_, i) => `line ${i}`).join("\n"),
+  );
+  const statusAt = (
+    top: number,
+    isDiff = false,
+    cursor: ViewState["cursor"] = null,
+  ) =>
+    stripAnsi(
+      renderFrame(
+        doc,
+        baseView({
+          width: 30,
+          height: 9,
+          color: false,
+          top,
+          isDiff,
+          cursor,
+        }),
+      ).at(-1)!,
+    );
+
+  assert(statusAt(4).includes("END"), "ordinary pager reached the file end");
+  assert(
+    !statusAt(4, true).includes("END"),
+    "diff padding remains below the view",
+  );
+  assert(statusAt(10, true).includes("END"), "diff reached its padded limit");
+  assert(
+    statusAt(4, true, { line: 11, col: 0 }).includes("END"),
+    "editor reached its ordinary document limit",
+  );
 });
 
 Deno.test("renderFrame: overlay paints its title over the content", () => {

--- a/packages/cli/test/view-render.test.ts
+++ b/packages/cli/test/view-render.test.ts
@@ -1,6 +1,11 @@
 import { assert, assertEquals } from "@std/assert";
 import { bgCode, fgCode, parseDocument, SAMPLE } from "./view-helpers.ts";
-import { overlayBox, renderFrame, type ViewState } from "../lib/view/render.ts";
+import {
+  labeledDiffMetadataLine,
+  overlayBox,
+  renderFrame,
+  type ViewState,
+} from "../lib/view/render.ts";
 import { _internal } from "../lib/view/render.ts";
 import { stripAnsi, visibleWidth } from "../lib/view/ansi.ts";
 import { renderLineColored } from "../lib/view/highlight.ts";
@@ -383,6 +388,17 @@ Deno.test("renderFrame: a wrapped edge labels only its closest connector", () =>
     "abc   ◢",
     "meta^L█",
   ]);
+});
+
+Deno.test("labeledDiffMetadataLine tolerates a missing expansion line", () => {
+  const doc = parseDocument("metadata");
+  assertEquals(
+    labeledDiffMetadataLine(doc.lines, "pictures", 7, [
+      { line: 1, kind: "expandDown" },
+      { line: 2, kind: "diffMetadata" },
+    ]),
+    2,
+  );
 });
 
 Deno.test("renderFrame: the expansion margin preserves an exact-width line", () => {

--- a/packages/cli/test/view-render.test.ts
+++ b/packages/cli/test/view-render.test.ts
@@ -1112,6 +1112,50 @@ Deno.test("renderFrame: END means the mode-specific scroll limit", () => {
   );
 });
 
+Deno.test("renderFrame: diff status excludes only its terminal parser row", () => {
+  const status = (text: string, view: Partial<ViewState> = {}) =>
+    stripAnsi(
+      renderFrame(
+        parseDocument(text),
+        baseView({
+          width: 30,
+          height: 9,
+          color: false,
+          ...view,
+        }),
+      ).at(-1)!,
+    );
+
+  const lines = Array.from({ length: 12 }, (_, i) => `line ${i + 1}`);
+  const intermediate = status(`${lines.join("\n")}\n`, {
+    top: 5,
+    isDiff: true,
+  });
+  assert(intermediate.includes("6-12/12  45%"), intermediate);
+
+  const wrapped = status(`${"a".repeat(25)}\nz\n`, {
+    width: 20,
+    height: 4,
+    top: 1,
+    isDiff: true,
+    wrapLines: true,
+  });
+  assert(wrapped.includes("1-2/2  50%"), wrapped);
+
+  const emptyDiff = status("", { isDiff: true });
+  assert(emptyDiff.includes("0-0/0  END"), emptyDiff);
+
+  const editableDiff = status("done\n", {
+    height: 3,
+    isDiff: true,
+    cursor: { line: 0, col: 0 },
+  });
+  assert(editableDiff.includes("1-2/2  END"), editableDiff);
+
+  const ordinary = status("done\n", { height: 3 });
+  assert(ordinary.includes("1-2/2  END"), ordinary);
+});
+
 Deno.test("renderFrame: overlay paints its title over the content", () => {
   const doc = parseDocument(SAMPLE);
   const rows = renderFrame(

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -1733,11 +1733,13 @@ Deno.test("diffcov: pager-mode ctrl-l expands the hunk in view", () => {
       diffSource(ws, edit),
     );
     assert(s.view().canExpand, "expand advertised");
-    press(s, "ctrl-l"); // pager mode expand
-    assert(
-      s.doc.text.includes("alpha") || s.doc.text.includes("beta"),
-      s.doc.text,
+    assertEquals(
+      s.view().expandUp,
+      false,
+      "the quarter-screen target marks the lower hunk edge",
     );
+    press(s, "ctrl-l"); // pager mode expand
+    assert(s.doc.text.includes("theta"), s.doc.text);
   } finally {
     done();
   }
@@ -1845,6 +1847,45 @@ Deno.test("diffcov: pager-mode ctrl-l at a hunk's bottom expands downwards", () 
     assert(!s.doc.text.includes("L24"), "did not reveal above the hunk");
   } finally {
     done();
+  }
+});
+
+Deno.test("diffcov: padded blank rows do not move the quarter-screen target", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const lines = Array.from({ length: 30 }, (_, i) => `line ${i + 1}`);
+    lines[9] = "new";
+    Deno.writeTextFileSync(join(root, "t.ts"), `${lines.join("\n")}\n`);
+    const diff = `diff --git a/t.ts b/t.ts
+index 0000000..1111111 100644
+--- a/t.ts
++++ b/t.ts
+@@ -10,1 +10,1 @@
+-old
++new`;
+    const ws: DiffWorkspace = {
+      resolve: (path) => join(root, path),
+      read: (path) => Deno.readTextFileSync(path),
+    };
+    const model = parseDiff(diff)!;
+    const { doc, edit } = buildDiffDocument(diff, model, ws);
+    const s = new Session(
+      doc,
+      { color: false, showLineNumbers: false },
+      { width: 80, height: 21 },
+      undefined,
+      diffSource(ws, edit),
+    );
+
+    press(s, "G");
+    assertEquals(s.view().top, 2);
+    assertEquals(
+      s.view().expandUp,
+      false,
+      "the viewport quarter is nearest the hunk's bottom edge",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
   }
 });
 

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -2188,6 +2188,36 @@ Deno.test("diffcov: wrapped expansion holds the content after the hunk still", (
   }
 });
 
+Deno.test("diffcov: wrapped reveal keeps the next triangle on screen", () => {
+  const { s, done } = tallSession(9);
+  try {
+    s.resize(20, 9);
+    press(s, "\\", "ctrl-l");
+
+    const view = s.view();
+    assert(
+      (view.diffMetadataRows?.length ?? 0) > 0,
+      "the next edge has adjacent metadata",
+    );
+    assertEquals(
+      view.diffAnnotations,
+      [{ line: 5, kind: "expandUp" }],
+      "the metadata label is withheld when its reflow would hide the triangle",
+    );
+    const rendered = renderFrame(s.displayDoc(), view);
+    assert(
+      rendered.slice(0, -1).some((row) => row.endsWith("◥")),
+      "the next expansion triangle remains visible",
+    );
+    assert(
+      rendered.every((row) => !row.includes("^L") && !row.endsWith("█")),
+      "no orphan metadata connector is drawn",
+    );
+  } finally {
+    done();
+  }
+});
+
 /** The row texts a frame — or the session itself — puts on screen. */
 function rows(f: { doc: Document; view: ViewState }): string[] {
   return f.doc.lines.slice(f.view.top, f.view.top + f.view.height - 1)

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -2254,7 +2254,7 @@ Deno.test("diffcov: wrapped reveal keeps the next triangle on screen", () => {
       rendered.slice(0, -1).every((row) =>
         !row.includes("^L") && !row.endsWith("█")
       ),
-      "no orphan metadata connector is drawn",
+      "no orphan metadata connector is drawn in document rows",
     );
   } finally {
     done();

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -2251,7 +2251,9 @@ Deno.test("diffcov: wrapped reveal keeps the next triangle on screen", () => {
       "the next expansion triangle remains visible",
     );
     assert(
-      rendered.every((row) => !row.includes("^L") && !row.endsWith("█")),
+      rendered.slice(0, -1).every((row) =>
+        !row.includes("^L") && !row.endsWith("█")
+      ),
       "no orphan metadata connector is drawn",
     );
   } finally {

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -15,9 +15,9 @@ import type { DirEntry, FileGateway } from "../lib/view/filegateway.ts";
 import { parseDiff } from "../lib/view/diff.ts";
 import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { diffSource } from "../lib/view/diffedit.ts";
-import { overlayBox, type ViewState } from "../lib/view/render.ts";
+import { overlayBox, renderFrame, type ViewState } from "../lib/view/render.ts";
 import type { Document } from "../lib/view/model.ts";
-import { frameTop } from "../lib/view/actions.ts";
+import { frameTop, maxTop } from "../lib/view/actions.ts";
 
 // --- key helpers -----------------------------------------------------------
 
@@ -31,6 +31,15 @@ function press(s: Session, ...names: string[]): void {
 
 function type(s: Session, text: string): void {
   for (const ch of text) s.handleKey({ name: ch, char: ch });
+}
+
+/** Put the final display row on the viewport's last content row. */
+function lastFullPage(s: Session): void {
+  const view = s.view();
+  const rowCount = view.wrapPlan?.rowCount ?? s.displayDoc().lines.length;
+  const top = maxTop(rowCount, view.height);
+  press(s, "G");
+  press(s, ...Array(s.view().top - top).fill("k"));
 }
 
 function alt(name: string, char?: string): Key {
@@ -483,11 +492,14 @@ Deno.test("session: info-card letter shortcuts match the help text", () => {
     assert(s.view().overlay, "the info card opened");
     press(s, reveal);
     assertEquals(s.view().overlay, null, `${reveal} revealed the card subject`);
-    const expectedTop = frameTop(
-      subject.startLine,
-      subject.endLine,
-      s.view().height,
-      s.doc.lines.length,
+    const expectedTop = Math.min(
+      frameTop(
+        subject.startLine,
+        subject.endLine,
+        s.view().height,
+        s.doc.lines.length,
+      ),
+      maxTop(s.doc.lines.length, s.view().height),
     );
     assert(expectedTop !== beforeTop, "the fixture requires reframing");
     assertEquals(
@@ -1752,8 +1764,8 @@ Deno.test("diffcov: pager-mode ctrl-l with a selected hunk expands that hunk", (
   }
 });
 
-// A hunk tall enough that the middle of the screen can be scrolled into either
-// half of it, with room to reveal a full expansion (10 lines) above and below.
+// A hunk tall enough that the quarter-screen expansion target can be scrolled
+// into either half, with room to reveal a full expansion above and below.
 const TALL_LINES = Array.from(
   { length: 60 },
   (_, i) => `L${String(i + 1).padStart(2, "0")}`,
@@ -1799,8 +1811,8 @@ function tallSession(height: number): { s: Session; done: () => void } {
 Deno.test("diffcov: pager-mode ctrl-l at a hunk's top expands upwards", () => {
   const { s, done } = tallSession(13);
   try {
-    // Viewport at the top of the hunk: the middle of the screen sits in the
-    // hunk's upper half, so the context comes from above it.
+    // With the viewport at the top of the hunk, the quarter-screen target is in
+    // the hunk's upper half, so the context comes from above it.
     press(s, "ctrl-l");
     assert(s.view().message.startsWith("Showing line"), s.view().message);
     assert(s.doc.text.includes("L24"), "revealed the line above the hunk");
@@ -1813,9 +1825,21 @@ Deno.test("diffcov: pager-mode ctrl-l at a hunk's top expands upwards", () => {
 Deno.test("diffcov: pager-mode ctrl-l at a hunk's bottom expands downwards", () => {
   const { s, done } = tallSession(13);
   try {
-    // Scrolled to the end, the middle of the screen sits in the hunk's lower
+    // Scrolled to the end, the quarter-screen target is in the hunk's lower
     // half, so the context comes from below it.
-    press(s, "G", "ctrl-l");
+    press(s, "G");
+    const view = s.view();
+    assertEquals(view.expandUp, false);
+    assert(
+      view.expandRow !== null,
+      "the bottom body line carries the triangle",
+    );
+    assertEquals(
+      view.diffMetadataRows,
+      [],
+      "there is no adjacent metadata below the triangle",
+    );
+    press(s, "ctrl-l");
     assert(s.view().message.startsWith("Showing line"), s.view().message);
     assert(s.doc.text.includes("L45"), "revealed the line below the hunk");
     assert(!s.doc.text.includes("L24"), "did not reveal above the hunk");
@@ -1824,7 +1848,7 @@ Deno.test("diffcov: pager-mode ctrl-l at a hunk's bottom expands downwards", () 
   }
 });
 
-Deno.test("diffcov: pager-mode ctrl-l follows the middle as the view scrolls", () => {
+Deno.test("diffcov: pager-mode ctrl-l follows the quarter-screen target as the view scrolls", () => {
   const { s, done } = tallSession(13);
   try {
     // The same session expands up first, then down once scrolled, rather than
@@ -1843,9 +1867,12 @@ Deno.test("diffcov: pager-mode ctrl-l measures a selection's hunk from the selec
   // nearest is a real question rather than the only one left.
   const plain = tallSession(30);
   try {
-    // Left alone, the middle of the screen is nearer the hunk's top edge.
+    // Left alone, the quarter-screen target is nearer the hunk's top edge.
     press(plain.s, "ctrl-l");
-    assert(plain.s.doc.text.includes("L24"), "the middle reached upwards");
+    assert(
+      plain.s.doc.text.includes("L24"),
+      "the quarter-screen target reached upwards",
+    );
   } finally {
     plain.done();
   }
@@ -1930,8 +1957,8 @@ Deno.test("filepicker: opening it after an edit leaves the structure tree curren
   }
 });
 
-// Three files, the middle one big enough that hiding it takes a large slice of
-// the document off screen while leaving one row behind.
+// Four files, one big enough that hiding it takes a large slice of the document
+// off screen while leaving one row behind.
 const FOLD_FILE = (p: string) =>
   `${
     Array.from(
@@ -1967,12 +1994,20 @@ ${
     .join("\n")
 }
 ${FOLD_SMALL("c.ts", "C")}
+${FOLD_SMALL("d.ts", "D")}
 `;
 
 Deno.test("diffcov: pager-mode ctrl-l measures nearest in rows, not document lines", () => {
   const root = Deno.makeTempDirSync();
   try {
-    for (const [name, p] of [["a.ts", "A"], ["big.ts", "B"], ["c.ts", "C"]]) {
+    for (
+      const [name, p] of [
+        ["a.ts", "A"],
+        ["big.ts", "B"],
+        ["c.ts", "C"],
+        ["d.ts", "D"],
+      ]
+    ) {
       Deno.writeTextFileSync(join(root, name), FOLD_FILE(p));
     }
     const ws: DiffWorkspace = {
@@ -1990,20 +2025,20 @@ Deno.test("diffcov: pager-mode ctrl-l measures nearest in rows, not document lin
     const s = new Session(
       doc,
       { color: false, showLineNumbers: false },
-      { width: 80, height: 20 },
+      { width: 80, height: 23 },
       undefined,
       diffSource(ws, edit),
     );
     selectByLabel(s, "big.ts");
-    press(s, "f", "escape", "G"); // hide the middle file, drop the selection
-    // The middle of the screen lands on c.ts's header, two rows below a.ts's
-    // hunk and four above c.ts's. a.ts is what the eye is nearest, so a.ts is
-    // what grows — even though big.ts's hidden lines put it 27 document lines
-    // away against c.ts's four.
+    press(s, "f", "escape"); // hide the big file, drop the selection
+    lastFullPage(s);
+    // The quarter-screen target is two display rows above c.ts's hunk and four
+    // below a.ts's. c.ts is what the eye is nearest, so c.ts grows even though
+    // big.ts's hidden lines put its header much farther away in the document.
     press(s, "ctrl-l");
     assert(s.view().message.startsWith("Showing line"), s.view().message);
-    assert(s.doc.text.includes("A023"), "the hunk nearest on screen grew");
-    assert(!s.doc.text.includes("C019"), "the hunk further away did not");
+    assert(s.doc.text.includes("C019"), "the hunk nearest on screen grew");
+    assert(!s.doc.text.includes("A023"), "the hunk further away did not");
   } finally {
     Deno.removeSync(root, { recursive: true });
   }
@@ -2096,7 +2131,8 @@ Deno.test("diffcov: expanding upwards holds the content before the hunk still", 
 Deno.test("diffcov: expanding downwards holds the content after the hunk still", () => {
   const { s, done } = pinSession();
   try {
-    press(s, "ctrl-d", "ctrl-d", "j", "j", "j"); // the middle in its lower half
+    // Put the quarter-screen target in the hunk's lower half.
+    press(s, "ctrl-d", "ctrl-d", "j", "j", "j");
     const held = screenRow(s, "diff --git a/b.ts b/b.ts");
     press(s, "ctrl-l");
     assert(s.view().message.startsWith("Showing line"), s.view().message);
@@ -2112,6 +2148,43 @@ Deno.test("diffcov: expanding downwards holds the content after the hunk still",
     );
   } finally {
     done();
+  }
+});
+
+Deno.test("diffcov: wrapped expansion holds the content after the hunk still", () => {
+  for (
+    const { width, scroll } of [
+      { width: 2, scroll: 144 },
+      { width: 3, scroll: 79 },
+      { width: 4, scroll: 44 },
+      { width: 5, scroll: 35 },
+    ]
+  ) {
+    const { s, done } = pinSession();
+    try {
+      s.resize(width, 13);
+      press(s, "\\", ...Array(scroll).fill("j"));
+      const before = s.view();
+      assertEquals(before.expandUp, false);
+      const heldLine = s.displayDoc().lines.findIndex((line) =>
+        line.text === "diff --git a/b.ts b/b.ts"
+      );
+      const heldRow = before.wrapPlan!.firstRow[heldLine] - before.top;
+      assertEquals(heldRow, 11, `initial row at width ${width}`);
+
+      press(s, "ctrl-l");
+      const after = s.view();
+      const movedLine = s.displayDoc().lines.findIndex((line) =>
+        line.text === "diff --git a/b.ts b/b.ts"
+      );
+      assertEquals(
+        after.wrapPlan!.firstRow[movedLine] - after.top,
+        heldRow,
+        `held row at width ${width}`,
+      );
+    } finally {
+      done();
+    }
   }
 });
 
@@ -2145,6 +2218,42 @@ Deno.test("diffcov: the reveal frames run from the screen before to the one afte
       "the header is already at the range it is heading for",
     );
     assertEquals(rows(s.revealFrame(reveal.count)!), screenOf(s));
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: reveal-frame metadata stays beside its triangle", () => {
+  const { s, done } = pinSession();
+  try {
+    press(s, "ctrl-l");
+    const reveal = s.pendingReveal!;
+    for (let shown = 0; shown <= reveal.count; shown++) {
+      const frame = s.revealFrame(shown)!;
+      const annotations = frame.view.diffAnnotations ?? [];
+      const triangle = annotations.find((annotation) =>
+        annotation.kind !== "diffMetadata"
+      );
+      for (
+        const metadata of annotations.filter((annotation) =>
+          annotation.kind === "diffMetadata"
+        )
+      ) {
+        assert(triangle, `metadata has no triangle at frame ${shown}`);
+        assertEquals(
+          Math.abs(metadata.line - triangle.line),
+          1,
+          `metadata is not adjacent at frame ${shown}`,
+        );
+      }
+      const rendered = renderFrame(frame.doc, frame.view);
+      if (rendered.some((row) => row.includes("^L█"))) {
+        assert(
+          rendered.some((row) => row.includes("◥") || row.includes("◢")),
+          `rendered metadata has no triangle at frame ${shown}`,
+        );
+      }
+    }
   } finally {
     done();
   }
@@ -2203,14 +2312,16 @@ Deno.test("diffcov: the next key ends the reveal", () => {
 Deno.test("diffcov: pager-mode ctrl-l drops a selection that scrolls out of view", () => {
   const { s, done } = tallSession(13);
   try {
-    // The selected line governs only while the user can see it. Scrolling it
-    // off the top hands the decision back to the middle, which is in the
-    // hunk's upper half and so expands upwards — the opposite of what the
-    // selection alone would have chosen.
+    // The selected line is nearer the hunk's bottom edge. Scrolling it off the
+    // top hands the decision back to the quarter-screen target, which is in the
+    // hunk's upper half and expands upwards.
     selectByLabel(s, "L37");
     press(s, "g", "ctrl-l");
     assert(s.view().message.startsWith("Showing line"), s.view().message);
-    assert(s.doc.text.includes("L24"), "the middle decided, not the selection");
+    assert(
+      s.doc.text.includes("L24"),
+      "the quarter-screen target decided, not the selection",
+    );
     assert(!s.doc.text.includes("L45"), "the off-screen selection did not");
   } finally {
     done();
@@ -2233,11 +2344,12 @@ Deno.test("diffcov: pager-mode ctrl-l with a hidden file reports move-to-a-hunk"
   }
 });
 
-Deno.test("diffcov: pager-mode ctrl-l with the file node selected uses the middle", () => {
+Deno.test("diffcov: pager-mode ctrl-l with the file node selected uses the quarter-screen target", () => {
   const { s, done } = tallSession(13);
   try {
     // The file node spans the hunk rather than sitting in it, so it does not
-    // pin the reference line to its own start; the middle still decides.
+    // pin the reference line to its own start. The quarter-screen target still
+    // decides.
     // Selecting scrolls to the node, so scroll to the end after selecting.
     press(s, "tab", "a", "a", "a");
     assert(s.view().selected?.label?.includes("t.ts"), "file node selected");
@@ -2944,6 +3056,22 @@ index 0000000..1111111 100644
  line3
 `;
 
+const JOINABLE_HUNKS_DIFF = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -4,3 +4,3 @@
+ line4
+-OLD5
++line5
+ line6
+@@ -14,3 +14,3 @@
+ line14
+-OLD15
++line15
+ line16
+`;
+
 Deno.test("diffcov: a hunk with neither edge on screen offers nothing to expand", () => {
   const { s, done } = tallSession(13);
   try {
@@ -2969,8 +3097,16 @@ Deno.test("diffcov: a hunk against the top of its file says so", () => {
   const { s, done } = edgeSession(AT_TOP_DIFF, 20, 13);
   try {
     // The hunk starts at file line 1, so its top edge — the nearest one to the
-    // middle — has nowhere to go.
-    assertEquals(s.view().canExpand, false);
+    // expansion target — has nowhere to go.
+    const view = s.view();
+    assertEquals(view.canExpand, false);
+    assertEquals(view.diffAnnotations, []);
+    assert(
+      !renderFrame(s.displayDoc(), view).slice(0, -1).some((row) =>
+        row.endsWith("█")
+      ),
+      "the file boundary has no unpaired block",
+    );
     const before = s.doc.text;
     press(s, "ctrl-l");
     assertEquals(s.view().message, "Top of file.");
@@ -2998,7 +3134,15 @@ index 0000000..1111111 100644
   const { s, done } = edgeSession(diff, 20, 6);
   try {
     press(s, "G");
-    assertEquals(s.view().canExpand, false);
+    const view = s.view();
+    assertEquals(view.canExpand, false);
+    assertEquals(view.diffAnnotations, []);
+    assert(
+      !renderFrame(s.displayDoc(), view).slice(0, -1).some((row) =>
+        row.endsWith("█")
+      ),
+      "the file boundary has no unpaired block",
+    );
     const before = s.doc.text;
     press(s, "ctrl-l");
     assertEquals(s.view().message, "Bottom of file.");
@@ -3011,24 +3155,214 @@ index 0000000..1111111 100644
   }
 });
 
-Deno.test("diffcov: revealing the last line between two hunks joins them", () => {
+Deno.test("diffcov: metadata is not marked without a Ctrl-L edge", () => {
   const diff = `diff --git a/m.ts b/m.ts
+old mode 100644
+new mode 100755
 index 0000000..1111111 100644
 --- a/m.ts
 +++ b/m.ts
-@@ -4,3 +4,3 @@
- line4
--OLD5
-+line5
- line6
-@@ -14,3 +14,3 @@
- line14
--OLD15
-+line15
- line16
+@@ -1,5 +1,5 @@
+-OLD1
++line1
+ line2
+ line3
+-OLD4
++line4
+ line5
+\\ No newline at end of file
 `;
-  const { s, done } = edgeSession(diff, 20, 20);
+  const ws: DiffWorkspace = {
+    resolve: (path) => path,
+    read: () => null,
+  };
+  const { doc, edit } = buildDiffDocument(diff, parseDiff(diff)!, ws);
+  const s = new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 80, height: 20 },
+    undefined,
+    diffSource(ws, edit),
+  );
+  const view = s.view();
+  assertEquals(view.expandMargin, false);
+  assertEquals(view.canExpand, false);
+  assertEquals(view.diffMetadataRows, []);
+});
+
+Deno.test("diffcov: wrapped expansion annotations are stable between frames", () => {
+  const diff = `diff --git a/a.ts b/a.ts
+index 11111111111111111111..222 100644
+--- a/a.ts
++++ b/a.ts
+@@ -2,3 +2,3 @@
+ old_old_old_old_old
+-OLD_OLD_OLD_OLD_OLD
++NEW_NEW_NEW_NEW_NEW
+ tail_tail_tail_tail_tail`;
+  const ws: DiffWorkspace = {
+    resolve: (path) => path,
+    read: () =>
+      "pre\nold_old_old_old_old\nNEW_NEW_NEW_NEW_NEW\n" +
+      "tail_tail_tail_tail_tail\nafter",
+  };
+  const model = parseDiff(diff)!;
+  const { doc, edit } = buildDiffDocument(diff, model, ws);
+  const s = new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 10, height: 3 },
+    undefined,
+    diffSource(ws, edit),
+  );
+  press(s, "\\", ...Array(11).fill("j"));
+
+  const first = s.view();
+  const firstRows = renderFrame(s.displayDoc(), first);
+  const second = s.view();
+  assertEquals(second.top, first.top);
+  assertEquals(second.diffAnnotations, first.diffAnnotations);
+  assertEquals(renderFrame(s.displayDoc(), second), firstRows);
+});
+
+Deno.test("diffcov: a wrapped edge labels only its closest connector", () => {
+  const { s, done } = edgeSession(JOINABLE_HUNKS_DIFF, 20, 10);
   try {
+    s.resize(4, 10);
+    press(s, "\\", ...Array(33).fill("j"));
+    const view = s.view();
+    const annotations = view.diffAnnotations ?? [];
+    const triangle = annotations.find((annotation) =>
+      annotation.kind === "expandDown"
+    );
+    const metadata = annotations.find((annotation) =>
+      annotation.kind === "diffMetadata"
+    );
+    assert(triangle && metadata && view.wrapPlan);
+    assert(
+      view.wrapPlan.lastRow[triangle.line] >
+        view.wrapPlan.firstRow[triangle.line],
+      "the marked edge wraps",
+    );
+    const rendered = renderFrame(s.displayDoc(), view);
+    assertEquals(
+      rendered.filter((row) => row.includes("^L█")).length,
+      1,
+    );
+    const labelRow = view.wrapPlan.firstRow[triangle.line] + 1 - view.top;
+    const metadataRow = view.wrapPlan.firstRow[metadata.line] - view.top;
+    assert(rendered[labelRow].endsWith("^L█"));
+    assert(rendered[metadataRow].endsWith("\\█"));
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a moved annotation reclamps horizontal scrolling", () => {
+  const diff = `diff --git a/a.ts b/a.ts
+index 111..222 100644
+--- a/a.ts
++++ b/a.ts
+@@ -2,3 +2,3 @@ ${"z".repeat(40)}
+ old
+-OLD
++NEW
+ tail`;
+  const ws: DiffWorkspace = {
+    resolve: (path) => path,
+    read: () => "pre\nold\nNEW\ntail\nafter",
+  };
+  const model = parseDiff(diff)!;
+  const { doc, edit } = buildDiffDocument(diff, model, ws);
+  const s = new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 20, height: 7 },
+    undefined,
+    diffSource(ws, edit),
+  );
+  s.view();
+  press(s, ...Array(10).fill("l"));
+  assertEquals(s.view().left, 39);
+
+  press(s, "G");
+  const endView = s.view();
+  assertEquals(
+    endView.diffAnnotations?.find((annotation) =>
+      annotation.kind === "expandDown"
+    )?.line,
+    8,
+  );
+  const connectorRow = s.displayDoc().lines.length - endView.top;
+  assert(
+    renderFrame(s.displayDoc(), endView)[connectorRow].endsWith("^L█"),
+    "the connector adjacent to the final-line triangle labels Ctrl-L",
+  );
+  assertEquals(endView.left, 36);
+  press(s, "l");
+  assertEquals(s.view().left, 36, "right does not move the view backwards");
+});
+
+Deno.test("diffcov: repeated frames reuse the widest-line calculation", () => {
+  const parsed = parseDocument(
+    "ordinary line\n" +
+      "a much longer ordinary line that sets the horizontal limit\n",
+  );
+  let iterations = 0;
+  const lines = new Proxy([...parsed.lines], {
+    get(target, property, receiver) {
+      if (property === Symbol.iterator) {
+        return function* () {
+          iterations++;
+          yield* target;
+        };
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+  const doc = { ...parsed, lines };
+  const source: EditableSource = {
+    label: "width-cache",
+    editable: false,
+    parse: (text) => parseDocument(text),
+    save: () => "",
+    expandContext: () => null,
+  };
+  const s = new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 12, height: 5 },
+    undefined,
+    source,
+  );
+
+  s.view();
+  assertEquals(iterations, 1, "the first frame scans the ordinary lines");
+  s.view();
+  assertEquals(iterations, 1, "the second frame reuses the cached width");
+
+  press(s, "c");
+  assertEquals(iterations, 2, "a new display mode scans the lines once");
+  s.view();
+  assertEquals(iterations, 2, "the new display mode is cached too");
+});
+
+Deno.test("diffcov: revealing the last line between two hunks joins them", () => {
+  const { s, done } = edgeSession(JOINABLE_HUNKS_DIFF, 20, 10);
+  try {
+    lastFullPage(s);
+    const view = s.view();
+    assertEquals(view.expandUp, false);
+    assertEquals(
+      s.displayDoc().lines[view.expandRow!].text,
+      " line6",
+      "the first hunk's last body line carries the triangle",
+    );
+    assertEquals(
+      view.diffMetadataRows?.map((row) => s.displayDoc().lines[row]?.text),
+      ["@@ -14,3 +14,3 @@"],
+      "only the next hunk header carries the adjacent block",
+    );
     press(s, "ctrl-l"); // reveals the seven lines between the two hunks
     // Nothing is left between them, so the header that sat there described no
     // gap at all: one hunk covering both ranges takes its place.
@@ -3068,8 +3402,9 @@ index 0000000..1111111 100644
 +DIFFERENT15
  line16
 `;
-  const { s, done } = edgeSession(diff, 20, 20);
+  const { s, done } = edgeSession(diff, 20, 10);
   try {
+    lastFullPage(s);
     press(s, "ctrl-l");
     assertEquals(
       parseDiff(s.doc.text)!.files.flatMap((f) => f.hunks).length,
@@ -3097,13 +3432,80 @@ index 0000000..1111111 100644
 @@ -9,0 +10,1 @@
 +line10
 `;
-  const { s, done } = edgeSession(diff, 20, 4);
+  const { s, done } = edgeSession(diff, 20, 2);
   try {
-    press(s, "G"); // the middle of what is left lands on the bottom edge
+    selectByLabel(s, "@@");
+    press(s, "j"); // the header scrolls off while the sole body line remains
+    const view = s.view();
+    assertEquals(view.top, 5);
+    assertEquals(view.selected?.kind, "hunk");
+    assertEquals(view.expandRow, 5, "the sole body line is marked");
+    assertEquals(s.displayDoc().lines[view.expandRow!].text, "+line10");
     press(s, "ctrl-l");
     assert(s.view().message.startsWith("Showing line"), s.view().message);
     assert(s.doc.text.includes(" line11"), "revealed below the hunk");
     assert(!s.doc.text.includes(" line9"), "did not reveal above it");
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a header-only hunk expands without putting its triangle on the header", () => {
+  const diff = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -1,0 +2 @@
++line2
+`;
+  const { s, done } = edgeSession(diff, 20, 8);
+  try {
+    toLine(s, 5);
+    press(s, "end");
+    for (let i = 0; i < "line2".length + 1; i++) press(s, "backspace");
+    press(s, "escape");
+    assert(s.doc.text.includes("@@ -1,0 +1,0 @@"), s.doc.text);
+    assertEquals(s.view().canExpand, true, "the empty hunk can still expand");
+    assertEquals(
+      s.view().expandRow,
+      null,
+      "the header has no expansion triangle",
+    );
+    const before = s.doc.text;
+    press(s, "ctrl-l");
+    assert(s.doc.text !== before, "Ctrl-L expands the empty hunk");
+    assert(s.doc.text.includes(" line1"), s.doc.text);
+  } finally {
+    done();
+  }
+});
+
+Deno.test("diffcov: a header-only hunk at file top expands downward", () => {
+  const diff = `diff --git a/m.ts b/m.ts
+index 0000000..1111111 100644
+--- a/m.ts
++++ b/m.ts
+@@ -0,0 +1 @@
++line1
+`;
+  const { s, done } = edgeSession(diff, 20, 8);
+  try {
+    toLine(s, 5);
+    press(s, "end");
+    for (let i = 0; i < "line1".length + 1; i++) press(s, "backspace");
+    press(s, "escape");
+    assertEquals(
+      s.view().expandRow,
+      null,
+      "the header has no expansion triangle",
+    );
+    assertEquals(s.view().canExpand, true, "context below is available");
+    press(s, "ctrl-l");
+    assert(s.doc.text.includes(" line1"), s.doc.text);
+    assert(
+      s.view().message.includes("below the hunk"),
+      s.view().message,
+    );
   } finally {
     done();
   }
@@ -3148,9 +3550,10 @@ index 0000000..1111111 100644
 +line15
  line16
 `;
-  const { s, done } = edgeSession(diff, 20, 20);
+  const { s, done } = edgeSession(diff, 20, 10);
   try {
     // A header disappearing is otherwise left to be puzzled over.
+    lastFullPage(s);
     press(s, "ctrl-l");
     assertEquals(
       s.view().message,

--- a/packages/cli/test/view-session.test.ts
+++ b/packages/cli/test/view-session.test.ts
@@ -133,7 +133,10 @@ Deno.test("session: a trailing diff newline is not a padded content row", () => 
   const rows = renderFrame(s.displayDoc(), s.view());
   assertEquals(rows[0].trim(), "done");
   assertEquals(rows[1].trim(), "☙   ❦   ❧");
-  assert(rows.at(-1)!.includes("END"), "the content limit is the diff end");
+  assert(
+    rows.at(-1)!.includes("1-1/1  END"),
+    "the hidden terminator is absent from the status",
+  );
 });
 
 Deno.test("session: edit-mode scrolling keeps the ordinary document limit", () => {

--- a/packages/cli/test/view-session.test.ts
+++ b/packages/cli/test/view-session.test.ts
@@ -980,6 +980,10 @@ Deno.test("session: the help overlay documents file folding and scrolling", () =
   assert(text.includes("hide test"), "documents hiding test files");
   assert(text.includes("wrap / unwrap long lines"), "documents line wrapping");
   assert(
+    text.includes("reveal more context at the marked edge"),
+    "documents the pager's Ctrl-L marker",
+  );
+  assert(
     ov.footer.includes("scroll"),
     `footer advertises scrolling: ${ov.footer}`,
   );

--- a/packages/cli/test/view-session.test.ts
+++ b/packages/cli/test/view-session.test.ts
@@ -980,8 +980,11 @@ Deno.test("session: the help overlay documents file folding and scrolling", () =
   assert(text.includes("hide test"), "documents hiding test files");
   assert(text.includes("wrap / unwrap long lines"), "documents line wrapping");
   assert(
-    text.includes("reveal more context at the marked edge"),
-    "documents the pager's Ctrl-L marker",
+    ov.lines.some((line) =>
+      line.text.includes("^L") &&
+      line.text.includes("reveal more context at the marked edge")
+    ),
+    "documents the pager's Ctrl-L marker and its key",
   );
   assert(
     ov.footer.includes("scroll"),

--- a/packages/cli/test/view-session.test.ts
+++ b/packages/cli/test/view-session.test.ts
@@ -113,6 +113,29 @@ Deno.test("session: a diff leaves three quarters below the final line", () => {
   assertEquals(s.view().top, 10, "down stops at the padded diff end");
 });
 
+Deno.test("session: a trailing diff newline is not a padded content row", () => {
+  const source: EditableSource = {
+    label: null,
+    isDiff: true,
+    editable: false,
+    parse: (next) => parseDocument(next),
+    save: () => "",
+  };
+  const s = new Session(
+    parseDocument("done\n"),
+    { color: false, showLineNumbers: false },
+    { width: 30, height: 5 },
+    undefined,
+    source,
+  );
+  press(s, "G");
+  assertEquals(s.view().top, 0);
+  const rows = renderFrame(s.displayDoc(), s.view());
+  assertEquals(rows[0].trim(), "done");
+  assertEquals(rows[1].trim(), "☙   ❦   ❧");
+  assert(rows.at(-1)!.includes("END"), "the content limit is the diff end");
+});
+
 Deno.test("session: edit-mode scrolling keeps the ordinary document limit", () => {
   const text = Array.from({ length: 12 }, (_, i) => `line ${i}`).join("\n");
   const source: EditableSource = {

--- a/packages/cli/test/view-session.test.ts
+++ b/packages/cli/test/view-session.test.ts
@@ -1,8 +1,11 @@
 import { assert, assertEquals } from "@std/assert";
 import { parseDocument, SAMPLE } from "./view-helpers.ts";
+import { renderFrame } from "../lib/view/render.ts";
 import { Session } from "../lib/view/session.ts";
-import { frameTop } from "../lib/view/actions.ts";
+import { frameTop, maxTop } from "../lib/view/actions.ts";
 import { buildPeekCard } from "../lib/view/card.ts";
+import type { CardTarget } from "../lib/view/card.ts";
+import type { EditableSource } from "../lib/view/editsource.ts";
 import type { Key } from "../lib/view/keys.ts";
 import type { Semantics } from "../lib/view/languages/language.ts";
 
@@ -24,6 +27,28 @@ function press(session: Session, ...names: string[]): void {
   }
 }
 
+function expandableSession(
+  text: string,
+  width: number,
+  editable = false,
+): Session {
+  const source: EditableSource = {
+    label: null,
+    isDiff: true,
+    editable,
+    parse: (next) => parseDocument(next),
+    save: () => "",
+    expandContext: () => null,
+  };
+  return new Session(
+    parseDocument(text),
+    { color: false, showLineNumbers: false },
+    { width, height: 4 },
+    undefined,
+    source,
+  );
+}
+
 Deno.test("session: vertical scrolling and clamping", () => {
   // j/k scroll the pager (bare arrows scroll too; edit mode is entered with e).
   const s = makeSession();
@@ -42,6 +67,74 @@ Deno.test("session: vertical scrolling and clamping", () => {
   assertEquals(s.view().top, 0);
 });
 
+Deno.test("session: an ordinary file ends at the bottom of the viewport", () => {
+  const text = Array.from({ length: 12 }, (_, i) => `line ${i}`).join("\n");
+  const s = new Session(
+    parseDocument(text),
+    { color: false, showLineNumbers: false },
+    { width: 30, height: 9 },
+  );
+  press(s, "G");
+  assertEquals(s.view().top, maxTop(s.doc.lines.length, s.view().height));
+  const rows = renderFrame(s.displayDoc(), s.view());
+  assertEquals(rows[7].trim(), "line 11");
+  assert(
+    !rows.some((row) => /[☙❦❧]/u.test(row)),
+    "ordinary files omit the end mark",
+  );
+  press(s, "j");
+  assertEquals(s.view().top, 4, "down stops with the last line at the bottom");
+});
+
+Deno.test("session: a diff leaves three quarters below the final line", () => {
+  const text = Array.from({ length: 12 }, (_, i) => `line ${i}`).join("\n");
+  const source: EditableSource = {
+    label: null,
+    isDiff: true,
+    editable: false,
+    parse: (next) => parseDocument(next),
+    save: () => "",
+  };
+  const s = new Session(
+    parseDocument(text),
+    { color: false, showLineNumbers: false },
+    { width: 30, height: 9 },
+    undefined,
+    source,
+  );
+  press(s, "G");
+  assertEquals(s.view().top, 10);
+  const rows = renderFrame(s.displayDoc(), s.view());
+  assertEquals(rows[1].trim(), "line 11");
+  assertEquals(rows[2].trim(), "☙   ❦   ❧");
+  assertEquals(rows[3].trim(), "☙   ❧");
+  assertEquals(rows[4].trim(), "❦");
+  press(s, "j");
+  assertEquals(s.view().top, 10, "down stops at the padded diff end");
+});
+
+Deno.test("session: edit-mode scrolling keeps the ordinary document limit", () => {
+  const text = Array.from({ length: 12 }, (_, i) => `line ${i}`).join("\n");
+  const source: EditableSource = {
+    label: null,
+    editable: true,
+    parse: (next) => parseDocument(next),
+    save: () => "",
+  };
+  const s = new Session(
+    parseDocument(text),
+    { color: false, showLineNumbers: false },
+    { width: 30, height: 9 },
+    undefined,
+    source,
+  );
+  press(s, "e");
+  for (let i = 0; i < 20; i++) {
+    s.handleKey({ name: "down", alt: true });
+  }
+  assertEquals(s.view().top, maxTop(s.doc.lines.length, s.view().height));
+});
+
 Deno.test("session: horizontal scrolling", () => {
   const s = makeSession();
   press(s, "l");
@@ -50,6 +143,99 @@ Deno.test("session: horizontal scrolling", () => {
   assertEquals(s.view().left, 0);
   press(s, "h");
   assertEquals(s.view().left, 0, "left clamps at 0");
+});
+
+Deno.test("session: lines without diff annotations use the full width", () => {
+  const s = expandableSession("abcde", 7);
+  assertEquals(renderFrame(s.displayDoc(), s.view())[0], "abcde  ");
+  press(s, "l");
+  assertEquals(s.view().left, 0);
+  assertEquals(renderFrame(s.displayDoc(), s.view())[0], "abcde  ");
+});
+
+Deno.test("session: full-width lines count displayed cells", () => {
+  const cases = [
+    { text: "😀😀😀😀😀", displayModeKeys: 0, expected: "😀😀😀😀😀  " },
+    {
+      text: "\x1b[31mabcde\x1b[0m",
+      displayModeKeys: 1,
+      expected: "abcde  ",
+    },
+  ];
+  for (const { text, displayModeKeys, expected } of cases) {
+    const s = expandableSession(text, 7);
+    for (let i = 0; i < displayModeKeys; i++) press(s, "c");
+    press(s, "l", "l");
+    assertEquals(s.view().left, 0);
+    assertEquals(renderFrame(s.displayDoc(), s.view())[0], expected);
+  }
+});
+
+Deno.test("session: search keeps a fitting unannotated match in place", () => {
+  const s = expandableSession("abcdX", 7);
+  press(s, "/", "X", "enter");
+  assertEquals(s.view().left, 0);
+  assertEquals(renderFrame(s.displayDoc(), s.view())[0], "abcdX  ");
+});
+
+Deno.test("session: a card jump uses the full unannotated width", () => {
+  const s = expandableSession("abcdX", 7);
+  const target: CardTarget = {
+    cardLine: 0,
+    destLine: 0,
+    destCol: 4,
+  };
+  const jump = s as unknown as {
+    jumpToTarget(target: CardTarget): void;
+  };
+  jump.jumpToTarget(target);
+  assertEquals(s.view().left, 0);
+  assertEquals(renderFrame(s.displayDoc(), s.view())[0], "▶abcdX ");
+});
+
+Deno.test("session: clearing a selection clamps expansion-margin panning", () => {
+  const s = expandableSession("const x = 123456789;", 5);
+  press(s, "tab");
+  assert(s.view().selected, "a guide is present");
+  press(s, ...Array(25).fill("l"));
+  const withGuide = s.view().left;
+  press(s, "escape");
+  assertEquals(s.view().left, withGuide - 1);
+  const atRightEdge = s.view().left;
+  press(s, "l");
+  assertEquals(s.view().left, atRightEdge, "right does not move left");
+});
+
+Deno.test("session: removing the gutter clamps expansion-margin panning", () => {
+  const s = expandableSession("abcdefghijklmnopqrst", 10);
+  press(s, "#");
+  for (let i = 0; i < 10; i++) press(s, "l");
+  const withGutter = s.view().left;
+  press(s, "#", "#");
+  assertEquals(s.view().left, withGutter - 4);
+  const atRightEdge = s.view().left;
+  press(s, "l");
+  assertEquals(s.view().left, atRightEdge, "right does not move left");
+});
+
+Deno.test("session: leaving edit mode clamps expansion-margin panning", () => {
+  const s = expandableSession("abcdefghijklmnopqrst", 10, true);
+  press(s, "e", "end", "left");
+  for (let i = 0; i < 10; i++) {
+    s.handleKey({ name: "right", alt: true });
+  }
+  assertEquals(s.view().left, 20, "edit mode retains ordinary panning");
+  press(s, "escape");
+  assertEquals(s.view().left, 10);
+  press(s, "l");
+  assertEquals(s.view().left, 10, "right does not move left");
+});
+
+Deno.test("session: leaving edit mode keeps the former cursor column visible", () => {
+  const s = expandableSession("abcde", 7, true);
+  press(s, "e", "right", "right", "right", "right", "escape");
+  assertEquals(s.view().left, 0);
+  assertEquals(renderFrame(s.displayDoc(), s.view())[0], "abcde  ");
 });
 
 Deno.test("session: backslash toggles wrapping and continuation-row scrolling", () => {
@@ -117,7 +303,7 @@ Deno.test("session: a gutter-width change reflows wrapped rows around the anchor
   assert(s.view().showLineNumbers, "line numbers are on");
 });
 
-Deno.test("session: removing a gutter clamps a wrapped view that now fits", () => {
+Deno.test("session: removing a gutter reclamps a wrapped ordinary end", () => {
   const doc = parseDocument("abcdefghijklmnopqrst");
   const s = new Session(
     doc,
@@ -125,9 +311,15 @@ Deno.test("session: removing a gutter clamps a wrapped view that now fits", () =
     { width: 8, height: 4 },
   );
   press(s, "\\", "#", "G");
-  assertEquals(s.view().top, 4);
+  assertEquals(
+    s.view().top,
+    maxTop(s.view().wrapPlan!.rowCount, s.view().height),
+  );
   press(s, "#", "#");
-  assertEquals(s.view().top, 0, "the wider view is clamped to its only page");
+  assertEquals(
+    s.view().top,
+    maxTop(s.view().wrapPlan!.rowCount, s.view().height),
+  );
 });
 
 Deno.test("session: search reveals the wrapped row containing the match", () => {
@@ -496,12 +688,15 @@ Deno.test("session: a search reveal in a compacting mode scrolls to the display 
   assert(left > 0 && left <= 42, `reveal used a display column, left=${left}`);
 });
 
-Deno.test("session: resize reclamps scroll", () => {
+Deno.test("session: resize reclamps scroll to the ordinary end", () => {
   const s = makeSession();
   press(s, "G");
   const bottomTop = s.view().top;
   s.resize(80, 100); // taller than the doc
-  assertEquals(s.view().top, 0, "growing the viewport pulls top back to 0");
+  assertEquals(
+    s.view().top,
+    maxTop(s.displayDoc().lines.length, 100),
+  );
   assert(bottomTop >= 0);
 });
 

--- a/packages/cli/test/view-wrap.test.ts
+++ b/packages/cli/test/view-wrap.test.ts
@@ -4,6 +4,7 @@ import {
   buildWrapPlan,
   fitWrapChrome,
   wrappedRowAt,
+  wrappedRowForPosition,
 } from "../lib/view/wrap.ts";
 
 Deno.test("wrap layout: retains room for source text and a marker", () => {
@@ -32,11 +33,56 @@ Deno.test("wrap plan: splits long lines and keeps empty lines", () => {
   assertEquals(
     Array.from({ length: plan.rowCount }, (_, row) => wrappedRowAt(plan, row)),
     [
-      { line: 0, offset: 0, lastOffset: 6 },
-      { line: 0, offset: 3, lastOffset: 6 },
-      { line: 0, offset: 6, lastOffset: 6 },
-      { line: 1, offset: 0, lastOffset: 0 },
-      { line: 2, offset: 0, lastOffset: 0 },
+      {
+        row: 0,
+        line: 0,
+        offset: 0,
+        lastOffset: 6,
+        sourceWidth: 3,
+        continues: true,
+        wrapMarker: true,
+        suffixWidth: 0,
+      },
+      {
+        row: 1,
+        line: 0,
+        offset: 3,
+        lastOffset: 6,
+        sourceWidth: 3,
+        continues: true,
+        wrapMarker: true,
+        suffixWidth: 0,
+      },
+      {
+        row: 2,
+        line: 0,
+        offset: 6,
+        lastOffset: 6,
+        sourceWidth: 4,
+        continues: false,
+        wrapMarker: false,
+        suffixWidth: 0,
+      },
+      {
+        row: 3,
+        line: 1,
+        offset: 0,
+        lastOffset: 0,
+        sourceWidth: 4,
+        continues: false,
+        wrapMarker: false,
+        suffixWidth: 0,
+      },
+      {
+        row: 4,
+        line: 2,
+        offset: 0,
+        lastOffset: 0,
+        sourceWidth: 4,
+        continues: false,
+        wrapMarker: false,
+        suffixWidth: 0,
+      },
     ],
   );
   assertEquals(plan.rowWidth, 4);
@@ -50,9 +96,14 @@ Deno.test("wrap plan: exact-width lines do not add an empty row", () => {
   const plan = buildWrapPlan(doc.lines, "pictures", 4);
   assertEquals(plan.rowCount, 1);
   assertEquals(wrappedRowAt(plan, 0), {
+    row: 0,
     line: 0,
     offset: 0,
     lastOffset: 0,
+    sourceWidth: 4,
+    continues: false,
+    wrapMarker: false,
+    suffixWidth: 0,
   });
 });
 
@@ -63,15 +114,167 @@ Deno.test("wrap plan: a non-positive width behaves as one column", () => {
   assertEquals(plan.rowWidth, 1);
   assertEquals(plan.rowStride, 1);
   assertEquals(wrappedRowAt(plan, 0), {
+    row: 0,
     line: 0,
     offset: 0,
     lastOffset: 1,
+    sourceWidth: 1,
+    continues: true,
+    wrapMarker: false,
+    suffixWidth: 0,
   });
   assertEquals(wrappedRowAt(plan, 1), {
+    row: 1,
     line: 0,
     offset: 1,
     lastOffset: 1,
+    sourceWidth: 1,
+    continues: false,
+    wrapMarker: false,
+    suffixWidth: 0,
   });
+});
+
+Deno.test("wrap plan: a triangle reserves only its annotated line", () => {
+  const doc = parseDocument("abcdefghij\n1234567");
+  const plan = buildWrapPlan(
+    doc.lines,
+    "pictures",
+    7,
+    new Map([[0, { firstWidth: 1, continuationWidth: 1 }]]),
+  );
+
+  assertEquals(plan.firstRow, [0, 2]);
+  assertEquals(plan.lastRow, [1, 2]);
+  assertEquals(wrappedRowAt(plan, 0), {
+    row: 0,
+    line: 0,
+    offset: 0,
+    lastOffset: 5,
+    sourceWidth: 5,
+    continues: true,
+    wrapMarker: true,
+    suffixWidth: 1,
+  });
+  assertEquals(wrappedRowAt(plan, 1), {
+    row: 1,
+    line: 0,
+    offset: 5,
+    lastOffset: 5,
+    sourceWidth: 6,
+    continues: false,
+    wrapMarker: false,
+    suffixWidth: 1,
+  });
+  assertEquals(wrappedRowAt(plan, 2)?.sourceWidth, 7);
+});
+
+Deno.test("wrap plan: the first continuation can hold a wider label", () => {
+  const doc = parseDocument("abcdefghij");
+  const plan = buildWrapPlan(
+    doc.lines,
+    "pictures",
+    7,
+    new Map([[
+      0,
+      {
+        firstWidth: 1,
+        firstContinuationWidth: 3,
+        continuationWidth: 1,
+      },
+    ]]),
+  );
+
+  assertEquals(plan.rowCount, 3);
+  assertEquals(
+    Array.from({ length: 3 }, (_, row) => wrappedRowAt(plan, row)),
+    [
+      {
+        row: 0,
+        line: 0,
+        offset: 0,
+        lastOffset: 8,
+        sourceWidth: 5,
+        continues: true,
+        wrapMarker: true,
+        suffixWidth: 1,
+      },
+      {
+        row: 1,
+        line: 0,
+        offset: 5,
+        lastOffset: 8,
+        sourceWidth: 3,
+        continues: true,
+        wrapMarker: true,
+        suffixWidth: 3,
+      },
+      {
+        row: 2,
+        line: 0,
+        offset: 8,
+        lastOffset: 8,
+        sourceWidth: 6,
+        continues: false,
+        wrapMarker: false,
+        suffixWidth: 1,
+      },
+    ],
+  );
+  assertEquals(wrappedRowForPosition(plan, 0, 4)?.row, 0);
+  assertEquals(wrappedRowForPosition(plan, 0, 5)?.row, 1);
+  assertEquals(wrappedRowForPosition(plan, 0, 8)?.row, 2);
+});
+
+Deno.test("wrap plan: a metadata label connects through continuation rows", () => {
+  const doc = parseDocument("abcdefghij");
+  const plan = buildWrapPlan(
+    doc.lines,
+    "pictures",
+    7,
+    new Map([[0, { firstWidth: 3, continuationWidth: 1 }]]),
+  );
+
+  assertEquals(plan.rowCount, 3);
+  assertEquals(
+    Array.from({ length: 3 }, (_, row) => wrappedRowAt(plan, row)),
+    [
+      {
+        row: 0,
+        line: 0,
+        offset: 0,
+        lastOffset: 8,
+        sourceWidth: 3,
+        continues: true,
+        wrapMarker: true,
+        suffixWidth: 3,
+      },
+      {
+        row: 1,
+        line: 0,
+        offset: 3,
+        lastOffset: 8,
+        sourceWidth: 5,
+        continues: true,
+        wrapMarker: true,
+        suffixWidth: 1,
+      },
+      {
+        row: 2,
+        line: 0,
+        offset: 8,
+        lastOffset: 8,
+        sourceWidth: 6,
+        continues: false,
+        wrapMarker: false,
+        suffixWidth: 1,
+      },
+    ],
+  );
+  assertEquals(wrappedRowForPosition(plan, 0, 2)?.row, 0);
+  assertEquals(wrappedRowForPosition(plan, 0, 3)?.row, 1);
+  assertEquals(wrappedRowForPosition(plan, 0, 8)?.row, 2);
+  assertEquals(wrappedRowForPosition(plan, 0, 100)?.row, 2);
 });
 
 Deno.test("wrap plan: uses the active non-printable display mode", () => {


### PR DESCRIPTION
Show which hunk edge the next Ctrl-L will expand by choosing the edge nearest one quarter down the visible content. Draw a directional triangle on the first or last hunk body line, never on the hunk header. Put a Ctrl-L label and connecting block on adjacent diff metadata in the wrap-marker color.

Make the annotation margin specific to each rendered line so ordinary text keeps the full terminal width. In wrap mode, align the backslash with the annotation column and place it before labels or triangles. Carry connectors through wrapped continuations and below the diff only when they connect to a final downward triangle, with one Ctrl-L label on the connector nearest the triangle.

Let diff views scroll until their final row reaches the top quarter of the screen, then draw a centered gray cul-de-lampe after the document. Keep ordinary files clamped with their final row at the bottom of the viewport and omit the ornament. Apply the same mode-specific boundary to wrapping, viewport reframing, and END reporting for editable and read-only diffs.

Preserve viewport anchors, selections, and held expansion edges when transient annotations change wrapped geometry. Cache ordinary-line width calculations so repeated frames do not rescan the diff.

Regression coverage exercises edge selection, file boundaries, wrapping, narrow terminals, reveal frames, scrolling, connectors, end marks, ordinary files, stable layout, and cache reuse.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guide Ctrl‑L in the pager by marking the exact diff edge that will expand and keeping it anchored one quarter down the viewport. Diff paging ignores a trailing newline, scrolls until the last row reaches the top quarter, and shows a centered gray end mark for diffs.

- New Features
  - Visual hint: directional triangle on the nearest hunk body line; adjacent metadata shows a “Ctrl‑L” label.
  - Per‑line annotation margin so plain text uses full width; wrap marker aligns with the margin before labels/triangles.
  - Connector lines span wrapped rows and extend below the diff only for a final downward triangle, with one nearby label.
  - Keep anchors, selections, and chosen expansion edges stable when annotations reflow; cache ordinary‑line widths to avoid rescans.

- Bug Fixes
  - Read‑only diffs: place the end ornament immediately after real content; treat a trailing empty line as padding for scroll limits and END.
  - Pager status for read‑only diffs omits the parser’s trailing terminator from range, total, and percentage.
  - Edge selection keeps the Ctrl‑L target at one quarter of the content area even when the diff is shorter than the viewport.
  - Non‑diff files stay clamped at the bottom; folded‑file summaries suppress hidden triangles and metadata labels.
  - Help panel names the marked edge so guidance matches the on‑screen marker.

<sup>Written for commit 3077f87c483de20606052543653f3dbe7a4c8f33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

