### PR TITLE
feat(cli): select piped cf view source explicitly

### DIFF
--- a/docs/plans/cf-view-language-coverage.md
+++ b/docs/plans/cf-view-language-coverage.md
@@ -2,7 +2,8 @@
 
 Status: In progress. Unknown named files and filename-free source use plain
 text, while filename-free transformed compiler output keeps its TypeScript
-default. Python files with recognized extensions now have syntax highlighting.
+default. Piped source can select a language directly or through a virtual
+filename. Python files with recognized extensions now have syntax highlighting.
 The order is provisional because recent activity was measured in six of the 24
 active organization repositories.
 
@@ -85,7 +86,7 @@ relative value. Record the reason in this plan.
 - [x] Add a plain-text language and select it for unknown named files.
 - [x] Preserve the intentional TypeScript default only for transformed
   compiler output that has no filename.
-- [ ] Add `--language` and `--filename` overrides for piped input.
+- [x] Add `--language` and `--filename` overrides for piped input.
 - [ ] Represent extensions, exact filenames, compound filename patterns,
   aliases, and shebang interpreters as language metadata.
 - [ ] Keep content detection only for unambiguous containers such as unified

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,7 +7,12 @@ files, and unified diffs. Named Markdown, JSON, JSONC, YAML, and Python files
 use their own syntax highlighting. Transformed compiler output piped without a
 filename keeps TypeScript highlighting when its module header identifies it.
 Other filename-free source and named files with unrecognized syntax are shown as
-plain text.
+plain text. For piped source, `--filename` selects syntax as though the input
+had that name, while `--language` selects one of `typescript`, `markdown`,
+`json`, `yaml`, `python`, or `plain-text` directly. Both options keep the pipe
+read-only and suppress unified-diff auto-detection. An explicit language takes
+priority when both options are present. Use `--diff` instead when the pipe is a
+unified diff.
 
 Markdown files can switch between the source and a rendered terminal view with
 `V`. The rendered view formats headings, emphasis, links, quotes, lists, task
@@ -26,6 +31,8 @@ cf view .github/workflows/deno.yml
 cf view scripts/analyse.py
 git diff upstream/main | cf view
 cf view --rendered README.md
+generate-source | cf view --filename generated.py
+generate-markdown | cf view --language markdown --rendered
 ```
 
 ## Piece data search

--- a/packages/cli/commands/view.ts
+++ b/packages/cli/commands/view.ts
@@ -1,6 +1,7 @@
 import { Command } from "@cliffy/command";
 import { type ColorWhen, ViewError, viewMain } from "../lib/view/mod.ts";
 import { cliText } from "../lib/cli-name.ts";
+import { languageIds } from "../lib/view/languages/language.ts";
 
 const description = cliText(
   `Interactive, syntax-aware pager for transformed patterns, source files and diffs.
@@ -12,10 +13,12 @@ uses, so blocks, closures, schemas, type positions and Common Fabric builders
 Markdown, JSON, JSONC, YAML and Python files use syntax highlighting selected
 from their names. Filename-free compiler output keeps TypeScript highlighting
 when its transformed-module header identifies it. Other unnamed source and
-named files with unrecognized syntax remain plain text. The Markdown language
-also has a rendered view that formats headings, lists, quotes, tables, links,
-emphasis and code while retaining source line positions. Source views remain
-verbatim and add colour only.
+named files with unrecognized syntax remain plain text. Piped source can select
+syntax explicitly with '--language' or supply a virtual name with '--filename'.
+Either option suppresses unified-diff auto-detection; use '--diff' instead for a
+diff. The Markdown language also has a rendered view that formats headings,
+lists, quotes, tables, links, emphasis and code while retaining source line
+positions. Source views remain verbatim and add colour only.
 
 Unified diffs are detected automatically: piping 'git diff' in gives added and
 removed lines their tints, full syntax colour, a structure tree of the code
@@ -26,6 +29,7 @@ COMMON USAGE:
   cf check ./pattern.tsx --show-transformed --no-run | cf view
   git diff origin/main | cf view        # diff mode
   cf view transformed.ts                # view a saved file
+  generate-source | cf view --filename script.py
   cf check ./p.tsx --show-transformed --no-run | cf view --plain | bat
 
 KEYS (press ? in the viewer for the full list):
