### PR TITLE
fix(integration): settle the page inside the waits a browser test blo…

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -252,13 +252,19 @@ import {
   waitForCondition,
 } from "@commonfabric/integration";
 
-// Before interacting: wait until the shell has exposed its settle hook, then
-// settle the view so the click lands on a bound handler.
-await waitForCondition(page, () =>
-  typeof (globalThis as {
-    commonfabric?: { viewSettled?: unknown };
-  }).commonfabric?.viewSettled === "function");
-await awaitViewSettled(page);
+// Before interacting: settle the view on each check and pass only once a settle
+// has run with the control present, so the click lands on a bound handler. A
+// settle that ran before the control existed says nothing about it, and a check
+// that only watches the DOM never pumps the work that renders it.
+await waitForCondition(page, async (probe) => {
+  const settle = (globalThis as {
+    commonfabric?: { viewSettled?: () => Promise<void> };
+  }).commonfabric?.viewSettled;
+  if (!settle) return false;
+  await settle();
+  const target = probe.collect("cf-button[role='button']")[0];
+  return target !== undefined && probe.isRendered(target);
+});
 const button = await page.waitForSelector("cf-button[role='button']");
 await button.click(); // delivered to a bound handler
 
@@ -273,7 +279,11 @@ await waitForCondition(page, (probe) =>
 Pattern integration tests can reach for the higher-level wrappers in
 `packages/patterns/integration/cfc-browser-helpers.ts` — `waitForText`,
 `fillCfInput`, `clickCfButton`, `clickCfButtonAndWaitForText` — which bundle
-"settle the view, act once, wait for the effect" on top of these primitives.
+"settle the view with the control present, act once, wait for the effect" on top
+of these primitives. `clickCfButton` settles on each check and proceeds only
+once a settle has run with the control present; see
+`docs/development/waiting-in-tests.md` for why that ordering is the load-bearing
+part, and for which helpers do not yet have it.
 
 ### Do not reach for these instead
 

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -100,13 +100,13 @@ Waits split into two groups with different primitives.
   signal.
 - The higher-level wrappers in
   `packages/patterns/integration/cfc-browser-helpers.ts` — `waitForText`,
-  `waitForTextAbsent`, `fillCfInput`, `clickCfButton`, `clickNthCfButton`,
-  `clickCfButtonAndWaitForText`, `waitForRuntimeIdle`, `waitForRuntimeSynced` —
-  bundle "settle the view, act once, wait for the effect" on top of the two
-  primitives above. `clickCfButton` takes the first match and reaches through a
-  host's shadow root for its inner `[data-cf-button]`; `clickNthCfButton` takes
-  the `index`-th match of a selector that already resolves to the buttons
-  themselves.
+  `waitForSettledText`, `waitForTextAbsent`, `fillCfInput`, `clickCfButton`,
+  `clickNthCfButton`, `clickCfButtonAndWaitForText`, `waitForRuntimeIdle`,
+  `waitForRuntimeSynced` — bundle "settle the view with the control present,
+  act once, wait for the effect" on top of the two primitives above.
+  `clickCfButton` takes the first match and reaches through a host's shadow root
+  for its inner `[data-cf-button]`; `clickNthCfButton` takes the `index`-th
+  match of a selector that already resolves to the buttons themselves.
 
 To click a control that appears asynchronously, follow the `clickCfButton`
 shape rather than a find-and-click retry loop: a `waitForCondition` predicate
@@ -116,6 +116,26 @@ target to be rendered — laid out, and not `display:none` or `visibility:hidden
 — so a control still inside a collapsed menu is skipped until it becomes
 clickable rather than tagged while it has no layout box and then failing to
 click.
+
+Settle the view inside that predicate, on every check, and let the check pass
+only on one the settle preceded. Settling is what makes a rendered control
+interactive, so a settle that ran before the control existed says nothing about
+it: the click lands on an element whose handler is not bound, is silently
+dropped, and the wait for its effect runs to the stuck-condition safety net.
+
+Do not reach instead for a check that only watches the DOM. Asking the worker
+whether it is idle queues runnable pull work that nothing else would start, so a
+control that appears only once the page's own pending work runs never arrives
+under a purely passive wait. The settle is both the barrier and the pump, which
+is why it belongs inside the predicate rather than in front of it.
+
+When several controls are clicked as a group, resolve every one of them before
+marking any, so no settle falls between the marks and the clicks.
+
+`clickCfButton` and `clickCfButtonsConcurrently` work this way.
+`clickTrustedAction`, `submitViaEnter`, and `settleAndClickNoteButton` in
+`packages/patterns/integration/note-button-helpers.ts` still settle before
+resolving their target, and carry the gap described above.
 
 Ask `probe.isRendered` for that check rather than hand-rolling it, and note that
 it is deliberately not `probe.isVisible`, which additionally requires the
@@ -137,6 +157,19 @@ why it belongs in the predicate that tags the control. Whether the control is
 `disabled` is a separate question — a disabled control still takes the click and
 declines it. A test that needs a control enabled before clicking says so with
 `waitForDisabled(page, selector, false)`.
+
+Waiting for a click's effect carries the same requirement, for the same reason.
+Nothing in an integration test holds a UI subscription, so between one check and
+the next nothing drives the page. A rendering the page has to produce for
+itself — a tally recomputed from a vote, a card drawn for a list entry that
+has just arrived — can sit as runnable work no one schedules, one settle away
+from showing it. The wait then runs to the stuck-condition net, and the
+failure reads as "the state never arrived" when it had arrived and was never
+drawn. So `waitForText`, which only watches the DOM, is for text already there
+or that something else is already drawing. When the text is the effect of a
+stimulus, including one delivered to another browser sharing the same piece, use
+`waitForSettledText`, which settles the page on every check. The lunch-poll
+two-browser vote test uses it for all of its cross-browser waits.
 
 **Non-browser and off-page waits** have no page to observe. Resolve a `defer()`
 (from `packages/utils/src/defer.ts`) inside a callback the test already registers

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   clickCfButtonsConcurrently,
   clickNthCfButton,
   clickTrustedAction,
+  waitForSettledText,
 } from "./cfc-browser-helpers.ts";
 
 /** One element's live click marks, in attribute order. */
@@ -117,6 +118,115 @@ describe("CFC browser helpers", () => {
       "the click effect was not applied by a post-click view settle",
     );
     assertEquals(result.settleCalls, 2);
+  });
+
+  it("settles the view after a late target appears, before clicking it", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      document.body.append(host);
+
+      let settleCalls = 0;
+      let clickedAtSettle = 0;
+      let bound = false;
+      // The shell binds a control's handler when the vdom batch that rendered
+      // it is applied, which is one of the things a view settle waits for. So
+      // the handler here is bound by the first settle that runs with the
+      // control present, and a click delivered before that reaches nothing.
+      const bind = () => {
+        const button = root.querySelector("#late-vote-button");
+        if (!button || bound) return;
+        bound = true;
+        button.addEventListener("click", () => {
+          clickedAtSettle = settleCalls;
+        }, { once: true });
+      };
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = {
+        viewSettled: () => {
+          settleCalls++;
+          bind();
+          return Promise.resolve();
+        },
+      };
+
+      // The control arrives after the helper has started, the way an option
+      // card added by one browser reaches another. The delay states when the
+      // arrival happens rather than how long to wait for it: the helper's wait
+      // ends on the arrival, and only the five-minute stuck-condition net
+      // bounds it. What the delay has to outlast is one settle on the ordering
+      // this test guards against, which is a single protocol round trip.
+      setTimeout(() => {
+        const button = document.createElement("button");
+        button.id = "late-vote-button";
+        button.textContent = "Veto";
+        root.append(button);
+      }, 250);
+
+      (globalThis as typeof globalThis & {
+        __lateClickResult: () => {
+          settleCalls: number;
+          clickedAtSettle: number;
+        };
+      }).__lateClickResult = () => ({ settleCalls, clickedAtSettle });
+    });
+
+    await clickCfButton(page, "#late-vote-button");
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __lateClickResult: () => {
+          settleCalls: number;
+          clickedAtSettle: number;
+        };
+      }).__lateClickResult()
+    );
+    assert(
+      result.clickedAtSettle > 0,
+      "the click reached no handler: the view never settled with the target " +
+        "present before the click was dispatched",
+    );
+    // One settle found no control, one found it, and one followed the click.
+    assertEquals(result.settleCalls, 3);
+  });
+
+  it("drives the page while waiting for text", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const line = document.createElement("p");
+      line.id = "settled-text-line";
+      line.textContent = "no votes yet";
+      root.append(line);
+      document.body.append(host);
+
+      // A rendering the page produces for itself, not one pushed to it. Nothing
+      // outside a settle applies it, which is what makes a wait that only
+      // watches the DOM sit here until the stuck-condition net fires.
+      let settleCalls = 0;
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = {
+        viewSettled: () => {
+          settleCalls++;
+          if (settleCalls >= 2) line.textContent = "3 votes";
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __settledTextCalls: () => number;
+      }).__settledTextCalls = () => settleCalls;
+    });
+
+    await waitForSettledText(page, "#settled-text-line", "3 votes");
+
+    const settleCalls = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __settledTextCalls: () => number;
+      }).__settledTextCalls()
+    );
+    assertEquals(settleCalls, 2);
   });
 
   it("marks grouped targets between settlement barriers", async () => {

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -31,6 +31,27 @@ const textPresent = (
     probe.deepText(element).includes(text)
   );
 
+// Settle the view, then report whether `selector` contains `text`. Reaches the
+// same answer as `textPresent` on a page that is already up to date, and drives
+// one that is not: asking the worker whether it is idle queues runnable pull
+// work that nothing else would start, so a rendering that only the page's own
+// pending work produces arrives on a settling check and not on one that watches
+// the DOM alone.
+const settledTextPresent = async (
+  probe: ProbeApi,
+  selector: string,
+  text: string,
+): Promise<boolean> => {
+  const settle = (globalThis as typeof globalThis & {
+    commonfabric?: { viewSettled?: () => Promise<void> };
+  }).commonfabric?.viewSettled;
+  if (!settle) return false;
+  await settle();
+  return probe.collect(selector).some((element) =>
+    probe.deepText(element).includes(text)
+  );
+};
+
 const textAbsent = (
   probe: ProbeApi,
   selector: string,
@@ -253,6 +274,39 @@ const markForClick = (
   if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
   probe.addToken(clickTarget, attr, token);
   return true;
+};
+
+// Settle the view, then report whether every selector resolves to a rendered
+// click target, using the same resolution and rendered-ness test as
+// `markForClick`. The resolution is spelled out again because a predicate is
+// serialized into the page and closes over nothing in this module.
+//
+// The settle runs before the check, so a check that passes is a check on a
+// settled view: `viewSettled` returns only when a pass finds nothing pending,
+// so a target that rendered partway through is bound and drained by the time it
+// returns.
+//
+// The settle also drives the page forward. Asking the worker whether it is idle
+// queues runnable pull work that nothing else would start, so a target reached
+// only by the page's own pending work arrives on a settling check and not on
+// one that watches the DOM alone.
+const settledClickTargetsRendered = async (
+  probe: ProbeApi,
+  selectors: readonly string[],
+): Promise<boolean> => {
+  const settle = (globalThis as typeof globalThis & {
+    commonfabric?: { viewSettled?: () => Promise<void> };
+  }).commonfabric?.viewSettled;
+  if (!settle) return false;
+  await settle();
+  return selectors.every((selector) => {
+    const target = probe.collect(selector)[0] as HTMLElement | undefined;
+    if (!target) return false;
+    const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
+      | HTMLElement
+      | null) ?? target;
+    return clickTarget.isConnected && probe.isRendered(clickTarget);
+  });
 };
 
 // Tag the `index`-th element matching `selector` once it is rendered. Unlike
@@ -505,6 +559,40 @@ export async function waitForText(
   }
 }
 
+/**
+ * Wait for `selector` to contain `text`, settling `page` on each check.
+ *
+ * Reach for this rather than `waitForText` when the text is the effect of a
+ * stimulus — this page's own click, or one delivered to another browser sharing
+ * the piece. `waitForText` only watches the DOM, and an integration test holds
+ * no UI subscription, so nothing drives the page between its checks. A rendering
+ * that the page's own pending work has to produce then never arrives, and the
+ * wait runs to the stuck-condition safety net on a page that was one settle away
+ * from showing it.
+ *
+ * The settle is inside the predicate, so each re-check drives the page and reads
+ * the result of that same drive.
+ */
+export async function waitForSettledText(
+  page: Page,
+  selector: string,
+  text: string,
+) {
+  try {
+    await waitForCondition(page, settledTextPresent, {
+      args: [selector, text],
+    });
+  } catch (cause) {
+    const probe = await readTextProbe(page, selector).catch(() => undefined);
+    throw new Error(
+      `Timed out waiting for "${selector}" to contain "${text}". Last probe: ${
+        toIndentedDebugString(probe)
+      }`,
+      { cause },
+    );
+  }
+}
+
 export async function waitForTextAbsent(
   page: Page,
   selector: string,
@@ -650,25 +738,81 @@ async function clickRenderedCfButton(
   await clickMarked(page, token);
 }
 
+/**
+ * Resolve once `page` has settled with every selector rendered.
+ *
+ * A settle that runs before its target exists says nothing about that target: a
+ * control that appears afterwards is laid out with its handler not yet bound,
+ * the click is delivered to nothing, and the wait for its effect runs to the
+ * stuck-condition safety net.
+ *
+ * Every target is resolved before any of them is marked, so a grouped dispatch
+ * marks all of its targets with no settle in between.
+ */
+async function settleWithClickTargets(
+  page: Page,
+  selectors: readonly string[],
+): Promise<void> {
+  try {
+    await waitForCondition(page, settledClickTargetsRendered, {
+      args: [selectors],
+    });
+  } catch (cause) {
+    // Matches per selector, so the failure names which of a grouped dispatch's
+    // targets never rendered. Each match's `rect` and `visible` report whether
+    // the control was absent or present without a layout box. Every probe reads
+    // the same page, so the body text is reported once rather than once per
+    // selector.
+    const probes = await Promise.all(
+      selectors.map((selector) =>
+        readTextProbe(page, selector).catch(() => undefined)
+      ),
+    );
+    // Indented for readable test-log output
+    throw new Error(
+      `Timed out waiting for ${selectors.join(", ")} to render. Last probe: ${
+        toIndentedDebugString({
+          matches: Object.fromEntries(
+            selectors.map((selector, index) => [
+              selector,
+              probes[index]?.matches,
+            ]),
+          ),
+          bodyText: probes.find((probe) => probe !== undefined)?.bodyText,
+        })
+      }`,
+      { cause },
+    );
+  }
+}
+
 export async function clickCfButton(
   page: Page,
   selector: string,
 ) {
-  await settleView(page);
+  await settleWithClickTargets(page, [selector]);
   await clickRenderedCfButton(page, selector);
   await settleView(page);
 }
 
 /**
- * Settle every target page before dispatch. Mark every target before the first
- * click. Dispatch every click without an intervening view settle. Settle every
- * target page after dispatch.
+ * Settle every target page before dispatch, with all of that page's targets
+ * already rendered. Mark every target before the first click. Dispatch every
+ * click without an intervening view settle. Settle every target page after
+ * dispatch.
  */
 export async function clickCfButtonsConcurrently(
   targets: readonly { page: Page; selector: string }[],
 ): Promise<void> {
   const pages = [...new Set(targets.map(({ page }) => page))];
-  await Promise.all(pages.map((page) => settleView(page)));
+  await Promise.all(pages.map((page) =>
+    settleWithClickTargets(
+      page,
+      targets.filter((target) => target.page === page).map(({ selector }) =>
+        selector
+      ),
+    )
+  ));
 
   const markedByPage = pages.map((page) => ({
     page,

--- a/packages/patterns/integration/lunch-poll-vote.test.ts
+++ b/packages/patterns/integration/lunch-poll-vote.test.ts
@@ -38,7 +38,7 @@ import {
   logStepTimings,
   StepTimer,
   waitForRuntimeIdle,
-  waitForText,
+  waitForSettledText,
 } from "./cfc-browser-helpers.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
@@ -180,7 +180,7 @@ describe("lunch poll: two users vote on a shared option", () => {
       await clickCfButton(hostPage, "#lp-join-button");
       await timer.run(
         "host joined (name in roster)",
-        () => waitForText(hostPage, "body", HOST),
+        () => waitForSettledText(hostPage, "body", HOST),
       );
 
       // Guest joins second via the same guest path. The board shows a
@@ -194,8 +194,8 @@ describe("lunch poll: two users vote on a shared option", () => {
         "both join lands (count reaches 2)",
         () =>
           Promise.all([
-            waitForText(hostPage, "body", "2 joined"),
-            waitForText(guestPage, "body", GUEST),
+            waitForSettledText(hostPage, "body", "2 joined"),
+            waitForSettledText(guestPage, "body", GUEST),
           ]),
       );
 
@@ -206,8 +206,8 @@ describe("lunch poll: two users vote on a shared option", () => {
         "option A propagates to both",
         () =>
           Promise.all([
-            waitForText(hostPage, "body", OPTION_A),
-            waitForText(guestPage, "body", OPTION_A),
+            waitForSettledText(hostPage, "body", OPTION_A),
+            waitForSettledText(guestPage, "body", OPTION_A),
           ]),
       );
 
@@ -236,8 +236,8 @@ describe("lunch poll: two users vote on a shared option", () => {
         "both browsers see 2 love it (merge)",
         () =>
           Promise.all([
-            waitForText(hostPage, "body", "2 love it"),
-            waitForText(guestPage, "body", "2 love it"),
+            waitForSettledText(hostPage, "body", "2 love it"),
+            waitForSettledText(guestPage, "body", "2 love it"),
           ]),
       );
 
@@ -263,8 +263,8 @@ describe("lunch poll: two users vote on a shared option", () => {
       await fillCfInput(hostPage, "#lp-add-option-input", OPTION_B);
       await clickCfButton(hostPage, "#lp-add-option-button");
       await Promise.all([
-        waitForText(hostPage, "body", OPTION_B),
-        waitForText(guestPage, "body", OPTION_B),
+        waitForSettledText(hostPage, "body", OPTION_B),
+        waitForSettledText(guestPage, "body", OPTION_B),
       ]);
       await clickCfButton(guestPage, voteButton(OPTION_B, "red"));
       // The third vote (red on option B) lands on both browsers — the count
@@ -275,9 +275,9 @@ describe("lunch poll: two users vote on a shared option", () => {
         "option B vote lands (3 votes); option A unchanged",
         () =>
           Promise.all([
-            waitForText(hostPage, "body", "3 votes"),
-            waitForText(guestPage, "body", "3 votes"),
-            waitForText(hostPage, "body", "2 love it"),
+            waitForSettledText(hostPage, "body", "3 votes"),
+            waitForSettledText(guestPage, "body", "3 votes"),
+            waitForSettledText(hostPage, "body", "2 love it"),
           ]),
       );
     } finally {


### PR DESCRIPTION
…cks on

The two-browser lunch poll intermittently lost its third vote. The guest clicks the veto button on an option the host has just added, both browsers stay at two votes, and the test sits until the five-minute stuck-condition safety net fires. The page it timed out on carried both options in its header and both in its summary, and had not drawn the second option's card at all.

Two waits on that path never drove the page they were watching, and in an integration test nothing else drives it either. The test holds no user interface subscription, and asking the worker whether it is idle is itself what queues runnable pull work that nothing else would start. So a rendering the page has to produce for itself can sit as work no one schedules, on a page one settle away from showing it.

The first wait is the click helper's. It settled the view and then waited for its target. When the target is already on screen those two steps are in either order the same thing. When the target arrives during the wait, the settle ran before it existed, so the click reached an element whose handler was not bound and was dropped without a trace. Of the clicks this test makes, the veto is the only one whose target appears moments before it is clicked, which is why it is the one that failed. Move the settle into the wait's own predicate: settle, then check, and pass only on a check that settle preceded. A settle returns only once a pass finds nothing pending, so a target that rendered partway through one is bound and drained by the time the check reads it.

The second wait is the one that timed out. waitForText only watches the document, so a tally the page still has to recompute never arrives at it. Add waitForSettledText, which settles on every check, and use it for every wait in the lunch-poll vote test that observes the effect of a click — including the ones observing a click delivered to the other browser.

Cover the click ordering with a test that drives the helper against a page where the control arrives after the helper has started, and whose handler is bound by the first settle that runs with the control present. It records which settle the click was seen by, and fails when the click reached no handler at all. Cover the text wait with a page whose text only a settle produces.

Both new predicates report a probe when they give up, so a control or a string that never arrives names itself rather than failing as a bare timeout.

The remaining click helpers — clickTrustedAction, submitViaEnter, and settleAndClickNoteButton — still settle before resolving their target. The waiting guidance now says so rather than implying the ordering holds everywhere.

deflaked by Hixie's agent

Agent: Claude Opus 5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes the two-browser lunch-poll vote by settling the page inside the waits that block the test. Clicks now reach bound handlers and text waits drive rendering, removing intermittent timeouts.

- **Bug Fixes**
  - Moved view settle inside the click wait predicate and only proceed when the settle preceded the check, so late-appearing controls are clickable; applied to clickCfButton and grouped clicks.
  - Added waitForSettledText and switched all lunch-poll cross-browser waits to it; this drives the page while waiting, unlike waitForText which only watched the DOM.
  - Added tests for late target clicking and for text produced only after a settle; both would fail under the old behavior.
  - Improved timeout errors with last-probe details naming missing controls/text.
  - Updated testing docs with the new ordering guidance and noted helpers that still settle-before-resolve (clickTrustedAction, submitViaEnter, settleAndClickNoteButton).

<sup>Written for commit 32aefd9563077ca83f4d0838d393e9a057b1dd18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

