### PR TITLE
feat(dashboard): support proxied production health checks

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -176,7 +176,7 @@ surveillance tool.
 | commit CI Gantt → `/ci-gantt` | job and step timing for every successful main workflow run attached to one commit, linked from run durations in recent main runs | `GH_TOKEN` |
 | CI duration history → `/bench?view=ci` | labs and loom job, shard-group, and end-to-end workflow duration trends. The duration tiles open their matching repository view | `GH_TOKEN` |
 | CI run Gantt → `/bench?view=gantt` | detailed labs or loom job phases from `scripts/ci-gantt.ts`, backed by the CI history cache | `GH_TOKEN` |
-| production | synthetic HTTP check of the production server: `/_health` on `PROD_URL`'s origin, which answers only while the server is really serving. Defaults to estuary, the production toolshed. Estuary is on the tailnet, so a dashboard that cannot reach the tailnet needs `PROD_URL` pointed at something it can | `PROD_URL` (optional) |
+| production | synthetic HTTP check of the production server: `/_health` on `PROD_URL`'s origin, which answers only while the server is really serving. Defaults to estuary, the production toolshed. Estuary is on the tailnet, so a dashboard without direct tailnet access can route this check through `PROD_PROXY` or point `PROD_URL` at another truthful health source | `PROD_URL`, `PROD_PROXY` (optional) |
 | common.tools | synthetic HTTP check of the public site | `COMMON_TOOLS_URL` (optional; defaults to `https://common.tools`) |
 | prod errors | SigNoz trace error rate for one service (errored spans / all spans): last-12h headline, with a per-hour sparkline over the retained trace history (~2 weeks) and the last-12h slice that feeds the headline highlighted. Scoped to `PROD_SERVICE` — the same SigNoz holds staging and one-off perf runs, whose rates are not production's. Gray (not red) when SigNoz is unreachable. Pops out to the SigNoz logs explorer | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `SIGNOZ_UI_URL` for the pop-out |
 | cloud spend | BigQuery billing export, projected to month-end from the available part of a 14-day daily-cost window early in the month. The header shows actual MTD spend. The highlighted part of the 45-day chart shows the days used for the estimate | `GCP_BILLING_TABLE` (+ Workload Identity, or `GCP_SA_KEY` locally), optional `GCP_DAILY_BUDGET` |
@@ -307,13 +307,13 @@ dataset.
 6. For local development instead, grant those two roles to a service account,
    download a key for it, and set `GCP_SA_KEY` to the file's contents.
 
-The tile sums the raw `cost` column, i.e. total GCP spend across all services,
-gross of credits. It shows the estimated full-month spend as its headline and
-the actual month-to-date value in the header. The estimate uses every settled
-day in the current month. During the first half of the month, it fills that rate
-window from the prior month's tail until it covers 14 days or reaches the first
-available billing day. The chart shows up to 45 complete UTC days and
-highlights the part used for the estimate.
+The tile sums the raw `cost` column, i.e. total spend across every project tied
+to the exported billing account, gross of credits. It shows the estimated
+full-month spend as its headline and the actual month-to-date value in the
+header. The estimate uses every settled day in the current month. During the
+first half of the month, it fills that rate window from the prior month's tail
+until it covers 14 days or reaches the first available billing day. The chart
+shows up to 45 complete UTC days and highlights the part used for the estimate.
 
 ### `OPENAI_ADMIN_KEY`
 
@@ -384,6 +384,7 @@ it.
 | `GCP_SA_KEY` | cloud spend | a service-account key JSON (the whole file, as the value) for local development; in GKE, Workload Identity supplies the token and this is unset. |
 | `GCP_DAILY_BUDGET` | cloud spend | daily USD budget. The projected month is compared with this daily rate multiplied by the number of days in the month. |
 | `PROD_URL` | production | the production **server**, as an origin — the tile checks `/_health` on it and links to it. Defaults to estuary, the production toolshed. Note `production.commontools.dev` is the shell, a static site in a GCS bucket: it has no health endpoint, and its index page answers 200 whether or not the server behind it is serving, so it cannot see an outage. |
