### PR TITLE
fix(runner): converge an unloadable durable pattern pointer back to the running pattern (CT-1923)

### DIFF
--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -379,6 +379,16 @@ export class PatternManager {
   }
 
   /**
+   * Whether `identity` is a session-synthetic keyless pointer (minted by
+   * {@link ensureKeylessPatternIdentity}) rather than a durable
+   * content-addressed artifact identity. A fresh runtime can never load a
+   * keyless pointer, so such refs must never be written into durable state.
+   */
+  static isKeylessPatternIdentity(identity: string): boolean {
+    return identity.startsWith("keyless:");
+  }
+
+  /**
    * Make a cross-space child piece independently loadable from its own space
    * (CT-1687). A fresh runtime navigating to a `Factory.inSpace(...)` child
    * loads pattern artifacts from the CHILD's space — but the parent bundle's

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1820,6 +1820,12 @@ export class Runner {
     // pattern can only change via a fresh run(), not via the meta watcher).
     const KEYLESS = "\0keyless";
     let currentPatternKey: string | undefined;
+    // The identity of the pattern whose nodes are LIVE right now — which can
+    // differ from `currentPatternKey` (the pointer value last observed): a
+    // parent-driven start instantiates its given pattern while the durable
+    // pointer may still hold an older identity. The unloadable-pointer
+    // roll-forward below writes THIS ref back, never the observed key.
+    let runningRef: { identity: string; symbol: string } | undefined;
     let cancelNodes: Cancel | undefined;
     let initialSchedulerRehydrationAvailable = true;
 
@@ -1924,6 +1930,7 @@ export class Runner {
         }
         cancelNodes?.();
         instantiatePattern(pattern);
+        runningRef = newRef;
       };
       addCancel(
         resultCell.sinkMeta("patternIdentity", (newValue) => {
@@ -1962,6 +1969,61 @@ export class Runner {
                   "pattern-load-error",
                   `Failed to load pattern ${newRef.identity}#${newRef.symbol}`,
                 );
+                // CT-1923: an undefined result is a DEFINITIVE verdict — the
+                // load synced and found the identity's docs absent or
+                // uncompilable — while a pattern is still running here. Left
+                // alone, the durable pointer keeps naming an identity no
+                // session can load: every boot re-logs this error and any
+                // start-by-identity of this piece is dead (the stranded
+                // blank-section state). Roll the pointer back to the RUNNING
+                // pattern's identity, durably, with a superseded-check so a
+                // legitimate concurrent repoint wins. Gated on the same flag
+                // as the rest of the heal family; thrown load errors (which
+                // may be transient) never trigger this.
+                if (
+                  this.runtime.experimental.systemPatternAutoUpdate &&
+                  runningRef !== undefined &&
+                  patternIdentityKey(runningRef) !== newKey
+                ) {
+                  const revertRef = runningRef;
+                  void this.runtime.editWithRetry((tx) => {
+                    const cur = asPatternIdentityRef(
+                      resultCell.withTx(tx).getMetaRaw("patternIdentity", {
+                        meta: ignoreReadForScheduling,
+                      }),
+                    );
+                    if (!cur || patternIdentityKey(cur) !== newKey) {
+                      return false;
+                    }
+                    resultCell.withTx(tx).setMetaRaw("patternIdentity", {
+                      identity: revertRef.identity,
+                      symbol: revertRef.symbol,
+                    });
+                    return true;
+                  }).then((result) => {
+                    if (result.ok) {
+                      currentPatternKey = patternIdentityKey(revertRef);
+                      logger.warn(
+                        "unloadable-pointer-rolled-forward",
+                        () => [
+                          "durable patternIdentity named an unloadable",
+                          `identity (${newRef.identity}#${newRef.symbol});`,
+                          "rolled back to the running pattern",
+                          `${revertRef.identity}#${revertRef.symbol}`,
+                        ],
+                      );
+                    }
+                  }).catch((error) => {
+                    logger.warn(
+                      "unloadable-pointer-roll-forward-failed",
+                      () => [
+                        "could not roll the unloadable pointer back to the",
+                        "running pattern",
+                        error,
+                      ],
+                    );
+                  });
+                }
                 return;
               }
               logger.info("pattern changed", {
@@ -2097,6 +2159,12 @@ export class Runner {
       currentPatternKey = initialRef ? patternIdentityKey(initialRef) : KEYLESS;
       try {
         instantiateInitialPattern(givenPattern, initialRef, tx);
+        // Real artifact refs only: a keyless pattern's synthetic session
+        // pointer must never be written into durable state by the
+        // unloadable-pointer roll-forward.
+        runningRef =
+          this.runtime.patternManager.getArtifactEntryRef(givenPattern) ??
+            undefined;
       } catch (error) {
         // Without cleanup the piece stays registered in `this.cancels`, so
         // every later start() reports "already running" for a piece that has
@@ -2135,6 +2203,7 @@ export class Runner {
       initialRef,
       tx,
     );
+    runningRef = initialRef;
     if (!doNotUpdateOnPatternChange) {
       setupPatternWatcher();
     }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -13,6 +13,7 @@ import { hashOf } from "@commonfabric/data-model/value-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
+import { PatternManager } from "./pattern-manager.ts";
 import { rendererVDOMSchema } from "./schemas.ts";
 import { forEachSubschema } from "./schema-walk.ts";
 import {
@@ -1955,8 +1956,12 @@ export class Runner {
             return;
           }
           // Async load for a pattern change after initial start. Errors are
-          // logged here since there's no caller to propagate to.
-          this.runtime.patternManager
+          // logged here since there's no caller to propagate to. The whole
+          // chain (load attempt + any pointer roll-forward it decides on) is
+          // tracked so dispose() — and deterministic tests — can settle it
+          // without wall-clock waits (the runner suite runs under a frozen
+          // clock).
+          const watcherLoad = this.runtime.patternManager
             .loadPatternByIdentity(
               newRef.identity,
               newRef.symbol,
@@ -1983,10 +1988,20 @@ export class Runner {
                 // pattern's identity, durably, with a superseded-check so a
                 // legitimate concurrent repoint wins. Gated on the same flag
                 // as the rest of the heal family; thrown load errors (which
-                // may be transient) never trigger this.
+                // may be transient) never trigger this. Two verdicts are NOT
+                // definitive and must never trigger it either: with CFC
+                // enforcement disabled, loadPatternByIdentity returns
+                // undefined for anything outside the in-memory index (probe
+                // unsupported, not artifact dead); and a session-synthetic
+                // keyless running ref must never be written durably (a fresh
+                // runtime is guaranteed unable to load it).
                 if (
                   this.runtime.experimental.systemPatternAutoUpdate &&
+                  this.runtime.cfcEnforcementMode !== "disabled" &&
                   runningRef !== undefined &&
+                  !PatternManager.isKeylessPatternIdentity(
+                    runningRef.identity,
+                  ) &&
                   patternIdentityKey(runningRef) !== newKey
                 ) {
                   const revertRef = runningRef;
@@ -2056,6 +2071,10 @@ export class Runner {
                 err,
               );
             });
+          this.pendingPointerMaintenance.add(watcherLoad);
+          watcherLoad.finally(() =>
+            this.pendingPointerMaintenance.delete(watcherLoad)
+          );
         }),
       );
     };
@@ -2174,12 +2193,17 @@ export class Runner {
       currentPatternKey = initialRef ? patternIdentityKey(initialRef) : KEYLESS;
       try {
         instantiateInitialPattern(givenPattern, initialRef, tx);
-        // Real artifact refs only: a keyless pattern's synthetic session
-        // pointer must never be written into durable state by the
-        // unloadable-pointer roll-forward.
-        runningRef =
-          this.runtime.patternManager.getArtifactEntryRef(givenPattern) ??
-            undefined;
+        // Real artifact refs only: setup mints and INDEXES a `keyless:`
+        // session pointer for hand-built patterns, so getArtifactEntryRef
+        // returns it — filter synthetics explicitly, or the roll-forward
+        // would write a pointer no fresh runtime can load.
+        const givenRef = this.runtime.patternManager.getArtifactEntryRef(
+          givenPattern,
+        );
+        runningRef = givenRef !== undefined &&
+            !PatternManager.isKeylessPatternIdentity(givenRef.identity)
+          ? givenRef
+          : undefined;
       } catch (error) {
         // Without cleanup the piece stays registered in `this.cancels`, so
         // every later start() reports "already running" for a piece that has
@@ -3592,9 +3616,17 @@ export class Runner {
     return true;
   }
 
-  /** Settle in-flight pointer roll-forward commits (see dispose()). */
+  /**
+   * Settle in-flight watcher pattern loads and pointer roll-forward commits
+   * (see dispose()); loops because a roll-forward is spawned INSIDE its load
+   * chain. Also the deterministic synchronization point for tests — the
+   * runner suite runs under a frozen clock, so wall-clock polling cannot
+   * observe this work.
+   */
   async idlePointerMaintenance(): Promise<void> {
-    await Promise.allSettled([...this.pendingPointerMaintenance]);
+    while (this.pendingPointerMaintenance.size > 0) {
+      await Promise.allSettled([...this.pendingPointerMaintenance]);
+    }
   }
 
   stopAll(): void {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -844,8 +844,17 @@ export class Runner {
   private allCancels = new Set<Cancel>();
   // In-flight unloadable-pointer roll-forward commits (CT-1923). Deliberately
   // outside the scheduler, like PatternUpdater's checks — dispose() settles
-  // them before the storage sessions they write through close.
-  private pendingPointerMaintenance = new Set<Promise<unknown>>();
+  // them before the storage sessions they write through close. Bounded
+  // local commits only.
+  private pendingPointerCommits = new Set<Promise<unknown>>();
+  // In-flight watcher pattern-load attempts. NEVER awaited by dispose(): a
+  // load can be arbitrarily slow or wedged (network), and the
+  // fire-and-forget design guards post-settle work with lifecycle epochs
+  // instead — awaiting them would let one held load hang teardown (proven
+  // by reload-rehydration-safety's held-hot-swap-load test). Tracked solely
+  // so tests can synchronize deterministically under the frozen-clock
+  // preload, where wall-clock polling cannot observe this work.
+  private pendingWatcherPatternLoads = new Set<Promise<unknown>>();
   private locallyPreparedResults = new Map<
     `${MemorySpace}/${CellScope}/${URI}`,
     string
@@ -2049,9 +2058,9 @@ export class Runner {
                   });
                   // Track so dispose() can settle it before storage teardown
                   // (same contract as PatternUpdater's pending checks).
-                  this.pendingPointerMaintenance.add(rollForward);
+                  this.pendingPointerCommits.add(rollForward);
                   rollForward.finally(() =>
-                    this.pendingPointerMaintenance.delete(rollForward)
+                    this.pendingPointerCommits.delete(rollForward)
                   );
                 }
                 return;
