### PR TITLE
fix(piece): default-root heal fires from EVERY entry point, not just boot

### DIFF
--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -126,6 +126,16 @@ Two decisions carry the whole design:
    fire-and-forget check, and the existing watcher re-instantiates a verified
    replacement in place. No new apply machinery.
 
+   The awaited default-root reconcile has a second entry point beyond space
+   open: `PieceManager.getDefaultPattern` — the resolution every registry
+   listing, CLI `piece ls`, FUSE mount, and shell list cell goes through —
+   runs the same awaited check when starting the persisted root FAILS, then
+   re-resolves the slot and retries the start once (a failed retry surfaces
+   the original start error). Without this, an unloadable obsolete root
+   healed only for consumers that happened to enter through space open;
+   every headless/listing consumer died with the root (the 2026-07-29
+   cf-cell-context retirement, caught by the loom vendor gate).
+
 A root created before provenance stamping may be admitted to this loop only
 when its stored `{ identity, symbol }` exactly equals the advertised current
 official entry appropriate to the space (`home.tsx` for Home,

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -45,6 +45,8 @@ import {
   isLegacyPieceRegistryRoot,
 } from "../../runner/src/piece-helpers.ts";
 import { prepareSourceClosureVerification } from "../../runner/src/compilation-cache/cell-cache.ts";
+import type { PatternUpdateOutcome } from "../../runner/src/pattern-updater.ts";
+import { deriveSystemPatternUrl } from "./system-pattern-url.ts";
 ensureNotRenderThread();
 
 const PRIVILEGED_PIECE_LIST_SCHEMA = internSchema({
@@ -83,6 +85,12 @@ const PIECE_TRACE_TIMINGS = typeof Deno !== "undefined" &&
 // visible in the load summaries (browser worker included, where the
 // CF_CLI_TRACE_TIMINGS console path cannot run) as `piece/phase/<label>`.
 const pieceTimingLogger = getLogger("piece", { enabled: false });
+// Same channel the controller's heal path warns on, so a root healed through
+// the manager choke point shows up alongside the boot-path heal logs.
+const pieceHealLogger = getLogger("piece.update", {
+  enabled: true,
+  level: "warn",
+});
 
 async function timePiecePhase<T>(
   label: string,
@@ -240,15 +248,65 @@ export class PieceManager {
     ) {
       return undefined;
     }
-    return await timePiecePhase(
-      `getDefaultPattern.get(runIt=${runIt})`,
-      () =>
-        this.get(
-          defaultPattern,
-          runIt,
-          nameSchema,
-        ),
-    );
+    try {
+      return await timePiecePhase(
+        `getDefaultPattern.get(runIt=${runIt})`,
+        () =>
+          this.get(
+            defaultPattern,
+            runIt,
+            nameSchema,
+          ),
+      );
+    } catch (error) {
+      // An obsolete root whose stored pattern this runtime can no longer load
+      // used to heal on ONE entry point only — the boot path
+      // (PiecesController.ensureDefaultPattern reconciles before start).
+      // Every other consumer resolves the root HERE — piece registry
+      // listings, `cf piece ls`, FUSE, the shell's list cells — and
+      // inherited no heal at all: the load failure propagated and every
+      // listing died with the root (2026-07-29 vendor gate,
+      // the cf-cell-context type retirement). Run the same awaited updater
+      // check from this choke point and retry the start ONCE when it
+      // updated; any other outcome rethrows the original failure untouched.
+      if (!runIt || !this.runtime.experimental?.systemPatternAutoUpdate) {
+        throw error;
+      }
+      let outcome: PatternUpdateOutcome;
+      try {
+        const root = await this.get(defaultPattern, false, nameSchema);
+        outcome = await this.runtime.patternUpdater.checkDefaultPattern(
+          root,
+          deriveSystemPatternUrl(this.space, this.runtime),
+        );
+      } catch {
+        throw error;
+      }
+      if (outcome !== "updated" && outcome !== "repaired-provenance") {
+        throw error;
+      }
+      pieceHealLogger.warn("default-root-healed-on-load-failure", () => [
+        "getDefaultPattern: start failed, updater rolled the root forward;",
+        `retrying start once (${this.space})`,
+      ]);
+      // The metadata swap committed through a transaction view; settle, then
+      // resolve the root AGAIN so the retry observes the committed
+      // patternIdentity rather than the pre-transaction snapshot held by
+      // `defaultPattern` (same trap the boot path documents in
+      // startEnsuredDefaultPattern).
+      await this.runtime.idle();
+      const refreshedSlot = await timePiecePhase(
+        "getDefaultPattern.spaceCell.resync(after-heal)",
+        () => this.spaceCell.key("defaultPattern").sync(),
+      );
+      const healedPattern = refreshedSlot.get();
+      if (!healedPattern) throw error;
+      await healedPattern.sync();
+      return await timePiecePhase(
+        "getDefaultPattern.get(retry-after-heal)",
+        () => this.get(healedPattern, runIt, nameSchema),
+      );
+    }
   }
 
   /**

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -293,19 +293,31 @@ export class PieceManager {
       // resolve the root AGAIN so the retry observes the committed
       // patternIdentity rather than the pre-transaction snapshot held by
       // `defaultPattern` (same trap the boot path documents in
-      // startEnsuredDefaultPattern).
-      await this.runtime.idle();
-      const refreshedSlot = await timePiecePhase(
-        "getDefaultPattern.spaceCell.resync(after-heal)",
-        () => this.spaceCell.key("defaultPattern").sync(),
-      );
-      const healedPattern = refreshedSlot.get();
-      if (!healedPattern) throw error;
-      await healedPattern.sync();
-      return await timePiecePhase(
-        "getDefaultPattern.get(retry-after-heal)",
-        () => this.get(healedPattern, runIt, nameSchema),
-      );
+      // startEnsuredDefaultPattern). The whole settle/re-resolve/retry
+      // sequence surfaces the ORIGINAL start failure if anything in it goes
+      // wrong — a secondary failure here is a diagnostic detail, not the
+      // caller's error.
+      try {
+        await this.runtime.idle();
+        const refreshedSlot = await timePiecePhase(
+          "getDefaultPattern.spaceCell.resync(after-heal)",
+          () => this.spaceCell.key("defaultPattern").sync(),
+        );
+        const healedPattern = refreshedSlot.get();
+        if (!healedPattern) throw error;
+        await healedPattern.sync();
+        return await timePiecePhase(
+          "getDefaultPattern.get(retry-after-heal)",
+          () => this.get(healedPattern, runIt, nameSchema),
+        );
+      } catch (retryError) {
+        pieceHealLogger.warn("default-root-heal-retry-failed", () => [
+          "getDefaultPattern: post-heal retry failed; surfacing the",
+          `original start failure (${this.space})`,
+          retryError,
+        ]);
+        throw error;
+      }
     }
   }
 

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -36,31 +36,21 @@ import { homeSchema } from "@commonfabric/home-schemas";
 const PIECE_TRACE_TIMINGS = typeof Deno !== "undefined" &&
   Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
 
-// System space-root patterns, served as raw TSX by the toolshed patterns route.
-export const HOME_PATTERN_URL = "/api/patterns/system/home.tsx";
-export const DEFAULT_APP_PATTERN_URL = "/api/patterns/system/default-app.tsx";
+// System space-root pattern URLs and their derivation live in
+// ../system-pattern-url.ts (shared with PieceManager's default-root
+// heal-on-load-failure retry); re-exported here for existing importers.
+import {
+  DEFAULT_APP_PATTERN_URL,
+  deriveSystemPatternUrl,
+  HOME_PATTERN_URL,
+} from "../system-pattern-url.ts";
+export { DEFAULT_APP_PATTERN_URL, deriveSystemPatternUrl, HOME_PATTERN_URL };
 
 // Default roots have a stronger update policy than ordinary pieces: an
 // existing root is reconciled before start, while a new root is compiled from
 // the current source immediately before creation. Keep the runner's watcher,
 // but do not schedule its duplicate fire-and-forget source check.
 const DEFAULT_ROOT_RUN_OPTIONS = { schedulePatternUpdate: false } as const;
-
-/**
- * The official system space-root pattern URL for a space type — the home DID
- * gets home.tsx, every other space gets the default app. This derivation only
- * selects the identity to check; it never proves that a sourceless root tracks
- * that URL. Exact equality with the official content identity supplies
- * that proof below.
- */
-export function deriveSystemPatternUrl(
-  space: MemorySpace,
-  runtime: Runtime,
-): string {
-  return space === runtime.userIdentityDID
-    ? HOME_PATTERN_URL
-    : DEFAULT_APP_PATTERN_URL;
-}
 
 // Same logger as manager.ts's timePiecePhase: timing stats record even while
 // the logger is disabled, so controller phases show up in the load summaries

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -7,7 +7,6 @@ import {
   getPatternIdentityRef,
   getPieceSourceSnapshot,
   type JSONSchema,
-  type MemorySpace,
   type ModuleByteCache,
   type PatternCoverageCollector,
   type PatternUpdateOutcome,

--- a/packages/piece/src/system-pattern-url.ts
+++ b/packages/piece/src/system-pattern-url.ts
@@ -1,0 +1,25 @@
+import type { MemorySpace } from "@commonfabric/runner";
+import type { Runtime } from "@commonfabric/runner";
+
+// System space-root patterns, served as raw TSX by the toolshed patterns route.
+// Shared by PiecesController (boot-path reconciliation) and PieceManager (the
+// default-root heal-on-load-failure retry) — a home of its own so the manager
+// does not import the controller that wraps it.
+export const HOME_PATTERN_URL = "/api/patterns/system/home.tsx";
+export const DEFAULT_APP_PATTERN_URL = "/api/patterns/system/default-app.tsx";
+
+/**
+ * The official system space-root pattern URL for a space type — the home DID
+ * gets home.tsx, every other space gets the default app. This derivation only
+ * selects the identity to check; it never proves that a sourceless root tracks
+ * that URL. Exact equality with the official content identity supplies
+ * that proof at the check site.
+ */
+export function deriveSystemPatternUrl(
+  space: MemorySpace,
+  runtime: Runtime,
+): string {
+  return space === runtime.userIdentityDID
+    ? HOME_PATTERN_URL
+    : DEFAULT_APP_PATTERN_URL;
+}

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -861,6 +861,45 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(getPatternIdentityRef(healed)?.symbol).toBe("default");
   });
 
+  it("surfaces the ORIGINAL start failure when the post-heal retry fails", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const root = piece.getCell();
+    const staleIdentity = await identityForSource(
+      patternSource("unloadable-registry-path-root-retry-fails"),
+    );
+    await manager.stopPiece(root);
+    const { error } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).setMetaRaw("patternIdentity", {
+        identity: staleIdentity,
+        symbol: "default",
+      });
+    });
+    expect(error).toBeUndefined();
+    stub.setSource(SOURCE_V2);
+
+    // Inject a failure into the post-heal sequence: runtime.idle() is only
+    // awaited there on this path. The caller must still see the ORIGINAL
+    // "Could not load pattern" failure, not the injected secondary one.
+    const originalIdle = runtime.idle.bind(runtime);
+    let injected = false;
+    runtime.idle = () => {
+      if (!injected) {
+        injected = true;
+        return Promise.reject(new Error("secondary retry failure"));
+      }
+      return originalIdle();
+    };
+    try {
+      await expect(manager.getPieceRegistry()).rejects.toThrow(
+        "Could not load pattern",
+      );
+      expect(injected).toBe(true);
+    } finally {
+      runtime.idle = originalIdle;
+    }
+  });
+
   it("registry path still fails loudly when the flag is OFF", async () => {
     await setup({});
     const piece = await controller.ensureDefaultPattern();

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -821,6 +821,68 @@ describe("checkAndUpdateDefaultPattern", () => {
     expect(getPatternIdentityRef(updated.getCell())?.symbol).toBe("default");
   });
 
+  // The boot path (ensureDefaultPattern) reconciles an unloadable root before
+  // start — but registry listings, `cf piece ls`, FUSE, and the shell's list
+  // cells all resolve the root through PieceManager.getDefaultPattern instead,
+  // which used to inherit NO heal: the load failure propagated and every
+  // listing died with the root (2026-07-29 vendor gate, the cf-cell-context
+  // type retirement). The manager choke point must run the same awaited
+  // updater check and retry once.
+  it("heals an unloadable stale root on the REGISTRY path (not just boot)", async () => {
+    await setup({ systemPatternAutoUpdate: true });
+    const piece = await controller.ensureDefaultPattern();
+    const root = piece.getCell();
+
+    // A root left behind by an older runtime: well-formed identity, but its
+    // source closure was never persisted, so any start of it fails.
+    const staleIdentity = await identityForSource(
+      patternSource("unloadable-registry-path-root"),
+    );
+    await manager.stopPiece(root);
+    const { error } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).setMetaRaw("patternIdentity", {
+        identity: staleIdentity,
+        symbol: "default",
+      });
+    });
+    expect(error).toBeUndefined();
+
+    stub.setSource(SOURCE_V2);
+
+    // Straight to the registry — never through ensureDefaultPattern.
+    const registry = await manager.getPieceRegistry();
+    await runtime.idle();
+
+    expect(registry).toBeDefined();
+    const healed = (await manager.getDefaultPattern(false))!;
+    expect(getPatternIdentityRef(healed)?.identity).toBe(
+      await identityForSource(SOURCE_V2),
+    );
+    expect(getPatternIdentityRef(healed)?.symbol).toBe("default");
+  });
+
+  it("registry path still fails loudly when the flag is OFF", async () => {
+    await setup({});
+    const piece = await controller.ensureDefaultPattern();
+    const root = piece.getCell();
+    const staleIdentity = await identityForSource(
+      patternSource("unloadable-registry-path-root-no-flag"),
+    );
+    await manager.stopPiece(root);
+    const { error } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).setMetaRaw("patternIdentity", {
+        identity: staleIdentity,
+        symbol: "default",
+      });
+    });
+    expect(error).toBeUndefined();
+    stub.setSource(SOURCE_V2);
+
+    await expect(manager.getPieceRegistry()).rejects.toThrow(
+      "Could not load pattern",
+    );
+  });
+
   it("repairs persisted artifacts when the served identity is unchanged", async () => {
     await setup({ systemPatternAutoUpdate: true });
     const piece = await controller.ensureDefaultPattern();


### PR DESCRIPTION
## Why

The updater that replaces an unloadable obsolete space root
(`PatternUpdater.checkDefaultPattern` — whose own docs say it exists "so an
unloadable obsolete root can self-heal") was invoked from exactly ONE door:
`PiecesController.ensureDefaultPattern`, the shell's `getSpaceRoot` boot
path. Every other consumer of the default root — piece registry listings,
`cf piece ls`, FUSE, the shell's own list cells — resolves through
`PieceManager.getDefaultPattern`, which started the stored pattern directly
and inherited **no heal at all**: the load failure propagated and every
listing died with the root.

Live consequence, 2026-07-29: the loom vendor space-compat gate's cold-load
probe (`cf piece ls`) failed on a root stranded by the cf-cell-context type
retirement (#5132) — a state the boot path would have healed. In a browser
the space "worked" only because boot happens to take the guarded door first;
every headless/registry consumer hit the corpse. The same asymmetry is why a
sequence of heal-internals fixes (#4967/#4977/#5133) improved the guarded
door while listings kept failing.

## What Changed

`PieceManager.getDefaultPattern` is the choke point every consumer already
goes through, so the heal now lives there: on a start failure with
`systemPatternAutoUpdate` on, run the same awaited
`patternUpdater.checkDefaultPattern`, and — as the boot path already
documents — **re-resolve the root after the swap commits** (the caller's
cell holds a pre-transaction snapshot) before retrying the start once. Any
other outcome rethrows the original failure untouched; with the flag off the
failure stays loud.

`deriveSystemPatternUrl` + the system pattern URLs move to
`system-pattern-url.ts` (the manager cannot import the controller that wraps
it); `pieces-controller.ts` re-exports them for existing importers.

## Test plan

- New: "heals an unloadable stale root on the REGISTRY path (not just
  boot)" — the suite's existing unloadable-root fixture, driven through
  `getPieceRegistry` instead of `ensureDefaultPattern`; asserts the roll
  to the official identity. Failed before the fix with the exact gate
  signature ("Could not load pattern …#default").
- New: flag-off variant asserts the failure still propagates loudly.
- Full `packages/piece` suite green (351 steps).
- Next: the loom vendor gate re-runs against a labs main containing this —
  it should pass on merit (no `--skip-space-compat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the default space root self-heals across all entry points, not just during boot. This fixes cold-load failures in registry listings and headless tools when an obsolete stored root can’t load.

- **Bug Fixes**
  - Run self-heal in `PieceManager.getDefaultPattern` on start failure when `systemPatternAutoUpdate` is on, then re-resolve and retry once; otherwise rethrow. Tests cover the registry path heal and flag-off behavior.
  - Ensure the post-heal settle/re-resolve/retry path always surfaces the original start error if the retry fails. A regression test injects a secondary failure and asserts the original error is rethrown.

- **Refactors**
  - Extract `deriveSystemPatternUrl`, `HOME_PATTERN_URL`, and `DEFAULT_APP_PATTERN_URL` to `system-pattern-url.ts`, re-export from `pieces-controller.ts`, and drop the orphaned `MemorySpace` import.

<sup>Written for commit ec66f195754585bd7d098d80db583f4ee10e59fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




ACCEPT_COVERAGE_DEBT: coverage-debt: packages/piece uncovered lines = 220 lines
(the heal-path guard/log-lambda lines; the paths themselves are executed by the three new tests — LCOV attribution, not untested behavior)
