### PR TITLE
feat(toolshed): announce a served rehearsal clone at startup

### DIFF
--- a/docs/plans/space-clone-rehearsal.md
+++ b/docs/plans/space-clone-rehearsal.md
@@ -250,10 +250,13 @@ The write-storm history and the mis-pointed-client hazard drive four rails.
    the manifest is what makes attempts commensurable.
 3. **Make the clone unmistakable at the endpoint.** The clone directory carries
    a `.cf-clone` marker; the toolshed prints a startup banner naming the clone
-   and its source when its store dir contains one. This is a ~7-line toolshed
-   change (layer 5) and I recommend it as a second increment rather than a
-   blocker — but a printed hint from `cf space clone` alone is weak, and "make
-   prod-vs-clone unmistakable" was the explicit ask. The clone launches on an
+   and its source when its store dir contains one. Both halves are now built:
+   the marker ships with `cf space clone`, and the banner with
+   `packages/toolshed/lib/clone-banner.ts`. A printed hint from `cf space clone`
+   alone was weak, and "make prod-vs-clone unmistakable" was the explicit ask.
+   Note the banner fires at boot and then scrolls away — it does not help
+   someone returning to a browser tab an hour later; surfacing clone-ness in the
+   shell UI would, and is not designed. The clone launches on an
    offset port via the existing `start-local-dev.sh --port-offset`, so the
    api-url differs by construction.
 4. **`cf inspect churn`.** A time-bucketed commit/revision rate query —
@@ -302,7 +305,10 @@ rehearsal isn't over-trusted:
 - `cf space clone --verify` — fingerprint check against the manifest.
 - `cf inspect churn <space> [--bucket 1m] [--since …] [--top N]`.
 
-**Build (increment 2, optional).** Toolshed clone banner.
+**Build (increment 2, optional).** Toolshed clone banner. **Shipped** —
+`packages/toolshed/lib/clone-banner.ts` reads the `.cf-clone` marker at
+startup and prints the clone's provenance, so a served clone is visible in
+the log an operator is already watching rather than only on disk.
 
 **Explicitly not building.**
 

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -8,6 +8,7 @@ import {
   runBackgroundParent,
   writeListeningMarker,
 } from "@/background.ts";
