### PR TITLE
docs: give `cf space` a runbook and make it discoverable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,12 @@ If you are developing runtime code, read the following documentation:
   practices
 - `docs/development/DEPENDENCIES.md` - Adding and rolling dependencies, required
   version pins, and dependency troubleshooting
+- `docs/development/space-clone-rehearsal.md` - Rehearsing a pattern update on a
+  clone of a real space before touching a populated one: when a rehearsal is
+  required, how to get a snapshot, the clone/verify/reset loop (`cf space`), and
+  the reads that will mislead you (~20 s cold loads, unstepped result reads,
+  fresh-replica reads). Read it before any `setsrc` against a space with real
+  data
 - `docs/development/LOCAL_DEV_SERVERS.md` - **CRITICAL**: How to start local dev
   servers correctly (use `dev-local` for shell, not `dev`)
 - `docs/development/TESTING.md` - Running the test suites and the general unit

--- a/docs/development/space-clone-rehearsal.md
+++ b/docs/development/space-clone-rehearsal.md
@@ -1,0 +1,129 @@
+# Rehearsing a pattern update on a space clone
+
+Updating a deployed pattern on a populated space is a rehearsal-grade event.
+This is the procedure: make a writable copy of the real space, run the update
+against it, judge whether content survived, reset, repeat — then do it for real.
+
+The reasoning behind each decision (why clones keep the source DID, why
+generated cells are excluded from the fingerprint, what was deliberately not
+built) is in [`../plans/space-clone-rehearsal.md`](../plans/space-clone-rehearsal.md).
+This document is the operating procedure.
+
+## When a rehearsal is required
+
+Required when updating a **populated** space and any of:
+
+- the compat checker fails, or the update needs
+  `--dangerously-allow-incompatible-schema`;
+- the update changes a **result** schema a parent or sibling piece reads. This
+  is the "Topics (0)" failure from the 2026-07-10 board outage: old-generation
+  results lacking new fields make the *whole array* read empty, silently;
+- more than one pattern generation is live in the space;
+- the target is a board or collection whose children are separate pieces —
+  children and parent migrate separately and can disagree mid-flight.
+
+Not required for additive input fields with defaults, UI-only changes, or work
+on a fresh/scratch space.
+
+## Getting a snapshot
+
+The dump endpoint is deliberately off in production, and a whole-space dump is
+the entire contents of a space — a confidentiality decision, not an ergonomics
+one. So acquisition is manual:
+
+```bash
+# On the server, against the live store. VACUUM INTO never mutates the source
+# and emits one consistent file with no -wal/-shm companions.
+sqlite3 <store>/engine-v3/engine-v3/<did>.sqlite "VACUUM INTO '/tmp/<did>.sqlite'"
+# then copy it down (scp, or upload once and share the URL with the team)
+```
+
+Sharing **one** snapshot across operators is better hygiene than each taking
+their own: identical baselines make fingerprints comparable between people.
+
+On a staging host with `MEMORY_DUMP_ENABLED`, `cf inspect pull --remote <url>`
+does this for you.
+
+## The loop
+
+```bash
+# 1. Clone. --from takes a path or an https URL.
+deno task cf space clone <space-did> --from <snapshot> --to ~/clones/<name>
+
+# 2. Serve it — note the port offset; the clone keeps the source space's DID,
+#    so the port is what distinguishes it from production.
+MEMORY_DIR="file://$HOME/clones/<name>/" \
+  ./scripts/start-local-dev.sh --port-offset 10
+```
+
+The toolshed prints a `SERVING A REHEARSAL CLONE` banner at startup. If you do
+not see it, you are pointed at something else — stop and check before writing.
+
+```bash
+# 3. Baseline, before touching anything.
+deno task cf space verify ~/clones/<name>
+deno task cf inspect churn <space> --bucket 60      # confirm a quiet window
+
+# 4. Run the update against the CLONE's api-url. Children first, board last,
+#    serially — the parent's result recomputation is what storms.
+deno task cf piece setsrc … --api-url http://localhost:8010 …
+
+# 5. Judge it.
+deno task cf space verify ~/clones/<name>           # nonzero exit = content moved
+deno task cf inspect churn <space> --bucket 60 --since '<when you started>'
+
+# 6. Reset and go again.
+deno task cf space reset ~/clones/<name>
+```
+
+## Reading the verdict
+
+`cf space verify` compares the working copy against the manifest written at
+clone time:
+
+- **`content unchanged`** — durable content survived. **Growing commit and
+  revision counts are expected**: a migration writes. The fingerprint is the
+  signal, not the counts.
+- **`content CHANGED`** — something authored moved. Diff per-entity hashes to
+  see what:
+  ```bash
+  deno task cf space fingerprint <clone>/engine-v3/engine-v3/<did>.sqlite --per-entity
+  ```
+- **`baseline CORRUPTED`** — the pristine snapshot no longer matches the
+  manifest. Do not reset to it; re-clone.
+
+Compiler-generated internal cells are excluded by default, because a pattern
+update rotates their identities on purpose. Including them (`--include-generated`)
+answers "what moved at all?", never "did content survive?".
+
+`cf inspect churn` reports rates and never judges them. What you are looking for
+is the storm shape: a jump to a **sustained plateau**, not a spike. The July 2026
+incident ran at ~1,300 commits/minute for twenty minutes. A settle means the rate
+returns to baseline *and stays there*.
+
+## Things that will mislead you
+
+These are all failures that actually happened, not hypotheticals:
+
+- **A cold browser load takes ~20 s.** A production attempt was rolled back on
+  this false negative. Wait before concluding the board is broken.
+- **An unstepped CLI read of a computed result looks empty.** Use `--input` for
+  what durably committed and `--step` for computed results. An empty
+  `crossrefs --step` next to a non-empty `topics --input` is a
+  result-materialization problem, not an empty board.
+- **Never trust a fresh-replica read.** From the 2026-07-10 outage record:
+  "every wrong turn in this investigation traces to trusting a fresh-replica
+  read."
+- **Cross-space links resolve to empty, not to an error.** The memory server
+  creates space stores on demand, so a link to another space silently
+  manufactures an empty local one. A pattern with cross-space reads will look
+  cleaner on a clone than in production.
+- **A clone tests the store and the runtime, not the deployment.** CDN and shell
+  versions, and concurrent human traffic, are all absent.
+
+## Before going live
+
+- Two consecutive clean passes on the clone, resetting between them.
+- A rollback manifest written down *before* the live attempt: the pristine
+  snapshot path and the exact reset command.
+- Then repeat steps 3–5 against production, with that manifest in hand.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -31,5 +31,9 @@ a record: archive it to `docs/history/plans/` following the procedure in
   [pattern verb contract](pattern-verb-contract.md).
 - [CFC runner implementation](runner_cfc_implementation.md) defines the
   commit-boundary enforcement workstreams and rollout.
