### PR TITLE
docs(plans): verb contract — C3 is not exposed to the verb-marking divergence

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -198,22 +198,37 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
   ignored — design rule 1): emit `additionalProperties: false` for event
   payloads, confirm the runner enforces it at dispatch, and record the rule
   in the mapping spec.
-- **Settle before C3 — which signal marks a verb?** "Stream/handler
-  properties" is not a single predicate today. `isStream()` accepts three
-  independent signals, any one of which suffices: the cell's construction kind,
-  `asCell: ["stream"]` in the schema, and a stored `{$stream: true}` value
-  (`Cell.isStream`, `packages/runner/src/cell.ts:936-958`). If C3 keys emission
-  off the schema marker alone, a verb carrying only the stored marker gets no
-  result schema and rule 3 silently does not apply to it — and the WS-C exit
-  below would not catch that, since it exercises one CTS pattern that does
-  carry the marker.
-  That the signals diverge in practice is not hypothetical: the CLI has two
-  runtime workarounds for handlers whose schema lost the marker
+- **Which signal marks a verb — checked, and C3 is not exposed to it.** An
+  earlier revision of this bullet warned that "stream/handler properties" is
+  not one predicate, because `Cell.isStream` accepts three independent signals
+  — construction kind, `asCell: ["stream"]` in the schema, and a stored
+  `{$stream: true}` value (`packages/runner/src/cell.ts:936-958`) — and that
+  C3 might therefore skip verbs carried only by the stored one. That warning
+  was misdirected. C3 runs in schema-generator, off the **TypeScript checker**:
+  `getWrapperSchemaFromCallable` reads a property's call signatures and asks
+  `getCellWrapperInfo` whether the return type is a `Stream`
+  (`packages/schema-generator/src/formatters/object-formatter.ts:44-67`). The
+  `asCell` marker is that check's *output*, not its input, and the stored
+  `{$stream: true}` value is a runtime artifact schema-generator never sees. A
+  result schema would ride the same type check that already emits the marker,
+  so the two travel together: a property is either recognized as a stream and
+  gets both, or is unrecognized and is skipped from `properties` and `required`
+  entirely (mapping spec, "Functions / callables / constructables"). There is
+  no state where the marker lands and the result schema does not. Verified on
+  `packages/patterns/topics/main.tsx`: `addTopic`, `setMyName`, and
+  `submitTopic` all emit `asCell: ["stream"]` from their `Stream<T>`
+  declarations.
+- **The residual check, which belongs to durable-schema readers rather than to
+  C3:** the bullet above requires the result schema to reach the piece's
+  *durable* schema, and only generation was verified — not persistence. If
+  anything strips `asCell` between generation and storage, every consumer that
+  reads verbs back from a stored schema is affected, this workstream included.
+  The three-signal divergence is real at runtime, which is why the CLI carries
+  two workarounds for handlers whose stored schema lacks the marker
   (`tryResolvePieceHandler`, and the forced-stream probe in
-  `listPieceCallables`, whose comment says so). What is *not* yet established
-  is whether any pattern reaches schema-generator in that state. Determine that
-  first; if it can, C3 needs a predicate that agrees with dispatch, and the
-  exit criterion needs a second fixture that lacks the schema marker.
+  `listPieceCallables`). Worth confirming before anything downstream depends on
+  reading verbs out of a durable schema; the design doc's structural-interface
+  note rests on the same question.
 - ~~**runner:** plain-return projection~~ — **done (C4)**:
   `plainResultReceipts`, default-off, env-reachable
   (`EXPERIMENTAL_PLAIN_RESULT_RECEIPTS`); registry entry in

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -353,11 +353,13 @@ encodings — the cell's construction kind, `asCell: ["stream"]` in the schema,
 and a stored `{$stream: true}` value — and `Cell.isStream` accepts any one of
 them (`packages/runner/src/cell.ts:936-958`). A conformance check filtering on
 the schema marker therefore misses verbs carried only by the stored one, and
