### PR TITLE
feat(cli): install cf on PATH so shell completion works

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ can run their own spaces or use hosted versions.
 3. Run `mise trust && mise install` in the repo to install the pinned Deno
    version
 4. Install the Git hooks: `deno task install-hooks` (optional)
+   - mise puts this checkout's `bin/` on PATH, so `cf` works as a plain command.
+     Without mise: `ln -s "$PWD/bin/cf" ~/.local/bin/cf`. Shell completion needs
+     it — see
+     [Installing `cf` on PATH](./packages/cli/README.md#installing-cf-on-path).
 5. Start local dev servers: `./scripts/start-local-dev.sh`
 6. Access the application at <http://localhost:8000>
 

--- a/bin/cf
+++ b/bin/cf
@@ -1,0 +1,42 @@
+#!/bin/sh
+# `cf` on PATH, backed by this checkout's source.
+#
+# Shell completion is why this exists: the function `cf completion bash|zsh`
+# installs calls `cf completion complete` by name on every Tab, so completion
+# is silently dead for anyone without a `cf` on PATH — including for
+# `deno task cf <TAB>`, since the same function services the `deno` binding.
+#
+# Two ways to pick this up, neither of which needs the binary built:
+#   - mise users get it automatically (`_.path` in mise.toml)
+#   - everyone else: ln -s "$PWD/bin/cf" ~/.local/bin/cf
+#
+# Runs from source, so it never goes stale against the checkout. For the ~2x
+# faster compiled binary, see "Installing cf on PATH" in packages/cli/README.md.
+
+set -e
+
+# Resolve through symlinks so the `ln -s` install above reports the checkout
+# rather than the link. `readlink -f` is GNU and newer-macOS only, so the links
+# are walked by hand to keep this working on a stock macOS shell.
+target=$0
+while [ -L "$target" ]; do
+  link=$(readlink "$target")
+  case $link in
+    /*) target=$link ;;
+    *) target=$(dirname "$target")/$link ;;
+  esac
+done
+root=$(CDPATH= cd -- "$(dirname -- "$target")/.." && pwd -P)
+
+if ! command -v deno >/dev/null 2>&1; then
+  echo "cf: deno not found on PATH." >&2
+  echo "    Install it with mise (\`mise install\` in ${root}) or directly:" >&2
+  echo "    https://docs.deno.com/runtime/getting_started/installation/" >&2
+  exit 127
+fi
+
+# `--cwd "$PWD"` because the launcher otherwise prefers an inherited INIT_CWD,
+# which is stale whenever `cf` is called from inside a `deno task`. `--` keeps
+# launcher option parsing off the user's own arguments (`cf --config …`).
+exec deno run --allow-run --allow-env --allow-read \
+  "${root}/packages/cli/launcher.ts" --cwd "$PWD" -- "$@"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,12 @@
 [tools]
 deno = "2.8.1"
+
+# Puts this checkout's `bin/cf` on PATH, so `cf` resolves to the worktree you
+# are standing in. Shell completion needs a `cf` on PATH to work at all — see
+# "Installing cf on PATH" in packages/cli/README.md.
+#
+# mise is not guaranteed (README.md blesses a direct Deno install, and
+# tasks/check.sh only reads the pin out of this file), so this is a convenience
+# for mise users, not the mechanism. Non-mise users symlink bin/cf themselves.
+[env]
+_.path = ["bin"]

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -77,10 +77,19 @@ standard error and continues searching that piece and the rest of the space.
 
 ## Built Binary
 
-`deno task build-binaries --cli-only` compiles the CLI to `dist/cf` — fully
-cwd-independent with no Deno startup noise, the recommended entry point for
-agents and scripts. Rebuild after every `git pull`: a stale binary rejects newer
-flags and can hit wire-protocol skew against an updated server.
+`deno task build-binaries cf` compiles the CLI to `dist/cf` — fully
+cwd-independent, with no Deno startup noise and roughly half the per-invocation
+cost. (`--cli-only` is a legacy alias for the same thing.)
+
+It exists for CI, which downloads it in `cli-integration-test` (on
+`$GITHUB_PATH`) and `pattern-unit-test` (as `CF_BINARY`). A CI run never edits
+the source the binary was built from, so it cannot go stale mid-run.
+
+That does not hold for a working tree you are editing, and there is no
+invalidation story to catch it — see "Why not `dist/cf`" under Installing `cf`
+on PATH. Use `bin/cf` or `deno task cf` locally. If you do build it, rebuild
+after every `git pull`: a stale binary rejects newer flags and can hit
+wire-protocol skew against an updated server.
 
 ## Launcher Contract
 
@@ -195,9 +204,60 @@ launchers use them. Shell completion is the exception: it drops commands whose
 description opens with `Internal:`, because those are spawned by `cf fuse` and
 never typed at a prompt.
 
+## Installing `cf` on PATH
+
+Interactively, the CLI has always been invoked as `deno task cf`. Shell
+completion is the first thing that needs a `cf` on PATH on a developer machine:
+the function it installs calls `cf completion complete` by name on every Tab, so
+**completion does nothing at all without one** — including for
+`deno task cf <TAB>`, which the same function services. Because a failing
+completion is swallowed by design (it must never paste text into the command
+line), a missing `cf` shows up as "completion doesn't work", not as an error.
+`cf completion bash|zsh` therefore warns on stderr when it cannot find itself on
+PATH.
+
+(CI does resolve `cf` by name — `integration/integration.sh` runs `command cf`
+against a binary the workflow puts on `$GITHUB_PATH` — but it builds that PATH
+itself, and local runs of those same scripts set `CF_CLI_INTEGRATION_USE_LOCAL`
+to force the source CLI.)
+
+`bin/cf` is the install. It runs from source, so it never goes stale against the
+checkout, and it resolves the repo from its own location, so a symlink works:
+
+```bash
+# mise users: nothing to do. mise.toml puts this checkout's bin/ on PATH, so
+# `cf` follows the worktree you are standing in.
+mise trust    # only if this checkout has not been trusted yet
+
+# everyone else (mise is recommended in README.md but not required):
+ln -s "$PWD/bin/cf" ~/.local/bin/cf
+```
+
+### Why not `dist/cf`
+
+The compiled binary is roughly twice as fast per invocation (~0.33s versus
+~0.6s), which is tempting when every Tab press is a full CLI invocation. **Do
+not put `dist` on your PATH anyway.** There is no invalidation story for it:
+`tasks/build-binaries.ts` has no up-to-date check, nothing compares the binary
+against its sources, and the whole mechanism is the "rebuild after every
+`git pull`" instruction in the Built Binary section above. A stale `dist/cf`
+rejects newer flags and can hit wire-protocol skew against an updated server —
+see "FUSE mount wrapper mismatch" in `skills/cf/SKILL.md` for an instance of
+this actually biting.
+
+Nor is mtime a usable substitute: `revertWorkspace` restores `deno.jsonc` and
+the compile-cache version module _after_ the binary is written, so `dist/cf` is
+older than its own inputs the moment the build finishes.
+
+CI is a different case and legitimately uses the binary — a workflow run never
+mutates the source it was built from. `cli-integration-test` puts it on
+`$GITHUB_PATH` and `pattern-unit-test` passes it as `CF_BINARY`. That reasoning
+does not transfer to a working tree you are actively editing.
+
 ## Shell completion
 
-`cf completion <shell>` prints a completion script for bash or zsh.
+`cf completion <shell>` prints a completion script for bash or zsh. It requires
+`cf` on PATH — see "Installing `cf` on PATH" above.
 
 ```bash
 # zsh — eager form, in ~/.zshrc after compinit. Required for the `deno` binding

--- a/packages/cli/commands/completion.ts
+++ b/packages/cli/commands/completion.ts
@@ -17,6 +17,10 @@ import {
   zshCompletionScript,
 } from "../lib/completion/script.ts";
 import { complete, tokenizeLine } from "../lib/completion/mod.ts";
+import {
+  missingCommandWarning,
+  resolvesOnPath,
+} from "../lib/completion/install-check.ts";
 
 const description = `Generate shell completion scripts.
 
@@ -29,6 +33,13 @@ Live values need an identity and api-url, taken from the line being typed
 completes.
 
 These also complete "deno task ${cliName()} ..." — see DENO TASK below.
+
+REQUIRES '${cliName()}' ON PATH:
+  The installed function calls '${cliName()} completion complete' on every Tab,
+  and swallows its errors, so without a '${cliName()}' on PATH completion
+  silently yields nothing — including for "deno task ${cliName()} <TAB>".
+  mise puts the checkout's bin/ on PATH; otherwise symlink bin/${cliName()}.
+  See "Installing ${cliName()} on PATH" in packages/cli/README.md.
 
 INSTALL (zsh), in ~/.zshrc after compinit:
   source <(${cliName()} completion zsh)
@@ -133,6 +144,19 @@ const completeCommand = new Command()
     }
   });
 
+/**
+ * Warn on stderr when the generated script cannot reach the CLI it calls.
+ *
+ * stderr specifically: stdout is the script, and these commands are meant to be
+ * redirected into a file or `source <(…)`. A warning on stdout would be
+ * installed as shell code.
+ */
+function warnIfNotInstalled(name: string): void {
+  if (!resolvesOnPath(name)) {
+    console.error(missingCommandWarning(name));
+  }
+}
+
 export const completion = new Command()
   .description(description)
   .default("help")
@@ -145,11 +169,12 @@ export const completion = new Command()
         `Do not also complete "deno task ${cliName()} ...".`,
       )
       .noGlobals()