@@ -2071,9 +2080,9 @@ export class Runner {
                 err,
               );
             });
-          this.pendingPointerMaintenance.add(watcherLoad);
+          this.pendingWatcherPatternLoads.add(watcherLoad);
           watcherLoad.finally(() =>
-            this.pendingPointerMaintenance.delete(watcherLoad)
+            this.pendingWatcherPatternLoads.delete(watcherLoad)
           );
         }),
       );
@@ -3617,15 +3626,35 @@ export class Runner {
   }
 
   /**
-   * Settle in-flight watcher pattern loads and pointer roll-forward commits
-   * (see dispose()); loops because a roll-forward is spawned INSIDE its load
-   * chain. Also the deterministic synchronization point for tests — the
-   * runner suite runs under a frozen clock, so wall-clock polling cannot
-   * observe this work.
+   * Settle in-flight pointer roll-forward COMMITS — bounded local work,
+   * awaited by dispose() before the storage sessions they write through
+   * close. Deliberately excludes watcher pattern LOADS: a load can be
+   * arbitrarily slow or wedged, and its post-settle work is already
+   * lifecycle-epoch-guarded.
+   */
+  async settlePointerCommits(): Promise<void> {
+    while (this.pendingPointerCommits.size > 0) {
+      await Promise.allSettled([...this.pendingPointerCommits]);
+    }
+  }
+
+  /**
+   * TESTS ONLY: settle in-flight watcher pattern loads AND any pointer
+   * roll-forward commits they spawn; loops because a roll-forward is
+   * created inside its load chain. The deterministic synchronization point
+   * under the frozen-clock preload, where wall-clock polling cannot observe
+   * this work. Never called from dispose() — a held load would hang
+   * teardown.
    */
   async idlePointerMaintenance(): Promise<void> {
-    while (this.pendingPointerMaintenance.size > 0) {
-      await Promise.allSettled([...this.pendingPointerMaintenance]);
+    while (
+      this.pendingWatcherPatternLoads.size > 0 ||
+      this.pendingPointerCommits.size > 0
+    ) {
+      await Promise.allSettled([
+        ...this.pendingWatcherPatternLoads,
+        ...this.pendingPointerCommits,
+      ]);
     }
   }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -841,6 +841,10 @@ function dedupeNormalizedLinks(
 export class Runner {
   readonly cancels = new Map<`${MemorySpace}/${CellScope}/${URI}`, Cancel>();
   private allCancels = new Set<Cancel>();
+  // In-flight unloadable-pointer roll-forward commits (CT-1923). Deliberately
+  // outside the scheduler, like PatternUpdater's checks — dispose() settles
+  // them before the storage sessions they write through close.
+  private pendingPointerMaintenance = new Set<Promise<unknown>>();
   private locallyPreparedResults = new Map<
     `${MemorySpace}/${CellScope}/${URI}`,
     string
@@ -1986,7 +1990,7 @@ export class Runner {
                   patternIdentityKey(runningRef) !== newKey
                 ) {
                   const revertRef = runningRef;
-                  void this.runtime.editWithRetry((tx) => {
+                  const rollForward = this.runtime.editWithRetry((tx) => {
                     const cur = asPatternIdentityRef(
                       resultCell.withTx(tx).getMetaRaw("patternIdentity", {
                         meta: ignoreReadForScheduling,
@@ -2001,7 +2005,12 @@ export class Runner {
                     });
                     return true;
                   }).then((result) => {
-                    if (result.ok) {
+                    // Only reclaim the observed key while it is STILL the
+                    // failed one — a valid repoint that raced this rollback
+                    // has already advanced the watcher state, and clobbering
+                    // it would make the key guard discard that repoint's
+                    // in-flight load.
+                    if (result.ok && currentPatternKey === newKey) {
                       currentPatternKey = patternIdentityKey(revertRef);
                       logger.warn(
                         "unloadable-pointer-rolled-forward",
@@ -2023,6 +2032,12 @@ export class Runner {
                       ],
                     );
                   });
+                  // Track so dispose() can settle it before storage teardown
+                  // (same contract as PatternUpdater's pending checks).
+                  this.pendingPointerMaintenance.add(rollForward);
+                  rollForward.finally(() =>
+                    this.pendingPointerMaintenance.delete(rollForward)
+                  );
                 }
                 return;
               }
@@ -3575,6 +3590,11 @@ export class Runner {
       }
     }
     return true;
+  }
+
+  /** Settle in-flight pointer roll-forward commits (see dispose()). */
+  async idlePointerMaintenance(): Promise<void> {
+    await Promise.allSettled([...this.pendingPointerMaintenance]);
   }
 
   stopAll(): void {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1221,6 +1221,10 @@ export class Runtime {
     // and settle them before the storage sessions they may write through close.
     await this.patternUpdater.dispose();
 
+    // Same contract for the runner's unloadable-pointer roll-forward commits
+    // (CT-1923): settle before their storage sessions close.
+    await this.runner.idlePointerMaintenance();
+
     // Scheduler background work can still be using storage, for example the
     // lifecycle-guarded boot-time persistent-state listing. Let that finish
     // before tearing down storage sessions.

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1222,8 +1222,10 @@ export class Runtime {
     await this.patternUpdater.dispose();
 
     // Same contract for the runner's unloadable-pointer roll-forward commits
-    // (CT-1923): settle before their storage sessions close.
-    await this.runner.idlePointerMaintenance();
+    // (CT-1923): settle before their storage sessions close. Commits only —
+    // never the watcher pattern LOADS, which can be held/wedged arbitrarily
+    // long and are lifecycle-epoch-guarded instead.
+    await this.runner.settlePointerCommits();
 
     // Scheduler background work can still be using storage, for example the
     // lifecycle-guarded boot-time persistent-state listing. Let that finish

--- a/packages/runner/test/pattern-pointer-unloadable-swap.test.ts
+++ b/packages/runner/test/pattern-pointer-unloadable-swap.test.ts
@@ -8,21 +8,26 @@ import { getPatternIdentityRef, resolveEntryIdentity } from "../src/index.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 
 // CT-1923 (2026-07-29 estuary): a running piece whose durable patternIdentity
-// points at an identity this runtime CANNOT load sits stranded forever: the
-// watcher sees the pointer as a change, fails the load, logs
-// "pattern-load-error" — and leaves the unloadable pointer in place. Every
-// later session then starts the piece by that dead pointer and renders
+// names an identity this runtime cannot load sat stranded forever: the
+// watcher saw the pointer as a change, failed the load, logged
+// "pattern-load-error" — and left the unloadable pointer in place. Every
+// later session then started the piece by that dead pointer and rendered
 // nothing. Production shape: a nested home-section piece whose stored vintage
 // used a retired JSX element; the parent re-instantiates the CURRENT
 // sub-pattern each boot, but the durable pointer never rolls forward, so the
 // stranded state reasserts itself per session (blank Favorites/Profile).
 //
-// Desired: with systemPatternAutoUpdate on, a DEFINITIVE load failure of the
-// pointed-at identity (loadPatternByIdentity returns undefined after syncing
-// — the docs are absent or do not compile) while a pattern is RUNNING rolls
-// the pointer back to the running pattern's identity, durably. The stranded
-// state becomes self-converging instead of self-perpetuating. Without the
-// flag, behavior is unchanged (pointer left as written).
+// Desired: with systemPatternAutoUpdate on AND by-identity recovery enabled
+// (CFC enforcement not disabled), a DEFINITIVE load failure of the pointed-at
+// identity while a pattern is RUNNING rolls the pointer back to the running
+// pattern's identity, durably. The stranded state becomes self-converging
+// instead of self-perpetuating. NOT definitive, and never rolled back:
+// CFC-disabled probes (undefined means "probe unsupported" there), and
+// session-synthetic keyless refs are never written durably.
+//
+// All synchronization goes through runner.idlePointerMaintenance() — the
+// runner suite runs under a frozen clock (test/clock-preload.ts), so
+// wall-clock polling cannot observe this work.
 
 const signer = await Identity.fromPassphrase("pattern-pointer-unloadable");
 const space = signer.did();
@@ -31,6 +36,14 @@ const V1 = [
   "import { pattern } from 'commonfabric';",
   "export default pattern<Record<string, never>, { marker: string }>(() => {",
   "  return { marker: 'v1' };",
+  "});",
+  "",
+].join("\n");
+
+const V2_LOADABLE = [
+  "import { pattern } from 'commonfabric';",
+  "export default pattern<Record<string, never>, { marker: string }>(() => {",
+  "  return { marker: 'v2' };",
   "});",
   "",
 ].join("\n");
@@ -50,39 +63,41 @@ const programOf = (contents: string): RuntimeProgram => ({
   files: [{ name: "/main.tsx", contents }],
 });
 
+const unloadableIdentityPromise = resolveEntryIdentity(
+  "/main.tsx",
+  (name) =>
+    name === "/main.tsx"
+      ? Promise.resolve(UNLOADABLE_SOURCE)
+      : Promise.reject(new Error(`not found: ${name}`)),
+);
+
 describe("unloadable patternIdentity pointer vs a running pattern", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let rt: Runtime;
 
-  const newRuntime = (systemPatternAutoUpdate: boolean) =>
+  const newRuntime = (
+    systemPatternAutoUpdate: boolean,
+    extra: { cfcEnforcementMode?: "disabled" } = {},
+  ) =>
     new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
       experimental: { systemPatternAutoUpdate },
+      ...extra,
     });
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
   });
   afterEach(async () => {
-    // Drain the watcher's floating load attempt (and any roll-forward
-    // commit) before teardown so no promise is left pending at process exit
-    // — Deno's event-loop check fails the whole shard otherwise.
-    await rt?.idle();
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    // Settle the watcher's load attempt and any roll-forward before teardown
+    // so no promise is pending at process exit.
+    await rt?.runner.idlePointerMaintenance();
     await rt?.dispose();
     await storageManager?.close();
   });
 
-  const runV1ThenStrandPointer = async () => {
-    const unloadableIdentity = await resolveEntryIdentity(
-      "/main.tsx",
-      (name) =>
-        name === "/main.tsx"
-          ? Promise.resolve(UNLOADABLE_SOURCE)
-          : Promise.reject(new Error(`not found: ${name}`)),
-    );
-
+  const runV1 = async (cause: string) => {
     const tx = rt.edit();
     const v1 = await rt.patternManager.compilePattern(programOf(V1), {
       space,
@@ -91,7 +106,7 @@ describe("unloadable patternIdentity pointer vs a running pattern", () => {
     const v1Ref = rt.patternManager.getArtifactEntryRef(v1)!;
     const cell = rt.getCell<Record<string, unknown>>(
       space,
-      "unloadable-pointer-piece",
+      cause,
       undefined,
       tx,
     );
@@ -100,42 +115,31 @@ describe("unloadable patternIdentity pointer vs a running pattern", () => {
     await running.pull();
     expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v1");
     expect(getPatternIdentityRef(cell)?.identity).toBe(v1Ref.identity);
-
-    // The stranded durable state, however a session got there: pointer moved
-    // to an identity that cannot load while V1 keeps running.
-    const tx2 = rt.edit();
-    cell.withTx(tx2).setMetaRaw("patternIdentity", {
-      identity: unloadableIdentity,
-      symbol: "default",
-    });
-    await tx2.commit();
-    await rt.idle();
-
-    return { cell, v1Ref, unloadableIdentity };
+    return { cell, v1Ref };
   };
 
-  // The watcher's load attempt and any roll-forward commit are floating
-  // promises `rt.idle()` does not await; poll for the durable outcome.
-  const settleUntil = async (
-    predicate: () => boolean,
-    timeoutMs = 3000,
-  ): Promise<boolean> => {
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (predicate()) return true;
-      await new Promise((resolve) => setTimeout(resolve, 25));
-    }
-    return predicate();
+  const repointTo = async (
+    cell: ReturnType<Runtime["getCell"]>,
+    identity: string,
+  ) => {
+    const tx = rt.edit();
+    cell.withTx(tx).setMetaRaw("patternIdentity", {
+      identity,
+      symbol: "default",
+    });
+    await tx.commit();
+    await rt.idle();
+    // Deterministic: settles the watcher load chain and any roll-forward.
+    await rt.runner.idlePointerMaintenance();
+    await rt.idle();
+    await rt.runner.idlePointerMaintenance();
   };
 
   it("rolls the pointer back to the running identity (flag ON)", async () => {
     rt = newRuntime(true);
-    const { cell, v1Ref } = await runV1ThenStrandPointer();
+    const { cell, v1Ref } = await runV1("unloadable-pointer-flag-on");
+    await repointTo(cell, await unloadableIdentityPromise);
 
-    const converged = await settleUntil(
-      () => getPatternIdentityRef(cell)?.identity === v1Ref.identity,
-    );
-    expect(converged).toBe(true);
     const ref = getPatternIdentityRef(cell);
     expect(ref?.identity).toBe(v1Ref.identity);
     expect(ref?.symbol).toBe(v1Ref.symbol);
@@ -145,14 +149,84 @@ describe("unloadable patternIdentity pointer vs a running pattern", () => {
 
   it("leaves the pointer as written when the flag is OFF", async () => {
     rt = newRuntime(false);
-    const { cell, unloadableIdentity } = await runV1ThenStrandPointer();
+    const { cell } = await runV1("unloadable-pointer-flag-off");
+    const unloadableIdentity = await unloadableIdentityPromise;
+    await repointTo(cell, unloadableIdentity);
 
-    // Give a would-be roll-forward the same window the flag-ON case gets,
-    // then assert nothing moved the pointer.
-    await settleUntil(
-      () => getPatternIdentityRef(cell)?.identity !== unloadableIdentity,
-      500,
+    expect(getPatternIdentityRef(cell)?.identity).toBe(unloadableIdentity);
+  });
+
+  it("never rolls back under CFC-disabled probes (undefined is not a verdict)", async () => {
+    // With cfcEnforcementMode "disabled", loadPatternByIdentity returns
+    // undefined for anything outside the in-memory index — "probe
+    // unsupported", not "artifact dead". A legitimate repoint to a LOADABLE
+    // identity (persisted by another session) must survive.
+    rt = newRuntime(true, { cfcEnforcementMode: "disabled" });
+
+    // Persist a loadable V2 through a separate enforcing runtime so the
+    // artifact genuinely exists in the shared store.
+    const other = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: {},
+    });
+    let v2Identity: string;
+    try {
+      const otherTx = other.edit();
+      const v2 = await other.patternManager.compilePattern(
+        programOf(V2_LOADABLE),
+        { space, tx: otherTx },
+      );
+      v2Identity = other.patternManager.getArtifactEntryRef(v2)!.identity;
+      await otherTx.commit();
+      await other.idle();
+    } finally {
+      await other.dispose();
+    }
+
+    const { cell } = await runV1("unloadable-pointer-cfc-disabled");
+    await repointTo(cell, v2Identity);
+
+    // The repoint stands: no rollback to V1.
+    expect(getPatternIdentityRef(cell)?.identity).toBe(v2Identity);
+  });
+
+  it("never writes a keyless session pointer durably", async () => {
+    // A hand-built (keyless) pattern gets a session-synthetic `keyless:` ref
+    // minted and indexed during setup. If its piece is repointed to an
+    // unloadable identity, rolling back would write a pointer no fresh
+    // runtime can load — so the roll-forward must not engage at all.
+    rt = newRuntime(true);
+    const keylessPattern = {
+      argumentSchema: {},
+      resultSchema: {
+        type: "object",
+        properties: { marker: { type: "string" } },
+      },
+      result: { marker: "keyless" },
+      nodes: [],
+    };
+    const tx = rt.edit();
+    const cell = rt.getCell<Record<string, unknown>>(
+      space,
+      "unloadable-pointer-keyless",
+      undefined,
+      tx,
     );
+    // deno-lint-ignore no-explicit-any
+    const running = rt.run(tx, keylessPattern as any, {}, cell);
+    await tx.commit();
+    await running.pull();
+    const keylessRef = getPatternIdentityRef(cell);
+    if (keylessRef !== undefined) {
+      expect(keylessRef.identity).toMatch(/^keyless:/);
+    }
+
+    const unloadableIdentity = await unloadableIdentityPromise;
+    await repointTo(cell, unloadableIdentity);
+
+    // No rollback: the pointer keeps the (unloadable) repoint rather than
+    // gaining a session-synthetic identity.
     expect(getPatternIdentityRef(cell)?.identity).toBe(unloadableIdentity);
   });
 });

--- a/packages/runner/test/pattern-pointer-unloadable-swap.test.ts
+++ b/packages/runner/test/pattern-pointer-unloadable-swap.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { getPatternIdentityRef, resolveEntryIdentity } from "../src/index.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// CT-1923 (2026-07-29 estuary): a running piece whose durable patternIdentity
+// points at an identity this runtime CANNOT load sits stranded forever: the
+// watcher sees the pointer as a change, fails the load, logs
+// "pattern-load-error" — and leaves the unloadable pointer in place. Every
+// later session then starts the piece by that dead pointer and renders
+// nothing. Production shape: a nested home-section piece whose stored vintage
+// used a retired JSX element; the parent re-instantiates the CURRENT
+// sub-pattern each boot, but the durable pointer never rolls forward, so the
+// stranded state reasserts itself per session (blank Favorites/Profile).
+//
+// Desired: with systemPatternAutoUpdate on, a DEFINITIVE load failure of the
+// pointed-at identity (loadPatternByIdentity returns undefined after syncing
+// — the docs are absent or do not compile) while a pattern is RUNNING rolls
+// the pointer back to the running pattern's identity, durably. The stranded
+// state becomes self-converging instead of self-perpetuating. Without the
+// flag, behavior is unchanged (pointer left as written).
+
+const signer = await Identity.fromPassphrase("pattern-pointer-unloadable");
+const space = signer.did();
+
+const V1 = [
+  "import { pattern } from 'commonfabric';",
+  "export default pattern<Record<string, never>, { marker: string }>(() => {",
+  "  return { marker: 'v1' };",
+  "});",
+  "",
+].join("\n");
+
+// A well-formed content identity whose source closure is persisted NOWHERE in
+// this store — the "obsolete vintage this runtime cannot load" stand-in.
+const UNLOADABLE_SOURCE = [
+  "import { pattern } from 'commonfabric';",
+  "export default pattern<Record<string, never>, { marker: string }>(() => {",
+  "  return { marker: 'unloadable-vintage' };",
+  "});",
+  "",
+].join("\n");
+
+const programOf = (contents: string): RuntimeProgram => ({
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents }],
+});
+
+describe("unloadable patternIdentity pointer vs a running pattern", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let rt: Runtime;
+
+  const newRuntime = (systemPatternAutoUpdate: boolean) =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { systemPatternAutoUpdate },
+    });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await rt?.dispose();
+    await storageManager?.close();
+  });
+
+  const runV1ThenStrandPointer = async () => {
+    const unloadableIdentity = await resolveEntryIdentity(
+      "/main.tsx",
+      (name) =>
+        name === "/main.tsx"
+          ? Promise.resolve(UNLOADABLE_SOURCE)
+          : Promise.reject(new Error(`not found: ${name}`)),
+    );
+
+    const tx = rt.edit();
+    const v1 = await rt.patternManager.compilePattern(programOf(V1), {
+      space,
+      tx,
+    });
+    const v1Ref = rt.patternManager.getArtifactEntryRef(v1)!;
+    const cell = rt.getCell<Record<string, unknown>>(
+      space,
+      "unloadable-pointer-piece",
+      undefined,
+      tx,
+    );
+    const running = rt.run(tx, v1, {}, cell);
+    await tx.commit();
+    await running.pull();
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v1");
+    expect(getPatternIdentityRef(cell)?.identity).toBe(v1Ref.identity);
+
+    // The stranded durable state, however a session got there: pointer moved
+    // to an identity that cannot load while V1 keeps running.
+    const tx2 = rt.edit();
+    cell.withTx(tx2).setMetaRaw("patternIdentity", {
+      identity: unloadableIdentity,
+      symbol: "default",
+    });
+    await tx2.commit();
+    await rt.idle();
+
+    return { cell, v1Ref, unloadableIdentity };
+  };
+
+  // The watcher's load attempt and any roll-forward commit are floating
+  // promises `rt.idle()` does not await; poll for the durable outcome.
+  const settleUntil = async (
+    predicate: () => boolean,
+    timeoutMs = 3000,
+  ): Promise<boolean> => {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (predicate()) return true;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return predicate();
+  };
+
+  it("rolls the pointer back to the running identity (flag ON)", async () => {
+    rt = newRuntime(true);
+    const { cell, v1Ref } = await runV1ThenStrandPointer();
+
+    const converged = await settleUntil(
+      () => getPatternIdentityRef(cell)?.identity === v1Ref.identity,
+    );
+    expect(converged).toBe(true);
+    const ref = getPatternIdentityRef(cell);
+    expect(ref?.identity).toBe(v1Ref.identity);
+    expect(ref?.symbol).toBe(v1Ref.symbol);
+    // The running pattern was never torn down by the failed swap.
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v1");
+  });
+
+  it("leaves the pointer as written when the flag is OFF", async () => {
+    rt = newRuntime(false);
+    const { cell, unloadableIdentity } = await runV1ThenStrandPointer();
+
+    // Give a would-be roll-forward the same window the flag-ON case gets,
+    // then assert nothing moved the pointer.
+    await settleUntil(
+      () => getPatternIdentityRef(cell)?.identity !== unloadableIdentity,
+      500,
+    );
+    expect(getPatternIdentityRef(cell)?.identity).toBe(unloadableIdentity);
+  });
+});

--- a/packages/runner/test/pattern-pointer-unloadable-swap.test.ts
+++ b/packages/runner/test/pattern-pointer-unloadable-swap.test.ts
@@ -65,6 +65,11 @@ describe("unloadable patternIdentity pointer vs a running pattern", () => {
     storageManager = StorageManager.emulate({ as: signer });
   });
   afterEach(async () => {
+    // Drain the watcher's floating load attempt (and any roll-forward
+    // commit) before teardown so no promise is left pending at process exit
+    // — Deno's event-loop check fails the whole shard otherwise.
+    await rt?.idle();
+    await new Promise((resolve) => setTimeout(resolve, 150));
     await rt?.dispose();
     await storageManager?.close();
   });


### PR DESCRIPTION
## Why

The last member of this week's heal family (roots at boot: #4967; roots from
every entry point: #5146). A running piece whose **durable** `patternIdentity`
names an identity the runtime cannot load sat stranded forever: the watcher
saw the pointer as a change, failed the load, logged `pattern-load-error` —
and left the unloadable pointer in place. Every later session started the
piece by that dead pointer and rendered nothing.

Live on estuary (2026-07-29, deploy `ab8e132d48`): nested home-section pieces
whose stored vintage used the retired `cf-cell-context` element. The parent
re-instantiates the CURRENT sub-pattern each boot and optimistically writes
the pointer inside its batched instantiation commit — but that commit loses
to the incoming durable state, the pointer never rolls forward, and the
stranded state reasserts itself per session: blank Favorites and Profile tabs
on the user's home space, with `pattern-load-error … uMloj4n9…` on every
load.

## What Changed

With `systemPatternAutoUpdate` on, a **definitive** load failure (undefined
from `loadPatternByIdentity` — the load synced and found the identity's docs
absent or uncompilable) while a pattern is running rolls the pointer back to
the RUNNING pattern's identity through a small preconditioned commit:

- a concurrent legitimate repoint supersedes it (the commit re-reads the
  pointer and bails if it moved);
- thrown (possibly transient) load errors never trigger it — only the
  synced-verdict undefined;
- keyless patterns' synthetic session pointers are never written durably;
- flag off: behavior unchanged (pinned by test).

`startCore` now tracks the RUNNING pattern's ref separately from the last
observed pointer key — a parent-driven start instantiates its given pattern
while the durable pointer may still hold an older identity, and the
roll-forward must write what is actually live, not what was last observed.

The stranded state becomes self-converging instead of self-perpetuating: one
session with the flag on repairs the pointer durably, and every subsequent
session (and every start-by-identity consumer) finds a loadable pattern.

## Test plan

- New `pattern-pointer-unloadable-swap.test.ts`: reproduces the exact
  stranded state (running V1, durable pointer moved to a well-formed identity
  persisted nowhere) — flag ON converges the pointer back durably with the
  running pattern untouched (failed before this change: pointer stayed
  stranded); flag OFF leaves the pointer as written.
- Watcher/heal-family suites green: pattern-swap-link-argument,
  nested-piece-setup-repair, resume-output-redirect-partialcause,
  ensure-piece-running, runner.test.ts (its one pre-existing `clock` failure
  on main aside). Full `packages/piece` suite green (352 steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-heals durable `patternIdentity` pointers by reverting unloadable pointers to the currently running pattern on a definitive load failure, making stranded pieces converge and fixing blank Home tabs. Also cleans up shutdown by settling pointer roll-forward commits (not watcher loads) to avoid teardown hangs. Addresses CT-1923.

- **Bug Fixes**
  - On a definitive `undefined` from `loadPatternByIdentity` during a run and with `systemPatternAutoUpdate` on, roll the durable pointer back to the running pattern via a guarded commit. Bail if the pointer changed, and only reclaim the watcher key while it is still the failed one.
  - Never trigger on thrown/transient load errors, when `cfcEnforcementMode="disabled"`, or for session-synthetic `keyless:` refs (via `PatternManager.isKeylessPatternIdentity`). Track the running pattern ref separately from the last observed pointer key.
  - Track watcher loads and pointer roll-forward commits; expose `Runner.idlePointerMaintenance()` for deterministic tests. `Runtime.dispose()` now calls `Runner.settlePointerCommits()` to await commits only before storage sessions close.

<sup>Written for commit 8dbe4012eddc9f48321fe752dfd471cd4f525343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 6961 lines
(the roll-forward failure-path warn lambdas and dispose-settle guard lines; the behavior paths themselves are pinned by the four regression tests, all run under the frozen-clock preload)
