### PR TITLE
test(patterns): stamp every click mark additively, through one shared…

### DIFF
--- a/packages/integration/utils.ts
+++ b/packages/integration/utils.ts
@@ -100,6 +100,13 @@ export interface ProbeApi {
   isVisible(element: Element): boolean;
   /** Visible text of `root` plus its shadow and slotted descendants. */
   deepText(root: ParentNode): string;
+  /**
+   * Add `token` to the whitespace-separated token list held in `element`'s
+   * `attribute`, keeping the tokens already there. This is how a predicate
+   * tags an element it has resolved without disturbing a tag another wait
+   * placed on the same element. Adding a token twice leaves one copy.
+   */
+  addToken(element: Element, attribute: string, token: string): void;
 }
 
 /**
@@ -199,6 +206,13 @@ function installWaiter(
       };
       visit(root);
       return parts.join(" ");
+    },
+    addToken(element, attribute, token) {
+      const tokens = new Set(
+        (element.getAttribute(attribute) ?? "").split(/\s+/).filter(Boolean),
+      );
+      tokens.add(token);
+      element.setAttribute(attribute, [...tokens].join(" "));
     },
   };
 

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -5,7 +5,12 @@ import {
   CLICK_TARGET_ATTR,
   clickCfButton,
   clickCfButtonsConcurrently,
+  clickNthCfButton,
+  clickTrustedAction,
 } from "./cfc-browser-helpers.ts";
+
+/** One element's live click marks, in attribute order. */
+type MarkProbe = { clicks: number; marksAtClick: string[]; marks: string[] };
 
 describe("CFC browser helpers", () => {
   let browser: Browser;
@@ -190,5 +195,107 @@ describe("CFC browser helpers", () => {
       result.secondTargetMarkedAtFirstClick,
       `the second target did not carry ${CLICK_TARGET_ATTR} before dispatch`,
     );
+  });
+
+  // Every mark predicate adds its token to the marks already on the element, so
+  // a target another click has spoken for keeps that claim. The grouped test
+  // above exercises that for the by-selector predicate; these two cover the
+  // indexed and trusted-action ones.
+
+  it("keeps a co-resident mark when tagging an indexed target", async () => {
+    await page.evaluate((clickTargetAttr: string) => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const first = document.createElement("button");
+      first.className = "indexed-target";
+      first.textContent = "first";
+      const second = document.createElement("button");
+      second.className = "indexed-target";
+      second.textContent = "second";
+      second.setAttribute(clickTargetAttr, "held-by-another-click");
+      let clicks = 0;
+      let marksAtClick: string[] = [];
+      const marksOf = (element: Element): string[] =>
+        (element.getAttribute(clickTargetAttr) ?? "").split(/\s+/).filter(
+          Boolean,
+        );
+      second.addEventListener("click", () => {
+        clicks++;
+        marksAtClick = marksOf(second);
+      });
+      root.append(first, second);
+      document.body.append(host);
+
+      (globalThis as typeof globalThis & {
+        __indexedMarkProbe: () => unknown;
+      }).__indexedMarkProbe = () => ({
+        clicks,
+        marksAtClick,
+        marks: marksOf(second),
+      });
+    }, { args: [CLICK_TARGET_ATTR] });
+
+    await clickNthCfButton(page, ".indexed-target", 1);
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __indexedMarkProbe: () => MarkProbe;
+      }).__indexedMarkProbe()
+    ) as MarkProbe;
+    assertEquals(result.clicks, 1);
+    // Both marks are live when the click lands, and only this helper's own
+    // mark is cleared afterwards.
+    assert(
+      result.marksAtClick.includes("held-by-another-click"),
+      `the pre-existing mark was lost: ${result.marksAtClick.join(" ")}`,
+    );
+    assertEquals(result.marksAtClick.length, 2);
+    assertEquals(result.marks, ["held-by-another-click"]);
+  });
+
+  it("keeps a co-resident mark when tagging a trusted action", async () => {
+    await page.evaluate((clickTargetAttr: string) => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const button = document.createElement("button");
+      button.setAttribute("data-ui-action", "save-note");
+      button.textContent = "Save";
+      button.setAttribute(clickTargetAttr, "held-by-another-click");
+      let clicks = 0;
+      let marksAtClick: string[] = [];
+      const marksOf = (element: Element): string[] =>
+        (element.getAttribute(clickTargetAttr) ?? "").split(/\s+/).filter(
+          Boolean,
+        );
+      button.addEventListener("click", () => {
+        clicks++;
+        marksAtClick = marksOf(button);
+      });
+      root.append(button);
+      document.body.append(host);
+
+      (globalThis as typeof globalThis & {
+        __trustedMarkProbe: () => unknown;
+      }).__trustedMarkProbe = () => ({
+        clicks,
+        marksAtClick,
+        marks: marksOf(button),
+      });
+    }, { args: [CLICK_TARGET_ATTR] });
+
+    await clickTrustedAction(page, "save-note");
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __trustedMarkProbe: () => MarkProbe;
+      }).__trustedMarkProbe()
+    ) as MarkProbe;
+    assertEquals(result.clicks, 1);
+    assert(
+      result.marksAtClick.includes("held-by-another-click"),
+      `the pre-existing mark was lost: ${result.marksAtClick.join(" ")}`,
+    );
+    assertEquals(result.marksAtClick.length, 2);
+    assertEquals(result.marks, ["held-by-another-click"]);
   });
 });

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -251,11 +251,7 @@ const markForClick = (
     | HTMLElement
     | null) ?? target;
   if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