@@ -71,6 +75,14 @@ export const view = new Command()
     "Start in the rendered view when the input language supports one.",
   )
   .option(
+    "--language <language:string>",
+    `Select piped source explicitly: ${languageIds().join(", ")}.`,
+  )
+  .option(
+    "--filename <filename:string>",
+    "Select piped source as though it had this filename.",
+  )
+  .option(
     "--diff",
     "Treat the input as a unified diff, overriding auto-detection.",
   )
@@ -86,6 +98,8 @@ export const view = new Command()
         plain?: boolean;
         lineNumbers?: boolean;
         rendered?: boolean;
+        language?: string;
+        filename?: string;
         diff?: boolean;
       },
       file?: string,
@@ -102,6 +116,8 @@ export const view = new Command()
           plain: options.plain ?? false,
           lineNumbers: options.lineNumbers ?? false,
           rendered: options.rendered ?? false,
+          language: options.language,
+          filename: options.filename,
           file,
           diff: options.diff,
         });

--- a/packages/cli/lib/completion/static.ts
+++ b/packages/cli/lib/completion/static.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Option } from "@cliffy/command";
+import { languageIds } from "../view/languages/language.ts";
 import type { AnyCommand, CompletionLine, PreParseGlobal } from "./line.ts";
 import { longName, PRE_PARSE_GLOBALS } from "./line.ts";
 
