### PR TITLE
docs(piece): define registry-backed discovery limits

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -43,6 +43,7 @@ on the Common Fabric runtime.
 - [concepts/action.md](concepts/action.md) — handling events with `action()`
 - [concepts/handler.md](concepts/handler.md) — reusable parameterized handlers with `handler()`
 - [concepts/identity.md](concepts/identity.md) — object identity, `equals()`, why `===` fails across cells
+- [concepts/piece-discovery.md](concepts/piece-discovery.md) — the piece registry, searchable collections, link walks, and the limits of orphan-piece discovery
 - [concepts/self-reference.md](concepts/self-reference.md) — self-referential types with `SELF`
 - [concepts/types-and-schemas/writable.md](concepts/types-and-schemas/writable.md) — `Writable<>` and write access in type signatures
 - [concepts/types-and-schemas/default.md](concepts/types-and-schemas/default.md) — `Default<>` for input defaults

--- a/docs/common/concepts/piece-discovery.md
+++ b/docs/common/concepts/piece-discovery.md
@@ -1,0 +1,68 @@
+# Finding Pieces
+
+Common Fabric storage contains cells and links. It does not maintain a complete
+catalog of which stored cells are piece roots. The supported piece APIs
+therefore cannot enumerate every piece stored in a space.
+
+## The Piece Registry Is the Discovery Root
+
+The space's default pattern owns `pieceRegistry`. A piece in that list is a
+**registered piece**. Top-level creation normally registers the new piece
+through the default pattern's `addPiece` handler. Instantiating a child pattern
+does not register the child automatically.
+
+The following surfaces show registered pieces:
+
+| Surface | Discovery boundary |
+| --- | --- |
+| `cf piece ls` | Reads the piece registry, then starts each registered piece to obtain its display metadata |
+| `cf piece search` | Searches the readable input and result data of registered pieces only |
+| `cf piece map` | Compares links among registered pieces only |
+| `wish({ query: "#pieceRegistry" })` | Resolves the piece registry directly rather than running a hashtag search |
+| `PieceManager.getPieceRegistry()` and `PiecesController.getRegisteredPieces()` | Return the piece registry |
+| `RuntimeClient.getPiecesListCell()` | Returns a reactive handle to the piece registry |
+| The FUSE `pieces/` directory | Projects the piece registry as named directories |
+
+These are not storage-wide piece listings. In particular, `cf piece search`
+does not return an unregistered piece just because a registered piece links to
+data owned by it.
+
+## Finding Pieces Outside the Registry
+
+The ordinary piece-discovery surfaces can find a piece outside the registry
+only from information that is already known:
+
+- A pattern can publish it through a searchable collection such as
+  mentionables, favorites, or profile elements. `wish()` searches those
+  explicit collections.
+- A caller can start with a known piece, normally one from the registry, and
+  follow its stored links. Such a walk finds only pieces connected to its
+  starting points. There is no supported comprehensive piece-graph walk.
+- A caller that already has the exact piece address, including its scope, can
+  address the piece directly. Direct lookup is access by a known address, not
+  discovery.
+
+The FUSE `entities/` directory is a lower-level exception when the memory
+server supports identifier listing. It lists every live space-scoped entity ID.
+A caller can inspect each entity and use recognizable metadata to identify some
+piece roots. This provides a best-effort brute-force recovery path for
+space-scoped pieces even when a piece ID was lost. The listing does not classify
+entities as pieces, cannot enumerate user- or session-scoped roots, and may not
+distinguish an identity-less root from an ordinary entity. Its cost is
+proportional to every live entity rather than every piece.
+
+## Orphan Pieces
+
+An **orphan piece** is outside the registry and has no path from a known
+discovery collection or piece. It may still have durable data in storage, but
+it does not appear in `cf piece ls`, `cf piece search`, `cf piece map`, the
+named FUSE `pieces/` projection, or the registry APIs. A caller that knows its
+exact address, including scope, can address it directly. A caller that lost a
+space-scoped ID may be able to recover it by enumerating and inspecting
+unclassified entities through a supported low-level surface such as FUSE
+`entities/`. This recovery is not available for user- or session-scoped roots
+and is not guaranteed for roots without recognizable metadata.
+
+Removing a piece from the registry does not delete its cells. Register pieces
+that must remain discoverable, and deliberately publish or retain references to
+child pieces that should stay reachable.

