### PR TITLE
fix(runner): partialCause aliases must not abort a node's resume pre-sync scan

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -461,14 +461,30 @@ const recordRawBuiltinResultSchemaPolicyInput = (
  * suitable as the cause for the node's result cell instead of hashing the
  * pattern object (which drags in the session-varying `program`). Returns
  * undefined if the binding contains no write redirect.
+ *
+ * Exported for tests only.
  */
-function firstResolvedOutputRedirect(
+export function firstResolvedOutputRedirect(
   runtime: Runtime,
   tx: IExtendedStorageTransaction,
   binding: unknown,
   baseCell: Cell<any>,
 ): NormalizedFullLink | undefined {
   if (isWriteRedirectLink(binding) || isAliasBinding(binding)) {
+    // A partialCause alias denotes a DERIVED INTERNAL cell — of the child
+    // level it was deferred to when it still carried `defer` — never the
+    // node's reserved result spot, and it cannot be parsed as a link
+    // (parseAliasBinding throws by design). Before 2026-07 this threw here,
+    // and the caller's catch skipped the WHOLE node's owned-cell pre-sync —
+    // silently re-exposing the cold-cache commit-revert race the pre-sync
+    // exists to prevent, for every sub-pattern whose outputs lead with such
+    // an alias (seen live on estuary home spaces as "resume-owned-cells
+    // skipping…"). Skip just this entry and keep scanning: the derived
+    // cells themselves are collected from each pattern's own
+    // derivedInternalCells manifest.
+    if (isAliasBinding(binding) && binding.$alias.partialCause !== undefined) {
+      return undefined;
+    }
     const bindingBase = baseCell.getAsNormalizedFullLink();
     return resolveLink(
       runtime,

--- a/packages/runner/test/resume-output-redirect-partialcause.test.ts
+++ b/packages/runner/test/resume-output-redirect-partialcause.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { firstResolvedOutputRedirect } from "../src/runner.ts";
+
+// Seen live on estuary home spaces (2026-07-29): a sub-pattern node whose
+// stored outputs carry a DEFERRED partialCause alias unwraps to a bare
+// `{"$alias":{"partialCause":…}}` record, which parseAliasBinding refuses by
+// design — and the resume walk's catch then skipped the WHOLE node's
+// owned-cell pre-sync ("resume-owned-cells skipping a sub-pattern node whose
+// outputs did not bind or resolve"), silently re-exposing the cold-cache
+// commit-revert race the pre-sync exists to prevent. A partialCause alias is
+// a derived internal cell, never the node's reserved result spot: the scan
+// must skip the entry and keep looking, not abandon the node.
+
+const signer = await Identity.fromPassphrase("resume-output-partialcause");
+const space = signer.did();
+
+describe("firstResolvedOutputRedirect vs partialCause aliases", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let rt: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+  afterEach(async () => {
+    await rt?.dispose();
+    await storageManager?.close();
+  });
+
+  const partialCauseAlias = {
+    $alias: {
+      partialCause: { "$generated": 0 },
+      path: [],
+      scope: "space",
+    },
+  };
+
+  it("skips a partialCause alias and still finds the result spot after it", () => {
+    const tx = rt.edit();
+    const base = rt.getCell<Record<string, unknown>>(
+      space,
+      "partialcause-scan-base",
+      undefined,
+      tx,
+    );
+    const spot = rt.getCell<Record<string, unknown>>(
+      space,
+      "partialcause-scan-spot",
+      undefined,
+      tx,
+    );
+    const outputs = {
+      // The exact shape from the estuary logs — listed FIRST so the scan
+      // meets it before the real spot.
+      generated: partialCauseAlias,
+      result: spot.getAsWriteRedirectLink({ base }),
+    };
+
+    const found = firstResolvedOutputRedirect(rt, tx, outputs, base);
+    tx.abort("test: read-only");
+    expect(found?.id).toBe(spot.getAsNormalizedFullLink().id);
+  });
+
+  it("returns undefined (not a throw) when outputs hold ONLY such aliases", () => {
+    const tx = rt.edit();
+    const base = rt.getCell<Record<string, unknown>>(
+      space,
+      "partialcause-only-base",
+      undefined,
+      tx,
+    );
+    const found = firstResolvedOutputRedirect(
+      rt,
+      tx,
+      { generated: partialCauseAlias },
+      base,
+    );
+    tx.abort("test: read-only");
+    expect(found).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Why

After the #5133 deploy (4f29cd8f4), estuary home spaces log repeated

```
resume-owned-cells skipping a sub-pattern node whose outputs did not bind or resolve
Cannot parse partialCause alias as link: {"$alias":{"partialCause":{"$generated":0},"path":[],"scope":"space"}}
```

A deferred partialCause alias in a node's stored outputs unwraps (one level)
to a bare `$alias` record; `parseAliasBinding` refuses partialCause by design
(a derived internal cell is not a link); and the resume walk's per-node catch
then skips the WHOLE node's owned-cell pre-sync. That pre-sync exists to stop
a cold-cache race the code documents precisely: unsynced owned cells read
absent, the batched instantiation commit loses to the streaming durable
value, and the resumed sub-tree's state strands. Every affected sub-pattern
silently re-enters that race on every resume.

Suspected (NOT yet confirmed) user-visible symptom: the persistently empty
Profile tab on estuary home spaces — the same session logs show no other
signature. Confirmation requires a deployed build; the fix is correct
independent of that outcome.

## What Changed

A partialCause alias can never be a node's reserved result spot, so
`firstResolvedOutputRedirect` skips the entry and keeps scanning instead of
throwing out of the walk. The derived internal cells such aliases denote are
already collected from each pattern's own `derivedInternalCells` manifest at
every level of the resume recursion — nothing is lost by not resolving them
here.

## Test plan

- New `resume-output-redirect-partialcause.test.ts`: the exact logged alias
  shape listed BEFORE the real result spot still finds the spot; outputs
  holding ONLY such aliases return undefined instead of throwing.
- Resume/setup-adjacent suites green locally (nested-piece repair, swap-link
  argument, ensure-piece-running, resume-argument-link presync).

Follow-up (separate): the pattern auto-updater compiled the SPA's index.html
fallback as TypeScript when a space's patternSource is a non-official path —
filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runner resume pre-sync: `partialCause` aliases in stored outputs no longer abort a node scan. This prevents owned-cell pre-sync from being skipped and avoids the cold-cache race on resume.

- **Bug Fixes**
  - Skip `partialCause` alias entries in `firstResolvedOutputRedirect` and keep scanning; these derived cells are handled via `derivedInternalCells`.
  - Export `firstResolvedOutputRedirect` for tests and add `resume-output-redirect-partialcause.test.ts` to cover mixed and alias-only outputs.

<sup>Written for commit a96dd0cf4bae9659bb8834b23cd7f912c08ab127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

