### PR TITLE
fix(cli): limit unnamed TypeScript views to compiler output

### DIFF
--- a/docs/plans/cf-view-language-coverage.md
+++ b/docs/plans/cf-view-language-coverage.md
@@ -1,9 +1,10 @@
 # `cf view` language and syntax coverage plan
 
-Status: In progress. Unknown named files now use plain text. Python files with
-recognized extensions now have syntax highlighting. The order is provisional
-because recent activity was
-measured in six of the 24 active organization repositories.
+Status: In progress. Unknown named files and filename-free source use plain
+text, while filename-free transformed compiler output keeps its TypeScript
+default. Python files with recognized extensions now have syntax highlighting.
+The order is provisional because recent activity was measured in six of the 24
+active organization repositories.
 
 This plan takes `cf view` from its current TypeScript and JavaScript, Markdown,
 JSON and JSONC, YAML, extension-based Python highlighting, and diff support to
@@ -82,7 +83,7 @@ relative value. Record the reason in this plan.
 ## Stage 0: honest selection and implementation foundation
 
 - [x] Add a plain-text language and select it for unknown named files.
-- [ ] Preserve the intentional TypeScript default only for transformed
+- [x] Preserve the intentional TypeScript default only for transformed
   compiler output that has no filename.
 - [ ] Add `--language` and `--filename` overrides for piped input.
 - [ ] Represent extensions, exact filenames, compound filename patterns,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,17 +4,20 @@
 
 `cf view [file]` is an interactive pager for transformed TypeScript, source
 files, and unified diffs. Named Markdown, JSON, JSONC, YAML, and Python files
-use their own syntax highlighting. A named file with unrecognized syntax is
-shown as plain text. Markdown files can switch between the source and a rendered
-terminal view with `V`. The rendered view formats headings, emphasis, links,
-quotes, lists, task markers, tables, rules, and code. The same view is available
-for Markdown files inside a unified diff; diff markers, addition and deletion
-tints, line positions, and hunk expansion remain in place.
+use their own syntax highlighting. Transformed compiler output piped without a
+filename keeps TypeScript highlighting when its module header identifies it.
+Other filename-free source and named files with unrecognized syntax are shown as
+plain text.
 
