### PR TITLE
docs(plans): the Topics rehearsal upgrades from TWO generations, not one

### DIFF
--- a/docs/plans/topics-migration-rehearsal.md
+++ b/docs/plans/topics-migration-rehearsal.md
@@ -23,12 +23,53 @@ open decisions named rather than assumed.
 | --- | --- |
 | Space | `topics-dev-476ea34f` = `did:key:z6MkjcdxtxTiUWkPkPffhs8ENkCcJjuRCQPpJFb2xyzwHqEk` |
 | Board piece | `fid1:jtdD-DSmuGrLGSt_6sJ3DS_7jmerrkKTEnW3fZV9e34` |
-| Children | 73 topic pieces, each its own piece |
+| Children | 73 topic pieces, each its own piece, across **two** deployed generations |
 | Store size | ~1.0 GB, ~200k commits |
 
 The space DID is not recoverable from the store — it has no ACL doc — so it
 must be supplied explicitly. Passing the wrong one produces a clone that serves
 an empty space rather than an error.
+
+## What is being upgraded from
+
+Read out of the 2026-07-22 snapshot rather than assumed. The 73 topics are
+**not** on one version:
+
+| | pieces | pattern identity |
+| --- | ---: | --- |
+| topic generation A | 39 | `PB0GumS5vkDPyKAWciwh-4UtypoJwKFUXcDj3SsspHY` |
+| topic generation B | 34 | `-85Wmyd9iwUjbpwnTYR2YolxkMUHup9WHY6YsRUDA1E` |
+| board | 1 | `WpIRvAWL_WW45Q89ekZAlHWLObhQ16NDmQzvv_q2aI8` |
+
+Both topic generations are legacy — `createdByName` present, no
+`rejectMutation`, no body-at-create — and differ only slightly (681 vs 686
+authored lines of `topic.tsx`). The board's `main.tsx` mentions
+`AddTopicEvent.body` but not `rejectMutation`, so it predates #4991 as well.
+
+(The space holds 319 pieces across 150 pattern identities in total; only these
+74 are in scope.)
+
+**This is the condition that makes the rehearsal mandatory**, not incidental:
+"more than one pattern generation is live in the space" is a trigger in the
+generic runbook, and multiple live generations is what the incident record ties
+to cross-version write storms. The run is therefore *two* legacy→current
+transitions, and #4997's dangling-author and recursive-crossref fixes have to
+hold for both.
+
+Reproduce the grouping at any time with:
+
+```bash
+deno task cf inspect piece <space> <topic-fid>   # per piece
+```
+
+or read `patternIdentity` from each topic document directly — the board's
+`topics` input holds wrapper cells, so follow each wrapper's `result` link one
+hop to reach the piece that carries `patternIdentity`.
+
+**Upgrading to:** `packages/patterns/topics/{topic,main}.tsx` at current `main`
+(#4997's legacy-safety fixes plus #4991's body-at-create and thrown
+rejections). The target identity is computed at `setsrc` time and does not need
+to be known in advance — the acceptance check below is the better test.
 
 ## Gate 0 — prerequisites
 
@@ -59,8 +100,9 @@ a sustained plateau rather than a burst.
    sequence in a scratch space, which tests the transition in isolation but not
    against real data. **(a) is what #4997's rehearsal did** and what the tooling
    is built for. Confirm this reading before running.
-2. **Which pattern revision** to `setsrc` — the phase currently landing, or
-   latest `main`. Phase-scoped is what "continuous dogfood" implies.
+2. ~~**Which pattern revision** to `setsrc`.~~ **Resolved 2026-07-29: latest
+   `main`.** It is the transition that will actually happen, and #4997's
+   legacy-safety fixes are what make the legacy→current jump survivable.
 3. **Whether one clean pass is enough.** The generic runbook asks for two
    consecutive clean passes; a 1.0 GB clone makes each attempt ~15 s of clone
    plus the migration itself. Cheap enough to keep the bar at two.
