### PR TITLE
fix(runner): stop a dialog replica from racing its own long-running turn

### DIFF
--- a/docs/development/proposals/retiring-llm-tool-call-deadlines.md
+++ b/docs/development/proposals/retiring-llm-tool-call-deadlines.md
@@ -4,8 +4,7 @@ _Replacing the wall-clock deadline on LLM tool calls with a quiescence barrier
 scoped to a single pattern run, so a tool call ends because the work finished or
 because it was cancelled — never because a timer fired._
 
-**Status:** phases 1, 2, 3 and 5 landed; phase 4 outstanding · **Updated:**
-2026-07-29
+**Status:** all phases landed · **Updated:** 2026-07-29
 
 ---
 
@@ -226,7 +225,7 @@ someone cancels." The second is truthful, and phase 2 is what makes "someone
 cancels" a real option. It is also more visible, which is a product consequence
 worth stating rather than discovering.
 
-## Phase 4 — narrow the message-drop heuristic, which cannot be removed
+## Phase 4 — narrow the message-drop heuristic, which cannot be removed (landed)
 
 `pending` and `internal` are durable cells and a dialog runs in more than one
 replica. `safelyPerformUpdate` refreshes `internal.lastActivity` on every durable
@@ -240,15 +239,110 @@ An early fire lets a second request start alongside a live one; the `requestId`
 guard then rejects the older turn's writes, so the cost is a wasted model call
 rather than corrupted state.
 
-Narrow it rather than remove it. When *this* replica holds the turn no detection
-is needed — it knows. After phase 1 the turn is a single promise spanning the
-whole conversation, so a flag set when it starts and cleared when it settles
-answers exactly, and the heartbeat is consulted only for a turn belonging to
-another replica.
+The bound stays, and the set of turns it is asked about got smaller. When *this*
+replica holds the turn no detection is needed — it knows. Phase 1 made the turn
+a single promise spanning the whole conversation, and `llmDialog` now keeps the
+request id of the turn it is running in a closure variable,
+`localTurnRequestId`. It is set alongside the `trackAsyncWork` registration and
+cleared in a `finally` on the same promise, so its lifetime is exactly the
+turn's, and `startRequest` is an `async function`, so it cannot throw before the
+`finally` is attached. Setting the variable in the `addMessage` handler instead
+would leak it whenever the post-commit callback returns early and creates no
+promise for the `finally` to hang on — not in the supersede case that check is
+named for, where the next handler has already overwritten the variable with its
+own id, but when the reactive action has set `requestId` to `undefined` because
+`pending` went false in between. A superseded turn can also settle after a newer
+one has claimed the variable, so the clear only fires for the turn that still
+holds it.
 
