### PR TITLE
Fix some memory leaks

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -109,6 +109,15 @@ One line per archived document; each document's header carries the fuller
 - [piece-timeout-hangs-investigation.md](packages/cli/piece-timeout-hangs-investigation.md)
   — why the CLI tool-result poll was replaced event-driven and why the
   piece-start and sync bounds could not be removed at the CLI layer, July 2026.
+- [2026-07-27-session-paging-out-of-memory.md](packages/patterns/agent-sessions-debug/2026-07-27-session-paging-out-of-memory.md)
+  — paging the agent-sessions debug table exhausts the browser runtime's heap,
+  July 2026.
+- [2026-07-28-list-window-child-retention.md](packages/runner/2026-07-28-list-window-child-retention.md)
+  — why a moving list window retained every child run it started, and what the
+  fix covered, July 2026.
+- [2026-07-28-completed-transaction-retention.md](packages/runner/2026-07-28-completed-transaction-retention.md)
+  — a completed transaction kept the activity of everything it read, and the
+  unbounded document cache that still exhausts a browser tab, July 2026.
 
 ### Executed plans and work orders
 

--- a/docs/history/packages/patterns/agent-sessions-debug/2026-07-27-session-paging-out-of-memory.md
+++ b/docs/history/packages/patterns/agent-sessions-debug/2026-07-27-session-paging-out-of-memory.md
@@ -1,0 +1,134 @@
+---
+status: historical
+created: 2026-07-27
+archived: 2026-07-27
+reason: "Investigation record: paging the agent-sessions debug table exhausts the browser runtime's heap."
+---
+
+# Paging the session table exhausts the browser heap
+
+Clicking **Next** on the Sessions tab of the agent-sessions debug view a dozen
+or so times kills the browser tab. That view and its host were under
+development on a separate branch, so the packages this record names are not in
+this tree; the runner fixes the investigation produced are. This document records how the failure was
+reproduced, what was measured, and which explanations the measurements rule
+out. It is a record of one investigation on one machine, not a description of
+the current system.
+
+## Environment
+
+- The debug host published 716 sessions from two sources (`codex-app-server`
+  and `claude-agent-sdk`) into a single space.
+- The Sessions tab shows 20 rows per page, so the table had 36 pages. The
+  pattern projects a window of the current page plus the page on either side.
+- The shell ran against a local Toolshed. The runtime, as always in the shell,
+  ran in a web worker, so the growth reported below is the worker's isolate,
+  not the page's.
+
+## What happens
+
+The tab's renderer process grows by roughly a quarter of a gigabyte per page
+change until the process dies. Three runs, each starting from a freshly loaded
+view:
+
+| Run | Interaction | Start | End | Outcome |
+| --- | ----------- | ----- | --- | ------- |
+| 1 | Click Next repeatedly | 1.24 GB | 4.85 GB | Renderer process died after about 15 page turns, 137 seconds in |
+| 2 | Alternate Next and Previous between pages 1 and 2 | 2.01 GB | 4.53 GB | Renderer process died after about 30 page changes, 99 seconds in |
+| 3 | Click the Title sort header 40 times | 1.52 GB | 1.9 GB | Survived; memory levelled off |
+
+The figures are resident set size of the tab's renderer process, sampled from
+outside the browser every two or three seconds. The main thread's own heap
+stayed between 16 MB and 19 MB throughout every run, so all of the growth is
+in the worker that hosts the runtime.
+
+Run 2 is the important one. Alternating between the same two pages shows the
+same fatal growth as walking forward through all 36. The rows are the same 20
+sessions over and over, so the growth is not the cost of reaching new session
+data. It is the cost of the window changing at all.
+
+Run 3 is the control. Sorting re-renders the same 20 rows and does not move
+the projection window: no element runs are retired or started. That case is
+stable, which places the growth in the window change rather than in rendering
+or in reading the rows.
+
+The host process has the same problem from the other side. During this
+investigation the `agents-host` process itself died with
+`Fatal JavaScript out of memory: Ineffective mark-compacts near heap limit`
+after a periodic collection, having grown to about 5 GB resident and a 4 GB
+heap. That is a separate failure from the browser one and was not investigated
+further.
+
+## What the growth is not
+
+Each of these was measured while alternating between pages 1 and 2, the
+interaction that kills the tab in run 2.
+
+**Not scheduler nodes.** `getGraphSnapshot()` reports the live scheduler graph.
+Across ten page changes it oscillated between exactly 5551 and 6811 nodes, and
+between 13454 and 14094 edges, returning to the same numbers each time the same
+page came back. Element runs are being registered and unregistered correctly.
+Meanwhile resident memory rose from 1.84 GB to 2.77 GB.
+
+**Not new stored documents.** Ten page changes added 10 entities and 115
+commits to the space — the per-session view state, and nothing more. The map
+coordinator reuses its element result documents, as intended. Resident memory
+over the same ten changes rose from 2.77 GB to 3.87 GB.
+
+**Not the client's document cache.** Instrumenting the storage provider's
+document map showed it settling at about 3273 documents and staying there
+across page changes. The per-document pending-version list and materialized
+prefix cache never held more than one entry each.
+
+So the retained memory is not a structure whose size these counters report. It
+is retained values: object graphs derived from documents that outlive the
+element runs that produced them.
+
+## A separate finding: the table loads every session
+
+The same instrumentation showed what the client holds after the Sessions tab
+first renders, with only two pages' worth of rows on screen:
+
+```
+docs=2769  716×[chunks,complete,driver,formatVersion]
+           716×[active,archived,capabilities,contentHash]
+           444×[string] 121×[/] 90×[children,name,props,type] 86×[$stream]
+```
+
+The first group is every session manifest in the space. The second is every
+session row. All 716 of each are resident after the first render, though the
+window projects 40 rows. Native event chunks are not pulled, so the manifests'
+own contents stay behind their links, but the manifests themselves are all
+there. The pattern's README describes the table as reaching only the rows in
+its window; that is not what the client ends up holding.
+
+This alone accounts for a large fixed cost — the view sits at 1.2 GB to 2 GB
+before any paging — but it does not explain the per-page-change growth, since
+run 2 revisits sessions whose manifests are already resident.
+
+## Reproducing it
+
+1. Publish a few hundred sessions into a space with `deno task agents-host`,
+   so the Sessions tab has many pages.
+2. Open the debug piece in the shell and select the Sessions tab.
+3. Click Next repeatedly, or alternate Next and Previous, waiting for the view
+   to settle between clicks.
+4. Watch the resident size of the tab's renderer process from outside the
+   browser. The tab dies between 4.5 GB and 4.9 GB.
+
+The waiting in step 3 was done with `commonfabric.viewSettled()`, which
+resolves when the worker is idle and the rendered view has drained.
+
+## Where to look next
+
+The measurements point at values retained past the end of an element run,
+somewhere between the map coordinator's child release and the storage layer's
+materialized values. A useful next step is a headless harness: drive the same
+piece from a Deno runtime against the same Toolshed, alternate the page the
+same way, and force a full garbage collection between changes. That
+distinguishes memory that is genuinely reachable from garbage the browser's
+collector has not reclaimed, and it gives a place to bisect that does not need
+a browser. A synthetic harness — a sliding window over a list of cells, each
+row projecting a child pattern that holds a link to a large document, against
+an in-process memory server — did not reproduce the growth, so whatever is
+retained depends on something that harness lacked.

