### PR TITLE
fix(dashboard): preserve CI Gantt chart labels

### DIFF
--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -23,15 +23,11 @@ ARG DASHBOARD_GIT_COMMIT
 ENV DASHBOARD_GIT_COMMIT=${DASHBOARD_GIT_COMMIT}
 RUN printf '%s\n' "${DASHBOARD_GIT_COMMIT}" | grep -Eq '^[0-9a-f]{40}$'
 
-# Pre-fetch the dashboard's and the Gantt drill-down's dependencies, and make the
-# cache writable by the non-root runtime user (Deno and resvg write to it).
+# Pre-fetch the dashboard's and Gantt renderer's dependencies, then make the
+# cache writable by the non-root runtime user.
 ENV DENO_DIR=/deno-dir
 RUN deno cache packages/dashboard/server.ts scripts/ci-gantt.ts \
     && chown -R 65532:65532 /deno-dir
-
-# Fail the build if the linux/amd64 resvg native binary the Gantt drill-down
-# loads at runtime is missing from the cache (e.g. a wrong-arch build).
-RUN test -n "$(find /deno-dir -name 'resvgjs.linux-x64-gnu.node')"
 
 USER 65532
 ENV DASHBOARD_PORT=8731

--- a/packages/dashboard/tiles/ci-duration.test.ts
+++ b/packages/dashboard/tiles/ci-duration.test.ts
@@ -1,4 +1,4 @@
-// ci-duration's drill-down: the Gantt page and the /bench/gantt.png image behind it.
+// ci-duration's drill-down: the Gantt page and the /bench/gantt.svg image behind it.
 // The image handler shells out to scripts/ci-gantt.ts and writes a temp file.
 // The subprocess and the filesystem calls around it are replaced with
 // stubs that record what the handler asked for and hand back a canned result.
@@ -20,7 +20,9 @@ import {
   renderGanttRoute,
 } from "./ci-duration.ts";
 
