### PR TITLE
feat(memory): drop connections on hello protocol mismatch

### DIFF
--- a/docs/development/authorization-failure-surfacing.md
+++ b/docs/development/authorization-failure-surfacing.md
@@ -18,10 +18,10 @@ never will. A `session.open` is denied for one of two kinds of reason:
   stale signed `exp`. Each reconnect runs a fresh `hello` that issues a new
   challenge, so these do not recur — a token-refresh window or a challenge race
   heals on the next attempt.
-- **Permanent.** An audience or protocol mismatch, a malformed invocation, or an
-  ACL capability shortfall (the principal lacks `READ`, a malformed or ownerless
-  ACL, a genesis requirement). The same configuration or ACL state produces the
-  same denial every time.
+- **Permanent.** An audience or signed `session.open.args.protocol` mismatch, a
+  malformed invocation, or an ACL capability shortfall (the principal lacks
+  `READ`, a malformed or ownerless ACL, a genesis requirement). The same
+  configuration or ACL state produces the same denial every time.
 
 The server marks the recoverable subset with `retriable: true` on the
 `AuthorizationError` response (see
@@ -41,16 +41,23 @@ is read as permanent — the safe default for an authorization decision.
   `session.open` itself or the watch re-establishment a fresh (non-resumed)
   reopen issues. Sessions for other spaces on the same client keep running: a
   denial on one space is not a client-wide failure.
-- A **retriable** authorization race and every transport-level disconnect retry,
-  so a transient blip or a fresh-challenge race heals.
-- A **permanent protocol-flag mismatch at `hello`** — the peers disagree on a
-  data-model wire contract, so no session can open at all — stops the whole
-  reconnect loop and is remembered, so every request on that
-  fundamentally-incompatible transport fails fast with the real error.
+- A **retriable** authorization race and ordinary transport-level disconnect
+  retry, so a transient blip or a fresh-challenge race heals.
+- An **exact protocol identifier mismatch at `hello`** is client-wide and
+  permanent. A current server closes the WebSocket with code `1002` without a
+  response; a pre-`memory/v2.1` server returns its typed
+  `UnsupportedProtocol` rejection. The client recognizes both signals, closes
+  the transport when it is still open, and remembers the failure so it does not
+  reconnect forever.
+- A **capability-flag mismatch at `hello`** is also client-wide and permanent,
+  but remains on the finer-grained typed-error path. The peers agree on the
+  exact protocol identifier but disagree on a required data-model wire
+  capability, so no session can open.
 
 The reconnect loop therefore has no unbounded retry-on-anything path: a permanent
 failure ends it (per session for an authorization denial, client-wide for a
-handshake mismatch), and only recoverable and transport-level conditions retry.
+handshake mismatch), and only recoverable conditions and ordinary
+transport-level disconnects retry.
 
 ## Runner storage: record it per space, keep the barrier silent
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -17,6 +17,8 @@ rewrite. In particular:
 
 - the handshake is `hello` / `hello.ok`, not a bare `{ "protocol": ... }`
   declaration
+- the handshake carries an exact, versioned protocol identifier; either peer
+  drops the connection without a response when that identifier does not match
 - request messages are plain JSON envelopes; transport-level UCAN framing
   remains deferred for this pass
 - the toolshed v2 websocket route requires a signed `session.open`