--- a/docs/history/packages/runner/2026-07-28-completed-transaction-retention.md
+++ b/docs/history/packages/runner/2026-07-28-completed-transaction-retention.md
@@ -1,0 +1,90 @@
+---
+status: historical
+created: 2026-07-28
+archived: 2026-07-28
+reason: "Investigation record: a completed transaction's activity was retained, and what still grows after fixing it."
+---
+
+# Completed transactions kept the activity of everything they read
+
+This continues
+[the list-window child retention record](2026-07-28-list-window-child-retention.md),
+which fixed the first of the retentions behind
+[the session-paging heap exhaustion](../patterns/agent-sessions-debug/2026-07-27-session-paging-out-of-memory.md)
+and listed a smaller one still to find. This is that one, plus the cause that
+still exhausts a browser tab after both are fixed. It is a record of one
+investigation, not a description of the current system.
+
+## Finding it
+
+The first fix took the per-page-change growth from 10.9 MB to 2.3 MB. What was
+left had an unhelpful shape: it needed an element pattern that instantiates a
+nested pattern, it did not scale with row size, it needed the window to move,
+and no container in the scheduler, runner or storage layer grew.
+
+Two instruments settled it. A census that tagged every transaction with a
+serial and held a weak reference to it showed a single transaction surviving
+each page change, sourced from the list coordinator's action — but a weak
+reference is kept alive for the rest of the job that dereferences it, and a
+heap snapshot renders those references as edges, so both the count and the
+snapshot flattered the truth until the census was cleared before snapshotting.
+An ephemeron-correct retainer walk over the snapshot — one that follows a
+WeakMap value only once its key is reachable — then gave the shape: a
+transaction reached through a chain of cells and per-reconcile records, each
+link holding the transaction that created it.
+
+The decisive measurement was to release a transaction's state once it
+completed and re-run the harness. Growth fell from 2.3 MB to 0.25 MB per page
+change immediately, which put the bytes in the transaction rather than in
+whatever held it.
+
+## The cause
+
+A transaction accumulates what an open transaction needs: materialized
+branches, the address of every read and attempted write, and a cached
+reactivity log. All of it is consumed before the result is known. It was kept
+afterwards, so anything still holding a completed transaction also held every
+address that transaction had touched — and plenty holds one. A cell carries
+the transaction it was created with for its whole life. A run's cleanup
+closures capture the transaction they were registered in. The list builtin's
+commit guard keys its per-reconcile record off one. Each of those holders is
+bounded on its own; each pinned a whole transaction's activity, and the
+transaction that projects a window over a list has read every element in it.
+
+Completing a transaction now releases that state and keeps only the result.
+The regression test states it directly: a completed transaction reports no
+reads and no writes, whether it committed or failed.
+
+## What still exhausts the tab
+
+With both fixes, paging back and forth over the same rows settles: in a
+browser with 716 published sessions the tab levelled off at 4.1 GB instead of
+dying. Paging forward through all 36 pages still dies, at about page 20, and
+the cause is different from either retention above.
+
+The client watches and caches every document it has pulled or created, and
+releases neither. Instrumenting the storage provider during a forward walk:
+
+```
+docs=5276 watched=5276
+docs=5777 watched=5777
+docs=6278 watched=5777
+```
+
+Five hundred documents per page change, about twenty-five per newly visited
+row. Their shapes name them: the row projection's own state — vnodes, streams,
+element input documents and strings — created because each row instantiates a
+nested pattern for its raw-data link. On top of that, the first render alone
+pulls all 716 session manifests and all 716 session rows, which is what the
+pattern's README says it avoids.
+
+`#watchedIds` in the storage provider shrinks only when the server reports a
+document removed. There is no path that drops a subscription, or the cached
+document behind it, when the run that wanted it stops. So the working set is
+the union of everything the session ever touched, and a table with enough rows
+walks that union past the heap limit.
+
+Fixing it means bounding that working set: releasing a document's subscription
+and cached value once no live run reads it, and separately not creating
+twenty-five persistent documents per row merely to render a link. Neither is a
+small change, and neither was attempted here.