-That also fixes a live bug: a turn running longer than five minutes without a
-durable write stops refreshing the heartbeat, so today the replica running it
-accepts a new message and starts a second request **against itself**.
+`addMessage` reads the durable `requestId` alongside `pending`. A pending turn
+whose id is the one this replica is running is dropped outright; only a turn with
+some other id reaches the heartbeat read. Comparing against the durable id rather
+than the closure's own `requestId` matters: the reactive action clears
+`requestId` as soon as `pending` goes false, while the local turn is still
+winding down, and the durable id changes exactly when a different turn becomes
+the canonical one.
+
+That fixes the live bug the heuristic had: a turn running longer than five
+minutes without a durable write stops refreshing the heartbeat, so the replica
+running it used to accept a new message and start a second request **against
+itself**. The durable writes bracket a round of tool calls rather than falling
+between them, so the gaps that can reach five minutes are a single model call
+that runs that long, and a round of tool calls, which `executeToolCalls` runs
+one after another before writing their results. With phase 3 landed nothing
+bounds a tool call, so one of those on its own is enough.
+
+`packages/runner/test/llm-dialog-message-drop.test.ts` covers four cases. The
+second is the fix: a turn held open at `setMockResponseGate` while `clock.tick`
+moves logical time past the bound, after which a second message must reach
+neither the conversation nor the model. It counts requests at the mock gate, and
+against the previous code that count is two — the replica racing itself, which
+is the bug stated as an observation. The first is the everyday case the block
+existed for before any of this, a local turn young enough that the heartbeat
+would have caught it too; it passes either way today and is what a later
+refactor of the block would break silently.
+
+The last two hold the heartbeat where it still belongs, by putting `pending`
+back to true with no local turn running: within the bound the message is
+dropped, past it the message is taken. They are not a symmetric pair. The
+within-the-bound case is what proves the `pending` write reaches the dialog's own
+durable cell, since a dialog reading `pending` as false would have taken the
+message; the past-the-bound case rests on that and also guards the `finally`,
+failing if the clear is removed.
+
+**What the local branch gives up: nothing bounds a turn on it.** The old bound
+fired on a local turn whether that turn was healthy and long or genuinely stuck,
+and firing was the automatic repair for the stuck case — it aborted the wedged
+turn and started a fresh one. `startRequest` has waits that can hang with no
+abort coverage: `inputs.pull()` and the pinned-cell pulls at its head, a queue
+held by an earlier item, and the model call's own `fetch` and stream read, which
+carry no read deadline. A turn stuck in one of those now drops messages for as
+long as the tab lives.
+
+Taken deliberately, on two grounds. The repair was a guess, and it fired wrongly
+on exactly the case this phase is about, so keeping it means keeping the bug. And
+the determinate replacement is already present and already works: `pending`
+staying true is what makes `cf-prompt-input` show a stop button in place of send,
+`cancelGeneration` sets `pending` false, and the abort that follows reaches a
+running tool call rather than only the model call — `executeToolCall` races the
+signal and stops the child run. In the shipped chat UI a user
+cannot send into a pending dialog at all — the component blocks submit while
+`pending` holds — so the drop guard is a backstop for programmatic senders and
+for UIs that do not gate on `pending`, not the thing standing between a user and
+their message.
+
+The place a hung network call should be detected is the LLM client, where the
+information is, rather than a message-drop heuristic several layers above it.
+`packages/llm/src/client.ts` passes an abort signal to `fetch` and then reads the
+response stream in a loop with nothing watching for a peer that accepts the
+connection and then stops sending. That is the same shape as the deadlines in
+`fetch-utils.ts` noted below, and it belongs with them.
+
+**Refreshing the heartbeat on a schedule was considered and rejected.** It would
+close the remaining false positive, where a peer running a long turn looks gone
+to everyone else, and would let the bound come down. It needs a repeating timer,
+and it would put durable writes on a fixed interval from every replica running a
+turn. Under the runner's fake clock the cost is concrete rather than stylistic:
+a `setInterval` armed from `src/` is classified as a runtime timer, so the
+auto-advance pump would re-arm and fire it for as long as any dialog turn is
+open, moving logical time in tests that model no elapsed time at all. That is
+what carries the decision — a periodic heartbeat is not a timeout, a retry loop,
+or a sleep, so the rule in `AGENTS.md` does not reach it by name. The remaining
+false positive costs a wasted model call and no corrupted state, which is a
+smaller price.
+
+An event-driven refresh is available and narrower: `startRequest` passes
+`() => {}` as the streaming callback, under a standing `TODO(bf)`, and that
+callback fires on every text delta. Refreshing `lastActivity` from it would keep
+a long *model call* looking alive to peers with no timer at all. It does nothing
+for a long round of tool calls, which produce no deltas, so it narrows the
+remaining false positive rather than closing it, and it is worth taking on its
+own terms rather than as part of this.
+
+The surviving `Date.now()` read carries a comment naming that same fake-clock
+hazard: auto-advance can carry logical time past five minutes in a test that
+never meant to model elapsed time, and the branch it then takes is the one that
+accepts a message into a dialog whose turn is still running.
 
 ## Phase 5 — retire the real-clock exemptions (landed)
 

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -133,6 +133,10 @@ One line per archived document; each document's header carries the fuller
   — the CFC future-work epics (clause core, exchange rules/policy,
   observation classes, integrity floors, sqlite row-set, deployment flips),
   executed 2026-07.
+- [retiring-llm-tool-call-deadlines.md](development/proposals/retiring-llm-tool-call-deadlines.md)
+  — replacing the LLM tool-call deadline with a run-scoped quiescence barrier,
+  and narrowing the dialog message-drop heuristic the deadline's argument did
+  not reach, executed 2026-07.
 - [STANDARD_DECORATORS_MIGRATION_PLAN.md](development/STANDARD_DECORATORS_MIGRATION_PLAN.md)
   — the cutover to standard decorators.
 - [content-addressed-action-identity-implementation-plan.md](specs/content-addressed-action-identity-implementation-plan.md)

