### PR TITLE
docs(plans): strike the superseded C1 fork bullet

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -201,12 +201,13 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
   `EXPERIMENTAL_OPTIONS.md`, scheduler-v2 §7.6 receipt-content note, both
   flag states tested in `scheduler-event-receipts.test.ts`, including
   same-id redelivery retaining the original result.
-- **C1 design fork, decide first:** `Stream<T>` is a branded-cell interface
-  wired through a one-slot HKT (`AsStream`, `packages/api/index.ts:1239`), so
+- ~~**C1 design fork, decide first:** `Stream<T>` is a branded-cell interface
+  wired through a one-slot HKT (`AsStream`, `packages/api/index.ts:1358`), so
   `Stream<T, R = void>` ripples through the cell-type machinery; the
   alternative is a separate declared-result carrier (e.g.
   `StreamWithResult<T, R> extends Stream<T>`) that only the schema layer
-  interprets. Settle this at the top of the C1 PR.
+  interprets. Settle this at the top of the C1 PR.~~ — settled in #5123; the
+  decision and its measured costs are the **C1 fork — settled** bullet above.
 - **Exit:** a CTS pattern declares a verb returning `AddTopicResult`; the
   result schema appears in the durable schema; under the flag, both plain and
   reactive returns are readable in the receipt cell.


### PR DESCRIPTION
## Why

#5123 settled the C1 typing fork but left the older **"C1 design fork, decide first"** bullet standing, so the plan now tells an implementer both "settled" and "decide first" about the same question — with the older bullet still instructing them to settle it at the top of the C1 PR that already settled it.

Caught by cubic's review on #5123. I merged that PR before reading the review, which is my miss; this is the follow-up.

## What Changed

Struck the superseded bullet rather than deleting it, so the alternative that was weighed — a separate `StreamWithResult<T, R>` carrier — stays legible next to the decision instead of vanishing from the record. It now points at the **C1 fork — settled** bullet above it.

Its `AsStream` citation was also stale: `packages/api/index.ts:1239`, actually 1358. Corrected in passing, since a struck bullet is still read.

## Test plan

Doc-only. `deno task check-docs` covers the typed code blocks under `docs/`; this touches prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the C1 plan by striking the superseded “C1 design fork, decide first” bullet to remove conflicting guidance after #5123 settled the fork. Also updates the `AsStream` citation to `packages/api/index.ts:1358` and points readers to the “C1 fork — settled” bullet.

<sup>Written for commit 11aa2ffd382ab817342db07962e2ec8001e3b2f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