--- a/docs/history/packages/runner/2026-07-28-list-window-child-retention.md
+++ b/docs/history/packages/runner/2026-07-28-list-window-child-retention.md
@@ -1,0 +1,99 @@
+---
+status: historical
+created: 2026-07-28
+archived: 2026-07-28
+reason: "Investigation record: why a moving list window retained memory, and what the fix covered."
+---
+
+# A moving list window retained every child run it ever started
+
+This records the root cause behind
+[the session-paging heap exhaustion](../patterns/agent-sessions-debug/2026-07-27-session-paging-out-of-memory.md),
+the fix that landed, and the growth that remains. It is a record of one
+investigation, not a description of the current system.
+
+## How it was found
+
+The browser reproduction was too coarse to bisect, so the first step was a
+headless harness: publish synthetic sessions into an emulated storage manager,
+deploy the real debug pattern through the same code path the host uses, drive
+its pager by sending events to the rendered button, and report
+`Deno.memoryUsage().heapUsed` after a forced collection. That reproduced the
+growth at 10.9 MB per page change, in a process where a heap snapshot could be
+taken. That harness drives the debug pattern, so it lives with the
+agent-sessions work rather than in this tree;
+`packages/runner/test/window-retention-probe.ts` is the reduced form of it,
+which moves a window over a list through several projection shapes.
+
+Two snapshots, eight page changes apart, were compared by strongly-reachable
+population. The classes that grew were the closures a storage transaction
+installs — one set per `Runtime.edit()` — which said transactions were being
+retained. Tracing retainer paths, with weak edges and WeakMap ephemeron entries
+excluded, gave the same chain for every sampled transaction:
+
+```
+NodeRegistry.all → a live parent node → children (Set<Action>)
+  → a child action → action.lastFrame → frame.tx → the transaction's journal
+```
+
+## The cause
+
+`NodeRegistry.remove` cleared the removed action from the active-effect,
+active-computation and invalid sets, but not from its parent's child index.
+That index holds actions strongly. An action holds `lastFrame`, the frame of
+its last run; a frame holds that run's storage transaction; a transaction holds
+the values it read. So a child that left the index only when its parent was
+dropped kept a transaction and its journal alive for the parent's whole life —
+and a list coordinator lives as long as the piece.
+
+The session table projects a window of the current page and the pages on either
+side, and each projected row instantiates a nested pattern. Every page change
+therefore stopped twenty child runs and started twenty more, and each one left
+a retained transaction behind. The scheduler's own accounting looked healthy
+throughout, which is why the browser measurements had ruled so much out: the
+live node count returned to exactly the same value each time a page came back,
+because the nodes really were unregistered. Only the index kept the actions.
+
+## The fix
+
+`NodeRegistry.remove` now also drops the action from its parent's index. The
+record keeps its `parentAction`, so the parent stays known across a
+re-registration window, and re-subscribing re-enters the index through
+`linkParent`. The index has a single consumer, the scheduler graph snapshot,
+which now shows only children that are still registered.
+
+The regression test, `packages/runner/test/scheduler-child-lifetime.test.ts`,
+asserts the lifecycle rather than a memory figure: the registry drops an
+unsubscribed child, a child subscribed during a parent's run is dropped when it
+unsubscribes, and a sliding window over a list whose elements run a child
+pattern returns to the same retained-child count each time the window returns
+to a position it has already visited. Before the fix that last case gained
+twenty retained children per move.
+
+## What remains
+
+Retained growth in the headless harness fell from 10.9 MB to 2.3 MB per page
+change. The remainder is a distinct defect that was characterised but not
+found:
+
+- It appears whenever an element pattern instantiates a nested pattern, and
+  disappears when the projection stops doing so. It does not depend on what
+  that nested pattern contains: a version whose body returns constants leaks
+  the same amount.
+- It does not scale with row size. Padding each session with 100 KB leaves the
+  per-change figure unchanged, so it tracks the number of element runs.
+- It is specific to the window moving. Clicking the table's sort header forty
+  times, which re-renders the same rows without starting or stopping any
+  element run, is flat.
+- Roughly twenty-three storage transactions become newly reachable per page
+  change, along with the journals they hold, which is where the bytes are.
+- No named container accounts for it. The scheduler's observation-identity
+  index, trigger index and node registry, the runner's cancel map, cancel
+  groups, prepared and stopped result maps, and the storage provider's document
+  cache and per-document pending and materialized caches are all flat across
+  page changes.
+
+With real session data this remainder still exhausts the browser tab, so the
+reported crash is not resolved by the fix above. Reproducing it needs only a
+list with a moving window whose elements instantiate any nested pattern, which
+the probe and the regression harness both already set up.

--- a/packages/runner/src/scheduler/node-record.ts
+++ b/packages/runner/src/scheduler/node-record.ts
@@ -112,6 +112,17 @@ export class NodeRegistry {
     this.activeEffects.delete(action);
     this.activeComputations.delete(action);
     this.invalidNodes.delete(action);
+    // Drop the child from its parent's index. The index holds actions
+    // strongly, so a child left in it is retained by the parent — along with
+    // the frame of the child's last run, that run's storage transaction, and
+    // the values the transaction read — for as long as the parent lives. A
+    // parent that starts and stops children repeatedly, such as a list
+    // projecting a window that moves, accumulates one of those per child run.
+    // The record keeps `parentAction`, so the parent stays known across a
+    // re-registration window, and re-subscribing re-enters the index.
+    if (record.parentAction !== undefined) {
+      this.childActionsByParent.get(record.parentAction)?.delete(action);
+    }
     return record;
   }
 

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -907,6 +907,26 @@ export class V2StorageTransaction implements IStorageTransaction {
     doc: DocumentEntry;
   };
 