+| `PROD_PROXY` | production | optional proxy used only for the production health check. Use `socks5h://127.0.0.1:1055` with the Tailscale userspace proxy so the tailnet hostname resolves through it. Also accepts `socks5://`, `http://`, and `https://`; invalid values and URLs containing credentials fail closed instead of fetching directly. |
 | `COMMON_TOOLS_URL` | common.tools | override the public-site URL (e.g. the `www` host if the apex redirects). |
 | `DASHBOARD_REPO` | CI tiles, github users | which repo the CI tiles read. Its owner is the organization the **github users** tile reads (default `commontoolsinc/labs`). |
 | `DASHBOARD_CACHE_DIR` | server caches | directory for all persistent dashboard cache files (default: the platform temp directory). |
@@ -627,6 +628,8 @@ Env knobs for the dev loop:
 - `DASHBOARD_REPO` — point the CI tiles at any repo. Its owner selects the
   organization for GitHub users.
 - `PROD_URL` — point the production tile at a local server (`http://localhost:8000/`) instead of prod. It checks `/_health` on that origin.
+- `PROD_PROXY` — route only the production health check through a proxy, for
+  example `socks5h://127.0.0.1:1055` with a local Tailscale userspace proxy.
 - The other credential envs (see **Credentials** above — `SIGNOZ_*`, `GCP_*`,
   `OPENAI_ADMIN_KEY`/`ANTHROPIC_ADMIN_KEY`/`OPENROUTER_KEY`, `DISCORD_*`) — set
   one to develop that gated tile against its real backend.
@@ -678,19 +681,25 @@ its embedded tsnet).
 **One-time setup (human steps):**
 
 1. Tailscale admin console: add `tag:dashboard` to `tagOwners`, grant who may
-   reach it, and mint an **ephemeral** `tag:dashboard` auth key. The tailnet
-   also needs MagicDNS and HTTPS certificates enabled — `tailscale serve` fetches
-   a cert for `dashboard.<tailnet>.ts.net` and can't without them.
-2. `tofu apply` in `infra/tofu/gke` creates all the dev-dashboard Secret Manager
-   containers (authkey, github token, and the optional discord/signoz ones). Then
-   store the two required values:
+   reach it, and configure a federated identity restricted to `auth_keys` and
+   `tag:dashboard`. The infra overlay supplies that identity's public client ID
+   with `ephemeral=false&preauthorized=true` and its audience; no Tailscale auth
+   key or OAuth secret is stored in Kubernetes or Secret Manager. The tailnet
+   also needs MagicDNS and HTTPS certificates enabled — `tailscale serve`
+   fetches a cert for `dashboard.<tailnet>.ts.net` and can't without them.
+2. `tofu apply` in `infra/tofu/gke` creates the dev-dashboard Secret Manager
+   containers and Workload Identity/BigQuery grants. Store the required GitHub
+   token (and each provider credential you want to enable):
    ```bash
-   printf %s "tskey-auth-…" | gcloud secrets versions add k8s-stage-dashboard-authkey --data-file=-
    printf %s "github_pat_…" | gcloud secrets versions add k8s-stage-dashboard-github-token --data-file=-
    ```
    The GitHub token is fine-grained and read-only. It has Actions read for the
-   dashboard repositories. GitHub users also needs org Members read. CI spend
-   also needs org Administration read.
+   dashboard repositories. The GitHub users tile also needs org Members read;
+   CI spend also needs org Administration read.
+3. The infra manifests create separate 1 Gi `standard-rwo` PVCs for the Discord
+   history file and Tailscale node state. The dashboard remains a one-replica
+   `Recreate` Deployment; pod replacement reuses the same non-ephemeral
+   Tailscale node ID and `dashboard.<tailnet>.ts.net` name.
 
 **Build, push, deploy**
 
@@ -744,20 +753,21 @@ Tailscale console as `tag:dashboard`; open
 `https://dashboard.<tailnet>.ts.net/`. (The sidecar image is already pinned by
 `@sha256` digest in `03-deployment.yaml`, matching golink.)
 
