### PR TITLE
docs(plans): settle the C1 typing fork — widen Stream, no second carrier

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -132,23 +132,29 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
   `Stream<string>` when `R` appears nowhere), while `R` in a property
   position discriminates and forces the author to declare what the body
   returns.
-  Prototyped to measure rather than estimate the cost, following the
-  `CELL_INNER_TYPE` precedent — a `declare const` unique symbol read as a
-  property, which `AnyBrandedCell` already uses for exactly this reason
-  ("without a concrete property mentioning T, T would be a phantom
-  parameter"). The whole workspace type-checks clean with `Stream` widened:
-  **zero** compile errors, not the handful a grep suggested.
-  That is worse news than it sounds, and it is the one thing C1 must not get
-  wrong. The ten `Stream<any>` guards do not break — they *stop matching*.
-  `[T] extends [Stream<any>]` evaluates to a miss for `Stream<E, R>`, silently,
-  because nothing declares a result yet; `Stream<any, any>` matches both.
-  So widening those guards (`api/index.ts:867`, `:1488`, `:1967`, `:2320`,
-  `:3256`, `runner/src/link-utils.ts:54`, three in
-  `runner/src/builtins/llm-dialog.ts`, one pattern) is mandatory and **not
-  compiler-enforced**: the first pattern to declare a result would otherwise
-  change wrapping behaviour across the type system with nothing failing.
-  C1 carries a type-level test that a result-carrying stream satisfies each
-  guard. `AsStream` — one
+  Prototyped to measure rather than estimate, following the `CELL_INNER_TYPE`
+  precedent — a `declare const` unique symbol read as a property, which
+  `AnyBrandedCell` already uses for exactly this reason ("without a concrete
+  property mentioning T, T would be a phantom parameter"). The workspace
+  type-checks clean with `Stream` widened: zero errors.
+  **The conditional-type utilities do not need auditing.** An earlier draft of
+  this entry called for widening every `[T] extends [Stream<any>]` guard,
+  on the theory that a result-carrying stream would silently stop matching.
+  It does stop matching — but that does not reach the schema layer, which
+  reads the *written* `ts.TypeNode` and takes the result off the annotation's
+  second type argument (`schema-generator/src/type-utils.ts:427-437`). The
+  guards shape inference and authoring ergonomics, not schema extraction, and
+  dropping a result there is harmless for every helper that does not care
+  about one. Where a guard genuinely mishandles a returning verb it shows up
+  as a compile error in that pattern, loudly, and only for verbs that opted
+  in — so a single fixture declaring a result catches the class, and guards
+  widen reactively when that fixture proves they must. Removing the default
+  makes the compiler enumerate all 253 `Stream<` sites, which is a useful
+  one-time audit tool but not a prerequisite.
+  What must be threaded is the construction path, not the guards:
+  `Handler`/`HandlerFactory` return the stream, so they carry the result
+  parameter or an author's annotation cannot match what `handler()` produces.
+  `AsStream` — one
   slot, `Apply` and `IKeyable` assume that — keeps producing `Stream<A,
   void>`, so a projection through the HKT drops a declared result. That is
   acceptable because streams are leaves: patterns do not `key()` into a

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -114,9 +114,34 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
 
 - **api:** `action` overloads accept a return type (today both overloads type
   the callback `=> void`, `builder/module.ts:606-609`); `Stream<T, R = void>`
-  or equivalent so the result type is visible to the schema layer — the
-  defaulted parameter keeps every existing `Stream<T>` use compiling. A
-  `VerbError { code, message }` type for rule 4's typed rejections.
+  so the result type is visible to the schema layer — the defaulted parameter
+  keeps every existing `Stream<T>` use compiling. A `VerbError { code,
+  message }` type for rule 4's typed rejections.
+- **C1 fork — settled: widen `Stream`, do not add a second carrier.** The
+  alternative was a separate `StreamWithResult<T, R> extends Stream<T>` that
+  only the schema layer interprets, which is tempting because it leaves
+  `Stream<T>` and its one-slot `AsStream` HKT untouched. It loses on one
+  point that outweighs the rest: **a forgotten annotation stays silent.**
+  Because the carrier is a subtype, a verb whose body returns a value but
+  whose declaration still reads `Stream<T>` assigns cleanly, and the result
+  is erased exactly where the schema layer reads it — the same shape of
+  failure as the live board accepting and discarding `agentName`. Widening
+  `Stream` makes that a compile error instead, provided `R` sits in a
+  structural position rather than a phantom one: a purely unused parameter is
+  erased by structural typing (verified — `Stream<string, number>` assigns to
+  `Stream<string>` when `R` appears nowhere), while `R` in a property
+  position discriminates and forces the author to declare what the body
+  returns.
+  The costs are bounded and mechanical: ten `Stream<any>` guards widen to
+  `Stream<any, any>` (`api/index.ts:867`, `:1488`, `:1967`, `:2320`,
+  `:3256`, `runner/src/link-utils.ts:54`, three in
+  `runner/src/builtins/llm-dialog.ts`, one pattern), and `AsStream` — one
+  slot, `Apply` and `IKeyable` assume that — keeps producing `Stream<A,
+  void>`, so a projection through the HKT drops a declared result. That is
+  acceptable because streams are leaves: patterns do not `key()` into a
+  stream to reach another. Both options need a result parameter threaded
+  through `Handler`/`HandlerFactory` regardless, since the factory returns
+  the stream, so that work is not a differentiator.
 - **ts-transformers:** lowering for value-returning `action` bodies; CTS spec
   updates under `docs/specs/ts-transformer/`. (The runtime side already
   consumes returns — `handleJavaScriptHandlerResult` — so this is authoring

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -132,10 +132,23 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
   `Stream<string>` when `R` appears nowhere), while `R` in a property
   position discriminates and forces the author to declare what the body
   returns.
-  The costs are bounded and mechanical: ten `Stream<any>` guards widen to
-  `Stream<any, any>` (`api/index.ts:867`, `:1488`, `:1967`, `:2320`,
+  Prototyped to measure rather than estimate the cost, following the
+  `CELL_INNER_TYPE` precedent — a `declare const` unique symbol read as a
+  property, which `AnyBrandedCell` already uses for exactly this reason
+  ("without a concrete property mentioning T, T would be a phantom
+  parameter"). The whole workspace type-checks clean with `Stream` widened:
+  **zero** compile errors, not the handful a grep suggested.
+  That is worse news than it sounds, and it is the one thing C1 must not get
+  wrong. The ten `Stream<any>` guards do not break — they *stop matching*.
+  `[T] extends [Stream<any>]` evaluates to a miss for `Stream<E, R>`, silently,
+  because nothing declares a result yet; `Stream<any, any>` matches both.
+  So widening those guards (`api/index.ts:867`, `:1488`, `:1967`, `:2320`,
   `:3256`, `runner/src/link-utils.ts:54`, three in
-  `runner/src/builtins/llm-dialog.ts`, one pattern), and `AsStream` — one
+  `runner/src/builtins/llm-dialog.ts`, one pattern) is mandatory and **not
+  compiler-enforced**: the first pattern to declare a result would otherwise
+  change wrapping behaviour across the type system with nothing failing.
+  C1 carries a type-level test that a result-carrying stream satisfies each
+  guard. `AsStream` — one
   slot, `Apply` and `IKeyable` assume that — keeps producing `Stream<A,
   void>`, so a projection through the HKT drops a declared result. That is
   acceptable because streams are leaves: patterns do not `key()` into a

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -141,8 +141,14 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
   this entry called for widening every `[T] extends [Stream<any>]` guard,
   on the theory that a result-carrying stream would silently stop matching.
   It does stop matching — but that does not reach the schema layer, which
-  reads the *written* `ts.TypeNode` and takes the result off the annotation's
-  second type argument (`schema-generator/src/type-utils.ts:427-437`). The
+  detects wrappers from the author's annotation by two annotation-rooted
+  paths: the written `ts.TypeNode` name
+  (`schema-generator/src/type-utils.ts:427-437`) and the `[CELL_BRAND]:
+  "stream"` literal on the resolved type
+  (`schema-generator/src/typescript/cell-brand.ts:97-114`), whose
+  `extractWrapperTypeReference` exposes the full `typeArguments` where `R`
+  sits — so detection even survives an alias like
+  `type MyVerb = Stream<E, R>`. The
   guards shape inference and authoring ergonomics, not schema extraction, and
   dropping a result there is harmless for every helper that does not care
   about one. Where a guard genuinely mishandles a returning verb it shows up


### PR DESCRIPTION
## Context, for anyone not following the verb-contract arc

A **verb** is a pattern's callable handler — the unit an agent invokes from outside, as `cf piece call <piece> addTopic '{"title":"..."}'`. The arc this belongs to is about making any pattern drivable by an agent through the CLI ([design](docs/plans/pattern-verb-contract.md), [plan](docs/plans/pattern-verb-contract-implementation.md)).

**Today a verb cannot tell its caller anything.** The asymmetry is visible in the CLI: `callableCommandSpec` reports `outputSchemaSummary` for a *tool*, because a tool's pattern declares a `resultSchema`, but for a *handler* it reports `inputSchema` only. There is no second field to report, because there is nowhere to declare one.

The practical cost is the thing that started this work. An agent calls `addTopic` and gets back nothing identifying what it just created — so it re-reads the board and infers which topic is its own, by title match or by recency. Both are guesses, and both break under concurrency. Every "create then reference it" workflow an agent wants to run has this hole in the middle.

**The plumbing on both ends already exists.** The runtime consumes a handler's return value (`handleJavaScriptHandlerResult`), and C4 landed `plainResultReceipts`, which projects a plain return into the handling's durable receipt. D1 (#5087) and D2 (#5089) built the path back out: the receipt's address rides the sender's commit callback, and `cf piece call --invocation` reads it and prints it as `result`. A value written by a verb can already travel to the caller.

What is missing is the **declaration**. Nothing in an authored pattern states what a verb returns, so the schema layer never learns it, the piece's durable schema never carries it, and no client can discover, validate, or type it. The value can flow; nobody can say what it is.

## Why the declaration has to live on `Stream<>`

A verb *is* a stream property on the pattern's output. `handler(...)(state)` produces `Stream<EventType>`, and a pattern declares its verbs as exactly that:

```ts
interface Output {
  recordMessage: Stream<{ message: string }>;   // the event it accepts
}
```

The schema-generator builds the piece's **durable** schema by reading those declarations, recognising wrapper types by name. That durable schema is what `cf piece verbs` serves and what any client reads to discover the piece.

So the stream type is the only place a result can be declared such that it reaches the durable schema. Hence this PR's question is not "should verbs return values" — that is settled and half-built — but **what shape the stream type takes** so the result type rides along with the event type.

## The fork, and the decision

The plan named two options and said to settle at the top of the C1 PR:

- **Widen:** `Stream<T, R = void>`, one type, defaulted so existing uses compile.
- **Separate carrier:** `StreamWithResult<T, R> extends Stream<T>`, interpreted only by the schema layer.

**Settled: widen `Stream`. No second carrier.**

The separate carrier is genuinely the tempting option, and I want to be clear why: it leaves `Stream<T>` and its one-slot `AsStream` HKT completely untouched, so it is the lower-risk change on paper. The schema-generator would absorb it cleanly too — its wrapper registry is keyed by type *name* with a compile-time exhaustiveness check, and it already carries `Writable: "Cell"`, two spellings mapping to one kind. This was not rejected for want of a mechanism.

It loses on one point that outweighs the rest: **a forgotten annotation stays silent.** Because the carrier is a subtype, a verb whose body returns a value while its declaration still reads `Stream<T>` assigns cleanly, and the result is erased precisely where the schema layer reads it. That is the same failure shape as the live board accepting and discarding `agentName` — the class of bug this contract exists to eliminate. Widening `Stream` makes it a compile error and forces the author to say what the body returns.

## The condition the argument depends on, and what prototyping changed

The argument only holds if `R` sits in a **structural** position, so I checked rather than assumed — first on a toy interface, then on the real `Stream`, which inherits from `BrandedCell`, `IAnyCell`, `ICreatable`, and `IStreamable` and could well have behaved differently.

A phantom `R` appearing nowhere in the type is erased by structural typing: `Stream<string, number>` assigns to `Stream<string>` with no error, and the entire benefit evaporates. An `R` read as a property discriminates. On the real type:

```
Type 'Stream<{title}, {id}>' is not assignable to type 'Stream<{title}, void>'.
  Types of property '[CELL_RESULT_TYPE]' are incompatible.
```

There is an in-repo precedent to follow for this, which is what the implementation should use: `CELL_INNER_TYPE`, a `declare const` unique symbol read as a property on `AnyBrandedCell`, added for exactly this reason — its comment says "without a concrete property mentioning T, T would be a phantom parameter."

**Prototyping corrected the cost, twice.** I widened `Stream` for real and ran the workspace check: it passes clean, zero compile errors.

My first reading of that was alarmed — the ten `Stream<any>` guards do not break, they *stop matching*, so I argued they had to be enumerated and widened before the first pattern declared a result. Removing the default entirely turns that into a compiler-driven audit and lists all 253 `Stream<` sites, which is a genuinely useful one-time tool.

**That concern was misplaced, and the review of it is the more useful finding.** A guard ceasing to match only matters if it sits between the author's annotation and the schema. It does not. The schema-generator detects wrappers from the author's annotation by two annotation-rooted paths — the written `ts.TypeNode` name (`type-utils.ts:427-437`), and the `[CELL_BRAND]: "stream"` literal on the resolved type (`typescript/cell-brand.ts:97-114`), whose `extractWrapperTypeReference` exposes the full `typeArguments` where `R` sits, so detection even survives an alias like `type MyVerb = Stream<E, R>`. The conditional-type utilities in `packages/api` are in neither path. They shape inference and authoring ergonomics. A helper that does not care about a verb's result loses nothing by dropping it — which is the normal, correct behaviour for almost all of them.

Where a guard genuinely mishandles a returning verb, it surfaces as a compile error in that pattern, loudly, and only for verbs that opted in. So **one fixture declaring a result covers the class**, and guards widen reactively when that fixture proves they must. No audit, no tripwire.

## Costs, measured

- **Zero** compile errors workspace-wide from the widening itself.
- The construction path must thread the result parameter: `Handler`/`HandlerFactory` return the stream, so they carry it or an author's annotation cannot match what `handler()` produces. Required by both fork options, so it never separated them.
- `AsStream` stays one-slot — `Apply` and `IKeyable` assume that — so a projection through the HKT yields `Stream<A, void>`. Acceptable because streams are leaves: patterns do not `key()` into a stream to reach another.
- The 444 `Stream<` declarations in `packages/patterns` keep compiling on the defaulted parameter, and mean exactly what they should: this verb returns nothing.
- Conditional-type guards: no action required up front. Removing the default remains available as a repeatable completeness audit if one is ever wanted.
- `IStreamable.send` is untouched: a verb's result travels through the durable receipt (C4/D1/D2), never as a `send()` return value, so widening `Stream` changes no runtime surface.
- The one-slot `AsStream` HKT limitation only affects streams built through the `Stream` value constructor — verbs with results come from `handler()`/`action()`, which return the widened type directly.

## What this does not decide

The plan's other open WS-C question — which signal marks a verb, given `isStream()` accepts three independent ones — is untouched and still needs settling before C3. It interacts with this decision, since a type-level result declaration is a fourth signal.

## Test plan

Doc-only; the branch carries no code. Every claim above was checked by prototyping the widened `Stream` against the real type and running `deno task check` across the workspace, then reverting. The implementation PR carries the permanent type tests, including the guard-recognition one this review turned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