--- a/docs/common/conventions/adding-pieces.md
+++ b/docs/common/conventions/adding-pieces.md
@@ -4,6 +4,12 @@ To add a new piece to the space's piece registry, use the `addPiece` handler
 exported by the default app pattern. **Never** push to `pieceRegistry`
 directly.
 
+Registration is the root of the supported piece-discovery APIs. An
+unregistered piece must be published through a searchable collection or remain
+reachable by following links from a known piece. An orphan piece does not
+appear in the ordinary piece listings or searches. See
+[Finding Pieces](../concepts/piece-discovery.md).
+
 ## Why
 
 - **Type safety** — no `as any` casts needed

--- a/docs/common/conventions/mentionable.md
+++ b/docs/common/conventions/mentionable.md
@@ -44,6 +44,10 @@ return {
   global piece list, use the `addPiece` handler via `wish("#default")`.
   See [Adding Pieces](adding-pieces.md).
 
+Mentionables are one deliberate way to make an unregistered child discoverable.
+They do not provide a complete piece listing and cannot expose an orphan. See
+[Finding Pieces](../concepts/piece-discovery.md).
+
 ## Wishing for Mentionables
 
 Patterns can discover mentionables in the current space using `wish()`:

--- a/docs/common/conventions/wish.md
+++ b/docs/common/conventions/wish.md
@@ -6,6 +6,11 @@
 favorites, mentionables, and profile elements by tag, and returns a reactive
 `WishState<T>`.
 
+These are explicit discovery collections, not an index of every stored piece.
+They can expose pieces outside the space's registry, but they cannot find an
+orphan that was never published and is not reachable from a known piece. See
+[Finding Pieces](../concepts/piece-discovery.md).
+
 ```tsx
 // Shown inside a pattern body.
 const wishResult = wish<{ content: string }>({ query: "#note" });

--- a/docs/specs/fuse-filesystem/1-overview.md
+++ b/docs/specs/fuse-filesystem/1-overview.md
@@ -39,7 +39,7 @@ cf fuse mount ~/mnt/cf --api-url http://localhost:8000
 ls ~/mnt/cf/
 # => home/
 
-# List pieces in the home space
+# List registered pieces in the home space
 ls ~/mnt/cf/home/pieces/
 # => todo-app/  weather-widget/  notes/
 
@@ -77,6 +77,12 @@ echo '{"item":"New task"}' > ~/mnt/cf/home/pieces/todo-app/result/addItem.handle
 # Unmount
 cf fuse unmount ~/mnt/cf
 ```
+
+The named `pieces/` projection is seeded by the space's piece registry. It does
+not enumerate unregistered or orphan pieces. The separate `entities/`
+projection lists live entity IDs when the server supports identifier listing,
+without identifying which entities are piece roots. See
+[Finding Pieces](../../common/concepts/piece-discovery.md).
 
 ---
 

--- a/docs/specs/fuse-filesystem/11-entity-lookup-enumeration.md
+++ b/docs/specs/fuse-filesystem/11-entity-lookup-enumeration.md
@@ -80,7 +80,7 @@ parent link.
 
 Mount connection creates only the space's fixed synthetic files and
 directories. It does not request identifiers, the space root, the default
-pattern, `allPieces`, or any entity value. Its storage and inode cost is
+pattern, the piece registry, or any entity value. Its storage and inode cost is
 independent of the number of live entities.
 
 ## Hydration Boundary
@@ -346,7 +346,7 @@ must report entity, input, and result request counts explicitly.
 An older Memory v2 server may omit `entityIdListing`, `entityIdPagination`, or
 `entityIdLookup`; each omission parses as `false`. The client does not send an
 unknown request. Connecting the space never falls back to reading the space
-root, default pattern, or `allPieces`.
+root, default pattern, or piece registry.
 
 FUSE enumeration requires both identifier listing and pagination. Opening
 `entities/` fails when either capability is absent. It does not accept one
@@ -360,11 +360,12 @@ Connection health does not depend on these optional capabilities. A healthy
 older server can reconnect even though a later attempt to enumerate
 `entities/` will report that pagination is unsupported.
 
-If the caller later opens `pieces/`, the legacy `allPieces` projection is
-materialized. Its known controllers can support exact entity access, but they
-do not change the `entities/` enumeration. Compatibility remains explicit and
-fail closed; absence of a capability never triggers a hidden space-wide value
-scan.
+If the caller later opens `pieces/`, the piece-registry projection is
+materialized. An eligible legacy default root can still supply its retired
+`allPieces` registry. The resulting known controllers can support exact entity
+access, but they do not change the `entities/` enumeration. Compatibility
+remains explicit and fail closed; absence of a capability never triggers a
+hidden space-wide value scan.
 
 ---
 

--- a/docs/specs/fuse-filesystem/2-path-scheme.md
+++ b/docs/specs/fuse-filesystem/2-path-scheme.md
@@ -295,24 +295,24 @@ entities/
 ```
 
 The directory contains every live entity in the space scope, including
-entities that are not present in `allPieces`. Connecting the space requests no
-identifiers. Opening a fresh `entities/` directory handle requests stable,
-bounded pages of identifiers from memory. Continuation reads for that handle
-reuse its prepared virtual entries rather than repeating those requests. The
-identifiers are not retained as permanent filesystem-tree nodes.
+entities that are not present in the piece registry. Connecting the space
+requests no identifiers. Opening a fresh `entities/` directory handle requests
+stable, bounded pages of identifiers from memory. Continuation reads for that
+handle reuse its prepared virtual entries rather than repeating those requests.
+The identifiers are not retained as permanent filesystem-tree nodes.
 
 Looking up one exact identifier checks its liveness without listing the space.
 Opening that entity directory returns no projected child names and loads no
 value. Directly looking up a named child such as `result.json` or
 `result/title` loads that entity and builds the named projection.
 
-Mounting does not read the space root, its default pattern, or `allPieces`.
+Mounting does not read the space root, its default pattern, or piece registry.
 The named projections under `pieces/` are built when that directory is first
 accessed. This keeps every entity value out of the mount and `entities/`
 listing path, including values for the space root and entities that also appear
-in `allPieces`. When the memory server does not support identifier listing,
-`entities/` remains empty. Opening `pieces/` does not turn it into an
-`allPieces`-only enumeration.
+in the piece registry. When the memory server does not support identifier
+listing, opening `entities/` fails and the directory cannot be enumerated.
+Opening `pieces/` does not turn `entities/` into a registry-only enumeration.
 
 The hydration boundary is safe for recursive tools: a crawler can list and
 open every entity directory without requesting entity values because those

--- a/docs/specs/fuse-filesystem/6-reactivity.md
+++ b/docs/specs/fuse-filesystem/6-reactivity.md
@@ -48,7 +48,9 @@ subscribes lazily:
 1. Connecting a space creates only its fixed synthetic tree. Identifier
    discovery begins when an `entities/` directory handle is read.
 2. Opening `pieces/` for the first time materializes and subscribes to
-   `allPieces`; a mount that only uses `entities/` does not load it.
+   the piece registry. An eligible legacy default root supplies its retired
+   `allPieces` registry. A mount that only uses `entities/` does not load either
+   registry.
 3. Opening an exact entity directory remains identifier-only. Direct lookup of
    a named projected child loads that entity. Named projections under
    `pieces/` subscribe to their projected input and result cells.

--- a/docs/tutorial/05-composition-and-pieces.md
+++ b/docs/tutorial/05-composition-and-pieces.md
@@ -45,8 +45,8 @@ parent passes.
 ## Pieces: patterns, deployed
 
 A **pattern** is source code — a template. A **piece** is an instance of a
-pattern living in a space. Instantiation (via `cf piece new`, the shell, or
-another piece) does roughly this (see `packages/piece/src/manager.ts`):
+pattern living in a space. Top-level deployment through `cf piece new` or the
+shell does roughly this (see `packages/piece/src/manager.ts`):
 
 1. The pattern source is compiled and registered, so the space knows the
    program (not just its output).
@@ -60,9 +60,21 @@ another piece) does roughly this (see `packages/piece/src/manager.ts`):
    pattern graph is re-instantiated over the argument cell, and the result
    (including `[UI]`) flows from there.
 
+Instantiating a child pattern inside another piece creates its cells and
+metadata, but does not add the child to `pieceRegistry` automatically.
+
 A piece is identified by an entity id (a hash, e.g. `fid1:abc...`) and can carry
 a human **slug** for URLs. In the shell, `/{spaceName}/{pieceIdOrSlug}` shows
 a piece's UI.
+
+The registry is the root of the supported piece listings. A child piece that is
+not registered must be published through a searchable collection or remain
+reachable by following links from a known piece. An orphan piece does not
+appear in the piece-specific listings or searches. It can still be addressed
+when its exact address and scope are known. Some space-scoped roots with
+recognizable metadata can also be recovered by exhaustively inspecting
+low-level entity listings. See
+[Finding Pieces](../common/concepts/piece-discovery.md).
 
 ## Linking pieces
 

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -83,8 +83,8 @@ duplicates. `new` once, `setsrc` forever after.
 Everything a pattern exports (Chapter 3) is drivable without a browser:
 
 ```bash
-deno task cf piece ls -s myspace                       # list pieces
-deno task cf piece search -s myspace "invoice"         # find pieces by their data
+deno task cf piece ls -s myspace                       # list registered pieces
+deno task cf piece search -s myspace "invoice"         # search registered pieces
 deno task cf piece inspect --piece <ID>                # dump structure/state
 deno task cf piece get --piece <ID> items              # read one exported field
 deno task cf piece call addItem '{"title": "Test"}' --piece <ID>   # send to a stream

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,12 +28,31 @@ git diff upstream/main | cf view
 cf view --rendered README.md
 ```
 
+## Piece discovery
+
+`cf piece ls` lists the pieces in the selected space's piece registry. It reads
+the default pattern and starts each registered piece to obtain its name and
+pattern metadata. It does not enumerate every stored piece root.
+
+`cf piece search` also starts from the registry. It searches readable input and
+result data, but returns registered pieces only. `cf piece map` likewise shows
+connections among registered pieces rather than walking the complete stored
+graph.
+
+A piece outside the registry can be found only through a searchable collection
+that deliberately publishes it, by following links from a known piece, or by
+using an exact piece address, including its scope, that is already known. A
+piece with none of those paths is an orphan and cannot be discovered through the
+piece commands. See
+[Finding Pieces](../../docs/common/concepts/piece-discovery.md) for the complete
+boundary.
+
 ## Piece data search
 
-`cf piece search <query>` reads every piece in the selected space and returns
-the pieces whose input or result data contains the query. Matching uses full
-Unicode case folding and canonical normalization over nested object keys and
-scalar values. Canonically equivalent text matches, and a match cannot stop
+`cf piece search <query>` reads every registered piece in the selected space and
+returns the pieces whose input or result data contains the query. Matching uses
+full Unicode case folding and canonical normalization over nested object keys
+and scalar values. Canonically equivalent text matches, and a match cannot stop
 partway through one character's multi-letter fold. Readable nested cell values
 are included when they belong to the piece being searched. A cell owned by
 another piece is searched only with that owner, not with every piece that links

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -488,10 +488,7 @@ export const piece = new Command()
   .option("--json", "Output machine-readable JSON.")
   .action(listPiecesFromCommand)
   /* piece search */
-  .command(
-    "search",
-    "Search readable input and result data in registered pieces.",
-  )
+  .command("search", "Search input and result data in registered pieces.")
   .usage(`${spaceUsage} <query>`)
   .example(
     cliText(`cf piece search ${EX_ID} ${EX_COMP} "meeting notes"`),
@@ -1114,10 +1111,7 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
     );
   })
   /* piece map */
-  .command(
-    "map",
-    "Display registered pieces and the connections between them",
-  )
+  .command("map", "Show registered pieces and the connections between them")
   .usage(spaceUsage)
   .example(
     cliText(`cf piece map ${EX_ID} ${EX_COMP}`),

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -475,20 +475,23 @@ export const piece = new Command()
   .globalOption("-i,--identity <path:string>", "Path to an identity keyfile.")
   .globalOption("-s,--space <space:string>", "The space name or DID")
   /* piece ls */
-  .command("ls", "List pieces in space.")
+  .command("ls", "List pieces registered in the space.")
   .usage(spaceUsage)
   .example(
     cliText(`cf piece ls ${EX_ID} ${EX_COMP}`),
-    `Display a list of all pieces in "${RAW_EX_COMP.space}".`,
+    `Display the registered pieces in "${RAW_EX_COMP.space}".`,
   )
   .example(
     cliText(`cf piece ls ${EX_ID} ${EX_URL}`),
-    `Display a list of all pieces in "${RAW_EX_COMP.space}".`,
+    `Display the registered pieces in "${RAW_EX_COMP.space}".`,
   )
   .option("--json", "Output machine-readable JSON.")
   .action(listPiecesFromCommand)
   /* piece search */
-  .command("search", "Search readable input and result data in every piece.")
+  .command(
+    "search",
+    "Search readable input and result data in registered pieces.",
+  )
   .usage(`${spaceUsage} <query>`)
   .example(
     cliText(`cf piece search ${EX_ID} ${EX_COMP} "meeting notes"`),
@@ -1111,11 +1114,14 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
     );
   })
   /* piece map */
-  .command("map", "Display a visual map of all pieces and their connections")
+  .command(
+    "map",
+    "Display registered pieces and the connections between them",
+  )
   .usage(spaceUsage)
   .example(
     cliText(`cf piece map ${EX_ID} ${EX_COMP}`),
-    `Display a map of all pieces and connections in "${RAW_EX_COMP.space}".`,
+    `Display registered pieces and connections in "${RAW_EX_COMP.space}".`,
   )
   .example(
     cliText(`cf piece map ${EX_ID} ${EX_COMP} --format dot`),

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -410,17 +410,39 @@ describe("cli piece parsing", () => {
     expect(code).toBe(0);
   });
 
-  it("shows search as a space-scoped command with JSON output", async () => {
+  it("shows search as a registered-piece command with JSON output", async () => {
     const { code, stdout, stderr } = await cf("piece search --help");
     checkStderr(stderr);
     const output = stripAnsi(stdout.join("\n"));
     expect(output).toContain(
-      "Search readable input and result data in every piece.",
+      "Search readable input and result data in registered pieces.",
     );
     expect(output).toContain("<query>");
     expect(output).toContain("--space <space>");
     expect(output).toContain("--json");
     expect(code).toBe(0);
+  });
+
+  it("describes listing and mapping as registry-backed", async () => {
+    const commands = [
+      {
+        args: "piece ls --help",
+        description: "List pieces registered in the space.",
+      },
+      {
+        args: "piece map --help",
+        description:
+          "Display registered pieces and the connections between them",
+      },
+    ];
+    for (const command of commands) {
+      const { code, stdout, stderr } = await cf(command.args);
+      checkStderr(stderr);
+      const output = stripAnsi(stdout.join("\n"));
+      expect(output).toContain(command.description);
+      expect(output).not.toContain("all pieces");
+      expect(code).toBe(0);
+    }
   });
 
   it("documents the piece registry in link help", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -415,7 +415,7 @@ describe("cli piece parsing", () => {
     checkStderr(stderr);
     const output = stripAnsi(stdout.join("\n"));
     expect(output).toContain(
-      "Search readable input and result data in registered pieces.",
+      "Search input and result data in registered pieces.",
     );
     expect(output).toContain("<query>");
     expect(output).toContain("--space <space>");
@@ -431,8 +431,7 @@ describe("cli piece parsing", () => {
       },
       {
         args: "piece map --help",
-        description:
-          "Display registered pieces and the connections between them",
+        description: "Show registered pieces and the connections between them",
       },
     ];
     for (const command of commands) {

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -87,7 +87,7 @@ returns the subtree as JSON. Top-level callable children under `input/` and
 ### Reading
 
 ```bash
-# List all pieces in a space
+# List registered pieces in a space
 ls home/pieces/
 
 # Read the full result cell as JSON (pipe to jq for pretty printing)
@@ -121,6 +121,12 @@ cat home/pieces/todo-app/result.json | jq '.addItem, .search'
 # => {"/handler":"addItem"}
 # => {"/tool":"search"}
 ```
+
+The named directories under `pieces/` come from the space's piece registry. They
+do not include unregistered or orphan pieces. The `entities/` directory can
+enumerate live entity IDs when the server supports identifier listing, but it
+does not identify which entities are piece roots. See
+[Finding Pieces](../../docs/common/concepts/piece-discovery.md).
 
 The prefix-free `patternRef.identity` + `patternRef.symbol` are the
 authoritative reference to the artifact currently running the piece

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -1780,7 +1780,7 @@ Deno.test("FUSE callback traversal of mounted /entities transfers only identifie
   }
 });
 
-Deno.test("CellBridge materializes allPieces when /pieces is first read", async () => {
+Deno.test("CellBridge materializes the piece registry when /pieces is first read", async () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const piece = {

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -413,8 +413,8 @@ export class RuntimeInternals extends EventTarget {
    * about to be displayed. Pass `start: false` for read-only consumers
    * (e.g. listing piece names): the persisted result cell is synced and
    * readable without paying pattern instantiation for every piece
-   * (CT-1623: starting all pieces on reload cost ~10s of dependency
-   * collection, either in the reload wall or on the first interaction).
+   * (starting every registered piece on reload cost about ten seconds of
+   * dependency collection, either during reload or on the first interaction).
    *
    * Cached per (space, id) — a pattern's address. A cache entry created
    * with `start: false` is upgraded (re-fetched with start) when a

--- a/packages/patterns/experimental/email-task-engine.tsx
+++ b/packages/patterns/experimental/email-task-engine.tsx
@@ -463,7 +463,7 @@ export default pattern<PatternInput, PatternOutput>(({ overrideAuth }) => {
   const processingTasks = new Writable<string[]>([]).for("processingTasks");
   const sortNewestFirst = new Writable(true).for("sortNewestFirst");
 
-  // Get all pieces for note discovery
+  // Get registered pieces for note discovery
   const pieceRegistry = wish<NotePiece[]>({
     query: "#pieceRegistry",
   }).result!;

--- a/packages/patterns/record-backup.tsx
+++ b/packages/patterns/record-backup.tsx
@@ -1,11 +1,12 @@
 /**
  * Record Backup Pattern - Import/Export for Records
  *
- * Exports all Records in a space to a single JSON file and imports them back.
- * Designed for data survival after server wipes.
+ * Exports registered Records in a space to one JSON file and imports them
+ * back. Records outside the piece registry are not included, so this is not a
+ * complete backup of the space's stored data.
  *
  * Features:
- * - Discovers all Records using wish({ query: "#pieceRegistry" })
+ * - Discovers registered Records using wish({ query: "#pieceRegistry" })
  * - Extracts module data using registry's fieldMapping
  * - Preserves wiki-links in notes as-is
  * - Includes trashed modules in export
@@ -171,7 +172,7 @@ function extractModuleData(
 }
 
 /**
- * Build export data from all Records in the space
+ * Build export data from registered Records in the space.
  */
 const buildExportData = lift(
   (
@@ -623,7 +624,7 @@ const handleFileUpload = handler<
 
 export default pattern<Input, Output>((input) => {
   const { importJson } = input;
-  // Get all pieces in the space
+  // Get registered pieces in the space
   const pieceRegistry = wish<RecordPiece[]>({
     query: "#pieceRegistry",
   }).result!;

--- a/packages/patterns/system/backlinks-index.tsx
+++ b/packages/patterns/system/backlinks-index.tsx
@@ -73,16 +73,18 @@ const computeIndex = lift<
 });
 
 /**
- * BacklinksIndex builds a map of backlinks across all pieces and exposes a
- * unified mentionable list for consumers like editors.
+ * BacklinksIndex scans registered pieces for backlinks. It also exposes a
+ * mentionable list containing registered pieces and their recursively exported
+ * mentionables for consumers like editors.
  *
  * Behavior:
  * - Backlinks are computed by scanning each piece's `mentioned` list and
  *   mapping mention target -> list of source pieces.
  * - Mentionable list is a union of:
- *   - every piece in `pieceRegistry`
- *   - any items a piece exports via a `mentionable` property
- *     (either an array of pieces or a Cell of such an array)
+ *   - entries in `pieceRegistry` whose values exist and do not set
+ *     `isMentionable` to false
+ *   - items those entries recursively export through a `mentionable` property,
+ *     up to five levels deep
  *
  * The backlinks map is keyed by a piece's `content` value (falling back to
  * its `[NAME]`). This mirrors how existing note patterns identify notes when

--- a/packages/patterns/system/knowledge-graph.tsx
+++ b/packages/patterns/system/knowledge-graph.tsx
@@ -149,7 +149,7 @@ export const searchGraphPattern = pattern<
   return { edges: filteredEdges, compoundNodes: filteredNodes };
 });
 
-/** Pattern tool: lists all pieces with their summaries. */
+/** Pattern tool: lists the supplied pieces with their summaries. */
 const listPiecesPattern = pattern<
   {
     entries: Array<

--- a/packages/patterns/system/omnibox-fab.tsx
+++ b/packages/patterns/system/omnibox-fab.tsx
@@ -155,7 +155,7 @@ export default pattern<OmniboxFABInput>(
       return `You are a polite but efficient assistant. Think Star Trek computer - helpful and professional without unnecessary conversation. Let your actions speak for themselves.
 ${profileSection}${indexText}
 Tool usage priority:
-- For finding content in the space: use searchSpace with a query to search across all piece summaries and names
+- For finding content in the space: use searchSpace with a query to search the indexed mentionable pieces that have nonempty summaries
 - For patterns: review the available patterns listed above, then use fetchAndRunPattern to instantiate one
 - For existing pages/notes/content: searchSpace first, then listRecent or listMentionable to identify what they're referencing
 - Attach relevant items to conversation after instantiation/retrieval if they support ongoing tasks

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -322,9 +322,10 @@ export class PieceManager {
   }
 
   /**
-   * Get the cell containing the list of all pieces in this space.
-   * Reads the default pattern's pieceRegistry export. An eligible legacy
-   * system root is read through its retired registry export.
+   * Get the cell containing the registered pieces in this space.
+   * This is the discovery root, not a list of every stored piece root. Reads
+   * the default pattern's pieceRegistry export. An eligible legacy system root
+   * is read through its retired registry export.
    */
   async getPieceRegistry(): Promise<Cell<Cell<unknown>[]>> {
     const defaultPattern = await this.getDefaultPattern(true);
@@ -491,13 +492,13 @@ export class PieceManager {
   }
 
   /**
-   * Find all pieces that the given piece reads data from via sigil links.
-   * This identifies dependencies that the piece has on other pieces.
+   * Find registered pieces that the given piece reads from via sigil links.
+   * Unregistered targets are not returned.
    * @param piece The piece to check
-   * @returns Array of pieces that are read from
+   * @returns Array of registered pieces that are read from
    */
   async getReadingFrom(piece: Cell<unknown>): Promise<Cell<unknown>[]> {
-    // Get all pieces that might be referenced
+    // Get registered pieces that might be referenced
     const piecesCell = await this.getPieceRegistry();
     const registeredPieces = piecesCell.get();
     const result: Cell<unknown>[] = [];
@@ -648,13 +649,13 @@ export class PieceManager {
   }
 
   /**
-   * Find all pieces that read data from the given piece via sigil links.
-   * This identifies which pieces depend on this piece.
+   * Find registered pieces that read from the given piece via sigil links.
+   * Unregistered readers are not returned.
    * @param piece The piece to check
-   * @returns Array of pieces that read from this piece
+   * @returns Array of registered pieces that read from this piece
    */
   async getReadByPieces(piece: Cell<unknown>): Promise<Cell<unknown>[]> {
-    // Get all pieces to check
+    // Get registered pieces to check
     const piecesCell = await this.getPieceRegistry();
     const registeredPieces = piecesCell.get();
     const result: Cell<unknown>[] = [];
@@ -1212,16 +1213,16 @@ async function getCellByIdOrPiece(
         options?.targetScope,
       );
 
-      // Check if this cell is actually a piece by looking at the pieces list
+      // Check whether this cell is registered as a piece.
       const piecesCell = await manager.getPieceRegistry();
       const pieces = piecesCell.get();
-      const isActuallyPiece = pieces.some((piece: Cell<unknown>) => {
+      const isRegisteredPiece = pieces.some((piece: Cell<unknown>) => {
         const id = pieceId(piece);
-        // If we can't get the piece ID, it's not a valid piece
+        // An entry without a piece ID cannot establish registration.
         if (!id) return false;
         return id === cellId;
       });
-      return { cell, isPiece: isActuallyPiece };
+      return { cell, isPiece: isRegisteredPiece };
     } catch (_) {
       throw new Error(`${label} "${cellId}" not found as piece or cell`);
     }

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -184,6 +184,7 @@ export class PiecesController<T = unknown> {
     return new PieceController(this.#manager, cell);
   }
 
+  /** Return the piece registry, not every stored piece root. */
   async getRegisteredPieces() {
     this.disposeCheck();
     const piecesCell = await this.#manager.getPieceRegistry();

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -360,7 +360,8 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
 
   /**
    * Get the pieces list cell.
-   * Subscribe to this cell to get reactive updates of all pieces in the space.
+   * Subscribe to this cell to get reactive updates of registered pieces in the
+   * space. This is not a storage-wide piece listing.
    */
   async getPiecesListCell<T>(space: DID): Promise<CellHandle<T[]>> {
     const response = await this.#conn.request<RequestType.PageGetAll>({

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -652,7 +652,7 @@ export class XHeaderView extends BaseView {
   }
 
   /**
-   * Eagerly fetch all pieces in the current space as soon as the
+   * Eagerly fetch registered pieces in the current space as soon as the
    * runtime is available. Results are cached until the runtime or the
    * viewed space changes. This ensures the piece list is ready by the
    * time the user opens a dropdown.


### PR DESCRIPTION
Piece-facing lists, searches, maps, and named filesystem projections all begin with the space's piece registry, but several public descriptions promised every piece in the space. That wording hides unregistered children and makes orphan pieces appear discoverable through APIs that cannot return them.

Add a canonical piece-discovery guide and link it from pattern authoring, CLI, tutorial, runtime, and FUSE documentation. Distinguish explicit searchable collections and link walks from registry lookup. Document exact scoped addressing and the limited, best-effort recovery path through space-scoped FUSE entity enumeration. Correct registry-backed help text, backup claims, search prompts, and developer comments, while retaining the legacy allPieces exception only where it still applies.

Guard the CLI descriptions with help-output assertions. Verified with the repository-wide formatter and linter, documentation code-block checks, the CLI piece suite, focused FUSE coverage, and adversarial forward and reverse reviews.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that piece discovery is registry-backed and not space-wide. Adds a canonical guide, aligns CLI/FUSE docs and help text (now single-line for coverage), and tightens tests and comments; keeps legacy `allPieces` only where still supported.

- **New Features**
  - Added “Finding Pieces” guide covering the piece registry, searchable collections, link walks, exact scoped addressing, orphan pieces, and best‑effort recovery via FUSE `entities/`.
  - Updated CLI: `cf piece ls/search/map` help now says “registered pieces” on a single line; `packages/cli/README.md` explains registry scope; tests assert the help text and avoid “all pieces”.
  - Updated FUSE docs/tests: `pieces/` is registry-backed; `entities/` requires server identifier listing and stays separate; clarified hydration/reactivity and no hidden fallbacks to space-wide scans.
  - Updated tutorials, authoring docs, prompts, and comments to avoid “all pieces”; `packages/patterns/record-backup.tsx` now states it exports registered Records only.
  - Clarified APIs and usage: `PieceManager.getPieceRegistry()`, `PiecesController.getRegisteredPieces()`, and `RuntimeClient.getPiecesListCell()` now document registry scope; related prompts and comments in patterns align with registry-backed discovery.

<sup>Written for commit 4ef56d71d2d26048a72ac6b26826537daf0ce0cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