-- [`cf space clone` rehearsal](space-clone-rehearsal.md) proposes a
-  rehearsal-grade command for copying populated spaces.
+- [`cf space clone` rehearsal](space-clone-rehearsal.md) records the design for
+  rehearsal-grade copies of populated spaces. The tooling has shipped (`cf
+  space`, `cf inspect churn`); the operating procedure lives in
+  [`../development/space-clone-rehearsal.md`](../development/space-clone-rehearsal.md).
+  The plan stays live until the practice has been exercised on a real
+  migration.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -148,6 +148,11 @@ use `cf exec <mounted-file> --help --json` or
 
 The supported output switches are:
 
+- `cf space ... --json` serializes the clone manifest, verify result, or
+  fingerprint. `cf space verify` and `cf space reset` exit nonzero when the
+  clone does not match its baseline, so a rehearsal script can gate on them; the
+  printed report, not usage help, is the output in that case. The procedure
+  these commands serve is `docs/development/space-clone-rehearsal.md`.
 - `cf inspect ... --json` serializes an inspector result. `inspect html` does
   not have a JSON representation, so `html` and `--json` are mutually exclusive.
   `inspect graph --dot` and `--json` are also mutually exclusive.

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -132,6 +132,14 @@ deno task cf inspect html     z6Mkqa41 --out /tmp/space.html [--app-url https://
 # cross-space convergence (--all discovered, or --spaces a,b, or --dir)
 deno task cf inspect converge      of:fid1:… --all --path value
 deno task cf inspect converge-scan --all --json
+
+# rehearsal clones — `cf space` WRITES, so it sits outside inspect's read-only
+# contract, but clone.ts + fingerprint.ts live in this package. The operating
+# procedure is docs/development/space-clone-rehearsal.md.
+deno task cf space clone  <did> --from <snapshot|url> --to <dir>
+deno task cf space verify <dir>                 # nonzero exit when content moved
+deno task cf space reset  <dir>
+deno task cf space fingerprint <space> [--per-entity] [--include-generated]
 ```
 
 ### Remote (`--remote`) — inspect a staging/server without SSH

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -120,20 +120,21 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 
 ## Quick Command Reference
 
-| Operation         | Command                                                                                              |
-| ----------------- | ---------------------------------------------------------------------------------------------------- |
-| Type check        | `deno task cf check pattern.tsx --no-run`                                                            |
-| Deploy new        | `deno task cf piece new pattern.tsx --root . --repository REPO -i key -a url -s space`               |
-| Update existing   | `deno task cf piece setsrc pattern.tsx --root . --repository REPO --piece ID -i key -a url -s space` |
-| Inspect state     | `deno task cf piece inspect --piece ID ...`                                                          |
-| Get field         | `deno task cf piece get --piece ID fieldPath ...`                                                    |
-| Step + get        | `deno task cf piece get --piece ID fieldPath --step ...`                                             |
-| Set field         | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
-| Call handler      | `deno task cf piece call --piece ID handlerName ...`                                                 |
-| List verbs        | `deno task cf piece verbs --piece ID --json ...`                                                     |
-| Trigger recompute | `deno task cf piece step --piece ID ...`                                                             |
-| List pieces       | `deno task cf piece ls -i key -a url -s space`                                                       |
-| Visualize         | `deno task cf piece map ...`                                                                         |
+| Operation          | Command                                                                                              |
+| ------------------ | ---------------------------------------------------------------------------------------------------- |
+| Type check         | `deno task cf check pattern.tsx --no-run`                                                            |
+| Deploy new         | `deno task cf piece new pattern.tsx --root . --repository REPO -i key -a url -s space`               |
+| Update existing    | `deno task cf piece setsrc pattern.tsx --root . --repository REPO --piece ID -i key -a url -s space` |
+| Inspect state      | `deno task cf piece inspect --piece ID ...`                                                          |
+| Get field          | `deno task cf piece get --piece ID fieldPath ...`                                                    |
+| Step + get         | `deno task cf piece get --piece ID fieldPath --step ...`                                             |
+| Set field          | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
+| Call handler       | `deno task cf piece call --piece ID handlerName ...`                                                 |
+| List verbs         | `deno task cf piece verbs --piece ID --json ...`                                                     |
+| Trigger recompute  | `deno task cf piece step --piece ID ...`                                                             |
+| List pieces        | `deno task cf piece ls -i key -a url -s space`                                                       |
+| Visualize          | `deno task cf piece map ...`                                                                         |
+| Rehearse an update | `deno task cf space clone <did> --from <snapshot> --to <dir>` (then `verify` / `reset`)              |
 
 ## Check Command Flags
 


### PR DESCRIPTION
## Why

`cf space` shipped across four PRs (#5075, #5079, #5081, #5122, #5140) with almost no documentation. A search of the tree turns up exactly three mentions:

- ten lines in `skills/state-inspector/SKILL.md`
- the design doc, `docs/plans/space-clone-rehearsal.md`
- one line in `docs/plans/README.md` still saying the doc *"proposes"* a command that has already shipped

So discovering the command required already knowing to look in the **state-inspector** skill — the wrong place for something that is deliberately *not* `cf inspect`. Nothing in the `cf` skill, neither package README, and no entry in the runtime-docs index.

The bigger gap: **the operating procedure existed only inside a plan document marked `proposed`.** A checklist nobody can find, in a document whose own status says it hasn't been agreed, is not a procedure anyone will follow — and the first person to run a real rehearsal would have been reading it.

## What Changed

**New `docs/development/space-clone-rehearsal.md`** — the checklist promoted out of the plan into a runbook: when a rehearsal is required (and when it is not), how to obtain a snapshot and why acquisition stays manual, the clone → serve → migrate → verify → reset loop, how to read the verdict, and what to do before going live.

Its "Things that will mislead you" section is failures that actually happened, not hypotheticals:

- a ~20 s cold browser load, which caused a production attempt to be rolled back on a false negative
- unstepped CLI reads of computed results looking empty
- cross-space links resolving to *empty* rather than erroring, so a clone looks cleaner than production
- the 2026-07-10 outage record's "every wrong turn in this investigation traces to trusting a fresh-replica read"

It also states the thing most likely to be misread: **growing commit counts are expected** — a migration writes. The fingerprint is the signal, not the counts.

**Discoverability**, in the four places people actually look:

- `skills/cf/SKILL.md` — a row in the Quick Command Reference table
- `packages/state-inspector/README.md` — `clone.ts`/`fingerprint.ts` live there, noted alongside why `cf space` sits *outside* inspect's read-only contract
- `packages/cli/README.md` — the JSON/exit-code conventions, beside the existing `cf inspect` entry
- `AGENTS.md` — the runtime-docs index

**Correction:** `docs/plans/README.md` no longer calls a shipped command a proposal. The plan stays **live rather than archived**, because its subject is a practice that has never been exercised on a real migration — archiving it would imply the work is done when only the tooling is.

## Test plan

- `deno task check-docs` — 523 checked code blocks pass.
- `deno task check-skill-facts` — OK across 34 skill docs (it verifies the paths and imports skills cite still resolve).
- `deno fmt` clean. Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a clear runbook for rehearsing pattern updates with `cf space` and makes the command easy to find across our docs. This improves safety for live migrations and clarifies JSON/exit-code behavior for automation.

- **Documentation**
  - New runbook at docs/development/space-clone-rehearsal.md: when to rehearse, how to snapshot, the clone→serve→migrate→verify→reset loop, how to read results, common pitfalls, and a pre‑live checklist.
  - Improves discoverability of `cf space`: adds a Quick Command row in skills/cf/SKILL.md; notes in packages/state-inspector/README.md (where `clone.ts`/`fingerprint.ts` live and why `cf space` writes); clarifies JSON/exit‑code conventions in packages/cli/README.md with a pointer to the runbook; adds an index entry in AGENTS.md.
  - Updates docs/plans/README.md: no longer calls the shipped command a proposal, links to the runbook, and keeps the plan live until exercised on a real migration.

<sup>Written for commit 32b5c26a935d8c569484ba2eb219fba469098e89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