-  const tokens = new Set(
-    (clickTarget.getAttribute(attr) ?? "").split(/\s+/).filter(Boolean),
-  );
-  tokens.add(token);
-  clickTarget.setAttribute(attr, [...tokens].join(" "));
+  probe.addToken(clickTarget, attr, token);
   return true;
 };
 
@@ -275,7 +271,7 @@ const markNthForClick = (
   const target = probe.collect(selector)[index] as HTMLElement | undefined;
   if (!target) return false;
   if (!target.isConnected || !probe.isRendered(target)) return false;
-  target.setAttribute(attr, token);
+  probe.addToken(target, attr, token);
   return true;
 };
 
@@ -306,7 +302,7 @@ const markTrustedAction = (
       probe.isRendered(clickTarget) &&
       !isDisabled(target) && !isDisabled(clickTarget)
     ) {
-      clickTarget.setAttribute(attr, token);
+      probe.addToken(clickTarget, attr, token);
       clickTarget.addEventListener(
         "click",
         (event) => {
@@ -396,11 +392,7 @@ export async function clickTrustedAction(
     await waitForCondition(page, markTrustedAction, {
       args: [action, token, CLICK_TARGET_ATTR],
     });
-    const button = await page.waitForSelector(
-      `[${CLICK_TARGET_ATTR}="${token}"]`,
-      { strategy: "pierce" },
-    );
-    await button.click();
+    await clickMarked(page, token);
   } catch (cause) {
     probe ??= await readTrustedActionProbe(page, action).catch(() => undefined);
     // Indented for readable test-log output
@@ -410,8 +402,6 @@ export async function clickTrustedAction(
       }`,
       { cause },
     );
-  } finally {
-    await clearClickMark(page, token).catch(() => {});
   }
 }
 
@@ -766,9 +756,10 @@ export async function clickNthCfButton(
 /**
  * Resolve the element whose click marks contain `token` and click it, then
  * clear that mark.
- * Shared by `clickCfButton`, `clickNthCfButton`, and the text-matching click
- * helpers in `note-button-helpers.ts`: each one marks its target through its
- * own predicate, and the resolve/click/untag tail is the same for all of them.
+ * Shared by `clickCfButton`, `clickNthCfButton`, `clickTrustedAction`, and the
+ * text-matching click helpers in `note-button-helpers.ts`: each one marks its
+ * target through its own predicate, and the resolve/click/untag tail is the
+ * same for all of them.
  */
 export async function clickMarked(
   page: Page,

--- a/packages/patterns/integration/note-button-helpers.ts
+++ b/packages/patterns/integration/note-button-helpers.ts
@@ -45,7 +45,7 @@ const markNoteButton = (
     | HTMLElement
     | null) ?? target;
   if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
-  clickTarget.setAttribute(attr, token);
+  probe.addToken(clickTarget, attr, token);
   return true;
 };
 

--- a/packages/patterns/integration/topics-navigation.test.ts
+++ b/packages/patterns/integration/topics-navigation.test.ts
@@ -170,7 +170,7 @@ async function clickCellLink(page: Page, label: string): Promise<string> {
         const button = chip?.shadowRoot?.querySelector("button");
         if (!button || !probe.isRendered(button)) continue;
         link.setAttribute("data-topics-link-target", targetToken);
-        button.setAttribute(clickTargetAttribute, targetToken);
+        probe.addToken(button, clickTargetAttribute, targetToken);
         return true;
       }
       return false;


### PR DESCRIPTION
… helper

The click mark attribute holds a whitespace-separated set of live tokens, so two clicks in flight at once can both claim the same element without either losing its claim. Its docstring says so, `clearClickMark` strips one token and rewrites the rest, and `clickMarked` resolves with a `~=` word match.

Only one of the five predicates that stamp the attribute actually honoured that. `markForClick` added its token to whatever was already there; `markNthForClick`, `markTrustedAction`, `markNoteButton`, and the topics-navigation link predicate all called plain `setAttribute`, which replaces the whole value and destroys a co-resident token. The helper that lost its token then waits on a `~=` selector that can never match again. These waits are event-driven and take no timeout by design, so the loser does not fail with a diagnostic — it waits indefinitely, and its own cleanup never runs either.

No test reaches this today. Marks live only from the mark to the click to the clear, and the one helper that deliberately holds several at once, `clickCfButtonsConcurrently`, takes all of them through the additive `markForClick`; every other caller awaits a whole mark-click-clear before the next one starts. So this is correctness by construction rather than a fix for an observed failure. It arms itself the moment anyone adds an indexed, trusted- action, or by-text click to a grouped flow, and the symptom would be a hang rather than a failed assertion.

The five copies are why two of them could drift: each predicate open-coded the same read, split, add, and join, with nothing tying the copies together. They cannot share an ordinary function, because predicates are serialized with `toString()` and rebuilt in the page with `new Function`, so a reference to module scope does not survive the crossing. What does cross is the probe: `installWaiter` builds it inside the page and hands it to every predicate, and its interface is the documented place to add a capability, since the implementation must be written there too. So `ProbeApi` gains `addToken(element, attribute, token)` and all five stamp sites become one call each. The name and signature stay generic — add a token to a whitespace- separated attribute value, which is what `classList` does for `class` — so the integration package gains a DOM operation rather than any knowledge of what the patterns layer marks or why.

`clearClickMark` still splits the same attribute itself. It runs through `page.evaluate` rather than `waitForCondition`, so it never receives a probe and cannot reach the helper.

`clickTrustedAction` needed the resolve side to match. It carried the last inline copy of the resolve-click-untag tail, and that copy looked its element up with an exact whole-value match, which stops matching as soon as a second token joins the attribute. It now calls the shared `clickMarked`, which both fixes the match and removes the fourth copy of that tail. The two halves have to land together: an additive stamp under an exact-match resolve is what produces the indefinite wait described above. Folding in `clickMarked` also means the mark is cleared before the failure probe is read rather than after; nothing observes it, as `readTrustedActionProbe` reports `data-ui-action`, geometry, disabled state and body text, and never the mark attribute.

Two tests cover the invariant for the indexed and trusted-action predicates. Each pre-stamps a foreign token, then asserts both tokens are live at the moment the click lands and that only the helper's own token is cleared afterwards. That second assertion also pins `clearClickMark` against becoming a blanket `removeAttribute`. Both run against a hand-built DOM in a headless browser with no server, no sleeps and no polling, in about 16ms each.

Verified two ways. Against per-predicate clobbering, each new test fails at the co-residency assertion, reporting one live mark where two were expected, which is the clobber and not an incidental timeout; the pre-existing tests in the file still pass there and the click itself still succeeds, so the new tests isolate mark semantics rather than riding on a helper failure. Mutating the shared `addToken` to overwrite instead breaks all three co-residency tests, so the one implementation is load bearing for every caller. Every suite that exercises the touched predicates passes: cfc-browser-helpers, default-app, topics-navigation, home-profile, profile-embed, shared-profile, cf-render, nested-counter, cfc-authorized-save, cfc-staged-publish, cfc-spec-gallery, cfc-render-policy-demo, home-rehydration-churn, home-profile-reload-durability, lunch-poll-vote (which drives the grouped concurrent path), cfc-group-chat-demo-two-browsers, and patterns-reload. `deno fmt --check` repo-wide and `deno lint` on the touched files are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make click marks additive across all predicates via a shared helper, so concurrent clicks don’t clobber each other and hangs are avoided. Also route `clickTrustedAction` through `clickMarked` to resolve with `[attr~=token]` and clear marks reliably.

- **Bug Fixes**
  - All mark predicates now add tokens instead of overwriting: `markNthForClick`, `markTrustedAction`, `markNoteButton`, and topics navigation use `ProbeApi.addToken` (matching existing `markForClick`).
  - `clickTrustedAction` now resolves/clicks/clears via `clickMarked`, fixing exact-match lookups that broke with multiple tokens.
  - New tests assert co-resident marks survive the click and only the helper’s token is cleared.

- **Refactors**
  - Introduced `ProbeApi.addToken(element, attribute, token)` to append to whitespace-separated attributes, implemented in `installWaiter` and called by all predicates.
  - Removed the last inline resolve/click/untag logic by centralizing on `clickMarked`.

<sup>Written for commit fd501dad9081552cc861298bc49104628d40f923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

