### PR TITLE
test(cli): four retry scenarios for caller-supplied invocation ids (verb contract WS-D/D3)

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -233,7 +233,11 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   without racing a clock; a `--message` that differs on the retry proves the
   settled outcome stands rather than being overwritten. Each scenario spawns
   a fresh `cf` process, so the fresh-process case is the default rather than
-  a special one.
+  a special one. One half of the third scenario is not covered yet: the
+  collision is asserted through `deduplicated` and exit 0, but not by reading
+  a *result* back off the receipt, because a void verb leaves none to read.
+  That assertion joins when WS-C gives verbs return values — or sooner
+  against `plainResultReceipts`.
 - **Exit (Phase 2, before WS-C):** the duplicate-on-retry bug is dead on the
   live board. **Exit (Phase 4, with WS-C):** the retry returns the original
   result.

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -217,13 +217,23 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   fails if the path ever awaits `runtime.idle()` or `manager.synced()`. The
   live acceptance check — a deliberately slow derived recomputation cannot
   delay `addTopic` acknowledgement — rides with D3's integration scenarios.
-- Integration tests (isolated toolshed, `isolated-test-processes`
+- ~~Integration tests (isolated toolshed, `isolated-test-processes`
   conventions), four timeout/retry scenarios: timeout before dispatch (retry
   re-executes; one topic); timeout after dispatch, before commit
   acknowledgement; commit succeeded but the response was lost (retry
   collides, reads the original back, exits 0); and a retry from a fresh
   process with the same id — in every case exactly one topic exists
-  afterwards.
+  afterwards.~~ — **done (D3)**: `run_piece_call_retry` in
+  `packages/cli/integration/integration.sh`, running in the existing
+  `piece-call` shard against its own toolshed, each scenario in its own
+  space. Every scenario ends on the same assertion — exactly one message
+  recorded — because that is the property an agent depends on. The
+  killed-after-dispatch case is triggered by the CLI's own `invocation:`
+  announcement, read through a blocking pipe read, so it lands in the window
+  without racing a clock; a `--message` that differs on the retry proves the
+  settled outcome stands rather than being overwritten. Each scenario spawns
+  a fresh `cf` process, so the fresh-process case is the default rather than
+  a special one.
 - **Exit (Phase 2, before WS-C):** the duplicate-on-retry bug is dead on the
   live board. **Exit (Phase 4, with WS-C):** the retry returns the original
   result.

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -616,8 +616,30 @@ run_piece_call_retry() {
     error "cf piece call should announce its invocation id at dispatch"
   fi
 
-  cf piece call $SPACE_ARGS --piece "$RETRY_PIECE_2" --invocation "$INVOCATION_2" \
-    recordMessage -- --message "dispatched-then-killed" > /dev/null
+  # Whether the killed call got its commit in is genuinely racy, and both
+  # outcomes are correct — but they exercise different machinery, so record
+  # which one happened instead of letting a weak pass look like a strong one.
+  # If it committed, the retry MUST collide; if it did not, the retry must
+  # apply cleanly. Asserting only "exactly one" would also pass with
+  # --invocation ignored entirely, whenever the first commit failed to land.
+  COMMITTED_BEFORE_KILL=$(message_count "$RETRY_PIECE_2")
+  set +e
+  RETRY_2=$(cf piece call $SPACE_ARGS --piece "$RETRY_PIECE_2" --invocation "$INVOCATION_2" \
+    recordMessage -- --message "dispatched-then-killed" 2>/dev/null)
+  RETRY_2_STATUS=$?
+  set -e
+  if [ "$RETRY_2_STATUS" -ne 0 ]; then
+    error "Retrying a killed-after-dispatch call should exit 0, got $RETRY_2_STATUS"
+  fi
+  echo "killed-after-dispatch: committed before kill = $COMMITTED_BEFORE_KILL"
+  if [ "$COMMITTED_BEFORE_KILL" = "1" ]; then
+    echo "$RETRY_2" | jq -e '.deduplicated == true' > /dev/null ||
+      error "The killed call had committed, so its retry must deduplicate, got: $RETRY_2"
+  elif echo "$RETRY_2" | jq -e '.deduplicated == true' > /dev/null; then
+    # An `x && error` here would abort under set -e on the expected path,
+    # where jq exits non-zero; an if-condition is exempt.
+    error "The killed call never committed, so its retry must not deduplicate, got: $RETRY_2"
+  fi
   assert_message_count "$RETRY_PIECE_2" 1 \
     "Retrying a killed-after-dispatch call with the same id should leave exactly one message"
 

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -65,6 +65,56 @@ SCHEMA_INCOMPATIBLE_PATTERN_SRC="$SCRIPT_DIR/pattern/schema-incompatible.tsx"
 CUSTOM_EXPORT="customPatternExport" # for testing this feature
 SECTION="${CF_CLI_INTEGRATION_SECTION:-${1:-all}}"
 
+# A fresh invocation id. uuidgen is not present on every runner image, so this
+# falls back to Python, which the timing helper above already requires.
+new_invocation_id() {
+  if command -v uuidgen > /dev/null 2>&1; then
+    uuidgen
+  else
+    python3 -c 'import uuid; print(uuid.uuid4())'
+  fi
+}
+
+# Kill a backgrounded `cf` invocation. `cf` is a shell function, so $! is the
+# subshell rather than the Deno process doing the work; killing only the
+# subshell would leave that child running and still able to commit. Take the
+# children first, then the subshell.
+kill_process_tree() {
+  local pid="$1"
+  local child
+  for child in $(pgrep -P "$pid" 2>/dev/null); do
+    kill_process_tree "$child"
+  done
+  kill "$pid" 2> /dev/null || true
+  wait "$pid" 2> /dev/null || true
+}
+
+# Count the messages a piece recorded. A piece that has never handled an event
+# has nothing materialized to read, which reads as zero messages rather than as
+# a failure — the same tolerance read_piece_value_or_default gives scalars.
+message_count() {
+  local piece_id="$1"
+  local raw
+  raw=$(cf piece get $SPACE_ARGS --piece "$piece_id" messages 2>/dev/null || true)
+  if [ -z "$raw" ]; then
+    printf '0\n'
+    return 0
+  fi
+  printf '%s\n' "$raw" | jq 'length'
+}
+
+# Assert a piece recorded exactly `expected` messages.
+assert_message_count() {
+  local piece_id="$1"
+  local expected="$2"
+  local message="$3"
+  local actual
+  actual=$(message_count "$piece_id")
+  if [ "$actual" != "$expected" ]; then
+    error "$message (expected $expected, got $actual)"
+  fi
+}
+
 setup_space() {
   if [ -z "$API_URL" ]; then
     error "API_URL must be defined."
@@ -501,6 +551,119 @@ run_piece_call() {
   echo "Successfully ran CLI piece call integration tests for ${API_URL}/${SPACE}/${CALLABLE_PIECE_ID}."
 }
 
+# Retry semantics for caller-supplied invocation ids (verb contract WS-D/D3).
+# Every scenario ends with the SAME assertion — exactly one message recorded —
+# because that is the property an agent depends on: a retry it cannot avoid
+# must never double-apply the mutation.
+run_piece_call_retry() {
+  setup_space
+
+  echo "Testing invocation-id retry semantics..."
+
+  RETRY_PIECE_ID=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS "$SCRIPT_DIR/pattern/fuse-exec.tsx")
+  echo "Created retry-scenario piece: $RETRY_PIECE_ID"
+
+  # --- 1. A failure before dispatch leaves nothing behind. ------------------
+  # An unreachable API cannot dispatch, so the mutation provably never
+  # happened and no invocation id was ever announced to retry with. The
+  # caller's correct move is a fresh id, and that must yield exactly one.
+  set +e
+  cf piece call --api-url="http://127.0.0.1:1" --identity="$IDENTITY" --space="$SPACE" \
+    --piece "$RETRY_PIECE_ID" --invocation "never-dispatched" \
+    recordMessage -- --message "pre-dispatch" > /dev/null 2>&1
+  PRE_DISPATCH_STATUS=$?
+  set -e
+  if [ "$PRE_DISPATCH_STATUS" -eq 0 ]; then
+    error "A call to an unreachable API should fail, not report success"
+  fi
+  assert_message_count "$RETRY_PIECE_ID" 0 \
+    "A pre-dispatch failure must not record a message"
+
+  cf piece call $SPACE_ARGS --piece "$RETRY_PIECE_ID" --invocation "$(new_invocation_id)" \
+    recordMessage -- --message "pre-dispatch" > /dev/null
+  assert_message_count "$RETRY_PIECE_ID" 1 \
+    "A fresh-id retry after a pre-dispatch failure should record exactly one message"
+
+  # --- 2. Dispatched, then the caller died before acknowledgement. ----------
+  # The riskiest window: the event is on its way and the caller cannot know
+  # whether it committed. The kill is triggered by the CLI's own dispatch
+  # announcement, so this lands in the window deterministically rather than
+  # by racing a clock. Either outcome (committed or not) must leave exactly
+  # one message once the same id is retried.
+  RETRY_PIECE_2=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS "$SCRIPT_DIR/pattern/fuse-exec.tsx")
+  INVOCATION_2=$(new_invocation_id)
+  ANNOUNCE_FIFO=$(mktemp -u)
+  mkfifo "$ANNOUNCE_FIFO"
+  set +e
+  cf piece call $SPACE_ARGS --piece "$RETRY_PIECE_2" --invocation "$INVOCATION_2" \
+    recordMessage -- --message "dispatched-then-killed" > /dev/null 2> "$ANNOUNCE_FIFO" &
+  CALL_PID=$!
+  set -e
+  # Blocking read on the pipe — no poll, no deadline. If the process exits
+  # without announcing, the writer closes and the read ends at EOF.
+  ANNOUNCED=""
+  while IFS= read -r line; do
+    case "$line" in
+      *"invocation: $INVOCATION_2"*)
+        ANNOUNCED="yes"
+        break
+        ;;
+    esac
+  done < "$ANNOUNCE_FIFO"
+  kill_process_tree "$CALL_PID"
+  rm -f "$ANNOUNCE_FIFO"
+  if [ -z "$ANNOUNCED" ]; then
+    error "cf piece call should announce its invocation id at dispatch"
+  fi
+
+  cf piece call $SPACE_ARGS --piece "$RETRY_PIECE_2" --invocation "$INVOCATION_2" \
+    recordMessage -- --message "dispatched-then-killed" > /dev/null
+  assert_message_count "$RETRY_PIECE_2" 1 \
+    "Retrying a killed-after-dispatch call with the same id should leave exactly one message"
+
+  # --- 3. The commit succeeded but the response was lost. ------------------
+  # The retry collides on the handling's receipt, settles as success (exit 0)
+  # rather than as an error, and says so with deduplicated.
+  RETRY_PIECE_3=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS "$SCRIPT_DIR/pattern/fuse-exec.tsx")
+  INVOCATION_3=$(new_invocation_id)
+  cf piece call $SPACE_ARGS --piece "$RETRY_PIECE_3" --invocation "$INVOCATION_3" \
+    recordMessage -- --message "lost-response" > /dev/null
+
+  set +e
+  REPLAY=$(cf piece call $SPACE_ARGS --piece "$RETRY_PIECE_3" --invocation "$INVOCATION_3" \
+    recordMessage -- --message "lost-response" 2>/dev/null)
+  REPLAY_STATUS=$?
+  set -e
+  if [ "$REPLAY_STATUS" -ne 0 ]; then
+    error "A same-id retry should exit 0, got status $REPLAY_STATUS"
+  fi
+  echo "$REPLAY" | jq -e '.deduplicated == true' > /dev/null ||
+    error "A same-id retry should report deduplicated, got: $REPLAY"
+  echo "$REPLAY" | jq -e --arg id "$INVOCATION_3" '.invocation == $id' > /dev/null ||
+    error "A same-id retry should echo the caller's invocation id, got: $REPLAY"
+  assert_message_count "$RETRY_PIECE_3" 1 \
+    "A same-id retry after a successful commit should leave exactly one message"
+
+  # --- 4. A fresh process retrying the same id reads the ORIGINAL back. ----
+  # Sending a different payload under an id that already settled must not
+  # overwrite the original: the id identifies the invocation, so the second
+  # call reports the first one's outcome rather than applying its own.
+  RETRY_PIECE_4=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS "$SCRIPT_DIR/pattern/fuse-exec.tsx")
+  INVOCATION_4=$(new_invocation_id)
+  cf piece call $SPACE_ARGS --piece "$RETRY_PIECE_4" --invocation "$INVOCATION_4" \
+    recordMessage -- --message "original-payload" > /dev/null
+  cf piece call $SPACE_ARGS --piece "$RETRY_PIECE_4" --invocation "$INVOCATION_4" \
+    recordMessage -- --message "second-payload" > /dev/null
+  assert_message_count "$RETRY_PIECE_4" 1 \
+    "Reusing a settled id with a different payload should leave exactly one message"
+  LAST=$(cf piece get $SPACE_ARGS --piece "$RETRY_PIECE_4" lastMessage)
+  if [ "$LAST" != '"original-payload"' ]; then
+    error "The settled invocation's outcome should stand, got lastMessage: $LAST"
+  fi
+
+  echo "Successfully ran CLI piece call retry integration tests for ${API_URL}."
+}
+
 run_wish() {
   setup_space
 
@@ -534,6 +697,7 @@ case "$SECTION" in
     run_piece_values
     run_piece_links
     run_piece_call
+    run_piece_call_retry
     run_wish
     ;;
   piece-basics)
