### PR TITLE
fix(patterns): record — read modules through their pieces everywhere …

### DIFF
--- a/packages/patterns/record-trash-restore.test.tsx
+++ b/packages/patterns/record-trash-restore.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Test: a module survives a trash-and-restore round trip with its field data.
+ *
+ * A Record holds each module as a sub-piece, referenced through
+ * `SubPieceEntry.piece`. That field is declared `unknown`, and a field typed
+ * `unknown` reads back across a handler boundary as undefined rather than as the
+ * live handle. Trashing a module reads the active list and pushes the entry into
+ * the trash; restoring reads the trash and pushes the entry back. While those
+ * handlers read the lists through the declared `unknown` typing, each read drops
+ * the piece, so a trashed-then-restored module came back with no piece and
+ * rendered empty, its field values gone.
+ *
+ * The handlers now read both lists through a handle view that types the piece as
+ * a live Cell, so the handle survives into the trash and back. This test adds an
+ * email module (whose smart-default label is "Personal"), trashes it through the
+ * exposed `removeModule` stream, restores it through the trash section's restore
+ * button in the rendered UI, and reads the restored module's fields back through
+ * `getSummary`. The label reads "Personal" only if the piece survived the round
+ * trip.
+ *
+ * `removeModule` is a stream on the Output, so trashing is reachable headlessly.
+ * `restoreSubPiece` is a JSX button handler with no stream of its own, so the
+ * restore step walks the rendered tree to the trash section's restore control
+ * and sends the stream bound to its onClick, the way `map-demo.test.tsx` reaches
+ * an unexported handler. Reading a piece's own fields needs a handler read that
+ * types the piece as a Cell; a plain spread of the list materializes via the
+ * schema and strips the piece to undefined, so the restored field values are
+ * read through `getSummary` rather than a spread.
+ *
+ * The email module is added and the Record rendered once before it is trashed,
+ * so the auto-seeder latches on a non-empty list and never seeds its default
+ * modules. The active list is then just the email throughout, and after the
+ * round trip it holds exactly the restored module.
+ *
+ * Run: deno task cf test packages/patterns/record-trash-restore.test.tsx --root packages/patterns --verbose
+ */
+import { action, assert, pattern, UI, Writable } from "commonfabric";
+import { findElementByText, propsOf } from "./test/vnode-helpers.ts";
+import RecordPattern from "./record.tsx";
+
+interface AddResult {
+  success?: boolean;
+  moduleIndex?: number;
+}
+interface RemoveResult {
+  success?: boolean;
+}
+interface SummaryModule {
+  index?: number;
+  type?: string;
+  data?: { label?: string };
+}
+interface SummaryResult {
+  moduleCount?: number;
+  modules?: SummaryModule[];
+}
+
+// Send the stream bound to the first `<button>` whose text contains `text`, and
+// report whether such a button was found. The step that calls this records the
+// result so an assertion can pin that the control it depends on was in the tree
+// rather than pass vacuously when the button is missing.
+const clickButton = (root: unknown, text: string): boolean => {
+  const button = findElementByText(root, "button", text);
+  const onClick = propsOf(button)?.onClick;
+  if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+    (onClick as { send: (event: Record<string, never>) => void }).send({});
+    return true;
+  }
+  return false;
+};
+
+export default pattern(() => {
+  const subject = RecordPattern({
+    title: "Contact",
+    subPieces: [],
+    trashedSubPieces: [],
+  });
+
+  const emailAdd = new Writable<AddResult>();
+  const removeResult = new Writable<RemoveResult>();
+  const trashToggleFound = new Writable<boolean>();
+  const restoreFound = new Writable<boolean>();
+  const summary = new Writable<SummaryResult>();
+
+  // Add an email module. Its smart-default label is "Personal", stored on the
+  // module's own piece.
+  const action_add_email = action(() => {
+    subject.addModule!.send({ type: "email", result: emailAdd });
+  });
+  const assert_email_added = assert(() => {
+    const entries = [...(subject.subPieces ?? [])];
+    return entries.length === 1 && entries[0].type === "email";
+  });
+
+  // Trash the email through the exposed stream.
+  const action_remove_email = action(() => {
+    subject.removeModule!.send({ index: 0, result: removeResult });
+  });
+  const assert_email_trashed = assert(() => {
+    const entries = [...(subject.subPieces ?? [])];
+    const trashed = [...(subject.trashedSubPieces ?? [])];
+    return removeResult.get()?.success === true &&
+      entries.length === 0 &&
+      trashed.length === 1 && trashed[0].type === "email";
+  });
+
+  // Expand the trash section so its restore control renders, then restore.
+  // Both steps walk the rendered tree; the boolean each records lets the
+  // assertions pin that the control was present.
+  const action_expand_trash = action(() => {
+    trashToggleFound.set(clickButton(subject[UI], "Trash"));
+  });
+  const action_restore = action(() => {
+    restoreFound.set(clickButton(subject[UI], "\u{21A9}"));
+  });
+  const assert_trash_control_present = assert(() =>
+    trashToggleFound.get() === true
+  );
+  const assert_restore_control_present = assert(() =>
+    restoreFound.get() === true
+  );
+
+  // The module is back in the active list and gone from the trash.
+  const assert_email_restored = assert(() => {
+    const entries = [...(subject.subPieces ?? [])];
+    const trashed = [...(subject.trashedSubPieces ?? [])];
+    return entries.length === 1 && entries[0].type === "email" &&
+      trashed.length === 0;
+  });
+
+  // ...and it kept its piece: getSummary reads the restored module's own fields,
+  // and its smart-default label is still there. Before the fix, the round trip
+  // dropped the piece and this read came back with empty data.
+  const action_summary = action(() => {
+    subject.getSummary!.send({ result: summary });
+  });
+  const assert_restored_kept_data = assert(() => {
+    const modules = summary.get()?.modules ?? [];
+    const email = modules.find((m) => m.type === "email");
+    return !!email && email.data?.label === "Personal";
+  });
+
+  return {
+    tests: [
+      { action: action_add_email },
+      { assertion: assert_email_added },
+      { render: subject[UI] },
+
+      { action: action_remove_email },
+      { assertion: assert_email_trashed },
+
+      { action: action_expand_trash },
+      { assertion: assert_trash_control_present },
+      { action: action_restore },
+      { assertion: assert_restore_control_present },
+      { assertion: assert_email_restored },
+
+      { action: action_summary },
+      { assertion: assert_restored_kept_data },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -204,6 +204,14 @@ type SubPieceEntryHandle =
   & Omit<SubPieceEntry, "piece">
   & { piece: Cell<Record<string, unknown>> };
 
+// Trashing a module and restoring it moves the module's piece from the active
+// list into the trash and back. The move reads the piece across a handler
+// boundary, so a trashed entry types its piece as a live Cell too, the same way
+// the active list's handle does.
+type TrashedSubPieceEntryHandle =
+  & Omit<TrashedSubPieceEntry, "piece">
+  & { piece: Cell<Record<string, unknown>> };
+
 // ===== Module-Scope Handlers (avoid closures, use references not indices) =====
 
 // Toggle pin state for a sub-piece - uses entry reference, not index
@@ -323,8 +331,8 @@ const addSubPiece = handler<
 const trashSubPiece = handler<
   unknown,
   {
-    subPieces: Writable<SubPieceEntry[]>;
-    trashedSubPieces: Writable<TrashedSubPieceEntry[]>;
+    subPieces: Writable<SubPieceEntryHandle[]>;
+    trashedSubPieces: Writable<TrashedSubPieceEntryHandle[]>;
     expandedIndex: Writable<number | undefined>;
     settingsModuleIndex: Writable<number | undefined>;
     index: number;
@@ -380,8 +388,8 @@ const trashSubPiece = handler<
 const restoreSubPiece = handler<
   unknown,
   {
-    subPieces: Writable<SubPieceEntry[]>;
-    trashedSubPieces: Writable<TrashedSubPieceEntry[]>;
+    subPieces: Writable<SubPieceEntryHandle[]>;
+    trashedSubPieces: Writable<TrashedSubPieceEntryHandle[]>;
     trashIndex: number;
   }
 >((_event, { subPieces: sc, trashedSubPieces: trash, trashIndex }) => {
@@ -717,8 +725,8 @@ const handleUpdateModule = handler<
 const handleRemoveModule = handler<
   { index: number; result?: Writable<unknown> },
   {
-    subPieces: Writable<SubPieceEntry[]>;
-    trashedSubPieces: Writable<TrashedSubPieceEntry[]>;
+    subPieces: Writable<SubPieceEntryHandle[]>;
+    trashedSubPieces: Writable<TrashedSubPieceEntryHandle[]>;
   }
 >(({ index, result }, { subPieces: sc, trashedSubPieces: trash }) => {
   const current = sc.get() || [];
@@ -855,6 +863,19 @@ const Record = pattern<RecordInput, RecordOutput>(
 
     // Settings modal state - tracks which module's settings are being edited
     const settingsModuleIndex = new Writable<number | undefined>();
+
+    // Handle views of the two lists for the handlers that read or move a
+    // module's piece. The piece is declared `unknown` on the entry, which reads
+    // back across a handler boundary as undefined; typing it as a live Cell
+    // keeps the handle. getSummary and updateModule read the active list this
+    // way, and trashSubPiece, removeModule and restoreSubPiece carry a piece
+    // into the trash and back through both. The cast only bridges the declared
+    // list type to that view; the cell is the same either way.
+    // deno-lint-ignore no-explicit-any
+    const subPiecesHandle: Writable<SubPieceEntryHandle[]> = subPieces as any;
+    const trashedHandle: Writable<TrashedSubPieceEntryHandle[]> =
+      // deno-lint-ignore no-explicit-any
+      trashedSubPieces as any;
 
     // Create Record pattern JSON for wiki-links in Notes
     // Using computed() defers evaluation until render time, avoiding circular dependency
@@ -1371,8 +1392,8 @@ const Record = pattern<RecordInput, RecordOutput>(
                                   <button
                                     type="button"
                                     onClick={trashSubPiece({
-                                      subPieces,
-                                      trashedSubPieces,
+                                      subPieces: subPiecesHandle,
+                                      trashedSubPieces: trashedHandle,
                                       expandedIndex,
                                       settingsModuleIndex,
                                       index,
@@ -1663,8 +1684,8 @@ const Record = pattern<RecordInput, RecordOutput>(
                                     <button
                                       type="button"
                                       onClick={trashSubPiece({
-                                        subPieces,
-                                        trashedSubPieces,
+                                        subPieces: subPiecesHandle,
+                                        trashedSubPieces: trashedHandle,
                                         expandedIndex,
                                         settingsModuleIndex,
                                         index,
@@ -1948,8 +1969,8 @@ const Record = pattern<RecordInput, RecordOutput>(
                                 <button
                                   type="button"
                                   onClick={trashSubPiece({
-                                    subPieces,
-                                    trashedSubPieces,
+                                    subPieces: subPiecesHandle,
+                                    trashedSubPieces: trashedHandle,
                                     expandedIndex,
                                     settingsModuleIndex,
                                     index,
@@ -2073,8 +2094,8 @@ const Record = pattern<RecordInput, RecordOutput>(
                               <button
                                 type="button"
                                 onClick={restoreSubPiece({
-                                  subPieces,
-                                  trashedSubPieces,
+                                  subPieces: subPiecesHandle,
+                                  trashedSubPieces: trashedHandle,
                                   trashIndex,
                                 })}
                                 style={{
@@ -2266,16 +2287,16 @@ const Record = pattern<RecordInput, RecordOutput>(
       "#record": true,
       // LLM-callable streams for Omnibot integration
       // Omnibot can invoke these via: invoke({ "@link": "/of:record-id/getSummary" }, {})
-      // getSummary and updateModule read the piece handles the list holds, so
-      // they take the `SubPieceEntryHandle` view of `subPieces`, which types
-      // the piece as a live Cell. The cell is the same either way; the cast
-      // only bridges the two static views.
-      // deno-lint-ignore no-explicit-any
-      getSummary: handleGetSummary({ title, subPieces: subPieces as any }),
+      // getSummary, updateModule and removeModule reach the piece handles the
+      // lists hold, so they take the handle views (`subPiecesHandle`,
+      // `trashedHandle`) that type the piece as a live Cell.
+      getSummary: handleGetSummary({ title, subPieces: subPiecesHandle }),
       addModule: handleAddModule({ subPieces, trashedSubPieces, title }),
-      // deno-lint-ignore no-explicit-any
-      updateModule: handleUpdateModule({ subPieces: subPieces as any }),
-      removeModule: handleRemoveModule({ subPieces, trashedSubPieces }),
+      updateModule: handleUpdateModule({ subPieces: subPiecesHandle }),
+      removeModule: handleRemoveModule({
+        subPieces: subPiecesHandle,
+        trashedSubPieces: trashedHandle,
+      }),
       setTitle: handleSetTitle({ title }),
       listModuleTypes: handleListModuleTypes({}),
     };


### PR DESCRIPTION
…it matters

A Record holds each module as a sub-piece, referenced through `SubPieceEntry.piece`, a field typed `unknown`. An object read under a `{ type: "unknown" }` schema comes back undefined rather than materialized, and what decides materialization is the schema of the operand a value is read into, not the schema the field was declared with. Every Record feature that reached through a module's piece hit this, and each one silently fell back. This change fixes them together.

The module list rendered nothing. `allEntriesWithIndex` reads `seedRecord`'s result to demand the seed that fills a fresh Record with its Notes and TypePicker modules, and returns an empty list when that read is falsy. While that lift's result type was inferred rather than declared, the capture was left out of the reading lift's generated input schema, so the runner dropped it, the read came back undefined, and every module sat behind a guard that could never pass. Declaring the result type puts the capture in the schema. The transformer dropping a capture the call site passes is a separate defect, reproducible in a few lines outside this pattern, and is not fixed here.

The chrome the Record draws around each module reads fields off the module rather than off the Record's own list: each header shows the module's instance label (an email module's "Personal" or "Work"), a record-icon module supplies the record's icon, nickname modules supply the aliases in its name, and the settings dialog shows a module's own settings UI under a title carrying that same label. Every one of those reads went through the `unknown`-typed piece and came back undefined, so a header showed the module type name, a record-icon module never changed the icon, a nickname module never contributed an alias, and the settings dialog opened with an empty body. The reads now go through lifts that name the fields they want. `readDisplayFields` names label, icon and nickname, applied per entry by a `.map()` at pattern-body scope so each element stays a link; the same `.map()` inside a `computed()` runs over the already-materialized list, where the piece is undefined. It carries each module's type alongside the fields, so the icon and alias readers pick their module out of that one list rather than pairing it with `subPieces` by position. `readSettingsUI` names `piece` on its operand, which is what makes the read follow the entry's link into the module, and leaves the settings node permissive so it stays a reference to the module's own UI rather than a copy.

Trashing a module and restoring it brought it back empty. `trashSubPiece` (the UI trash button) and `handleRemoveModule` (the removeModule stream) read the active list and push the entry onto the trash list; `restoreSubPiece` reads the trash list and pushes the entry back. Each read dropped the piece, and because a push lands in a fresh list slot there is no prior link to fall back on, so the handle was lost. The missing handle also kept the trashed entry from materializing during render, so the restore control never even appeared. These handlers now read both lists through handle views that type the piece as a live Cell, the same bridge `getSummary` and `updateModule` use for the active list; `subPiecesHandle` and `trashedHandle` are the shared views, and the five piece-reading handlers route through them.

Entries for module types with no standard labels stored an explicit undefined in `label`, a field declared a string. A write of the whole list through the piece API validates that present-but-undefined property against the declaration and rejects the write ("subPieces: N: label: value does not match type string"), which is how this surfaced. The creation sites and the template builder now omit the field instead.

`RecordOutput` now declares `[NAME]`. The shell reads a piece's name with a schema of its own, so the name always reached the shell; a pattern holding a Record's output could not read it, which left the icon and alias behavior unobservable from a test.

Tests cover the revived behavior. `record-module-fields.test.tsx` drives the icon and aliases through the Record's `[NAME]`, setting both after the modules were added so it pins that the reads are live rather than a copy taken at creation, and walks the rendered `[UI]` to count the module cards and check that a labelled module's header shows its label while an unlabelled one falls back to the type name. `record-trash-restore.test.tsx` adds an email module, trashes it through the removeModule stream, restores it through the trash section's restore button in the rendered UI, and reads the module back through getSummary: the label survives the round trip only when the piece does. `integration/record-module-chrome.test.ts` covers what only exists in a browser — the headers, the settings dialog's title and body, and typing into that dialog reaching the module; its three cases each stand on their own, with the shell navigation moved into setup and the open-and-type flow merged into one case, so a failure surfaces as the thing that broke rather than as a downstream selector timeout.

The runtime behavior behind all of this — which values a `{ type: "unknown" }` schema drops, the operand schema deciding what materializes, naming the property, where the read has to happen, and the `Cell<>` form a handler needs — is written up as a gotcha under docs/development/debugging/.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Record sub-piece handling by reading modules through live `Cell` handles so data materializes correctly and survives trash/restore. Adds a test that trashes and restores an email module and verifies its "Personal" label persists.

- **Bug Fixes**
  - Use handle-typed views `subPiecesHandle` and `trashedHandle` to keep `SubPieceEntry.piece` as a `Cell`.
  - Pass these views to `trashSubPiece`, `restoreSubPiece`, `handleRemoveModule`, `getSummary`, and `updateModule`.
  - Restored modules keep their data, and the restore button renders reliably.

- **Tests**
  - Added `record-trash-restore.test.tsx`: add email, trash via `removeModule`, restore via UI, then assert the label remains "Personal" via `getSummary`.

<sup>Written for commit ddd1a3846a59bfd29bc000ff8e0a44c5fcf49126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