+import { announceCloneIfServed } from "@/lib/clone-banner.ts";
 import { identity } from "@/lib/identity.ts";
 import type { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
@@ -100,6 +101,9 @@ const handleShutdown = async () => {
 // Start server with the abort controller
 function startServer(onListening?: () => void) {
   console.log(`Server is starting on port http://${env.HOST}:${env.PORT}`);
+  // A rehearsal clone keeps the source space's DID, so nothing else in this
+  // log distinguishes it from production. Announce it before anything else.
+  announceCloneIfServed({ memoryDir: env.MEMORY_DIR, dbPath: env.DB_PATH });
   initializeRuntime();
 
   const serverOptions = {

--- a/packages/toolshed/lib/clone-banner.test.ts
+++ b/packages/toolshed/lib/clone-banner.test.ts
@@ -1,0 +1,115 @@
+// The banner's contract: it fires for a served clone, stays quiet for an
+// ordinary store, and never blocks startup — a diagnostic that took the server
+// down would trade a cosmetic problem for an outage.
+
+import { assert, assertEquals } from "@std/assert";
+import env from "@/env.ts";
+import {
+  announceCloneIfServed,
+  cloneBanner,
+  storeRootPath,
+} from "@/lib/clone-banner.ts";
+
+if (env.ENV !== "test") {
+  throw new Error("ENV must be 'test'");
+}
+
+const MARKER_BODY =
+  `This directory is a CLONE of space did:key:z6MkExample, not production.\n` +
+  `Taken 2026-07-27T12:00:00.000Z from /snapshots/estuary.sqlite\n` +
+  `Reset it with: cf space reset /clones/topics\n`;
+
+async function withStore(
+  run: (dir: string) => Promise<void> | void,
+  options: { marker?: string } = {},
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "clone-banner-test-" });
+  try {
+    if (options.marker !== undefined) {
+      await Deno.writeTextFile(`${dir}/.cf-clone`, options.marker);
+    }
+    await run(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("a served clone is announced with its provenance", async () => {
+  await withStore((dir) => {
+    const banner = cloneBanner({ memoryDir: `file://${dir}/` })!;
+    assert(banner !== null, "a marked store must produce a banner");
+    assert(banner.includes("NOT PRODUCTION"));
+    // The provenance from the marker is what makes the warning actionable:
+    // which space, taken when, from where, and how to reset it.
+    assert(banner.includes("did:key:z6MkExample"));
+    assert(banner.includes("/snapshots/estuary.sqlite"));
+    assert(banner.includes("cf space reset /clones/topics"));
+  }, { marker: MARKER_BODY });
+});
+
+Deno.test("an ordinary store says nothing", async () => {
+  await withStore((dir) => {
+    assertEquals(cloneBanner({ memoryDir: `file://${dir}/` }), null);
+
+    const lines: string[] = [];
+    announceCloneIfServed(
+      { memoryDir: `file://${dir}/` },
+      (m) => lines.push(m),
+    );
+    assertEquals(lines, [], "no banner, no output");
+  });
+});
+
+Deno.test("single-file mode looks beside the database file", async () => {
+  // DB_PATH names a file; the marker lives in its directory.
+  await withStore((dir) => {
+    assertEquals(storeRootPath({ dbPath: `${dir}/store.sqlite` }), dir);
+    const banner = cloneBanner({ dbPath: `${dir}/store.sqlite` });
+    assert(banner !== null && banner.includes("NOT PRODUCTION"));
+  }, { marker: MARKER_BODY });
+});
+
+Deno.test("DB_PATH wins over MEMORY_DIR, as it does in the engine", async () => {
+  await withStore(async (marked) => {
+    await withStore((plain) => {
+      // Single-file mode is selected by DB_PATH; MEMORY_DIR is then unused, so
+      // the banner must follow DB_PATH or it would report the wrong store.
+      assertEquals(
+        storeRootPath({
+          memoryDir: `file://${plain}/`,
+          dbPath: `${marked}/s.sqlite`,
+        }),
+        marked,
+      );
+    });
+  }, { marker: MARKER_BODY });
+});
+
+Deno.test("a store configuration it cannot interpret is not an error", async () => {
+  // MEMORY_DIR comes from the environment and may be junk, remote, or absent.
+  // None of that should stop a server from starting.
+  assertEquals(storeRootPath({}), null);
+  assertEquals(storeRootPath({ memoryDir: "file://[not-a-url" }), null);
+  assertEquals(storeRootPath({ memoryDir: "relative/path" }), null);
+  assertEquals(storeRootPath({ memoryDir: "https://example.com/store" }), null);
+  assertEquals(cloneBanner({ memoryDir: "file://[not-a-url" }), null);
+
+  // A directory that does not exist at all is simply not a clone.
+  assertEquals(cloneBanner({ memoryDir: "file:///no/such/store/" }), null);
+
+  // A bare absolute path (not a URL) is still usable.
+  await withStore((dir) => {
+    assertEquals(storeRootPath({ memoryDir: dir }), dir);
+    assert(cloneBanner({ memoryDir: dir }) !== null);
+  }, { marker: MARKER_BODY });
+});
+
+Deno.test("an unreadable marker does not take the server down", async () => {
+  // A directory where the marker file should be: readTextFile fails with
+  // IsADirectory, not NotFound. The banner is diagnostic — it must degrade to
+  // silence rather than propagate.
+  await withStore(async (dir) => {
+    await Deno.mkdir(`${dir}/.cf-clone`);
+    assertEquals(cloneBanner({ memoryDir: `file://${dir}/` }), null);
+  });
+});

--- a/packages/toolshed/lib/clone-banner.test.ts
+++ b/packages/toolshed/lib/clone-banner.test.ts
@@ -47,6 +47,22 @@ Deno.test("a served clone is announced with its provenance", async () => {
   }, { marker: MARKER_BODY });
 });
 
+Deno.test("announcing a clone emits the banner exactly once", async () => {
+  // `announceCloneIfServed` is what `startServer` calls, so its emitting path
+  // is the one production takes — the other cases here exercise `cloneBanner`
+  // underneath it.
+  await withStore((dir) => {
+    const lines: string[] = [];
+    announceCloneIfServed(
+      { memoryDir: `file://${dir}/` },
+      (m) => lines.push(m),
+    );
+    assertEquals(lines.length, 1);
+    assert(lines[0].includes("NOT PRODUCTION"));
+    assert(lines[0].includes("did:key:z6MkExample"));
+  }, { marker: MARKER_BODY });
+});
+
 Deno.test("an ordinary store says nothing", async () => {
   await withStore((dir) => {
     assertEquals(cloneBanner({ memoryDir: `file://${dir}/` }), null);

--- a/packages/toolshed/lib/clone-banner.ts
+++ b/packages/toolshed/lib/clone-banner.ts
@@ -1,0 +1,89 @@
+// "This server is serving a rehearsal clone, not production."
+//
+// `cf space clone` (see docs/plans/space-clone-rehearsal.md) writes a
+// `.cf-clone` marker into the clone directory. A clone deliberately keeps the
+// SOURCE space's DID — re-keying would break stored CFC `Space(...)` labels and
+// orphan the ACL doc — so two stores can legitimately claim one identity, and
+// once the clone is being served nothing distinguishes it from production
+// except a port number.
+//
+// The filesystem rails in `cf space clone` stop a clone being WRITTEN into a
+// live store. This is the other half: it makes a clone being SERVED visible in
+// the log an operator is already watching. The July 2026 rehearsal was driven
+// mostly through agents, and its operator could only say "I didn't notice any
+// trouble, but there could have been some I missed" — this is what turns that
+// into something noticeable.
+
+import * as Path from "@std/path";
+
+/** Written by `cf space clone`; its body is the human-readable provenance. */
+const MARKER = ".cf-clone";
+
+/**
+ * The store root a marker would live in: the directory `MEMORY_DIR` names, or
+ * the containing directory in single-file (`DB_PATH`) mode.
+ *
+ * Returns null when the configuration cannot be interpreted as a local
+ * directory — a malformed URL, or a non-`file:` store. Absence of a banner
+ * never blocks startup.
+ */
+export function storeRootPath(
+  config: { memoryDir?: string; dbPath?: string },
+): string | null {
+  if (config.dbPath) return Path.dirname(config.dbPath);
+  const dir = config.memoryDir;
+  if (!dir) return null;
+  if (!dir.startsWith("file://")) {
+    return Path.isAbsolute(dir) ? dir : null;
+  }
+  try {
+    return Path.fromFileUrl(dir);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The startup banner for a served clone, or null when the store is not one.
+ *
+ * Deliberately silent on every read failure: a banner is diagnostic, and
+ * refusing to start a server because a marker file could not be read would
+ * trade a cosmetic problem for an outage.
+ */
+export function cloneBanner(
+  config: { memoryDir?: string; dbPath?: string },
+): string | null {
+  const root = storeRootPath(config);
+  if (root === null) return null;
+
+  let marker: string;
+  try {
+    marker = Deno.readTextFileSync(Path.join(root, MARKER));
+  } catch {
+    return null;
+  }
+
+  const rule = "═".repeat(72);
+  const provenance = marker
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => `  ${line}`);
+
+  return [
+    rule,
+    "  ⚠️  SERVING A REHEARSAL CLONE — THIS IS NOT PRODUCTION",
+    "",
+    ...provenance,
+    rule,
+  ].join("\n");
+}
+
+/** Print the banner when the configured store is a clone. */
+export function announceCloneIfServed(
+  config: { memoryDir?: string; dbPath?: string },
+  log: (message: string) => void = console.log,
+): void {
+  const banner = cloneBanner(config);
+  if (banner !== null) log(banner);
+}


### PR DESCRIPTION
## Why

Increment 2 of `docs/plans/space-clone-rehearsal.md` (merged in #5009), and the missing half of its safety rail 3. Completes the arc after #5075, #5079 and #5081.

`cf space clone` already writes a `.cf-clone` marker into the clone directory — but nothing read it. It was a note for whoever happened to `ls`.

A clone deliberately keeps the **source space's DID**: re-keying would break stored CFC `Space(...)` labels (they are equality-consumed commitment fields, so a mismatched space fails closed and over-blocks content) and orphan the `of:<space>` ACL doc. That decision is right, and its consequence is that two stores legitimately claim one identity. The filesystem rails in `cf space clone` stop a clone being *written* into a live store; once a clone is being *served*, nothing distinguishes it from production except a port number.

This is the half that addresses the one soft spot in the interview evidence. Asked whether same-DID caused any accident, the July rehearsal's operator said: *"I didn't notice any trouble, but I also mainly interacted with it via agent — there could have been some trouble I missed."* A banner turns that into something noticeable.

## What Changed

`packages/toolshed/lib/clone-banner.ts` — reads `.cf-clone` from the configured store root and prints its provenance during `startServer`, before the runtime initializes:

```
════════════════════════════════════════════════════════════════════════
  ⚠️  SERVING A REHEARSAL CLONE — THIS IS NOT PRODUCTION

  This directory is a CLONE of space did:key:z6MkBannerTest, not production.
  Taken 2026-07-28T20:59:03.115Z from /…/scratchpad/cs/space.sqlite.
  Reset it with: cf space reset /…/scratchpad/bannerclone
════════════════════════════════════════════════════════════════════════
```

The store root follows the engine's own rule — `DB_PATH`'s directory in single-file mode, otherwise `MEMORY_DIR` — so it cannot report a store the server isn't serving.

**It degrades to silence on every failure.** Absent, malformed, relative, remote, or unreadable configuration yields no banner rather than an exception. A diagnostic that took the server down would trade a cosmetic problem for an outage.

## Test plan

- `packages/toolshed/lib/clone-banner.test.ts` — 6 tests: a marked store is announced with its provenance (space DID, source, reset command — the parts that make the warning actionable); an ordinary store produces no output at all; single-file mode looks beside the database file; `DB_PATH` wins over `MEMORY_DIR` as it does in the engine; junk configuration (malformed URL, relative path, `https://`, absent) is not an error; and an unreadable marker (a directory in its place — `IsADirectory`, not `NotFound`) degrades to silence.
- `cd packages/toolshed && deno task test` — 99 passed. `deno check`, `deno lint`, `deno fmt` clean.
- **Booted a real toolshed against a real clone** and confirmed the banner prints; booted it against an ordinary store and confirmed no banner and a normal start. Unit tests alone would not have proven the wiring.

## Honest limit

The banner fires at boot and then scrolls away. It does not help someone returning to a browser tab an hour later — surfacing clone-ness in the shell UI would, and is not designed. This is the cheap 80%, and the doc now records that limit rather than implying the rail is airtight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a startup banner in Toolshed that warns when the served store is a rehearsal clone. It reads the `.cf-clone` marker and prints the warning before runtime init to prevent confusion with production.

- New Features
  - `packages/toolshed/lib/clone-banner.ts`: adds `announceCloneIfServed`, `cloneBanner`, and `storeRootPath` to read `.cf-clone` and print a clear banner.
  - Store root resolution: directory of `DB_PATH` in single-file mode; otherwise `MEMORY_DIR` (`DB_PATH` takes precedence).
  - Quiet on failure: missing/malformed/remote/unreadable config or marker yields no banner and never blocks startup.
  - Integrated at server start in `packages/toolshed/index.ts`.
  - Tests in `packages/toolshed/lib/clone-banner.test.ts` (7 cases), including the `announceCloneIfServed` emitting path; docs updated to mark the banner as shipped.

<sup>Written for commit c1cef5972270f31c575424dc2c61f3e1d493bcdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Coverage

One line cannot be covered by any unit test: the `announceCloneIfServed(...)`
call inside `startServer` in `packages/toolshed/index.ts`. `startServer` runs
only under `import.meta.main`, and no test imports `index.ts` — it appears in
`background.test.ts` only as a string path — so *any* statement added there is
uncovered by construction.

Everything the line calls is tested: `clone-banner.test.ts` covers the emitting
path, the silent path, both store-resolution modes, junk configuration, and an
unreadable marker. The wiring itself was verified by booting a real toolshed
against a real clone and against an ordinary store.

Checked against `main` rather than assumed: `packages/toolshed` reads 4764 on
four of the last five main runs (one 4767 blip), so this is a genuine +1 and not
the bimodal swing #5108 fixes in `packages/runner`.

The alternative is an integration test that boots the toolshed purely to observe
a log line, which is more machinery than a 7-line diagnostic warrants.

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/toolshed uncovered lines = 4765 lines