--- a/docs/history/development/proposals/retiring-llm-tool-call-deadlines.md
+++ b/docs/history/development/proposals/retiring-llm-tool-call-deadlines.md
@@ -371,7 +371,8 @@ still firing.
 `fetch-utils.ts` and `fetch-program.ts` carry their own deadlines. Those raise a
 different question — what to do when a remote peer never answers — and are out
 of scope here. That question is settled separately in [The Fetch Builtins'
-Request Deadlines](../fetch-request-deadlines.md), which finds that neither
+Request Deadlines](../../../development/fetch-request-deadlines.md), which finds
+that neither
 deadline bounds a request at all: each is a lease on a claim held in durable
 state, and it decides when the replica holding that claim is presumed gone.
 Like the heartbeat bound in phase 4, both stay, because nothing reports another

--- a/docs/history/development/proposals/retiring-llm-tool-call-deadlines.md
+++ b/docs/history/development/proposals/retiring-llm-tool-call-deadlines.md
@@ -1,3 +1,10 @@
+---
+status: historical
+created: 2026-07-29
+archived: 2026-07-29
+reason: "Executed plan; the tool-call deadline is gone and the message-drop heuristic is narrowed."
+---
+
 # Retiring the LLM Tool-Call Deadline
 
 _Replacing the wall-clock deadline on LLM tool calls with a quiescence barrier
@@ -28,7 +35,7 @@ Do not delete it on the strength of the argument for the first.
 
 `TOOL_CALL_TIMEOUT` was the shape `AGENTS.md` rules out: a bound on how long
 success may take. By the test in