+  /**
+   * Complete the transaction, keeping its result and releasing the state that
+   * only an open transaction needs: the materialized branches, the read and
+   * write activity, and the cached reactivity log. Those are consumed while
+   * the transaction is open — the scheduler takes the reactivity log when the
+   * action that opened the transaction finishes, and the commit path takes the
+   * write details before the result is known. Whatever holds a completed
+   * transaction afterwards, such as a cell bound to it or a cleanup closure
+   * that captured it, would otherwise also hold every address that
+   * transaction read.
+   */
+  #finish(result: Result<Unit, StorageTransactionFailed>): void {
+    this.#state = { status: "done", result };
+    this.#branches.clear();
+    this.#readActivities.length = 0;
+    this.#writeAttemptLog.length = 0;
+    this.#reactivityLogCache = undefined;
+    this.#lastDocument = undefined;
+  }
+
   constructor(private readonly storage: IStorageManager) {}
 
   setReadOnly(reason = "runtime.readTx()"): void {
@@ -1963,7 +1983,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       schedulerObservationCommitSpace(this.#schedulerObservation);
     if (!writeSpace) {
       const result = { ok: {} } satisfies Result<Unit, CommitError>;
-      this.#state = { status: "done", result };
+      this.#finish(result);
       return result;
     }
 
@@ -1980,7 +2000,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       !hasCommitPreconditions && !hasSqliteOps
     ) {
       const result = { ok: {} } satisfies Result<Unit, CommitError>;
-      this.#state = { status: "done", result };
+      this.#finish(result);
       return result;
     }
 
@@ -2008,13 +2028,13 @@ export class V2StorageTransaction implements IStorageTransaction {
     this.#state = { status: "pending", promise };
     try {
       const result = await promise;
-      this.#state = { status: "done", result };
+      this.#finish(result);
       return result;
     } catch (error) {
       const result: Result<Unit, StorageTransactionRejected> = {
         error: toStoreError(error),
       };
-      this.#state = { status: "done", result };
+      this.#finish(result);
       return result;
     }
   }
@@ -2046,13 +2066,13 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     if (commits.length === 0) {
       const result = { ok: {} } satisfies Result<Unit, CommitError>;
-      this.#state = { status: "done", result };
+      this.#finish(result);
       return result;
     }
 
     const validation = this.validate();
     if (validation.error) {
-      this.#state = { status: "done", result: { error: validation.error } };
+      this.#finish({ error: validation.error });
       return { error: validation.error };
     }
 
@@ -2060,7 +2080,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     this.#state = { status: "pending", promise };
     try {
       const result = await promise;
-      this.#state = { status: "done", result };
+      this.#finish(result);
       return result;
     } catch (error) {
       // Mirror the single-space path: a rejected commit must still transition
@@ -2069,7 +2089,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       const result: Result<Unit, StorageTransactionRejected> = {
         error: toStoreError(error),
       };
-      this.#state = { status: "done", result };
+      this.#finish(result);
       return result;
     }
   }

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -2072,7 +2072,10 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     const validation = this.validate();
     if (validation.error) {
-      this.#finish({ error: validation.error });
+      this.#state = {
+        status: "done",
+        result: { error: validation.error },
+      };
       return { error: validation.error };
     }
 

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -917,6 +917,11 @@ export class V2StorageTransaction implements IStorageTransaction {
    * transaction afterwards, such as a cell bound to it or a cleanup closure
    * that captured it, would otherwise also hold every address that
    * transaction read.
+   *
+   * Only a commit that ran ends here. A transaction that never reached storage
+   * — aborted, or rejected by validation — keeps its activity, because the
+   * scheduler retries the action that opened it and re-establishes that
+   * action's dependencies from those reads.
    */
   #finish(result: Result<Unit, StorageTransactionFailed>): void {
     this.#state = { status: "done", result };
@@ -1948,6 +1953,8 @@ export class V2StorageTransaction implements IStorageTransaction {
     if (ready.error) {
       return { error: ready.error };
     }
+    // Aborted before reaching storage, so the activity stays: the scheduler
+    // rebuilds this action's dependencies from it and retries.
     this.#state = {
       status: "done",
       result: { error: TransactionAborted(reason) },
@@ -2009,6 +2016,8 @@ export class V2StorageTransaction implements IStorageTransaction {
       () => this.validate(),
     );
     if (validation.error) {
+      // Rejected before reaching storage, so the activity stays: the scheduler
+      // rebuilds this action's dependencies from it and retries.
       this.#state = {
         status: "done",
         result: { error: validation.error },
@@ -2072,6 +2081,8 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     const validation = this.validate();
     if (validation.error) {
+      // Rejected before reaching storage, so the activity stays: the scheduler
+      // rebuilds this action's dependencies from it and retries.
       this.#state = {
         status: "done",
         result: { error: validation.error },

--- a/packages/runner/test/scheduler-child-lifetime.test.ts
+++ b/packages/runner/test/scheduler-child-lifetime.test.ts
@@ -1,0 +1,178 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { NodeRegistry } from "../src/scheduler/node-record.ts";
+import type { Action } from "../src/scheduler/types.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// A parent action keeps an index of the children that subscribed while it ran.
+// The index holds action closures strongly, and an action holds the frame of
+// its last run, which holds that run's storage transaction and the values the
+// transaction read. A child that stays in the index after it is unsubscribed
+// therefore keeps a transaction alive for as long as the parent lives. A list
+// projecting a window that slides starts and stops a child run per element on
+// every move, so it accumulates one such transaction per element per move.
+
+const signer = await Identity.fromPassphrase("scheduler child lifetime");
+const space = signer.did();
+
+function retainedChildCount(registry: NodeRegistry): number {
+  let total = 0;
+  for (const action of [...registry.effects, ...registry.computations]) {
+    total += registry.childrenOf(action)?.size ?? 0;
+  }
+  return total;
+}
+
+function registryOf(runtime: Runtime): NodeRegistry {
+  return (runtime.scheduler as unknown as { nodes: NodeRegistry }).nodes;
+}
+
+const WINDOW_SIZE = 5;
+
+// Each element of the projected window runs a child pattern, so moving the
+// window starts and stops a child run per element, exactly as the session
+// table's row projection does.
+const SLIDING_WINDOW_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { computed, pattern } from 'commonfabric';",
+      "",
+      "const Detail = pattern<{ label: string }, { text: string }>(",
+      "  ({ label }) => ({ text: computed(() => `detail for ${label}`) }),",
+      ");",
+      "",
+      "const Row = pattern<",
+      "  { label: string },",
+      "  { label: string; shout: string; detail: { text: string } }",
+      ">(({ label }) => {",
+      "  const detail = Detail({ label });",
+      "  return { label, shout: computed(() => `${label}!`), detail };",
+      "});",
+      "",
+      "export default pattern<",
+      "  { items: { label: string }[]; start: number; size: number }",
+      ">(({ items, start, size }) => {",
+      "  const shown = computed(() => items.slice(start, start + size));",
+      "  return { rows: shown.map((item) => Row({ label: item.label })) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+describe("scheduler child action lifetime", () => {
+  it("drops an unsubscribed child from its parent's child index", () => {
+    const registry = new NodeRegistry();
+    const parent: Action = () => {};
+    const child: Action = () => {};
+    registry.register(parent, "effect");
+    registry.register(child, "computation");
+    registry.linkParent(child, parent);
+    expect(registry.childrenOf(parent)?.size).toBe(1);
+
+    registry.remove(child);
+
+    expect(registry.childrenOf(parent)?.size ?? 0).toBe(0);
+  });
+
+  it("drops a child subscribed during a parent's run when it unsubscribes", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const child: Action = () => {};
+      let subscribedChild = false;
+      const parent: Action = () => {
+        if (subscribedChild) return;
+        subscribedChild = true;
+        runtime.scheduler.subscribe(
+          child,
+          { reads: [], shallowReads: [], writes: [] },
+          { isEffect: true },
+        );
+      };
+      runtime.scheduler.subscribe(
+        parent,
+        { reads: [], shallowReads: [], writes: [] },
+        { isEffect: true },
+      );
+      await runtime.idle();
+
+      const registry = registryOf(runtime);
+      expect(registry.childrenOf(parent)?.size).toBe(1);
+
+      runtime.scheduler.unsubscribe(child);
+
+      expect(registry.childrenOf(parent)?.size ?? 0).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps retained children bounded while a projection window slides", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const compiled = await runtime.patternManager.compilePattern(
+        SLIDING_WINDOW_PROGRAM,
+        { space },
+      );
+      const items = Array.from(
+        { length: WINDOW_SIZE * 4 },
+        (_, index) => ({ label: `row-${index}` }),
+      );
+
+      const tx = runtime.edit();
+      const result = runtime.getCell<{ rows: unknown[] }>(
+        space,
+        "sliding-window-result",
+        compiled.resultSchema,
+        tx,
+      );
+      const argument = runtime.getCell<
+        { items: typeof items; start: number; size: number }
+      >(space, "sliding-window-argument", undefined, tx);
+      argument.set({ items, start: 0, size: WINDOW_SIZE });
+      runtime.run(tx, compiled, argument, result);
+      await tx.commit();
+      // The list projects on demand, so hold a reader open for the whole run.
+      const stopReading = result.key("rows").sink(() => {});
+      await runtime.idle();
+
+      const registry = registryOf(runtime);
+      const moveWindow = async (start: number) => {
+        const moveTx = runtime.edit();
+        argument.withTx(moveTx).key("start").set(start);
+        await moveTx.commit();
+        await runtime.idle();
+      };
+
+      // The window alternates between two positions, so the same two sets of
+      // element runs recur. Whatever the scheduler retains after the window
+      // has been in both positions is all it ever needs to retain.
+      await moveWindow(WINDOW_SIZE);
+      await moveWindow(0);
+      const settled = retainedChildCount(registry);
+
+      for (let move = 0; move < 8; move++) {
+        await moveWindow(move % 2 === 0 ? WINDOW_SIZE : 0);
+      }
+
+      expect(retainedChildCount(registry)).toBe(settled);
+      stopReading();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/storage-transaction-completion.test.ts
+++ b/packages/runner/test/storage-transaction-completion.test.ts
@@ -7,18 +7,31 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 // A transaction's read and write activity is consumed while it is open: the
 // scheduler takes the reactivity log when the action that opened the
 // transaction finishes, and the commit path takes the write details before the
-// result is known. Holding that activity past completion pins every address
-// the transaction touched, so anything that keeps a completed transaction — a
+// result is known. Holding that activity past a completed commit pins every
+// address the transaction touched, so anything that keeps the transaction — a
 // cell bound to it, a cleanup closure that captured it — keeps those too. A
 // list projecting a window that moves opens one transaction per move, so this
 // is the difference between a bounded working set and one that grows with
 // every page turn.
+//
+// A transaction that never reached storage is the other case. The scheduler
+// re-establishes an action's dependencies from the reads of the transaction it
+// aborted or had rejected, and retries the action; releasing those would leave
+// it with no dependencies and nothing to wake it.
 
 const signer = await Identity.fromPassphrase("storage transaction completion");
 const space = signer.did();
 
+function reactivityLogOf(
+  tx: { getReactivityLog?: () => { reads: unknown[]; writes: unknown[] } },
+): { reads: unknown[]; writes: unknown[] } {
+  const log = tx.getReactivityLog?.();
+  if (!log) throw new Error("transaction has no reactivity log");
+  return log;
+}
+
 describe("a completed storage transaction", () => {
-  it("reports no activity once it has committed", async () => {
+  it("releases its activity once its commit completes", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
@@ -33,19 +46,12 @@ describe("a completed storage transaction", () => {
       const tx = runtime.edit();
       cell.withTx(tx).set({ value: 1 });
       cell.withTx(tx).get();
-
-      const readLog = (): { reads: unknown[]; writes: unknown[] } => {
-        const log = tx.getReactivityLog?.();
-        if (!log) throw new Error("transaction has no reactivity log");
-        return log;
-      };
-      const open = readLog();
-      expect(open.writes.length).toBeGreaterThan(0);
+      expect(reactivityLogOf(tx).writes.length).toBeGreaterThan(0);
 
       const result = await tx.commit();
       expect(result.error).toBeUndefined();
 
-      const completed = readLog();
+      const completed = reactivityLogOf(tx);
       expect(completed.reads.length).toBe(0);
       expect(completed.writes.length).toBe(0);
     } finally {
@@ -54,7 +60,7 @@ describe("a completed storage transaction", () => {
     }
   });
 
-  it("reports no activity once it has failed", async () => {
+  it("keeps the activity of a commit rejected before it reached storage", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
@@ -63,19 +69,56 @@ describe("a completed storage transaction", () => {
     try {
       const cell = runtime.getCell<{ value: number }>(
         space,
-        "transaction-completion-failure",
+        "transaction-completion-rejected",
+        undefined,
+      );
+      const seed = runtime.edit();
+      cell.withTx(seed).set({ value: 0 });
+      await seed.commit();
+
+      // Two transactions read and write the same document. The second one is
+      // rejected: the document moved underneath it.
+      const first = runtime.edit();
+      const second = runtime.edit();
+      cell.withTx(first).get();
+      cell.withTx(first).set({ value: 1 });
+      cell.withTx(second).get();
+      cell.withTx(second).set({ value: 2 });
+
+      expect((await first.commit()).error).toBeUndefined();
+      const rejected = await second.commit();
+      expect(rejected.error?.name).toBe("StorageTransactionInconsistent");
+
+      const completed = reactivityLogOf(second);
+      expect(completed.reads.length).toBeGreaterThan(0);
+      expect(completed.writes.length).toBeGreaterThan(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps the activity of a transaction it aborted", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const cell = runtime.getCell<{ value: number }>(
+        space,
+        "transaction-completion-abort",
         undefined,
       );
       const tx = runtime.edit();
       cell.withTx(tx).set({ value: 1 });
-      await tx.commit();
+      cell.withTx(tx).get();
 
-      // A second commit on the same transaction fails; the transaction still
-      // holds no activity afterwards.
-      const completed = tx.getReactivityLog?.();
-      if (!completed) throw new Error("transaction has no reactivity log");
-      expect(completed.reads.length).toBe(0);
-      expect(completed.writes.length).toBe(0);
+      tx.abort("test");
+
+      const completed = reactivityLogOf(tx);
+      expect(completed.reads.length).toBeGreaterThan(0);
+      expect(completed.writes.length).toBeGreaterThan(0);
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/storage-transaction-completion.test.ts
+++ b/packages/runner/test/storage-transaction-completion.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+
+// A transaction's read and write activity is consumed while it is open: the
+// scheduler takes the reactivity log when the action that opened the
+// transaction finishes, and the commit path takes the write details before the
+// result is known. Holding that activity past completion pins every address
+// the transaction touched, so anything that keeps a completed transaction — a
+// cell bound to it, a cleanup closure that captured it — keeps those too. A
+// list projecting a window that moves opens one transaction per move, so this
+// is the difference between a bounded working set and one that grows with
+// every page turn.
+
+const signer = await Identity.fromPassphrase("storage transaction completion");
+const space = signer.did();
+
+describe("a completed storage transaction", () => {
+  it("reports no activity once it has committed", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const cell = runtime.getCell<{ value: number }>(
+        space,
+        "transaction-completion",
+        undefined,
+      );
+      const tx = runtime.edit();
+      cell.withTx(tx).set({ value: 1 });
+      cell.withTx(tx).get();
+
+      const readLog = (): { reads: unknown[]; writes: unknown[] } => {
+        const log = tx.getReactivityLog?.();
+        if (!log) throw new Error("transaction has no reactivity log");
+        return log;
+      };
+      const open = readLog();
+      expect(open.writes.length).toBeGreaterThan(0);
+
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+
+      const completed = readLog();
+      expect(completed.reads.length).toBe(0);
+      expect(completed.writes.length).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("reports no activity once it has failed", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const cell = runtime.getCell<{ value: number }>(
+        space,
+        "transaction-completion-failure",
+        undefined,
+      );
+      const tx = runtime.edit();
+      cell.withTx(tx).set({ value: 1 });
+      await tx.commit();
+
+      // A second commit on the same transaction fails; the transaction still
+      // holds no activity afterwards.
+      const completed = tx.getReactivityLog?.();
+      if (!completed) throw new Error("transaction has no reactivity log");
+      expect(completed.reads.length).toBe(0);
+      expect(completed.writes.length).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/window-retention-probe.ts
+++ b/packages/runner/test/window-retention-probe.ts
@@ -1,0 +1,271 @@
+// Retained heap while a list projects a window that moves back and forth.
+//
+//   deno run -A --v8-flags=--expose-gc \
+//     packages/runner/test/window-retention-probe.ts [shape] [moves]
+//
+// Shapes select what the projection does with each element:
+//   inline   — elements are plain values, the element pattern returns fields
+//   child    — the element pattern also instantiates a nested pattern
+//   cells    — elements are stable child cells, projected the same way
+//   opaque   — elements are stable child cells, and the nested pattern takes
+//              one of them as an opaque cell input
+//
+// The heap is reported after a forced collection, so the figures are reachable
+// memory rather than uncollected garbage.
+
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("window retention probe");
+const space = signer.did();
+
+const WINDOW_SIZE = 20;
+
+const PROGRAMS: Record<string, string> = {
+  inline: `
+import { computed, pattern } from 'commonfabric';
+
+const Row = pattern<{ label: string }, { label: string; shout: string }>(
+  ({ label }) => ({ label, shout: computed(() => label + '!') }),
+);
+
+export default pattern<
+  { items: { label: string }[]; start: number; size: number }
+>(({ items, start, size }) => {
+  const shown = computed(() => items.slice(start, start + size));
+  return { rows: shown.map((item) => Row({ label: item.label })) };
+});
+`,
+  child: `
+import { computed, pattern } from 'commonfabric';
+
+const Detail = pattern<{ label: string }, { text: string }>(
+  ({ label }) => ({ text: computed(() => 'detail ' + label) }),
+);
+
+const Row = pattern<
+  { label: string },
+  { label: string; detail: { text: string } }
+>(({ label }) => ({ label, detail: Detail({ label }) }));
+
+export default pattern<
+  { items: { label: string }[]; start: number; size: number }
+>(({ items, start, size }) => {
+  const shown = computed(() => items.slice(start, start + size));
+  return { rows: shown.map((item) => Row({ label: item.label })) };
+});
+`,
+  cells: `
+import { computed, type OpaqueCell, pattern } from 'commonfabric';
+
+interface Payload {}
+
+const Detail = pattern<{ label: string }, { text: string }>(
+  ({ label }) => ({ text: computed(() => 'detail ' + label) }),
+);
+
+const Row = pattern<
+  { label: string; payload: OpaqueCell<Payload> },
+  { label: string; detail: { text: string } }
+>(({ label }) => ({ label, detail: Detail({ label }) }));
+
+export default pattern<
+  {
+    items: { label: string; payload: OpaqueCell<Payload> }[];
+    start: number;
+    size: number;
+  }
+>(({ items, start, size }) => {
+  const shown = computed(() => items.slice(start, start + size));
+  return {
+    rows: shown.map((item) => Row({ label: item.label, payload: item.payload })),
+  };
+});
+`,
+  opaque: `
+import { computed, type OpaqueCell, pattern } from 'commonfabric';
+
+interface Payload {}
+
+const Detail = pattern<
+  { label: string; payload: OpaqueCell<Payload> },
+  { text: string }
+>(({ label }) => ({ text: computed(() => 'detail ' + label) }));
+
+const Row = pattern<
+  { label: string; payload: OpaqueCell<Payload> },
+  { label: string; detail: { text: string } }
+>(({ label, payload }) => ({ label, detail: Detail({ label, payload }) }));
+
+export default pattern<
+  {
+    items: { label: string; payload: OpaqueCell<Payload> }[];
+    start: number;
+    size: number;
+  }
+>(({ items, start, size }) => {
+  const shown = computed(() => items.slice(start, start + size));
+  return {
+    rows: shown.map((item) => Row({ label: item.label, payload: item.payload })),
+  };
+});
+`,
+  index: `
+import { computed, type OpaqueCell, pattern } from 'commonfabric';
+
+interface Manifest {}
+
+interface RowInput {
+  label: string;
+  filler: string;
+  manifest: OpaqueCell<Manifest>;
+}
+
+const Detail = pattern<
+  { label: string; manifest: OpaqueCell<Manifest> },
+  { text: string }
+>(({ label }) => ({ text: computed(() => 'detail ' + label) }));
+
+const Row = pattern<
+  { element: RowInput },
+  { label: string; size: number; detail: { text: string } }
+>(({ element }) => ({
+  label: element.label,
+  size: computed(() => (element.filler ?? '').length),
+  detail: Detail({ label: element.label, manifest: element.manifest }),
+}));
+
+export default pattern<
+  {
+    index: { rows: OpaqueCell<RowInput>[] };
+    start: number;
+    size: number;
+  }
+>(({ index, start, size }) => {
+  const shown = computed(() => (index?.rows ?? []).slice(start, start + size));
+  // deno-lint-ignore no-explicit-any
+  const projected = (shown as any).mapWithPattern(Row as any, {});
+  return { rows: projected };
+});
+`,
+};
+
+const shape = Deno.args[0] ?? "child";
+const moves = Number(Deno.args[1] ?? 10);
+const rowCount = WINDOW_SIZE * 4;
+const rowBytes = Number(Deno.args[2] ?? 100);
+const source = PROGRAMS[shape];
+if (source === undefined) {
+  throw new Error(`unknown shape ${shape}; try ${Object.keys(PROGRAMS)}`);
+}
+const program: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents: source }],
+};
+
+const gc = (globalThis as { gc?: () => void }).gc;
+function heapMb(): number {
+  gc?.();
+  gc?.();
+  gc?.();
+  return Deno.memoryUsage().heapUsed / 1024 / 1024;
+}
+
+const storageManager = StorageManager.emulate({ as: signer });
+const runtime = new Runtime({
+  apiUrl: new URL(import.meta.url),
+  storageManager,
+});
+try {
+  const compiled = await runtime.patternManager.compilePattern(program, {
+    space,
+  });
+  const tx = runtime.edit();
+  const usesCells = shape === "cells" || shape === "opaque";
+  const items = Array.from({ length: rowCount }, (_, index) => {
+    if (!usesCells) return { label: `row-${index}` };
+    const payload = runtime.getCell<{ text: string }>(
+      space,
+      `payload-${index}`,
+      undefined,
+      tx,
+    );
+    payload.set({ text: `payload ${index}` });
+    return { label: `row-${index}`, payload };
+  });
+  const result = runtime.getCell<{ rows: unknown[] }>(
+    space,
+    "window-result",
+    compiled.resultSchema,
+    tx,
+  );
+  const argument = runtime.getCell<
+    { items: unknown; index?: unknown; start: number; size: number }
+  >(space, "window-argument", undefined, tx);
+  if (shape === "index") {
+    // Rows live in their own documents, linked from an index document, the way
+    // a connector publishes a session index.
+    const rows = Array.from({ length: rowCount }, (_, position) => {
+      const manifest = runtime.getCell<{ text: string }>(
+        space,
+        `manifest-${position}`,
+        undefined,
+        tx,
+      );
+      manifest.set({ text: `manifest ${position}` });
+      const row = runtime.getCell<
+        { label: string; filler: string; manifest: unknown }
+      >(space, `row-${position}`, undefined, tx);
+      row.set({
+        label: `row-${position}`,
+        filler: "x".repeat(rowBytes),
+        manifest,
+      });
+      return row;
+    });
+    const indexCell = runtime.getCell<{ rows: unknown[] }>(
+      space,
+      "window-index",
+      undefined,
+      tx,
+    );
+    indexCell.set({ rows });
+    argument.set({ index: indexCell, items: [], start: 0, size: WINDOW_SIZE });
+  } else {
+    argument.set({ items, start: 0, size: WINDOW_SIZE });
+  }
+  runtime.run(tx, compiled, argument, result);
+  await tx.commit();
+  const stopReading = result.key("rows").sink(() => {});
+  await runtime.idle();
+
+  const moveWindow = async (start: number) => {
+    const moveTx = runtime.edit();
+    argument.withTx(moveTx).key("start").set(start);
+    await moveTx.commit();
+    await runtime.idle();
+  };
+  await moveWindow(WINDOW_SIZE);
+  await moveWindow(0);
+
+  const baseline = heapMb();
+  console.log(`shape=${shape} rows=${rowCount} window=${WINDOW_SIZE}`);
+  console.log(
+    `after the window has visited both positions: ${baseline.toFixed(1)} MB`,
+  );
+  for (let move = 0; move < moves; move++) {
+    await moveWindow(move % 2 === 0 ? WINDOW_SIZE : 0);
+    if (move % 2 === 1) {
+      console.log(
+        `after ${move + 1} more moves: ${heapMb().toFixed(1)} MB ` +
+          `(+${(heapMb() - baseline).toFixed(1)})`,
+      );
+    }
+  }
+  stopReading();
+} finally {
+  await runtime.dispose();
+  await storageManager.close();
+}

--- a/packages/runner/test/window-retention-probe.ts
+++ b/packages/runner/test/window-retention-probe.ts
@@ -258,9 +258,10 @@ try {
   for (let move = 0; move < moves; move++) {
     await moveWindow(move % 2 === 0 ? WINDOW_SIZE : 0);
     if (move % 2 === 1) {
+      const heap = heapMb();
       console.log(
-        `after ${move + 1} more moves: ${heapMb().toFixed(1)} MB ` +
-          `(+${(heapMb() - baseline).toFixed(1)})`,
+        `after ${move + 1} more moves: ${heap.toFixed(1)} MB ` +
+          `(+${(heap - baseline).toFixed(1)})`,
       );
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes two memory leaks in `packages/runner` that caused heap growth when sliding list windows: child actions left in a parent’s index and transactions retaining activity after commit. Back-and-forth paging now stabilizes and per-move growth drops from ~11 MB to ~0.15–0.25 MB.

- **Bug Fixes**
  - Scheduler: `NodeRegistry.remove` now also deletes the child from its parent’s child index to avoid retaining the child’s last frame and storage transaction. Adds `scheduler-child-lifetime.test.ts` to assert the lifecycle and a bounded sliding-window case.
  - Storage: `V2StorageTransaction` now releases branches, read/write logs, the reactivity cache, and last-doc only after a commit that actually ran; it keeps activity for aborted transactions and commits rejected before reaching storage so retries can re-establish dependencies. Adds `storage-transaction-completion.test.ts` and inline code docs explaining why the reject/abort paths retain activity.
  - Investigation artifacts: adds historical records under `docs/history/...` and a headless probe (`packages/runner/test/window-retention-probe.ts`), and fixes the probe’s reporting. Note: a separate unbounded document cache still grows when paging forward across new rows.

<sup>Written for commit 9f8bd99f9819e9f939f573aee308b9e183347210. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

