### PR TITLE
dashboard: show Fabric Wall shortcut in header

### DIFF
--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -9,7 +9,6 @@ import {
   shell,
 } from "./render.ts";
 import { humanSpan } from "./lib.ts";
-import { REPO } from "./config.ts";
 import { FAVICON_VERSION } from "./favicon.ts";
 
 const TEST_VERSION = "1".repeat(40);
@@ -355,9 +354,9 @@ Deno.test("shell: server-measured red age changes the favicon after one hour", (
   assert(!html.includes("faviconSvg"));
 });
 
-Deno.test("shell: the repo name in the header is escaped", () => {
+Deno.test("shell: the header names the Fabric Wall shortcut", () => {
   assertStringIncludes(
     shell("", "", 0, 1000, TEST_VERSION, "good"),
-    `<span>${REPO.replace(/&/g, "&amp;")}</span>`,
+    "<span>go/fabricwall</span>",
   );
 });

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -2,7 +2,6 @@
 // the shell wraps the grid + wide tiles in the dark page with the SSE client.
 import type { TileView } from "./types.ts";
 import { durationTag, escapeHtml, STATUS_DOT } from "./lib.ts";
-import { REPO } from "./config.ts";
 import { faviconHref, faviconLink, type FaviconStatus } from "./favicon.ts";
 import { paintStatusFavicon } from "./favicon-client.ts";
 
@@ -130,9 +129,7 @@ ${faviconLink(status)}
   code{background:#1b1e24;padding:1px 5px;border-radius:4px}
 </style></head><body>
   <div class="top">
-    <div class="brand"><b>Fabric wall</b><span class="badge" id="livebadge">● LIVE</span><span>${
-    escapeHtml(REPO)
-  }</span></div>
+    <div class="brand"><b>Fabric wall</b><span class="badge" id="livebadge">● LIVE</span><span>go/fabricwall</span></div>
     <div class="live"><span class="dot green" id="freshdot"></span> <span id="agotext">updated ${ago}s ago</span></div>
   </div>
   <div class="grid" id="dashboard-grid">${gridHtml}</div>


### PR DESCRIPTION
The dashboard header exposed the GitHub repository name even though the intended display text is the Fabric Wall shortcut. This also tied the visible label to the repository setting used for API requests.\n\nRender go/fabricwall as fixed header text while leaving DASHBOARD_REPO responsible for backend repository selection. Update the shell rendering test to cover the new label.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the Fabric Wall shortcut `go/fabricwall` in the dashboard header instead of the GitHub repo name. Keep `DASHBOARD_REPO` for backend repo selection; remove header dependency on `REPO` and update the shell render test.

<sup>Written for commit f188014513fd0c2eadc4b1bb6c3275dd098f7fad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

