### PR TITLE
Make Fabric values deeply immutable

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -266,6 +266,13 @@ export declare const FabricError: FabricErrorConstructor;
 
 /**
  * The full set of values that the fabric storage layer can represent.
+ *
+ * From a typesystem perspective, all `FabricValue`s are immutable (deeply
+ * read-only), _except_ members of the `FabricInstance` tree. `FabricInstance`s
+ * expose arbitrary methods which can cause a change of instance state including
+ * changing the set of outgoing references from the instance. This is an
+ * _intentional_ hole, because TypeScript has no ergonomic/pithy way to express
+ * the desired semantics. (To be clear, it _can_ be done, just not cleanly.)
  */
 export type FabricValue =
   | null

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -282,11 +282,12 @@ export type FabricValue =
 /** A fabric value other than `null` or `undefined`. */
 export type NonNullableFabricValue = NonNullable<FabricValue>;
 
-/** An array of fabric values. */
-export interface FabricArray extends ArrayLike<FabricValue> {}
+/** Read-only array of fabric values. */
+export interface FabricArray extends ReadonlyArray<FabricValue> {}
 
-/** An object/record of fabric values. */
-export interface FabricPlainObject extends Record<string, FabricValue> {}
+/** Read-only object/record of fabric values. */
+export interface FabricPlainObject
+  extends Readonly<Record<string, FabricValue>> {}
 
 // ============================================================================
 // Runtime Constants

--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -11,6 +11,9 @@ export {
   FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
+  type MutableFabricArrayLayer,
+  type MutableFabricPlainObjectLayer,
+  type MutableFabricValueLayer,
   type NonNullableFabricValue,
 } from "./interface.ts";
 

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -173,8 +173,8 @@ export type FabricValue =
 /** A fabric value other than `null` or `undefined`. */
 export type NonNullableFabricValue = NonNullable<FabricValue>;
 
-/** Array of fabric values. */
-export interface FabricArray extends ArrayLike<FabricValue> {}
+/** Read-only array of fabric values. */
+export interface FabricArray extends ReadonlyArray<FabricValue> {}
 
 /**
  * Object/record of fabric values.
@@ -184,7 +184,8 @@ export interface FabricArray extends ArrayLike<FabricValue> {}
  * If prototype pollution becomes a concern, add boundary validation where
  * values enter the fabric system (e.g., `fabricFromNativeValue()`).
  */