@@ -48,7 +50,7 @@ The client MUST declare its protocol version in the first WebSocket message:
 ```json
 {
   "type": "hello",
-  "protocol": "memory",
+  "protocol": "memory/v2.1",
   "flags": {
     "modernCellRep": true,
     "persistentSchedulerState": true,
@@ -65,7 +67,7 @@ If the server accepts the protocol, it returns:
 ```json
 {
   "type": "hello.ok",
-  "protocol": "memory",
+  "protocol": "memory/v2.1",
   "flags": {
     "modernCellRep": true,
     "persistentSchedulerState": true,
@@ -84,9 +86,14 @@ If the server accepts the protocol, it returns:
 }
 ```
 
-If the server does not support the requested version or the required data-model
-flags do not match what it implements, it returns a typed error response and
-does not mark the connection ready.
+The versioned `protocol` identifier is an exact compatibility boundary. If it
+does not match, the recipient closes the WebSocket without sending a handshake
+response. This is reserved for changes where the two versions cannot
+interoperate safely.
+
+Capability flags remain the finer-grained compatibility mechanism. If required
+data-model flags do not match what the server implements, it returns a typed
+error response and does not mark the connection ready.
 
 Memory hosts include `sessionOpen.audience` and `sessionOpen.challenge` in
 `hello.ok`. The audience is the server DID the client must sign for. Toolshed
@@ -185,7 +192,7 @@ interface SessionOpenInvocation {
   sub: SpaceId;
   aud: DID;
   args: {
-    protocol: "memory";
+    protocol: "memory/v2.1";
     session: {
       sessionId?: SessionId;
       seenSeq?: number;
@@ -265,7 +272,7 @@ semantic commit body. Per-commit signed UCAN envelopes remain deferred.
 // Shown at module scope.
 interface HelloMessage {
   type: "hello";
-  protocol: "memory";
+  protocol: "memory/v2.1";
   flags: {
     modernCellRep: boolean;
     persistentSchedulerState?: boolean;

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -86,10 +86,29 @@ If the server accepts the protocol, it returns:
 }
 ```
 
-The versioned `protocol` identifier is an exact compatibility boundary. If it
-does not match, the recipient closes the WebSocket without sending a handshake
-response. This is reserved for changes where the two versions cannot
-interoperate safely.
+The versioned `protocol` identifier is an explicit compatibility boundary. The
+current implementation accepts only `memory/v2.1`; for every other identifier,
+the recipient closes the WebSocket without sending a handshake response.
+
+Future implementations may accept multiple exact protocol identifiers. An
+accepted identifier means the recipient implements that identifier's complete
+wire contract, either natively or through a compatibility adapter. The client
+still proposes one identifier, `hello.ok` echoes that identifier, and signed
+`session.open.args.protocol` binds the session to it. Accepting multiple
+identifiers is therefore not an implicit downgrade negotiation.
+
+For an identifier outside the accepted set, the failure mode depends on the
+compatibility boundary:
+
+- if the recipient understands enough of that identifier's handshake framing
+  to know that the peer can safely decode a structured response, it may return
+  a typed `UnsupportedProtocol` rejection
+- if the versions cannot safely exchange even that structured response, the
+  recipient closes the connection without one
+
+Removing an identifier from the accepted set is how a breaking change
+establishes the latter, hard boundary. Adding compatibility for a known
+identifier does not weaken the close behavior for unknown or unsafe versions.
 
 Capability flags remain the finer-grained compatibility mechanism. If required
 data-model flags do not match what the server implements, it returns a typed

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -250,9 +250,13 @@ Rules:
   `retriable` is permanent: the client stops reopening that session and
   terminates it with the real error rather than retrying the identical handshake
   forever. A `retriable` authorization race (an expired, used, or mismatched
-  challenge; a stale signed `exp`) and every transport-level disconnect still
-  retry, so a transient blip or a fresh-challenge race heals. A permanent
-  protocol-flag mismatch at `hello` ends the whole connection the same way. See
+  challenge; a stale signed `exp`) and ordinary transport-level disconnects
+  still retry, so a transient blip or a fresh-challenge race heals. An exact
+  protocol identifier mismatch at `hello` is instead client-wide and permanent:
+  current servers close with WebSocket code `1002`, while pre-`memory/v2.1`
+  servers return a typed `UnsupportedProtocol` rejection. A capability-flag
+  mismatch at `hello` also ends the whole connection, but stays on the typed
+  handshake-error path. See
   [`../../development/authorization-failure-surfacing.md`](../../development/authorization-failure-surfacing.md)
   for how the client, the runner storage layer, and the CLI act on this
   classification end to end.
@@ -321,10 +325,12 @@ interface ResponseMessage<Result> {
     // On an AuthorizationError, present and `true` when the denial is an
     // anti-replay handshake race a fresh reconnect heals (an expired, used, or
     // mismatched connection challenge; a stale signed `exp`). Absent marks a
-    // permanent denial — an audience or protocol mismatch, or an ACL capability
-    // shortfall — that no retry changes. The client uses it to decide whether to
-    // keep reopening a denied session or to terminate it. An older server sends
-    // no marker, so its AuthorizationError is read as permanent.
+    // permanent denial — an audience or signed session.open.args.protocol
+    // mismatch, or an ACL capability shortfall — that no retry changes. This is
+    // distinct from the exact protocol identifier and capability flags
+    // negotiated by `hello`. The client uses this marker to decide whether to
+    // keep reopening a denied session or terminate it. An older server sends no
+    // marker, so its AuthorizationError is read as permanent.
     retriable?: boolean;
   };
 }

--- a/packages/memory/test/v2-client-reconnect-auth-test.ts
+++ b/packages/memory/test/v2-client-reconnect-auth-test.ts
@@ -11,6 +11,7 @@ import {
   permanentProtocolError,
   type Transport,
 } from "../v2/client.ts";
+import { respondToHello } from "../v2/handshake.ts";
 
 const TEST_AUDIENCE = "did:key:z6Mk-reconnect-auth-audience";
 