@@ -21,11 +22,13 @@ export interface Candidate {
  * long name. Kept here rather than inline in the provider table because these
  * are facts about the CLI's accepted vocabulary, not about live data.
  *
- * `log-level` mirrors `lib/log-level.ts`; `color` mirrors `cf view --color`.
+ * `log-level` mirrors `lib/log-level.ts`; `color` mirrors the corresponding
+ * `cf view` option. Language identifiers come from the view language registry.
  */
 const ENUMERATED_OPTION_VALUES: Readonly<Record<string, readonly string[]>> = {
   "log-level": ["debug", "info", "warn", "error", "silent"],
   "color": ["auto", "always", "never"],
+  "language": languageIds(),
   "cfc-mode": ["off", "warn", "enforce"],
 };
 

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -202,16 +202,7 @@ export function fileSource(path: string): EditableSource {
   // The language is chosen once, from the path, and every edit-time operation
   // dispatches through it.
   const language = languageForFile(path);
-  const render = language.renderLines
-    ? {
-      render: (source: Document): Document => {
-        return {
-          ...source,
-          lines: renderedLinesFor(language, source.text, path)!,
-        };
-      },
-    }
-    : {};
+  const render = sourceRenderer(language, path);
   return {
     label: shortName(path),
     editable: true,
@@ -241,12 +232,29 @@ export function readonlySource(
   language: Language = languageForFile(undefined),
   fileName?: string,
 ): EditableSource {
+  const render = sourceRenderer(language, fileName);
   return {
     label: null,
     editable: false,
     reason,
     parse: (text) => language.parseDocument(text, fileName),
+    ...render,
     save: () => reason,
+  };
+}
+
+function sourceRenderer(
+  language: Language,
+  fileName?: string,
+): Partial<Pick<EditableSource, "render">> {
+  if (!language.renderLines) return {};
+  return {
+    render: (source: Document): Document => {
+      return {
+        ...source,
+        lines: renderedLinesFor(language, source.text, fileName)!,
+      };
+    },
   };
 }
 

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -226,11 +226,11 @@ export function renderedLinesFor(
 let languages: readonly Language[] | undefined;
 function allLanguages(): readonly Language[] {
   return languages ??= [
+    typeScriptLanguage,
     markdownLanguage,
     jsonLanguage,
     yamlLanguage,
     pythonLanguage,
-    typeScriptLanguage,
     plainTextLanguage,
   ];
 }
@@ -242,6 +242,16 @@ export function languageForFile(fileName: string | undefined): Language {
     if (language.matches(fileName)) return language;
   }
   return plainTextLanguage;
+}
+
+/** Look up a language by its stable identifier for an explicit override. */
+export function languageForId(id: string): Language | undefined {
+  return allLanguages().find((language) => language.id === id);
+}
+
+/** Stable identifiers accepted by an explicit language override. */
+export function languageIds(): string[] {
+  return allLanguages().map((language) => language.id);
 }
 
 /** The TypeScript default for filename-free `cf check --show-transformed`

--- a/packages/cli/lib/view/mod.ts
+++ b/packages/cli/lib/view/mod.ts
@@ -5,8 +5,9 @@
  * pager (when stdout is a TTY) or prints the selected source or rendered
  * representation and exits, mirroring how `less`/`bat` behave when their
  * output is redirected.
- * Filename-free compiler output keeps the transformed TypeScript default;
- * other filename-free source uses plain text.
+ * Filename-free compiler output keeps the transformed TypeScript default.
+ * Other filename-free source uses plain text unless an explicit language or
+ * virtual filename selects another language.
  */
 import { renderLineColored } from "./highlight.ts";
 import { runPager } from "./pager.ts";
@@ -18,12 +19,15 @@ import {
   realWorkspace,
   type WorkspaceCache,
 } from "./diffdoc.ts";
-import type { Semantics } from "./languages/language.ts";
 import {
   diffSemanticsFor,
   distinctLanguages,
+  type Language,
   languageForFile,
+  languageForId,
   languageForTransformedOutput,
+  languageIds,
+  type Semantics,
 } from "./languages/language.ts";
 import {
   type EditableSource,
@@ -44,11 +48,16 @@ export interface ViewOptions {
   /** Start in the rendered representation when one is available. */
   rendered?: boolean;
   file?: string;
+  /** Select piped source with this stable language identifier. */
+  language?: string;
+  /** Select piped source as though it had this filename. */
+  filename?: string;
   /** Force (true) or suppress (false) diff mode; undefined auto-detects. */
   diff?: boolean;
 }
 
 export async function viewMain(options: ViewOptions): Promise<void> {
+  const selection = pipedSelection(options);
   const text = await readInput(options.file);
   if (text.trim().length === 0) {
     throw new ViewError(
@@ -65,6 +74,7 @@ export async function viewMain(options: ViewOptions): Promise<void> {
     text,
     options.file,
     options.diff,
+    selection,
   );
   const stdoutTty = Deno.stdout.isTerminal();
   const interactive = !options.plain && stdoutTty;
@@ -92,6 +102,50 @@ export async function viewMain(options: ViewOptions): Promise<void> {
   printDocument(shown, color, options.lineNumbers);
 }
 
+function pipedSelection(options: ViewOptions): SourceSelection {
+  validateSourceSelection(
+    options.file,
+    options.diff,
+    options.language !== undefined || options.filename !== undefined,
+  );
+  if (options.language === undefined) {
+    return { fileName: options.filename };
+  }
+  const language = languageForId(options.language);
+  if (!language) {
+    throw new ViewError(
+      `cf view: unknown language "${options.language}". Available languages: ${
+        languageIds().join(", ")
+      }`,
+    );
+  }
+  return { language, fileName: options.filename };
+}
+
+/** Explicit syntax selection for source received through a pipe. */
+export interface SourceSelection {
+  readonly language?: Language;
+  readonly fileName?: string;
+}
+
+function validateSourceSelection(
+  file: string | undefined,
+  forceDiff: boolean | undefined,
+  sourceSelected: boolean,
+): void {
+  if (!sourceSelected) return;
+  if (file !== undefined) {
+    throw new ViewError(
+      "cf view: --language and --filename cannot be used with a file argument",
+    );
+  }
+  if (forceDiff === true) {
+    throw new ViewError(
+      "cf view: --diff cannot be combined with --language or --filename",
+    );
+  }
+}
+
 /**
  * Parse the input into a Document and pick the matching semantic service:
  * diff input gets a program over the current workspace files it names; a
@@ -102,18 +156,26 @@ export async function viewMain(options: ViewOptions): Promise<void> {
  * diff is accepted only if a reasonable share of its lines actually parse as
  * diff content — so a source file that merely EMBEDS a diff (in a string, a
  * test fixture) still views as source. Exported for tests.
+ *
+ * `selection` chooses syntax for piped source. Its virtual filename is
+ * advisory and does not make the source editable.
  */
 export function buildView(
   text: string,
   file?: string,
   forceDiff?: boolean,
+  selection: SourceSelection = {},
 ): {
   doc: Document;
   semantics: () => Semantics | undefined;
   editSource: EditableSource;
 } {
   const commitOutput = looksLikeCommitOutput(text);
-  const tryDiff = forceDiff ?? (looksLikeDiff(text) || commitOutput);
+  const sourceSelected = selection.language !== undefined ||
+    selection.fileName !== undefined;
+  validateSourceSelection(file, forceDiff, sourceSelected);
+  const tryDiff = forceDiff ??
+    (!sourceSelected && (looksLikeDiff(text) || commitOutput));
   const parsedDiff = tryDiff ? parseDiff(text) : null;
   const model: DiffModel | null = parsedDiff ??
     (tryDiff && commitOutput
@@ -152,21 +214,23 @@ export function buildView(
       ),
     };
   }
-  const transformedOutput = file === undefined &&
+  const fileName = selection.fileName ?? file;
+  const transformedOutput = fileName === undefined &&
     looksLikeTransformedOutput(text);
-  const language = transformedOutput
-    ? languageForTransformedOutput()
-    : languageForFile(file);
-  const doc = language.parseDocument(text, file);
+  const language = selection.language ??
+    (transformedOutput
+      ? languageForTransformedOutput()
+      : languageForFile(fileName));
+  const doc = language.parseDocument(text, fileName);
   return {
     doc,
     semantics: () =>
-      language.createSemantics?.(text, { cwd: safeCwd(), fileName: file }),
+      language.createSemantics?.(text, { cwd: safeCwd(), fileName }),
     // A real file is editable; a pipe (transformed output, etc.) is not.
     editSource: file ? fileSource(file) : readonlySource(
       "This view is of a pipe — there is no underlying file to edit.",
       language,
-      file,
+      fileName,
     ),
   };
 }

--- a/packages/cli/test/completion-output.test.ts
+++ b/packages/cli/test/completion-output.test.ts
@@ -9,6 +9,7 @@ import {
   bashCompletionScript,
   zshCompletionScript,
 } from "../lib/completion/script.ts";
+import { languageIds } from "../lib/view/languages/language.ts";
 import { main } from "../commands/main.ts";
 
 function staticFor(line: string): string[] {
@@ -84,6 +85,10 @@ Deno.test("--log-level=<value> keeps the inline prefix on candidates", async () 
   // The shell replaces the whole token, so a bare `debug` would produce
   // `cf --log-level=debug` -> `cf debug`.
   assertEquals(await completeFor("cf --log-level=de"), ["--log-level=debug"]);
+});
+
+Deno.test("cf view --language completes its accepted identifiers", async () => {
+  assertEquals(await completeFor("cf view --language "), languageIds());
 });
 
 Deno.test("candidates are filtered by the typed prefix", async () => {

--- a/packages/cli/test/view-cli.test.ts
+++ b/packages/cli/test/view-cli.test.ts
@@ -85,6 +85,57 @@ Deno.test("cf view --plain --no-diff is accepted and views a diff as source", as
   assertEquals(code, 0);
 });
 
+Deno.test("cf view --filename selects piped source by its virtual name", async () => {
+  const source = "# Title with **weight**\n";
+  const { code, stdout } = await cf(
+    "view --plain --rendered --color never --filename notes.md",
+    source,
+  );
+  assertEquals(code, 0);
+  assertEquals(stdout, ["Title with weight"]);
+});
+
+Deno.test("cf view --language overrides a piped virtual filename", async () => {
+  const source = "# Title with **weight**\n";
+  const { code, stdout } = await cf(
+    "view --plain --rendered --color never --language markdown --filename notes.txt",
+    source,
+  );
+  assertEquals(code, 0);
+  assertEquals(stdout, ["Title with weight"]);
+});
+
+Deno.test("cf view rejects an unknown --language", async () => {
+  const { code, stderr } = await cf("view --plain --language ruby", SRC);
+  assertEquals(code, 1);
+  assert(
+    stderr.join("\n").includes('unknown language "ruby"'),
+    stderr.join("\n"),
+  );
+  assert(stderr.join("\n").includes("python"), stderr.join("\n"));
+});
+
+Deno.test("cf view rejects source selection combined with forced diff mode", async () => {
+  for (
+    const selector of [
+      "--language plain-text",
+      "--filename virtual.ts",
+    ]
+  ) {
+    const { code, stderr } = await cf(
+      `view --plain --diff ${selector}`,
+      DIFF,
+    );
+    assertEquals(code, 1);
+    assert(
+      stderr.join("\n").includes(
+        "--diff cannot be combined with --language or --filename",
+      ),
+      stderr.join("\n"),
+    );
+  }
+});
+
 Deno.test("cf view rejects an invalid --color", async () => {
   const { code, stderr } = await cf("view --plain --color bogus", SRC);
   assertEquals(code, 1);
@@ -108,6 +159,24 @@ Deno.test("cf view reads and prints a file argument", async () => {
     const { code, stdout } = await cf(`view --plain ${file}`);
     assertEquals(code, 0);
     assert(stdout.join("\n").includes("pattern"));
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
+  }
+});
+
+Deno.test("cf view rejects piped-input overrides with a file argument", async () => {
+  const dir = Deno.makeTempDirSync();
+  try {
+    const file = `${dir}/source.txt`;
+    Deno.writeTextFileSync(file, SRC);
+    const { code, stderr } = await cf(
+      `view --plain --language typescript ${file}`,
+    );
+    assertEquals(code, 1);
+    assert(
+      stderr.join("\n").includes("cannot be used with a file argument"),
+      stderr.join("\n"),
+    );
   } finally {
     Deno.removeSync(dir, { recursive: true });
   }

--- a/packages/cli/test/view-language.test.ts
+++ b/packages/cli/test/view-language.test.ts
@@ -11,7 +11,9 @@ import {
   diffSemanticsFor,
   distinctLanguages,
   languageForFile,
+  languageForId,
   languageForTransformedOutput,
+  languageIds,
   renderedLinesFor,
 } from "../lib/view/languages/language.ts";
 import { typeScriptLanguage } from "../lib/view/languages/typescript/language.ts";
@@ -47,6 +49,25 @@ Deno.test("languageForFile: named JavaScript uses the TypeScript-family parser",
   const doc = languageForFile("answer.js").parseDocument(source, "answer.js");
   assertEquals(doc.text, source);
   assert(doc.lines[0].spans.some((span) => span.cls === "storageKeyword"));
+});
+
+Deno.test("languageForId: stable identifiers resolve explicit overrides", () => {
+  assertEquals(languageForId("typescript"), typeScriptLanguage);
+  assertEquals(languageForId("markdown"), markdownLanguage);
+  assertEquals(languageForId("json"), jsonLanguage);
+  assertEquals(languageForId("yaml"), yamlLanguage);
+  assertEquals(languageForId("python"), pythonLanguage);
+  assertEquals(languageForId("plain-text"), plainTextLanguage);
+  assertEquals(languageForId("TypeScript"), undefined);
+  assertEquals(languageForId("ruby"), undefined);
+  assertEquals(languageIds(), [
+    "typescript",
+    "markdown",
+    "json",
+    "yaml",
+    "python",
+    "plain-text",
+  ]);
 });
 
 Deno.test("distinctLanguages: dedupes in first-seen order", () => {

--- a/packages/cli/test/view-mod-cov.test.ts
+++ b/packages/cli/test/view-mod-cov.test.ts
@@ -4,8 +4,10 @@
  * semantic service only when launching the pager, so these call the returned
  * closure directly to exercise both the diff and source semantics paths.
  */
-import { assert, assertEquals } from "@std/assert";
-import { buildView } from "../lib/view/mod.ts";
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { markdownLanguage } from "../lib/view/languages/markdown/language.ts";
+import { plainTextLanguage } from "../lib/view/languages/plain-text/language.ts";
+import { buildView, ViewError } from "../lib/view/mod.ts";
 
 const SRC = "export const x = 1;\nconst y = x + 1;\n";
 const TRANSFORMED = `// transformed: /app.ts
@@ -58,6 +60,86 @@ Deno.test("buildView: transformed compiler output keeps the TypeScript default",
     r.editSource.parse(TRANSFORMED),
     r.doc,
     "read-only reparsing keeps the selected language",
+  );
+});
+
+Deno.test("buildView: a virtual filename selects piped source without making it editable", () => {
+  const source = 'def greet(name):\n    return f"Hello, {name}"\n';
+  const r = buildView(source, undefined, undefined, {
+    fileName: "scripts/greet.py",
+  });
+
+  assert(
+    r.doc.lines.flatMap((line) => line.spans).some((span) =>
+      span.cls === "storageKeyword"
+    ),
+    "the virtual Python filename selects Python highlighting",
+  );
+  assertEquals(r.editSource.editable, false);
+  assertEquals(r.editSource.path, undefined);
+  assertEquals(r.editSource.parse(source), r.doc);
+});
+
+Deno.test("buildView: an explicit language takes priority over a virtual filename", () => {
+  const source = "# **Piped heading**\n";
+  const r = buildView(source, undefined, undefined, {
+    language: markdownLanguage,
+    fileName: "notes.txt",
+  });
+
+  assert(
+    r.doc.structure.some((node) =>
+      node.kind === "section" && node.name === "**Piped heading**"
+    ),
+    "the explicit Markdown language overrides the plain-text filename",
+  );
+  assertEquals(
+    r.editSource.render?.(r.doc).lines[0].text,
+    "Piped heading",
+  );
+});
+
+Deno.test("buildView: explicit source selection suppresses automatic detection", () => {
+  const transformed = buildView(TRANSFORMED, undefined, undefined, {
+    language: plainTextLanguage,
+  });
+  assertEquals(transformed.doc.structure, []);
+
+  const filenameDiff = buildView(DIFF, undefined, undefined, {
+    fileName: "piped.py",
+  });
+  assertEquals(filenameDiff.editSource.isDiff, undefined);
+  assert(
+    !filenameDiff.doc.flatStructure.some((node) => node.kind === "hunk"),
+    "the virtual source filename overrides diff content detection",
+  );
+
+  const languageDiff = buildView(DIFF, undefined, undefined, {
+    language: plainTextLanguage,
+  });
+  assertEquals(languageDiff.editSource.isDiff, undefined);
+  assert(
+    !languageDiff.doc.flatStructure.some((node) => node.kind === "hunk"),
+    "the explicit language overrides diff content detection",
+  );
+});
+
+Deno.test("buildView: source selection rejects incompatible direct calls", () => {
+  assertThrows(
+    () =>
+      buildView(SRC, "actual.ts", undefined, {
+        language: plainTextLanguage,
+      }),
+    ViewError,
+    "cannot be used with a file argument",
+  );
+  assertThrows(
+    () =>
+      buildView(SRC, undefined, true, {
+        fileName: "virtual.ts",
+      }),
+    ViewError,
+    "--diff cannot be combined",
   );
 });
 


### PR DESCRIPTION
Filename-free pipes intentionally fall back to plain text unless they contain transformed compiler output. Generated source without a real path therefore had no way to select one of the supported syntaxes.

Add --filename for virtual filename selection and --language for stable language identifiers. Give an explicit language priority over the virtual filename, suppress automatic diff and transformed-output detection when either selector is present, and keep virtual sources read-only while preserving their parser and rendered representation.

Reject source selectors with a real file or forced diff mode at both the command boundary and the exported buildView boundary. Derive help and shell-completion values from the language registry so accepted identifiers stay synchronized.

Update the live coverage plan and CLI reference. Cover rendering, precedence, read-only behavior, automatic-detection overrides, invalid identifiers, incompatible combinations, direct callers, and completion.

Verified with the complete CLI package test suite, the repository type check, deno fmt --check, deno lint, and independent forward and reverse reviews.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit syntax selection for piped input in `cf view` via `--language` and `--filename`. This lets generated or unnamed sources render with the right syntax while keeping the pipe read-only and disabling auto-diff detection.

- **New Features**
  - `--language <id>` selects a stable language (`typescript`, `markdown`, `json`, `yaml`, `python`, `plain-text`); help and shell completion read from the registry.
  - `--filename <name>` selects syntax as if the piped input had that name.
  - Precedence: language > filename. Both suppress diff and transformed-output auto-detection; virtual sources stay read-only; rendered views still work.
  - Validation: rejects use with a file argument, and rejects combining with `--diff`. Errors list accepted language IDs.
  - Docs updated (`README` and plan). Tests cover rendering, precedence, overrides, invalid identifiers/combos, direct callers, and completion.

<sup>Written for commit c06f2382a7f4cdac87af3493091b26f6ff3d0589. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

