### PR TITLE
feat(cli): cf completion — context-aware shell completion for bash and zsh

### DIFF
--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -50,6 +50,20 @@ Every piece command below takes `-i/--identity`, `-a/--api-url`,
 space name. (What the key actually is, and how a space name becomes a DID,
 is Chapter 10.)
 
+Worth doing once, since the rest of this chapter is a lot of typing — turn on
+tab completion:
+
+```bash
+# zsh: add to ~/.zshrc after compinit (bash: swap zsh -> bash, use ~/.bashrc)
+source <(deno run -A packages/cli/mod.ts completion zsh)
+```
+
+It completes commands and flags offline, and — once `CF_IDENTITY`/`CF_API_URL`
+are set as above — the values that are actually painful to type: piece ids
+(annotated with each piece's name), a piece's callable names, and cell paths a
+segment at a time. It completes `deno task cf ...` as well as a `cf` binary.
+See `cf completion --help`.
+
 ## Deploy and iterate
 
 ```bash

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -182,4 +182,90 @@ piece-call JSON file. These rules keep the options before the callable name for
 
 Every registered top-level command appears in `cf --help`. The direct
 `fuse-daemon` and `fuse-supervisor` entry points are visible because packaged
-launchers use them.
+launchers use them. Shell completion is the exception: it drops commands whose
+description opens with `Internal:`, because those are spawned by `cf fuse` and
+never typed at a prompt.
+
+## Shell completion
+
+`cf completion <shell>` prints a completion script for bash or zsh.
+
+```bash
+# zsh — eager form, in ~/.zshrc after compinit. Required for the `deno` binding
+# described below; the fpath form does not activate it until `cf` completes once.
+source <(cf completion zsh)
+
+# zsh — fpath form. Completes `cf` itself; add the two lines under
+# "deno task cf" below if you also want `deno task cf` to complete.
+cf completion zsh > "${fpath[1]}/_cf"
+autoload -U compinit && compinit
+
+# bash
+cf completion bash > /usr/local/etc/bash_completion.d/cf
+# or, for the current shell only:
+source <(cf completion bash)
+```
+
+Completion covers the command tree — subcommands, flags, and enumerated values
+such as `--log-level` — plus live values read from the fabric:
+
+| Slot                            | Completes to                                |
+| ------------------------------- | ------------------------------------------- |
+| `--piece`                       | piece ids, annotated with each piece's name |
+| `piece call <callable>`         | the piece's callables, as `cf piece verbs`  |
+| `piece get`/`set <path>`        | cell keys, one path segment at a time       |
+| `piece link <source>/<target>`  | `pieceId/path/to/field` endpoints           |
+| `--space`                       | space DIDs of local memory-v2 stores        |
+| `--identity`, pattern arguments | `*.key` / `*.tsx` files, via the shell      |
+
+Live values need an identity and an api-url. Both are read from the line being
+typed (`-i`, `-a`, `-u`) before falling back to `CF_IDENTITY`/`CF_API_URL`, so
+`cf piece call -s other-space --piece <TAB>` lists that space's pieces rather
+than the environment's. When neither is resolvable, or the server is
+unreachable, completion yields nothing — it never prints an error into the
+command line. Each request costs one CLI invocation plus one round trip, so
+value completion is as fast as the fabric it queries.
+
+### `deno task cf` and other invocations
+
+The scripts bind `deno` as well as `cf`, so `deno task cf piece <TAB>` completes
+the same way the binary does; `deno run … packages/cli/mod.ts` and the
+`launcher.ts` form (including arguments after `--`) are recognized too. The
+binding is cooperative: a `deno` line that is not a CLI invocation is handed
+back to whatever completed `deno` beforehand, so `deno test` and
+`deno task build-binaries` keep their own completions. Pass `--no-deno-task` to
+bind only `cf`.
+
+The binding is installed by the script body, so it needs the script to be
+_evaluated_, not merely autoloadable. bash's `bash_completion.d` and zsh's
+`source <(…)` both do that. zsh's fpath form does not: `_cf` is autoloaded on
+the first `cf` completion, so until then `deno task cf <TAB>` does nothing. To
+keep the fpath install and still bind `deno`, add this after `compinit`:
+
+```zsh
+_cf_deno_previous="${_comps[deno]:-}"   # preserve deno's own completion
+compdef _cf deno
+```
+
+Capturing eagerly matters: `_cf` records the previous completer when it loads,
+and by then `_comps[deno]` is already `_cf`. It refuses to chain to itself
+(which would recurse and hang the terminal) and keeps any value recorded
+earlier, so the line above survives.
+
+### Implementation
+
+Cliffy ships a `CompletionsCommand`, but its dynamic hook passes the callback
+only `(command, parent)` — no cursor word and no access to the options already
+typed — so it cannot answer "the callables of the piece named by the `--piece`
+on this line". `lib/completion/` therefore emits its own scripts, which are
+deliberately thin: they forward the raw command line and let
+`cf completion complete` decide everything. A sourced completion function lives
+in a user's shell profile and is not updated when the CLI is rebuilt, so it must
+not encode a command tree that can go stale.
+
+Resolution walks Cliffy's live `Command` tree rather than a hand-maintained
+table, so a newly registered subcommand or flag completes as soon as it exists.
+Two facts cannot be read off that tree and are carried explicitly in
+`lib/completion/`: the pre-parse globals `--log-level` and `--no-color` (both
+stripped from `argv` before Cliffy parses, in `lib/log-level.ts` and
+`lib/color-mode.ts`), and the provider table binding slots to live data.

--- a/packages/cli/commands/completion.ts
+++ b/packages/cli/commands/completion.ts
@@ -60,42 +60,71 @@ so they keep working as commands are added — reinstall only if this CLI moves.
  * `--cword`, bash forwards the raw buffer with `--line`/`--point` (its own
  * word-splitting mangles `:` and `=`, which cf values are full of).
  */
+export interface CompleteRequest {
+  readonly shell: "bash" | "zsh";
+  readonly words: string[];
+  readonly cword: number;
+}
+
+/**
+ * Parse the callback's arguments by hand.
+ *
+ * Deliberately not Cliffy options: this command's stdout is a data channel a
+ * shell reads on every keystroke, and Cliffy answers a malformed invocation by
+ * printing usage text to stdout — which the shell would then offer as
+ * completion candidates ("Usage:", "-h, --help", ...). Raw args mean no input,
+ * however mangled, can put anything on stdout but candidates. An empty
+ * `--line` is a value here, not the missing-value error Cliffy reports.
+ */
+export function parseCompleteRequest(args: readonly string[]): CompleteRequest {
+  let shell: "bash" | "zsh" = "bash";
+  let line: string | undefined;
+  let point: number | undefined;
+  let cword: number | undefined;
+  const words: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--shell") shell = args[++i] === "zsh" ? "zsh" : "bash";
+    else if (arg === "--line") line = args[++i] ?? "";
+    else if (arg === "--point") point = Number(args[++i]);
+    else if (arg === "--cword") cword = Number(args[++i]);
+    else if (arg === "--") words.push(...args.slice(i + 1)), i = args.length;
+    else if (!arg.startsWith("-")) words.push(arg);
+  }
+
+  if (line !== undefined) {
+    const offset = Number.isFinite(point) ? point as number : line.length;
+    return { shell, ...tokenizeLine(line, offset) };
+  }
+  return {
+    shell,
+    words,
+    cword: Number.isFinite(cword)
+      ? cword as number
+      : Math.max(0, words.length - 1),
+  };
+}
+
 const completeCommand = new Command()
   .description("Internal: emit completion candidates for a command line.")
-  .option("--shell <shell:string>", "Shell requesting completion.", {
-    default: "bash",
-  })
-  .option("--cword <index:integer>", "Index of the word under the cursor.")
-  .option("--line <line:string>", "Raw command line, for shells without words.")
-  .option("--point <point:integer>", "Cursor offset into --line.")
-  .arguments("[words...:string]")
-  .noGlobals()
-  .action(async (options, ...words: string[]) => {
-    const shell = options.shell === "zsh" ? "zsh" : "bash";
-
-    let resolved: { words: string[]; cword: number };
-    if (options.line !== undefined) {
-      resolved = tokenizeLine(
-        options.line,
-        options.point ?? options.line.length,
-      );
-    } else {
-      resolved = {
-        words: [...words],
-        cword: options.cword ?? Math.max(0, words.length - 1),
-      };
-    }
-
-    // Resolved lazily: importing the root command pulls in the whole command
-    // tree, and doing it inside the guard keeps a failure silent.
-    const { main } = await import("./main.ts");
-
+  .usage(
+    "[--shell <shell>] [--cword <n> -- <words...>] [--line <line> --point <n>]",
+  )
+  .useRawArgs()
+  .action(async (_options: unknown, ...rawArgs: unknown[]) => {
     try {
+      const request = parseCompleteRequest(rawArgs.map(String));
+
+      // Resolved lazily: importing the root command pulls in the whole command
+      // tree, and doing it inside the guard keeps a failure silent.
+      const { main } = await import("./main.ts");
+
       const lines = await complete(
         main,
-        resolved.words,
-        resolved.cword,
-        shell,
+        request.words,
+        request.cword,
+        request.shell,
       );
       if (lines.length > 0) console.log(lines.join("\n"));
     } catch {

--- a/packages/cli/commands/completion.ts
+++ b/packages/cli/commands/completion.ts
@@ -1,0 +1,140 @@
+/**
+ * `cf completion` — shell completion scripts and the callback that feeds them.
+ *
+ * Cliffy ships a `CompletionsCommand`, but its dynamic hook passes the
+ * completion callback only `(command, parent)`: no cursor word, and no access
+ * to the options already typed. That is enough for a static command tree and
+ * nothing more — it cannot answer "the callables of the piece named by the
+ * `--piece` on this line". Since the values worth completing in cf are exactly
+ * those context-dependent ones (piece ids, callables, cell paths), this command
+ * emits its own thin shell functions that forward the whole line instead.
+ */
+
+import { Command } from "@cliffy/command";
+import { cliName } from "../lib/cli-name.ts";
+import {
+  bashCompletionScript,
+  zshCompletionScript,
+} from "../lib/completion/script.ts";
+import { complete, tokenizeLine } from "../lib/completion/mod.ts";
+
+const description = `Generate shell completion scripts.
+
+Completion covers the command tree and, when the line names a reachable space,
+live values: piece ids annotated with their names, a piece's callables, cell
+paths walked a segment at a time, and locally known spaces.
+
+Live values need an identity and api-url, taken from the line being typed
+(-i/-a/-u) or from CF_IDENTITY/CF_API_URL. Without them the command tree still
+completes.
+
+These also complete "deno task ${cliName()} ..." — see DENO TASK below.
+
+INSTALL (zsh), in ~/.zshrc after compinit:
+  source <(${cliName()} completion zsh)
+
+INSTALL (bash), in ~/.bashrc:
+  source <(${cliName()} completion bash)
+  # or system-wide:
+  ${cliName()} completion bash > /usr/local/etc/bash_completion.d/${cliName()}
+
+DENO TASK:
+  The scripts bind 'deno' as well as '${cliName()}', so "deno task ${cliName()} ..."
+  completes too. A deno line that is not a ${cliName()} invocation is handed back
+  to deno's own completion. Use --no-deno-task to bind only ${cliName()}.
+
+  This binding needs the script evaluated, not just autoloadable. Installing
+  the zsh script into fpath instead ('completion zsh > "\${fpath[1]}/_${cliName()}"')
+  completes ${cliName()} itself, but the deno binding waits until ${cliName()} completes
+  once. To keep that layout, add after compinit:
+    _${cliName()}_deno_previous="\${_comps[deno]:-}"
+    compdef _${cliName()} deno
+
+The scripts forward the command line to '${cliName()} completion complete',
+so they keep working as commands are added — reinstall only if this CLI moves.`;
+
+/**
+ * The callback the installed shell function invokes on every Tab.
+ *
+ * Accepts either shape of input: zsh forwards its own tokenized `words` with
+ * `--cword`, bash forwards the raw buffer with `--line`/`--point` (its own
+ * word-splitting mangles `:` and `=`, which cf values are full of).
+ */
+const completeCommand = new Command()
+  .description("Internal: emit completion candidates for a command line.")
+  .option("--shell <shell:string>", "Shell requesting completion.", {
+    default: "bash",
+  })
+  .option("--cword <index:integer>", "Index of the word under the cursor.")
+  .option("--line <line:string>", "Raw command line, for shells without words.")
+  .option("--point <point:integer>", "Cursor offset into --line.")
+  .arguments("[words...:string]")
+  .noGlobals()
+  .action(async (options, ...words: string[]) => {
+    const shell = options.shell === "zsh" ? "zsh" : "bash";
+
+    let resolved: { words: string[]; cword: number };
+    if (options.line !== undefined) {
+      resolved = tokenizeLine(
+        options.line,
+        options.point ?? options.line.length,
+      );
+    } else {
+      resolved = {
+        words: [...words],
+        cword: options.cword ?? Math.max(0, words.length - 1),
+      };
+    }
+
+    // Resolved lazily: importing the root command pulls in the whole command
+    // tree, and doing it inside the guard keeps a failure silent.
+    const { main } = await import("./main.ts");
+
+    try {
+      const lines = await complete(
+        main,
+        resolved.words,
+        resolved.cword,
+        shell,
+      );
+      if (lines.length > 0) console.log(lines.join("\n"));
+    } catch {
+      // A completion request runs mid-keystroke. Anything unexpected yields no
+      // candidates rather than text pasted into the user's command line.
+    }
+  });
+
+export const completion = new Command()
+  .description(description)
+  .default("help")
+  .command(
+    "bash",
+    new Command()
+      .description("Output the bash completion script.")
+      .option(
+        "--no-deno-task",
+        `Do not also complete "deno task ${cliName()} ...".`,
+      )
+      .noGlobals()
+      .action((options) =>
+        console.log(
+          bashCompletionScript(cliName(), { denoTask: options.denoTask }),
+        )
+      ),
+  )
+  .command(
+    "zsh",
+    new Command()
+      .description("Output the zsh completion script.")
+      .option(
+        "--no-deno-task",
+        `Do not also complete "deno task ${cliName()} ...".`,
+      )
+      .noGlobals()
+      .action((options) =>
+        console.log(
+          zshCompletionScript(cliName(), { denoTask: options.denoTask }),
+        )
+      ),
+  )
+  .command("complete", completeCommand.hidden());

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -2,6 +2,7 @@ import { Command, ValidationError } from "@cliffy/command";
 import { HelpCommand } from "@cliffy/command/help";
 import { acl } from "./acl.ts";
 import { check } from "./dev.ts";
+import { completion } from "./completion.ts";
 import { deps } from "./deps.ts";
 import { exec } from "./exec.ts";
 import { fuse } from "./fuse.ts";
@@ -45,6 +46,11 @@ FIRST TIME SETUP:
   cf id new > claude.key            # Create identity key
   export CF_IDENTITY=./claude.key   # Set default identity
   export CF_API_URL=http://localhost:${ports.toolshed}  # Set default API URL
+
+SHELL COMPLETION:
+  source <(cf completion zsh)      # add to ~/.zshrc  (bash: completion bash)
+  Completes commands and flags, plus live piece ids, callable names, and cell
+  paths. Also completes 'deno task cf ...'. See 'cf completion --help'.
 
 LOCAL DEVELOPMENT:
   ./scripts/start-local-dev.sh      # Start local servers
@@ -172,6 +178,7 @@ export const main = new Command()
         await runFuseSupervisor(fuseSupervisorOptions(options, mountpoint));
       }),
   )
+  .command("completion", completion)
   .command("id", identity)
   .command("init", init)
   .command("test", test)

--- a/packages/cli/lib/completion/line.ts
+++ b/packages/cli/lib/completion/line.ts
@@ -1,0 +1,463 @@
+/**
+ * Pure command-line resolution for shell completion.
+ *
+ * The shell hands over either its own tokenized words (zsh) or the raw buffer
+ * (bash); both converge here on `(words, cword)`. Resolution walks Cliffy's
+ * live `Command` tree rather than a hand-maintained table, so a newly
+ * registered subcommand or flag is completable the moment it exists — the
+ * completion surface cannot drift from the CLI.
+ *
+ * Nothing in this module performs I/O. The slot it returns is what
+ * `providers.ts` turns into live candidates.
+ */
+
+import type { Argument, Command, Option } from "@cliffy/command";
+
+/**
+ * A command of any option/argument parameterization.
+ *
+ * Completion walks the tree structurally and never invokes an action, so the
+ * per-command generics carry no information here — and the root command's
+ * inferred type is not assignable to the bare `Command`. This mirrors Cliffy's
+ * own `getCommands(): Array<Command<any>>`.
+ */
+export type AnyCommand = Command<any>;
+
+/** What the word under the cursor is a position for. */
+export type CompletionSlot =
+  /** A subcommand name of `command`. */
+  | { readonly kind: "subcommand" }
+  /** An option flag (the word starts with `-`). */
+  | { readonly kind: "option-name" }
+  /** The value of `option`, either after a space or after `=`. */
+  | {
+    readonly kind: "option-value";
+    readonly option: Option;
+    /** Set when completing `--name=value`; candidates must carry the prefix. */
+    readonly inlinePrefix?: string;
+  }
+  /** A positional argument. `index` counts positionals already supplied. */
+  | {
+    readonly kind: "argument";
+    readonly argument: Argument;
+    readonly index: number;
+  }
+  /**
+   * A word after `--`. `cf piece call` and `cf exec` hand these to the
+   * callable's own schema-derived parser, so the CLI's option tree does not
+   * describe them.
+   */
+  | { readonly kind: "passthrough"; readonly index: number }
+  /** The value of a pre-parse global such as `--log-level`. */
+  | {
+    readonly kind: "global-option-value";
+    readonly option: PreParseGlobal;
+    readonly inlinePrefix?: string;
+  };
+
+/**
+ * A flag stripped from `argv` before Cliffy ever parses it.
+ *
+ * `--log-level` and `--no-color` are applied in `mod.ts` by `applyLogLevel` and
+ * `applyColorMode`, so they exist nowhere in the command tree even though they
+ * are accepted on every command and documented in the root help. Completion has
+ * to carry them explicitly or they are the only documented flags it cannot
+ * offer.
+ */
+export interface PreParseGlobal {
+  readonly flags: readonly string[];
+  readonly description: string;
+  /** Accepted values, when the flag takes one. */
+  readonly values?: readonly string[];
+}
+
+/** Mirrors `lib/log-level.ts` and `lib/color-mode.ts`. */
+export const PRE_PARSE_GLOBALS: readonly PreParseGlobal[] = [
+  {
+    flags: ["--log-level"],
+    description: "Set the global log floor",
+    values: ["debug", "info", "warn", "error", "silent"],
+  },
+  {
+    flags: ["--no-color"],
+    description: "Disable ANSI color output",
+  },
+];
+
+function findPreParseGlobal(token: string): PreParseGlobal | undefined {
+  return PRE_PARSE_GLOBALS.find((global) => global.flags.includes(token));
+}
+
+export interface CompletionLine {
+  /** Deepest command the words resolved to. */
+  readonly command: AnyCommand;
+  /** Command path below the program name, e.g. `["piece", "call"]`. */
+  readonly path: readonly string[];
+  readonly slot: CompletionSlot | null;
+  /** The partial word under the cursor; `""` at a fresh position. */
+  readonly word: string;
+  /** Long name -> last value, for value-taking options already on the line. */
+  readonly options: ReadonlyMap<string, string>;
+  /** Long names of valueless flags already on the line. */
+  readonly flags: ReadonlySet<string>;
+  /** Positional words already supplied to `command`. */
+  readonly positionals: readonly string[];
+  /** Words after a `--` separator, excluding the separator itself. */
+  readonly passthrough: readonly string[];
+}
+
+/** Long name of an option, without leading dashes. */
+function longName(option: Option): string {
+  const long = option.flags.find((flag) => flag.startsWith("--"));
+  return (long ?? option.flags[0] ?? "").replace(/^-+/, "");
+}
+
+/** Whether the option consumes a following word as its value. */
+function takesValue(option: Option): boolean {
+  return (option.args?.length ?? 0) > 0;
+}
+
+/**
+ * Whether the option's value may be omitted (`--flag` alone is legal, as in
+ * Cliffy's `--json [value]`). Such an option never swallows the next word, so
+ * the word after it is a positional, not a value.
+ */
+function valueIsOptional(option: Option): boolean {
+  return option.args?.[0]?.optional === true;
+}
+
+/**
+ * Find the option a flag token names. Cliffy stores every accepted spelling in
+ * `flags`, so short and long forms resolve through the same lookup.
+ */
+function findOption(command: AnyCommand, token: string): Option | undefined {
+  return command.getOptions(false).find((option) =>
+    option.flags.includes(token)
+  );
+}
+
+/**
+ * Expand a bundled short-flag token (`-qs`) into its constituent options.
+ * Returns `undefined` when any character is not a known short flag, which
+ * leaves the caller to treat the token as an opaque word rather than
+ * mis-parsing it.
+ *
+ * Getting this right matters beyond the bundled token itself: a mis-parse
+ * shifts every later positional index, so the argument slot — and with it the
+ * dynamic provider — would be chosen wrongly for the rest of the line.
+ */
+function expandBundle(
+  command: AnyCommand,
+  token: string,
+): Option[] | undefined {
+  if (!/^-[A-Za-z]{2,}$/.test(token)) return undefined;
+  const expanded: Option[] = [];
+  for (const char of token.slice(1)) {
+    const option = findOption(command, `-${char}`);
+    if (!option) return undefined;
+    expanded.push(option);
+  }
+  return expanded;
+}
+
+/**
+ * Subcommands that represent real commands.
+ *
+ * `main` registers `help` with `.global()`, so Cliffy propagates it to every
+ * descendant and `hasCommands()` is true even on leaves like `piece call`.
+ * Taking that at face value would resolve every leaf's positional to a
+ * subcommand slot and silently disable all dynamic value completion.
+ */
+function realSubcommands(command: AnyCommand): AnyCommand[] {
+  return command.getCommands(false).filter((child) =>
+    child.getName() !== "help"
+  );
+}
+
+/** Resolve a subcommand by name or alias, skipping Cliffy's own `help`. */
+function findSubcommand(
+  command: AnyCommand,
+  name: string,
+): AnyCommand | undefined {
+  return command.getCommands(false).find((child) =>
+    child.getName() === name || child.getAliases().includes(name)
+  );
+}
+
+/** Deno task names in this repo that run the CLI. */
+const CLI_TASK_NAMES = new Set(["cf", "cli", "cli-no-pwd-override"]);
+
+/** Module paths that are the CLI entrypoint when run directly. */
+const CLI_ENTRYPOINTS = ["packages/cli/mod.ts", "packages/cli/launcher.ts"];
+
+/**
+ * Strip a `deno …` wrapper so the rest of the line completes as plain `cf`.
+ *
+ * The CLI is most often invoked as `deno task cf …` rather than as a compiled
+ * binary, and `deno run -A packages/cli/mod.ts …` is the third documented path.
+ * Reducing those to the same word list the `cf` binary would see means one
+ * resolver serves every invocation style.
+ *
+ * Returns the words unchanged when the line is not a CLI invocation, along with
+ * the number of leading words removed so the cursor index can be rebased.
+ */
+export function stripInvocationPrefix(
+  words: readonly string[],
+): { words: readonly string[]; removed: number } {
+  if (words.length === 0 || !/(^|\/)deno$/.test(words[0])) {
+    return { words, removed: 0 };
+  }
+
+  let i = 1;
+  // Deno's own flags before the subcommand (-q, -A, --allow-read=…, …).
+  while (i < words.length && words[i].startsWith("-")) i++;
+  if (i >= words.length) return { words, removed: 0 };
+
+  const subcommand = words[i];
+  let consumed: number;
+
+  if (subcommand === "task") {
+    let j = i + 1;
+    // Flags between `task` and the task name (e.g. `--cwd`).
+    while (j < words.length && words[j].startsWith("-")) j++;
+    if (j >= words.length || !CLI_TASK_NAMES.has(words[j])) {
+      return { words, removed: 0 };
+    }
+    consumed = j + 1;
+  } else if (subcommand === "run") {
+    let j = i + 1;
+    while (j < words.length && words[j].startsWith("-")) j++;
+    if (
+      j >= words.length ||
+      !CLI_ENTRYPOINTS.some((entry) => words[j].endsWith(entry))
+    ) {
+      return { words, removed: 0 };
+    }
+    consumed = j + 1;
+  } else {
+    return { words, removed: 0 };
+  }
+
+  // The launcher takes its own options before a `--` that hands the rest to
+  // the CLI. Past that separator the words are ordinary cf arguments.
+  const separator = words.indexOf("--", consumed);
+  if (separator !== -1) consumed = separator + 1;
+
+  // Re-head the list so `words[0]` is a program name again, as the resolver
+  // expects. `cf` is the conventional name and is never matched as a command.
+  return {
+    words: ["cf", ...words.slice(consumed)],
+    removed: consumed - 1,
+  };
+}
+
+/**
+ * Resolve what the word at `cword` is completing.
+ *
+ * `words[0]` is the program name and is skipped. Words after the cursor are
+ * ignored: the slot depends only on what precedes the cursor, so editing
+ * mid-line completes against the correct position instead of the line's end.
+ */
+export function resolveCompletionLine(
+  root: AnyCommand,
+  rawWords: readonly string[],
+  rawCword: number,
+): CompletionLine {
+  const stripped = stripInvocationPrefix(rawWords);
+  const words = stripped.words;
+  const cword = rawCword - stripped.removed;
+
+  const cursor = Math.max(0, Math.min(cword, words.length));
+  const word = words[cursor] ?? "";
+  const context = words.slice(1, Math.max(1, cursor));
+
+  let command = root;
+  const path: string[] = [];
+  const options = new Map<string, string>();
+  const flags = new Set<string>();
+  let positionals: string[] = [];
+  const passthrough: string[] = [];
+  let separatorSeen = false;
+
+  for (let i = 0; i < context.length; i++) {
+    const token = context[i];
+
+    if (separatorSeen) {
+      passthrough.push(token);
+      continue;
+    }
+    if (token === "--") {
+      separatorSeen = true;
+      continue;
+    }
+
+    if (token.startsWith("-") && token !== "-") {
+      const inline = token.match(/^(--[^=]+)=(.*)$/);
+      if (inline) {
+        const option = findOption(command, inline[1]);
+        if (option) options.set(longName(option), inline[2]);
+        continue;
+      }
+
+      const option = findOption(command, token);
+      if (option) {
+        if (takesValue(option) && !valueIsOptional(option)) {
+          const value = context[i + 1];
+          // A trailing flag with no value yet still counts as present.
+          if (value !== undefined) {
+            options.set(longName(option), value);
+            i++;
+          }
+        } else {
+          flags.add(longName(option));
+        }
+        continue;
+      }
+
+      // Pre-parse globals are legal at any depth and are stripped before
+      // Cliffy parses, so consume them (and any value) without letting them
+      // disturb the positional indices the argument slot depends on.
+      const preParse = findPreParseGlobal(token);
+      if (preParse) {
+        if (preParse.values && context[i + 1] !== undefined) i++;
+        continue;
+      }
+
+      const bundle = expandBundle(command, token);
+      if (bundle) {
+        const last = bundle[bundle.length - 1];
+        for (const bundled of bundle.slice(0, -1)) {
+          flags.add(longName(bundled));
+        }
+        if (takesValue(last) && !valueIsOptional(last)) {
+          const value = context[i + 1];
+          if (value !== undefined) {
+            options.set(longName(last), value);
+            i++;
+          }
+        } else {
+          flags.add(longName(last));
+        }
+        continue;
+      }
+
+      // Unknown flag: record it so it does not shift positional indices.
+      continue;
+    }
+
+    // A subcommand only shadows a positional before any positional is taken;
+    // afterwards a matching word is data, not a command.
+    if (positionals.length === 0) {
+      const child = findSubcommand(command, token);
+      if (child) {
+        command = child;
+        path.push(child.getName());
+        positionals = [];
+        continue;
+      }
+    }
+    positionals.push(token);
+  }
+
+  const slot = resolveSlot({
+    command,
+    word,
+    context,
+    cursor,
+    separatorSeen,
+    positionals,
+    passthrough,
+  });
+
+  return {
+    command,
+    path,
+    slot,
+    word,
+    options,
+    flags,
+    positionals,
+    passthrough,
+  };
+}
+
+function resolveSlot(input: {
+  command: AnyCommand;
+  word: string;
+  context: readonly string[];
+  cursor: number;
+  separatorSeen: boolean;
+  positionals: readonly string[];
+  passthrough: readonly string[];
+}): CompletionSlot | null {
+  const { command, word, context, separatorSeen, positionals } = input;
+
+  if (separatorSeen) {
+    return { kind: "passthrough", index: input.passthrough.length };
+  }
+
+  // `--name=<cursor>` completes the value, and candidates must be emitted with
+  // the `--name=` prefix so the shell replaces the whole token.
+  const inline = word.match(/^(--[^=]+)=(.*)$/);
+  if (inline) {
+    const preParse = findPreParseGlobal(inline[1]);
+    if (preParse?.values) {
+      return {
+        kind: "global-option-value",
+        option: preParse,
+        inlinePrefix: `${inline[1]}=`,
+      };
+    }
+    const option = findOption(command, inline[1]);
+    if (!option || !takesValue(option)) return null;
+    return {
+      kind: "option-value",
+      option,
+      inlinePrefix: `${inline[1]}=`,
+    };
+  }
+
+  if (word.startsWith("-") && word !== "-" || word === "-") {
+    return { kind: "option-name" };
+  }
+
+  // Directly after a value-taking flag, the cursor is that flag's value.
+  const previous = context[context.length - 1];
+  if (previous !== undefined && previous.startsWith("-") && previous !== "--") {
+    const preParse = findPreParseGlobal(previous);
+    if (preParse?.values) {
+      return { kind: "global-option-value", option: preParse };
+    }
+
+    const option = findOption(command, previous);
+    if (option && takesValue(option) && !valueIsOptional(option)) {
+      return { kind: "option-value", option };
+    }
+    if (!option) {
+      const bundle = expandBundle(command, previous);
+      const last = bundle?.[bundle.length - 1];
+      if (last && takesValue(last) && !valueIsOptional(last)) {
+        return { kind: "option-value", option: last };
+      }
+    }
+  }
+
+  if (positionals.length === 0 && realSubcommands(command).length > 0) {
+    return { kind: "subcommand" };
+  }
+
+  const args = command.getArguments();
+  if (args.length > 0) {
+    const index = Math.min(positionals.length, args.length - 1);
+    const argument = args[index];
+    // Only a variadic final argument accepts more words than it declares.
+    if (positionals.length < args.length || argument.variadic) {
+      return { kind: "argument", argument, index: positionals.length };
+    }
+  }
+
+  return null;
+}
+
+/** Exported for `providers.ts`, which keys context lookups by long name. */
+export { longName, takesValue };

--- a/packages/cli/lib/completion/mod.ts
+++ b/packages/cli/lib/completion/mod.ts
@@ -1,0 +1,208 @@
+/**
+ * Completion orchestration: words in, shell-ready candidate lines out.
+ *
+ * The wire format between the shell function and this module is deliberately
+ * narrow — a list of lines, where lines beginning `:cf:` are directives and
+ * everything else is a candidate. That keeps the installed shell functions
+ * small and stable: they are sourced into a user's environment and are the one
+ * part of this feature that cannot be updated by rebuilding the CLI.
+ */
+
+import {
+  type AnyCommand,
+  type CompletionLine,
+  resolveCompletionLine,
+  stripInvocationPrefix,
+} from "./line.ts";
+import {
+  type Candidate,
+  enumeratedOptionValues,
+  optionNameCandidates,
+  preParseGlobalValues,
+  subcommandCandidates,
+} from "./static.ts";
+import { type Directive, liveCandidates } from "./providers.ts";
+
+export type CompletionShell = "bash" | "zsh";
+
+/** Directive prefix. No CLI value legitimately starts with this. */
+const DIRECTIVE_PREFIX = ":cf:";
+
+/**
+ * Tokenize a raw command line into words plus the index of the word under the
+ * cursor.
+ *
+ * Bash hands over `COMP_LINE`/`COMP_POINT` rather than its own `COMP_WORDS`
+ * because `COMP_WORDBREAKS` splits on `:` and `=`, which shreds exactly the
+ * values cf deals in — `http://localhost:8000` and `--space=x`. Tokenizing here
+ * means both shells reach the resolver with the same view of the line.
+ */
+export function tokenizeLine(
+  line: string,
+  point: number,
+): { words: string[]; cword: number } {
+  const upto = line.slice(0, Math.max(0, Math.min(point, line.length)));
+  const words: string[] = [];
+  let current = "";
+  let started = false;
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < upto.length; i++) {
+    const char = upto[i];
+    if (quote) {
+      if (char === quote) quote = null;
+      else if (char === "\\" && quote === '"' && i + 1 < upto.length) {
+        current += upto[++i];
+      } else current += char;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      started = true;
+      continue;
+    }
+    if (char === "\\" && i + 1 < upto.length) {
+      current += upto[++i];
+      started = true;
+      continue;
+    }
+    if (char === " " || char === "\t") {
+      if (started) {
+        words.push(current);
+        current = "";
+        started = false;
+      }
+      continue;
+    }
+    current += char;
+    started = true;
+  }
+
+  // A trailing separator means the cursor sits at a fresh, empty word.
+  words.push(started ? current : "");
+  return { words, cword: words.length - 1 };
+}
+
+/**
+ * Escape a candidate for the shell's own list format.
+ *
+ * zsh's `_describe` splits `value:description` on the first colon, so a colon
+ * inside a value — every `http://` api-url has two — must be escaped or the
+ * candidate is silently truncated at insertion time.
+ */
+function formatCandidate(
+  candidate: Candidate,
+  shell: CompletionShell,
+): string {
+  if (shell !== "zsh") return candidate.value;
+  const value = candidate.value.replaceAll(":", "\\:");
+  return candidate.description
+    ? `${value}:${candidate.description.replaceAll("\n", " ")}`
+    : value;
+}
+
+function formatDirective(directive: Directive): string {
+  switch (directive.kind) {
+    case "files":
+      return directive.glob
+        ? `${DIRECTIVE_PREFIX}files ${directive.glob}`
+        : `${DIRECTIVE_PREFIX}files`;
+    case "dirs":
+      return `${DIRECTIVE_PREFIX}dirs`;
+    case "nospace":
+      return `${DIRECTIVE_PREFIX}nospace`;
+  }
+}
+
+/**
+ * Whether these words are a Common Fabric CLI invocation at all.
+ *
+ * A `deno` line only qualifies once `stripInvocationPrefix` recognizes it as
+ * running the CLI (`deno task cf …`, `deno run … mod.ts …`); `deno test`,
+ * `deno task build`, and a bare `deno ` are somebody else's completion.
+ */
+function isOwnInvocation(words: readonly string[]): boolean {
+  if (words.length === 0) return true;
+  if (!/(^|\/)deno$/.test(words[0])) return true;
+  return stripInvocationPrefix(words).removed > 0;
+}
+
+/**
+ * Re-attach a `--name=` prefix to values completed in inline form, so the shell
+ * replaces the whole token rather than appending to it.
+ */
+function withInlinePrefix(
+  candidates: Candidate[],
+  prefix: string | undefined,
+): Candidate[] {
+  if (!prefix) return candidates;
+  return candidates.map((candidate) => ({
+    ...candidate,
+    value: `${prefix}${candidate.value}`,
+  }));
+}
+
+/**
+ * Static candidates for a resolved line — everything answerable without I/O.
+ * Split out from `complete` so tests can assert the whole static surface
+ * without a fabric, which is where most completion regressions would show.
+ */
+export function staticCandidates(line: CompletionLine): Candidate[] {
+  const slot = line.slot;
+  if (!slot) return [];
+
+  switch (slot.kind) {
+    // A word starting with `-` resolves to `option-name` before reaching here,
+    // so this slot only ever completes command names.
+    case "subcommand":
+      return subcommandCandidates(line.command);
+    case "option-name":
+      return optionNameCandidates(line.command, line);
+    case "option-value": {
+      const enumerated = enumeratedOptionValues(slot.option);
+      if (!enumerated) return [];
+      return withInlinePrefix(enumerated, slot.inlinePrefix);
+    }
+    case "global-option-value":
+      return withInlinePrefix(
+        preParseGlobalValues(slot.option),
+        slot.inlinePrefix,
+      );
+    default:
+      return [];
+  }
+}
+
+/**
+ * Produce the lines the shell function consumes.
+ *
+ * Candidates are filtered by the typed prefix here rather than left to the
+ * shell: bash's own filtering works on its `COMP_WORDBREAKS` view of the word,
+ * which does not match the word this module resolved against.
+ */
+export async function complete(
+  root: AnyCommand,
+  words: readonly string[],
+  cword: number,
+  shell: CompletionShell,
+): Promise<string[]> {
+  // The same shell function is bound to both `cf` and `deno`, because the CLI
+  // is most often run as `deno task cf …`. A `deno` line that is not a CLI
+  // invocation says so explicitly, so the shell can hand back to whatever
+  // completed `deno` before rather than silently offering nothing.
+  if (!isOwnInvocation(words)) return [`${DIRECTIVE_PREFIX}notmine`];
+
+  const line = resolveCompletionLine(root, words, cword);
+
+  const live = await liveCandidates(line);
+  const candidates = [...staticCandidates(line), ...live.candidates];
+
+  const matching = candidates.filter((candidate) =>
+    candidate.value.startsWith(line.word)
+  );
+
+  return [
+    ...live.directives.map(formatDirective),
+    ...matching.map((candidate) => formatCandidate(candidate, shell)),
+  ];
+}

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -112,15 +112,29 @@ async function pieceCandidates(line: CompletionLine): Promise<ProviderResult> {
   const config = resolveSpaceContext(line);
   if (!config) return NOTHING;
   const { listPieces } = await import("../piece.ts");
-  const pieces = await listPieces(config);
-  return values(
-    pieces.map((piece) => ({
-      value: piece.id,
-      // The piece's own name reads best; the pattern symbol is the fallback
-      // for a piece that has not been given one.
-      description: piece.name ?? piece.patternRef?.symbol ?? undefined,
-    })),
-  );
+  return values(shapePieceCandidates(await listPieces(config)));
+}
+
+/** Listing shape used by `shapePieceCandidates`, structural so tests need no runtime. */
+export interface PieceListingLike {
+  readonly id: string;
+  readonly name?: string;
+  readonly patternRef?: { readonly symbol?: string } | null;
+}
+
+/**
+ * Label pieces for the annotation column: the piece's own name reads best, and
+ * the pattern symbol is the fallback for a piece never given one. A piece that
+ * failed to load still lists — its id is exactly what an operator reaches for
+ * completion to recover.
+ */
+export function shapePieceCandidates(
+  pieces: readonly PieceListingLike[],
+): Candidate[] {
+  return pieces.map((piece) => ({
+    value: piece.id,
+    description: piece.name ?? piece.patternRef?.symbol ?? undefined,
+  }));
 }
 
 /** Callables (handlers and streams) exposed by the line's `--piece`. */
