### PR TITLE
fix(state-inspector): write clones where a server actually reads them

### DIFF
--- a/docs/plans/space-clone-rehearsal.md
+++ b/docs/plans/space-clone-rehearsal.md
@@ -305,6 +305,25 @@ rehearsal isn't over-trusted:
 - `cf space clone --verify` — fingerprint check against the manifest.
 - `cf inspect churn <space> [--bucket 1m] [--since …] [--top N]`.
 
+**Layout correction (2026-07-28).** The first implementation wrote the working
+copy to `<dir>/engine-v3/<did>.sqlite` and told the operator to point
+`MEMORY_DIR` at `<dir>`. A server pointed there actually reads
+`<dir>/engine-v3/engine-v3/<did>.sqlite`: toolshed's
+`resolveMemoryEngineStoreRootUrl` appends `engine-v3`, and memory's
+`resolveSpaceStoreUrl` appends it again. Every clone produced was therefore
+unservable — the server found nothing and silently created a fresh empty space
+— and every test passed, because they all checked the layout against the
+tool's own hardcoded constant rather than against the resolvers. Only booting a
+real toolshed and reading the board back exposed it.
+
+The fix is not to hardcode the doubled path, which would be a third statement
+of the layout. `resolveMemoryEngineStoreRootUrl` moved into
+`memory/v2/storage-path.ts` beside `resolveSpaceStoreUrl`, and both the clone
+and its tests now COMPOSE the two. If the redundant append is ever removed,
+clones follow with no further change. The doubling itself is a latent bug worth
+its own change: every existing store depends on it, so removing it is a
+migration, not a drive-by.
+
 **Build (increment 2, optional).** Toolshed clone banner. **Shipped** —
 `packages/toolshed/lib/clone-banner.ts` reads the `.cf-clone` marker at
 startup and prints the clone's provenance, so a served clone is visible in

--- a/packages/cli/test/space.test.ts
+++ b/packages/cli/test/space.test.ts
@@ -9,6 +9,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Database } from "@db/sqlite";
+import { clonePaths } from "@commonfabric/state-inspector";
 import { cf, withEnv } from "./utils.ts";
 
 /** `CliResult` streams are line arrays; join before substring assertions. */
@@ -73,9 +74,14 @@ function appendDocs(db: Database, docs: [string, unknown][]): void {
   });
 }
 
+/** The working copy's path, derived the way the server resolves it — never
+ *  spelled out here, which is what let an earlier version of this suite pass
+ *  against a store no server would read. */
+const workingCopy = (dir: string): string => clonePaths(dir, SPACE).workingPath;
+
 /** Apply writes to the clone's working copy, as a rehearsal attempt would. */
 function writeToWorkingCopy(dir: string, docs: [string, unknown][]): void {
-  const db = new Database(`${dir}/engine-v3/${SPACE}.sqlite`);
+  const db = new Database(workingCopy(dir));
   appendDocs(db, docs);
   db.close();
 }
