### PR TITLE
test(ui): replace a real sleep in the cf-cfc-authorship retry test

### DIFF
--- a/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.test.ts
+++ b/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { FakeTime } from "@std/testing/time";
 import {
   authorshipStateForLabel,
   CFCFCAuthorship,
@@ -135,6 +136,13 @@ describe("CFCFCAuthorship", () => {
       }],
     };
     let labelAvailable = false;
+    // Open the fake clock up front. The component schedules its retry poll as a
+    // real setTimeout in `scheduleLabelRetry()`, which the `refreshLabel()` call
+    // below reaches through `reconcileLabelRetry()` — so the timer is armed
+    // there, not here. FakeTime only intercepts timers scheduled after it is
+    // installed, so it has to be in place before the element runs any of its own
+    // code. The `using` declaration restores the real clock when the test ends.
+    using time = new FakeTime();
     const element = new CFCFCAuthorship();
     Object.defineProperty(element, "isConnected", {
       value: true,
@@ -156,7 +164,15 @@ describe("CFCFCAuthorship", () => {
       expect(element.authorshipState).not.toBe("verified");
 
       labelAvailable = true;
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      // Advance the clock. runAllAsync() is the actual advance: it jumps logical
+      // time to the one pending retry timer and fires it, so the test never
+      // hardcodes the poll interval. Firing the retry starts an async re-read of
+      // the now-loaded resolved label (getCfcLabel resolves through microtasks).
+      // runAllAsync drains microtasks before each timer it fires, not after the
+      // last one, so runMicrotasks() flushes that trailing re-read to completion.
+      // runMicrotasks() does not move the clock.
+      await time.runAllAsync();
+      await time.runMicrotasks();
 
       expect(element.authorshipState).toBe("verified");
     } finally {


### PR DESCRIPTION
The "retries the resolved cell label until its cold doc loads" test waited 150 milliseconds of real wall-clock time for the component to re-resolve a label. cf-cfc-authorship reads a bound value's CFC label through a pure, non-blocking store read; when the value resolves to a cell whose document has not loaded yet, that read returns nothing. The component does not subscribe to the internally-resolved cell, so it schedules a repeating timer to re-read the label until it lands. The test drove that timer by sleeping past one poll interval.

That sleep is the kind of wait this repository is removing. It puts a floor under the test's runtime and, being timing-based, flakes when the machine is loaded or paused: the retry interval is a production constant, so a sleep sized just above it is only ever a heuristic, not a guarantee.

The re-resolution depends on a genuine production timer rather than on microtasks, so the honest replacement is a controlled clock. Open a FakeTime (from @std/testing/time) with a `using` declaration before the element is wired up, so the retry timer is armed on the fake clock. Then fire that timer explicitly with runAllAsync and flush the promise chain the fired retry starts with runMicrotasks, instead of advancing real time. This matches the lighter of the two fake-clock approaches the waiting-in-tests guidance describes — a directly-imported FakeTime for the one test that measures a delay, rather than a package-wide preload.

The test keeps its teeth: neutralizing the component's retry scheduling makes it fail, and it fails for the right reason, reporting the authorship state as "unknown" because the label never re-lands, rather than timing out. The whole file now runs in about twenty milliseconds instead of being dominated by the single sleep.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the 150ms real-time sleep in the `cf-cfc-authorship` retry test with a controlled fake clock to make the test fast and deterministic.

- **Refactors**
  - Use `FakeTime` from `@std/testing/time` (via `using`) before component setup so the retry timer is registered on the fake clock.
  - Trigger the retry with `time.runAllAsync()` and flush the follow-up microtasks with `time.runMicrotasks()`.
  - Removes timing-based flakiness and speeds the test file to ~20ms.

<sup>Written for commit 40bfbf711ca96b004a30c17b1c0315e124f376fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

