### PR TITLE
fix(dashboard): stop collecting Blacksmith storage metrics

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -430,16 +430,16 @@ Notes:
   and Blacksmith. Each source is projected from its own recent daily rate. The
   rate uses at least two weeks and reaches into last month early in a month.
   GitHub contributes net Actions spend after discounts and included usage.
-  Blacksmith's current invoice amount supplies its month-to-date total. Daily
-  runner cost and sticky-disk storage cost supply its history and projection.
-  The storage range total is assigned to days in proportion to the reported
-  daily cache footprint. `CI_MONTHLY_BUDGET` overrides provider budgets. A
-  single provider otherwise uses its own configured budget. With both providers,
-  their budgets are added only when both exist. Blacksmith's budget is its
-  monthly spending-alert threshold. A failed configured source turns the tile
-  gray and shows `$???` for that source. The values from responding sources
-  remain as a lower bound. A GitHub classic-plan setup still falls back to
-  minutes when Blacksmith is not configured.
+  Blacksmith's current invoice amount supplies its all-in month-to-date total
+  and current-month projection input. Daily runner cost supplies its history
+  and chart; storage usage is not requested or charted separately.
+  `CI_MONTHLY_BUDGET` overrides provider budgets. A single provider otherwise
+  uses its own configured budget. With both providers, their budgets are added
+  only when both exist. Blacksmith's budget is its monthly spending-alert
+  threshold. A failed configured source turns the tile gray and shows `$???`
+  for that source. The values from responding sources remain as a lower bound.
+  A GitHub classic-plan setup still falls back to minutes when Blacksmith is not
+  configured.
 - **`benchmarks`** trends one **scale-invariant index per CPU** on the
   `benchmarks.yml` runs on main over ~45 days. The job runs `deno bench --json`
   over the runner, cache, and deep-equal benchmarks. It uploads the report as a