-**Gated tiles** stay gray until wired: add the Secret Manager *value* (the
-container already exists from `tofu apply`), uncomment the ExternalSecret in
-`dashboard-secrets.yaml` and the env block in `03-deployment.yaml`, then re-run
-`make apply-dev-dashboard-stage`. So you can deploy green and light tiles up one
-at a time.
+**Provider-gated tiles** stay gray until their credential or public configuration
+is wired: add the Secret Manager *value* (the container already exists from
+`tofu apply`), enable the matching ExternalSecret/env when needed, then re-run
+`make apply-dev-dashboard-stage`. Stage's Cloud Billing table is already wired;
+during Google's initial export backfill it reports `no billing data yet` rather
+than a false zero.
 
 Every backend is reached over HTTP, so the image carries no cloud CLI. The
 GitHub tiles use `GH_TOKEN`. The Blacksmith share of CI spend uses
 `BLACKSMITH_API_TOKEN`. The cloud-spend tile queries BigQuery as the pod's
 own service account through Workload Identity. The infra repo's
 `tofu/gke/dashboard.tf` provisions that account, the Workload Identity binding,
-and its BigQuery Job User and Data Viewer grants. Lighting the cloud-spend tile
-up is then just setting `GCP_BILLING_TABLE` and
-`dashboard_billing_dataset` for the export dataset.
+and its BigQuery Job User and Data Viewer grants, so no key is stored in the
+cluster. The stage deployment sets `GCP_BILLING_TABLE` to the standard export
+table, and `dashboard_billing_dataset` scopes its dataset reader grant.
 
 ## Design notes
 

--- a/packages/dashboard/tiles/common-tools-up.test.ts
+++ b/packages/dashboard/tiles/common-tools-up.test.ts
@@ -64,6 +64,34 @@ Deno.test("common.tools: a prompt 200 -> good, headlining the round-trip time", 
   assertEquals(v.hint, "open ↗");
 });
 
