### PR TITLE
fix(patterns): record — show the modules, and what each one says abou…

### DIFF
--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -25,6 +25,7 @@ Quick error reference and debugging workflows. For detailed explanations, see li
 | Can't access variable in nested scope | Variable scoping limitation | Pre-compute grouped data or use lift() with explicit params ([reactivity-issues](reactivity-issues.md#variable-scoping-in-reactive-contexts)) |
 | "Cannot access cell via closure" | Using lift() with closure | Pass all reactive deps as params to lift() ([@reactivity](../../common/concepts/reactivity.md)) |
 | CLI `get` returns stale computed values | `piece set` doesn't trigger recompute | Run `piece step` after `set` to trigger re-evaluation ([cli-debugging](cli-debugging.md#stale-computed-values-after-piece-set)) |
+| A field reads as `undefined` though the value is there; rendering the same path works | The field is typed `unknown`, whose schema the runner reads back as undefined while keeping the link | Name the field on the operand reading it — a lift/computed operand shape, or a `Cell<>` in a handler ([gotchas/unknown-typed-field-reads-undefined](gotchas/unknown-typed-field-reads-undefined.md)) |
 | Browser UI stale after a handler write | The write usually worked — the cell, piece, or render path is what to check | Inspect actual cell state first via `readCell`; don't rewrite the mutation ([gotchas/browser-stale-ui](gotchas/browser-stale-ui.md)) |
 | "handler() should be defined at module scope" | handler() inside pattern body | Move handler() outside pattern ([gotchas/handler-inside-pattern](gotchas/handler-inside-pattern.md)) |
 | UI churning, high CPU, never settles | Non-idempotent computed or action cycle | Run `await commonfabric.detectNonIdempotent()` ([non-idempotent-detection](non-idempotent-detection.md)) |
@@ -73,6 +74,7 @@ inside computed(); Stream subscribe doesn't exist; binding the whole item to
 - [Scoped Cell Pitfalls](gotchas/scoped-cell-pitfalls.md) - `PerSpace`/`PerUser`/`PerSession` gotchas, incl. guarding render-path `.get().map()` against undefined-before-sync
 - [Closure Capture in Nested map()](gotchas/closure-capture-in-nested-map.md) - `(cellCall() ?? []).map(...)` nested in an outer `.map(...)` is a code smell; three recipes (map the cell directly; pre-bake top-level computed; local computed bridge)
 - [Browser UI Stale After a Handler Write](gotchas/browser-stale-ui.md) - Inspect actual cell state before assuming the write failed
+- [A Field Typed `unknown` Reads Back as Undefined](gotchas/unknown-typed-field-reads-undefined.md) - The reading operand's schema decides what materializes; naming the field is what makes the read follow the link
 
 ### Compatibility entry points
 