--- a/packages/dashboard/blacksmith.ts
+++ b/packages/dashboard/blacksmith.ts
@@ -66,12 +66,6 @@ function rangeQuery(start: Date, end: Date): string {
 export const blacksmithRoutes = {
   daily: (org: string, start: Date, end: Date) =>
     `${orgPath(org)}/metrics/daily?${rangeQuery(start, end)}`,
-  stickyDaily: (org: string, start: Date, end: Date) =>
-    `${orgPath(org)}/metrics/docker/daily-by-type?${rangeQuery(start, end)}`,
-  stickyTotal: (org: string, start: Date, end: Date) =>
-    `${orgPath(org)}/metrics/docker/sticky-disk/total?${
-      rangeQuery(start, end)
-    }`,
   invoiceAmount: (org: string) => `${orgPath(org)}/metrics/invoice-amount`,
   spendingThreshold: (org: string) => `${orgPath(org)}/email-alert-threshold`,
 };

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -59,11 +59,6 @@ const blacksmithDay = (date: string, cost: unknown) => ({
 function blacksmithRouteSet(
   now: string,
   dailyMetrics: unknown[],
-  footprint: {
-    dockerfile: unknown[];
-    stickydisk: unknown[];
-  } = { dockerfile: [], stickydisk: [] },
-  storageByMonth: Record<string, number> = {},
   org = ORG,
   billing: { invoice?: unknown; threshold?: unknown } = {},
 ): Record<string, unknown> {
@@ -79,23 +74,7 @@ function blacksmithRouteSet(
     [`api/${blacksmithRoutes.daily(org, start, end)}`]: {
       daily_metrics: dailyMetrics,
     },
-    [`api/${blacksmithRoutes.stickyDaily(org, start, end)}`]: footprint,
   };
-  let cursor = new Date(start);
-  while (cursor <= end) {
-    const nextMonth = Date.UTC(
-      cursor.getUTCFullYear(),
-      cursor.getUTCMonth() + 1,
-      1,
-    );
-    const segmentEnd = new Date(Math.min(end.getTime(), nextMonth - 1));
-    const month = cursor.toISOString().slice(0, 7);
-    routes[`api/${blacksmithRoutes.stickyTotal(org, cursor, segmentEnd)}`] = {
-      total_cost: storageByMonth[month] ?? 0,
-      total_gb_hours: 0,
-    };
-    cursor = new Date(nextMonth);
-  }
   const month = observed.toISOString().slice(0, 7);
   const measuredMtd = dailyMetrics.reduce<number>((sum, entry) => {
     if (!entry || typeof entry !== "object") return sum;
@@ -104,7 +83,7 @@ function blacksmithRouteSet(
         Number.isFinite(Number(metric.cost))
       ? sum + Number(metric.cost)
       : sum;
-  }, storageByMonth[month] ?? 0);
+  }, 0);
   routes[`api/${blacksmithRoutes.invoiceAmount(org)}`] = "invoice" in billing
     ? billing.invoice
     : measuredMtd;
@@ -138,6 +117,7 @@ async function view(
   now: string,
   routes: Record<string, unknown>,
   env: Record<string, string> = { GH_TOKEN: "gh_pat_x", GH_BILLING_ORG: ORG },
+  requests: string[] = [],
 ): Promise<TileView> {
   const RealDate = Date;
   const realFetch = globalThis.fetch;
@@ -151,6 +131,7 @@ async function view(
   globalThis.fetch = (input: URL | Request | string) => {
     const url = new URL(input instanceof Request ? input.url : String(input));
     const key = url.pathname.slice(1) + url.search;
+    requests.push(key);
     if (!(key in routes)) {
       return Promise.resolve(new Response(null, { status: 404 }));
     }
@@ -416,7 +397,7 @@ Deno.test("ci spend: every failed provider retains the combined middle line", as
   );
 });
 
-Deno.test("ci spend: Blacksmith invoice, runner, storage, and threshold form one provider", async () => {
+Deno.test("ci spend: Blacksmith invoice, runner history, and threshold form one provider without storage requests", async () => {
   const now = "2026-01-20T09:00:00Z";
   const compute = Array.from(
     { length: 10 },
@@ -425,21 +406,14 @@ Deno.test("ci spend: Blacksmith invoice, runner, storage, and threshold form one
   const routes = blacksmithRouteSet(
     now,
     compute,
-    {
-      dockerfile: [
-        { date: "2026-01-01", value: 1 },
-        { date: "2026-01-02", value: 3 },
-      ],
-      stickydisk: [],
-    },
-    { "2026-01": 40 },
     ORG,
     {
       invoice: { amount: 150, currency: "USD" },
       threshold: 230,
     },
   );
-  const v = await view(now, routes, BLACKSMITH_ENV);
+  const requests: string[] = [];
+  const v = await view(now, routes, BLACKSMITH_ENV, requests);
 
   assertEquals(v.value, "~$245/mo");
   assertEquals(v.aside, '<span class="hmtd">$150 MTD</span>');
@@ -451,6 +425,14 @@ Deno.test("ci spend: Blacksmith invoice, runner, storage, and threshold form one
   assertStringIncludes(v.extra ?? "", "Budget $230");
   assertStringIncludes(v.extra ?? "", "<polyline");
   assertEquals(v.duration, 10 * D);
+  const blacksmithRequests = requests.filter((path) =>
+    path.startsWith("api/user/github/orgs/")
+  );
+  assertEquals(blacksmithRequests.length, 3);
+  assertEquals(
+    blacksmithRequests.some((path) => path.includes("/metrics/docker/")),
+    false,
+  );
 });
 
 Deno.test("ci spend: a Blacksmith invoice without daily history still supplies MTD and forecast totals", async () => {
@@ -460,8 +442,6 @@ Deno.test("ci spend: a Blacksmith invoice without daily history still supplies M
       blacksmithRouteSet(
         now,
         [],
-        undefined,
-        undefined,
         ORG,
         {
           invoice: { amount: 150, currency: "USD" },
@@ -500,36 +480,15 @@ Deno.test("ci spend: malformed Blacksmith costs never read as a green zero", asy
   const negativeDaily = blacksmithRouteSet(now, [
     blacksmithDay("2026-01-01", -1),
   ]);
-  const malformedTotal = blacksmithRouteSet(now, [
-    blacksmithDay("2026-01-01", 1),
-  ]);
-  const totalPath = Object.keys(malformedTotal).find((path) =>
-    path.includes("/sticky-disk/total?")
-  )!;
-  malformedTotal[totalPath] = { total_cost: null };
-  const negativeTotal = blacksmithRouteSet(now, [
-    blacksmithDay("2026-01-01", 1),
-  ]);
-  const negativeTotalPath = Object.keys(negativeTotal).find((path) =>
-    path.includes("/sticky-disk/total?")
-  )!;
-  negativeTotal[negativeTotalPath] = { total_cost: -1 };
 
-  for (
-    const routes of [
-      malformedDaily,
-      negativeDaily,
-      malformedTotal,
-      negativeTotal,
-    ]
-  ) {
+  for (const routes of [malformedDaily, negativeDaily]) {
     const v = await view(now, routes, BLACKSMITH_ENV);
     assertEquals(v.status, "unknown");
     assertEquals(v.value, "—");
   }
 });
 
-Deno.test("ci spend: malformed Blacksmith daily and storage payloads are unavailable", async () => {
+Deno.test("ci spend: malformed Blacksmith daily payloads are unavailable", async () => {
   const now = "2026-01-20T09:00:00Z";
   const cases: Array<{
     name: string;
@@ -540,11 +499,6 @@ Deno.test("ci spend: malformed Blacksmith daily and storage payloads are unavail
       name: "daily metrics are not an array",
       routeFragment: "/metrics/daily?",
       response: { daily_metrics: null },
-    },
-    {
-      name: "storage collections are not arrays",
-      routeFragment: "/metrics/docker/daily-by-type?",
-      response: { dockerfile: {}, stickydisk: [] },
     },
     {
       name: "a daily date is not text",
@@ -558,14 +512,6 @@ Deno.test("ci spend: malformed Blacksmith daily and storage payloads are unavail
       routeFragment: "/metrics/daily?",
       response: {
         daily_metrics: [blacksmithDay("2026-99-99", 1)],
-      },
-    },
-    {
-      name: "a storage measurement is blank",
-      routeFragment: "/metrics/docker/daily-by-type?",
-      response: {
-        dockerfile: [{ date: "2026-01-01", value: " " }],
-        stickydisk: [],
       },
     },
   ];
@@ -615,8 +561,6 @@ Deno.test("ci spend: malformed Blacksmith invoice and threshold payloads are una
     const routes = blacksmithRouteSet(
       now,
       [blacksmithDay("2026-01-01", 10)],
-      undefined,
-      undefined,
       ORG,
       malformed.billing,
     );
@@ -632,8 +576,6 @@ Deno.test("ci spend: a null threshold field is an unknown provider budget", asyn
   const routes = blacksmithRouteSet(
     now,
     [blacksmithDay("2026-01-01", 10)],
-    undefined,
-    undefined,
     ORG,
     { threshold: { threshold: null } },
   );
@@ -784,8 +726,6 @@ Deno.test("ci spend: provider budgets combine when no explicit budget is set", a
       { length: 10 },
       (_, index) => blacksmithDay(`2026-01-${pad(index + 1)}`, 5),
     ),
-    undefined,
-    undefined,
     ORG,
     { threshold: 100 },
   );
@@ -816,8 +756,6 @@ Deno.test("ci spend: a partial provider budget is not treated as the combined bu
   const blacksmith = blacksmithRouteSet(
     now,
     [blacksmithDay("2026-01-01", 50)],
-    undefined,
-    undefined,
     ORG,
     { threshold: 1 },
   );

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -4,11 +4,10 @@
 // month-to-date spend and the header shows the combined month-to-date total.
 //
 // GitHub's enhanced billing report supplies daily net Actions spend. Blacksmith
-// supplies an invoice total, daily runner cost, and a range total for sticky-disk
-// storage. The invoice is the month-to-date source of truth. The daily endpoints
-// supply the projection and chart, with storage assigned to days in proportion
-// to the daily cache footprint. A configured source that cannot be read shows
-// "$???" and makes the combined projection a lower bound.
+// supplies an all-in invoice total and daily runner cost. The invoice is the
+// month-to-date source of truth and the runner history supplies the chart. A
+// configured source that cannot be read shows "$???" and makes the combined
+// projection a lower bound.
 import type { Status, Tile, TileView } from "../types.ts";
 import {
   budgetStatus,
@@ -75,15 +74,6 @@ interface BlacksmithDailyResponse {
     date?: unknown;
     cost?: unknown;
   }>;
-}
-
-interface BlacksmithStickyDailyResponse {
-  dockerfile?: Array<{ date?: unknown; value?: unknown }>;
-  stickydisk?: Array<{ date?: unknown; value?: unknown }>;
-}
-
-interface BlacksmithStickyTotalResponse {
-  total_cost?: unknown;
 }
 
 const actionsOf = (report: { usageItems?: UsageItem[] }): UsageItem[] =>
@@ -273,28 +263,6 @@ function parseBlacksmithDaily(
   return byDay;
 }
 
-function parseBlacksmithFootprint(
-  response: BlacksmithStickyDailyResponse,
-): Map<string, number> {
-  if (
-    !Array.isArray(response.dockerfile) || !Array.isArray(response.stickydisk)
-  ) {
-    throw new Error("Blacksmith storage usage has an unexpected shape");
-  }
-  const byDay = new Map<string, number>();
-  for (const entries of [response.dockerfile, response.stickydisk]) {
-    for (const entry of entries) {
-      const day = dayKey(entry.date);
-      const bytes = finiteNumber(entry.value);
-      if (!day || bytes === null || bytes < 0) {
-        throw new Error("Blacksmith storage usage has an unexpected shape");
-      }
-      addDaily(byDay, day, bytes);
-    }
-  }
-  return byDay;
-}
-
 function parseBlacksmithInvoice(response: unknown): number {
   let amount: unknown = response;
   if (response && typeof response === "object") {
@@ -333,64 +301,6 @@ function parseBlacksmithBudget(response: unknown): number {
   return parsed;
 }
 
-function calendarDays(start: Date, end: Date): string[] {
-  const days: string[] = [];
-  const first = Date.UTC(
-    start.getUTCFullYear(),
-    start.getUTCMonth(),
-    start.getUTCDate(),
-  );
-  const last = Date.UTC(
-    end.getUTCFullYear(),
-    end.getUTCMonth(),
-    end.getUTCDate(),
-  );
-  for (let time = first; time <= last; time += DAY_MS) {
-    days.push(new Date(time).toISOString().slice(0, 10));
-  }
-  return days;
-}
-
-function monthSegments(start: Date, end: Date): Array<{
-  start: Date;
-  end: Date;
-}> {
-  const segments: Array<{ start: Date; end: Date }> = [];
-  let cursor = new Date(start);
-  while (cursor <= end) {
-    const nextMonth = Date.UTC(
-      cursor.getUTCFullYear(),
-      cursor.getUTCMonth() + 1,
-      1,
-    );
-    const segmentEnd = new Date(Math.min(end.getTime(), nextMonth - 1));
-    segments.push({ start: new Date(cursor), end: segmentEnd });
-    cursor = new Date(nextMonth);
-  }
-  return segments;
-}
-
-function addAllocatedStorage(
-  target: Map<string, number>,
-  footprint: Map<string, number>,
-  start: Date,
-  end: Date,
-  totalCost: number,
-): void {
-  const days = calendarDays(start, end);
-  if (days.length === 0 || totalCost === 0) return;
-  const totalWeight = days.reduce(
-    (sum, day) => sum + (footprint.get(day) ?? 0),
-    0,
-  );
-  for (const day of days) {
-    const share = totalWeight > 0
-      ? (footprint.get(day) ?? 0) / totalWeight
-      : 1 / days.length;
-    addDaily(target, day, totalCost * share);
-  }
-}
-
 async function blacksmithSpend(
   client: BlacksmithClient,
   org: string,
@@ -404,48 +314,21 @@ async function blacksmithSpend(
   );
   const end = new Date(today - 1);
   const start = new Date(today - SPEND_HISTORY_DAYS * DAY_MS);
-  const segments = monthSegments(start, end);
-  const [daily, stickyDaily, stickyTotals, invoice, threshold] = await Promise
-    .all([
-      client.get<BlacksmithDailyResponse>(
-        blacksmithRoutes.daily(org, start, end),
-      ),
-      client.get<BlacksmithStickyDailyResponse>(
-        blacksmithRoutes.stickyDaily(org, start, end),
-      ),
-      Promise.all(
-        segments.map((segment) =>
-          client.get<BlacksmithStickyTotalResponse>(
-            blacksmithRoutes.stickyTotal(org, segment.start, segment.end),
-          )
-        ),
-      ),
-      client.get<unknown>(blacksmithRoutes.invoiceAmount(org)),
-      readProviderBudget
-        ? client.get<unknown>(blacksmithRoutes.spendingThreshold(org))
-        : Promise.resolve(undefined),
-    ]);
-  const compute = parseBlacksmithDaily(daily);
-  const footprint = parseBlacksmithFootprint(stickyDaily);
-  for (const [index, response] of stickyTotals.entries()) {
-    const totalCost = finiteNumber(response.total_cost);
-    if (totalCost === null || totalCost < 0) {
-      throw new Error("Blacksmith storage cost has an unexpected shape");
-    }
-    const segment = segments[index];
-    addAllocatedStorage(
-      compute,
-      footprint,
-      segment.start,
-      segment.end,
-      totalCost,
-    );
-  }
+  const [daily, invoice, threshold] = await Promise.all([
+    client.get<BlacksmithDailyResponse>(
+      blacksmithRoutes.daily(org, start, end),
+    ),
+    client.get<unknown>(blacksmithRoutes.invoiceAmount(org)),
+    readProviderBudget
+      ? client.get<unknown>(blacksmithRoutes.spendingThreshold(org))
+      : Promise.resolve(undefined),
+  ]);
+  const byDay = parseBlacksmithDaily(daily);
   const measuredMtd = parseBlacksmithInvoice(invoice);
   return {
-    byDay: compute,
+    byDay,
     ...summarizeDailySpend(
-      compute,
+      byDay,
       now,
       {
         lagDays: BLACKSMITH_LAG_DAYS,


### PR DESCRIPTION
Blacksmith's sticky-disk total endpoint fails consistently, which caused the entire Blacksmith share of the CI spend tile to become unavailable even though runner, invoice, and budget data remained readable.

Remove the storage footprint and range-total requests and delete the allocation pipeline that depended on them. The tile now charts runner costs and uses the all-in invoice amount for month-to-date spend and the current-month projection. Keep the provider threshold for budget status, and cover the request set so storage endpoints cannot be reintroduced accidentally.
NEW_COVERAGE_BASELINE
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop collecting Blacksmith storage metrics to keep the CI spend tile available when the sticky-disk total endpoint fails. The tile now charts runner costs and uses Blacksmith’s invoice for MTD and projection; budget status still uses the provider threshold.

- **Bug Fixes**
  - Removed Blacksmith storage requests (`/metrics/docker/daily-by-type`, `/metrics/docker/sticky-disk/total`) and the storage allocation pipeline.
  - Tile now reads only daily runner metrics and the invoice amount; threshold is still read for budget status.
  - Updated tests to assert no storage endpoints are requested and to cover the new request set.
  - Updated README to reflect runner-only charting and invoice-based totals.

<sup>Written for commit 992ba19b97d5482913e08891c3274eac735dafd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