+Deno.test("common.tools: cancels the response body before returning", async () => {
+  let cancelled = false;
+  await withFetch(() => {
+    return new Response(new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true;
+      },
+    }), { status: 200 });
+  }, () => commonToolsUp.collect(ctx()));
+  assertEquals(cancelled, true);
+});
+
+Deno.test("common.tools: a cancellation error does not hide the received status", async () => {
+  let cancellationAttempted = false;
+  const view = await withFetch(() => {
+    return new Response(new ReadableStream<Uint8Array>({
+      cancel() {
+        cancellationAttempted = true;
+        throw new Error("body cleanup failed");
+      },
+    }), { status: 503 });
+  }, () => commonToolsUp.collect(ctx()));
+  assertEquals(cancellationAttempted, true);
+  assertEquals(view.status, "bad");
+  assertEquals(view.value, "erroring");
+  assertEquals(view.sub, "HTTP 503 · common.tools");
+});
+
 Deno.test("common.tools: a redirect is not followed and still reads as good", async () => {
   // redirect: "manual" means the 301 is the answer, not a hop to chase.
   const v = await withFetch(ok(301), () => withElapsed(80, () => commonToolsUp.collect(ctx())));

--- a/packages/dashboard/tiles/common-tools-up.ts
+++ b/packages/dashboard/tiles/common-tools-up.ts
@@ -19,6 +19,11 @@ export const commonToolsUp: Tile = {
       const t0 = Date.now();
       const res = await fetch(url, { signal: AbortSignal.timeout(8000), redirect: "manual" });
       const ms = Date.now() - t0;
+      try {
+        await res.body?.cancel();
+      } catch {
+        // A received status establishes reachability when body cleanup fails.
+      }
       fails = 0; // reachable — reset the outage counter
 
       const status: Status = res.status >= 500 ? "bad" : res.status >= 400 || ms > 2500 ? "warn" : "good";

--- a/packages/dashboard/tiles/gcp-spend.test.ts
+++ b/packages/dashboard/tiles/gcp-spend.test.ts
@@ -142,7 +142,7 @@ Deno.test(
       result.aside,
       '<span class="hmtd">$180 MTD</span>',
     );
-    assertEquals(result.sub, "project spend");
+    assertEquals(result.sub, "billing account spend");
     assertEquals(result.duration, 45 * DAY);
 
     const polylines = [

--- a/packages/dashboard/tiles/gcp-spend.ts
+++ b/packages/dashboard/tiles/gcp-spend.ts
@@ -179,7 +179,7 @@ export const gcpSpend: Tile = {
       status,
       value: `~${usd(summary.projected)}/mo`,
       aside: `<span class="hmtd">${usd(history.actualMtd)} MTD</span>`,
-      sub: "project spend",
+      sub: "billing account spend",
       extra: chart.chart,
       duration: chart.duration,
     };

--- a/packages/dashboard/tiles/prod-uptime.test.ts
+++ b/packages/dashboard/tiles/prod-uptime.test.ts
@@ -3,7 +3,12 @@
 // advances by a set latency across the round trip. No real network.
 import { assertEquals, assertRejects } from "@std/assert";
 import type { Ctx } from "../types.ts";
-import { prodUptime } from "./prod-uptime.ts";
+import {
+  prodUptime,
+  setProdUptimeHttpClientFactoryForTest,
+} from "./prod-uptime.ts";
+
+type ProxyFetchInit = RequestInit & { client?: Deno.HttpClient };
 
 function ctx(env: Record<string, string> = {}): Ctx {
   return {
@@ -16,14 +21,17 @@ function ctx(env: Record<string, string> = {}): Ctx {
 // Replaces fetch and the clock for one test. `reply` returns the canned response,
 // or throws to stand in for an unreachable host. The clock jumps by `latencyMs`
 // when fetch is called, which is what the tile measures as the round trip.
-function stub(reply: (url: string) => Response, latencyMs = 12) {
+function stub(
+  reply: (url: string, init: ProxyFetchInit | undefined) => Response,
+  latencyMs = 12,
+) {
   const realFetch = globalThis.fetch;
   const realNow = Date.now;
   let now = 1_700_000_000_000;
   Date.now = () => now;
-  globalThis.fetch = ((input: string | URL | Request) => {
+  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
     now += latencyMs;
-    return Promise.resolve(reply(String(input)));
+    return Promise.resolve(reply(String(input), init));
   }) as typeof fetch;
   return () => {
     globalThis.fetch = realFetch;
@@ -35,6 +43,15 @@ const ok = (status: number) => () => new Response(null, { status });
 const unreachable = () => {
   throw new TypeError("error sending request for url");
 };
+
+function fakeClient(onClose: () => void = () => {}): Deno.HttpClient {
+  return {
+    close: onClose,
+    [Symbol.dispose]() {
+      this.close();
+    },
+  };
+}
 
 // The tile keeps a consecutive-failure counter across calls. A reachable check
 // clears it, so tests that care about the counter start from a known zero.
@@ -50,7 +67,9 @@ async function resetFailCounter() {
 Deno.test("prod uptime: a fast 2xx -> good, headlined with the measured round trip", async () => {
   const restore = stub(ok(200), 137);
   try {
-    const v = await prodUptime.collect(ctx({ PROD_URL: "https://prod.example.com/" }));
+    const v = await prodUptime.collect(
+      ctx({ PROD_URL: "https://prod.example.com/" }),
+    );
     assertEquals(v.label, "production");
     assertEquals(v.status, "good");
     assertEquals(v.value, "137 ms");
@@ -66,7 +85,9 @@ Deno.test("prod uptime: a redirect is followed by nothing and still counts as re
   // redirect: "manual" means the 301 comes back as-is rather than being chased.
   const restore = stub(ok(301), 20);
   try {
-    const v = await prodUptime.collect(ctx({ PROD_URL: "https://prod.example.com/" }));
+    const v = await prodUptime.collect(
+      ctx({ PROD_URL: "https://prod.example.com/" }),
+    );
     assertEquals(v.status, "good");
     assertEquals(v.value, "20 ms");
     assertEquals(v.sub, "HTTP 301 · prod.example.com");
@@ -80,7 +101,9 @@ Deno.test("prod uptime: 5xx -> bad at once, and says erroring rather than a late
   // is no consecutive-failure grace period for it.
   const restore = stub(ok(503), 15);
   try {
-    const v = await prodUptime.collect(ctx({ PROD_URL: "https://prod.example.com/" }));
+    const v = await prodUptime.collect(
+      ctx({ PROD_URL: "https://prod.example.com/" }),
+    );
     assertEquals(v.status, "bad");
     assertEquals(v.value, "erroring");
     assertEquals(v.sub, "HTTP 503 · prod.example.com");
@@ -92,7 +115,9 @@ Deno.test("prod uptime: 5xx -> bad at once, and says erroring rather than a late
 Deno.test("prod uptime: 4xx -> warn, not bad", async () => {
   const restore = stub(ok(404), 15);
   try {
-    const v = await prodUptime.collect(ctx({ PROD_URL: "https://prod.example.com/" }));
+    const v = await prodUptime.collect(
+      ctx({ PROD_URL: "https://prod.example.com/" }),
+    );
     assertEquals(v.status, "warn");
     assertEquals(v.value, "15 ms");
     assertEquals(v.sub, "HTTP 404 · prod.example.com");
@@ -104,7 +129,9 @@ Deno.test("prod uptime: 4xx -> warn, not bad", async () => {
 Deno.test("prod uptime: a slow 200 -> warn on latency alone", async () => {
   const restore = stub(ok(200), 2501);
   try {
-    const v = await prodUptime.collect(ctx({ PROD_URL: "https://prod.example.com/" }));
+    const v = await prodUptime.collect(
+      ctx({ PROD_URL: "https://prod.example.com/" }),
+    );
     assertEquals(v.status, "warn");
     assertEquals(v.value, "2501 ms"); // still a latency, not "erroring" — it answered
   } finally {
@@ -113,7 +140,11 @@ Deno.test("prod uptime: a slow 200 -> warn on latency alone", async () => {
   // 2500 is the edge and stays green.
   const restoreEdge = stub(ok(200), 2500);
   try {
-    assertEquals((await prodUptime.collect(ctx({ PROD_URL: "https://prod.example.com/" }))).status, "good");
+    assertEquals(
+      (await prodUptime.collect(ctx({ PROD_URL: "https://prod.example.com/" })))
+        .status,
+      "good",
+    );
   } finally {
     restoreEdge();
   }
@@ -134,10 +165,209 @@ Deno.test("prod uptime: PROD_URL is the server; the tile checks its health and l
     assertEquals(v.href, "https://estuary.saga-castor.ts.net"); // the origin is what opens
     assertEquals(v.sub, "HTTP 200 · estuary.saga-castor.ts.net");
     // A PROD_URL carrying a path still means the server it points at.
-    await prodUptime.collect(ctx({ PROD_URL: "https://example.test/some/page" }));
+    await prodUptime.collect(
+      ctx({ PROD_URL: "https://example.test/some/page" }),
+    );
     assertEquals(asked, "https://example.test/_health");
   } finally {
     globalThis.fetch = real;
+  }
+});
+
+Deno.test("prod uptime: unset PROD_PROXY does not create or pass a Deno client", async () => {
+  let created = 0;
+  let seenInit: RequestInit | undefined;
+  const restoreClient = setProdUptimeHttpClientFactoryForTest(() => {
+    created++;
+    return fakeClient();
+  });
+  const restore = stub((_url, init) => {
+    seenInit = init;
+    return new Response("ok", { status: 200 });
+  });
+  try {
+    const v = await prodUptime.collect(
+      ctx({ PROD_URL: "https://prod.example.com/" }),
+    );
+    assertEquals(v.status, "good");
+    assertEquals(created, 0);
+    assertEquals(seenInit === undefined ? false : "client" in seenInit, false);
+  } finally {
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: socks5h PROD_PROXY creates a socks5 client, passes it to fetch, cancels the body, and closes it", async () => {
+  let options: Parameters<typeof Deno.createHttpClient>[0] | undefined;
+  let closed = false;
+  let cancelled = false;
+  const client = fakeClient(() => {
+    closed = true;
+    assertEquals(cancelled, true);
+  });
+  const restoreClient = setProdUptimeHttpClientFactoryForTest((opts) => {
+    options = opts;
+    return client;
+  });
+  const restore = stub((_url, init) => {
+    assertEquals(init?.client, client);
+    return new Response(new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true;
+      },
+    }), { status: 200 });
+  });
+  try {
+    const v = await prodUptime.collect(ctx({
+      PROD_URL: "https://prod.example.com/",
+      PROD_PROXY: "socks5h://127.0.0.1:1055",
+    }));
+    assertEquals(v.status, "good");
+    assertEquals(options, {
+      proxy: { transport: "socks5", url: "socks5h://127.0.0.1:1055" },
+    });
+    assertEquals(closed, true);
+  } finally {
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: HTTP PROD_PROXY creates an HTTP proxy client", async () => {
+  let options: Parameters<typeof Deno.createHttpClient>[0] | undefined;
+  let closed = false;
+  const client = fakeClient(() => {
+    closed = true;
+  });
+  const restoreClient = setProdUptimeHttpClientFactoryForTest((opts) => {
+    options = opts;
+    return client;
+  });
+  const restore = stub((_url, init) => {
+    assertEquals(init?.client, client);
+    return new Response("ok", { status: 200 });
+  });
+  try {
+    const v = await prodUptime.collect(
+      ctx({ PROD_PROXY: "http://proxy.example:8080" }),
+    );
+    assertEquals(v.status, "good");
+    assertEquals(options, { proxy: { url: "http://proxy.example:8080" } });
+    assertEquals(closed, true);
+  } finally {
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: proxy client closes when fetch fails", async () => {
+  await resetFailCounter();
+  let closed = false;
+  const client = fakeClient(() => {
+    closed = true;
+  });
+  const restoreClient = setProdUptimeHttpClientFactoryForTest(() => client);
+  const restore = stub(() => {
+    throw new TypeError("proxy tunnel failed");
+  });
+  try {
+    const v = await prodUptime.collect(
+      ctx({ PROD_PROXY: "socks5://127.0.0.1:1055" }),
+    );
+    assertEquals(v.status, "unknown");
+    assertEquals(v.value, "—");
+    assertEquals(closed, true);
+  } finally {
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: a cancellation error preserves the received status and closes the proxy client", async () => {
+  let cancellationAttempted = false;
+  let closed = false;
+  const client = fakeClient(() => {
+    closed = true;
+  });
+  const restoreClient = setProdUptimeHttpClientFactoryForTest(() => client);
+  const restore = stub(() => {
+    return new Response(new ReadableStream<Uint8Array>({
+      cancel() {
+        cancellationAttempted = true;
+        throw new Error("body cleanup failed");
+      },
+    }), { status: 503 });
+  });
+  try {
+    const view = await prodUptime.collect(
+      ctx({ PROD_PROXY: "http://proxy.example:8080" }),
+    );
+    assertEquals(view.status, "bad");
+    assertEquals(view.value, "erroring");
+    assertEquals(view.sub, "HTTP 503 · estuary.saga-castor.ts.net");
+    assertEquals(cancellationAttempted, true);
+    assertEquals(closed, true);
+  } finally {
+    restore();
+    restoreClient();
+  }
+});
+
+Deno.test("prod uptime: invalid PROD_PROXY stays a configuration error without falling back or becoming an outage", async () => {
+  await resetFailCounter();
+  let created = 0;
+  let fetched = 0;
+  let failFetch = false;
+  const restoreClient = setProdUptimeHttpClientFactoryForTest((options) => {
+    created++;
+    if (
+      options.proxy !== undefined &&
+      "url" in options.proxy &&
+      options.proxy.url === "socks5:///foo"
+    ) {
+      throw new TypeError("invalid proxy URL");
+    }
+    return fakeClient();
+  });
+  const restore = stub(() => {
+    fetched++;
+    if (failFetch) throw new TypeError("network unreachable");
+    return new Response("ok", { status: 200 });
+  });
+  try {
+    for (
+      const proxy of [
+        "not a url",
+        "ftp://proxy.example",
+        "http://user:password@proxy.example",
+      ]
+    ) {
+      const invalid = await prodUptime.collect(ctx({ PROD_PROXY: proxy }));
+      assertEquals(invalid.status, "unknown");
+      assertEquals(invalid.value, "—");
+      assertEquals(invalid.sub, "invalid PROD_PROXY");
+    }
+    assertEquals(created, 0);
+    assertEquals(fetched, 0);
+
+    const runtimeInvalid = await prodUptime.collect(
+      ctx({ PROD_PROXY: "socks5:///foo" }),
+    );
+    assertEquals(runtimeInvalid.status, "unknown");
+    assertEquals(runtimeInvalid.value, "—");
+    assertEquals(runtimeInvalid.sub, "invalid PROD_PROXY");
+    assertEquals(created, 1);
+    assertEquals(fetched, 0);
+
+    failFetch = true;
+    const unreachable = await prodUptime.collect(ctx());
+    assertEquals(unreachable.status, "unknown");
+    assertEquals(unreachable.sub, "unreachable · estuary.saga-castor.ts.net");
+    assertEquals(fetched, 1);
+  } finally {
+    restore();
+    restoreClient();
   }
 });
 
@@ -146,19 +376,25 @@ Deno.test("prod uptime: one unreachable check is gray 'can't tell', only three i
   const restore = stub(unreachable);
   try {
     // A single blip on the dashboard's side must not read as an outage.
-    const first = await prodUptime.collect(ctx({ PROD_URL: "https://prod.example.com/" }));
+    const first = await prodUptime.collect(
+      ctx({ PROD_URL: "https://prod.example.com/" }),
+    );
     assertEquals(first.status, "unknown");
     assertEquals(first.value, "—");
     assertEquals(first.sub, "unreachable · prod.example.com");
     assertEquals(first.href, "https://prod.example.com");
     assertEquals(first.hint, "open ↗");
 
-    const second = await prodUptime.collect(ctx({ PROD_URL: "https://prod.example.com/" }));
+    const second = await prodUptime.collect(
+      ctx({ PROD_URL: "https://prod.example.com/" }),
+    );
     assertEquals(second.status, "unknown");
     assertEquals(second.value, "—");
 
     // The third consecutive failure is a sustained run, and escalates.
-    const third = await prodUptime.collect(ctx({ PROD_URL: "https://prod.example.com/" }));
+    const third = await prodUptime.collect(
+      ctx({ PROD_URL: "https://prod.example.com/" }),
+    );
     assertEquals(third.status, "bad");
     assertEquals(third.value, "down");
     assertEquals(third.sub, "unreachable · prod.example.com");

--- a/packages/dashboard/tiles/prod-uptime.ts
+++ b/packages/dashboard/tiles/prod-uptime.ts
@@ -18,30 +18,98 @@
 //
 // Estuary is on the tailnet. A dashboard that cannot reach the tailnet reads it as
 // unreachable, and a sustained run of that is a red "down" about the dashboard
-// rather than about production, so such a deployment needs PROD_URL pointed at
-// something it can reach.
+// rather than about production, so such a deployment must route this check over
+// the tailnet with PROD_PROXY or point PROD_URL at another truthful health source.
 import type { Status, Tile, TileView } from "../types.ts";
 
 const FAIL_THRESHOLD = 3; // consecutive unreachable checks before declaring "down"
 const HEALTH_PATH = "/_health";
 let fails = 0;
 
+type CreateHttpClient = typeof Deno.createHttpClient;
+type HttpClientOptions = Parameters<CreateHttpClient>[0];
+type ProxyFetchInit = RequestInit & { client?: Deno.HttpClient };
+
+let createHttpClient: CreateHttpClient = Deno.createHttpClient;
+
+export function setProdUptimeHttpClientFactoryForTest(
+  factory: CreateHttpClient,
+): () => void {
+  const previous = createHttpClient;
+  createHttpClient = factory;
+  return () => {
+    createHttpClient = previous;
+  };
+}
+
+function optionsForProxy(proxy: string): HttpClientOptions {
+  let url: URL;
+  try {
+    url = new URL(proxy);
+  } catch (cause) {
+    throw new TypeError(`invalid PROD_PROXY URL: ${proxy}`, { cause });
+  }
+
+  if (url.username !== "" || url.password !== "") {
+    throw new TypeError("PROD_PROXY URL must not contain credentials");
+  }
+  if (url.protocol === "socks5:" || url.protocol === "socks5h:") {
+    return { proxy: { transport: "socks5", url: proxy } };
+  }
+  if (url.protocol === "http:" || url.protocol === "https:") {
+    return { proxy: { url: proxy } };
+  }
+
+  throw new TypeError(`unsupported PROD_PROXY URL scheme: ${url.protocol}`);
+}
+
 export const prodUptime: Tile = {
   id: "prod-uptime",
   intervalMs: 30_000,
   async collect(ctx): Promise<TileView> {
-    const origin = new URL(ctx.env("PROD_URL") ?? "https://estuary.saga-castor.ts.net").origin;
+    const origin =
+      new URL(ctx.env("PROD_URL") ?? "https://estuary.saga-castor.ts.net")
+        .origin;
+    const proxy = ctx.env("PROD_PROXY");
     const url = `${origin}${HEALTH_PATH}`;
     const host = new URL(origin).host;
     const drill = { href: origin, hint: "open ↗" };
+    let client: Deno.HttpClient | undefined;
+    try {
+      client = proxy === undefined
+        ? undefined
+        : createHttpClient(optionsForProxy(proxy));
+    } catch {
+      return {
+        ...drill,
+        label: "production",
+        status: "unknown",
+        value: "—",
+        sub: "invalid PROD_PROXY",
+      };
+    }
 
     try {
       const t0 = Date.now();
-      const res = await fetch(url, { signal: AbortSignal.timeout(8000), redirect: "manual" });
+      const init: ProxyFetchInit = {
+        signal: AbortSignal.timeout(8000),
+        redirect: "manual",
+      };
+      if (client !== undefined) init.client = client;
+      const res = await fetch(url, init);
       const ms = Date.now() - t0;
+      try {
+        await res.body?.cancel();
+      } catch {
+        // A received status establishes reachability when body cleanup fails.
+      }
       fails = 0; // reachable — reset the outage counter
 
-      const status: Status = res.status >= 500 ? "bad" : res.status >= 400 || ms > 2500 ? "warn" : "good";
+      const status: Status = res.status >= 500
+        ? "bad"
+        : res.status >= 400 || ms > 2500
+        ? "warn"
+        : "good";
       return {
         ...drill,
         label: "production",
@@ -52,7 +120,15 @@ export const prodUptime: Tile = {
     } catch {
       fails++;
       const status: Status = fails >= FAIL_THRESHOLD ? "bad" : "unknown";
-      return { ...drill, label: "production", status, value: fails >= FAIL_THRESHOLD ? "down" : "—", sub: `unreachable · ${host}` };
+      return {
+        ...drill,
+        label: "production",
+        status,
+        value: fails >= FAIL_THRESHOLD ? "down" : "—",
+        sub: `unreachable · ${host}`,
+      };
+    } finally {
+      client?.close();
     }
   },
 };


### PR DESCRIPTION
The dashboard can run outside the production tailnet while the configured production URL remains private. Add optional HTTP, HTTPS, SOCKS5, and SOCKS5H proxy support to the production uptime collector. Validate the proxy before checking health, keep configuration and client-construction failures separate from outage tracking, close each per-check client, and never fall back to a direct request.

Cancel unused response bodies in both uptime collectors without hiding an HTTP status that was already received. Cover cleanup failures, malformed and credential-bearing proxy settings, client lifecycle behavior, and the distinction between configuration errors and sustained network outages.

Document the proxy and persistent stage deployment settings, including the required GitHub token permissions. Rename the GCP spend subtitle to billing account spend because the export covers every project attached to the configured billing account.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional proxy support for the production health check so the dashboard can run outside the tailnet without exposing prod. Also harden uptime collectors by cancelling response bodies and treating config errors separately from outages; update docs and rename the GCP spend subtitle.

- **New Features**
  - `PROD_PROXY` for the production uptime check with `http://`, `https://`, `socks5://`, and `socks5h://` support.
  - Validate proxy before use; credential-bearing or malformed URLs fail closed as configuration errors (no direct fallback).
  - Create a per-check `Deno.HttpClient`, pass it to `fetch`, and close it after each check.
  - Docs: add proxy guidance, stage deployment notes (GitHub token perms, Tailscale identity), and rename spend subtitle to “billing account spend”.

- **Bug Fixes**
  - Cancel unused response bodies in prod and common.tools collectors; cancellation errors don’t hide a received HTTP status.
  - Keep configuration/client-construction failures separate from outage tracking; only sustained unreachable checks trip “down”.

<sup>Written for commit b8079c707d084bab4c5e478dc23a0b2ba9856dd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