-export interface FabricPlainObject extends Record<string, FabricValue> {}
+export interface FabricPlainObject
+  extends Readonly<Record<string, FabricValue>> {}
 
 /**
  * Single "layer" of fabric conversion -- the result of shallow conversion

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -197,6 +197,22 @@ export type FabricValueLayer =
   | unknown[]
   | Record<string, unknown>;
 
+/** A mutable array root whose elements remain fabric values. */
+export type MutableFabricArrayLayer = FabricValue[];
+
+/** A mutable record root whose values remain fabric values. */
+export type MutableFabricPlainObjectLayer = Record<string, FabricValue>;
+
+/**
+ * A fabric value with a mutable root container. Nested containers remain
+ * ordinary (readonly) `FabricValue`s, so this models a single construction
+ * layer rather than a deep thaw.
+ */
+export type MutableFabricValueLayer =
+  | Exclude<FabricValue, FabricArray | FabricPlainObject>
+  | MutableFabricArrayLayer
+  | MutableFabricPlainObjectLayer;
+
 /**
  * Union of raw native JS **object** types that the fabric type system can
  * convert into `FabricInstance` wrappers or `FabricPrimitive` values. These

--- a/packages/data-model/test/fabric-instances/FabricLink.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricLink.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { FabricInstance, FabricPrimitive } from "@/interface.ts";
+import {
+  FabricInstance,
+  FabricPrimitive,
+  type MutableFabricPlainObjectLayer,
+} from "@/interface.ts";
 import {
   DEEP_FREEZE,
   IS_DEEP_FROZEN,
@@ -125,7 +129,7 @@ describe("FabricLink", () => {
       const clone = link.deepClone(false) as FabricLink;
       expect(Object.isFrozen(clone)).toBe(false);
       expect(clone.payload).not.toBe(link.payload);
-      clone.payload.id = "fid1:xyz";
+      (clone.payload as MutableFabricPlainObjectLayer).id = "fid1:xyz";
       expect(link.payload.id).toBe("fid1:abc");
     });
 

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -14,8 +14,8 @@ import {
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
 import type {
-  FabricPlainObject,
   FabricValue,
+  MutableFabricPlainObjectLayer,
 } from "@commonfabric/data-model/fabric-value";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { JSONSchema } from "@commonfabric/api";
@@ -184,7 +184,7 @@ Deno.test("sync schema table reports each repeated schema once", () => {
 Deno.test("sync schema table preserves own __proto__ fields", () => {
   const value = JSON.parse(
     '{"__proto__":{"safe":true}}',
-  ) as FabricPlainObject;
+  ) as MutableFabricPlainObjectLayer;
   value.ref = linkRefFrom({
     id: "of:target",
     path: [],

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -4,6 +4,7 @@ import {
   linkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
 import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
+import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model/fabric-value";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 export const REQUEST_SCHEMA_CAS_REF_PREFIX = "schema-cas@1:";
@@ -146,7 +147,7 @@ const mapRecordChildren = (
   }
   if (!childChanged) return record;
 
-  const mapped: FabricPlainObject = {};
+  const mapped: MutableFabricPlainObjectLayer = {};
   for (let index = 0; index < entries.length; index += 1) {
     const key = entries[index][0];
     const next = mappedChildren[index];

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -19,6 +19,7 @@
 // Pure module: no FFI, no engine imports — safe for client-side import.
 
 import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
+import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model/fabric-value";
 
 /** A reference to a declared column, handed to the rule as `f.<col>`. */
 export type FieldRef = {
@@ -73,7 +74,7 @@ export function match(
   assertField(field, "match()");
   assertRegExp(re, "match()");
   const flags = re.flags.includes("g") ? re.flags : re.flags + "g";
-  const node: FabricPlainObject = {
+  const node: MutableFabricPlainObjectLayer = {
     field: field.field,
     source: re.source,
     flags,

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1,9 +1,10 @@
-import { Immutable, isRecord } from "@commonfabric/utils/types";
+import { type Immutable, isRecord } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
   type FabricPlainObject,
   type FabricValue,
+  type MutableFabricPlainObjectLayer,
   shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
@@ -1637,7 +1638,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       // just start with {}. But if errorPath has content (e.g., ["foo"]), the
       // document exists and we need to read from lastExistingPath to preserve
       // existing fields.
-      let valueObj: FabricPlainObject;
+      let valueObj: MutableFabricPlainObjectLayer;
       if (errorPath.length === 0) {
         valueObj = {};
       } else {
@@ -1659,7 +1660,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         // the shared input.
         valueObj = shallowMutableClone(
           currentValue as FabricValue,
-        ) as FabricPlainObject;
+        ) as MutableFabricPlainObjectLayer;
       }
       const remainingPath = address.path.slice(lastExistingPath.length);
       if (remainingPath.length === 0) {
@@ -1668,7 +1669,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         );
       }
       const lastKey = remainingPath.pop()!;
-      let nextValue: FabricPlainObject = valueObj;
+      let nextValue: MutableFabricPlainObjectLayer = valueObj;
       // Create intermediate containers. The container type depends on whether
       // the NEXT key (the one that will access this container) is a valid array
       // index.

--- a/packages/runner/test/frozen-reads-cache.bench.ts
+++ b/packages/runner/test/frozen-reads-cache.bench.ts
@@ -23,7 +23,7 @@
  *     --allow-write=/tmp,/var/folders test/frozen-reads-cache.bench.ts
  */
 
-import type { FabricPlainObject } from "@commonfabric/data-model/interface";
+import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
@@ -36,7 +36,7 @@ const ITERATIONS = 200;
 const ID = "of:frozen-reads-cache-bench" as const;
 
 const seedSiblings = (subtreeCount: number) => {
-  const value: FabricPlainObject = {};
+  const value: MutableFabricPlainObjectLayer = {};
   for (let i = 0; i < subtreeCount; i++) {
     value[`sub${i}`] = { count: 0, label: `sub${i}` };
   }


### PR DESCRIPTION
## Summary
- make FabricArray and FabricPlainObject readonly at the public and canonical type boundaries
- add single-layer mutable Fabric construction types and use them at builder call sites
- document the FabricValue immutability contract and its current limitation

## Validation
- deno task check
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Fabric value containers deeply immutable and clarify the immutability contract. Builders now use single-layer mutable types to construct values safely; `FabricLink` clone payloads are typed as mutable for safe edits.

- **New Features**
  - `FabricArray` and `FabricPlainObject` are now readonly in `@commonfabric/api`.
  - Added `MutableFabricArrayLayer`, `MutableFabricPlainObjectLayer`, and `MutableFabricValueLayer` for builder-time mutation, exported from `@commonfabric/data-model`.
  - Documented the immutability model, noting `FabricInstance` methods can change instance state.

- **Migration**
  - Treat `FabricArray`/`FabricPlainObject` as readonly; avoid direct mutation.
  - When constructing or transforming values, annotate with the new mutable layer types and use `shallowMutableClone()` if you need a writable root.

<sup>Written for commit 03638c93cae495065ecfb9bf0b4df45e23d38c5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

