### PR TITLE
fix(shell): stop the runtime task from clearing the view's space

### DIFF
--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -127,9 +127,10 @@ export class XRootView extends BaseView {
         }
 
         if (!app || !app.identity) {
-          // Clear the runtime and space when no app state
+          // Clear the runtime when no app state. The space belongs to the
+          // view, and #syncViewSpace has already cleared it for the same
+          // change that took the identity away.
           this.runtime = undefined;
-          this.space = undefined;
           this.#telemetry = undefined;
           clearRuntimeDebugGlobals(getCommonfabricGlobal());
           return undefined;
@@ -175,9 +176,11 @@ export class XRootView extends BaseView {
         });
 
         if (signal.aborted) {
+          // A newer creation replaced this one. Drop what this one built and
+          // leave the space alone: which space the view addresses does not
+          // depend on which runtime creation won.
           rt.dispose().catch(console.error);
           this.runtime = undefined;
-          this.space = undefined;
           clearRuntimeDebugGlobals(getCommonfabricGlobal());
           return;
         }

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -312,6 +312,77 @@ describe("XRootView", () => {
     }
   });
 
+  it("keeps the view's space when a superseded runtime creation unwinds", async () => {
+    const restore = installBrowserGlobals();
+    const originalError = console.error;
+    console.error = () => {};
+    const { RuntimeInternals, resolveSpaceDid } = await import(
+      "@commonfabric/lib-shell"
+    );
+    const originalCreate = RuntimeInternals.create;
+    // The abandoned creation disposes the runtime it built. Resolving off that
+    // call lands after the whole abandonment block has run.
+    let abandoned!: () => void;
+    const disposed = new Promise<void>((resolve) => {
+      abandoned = resolve;
+    });
+    RuntimeInternals.create = (() =>
+      Promise.resolve({
+        runtime: () => ({}),
+        dispose: () => {
+          abandoned();
+          return Promise.resolve();
+        },
+      } as unknown as Awaited<
+        ReturnType<typeof RuntimeInternals.create>
+      >)) as typeof RuntimeInternals.create;
+
+    try {
+      const { XRootView } = await import("../src/views/RootView.ts");
+      const view = new XRootView();
+      const identity = await Identity.fromPassphrase(
+        "root-view-superseded-runtime-test",
+      );
+      const atlas = await resolveSpaceDid(identity, "atlas");
+      const lifecycle = view as unknown as {
+        willUpdate(changed: Map<string, unknown>): void;
+      };
+
+      view.app = {
+        ...view.app,
+        identity,
+        view: { spaceName: "atlas" } as typeof view.app.view,
+      };
+      lifecycle.willUpdate(new Map([["app", undefined]]));
+      await view.spaceResolved();
+      expect(view.getRuntimeSpaceDID()).toBe(atlas);
+
+      const task = (view as unknown as {
+        _rt: {
+          run(args: [typeof view.app]): void;
+          taskComplete: Promise<unknown>;
+        };
+      })._rt;
+
+      // One runtime creation starts and a second supersedes it, which is what
+      // a compiler stack reload does to a creation already under way.
+      task.run([view.app]);
+      task.run([view.app]);
+      await task.taskComplete;
+      await disposed;
+
+      // The abandoned creation says nothing about which space the view
+      // addresses, so the space it resolved has to survive. Nothing would
+      // restore it: the view still names atlas, so no lookup runs again.
+      expect(view.getRuntimeSpaceDID()).toBe(atlas);
+    } finally {
+      RuntimeInternals.create = originalCreate;
+      console.error = originalError;
+      delete (globalThis as { commonfabric?: unknown }).commonfabric;
+      restore();
+    }
+  });
+
   it("guards a browser reload only while the runtime reports pending writes", async () => {
     const restore = installBrowserGlobals();
     try {


### PR DESCRIPTION
The space a view addresses is derived from the view, and RootView keeps it current in willUpdate. The task that builds the runtime was also writing to it, in two places, and one of those is wrong.

When a second runtime creation supersedes one already under way, the abandoned one carries on to its own completion and then discovers its signal is aborted. It drops what it built, which is right, and it also cleared the space, which is not: which space the view addresses has nothing to do with which runtime creation won the race. A compiler stack reload does exactly this, replacing a worker while a creation is in flight.

That clearing used to be self-correcting, because the derivation ran again on the next app state change and put the space back. It is not self-correcting any more. The derivation now reuses the space it already resolved whenever the view keeps naming the same space, so it returns early and never restores what the abandoned creation took away. The view is left addressing no space, showing nothing, until the user navigates to a space with a different name.

Remove both writes. The logout case is already covered: the same app state change that takes the identity away runs the derivation, which clears the space because no identity means no space. The abandoned case should never have touched it. This leaves the space with a single writer, which is the point — the guard that decides whether a resolution is still current lives there, and a write that goes around it cannot be ordered against the resolutions it races.

Adds a test that supersedes a creation mid-flight and asserts the space survives it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented the runtime creation task from clearing the view’s space, fixing blank views when a creation is superseded (e.g., compiler reload). The space is now managed only by `RootView`’s derivation.

- **Bug Fixes**
  - Removed `this.space` writes from the runtime task in both “no app/identity” and “aborted creation” paths.
  - On logout/no identity, clear only the runtime; `#syncViewSpace` already clears the space.
  - On aborted creation, dispose and clear the runtime only; keep the space unchanged.
  - Added a test that supersedes a creation mid-flight and asserts the view’s space persists.

<sup>Written for commit ed3895f7d956899583e50a4153027aaf4b28c9c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