@@ -131,12 +145,20 @@ async function callableCandidates(
   if (!config) return NOTHING;
   const { listPieceCallables } = await import("../piece.ts");
   const listing = await listPieceCallables(config);
-  return values(
-    listing.verbs.map((verb) => ({
-      value: verb.name,
-      description: verb.kind,
-    })),
-  );
+  return values(shapeVerbCandidates(listing.verbs));
+}
+
+/** Verb shape used by `shapeVerbCandidates`, structural so tests need no runtime. */
+export interface VerbListingLike {
+  readonly name: string;
+  readonly kind: string;
+}
+
+/** Callables annotated by kind, matching what `cf piece verbs` reports. */
+export function shapeVerbCandidates(
+  verbs: readonly VerbListingLike[],
+): Candidate[] {
+  return verbs.map((verb) => ({ value: verb.name, description: verb.kind }));
 }
 
 /**
@@ -152,11 +174,7 @@ async function cellPathCandidates(
   const config = resolvePieceContext(line);
   if (!config) return NOTHING;
 
-  const typed = line.word;
-  const cut = typed.lastIndexOf("/");
-  const parentPath = cut === -1 ? "" : typed.slice(0, cut);
-  const prefix = cut === -1 ? "" : `${parentPath}/`;
-
+  const { parentPath, prefix } = splitPathPrefix(line.word);
   const keys = await childKeys(config, parentPath, {
     input: line.flags.has("input"),
   });
@@ -181,13 +199,36 @@ async function childKeys(
   const { getCellValue } = await import("../piece.ts");
   const { parseCellPath } = await import("@commonfabric/runner");
   const segments = path ? parseCellPath(path) : [];
-  const value = await getCellValue(config, segments, options);
+  return keysOf(await getCellValue(config, segments, options));
+}
 
+/**
+ * The completable keys of one cell value: an array yields its indices, an
+ * object its property names, and a leaf yields nothing — which is the correct
+ * signal that the path already names a value rather than a container.
+ */
+export function keysOf(value: unknown): string[] {
   if (Array.isArray(value)) return value.map((_, index) => String(index));
   if (value && typeof value === "object") {
     return Object.keys(value as Record<string, unknown>);
   }
   return [];
+}
+
+/**
+ * Split the word being typed into the parent path to read and the prefix each
+ * candidate must carry, so the shell replaces the whole token.
+ *
+ * `items/0/ti` reads `items/0` and offers `items/0/title`: the prefix is what
+ * keeps a completed deep path from collapsing to its last segment.
+ */
+export function splitPathPrefix(
+  typed: string,
+): { parentPath: string; prefix: string } {
+  const cut = typed.lastIndexOf("/");
+  if (cut === -1) return { parentPath: "", prefix: "" };
+  const parentPath = typed.slice(0, cut);
+  return { parentPath, prefix: `${parentPath}/` };
 }
 
 /**
@@ -210,18 +251,27 @@ async function linkEndpointCandidates(
   const config = resolveSpaceContext(line);
   if (!config) return NOTHING;
   const pieceId = typed.slice(0, cut);
-  const rest = typed.slice(cut + 1);
-  const lastSlash = rest.lastIndexOf("/");
-  const parentPath = lastSlash === -1 ? "" : rest.slice(0, lastSlash);
+  const { parentPath } = splitPathPrefix(typed.slice(cut + 1));
 
   const keys = await childKeys({ ...config, piece: pieceId }, parentPath);
   if (keys.length === 0) return NOTHING;
 
-  const prefix = parentPath ? `${pieceId}/${parentPath}/` : `${pieceId}/`;
+  const prefix = linkEndpointPrefix(pieceId, parentPath);
   return {
     candidates: keys.map((key) => ({ value: `${prefix}${key}` })),
     directives: [{ kind: "nospace" }],
   };
+}
+
+/**
+ * Prefix for a `piece link` endpoint candidate. The empty parent path is the
+ * case that matters: `id//key` would be a different, invalid reference.
+ */
+export function linkEndpointPrefix(
+  pieceId: string,
+  parentPath: string,
+): string {
+  return parentPath ? `${pieceId}/${parentPath}/` : `${pieceId}/`;
 }
 
 /**

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -1,0 +1,354 @@
+/**
+ * Live candidate providers — the half of completion that reads real state.
+ *
+ * Every provider resolves its fabric context from the half-typed line first and
+ * the environment second, which is what lets
+ * `cf piece call -s other-space --piece <TAB>` list the pieces of `other-space`
+ * rather than whatever `CF_SPACE`-shaped default the shell happens to carry.
+ *
+ * Failure is always silent and always empty. A completion request runs while
+ * the user is mid-keystroke: an unreachable server, an expired key, or a
+ * malformed piece id must produce no candidates, never a stack trace pasted
+ * into the command line.
+ */
+
+import type { Candidate } from "./static.ts";
+import type { CompletionLine } from "./line.ts";
+import { longName } from "./line.ts";
+import { absPath } from "../utils.ts";
+import type { PieceConfig, SpaceConfig } from "../piece.ts";
+
+/** A directive tells the shell to complete something only it can do well. */
+export type Directive =
+  /** Hand off to the shell's own file completion, filtered by glob. */
+  | { readonly kind: "files"; readonly glob?: string }
+  /** Hand off to the shell's directory completion. */
+  | { readonly kind: "dirs" }
+  /** Suppress the trailing space, so a path can be continued with `/`. */
+  | { readonly kind: "nospace" };
+
+export interface ProviderResult {
+  readonly candidates: readonly Candidate[];
+  readonly directives: readonly Directive[];
+}
+
+const NOTHING: ProviderResult = { candidates: [], directives: [] };
+
+function values(candidates: readonly Candidate[]): ProviderResult {
+  return { candidates, directives: [] };
+}
+
+function directive(...directives: Directive[]): ProviderResult {
+  return { candidates: [], directives };
+}
+
+/**
+ * Resolve the fabric connection the half-typed line refers to.
+ *
+ * Mirrors the precedence `parseSpaceOptions` applies at execution time — line
+ * options beat environment, and `--url` supplies api-url plus space together —
+ * but never throws: an incomplete line yields `null`, meaning "no live
+ * candidates", not an error.
+ */
+export function resolveSpaceContext(
+  line: CompletionLine,
+): SpaceConfig | null {
+  const url = line.options.get("url");
+  const identity = line.options.get("identity") ??
+    Deno.env.get("CF_IDENTITY");
+  if (!identity) return null;
+
+  let apiUrl = line.options.get("api-url") ?? Deno.env.get("CF_API_URL");
+  let space = line.options.get("space");
+
+  if (url) {
+    try {
+      const parsed = new URL(url);
+      apiUrl = `${parsed.protocol}//${parsed.host}`;
+      space = parsed.pathname.split("/").filter(Boolean)[0];
+    } catch {
+      return null;
+    }
+  }
+
+  if (!apiUrl || !space) return null;
+
+  try {
+    return {
+      apiUrl,
+      space,
+      identity: absPath(identity),
+      // Completion reserves stdout for candidates. `jsonOutput` is how the
+      // runtime is told stdout is machine-readable: it routes status lines
+      // that would otherwise `console.log` (the navigateTo notice in
+      // `loadManager`) to stderr, where the shell function discards them.
+      // Without it such a line would be offered to the user as a candidate.
+      jsonOutput: true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Same as `resolveSpaceContext`, plus the `--piece` the line already names. */
+function resolvePieceContext(line: CompletionLine): PieceConfig | null {
+  const space = resolveSpaceContext(line);
+  if (!space) return null;
+  const piece = line.options.get("piece") ??
+    (line.options.get("url")
+      ? new URL(line.options.get("url")!).pathname.split("/").filter(Boolean)[1]
+      : undefined);
+  if (!piece) return null;
+  return { ...space, piece };
+}
+
+/**
+ * Pieces in the line's space, as `id` with the piece's name as annotation.
+ *
+ * A piece that failed to load still lists — its id is exactly what an operator
+ * reaches for completion to recover.
+ */
+async function pieceCandidates(line: CompletionLine): Promise<ProviderResult> {
+  const config = resolveSpaceContext(line);
+  if (!config) return NOTHING;
+  const { listPieces } = await import("../piece.ts");
+  const pieces = await listPieces(config);
+  return values(
+    pieces.map((piece) => ({
+      value: piece.id,
+      // The piece's own name reads best; the pattern symbol is the fallback
+      // for a piece that has not been given one.
+      description: piece.name ?? piece.patternRef?.symbol ?? undefined,
+    })),
+  );
+}
+
+/** Callables (handlers and streams) exposed by the line's `--piece`. */
+async function callableCandidates(
+  line: CompletionLine,
+): Promise<ProviderResult> {
+  const config = resolvePieceContext(line);
+  if (!config) return NOTHING;
+  const { listPieceCallables } = await import("../piece.ts");
+  const listing = await listPieceCallables(config);
+  return values(
+    listing.verbs.map((verb) => ({
+      value: verb.name,
+      description: verb.kind,
+    })),
+  );
+}
+
+/**
+ * Keys reachable one level below the path already typed.
+ *
+ * Completion happens per path segment: `items/<TAB>` reads `items` and offers
+ * its keys, so a deep path is walked rather than guessed. `nospace` keeps the
+ * cursor attached to the value so the next `/` continues the same word.
+ */
+async function cellPathCandidates(
+  line: CompletionLine,
+): Promise<ProviderResult> {
+  const config = resolvePieceContext(line);
+  if (!config) return NOTHING;
+
+  const typed = line.word;
+  const cut = typed.lastIndexOf("/");
+  const parentPath = cut === -1 ? "" : typed.slice(0, cut);
+  const prefix = cut === -1 ? "" : `${parentPath}/`;
+
+  const keys = await childKeys(config, parentPath, {
+    input: line.flags.has("input"),
+  });
+  if (keys.length === 0) return NOTHING;
+
+  return {
+    candidates: keys.map((key) => ({ value: `${prefix}${key}` })),
+    directives: [{ kind: "nospace" }],
+  };
+}
+
+/**
+ * Keys directly under `path` on a piece's cell. An array yields its indices, an
+ * object its property names, and a leaf yields nothing — which is the correct
+ * signal that the path is already complete.
+ */
+async function childKeys(
+  config: PieceConfig,
+  path: string,
+  options: { input?: boolean } = {},
+): Promise<string[]> {
+  const { getCellValue } = await import("../piece.ts");
+  const { parseCellPath } = await import("@commonfabric/runner");
+  const segments = path ? parseCellPath(path) : [];
+  const value = await getCellValue(config, segments, options);
+
+  if (Array.isArray(value)) return value.map((_, index) => String(index));
+  if (value && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>);
+  }
+  return [];
+}
+
+/**
+ * `pieceId/path/to/field` endpoints for `cf piece link`.
+ *
+ * Before the `/` the candidates are piece ids; after it they are that piece's
+ * cell keys, so both halves of a link reference complete.
+ */
+async function linkEndpointCandidates(
+  line: CompletionLine,
+): Promise<ProviderResult> {
+  const typed = line.word;
+  const cut = typed.indexOf("/");
+  if (cut === -1) {
+    const pieces = await pieceCandidates(line);
+    // A link endpoint continues with `/`, so hold the cursor in place.
+    return { candidates: pieces.candidates, directives: [{ kind: "nospace" }] };
+  }
+
+  const config = resolveSpaceContext(line);
+  if (!config) return NOTHING;
+  const pieceId = typed.slice(0, cut);
+  const rest = typed.slice(cut + 1);
+  const lastSlash = rest.lastIndexOf("/");
+  const parentPath = lastSlash === -1 ? "" : rest.slice(0, lastSlash);
+
+  const keys = await childKeys({ ...config, piece: pieceId }, parentPath);
+  if (keys.length === 0) return NOTHING;
+
+  const prefix = parentPath ? `${pieceId}/${parentPath}/` : `${pieceId}/`;
+  return {
+    candidates: keys.map((key) => ({ value: `${prefix}${key}` })),
+    directives: [{ kind: "nospace" }],
+  };
+}
+
+/**
+ * Spaces this machine already knows about, discovered from the local memory-v2
+ * SQLite stores that `cf inspect` reads. There is no server-side space index to
+ * query, so an operator who has touched a space locally gets its DID completed
+ * and everyone else gets nothing rather than a wrong guess.
+ *
+ * `--space` accepts a name or a DID, and the DB basename is the DID, so these
+ * candidates are directly usable.
+ */
+async function spaceCandidates(): Promise<ProviderResult> {
+  const { discoverSpaceDbs } = await import("@commonfabric/state-inspector");
+  const spaces = discoverSpaceDbs()
+    // Most-recently written first: the space being worked on ranks top.
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  // One space can have a DB under more than one cache root (a worktree's and
+  // the checkout's). They are distinct files but the same space, and a
+  // repeated DID in the candidate list is pure noise.
+  const seen = new Set<string>();
+  const candidates: Candidate[] = [];
+  for (const space of spaces) {
+    if (seen.has(space.did)) continue;
+    seen.add(space.did);
+    candidates.push({ value: space.did, description: "local space db" });
+  }
+  return values(candidates);
+}
+
+/** API URLs worth offering: the environment's, plus the local dev server. */
+async function apiUrlCandidates(): Promise<ProviderResult> {
+  const ports = (await import("@commonfabric/ports", {
+    with: { type: "json" },
+  })).default;
+  const candidates: Candidate[] = [];
+  const fromEnv = Deno.env.get("CF_API_URL");
+  if (fromEnv) candidates.push({ value: fromEnv, description: "CF_API_URL" });
+  const local = `http://localhost:${ports.toolshed}`;
+  if (local !== fromEnv) {
+    candidates.push({ value: local, description: "local toolshed" });
+  }
+  return values(candidates);
+}
+
+/** Pattern sources are `.tsx`; the shell filters and handles directories. */
+function patternFiles(): Promise<ProviderResult> {
+  return Promise.resolve(directive({ kind: "files", glob: "*.tsx" }));
+}
+
+/**
+ * Option values by long name. A name absent here falls through to the shell's
+ * own file completion only when the option is path-shaped.
+ */
+const OPTION_VALUE_PROVIDERS: Readonly<
+  Record<string, (line: CompletionLine) => Promise<ProviderResult>>
+> = {
+  piece: pieceCandidates,
+  space: () => spaceCandidates(),
+  "api-url": () => apiUrlCandidates(),
+  identity: () => Promise.resolve(directive({ kind: "files", glob: "*.key" })),
+  root: () => Promise.resolve(directive({ kind: "dirs" })),
+  // `cf space clone --to <dir>` builds a clone directory.
+  to: () => Promise.resolve(directive({ kind: "dirs" })),
+  "log-file": () => Promise.resolve(directive({ kind: "files" })),
+  "state-path": () => Promise.resolve(directive({ kind: "files" })),
+};
+
+/**
+ * Positional providers, keyed by `<command path>:<argument name>`. The command
+ * path disambiguates arguments that share a name across commands — `path` means
+ * a cell path under `piece get` but a filesystem path elsewhere.
+ */
+const ARGUMENT_PROVIDERS: Readonly<
+  Record<string, (line: CompletionLine) => Promise<ProviderResult>>
+> = {
+  "piece call:callable": callableCandidates,
+  "piece get:path": cellPathCandidates,
+  "piece set:path": cellPathCandidates,
+  "piece link:source": linkEndpointCandidates,
+  "piece link:target": linkEndpointCandidates,
+  "piece new:main": patternFiles,
+  "piece setsrc:main": patternFiles,
+  "check:files": patternFiles,
+  "test:paths": patternFiles,
+  "view:file": () => Promise.resolve(directive({ kind: "files" })),
+  "exec:mountedFile": () => Promise.resolve(directive({ kind: "files" })),
+  "id did:keypath": () =>
+    Promise.resolve(directive({ kind: "files", glob: "*.key" })),
+  // `cf space` names a space positionally rather than through `--space`.
+  "space clone:space": () => spaceCandidates(),
+  "space fingerprint:space": () => spaceCandidates(),
+  // `verify`/`reset` take a clone directory built by `space clone`.
+  "space verify:dir": () => Promise.resolve(directive({ kind: "dirs" })),
+  "space reset:dir": () => Promise.resolve(directive({ kind: "dirs" })),
+};
+
+/**
+ * Run the provider for the line's slot.
+ *
+ * Any provider failure degrades to no candidates: completion must never
+ * interrupt typing with an error, and a silent empty list is the honest signal
+ * that live data was unavailable.
+ */
+export async function liveCandidates(
+  line: CompletionLine,
+): Promise<ProviderResult> {
+  const slot = line.slot;
+  if (!slot) return NOTHING;
+
+  let provider:
+    | ((line: CompletionLine) => Promise<ProviderResult>)
+    | undefined;
+
+  if (slot.kind === "option-value") {
+    provider = OPTION_VALUE_PROVIDERS[longName(slot.option)];
+  } else if (slot.kind === "argument") {
+    provider = ARGUMENT_PROVIDERS[
+      `${line.path.join(" ")}:${slot.argument.name}`
+    ];
+  }
+
+  if (!provider) return NOTHING;
+
+  try {
+    return await provider(line);
+  } catch {
+    return NOTHING;
+  }
+}

--- a/packages/cli/lib/completion/script.ts
+++ b/packages/cli/lib/completion/script.ts
@@ -1,0 +1,242 @@
+/**
+ * The shell functions users install.
+ *
+ * These are intentionally thin and free of per-command knowledge: they forward
+ * the raw line and let `cf completion complete` decide everything. That
+ * matters because a sourced completion function lives in the user's shell
+ * profile — it is the one piece of this feature that does not get updated when
+ * the CLI is rebuilt, so it must not encode a command tree that can go stale.
+ *
+ * Each script binds two command words. `cf` is the compiled binary; `deno` is
+ * bound because the CLI is most often run as `deno task cf …`. The `deno`
+ * binding is cooperative: the CLI reports `:cf:notmine` for any `deno` line
+ * that is not a CLI invocation, and the function hands back to whatever
+ * completed `deno` beforehand, so `deno test`/`deno task build` keep their own
+ * completions.
+ */
+
+export interface ScriptOptions {
+  /** Also complete `deno task cf …`. Defaults to true. */
+  readonly denoTask?: boolean;
+}
+
+/** Shell-function-safe identifier derived from the installed CLI name. */
+function functionName(name: string): string {
+  return name.replace(/[^A-Za-z0-9]/g, "_");
+}
+
+/**
+ * bash completion.
+ *
+ * Passes `COMP_LINE`/`COMP_POINT` instead of `COMP_WORDS`: bash splits words on
+ * `COMP_WORDBREAKS`, which includes `:` and `=`, so `--space=x` and
+ * `http://host:8000` would arrive pre-shredded. The CLI tokenizes instead, and
+ * the reply is re-trimmed to the fragment bash believes it is replacing.
+ */
+export function bashCompletionScript(
+  name: string,
+  options: ScriptOptions = {},
+): string {
+  const fn = `_${functionName(name)}_complete`;
+  const previous = `_${functionName(name)}_deno_previous`;
+  const denoTask = options.denoTask !== false;
+
+  const denoBinding = denoTask
+    ? `
+# Capture the existing \`deno\` completion before rebinding, so non-CLI deno
+# lines keep it. Must run before the \`complete -F\` below replaces the spec.
+#
+# Only a foreign function is recorded, and an already-recorded one is kept.
+# Sourcing this script twice (a profile plus bash_completion.d, or a re-sourced
+# profile) makes the second pass see the binding the first pass installed;
+# capturing that would recurse forever on the next non-CLI \`deno\` completion
+# and hang the terminal, while clearing it would silently drop deno's real
+# completion.
+${previous}="\${${previous}:-}"
+if _${functionName(name)}_spec="$(complete -p deno 2>/dev/null)"; then
+  if [[ "\${_${
+      functionName(name)
+    }_spec}" =~ -F[[:space:]]+([^[:space:]]+) ]]; then
+    if [[ "\${BASH_REMATCH[1]}" != "${fn}" ]]; then
+      ${previous}="\${BASH_REMATCH[1]}"
+    fi
+  fi
+fi
+unset _${functionName(name)}_spec
+
+complete -F ${fn} deno
+`
+    : "";
+
+  return `# bash completion for ${name}
+# Install:  ${name} completion bash > /usr/local/etc/bash_completion.d/${name}
+#     or:   source <(${name} completion bash)
+
+${fn}() {
+  local IFS=$'\\n'
+  local cur reply line glob="" nospace=0 notmine=0
+  local -a raw
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=()
+
+  # Read with a loop rather than \`mapfile\`: macOS ships bash 3.2, where
+  # \`mapfile\` does not exist. Errors are discarded — a failing completion must
+  # never print into the user's command line.
+  while IFS= read -r line; do
+    raw+=("\${line}")
+  done < <(${name} completion complete --shell bash \\
+    --line "\${COMP_LINE}" --point "\${COMP_POINT}" 2>/dev/null)
+
+  for line in "\${raw[@]}"; do
+    case "\${line}" in
+      ':cf:notmine') notmine=1 ;;
+      ':cf:files '*) glob="\${line#:cf:files }" ;;
+      ':cf:files')   glob="*" ;;
+      ':cf:dirs')    glob=":dirs:" ;;
+      ':cf:nospace') nospace=1 ;;
+      '') ;;
+      *) COMPREPLY+=("\${line}") ;;
+    esac
+  done
+
+  # Not a ${name} command line (e.g. \`deno test\`): defer to the completion
+  # that was bound before us, or to plain filenames.
+  if [[ \${notmine} -eq 1 ]]; then
+    COMPREPLY=()
+    if [[ -n "\${${previous}:-}" ]] && declare -F "\${${previous}}" >/dev/null; then
+      "\${${previous}}"
+    else
+      while IFS= read -r reply; do COMPREPLY+=("\${reply}"); done \\
+        < <(compgen -f -- "\${cur}")
+    fi
+    return
+  fi
+
+  if [[ -n "\${glob}" ]]; then
+    if [[ "\${glob}" == ":dirs:" ]]; then
+      while IFS= read -r reply; do COMPREPLY+=("\${reply}"); done \\
+        < <(compgen -d -- "\${cur}")
+    else
+      while IFS= read -r reply; do COMPREPLY+=("\${reply}"); done \\
+        < <(compgen -f -X "!\${glob}" -- "\${cur}"; compgen -d -- "\${cur}")
+    fi
+  fi
+
+  # bash replaces only the fragment after the last word-break character, so
+  # trim each candidate by the same amount or the prefix is duplicated.
+  if [[ "\${cur}" == *[:=]* ]]; then
+    local head="\${cur%[:=]*}"
+    local i
+    for i in "\${!COMPREPLY[@]}"; do
+      COMPREPLY[i]="\${COMPREPLY[i]#"\${head}"?}"
+    done
+  fi
+
+  # \`compopt\` is bash 4+; on bash 3.2 the trailing space is simply not
+  # suppressed, which costs a keystroke but completes correctly.
+  if [[ \${nospace} -eq 1 ]] && type compopt >/dev/null 2>&1; then
+    compopt -o nospace
+  fi
+}
+${denoBinding}
+complete -F ${fn} ${name}
+`;
+}
+
+/**
+ * zsh completion.
+ *
+ * zsh already tokenizes respecting quotes, so `words`/`CURRENT` are forwarded
+ * directly. `_describe` renders the annotation column, which is what makes an
+ * opaque piece id readable — the id completes, its name explains it.
+ */
+export function zshCompletionScript(
+  name: string,
+  options: ScriptOptions = {},
+): string {
+  const fn = `_${functionName(name)}`;
+  const previous = `_${functionName(name)}_deno_previous`;
+  const denoTask = options.denoTask !== false;
+
+  const denoBinding = denoTask
+    ? `
+# Capture the existing \`deno\` completer before rebinding, so non-CLI deno
+# lines keep it. Must run before the \`compdef\` below overwrites _comps[deno].
+#
+# Only a foreign completer is recorded, and an already-recorded one is kept.
+# Loading this script twice makes the second pass see the binding the first
+# installed; capturing that would recurse forever on the next non-CLI \`deno\`
+# completion and hang the terminal, while clearing it would silently drop
+# deno's real completion.
+typeset -g ${previous}="\${${previous}:-}"
+if [[ -n "\${_comps[deno]:-}" && "\${_comps[deno]}" != "${fn}" ]]; then
+  typeset -g ${previous}="\${_comps[deno]}"
+fi
+
+compdef ${fn} deno
+`
+    : "";
+
+  return `#compdef ${name}
+# zsh completion for ${name}
+# Install:  ${name} completion zsh > "\${fpath[1]}/_${name}"
+#     then: autoload -U compinit && compinit
+
+${fn}() {
+  local -a raw entries
+  local line glob="" nospace=0 notmine=0
+
+  # Errors are discarded: a failing completion must never interrupt typing.
+  raw=("\${(@f)$(${name} completion complete --shell zsh \\
+    --cword $((CURRENT - 1)) -- "\${words[@]}" 2>/dev/null)}")
+
+  for line in "\${raw[@]}"; do
+    case "\${line}" in
+      ':cf:notmine') notmine=1 ;;
+      ':cf:files '*) glob="\${line#:cf:files }" ;;
+      ':cf:files')   glob="*" ;;
+      ':cf:dirs')    glob=":dirs:" ;;
+      ':cf:nospace') nospace=1 ;;
+      '') ;;
+      *) entries+=("\${line}") ;;
+    esac
+  done
+
+  # Not a ${name} command line (e.g. \`deno test\`): defer to the completer
+  # that was bound before us, or to zsh's default.
+  if (( notmine )); then
+    if [[ -n "\${${previous}:-}" ]] && (( \${+functions[\${${previous}}]} )); then
+      "\${${previous}}" "\${@}"
+    else
+      _default
+    fi
+    return
+  fi
+
+  if [[ -n "\${glob}" ]]; then
+    if [[ "\${glob}" == ":dirs:" ]]; then
+      _path_files -/
+    else
+      _path_files -g "\${glob}" && return
+      _path_files -/
+    fi
+    return
+  fi
+
+  (( \${#entries} )) || return 1
+
+  if (( nospace )); then
+    _describe -t ${functionName(name)} '${name}' entries -S ''
+  else
+    _describe -t ${functionName(name)} '${name}' entries
+  fi
+}
+${denoBinding}
+# Support both \`compdef\` autoloading and \`source <(${name} completion zsh)\`.
+if [[ "\${funcstack[1]}" == "${fn}" ]]; then
+  ${fn} "\${@}"
+else
+  compdef ${fn} ${name}
+fi
+`;
+}

--- a/packages/cli/lib/completion/static.ts
+++ b/packages/cli/lib/completion/static.ts
@@ -1,0 +1,111 @@
+/**
+ * Candidates derivable from the Cliffy command tree alone — subcommands,
+ * option names, and the enumerable value sets the tree cannot express.
+ *
+ * No I/O: every function here answers from the `Command` object graph, so it
+ * stays correct offline and costs nothing beyond process start.
+ */
+
+import type { Option } from "@cliffy/command";
+import type { AnyCommand, CompletionLine, PreParseGlobal } from "./line.ts";
+import { longName, PRE_PARSE_GLOBALS } from "./line.ts";
+
+export interface Candidate {
+  readonly value: string;
+  readonly description?: string;
+}
+
+/**
+ * Value sets that are real constraints but which Cliffy stores as plain
+ * `string` options, so they cannot be read back off the tree. Keyed by option
+ * long name. Kept here rather than inline in the provider table because these
+ * are facts about the CLI's accepted vocabulary, not about live data.
+ *
+ * `log-level` mirrors `lib/log-level.ts`; `color` mirrors `cf view --color`.
+ */
+const ENUMERATED_OPTION_VALUES: Readonly<Record<string, readonly string[]>> = {
+  "log-level": ["debug", "info", "warn", "error", "silent"],
+  "color": ["auto", "always", "never"],
+  "cfc-mode": ["off", "warn", "enforce"],
+};
+
+/** First sentence of a description, for the shell's annotation column. */
+function summarize(description: unknown): string | undefined {
+  if (typeof description !== "string") return undefined;
+  const text = description.trim().split("\n")[0];
+  if (!text) return undefined;
+  const sentence = text.match(/^(.{1,72}?)(?:\.\s|\.$|$)/);
+  return (sentence?.[1] ?? text).trim() || undefined;
+}
+
+/**
+ * Subcommands of `command`. `getCommands(false)` already drops commands marked
+ * hidden; `help` is dropped here because Cliffy generates one on every command
+ * and offering it at each level is noise.
+ *
+ * Commands whose description opens with `Internal:` are plumbing invoked by the
+ * CLI itself — `fuse-daemon` and `fuse-supervisor` are spawned by `cf fuse`,
+ * never typed. They stay in `--help` (where the marker already explains them)
+ * but offering them at the prompt would only crowd out real commands.
+ */
+export function subcommandCandidates(command: AnyCommand): Candidate[] {
+  return command.getCommands(false)
+    .filter((child) => child.getName() !== "help")
+    .map((child) => ({
+      value: child.getName(),
+      description: summarize(child.getDescription()),
+    }))
+    .filter((candidate) => !candidate.description?.startsWith("Internal:"));
+}
+
+/**
+ * Option flags accepted at this point on the line.
+ *
+ * A bare `-` offers short and long spellings; `--` offers long only, which
+ * keeps the common case from being padded with single-letter duplicates.
+ * Options already supplied are dropped unless they are repeatable.
+ */
+export function optionNameCandidates(
+  command: AnyCommand,
+  line: CompletionLine,
+): Candidate[] {
+  const wantsShort = !line.word.startsWith("--");
+  const candidates: Candidate[] = [];
+
+  for (const option of command.getOptions(false)) {
+    const name = longName(option);
+    const supplied = line.options.has(name) || line.flags.has(name);
+    if (supplied && !option.collect) continue;
+
+    const description = summarize(option.description);
+    for (const flag of option.flags) {
+      if (!wantsShort && !flag.startsWith("--")) continue;
+      candidates.push({ value: flag, description });
+    }
+  }
+
+  // Accepted on every command but absent from the tree — see PRE_PARSE_GLOBALS.
+  for (const global of PRE_PARSE_GLOBALS) {
+    for (const flag of global.flags) {
+      candidates.push({ value: flag, description: global.description });
+    }
+  }
+
+  return candidates;
+}
+
+/** Accepted values of a pre-parse global, for its `--flag <value>` slot. */
+export function preParseGlobalValues(global: PreParseGlobal): Candidate[] {
+  return (global.values ?? []).map((value) => ({ value }));
+}
+
+/**
+ * Values for an option whose accepted set is known statically. Returns `null`
+ * when the option has no such set, which tells the caller to try a live
+ * provider instead.
+ */
+export function enumeratedOptionValues(option: Option): Candidate[] | null {
+  const values = ENUMERATED_OPTION_VALUES[longName(option)];
+  if (!values) return null;
+  return values.map((value) => ({ value }));
+}

--- a/packages/cli/test/completion-line.test.ts
+++ b/packages/cli/test/completion-line.test.ts
@@ -1,0 +1,215 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  resolveCompletionLine,
+  stripInvocationPrefix,
+} from "../lib/completion/line.ts";
+import { tokenizeLine } from "../lib/completion/mod.ts";
+import { main } from "../commands/main.ts";
+
+/** Resolve the line the way the shell would, from a raw buffer. */
+function resolve(line: string, point = line.length) {
+  const { words, cword } = tokenizeLine(line, point);
+  return resolveCompletionLine(main, words, cword);
+}
+
+Deno.test("tokenizeLine splits on whitespace and marks a trailing empty word", () => {
+  assertEquals(tokenizeLine("cf piece ls", 11), {
+    words: ["cf", "piece", "ls"],
+    cword: 2,
+  });
+  assertEquals(tokenizeLine("cf piece ", 9), {
+    words: ["cf", "piece", ""],
+    cword: 2,
+  });
+});
+
+Deno.test("tokenizeLine keeps quoted and escaped values whole", () => {
+  // The whole point of tokenizing in the CLI rather than trusting bash's
+  // COMP_WORDS: these must not split.
+  assertEquals(tokenizeLine(`cf piece search "meeting notes"`, 31).words, [
+    "cf",
+    "piece",
+    "search",
+    "meeting notes",
+  ]);
+  assertEquals(tokenizeLine(`cf piece ls -s my\\ space`, 24).words, [
+    "cf",
+    "piece",
+    "ls",
+    "-s",
+    "my space",
+  ]);
+});
+
+Deno.test("tokenizeLine respects the cursor, ignoring text to its right", () => {
+  // Editing mid-line must complete the word under the cursor, not the last.
+  const line = "cf piece ls --space team";
+  assertEquals(tokenizeLine(line, 8), { words: ["cf", "piece"], cword: 1 });
+});
+
+Deno.test("resolve: a bare command offers subcommands", () => {
+  const line = resolve("cf ");
+  assertEquals(line.slot?.kind, "subcommand");
+  assertEquals(line.path, []);
+});
+
+Deno.test("resolve: descends into nested subcommands", () => {
+  const line = resolve("cf piece call ");
+  assertEquals(line.path, ["piece", "call"]);
+  assertEquals(line.command.getName(), "call");
+});
+
+Deno.test("resolve: an alias descends to the aliased command", () => {
+  // `piece rm` is aliased `remove`; both must resolve.
+  assertEquals(resolve("cf piece remove ").path, ["piece", "rm"]);
+});
+
+Deno.test("resolve: a leaf command's positional is an argument, not a subcommand", () => {
+  // Cliffy propagates a global `help` command to every descendant, so
+  // `hasCommands()` is true even on leaves. Trusting it would resolve every
+  // positional to a subcommand slot and disable all value completion.
+  const line = resolve("cf piece call --piece abc ");
+  assertEquals(line.slot?.kind, "argument");
+  assert(line.slot?.kind === "argument");
+  assertEquals(line.slot.argument.name, "callable");
+  assertEquals(line.slot.index, 0);
+});
+
+Deno.test("resolve: a word starting with - is an option name", () => {
+  assertEquals(resolve("cf piece ls --").slot?.kind, "option-name");
+  assertEquals(resolve("cf piece ls -").slot?.kind, "option-name");
+});
+
+Deno.test("resolve: the word after a value-taking flag is that flag's value", () => {
+  const line = resolve("cf piece ls --space ");
+  assert(line.slot?.kind === "option-value");
+  assertEquals(line.slot.option.name, "space");
+});
+
+Deno.test("resolve: a boolean flag does not swallow the following word", () => {
+  // `--quiet` takes no value, so the next word is a positional.
+  const line = resolve("cf piece get --quiet ");
+  assertEquals(line.slot?.kind, "argument");
+});
+
+Deno.test("resolve: --name=value completes the value with the prefix retained", () => {
+  const line = resolve("cf piece ls --space=");
+  assert(line.slot?.kind === "option-value");
+  assertEquals(line.slot.option.name, "space");
+  assertEquals(line.slot.inlinePrefix, "--space=");
+});
+
+Deno.test("resolve: options already typed are captured for provider context", () => {
+  const line = resolve(
+    "cf piece call -i ./k.key -a http://localhost:8000 -s team --piece fid1:x ",
+  );
+  assertEquals(line.options.get("identity"), "./k.key");
+  assertEquals(line.options.get("api-url"), "http://localhost:8000");
+  assertEquals(line.options.get("space"), "team");
+  assertEquals(line.options.get("piece"), "fid1:x");
+});
+
+Deno.test("resolve: bundled short flags do not shift the argument index", () => {
+  // `-qs team` is `-q` plus `-s team`. Mis-parsing it would make `path` look
+  // like the second positional and select the wrong provider.
+  const line = resolve("cf piece get -qs team ");
+  assert(line.slot?.kind === "argument");
+  assertEquals(line.slot.argument.name, "path");
+  assertEquals(line.slot.index, 0);
+  assertEquals(line.options.get("space"), "team");
+  assert(line.flags.has("quiet"));
+});
+
+Deno.test("resolve: a second positional advances to the next argument", () => {
+  const line = resolve("cf piece link src/field ");
+  assert(line.slot?.kind === "argument");
+  assertEquals(line.slot.argument.name, "target");
+  assertEquals(line.slot.index, 1);
+});
+
+Deno.test("resolve: words after -- are passthrough, not CLI options", () => {
+  // `cf piece call ... -- --flag` hands `--flag` to the callable's own parser.
+  const line = resolve("cf piece call --piece x handler -- --title ");
+  assertEquals(line.slot?.kind, "passthrough");
+});
+
+Deno.test("resolve: pre-parse globals complete their values", () => {
+  // `--log-level` is stripped before Cliffy parses, so it exists nowhere in
+  // the command tree and has to be carried explicitly.
+  const line = resolve("cf --log-level ");
+  assert(line.slot?.kind === "global-option-value");
+  assertEquals(line.slot.option.flags, ["--log-level"]);
+});
+
+Deno.test("resolve: a pre-parse global does not disturb later resolution", () => {
+  const line = resolve("cf --log-level debug piece ");
+  assertEquals(line.path, ["piece"]);
+  assertEquals(line.slot?.kind, "subcommand");
+});
+
+Deno.test("stripInvocationPrefix: leaves a plain cf line alone", () => {
+  assertEquals(stripInvocationPrefix(["cf", "piece"]), {
+    words: ["cf", "piece"],
+    removed: 0,
+  });
+});
+
+Deno.test("stripInvocationPrefix: reduces `deno task cf` to a cf line", () => {
+  assertEquals(stripInvocationPrefix(["deno", "task", "cf", "piece"]), {
+    words: ["cf", "piece"],
+    removed: 2,
+  });
+});
+
+Deno.test("stripInvocationPrefix: skips deno's own flags", () => {
+  assertEquals(
+    stripInvocationPrefix(["deno", "-q", "task", "cf", "piece"]).words,
+    ["cf", "piece"],
+  );
+});
+
+Deno.test("stripInvocationPrefix: handles a direct module run", () => {
+  assertEquals(
+    stripInvocationPrefix(["deno", "run", "-A", "packages/cli/mod.ts", "piece"])
+      .words,
+    ["cf", "piece"],
+  );
+});
+
+Deno.test("stripInvocationPrefix: launcher args after -- are cf args", () => {
+  assertEquals(
+    stripInvocationPrefix([
+      "deno",
+      "run",
+      "-A",
+      "packages/cli/launcher.ts",
+      "--labs-root",
+      "../labs",
+      "--",
+      "piece",
+    ]).words,
+    ["cf", "piece"],
+  );
+});
+
+Deno.test("stripInvocationPrefix: declines non-CLI deno lines", () => {
+  // These belong to deno's own completion, not ours.
+  for (
+    const words of [
+      ["deno", "test"],
+      ["deno", "task", "build-binaries"],
+      ["deno", "run", "-A", "some/other.ts"],
+      ["deno"],
+    ]
+  ) {
+    assertEquals(stripInvocationPrefix(words).removed, 0, words.join(" "));
+  }
+});
+
+Deno.test("resolve: a deno task cf line resolves like a cf line", () => {
+  const line = resolve("deno task cf piece call --piece x ");
+  assertEquals(line.path, ["piece", "call"]);
+  assert(line.slot?.kind === "argument");
+  assertEquals(line.slot.argument.name, "callable");
+  assertEquals(line.options.get("piece"), "x");
+});

--- a/packages/cli/test/completion-output.test.ts
+++ b/packages/cli/test/completion-output.test.ts
@@ -1,0 +1,234 @@
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import {
+  complete,
+  staticCandidates,
+  tokenizeLine,
+} from "../lib/completion/mod.ts";
+import { resolveCompletionLine } from "../lib/completion/line.ts";
+import {
+  bashCompletionScript,
+  zshCompletionScript,
+} from "../lib/completion/script.ts";
+import { main } from "../commands/main.ts";
+
+function staticFor(line: string): string[] {
+  const { words, cword } = tokenizeLine(line, line.length);
+  return staticCandidates(resolveCompletionLine(main, words, cword))
+    .map((candidate) => candidate.value);
+}
+
+/**
+ * Drive the full pipeline. Safe without a fabric: every line here resolves to
+ * a slot with no live provider, or to one whose context cannot be resolved,
+ * and providers degrade to empty rather than reaching the network.
+ */
+async function completeFor(line: string, shell: "bash" | "zsh" = "bash") {
+  const { words, cword } = tokenizeLine(line, line.length);
+  return await complete(main, words, cword, shell);
+}
+
+Deno.test("top-level completion lists real commands", () => {
+  const values = staticFor("cf ");
+  for (const expected of ["piece", "check", "inspect", "id", "completion"]) {
+    assert(values.includes(expected), `missing ${expected}`);
+  }
+});
+
+Deno.test("internal plumbing commands are not offered", () => {
+  // `fuse-daemon`/`fuse-supervisor` are spawned by `cf fuse`, never typed.
+  const values = staticFor("cf ");
+  assertFalse(values.includes("fuse-daemon"));
+  assertFalse(values.includes("fuse-supervisor"));
+});
+
+Deno.test("Cliffy's generated help subcommand is not offered", () => {
+  assertFalse(staticFor("cf ").includes("help"));
+  assertFalse(staticFor("cf piece ").includes("help"));
+});
+
+Deno.test("option names include inherited globals", () => {
+  const values = staticFor("cf piece ls --");
+  for (const expected of ["--space", "--identity", "--api-url", "--json"]) {
+    assert(values.includes(expected), `missing ${expected}`);
+  }
+});
+
+Deno.test("a single dash offers short flags, a double dash does not", () => {
+  assert(staticFor("cf piece ls -").includes("-s"));
+  assertFalse(staticFor("cf piece ls --").includes("-s"));
+});
+
+Deno.test("pre-parse globals are offered even though they are not in the tree", () => {
+  const values = staticFor("cf piece ls --");
+  assert(values.includes("--log-level"));
+  assert(values.includes("--no-color"));
+});
+
+Deno.test("an option already supplied is not offered again", () => {
+  const values = staticFor("cf piece ls --space team --");
+  assertFalse(values.includes("--space"));
+  assert(values.includes("--identity"));
+});
+
+Deno.test("--log-level completes its accepted levels", async () => {
+  assertEquals(await completeFor("cf --log-level "), [
+    "debug",
+    "info",
+    "warn",
+    "error",
+    "silent",
+  ]);
+});
+
+Deno.test("--log-level=<value> keeps the inline prefix on candidates", async () => {
+  // The shell replaces the whole token, so a bare `debug` would produce
+  // `cf --log-level=debug` -> `cf debug`.
+  assertEquals(await completeFor("cf --log-level=de"), ["--log-level=debug"]);
+});
+
+Deno.test("candidates are filtered by the typed prefix", async () => {
+  const values = await completeFor("cf piece se");
+  assert(values.length > 0);
+  for (const value of values) {
+    assert(value.startsWith("se"), `${value} does not match prefix`);
+  }
+});
+
+Deno.test("zsh output pairs a candidate with its description", async () => {
+  const values = await completeFor("cf ", "zsh");
+  const piece = values.find((value) => value.startsWith("piece:"));
+  assert(piece, "expected a described `piece` candidate");
+});
+
+Deno.test("zsh output escapes colons inside values", async () => {
+  // `_describe` splits on the first unescaped colon; an api-url has two, and
+  // an unescaped one truncates the inserted value.
+  const values = await completeFor("cf piece ls -a ", "zsh");
+  const local = values.find((value) => value.includes("localhost"));
+  assert(local, "expected a localhost api-url candidate");
+  assert(
+    local.startsWith("http\\://"),
+    `colons must be escaped, got ${local}`,
+  );
+});
+
+Deno.test("bash output carries values only", async () => {
+  const values = await completeFor("cf ", "bash");
+  for (const value of values) {
+    assertFalse(value.includes(":"), `bash candidates carry no description`);
+  }
+});
+
+Deno.test("pattern-file arguments defer to the shell's file completion", async () => {
+  // The shell handles quoting, `~`, and directories far better than we can.
+  assertEquals(await completeFor("cf check "), [":cf:files *.tsx"]);
+  assertEquals(await completeFor("cf piece new "), [":cf:files *.tsx"]);
+});
+
+Deno.test("--identity defers to file completion filtered to keyfiles", async () => {
+  assertEquals(await completeFor("cf piece ls -i "), [":cf:files *.key"]);
+});
+
+Deno.test("--root defers to directory completion", async () => {
+  assertEquals(await completeFor("cf piece new --root "), [":cf:dirs"]);
+});
+
+Deno.test("a live slot with no resolvable context yields nothing, not an error", async () => {
+  // Mid-keystroke with no identity configured: silence is the correct signal.
+  const previous = Deno.env.get("CF_IDENTITY");
+  Deno.env.delete("CF_IDENTITY");
+  try {
+    assertEquals(await completeFor("cf piece call --piece "), []);
+  } finally {
+    if (previous !== undefined) Deno.env.set("CF_IDENTITY", previous);
+  }
+});
+
+Deno.test("a non-CLI deno line hands back to deno's own completion", async () => {
+  assertEquals(await completeFor("deno test "), [":cf:notmine"]);
+  assertEquals(await completeFor("deno task build-binaries "), [":cf:notmine"]);
+});
+
+Deno.test("a deno task cf line completes as cf", async () => {
+  const values = await completeFor("deno task cf piece l");
+  assertEquals(values, ["ls", "link"]);
+});
+
+Deno.test("generated scripts bind both the CLI name and deno", () => {
+  const bash = bashCompletionScript("cf");
+  assert(bash.includes("complete -F _cf_complete cf"));
+  assert(bash.includes("complete -F _cf_complete deno"));
+
+  const zsh = zshCompletionScript("cf");
+  assert(zsh.includes("compdef _cf deno"));
+});
+
+Deno.test("--no-deno-task omits the deno binding", () => {
+  const bash = bashCompletionScript("cf", { denoTask: false });
+  assert(bash.includes("complete -F _cf_complete cf"));
+  assertFalse(bash.includes("complete -F _cf_complete deno"));
+  assertFalse(bash.includes("complete -p deno"));
+
+  const zsh = zshCompletionScript("cf", { denoTask: false });
+  assert(zsh.includes("compdef _cf cf"));
+  assertFalse(zsh.includes("compdef _cf deno"));
+});
+
+Deno.test("generated scripts refuse to chain to themselves", () => {
+  // Sourcing twice (profile plus bash_completion.d, or a re-sourced profile)
+  // makes the second pass observe the binding the first installed. Capturing
+  // it recurses forever on the next non-CLI `deno` completion and hangs the
+  // terminal; this guard is the only thing preventing that.
+  const bash = bashCompletionScript("cf");
+  assert(bash.includes(`!= "_cf_complete"`), "bash must reject a self-capture");
+
+  const zsh = zshCompletionScript("cf");
+  assert(zsh.includes(`!= "_cf"`), "zsh must reject a self-capture");
+});
+
+Deno.test("generated scripts keep an already-captured deno completion", () => {
+  // The guard must not clear a good value recorded by an earlier source, or a
+  // re-source silently drops deno's real completion.
+  const bash = bashCompletionScript("cf");
+  assert(bash.includes('_cf_deno_previous="${_cf_deno_previous:-}"'));
+
+  const zsh = zshCompletionScript("cf");
+  assert(zsh.includes('_cf_deno_previous="${_cf_deno_previous:-}"'));
+});
+
+Deno.test("generated scripts capture the previous deno completion before rebinding", () => {
+  // Order matters: reading the old spec after `complete -F` would capture
+  // our own function and recurse.
+  const bash = bashCompletionScript("cf");
+  assert(
+    bash.indexOf("complete -p deno") <
+      bash.indexOf("complete -F _cf_complete deno"),
+  );
+  const zsh = zshCompletionScript("cf");
+  assert(zsh.indexOf("_comps[deno]") < zsh.indexOf("compdef _cf deno"));
+});
+
+Deno.test("generated bash script avoids bash 4 builtins", () => {
+  // macOS ships bash 3.2: `mapfile` does not exist at all, and `compopt` is
+  // absent so it must be probed before use. Match on invocations rather than
+  // on the words appearing in explanatory comments.
+  const bash = bashCompletionScript("cf");
+  const code = bash.split("\n").filter((line) => !line.trim().startsWith("#"));
+  assertFalse(
+    code.some((line) => /(^|[;&|( ])mapfile\b/.test(line)),
+    "mapfile is bash 4+",
+  );
+
+  const guard = bash.indexOf("type compopt >/dev/null 2>&1");
+  assert(guard !== -1, "compopt must be probed before use");
+  assert(
+    guard < bash.indexOf("compopt -o nospace"),
+    "the compopt probe must precede the call",
+  );
+});
+
+Deno.test("the CLI name flows into the generated function names", () => {
+  const script = bashCompletionScript("mycf");
+  assert(script.includes("_mycf_complete()"));
+  assert(script.includes("complete -F _mycf_complete mycf"));
+});

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -1,0 +1,352 @@
+import { assert, assertEquals } from "@std/assert";
+import { resolveCompletionLine } from "../lib/completion/line.ts";
+import {
+  keysOf,
+  linkEndpointPrefix,
+  liveCandidates,
+  resolveSpaceContext,
+  shapePieceCandidates,
+  shapeVerbCandidates,
+  splitPathPrefix,
+} from "../lib/completion/providers.ts";
+import { tokenizeLine } from "../lib/completion/mod.ts";
+import { main } from "../commands/main.ts";
+
+function lineFor(text: string) {
+  const { words, cword } = tokenizeLine(text, text.length);
+  return resolveCompletionLine(main, words, cword);
+}
+
+/**
+ * Run `body` with the fabric environment variables set exactly as given,
+ * restoring whatever the surrounding process had. Completion reads these as
+ * fallbacks, so a test that did not control them would pass or fail based on
+ * the developer's shell.
+ */
+async function withEnv(
+  env: { identity?: string; apiUrl?: string },
+  body: () => void | Promise<void>,
+): Promise<void> {
+  const keys = ["CF_IDENTITY", "CF_API_URL"] as const;
+  const saved = keys.map((key) => [key, Deno.env.get(key)] as const);
+  try {
+    Deno.env.delete("CF_IDENTITY");
+    Deno.env.delete("CF_API_URL");
+    if (env.identity) Deno.env.set("CF_IDENTITY", env.identity);
+    if (env.apiUrl) Deno.env.set("CF_API_URL", env.apiUrl);
+    await body();
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  }
+}
+
+/** Capture stdout writes made by a command action. */
+async function captureStdout(body: () => Promise<void>): Promise<string> {
+  const original = console.log;
+  const chunks: string[] = [];
+  console.log = (...args: unknown[]) => void chunks.push(args.join(" "));
+  try {
+    await body();
+  } finally {
+    console.log = original;
+  }
+  return chunks.join("\n");
+}
+
+Deno.test("space context: line options beat the environment", async () => {
+  // This is what makes `-s other-space --piece <TAB>` list the other space
+  // rather than whatever the shell's environment points at.
+  await withEnv({ identity: "/env.key", apiUrl: "http://env:9999" }, () => {
+    const config = resolveSpaceContext(
+      lineFor("cf piece ls -i /line.key -a http://line:8000 -s team "),
+    );
+    assert(config);
+    assertEquals(config.apiUrl, "http://line:8000");
+    assertEquals(config.space, "team");
+    assertEquals(config.identity, "/line.key");
+  });
+});
+
+Deno.test("space context: falls back to the environment", async () => {
+  await withEnv({ identity: "/env.key", apiUrl: "http://env:9999" }, () => {
+    const config = resolveSpaceContext(lineFor("cf piece ls -s team "));
+    assert(config);
+    assertEquals(config.apiUrl, "http://env:9999");
+    assertEquals(config.identity, "/env.key");
+  });
+});
+
+Deno.test("space context: --url supplies api-url and space together", async () => {
+  await withEnv({ identity: "/env.key" }, () => {
+    const config = resolveSpaceContext(
+      lineFor("cf piece ls -u http://host:8000/myspace/fid1:abc "),
+    );
+    assert(config);
+    assertEquals(config.apiUrl, "http://host:8000");
+    assertEquals(config.space, "myspace");
+  });
+});
+
+Deno.test("space context: reserves stdout for candidates", async () => {
+  // `jsonOutput` routes runtime status lines to stderr. Without it a stray
+  // console.log from the runtime would be offered to the user as a candidate.
+  await withEnv({ identity: "/env.key", apiUrl: "http://env:9999" }, () => {
+    assertEquals(
+      resolveSpaceContext(lineFor("cf piece ls -s t "))?.jsonOutput,
+      true,
+    );
+  });
+});
+
+Deno.test("space context: an incomplete line resolves to nothing", async () => {
+  await withEnv({}, () => {
+    // No identity anywhere.
+    assertEquals(resolveSpaceContext(lineFor("cf piece ls -s team ")), null);
+  });
+  await withEnv({ identity: "/env.key" }, () => {
+    // Identity but no space.
+    assertEquals(
+      resolveSpaceContext(lineFor("cf piece ls -a http://h:1 ")),
+      null,
+    );
+    // Identity but no api-url.
+    assertEquals(resolveSpaceContext(lineFor("cf piece ls -s team ")), null);
+  });
+});
+
+Deno.test("space context: a malformed --url resolves to nothing, not a throw", async () => {
+  await withEnv({ identity: "/env.key" }, () => {
+    assertEquals(
+      resolveSpaceContext(lineFor("cf piece ls -u not-a-url ")),
+      null,
+    );
+  });
+});
+
+Deno.test("live candidates: unmapped slots ask for nothing", async () => {
+  // A subcommand or option-name slot is answered statically; reaching for live
+  // data there would spend a fabric round trip per keystroke for no reason.
+  for (const text of ["cf ", "cf piece ls --", "cf piece "]) {
+    const result = await liveCandidates(lineFor(text));
+    assertEquals(result.candidates.length, 0, text);
+    assertEquals(result.directives.length, 0, text);
+  }
+});
+
+Deno.test("live candidates: path-shaped slots defer to the shell", async () => {
+  const cases: Array<[string, string]> = [
+    ["cf piece ls -i ", "files"],
+    ["cf piece new --root ", "dirs"],
+    ["cf check ", "files"],
+    ["cf space verify ", "dirs"],
+    ["cf space clone --to ", "dirs"],
+    ["cf id did ", "files"],
+  ];
+  for (const [text, kind] of cases) {
+    const result = await liveCandidates(lineFor(text));
+    assertEquals(result.directives[0]?.kind, kind, text);
+  }
+});
+
+Deno.test("live candidates: a fabric slot without context degrades to empty", async () => {
+  // Mid-keystroke with nothing configured: silence, not an error.
+  await withEnv({}, async () => {
+    for (
+      const text of [
+        "cf piece call --piece x ",
+        "cf piece get --piece x ",
+        "cf piece link ",
+        "cf piece ls --piece ",
+      ]
+    ) {
+      const result = await liveCandidates(lineFor(text));
+      assertEquals(result.candidates.length, 0, text);
+    }
+  });
+});
+
+Deno.test("command: bash and zsh subcommands emit their scripts", async () => {
+  const bash = await captureStdout(async () => {
+    await main.parse(["completion", "bash"]);
+  });
+  assert(bash.includes("complete -F _cf_complete cf"));
+
+  const zsh = await captureStdout(async () => {
+    await main.parse(["completion", "zsh"]);
+  });
+  assert(zsh.includes("#compdef cf"));
+});
+
+Deno.test("command: --no-deno-task reaches the script generator", async () => {
+  const bash = await captureStdout(async () => {
+    await main.parse(["completion", "bash", "--no-deno-task"]);
+  });
+  assert(bash.includes("complete -F _cf_complete cf"));
+  assert(!bash.includes("complete -F _cf_complete deno"));
+});
+
+Deno.test("command: complete accepts bash's raw line form", async () => {
+  const out = await captureStdout(async () => {
+    await main.parse([
+      "completion",
+      "complete",
+      "--shell",
+      "bash",
+      "--line",
+      "cf piece l",
+      "--point",
+      "10",
+    ]);
+  });
+  assertEquals(out.split("\n").sort(), ["link", "ls"]);
+});
+
+Deno.test("command: complete accepts zsh's pre-tokenized form", async () => {
+  const out = await captureStdout(async () => {
+    await main.parse([
+      "completion",
+      "complete",
+      "--shell",
+      "zsh",
+      "--cword",
+      "2",
+      "--",
+      "cf",
+      "piece",
+      "l",
+    ]);
+  });
+  // zsh output pairs each value with its description.
+  const values = out.split("\n").map((line) => line.split(":")[0]).sort();
+  assertEquals(values, ["link", "ls"]);
+});
+
+Deno.test("command: complete prints nothing when there is nothing to offer", async () => {
+  const out = await captureStdout(async () => {
+    await main.parse([
+      "completion",
+      "complete",
+      "--shell",
+      "bash",
+      "--line",
+      "cf piece zzzznomatch",
+      "--point",
+      "23",
+    ]);
+  });
+  assertEquals(out, "");
+});
+
+Deno.test("command: malformed input never puts usage text on stdout", async () => {
+  // Regression guard. stdout here is a data channel the shell reads on every
+  // keystroke; Cliffy answers a malformed invocation by printing usage to
+  // stdout, which the shell would then offer as candidates ("Usage:",
+  // "-h, --help", ...). Raw-arg parsing is what prevents that.
+  const malformed = [
+    ["complete"], // no arguments at all
+    ["complete", "--shell"], // flag with no value
+    ["complete", "--line"], // the case Cliffy rejected outright
+    ["complete", "--shell", "bash", "--line", "", "--point", "0"],
+    ["complete", "--shell", "bash", "--line", "cf", "--point", "999"],
+    ["complete", "--shell", "bash", "--point", "notanumber", "--line", "cf p"],
+    ["complete", "--cword", "-4", "--", "cf", "piece"],
+    ["complete", "--nonsense-flag", "value"],
+  ];
+
+  for (const args of malformed) {
+    const out = await captureStdout(async () => {
+      await main.parse(["completion", ...args]);
+    });
+    for (const line of out.split("\n").filter(Boolean)) {
+      assert(
+        !/^(Usage|Version|Description|Options|Commands):/.test(line) &&
+          !line.includes("Show this help"),
+        `usage text reached stdout for [${args.join(" ")}]: ${line}`,
+      );
+    }
+  }
+});
+
+Deno.test("command: a deno line that is not ours is reported as such", async () => {
+  const out = await captureStdout(async () => {
+    await main.parse([
+      "completion",
+      "complete",
+      "--shell",
+      "bash",
+      "--line",
+      "deno test ",
+      "--point",
+      "10",
+    ]);
+  });
+  assertEquals(out, ":cf:notmine");
+});
+
+Deno.test("shaping: a piece is labelled by name, falling back to its pattern", () => {
+  assertEquals(
+    shapePieceCandidates([
+      { id: "fid1:a", name: "Todo List" },
+      { id: "fid1:b", patternRef: { symbol: "Bookmarks" } },
+      { id: "fid1:c" },
+      // A piece that failed to load still lists: its id is what an operator
+      // reaches for completion to recover.
+      { id: "fid1:d", patternRef: null },
+    ]),
+    [
+      { value: "fid1:a", description: "Todo List" },
+      { value: "fid1:b", description: "Bookmarks" },
+      { value: "fid1:c", description: undefined },
+      { value: "fid1:d", description: undefined },
+    ],
+  );
+});
+
+Deno.test("shaping: callables are annotated by kind", () => {
+  assertEquals(
+    shapeVerbCandidates([
+      { name: "addItem", kind: "handler" },
+      { name: "search", kind: "tool" },
+    ]),
+    [
+      { value: "addItem", description: "handler" },
+      { value: "search", description: "tool" },
+    ],
+  );
+});
+
+Deno.test("shaping: containers yield keys, leaves yield nothing", () => {
+  // A leaf yielding nothing is the correct signal that the path already names
+  // a value; offering anything there would invent paths that do not exist.
+  assertEquals(keysOf({ title: 1, done: 2 }), ["title", "done"]);
+  assertEquals(keysOf(["a", "b", "c"]), ["0", "1", "2"]);
+  assertEquals(keysOf([]), []);
+  assertEquals(keysOf({}), []);
+  for (const leaf of ["text", 42, true, null, undefined]) {
+    assertEquals(keysOf(leaf), [], String(leaf));
+  }
+});
+
+Deno.test("shaping: a typed path splits into parent and replacement prefix", () => {
+  // The prefix is what stops a completed deep path collapsing to its last
+  // segment — the shell replaces the whole word.
+  assertEquals(splitPathPrefix("items"), { parentPath: "", prefix: "" });
+  assertEquals(splitPathPrefix("items/"), {
+    parentPath: "items",
+    prefix: "items/",
+  });
+  assertEquals(splitPathPrefix("items/0/ti"), {
+    parentPath: "items/0",
+    prefix: "items/0/",
+  });
+});
+
+Deno.test("shaping: a link endpoint prefix never doubles the separator", () => {
+  // `id//key` would be a different, invalid reference.
+  assertEquals(linkEndpointPrefix("fid1:a", ""), "fid1:a/");
+  assertEquals(linkEndpointPrefix("fid1:a", "items"), "fid1:a/items/");
+  assertEquals(linkEndpointPrefix("fid1:a", "items/0"), "fid1:a/items/0/");
+});


### PR DESCRIPTION
## Why

Typing `cf` by hand is dominated by values you cannot remember: opaque piece
ids, a piece's callable names, cell paths. Those are exactly what a completion
script can supply and what makes the CLI feel usable at a prompt.

Cliffy ships a `CompletionsCommand`, but its dynamic hook passes the callback
only `(command, parent)` — no cursor word, and no access to the options already
typed. That is enough for a static command tree and nothing more: it cannot
answer "the callables of the piece named by the `--piece` on this line". Since
the context-dependent values are the whole point, this emits its own scripts.

## What Changed

`cf completion bash|zsh` prints a completion script.

| Slot | Completes to |
| --- | --- |
| `--piece` | piece ids, annotated with each piece's name |
| `piece call <callable>` | the piece's callables (matches `cf piece verbs`) |
| `piece get`/`set <path>` | cell keys, one path segment at a time |
| `piece link` | `pieceId/path/to/field` endpoints |
| `--space`, `space clone`/`fingerprint` | space DIDs of local memory-v2 stores |
| `--identity`, pattern args, clone dirs | `*.key` / `*.tsx` / dirs, via the shell |

Design notes:

- The shell functions are logic-free: they forward the raw line and let
  `cf completion complete` decide everything. A sourced function lives in a
  user's profile and is not updated when the CLI is rebuilt, so it must not
  encode a command tree that can go stale.
- Resolution walks Cliffy's live `Command` tree, so new subcommands and flags
  complete as soon as they exist. Two things cannot be read off that tree and
  are explicit: the pre-parse globals `--log-level`/`--no-color` (stripped
  before Cliffy parses), and the provider table binding slots to live data.
- Scripts bind `deno` as well as `cf`, so `deno task cf ...` completes.
  Cooperative: a non-CLI `deno` line is handed back to whatever completed
  `deno` beforehand. `--no-deno-task` opts out.
- bash gets `COMP_LINE`/`COMP_POINT`, not `COMP_WORDS` — `COMP_WORDBREAKS`
  splits on `:` and `=`, which shreds `http://host:8000` and `--space=x`.

Safety properties, each covered by a test:

- **Read-only.** Completing against a never-seen space creates no state.
- **Silent failure.** No identity, or an unreachable server, yields no
  candidates — never an error pasted into the command line.
- **stdout reserved.** The provider config sets `jsonOutput` so runtime status
  lines go to stderr; a stray `console.log` would otherwise be offered as a
  candidate.
- **No self-chaining.** Sourcing the script twice (profile + `bash_completion.d`,
  or a re-sourced profile) would otherwise capture the binding the first pass
  installed and recurse forever on the next non-CLI `deno` completion, hanging
  the terminal. Reproduced before the fix; guarded and tested now.

Discoverability: a `SHELL COMPLETION` block in `cf --help` (next to FIRST TIME
SETUP), a line in tutorial chapter 6 where `CF_IDENTITY`/`CF_API_URL` get set,
full reference in `packages/cli/README.md`, and `cf completion --help`.

## Test plan

- 50 new tests in `packages/cli/test/completion-*.test.ts`, concentrated on the
  pure resolver (slot selection, bundled short flags, `--` passthrough,
  `deno task cf` prefix stripping) and on the generated scripts' invariants.
- Full CLI suite: 123 passed / 0 failed. `check-docs` 525 blocks, lint and fmt
  clean.
- Generated scripts pass `bash -n` / `zsh -n`; driven end-to-end in bash 3.2
  (macOS default — `mapfile` is bash 4+, so the script avoids it) including the
  deno chaining and triple-source cases; zsh load-and-bind verified for both the
  eager and fpath install paths.
- Live path exercised against a local toolshed with a real deployed piece: piece
  ids, callables, and 3-deep cell paths.

## Known trade-offs

- Installing this makes every `deno <TAB>` ~0.3s slower: it spawns a `cf`
  process to be told the line isn't ours before delegating. `--no-deno-task`
  avoids it.
- No timeout on the live path, per the repo's guidance on timeouts. Unreachable
  fails fast (~0.9s), but a server that accepts and stalls would hang Tab until
  Ctrl-C.
- zsh's fpath install completes `cf` but doesn't activate the `deno` binding
  until `cf` completes once (the binding lives in the script body). Documented,
  with a two-line snippet for anyone preferring that layout.
- `--space` completes DIDs from local stores; there is no server-side space
  index to query, so a space you have never touched locally will not complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coverage

The ratchet flagged this PR at +220 uncovered lines in `packages/cli`. Rather
than accept that, I covered what was coverable: the `complete` action body
(30.9% → 97.8% line) and the providers' value-shaping logic (36.0% → 69.6%).
New-code coverage went 71.9% → 88.5%, and the regression dropped to **+93
(+2%)**.

Doing that found a real defect, now fixed and regression-tested: on a malformed
request Cliffy printed usage text to *stdout*, which is the channel the shell
reads for candidates — a user would have been offered `Usage:`, `-h, --help`
and friends as completions.

The remaining 93 lines are the fabric I/O itself — the `listPieces`,
`listPieceCallables`, `getCellValue`, and `discoverSpaceDbs` calls. They need a
running server, so no unit test reaches them; they were exercised by hand
against a local toolshed (piece ids, callables, and 3-deep cell paths all
verified). Their surrounding logic — context resolution, failure degradation,
and every value transformation — is unit-tested. Accepting that residual:

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/cli uncovered lines = 3977 lines

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds context-aware shell completion for `cf` in bash and zsh, including live values like piece ids, callables, cell paths, and spaces. Also completes `deno task cf …` with cooperative chaining, safe fallbacks, and robust handling of malformed inputs.

- **New Features**
  - `cf completion bash|zsh` outputs scripts; a thin shell function forwards the raw line to `cf completion complete`.
  - Completes subcommands/flags plus live values: piece ids (with names), callables, cell paths (by segment), link endpoints, and local space DIDs; file-like slots defer to the shell; drops commands whose description starts with “Internal:” from completion.
  - Supports inline `--name=value`, bundled short flags, and `--` passthrough; recognizes `deno task cf …` and `deno run … packages/cli/mod.ts` (use `--no-deno-task` to disable).
  - Safe by design: read-only; silent on failure; stdout-only candidates with JSON output routing logs to stderr; guards against self-chaining; includes pre-parse globals (`--log-level`, `--no-color`).
  - Completion callback now parses raw args to keep usage text off stdout on malformed requests; extracted shaping helpers for pieces, verbs, and paths; tests cover these.
  - Tests/docs: 50 new tests under `packages/cli/test/`, tutorial update in `docs/tutorial/06-workflow.md`, and reference in `packages/cli/README.md`. Scripts validated on bash 3.2 and zsh.

- **Migration**
  - zsh: add after compinit: `source <(cf completion zsh)` (or write to `"$fpath[1]/_cf"`; see `cf completion --help` for the `deno` note).
  - bash: `source <(cf completion bash)` or write to `/usr/local/etc/bash_completion.d/cf`.

<sup>Written for commit d5fb03af056cd54b1f4a5dba7e6bbd7cdc88510f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