-those exist in practice: the CLI keeps a forced-stream fallback specifically to
-dispatch them. The same question gates result-schema emission in the
-implementation plan, so settling which signal is authoritative serves both.
-Until it is settled, treat structural conformance as available in principle
-rather than in hand.
+the CLI keeps a forced-stream fallback specifically to dispatch such handlers.
+Note where this does and does not bite: schema *generation* is not exposed to
+it, because schema-generator decides stream-ness from the TypeScript type and
+emits the marker as its own output — the divergence is a property of schemas
+and values already stored. Conformance checking reads exactly those, so it is
+exposed. Until the authoritative signal is settled, treat structural
+conformance as available in principle rather than in hand.
 
 One further precondition, cheap to hold and easy to lose: **verbs must stay in
 the piece's own schema.** Moving the verb list into a separate index cell — a


### PR DESCRIPTION
## Why

#5104 recorded a prerequisite before WS-C's C3: that "stream/handler
properties" is not one predicate, because `Cell.isStream` accepts three
independent signals — construction kind, `asCell: ["stream"]` in the schema,
and a stored `{$stream: true}` value — so C3 might emit result schemas off the
marker alone and silently skip verbs carried only by the stored one.

I wrote that bullet. Running the check it asked for shows it was misdirected.

**C3 never reads the marker.** It runs in schema-generator, off the TypeScript
checker: `getWrapperSchemaFromCallable` reads a property's call signatures and
asks `getCellWrapperInfo` whether the return type is a `Stream`
(`packages/schema-generator/src/formatters/object-formatter.ts:44-67`). The
`asCell` marker is that check's **output**, not its input, and the stored
`{$stream: true}` value is a runtime artifact the generator never sees.

So a result schema would ride the same type check that already emits the
marker. The two travel together: a property is either recognized as a stream
and gets both, or is unrecognized and is skipped from `properties` and
`required` entirely (mapping spec, "Functions / callables / constructables").
There is no state where the marker lands and the result schema does not —
which is precisely the failure the old bullet warned about.

Verified on `packages/patterns/topics/main.tsx` via
`deno task cf check --show-transformed --no-run`: `addTopic`, `setMyName`, and
`submitTopic` all emit `asCell: ["stream"]` from their `Stream<T>`
declarations.

Left standing, this would have sent whoever picks up C3 chasing a hazard that
cannot occur, and pointed the WS-C exit criterion at a second fixture it does
not need.

## What Changed

**Implementation doc.** The prerequisite bullet is replaced by two:

1. The check, and its result — C3 is not exposed, with the reason and the
   verification.
2. **The residual question, reassigned.** Only *generation* was verified, not
   *persistence*. Whether `asCell` survives into the piece's durable schema is
   still open, and that belongs to every consumer reading verbs back out of a
   stored schema — not to C3 specifically. The three-signal divergence is real
   at runtime, which is why the CLI carries two workarounds
   (`tryResolvePieceHandler`, and the forced-stream probe in
   `listPieceCallables`).

**Design doc.** Its structural-interface note claimed "the same question gates
result-schema emission in the implementation plan," which is the same error.
Corrected to say where the divergence does and does not bite: generation is not
exposed because the generator works from types; conformance checking reads
stored schemas and values, so it is. The caveat itself stands — structural
conformance is available in principle, not in hand.

## Test plan

- `deno task check-docs plans` — passes.
- `docs/` is fmt-excluded; prose hand-wrapped at 80 columns (verified no added
  line exceeds it).
- Every added citation swept against the merge base, including the bare
  back-references: `object-formatter.ts:44-67` and `cell.ts:936-958` both
  resolve to the symbols named.
- Behavioural claim reproduced with
  `deno task cf check packages/patterns/topics/main.tsx --show-transformed
  --no-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the verb-contract docs: C3 does not rely on the `asCell` marker and isn’t exposed to the stream/handler predicate divergence, because `schema-generator` decides stream-ness from TypeScript types and emits the marker as output. Reframes the remaining risk as a persistence concern for consumers of durable schemas, and updates both the implementation and design docs accordingly.

<sup>Written for commit 6a36f08bc196cb966448ef171f7bc0ea729f4cfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