-[`waiting-in-tests.md`](../waiting-in-tests.md#wall-clock-time-is-not-a-measure-of-progress)
+[`waiting-in-tests.md`](../../../development/waiting-in-tests.md#wall-clock-time-is-not-a-measure-of-progress)
 — "is firing early safe?" — it is not. Firing early discards a real result and
 misreports it to the model as a failure.
 
@@ -352,7 +359,7 @@ With no deadline in the tool call, the three cases in
 fire early. They are folded back into `generate-object-tools.test.ts` and
 `llm-dialog.test.ts`, both split files are deleted, both entries are gone from
 the runner preload's `realClockFiles`, and the "dynamic-schema subagent shape"
-section is gone from [`waiting-in-tests.md`](../waiting-in-tests.md). Only the
+section is gone from [`waiting-in-tests.md`](../../../development/waiting-in-tests.md). Only the
 resume test is left on the list, and it is there for an unrelated reason.
 
 Each case asserts on the delegate's own tool result, so this step proves itself:

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2353,6 +2353,7 @@ function createToolResultMessages(
 }
 
 export const llmDialogTestHelpers = {
+  REQUEST_TIMEOUT,
   getCellSchema,
   parseLLMFriendlyLink,
   traverseAndSerialize,
@@ -3001,6 +3002,12 @@ export function llmDialog(
   let cellScope: CellScope | undefined;
   let requestId: string | undefined = undefined;
   let abortController: AbortController | undefined = undefined;
+  // The request id of the turn this replica is running, if any. Set when that
+  // turn's promise is registered with `trackAsyncWork` and cleared when the
+  // promise settles, so it spans the whole conversation the turn drives,
+  // including its tool calls. A turn running here needs no failure detection:
+  // this replica knows it is alive.
+  let localTurnRequestId: string | undefined = undefined;
 
   // This is called when the pattern containing this node is being stopped.
   addCancel(() => {
@@ -3098,16 +3105,45 @@ export function llmDialog(
         // Cast is necessary as .key doesn't yet correctly handle Stream<>
         result.key("addMessage") as unknown as Stream<BuiltInLLMMessage>,
         (tx: IExtendedStorageTransaction, event: BuiltInLLMMessage) => {
-          if (
-            pending.withTx(tx).get() && (
+          if (pending.withTx(tx).get()) {
+            // A message added while a turn is running is dropped. The add
+            // message UI should either be disabled or change the send button
+            // to be a stop button.
+            const activeRequestId = internal.withTx(tx).key("requestId").get();
+            if (
+              localTurnRequestId !== undefined &&
+              localTurnRequestId === activeRequestId
+            ) {
+              // The running turn is this replica's own, so its liveness is not
+              // in question and the heartbeat is not consulted. A turn can run
+              // longer than the heartbeat's staleness bound without a durable
+              // write, and the heartbeat then reads stale for a turn that is
+              // plainly alive. The writes bracket a round of tool calls rather
+              // than falling between them, and nothing bounds a tool call, so a
+              // single one that runs long enough is already such a gap.
+              //
+              // Nothing bounds a turn on this branch. A local turn that never
+              // settles keeps dropping messages until `cancelGeneration` sets
+              // `pending` false, which is the stop button `cf-prompt-input`
+              // shows in place of send for as long as `pending` holds.
+              return;
+            }
+            // The turn belongs to another replica. `lastActivity` is that
+            // replica's heartbeat, refreshed by `safelyPerformUpdate` on every
+            // durable write of the turn, and a stale one is the only sign
+            // available that the tab which started the turn went away.
+            //
+            // This `Date.now()` is a latent hazard under the runner's fake
+            // clock, whose auto-advance can carry logical time past the
+            // five-minute mark in a test that never meant to model elapsed
+            // time. The branch it then takes accepts a message into a dialog
+            // whose turn is still running.
+            if (
               internal.withTx(tx).key("lastActivity").get() >
                 Date.now() - REQUEST_TIMEOUT
-            )
-          ) {
-            // For now, let's drop messages added while request is pending for
-            // less than five minutes. Add message UI should either be disabled
-            // or change the send button to be a stop button.
-            return;
+            ) {
+              return;
+            }
           }
 
           // Before starting request, set pending and append the new message.
@@ -3161,6 +3197,9 @@ export function llmDialog(
               }
 
               abortController = new AbortController();
+              // Set alongside starting the turn and cleared when the turn's
+              // promise settles, so the flag's lifetime is exactly the turn's.
+              localTurnRequestId = nextRequestId;
               // Track the dialog turn (LLM call + writeback) as async builtin
               // work owned by this run, so `runtime.settled()` and
               // `runtime.settledFor(parentCell)` both wait for the result;
@@ -3178,7 +3217,15 @@ export function llmDialog(
                   nextRequestId,
                   abortController.signal,
                   capturedRequest,
-                ),
+                ).finally(() => {
+                  // A superseded turn keeps running until its abort reaches
+                  // every await inside it, so it can settle after a newer turn
+                  // has claimed the flag. Only the turn that still holds the
+                  // flag clears it.
+                  if (localTurnRequestId === nextRequestId) {
+                    localTurnRequestId = undefined;
+                  }
+                }),
                 parentCell,
               );
             },

--- a/packages/runner/test/llm-dialog-message-drop.test.ts
+++ b/packages/runner/test/llm-dialog-message-drop.test.ts
@@ -15,9 +15,9 @@
  * that split. The second is the one that used to be wrong: a turn making no
  * durable writes for longer than the bound had the replica running it declare
  * the turn dead and start a second request against itself. A single model call
- * that runs that long produces such a turn, and so does a round of several
- * tool calls, which run one after another and write their results only once
- * they have all returned.
+ * that runs that long produces such a turn. So does a tool call, which nothing
+ * bounds, and so does a round of several, which run one after another and write
+ * their results only once they have all returned.
  *
  * The two peer cases put `pending` back to true with no turn running locally.
  * That the write reaches the dialog's own durable cell is what the

--- a/packages/runner/test/llm-dialog-message-drop.test.ts
+++ b/packages/runner/test/llm-dialog-message-drop.test.ts
@@ -1,0 +1,324 @@
+/// <reference path="./clock.d.ts" />
+/**
+ * A message added while a dialog turn is already running is dropped, and how
+ * `addMessage` decides a turn is still running depends on who is running it.
+ *
+ * A dialog is durable and runs in more than one replica, so a turn started in
+ * one tab is visible in another as `pending` being true. For a turn belonging
+ * to another replica the only signal available is `internal.lastActivity`, a
+ * heartbeat refreshed on every durable write of the turn, and `REQUEST_TIMEOUT`
+ * is the bound past which that replica is presumed gone. Nothing distinguishes
+ * a crashed peer from a slow one, so the bound stays.
+ *
+ * For a turn this replica is running there is nothing to detect: it knows the
+ * turn is alive, because it is the one running it. The four cases below pin
+ * that split. The second is the one that used to be wrong: a turn making no
+ * durable writes for longer than the bound had the replica running it declare
+ * the turn dead and start a second request against itself. A single model call
+ * that runs that long produces such a turn, and so does a round of several
+ * tool calls, which run one after another and write their results only once
+ * they have all returned.
+ *
+ * The two peer cases put `pending` back to true with no turn running locally.
+ * That the write reaches the dialog's own durable cell is what the
+ * within-the-bound case proves, by dropping a message that a dialog reading
+ * `pending` as false would have taken; the past-the-bound case rests on it.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  clearMockResponses,
+  enableMockMode,
+  loadConversationFixture,
+  setMockResponseGate,
+} from "@commonfabric/llm/client";
+import type { BuiltInLLMMessage, JSONSchema } from "@commonfabric/api";
+import { defer } from "@commonfabric/utils/defer";
+import { createBuilder } from "../src/builder/factory.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
+import { llmDialogTestHelpers } from "../src/builtins/llm-dialog.ts";
+
+const { REQUEST_TIMEOUT } = llmDialogTestHelpers;
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+enableMockMode();
+
+const resultSchema = {
+  type: "object",
+  properties: {
+    addMessage: { ...LLMMessageSchema, asCell: ["stream"] },
+    pending: { type: "boolean" },
+    messages: {
+      type: "array",
+      items: { type: "object", additionalProperties: true },
+    },
+  },
+  required: ["addMessage"],
+} as const satisfies JSONSchema;
+
+describe("llmDialog drops messages added during a running turn", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let Cell: ReturnType<typeof createBuilder>["commonfabric"]["Cell"];
+  let pattern: ReturnType<typeof createBuilder>["commonfabric"]["pattern"];
+  let llmDialog: ReturnType<typeof createBuilder>["commonfabric"]["llmDialog"];
+
+  beforeEach(() => {
+    clearMockResponses();
+    clock.reset();
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+
+    const { commonfabric } = createTrustedBuilder(runtime);
+    ({ pattern, llmDialog, Cell } = commonfabric);
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime.idle();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  // Start the dialog and return its result cell. The caller sends messages
+  // through `addMessage` and reads `messages` and `pending` back.
+  const startDialog = (cause: string) => {
+    const testPattern = pattern(
+      () => {
+        const messages = Cell.of<BuiltInLLMMessage[]>([]);
+        const dialog = llmDialog({ messages });
+        return {
+          addMessage: dialog.addMessage,
+          pending: dialog.pending,
+          messages,
+        };
+      },
+      false,
+      resultSchema,
+    );
+
+    const resultCell = runtime.getCell(space, cause, resultSchema, tx);
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    tx.commit();
+    return result;
+  };
+
+  // deno-lint-ignore no-explicit-any
+  const contentsOf = (result: any) =>
+    (result.withTx().key("messages").get() ?? []).map(
+      (message: BuiltInLLMMessage) => message.content,
+    );
+
+  it("drops while its own turn runs within the staleness bound", async () => {
+    loadConversationFixture({
+      description: "one answer for the held turn, one a second request would " +
+        "take if the dropped message started one",
+      responses: [
+        {
+          type: "sendRequest",
+          response: { role: "assistant", content: "Hi there!", id: "r1" },
+        },
+        {
+          type: "sendRequest",
+          response: { role: "assistant", content: "Second answer", id: "r2" },
+        },
+      ],
+    });
+
+    const result = startDialog("llmDialog-message-drop-own-fresh-turn");
+
+    let requestsSeen = 0;
+    const requestReached = defer<void>();
+    const held = defer<void>();
+    setMockResponseGate(() => {
+      requestsSeen++;
+      requestReached.resolve();
+      return held.promise;
+    });
+
+    const addMessage = await result.key("addMessage").pull();
+    addMessage.send({ role: "user", content: "First" });
+    await requestReached.promise;
+
+    // The ordinary case, and what the whole `pending` block was there for
+    // before any of this: a second message arrives while the turn that is
+    // running is young enough that the heartbeat would have caught it too.
+    addMessage.send({ role: "user", content: "Second" });
+    await clock.settle();
+
+    held.resolve();
+    await runtime.settled();
+
+    expect(contentsOf(result)).toEqual(["First", "Hi there!"]);
+    expect(requestsSeen).toBe(1);
+    expect(result.withTx().key("pending").get()).toBe(false);
+  });
+
+  it("keeps dropping while its own turn runs past the staleness bound", async () => {
+    loadConversationFixture({
+      description: "one answer for the held turn, one a second request would " +
+        "take if the dropped message started one",
+      responses: [
+        {
+          type: "sendRequest",
+          response: { role: "assistant", content: "Hi there!", id: "r1" },
+        },
+        {
+          type: "sendRequest",
+          response: { role: "assistant", content: "Second answer", id: "r2" },
+        },
+      ],
+    });
+
+    const result = startDialog("llmDialog-message-drop-own-turn");
+
+    // Hold the model's answer so the turn stays genuinely in flight, and count
+    // the requests that reach the model. A dropped message starts no request,
+    // so the count is what separates the two outcomes.
+    let requestsSeen = 0;
+    const requestReached = defer<void>();
+    const held = defer<void>();
+    setMockResponseGate(() => {
+      requestsSeen++;
+      requestReached.resolve();
+      return held.promise;
+    });
+
+    const addMessage = await result.key("addMessage").pull();
+    addMessage.send({ role: "user", content: "First" });
+
+    // The gate is entered from inside the turn, so this is the turn announcing
+    // that it is running rather than a guess that it has started by now.
+    await requestReached.promise;
+    expect(result.withTx().key("pending").get()).toBe(true);
+
+    // Move logical time past the staleness bound while the turn is held. This
+    // is the shape of a long tool call: the turn is running and writing
+    // nothing durable, so the heartbeat it would refresh stands still and goes
+    // stale under a replica that is plainly alive.
+    const before = Date.now();
+    await clock.tick(REQUEST_TIMEOUT + 60_000);
+    expect(Date.now() - before).toBeGreaterThan(REQUEST_TIMEOUT);
+
+    addMessage.send({ role: "user", content: "Second" });
+    // Drain reactive work to a fixpoint, so a second request this message was
+    // going to start has started by the time the gate count is read.
+    await clock.settle();
+    expect(requestsSeen).toBe(1);
+
+    held.resolve();
+    await runtime.settled();
+
+    // The dropped message never reached the conversation, and the held turn
+    // finished as the only turn there was.
+    expect(contentsOf(result)).toEqual(["First", "Hi there!"]);
+    expect(requestsSeen).toBe(1);
+    expect(result.withTx().key("pending").get()).toBe(false);
+  });
+
+  it("drops while another replica's turn is within the staleness bound", async () => {
+    loadConversationFixture({
+      description: "one answer, plus one a second request would take",
+      responses: [
+        {
+          type: "sendRequest",
+          response: { role: "assistant", content: "Hi there!", id: "r1" },
+        },
+        {
+          type: "sendRequest",
+          response: { role: "assistant", content: "Second answer", id: "r2" },
+        },
+      ],
+    });
+
+    const result = startDialog("llmDialog-message-drop-live-peer");
+
+    const addMessage = await result.key("addMessage").pull();
+    addMessage.send({ role: "user", content: "First" });
+    await runtime.settled();
+    expect(contentsOf(result)).toEqual(["First", "Hi there!"]);
+
+    // The finished turn left a fresh heartbeat behind. Putting `pending` back
+    // to true is what this replica sees when another one starts a turn: the
+    // flag is durable, and only the replica running the turn holds anything
+    // more than the heartbeat.
+    let requestsSeen = 0;
+    setMockResponseGate(() => {
+      requestsSeen++;
+      return Promise.resolve();
+    });
+    const pendingTx = runtime.edit();
+    result.withTx(pendingTx).key("pending").set(true);
+    await pendingTx.commit();
+    await runtime.settled();
+
+    addMessage.send({ role: "user", content: "Second" });
+    await runtime.settled();
+
+    expect(contentsOf(result)).toEqual(["First", "Hi there!"]);
+    expect(requestsSeen).toBe(0);
+  });
+
+  it("accepts once another replica's turn passes the staleness bound", async () => {
+    loadConversationFixture({
+      description: "one answer, then the answer to the message that takes " +
+        "over from the presumed-gone replica",
+      responses: [
+        {
+          type: "sendRequest",
+          response: { role: "assistant", content: "Hi there!", id: "r1" },
+        },
+        {
+          type: "sendRequest",
+          response: { role: "assistant", content: "Second answer", id: "r2" },
+        },
+      ],
+    });
+
+    const result = startDialog("llmDialog-message-drop-gone-peer");
+
+    const addMessage = await result.key("addMessage").pull();
+    addMessage.send({ role: "user", content: "First" });
+    await runtime.settled();
+    expect(contentsOf(result)).toEqual(["First", "Hi there!"]);
+
+    let requestsSeen = 0;
+    setMockResponseGate(() => {
+      requestsSeen++;
+      return Promise.resolve();
+    });
+    const pendingTx = runtime.edit();
+    result.withTx(pendingTx).key("pending").set(true);
+    await pendingTx.commit();
+    await runtime.settled();
+
+    // No replica refreshed the heartbeat for longer than the bound, so the one
+    // that started the turn is presumed gone and the message is taken. This
+    // replica is running no turn of its own, so it has nothing better to go on.
+    await clock.tick(REQUEST_TIMEOUT + 60_000);
+
+    addMessage.send({ role: "user", content: "Second" });
+    await runtime.settled();
+
+    expect(contentsOf(result)).toEqual([
+      "First",
+      "Hi there!",
+      "Second",
+      "Second answer",
+    ]);
+    expect(requestsSeen).toBe(1);
+  });
+});

--- a/packages/runner/test/llm-dialog-message-drop.test.ts
+++ b/packages/runner/test/llm-dialog-message-drop.test.ts
@@ -94,8 +94,10 @@ describe("llmDialog drops messages added during a running turn", () => {
   });
 
   // Start the dialog and return its result cell. The caller sends messages
-  // through `addMessage` and reads `messages` and `pending` back.
-  const startDialog = (cause: string) => {
+  // through `addMessage` and reads `messages` and `pending` back. The setup
+  // commit is awaited so a failure to write the dialog into place is reported
+  // here rather than as whatever the rest of the case does without it.
+  const startDialog = async (cause: string) => {
     const testPattern = pattern(
       () => {
         const messages = Cell.of<BuiltInLLMMessage[]>([]);
@@ -112,7 +114,8 @@ describe("llmDialog drops messages added during a running turn", () => {
 
     const resultCell = runtime.getCell(space, cause, resultSchema, tx);
     const result = runtime.run(tx, testPattern, {}, resultCell);
-    tx.commit();
+    const { error } = await tx.commit();
+    if (error) throw error;
     return result;
   };
 
@@ -138,7 +141,7 @@ describe("llmDialog drops messages added during a running turn", () => {
       ],
     });
 
-    const result = startDialog("llmDialog-message-drop-own-fresh-turn");
+    const result = await startDialog("llmDialog-message-drop-own-fresh-turn");
 
     let requestsSeen = 0;
     const requestReached = defer<void>();
@@ -183,7 +186,7 @@ describe("llmDialog drops messages added during a running turn", () => {
       ],
     });
 
-    const result = startDialog("llmDialog-message-drop-own-turn");
+    const result = await startDialog("llmDialog-message-drop-own-turn");
 
     // Hold the model's answer so the turn stays genuinely in flight, and count
     // the requests that reach the model. A dropped message starts no request,
@@ -244,7 +247,7 @@ describe("llmDialog drops messages added during a running turn", () => {
       ],
     });
 
-    const result = startDialog("llmDialog-message-drop-live-peer");
+    const result = await startDialog("llmDialog-message-drop-live-peer");
 
     const addMessage = await result.key("addMessage").pull();
     addMessage.send({ role: "user", content: "First" });
@@ -288,7 +291,7 @@ describe("llmDialog drops messages added during a running turn", () => {
       ],
     });
 
-    const result = startDialog("llmDialog-message-drop-gone-peer");
+    const result = await startDialog("llmDialog-message-drop-gone-peer");
 
     const addMessage = await result.key("addMessage").pull();
     addMessage.send({ role: "user", content: "First" });


### PR DESCRIPTION
`llmDialog`'s `addMessage` handler drops a message added while a turn is already running. A dialog is durable and runs in more than one replica, so the handler has to decide whether the turn that `pending` reports is still being worked on. It decided by reading `internal.lastActivity`, a heartbeat that `safelyPerformUpdate` refreshes on every durable write of a turn, and treating a heartbeat older than five minutes as evidence that the tab which started the turn went away.

That question only makes sense for a turn belonging to another replica, and the handler was asking it about every turn, including its own. A turn can run longer than five minutes without a durable write, and it then stops refreshing the heartbeat while it is plainly still running. The replica running such a turn read its own stale heartbeat, concluded the turn was dead, accepted the new message, and started a second request against itself. The `requestId` guard then discarded the first turn's writeback, so the state stayed coherent and the cost was a wasted model call and a lost turn.

The durable writes bracket a round of tool calls rather than falling between them: the assistant message goes down before the round and the tool results after it. So the gaps that can reach five minutes today are a single model call that runs that long, and a round of several tool calls, which `executeToolCalls` runs one after another. A single tool call joins them once the tool-call deadline is retired.

When this replica holds the turn there is nothing to detect: it knows. An earlier change made a turn a single promise spanning the whole conversation it drives, tool calls included, so `llmDialog` now keeps that turn's request id in a closure variable. It is set alongside the `trackAsyncWork` registration and cleared in a `finally` on the same promise, giving it exactly the turn's lifetime; `startRequest` is an `async function`, so it cannot throw before the `finally` is attached. A superseded turn can settle after a newer one has claimed the variable, so the clear only fires for the turn that still holds it.

Setting the variable in the handler instead would leak it whenever the post-commit callback returns early and creates no promise for a `finally` to hang on. Not in the supersede case that callback's request-id check is named for — there the next handler has already overwritten the variable with its own id — but when the reactive action sets `requestId` to `undefined` because `pending` went false in between.

`addMessage` now reads the durable request id alongside `pending`: a pending turn this replica is running is dropped outright, and only a turn with some other id reaches the heartbeat. Comparing against the durable id rather than the closure's own `requestId` matters, because the reactive action clears that one as soon as `pending` goes false, while the local turn is still winding down.

The heartbeat and its five-minute bound stay. Nothing distinguishes a crashed peer from a slow one, so failure detection across replicas cannot be made exact, and an early fire there costs a wasted model call rather than corrupted state.

Refreshing the heartbeat on a schedule during a long turn was considered and rejected. It would close the remaining false positive, where a peer running a long turn looks gone to everyone else, but it needs a repeating timer and would put durable writes on a fixed interval from every replica running a turn. Under the test fake clock a timer armed from runtime code is auto-advanced, so the pump would re-arm and fire it for as long as any dialog turn is open, moving logical time in tests that model no elapsed time at all. An event-driven refresh is narrower and is recorded as follow-up: the streaming callback that `startRequest` currently discards under a standing `TODO(bf)` would keep a long model call looking alive to peers with no timer, though it does nothing for a long round of tool calls, which produce no deltas.

The surviving `Date.now()` read carries a comment naming a hazard from the other side: under the fake clock, auto-advance can carry logical time past the five-minute mark in a test that never meant to model elapsed time, and the branch it then takes accepts a message into a dialog whose turn is still running.

The change gives one thing up. The old bound fired on a local turn whether that turn was healthy and long or genuinely stuck, and firing was the automatic repair for the stuck case: it aborted the wedged turn and started a fresh one. `startRequest` has waits that can hang with no abort coverage — the pulls at its head, a queue held by an earlier item, and the model call's own fetch and stream read, which carry no read deadline. A turn stuck in one of those now drops messages for as long as the tab lives. The trade stands, because the repair was a guess that fired wrongly on exactly the case being fixed, and because the determinate replacement is already wired: `pending` staying true is what makes `cf-prompt-input` show a stop button in place of send and block submit entirely, `cancelGeneration` sets `pending` false, and the abort that follows reaches a running tool call rather than only the model call. The proposal records this, and points at the LLM client's unwatched stream read as where a hung network call should be detected.

The new test covers four cases. A turn held open at the mock response gate while logical time moves past the bound must leave a second message reaching neither the conversation nor the model; it counts requests at the gate, and against the previous code that count is two. A turn young enough that the heartbeat would have caught it too covers the everyday shape the block existed for, which had no coverage and which a later refactor would break silently. Two more put `pending` back to true with no local turn running: the within-the-bound one proves that write reaches the dialog's own durable cell, and the past-the-bound one rests on that and additionally fails if the `finally` clearing the turn's request id is removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `llmDialog` racing its own long-running turn by distinguishing local vs. remote turns in `addMessage`. Prevents duplicate requests, wasted model calls, and lost turns while keeping peer liveness checks.

- **Bug Fixes**
  - Track the local turn via `localTurnRequestId`; set at start, clear in `finally` only if it still matches; spans the LLM call and all tool calls.
  - In `addMessage`, if `pending` and durable `internal.requestId` equals `localTurnRequestId`, drop immediately; otherwise consult `internal.lastActivity` and drop only within `REQUEST_TIMEOUT` (5 minutes).
  - Keep the heartbeat-based peer check; add a note about the fake-clock hazard around `Date.now()`.
  - Export `REQUEST_TIMEOUT` from `llmDialogTestHelpers`.
  - Tests: add `packages/runner/test/llm-dialog-message-drop.test.ts` with four cases and mock request counting; setup now awaits `tx.commit()` and throws on error; notes that a single long tool call can exceed the bound.
  - Docs: archive `retiring-llm-tool-call-deadlines.md` to `docs/history/` with status metadata; update the history index and fix links, including the fetch-deadline reference.

<sup>Written for commit b0191f000c71c61f70c0a7c95ffe150cb08c7bd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