@@ -85,6 +127,10 @@ The order is not stylistic. The board's result recomputation is what storms,
 and a board pointing at half-migrated children is the "Topics (0)" failure from
 the 2026-07-10 outage: old-generation results lacking new fields make the whole
 array read empty, silently.
+
+Do generation A's 39 first, then generation B's 34, then the board. Keeping
+the two transitions separable means that if one storms you know which;
+interleaving them blurs that signal for no benefit.
 
 ```bash
 # each of the 73 topics, one at a time, against the CLONE's api-url
@@ -121,7 +167,12 @@ Then the acceptance items from the implementation plan's live checklist, which
 - an undeclared field fails with a nonzero exit;
 - the deployed verb schema matches the skill driving it (`cf piece verbs`);
 - churn returns to baseline **and stays there** — a storm is a steady state,
-  not a spike.
+  not a spike;
+- **the 73 topics report exactly ONE pattern identity afterwards**, not two.
+  This is the cheapest proof the migration converged rather than half-landing,
+  and neither `cf space verify` nor the content fingerprint would catch a
+  half-migration on its own: leaving generation B behind changes no authored
+  content, so the fingerprint is unmoved and the counts merely grow.
 
 `cf space verify` reporting `content unchanged` while commit counts grow is the
 expected result: a migration writes, and generated cells are excluded from the


### PR DESCRIPTION
## Why

The script merged in #5153 assumed the 73 topics were on a single "from" version. They are not. Reading the 2026-07-22 snapshot instead of assuming:

| | pieces | pattern identity |
| --- | ---: | --- |
| topic generation A | **39** | `PB0GumS5vkDPyKAWciwh-4UtypoJwKFUXcDj3SsspHY` |
| topic generation B | **34** | `-85Wmyd9iwUjbpwnTYR2YolxkMUHup9WHY6YsRUDA1E` |
| board | 1 | `WpIRvAWL_WW45Q89ekZAlHWLObhQ16NDmQzvv_q2aI8` |

All legacy — `createdByName` present, no `rejectMutation`, no body-at-create. The two topic generations differ by only a few authored lines (681 vs 686 in `topic.tsx`), but they are distinct content-addressed identities, which is what matters.

**This is not a detail.** "More than one pattern generation is live in the space" is a trigger for mandatory rehearsal in the generic runbook, and multiple live generations is exactly what the incident record ties to cross-version write storms. The run is *two* legacy→current transitions in one pass, and #4997's dangling-author and recursive-crossref fixes have to hold for both.

## What Changed

- The board table and a new **"What is being upgraded from"** section carrying the measured numbers and how to reproduce them.
- **Migrate order:** generation A's 39, then B's 34, then the board. If one storms you know which; interleaving blurs the signal for nothing.
- **A new acceptance item that closes a real hole:** afterwards, the 73 topics must report exactly **one** pattern identity.

  That last one matters because neither `cf space verify` nor the content fingerprint would catch a half-migration. Leaving generation B behind changes no *authored* content — so the fingerprint is unmoved, the counts merely grow, and every existing check passes on a run that only did half the work.
- Decision 2 recorded as resolved: **latest `main`**.

## Test plan

`deno task check-docs` — 523 blocks pass. Docs only; the script remains unexecuted.

Found while answering "what versions are you upgrading from?" before starting the run — the kind of question that is cheaper to answer from the store than to discover halfway through a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Topics migration rehearsal docs to show we are upgrading from two topic generations, not one, making this a double legacy→current transition. Adds a new "What is being upgraded from" section with counts and identities, sets the migrate order (gen A’s 39, gen B’s 34, then the board), introduces an acceptance check that all 73 topics share exactly one pattern identity after the run, and records the decision to target latest `main`.

<sup>Written for commit 24a59adf86c0fca57f92b2ef1a17662a3cc4ff15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

