### PR TITLE
fix: un-brick stored patterns against toolchain drift — TS2578 non-fatal + hot-swap survives unreadable argument slots (CT-1916, CT-1917)

### DIFF
--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -52,22 +52,35 @@ const TESTS: TestDef[] = [
     expectedError: "Cannot find module './foo.ts'",
   },
   {
-    // Stored sources are recompiled by every future toolchain against
-    // PLATFORM-supplied types; a directive that becomes unnecessary when
-    // those types improve must not brick the source (CT-1916 — 2026-07-28
-    // estuary, loom-mobile patterns vs. a jsx.d.ts that gained a prop).
-    name: "Unused @ts-expect-error compiles (durable-source drift)",
+    // Authoring surfaces stay strict: with the author present, the right fix
+    // for a stale directive is removing it.
+    name: "Throws: unused @ts-expect-error is fatal when authoring",
     source: [
       "const add = (x: number, y: number): number => x + y;",
       "// @ts-expect-error -- suppressed an error under an older type env",
       "export default add(1, 2);",
       "",
     ].join("\n"),
+    expectedError: "Unused '@ts-expect-error' directive.",
   },
   {
-    // The suppression is code-2578-narrow: a directive that still covers a
-    // REAL error keeps suppressing it, and errors outside any directive
-    // still fail (covered by "Throws: type check failure" above).
+    // Stored sources are recompiled by every future toolchain against
+    // PLATFORM-supplied types; a directive that becomes unnecessary when
+    // those types improve must not brick the reload (CT-1916 — 2026-07-28
+    // estuary, loom-mobile patterns vs. a jsx.d.ts that gained a prop).
+    name: "Unused @ts-expect-error compiles under storedSource",
+    source: [
+      "const add = (x: number, y: number): number => x + y;",
+      "// @ts-expect-error -- suppressed an error under an older type env",
+      "export default add(1, 2);",
+      "",
+    ].join("\n"),
+    storedSource: true,
+  },
+  {
+    // The tolerance is code-2578-narrow: a directive that still covers a
+    // REAL error keeps suppressing it in either mode, and errors outside any
+    // directive still fail (covered by "Throws: type check failure" above).
     name: "@ts-expect-error still suppresses a live error",
     source: [
       "const add = (x: number, y: number): number => x + y;",
@@ -75,6 +88,15 @@ const TESTS: TestDef[] = [
       "export default add('1', 2);",
       "",
     ].join("\n"),
+  },
+  {
+    // storedSource must not weaken real type errors — only hygiene codes.
+    name: "Throws: real type error still fatal under storedSource",
+    source:
+      "function add(x:number, y:number): number {return x+y}; export default add(`0`, 2);",
+    storedSource: true,
+    expectedError:
+      "Argument of type 'string' is not assignable to parameter of type 'number'.",
   },
 ];
 
@@ -151,10 +173,10 @@ describe("TypeScriptCompiler", () => {
     ]);
   });
 