-      .action((options) =>
+      .action((options) => {
+        warnIfNotInstalled(cliName());
         console.log(
           bashCompletionScript(cliName(), { denoTask: options.denoTask }),
-        )
-      ),
+        );
+      }),
   )
   .command(
     "zsh",
@@ -160,10 +185,11 @@ export const completion = new Command()
         `Do not also complete "deno task ${cliName()} ...".`,
       )
       .noGlobals()
-      .action((options) =>
+      .action((options) => {
+        warnIfNotInstalled(cliName());
         console.log(
           zshCompletionScript(cliName(), { denoTask: options.denoTask }),
-        )
-      ),
+        );
+      }),
   )
   .command("complete", completeCommand.hidden());

--- a/packages/cli/lib/completion/install-check.ts
+++ b/packages/cli/lib/completion/install-check.ts
@@ -1,0 +1,88 @@
+/**
+ * Guard against the one way a correct completion script still does nothing.
+ *
+ * The emitted function calls `cf completion complete` *by name* on every Tab,
+ * and discards that command's errors so a failing completion can never paste
+ * text into the user's command line. Those two facts compose badly: with no
+ * `cf` on PATH, every Tab silently yields zero candidates, and the script the
+ * user just installed looks like it simply does not work. The `deno` binding
+ * inherits the same fate, so `deno task cf <TAB>` — the invocation most people
+ * actually type — is dead too.
+ *
+ * CI already resolves `cf` by name — `packages/cli/integration/integration.sh`
+ * runs `command cf`, and the workflow puts the downloaded binary on
+ * `$GITHUB_PATH` — but it constructs that PATH itself, and local runs of the
+ * same scripts set `CF_CLI_INTEGRATION_USE_LOCAL` to force the source CLI
+ * instead. Completion is therefore the first thing to require `cf` on PATH on
+ * a *developer's own machine*, where nothing sets it up. This check makes that
+ * requirement legible when the script is generated rather than at some later
+ * Tab press.
+ */
+
+/** Injectable filesystem probe, so the lookup is testable without a PATH. */
+export interface PathProbe {
+  (path: string): { isFile: boolean; mode: number | null } | undefined;
+}
+
+export interface ResolveOptions {
+  readonly path?: string | undefined;
+  readonly separator?: string;
+  readonly probe?: PathProbe;
+}
+
+const defaultProbe: PathProbe = (path) => {
+  try {
+    const info = Deno.statSync(path);
+    return { isFile: info.isFile, mode: info.mode };
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Whether `name` resolves to an executable file on PATH.
+ *
+ * `mode` is null on filesystems that do not report it, in which case an
+ * existing file is accepted: a false "installed" is a missing warning, while a
+ * false "missing" is a confusing warning on a working setup.
+ */
+export function resolvesOnPath(
+  name: string,
+  options: ResolveOptions = {},
+): boolean {
+  const separator = options.separator ??
+    (Deno.build.os === "windows" ? ";" : ":");
+  const path = options.path ?? Deno.env.get("PATH") ?? "";
+  const probe = options.probe ?? defaultProbe;
+
+  for (const directory of path.split(separator)) {
+    if (directory === "") continue;
+    const info = probe(`${directory.replace(/\/+$/, "")}/${name}`);
+    if (info?.isFile && (info.mode === null || (info.mode & 0o111) !== 0)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * The stderr warning shown when the script is generated without `name` on
+ * PATH. Deliberately not thrown: the script itself is correct and printing it
+ * to a redirect must keep working, so this informs without failing.
+ */
+export function missingCommandWarning(name: string): string {
+  // `$PWD` rather than a resolved root: the documented way to reach this
+  // command is from the checkout, and a literal the user can paste beats a
+  // path that would be wrong for a compiled binary run from elsewhere.
+  const link = `ln -s "$PWD/bin/${name}" ~/.local/bin/${name}`;
+  return [
+    `warning: '${name}' is not on your PATH, so this completion script will`,
+    `         silently do nothing — it calls '${name} completion complete' on`,
+    `         every Tab, and that failure is swallowed by design.`,
+    ``,
+    `  mise users: already handled by mise.toml; run 'mise trust' in the repo.`,
+    `  otherwise:  ${link}`,
+    ``,
+    `  See "Installing ${name} on PATH" in packages/cli/README.md.`,
+  ].join("\n");
+}

--- a/packages/cli/test/completion-install-check.test.ts
+++ b/packages/cli/test/completion-install-check.test.ts
@@ -1,0 +1,110 @@
+import {
+  assert,
+  assertEquals,
+  assertFalse,
+  assertStringIncludes,
+} from "@std/assert";
+import {
+  missingCommandWarning,
+  type PathProbe,
+  resolvesOnPath,
+} from "../lib/completion/install-check.ts";
+
+/** A probe backed by a literal map, so no real PATH or filesystem is touched. */
+function probeFor(
+  entries: Record<string, { isFile: boolean; mode: number | null }>,
+): PathProbe {
+  return (path) => entries[path];
+}
+
+Deno.test("an executable on PATH resolves", () => {
+  assert(resolvesOnPath("cf", {
+    path: "/usr/bin:/opt/labs/bin",
+    separator: ":",
+    probe: probeFor({
+      "/opt/labs/bin/cf": { isFile: true, mode: 0o755 },
+    }),
+  }));
+});
+
+Deno.test("a name absent from every PATH entry does not resolve", () => {
+  assertFalse(resolvesOnPath("cf", {
+    path: "/usr/bin:/opt/labs/bin",
+    separator: ":",
+    probe: probeFor({ "/usr/bin/deno": { isFile: true, mode: 0o755 } }),
+  }));
+});
+
+Deno.test("a non-executable file does not count as installed", () => {
+  // A stray `cf` data file on PATH must not suppress the warning: the shell
+  // would not run it either, so completion would still be dead.
+  assertFalse(resolvesOnPath("cf", {
+    path: "/opt/labs/bin",
+    separator: ":",
+    probe: probeFor({ "/opt/labs/bin/cf": { isFile: true, mode: 0o644 } }),
+  }));
+});
+
+Deno.test("a directory named cf does not count as installed", () => {
+  assertFalse(resolvesOnPath("cf", {
+    path: "/opt/labs/bin",
+    separator: ":",
+    probe: probeFor({ "/opt/labs/bin/cf": { isFile: false, mode: 0o755 } }),
+  }));
+});
+
+Deno.test("an unreported mode is accepted rather than warned about", () => {
+  // Filesystems that do not report mode would otherwise produce a confusing
+  // warning on a setup that actually works.
+  assert(resolvesOnPath("cf", {
+    path: "/opt/labs/bin",
+    separator: ":",
+    probe: probeFor({ "/opt/labs/bin/cf": { isFile: true, mode: null } }),
+  }));
+});
+
+Deno.test("empty PATH entries are skipped, not read as the root", () => {
+  assertFalse(resolvesOnPath("cf", {
+    path: "::",
+    separator: ":",
+    probe: probeFor({ "/cf": { isFile: true, mode: 0o755 } }),
+  }));
+});
+
+Deno.test("a trailing slash on a PATH entry still resolves", () => {
+  assert(resolvesOnPath("cf", {
+    path: "/opt/labs/bin/",
+    separator: ":",
+    probe: probeFor({ "/opt/labs/bin/cf": { isFile: true, mode: 0o755 } }),
+  }));
+});
+
+Deno.test("an absent PATH resolves nothing rather than throwing", () => {
+  assertFalse(resolvesOnPath("cf", {
+    path: "",
+    separator: ":",
+    probe: probeFor({}),
+  }));
+});
+
+Deno.test("the warning names the failure and both installs", () => {
+  const warning = missingCommandWarning("cf");
+  assertStringIncludes(warning, "not on your PATH");
+  assertStringIncludes(warning, "cf completion complete");
+  assertStringIncludes(warning, "mise");
+  assertStringIncludes(warning, "ln -s");
+});
+
+Deno.test("the symlink hint is pasteable from the checkout", () => {
+  assertStringIncludes(
+    missingCommandWarning("cf"),
+    'ln -s "$PWD/bin/cf" ~/.local/bin/cf',
+  );
+});
+
+Deno.test("the warning is a single block with no stdout-looking prefix", () => {
+  // It is printed alongside a shell script on stdout; a line that could be
+  // mistaken for script text would be confusing when both land in a terminal.
+  const lines = missingCommandWarning("cf").split("\n");
+  assertEquals(lines[0].startsWith("warning:"), true);
+});

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -20,19 +20,12 @@ deno task cf check --help     # Type checking
 
 ## Invocation Paths
 
-Three equivalent ways to run the CLI, in order of preference for agents:
+Three ways to run the CLI, in order of preference. All run from source, so they
+always match the working tree:
 
-1. **Built binary (recommended for scripted/agent use):**
-
-   ```bash
-   deno task build-binaries --cli-only   # produces dist/cf
-   export PATH="$PWD/dist:$PATH"         # or copy dist/cf onto PATH
-   cf piece ls ...                       # works from any cwd, no Deno noise
-   ```
-
-   The binary is fully cwd-independent and prints nothing but CLI output.
-   **Rebuild it after every `git pull`** — a stale binary rejects newer flags
-   and can hit wire-protocol skew against an updated server.
+1. **`cf` (via `bin/cf`)** — a plain `cf` backed by this checkout's source.
+   Already on PATH under mise; otherwise `ln -s "$PWD/bin/cf" ~/.local/bin/cf`.
+   Works from any cwd, and shell completion requires a `cf` on PATH.
 
 2. **`deno task cf ...`** — works from any directory inside the repo (the
    launcher resolves the repo root itself and runs the CLI from your invoking
@@ -42,6 +35,14 @@ Three equivalent ways to run the CLI, in order of preference for agents:
 3. **`deno run -q -A packages/cli/mod.ts ...`** — repo-root-relative; only works
    with the repo root as cwd. The `-q` suppresses Deno's own warnings (e.g. the
    npm "Ignored build scripts" banner).
+
+**Do not put `dist/cf` on your PATH.** `deno task build-binaries cf` still
+produces it, and CI uses it (a CI run never edits the source it was built from),
+but there is no invalidation story for a working tree you are actively editing:
+nothing compares the binary against its sources, so it silently serves stale
+behavior after a `git pull` or a local edit. See "Why not `dist/cf`" in
+`packages/cli/README.md`, and the "FUSE mount wrapper mismatch" entry below for
+what this looks like when it bites.
 
 ## Output Conventions (scripts & agents)
 


### PR DESCRIPTION
## Why

We recently added tab-completion to `cf`, but it silently does nothing for most
people. The function `cf completion bash|zsh` installs calls
`cf completion complete` **by name** on every Tab, and discards that command's
errors by design (a failing completion must never paste text into the command
line). Those two facts compose badly: with no `cf` on PATH, every Tab yields
zero candidates and the feature looks simply broken. The `deno` binding inherits
the same fate, so `deno task cf <TAB>` — the invocation people actually type —
is dead too.

Nothing in the repo put `cf` on a developer's PATH. We build three binaries
(`toolshed`, `bg-piece-service`, `cf`) and CI signs and ships them, but that is
a deploy channel keyed by commit SHA: `dist/` is gitignored, and a fresh clone
has none of them. So completion effectively worked only inside CI, which
constructs its own PATH via `$GITHUB_PATH`.

## What Changed

- **`bin/cf`** — the install. Runs from source so it never goes stale against
  the checkout, resolves the repo from its own location so `ln -s` works, and
  passes `--cwd "$PWD"` (the launcher otherwise prefers a stale inherited
  `INIT_CWD`) plus `--` so `cf --config …` is not eaten by launcher parsing.
- **`mise.toml`** — `_.path = ["bin"]`, which mise resolves relative to the
  config file, so `cf` follows whichever worktree you are standing in. This is a
  convenience layer, not the mechanism: mise is *not* guaranteed (README blesses
  a direct Deno install, and `tasks/check.sh` only `sed`s the pin out of
  `mise.toml` — it never invokes mise). Non-mise users symlink `bin/cf`.
- **`packages/cli/lib/completion/install-check.ts`** + wiring — `cf completion
  bash|zsh` warns on **stderr** (stdout is the script) when it cannot find
  itself on PATH. This is what protects everyone who does not get `cf` via mise,
  and it is independent of how they install.
- **Docs** — `packages/cli/README.md` (new "Installing `cf` on PATH", plus a
  "Why not `dist/cf`" subsection), root `README.md`, `skills/cf/SKILL.md`, and
  `cf completion --help`.

### On `dist/cf`

The compiled binary is ~2x faster per invocation, which is tempting when every
Tab is a full CLI invocation. It stays CI-only anyway, because there is no
invalidation story: `tasks/build-binaries.ts` has no up-to-date check, nothing
compares the binary against its sources, and mtime cannot substitute —
`revertWorkspace` restores `deno.jsonc` and the compile-cache version module
*after* the binary is written, so `dist/cf` is older than its own inputs the
moment the build finishes. CI is the legitimate consumer (`cli-integration-test`
via `$GITHUB_PATH`, `pattern-unit-test` via `CF_BINARY`) precisely because a run
never edits the source it was built from. The docs now say this instead of
recommending the binary; `skills/cf/SKILL.md` already carried a "FUSE mount
wrapper mismatch" entry that is a recorded instance of this biting someone.

## Test plan

- `deno task test` in `packages/cli` — passes, exit 0. (Nested "failed" counts
  in the log are captured child-process output from tests that deliberately
  provoke assertion failures, e.g. `assert-diagnostics.test.ts`.)
- 11 new tests in `packages/cli/test/completion-install-check.test.ts` cover
  PATH resolution: executable found, absent, non-executable file, directory,
  unreported mode, empty entries, trailing slash, empty PATH, warning content.
- Manual, both directions: with `cf` absent from PATH the warning appears on
  stderr and stdout is still a clean script; with it present, stderr is empty.
- Manual `bin/cf`: resolves under mise and via symlink from outside the repo;
  cwd-independent; `cf --config …` reaches the CLI rather than the launcher;
  arguments containing spaces survive.
- `deno task check-skill-facts` passes; pre-commit ran repo-wide fmt + lint.

## Follow-ups (not in this PR)

- `Dockerfile.toolshed:22` runs `deno task build-binaries` with no arguments, so
  it compiles all three binaries and then copies only `dist/toolshed`. `cf` and
  `bg-piece-service` are built and discarded on every image build. Left alone in
  case the no-arg form is deliberately validating that all three still compile.
- If we ever want `dist/cf` on a developer PATH, the prerequisite is a build id.
  The pattern already exists for `toolshed` (`prepareWorkspace` writes
  `packages/toolshed/COMPILED`, baked in via `deno compile --include` and read
  back by `packages/toolshed/lib/build-info.ts`); `cf` is already compiled with
  several `--include`s, so extending it is small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures shell completion actually works by putting `cf` on PATH and warning when it’s missing. Also clarifies not to use `dist/cf` locally; completion now works for `deno task cf` too.

- **New Features**
  - Added `bin/cf`: source-backed launcher that resolves via symlinks, runs the repo CLI, and forwards `--cwd "$PWD"` and `--`.
  - Updated `mise.toml` to add `bin/` to PATH per worktree.
  - `cf completion bash|zsh` now warns on stderr if `cf` isn’t on PATH.

- **Migration**
  - `mise` users: run `mise trust && mise install` (if not yet trusted) and you’re done.
  - Others: add `cf` via symlink: `ln -s "$PWD/bin/cf" ~/.local/bin/cf`.
  - Do not add `dist/cf` to PATH for local use.

<sup>Written for commit 4935fdd35f24998ee85b3423be51d75cef43cf69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