@@ -295,9 +296,10 @@ Deno.test(
  * data-model flag, the permanent handshake failure.
  */
 class FlagMismatchOnReconnectTransport implements Transport {
+  helloCount = 0;
+  closeCount = 0;
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
-  #helloCount = 0;
 
   setReceiver(receiver: (payload: string) => void): void {
     this.#receiver = receiver;
@@ -318,13 +320,21 @@ class FlagMismatchOnReconnectTransport implements Transport {
     };
     switch (message.type) {
       case "hello": {
-        this.#helloCount += 1;
+        this.helloCount += 1;
         const flags = getMemoryProtocolFlags();
-        this.#respond(
-          this.#helloCount === 1
-            ? helloOk()
-            : helloOk({ ...flags, modernCellRep: !flags.modernCellRep }),
-        );
+        if (this.helloCount === 1) {
+          this.#respond(helloOk());
+        } else {
+          const response = respondToHello({
+            type: "hello",
+            protocol: MEMORY_PROTOCOL,
+            flags: { ...flags, modernCellRep: !flags.modernCellRep },
+          });
+          if (response === null) {
+            throw new Error("Flag mismatch unexpectedly closed the connection");
+          }
+          this.#respond(response);
+        }
         return Promise.resolve();
       }
       case "session.open":
@@ -336,6 +346,7 @@ class FlagMismatchOnReconnectTransport implements Transport {
   }
 
   close(): Promise<void> {
+    this.closeCount += 1;
     return Promise.resolve();
   }
 
@@ -434,12 +445,15 @@ Deno.test(
         "flag mismatch",
       );
       assertEquals(error.name, "ProtocolError");
+      assertEquals(transport.helloCount, 2);
+      assertEquals(transport.closeCount, 0);
       // Still fatal on the next attempt, without reconnecting.
       await assertRejects(
         () => client.restoreConnection(),
         Error,
         "flag mismatch",
       );
+      assertEquals(transport.helloCount, 2);
     } finally {
       await client.close();
     }

--- a/packages/memory/test/v2-client-reconnect-auth-test.ts
+++ b/packages/memory/test/v2-client-reconnect-auth-test.ts
@@ -6,7 +6,11 @@ import {
   getMemoryProtocolFlags,
   MEMORY_PROTOCOL,
 } from "../v2.ts";
-import { connect, type Transport } from "../v2/client.ts";
+import {
+  connect,
+  permanentProtocolError,
+  type Transport,
+} from "../v2/client.ts";
 
 const TEST_AUDIENCE = "did:key:z6Mk-reconnect-auth-audience";
 
@@ -340,6 +344,77 @@ class FlagMismatchOnReconnectTransport implements Transport {
   }
 }
 
+type VersionMismatchSignal = "protocol-close" | "legacy-response";
+
+/**
+ * A transport that connects to the current protocol once, then models the two
+ * signals a mixed-version deployment can produce on reconnect: a current
+ * server's WebSocket close 1002 after `hello`, or a pre-v2.1 server's typed
+ * `UnsupportedProtocol` handshake response.
+ */
+class VersionMismatchOnReconnectTransport implements Transport {
+  helloCount = 0;
+  closeCount = 0;
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+
+  constructor(private readonly signal: VersionMismatchSignal) {}
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  triggerClose(): void {
+    this.#closeReceiver(new Error("disconnect"));
+  }
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+    };
+    switch (message.type) {
+      case "hello":
+        this.helloCount += 1;
+        if (this.helloCount === 1) {
+          this.#respond(helloOk());
+        } else if (this.signal === "protocol-close") {
+          this.#closeReceiver(
+            permanentProtocolError("memory protocol version mismatch"),
+          );
+        } else {
+          this.#respond({
+            type: "response",
+            requestId: "handshake",
+            error: {
+              name: "UnsupportedProtocol",
+              message: `Unsupported protocol: ${MEMORY_PROTOCOL}`,
+            },
+          });
+        }
+        return Promise.resolve();
+      case "session.open":
+        this.#respond(openOk(message.requestId!));
+        return Promise.resolve();
+      default:
+        throw new Error(`Unhandled version-mismatch message: ${message.type}`);
+    }
+  }
+
+  close(): Promise<void> {
+    this.closeCount += 1;
+    return Promise.resolve();
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
 Deno.test(
   "a permanent handshake mismatch on reconnect fails fast instead of looping",
   async () => {
@@ -370,3 +445,53 @@ Deno.test(
     }
   },
 );
+
+for (
+  const testCase of [
+    {
+      signal: "protocol-close",
+      name: "ProtocolError",
+      message: "memory protocol version mismatch",
+      closeCount: 0,
+    },
+    {
+      signal: "legacy-response",
+      name: "UnsupportedProtocol",
+      message: "Unsupported protocol",
+      closeCount: 1,
+    },
+  ] as const
+) {
+  Deno.test(
+    `a ${testCase.signal} version mismatch on reconnect is permanent`,
+    async () => {
+      const transport = new VersionMismatchOnReconnectTransport(
+        testCase.signal,
+      );
+      const client = await connect({ transport });
+      await client.mount(`did:key:z6Mk-reconnect-${testCase.signal}`);
+
+      try {
+        transport.triggerClose();
+
+        const error = await assertRejects(
+          () => client.restoreConnection(),
+          Error,
+          testCase.message,
+        );
+        assertEquals(error.name, testCase.name);
+        assertEquals(transport.helloCount, 2);
+        assertEquals(transport.closeCount, testCase.closeCount);
+
+        await assertRejects(
+          () => client.restoreConnection(),
+          Error,
+          testCase.message,
+        );
+        assertEquals(transport.helloCount, 2);
+      } finally {
+        await client.close();
+      }
+    },
+  );
+}

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -3215,6 +3215,36 @@ Deno.test("memory v2 client drops connections when protocol versions disagree", 
   assertEquals(helloCount, 1);
 });
 