-  it("compileToModulesCollecting reports real errors, drops non-fatal codes", async () => {
-    // The corpus-collecting path applies the same non-fatal filter as the
-    // throwing path: an unused @ts-expect-error (TS2578) is dropped, a real
-    // type error in another file is still attributed and reported.
+  it("compileToModulesCollecting reports stale directives AND real errors", async () => {
+    // The corpus check is an AUTHORING surface — no stored-source tolerance:
+    // an unused @ts-expect-error is reported (for the author to remove)
+    // alongside real type errors, each attributed to its file.
     const compiler = new TypeScriptCompiler(types);
     const resolved = await compiler.resolveProgram(
       new InMemoryProgram("/main.ts", {
@@ -169,8 +191,18 @@ describe("TypeScriptCompiler", () => {
       }),
     );
     const collected = compiler.compileToModulesCollecting(resolved);
-    expect(collected.diagnostics.map((d) => d.file)).toEqual(["/bad.ts"]);
-    expect(collected.diagnostics[0].message).toContain(
+    // The emit pass re-reports per-file diagnostics, so assert the SET of
+    // attributed files rather than exact multiplicity.
+    expect([...new Set(collected.diagnostics.map((d) => d.file))].sort())
+      .toEqual([
+        "/bad.ts",
+        "/main.ts",
+      ]);
+    const byFile = Object.fromEntries(
+      collected.diagnostics.map((d) => [d.file, d.message]),
+    );
+    expect(byFile["/main.ts"]).toContain("Unused '@ts-expect-error'");
+    expect(byFile["/bad.ts"]).toContain(
       "Type 'string' is not assignable to type 'number'.",
     );
   });

--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -41,6 +41,31 @@ const TESTS: TestDef[] = [
     source: "import { foo } from './foo.ts';export default foo()",
     expectedError: "Cannot find module './foo.ts'",
   },
+  {
+    // Stored sources are recompiled by every future toolchain against
+    // PLATFORM-supplied types; a directive that becomes unnecessary when
+    // those types improve must not brick the source (CT-1916 — 2026-07-28
+    // estuary, loom-mobile patterns vs. a jsx.d.ts that gained a prop).
+    name: "Unused @ts-expect-error compiles (durable-source drift)",
+    source: [
+      "const add = (x: number, y: number): number => x + y;",
+      "// @ts-expect-error -- suppressed an error under an older type env",
+      "export default add(1, 2);",
+      "",
+    ].join("\n"),
+  },
+  {
+    // The suppression is code-2578-narrow: a directive that still covers a
+    // REAL error keeps suppressing it, and errors outside any directive
+    // still fail (covered by "Throws: type check failure" above).
+    name: "@ts-expect-error still suppresses a live error",
+    source: [
+      "const add = (x: number, y: number): number => x + y;",
+      "// @ts-expect-error -- intentionally wrong argument type",
+      "export default add('1', 2);",
+      "",
+    ].join("\n"),
+  },
 ];
 
 const staticCache = new StaticCacheFS();

--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -47,6 +47,16 @@ const TESTS: TestDef[] = [
     expectedError: "Expression expected.",
   },
   {
+    // The most permissive mode combination: storedSource turns noEmitOnError
+    // off and noCheck skips semantics — the explicit syntactic gate is the
+    // ONLY thing standing, and it must still stand.
+    name: "Throws: syntax error still fatal under storedSource + noCheck",
+    source: "export const x = ;",
+    storedSource: true,
+    noCheck: true,
+    expectedError: "Expression expected.",
+  },
+  {
     name: "Throws: Invalid import",
     source: "import { foo } from './foo.ts';export default foo()",
     expectedError: "Cannot find module './foo.ts'",

--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -32,9 +32,19 @@ const TESTS: TestDef[] = [
       "Argument of type 'string' is not assignable to parameter of type 'number'.",
   },
   {
+    // Parse errors fail at the syntactic gate, before type-checking.
     name: "Throws: Invalid source",
     source: "}x",
-    expectedError: "Cannot find name 'x'.",
+    expectedError: "Declaration or statement expected.",
+  },
+  {
+    // `noCheck` skips type-checking, never parsing. With noEmitOnError off,
+    // this explicit gate is the only thing between malformed source and a
+    // malformed emit.
+    name: "Throws: syntax error still fatal under noCheck",
+    source: "export const x = ;",
+    noCheck: true,
+    expectedError: "Expression expected.",
   },
   {
     name: "Throws: Invalid import",

--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -141,6 +141,30 @@ describe("TypeScriptCompiler", () => {
     ]);
   });
 
+  it("compileToModulesCollecting reports real errors, drops non-fatal codes", async () => {
+    // The corpus-collecting path applies the same non-fatal filter as the
+    // throwing path: an unused @ts-expect-error (TS2578) is dropped, a real
+    // type error in another file is still attributed and reported.
+    const compiler = new TypeScriptCompiler(types);
+    const resolved = await compiler.resolveProgram(
+      new InMemoryProgram("/main.ts", {
+        "/main.ts": [
+          "import { bad } from './bad.ts';",
+          "const add = (x: number, y: number): number => x + y;",
+          "// @ts-expect-error -- suppressed under an older type env",
+          "export default add(1, 2) + bad;",
+          "",
+        ].join("\n"),
+        "/bad.ts": "export const bad: number = 'not a number';\n",
+      }),
+    );
+    const collected = compiler.compileToModulesCollecting(resolved);
+    expect(collected.diagnostics.map((d) => d.file)).toEqual(["/bad.ts"]);
+    expect(collected.diagnostics[0].message).toContain(
+      "Type 'string' is not assignable to type 'number'.",
+    );
+  });
+
   it("compileToModulesInterleaved emits byte-identical output to compileToModules", async () => {
     // The interleaved driver only changes WHERE the event loop can run
     // (macrotask yields at module boundaries) — never what is emitted. Pin

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -23,6 +23,7 @@ import {
   Checker,
   type DiagnosticMessageTransformer,
   formatTransformerDiagnostic,
+  isNonFatalDiagnosticCode,
   TransformerDiagnosticInfo,
   TransformerError,
 } from "./diagnostics/mod.ts";
@@ -572,10 +573,14 @@ export class TypeScriptCompiler {
     };
 
     // Type + declaration diagnostics for authored files only (skipLibCheck
-    // already excludes the declaration libs).
+    // already excludes the declaration libs). Non-fatal codes are dropped the
+    // same way Checker drops them, so a corpus check reports exactly what
+    // would fail to load.
     for (const sourceFile of tsProgram.getSourceFiles()) {
       if (!authored.has(sourceFile.fileName)) continue;
-      for (const d of tsProgram.getSemanticDiagnostics(sourceFile)) pushTs(d);
+      for (const d of tsProgram.getSemanticDiagnostics(sourceFile)) {
+        if (!isNonFatalDiagnosticCode(d.code)) pushTs(d);
+      }
       for (const d of tsProgram.getSyntacticDiagnostics(sourceFile)) pushTs(d);
     }
 

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -23,7 +23,6 @@ import {
   Checker,
   type DiagnosticMessageTransformer,
   formatTransformerDiagnostic,
-  isNonFatalDiagnosticCode,
   TransformerDiagnosticInfo,
   TransformerError,
 } from "./diagnostics/mod.ts";
@@ -282,6 +281,18 @@ export type BeforeTransformersResult =
 export interface TypeScriptCompilerOptions {
   // Skip type checking.
   noCheck?: boolean;
+  /**
+   * The program is DURABLE STORED pattern source being reloaded — bytes
+   * nobody can re-author, recompiled by a toolchain newer than the one that
+   * accepted them. Diagnostics that only signal authoring hygiene (currently
+   * TS2578, "Unused '@ts-expect-error' directive" — a suppression obsoleted
+   * by a platform type improvement) are non-fatal in this mode, so a types
+   * bump cannot retroactively brick a stored pattern (CT-1916, 2026-07-28
+   * estuary). Authoring paths (cf check, deploy, the corpus check) leave
+   * this off and stay strict: there the author is present and can fix the
+   * directive.
+   */
+  storedSource?: boolean;
   // Optional mapping of runtime module name e.g. `"@commonfabric/framework"`,
   // and its corresponding type definitions.
   runtimeModules?: string[];
@@ -391,6 +402,7 @@ export class TypeScriptCompiler {
     inputOptions: TypeScriptCompilerOptions,
   ): Generator<void, Map<string, CompiledTypeScriptModule>, void> {
     const noCheck = inputOptions.noCheck ?? false;
+    const storedSource = inputOptions.storedSource ?? false;
     const runtimeModules = inputOptions.runtimeModules ?? [];
 
     validateSource(program);
@@ -401,6 +413,10 @@ export class TypeScriptCompiler {
     // to type-check authored code, so skip checking the declaration libs
     // themselves.
     tsOptions.skipLibCheck = true;
+    // Stored-source reloads drop authoring-hygiene codes (TS2578) at the
+    // checker; TypeScript's own emit veto would re-block exactly what was
+    // filtered, so the explicit gates below are the only gates in this mode.
+    if (storedSource) tsOptions.noEmitOnError = false;
 
     const host = new TypeScriptHost(
       program,
@@ -415,10 +431,12 @@ export class TypeScriptCompiler {
 
     const checker = new Checker(tsProgram, {
       messageTransformer: inputOptions.diagnosticMessageTransformer,
+      storedSource,
     });
     // Parse and program-level errors are fatal unconditionally — `noCheck`
-    // skips type-checking, never parsing. This gate replaced TypeScript's
-    // own `noEmitOnError` veto (see options.ts): without it, malformed
+    // skips type-checking, never parsing, and stored-source mode filters
+    // only semantic hygiene codes. On stored-source compiles this gate
+    // replaces TypeScript's own `noEmitOnError` veto: without it, malformed
     // source would EMIT malformed JavaScript.
     {
       const errors = checker.collectProgramErrors();
@@ -591,14 +609,13 @@ export class TypeScriptCompiler {
     for (const d of tsProgram.getGlobalDiagnostics()) pushTs(d);
 
     // Type + declaration diagnostics for authored files only (skipLibCheck
-    // already excludes the declaration libs). Non-fatal codes are dropped the
-    // same way Checker drops them, so a corpus check reports exactly what
-    // would fail to load.
+    // already excludes the declaration libs). The corpus check is an
+    // AUTHORING surface, so no stored-source tolerance applies here: a
+    // stale ts-expect-error directive in the repo corpus is reported for
+    // the author to remove.
     for (const sourceFile of tsProgram.getSourceFiles()) {
       if (!authored.has(sourceFile.fileName)) continue;
-      for (const d of tsProgram.getSemanticDiagnostics(sourceFile)) {
-        if (!isNonFatalDiagnosticCode(d.code)) pushTs(d);
-      }
+      for (const d of tsProgram.getSemanticDiagnostics(sourceFile)) pushTs(d);
       for (const d of tsProgram.getSyntacticDiagnostics(sourceFile)) pushTs(d);
     }
 

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -584,6 +584,12 @@ export class TypeScriptCompiler {
       }
     };
 
+    // Program-level (options + global) diagnostics first — with noEmitOnError
+    // off these no longer surface through emit, so omitting them here would
+    // return `diagnostics: []` for a program the throwing path refuses.
+    for (const d of tsProgram.getOptionsDiagnostics()) pushTs(d);
+    for (const d of tsProgram.getGlobalDiagnostics()) pushTs(d);
+
     // Type + declaration diagnostics for authored files only (skipLibCheck
     // already excludes the declaration libs). Non-fatal codes are dropped the
     // same way Checker drops them, so a corpus check reports exactly what

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -416,6 +416,18 @@ export class TypeScriptCompiler {
     const checker = new Checker(tsProgram, {
       messageTransformer: inputOptions.diagnosticMessageTransformer,
     });
+    // Parse and program-level errors are fatal unconditionally — `noCheck`
+    // skips type-checking, never parsing. This gate replaced TypeScript's
+    // own `noEmitOnError` veto (see options.ts): without it, malformed
+    // source would EMIT malformed JavaScript.
+    {
+      const errors = checker.collectProgramErrors();
+      for (const sourceFile of checker.checkableSources()) {
+        errors.push(...checker.collectSyntacticErrors(sourceFile));
+      }
+      checker.throwIfErrors(errors);
+      yield;
+    }
     if (!noCheck) {
       const errors = [];
       for (const sourceFile of checker.checkableSources()) {

--- a/packages/js-compiler/typescript/diagnostics/checker.ts
+++ b/packages/js-compiler/typescript/diagnostics/checker.ts
@@ -22,6 +22,21 @@ const KNOWN_EXPORTED_SYMBOLS = [
   "SCOPE_BRAND",
 ];
 
+// TS2578 "Unused '@ts-expect-error' directive." must not fail compilation
+// here. Pattern sources are DURABLE: the same stored bytes are recompiled by
+// every future toolchain, while the type environment they check against
+// (vendored jsx.d.ts and friends) is supplied by the PLATFORM, not the
+// author. A directive that suppressed a real error when authored becomes
+// "unused" the moment the platform's types improve — treating that as fatal
+// retroactively bricks every stored pattern that carried it (2026-07-28
+// estuary: loom-mobile patterns embedding a `cf-cell-link label` directive
+// hard-failed to load after the vendored JSX types gained `label`, CT-1916).
+const UNUSED_TS_EXPECT_ERROR = 2578;
+
+/** Diagnostic codes {@link Checker} refuses to treat as fatal. */
+export const isNonFatalDiagnosticCode = (code: number): boolean =>
+  code === UNUSED_TS_EXPECT_ERROR;
+
 export class Checker {
   private program: Program;
   private messageTransformer?: DiagnosticMessageTransformer;
@@ -59,9 +74,11 @@ export class Checker {
 
   /** Per-file semantic diagnostics, as the error details typeCheck throws. */
   collectSemanticErrors(sourceFile: SourceFile): ErrorDetails[] {
-    return this.program.getSemanticDiagnostics(sourceFile).map(
-      (diagnostic) => ({ diagnostic, source: sourceFile.text }),
-    );
+    return this.program.getSemanticDiagnostics(sourceFile)
+      .filter((diagnostic) => !isNonFatalDiagnosticCode(diagnostic.code))
+      .map(
+        (diagnostic) => ({ diagnostic, source: sourceFile.text }),
+      );
   }
 
   /**
@@ -95,11 +112,16 @@ export class Checker {
   }
 
   check(diagnostics: readonly Diagnostic[] | undefined) {
-    if (!diagnostics || diagnostics.length === 0) {
+    // The emit path re-reports some semantic codes (TS surfaces 2578 through
+    // per-file emit diagnostics), so the non-fatal filter applies here too.
+    const fatal = (diagnostics ?? []).filter(
+      (diagnostic) => !isNonFatalDiagnosticCode(diagnostic.code),
+    );
+    if (fatal.length === 0) {
       return;
     }
     throw new CompilerError(
-      diagnostics.map((diagnostic) => ({ diagnostic })),
+      fatal.map((diagnostic) => ({ diagnostic })),
       this.messageTransformer,
     );
   }

--- a/packages/js-compiler/typescript/diagnostics/checker.ts
+++ b/packages/js-compiler/typescript/diagnostics/checker.ts
@@ -82,6 +82,27 @@ export class Checker {
   }
 
   /**
+   * Per-file syntactic diagnostics. With `noEmitOnError` off, TypeScript's
+   * emit no longer refuses malformed source on its own — this collection is
+   * what keeps a parse error fatal, on every path INCLUDING `noCheck` (which
+   * skips type-checking, never parsing). No non-fatal filter: the suppressed
+   * codes are semantic; a file that does not parse can never be loaded.
+   */
+  collectSyntacticErrors(sourceFile: SourceFile): ErrorDetails[] {
+    return this.program.getSyntacticDiagnostics(sourceFile).map(
+      (diagnostic) => ({ diagnostic, source: sourceFile.text }),
+    );
+  }
+
+  /** Program-level (options + global) diagnostics, same fatality contract. */
+  collectProgramErrors(): ErrorDetails[] {
+    return [
+      ...this.program.getOptionsDiagnostics(),
+      ...this.program.getGlobalDiagnostics(),
+    ].map((diagnostic) => ({ diagnostic }));
+  }
+
+  /**
    * Per-file declaration diagnostics, filtered exactly as declarationCheck
    * filters them (known exported-symbol false positives skipped).
    */

--- a/packages/js-compiler/typescript/diagnostics/checker.ts
+++ b/packages/js-compiler/typescript/diagnostics/checker.ts
@@ -7,6 +7,12 @@ import {
 
 export interface CheckerOptions {
   messageTransformer?: DiagnosticMessageTransformer;
+  /**
+   * Compiling durable STORED pattern source (see
+   * `TypeScriptCompilerOptions.storedSource`): authoring-hygiene-only codes
+   * ({@link isNonFatalDiagnosticCode}) are dropped instead of thrown.
+   */
+  storedSource?: boolean;
 }
 
 // These symbols are exported from commonfabric but TypeScript's declaration
@@ -22,28 +28,33 @@ const KNOWN_EXPORTED_SYMBOLS = [
   "SCOPE_BRAND",
 ];
 
-// TS2578 "Unused '@ts-expect-error' directive." must not fail compilation
-// here. Pattern sources are DURABLE: the same stored bytes are recompiled by
-// every future toolchain, while the type environment they check against
-// (vendored jsx.d.ts and friends) is supplied by the PLATFORM, not the
-// author. A directive that suppressed a real error when authored becomes
-// "unused" the moment the platform's types improve — treating that as fatal
-// retroactively bricks every stored pattern that carried it (2026-07-28
-// estuary: loom-mobile patterns embedding a `cf-cell-link label` directive
-// hard-failed to load after the vendored JSX types gained `label`, CT-1916).
+// TS2578 "Unused '@ts-expect-error' directive." must not fail STORED-source
+// recompiles. Pattern sources are DURABLE: the same stored bytes are
+// recompiled by every future toolchain, while the type environment they
+// check against (vendored jsx.d.ts and friends) is supplied by the PLATFORM,
+// not the author. A directive that suppressed a real error when authored
+// becomes "unused" the moment the platform's types improve — treating that
+// as fatal retroactively bricks every stored pattern that carried it
+// (2026-07-28 estuary: loom-mobile patterns embedding a `cf-cell-link label`
+// directive hard-failed to load after the vendored JSX types gained `label`,
+// CT-1916). Authoring paths stay strict — there the author is present and
+// removing the stale directive is the right fix.
 const UNUSED_TS_EXPECT_ERROR = 2578;
 
-/** Diagnostic codes {@link Checker} refuses to treat as fatal. */
+/** Diagnostic codes dropped when compiling stored source (see
+ * `CheckerOptions.storedSource`). */
 export const isNonFatalDiagnosticCode = (code: number): boolean =>
   code === UNUSED_TS_EXPECT_ERROR;
 
 export class Checker {
   private program: Program;
   private messageTransformer?: DiagnosticMessageTransformer;
+  private storedSource: boolean;
 
   constructor(program: Program, options: CheckerOptions = {}) {
     this.program = program;
     this.messageTransformer = options.messageTransformer;
+    this.storedSource = options.storedSource === true;
   }
 
   typeCheck() {
@@ -75,7 +86,9 @@ export class Checker {
   /** Per-file semantic diagnostics, as the error details typeCheck throws. */
   collectSemanticErrors(sourceFile: SourceFile): ErrorDetails[] {
     return this.program.getSemanticDiagnostics(sourceFile)
-      .filter((diagnostic) => !isNonFatalDiagnosticCode(diagnostic.code))
+      .filter((diagnostic) =>
+        !this.storedSource || !isNonFatalDiagnosticCode(diagnostic.code)
+      )
       .map(
         (diagnostic) => ({ diagnostic, source: sourceFile.text }),
       );
@@ -134,9 +147,11 @@ export class Checker {
 
   check(diagnostics: readonly Diagnostic[] | undefined) {
     // The emit path re-reports some semantic codes (TS surfaces 2578 through
-    // per-file emit diagnostics), so the non-fatal filter applies here too.
+    // per-file emit diagnostics), so the stored-source filter applies here
+    // too.
     const fatal = (diagnostics ?? []).filter(
-      (diagnostic) => !isNonFatalDiagnosticCode(diagnostic.code),
+      (diagnostic) =>
+        !this.storedSource || !isNonFatalDiagnosticCode(diagnostic.code),
     );
     if (fatal.length === 0) {
       return;

--- a/packages/js-compiler/typescript/diagnostics/mod.ts
+++ b/packages/js-compiler/typescript/diagnostics/mod.ts
@@ -1,4 +1,4 @@
-export { Checker } from "./checker.ts";
+export { Checker, isNonFatalDiagnosticCode } from "./checker.ts";
 export {
   CompilationError,
   type CompilationErrorType,

--- a/packages/js-compiler/typescript/options.ts
+++ b/packages/js-compiler/typescript/options.ts
@@ -28,13 +28,13 @@ export const getCompilerOptions = (): CompilerOptions => {
      */
 
     removeComments: true,
-    // Fatality is decided by the pipeline's explicit checks (Checker filters
-    // non-fatal codes like TS2578, then throws on what remains — see
-    // isNonFatalDiagnosticCode). TypeScript's own emit veto is a redundant
-    // second gate that disagrees exactly when a code was deliberately
-    // filtered: with it on, an unused '@ts-expect-error' in a stored pattern
-    // source still blocked emit after the checker accepted the file (CT-1916).
-    noEmitOnError: false,
+    // Belt-and-suspenders on authoring paths; the pipeline's explicit checks
+    // (syntactic + program + semantic gates) throw first. Stored-source
+    // compiles override this to false (see compileToModulesSteps): there the
+    // checker deliberately drops authoring-hygiene codes like TS2578, and
+    // TypeScript's own emit veto would re-block exactly what was filtered
+    // (CT-1916).
+    noEmitOnError: true,
     // Note: declaration emit is disabled because TypeScript's declaration emit
     // has trouble with unique symbols (CELL_BRAND, CELL_INNER_TYPE) in exported
     // types, causing emit to skip entirely. Declaration checking is done

--- a/packages/js-compiler/typescript/options.ts
+++ b/packages/js-compiler/typescript/options.ts
@@ -28,7 +28,13 @@ export const getCompilerOptions = (): CompilerOptions => {
      */
 
     removeComments: true,
-    noEmitOnError: true,
+    // Fatality is decided by the pipeline's explicit checks (Checker filters
+    // non-fatal codes like TS2578, then throws on what remains — see
+    // isNonFatalDiagnosticCode). TypeScript's own emit veto is a redundant
+    // second gate that disagrees exactly when a code was deliberately
+    // filtered: with it on, an unused '@ts-expect-error' in a stored pattern
+    // source still blocked emit after the checker accepted the file (CT-1916).
+    noEmitOnError: false,
     // Note: declaration emit is disabled because TypeScript's declaration emit
     // has trouble with unique symbols (CELL_BRAND, CELL_INNER_TYPE) in exported
     // types, causing emit to skip entirely. Declaration checking is done

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -821,6 +821,10 @@ export class Engine extends EventTarget implements Harness {
     const emitted = compiler.compileToModules(resolvedForCompile, {
       runtimeModules: Engine.runtimeModuleNames(),
       specifierAliases,
+      // These bytes are durable stored source nobody can re-author;
+      // authoring-hygiene diagnostics (a now-unused @ts-expect-error) must
+      // not brick the reload (CT-1916).
+      storedSource: true,
       beforeTransformers: (program) => {
         const pipeline = new (compilerStack()
           .CommonFabricTransformerPipeline)({

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -689,6 +689,68 @@ type RunnerRunOptions = {
   awaitSyncBeforeInitialRun?: boolean;
 };
 
+// Placeholder standing in for an argument slot whose stored raw value is a
+// link that cannot be dereferenced in the current transaction (target doc
+// absent or not yet synced). Validation accepts it anywhere: the slot HAS a
+// value — we just cannot read it right now — so its schema check is deferred
+// to instantiation-time reactive reads, exactly like the running pattern's
+// own reads of the same slot. See applySetupState's pattern-change branch.
+const UNRESOLVED_LINK_PLACEHOLDER = Object.freeze({
+  "unresolved cell link": true,
+});
+
+const acceptsOpaqueCellOrUnresolvedLink = (
+  value: unknown,
+  schema: JSONSchema,
+): boolean =>
+  value === UNRESOLVED_LINK_PLACEHOLDER ||
+  schemaAcceptsOpaqueCellValue(value, schema);
+
+/**
+ * Rebuild `materialized` so every slot whose counterpart in `raw` is a link
+ * that materialized to nothing carries {@link UNRESOLVED_LINK_PLACEHOLDER}
+ * instead of being absent/undefined. Slots that DID materialize keep their
+ * materialized value (and full strict validation); everything else is
+ * returned unchanged.
+ */
+function overlayUnresolvedLinkPlaceholders(
+  materialized: unknown,
+  raw: unknown,
+): unknown {
+  if (isCellLink(raw)) {
+    return materialized === undefined
+      ? UNRESOLVED_LINK_PLACEHOLDER
+      : materialized;
+  }
+  if (Array.isArray(raw)) {
+    if (!Array.isArray(materialized)) return materialized;
+    let result: unknown[] | undefined;
+    for (let i = 0; i < raw.length; i++) {
+      const child = overlayUnresolvedLinkPlaceholders(materialized[i], raw[i]);
+      if (child !== materialized[i]) {
+        result ??= materialized.slice();
+        result[i] = child;
+      }
+    }
+    return result ?? materialized;
+  }
+  if (isRecord(raw) && isRecord(materialized)) {
+    let result: Record<string, unknown> | undefined;
+    for (const [key, rawChild] of Object.entries(raw)) {
+      const child = overlayUnresolvedLinkPlaceholders(
+        (materialized as Record<string, unknown>)[key],
+        rawChild,
+      );
+      if (child !== (materialized as Record<string, unknown>)[key]) {
+        result ??= { ...(materialized as Record<string, unknown>) };
+        result[key] = child;
+      }
+    }
+    return result ?? materialized;
+  }
+  return materialized;
+}
+
 function dedupeNormalizedLinks(
   links: readonly NormalizedFullLink[],
 ): NormalizedFullLink[] {
@@ -971,16 +1033,28 @@ export class Runner {
   }
 
   /** Stage an argument write, materialize aliases in the same transaction, and
-   * reject the transaction unless the resulting value satisfies its schema. */
+   * reject the transaction unless the resulting value satisfies its schema.
+   * `unresolvedLinkRaw` (the staged pre-materialization value) makes slots
+   * whose raw value is a link that cannot currently be dereferenced validate
+   * as opaque instead of as their unreadable materialization — pass it only
+   * when re-staging a STORED argument (pattern hot-swap), never for a
+   * caller-supplied value. */
   private updateAndValidateArgument<T>(
     tx: IExtendedStorageTransaction,
     argumentLink: NormalizedFullLink,
     argument: T,
     argumentSchema: JSONSchema,
     defaults: FabricValue,
+    options: { unresolvedLinkRaw?: unknown } = {},
   ): void {
     this.updateArgument(tx, argumentLink, argument, argumentSchema);
-    this.validateArgument(tx, argumentLink, argumentSchema, defaults);
+    this.validateArgument(
+      tx,
+      argumentLink,
+      argumentSchema,
+      defaults,
+      options,
+    );
   }
 
   private validateArgument(
@@ -988,6 +1062,7 @@ export class Runner {
     argumentLink: NormalizedFullLink,
     argumentSchema: JSONSchema,
     defaults: FabricValue,
+    options: { unresolvedLinkRaw?: unknown } = {},
   ): void {
     const argumentCell = this.runtime.getCellFromLink(
       argumentLink,
@@ -996,17 +1071,23 @@ export class Runner {
     );
     const materializedArgument = argumentCell.asSchema(undefined).withTx(tx)
       .get();
-    const validationArgument = mergeSchemaDefaults(
+    let validationArgument: unknown = mergeSchemaDefaults(
       materializedArgument,
       defaults,
       argumentSchema,
       { mergeMaterializedLinks: true },
     );
+    if (options.unresolvedLinkRaw !== undefined) {
+      validationArgument = overlayUnresolvedLinkPlaceholders(
+        validationArgument,
+        options.unresolvedLinkRaw,
+      );
+    }
     const validationFailure = validateSchemaValue(
       argumentSchema,
       validationArgument,
       argumentSchema,
-      { acceptOpaqueValue: schemaAcceptsOpaqueCellValue },
+      { acceptOpaqueValue: acceptsOpaqueCellOrUnresolvedLink },
     );
     if (validationFailure !== undefined) {
       throw new Error(
@@ -1261,11 +1342,6 @@ export class Runner {
       const previousArgument = previousArgumentCell.getRaw({
         meta: ignoreReadForScheduling,
       }) as T | undefined;
-      nextArgument = mergeSchemaDefaults<T>(
-        argument === undefined ? previousArgument : argument,
-        defaults as Partial<T>,
-        pattern.argumentSchema,
-      );
 
       const nextArgumentCell = previousArgumentCell.asSchema(
         pattern.argumentSchema,
@@ -1278,27 +1354,53 @@ export class Runner {
       resultCell.withTx(tx).setMetaRaw("argument", nextArgumentSigilLink);
       argumentLink = nextArgumentCell.getAsNormalizedFullLink();
 
-      // Stage the exact Fabric-layer representation before validating it. The
-      // untyped materialization below resolves ordinary sigil links through
-      // this same transaction without dropping fields that fail the candidate
-      // schema. A thrown validation error aborts the transaction, so neither
-      // this write nor the schema retarget can become durable on failure.
-      if (nextArgument !== undefined) {
-        this.updateAndValidateArgument(
-          tx,
-          argumentLink,
-          nextArgument,
-          pattern.argumentSchema,
-          defaults,
-        );
-        argumentUpdated = true;
+      if (argument === undefined && previousArgument === undefined) {
+        // Pattern change over an argument doc that reads nothing right now.
+        // This is the normal client state whenever the argument links into a
+        // piece that is down or a doc that has not synced — a nested piece's
+        // argument lives in its HOST's doc (CT-1917: BacklinksIndex's
+        // `pieceRegistry` argument under a host whose own pattern failed to
+        // load). There is no supplied value to stage, and validating — or
+        // writing defaults over — a doc we cannot read would either kill the
+        // swap or clobber whatever the doc really holds. Keep the stored
+        // bytes; instantiation reads the argument reactively once it loads.
+        nextArgument = undefined;
       } else {
-        this.validateArgument(
-          tx,
-          argumentLink,
+        nextArgument = mergeSchemaDefaults<T>(
+          argument === undefined ? previousArgument : argument,
+          defaults as Partial<T>,
           pattern.argumentSchema,
-          defaults,
         );
+
+        // Stage the exact Fabric-layer representation before validating it.
+        // The untyped materialization below resolves ordinary sigil links
+        // through this same transaction without dropping fields that fail the
+        // candidate schema. A thrown validation error aborts the transaction,
+        // so neither this write nor the schema retarget can become durable on
+        // failure. When no argument was supplied (a pattern hot-swap re-using
+        // the stored value), a slot holding a link whose target cannot be
+        // read RIGHT NOW must not fail validation — the staged raw is passed
+        // so such slots validate as opaque instead of as their (unreadable)
+        // materialization. A supplied argument keeps strict validation:
+        // callers stage exactly the value they were given.
+        if (nextArgument !== undefined) {
+          this.updateAndValidateArgument(
+            tx,
+            argumentLink,
+            nextArgument,
+            pattern.argumentSchema,
+            defaults,
+            argument === undefined ? { unresolvedLinkRaw: nextArgument } : {},
+          );
+          argumentUpdated = true;
+        } else {
+          this.validateArgument(
+            tx,
+            argumentLink,
+            pattern.argumentSchema,
+            defaults,
+          );
+        }
       }
     }
     if (nextArgument !== undefined && !argumentUpdated) {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1382,25 +1382,18 @@ export class Runner {
         // read RIGHT NOW must not fail validation — the staged raw is passed
         // so such slots validate as opaque instead of as their (unreadable)
         // materialization. A supplied argument keeps strict validation:
-        // callers stage exactly the value they were given.
-        if (nextArgument !== undefined) {
-          this.updateAndValidateArgument(
-            tx,
-            argumentLink,
-            nextArgument,
-            pattern.argumentSchema,
-            defaults,
-            argument === undefined ? { unresolvedLinkRaw: nextArgument } : {},
-          );
-          argumentUpdated = true;
-        } else {
-          this.validateArgument(
-            tx,
-            argumentLink,
-            pattern.argumentSchema,
-            defaults,
-          );
-        }
+        // callers stage exactly the value they were given. (At least one of
+        // `argument`/`previousArgument` is defined here — the skip branch
+        // above owns the both-undefined case — so the merge yields a value.)
+        this.updateAndValidateArgument(
+          tx,
+          argumentLink,
+          nextArgument,
+          pattern.argumentSchema,
+          defaults,
+          argument === undefined ? { unresolvedLinkRaw: nextArgument } : {},
+        );
+        argumentUpdated = true;
       }
     }
     if (nextArgument !== undefined && !argumentUpdated) {

--- a/packages/runner/test/pattern-swap-link-argument.test.ts
+++ b/packages/runner/test/pattern-swap-link-argument.test.ts
@@ -138,6 +138,18 @@ describe("pattern swap with a link-valued argument slot", () => {
     expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v2");
   });
 
+  it("swaps when a link INSIDE an array slot is cold (item-level link)", async () => {
+    // Links live at any depth: an array slot whose ITEM is a link to an
+    // absent doc must get the same deferral as a link at the slot itself.
+    const entry = rt.getCell<{ name?: string }>(
+      space,
+      "swap-link-argument-array-item-absent",
+    );
+
+    const { cell } = await startThenSwap([entry]);
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v2");
+  });
+
   it("swaps when the argument doc itself reads cold (nested-piece shape)", async () => {
     // A nested piece's argument meta links into its HOST's doc; when the host
     // is down that whole doc reads cold. Production signature: "missing

--- a/packages/runner/test/pattern-swap-link-argument.test.ts
+++ b/packages/runner/test/pattern-swap-link-argument.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// CT-1917 (2026-07-28 estuary): a hot-swap to a new pattern version re-runs
+// setup, and setup re-validates the STORED argument against the candidate
+// schema by materializing it — dereferencing every link. An argument slot
+// whose stored value is a link to a doc that is absent (or simply not loaded
+// in this session — the normal client cold state) materializes to nothing,
+// the key is dropped, and required-validation kills the swap with
+// "missing required property <slot>". The piece then stays pinned to the old
+// pattern (or, on a fresh open, never comes up) even though the stored
+// argument is exactly what the original instantiation wrote.
+//
+// Production shape: BacklinksIndex's `pieceRegistry` argument links into its
+// host default-app's registry cell; the host was down (its own pattern failed
+// to compile), the link read cold, and the official-pattern upgrade of
+// BacklinksIndex died on "missing required property pieceRegistry".
+
+const signer = await Identity.fromPassphrase("pattern-swap-link-argument");
+const space = signer.did();
+
+// V1/V2 share the argument schema — `registry` is a required array slot —
+// and differ only in a result marker so the running version is observable.
+// The lift tolerates an unreadable registry the way real index patterns do.
+const patternWithMarker = (marker: string): string =>
+  [
+    "import { lift, pattern } from 'commonfabric';",
+    "type Entry = { name?: string };",
+    "type Input = { registry: Entry[] };",
+    "const count = lift<{ registry: Entry[] | undefined }, number>(",
+    "  ({ registry }) => (registry ?? []).length,",
+    ");",
+    "export default pattern<Input, { marker: string; total: number }>(",
+    "  ({ registry }) => {",
+    `    return { marker: ${
+      JSON.stringify(marker)
+    }, total: count({ registry }) };`,
+    "  },",
+    ");",
+    "",
+  ].join("\n");
+
+const programOf = (contents: string): RuntimeProgram => ({
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents }],
+});
+
+describe("pattern swap with a link-valued argument slot", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let rt: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+  afterEach(async () => {
+    await rt?.dispose();
+    await storageManager?.close();
+  });
+
+  // Start V1 with `registry` supplied as a CELL (stored as a link), then move
+  // patternIdentity to V2 so the armed watcher performs the hot-swap.
+  const startThenSwap = async (
+    registryCell: unknown,
+  ): Promise<{
+    cell: ReturnType<Runtime["getCell"]>;
+    v2Identity: string;
+  }> => {
+    const tx = rt.edit();
+    const pm = rt.patternManager;
+    const v1 = await pm.compilePattern(programOf(patternWithMarker("v1")), {
+      space,
+      tx,
+    });
+    const v2 = await pm.compilePattern(programOf(patternWithMarker("v2")), {
+      space,
+      tx,
+    });
+    const v2Ref = pm.getArtifactEntryRef(v2)!;
+    const cell = rt.getCell<Record<string, unknown>>(
+      space,
+      "swap-link-argument-piece",
+      undefined,
+      tx,
+    );
+    const running = rt.run(tx, v1, { registry: registryCell }, cell);
+    await tx.commit();
+    await running.pull();
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v1");
+
+    const tx2 = rt.edit();
+    cell.withTx(tx2).setMetaRaw("patternIdentity", {
+      identity: v2Ref.identity,
+      symbol: v2Ref.symbol,
+    });
+    await tx2.commit();
+    await rt.idle();
+    await cell.pull();
+    return { cell, v2Identity: v2Ref.identity };
+  };
+
+  it("swaps when the linked registry doc has data (warm control)", async () => {
+    const tx = rt.edit();
+    const registry = rt.getCell<{ name?: string }[]>(
+      space,
+      "swap-link-argument-registry-warm",
+      undefined,
+      tx,
+    );
+    registry.set([{ name: "one" }]);
+    await tx.commit();
+
+    const { cell } = await startThenSwap(registry);
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v2");
+  });
+
+  it("swaps when the linked registry doc is absent (cold link)", async () => {
+    // Never written: models the client whose link target is not loaded — the
+    // production state whenever the argument links into a piece that is down.
+    const registry = rt.getCell<{ name?: string }[]>(
+      space,
+      "swap-link-argument-registry-absent",
+    );
+
+    const { cell } = await startThenSwap(registry);
+    // Bug under test: swap-setup rejects with "registry: value does not match
+    // type array" (the link-valued slot dereferenced to nothing), so the piece
+    // stays on V1. The stored argument still holds the link and is exactly
+    // what V1's own instantiation wrote — the swap must survive it.
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v2");
+  });
+
+  it("swaps when the argument doc itself reads cold (nested-piece shape)", async () => {
+    // A nested piece's argument meta links into its HOST's doc; when the host
+    // is down that whole doc reads cold. Production signature: "missing
+    // required property pieceRegistry" — validation ran against bare defaults
+    // after the argument link dereferenced to nothing.
+    const tx = rt.edit();
+    const pm = rt.patternManager;
+    const v1 = await pm.compilePattern(programOf(patternWithMarker("v1")), {
+      space,
+      tx,
+    });
+    const v2 = await pm.compilePattern(programOf(patternWithMarker("v2")), {
+      space,
+      tx,
+    });
+    const v2Ref = pm.getArtifactEntryRef(v2)!;
+    const cell = rt.getCell<Record<string, unknown>>(
+      space,
+      "swap-link-argument-piece-cold-doc",
+      undefined,
+      tx,
+    );
+    const running = rt.run(tx, v1, { registry: [{ name: "one" }] }, cell);
+    await tx.commit();
+    await running.pull();
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v1");
+
+    // Retarget the argument meta at a doc that was never written — the swap
+    // must not treat "argument unreadable right now" as "argument invalid".
+    const coldArgument = rt.getCell<Record<string, unknown>>(
+      space,
+      "swap-link-argument-cold-argument-doc",
+    );
+    const tx2 = rt.edit();
+    cell.withTx(tx2).setMetaRaw(
+      "argument",
+      coldArgument.getAsWriteRedirectLink({ base: cell }),
+    );
+    cell.withTx(tx2).setMetaRaw("patternIdentity", {
+      identity: v2Ref.identity,
+      symbol: v2Ref.symbol,
+    });
+    await tx2.commit();
+    await rt.idle();
+    await cell.pull();
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v2");
+  });
+});

--- a/packages/runner/test/stored-source-directive-drift.test.ts
+++ b/packages/runner/test/stored-source-directive-drift.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  Engine,
+  Runtime,
+  signer,
+  StorageManager,
+} from "./engine-test-support.ts";
+
+// CT-1916 (2026-07-28 estuary): a `@ts-expect-error` that was valid when a
+// pattern was AUTHORED becomes "unused" (TS2578) once the platform's vendored
+// types improve — and the same stored bytes then hard-failed recompile on
+// load, bricking every piece embedding them (loom-mobile patterns vs. a
+// jsx.d.ts that gained `label`; the space root died with "failed to load
+// piece"). The split contract under test:
+//
+// - the STORED-source reload path (`compileResolvedToRecordGraph`, the only
+//   compile of bytes nobody can re-author under a toolchain newer than the
+//   one that accepted them) tolerates the stale directive;
+// - AUTHORING compiles (`compilePattern` — cf check, deploy, corpus) stay
+//   strict, because there the author is present and the fix is removal.
+
+const space = signer.did();
+
+// Valid TypeScript whose directive suppresses nothing — the exact shape a
+// platform type-improvement leaves behind in stored source.
+const DRIFTED_SOURCE = [
+  "import { pattern } from 'commonfabric';",
+  "const add = (x: number, y: number): number => x + y;",
+  "// @ts-expect-error -- suppressed an error under an older type env",
+  "const total = add(1, 2);",
+  "export default pattern<Record<string, never>, { total: number }>(() => {",
+  "  return { total };",
+  "});",
+  "",
+].join("\n");
+
+describe("stored-source directive drift (CT-1916)", () => {
+  let runtime: Runtime;
+  let engine: Engine;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    engine = runtime.harness as Engine;
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("the stored-source reload path compiles despite the stale directive", async () => {
+    const compiled = await engine.compileResolvedToRecordGraph(
+      [{ name: "/main.tsx", contents: DRIFTED_SOURCE }],
+      "/main.tsx",
+      { fabricImports: { space } },
+    );
+    expect(compiled.entryIdentity).toBeDefined();
+    expect(compiled.modules.length).toBeGreaterThan(0);
+  });
+
+  it("authoring compiles stay strict on the same source", async () => {
+    await expect(
+      runtime.patternManager.compilePattern(
+        {
+          main: "/main.tsx",
+          files: [{ name: "/main.tsx", contents: DRIFTED_SOURCE }],
+        },
+        { space },
+      ),
+    ).rejects.toThrow("Unused '@ts-expect-error' directive.");
+  });
+});


### PR DESCRIPTION
# fix: un-brick stored patterns against toolchain drift — TS2578 non-fatal + hot-swap survives unreadable argument slots (CT-1916, CT-1917)

## Why

The 2026-07-28 estuary deploy (#5094, healthy otherwise) surfaced two ways a
**stored** pattern can brick against an **evolving toolchain**, both live in
production in `ben-loom-dev-6` (log-verified, and reproduced against the real
space via `cf piece ls` / local tests):

1. **CT-1916 — stale `@ts-expect-error` bricks recompile.** Loom-mobile
   patterns stored in the space carry
   `// @ts-expect-error -- the vendored jsx.d.ts omits cf-cell-link's label`.
   The labs types bump added `label`, so the *identical stored bytes* now
   recompile with the directive **unused** → TS2578 → fatal `CompilerError` →
   "Could not load pattern …" → the space root (`cf-loom-mobile`) dies →
   `getSpaceRoot` times out → **"failed to load piece"**, retried ~1/s forever.
   There is no upgrade path out: these are user-deployed patterns whose stored
   source IS the latest version — nothing to roll forward to, and the compile
   failure is spurious (only the suppression comment went stale, not the code).

2. **CT-1917 — hot-swap dies on argument slots it cannot read.** The official
   `backlinks-index.tsx` upgrade swap re-ran setup, which re-validates the
   STORED argument by materializing it — dereferencing every link. Its
   `pieceRegistry` argument links into the loom-mobile host's registry doc;
   the host was down (see 1), the link read cold, the key vanished from the
   materialized value, and the swap died with
   `updated arguments do not match the candidate schema: missing required
   property pieceRegistry`. The stored argument was exactly what the original
   instantiation wrote — "unreadable right now" was treated as "invalid".

The two compound: 1916 killed the host, which made 1917's link read cold.
Together they are the third instance in a week of one systemic mechanism —
durable stored patterns/docs drifting against a moving toolchain with a
fail-closed upgrade path (see CT-1918 for the deploy-gate arc; prior
instances: #4967, #4977, #5094).

## What Changed

**js-compiler (CT-1916):** TS2578 ("Unused '@ts-expect-error' directive")
is non-fatal **only when recompiling durable STORED pattern source** — a new
`storedSource` compile option set by exactly one caller,
`compileResolvedToRecordGraph` (the reload of stored source docs by
identity, the only place bytes nobody can re-author meet a toolchain newer
than the one that accepted them). Authoring surfaces — `cf check`, deploy,
the corpus check — stay fully strict: there the author is present and
removing the stale directive is the right fix. `noEmitOnError` stays on for
authoring and is disabled only in stored mode, where the pipeline's explicit
syntactic/program/semantic gates decide fatality. Rationale: stored sources
are recompiled by every future toolchain while their type environment is
supplied by the platform; a suppression obsoleted by a platform type
improvement must not retroactively brick the stored artifact — but should
absolutely be reported to a present author.

**runner (CT-1917):** swap-path argument validation (`argument === undefined`,
i.e. re-staging the STORED value on a pattern change) now:

- **skips staging/validation entirely when the argument doc reads nothing** —
  a nested piece's argument lives in its host's doc; when that is cold there
  is nothing to stage, and writing schema defaults over an unreadable doc
  would clobber whatever it really holds;
- **validates slots whose raw value is a link that materialized to nothing as
  opaque placeholders** — the slot has a value we cannot read right now, so
  its schema check defers to instantiation-time reactive reads, exactly like
  the running pattern's own reads of the same slot.

Caller-supplied arguments (piece API, `setup()` with a value) keep strict
validation of exactly the supplied value.

## Test plan

- `packages/runner/test/pattern-swap-link-argument.test.ts` (new): warm-link
  control (passed before and after), cold slot-link swap, and cold
  argument-doc swap (both bricked before — the exact production shades:
  "value does not match type array" / "missing required property").
- `packages/js-compiler/test/typescript.compiler.test.ts`: unused directive
  compiles; a directive covering a live error still suppresses it; genuine
  errors still throw (pre-existing cases).
- Full `packages/js-compiler` suite green; full `packages/piece` suite green
  (298 steps); full `packages/runner` suite diffed against an origin/main
  baseline run (identical pre-existing local CFC-env failures, no new ones).
- `deno task cfcheck` (pattern corpus) green with the modified compiler.
- **Against production (read-only):** `cf piece ls` on the affected estuary
  space with this branch's toolchain — every previously-bricked piece
  (`Loom Mobile`, `Loom Files`, `Loom Activity`, `Folder`, `Loom Page`)
  compiles from its current stored source and lists correctly; on the
  deployed build the same command shows five `<error: Could not load pattern
  …>` rows.

## Deferred / follow-ups

- Loom-side: remove the now-stale directive in loom's
  `src/patterns/cf-loom-mobile/files.tsx` (owner: Ben; heals via redeploy).
- CT-1918: deploy gate compiling real vintage spaces against candidate
  toolchains — would have caught both of these pre-deploy.
- The input/output additive-required rule (element 1) remains open; it is a
  DIFFERENT gap from CT-1917 (this incident was never a schema-evolution
  refusal — tracked in CT-1904).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stored patterns from bricking after toolchain changes and lets hot-swaps proceed when argument links are unreadable. Narrows TS2578 tolerance to stored-source reloads only while authoring stays strict. Addresses CT-1916 and CT-1917.

- **Bug Fixes**
  - `packages/js-compiler` (CT-1916): Treat TS2578 ("Unused `@ts-expect-error`") as non-fatal only when compiling durable stored source; authoring surfaces (`cf check`, deploy, corpus) report it. Keep `noEmitOnError` on by default and disable it only in stored-source mode; add explicit fatal gates for syntactic and program diagnostics (including under `noCheck`) so malformed source never emits; the corpus-collecting path now includes options/global diagnostics. Real errors still fail and directives still only suppress covered errors.
  - `packages/runner` (CT-1917): On pattern swap with no new argument, skip staging/validation when the argument doc reads nothing; validate slots whose raw value is a link that materializes to nothing as opaque placeholders (including inside arrays and nested paths); keep strict validation for caller-supplied arguments.

- **Refactors**
  - Expanded tests: stored-source directive drift vs authoring strictness, storedSource + `noCheck` syntax gate, collecting-path program diagnostics, and link-placeholder overlay during swaps. Removed an unreachable swap-setup validation branch.

<sup>Written for commit 5bc0417aac4ea188755d6b0a60033ead77edf352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 6915 lines
(one defensive shape-mismatch guard line in the link-overlay walker; the meaningful branches are covered by the four swap tests)

