### PR TITLE
test(clock): read caller frames through SES getStackString so the fak…

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -371,26 +371,37 @@ logical time to zero and drops pending timers: one frozen clock wraps a whole
 `describe`, so a suite whose cases each read absolute coarsened time (the `#now`
 grid tests) calls it from `beforeEach` to start each case from a known instant.
 
-Two files stay on the real clock, listed with their reasons in the runner
-preload's `realClockFiles` list. A resume runtime drives a real loopback
-memory-client transport whose
-connect/mount/sync does not complete under the fake clock, so the resume
-deadlocks. And a nested-subagent generateObject aborts its delegate tool because
-the tool-calling path's own timeout auto-advances against the subagent's outbox
+Three files stay on the real clock, listed with their reasons in the runner
+preload's `realClockFiles` list. Two are resume tests, where a second runtime
+resumes from storage over a real loopback memory-client transport. In the first,
+the transport's connect/mount/sync does not complete under the fake clock, so
+the resume deadlocks. In the second, the reload holds each per-element child
+document back by a delay to open the resume window it observes; that delay is a
+frozen test-file timer, and the resuming runtime's pull/idle machinery blocks on
+the deliveries it gates, so the resume deadlocks there too. The third is a
+nested-subagent generateObject that aborts its delegate tool because the
+tool-calling path's own timeout auto-advances against the subagent's outbox
 progress rather than the wall clock, so the delegate reports "tool call timed
 out" before it completes. These are the honest exceptions: the clock they need
 is the real one, and their own sleeps are the honest way to wait.
 
