### PR TITLE
Remove redundant immutable Fabric value wrappers

### DIFF
--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -1,5 +1,5 @@
 import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
-import { type Immutable, isPlainObject } from "@commonfabric/utils/types";
+import { isPlainObject } from "@commonfabric/utils/types";
 
 import {
   type FabricPlainObject,
@@ -173,9 +173,6 @@ export function isFabricValue(value: unknown): value is FabricValue {
 export function isFabricObjectOrArray(
   value: FabricValue,
 ): value is FabricValue & object;
-export function isFabricObjectOrArray(
-  value: Immutable<FabricValue>,
-): value is Immutable<FabricValue> & object;
 export function isFabricObjectOrArray(value: unknown): boolean {
   return typeof value === "object" && value !== null;
 }
@@ -191,9 +188,6 @@ export function isFabricObjectOrArray(value: unknown): boolean {
 export function isFabricPlainObject(
   value: FabricValue,
 ): value is FabricPlainObject;
-export function isFabricPlainObject(
-  value: Immutable<FabricValue>,
-): value is Immutable<FabricPlainObject>;
 export function isFabricPlainObject(value: unknown): boolean {
   return isPlainObject(value);
 }

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -171,9 +171,8 @@ export function isFabricValue(value: unknown): value is FabricValue {
  * two are not interchangeable.
  */
 export function isFabricObjectOrArray(
-  value: FabricValue,
-): value is FabricValue & object;
-export function isFabricObjectOrArray(value: unknown): boolean {
+  value: unknown,
+): value is FabricValue & object {
   return typeof value === "object" && value !== null;
 }
 
@@ -186,8 +185,7 @@ export function isFabricObjectOrArray(value: unknown): boolean {
  * keeps an indexed value typed as a `FabricValue`.
  */
 export function isFabricPlainObject(
-  value: FabricValue,
-): value is FabricPlainObject;
-export function isFabricPlainObject(value: unknown): boolean {
+  value: unknown,
+): value is FabricPlainObject {
   return isPlainObject(value);
 }

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -171,7 +171,7 @@ export function isFabricValue(value: unknown): value is FabricValue {
  * two are not interchangeable.
  */
 export function isFabricObjectOrArray(
-  value: unknown,
+  value: FabricValue,
 ): value is FabricValue & object {
   return typeof value === "object" && value !== null;
 }
@@ -185,7 +185,7 @@ export function isFabricObjectOrArray(
  * keeps an indexed value typed as a `FabricValue`.
  */
 export function isFabricPlainObject(
-  value: unknown,
+  value: FabricValue,
 ): value is FabricPlainObject {
   return isPlainObject(value);
 }

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -17,7 +17,7 @@ import {
 import type { JSONSchema } from "../../runner/src/builder/types.ts";
 import { ExtendedStorageTransaction } from "../../runner/src/storage/extended-storage-transaction.ts";
 import { ContextualFlowControl } from "../../runner/src/cfc.ts";
-import { type Immutable, isObject } from "@commonfabric/utils/types";
+import { isObject } from "@commonfabric/utils/types";
 import type { FabricValue } from "@commonfabric/api";
 import type { MemorySpace, MIME, URI } from "../interface.ts";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
@@ -140,7 +140,7 @@ export class EngineObjectManager implements ObjectStorageManager {
         type: type as MIME,
         path: [],
       },
-      value: state.document as unknown as Immutable<FabricValue>,
+      value: state.document as unknown as FabricValue,
     };
     this.#attestations.set(key, attestation);
     this.#details.set(key, {
@@ -310,7 +310,7 @@ export const trackGraph = (
     reuse?.managers?.set(managerKey, manager);
   }
   const tracker = new CompoundCycleTracker<
-    Immutable<FabricValue>,
+    FabricValue,
     JSONSchema | undefined
   >();
   const schemaTracker = new MapSetStringToPathSelectors(true);
@@ -678,7 +678,7 @@ const evaluateTrackedDocument = (
     return;
   }
   const tracker = new CompoundCycleTracker<
-    Immutable<FabricValue>,
+    FabricValue,
     JSONSchema | undefined
   >();
   const cfc = new ContextualFlowControl();

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -336,7 +336,7 @@ declare module "@commonfabric/api" {
     ): Cancel;
     sinkMeta(
       metaField: MetaField,
-      callback: (value: Immutable<FabricValue>) => Cancel | undefined | void,
+      callback: (value: FabricValue) => Cancel | undefined | void,
       options?: SinkOptions,
     ): Cancel;
     sync(): Promise<Cell<T>>;
@@ -370,14 +370,14 @@ declare module "@commonfabric/api" {
      * conform to `T` (e.g., `SigilLink` references, stream markers).
      *
      * By default (or with `{ frozen: true }`), returns a deep-frozen
-     * `Immutable<FabricValue>`. Pass `{ frozen: false }` to get a mutable
+     * `FabricValue`. Pass `{ frozen: false }` to get a mutable
      * deep copy instead.
      *
      * Prefer `getRaw()` when the value is expected to match `T`.
      */
     getRawUntyped(
       options?: RawCellReadOptions & { frozen?: true },
-    ): Immutable<FabricValue>;
+    ): FabricValue;
     getRawUntyped(
       options: RawCellReadOptions & { frozen: false },
     ): FabricValue;
@@ -2084,7 +2084,7 @@ export class CellImpl<T extends FabricValue>
 
   sinkMeta(
     metaField: MetaField,
-    callback: (value: Immutable<FabricValue>) => Cancel | undefined | void,
+    callback: (value: FabricValue) => Cancel | undefined | void,
     options: SinkOptions = {},
   ): Cancel {
     if (!this.synced) this.sync();
@@ -2204,7 +2204,7 @@ export class CellImpl<T extends FabricValue>
    */
   getRawUntyped(
     options?: RawCellReadOptions & { frozen?: true },
-  ): Immutable<FabricValue>;
+  ): FabricValue;
   getRawUntyped(
     options: RawCellReadOptions & { frozen: false },
   ): FabricValue;

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -3,7 +3,7 @@ import {
   isFabricPlainObject,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
-import { type Immutable } from "@commonfabric/utils/types";
+
 import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
@@ -69,8 +69,8 @@ export function makeAddressKey(addr: IMemorySpaceAddress): string {
 }
 
 function unwrapTransactionDetailValue(
-  value: Immutable<FabricValue>,
-): Immutable<FabricValue> {
+  value: FabricValue,
+): FabricValue {
   return isFabricPlainObject(value) && "value" in value ? value.value : value;
 }
 
@@ -205,11 +205,11 @@ function transactionReadInvariants(
   spaces: ReadonlySet<IMemorySpaceAddress["space"]>,
 ): Map<
   string,
-  { address: IMemorySpaceAddress; value?: Immutable<FabricValue> }
+  { address: IMemorySpaceAddress; value?: FabricValue }
 > {
   const invariants = new Map<
     string,
-    { address: IMemorySpaceAddress; value?: Immutable<FabricValue> }
+    { address: IMemorySpaceAddress; value?: FabricValue }
   >();
   for (const space of spaces) {
     try {

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1,11 +1,7 @@
 import { AnyCellWrapping } from "@commonfabric/api";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
-import {
-  Immutable,
-  isReadonlyRecord,
-  isRecord,
-} from "@commonfabric/utils/types";
+import { isReadonlyRecord, isRecord } from "@commonfabric/utils/types";
 import { storedCfcMetadataAppliesToPath } from "./cfc/metadata.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import { type JSONSchema } from "./builder/types.ts";
@@ -1273,7 +1269,7 @@ class TransformObjectCreator
   // This controls the behavior when properties is specified, but
   // additonalProperties is not.
   addOptionalProperty(
-    _obj: Record<string, Immutable<FabricValue>>,
+    _obj: Record<string, FabricValue>,
     _key: string,
     _value: FabricValue,
   ) {

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1,4 +1,4 @@
-import { type Immutable, isRecord } from "@commonfabric/utils/types";
+import { isRecord } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
@@ -1567,7 +1567,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   readOrThrow(
     address: IMemorySpaceAddress,
     options?: IReadOptions,
-  ): Immutable<FabricValue> {
+  ): FabricValue {
     options = this.#withAmbientReadMeta(options);
     this.prepareRead(address);
     const readResult = this.tx.read(address, options);
@@ -1588,7 +1588,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   readValueOrThrow(
     address: NormalizedFullLink,
     options?: IReadOptions,
-  ): Immutable<FabricValue> {
+  ): FabricValue {
     return this.readOrThrow(toMemorySpaceAddress(address), options);
   }
 

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -710,11 +710,11 @@ export interface IMemoryChange {
   /**
    * Value memory address had before change.
    */
-  before: Immutable<FabricValue>;
+  before: FabricValue;
   /**
    * Value memory address has after change.
    */
-  after: Immutable<FabricValue>;
+  after: FabricValue;
 }
 
 export type StorageTransactionStatus =
@@ -1785,8 +1785,8 @@ export interface TransactionReactivityLog {
 
 export interface TransactionWriteDetail {
   address: IMemorySpaceAddress;
-  value?: Immutable<FabricValue>;
-  previousValue?: Immutable<FabricValue>;
+  value?: FabricValue;
+  previousValue?: FabricValue;
   /**
    * Pre-transaction slot presence at `address.path` — distinguishes an
    * absent slot from a present slot holding `undefined`, which
@@ -1799,7 +1799,7 @@ export interface TransactionWriteDetail {
 
 export interface TransactionReadDetail {
   address: IMemorySpaceAddress;
-  value?: Immutable<FabricValue>;
+  value?: FabricValue;
 }
 
 export type NativeStorageCommitOperation =
@@ -1943,13 +1943,13 @@ export interface ITypeMismatchError extends IStorageError {
  */
 export interface IAttestation {
   readonly address: IMemoryAddress;
-  readonly value?: Immutable<FabricValue>;
+  readonly value?: FabricValue;
 }
 
 // An IAttestation where the address is an IMemorySpaceAddress
 export interface IMemorySpaceAttestation {
   readonly address: IMemorySpaceAddress;
-  readonly value?: Immutable<FabricValue>;
+  readonly value?: FabricValue;
 }
 
 // Re-export transaction wrapper utilities from implementation

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1046,7 +1046,7 @@ export class CompoundCycleTracker<
 }
 
 export type PointerCycleTracker = CompoundCycleTracker<
-  Immutable<FabricValue>,
+  FabricValue,
   JSONSchema | undefined,
   any
 >;
@@ -1105,7 +1105,7 @@ export function createDefaultTraversalContext(
 ): TraversalContext {
   return createTraversalContext(
     new CompoundCycleTracker<
-      Immutable<FabricValue>,
+      FabricValue,
       JSONSchema | undefined
     >(),
     new ContextualFlowControl(),
@@ -1378,12 +1378,12 @@ export abstract class BaseObjectTraverser {
     // Identity passthrough unless CF_TRAVERSE_CAPTURE is recording a fixture.
     this.tx = wrapTxForTraverseCapture(tx);
   }
-  protected dagMemo = new Map<string, Immutable<FabricValue>>();
+  protected dagMemo = new Map<string, FabricValue>();
   traverseDAGCalls = 0;
   getDocAtPathCalls = 0;
   abstract traverse(
     doc: IMemorySpaceValueAttestation,
-  ): TraverseResult<Immutable<FabricValue>>;
+  ): TraverseResult<FabricValue>;
 
   protected get tracker(): PointerCycleTracker {
     return this.context.tracker;
@@ -1421,7 +1421,7 @@ export abstract class BaseObjectTraverser {
     doc: IMemorySpaceValueAttestation,
     defaultValue?: FabricValue,
     itemLink?: NormalizedFullLink,
-  ): Immutable<FabricValue> {
+  ): FabricValue {
     this.traverseDAGCalls++;
     // Memoize by cell address + itemLink to avoid exponential path explosion
     // in DAGs. When multiple parents share children, every unique path triggers
@@ -1451,7 +1451,7 @@ export abstract class BaseObjectTraverser {
     } else if (isPrimitive(doc.value)) {
       return doc.value;
     } else if (Array.isArray(doc.value)) {
-      const newValue = new Array<Immutable<FabricValue>>(doc.value.length);
+      const newValue = new Array<FabricValue>(doc.value.length);
       using t = this.tracker.include(doc.value, true, newValue, doc);
       if (t === null) {
         return this.tracker.getExisting(doc.value, true);
@@ -1577,7 +1577,7 @@ export abstract class BaseObjectTraverser {
           itemLink,
         );
       } else {
-        const newValue: Record<string, Immutable<FabricValue>> = {};
+        const newValue: Record<string, FabricValue> = {};
         using t = this.tracker.include(doc.value, true, newValue, doc);
         if (t === null) {
           return this.tracker.getExisting(doc.value, true);
@@ -1739,7 +1739,7 @@ export abstract class BaseObjectTraverser {
     _linkSchema: JSONSchema | undefined,
     defaultValue: FabricValue,
     itemLink: NormalizedFullLink | undefined,
-  ): Immutable<FabricValue> {
+  ): FabricValue {
     return this.traverseDAG(doc, defaultValue, itemLink);
   }
 }
@@ -1858,7 +1858,7 @@ export function getAtPath(
           ...curDoc.address,
           path: appendToPath(curDoc.address.path, part),
         },
-        value: cursorObj[part] as Immutable<FabricValue>,
+        value: cursorObj[part] as FabricValue,
       };
       tx.read(curDoc.address, READ_NON_RECURSIVE_FOR_SCHEDULING);
     } else {
@@ -2323,7 +2323,7 @@ function traverseMetaLinkedDoc(
 
   const docContext = createTraversalContext(
     new CompoundCycleTracker<
-      Immutable<FabricValue>,
+      FabricValue,
       JSONSchema | undefined
     >(),
     context.cfc,
@@ -2343,7 +2343,7 @@ function traverseMetaLinkedDoc(
       ...doc.address,
       path: ["value"],
     },
-    value: fullDoc.value as Immutable<FabricValue>,
+    value: fullDoc.value as FabricValue,
   });
 }
 
@@ -2865,7 +2865,7 @@ type TraverseResult<T> = { ok: T; error?: never } | {
 };
 
 /** Schema memo cache shared across SchemaObjectTraverser instances within a query */
-export type SchemaMemo = Map<string, TraverseResult<Immutable<FabricValue>>>;
+export type SchemaMemo = Map<string, TraverseResult<FabricValue>>;
 
 /** Create a shared memo cache to pass to multiple SchemaObjectTraverser instances */
 export function createSchemaMemo(): SchemaMemo {
@@ -2909,13 +2909,13 @@ export class SchemaObjectTraverser<V extends FabricValue>
   // multiple traverse() calls for the same selectSchema query).
   private schemaMemo = new Map<
     string,
-    TraverseResult<Immutable<FabricValue>>
+    TraverseResult<FabricValue>
   >();
   schemaMemoHits = 0;
 
   private get activeMemo(): Map<
     string,
-    TraverseResult<Immutable<FabricValue>>
+    TraverseResult<FabricValue>
   > {
     return this.sharedSchemaMemo ?? this.schemaMemo;
   }
@@ -2925,7 +2925,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     linkSchema: JSONSchema | undefined,
     defaultValue: FabricValue,
     itemLink: NormalizedFullLink | undefined,
-  ): Immutable<FabricValue> {
+  ): FabricValue {
     if (
       linkSchema !== undefined &&
       !ContextualFlowControl.isTrueSchema(linkSchema)
@@ -2950,7 +2950,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
   override traverse(
     doc: IMemorySpaceValueAttestation,
     link?: NormalizedFullLink,
-  ): TraverseResult<Immutable<FabricValue>> {
+  ): TraverseResult<FabricValue> {
     // No-op unless CF_TRAVERSE_CAPTURE is recording a fixture.
     recordTraverseInvocation(
       doc,
@@ -3048,7 +3048,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     doc: IMemorySpaceValueAttestation,
     selector: SchemaPathSelector,
     link?: NormalizedFullLink,
-  ): TraverseResult<Immutable<FabricValue>> {
+  ): TraverseResult<FabricValue> {
     const docPath = doc.address.path;
     if (deepEqual(docPath, selector.path)) {
       return this.traverseWithSchema(doc, selector.schema!, link);
@@ -3122,7 +3122,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     doc: IMemorySpaceValueAttestation,
     schema: JSONSchema,
     link?: NormalizedFullLink,
-  ): TraverseResult<Immutable<FabricValue>> {
+  ): TraverseResult<FabricValue> {
     this.traverseWithSchemaCalls++;
     this.currentDepth++;
     if (this.currentDepth > this.maxDepth) this.maxDepth = this.currentDepth;
@@ -3160,7 +3160,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     doc: IMemorySpaceValueAttestation,
     schema: JSONSchema,
     link?: NormalizedFullLink,
-  ): TraverseResult<Immutable<FabricValue>> {
+  ): TraverseResult<FabricValue> {
     // Track both the unresolved version of our schema (possibly with top
     // level $ref) and the resolved version.
     let resolved: JSONSchema | undefined = schema;
@@ -3185,7 +3185,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
       // There are a lot of valid logical schema flags, and we only handle
       // a very limited set here, with no support for combinations.
       if (resolved.anyOf) {
-        const matches: Immutable<FabricValue>[] = [];
+        const matches: FabricValue[] = [];
         if (typeof resolved === "boolean" || !isInternedSchema(resolved)) {
           // Non-interned schema: identity reuse is not guaranteed (frozen
           // schemas can be freshly minted per evaluation), so the prepared
@@ -3320,7 +3320,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
           ...oneOf.filter(SchemaObjectTraverser.hasAsCell),
         ];
         let matchCount = 0;
-        let match: Immutable<FabricValue> | undefined = undefined;
+        let match: FabricValue | undefined = undefined;
         for (const optionSchema of sortedOneOf) {
           if (ContextualFlowControl.isFalseSchema(optionSchema)) {
             continue;
@@ -3363,7 +3363,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
         );
         return fail(TRAVERSE_FAILURES.multipleMatchingOneOf);
       } else if (resolved.allOf) {
-        const matches: Immutable<FabricValue>[] = [];
+        const matches: FabricValue[] = [];
         const allOf = resolved.allOf;
         const restSchema = combinatorRestSchema(resolved, "allOf");
         for (const optionSchema of allOf) {
@@ -3496,7 +3496,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
         return fail(TRAVERSE_FAILURES.invalidType);
       }
 
-      const newValue: Immutable<FabricValue>[] = [];
+      const newValue: FabricValue[] = [];
       // Our link is based on the last link in the chain and not the first.
       const newLink = link ?? getNormalizedLink(
         doc.address,
@@ -3549,7 +3549,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
       if (valid === TypeValidity.False) {
         return fail(TRAVERSE_FAILURES.invalidType);
       }
-      const newValue: Record<string, Immutable<FabricValue>> = {};
+      const newValue: Record<string, FabricValue> = {};
       // Our link is based on the last link in the chain and not the first.
       const newLink = link ?? getNormalizedLink(doc.address, schemaObj);
       using t = this.tracker.include(doc.value, schemaObj, newValue, doc);
@@ -3609,7 +3609,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     doc: IMemorySpaceValueAttestation,
     plan: PlainSchemaPlan,
     link?: NormalizedFullLink,
-  ): TraverseResult<Immutable<FabricValue>> | undefined {
+  ): TraverseResult<FabricValue> | undefined {
     const { path: _path, ...address } = doc.address;
     const reads: PlainSchemaReads = { address, paths: [] };
     const result = this.traversePlainSchemaWithReads(doc, plan, link, reads);
@@ -3643,7 +3643,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
       | Record<string, FabricValue | undefined>
       | FabricValue
       | undefined,
-  ): Immutable<FabricValue> {
+  ): FabricValue {
     return this.objectCreator.createPlainSchemaObject?.(link, value) ??
       this.objectCreator.createObject(link, value);
   }
@@ -3653,7 +3653,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     plan: PlainSchemaPlan,
     link: NormalizedFullLink | undefined,
     reads: PlainSchemaReads,
-  ): TraverseResult<Immutable<FabricValue>> | undefined {
+  ): TraverseResult<FabricValue> | undefined {
     if (isSigilLink(doc.value)) return undefined;
 
     if (plan.kind === "primitive") {
@@ -3671,7 +3671,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
       }
       if (doc.value.some(isSigilLink)) return undefined;
 
-      const newValue = new Array<Immutable<FabricValue>>(doc.value.length);
+      const newValue = new Array<FabricValue>(doc.value.length);
       const newLink = link ?? getNormalizedLink(doc.address, plan.schema);
       // Match traverseArrayWithSchema's structural and per-index reads.
       reads.paths.push(doc.address.path);
@@ -3710,7 +3710,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     }
     if (!isRecord(doc.value)) return fail(TRAVERSE_FAILURES.invalidType);
 
-    const newValue: Record<string, Immutable<FabricValue>> = {};
+    const newValue: Record<string, FabricValue> = {};
     const newLink = link ?? getNormalizedLink(doc.address, plan.schema);
     for (const propKey of Object.keys(doc.value)) {
       const propValue = doc.value[propKey];
@@ -3774,7 +3774,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
   }
 
   private ordinaryArrayItemLinkTarget(
-    value: Immutable<FabricValue>,
+    value: FabricValue,
     source: IMemorySpaceValueAddress,
   ): IMemorySpaceValueAddress | undefined {
     const link = parseLink(value, source);
@@ -3844,7 +3844,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
    */
   private preparePlainArrayItemLinks(
     doc: IMemorySpaceValueAttestation,
-    docArray: readonly Immutable<FabricValue>[],
+    docArray: readonly FabricValue[],
     itemSchema: JSONSchema | undefined,
   ):
     | {
@@ -3899,10 +3899,10 @@ export class SchemaObjectTraverser<V extends FabricValue>
     doc: IMemorySpaceValueAttestation,
     schema: JSONSchemaObj,
     _link?: NormalizedFullLink,
-  ): Immutable<FabricValue>[] | undefined {
+  ): FabricValue[] | undefined {
     this.traverseArrayCalls++;
-    const docArray = doc.value as Immutable<FabricValue>[];
-    const arrayObj = new Array<Immutable<FabricValue>>(docArray.length);
+    const docArray = doc.value as FabricValue[];
+    const arrayObj = new Array<FabricValue>(docArray.length);
     const directItems = plainArrayItems(schema);
 
     // Rendering or otherwise consuming a schema-backed array depends on its
@@ -4193,9 +4193,9 @@ export class SchemaObjectTraverser<V extends FabricValue>
     doc: IMemorySpaceValueAttestation,
     schema: JSONSchemaObj,
     _link?: NormalizedFullLink,
-  ): Record<string, Immutable<FabricValue>> | undefined {
+  ): Record<string, FabricValue> | undefined {
     this.traverseObjectCalls++;
-    const filteredObj: Record<string, Immutable<FabricValue>> = {};
+    const filteredObj: Record<string, FabricValue> = {};
     const directProperties = plainObjectProperties(schema);
     for (const [propKey, propValue] of Object.entries(doc.value!)) {
       // We'll use marker schemas to detect some places where we want special
@@ -4340,7 +4340,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     doc: IMemorySpaceValueAttestation,
     schema: JSONSchema,
     link?: NormalizedFullLink,
-  ): TraverseResult<Immutable<FabricValue>> {
+  ): TraverseResult<FabricValue> {
     this.traversePointerCalls++;
     const selector = { path: doc.address.path, schema };
     const alreadyTracked = this.traverseCells &&
@@ -4457,7 +4457,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
   private traversePrimitive(
     doc: IMemorySpaceValueAttestation,
     schema: JSONSchema,
-  ): Immutable<FabricValue> {
+  ): FabricValue {
     if (SchemaObjectTraverser.hasAsCell(schema)) {
       return this.objectCreator.createObject(
         getNormalizedLink(doc.address, schema),

--- a/packages/runner/test/traverse-cycle.test.ts
+++ b/packages/runner/test/traverse-cycle.test.ts
@@ -9,7 +9,7 @@ import type {
   URI,
 } from "@commonfabric/memory/interface";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { Immutable } from "@commonfabric/utils/types";
+
 import {
   CompoundCycleTracker,
   ManagedStorageTransaction,
@@ -77,12 +77,12 @@ describe("SchemaObjectTraverser cycle fallback (traverseDAG, true schema)", () =
     // Confirm the tracker selects the fallback for this value: a second
     // include of the same value with the same schema returns null.
     const tracker = new CompoundCycleTracker<
-      Immutable<FabricValue>,
+      FabricValue,
       JSONSchema | undefined
     >();
-    expect(tracker.include(value as Immutable<FabricValue>, true)).not
+    expect(tracker.include(value as FabricValue, true)).not
       .toBeNull();
-    expect(tracker.include(value as Immutable<FabricValue>, true)).toBeNull();
+    expect(tracker.include(value as FabricValue, true)).toBeNull();
 
     const store = storeWith(docUri, value);
     const traverser = getTraverser(store, { path: ["value"], schema: true });

--- a/packages/runner/test/traverse-replay/replay.ts
+++ b/packages/runner/test/traverse-replay/replay.ts
@@ -42,7 +42,6 @@ import {
   type TraverseFixture,
 } from "../../src/traverse-recorder.ts";
 import { readMaybeGzippedText } from "./gzip.ts";
-import type { Immutable } from "../../../utils/src/types.ts";
 
 export type ReplayInvocationOracle = {
   ok: boolean;
@@ -172,7 +171,7 @@ export class FixtureObjectManager implements ObjectStorageManager {
       // (decodeMemoryBoundary), so frozen corpus values are the faithful
       // replay shape — without this, frozen-identity fast paths in traverse
       // can never engage during replay even though they do in production.
-      value: deepFreeze(value) as Immutable<FabricValue>,
+      value: deepFreeze(value) as FabricValue,
     };
     this.attestations.set(key, attestation);
     return attestation;

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -33,7 +33,7 @@ import { StoreObjectManager } from "../src/storage/query.ts";
 import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
-import { Immutable } from "@commonfabric/utils/types";
+
 import { ContextualFlowControl } from "@commonfabric/runner";
 import { IMemorySpaceValueAttestation } from "../src/traverse.ts";
 
@@ -682,7 +682,7 @@ describe("SchemaObjectTraverser array traversal", () => {
       const managedTx = new ManagedStorageTransaction(manager);
       const tx = new ExtendedStorageTransaction(managedTx);
       const tracker = new CompoundCycleTracker<
-        Immutable<FabricValue>,
+        FabricValue,
         JSONSchema | undefined
       >();
       const cfc = new ContextualFlowControl();
@@ -745,7 +745,7 @@ describe("SchemaObjectTraverser array traversal", () => {
       const managedTx = new ManagedStorageTransaction(manager);
       const tx = new ExtendedStorageTransaction(managedTx);
       const tracker = new CompoundCycleTracker<
-        Immutable<FabricValue>,
+        FabricValue,
         JSONSchema | undefined
       >();
       const cfc = new ContextualFlowControl();
@@ -809,7 +809,7 @@ describe("SchemaObjectTraverser array traversal", () => {
       const managedTx = new ManagedStorageTransaction(manager);
       const tx = new ExtendedStorageTransaction(managedTx);
       const tracker = new CompoundCycleTracker<
-        Immutable<FabricValue>,
+        FabricValue,
         JSONSchema | undefined
       >();
       const cfc = new ContextualFlowControl();
@@ -884,7 +884,7 @@ describe("getAtPath array index validation", () => {
     const managedTx = new ManagedStorageTransaction(manager);
     const tx = new ExtendedStorageTransaction(managedTx);
     const tracker: PointerCycleTracker = new CompoundCycleTracker<
-      Immutable<FabricValue>,
+      FabricValue,
       JSONSchema | undefined
     >();
     const cfc = new ContextualFlowControl();


### PR DESCRIPTION
## Summary
- replace every literal Immutable<FabricValue> annotation with FabricValue
- remove imports and overloads made redundant by that equivalence
- retain Immutable<T> uses whose type argument is not FabricValue

FabricValue is now recursively readonly: its array and plain-object arms are readonly, while its special-object arm exposes only a readonly nominal brand. The TypeScript compiler confirms Immutable<FabricValue> and FabricValue are bidirectionally equivalent.

## Validation
- deno task check
- deno task --cwd packages/memory test
- focused runner traversal tests
- git diff --check

## Coverage Baseline

This is a type-annotation-only PR, so the following accounts for a spurious complaint:

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 6948 lines


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant `Immutable<FabricValue>` wrappers and aligned APIs to use `FabricValue`. Restored Fabric value guards to take `FabricValue` inputs to preserve existing contracts; no behavior changes.

- **Refactors**
  - Replaced all `Immutable<FabricValue>` annotations with `FabricValue` across traversal, scheduler, storage, query, and tests.
  - Simplified type guards: `isFabricObjectOrArray` and `isFabricPlainObject` now take `FabricValue` and narrow to concrete types; removed overloads (including `Immutable` variants and the generic boolean signatures).
  - Updated `Cell.sinkMeta` callback and `getRawUntyped({ frozen: true })` to use `FabricValue`.
  - Storage types now expose `FabricValue` for `IMemoryChange.before/after`, transaction read/write details, and attestations.
  - Updated generics and caches (e.g., `CompoundCycleTracker`, schema memo) to track `FabricValue`.

- **Migration**
  - Use `FabricValue` instead of `Immutable<FabricValue>`.
  - Adjust API consumers for `Cell.sinkMeta` and `getRawUntyped({ frozen: true })` to expect `FabricValue`.
  - Remove unused `Immutable` imports where they previously wrapped `FabricValue`.

<sup>Written for commit 93878ff962b3604677e13a1da359a46915180446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