+Deno.test("memory v2 loopback marks protocol mismatch closes permanent", async () => {
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://memory-v2-client-loopback-version-mismatch"),
+  });
+  const transport = loopback(server);
+  let closeError: Error | undefined;
+  transport.setCloseReceiver?.((error) => {
+    closeError = error;
+  });
+
+  try {
+    await transport.send(encodeMemoryBoundary({
+      type: "hello",
+      protocol: "memory/v2.2",
+      flags: getMemoryProtocolFlags(),
+    }));
+
+    assertExists(closeError);
+    assertEquals(closeError.name, "ProtocolError");
+    assertEquals(
+      (closeError as Error & { permanent?: boolean }).permanent,
+      true,
+    );
+  } finally {
+    await transport.close();
+    await server.close();
+  }
+});
+
 Deno.test("memory v2 client stores the server's advertised flags (capability handshake)", async () => {
   // An OLD server's hello.ok omits sqliteCommitRowLabelEval: the parsed
   // server flags must read false (the runner's write gate then keeps failing

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -3137,6 +3137,7 @@ Deno.test("memory v2 client close ends a reconnect parked in the handshake", asy
 
 Deno.test("memory v2 client rejects hello.ok when flags disagree", async () => {
   let receiver = (_payload: string) => {};
+  let closeCount = 0;
   const transport: Transport = {
     send(payload): Promise<void> {
       const message = decodeMemoryBoundary(payload) as { type?: string };
@@ -3151,7 +3152,10 @@ Deno.test("memory v2 client rejects hello.ok when flags disagree", async () => {
       }
       return Promise.resolve();
     },
-    async close() {},
+    close() {
+      closeCount += 1;
+      return Promise.resolve();
+    },
     setReceiver(next) {
       receiver = next;
     },
@@ -3163,6 +3167,52 @@ Deno.test("memory v2 client rejects hello.ok when flags disagree", async () => {
     Error,
     "memory flag mismatch",
   );
+  assertEquals(closeCount, 0);
+});
+
+Deno.test("memory v2 client drops connections when protocol versions disagree", async () => {
+  let receiver = (_payload: string) => {};
+  let closeReceiver = (_error?: Error) => {};
+  let sentProtocol: unknown;
+  let closeCount = 0;
+  let helloCount = 0;
+  const transport: Transport = {
+    send(payload): Promise<void> {
+      const message = decodeMemoryBoundary(payload) as {
+        type?: string;
+        protocol?: unknown;
+      };
+      if (message.type === "hello") {
+        helloCount += 1;
+        sentProtocol = message.protocol;
+        receiver(encodeMemoryBoundary({
+          ...HELLO_OK,
+          protocol: "memory/v2.2",
+        }));
+      }
+      return Promise.resolve();
+    },
+    close() {
+      closeCount += 1;
+      closeReceiver();
+      return Promise.resolve();
+    },
+    setReceiver(next) {
+      receiver = next;
+    },
+    setCloseReceiver(next) {
+      closeReceiver = next;
+    },
+  };
+
+  await assertRejects(
+    () => connect({ transport }),
+    Error,
+    "memory protocol version mismatch",
+  );
+  assertEquals(sentProtocol, MEMORY_PROTOCOL);
+  assertEquals(closeCount, 1);
+  assertEquals(helloCount, 1);
 });
 
 Deno.test("memory v2 client stores the server's advertised flags (capability handshake)", async () => {

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -1181,7 +1181,7 @@ Deno.test("memory v2 server rejects handshakes when modernCellRep flags disagree
   const connection = server.connect((message) => messages.push(message));
 
   try {
-    await connection.receive(encodeMemoryBoundary({
+    const disposition = await connection.receive(encodeMemoryBoundary({
       type: "hello",
       protocol: MEMORY_PROTOCOL,
       flags: {
@@ -1189,6 +1189,7 @@ Deno.test("memory v2 server rejects handshakes when modernCellRep flags disagree
       },
     }));
 
+    assertEquals(disposition, "open");
     assertEquals(shiftMessage(messages), {
       type: "response",
       requestId: "handshake",
@@ -1201,6 +1202,27 @@ Deno.test("memory v2 server rejects handshakes when modernCellRep flags disagree
         } server=${JSON.stringify(HELLO_FLAGS)}`,
       },
     });
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 server drops connections when protocol versions disagree", async () => {
+  const server = createServer("memory://memory-v2-server-handshake-version");
+
+  try {
+    for (const protocol of [undefined, "memory/v2.2"]) {
+      const messages: ServerMessage[] = [];
+      const connection = server.connect((message) => messages.push(message));
+      const disposition = await connection.receive(encodeMemoryBoundary({
+        type: "hello",
+        ...(protocol === undefined ? {} : { protocol }),
+        flags: HELLO_FLAGS,
+      }));
+
+      assertEquals(disposition, "closed");
+      assertEquals(messages, []);
+    }
   } finally {
     await server.close();
   }

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -48,7 +48,7 @@ const toEntityDocument = (
 
 describe("memory v2 protocol constants", () => {
   it("exports the phase-1 protocol constants", () => {
-    assertEquals(MEMORY_PROTOCOL, "memory");
+    assertEquals(MEMORY_PROTOCOL, "memory/v2.1");
     assertEquals(DEFAULT_BRANCH, "");
   });
 });

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -16,7 +16,8 @@ import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-commo
 import { isObject, isRecord } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
-export const MEMORY_PROTOCOL = "memory" as const;
+/** Exact hello-handshake compatibility boundary for the memory protocol. */
+export const MEMORY_PROTOCOL = "memory/v2.1" as const;
 export const DEFAULT_BRANCH = "" as const;
 
 export type EntityId = string;

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -354,7 +354,7 @@ export class Client {
         if (message.error) {
           const error = new Error(message.error.message);
           error.name = message.error.name;
-          if (error.name === "UnsupportedProtocol") {
+          if (isPermanentHandshakeError(error)) {
             Object.assign(error, { permanent: true });
             this.#fatalError = error;
           }
@@ -1618,6 +1618,13 @@ const isPermanentAuthorizationError = (error: unknown): boolean =>
 // that would take down sessions for other spaces.
 const isPermanentConnectionFailure = (error: Error): boolean =>
   (error as { permanent?: unknown }).permanent === true;
+
+// Every typed protocol rejection produced while `hello` is pending describes a
+// peer incompatibility that reconnecting to the same endpoint cannot heal.
+// `UnsupportedProtocol` is the legacy pre-v2.1 version signal; `ProtocolError`
+// is the current capability-flag rejection.
+const isPermanentHandshakeError = (error: Error): boolean =>
+  error.name === "UnsupportedProtocol" || error.name === "ProtocolError";
 
 const requireSessionOpenAuthMetadata = (
   value: unknown,

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -119,11 +119,12 @@ export class Client {
   #connected = false;
   #closed = false;
   // Set when a reconnect handshake fails for a reason retrying cannot change (a
-  // protocol-flag mismatch — the transport is fundamentally incompatible). The
-  // client stops reconnecting and fails every further request with it, instead
-  // of looping forever. A per-session authorization denial does NOT land here:
-  // it terminates only that session (see SpaceSession.restore), leaving sessions
-  // for other spaces on this client alive.
+  // protocol-version or flag mismatch — the transport is fundamentally
+  // incompatible). The client stops reconnecting and fails every further
+  // request with it, instead of looping forever. A per-session authorization
+  // denial does NOT land here: it terminates only that session (see
+  // SpaceSession.restore), leaving sessions for other spaces on this client
+  // alive.
   #fatalError: Error | null = null;
 
   private constructor(
@@ -299,7 +300,16 @@ export class Client {
 
     if (this.#helloPending !== null) {
       const helloOk = parseHelloOk(message);
-      if (helloOk !== null) {
+      if (helloOk?.kind === "incompatible") {
+        const error = permanentProtocolError(
+          "memory protocol version mismatch",
+        );
+        this.#fatalError = error;
+        this.#helloPending.reject(error);
+        void this.transport.close().catch(() => undefined);
+        return;
+      }
+      if (helloOk?.kind === "ok") {
         const expectedFlags = getMemoryProtocolFlags();
         if (!compatibleMemoryProtocolFlags(helloOk.flags, expectedFlags)) {
           // A data-model wire-contract mismatch: this client and server cannot
@@ -414,6 +424,9 @@ export class Client {
       session.handleDisconnect();
     }
     this.rejectPending(toConnectionError(error));
+    if (this.#fatalError) {
+      return;
+    }
     void this.reconnect().catch(() => undefined);
   }
 
@@ -429,7 +442,7 @@ export class Client {
     }
     this.#reconnecting = (async () => {
       let attempt = 0;
-      while (!this.#closed) {
+      while (!this.#closed && !this.#fatalError) {
         try {
           await this.hello();
           for (const session of this.#spaces) {
@@ -441,8 +454,8 @@ export class Client {
           const err = error instanceof Error ? error : new Error(String(error));
           if (isPermanentConnectionFailure(err)) {
             // A handshake the server refuses identically every time (a
-            // protocol-flag mismatch). Stop looping and remember the failure so
-            // every present and future request fails fast with it.
+            // protocol-version or flag mismatch). Stop looping and remember the
+            // failure so every present and future request fails fast with it.
             this.#fatalError = err;
             this.rejectPending(err);
             return;
@@ -1526,12 +1539,15 @@ export const connect = Client.connect;
 
 export const loopback = (server: Server): Transport => {
   let receiver = (_payload: string) => {};
+  let closeReceiver = (_error?: Error) => {};
   const connection = server.connect((message) => {
     receiver(encodeMemoryBoundary(message));
   });
   return {
     async send(payload: string) {
-      await connection.receive(payload);
+      if (await connection.receive(payload) === "closed") {
+        closeReceiver(protocolError("memory protocol version mismatch"));
+      }
     },
     close() {
       connection.close();
@@ -1540,7 +1556,9 @@ export const loopback = (server: Server): Transport => {
     setReceiver(next) {
       receiver = next;
     },
-    setCloseReceiver() {},
+    setCloseReceiver(next) {
+      closeReceiver = next;
+    },
   };
 };
 
@@ -1651,10 +1669,14 @@ const requireSessionOpenAuthMetadata = (
 
 const parseHelloOk = (
   message: unknown,
-): {
-  flags: MemoryProtocolFlags;
-  sessionOpen?: unknown;
-} | null => {
+):
+  | {
+    kind: "ok";
+    flags: MemoryProtocolFlags;
+    sessionOpen?: unknown;
+  }
+  | { kind: "incompatible" }
+  | null => {
   if (typeof message !== "object" || message === null) {
     return null;
   }
@@ -1664,14 +1686,17 @@ const parseHelloOk = (
     flags?: unknown;
     sessionOpen?: unknown;
   };
-  if (obj.type !== "hello.ok" || obj.protocol !== MEMORY_PROTOCOL) {
+  if (obj.type !== "hello.ok") {
     return null;
+  }
+  if (obj.protocol !== MEMORY_PROTOCOL) {
+    return { kind: "incompatible" };
   }
   const parsed = parseMemoryProtocolFlags(obj.flags);
   if (parsed === null) {
     return null;
   }
-  return { flags: parsed, sessionOpen: obj.sessionOpen };
+  return { kind: "ok", flags: parsed, sessionOpen: obj.sessionOpen };
 };
 
 const isSessionEffect = (

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -47,6 +47,13 @@ export type Transport = {
   setCloseReceiver?(receiver: (error?: Error) => void): void;
 };
 
+/** A protocol incompatibility that a fresh connection cannot heal. */
+export const permanentProtocolError = (message: string): Error =>
+  Object.assign(new Error(message), {
+    name: "ProtocolError",
+    permanent: true,
+  });
+
 export type ConnectOptions = {
   transport: Transport;
 };
@@ -347,7 +354,14 @@ export class Client {
         if (message.error) {
           const error = new Error(message.error.message);
           error.name = message.error.name;
+          if (error.name === "UnsupportedProtocol") {
+            Object.assign(error, { permanent: true });
+            this.#fatalError = error;
+          }
           this.#helloPending.reject(error);
+          if (error.name === "UnsupportedProtocol") {
+            void this.transport.close().catch(() => undefined);
+          }
         } else {
           const error = new Error("memory handshake failed");
           error.name = "ProtocolError";
@@ -419,11 +433,17 @@ export class Client {
     if (this.#closed) {
       return;
     }
+    const closeError = error && isPermanentConnectionFailure(error)
+      ? error
+      : toConnectionError(error);
+    if (isPermanentConnectionFailure(closeError)) {
+      this.#fatalError = closeError;
+    }
     this.#connected = false;
     for (const session of this.#spaces) {
       session.handleDisconnect();
     }
-    this.rejectPending(toConnectionError(error));
+    this.rejectPending(closeError);
     if (this.#fatalError) {
       return;
     }
@@ -1582,11 +1602,6 @@ const protocolError = (message: string): Error => {
   error.name = "ProtocolError";
   return error;
 };
-
-// A ProtocolError that no retry can heal (the peers disagree on a data-model
-// wire contract). Tagged so the reconnect loop gives up rather than retrying it.
-const permanentProtocolError = (message: string): Error =>
-  Object.assign(new Error(message), { name: "ProtocolError", permanent: true });
 
 // An authorization denial retrying cannot change. A retriable auth failure — an
 // anti-replay race the server marked `retriable` (an expired/used/mismatched

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -1566,7 +1566,9 @@ export const loopback = (server: Server): Transport => {
   return {
     async send(payload: string) {
       if (await connection.receive(payload) === "closed") {
-        closeReceiver(protocolError("memory protocol version mismatch"));
+        closeReceiver(
+          permanentProtocolError("memory protocol version mismatch"),
+        );
       }
     },
     close() {

--- a/packages/memory/v2/handshake.ts
+++ b/packages/memory/v2/handshake.ts
@@ -20,18 +20,24 @@ const toError = (name: string, message: string): TypedError => ({
   message,
 });
 
-export const respondToHello = (message: HelloMessage): ServerMessage => {
-  const expectedFlags = getMemoryProtocolFlags();
+type IncomingHelloMessage =
+  & Omit<HelloMessage, "protocol" | "flags">
+  & {
+    protocol: unknown;
+    flags: unknown;
+  };
+
+/**
+ * Returns `null` when the peer speaks a different protocol version. Callers
+ * must drop the connection without sending a response in that case.
+ */
+export const respondToHello = (
+  message: IncomingHelloMessage,
+): ServerMessage | null => {
   if (message.protocol !== MEMORY_PROTOCOL) {
-    return {
-      type: "response",
-      requestId: "handshake",
-      error: toError(
-        "UnsupportedProtocol",
-        `Unsupported protocol: ${message.protocol}`,
-      ),
-    };
+    return null;
   }
+  const expectedFlags = getMemoryProtocolFlags();
   const parsed = parseMemoryProtocolFlags(message.flags);
   if (
     parsed === null ||

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -51,7 +51,6 @@ import {
   type WatchSetRequest,
   type WatchSetResult,
   type WatchSpec,
-  type WireMemoryProtocolFlags,
 } from "../v2.ts";
 import * as Engine from "./engine.ts";
 import {
@@ -341,6 +340,8 @@ const sessionKey = (space: string, sessionId: string): string =>
 
 type Send = (message: ServerMessage) => void;
 
+export type ConnectionDisposition = "open" | "closed";
+
 type SessionOpenAuthContext = {
   audience: string;
   challenge: SessionOpenChallenge;
@@ -511,7 +512,7 @@ class Connection {
     }
   }
 
-  async receive(payload: string): Promise<void> {
+  async receive(payload: string): Promise<ConnectionDisposition> {
     this.#pendingReceives += 1;
     try {
       const previous = this.#receiving;
@@ -519,7 +520,7 @@ class Connection {
         this.receiveOrdered(payload)
       );
       this.#receiving = current.then(() => undefined, () => undefined);
-      return await current;
+      await current;
     } finally {
       this.#pendingReceives = Math.max(0, this.#pendingReceives - 1);
       if (this.#pendingReceives === 0) {
@@ -527,6 +528,7 @@ class Connection {
         this.#receiveIdle = null;
       }
     }
+    return this.#closed ? "closed" : "open";
   }
 
   hasPendingReceives(): boolean {
@@ -605,6 +607,10 @@ class Connection {
         return;
       }
       const response = respondToHello(parsed);
+      if (response === null) {
+        this.close();
+        return;
+      }
       if (response.type === "hello.ok") {
         response.sessionOpen = this.issueSessionOpenAuth();
       }
@@ -3395,6 +3401,9 @@ export class Server {
     const parsed = parseClientMessage(payload);
     if (parsed?.type === "hello") {
       const response = respondToHello(parsed);
+      if (response === null) {
+        return Promise.resolve(null);
+      }
       if (response.type !== "hello.ok") {
         return Promise.resolve(encodeMemoryBoundary(response));
       }
@@ -3706,9 +3715,20 @@ const parseSchedulerSnapshotQuery = (
   };
 };
 
+export type ParsedHelloMessage =
+  & Omit<HelloMessage, "protocol" | "flags">
+  & {
+    protocol: unknown;
+    flags: unknown;
+  };
+
+export type ParsedClientMessage =
+  | ParsedHelloMessage
+  | Exclude<ClientMessage, HelloMessage>;
+
 export const parseClientMessage = (
   payload: string,
-): ClientMessage | null => {
+): ParsedClientMessage | null => {
   let parsed: unknown;
   try {
     parsed = decodeMemoryBoundary(payload);
@@ -3720,17 +3740,11 @@ export const parseClientMessage = (
     return null;
   }
 
-  if (
-    parsed.type === "hello" &&
-    typeof parsed.protocol === "string"
-  ) {
-    if (parseMemoryProtocolFlags(parsed.flags) === null) {
-      return null;
-    }
+  if (parsed.type === "hello") {
     return {
       type: "hello",
-      protocol: parsed.protocol as HelloMessage["protocol"],
-      flags: parsed.flags as WireMemoryProtocolFlags,
+      protocol: parsed.protocol,
+      flags: parsed.flags,
     };
   }
 

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -85,12 +85,22 @@ export class StandaloneMemoryServer {
         if (debugWrites) {
           logCommitOperations(connectionTag, event.data);
         }
-        connection.receive(event.data).catch(() => {
-          if (socket.readyState === WebSocket.OPEN) {
-            socket.close(1011, "memory websocket receive failure");
-          }
-          connection.close();
-        });
+        connection.receive(event.data).then(
+          (disposition) => {
+            if (
+              disposition === "closed" &&
+              socket.readyState === WebSocket.OPEN
+            ) {
+              socket.close(1002, "memory protocol mismatch");
+            }
+          },
+          () => {
+            if (socket.readyState === WebSocket.OPEN) {
+              socket.close(1011, "memory websocket receive failure");
+            }
+            connection.close();
+          },
+        );
       });
       socket.addEventListener("close", () => connection.close());
       socket.addEventListener("error", () => connection.close());

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -153,14 +153,20 @@ export class WebSocketTransport implements MemoryClient.Transport {
           this.#receiver(event.data);
         }
       });
-      socket.addEventListener("close", () => {
+      socket.addEventListener("close", (event) => {
         if (this.#socket === socket) {
           this.#socket = null;
         }
         if (this.#opening === opening) {
           this.#opening = null;
         }
-        this.#closeReceiver();
+        this.#closeReceiver(
+          (event as CloseEvent).code === 1002
+            ? MemoryClient.permanentProtocolError(
+              "memory protocol version mismatch",
+            )
+            : undefined,
+        );
         if (!opened) {
           reject(new Error("memory websocket transport closed before opening"));
         }

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -305,6 +305,33 @@ describe("WebSocketTransport failure signalling", () => {
     });
   });
 
+  it("surfaces protocol close 1002 as a permanent version mismatch", async () => {
+    await withTransport(async (transport, socket) => {
+      let closeError: Error | undefined;
+      transport.setCloseReceiver((error) => {
+        closeError = error;
+      });
+
+      const send = transport.send("frame");
+      const activeSocket = socket();
+      activeSocket.readyState = DrivableWebSocket.OPEN;
+      activeSocket.dispatchEvent(new Event("open"));
+      await send;
+
+      activeSocket.readyState = DrivableWebSocket.CLOSED;
+      activeSocket.dispatchEvent(
+        new CloseEvent("close", {
+          code: 1002,
+          reason: "Memory protocol mismatch",
+        }),
+      );
+
+      expect(closeError?.name).toBe("ProtocolError");
+      expect(closeError?.message).toBe("memory protocol version mismatch");
+      expect((closeError as { permanent?: boolean }).permanent).toBe(true);
+    });
+  });
+
   it("surfaces the underlying Error of a socket error to the close receiver", async () => {
     await withTransport(async (transport, socket) => {
       let closeError: Error | undefined;

--- a/packages/runner/test/memory-v2-test-utils.ts
+++ b/packages/runner/test/memory-v2-test-utils.ts
@@ -5,6 +5,7 @@ import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
   type SessionOpenAuthMetadata,
   type SessionSync,
 } from "@commonfabric/memory/v2";
@@ -188,7 +189,7 @@ export abstract class ScriptedSessionTransport
         );
         this.respond({
           type: "hello.ok",
-          protocol: "memory",
+          protocol: MEMORY_PROTOCOL,
           flags: this.helloFlags(),
           sessionOpen: this.#sessionOpen,
         });

--- a/packages/runner/test/scheduler-observation-capability-skew.test.ts
+++ b/packages/runner/test/scheduler-observation-capability-skew.test.ts
@@ -34,6 +34,7 @@ import type { URI } from "@commonfabric/memory/interface";
 import {
   type ClientCommit,
   getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
   resetPersistentSchedulerStateConfig,
   setPersistentSchedulerStateConfig,
 } from "@commonfabric/memory/v2";
@@ -98,7 +99,7 @@ class FlagOffServerTransport implements MemoryV2Client.Transport {
       case "hello":
         this.respond({
           type: "hello.ok",
-          protocol: "memory",
+          protocol: MEMORY_PROTOCOL,
           // The one divergence from this realm's ambient flags: the server
           // never advertises persistentSchedulerState (an off-flag or older
           // deployment). Everything else mirrors the real handshake.

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -210,13 +210,7 @@ const attachMemorySocketPipeline = (
           // Trace only after the receive resolves, so a message whose receive
           // fails (the fatal-error path below) is not logged as a write.
           void connection.receive(message).then(
-            (nextDisposition) => {
-              if (nextDisposition === "closed") {
-                safeSocketClose(1002, "Memory protocol mismatch");
-                return;
-              }
-              logMemWrites(message);
-            },
+            () => logMemWrites(message),
             () => {
               safeSocketClose(1011, "Memory websocket receive failure");
               closeConnection();

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -199,14 +199,24 @@ const attachMemorySocketPipeline = (
 
   void (async () => {
     try {
-      await connection.receive(firstMessage);
+      const disposition = await connection.receive(firstMessage);
+      if (disposition === "closed") {
+        safeSocketClose(1002, "Memory protocol mismatch");
+        return;
+      }
       logMemWrites(firstMessage);
       negotiation.handoff({
         onMessage(message) {
           // Trace only after the receive resolves, so a message whose receive
           // fails (the fatal-error path below) is not logged as a write.
           void connection.receive(message).then(
-            () => logMemWrites(message),
+            (nextDisposition) => {
+              if (nextDisposition === "closed") {
+                safeSocketClose(1002, "Memory protocol mismatch");
+                return;
+              }
+              logMemWrites(message);
+            },
             () => {
               safeSocketClose(1011, "Memory websocket receive failure");
               closeConnection();

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -687,6 +687,34 @@ serialTest(
 );
 
 serialTest(
+  "memory websocket drops connections when protocol versions disagree",
+  async () => {
+    const server = Deno.serve({ port: 0 }, app.fetch);
+    const address = new URL(
+      `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+    );
+
+    try {
+      const socket = await openSocket(address);
+      const closed = new Promise<CloseEvent>((resolve) => {
+        socket.addEventListener("close", (event) => resolve(event), {
+          once: true,
+        });
+      });
+      socket.send(encodeMemoryBoundary({
+        ...HELLO,
+        protocol: "memory/v2.2",
+      }));
+
+      const event = await closed;
+      assertEquals(event.code, 1002);
+    } finally {
+      await server.shutdown();
+    }
+  },
+);
+
+serialTest(
   "memory websocket discovers newly linked documents for a subscribed memory runtime",
   async () => {
     const identity = await Identity.fromPassphrase(


### PR DESCRIPTION
## Summary

- version the memory wire protocol as `memory/v2.1`
- drop hello connections without a response when the protocol identifier does not match
- keep capability-flag incompatibilities on the existing typed-error path
- make protocol mismatch permanent on the client and close the transport
- document the exact compatibility boundary and cover server, client, standalone, and Toolshed behavior

## Why

Some memory protocol changes cannot be made backward compatible through capability flags. Encoding the version in the existing `MEMORY_PROTOCOL` identifier gives those changes a single exact compatibility boundary and also binds the version into signed `session.open` authorization.

Previously, an unsupported protocol produced a typed handshake rejection while leaving the WebSocket open. During reconnect this could repeatedly reject on the same open connection. The new behavior immediately drops incompatible transports.

## Validation

- `deno task check` (`packages/memory`)
- focused memory suite: 91 passed
- Toolshed memory WebSocket route suite: 21 passed
- runner capability-skew regression: passed
- relevant lint and targeted typechecks
- `deno task check-docs`: 521 code blocks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Version the memory wire protocol to `memory/v2.1` and drop `hello` on protocol mismatch to enforce a strict compatibility boundary and stop mixed-version reconnect loops. Docs now explain how compatibility can evolve and how the client interprets both legacy and new signals.

- **New Features**
  - `MEMORY_PROTOCOL` is now `memory/v2.1`; `hello` and `hello.ok` must match exactly.
  - On version mismatch, recipients drop: servers close without a response; `toolshed` and standalone WebSocket routes close with code 1002; clients treat mismatched `hello.ok` and legacy `UnsupportedProtocol` as permanent, close the transport, and stop reconnecting. Capability-flag mismatches stay typed (`ProtocolError`) and are permanent.
  - Runner `WebSocketTransport` maps 1002 to a permanent `ProtocolError`; loopback in `@commonfabric/memory/v2` surfaces a permanent protocol mismatch; reconnect paths updated to remember the failure.
  - Docs expanded: exact identifier boundary, accepted-identifier set (no implicit downgrade), and a clear split between `hello` negotiation and `AuthorizationError.retriable`. Tests cover client/server, Toolshed, runner, loopback, and mixed-version reconnect.

- **Migration**
  - Ensure both sides send and expect `memory/v2.1` in `hello` and `hello.ok`.
  - Update any code that assumed `"memory"` to use `MEMORY_PROTOCOL`.
  - Adjust tests/integrations to expect WebSocket close code 1002 on protocol mismatch.

<sup>Written for commit e3dfdc150967cb3836e73a0e4b4888ba7eef0e2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