--- a/docs/development/debugging/gotchas/unknown-typed-field-reads-undefined.md
+++ b/docs/development/debugging/gotchas/unknown-typed-field-reads-undefined.md
@@ -1,0 +1,148 @@
+# A field typed `unknown` reads back as undefined
+
+**Symptom:** a field holds a real value — another piece, a nested object — and
+every read of it through the declaring type is `undefined`. No compile error, no
+runtime error, no warning. Rendering the same path still works, which is what
+makes this confusing: `<cf-render $cell={entry.piece} />` shows the piece while
+`entry.piece.label` right beside it is undefined.
+
+```typescript
+// Shown at module scope.
+interface Entry {
+  type: string;
+  piece: unknown; // holds a link to another piece
+}
+```
+
+**Why:** `unknown` lowers to the schema `{ type: "unknown" }`, and the runner's
+traversal will not materialize an **object or array** read under it: those two
+arms short-circuit to `undefined` (`runner/src/traverse.ts`,
+`_traverseWithSchemaInner`). A primitive is unaffected — the string, number,
+boolean and null arms treat the same schema as a match and return the value — so
+a field typed `unknown` that holds a string reads back fine, and only one that
+holds an object or a list goes quiet. An `asCell` alongside it also still
+produces a cell; `{ type: ["unknown", …] }` and an `anyOf` with an unknown branch
+behave like the bare form.
+
+The path survives even when the value does not, which is why cells and rendering
+still work: a `$cell` binding passes the path, and the renderer reads it under a
+schema of its own (`asSchema(rendererVDOMSchema)` — `runner/src/runner.ts` on the
+mainline path, `shell/src/views/BodyView.ts`, and `html/src/render.ts` for legacy
+main-thread rendering), while every read of the *value* comes back empty.
+
+Two transformer diagnostics cover neighbouring cases and neither catches this
+one: `reactive-capture:unknown-type` reports a closure capture whose inferred
+type is `unknown`, and `schema:unknown-type-access` reports a property typed
+`unknown` accessed directly on a lift or handler parameter
+(`ts-transformers/src/transformers/type-shrinking.ts`). Reaching the field
+through an array element inside a callback, as below, is outside both.
+
+## What decides whether a read materializes
+
+The schema of the **operand the value is read into**, not the schema the field
+was declared with. A lift or handler that names the fields it wants gets them:
+the read follows the link into the target and materializes them, and re-runs
+when the target changes them.
+
+```typescript
+// Shown at module scope.
+// The operand names the field, so this read follows the link and materializes.
+const readLabel = lift<{ piece: { label?: string } }, string | undefined>(
+  ({ piece }) => piece?.label,
+);
+```
+
+Three rules decide whether such a read reaches the value:
+
+**Name the property.** Naming it is what reliably overrides a declared field
+schema. An operand of `entries?: any[]` can lower to `items: true`, and a `true`
+schema defers to the schema the cell itself carries (`traverse.ts`,
+`combineOptionalSchema`: a true parent falls through to
+`combineSchema(parentSchema, linkSchema)`) — with `piece: unknown` still inside
+it, so `entries[0].piece` is undefined. `entries?: { piece: any }[]` names the
+property, and the piece materializes: the same read of
+`entries[0].piece.nickname` yields the module's real nickname under the second
+operand and `undefined` under the first.
+
+Do not read `any[]` as always lowering to `items: true`. Type shrinking narrows
+an operand from the accesses in the lift body, so a body that indexes a literal
+position can get a structural schema that materializes, while the same
+annotation with a variable index gets `items: true` and does not. Naming the
+fields is what makes the read independent of that; `--show-transformed` below is
+how to see which one you got.
+
+**Apply the lift where the value is still a link.** A `.map()` at pattern-body
+scope keeps each element reactive, so a lift applied inside it is a real lift
+application on a link. The same `.map()` inside a `computed()` is not: the whole
+`computed()` body becomes a single lift, and the `.map()` there is plain
+JavaScript over the already-materialized list, where the field is already
+`undefined`.
+
+```typescript
+// Shown at module scope.
+const readEntryLabel = lift<{ piece: { label?: string } }, string | undefined>(
+  ({ piece }) => piece?.label,
+);
+
+export default pattern<{ entries: { type: string; piece: unknown }[] }>(
+  ({ entries }) => {
+    // Each element is still a link here, so the lift reads through it. The
+    // same expression inside a `computed()` would not.
+    const labels = entries.map((entry) =>
+      readEntryLabel({ piece: entry.piece as { label?: string } })
+    );
+    return { labels };
+  },
+);
+```
+
+**In a handler, ask for a cell.** A handler receives its operands as values, so
+there is no link left to follow. Type the field as a `Cell<...>` and call
+`get()` on it:
+
+```typescript
+// Shown at module scope.
+interface ListEntry {
+  type: string;
+  piece: unknown;
+}
+type EntryHandle =
+  & Omit<ListEntry, "piece">
+  & { piece: Cell<Record<string, unknown>> };
+
+const reportFirstLabel = handler<
+  { result: Writable<unknown> },
+  { entries: Writable<EntryHandle[]> }
+>(({ result }, { entries }) => {
+  result.set(entries.get()[0]?.piece?.get()?.label);
+});
+```
+
+The declaring type and the operand type describe the same cell; the call site
+casts between the two views. Casting **to** a `Cell<>` is rejected by the
+transformer, so a handler that also builds new entries cannot take this view of
+the list it writes: the entry it constructs would have to be cast into it.
+
+## Confirming it
+
+The emitted operand schema is the ground truth, and
+`--show-transformed` prints it:
+
+```bash
+deno task cf check <pattern>.tsx --show-transformed --no-run
+```
+
+A field you expect to read shows as `{ type: "unknown" }` when the read will
+come back undefined, and as the shape you named when it will materialize.
+
+## Where this has bitten
+
+`packages/patterns/record.tsx` holds each of its modules as
+`SubPieceEntry.piece: unknown`. Every feature that read a field off a module —
+the module's own label in its header, the icon a record-icon module carries, the
+aliases a nickname module carries, the settings dialog's contents, the LLM
+summary's per-module data, and the smart-default label picker — read `undefined`
+and silently fell back, each discovered separately. The label picker was fixed
+by recording the chosen label on the entry beside the piece; the rest read
+through the module, as above. See `packages/patterns/record-module-fields.test.tsx`
+and `packages/patterns/integration/record-module-chrome.test.ts`.

--- a/packages/patterns/integration/record-module-chrome.test.ts
+++ b/packages/patterns/integration/record-module-chrome.test.ts
@@ -13,6 +13,9 @@
  * dialog opened with a body that was always null. record.tsx now takes them
  * through lifts whose operands name the fields being read.
  *
+ * The shell is navigated once in the setup, and each case below drives the
+ * page from there, so neither depends on the other having run.
+ *
  * This is a browser test because the values it checks exist only in the
  * rendered UI. `record-module-fields.test.tsx` covers the same reads where a
  * headless pattern test can see them: the icon and the aliases in [NAME].