@@ -548,6 +712,10 @@ case "$SECTION" in
     ;;
   piece-call)
     run_piece_call
+    run_piece_call_retry
+    ;;
+  piece-call-retry)
+    run_piece_call_retry
     ;;
   wish)
     run_wish


### PR DESCRIPTION
Supersedes #5114, which GitHub auto-closed when its base branch (`cli/ws-d2-invocation`) was deleted on merge of #5089. Same branch, same commits, now targeting `main`.

## Why

The duplicate-on-retry bug is what started this arc: three times in one evening on the live topics board, a mutation timed out with unknowable commit state and no safe retry. D1 (#5087) built the runner machinery and D2 (#5089) the CLI surface — both merged. This is the evidence the guarantee holds against a real server rather than against test doubles, and the plan's Phase 2 exit criterion.

## What Changed

`run_piece_call_retry` in `packages/cli/integration/integration.sh`, running in the existing `piece-call` shard. No new CI job: the CI policy discourages adding matrix entries proactively, `setup_space` already isolates each scenario in its own space, and the measured cost is +12.9s on a shard that runs ~50s.

Four scenarios, each ending on the **same** assertion — exactly one message recorded — because that single property is what an agent depends on when it retries a call it could not observe:

1. **A failure before dispatch leaves nothing behind.** An unreachable API provably cannot dispatch, so no id was ever announced; the fresh-id retry that forces records exactly one.
2. **Killed after dispatch, before acknowledgement** — the riskiest window, where the caller cannot know whether the commit landed. The kill is triggered by the CLI's own `invocation:` announcement, read through a blocking pipe read, so it lands in the window without racing a clock or sleeping. Committed or not, the same-id retry leaves exactly one.
3. **Commit succeeded but the response was lost.** The retry settles as success — exit 0, `deduplicated: true` — rather than surfacing the receipt collision as an error.
4. **A settled id reused with a different payload does not overwrite.** The id identifies the invocation, so the second call reports the first one's outcome and `lastMessage` still holds `original-payload`.

Every scenario spawns a fresh `cf` process, so the plan's "retry from a fresh process" case is the default rather than a special one.

Support: `message_count` treats a piece with nothing materialized as zero messages rather than a read failure (matching `read_piece_value_or_default`); `new_invocation_id` falls back to Python where `uuidgen` is absent; `kill_process_tree` takes the children first, because `cf` is a shell function and `$!` is the subshell rather than the process that would otherwise still commit.

## Known gap

Scenario 3 asserts the collision (`deduplicated`, exit 0) but not a *result* read back off the receipt — `recordMessage` returns nothing to read. That assertion joins when WS-C gives verbs return values, or sooner against `plainResultReceipts`. The plan checkoff says so rather than implying full coverage.

## Test plan

Verified against a local toolshed two ways: through `deno task cli`, and through the **compiled `cf` binary** that CI actually uses — the second because `kill_process_tree` walks a process tree whose shape differs between them, and scenario 2 depends on that. Both pass, and dedup genuinely engages rather than passing vacuously: 6 receipt-race events across two distinct `evt:caller:<hash>` ids, which is D1's hash-scoped caller id doing its job.

Residual risk: both runs were on macOS. `pgrep -P` and stderr flush semantics are standard on Linux, but scenario 2 is where a difference would surface, and this suite has not yet run in CI — it could not, while the PR was stacked on a non-main base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four end-to-end retry scenarios for caller-supplied invocation IDs to prove idempotent mutation semantics against a real server (WS-D/D3). Strengthens the killed-after-dispatch case by detecting whether the first commit landed and asserting the correct dedup path.

- New Features
  - Adds `run_piece_call_retry` in `packages/cli/integration/integration.sh` with four scenarios:
    - Pre-dispatch failure → fresh-id retry.
    - Killed after dispatch, before ack → same-id retry; kill triggered by the CLI’s own “invocation:” line via blocking pipe; now records whether it committed and requires dedup only when it did.
    - Commit succeeded but response lost → same-id retry deduplicates and exits 0.
    - Reusing a settled id with a different payload → original outcome preserved.

- Refactors
  - `message_count` returns 0 when nothing is materialized.
  - `new_invocation_id` falls back to Python when `uuidgen` is missing.
  - `kill_process_tree` kills children before the subshell to avoid stray commits.
  - Wires tests into the `piece-call` shard, adds a `piece-call-retry` section; updates `docs/plans/pattern-verb-contract-implementation.md` to mark D3 done and note the small gap for scenario 3 result reads.

<sup>Written for commit b6358fa11996d9791b54ca994c4a149e80e88a80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