@@ -104,7 +110,7 @@ describe("cf space", () => {
       expect(cloned.code).toBe(0);
       // The working copy lands where the memory server resolves a space store,
       // so MEMORY_DIR can serve the clone under the same DID.
-      expect(text(cloned.stdout)).toContain(`engine-v3/${SPACE}.sqlite`);
+      expect(text(cloned.stdout)).toContain(workingCopy(clone));
       expect(text(cloned.stdout)).toContain("1 generated cells excluded");
 
       const clean = await cf(`space verify ${clone}`);
@@ -168,7 +174,7 @@ describe("cf space", () => {
   it("reports a fingerprint that ignores generated-cell churn", async () => {
     await withFixture(async ({ snapshot, clone }) => {
       await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
-      const working = `${clone}/engine-v3/${SPACE}.sqlite`;
+      const working = workingCopy(clone);
 
       const before = await cf(`space fingerprint ${working}`);
       expect(before.code).toBe(0);
@@ -280,7 +286,7 @@ describe("cf space", () => {
     // listing must name it rather than let it vanish from the roll-up.
     await withFixture(async ({ snapshot, clone }) => {
       await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
-      const working = `${clone}/engine-v3/${SPACE}.sqlite`;
+      const working = workingCopy(clone);
       let deep: unknown = null;
       for (let i = 0; i < 5000; i++) deep = { a: deep };
       writeToWorkingCopy(clone, [["of:pathological", { value: deep }]]);
@@ -300,7 +306,7 @@ describe("cf space", () => {
       await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
       // Corrupt the baseline itself: reset will "succeed" mechanically but the
       // clone no longer matches its manifest, which must not report success.
-      const pristine = `${clone}/pristine/${SPACE}.sqlite`;
+      const pristine = clonePaths(clone, SPACE).pristinePath;
       const db = new Database(pristine);
       appendDocs(db, [["of:input", { value: { title: "ROTTED BASELINE" } }]]);
       db.close();
@@ -385,7 +391,7 @@ describe("cf space", () => {
     // hide a real content change, so it must never be silent.
     await withFixture(async ({ snapshot, clone }) => {
       await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
-      const working = `${clone}/engine-v3/${SPACE}.sqlite`;
+      const working = workingCopy(clone);
       writeToWorkingCopy(clone, [
         ["of:second-piece", {
           value: { $NAME: "Other" },

--- a/packages/memory/v2/storage-path.ts
+++ b/packages/memory/v2/storage-path.ts
@@ -31,6 +31,37 @@ const isSingleFileStore = (store: URL): boolean => {
   return Path.extname(storePath) !== "";
 };
 
+/**
+ * The engine store root a server derives from its configured store location
+ * (`MEMORY_DIR`, or `DB_PATH` in single-file mode).
+ *
+ * Lives here, beside {@link resolveSpaceStoreUrl}, because the two compose into
+ * the on-disk layout and must be read together: this appends `engine-v3`, and
+ * `resolveSpaceStoreUrl` then appends it AGAIN, so the realized directory-mode
+ * path is `<MEMORY_DIR>/engine-v3/engine-v3/<did>.sqlite`. That doubling is
+ * almost certainly unintentional, but every existing store depends on it, so it
+ * cannot be removed without migrating them; `state-inspector/discover.ts` works
+ * around it when hunting for stores.
+ *
+ * Anything that needs to READ or WRITE a store the server will serve must
+ * compose these two functions rather than restating `engine-v3` — a third
+ * spelling of the layout is how a tool ends up writing where nothing looks.
+ */
+export const resolveMemoryEngineStoreRootUrl = (
+  storeUrl: URL,
+  options: { singleFileMode?: boolean } = {},
+): URL => {
+  const storePath = Path.fromFileUrl(storeUrl);
+  const isSingleFile = options.singleFileMode ?? Path.extname(storePath) !== "";
+  const rootPath = isSingleFile
+    ? Path.join(
+      Path.dirname(storePath),
+      `${Path.basename(storePath, Path.extname(storePath))}.engine-v3`,
+    )
+    : Path.join(storePath, "engine-v3");
+  return Path.toFileUrl(`${rootPath}/`);
+};
+
 export const resolveSpaceStoreUrl = (
   store: URL,
   subject: MemorySpace,

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -24,6 +24,11 @@
 // serves the clone as a live space under the SAME DID.
 
 import * as Path from "@std/path";
+import {
+  resolveMemoryEngineStoreRootUrl,
+  resolveSpaceStoreUrl,
+} from "@commonfabric/memory/v2/storage-path";
+import type { MemorySpace } from "@commonfabric/memory/interface";
 import { createHasher } from "@commonfabric/content-hash";
 import { openSpace } from "./db.ts";
 import { contentFingerprint, type FingerprintReport } from "./fingerprint.ts";
@@ -32,8 +37,6 @@ import { contentFingerprint, type FingerprintReport } from "./fingerprint.ts";
 const MANIFEST = "clone.json";
 const MARKER = ".cf-clone";
 const PRISTINE_DIR = "pristine";
-/** The memory server's own per-space directory name — must match the engine. */
-const WORKING_DIR = "engine-v3";
 
 export interface CloneManifest {
   /** Schema version of this file, so a future reader can refuse politely. */
@@ -81,14 +84,31 @@ export interface ClonePaths {
   workingPath: string;
 }
 
-/** Where each artifact lives for a clone of `space` in `dir`. */
+/**
+ * Where each artifact lives for a clone of `space` in `dir`.
+ *
+ * The working copy's path is DERIVED, never spelled out: `dir` is used exactly
+ * as a server's `MEMORY_DIR`, and the store lands wherever composing
+ * `resolveMemoryEngineStoreRootUrl` with `resolveSpaceStoreUrl` puts it — which
+ * today means a doubled `engine-v3/engine-v3/`. Restating that here is how the
+ * first version of this file wrote a clone to a path no server ever reads: the
+ * copy/verify/reset loop was self-consistent and served nothing.
+ */
 export function clonePaths(dir: string, space: string): ClonePaths {
-  const file = `${space}.sqlite`;
+  const workingPath = Path.fromFileUrl(
+    resolveSpaceStoreUrl(
+      resolveMemoryEngineStoreRootUrl(
+        Path.toFileUrl(dir.endsWith("/") ? dir : `${dir}/`),
+        { singleFileMode: false },
+      ),
+      space as MemorySpace,
+    ),
+  );
   return {
     dir,
     manifestPath: `${dir}/${MANIFEST}`,
-    pristinePath: `${dir}/${PRISTINE_DIR}/${file}`,
-    workingPath: `${dir}/${WORKING_DIR}/${file}`,
+    pristinePath: `${dir}/${PRISTINE_DIR}/${space}.sqlite`,
+    workingPath,
   };
 }
 
@@ -119,7 +139,7 @@ export async function createClone(
 
   const paths = clonePaths(dir, options.space);
   await Deno.mkdir(`${dir}/${PRISTINE_DIR}`, { recursive: true });
-  await Deno.mkdir(`${dir}/${WORKING_DIR}`, { recursive: true });
+  await Deno.mkdir(Path.dirname(paths.workingPath), { recursive: true });
 
   // Plain copies. `VACUUM INTO` server-side already produced a consistent,
   // companion-free file; re-vacuuming here would need the live source, which by

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -5,6 +5,11 @@
 
 import { assert, assertEquals, assertRejects } from "@std/assert";
 import { Database } from "@db/sqlite";
+import * as Path from "@std/path";
+import {
+  resolveMemoryEngineStoreRootUrl,
+  resolveSpaceStoreUrl,
+} from "@commonfabric/memory/v2/storage-path";
 
 import {
   clonePaths,
@@ -109,9 +114,20 @@ Deno.test("a clone is servable, recorded, and leaves the source untouched", asyn
     });
 
     const paths = clonePaths(clone, SPACE);
-    // The working copy sits where the memory server resolves a space store, so
-    // pointing MEMORY_DIR at the clone dir serves it under the same DID.
-    assert(paths.workingPath.endsWith(`engine-v3/${SPACE}.sqlite`));
+    // The working copy must sit exactly where a server pointed at this
+    // directory looks — computed here through the SAME resolvers the server
+    // composes, so this cannot drift into agreeing only with itself.
+    assertEquals(
+      paths.workingPath,
+      Path.fromFileUrl(
+        resolveSpaceStoreUrl(
+          resolveMemoryEngineStoreRootUrl(Path.toFileUrl(`${clone}/`), {
+            singleFileMode: false,
+          }),
+          SPACE as never,
+        ),
+      ),
+    );
     assertEquals((await Deno.stat(paths.workingPath)).isFile, true);
     assertEquals((await Deno.stat(paths.pristinePath)).isFile, true);
     assertEquals((await Deno.stat(`${clone}/.cf-clone`)).isFile, true);

--- a/packages/toolshed/routes/storage/memory-path.ts
+++ b/packages/toolshed/routes/storage/memory-path.ts
@@ -1,16 +1,5 @@
-import * as Path from "@std/path";
-
-export const resolveMemoryEngineStoreRootUrl = (
-  storeUrl: URL,
-  options: { singleFileMode?: boolean } = {},
-): URL => {
-  const storePath = Path.fromFileUrl(storeUrl);
-  const isSingleFile = options.singleFileMode ?? Path.extname(storePath) !== "";
-  const rootPath = isSingleFile
-    ? Path.join(
-      Path.dirname(storePath),
-      `${Path.basename(storePath, Path.extname(storePath))}.engine-v3`,
-    )
-    : Path.join(storePath, "engine-v3");
-  return Path.toFileUrl(`${rootPath}/`);
-};
+// The engine store root now lives with the rest of the on-disk layout contract
+// in `@commonfabric/memory/v2/storage-path`, so the two functions that compose
+// into a store path are read and changed together. Re-exported here for the
+// existing import sites.
+export { resolveMemoryEngineStoreRootUrl } from "@commonfabric/memory/v2/storage-path";


### PR DESCRIPTION
## Why

**`cf space clone` as merged produces clones that cannot be served.** That is the entire point of the command, so this is a straight bug fix on top of #5081.

The command wrote the working copy to `<dir>/engine-v3/<did>.sqlite` and printed `MEMORY_DIR=<dir>` as the way to serve it. A server pointed at `<dir>` actually reads:

```
<dir>/engine-v3/engine-v3/<did>.sqlite
```

`resolveMemoryEngineStoreRootUrl` (toolshed) appends `engine-v3`, and `resolveSpaceStoreUrl` (memory) appends it **again**. Local dev stores show the same doubling, and `state-inspector/discover.ts` already carries the comment *"The engine-v3 segment is sometimes doubled."*

The failure is silent in the worst way: the memory server creates a space store on demand, so a clone at the wrong path yields a **fresh empty space** rather than an error. It surfaces far downstream as `piece missing argument cell`.

### Why the tests did not catch it

Every test asserted the layout against this file's own `WORKING_DIR = "engine-v3"` constant. The clone → verify → reset loop was perfectly self-consistent — and wrong about the only thing that matters. Even the run against the real 1.1 GB Estuary snapshot passed, because it never served the result.

It took booting a real toolshed against a real clone and reading the board back.

## What Changed

**Not** hardcoding the doubled path — that would be a *third* statement of a layout already spelled in two places, and would entrench the bug in a new spot.

- `resolveMemoryEngineStoreRootUrl` moves from `toolshed/routes/storage/memory-path.ts` into `memory/v2/storage-path.ts`, beside `resolveSpaceStoreUrl`. The two compose into the on-disk contract and must be read together; the docstring now says so, including why the doubling cannot simply be deleted. Toolshed keeps a re-export for its existing import sites — no behavior change.
- `clonePaths` **derives** the working path by composing the two resolvers, using the clone directory exactly as a server's `MEMORY_DIR`.
- Both suites assert against that composition instead of a constant, so they can no longer agree only with themselves.

If the redundant append is ever removed, clones follow automatically.

## Test plan

- `packages/state-inspector` — 79 passed; `packages/cli` — 123 passed; `packages/toolshed` — 100 passed; `packages/memory` — 449 passed. `deno check`, `deno lint`, `deno fmt` clean.
- **End to end, the check that was missing:** `cf space clone` of the 1.1 GB Estuary Topics snapshot → served by an **unmodified** toolshed → `cf piece get` returns **all 73 topics** under the same DID with an existing team key.

That last run is the design doc's central claim finally observed rather than reasoned from source: *genesis/ACLs ride inside the store, so existing team keys authorize on a copy.*

## Follow-up, deliberately not here

The doubling itself is a latent bug. Every existing store — every dev machine, staging, production — depends on it, so removing it is a migration with its own rollout, not a drive-by. Filed here as a note rather than attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cf space clone` so the working copy lands where the server actually reads it. Clones are now immediately servable with `MEMORY_DIR=<cloneDir>` under the same DID.

- **Bug Fixes**
  - Derive the working path by composing `resolveMemoryEngineStoreRootUrl` + `resolveSpaceStoreUrl` from `@commonfabric/memory/v2/storage-path`, matching the server’s on-disk layout.
  - Create the working directory based on the derived path; remove the hardcoded `engine-v3`.
  - Update tests to assert the composed path and add an end-to-end check that a cloned Estuary snapshot is served correctly.

- **Refactors**
  - Move `resolveMemoryEngineStoreRootUrl` to `@commonfabric/memory/v2/storage-path` beside `resolveSpaceStoreUrl`; `@commonfabric/toolshed` now re-exports it.
  - Update docs and test helpers to use `clonePaths` and the shared resolvers.

<sup>Written for commit f23908d7a3468315b4c9cac2cf5f541434de006a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Coverage

The `packages/cli` gate failure is a baseline artifact, not a regression from this PR — **this PR changes no `packages/cli` source at all**, only `packages/cli/test/space.test.ts`.

That group is bimodal, the same coin-flip #5108 fixes for `packages/runner`. Reading the `perf-metrics` artifact from the last five successful `main` runs:

| main run | `packages/cli` uncovered |
| --- | ---: |
| 5b120aa68 | **3968** |
| ede60d33c | 3977 |
| 0a25bf284 | 3977 |
| 7714841e7 | 3977 |
| 2e2245ee0 | 3977 |

This branch measures **3974** — *below* the value four of the last five main runs report. The ratchet seeds from the latest non-cold run, which happened to be the single low sample, so the comparison is against 3968 rather than the mode.

Re-running would just re-roll the same dice, which is the behavior `AGENTS.md` warns against. Accepting the metric explicitly instead, with the evidence above.

Worth its own change: identifying which `packages/cli` lines swing and making them deterministic, exactly as #5108 did for `traverse.ts`.

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/cli uncovered lines = 3974 lines