@@ -139,6 +142,15 @@ describe("record module chrome integration test", () => {
     );
     await cc.manager().runtime.idle();
     await cc.manager().synced();
+
+    // Navigate once, here rather than in the first case, so each case below
+    // starts from a shell showing the Record and none of them depends on an
+    // earlier one having navigated.
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: SPACE_NAME, pieceId },
+      identity,
+    });
   });
 
   afterAll(async () => {
@@ -147,11 +159,6 @@ describe("record module chrome integration test", () => {
   });
 
   it("heads each module with that module's own label", async () => {
-    await shell.goto({
-      frontendUrl: FRONTEND_URL,
-      view: { spaceName: SPACE_NAME, pieceId },
-      identity,
-    });
     const page = shell.page();
     await settleView(page);
 
@@ -164,7 +171,7 @@ describe("record module chrome integration test", () => {
     await waitForText(page, "body", "📷 Portrait");
   });
 
-  it("opens a module's own settings under a title naming that module", async () => {
+  it("opens a module's own settings, bound to the module they came from", async () => {
     const page = shell.page();
     await settleView(page);
 
@@ -181,14 +188,10 @@ describe("record module chrome integration test", () => {
     // module's own settings control.
     await waitForText(page, "cf-modal[open]", "📷 Portrait Settings");
     await waitForText(page, "cf-modal[open]", "Photo Label");
-  });
 
-  it("keeps the dialog's controls bound to the module they came from", async () => {
-    const page = shell.page();
-
-    // The dialog holds the module's own settings node rather than a copy of it:
-    // typing a new label into it reaches the photo module, and the Record's
-    // header follows the module's new label.
+    // That control is the module's own node rather than a copy of it: typing a
+    // new label into it reaches the photo module, and the Record's header
+    // follows the module's new label.
     await fillCfInput(page, "cf-modal[open] cf-input", "Headshot");
     await settleView(page);
     await waitForText(page, "body", "📷 Headshot");

--- a/packages/patterns/integration/record-module-chrome.test.ts
+++ b/packages/patterns/integration/record-module-chrome.test.ts
@@ -1,0 +1,196 @@
+/**
+ * The chrome a Record draws around each module it holds: the header label and
+ * the settings dialog.
+ *
+ * Both read fields off the module itself rather than off the Record's own list.
+ * The header shows the module's instance label — the email module's "Personal"
+ * or "Work" — falling back to the module type's generic name ("Email") when the
+ * module has none, and the settings dialog shows the module's own `settingsUI`
+ * under a title carrying that same instance label. Reading either means going
+ * through `SubPieceEntry.piece`, which is typed `unknown`: that is the schema
+ * the runner reads back as undefined instead of materializing the value, so
+ * these reads saw nothing, the header fell back to the type name, and the
+ * dialog opened with a body that was always null. record.tsx now takes them
+ * through lifts whose operands name the fields being read.
+ *
+ * This is a browser test because the values it checks exist only in the
+ * rendered UI. `record-module-fields.test.tsx` covers the same reads where a
+ * headless pattern test can see them: the icon and the aliases in [NAME].
+ *
+ * The setup is also the only coverage of one thing the Record does not show:
+ * writing the module list through the piece API. An entry that stores an
+ * explicit undefined in its string-typed `label` makes that write fail, so the
+ * `updateModule` send below is what catches a regression there.
+ *
+ * The assertions read the rendered text of the whole page, so each one names
+ * text only the Record's own chrome produces. The type icon and the instance
+ * label sit together in the header ("📧 Personal"), which no module body
+ * renders: an email module shows its label only as the value of an input, and
+ * the photo module shows its label only once a photo is uploaded.
+ */
+import {
+  env,
+  type Page,
+  type ProbeApi,
+  waitForCondition,
+} from "@commonfabric/integration";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import {
+  initializePiecesController,
+  PieceController,
+  PiecesController,
+} from "./pieces-controller.ts";
+import {
+  fillCfInput,
+  settleView,
+  waitForText,
+  waitForTextAbsent,
+} from "./cfc-browser-helpers.ts";
+
+const { API_URL, FRONTEND_URL } = env;
+const SPACE_NAME = "record-module-chrome-" + Date.now().toString(36);
+
+const CLICK_TARGET_ATTR = "data-record-click-target";
+
+/**
+ * Tag the first rendered element matching `selector` so the test can click it.
+ * Runs in the page, so it closes over nothing in this module. The Record's
+ * module-header controls are plain buttons that carry their purpose in `title`,
+ * which is what the selector addresses.
+ */
+const markClickTarget = (
+  probe: ProbeApi,
+  selector: string,
+  token: string,
+  attr: string,
+): boolean => {
+  for (const element of probe.collect(selector)) {
+    if (!probe.isRendered(element)) continue;
+    element.setAttribute(attr, token);
+    return true;
+  }
+  return false;
+};
+
+/** Click the first rendered element matching `selector`. */
+async function clickBySelector(page: Page, selector: string): Promise<void> {
+  const token = `record-target-${crypto.randomUUID()}`;
+  await waitForCondition(page, markClickTarget, {
+    args: [selector, token, CLICK_TARGET_ATTR],
+  });
+  const target = await page.waitForSelector(
+    `[${CLICK_TARGET_ATTR}="${token}"]`,
+    { strategy: "pierce" },
+  );
+  await target.click();
+}
+
+describe("record module chrome integration test", () => {
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
+
+  let identity: Identity;
+  let cc: PiecesController;
+  let record: PieceController;
+  let pieceId: string;
+  const cancels: Array<() => void> = [];
+
+  beforeAll(async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+    cc = await initializePiecesController({
+      spaceName: SPACE_NAME,
+      apiUrl: new URL(API_URL),
+      identity,
+    });
+    const program = await cc.manager().runtime.harness.resolve(
+      new FileSystemProgramResolver(
+        join(import.meta.dirname!, "..", "record.tsx"),
+      ),
+    );
+    record = await cc.create(program, {
+      input: { title: "Elizabeth Bennet", subPieces: [], trashedSubPieces: [] },
+      start: true,
+    });
+    pieceId = record.id;
+    // Keep the piece reactive (pull mode) so its handlers run on send.
+    cancels.push(cc.manager().getResult(record.getCell()).sink(() => {}));
+
+    // Two emails take the first two standard labels, "Personal" and "Work". The
+    // photo module is the one that exports a settingsUI; its label is set
+    // explicitly, so the dialog title has an instance label to show.
+    for (const type of ["email", "email", "photo"]) {
+      await record.result.set({ type }, ["addModule"]);
+      await cc.manager().runtime.idle();
+    }
+    // The list also holds the modules the Record seeded itself with, so the
+    // photo is addressed by its type rather than by the order it was added in.
+    const entries = await record.result.get(["subPieces"]) as {
+      type?: string;
+    }[];
+    const photoIndex = entries.findIndex((entry) => entry?.type === "photo");
+    if (photoIndex < 0) throw new Error("the photo module was not added");
+    await record.result.set(
+      { index: photoIndex, field: "label", value: "Portrait" },
+      ["updateModule"],
+    );
+    await cc.manager().runtime.idle();
+    await cc.manager().synced();
+  });
+
+  afterAll(async () => {
+    for (const cancel of cancels) cancel();
+    if (cc) await cc.dispose();
+  });
+
+  it("heads each module with that module's own label", async () => {
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: SPACE_NAME, pieceId },
+      identity,
+    });
+    const page = shell.page();
+    await settleView(page);
+
+    // The modules themselves render: an email module's own UI is on screen.
+    await waitForText(page, "cf-field", "Email");
+
+    // Each header names the module instance rather than its type.
+    await waitForText(page, "body", "📧 Personal");
+    await waitForText(page, "body", "📧 Work");
+    await waitForText(page, "body", "📷 Portrait");
+  });
+
+  it("opens a module's own settings under a title naming that module", async () => {
+    const page = shell.page();
+    await settleView(page);
+
+    // Nothing of the photo module's settings is on the page until the dialog
+    // opens, so the text below is what the click produces.
+    await waitForTextAbsent(page, "body", "Photo Label");
+
+    // The gear appears only on a module that exports a settingsUI, so finding
+    // one to click also pins that the photo module is offering one.
+    await clickBySelector(page, 'button[title="Settings"]');
+    await settleView(page);
+
+    // The title carries the module's instance label, and the body is the photo
+    // module's own settings control.
+    await waitForText(page, "cf-modal[open]", "📷 Portrait Settings");
+    await waitForText(page, "cf-modal[open]", "Photo Label");
+  });
+
+  it("keeps the dialog's controls bound to the module they came from", async () => {
+    const page = shell.page();
+
+    // The dialog holds the module's own settings node rather than a copy of it:
+    // typing a new label into it reaches the photo module, and the Record's
+    // header follows the module's new label.
+    await fillCfInput(page, "cf-modal[open] cf-input", "Headshot");
+    await settleView(page);
+    await waitForText(page, "body", "📷 Headshot");
+  });
+});

--- a/packages/patterns/record-module-fields.test.tsx
+++ b/packages/patterns/record-module-fields.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * Test: the Record reads its modules' own fields.
+ *
+ * A Record shows things that live on the modules it holds rather than on its
+ * own list: the icon a record-icon module carries, the aliases the nickname
+ * modules carry, and each module's instance label. Reading them means reaching
+ * through `SubPieceEntry.piece`, which is typed `unknown`; that schema is the
+ * one the runner reads back as undefined instead of materializing the value, so
+ * every such read saw nothing. The reads now go through `readDisplayFields`,
+ * whose operand names the fields, and the runner materializes them by following
+ * the entry's link into the module.
+ *
+ * The icon and the aliases are visible in the Record's [NAME], which this file
+ * drives: `[NAME]` is `${recordIcon} ${displayNameWithAlias}`, so a
+ * record-icon module's emoji replaces the type-inferred icon and each nickname
+ * module's value joins the "(aka ...)" suffix. Both start empty and are set
+ * through updateModule, so the assertions also pin that the reads are live: the
+ * Record follows an edit made after the module was added, rather than a copy
+ * taken when it was created.
+ *
+ * The same reads supply each module's header label, which the second half of
+ * this file checks by walking the rendered [UI] for its text. Those assertions
+ * also cover the module list being rendered at all: `allEntriesWithIndex` gates
+ * on reading `seedRecord`'s result, and while that lift's result type was
+ * inferred the capture was left out of the reading lift's input schema, so the
+ * read came back undefined and every module was hidden. Counting the cards is
+ * what catches that, though not what pins the fix: declaring the result type is
+ * one of two things that put the capture back in the schema, and the reading
+ * lift's other captures currently do it too, so the count passes with the
+ * annotation removed. It fails on the version of the pattern that had
+ * neither.
+ *
+ * The settings dialog reads the same way and can only be seen in a browser;
+ * `integration/record-module-chrome.test.ts` covers it, together with the
+ * dialog's controls staying bound to the module they came from.
+ * `record-llm-streams.test.tsx` covers the module field data that getSummary
+ * reports.
+ *
+ * The first Record is never rendered, so its seeder never runs and its module
+ * list starts empty, which makes the module indices the add order.
+ *
+ * Run: deno task cf test packages/patterns/record-module-fields.test.tsx --root packages/patterns --verbose
+ */
+import { action, assert, NAME, pattern, UI, Writable } from "commonfabric";
+import RecordPattern from "./record.tsx";
+
+interface AddResult {
+  success?: boolean;
+  moduleIndex?: number;
+}
+interface UpdateResult {
+  success?: boolean;
+  error?: string;
+}
+
+// ===== Reading the rendered module list =====
+// The module headers are only in the Record's [UI], so the header assertions
+// walk the rendered tree and collect its text. A reactive value in the tree is
+// read through `get()` where it has one.
+
+const isNode = (value: unknown): value is Record<PropertyKey, unknown> =>
+  typeof value === "object" && value !== null;
+
+const readNode = (value: unknown): unknown => {
+  if (!isNode(value) || typeof value.get !== "function") return value;
+  return (value.get as () => unknown)();
+};
+
+const childNodesOf = (node: unknown): unknown[] => {
+  const value = readNode(node);
+  if (Array.isArray(value)) return value;
+  if (!isNode(value)) return [];
+  const children = readNode(value.children);
+  if (Array.isArray(children)) return children;
+  return children === undefined || children === null ? [] : [children];
+};
+
+/** Every text node in `root`, in tree order. */
+const collectText = (root: unknown, out: string[], depth = 0): string[] => {
+  // A cycle would otherwise walk forever. Thrown rather than returned, so a
+  // tree that outgrows this never turns an assertion on absent text into a
+  // silent pass.
+  if (depth > 100) throw new Error(`vdom walk exceeded ${depth} levels`);
+  const value = readNode(root);
+  if (typeof value === "string") {
+    const text = value.trim();
+    if (text) out.push(text);
+    return out;
+  }
+  for (const child of childNodesOf(value)) collectText(child, out, depth + 1);
+  return out;
+};
+
+export default pattern(() => {
+  const subject = RecordPattern({
+    title: "Elizabeth",
+    subPieces: [],
+    trashedSubPieces: [],
+  });
+
+  const addIcon = new Writable<AddResult>();
+  const addFirstNickname = new Writable<AddResult>();
+  const addSecondNickname = new Writable<AddResult>();
+  const setIcon = new Writable<UpdateResult>();
+  const clearIcon = new Writable<UpdateResult>();
+  const setFirstNickname = new Writable<UpdateResult>();
+  const setSecondNickname = new Writable<UpdateResult>();
+
+  const action_add_icon_module = action(() => {
+    subject.addModule!.send({ type: "record-icon", result: addIcon });
+  });
+  const action_add_first_nickname = action(() => {
+    subject.addModule!.send({ type: "nickname", result: addFirstNickname });
+  });
+  const action_add_second_nickname = action(() => {
+    subject.addModule!.send({ type: "nickname", result: addSecondNickname });
+  });
+  const action_set_icon = action(() => {
+    subject.updateModule!.send({
+      index: 0,
+      field: "icon",
+      value: "\u{1F419}",
+      result: setIcon,
+    });
+  });
+  const action_clear_icon = action(() => {
+    subject.updateModule!.send({
+      index: 0,
+      field: "icon",
+      value: "   ",
+      result: clearIcon,
+    });
+  });
+  const action_set_first_nickname = action(() => {
+    subject.updateModule!.send({
+      index: 1,
+      field: "nickname",
+      value: "Liz",
+      result: setFirstNickname,
+    });
+  });
+  const action_set_second_nickname = action(() => {
+    subject.updateModule!.send({
+      index: 2,
+      field: "nickname",
+      value: "Beth",
+      result: setSecondNickname,
+    });
+  });
+
+  // A record with no modules falls back to the type-inferred icon (the generic
+  // clipboard, since nothing indicates a more specific type) and shows its
+  // title alone.
+  const assert_plain_name = assert(() =>
+    subject[NAME] === "\u{1F4CB} Elizabeth"
+  );
+
+  // An empty record-icon module does not override the inferred icon.
+  const assert_empty_icon_module_ignored = assert(() =>
+    subject[NAME] === "\u{1F4CB} Elizabeth"
+  );
+
+  // Setting the module's icon replaces the inferred one.
+  const assert_icon_override = assert(() =>
+    subject[NAME] === "\u{1F419} Elizabeth"
+  );
+
+  // A whitespace-only icon is not an override, so the inferred icon returns.
+  const assert_blank_icon_falls_back = assert(() =>
+    subject[NAME] === "\u{1F4CB} Elizabeth"
+  );
+
+  const assert_writes_accepted = assert(() =>
+    setIcon.get()?.success === true &&
+    setFirstNickname.get()?.success === true &&
+    setSecondNickname.get()?.success === true
+  );
+
+  // An empty nickname module contributes no alias.
+  const assert_empty_nickname_ignored = assert(() =>
+    subject[NAME] === "\u{1F4CB} Elizabeth"
+  );
+
+  // One nickname module shows its value as an alias.
+  const assert_single_alias = assert(() =>
+    subject[NAME] === "\u{1F4CB} Elizabeth (aka Liz)"
+  );
+
+  // Every nickname module contributes, in list order.
+  const assert_both_aliases = assert(() =>
+    subject[NAME] === "\u{1F4CB} Elizabeth (aka Liz, Beth)"
+  );
+
+  // The modules are where the values live: an entry carries none of them, only
+  // the module type and the Record's own bookkeeping, so a Record that could
+  // not read through to its modules would show none of the above.
+  const assert_entry_types = assert(() => {
+    const types = [...(subject.subPieces ?? [])].map((entry) => entry.type);
+    return types.length === 3 &&
+      types[0] === "record-icon" &&
+      types[1] === "nickname" &&
+      types[2] === "nickname";
+  });
+
+  // ===== The rendered module list =====
+  // A second Record, driven through a render step, to read what the module
+  // headers say. Its modules are added before it is rendered, so its list is
+  // not empty when the UI first asks for it and the seeder leaves it alone:
+  // the cards below are exactly the email and the photo.
+  const renderedSubject = RecordPattern({
+    title: "Rendered",
+    subPieces: [],
+    trashedSubPieces: [],
+  });
+  const renderedEmail = new Writable<AddResult>();
+  const renderedPhoto = new Writable<AddResult>();
+  const action_render_add_email = action(() => {
+    renderedSubject.addModule!.send({ type: "email", result: renderedEmail });
+  });
+  const action_render_add_photo = action(() => {
+    renderedSubject.addModule!.send({ type: "photo", result: renderedPhoto });
+  });
+
+  // One card per module. The collapse toggle is per card, so counting those
+  // counts the cards: a module list that renders nothing has none of them.
+  // Each assertion reads `[UI]` itself, which demands the tree it walks; the
+  // render step before them is what first drives the Record's own seeding.
+  const assert_two_cards_rendered = assert(() => {
+    const texts = collectText(renderedSubject[UI], []);
+    return texts.filter((text) => text === "▶").length === 2;
+  });
+
+  // The email module took the "Personal" standard label, and its header shows
+  // that rather than the type name "Email". The photo module has no label of
+  // its own, so its header falls back to the type name.
+  const assert_header_shows_instance_label = assert(() => {
+    const rendered = collectText(renderedSubject[UI], []).join(" ");
+    return rendered.includes("\u{1F4E7} Personal") &&
+      !rendered.includes("\u{1F4E7} Email");
+  });
+  const assert_header_falls_back_to_type = assert(() => {
+    const rendered = collectText(renderedSubject[UI], []).join(" ");
+    return rendered.includes("\u{1F4F7} Photo");
+  });
+
+  return {
+    tests: [
+      { assertion: assert_plain_name },
+
+      { action: action_add_icon_module },
+      { assertion: assert_empty_icon_module_ignored },
+      { action: action_set_icon },
+      { assertion: assert_icon_override },
+      { action: action_clear_icon },
+      { assertion: assert_blank_icon_falls_back },
+      { action: action_set_icon },
+      { assertion: assert_icon_override },
+
+      { action: action_add_first_nickname },
+      { action: action_add_second_nickname },
+      { assertion: assert_entry_types },
+
+      { action: action_clear_icon },
+      { assertion: assert_empty_nickname_ignored },
+
+      { action: action_set_first_nickname },
+      { assertion: assert_single_alias },
+      { action: action_set_second_nickname },
+      { assertion: assert_both_aliases },
+      { assertion: assert_writes_accepted },
+
+      { action: action_render_add_email },
+      { action: action_render_add_photo },
+      { render: renderedSubject[UI] },
+      { assertion: assert_two_cards_rendered },
+      { assertion: assert_header_shows_instance_label },
+      { assertion: assert_header_falls_back_to_type },
+    ],
+    subject,
+    renderedSubject,
+  };
+});

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -51,6 +51,7 @@ interface RecordInput {
 }
 
 export interface RecordOutput {
+  [NAME]?: string;
   [UI]?: VNode;
   title?: string | Default<"">;
   subPieces?: SubPieceEntry[] | Default<[]>;
@@ -98,7 +99,12 @@ const seedRecord = lift<{
   notesPiece: Cell<NoteOutput>;
   typePickerPiece: Cell<TypePickerOutput>;
   isInitialized: Writable<boolean>;
-}>(({
+  // The result type is declared rather than inferred. The body reads this
+  // lift's result to demand the seed, and a capture the schema generator leaves
+  // out of the reading lift's input schema is dropped on read: the read came
+  // back undefined, the guard on it treated a seeded Record as unseeded, and
+  // the module list rendered empty.
+}, boolean>(({
   currentPieces,
   subPieces,
   notesPiece,
@@ -128,6 +134,40 @@ const seedRecord = lift<{
   return true;
 });
 
+// ===== Reading a sub-piece's own fields =====
+//
+// SubPieceEntry.piece is typed `unknown`, which lowers to `{ type: "unknown" }`,
+// and an object read under that schema comes back as undefined rather than
+// materialized. So `entry.piece.label` and its siblings read as undefined
+// wherever the entry carries its declared schema. What materializes a read is
+// the schema of the operand it is read into, so the lifts below name the fields
+// they want: the read then follows the entry's link into the sub-piece and
+// materializes them, and re-runs when the sub-piece changes them. The call sites
+// cast the `unknown` handle to the operand's shape; the cell is the same either
+// way.
+
+/** What the Record's own chrome displays about a module it holds. */
+interface SubPieceDisplayFields {
+  /** The module type, carried through so a reader can pick modules by it. */
+  type: string;
+  /** Instance label, e.g. the email module's "Personal" or "Work". */
+  label?: string;
+  /** Icon chosen in a record-icon module. */
+  icon?: string;
+  /** Alias held by a nickname module. */
+  nickname?: string;
+}
+
+const readDisplayFields = lift<
+  { type: string; piece: Omit<SubPieceDisplayFields, "type"> },
+  SubPieceDisplayFields
+>(({ type, piece }) => ({
+  type,
+  label: piece?.label,
+  icon: piece?.icon,
+  nickname: piece?.nickname,
+}));
+
 // Helper to check if a module has settings UI
 const moduleHasSettings = lift(
   // deno-lint-ignore no-explicit-any
@@ -136,6 +176,33 @@ const moduleHasSettings = lift(
     return !!piece?.settingsUI;
   },
 );
+
+// The settings UI exported by the module at `index`, or null when no module is
+// selected or the module exports none. Naming `piece` on the operand is what
+// makes the read follow the link: an operand that only says the entries are
+// permissive leaves each element resolving against its own declared schema,
+// with `piece: unknown` still in it. The settings node itself is left
+// permissive, which keeps it a reference to the sub-piece's own UI rather than
+// a copy, so the controls in it stay bound to the sub-piece.
+const readSettingsUI = lift(
+  ({ entries, index }: {
+    // deno-lint-ignore no-explicit-any
+    entries?: { piece: any }[];
+    index?: number;
+  }) => {
+    if (index === undefined || index === null) return null;
+    return entries?.[index]?.piece?.settingsUI ?? null;
+  },
+);
+
+// The same field reads inside a handler go through a live Cell rather than a
+// declared operand shape: a handler receives the entry list as a value, so the
+// piece has to survive the boundary as a handle it can call `get()` on. A
+// handler that reads or writes a module's fields takes this view of the same
+// `subPieces` cell, and the call site casts to bridge the two views.
+type SubPieceEntryHandle =
+  & Omit<SubPieceEntry, "piece">
+  & { piece: Cell<Record<string, unknown>> };
 
 // ===== Module-Scope Handlers (avoid closures, use references not indices) =====
 
@@ -241,7 +308,12 @@ const addSubPiece = handler<
     pinned: false,
     collapsed: false,
     piece,
-    label: nextLabel,
+    // Omitted rather than stored as undefined when the type has no standard
+    // labels: the field is declared a string, and a write of the whole list
+    // through the piece API validates a present-but-undefined property against
+    // that declaration and rejects the write ("subPieces: N: label: value does
+    // not match type string").
+    ...(nextLabel ? { label: nextLabel } : {}),
   }]);
   sat.set("");
 });
@@ -437,16 +509,6 @@ const toggleTrashExpanded = handler<unknown, { expanded: Writable<boolean> }>(
 // IMPORTANT: Handlers must use result.set() to return data to the LLM.
 // The 'result' Cell is injected by llm-dialog.ts invoke() - return statements are ignored!
 
-// SubPieceEntry as an LLM handler that touches the piece must type it. The
-// shared SubPieceEntry declares `piece: unknown`, and a field typed `unknown`
-// reads back across the handler boundary as undefined, so a handler that needs
-// to read the piece's fields or write them types the piece as a live Cell
-// instead. The handler still receives the same `subPieces` cell; the call site
-// casts to bridge the two views.
-type SubPieceEntryHandle =
-  & Omit<SubPieceEntry, "piece">
-  & { piece: Cell<Record<string, unknown>> };
-
 // Get a structured summary of all modules in this record
 // Returns module types, their data, and schemas for LLM context
 const handleGetSummary = handler<
@@ -573,7 +635,7 @@ const handleAddModule = handler<
     pinned: false,
     collapsed: false,
     piece,
-    label: entryLabel,
+    ...(entryLabel ? { label: entryLabel } : {}),
   }]);
 
   if (result) {
@@ -747,7 +809,7 @@ const createSibling = handler<
     pinned: false,
     collapsed: false,
     piece,
-    label: nextLabel,
+    ...(nextLabel ? { label: nextLabel } : {}),
   });
   sc.set(updated);
 });
@@ -824,6 +886,27 @@ const Record = pattern<RecordInput, RecordOutput>(
     // Display name with fallback
     const displayName = computed(() => title?.trim() || "(Untitled Record)");
 
+    // Each module's own label, icon and nickname, in list order. The reads live
+    // here rather than inside the computeds below because a `.map()` at pattern
+    // scope keeps each element a link, so `readDisplayFields` is applied to the
+    // entry's piece itself; the same `.map()` inside a `computed()` would run
+    // over the already-materialized list, where the piece is undefined. Each
+    // element carries its module type, so a reader that wants one kind of
+    // module picks it out of this list rather than pairing it with `subPieces`
+    // by position.
+    const displayFields = subPieces.map((entry) =>
+      readDisplayFields({
+        type: entry.type,
+        piece: entry.piece as Omit<SubPieceDisplayFields, "type">,
+      })
+    );
+    const trashedDisplayFields = trashedSubPieces.map((entry) =>
+      readDisplayFields({
+        type: entry.type,
+        piece: entry.piece as Omit<SubPieceDisplayFields, "type">,
+      })
+    );
+
     // Entry with index for rendering - preserves piece references (no spreading!)
     // isExpanded is pre-computed to avoid closure issues inside .map() callbacks
     // displayInfo is computed using module-scope lift() that properly unwraps Cell values
@@ -852,8 +935,7 @@ const Record = pattern<RecordInput, RecordOutput>(
         // This works because CTS transforms .map() to properly unwrap reactive values
         const displayInfo = getDisplayInfo(
           entry.type,
-          // deno-lint-ignore no-explicit-any
-          (entry.piece as any)?.label,
+          displayFields[index]?.label,
         );
         return {
           entry,
@@ -923,11 +1005,10 @@ const Record = pattern<RecordInput, RecordOutput>(
 
     // Check for manual icon override from record-icon module
     const manualIcon = computed(() => {
-      const iconModule = subPieces.find((e) => e?.type === "record-icon");
-      if (!iconModule) return null;
-      // deno-lint-ignore no-explicit-any
-      const iconValue = (iconModule.piece as any)?.icon;
-      if (!iconValue) return null;
+      const iconModule = (displayFields || []).find((fields) =>
+        fields?.type === "record-icon"
+      );
+      const iconValue = iconModule?.icon;
       return typeof iconValue === "string" && iconValue.trim()
         ? iconValue.trim()
         : null;
@@ -942,17 +1023,12 @@ const Record = pattern<RecordInput, RecordOutput>(
 
     // Extract nicknames from nickname modules for display in NAME
     const nicknamesList = computed(() => {
-      const nicknameModules = subPieces.filter((e) => e?.type === "nickname");
       const nicknames: string[] = [];
-      for (const mod of nicknameModules) {
-        try {
-          // deno-lint-ignore no-explicit-any
-          const nicknameValue = (mod.piece as any)?.nickname;
-          if (typeof nicknameValue === "string" && nicknameValue.trim()) {
-            nicknames.push(nicknameValue.trim());
-          }
-        } catch {
-          // Ignore errors
+      for (const fields of displayFields || []) {
+        if (fields?.type !== "nickname") continue;
+        const nicknameValue = fields.nickname;
+        if (typeof nicknameValue === "string" && nicknameValue.trim()) {
+          nicknames.push(nicknameValue.trim());
         }
       }
       return nicknames;
@@ -975,8 +1051,7 @@ const Record = pattern<RecordInput, RecordOutput>(
         // Get display info using plain helper function
         const displayInfo = getDisplayInfo(
           entry.type,
-          // deno-lint-ignore no-explicit-any
-          (entry.piece as any)?.label,
+          trashedDisplayFields[trashIndex]?.label,
         );
         return { entry, trashIndex, displayInfo };
       });
@@ -991,13 +1066,9 @@ const Record = pattern<RecordInput, RecordOutput>(
     // ===== Settings Modal Computed Values =====
 
     // Get the settings UI for the currently selected module (if any)
-    const currentSettingsUI = computed(() => {
-      const idx = settingsModuleIndex.get();
-      if (idx === undefined) return null;
-      const entry = subPieces[idx];
-      if (!entry) return null;
-      // deno-lint-ignore no-explicit-any
-      return (entry.piece as any)?.settingsUI || null;
+    const currentSettingsUI = readSettingsUI({
+      entries: subPieces,
+      index: settingsModuleIndex,
     });
 
     // Get display info for the module whose settings are open
@@ -1007,11 +1078,7 @@ const Record = pattern<RecordInput, RecordOutput>(
       const entry = subPieces[idx];
       if (!entry) return { icon: "", label: "Settings" };
       // Use plain helper function to get display info
-      return getDisplayInfo(
-        entry.type,
-        // deno-lint-ignore no-explicit-any
-        (entry.piece as any)?.label,
-      );
+      return getDisplayInfo(entry.type, displayFields[idx]?.label);
     });
 
     // ===== Main UI =====

--- a/packages/patterns/record/template-registry.ts
+++ b/packages/patterns/record/template-registry.ts
@@ -198,7 +198,11 @@ export function createTemplateModules(
         type: moduleType,
         pinned: template.defaultPinned.includes(moduleType),
         piece,
-        label,
+        // Omitted rather than stored as undefined when the type has no
+        // standard labels: the field is declared a string, and a write of the
+        // whole list through the piece API validates a present-but-undefined
+        // property against that declaration and rejects the write.
+        ...(label ? { label } : {}),
       });
     } catch (error) {
       console.warn(


### PR DESCRIPTION
…t itself

A Record's module list rendered nothing. `allEntriesWithIndex` reads `seedRecord`'s result to demand the seed that fills a fresh Record with its Notes and TypePicker modules, and returns an empty list when that read is falsy. While that lift's result type was inferred rather than declared, the capture was left out of the reading lift's generated input schema, so the runner dropped it, the read came back undefined, and every module sat behind a guard that could never pass. Declaring the result type puts the capture in the schema. The transformer dropping a capture that the call site passes is a separate defect, reproducible in a few lines outside this pattern, and is not fixed here.

Behind that, the chrome the Record draws around each module reads fields off the module rather than off the Record's own list: each module's header shows its instance label (an email module's "Personal" or "Work"), a record-icon module supplies the record's icon, nickname modules supply the aliases in its name, and the settings dialog shows a module's own settings UI under a title carrying that same instance label. Every one of those reads went through `SubPieceEntry.piece`, which is typed `unknown`, and an object read under that schema comes back as undefined rather than materialized. So each feature silently fell back: a header showed the module type name, a record-icon module never changed the icon, a nickname module never contributed an alias, and the settings dialog opened with an empty body.

What materializes a read is the schema of the operand the value is read into, not the schema the field was declared with, so the reads now go through lifts that name the fields they want. `readDisplayFields` names label, icon and nickname, and is applied per entry by a `.map()` at pattern-body scope, because that keeps each element a link: the same `.map()` inside a `computed()` runs over the already-materialized list, where the piece is undefined. It carries each module's type alongside the fields, so the icon and alias readers pick their module out of that one list rather than pairing it with `subPieces` by position.

`readSettingsUI` names `piece` on its operand, which is the load-bearing part: naming the property is what makes the read follow the entry's link into the module, and leaving the settings node itself permissive keeps it a reference to the module's own UI rather than a copy — so typing a new label into the photo module's settings reaches the module, and the Record's header follows. The gear that opens the dialog already worked, because the lift behind it names the piece that way; that is why the gear appeared over a dialog that had nothing in it.

Entries for module types that have no standard labels stored an explicit undefined in `label`, a field declared a string. A write of the whole list through the piece API validates that present-but-undefined property against the declaration and rejects the write ("subPieces: N: label: value does not match type string"), which is how this surfaced. The creation sites and the template builder now omit the field instead.

`RecordOutput` now declares `[NAME]`. The shell reads a piece's name with a schema of its own, so the name always reached the shell; a pattern holding a Record's output could not read it, which also left the icon and alias behavior unobservable from a test.

Two tests cover the revived behavior. `record-module-fields.test.tsx` drives the icon and the aliases through the Record's `[NAME]`, setting both after the modules were added so it pins that the reads are live rather than a copy taken at creation, and walks the rendered `[UI]`: it counts the module cards, so a list that renders nothing fails, and it checks that a labelled module's header shows its label while an unlabelled one falls back to the type name. Reverting the header read leaves that assertion reading "Email" instead of "Personal". `integration/record-module-chrome.test.ts` covers what only exists in a browser — the headers, the settings dialog's title and body, and typing into that dialog reaching the module — and its setup is also the only thing exercising a write of the module list through the piece API.

The runtime behavior behind all of this — which values a `{ type: "unknown" }` schema drops, the operand schema deciding what materializes, naming the property, where the read has to happen, and the `Cell<>` form a handler needs — is written up as a gotcha under docs/development/debugging/, since this is the third change in this area to be caused by it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Record pattern so modules render and the UI shows each module’s own label, icon, nickname, and settings. Also adds tests and a debugging note for `unknown`-typed field reads.

- **Bug Fixes**
  - Declared `seedRecord`’s result type so `allEntriesWithIndex` reliably sees the seed; module cards now render.
  - Read module fields through lifts (`readDisplayFields`, `readSettingsUI`) instead of `SubPieceEntry.piece: unknown`; headers show instance labels, icon overrides and nicknames appear in `[NAME]`, and the settings dialog renders the module’s own UI and updates live.
  - Omit empty `label` fields when creating entries (pattern and template registry) to avoid piece write validation errors.
  - Exposed `RecordOutput` `[NAME]` so patterns/tests can read it.
  - Added tests for `[NAME]` (icon and aliases) and browser chrome (headers, settings dialog), plus a gotcha doc: “A field typed `unknown` reads back as undefined.”

- **Refactors**
  - Made the browser tests independent: moved shell navigation into setup and merged settings-open + typing into one flow for clearer failures.

<sup>Written for commit 153ee370340f2bb5a3be69002c3b57d1ca60a2ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