-One caveat governs whether a runner test can leave the exemption list, and it is
-worth stating because it is easy to trip over. The `test/` versus `src/`
-classification reads the caller's stack frame through `new Error().stack`, and
-SES's `errorTaming` blanks that stack once a runtime locks down. From the first
-`Runtime` a test builds, the harness can no longer see the `test/` frame that
-scheduled a timer, so a positive-delay `setTimeout` written in test code is
-classified as a production timer and auto-advances instead of freezing. A test
-that schedules its own wall-clock deadline — a `setTimeout(reject, ms)` guarding
-a wait — therefore has that deadline fire early under auto-advance rather than
-acting as a backstop. The fix is the same one the rest of this note prescribes:
+The `test/` versus `src/` classification reads the scheduling frame from a stack
+trace, and that has to keep working after a runtime is running. SES's
+`errorTaming` blanks `new Error().stack` from the first `Runtime` a test builds
+onward — safe taming still captures each error's frames but hides them behind the
+tamed `stack` accessor, which reads back empty for the rest of the process. So
+the harness does not read the frame that way. It reads it through
+`getStackString`, the hook SES installs on the global during lockdown, which
+still returns the real frames after the plain accessor has gone empty; the
+runtime's own error mapping reads stacks through the same hook. A positive-delay
+`setTimeout` written in test code is therefore classified as a `test/` timer and
+freezes across the lockdown boundary, exactly as it does before any runtime
+exists.
+
+One consequence is worth stating because it is easy to trip over. A test that
+guards a wait with its own wall-clock deadline — a `setTimeout(reject, ms)` — has
+that deadline frozen along with every other test sleep, so it never fires and
+backstops nothing. The remedy is the one the rest of this note prescribes:
 resolve the wait on the event itself with no deadline, and let a signal that
 never arrives quiesce the loop so Deno fails the pending wait. That is what let
 the multi-space mergeable-commit test move onto the fake clock — its retry

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -20,6 +20,12 @@ installFakeClock({
     // whose connect/mount/sync machinery does not complete under the fake clock:
     // the resume deadlocks rather than settling.
     "list-resume-container-defer",
+    // The sibling resume test: its reload storage manager holds each per-element
+    // child document back by a real delay to open the resume window it observes,
+    // and the resuming runtime's pull/idle machinery blocks on those deliveries.
+    // Under the fake clock the delay is a frozen test-file timer that pull/idle
+    // wait on, so the resume deadlocks; the real clock delivers them as intended.
+    "list-resume-preserve",
     // Drives a nested-subagent generateObject: a delegate tool runs a child
     // pattern whose result feeds back to the parent through the post-commit
     // outbox across several cycles. The tool-calling path carries its own

--- a/packages/runner/test/fake-clock-lockdown-classification.test.ts
+++ b/packages/runner/test/fake-clock-lockdown-classification.test.ts
@@ -1,0 +1,72 @@
+/// <reference path="./clock.d.ts" />
+// The fake-clock harness (auto-advance mode) sorts every positive-delay
+// `setTimeout` into a `src/` timer, which auto-advances so the runtime's own
+// throttle/backoff windows elapse instantly, or a `test/` timer, which freezes
+// so a stray wall-clock sleep written in test code deadlocks and the async-op
+// sanitizer catches it. It decides by reading the scheduling frame's file path.
+//
+// SES's `errorTaming: "safe"` (the runner's production lockdown) blanks
+// `new Error().stack` for the rest of the process from the first lockdown on.
+// Reading the frame through `new Error().stack` therefore saw nothing after
+// lockdown, and every test-scheduled sleep was misfiled as a `src/` timer and
+// auto-advanced — silently defeating the freeze-and-catch guarantee for the
+// whole suite. The harness reads the frames through SES's `getStackString`
+// hook, which keeps returning them after lockdown (the same hook the runtime's
+// own error mapping uses). These tests pin the classification across the
+// lockdown boundary and the SES contract it stands on.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { sleep } from "@commonfabric/utils/sleep";
+import { ensureSESLockdown } from "../src/sandbox/ses-runtime.ts";
+
+// One real macrotask turn. A zero-delay `setTimeout` fires on a real macrotask
+// through the harness's kick, and the auto-advance pump runs on a real macrotask
+// armed the moment a `src/` timer is scheduled — armed earlier, so it runs
+// first. After this yield a `src/` timer the pump owns has fired, while a frozen
+// `test/` timer has not.
+const macrotaskTurn = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("fake-clock caller classification survives SES lockdown", () => {
+  it("SES blanks Error.stack yet exposes the frames through getStackString", () => {
+    ensureSESLockdown();
+    // The hazard: the tamed `stack` accessor reads back empty post-lockdown.
+    expect(new Error().stack ?? "").toBe("");
+    // The mechanism the harness stands on: the real frames, this file among them.
+    const getStackString = (globalThis as {
+      getStackString?: (error: Error) => string;
+    }).getStackString;
+    expect(typeof getStackString).toBe("function");
+    const frames = getStackString!(new Error());
+    expect(frames.length).toBeGreaterThan(0);
+    expect(frames).toContain(".test.ts");
+  });
+
+  it("a test-scheduled positive-delay setTimeout freezes after lockdown", async () => {
+    ensureSESLockdown();
+    let fired = false;
+    setTimeout(() => {
+      fired = true;
+    }, 500);
+    await macrotaskTurn();
+    // Frozen, not auto-advanced: the harness saw this file's `test/` frame.
+    expect(fired).toBe(false);
+    // Still a live timer — explicit time advancement fires it.
+    await clock.tick(500);
+    expect(fired).toBe(true);
+  });
+
+  it("a src/-scheduled positive-delay setTimeout still auto-advances after lockdown", async () => {
+    ensureSESLockdown();
+    let fired = false;
+    // `sleep` arms the timer from `packages/utils/src`, a `src/` frame, so the
+    // harness auto-advances it — the runtime's own throttle and backoff timers
+    // are armed the same way and must keep elapsing on their own.
+    sleep(500).then(() => {
+      fired = true;
+    });
+    await macrotaskTurn();
+    expect(fired).toBe(true);
+  });
+});

--- a/packages/runner/test/list-resume-preserve.test.ts
+++ b/packages/runner/test/list-resume-preserve.test.ts
@@ -51,6 +51,13 @@ const space = signer.did();
 const FILTER_CHILD_DOC = /"type":"boolean"/;
 const FLATMAP_CHILD_DOC = /"type":"number"/;
 
+// How long the reload's storage manager holds back each per-element child
+// document before delivering it, which is what opens the resume window the
+// tests observe. The resuming runtime's pull/idle machinery blocks on these
+// deliveries, so this file runs on the real clock (see the `realClockFiles`
+// note in `test/clock-preload.ts`).
+const CHILD_DELAY_MS = 80;
+
 function delayingLoopback(
   server: MemoryV2Server.Server,
   childDelayMs: number,
@@ -190,7 +197,7 @@ describe("list builtin resume preservation", () => {
     sm2 = DelayingStorageManager.make(
       signer,
       server,
-      80,
+      CHILD_DELAY_MS,
       FILTER_CHILD_DOC,
       () => delayed++,
     );
@@ -400,7 +407,7 @@ describe("flatMap builtin resume preservation", () => {
     sm2 = DelayingStorageManager.make(
       signer,
       server,
-      80,
+      CHILD_DELAY_MS,
       FLATMAP_CHILD_DOC,
       () => delayed++,
     );

--- a/packages/runner/test/sandbox-timers.test.ts
+++ b/packages/runner/test/sandbox-timers.test.ts
@@ -1,3 +1,4 @@
+/// <reference path="./clock.d.ts" />
 // The SES pattern compartment endows no timers (part of the structural barrier
 // pinned by security-timing.test.ts). Pattern code that needs a delay — API
 // clients doing retry/backoff — must therefore guard its timer use: read
@@ -74,8 +75,10 @@ describe("sandbox timers (channel: no fine clock)", () => {
 
   it("the same guard DOES wait when a timer is present (host behavior unchanged)", async () => {
     // Outside the sandbox (this test's own Deno global has setTimeout), the guard
-    // takes the real-wait branch, so the API clients' plain-Deno unit tests keep
-    // exercising actual backoff.
+    // takes the waiting branch, so the API clients' plain-Deno unit tests keep
+    // exercising actual backoff. This runs under the package's fake clock, so the
+    // waiting branch's `setTimeout` is a frozen test-file timer: it does not
+    // resolve on its own, and `clock.tick` advances logical time to fire it.
     const sleep = (ms: number): Promise<void> => {
       if (ms <= 0) return Promise.resolve();
       const timer =
@@ -89,7 +92,8 @@ describe("sandbox timers (channel: no fine clock)", () => {
     const p = sleep(10).then(() => {
       fired = true;
     });
-    expect(fired).toBe(false); // did not resolve synchronously — a real wait
+    expect(fired).toBe(false); // did not resolve synchronously — the waiting branch
+    await clock.tick(10);
     await p;
     expect(fired).toBe(true);
   });

--- a/packages/test-support/test/clock-preload.ts
+++ b/packages/test-support/test/clock-preload.ts
@@ -101,10 +101,39 @@ const PRESETS: Record<FakeClockMode, Omit<ResolvedConfig, "realClockFiles">> = {
   },
 };
 
+// The current call stack, as newline-separated frames with the innermost first.
+//
+// A plain `new Error().stack` is enough until SES enters the picture. The runner
+// package locks SES down the first time a test builds a `Runtime`, with
+// `errorTaming` set to "safe" — a permanent, process-global change. Safe taming
+// still captures each error's frames, but hides them behind the tamed `stack`
+// accessor, which from then on reads back as the empty string. Every timer a
+// test schedules after that first lockdown would otherwise arrive here with no
+// stack to classify, so `callerIsTest` would read every one as `src/` and let a
+// stray test sleep auto-advance instead of freezing.
+//
+// SES hands the real frames back through `getStackString`, the sanctioned hook
+// it installs on the global during lockdown; the runtime's own error mapping
+// reads stacks through the same hook. We use it whenever lockdown has installed
+// it, and fall back to the native `stack` before lockdown, and in a package that
+// loads this harness without ever loading SES. Reading the frames this way keeps
+// the caller classification working without relaxing the production error
+// taming.
+function currentStack(): string {
+  const error = new Error();
+  const getStackString = (globalThis as {
+    getStackString?: (error: Error) => string;
+  }).getStackString;
+  if (typeof getStackString === "function") {
+    return getStackString(error) ?? "";
+  }
+  return error.stack ?? "";
+}
+
 // The immediate caller of setTimeout: the first stack frame outside this file.
 // A frame in a `test/` directory (or a `.test.ts` file) is test code.
 function callerIsTest(): boolean {
-  const stack = new Error().stack ?? "";
+  const stack = currentStack();
   for (const line of stack.split("\n").slice(1)) {
     if (line.includes(HARNESS_FILE)) continue;
     return /\/test\//.test(line) || /\.test\.ts/.test(line);
@@ -346,7 +375,7 @@ function registeredFromRealClockFile(
   realClockFiles: readonly string[],
 ): boolean {
   if (realClockFiles.length === 0) return false;
-  const stack = new Error().stack ?? "";
+  const stack = currentStack();
   return realClockFiles.some((name) => stack.includes(`${name}.test.ts`));
 }
 


### PR DESCRIPTION
…e clock still classifies test timers after lockdown

The shared fake-clock harness (auto-advance mode) sorts each positive-delay setTimeout by who scheduled it: a timer armed from src/ (the runtime's own throttle/backoff windows) auto-advances so those windows elapse instantly, while a timer armed from a test/ file is a wall-clock sleep that freezes, so a stray test sleep deadlocks and Deno's async-op sanitizer catches it. It decides by reading the immediate caller's stack frame from new Error().stack.

The runner locks SES down with errorTaming "safe" the first time any test builds a Runtime. That lockdown is process-global and permanent, and safe taming blanks new Error().stack: the frames are still captured but hidden behind the tamed stack accessor, which from then on reads back as the empty string. So from the first Runtime onward -- i.e. for essentially the whole runner suite -- the classifier saw an empty stack and fell through to "not a test frame", and every positive-delay setTimeout scheduled from test code was misfiled as a src/ timer and auto-advanced instead of freezing. The freeze-and-catch safety net was silently defeated: a test that wrote setTimeout(fn, 500) got it advanced to instant rather than caught.

Read the frames through SES's getStackString hook instead. Lockdown installs it on the global specifically to hand back the real frames after the tamed stack accessor goes empty, and the runtime's own error mapping already reads stacks through it (materializeHostVisibleStack in ses-runtime.ts). A new currentStack() helper uses getStackString whenever lockdown has installed it and falls back to the native stack before lockdown and in a package that loads the harness without ever loading SES; both callerIsTest() and registeredFromRealClockFile() go through it. This needs no change to the production error taming.

Restoring the freeze flips behavior for test-scheduled timers, so two tests that relied on the old auto-advance are updated. The sandbox-timers "host behavior unchanged" case drives its now-frozen local sleep with clock.tick. And list-resume-preserve joins the runner preload's real-clock exemption list: its reload holds each per-element child document back by a delay to open the resume window it observes, and the resuming runtime's pull/idle machinery blocks on those deliveries, so under the fake clock that frozen test-file timer deadlocks the resume -- the same class of test as its already-exempt sibling list-resume-container-defer. Every other test-scheduled positive-delay timer in the suite is a race backstop whose deadline is expected to lose, so freezing it is a no-op on the passing path.

Add a regression test that pins the classification across the lockdown boundary (a test-frame timer freezes, a src/-frame timer still auto-advances) and the SES contract it stands on (stack blanks, getStackString still returns the frames). Update waiting-in-tests.md: the caveat that the classification breaks after lockdown is replaced by how it now survives, and the exemption count goes from two files to three.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fake-clock timer classification under SES lockdown by reading caller frames via `getStackString`, so test-scheduled timers freeze again and src timers still auto-advance. Restores deadlock detection for stray test sleeps.

- Bug Fixes
  - Added `currentStack()` in `packages/test-support/test/clock-preload.ts` to read frames via global `getStackString` (fallback to `Error.stack`), used by `callerIsTest()` and `registeredFromRealClockFile()`.
  - Added regression test `packages/runner/test/fake-clock-lockdown-classification.test.ts` to pin classification and SES behavior across lockdown.
  - Marked `list-resume-preserve` as a real-clock test in `packages/runner/test/clock-preload.ts`; defined `CHILD_DELAY_MS` in the test.
  - Updated `packages/runner/test/sandbox-timers.test.ts` to drive frozen waits with `clock.tick`.
  - Updated docs (`docs/development/waiting-in-tests.md`) to note the classification now survives lockdown and the exemptions increase from 2 to 3.

<sup>Written for commit c98dd0312faf15586fac463243c4fd543a6848a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