-A piped input without a file name remains TypeScript unless it is detected as a
-diff. Redirected output keeps the source text verbatim by default and adds ANSI
-color only when the selected color mode permits it. Pass `--rendered` to start
-in, or print, the rendered representation when one is available. Editing from a
+Markdown files can switch between the source and a rendered terminal view with
+`V`. The rendered view formats headings, emphasis, links, quotes, lists, task
+markers, tables, rules, and code. The same view is available for Markdown files
+inside a unified diff; diff markers, addition and deletion tints, line
+positions, and hunk expansion remain in place.
+
+Redirected output keeps the source text verbatim by default and adds ANSI color
+only when the selected color mode permits it. Pass `--rendered` to start in, or
+print, the rendered representation when one is available. Editing from a
 rendered view returns to source first.
 
 ```bash

--- a/packages/cli/commands/view.ts
+++ b/packages/cli/commands/view.ts
@@ -10,9 +10,12 @@ files. Transformed TypeScript is parsed with the same parser the transformer
 uses, so blocks, closures, schemas, type positions and Common Fabric builders
 (pattern/lift/handler/…) are coloured exactly as the compiler sees them.
 Markdown, JSON, JSONC, YAML and Python files use syntax highlighting selected
-from their names. Named files with unrecognized syntax remain plain text. The
-Markdown language also has a rendered view that formats headings, lists,
-quotes, tables, links, emphasis and code while retaining source line positions.
+from their names. Filename-free compiler output keeps TypeScript highlighting
+when its transformed-module header identifies it. Other unnamed source and
+named files with unrecognized syntax remain plain text. The Markdown language
+also has a rendered view that formats headings, lists, quotes, tables, links,
+emphasis and code while retaining source line positions. Source views remain
+verbatim and add colour only.
 
 Unified diffs are detected automatically: piping 'git diff' in gives added and
 removed lines their tints, full syntax colour, a structure tree of the code

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -9,7 +9,7 @@
  * editable text back onto the files it touches.
  */
 import type { Document, Line } from "./model.ts";
-import type { Highlighter } from "./languages/language.ts";
+import type { Highlighter, Language } from "./languages/language.ts";
 import { languageForFile, renderedLinesFor } from "./languages/language.ts";
 
 /** How much a revert restores: the cursor's hunk, the cursor's file, the commit
@@ -236,12 +236,16 @@ export function fileSource(path: string): EditableSource {
 }
 
 /** A non-file view (a pipe / a diff matching nothing): readable, not editable. */
-export function readonlySource(reason: string): EditableSource {
+export function readonlySource(
+  reason: string,
+  language: Language = languageForFile(undefined),
+  fileName?: string,
+): EditableSource {
   return {
     label: null,
     editable: false,
     reason,
-    parse: (text) => languageForFile(undefined).parseDocument(text),
+    parse: (text) => language.parseDocument(text, fileName),
     save: () => reason,
   };
 }

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -2,10 +2,11 @@
  * The contract every source language plugs into so the `cf view` pager can
  * colour, navigate, edit and (optionally) reason about it, plus selecting the
  * right language for a file. A language is a stateless strategy object: one
- * instance describes each supported syntax, and plain text handles unknown
- * named files. The pager selects the right one for a file ONCE (via {@link
- * languageForFile}) and then dispatches every operation through that object's
- * methods — there is no per-operation branch on the file extension.
+ * instance describes each supported syntax, and plain text handles input that
+ * has no recognized filename. The pager selects the right one for a file ONCE
+ * (via {@link languageForFile}) and then dispatches every operation through
+ * that object's methods — there is no per-operation branch on the file
+ * extension.
  *
  * Per-file mutable state (a warm incremental parse, a language service) is not
  * held on the language; the language is a factory for the small stateful
@@ -213,8 +214,8 @@ export function renderedLinesFor(
 /**
  * Every language the pager knows, most specific first, built on first use.
  * Plain text comes last because it claims every named file left after the
- * syntax-specific languages. An input with no filename is handled by the
- * fallback below.
+ * syntax-specific languages. The fallback below also uses it when no filename
+ * exists.
  *
  * The list is lazy so this module's top level never reads the concrete language
  * singletons: they and this module form an import cycle (a language's semantic
@@ -234,13 +235,18 @@ function allLanguages(): readonly Language[] {
   ];
 }
 
-/** The language for `fileName` — the first that claims it. Plain text claims
- * otherwise unknown named files. TypeScript remains the fallback for an
- * unnamed pipe of transformed compiler output. */
+/** The language for `fileName` — the first that claims it. Plain text handles
+ * unknown named files and input without a filename. */
 export function languageForFile(fileName: string | undefined): Language {
   for (const language of allLanguages()) {
     if (language.matches(fileName)) return language;
   }
+  return plainTextLanguage;
+}
+
+/** The TypeScript default for filename-free `cf check --show-transformed`
+ * output. The caller checks the compiler's module header before selecting it. */
+export function languageForTransformedOutput(): Language {
   return typeScriptLanguage;
 }
 

--- a/packages/cli/lib/view/languages/plain-text/language.ts
+++ b/packages/cli/lib/view/languages/plain-text/language.ts
@@ -1,7 +1,8 @@
 /**
- * The plain-text language for named files whose syntax `cf view` does not
- * recognize. It must remain last in the language registry because it claims
- * every filename left after the syntax-specific languages.
+ * The plain-text language for input whose syntax `cf view` cannot select from
+ * a filename. It must remain last in the language registry because it claims
+ * every named file left after the syntax-specific languages; the registry also
+ * returns it when no filename exists.
  */
 import type { Language } from "../language.ts";
 import {

--- a/packages/cli/lib/view/languages/typescript/language.ts
+++ b/packages/cli/lib/view/languages/typescript/language.ts
@@ -1,8 +1,8 @@
 /**
  * The TypeScript (and TSX/JS) language for the pager. It handles named files in
- * that language family. It is also the intentional default for unnamed
- * transformed-pattern output. Highlighting, structure, incremental editing and
- * the semantic layer all live in the neighbouring {@link ./parse.ts} and
+ * that language family. The selection layer also uses it for filename-free
+ * transformed compiler output. Highlighting, structure, incremental editing
+ * and the semantic layer all live in the neighbouring {@link ./parse.ts} and
  * {@link ./semantics.ts}; this module only adapts them to the {@link Language}
  * contract.
  */
@@ -20,8 +20,7 @@ export const typeScriptLanguage: Language = {
   id: "typescript",
 
   // Claims the TypeScript / JavaScript family (`.ts`, `.tsx`, `.mts`, `.cts`,
-  // `.js`, `.jsx`, `.mjs`, `.cjs`). `languageForFile` also selects it for an
-  // unnamed pipe of transformed compiler output.
+  // `.js`, `.jsx`, `.mjs`, `.cjs`).
   matches: (fileName) =>
     fileName !== undefined && /\.[cm]?[jt]sx?$/i.test(fileName),
 

--- a/packages/cli/lib/view/mod.ts
+++ b/packages/cli/lib/view/mod.ts
@@ -2,9 +2,11 @@
  * Entry point for `cf view`. Reads the input (a file argument or piped stdin),
  * parses it once — as a unified diff when it reads as one, otherwise with the
  * language selected from its filename — then either launches the interactive
- * TTY) or prints the selected source/rendered representation and exits,
- * mirroring how `less`/`bat` behave when their output is redirected. An
- * unnamed pipe remains transformed TypeScript.
+ * pager (when stdout is a TTY) or prints the selected source or rendered
+ * representation and exits, mirroring how `less`/`bat` behave when their
+ * output is redirected.
+ * Filename-free compiler output keeps the transformed TypeScript default;
+ * other filename-free source uses plain text.
  */
 import { renderLineColored } from "./highlight.ts";
 import { runPager } from "./pager.ts";
@@ -21,6 +23,7 @@ import {
   diffSemanticsFor,
   distinctLanguages,
   languageForFile,
+  languageForTransformedOutput,
 } from "./languages/language.ts";
 import {
   type EditableSource,
@@ -149,8 +152,12 @@ export function buildView(
       ),
     };
   }
-  const language = languageForFile(file);
-  const doc = language.parseDocument(text, file ?? "transformed.tsx");
+  const transformedOutput = file === undefined &&
+    looksLikeTransformedOutput(text);
+  const language = transformedOutput
+    ? languageForTransformedOutput()
+    : languageForFile(file);
+  const doc = language.parseDocument(text, file);
   return {
     doc,
     semantics: () =>
@@ -158,8 +165,22 @@ export function buildView(
     // A real file is editable; a pipe (transformed output, etc.) is not.
     editSource: file ? fileSource(file) : readonlySource(
       "This view is of a pipe — there is no underlying file to edit.",
+      language,
+      file,
     ),
   };
+}
+
+/** `cf check --show-transformed` starts each output module with this header. */
+function looksLikeTransformedOutput(text: string): boolean {
+  const lineEnd = text.indexOf("\n");
+  const firstLine = (lineEnd < 0 ? text : text.slice(0, lineEnd)).replace(
+    /\r$/,
+    "",
+  );
+  const prefix = "// transformed: ";
+  return firstLine.startsWith(prefix) &&
+    firstLine.slice(prefix.length).trim().length > 0;
 }
 
 /** A standard `git show` or `git log` header. Unlike a diff heuristic, this also

--- a/packages/cli/test/view-json.test.ts
+++ b/packages/cli/test/view-json.test.ts
@@ -49,7 +49,7 @@ Deno.test("json: the registry selects JSON for .json and .jsonc", () => {
   // Other registered selections remain unchanged.
   assertEquals(languageForFile("main.ts").id, "typescript");
   assertEquals(languageForFile("notes.md").id, "markdown");
-  assertEquals(languageForFile(undefined).id, "typescript");
+  assertEquals(languageForFile(undefined).id, "plain-text");
 });
 
 Deno.test("json: keys, values, and literals get distinct classes", () => {

--- a/packages/cli/test/view-language.test.ts
+++ b/packages/cli/test/view-language.test.ts
@@ -1,9 +1,9 @@
 /**
- * Language selection: `languageForFile` picks a language by extension, uses
- * plain text for unknown named files, and keeps TypeScript for unnamed pipes.
- * `distinctLanguages` dedupes the languages a diff touches, and
- * `diffSemanticsFor` composes the diff view's semantic layer from the languages
- * present, scoped to each one's files.
+ * Language selection: `languageForFile` picks a language by extension and uses
+ * plain text when no filename matches. Transformed compiler output selects
+ * TypeScript through a separate path. `distinctLanguages` dedupes the languages
+ * a diff touches, and `diffSemanticsFor` composes the diff view's semantic layer
+ * from the languages present, scoped to each one's files.
  */
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
@@ -11,6 +11,7 @@ import {
   diffSemanticsFor,
   distinctLanguages,
   languageForFile,
+  languageForTransformedOutput,
   renderedLinesFor,
 } from "../lib/view/languages/language.ts";
 import { typeScriptLanguage } from "../lib/view/languages/typescript/language.ts";
@@ -27,7 +28,7 @@ import {
 import { parseDiff } from "../lib/view/diff.ts";
 import type { Line } from "../lib/view/model.ts";
 
-Deno.test("languageForFile: named files resolve and unnamed input defaults to TypeScript", () => {
+Deno.test("languageForFile: named files resolve and missing names use plain text", () => {
   for (const ts of ["a.ts", "a.tsx", "a.mts", "a.cts", "a.js", "a.jsx"]) {
     assertEquals(languageForFile(ts).id, "typescript", ts);
   }
@@ -37,7 +38,8 @@ Deno.test("languageForFile: named files resolve and unnamed input defaults to Ty
   assertEquals(languageForFile("script.py").id, "python");
   assertEquals(languageForFile("notes.xyz").id, "plain-text");
   assertEquals(languageForFile("LICENSE").id, "plain-text");
-  assertEquals(languageForFile(undefined).id, "typescript");
+  assertEquals(languageForFile(undefined).id, "plain-text");
+  assertEquals(languageForTransformedOutput().id, "typescript");
 });
 
 Deno.test("languageForFile: named JavaScript uses the TypeScript-family parser", () => {

--- a/packages/cli/test/view-mod-cov.test.ts
+++ b/packages/cli/test/view-mod-cov.test.ts
@@ -61,6 +61,21 @@ Deno.test("buildView: transformed compiler output keeps the TypeScript default",
   );
 });
 
+Deno.test("buildView: transformed declarations without bodies retain function structure", () => {
+  const r = buildView(
+    "// transformed: /types.ts\nexport declare function run(): void;\n",
+  );
+
+  assert(
+    r.doc.structure.some((node) =>
+      node.children.some((child) =>
+        child.kind === "function" && child.name === "run"
+      )
+    ),
+    "the declaration remains a TypeScript function",
+  );
+});
+
 Deno.test("buildView: only an exact first-line transformed header selects TypeScript", () => {
   for (
     const text of [

--- a/packages/cli/test/view-mod-cov.test.ts
+++ b/packages/cli/test/view-mod-cov.test.ts
@@ -8,6 +8,8 @@ import { assert, assertEquals } from "@std/assert";
 import { buildView } from "../lib/view/mod.ts";
 
 const SRC = "export const x = 1;\nconst y = x + 1;\n";
+const TRANSFORMED = `// transformed: /app.ts
+${SRC}`;
 const DIFF = `diff --git a/a.ts b/a.ts
 --- a/a.ts
 +++ b/a.ts