-const PNG = Uint8Array.from([137, 80, 78, 71]);
+const SVG = new TextEncoder().encode(
+  '<svg xmlns="http://www.w3.org/2000/svg"><text>chart</text></svg>',
+);
 
 function ctx(runs: Run[]): Ctx {
   return {
@@ -92,7 +94,7 @@ async function gantt(
     };
     Deno.readFile = (path: string | URL) =>
       live.has(String(path))
-        ? Promise.resolve(PNG)
+        ? Promise.resolve(SVG)
         : Promise.reject(new Deno.errors.NotFound(String(path)));
     Deno.writeTextFile = (
       _path: string | URL,
@@ -137,7 +139,7 @@ async function gantt(
     });
     console.error = (...parts: unknown[]) =>
       void logged.push(parts.map(String).join(" "));
-    const url = new URL(`http://d/bench/gantt.png${query}`);
+    const url = new URL(`http://d/bench/gantt.svg${query}`);
     const res = await renderGantt(
       url.searchParams,
       (source, options) => {
@@ -210,7 +212,7 @@ Deno.test("the Gantt page shares the performance view selector", async () => {
     'href="/bench?view=gantt&amp;repo=labs&amp;days=45&amp;sort=job&amp;stat=p99" aria-current="page">CI run Gantt</a>',
   );
   assertStringIncludes(html, '<option value="labs" selected>labs</option>');
-  assertStringIncludes(html, "/bench/gantt.png?"); // the controls point at the image route
+  assertStringIncludes(html, "/bench/gantt.svg?"); // the controls point at the image route
   assertStringIncludes(html, 'id="fetch-progress"');
   assertStringIncludes(html, 'id="fetch-title">Idle</strong>');
   assertStringIncludes(html, 'aria-label="CI Gantt fetch progress"');
@@ -250,10 +252,17 @@ Deno.test("the Gantt page shares the performance view selector", async () => {
       route.path === "/bench/gantt-progress"
     ),
   );
-  for (const path of ["/ci-gantt", "/ci-gantt.png", "/ci-gantt-progress"]) {
+  for (
+    const path of [
+      "/ci-gantt",
+      "/ci-gantt.svg",
+      "/ci-gantt.png",
+      "/ci-gantt-progress",
+    ]
+  ) {
     assert(labsCiDuration.routes?.some((route) => route.path === path));
   }
-  for (const path of ["/ci-gantt.png", "/ci-gantt-progress"]) {
+  for (const path of ["/ci-gantt.svg", "/ci-gantt-progress"]) {
     const route = labsCiDuration.routes?.find((route) => route.path === path);
     assert(route);
     const invalid = new URL(`http://d${path}?sha=invalid`);
@@ -270,6 +279,22 @@ Deno.test("the Gantt page shares the performance view selector", async () => {
     assertEquals(
       (await route.handler(new Request(tooMany), tooMany)).status,
       400,
+    );
+  }
+  for (
+    const [path, target] of [
+      ["/ci-gantt.png", "/ci-gantt.svg"],
+      ["/bench/gantt.png", "/bench/gantt.svg"],
+    ]
+  ) {
+    const route = labsCiDuration.routes?.find((route) => route.path === path);
+    assert(route);
+    const legacy = new URL(`http://d${path}?repo=loom&limit=12`);
+    const response = await route.handler(new Request(legacy), legacy);
+    assertEquals(response.status, 308);
+    assertEquals(
+      response.headers.get("location"),
+      `${target}?repo=loom&limit=12`,
     );
   }
 
@@ -303,7 +328,7 @@ Deno.test("the commit Gantt page contains only one commit selection", () => {
     `href="https://github.com/${LOOM_REPO}/commit/${sha}"`,
   );
   assertStringIncludes(html, 'aria-label="Commit CI Gantt fetch progress"');
-  assertStringIncludes(html, "/ci-gantt.png?");
+  assertStringIncludes(html, "/ci-gantt.svg?");
   assertStringIncludes(html, "/ci-gantt-progress?");
   assertStringIncludes(
     html,
@@ -326,7 +351,7 @@ Deno.test("the commit Gantt page contains only one commit selection", () => {
     empty,
     "No successful main CI runs were supplied for this commit.",
   );
-  assert(!empty.includes("/ci-gantt.png?"));
+  assert(!empty.includes("/ci-gantt.svg?"));
 });
 
 Deno.test("commit Gantt data routes start the exact selected collection", async () => {
@@ -341,10 +366,10 @@ Deno.test("commit Gantt data routes start the exact selected collection", async 
   }&limit=1&mainOnly=1&run=9007199254740991:1`;
   try {
     const imageRoute = labsCiDuration.routes?.find((route) =>
-      route.path === "/ci-gantt.png"
+      route.path === "/ci-gantt.svg"
     );
     assert(imageRoute);
-    const imageUrl = new URL(`http://d/ci-gantt.png?${selection}`);
+    const imageUrl = new URL(`http://d/ci-gantt.svg?${selection}`);
     const image = await imageRoute.handler(new Request(imageUrl), imageUrl);
     assertEquals(image.status, 500);
     assertEquals(await image.text(), "set GH_TOKEN");
@@ -397,26 +422,26 @@ Deno.test("CI duration tiles link to their repository histories", async () => {
   );
 });
 
-Deno.test("/bench/gantt.png: a successful render returns the PNG bytes uncached", async () => {
+Deno.test("/bench/gantt.svg: a successful render returns SVG uncached", async () => {
   const { res, args, input, leftover, requested } = await gantt("?limit=30");
   assertEquals(res.status, 200);
-  assertEquals(res.headers.get("content-type"), "image/png");
+  assertEquals(res.headers.get("content-type"), "image/svg+xml");
   assertEquals(res.headers.get("cache-control"), "no-store");
-  assertEquals(new Uint8Array(await res.arrayBuffer()), PNG);
+  assertEquals(new Uint8Array(await res.arrayBuffer()), SVG);
   assertEquals(opt(args, "--repo"), REPO);
   assertEquals(opt(args, "--workflow"), CI_WORKFLOW);
   assertEquals(opt(args, "--limit"), "30");
-  assertEquals(opt(args, "--out"), "/fake-tmp/ci-gantt-1.png"); // the bytes come from where it was told to write
+  assertEquals(opt(args, "--out"), "/fake-tmp/ci-gantt-1.svg"); // the bytes come from where it was told to write
   assertEquals(opt(args, "--input"), "/fake-tmp/ci-gantt-input-2.json");
   assert(!args.includes("--allow-net"));
   assert(!args.includes("--allow-env"));
-  assert(args.includes("--allow-read"));
+  assert(args.includes("--allow-read=/fake-tmp/ci-gantt-input-2.json"));
+  assert(!args.includes("--allow-read"));
   assert(!args.includes("--allow-write"));
-  assert(args.includes("--allow-ffi"));
-  assert(args.includes("--allow-sys=cpus,networkInterfaces,hostname"));
-  assert(!args.includes("--allow-read=/fake-tmp/ci-gantt-input-2.json"));
-  assert(args.includes("--allow-write=/fake-tmp/ci-gantt-1.png"));
-  assertEquals(opt(args, "--scale"), "2");
+  assert(!args.includes("--allow-ffi"));
+  assert(!args.includes("--allow-sys=cpus,networkInterfaces,hostname"));
+  assert(args.includes("--allow-write=/fake-tmp/ci-gantt-1.svg"));
+  assertEquals(opt(args, "--scale"), undefined);
   assertEquals(input.runs.length, 30);
   assertEquals(requested.source.key, "labs");
   assertEquals(requested.options, {
@@ -427,10 +452,52 @@ Deno.test("/bench/gantt.png: a successful render returns the PNG bytes uncached"
   assertEquals(leftover, []); // the temp file is cleaned up on the way out
 });
 
-Deno.test("/bench/gantt.png finishes collection but skips an abandoned render", async () => {
+Deno.test("/bench/gantt.svg includes chart labels without server fonts", async () => {
+  const response = await renderGantt(
+    new URLSearchParams("limit=1&mainOnly=1"),
+    () =>
+      Promise.resolve({
+        runs: [{
+          run: {
+            attempt: 1,
+            databaseId: 123,
+            status: "completed",
+            conclusion: "success",
+            event: "push",
+            headBranch: "main",
+            startedAt: "2026-07-28T18:00:00Z",
+            workflowName: CI_WORKFLOW,
+          },
+          jobs: [{
+            name: "Check dashboard labels",
+            status: "completed",
+            conclusion: "success",
+            started_at: "2026-07-28T18:00:05Z",
+            completed_at: "2026-07-28T18:01:05Z",
+            steps: [{
+              name: "🔎 Check",
+              number: 1,
+              conclusion: "success",
+              started_at: "2026-07-28T18:00:10Z",
+              completed_at: "2026-07-28T18:01:00Z",
+            }],
+          }],
+        }],
+      }),
+  );
+
+  assertEquals(response.status, 200);
+  assertEquals(response.headers.get("content-type"), "image/svg+xml");
+  const svg = await response.text();
+  assertStringIncludes(svg, "<svg");
+  assertStringIncludes(svg, ">Check dashboard labels</text>");
+  assertStringIncludes(svg, ">runs</text>");
+});
+
+Deno.test("/bench/gantt.svg finishes collection but skips an abandoned render", async () => {
   const controller = new AbortController();
   controller.abort();
-  const request = new Request("http://d/bench/gantt.png?limit=12", {
+  const request = new Request("http://d/bench/gantt.svg?limit=12", {
     signal: controller.signal,
   });
   const url = new URL(request.url);
@@ -452,7 +519,7 @@ Deno.test("/bench/gantt.png finishes collection but skips an abandoned render", 
   }
 });
 
-Deno.test("/bench/gantt.png stops rasterizing when its request is abandoned", async () => {
+Deno.test("/bench/gantt.svg stops rendering when its request is abandoned", async () => {
   const controller = new AbortController();
   const result = await gantt(
     "?limit=12",
@@ -465,7 +532,7 @@ Deno.test("/bench/gantt.png stops rasterizing when its request is abandoned", as
   assertEquals(result.leftover, []);
 });
 
-Deno.test("/bench/gantt.png drops an image completed after abandonment", async () => {
+Deno.test("/bench/gantt.svg drops an image completed after abandonment", async () => {
   const controller = new AbortController();
   const result = await gantt(
     "?limit=12",
@@ -477,7 +544,7 @@ Deno.test("/bench/gantt.png drops an image completed after abandonment", async (
   assertEquals(result.leftover, []);
 });
 
-Deno.test("/bench/gantt.png selects loom for both cached data and rendering", async () => {
+Deno.test("/bench/gantt.svg selects loom for both cached data and rendering", async () => {
   const { args, requested, input } = await gantt(
     "?repo=loom&limit=12&mainOnly=1",
   );
@@ -516,14 +583,14 @@ Deno.test("a commit Gantt image requests the selected run attempts", async () =>
   assertEquals(opt(selected.args, "--min-runs"), "1");
 });
 
-Deno.test("/bench/gantt.png: limit is clamped to the slider's range, junk falls back to 60", async () => {
+Deno.test("/bench/gantt.svg: limit is clamped to the slider's range, junk falls back to 60", async () => {
   assertEquals(opt((await gantt("?limit=500")).args, "--limit"), "150");
   assertEquals(opt((await gantt("?limit=0")).args, "--limit"), "1");
   assertEquals(opt((await gantt("?limit=abc")).args, "--limit"), "60");
   assertEquals(opt((await gantt("")).args, "--limit"), "60");
 });
 
-Deno.test("/bench/gantt.png: the checkboxes are off unless set to 1", async () => {
+Deno.test("/bench/gantt.svg: the checkboxes are off unless set to 1", async () => {
   const offResult = await gantt("?mainOnly=0&allConclusions=yes");
   const off = offResult.args;
   assert(!off.includes("--main-only"), "mainOnly=0 is not main-only");
@@ -537,7 +604,7 @@ Deno.test("/bench/gantt.png: the checkboxes are off unless set to 1", async () =
   assertEquals(onResult.requested.options.allConclusions, true);
 });
 
-Deno.test("/bench/gantt.png: automatic min-runs fits every window", async () => {
+Deno.test("/bench/gantt.svg: automatic min-runs fits every window", async () => {
   // A main-only window can be thin. The floor is capped at the run count so even a
   // one-run window still draws instead of having every job dropped.
   assertEquals(opt((await gantt("?mainOnly=1")).args, "--min-runs"), "2");
@@ -549,14 +616,14 @@ Deno.test("/bench/gantt.png: automatic min-runs fits every window", async () => 
   assertEquals(opt((await gantt("?limit=4")).args, "--min-runs"), "4");
 });
 
-Deno.test("/bench/gantt.png ignores the removed minRuns parameter", async () => {
+Deno.test("/bench/gantt.svg ignores the removed minRuns parameter", async () => {
   assertEquals(
     opt((await gantt("?mainOnly=1&minRuns=9")).args, "--min-runs"),
     "2",
   );
 });
 
-Deno.test("/bench/gantt.png: a failing ci-gantt is a 500, with its stderr in the server log only", async () => {
+Deno.test("/bench/gantt.svg: a failing ci-gantt is a 500, with its stderr in the server log only", async () => {
   const { res, logged, leftover } = await gantt("?limit=5", {
     success: false,
     stderr: "no runs matched --min-runs",
@@ -567,7 +634,7 @@ Deno.test("/bench/gantt.png: a failing ci-gantt is a 500, with its stderr in the
   assertEquals(leftover, []);
 });
 
-Deno.test("/bench/gantt.png: a spawn that throws is a 500, not an unhandled rejection", async () => {
+Deno.test("/bench/gantt.svg: a spawn that throws is a 500, not an unhandled rejection", async () => {
   const { res, logged, leftover } = await gantt("", {
     throws: new Error("deno: command not found"),
   });
@@ -578,7 +645,7 @@ Deno.test("/bench/gantt.png: a spawn that throws is a 500, not an unhandled reje
   assertEquals(leftover, []); // the temp file is removed even on the error path
 });
 
-Deno.test("/bench/gantt.png reports the performance-history boundary as a rate limit hit", async () => {
+Deno.test("/bench/gantt.svg reports the performance-history boundary as a rate limit hit", async () => {
   const originalError = console.error;
   console.error = () => {};
   try {
@@ -599,7 +666,7 @@ Deno.test("/bench/gantt.png reports the performance-history boundary as a rate l
   }
 });
 
-Deno.test("/bench/gantt.png returns a safe collection error to the page", async () => {
+Deno.test("/bench/gantt.svg returns a safe collection error to the page", async () => {
   const originalError = console.error;
   console.error = () => {};
   try {

--- a/packages/dashboard/tiles/ci-duration.ts
+++ b/packages/dashboard/tiles/ci-duration.ts
@@ -68,7 +68,7 @@ export async function renderGantt(
         headers: { "cache-control": "no-store" },
       });
     }
-    out = await Deno.makeTempFile({ prefix: "ci-gantt-", suffix: ".png" });
+    out = await Deno.makeTempFile({ prefix: "ci-gantt-", suffix: ".svg" });
     input = await Deno.makeTempFile({
       prefix: "ci-gantt-input-",
       suffix: ".json",
@@ -76,10 +76,8 @@ export async function renderGantt(
     await Deno.writeTextFile(input, JSON.stringify(data));
     const args = [
       "run",
-      "--allow-read",
+      `--allow-read=${input}`,
       `--allow-write=${out}`,
-      "--allow-ffi",
-      "--allow-sys=cpus,networkInterfaces,hostname",
       CIGANTT,
       "--input",
       input,
@@ -89,8 +87,6 @@ export async function renderGantt(
       source.workflow,
       "--limit",
       String(limit),
-      "--scale",
-      "2",
       "--theme",
       "dark",
       "--out",
@@ -110,7 +106,7 @@ export async function renderGantt(
       "--min-runs",
       String(Math.min(defaultMinimum, Math.max(1, data.runs.length))),
     );
-    const { success, stderr } = await new Deno.Command("deno", {
+    const { success, stderr } = await new Deno.Command(Deno.execPath(), {
       args,
       stdout: "piped",
       stderr: "piped",
@@ -128,7 +124,7 @@ export async function renderGantt(
     }
     return new Response(await Deno.readFile(out), {
       headers: {
-        "content-type": "image/png",
+        "content-type": "image/svg+xml",
         "cache-control": "no-store",
       },
     });
@@ -227,7 +223,7 @@ export function ciGanttPage(url: URL): string {
   function imageUrl(){
     const p = parameters();
     p.set('t', Date.now());
-    return '/bench/gantt.png?' + p.toString();
+    return '/bench/gantt.svg?' + p.toString();
   }
   function progressUrl(){
     return '/bench/gantt-progress?' + parameters().toString();
@@ -434,7 +430,7 @@ export function ciCommitGanttPage(url: URL): string {
   const shortSha = sha.slice(0, 7) || "unknown commit";
   const runCount = parameters?.getAll("run").length ?? 0;
   const commitUrl = `https://github.com/${source.repo}/commit/${sha}`;
-  const imageUrl = parameters ? `/ci-gantt.png?${parameters}` : "";
+  const imageUrl = parameters ? `/ci-gantt.svg?${parameters}` : "";
   const progressUrl = parameters ? `/ci-gantt-progress?${parameters}` : "";
   const chart = parameters
     ? `<div class="imgwrap"><img id="g" alt="CI Gantt for ${
@@ -578,6 +574,13 @@ function commitGanttUrl(url: URL): URL | null {
   return normalized;
 }
 
+function redirectGanttImage(url: URL, pathname: string): Response {
+  return new Response(null, {
+    status: 308,
+    headers: { location: `${pathname}${url.search}` },
+  });
+}
+
 const ganttRoutes: Route[] = [
   {
     path: "/ci-gantt",
@@ -588,7 +591,7 @@ const ganttRoutes: Route[] = [
     },
   },
   {
-    path: "/ci-gantt.png",
+    path: "/ci-gantt.svg",
     handler(request, url) {
       const normalized = commitGanttUrl(url);
       return normalized
@@ -602,6 +605,12 @@ const ganttRoutes: Route[] = [
     },
   },
   {
+    path: "/ci-gantt.png",
+    handler(_request, url) {
+      return redirectGanttImage(url, "/ci-gantt.svg");
+    },
+  },
+  {
     path: "/ci-gantt-progress",
     handler(request, url) {
       const normalized = commitGanttUrl(url);
@@ -611,8 +620,14 @@ const ganttRoutes: Route[] = [
     },
   },
   {
-    path: "/bench/gantt.png",
+    path: "/bench/gantt.svg",
     handler: renderGanttRoute,
+  },
+  {
+    path: "/bench/gantt.png",
+    handler(_request, url) {
+      return redirectGanttImage(url, "/bench/gantt.svg");
+    },
   },
   {
     path: "/bench/gantt-progress",


### PR DESCRIPTION
The dashboard rasterized each generated Gantt SVG inside its minimal container. The container has no usable system fonts, so the rasterizer drew the bars and grid while omitting every title, axis label, job name, and duration.

Serve the renderer's existing SVG output directly and let the browser supply fonts. Use explicit SVG routes and keep the former PNG routes as permanent origin-relative redirects. Relative locations preserve the public HTTPS scheme and authority when TLS terminates at a sidecar.

Remove the native rasterizer permissions and image-build check that the dashboard path no longer needs. Invoke the same Deno executable as the server and restrict the child process to its input file. Add a real renderer regression test that checks chart labels in the served SVG, alongside route, response, permission, and compatibility coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the CI Gantt chart as SVG instead of rasterizing to PNG so labels render correctly in the browser. Legacy PNG endpoints now permanently redirect to SVG.

- **Bug Fixes**
  - Serve `/bench/gantt.svg` and `/ci-gantt.svg` with `image/svg+xml`, restoring titles, axes, job names, and durations.
  - Keep `/bench/gantt.png` and `/ci-gantt.png` as 308 origin-relative redirects to their `.svg` counterparts.

- **Refactors**
  - Remove native rasterizer and image-build check; invoke the server’s `Deno.execPath()` and restrict the child process to `--allow-read=<input>` and `--allow-write=<out>`.
  - Add a renderer regression test that asserts label text in the served SVG and update route/abort/compat coverage.

<sup>Written for commit 9428355ba048a0f66d82af8b8d60dbafeddade27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

