### PR TITLE
test(patterns): settle the view before the cold-load cf-cell-link cli…

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -231,6 +231,16 @@ Only stage 1 is visible through the runtime idle signal, so an element can exist
 in the DOM, be found by a selector, and still drop a click because its handler
 is not bound yet.
 
+Settling first also keeps a trusted click from missing its target. A trusted
+click resolves the element's layout box and then dispatches the mouse events at
+that point. On a cold load the page keeps reflowing for a few frames as content
+above the control fills in — a topic's markdown body renders, a form or card
+below it appears — so a control that has just become rendered is still moving.
+If the box moves between when the click resolves it and when the mouse events
+fire, the click lands on whatever shifted into that spot instead of the control,
+and nothing happens. Settling the view drains the pending reflow so the target
+is stationary when it is clicked.
+
 **Use `awaitViewSettled(page)`** from `@commonfabric/integration` before issuing
 the first click or keystroke after navigation or any state change. It resolves
 once all three stages are done, so a single click then lands on a bound handler:

--- a/packages/patterns/integration/topics-navigation.test.ts
+++ b/packages/patterns/integration/topics-navigation.test.ts
@@ -8,6 +8,7 @@ import { join } from "@std/path";
 import {
   CLICK_TARGET_ATTR,
   clickMarked,
+  settleView,
   waitForRuntimeIdle,
   waitForText,
 } from "./cfc-browser-helpers.ts";
@@ -130,8 +131,21 @@ async function topicAt(
  * Wait for a resolved cf-cell-link, mark its native button, then issue one
  * trusted browser click. Returning the link's fid lets the test assert the
  * shell selected exactly the destination represented by the rendered data.
+ *
+ * Settle the view before marking, the same ordering `clickCfButton` uses. A
+ * cold-loaded detail page keeps reflowing as content above the crossref links
+ * settles (the topic body's markdown fills in, the links form and Connections
+ * card render), so the link's layout box moves for a few frames after it first
+ * becomes rendered and resolvable. A trusted click resolves the button's box
+ * and then dispatches the mouse events; if the box moved in between, the click
+ * lands on the shifted-away layout instead of the button, no navigation fires,
+ * and the following `waitForTopicView` waits out its full safety net. Settling
+ * first drains the pipeline that carries a change from the worker through an
+ * applied vdom batch to a finished Lit update, so the target is stationary when
+ * it is clicked.
  */
 async function clickCellLink(page: Page, label: string): Promise<string> {
+  await settleView(page);
   const token = `topics-cell-link-${crypto.randomUUID()}`;
   await waitForCondition(
     page,


### PR DESCRIPTION
…cks in topics navigation

The topics durable-navigation integration test ("opens topics and crossrefs after a cold browser load without scheduler handlers") intermittently hung and then failed with "waitForCondition did not resolve within 300000ms". The stuck wait was the one that runs after the crossref link is clicked and waits for the shell view to change to the crossref destination. The click was delivered, but no navigation ever happened, so that wait sat until its five-minute safety net.

The cause is in the test's own click helper, not in the topics pattern or the shell navigation path. clickCellLink finds a resolved cf-cell-link, marks its inner button, and issues one trusted browser click, but it does not settle the view first. A trusted click resolves the target's layout box and then dispatches the mouse events at that point. On a cold load the detail page keeps reflowing for a few frames after the crossref link first becomes rendered and resolvable: the opened topic's markdown body fills in, the links form and the Connections card render, and each of these grows the content above the link and shifts the link down. When that downward shift falls between the moment the click resolves the button's box and the moment the mouse events fire, the click lands on the layout that slid into that spot instead of on the button. The link's own click handler never runs, no navigation event is dispatched, the view does not change, and the following waitForTopicView waits out the full safety net.

The fix settles the view before marking and clicking, the same ordering the shared clickCfButton helper already uses. Settling drains the pipeline that carries a change from the worker, through an applied vdom batch, to a finished Lit update, so the reflow completes and the link is stationary when it is clicked. The settle is event-driven, through the shell's viewSettled hook, so it adds no sleep, fixed timeout, or retry.

Confirmed by cold-loading the board, opening a topic, and clicking its crossref link many times in one warm browser, which is the condition the integration lane runs under, where all files share one long-lived process. Without the settle the click missed roughly once every seventy cold loads, and four of six sixty-iteration runs hung on the crossref view wait exactly as CI did. With the settle, five hundred and forty consecutive cold loads navigated cleanly with no hang.

docs/development/UI_TESTING.md already tells tests to settle before clicking, but framed the reason only as an unbound handler. It now also records that settling keeps a trusted click from missing a control whose layout box is still moving on a cold load.

deflaked by Hixie's agent (Claude Opus 4.8)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an intermittent hang in the topics navigation integration test by settling the view before clicking crossref links after a cold load. Updates UI testing docs to explain how settling prevents trusted clicks from missing moving targets.

- **Bug Fixes**
  - Call `settleView(page)` before marking and clicking `cf-cell-link` in `packages/patterns/integration/topics-navigation.test.ts` to avoid missed clicks during reflow.
  - Add guidance to `docs/development/UI_TESTING.md` on settling to prevent clicks landing on shifted layout.

<sup>Written for commit 5595f79308a218d933ca8d0029a09c5781fc76fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