@@ -25,10 +27,52 @@ Deno.test("buildView: a named source file is editable and its semantics closure 
   assertEquals(r.editSource.editable, true, "a named file is editable");
 });
 
-Deno.test("buildView: a pipe with no file is a read-only source", () => {
+Deno.test("buildView: an ordinary pipe with no file is read-only plain text", () => {
   const r = buildView(SRC);
-  r.semantics();
+
+  assertEquals(r.doc.structure, []);
+  assertEquals(
+    r.doc.lines.flatMap((line) => line.spans.map((span) => span.cls)),
+    ["plain", "plain"],
+  );
+  assertEquals(r.semantics(), undefined);
   assertEquals(r.editSource.editable, false);
+});
+
+Deno.test("buildView: transformed compiler output keeps the TypeScript default", () => {
+  const r = buildView(TRANSFORMED);
+
+  assert(
+    r.doc.structure.some((node) => node.kind === "section"),
+    "the transformed module has TypeScript structure",
+  );
+  assert(
+    r.doc.lines.flatMap((line) => line.spans).some((span) =>
+      span.cls === "storageKeyword"
+    ),
+    "the transformed module has TypeScript highlighting",
+  );
+  const semantics = r.semantics();
+  assert(semantics, "transformed output has TypeScript semantics");
+  assertEquals(
+    r.editSource.parse(TRANSFORMED),
+    r.doc,
+    "read-only reparsing keeps the selected language",
+  );
+});
+
+Deno.test("buildView: only an exact first-line transformed header selects TypeScript", () => {
+  for (
+    const text of [
+      "ordinary text",
+      `\n${TRANSFORMED}`,
+      "// transformed:\nexport const x = 1;\n",
+      "// transformed:   \nexport const x = 1;\n",
+      "// Transformed: /app.ts\nexport const x = 1;\n",
+    ]
+  ) {
+    assertEquals(buildView(text).doc.structure, [], JSON.stringify(text));
+  }
 });
 
 Deno.test("buildView: blank input remains a read-only source", () => {
@@ -212,7 +256,7 @@ Deno.test("buildView: forceDiff=false views a real diff as source (--no-diff)", 
 
 Deno.test("buildView: text that only embeds a diff stays source (mostlyDiff is false)", () => {
   // Looks like a diff at the top, but the bulk is ordinary source, so the
-  // diff-share heuristic rejects it and it renders as TypeScript.
+  // diff-share heuristic rejects it and it renders as plain text.
   const embedded = "diff --git a/x b/x\n" +
     Array.from({ length: 40 }, (_, i) => `const v${i} = ${i};`).join("\n") +
     "\n";

--- a/packages/cli/test/view-mod-cov.test.ts
+++ b/packages/cli/test/view-mod-cov.test.ts
@@ -65,15 +65,17 @@ Deno.test("buildView: transformed declarations without bodies retain function st
   const r = buildView(
     "// transformed: /types.ts\nexport declare function run(): void;\n",
   );
+  const declaration = r.doc.flatStructure.find((node) => node.name === "run");
 
-  assert(
-    r.doc.structure.some((node) =>
-      node.children.some((child) =>
-        child.kind === "function" && child.name === "run"
-      )
-    ),
-    "the declaration remains a TypeScript function",
-  );
+  assert(declaration, "the declaration remains in the TypeScript structure");
+  assertEquals(declaration.kind, "function");
+  assertEquals(declaration.children, []);
+  assertEquals(declaration.meta, {
+    kind: "closure",
+    params: [],
+    returns: undefined,
+    signature: "() → void",
+  });
 });
 
 Deno.test("buildView: only an exact first-line transformed header selects TypeScript", () => {

--- a/packages/cli/test/view-plain-text.test.ts
+++ b/packages/cli/test/view-plain-text.test.ts
@@ -1,7 +1,8 @@
 /**
- * Plain-text handling for named files whose syntax `cf view` does not
- * recognize. Direct documents, diffs, and live diff edits must preserve the
- * complete input without TypeScript coloring or structure.
+ * Plain-text handling for files whose syntax `cf view` does not recognize and
+ * filename-free input that is not transformed compiler output. Direct
+ * documents, diffs, and live diff edits must preserve the complete input
+ * without TypeScript coloring or structure.
  */
 import { assertEquals } from "@std/assert";
 import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
@@ -18,10 +19,10 @@ function verbatim(lines: readonly Line[]): string {
     .join("\n");
 }
 
-Deno.test("plain text: unknown named files select plain text while unnamed input stays TypeScript", () => {
+Deno.test("plain text: unknown and unnamed files select plain text", () => {
   assertEquals(languageForFile("LICENSE").id, "plain-text");
   assertEquals(languageForFile("checksums.sha256").id, "plain-text");
-  assertEquals(languageForFile(undefined).id, "typescript");
+  assertEquals(languageForFile(undefined).id, "plain-text");
 });
 
 Deno.test("plain text: direct documents preserve source without structure", () => {
@@ -44,6 +45,18 @@ Deno.test("plain text: direct documents preserve source without structure", () =
   assertEquals(view.semantics(), undefined);
   assertEquals(view.editSource.editable, true);
   assertEquals(view.editSource.parse(text), doc);
+});
+
+Deno.test("plain text: a filename takes priority over a transformed-looking header", () => {
+  const text = "// transformed: /fake.ts\nexport const answer = 42;\n";
+  const view = buildView(text, "compiler-output.txt");
+
+  assertEquals(view.doc.text, text);
+  assertEquals(view.doc.structure, []);
+  assertEquals(
+    view.doc.lines.flatMap((line) => line.spans.map((span) => span.cls)),
+    ["plain", "plain"],
+  );
 });
 
 Deno.test("plain text: live edits remain lossless and plain", () => {

--- a/packages/cli/test/view-python.test.ts
+++ b/packages/cli/test/view-python.test.ts
@@ -69,7 +69,7 @@ Deno.test("python: the language registry selects Python extensions", () => {
   assertEquals(languageForFile("types.pyi").id, "python");
   assertEquals(languageForFile("app.pyw").id, "python");
   assertEquals(languageForFile("main.ts").id, "typescript");
-  assertEquals(languageForFile(undefined).id, "typescript");
+  assertEquals(languageForFile(undefined).id, "plain-text");
   assertEquals(
     verbatim(python.createHighlighter("answer = True").lines),
     "answer = True",


### PR DESCRIPTION
cf view treated every filename-free pipe as transformed TypeScript. That gave ordinary piped text misleading syntax colors, structure, and semantic work even though compiler output has an exact module header.

Recognize the compiler's transformed module header before selecting the TypeScript default. Use plain text for other unnamed input, keep real filenames authoritative, and retain the selected language when a read-only view reparses.

Update the coverage plan and CLI help. Add regression coverage for ordinary pipes, valid and malformed compiler headers, named-file priority, semantics, and read-only reparsing.

Verified with the complete CLI test suite under the repository-pinned Deno, the repository type check, deno fmt --check, and deno lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits `cf view`’s TypeScript default to filename-free compiler output identified by an exact first-line `// transformed: <path>` header. Other unnamed input renders as plain text; named files still use extension-based selection.

- **Bug Fixes**
  - Gate TypeScript selection on an exact first-line `// transformed: <non-empty path>` header (CRLF-safe); ordinary pipes render as plain text.
  - Keep real filenames authoritative even if contents look transformed.
  - Split selection paths: `languageForFile(undefined)` returns plain text; `languageForTransformedOutput()` selects TypeScript; `readonlySource(...)` preserves the chosen language on read-only reparses.
  - Update `README`/CLI help and the coverage plan; add tests for ordinary pipes, transformed modules, malformed headers, named-file priority, semantics, and bodyless transformed declarations with metadata.

<sup>Written for commit 8fefc2cde220f30fb4a2c7af13672abcfd3e0560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

