### PR TITLE
Make `isArrayWithOnlyIndexProperties()` mean what its name says

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1185,8 +1185,8 @@ Section 4.5.
 - Sparse arrays (arrays with holes) are supported; holes are distinct from
   `undefined` and are represented using run-length encoding in serialized forms
   (see below and Section 3 of `3-json-encoding.md` for the specific JSON encoding)
-- Non-index keys cause rejection: both enumerable named (string-keyed)
-  properties and symbol-keyed properties of any enumerability
+- Non-index keys cause rejection, `length` aside: named (string-keyed) and
+  symbol-keyed properties alike, whether or not they are enumerable
 
 > **Holes vs. `undefined`.** A hole (sparse slot) is distinct from an
 > explicitly-set `undefined` element. Given `const a = [1, , 3]`, index `1` is

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -385,8 +385,10 @@ stored value contains only the essential native data (entries, items,
 epoch value, bytes respectively). Extra enumerable properties on the source
 native object cause **rejection** — the conversion function throws. This follows
 the principle "Death before confusion!" (Mark Miller): it is better to fail
-loudly than to silently lose data. This matches the treatment of arrays, where
-extra non-index properties also cause rejection (Section 1.5). Unlike `Error`,
+loudly than to silently lose data. This is in the same spirit as the treatment
+of arrays, where extra non-index properties also cause rejection (Section 1.5)
+— though the array rule is stricter still, rejecting non-enumerable and
+symbol-keyed properties as well. Unlike `Error`,
 these native types have no established convention for custom properties.
 
 #### 1.4.2 `FabricError`

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1185,7 +1185,8 @@ Section 4.5.
 - Sparse arrays (arrays with holes) are supported; holes are distinct from
   `undefined` and are represented using run-length encoding in serialized forms
   (see below and Section 3 of `3-json-encoding.md` for the specific JSON encoding)
-- Non-index keys (named properties on arrays) cause rejection
+- Non-index keys cause rejection: both enumerable named (string-keyed)
+  properties and symbol-keyed properties of any enumerability
 
 > **Holes vs. `undefined`.** A hole (sparse slot) is distinct from an
 > explicitly-set `undefined` element. Given `const a = [1, , 3]`, index `1` is

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -69,7 +69,8 @@ authoritative statement of these rules.
 
 - **Top-level**: Indicates deletion (remove the stored value)
 - **Object property**: Treated as absent (property is omitted)
-- **Array element**: Converted to `null` during storage
+- **Array element**: Stored as `undefined`, and remains distinguishable from
+  both a hole and a `null`
 
 #### Non-Fabric Types
 

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -43,11 +43,15 @@ All IEEE 754 binary64 values are accepted, including `-0`, `NaN`,
 
 #### Arrays
 
-- Must be dense (no holes)
-- Must not contain `undefined` elements
-- Sparse arrays are densified during conversion (`undefined` → `null`)
-- Non-index keys (named properties, and symbol keys) cause rejection as
-  non-fabric
+- May be dense or sparse; holes are preserved, and are distinct from an
+  explicitly-stored `undefined`
+- Elements may be `undefined`, that being a first-class fabric value
+- Non-index keys cause rejection as non-fabric, `length` aside: named
+  (string-keyed) and symbol-keyed properties alike, whether or not they are
+  enumerable
+
+See `space-model-formal-spec/1-fabric-values.md` Section 1.5 for the
+authoritative statement of these rules.
 
 #### Objects
 

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -46,7 +46,8 @@ All IEEE 754 binary64 values are accepted, including `-0`, `NaN`,
 - Must be dense (no holes)
 - Must not contain `undefined` elements
 - Sparse arrays are densified during conversion (`undefined` → `null`)
-- Non-index keys (named properties) cause rejection as non-fabric
+- Non-index keys (named properties, and symbol keys) cause rejection as
+  non-fabric
 
 #### Objects
 

--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -41,6 +41,7 @@ export {
   fabricFromNativeValue,
   isFabricCompatible,
   nativeFromFabricValue,
+  shallowCleanArray,
   shallowFabricFromNativeValue,
 } from "./native-conversion.ts";
 

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -142,11 +142,12 @@ export function shallowFabricFromNativeValue(
 
     case NATIVE_TAGS.Array: {
       // Arrays may only carry numeric index properties. An enumerable named
-      // property has no fabric representation, so reject it outright rather
-      // than silently dropping it ("death before confusion").
+      // property or a symbol-keyed one has no fabric representation, so reject
+      // it outright rather than silently dropping it ("death before
+      // confusion").
       if (!isArrayWithOnlyIndexProperties(value as unknown[])) {
         throw new Error(
-          "Cannot store array with enumerable named properties",
+          "Cannot store array with non-index properties",
         );
       }
       // Delegate frozenness handling to `cloneHelper()`.
@@ -530,7 +531,7 @@ function isFabricCompatibleInternal(
       seen.add(value);
 
       if (Array.isArray(value)) {
-        // Check array structure (no named properties).
+        // Check array structure (no non-index properties).
         if (!isArrayWithOnlyIndexProperties(value)) {
           seen.delete(value);
           return false;

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -198,7 +198,7 @@ export function shallowFabricFromNativeValue(
       // Arrays may only carry numeric index properties. A named property or a
       // symbol-keyed one has no fabric representation, so reject it outright
       // rather than silently dropping it ("death before confusion").
-      if (!isArrayWithOnlyIndexProperties(value as unknown[])) {
+      if (!isArrayWithOnlyIndexProperties(value)) {
         throw new Error(
           "Cannot store array with non-index properties",
         );

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -70,9 +70,14 @@ export function shallowCleanArray(
   const from = value as unknown as Record<string, unknown>;
   const to = result as unknown as Record<string, unknown>;
 
-  // `for...in` visits only the keys an array actually has, so a sparse one
-  // costs O(elements) rather than O(length) -- `length` can run to 2**32 - 2 --
-  // and it gets there without materializing a key array. It also yields any
+  // `for...in` visits only the keys an array actually has, so a sparse one --
+  // `length` can run to 2**32 - 2 -- does no JS-level work per absent slot, and
+  // no key array gets materialized either. Note this is a large constant
+  // factor, not a change of order: the engine still scans the index range to
+  // work out which keys exist, measured at roughly 10x per 10x of `length` on a
+  // two-element array. What it buys is that the scan happens inside the engine
+  // instead of as a JS iteration, which for a proxied array also means one
+  // `ownKeys` trap rather than a `has` trap per slot. It also yields any
   // named properties, which the index test drops, those being the whole point
   // of this function. Inherited keys are not a concern: this project bans
   // prototype pollution of the globals, and `Array.prototype`'s own methods are

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -37,8 +37,8 @@ function rejectExtraProperties(value: object, typeName: string): void {
 }
 
 /**
- * Returns a shallow clone of the given array carrying nothing but its index
- * properties and `length`, that is, one which satisfies
+ * Returns a shallow clone of the given array carrying nothing but its
+ * enumerable index properties and `length`, that is, one which satisfies
  * `isArrayWithOnlyIndexProperties()`. Holes are preserved as holes, and
  * elements are copied by reference without themselves being converted or
  * validated, this being a shallow operation.
@@ -63,10 +63,6 @@ export function shallowCleanArray(
   // present elements would leave `length` short.
   result.length = value.length;
 
-  // Iterate the own keys rather than counting from `0` to `length`: a sparse
-  // array's `length` can run to 2**32 - 2 while holding a handful of elements,
-  // and only the elements it actually has need copying. Every index key is
-  // necessarily below `length`, so none of these assignments extends it.
   // A canonical index string addresses exactly the element slot it names, so
   // these are indexed by key directly, with no number parsing. The record views
   // exist only to say as much to TypeScript, which otherwise rejects a string
@@ -74,8 +70,16 @@ export function shallowCleanArray(
   const from = value as unknown as Record<string, unknown>;
   const to = result as unknown as Record<string, unknown>;
 
-  for (const key of Reflect.ownKeys(value)) {
-    if ((typeof key === "string") && isArrayIndexPropertyName(key)) {
+  // `for...in` visits only the keys an array actually has, so a sparse one
+  // costs O(elements) rather than O(length) -- `length` can run to 2**32 - 2 --
+  // and it gets there without materializing a key array. It also yields any
+  // named properties, which the index test drops, those being the whole point
+  // of this function. Inherited keys are not a concern: this project bans
+  // prototype pollution of the globals, and `Array.prototype`'s own methods are
+  // non-enumerable. Every index key is necessarily below `length`, so none of
+  // these assignments extends it.
+  for (const key in value) {
+    if (isArrayIndexPropertyName(key)) {
       to[key] = from[key];
     }
   }

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -3,7 +3,10 @@ import {
   isRecord,
   isUnsafeObjectKey,
 } from "@commonfabric/utils/types";
-import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
+import {
+  isArrayIndexPropertyName,
+  isArrayWithOnlyIndexProperties,
+} from "@commonfabric/utils/arrays";
 
 import {
   type FabricOrConvertibleNativeValue,
@@ -31,6 +34,57 @@ function rejectExtraProperties(value: object, typeName: string): void {
       `Cannot store ${typeName} with extra enumerable properties`,
     );
   }
+}
+
+/**
+ * Returns a shallow clone of the given array carrying nothing but its index
+ * properties and `length`, that is, one which satisfies
+ * `isArrayWithOnlyIndexProperties()`. Holes are preserved as holes, and
+ * elements are copied by reference without themselves being converted or
+ * validated, this being a shallow operation.
+ *
+ * This exists for a caller holding an array that has picked up non-index own
+ * properties which it knows are not content -- a runtime annotation, say --
+ * and which the conversion functions here would therefore reject outright.
+ * Calling this is how such a caller says explicitly that it means to drop
+ * them. Code with no such warrant should let the rejection happen ("death
+ * before confusion").
+ *
+ * @param value The array to clean.
+ * @param frozen Whether to freeze the result. Defaults to `true`.
+ */
+export function shallowCleanArray(
+  value: unknown[],
+  frozen = true,
+): FabricValueLayer {
+  const result: unknown[] = [];
+
+  // Set the extent first, so that trailing holes survive; assigning only the
+  // present elements would leave `length` short.
+  result.length = value.length;
+
+  // Iterate the own keys rather than counting from `0` to `length`: a sparse
+  // array's `length` can run to 2**32 - 2 while holding a handful of elements,
+  // and only the elements it actually has need copying. Every index key is
+  // necessarily below `length`, so none of these assignments extends it.
+  // A canonical index string addresses exactly the element slot it names, so
+  // these are indexed by key directly, with no number parsing. The record views
+  // exist only to say as much to TypeScript, which otherwise rejects a string
+  // index on an array (TS7015).
+  const from = value as unknown as Record<string, unknown>;
+  const to = result as unknown as Record<string, unknown>;
+
+  for (const key of Reflect.ownKeys(value)) {
+    if ((typeof key === "string") && isArrayIndexPropertyName(key)) {
+      to[key] = from[key];
+    }
+  }
+
+  if (frozen) {
+    Object.freeze(result);
+  }
+
+  return result as FabricValueLayer;
 }
 
 /**

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -141,10 +141,9 @@ export function shallowFabricFromNativeValue(
     }
 
     case NATIVE_TAGS.Array: {
-      // Arrays may only carry numeric index properties. An enumerable named
-      // property or a symbol-keyed one has no fabric representation, so reject
-      // it outright rather than silently dropping it ("death before
-      // confusion").
+      // Arrays may only carry numeric index properties. A named property or a
+      // symbol-keyed one has no fabric representation, so reject it outright
+      // rather than silently dropping it ("death before confusion").
       if (!isArrayWithOnlyIndexProperties(value as unknown[])) {
         throw new Error(
           "Cannot store array with non-index properties",

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -41,7 +41,7 @@ export function isFabricValueLayer(
       }
       if (Array.isArray(value)) {
         // Arrays with `undefined` elements and sparse holes are accepted, but
-        // not arrays with enumerable named or symbol-keyed properties.
+        // not arrays carrying named or symbol-keyed properties.
         return isArrayWithOnlyIndexProperties(value);
       }
       // Plain objects are accepted; class instances are not (except
@@ -69,9 +69,9 @@ export function isFabricValueLayer(
  * Returns `true` for any scalar (`null`, `undefined`, `boolean`, `number`
  * -- including `-0`, `NaN`, and `±Infinity` -- `string`, `bigint`, and
  * registry-interned (`Symbol.for(...)`) symbols), any `FabricInstance` or
- * `FabricPrimitive`, an array of `FabricValue`s with no enumerable named
- * properties and no symbol-keyed ones (sparse holes allowed), or a plain
- * object whose values are all
+ * `FabricPrimitive`, an array of `FabricValue`s with no named or symbol-keyed
+ * properties, `length` aside (sparse holes allowed), or a plain object whose
+ * values are all
  * `FabricValue`s. Returns `false` for a `function` or a unique (uninterned)
  * symbol -- whether the value itself or reached anywhere within it -- and for
  * any other class instance (`Date`, `Map`, ...) not representable as a
@@ -133,8 +133,8 @@ export function isFabricValue(value: unknown): value is FabricValue {
       // type and does not recurse.
       return true;
     } else if (Array.isArray(item)) {
-      // Arrays with enumerable named (non-index) or symbol-keyed properties
-      // have no fabric representation.
+      // Arrays with named (non-index) or symbol-keyed properties have no
+      // fabric representation.
       if (!isArrayWithOnlyIndexProperties(item)) return false;
       for (let i = 0; i < item.length; i++) {
         if (!(i in item)) continue; // sparse hole

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -41,7 +41,7 @@ export function isFabricValueLayer(
       }
       if (Array.isArray(value)) {
         // Arrays with `undefined` elements and sparse holes are accepted, but
-        // not arrays with non-index properties.
+        // not arrays with enumerable named or symbol-keyed properties.
         return isArrayWithOnlyIndexProperties(value);
       }
       // Plain objects are accepted; class instances are not (except
@@ -69,8 +69,9 @@ export function isFabricValueLayer(
  * Returns `true` for any scalar (`null`, `undefined`, `boolean`, `number`
  * -- including `-0`, `NaN`, and `±Infinity` -- `string`, `bigint`, and
  * registry-interned (`Symbol.for(...)`) symbols), any `FabricInstance` or
- * `FabricPrimitive`, an array of `FabricValue`s with no enumerable non-index
- * properties (sparse holes allowed), or a plain object whose values are all
+ * `FabricPrimitive`, an array of `FabricValue`s with no enumerable named
+ * properties and no symbol-keyed ones (sparse holes allowed), or a plain
+ * object whose values are all
  * `FabricValue`s. Returns `false` for a `function` or a unique (uninterned)
  * symbol -- whether the value itself or reached anywhere within it -- and for
  * any other class instance (`Date`, `Map`, ...) not representable as a
@@ -132,8 +133,8 @@ export function isFabricValue(value: unknown): value is FabricValue {
       // type and does not recurse.
       return true;
     } else if (Array.isArray(item)) {
-      // Arrays with enumerable named (non-index) properties have no fabric
-      // representation.
+      // Arrays with enumerable named (non-index) or symbol-keyed properties
+      // have no fabric representation.
       if (!isArrayWithOnlyIndexProperties(item)) return false;
       for (let i = 0; i < item.length; i++) {
         if (!(i in item)) continue; // sparse hole

--- a/packages/data-model/src/valueEqual.ts
+++ b/packages/data-model/src/valueEqual.ts
@@ -25,7 +25,8 @@ import { toCompactDebugString } from "./value-debug.ts";
  * — so a special object nested arbitrarily deep is still compared by content.
  *
  * (Unlike `deepEqual()` it does not handle non-`Fabric` class instances or
- * named properties on arrays: those are not representable as `FabricValue`s.)
+ * non-index properties on arrays: those are not representable as
+ * `FabricValue`s.)
  */
 export function valueEqual(a: FabricValue, b: FabricValue): boolean {
   if (Object.is(a, b)) return true;

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -2026,6 +2026,24 @@ describe("native-conversion", () => {
       expect(probes).toBeLessThan(100);
     });
 
+    it("copies every index even when a proxy reports a named key first", () => {
+      // A `Proxy` chooses its own key order, so index keys need not come first
+      // the way they do on an ordinary array. Stopping at the first non-index
+      // key would therefore silently drop elements -- here, all of them.
+      const target = [10, 20];
+      const reordered = new Proxy(target, {
+        ownKeys: () => ["foo", "0", "1", "length"],
+        getOwnPropertyDescriptor: (t, p) => {
+          if (p === "foo") {
+            return { configurable: true, enumerable: true, value: "x" };
+          }
+          return Object.getOwnPropertyDescriptor(t, p);
+        },
+      });
+
+      expect(shallowCleanArray(reordered)).toEqual([10, 20]);
+    });
+
     it("distinguishes a stored `undefined` from a hole", () => {
       const arr: unknown[] = [undefined, 2];
 

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -2001,8 +2001,11 @@ describe("native-conversion", () => {
       expect(1 in result).toBe(false);
     });
 
-    it("touches only the present elements, not every index below `length`", () => {
-      // A hugely sparse array must cost O(present elements), not O(length).
+    it("does not probe every index below `length`", () => {
+      // A hugely sparse array must not be walked slot by slot from JS. The
+      // engine still scans the index range to find which keys exist, so this
+      // is not O(present elements); what it pins is that the scan is not done
+      // here, one property access at a time.
       const target: unknown[] = [];
       target.length = 1_000_000;
       target[5] = "x";

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -1543,6 +1543,19 @@ describe("native-conversion", () => {
         );
       });
 
+      it("throws for a non-array whose prototype is `Array.prototype`", () => {
+        // Such a value has `constructor === Array`, so type-tag dispatch routes
+        // it to array handling even though `Array.isArray()` is `false` for it.
+        // It has no fabric representation as either an array or an object, so
+        // it must be rejected rather than quietly converted.
+        const fake = Object.create(Array.prototype) as Record<string, unknown>;
+        fake[0] = "a";
+        fake.length = 1;
+        expect(() => fabricFromNativeValue(fake)).toThrow(
+          "Cannot store array with non-index properties",
+        );
+      });
+
       it("throws for a nested array with a symbol-keyed property", () => {
         const arr = [1, 2];
         (arr as unknown as Record<symbol, unknown>)[Symbol.for("extra")] = 42;

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -19,8 +19,10 @@ import {
   isConvertibleNativeInstance,
   isFabricCompatible,
   nativeFromFabricValue,
+  shallowCleanArray,
   shallowFabricFromNativeValue,
 } from "@/native-conversion.ts";
+import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
 import { FrozenMap, FrozenSet } from "@/frozen-builtins.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
@@ -1930,6 +1932,144 @@ describe("native-conversion", () => {
       const arr = [1] as number[] & { extra?: string };
       arr.extra = "nope";
       expect(isFabricCompatible({ list: arr })).toBe(false);
+    });
+  });
+
+  describe("shallowCleanArray()", () => {
+    it("drops an enumerable named property", () => {
+      const arr = [1, 2, 3] as unknown[] & { foo?: string };
+      arr.foo = "bar";
+
+      const result = shallowCleanArray(arr) as unknown[];
+
+      expect(isArrayWithOnlyIndexProperties(result)).toBe(true);
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it("drops a non-enumerable named property", () => {
+      const arr = [1, 2, 3];
+      Object.defineProperty(arr, "foo", { value: "bar", enumerable: false });
+
+      const result = shallowCleanArray(arr) as unknown[];
+
+      expect(isArrayWithOnlyIndexProperties(result)).toBe(true);
+      expect(Object.getOwnPropertyNames(result)).toEqual([
+        "0",
+        "1",
+        "2",
+        "length",
+      ]);
+    });
+
+    it("drops a symbol-keyed property, enumerable or not", () => {
+      const arr = [1, 2];
+      (arr as unknown as Record<symbol, unknown>)[Symbol("enum")] = "x";
+      Object.defineProperty(arr, Symbol("nonEnum"), {
+        value: "y",
+        enumerable: false,
+      });
+
+      const result = shallowCleanArray(arr) as unknown[];
+
+      expect(isArrayWithOnlyIndexProperties(result)).toBe(true);
+      expect(Object.getOwnPropertySymbols(result)).toEqual([]);
+    });
+
+    it("preserves interior holes as holes rather than `undefined`", () => {
+      const arr: unknown[] = [];
+      arr[0] = 1;
+      arr[2] = 3;
+
+      const result = shallowCleanArray(arr) as unknown[];
+
+      expect(result.length).toBe(3);
+      expect(0 in result).toBe(true);
+      expect(1 in result).toBe(false); // the hole
+      expect(2 in result).toBe(true);
+    });
+
+    it("preserves trailing holes, so `length` survives", () => {
+      // Assigning element-by-element without setting `length` first would
+      // truncate these away.
+      const arr: unknown[] = [];
+      arr[0] = 1;
+      arr.length = 10;
+
+      const result = shallowCleanArray(arr) as unknown[];
+
+      expect(result.length).toBe(10);
+      expect(1 in result).toBe(false);
+    });
+
+    it("touches only the present elements, not every index below `length`", () => {
+      // A hugely sparse array must cost O(present elements), not O(length).
+      const target: unknown[] = [];
+      target.length = 1_000_000;
+      target[5] = "x";
+
+      let probes = 0;
+      const counting = new Proxy(target, {
+        has(t, p) {
+          probes++;
+          return Reflect.has(t, p);
+        },
+        get(t, p, r) {
+          if (p !== "length") probes++;
+          return Reflect.get(t, p, r);
+        },
+      });
+
+      const result = shallowCleanArray(counting) as unknown[];
+
+      expect(result.length).toBe(1_000_000);
+      expect(result[5]).toBe("x");
+      expect(probes).toBeLessThan(100);
+    });
+
+    it("distinguishes a stored `undefined` from a hole", () => {
+      const arr: unknown[] = [undefined, 2];
+
+      const result = shallowCleanArray(arr) as unknown[];
+
+      expect(0 in result).toBe(true);
+      expect(result[0]).toBe(undefined);
+    });
+
+    it("returns a frozen result by default, and a mutable one on request", () => {
+      const arr = [1, 2, 3];
+
+      expect(Object.isFrozen(shallowCleanArray(arr) as unknown[])).toBe(true);
+      expect(Object.isFrozen(shallowCleanArray(arr, false) as unknown[]))
+        .toBe(false);
+    });
+
+    it("does not mutate or alias its input", () => {
+      const arr = [1, 2, 3] as unknown[] & { foo?: string };
+      arr.foo = "bar";
+
+      const result = shallowCleanArray(arr) as unknown[];
+
+      expect(result).not.toBe(arr);
+      expect(arr.foo).toBe("bar"); // input untouched
+    });
+
+    it("copies elements by reference, being a shallow operation", () => {
+      const inner = { a: 1 };
+      const arr = [inner] as unknown[] & { foo?: string };
+      arr.foo = "bar";
+
+      const result = shallowCleanArray(arr) as unknown[];
+
+      expect(result[0]).toBe(inner);
+    });
+
+    it("produces a value the conversion functions accept", () => {
+      const arr = [1, 2, 3] as unknown[] & { foo?: string };
+      arr.foo = "bar";
+
+      expect(() => shallowFabricFromNativeValue(arr)).toThrow();
+      expect(() => shallowFabricFromNativeValue(shallowCleanArray(arr, false)))
+        .not.toThrow();
     });
   });
 });

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -596,7 +596,7 @@ describe("native-conversion", () => {
         const arr = [1, 2, 3] as unknown[] & { foo?: string };
         arr.foo = "bar";
         expect(() => shallowFabricFromNativeValue(arr)).toThrow(
-          "Cannot store array with enumerable named properties",
+          "Cannot store array with non-index properties",
         );
       });
     });
@@ -1489,12 +1489,12 @@ describe("native-conversion", () => {
       });
     });
 
-    describe("throws for arrays with enumerable named properties", () => {
+    describe("throws for arrays with non-index properties", () => {
       it("throws for a top-level array with named properties", () => {
         const arr = [1, 2, 3] as unknown[] & { foo?: string };
         arr.foo = "bar";
         expect(() => fabricFromNativeValue(arr)).toThrow(
-          "Cannot store array with enumerable named properties",
+          "Cannot store array with non-index properties",
         );
       });
 
@@ -1502,7 +1502,7 @@ describe("native-conversion", () => {
         const arr = [1, 2] as unknown[] & { extra?: number };
         arr.extra = 42;
         expect(() => fabricFromNativeValue({ data: arr })).toThrow(
-          "Cannot store array with enumerable named properties",
+          "Cannot store array with non-index properties",
         );
       });
 
@@ -1512,7 +1512,7 @@ describe("native-conversion", () => {
         sparse[2] = 3;
         sparse.name = "test";
         expect(() => fabricFromNativeValue(sparse)).toThrow(
-          "Cannot store array with enumerable named properties",
+          "Cannot store array with non-index properties",
         );
       });
 
@@ -1523,7 +1523,23 @@ describe("native-conversion", () => {
         arr.foo = "bar";
         Object.freeze(arr);
         expect(() => fabricFromNativeValue(arr)).toThrow(
-          "Cannot store array with enumerable named properties",
+          "Cannot store array with non-index properties",
+        );
+      });
+
+      it("throws for a top-level array with a symbol-keyed property", () => {
+        const arr = [1, 2, 3];
+        (arr as unknown as Record<symbol, unknown>)[Symbol("foo")] = "bar";
+        expect(() => fabricFromNativeValue(arr)).toThrow(
+          "Cannot store array with non-index properties",
+        );
+      });
+
+      it("throws for a nested array with a symbol-keyed property", () => {
+        const arr = [1, 2];
+        (arr as unknown as Record<symbol, unknown>)[Symbol.for("extra")] = 42;
+        expect(() => fabricFromNativeValue({ data: arr })).toThrow(
+          "Cannot store array with non-index properties",
         );
       });
     });

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -1535,6 +1535,14 @@ describe("native-conversion", () => {
         );
       });
 
+      it("throws for an array with a non-enumerable named property", () => {
+        const arr = [1, 2, 3];
+        Object.defineProperty(arr, "foo", { value: "bar", enumerable: false });
+        expect(() => fabricFromNativeValue(arr)).toThrow(
+          "Cannot store array with non-index properties",
+        );
+      });
+
       it("throws for a nested array with a symbol-keyed property", () => {
         const arr = [1, 2];
         (arr as unknown as Record<symbol, unknown>)[Symbol.for("extra")] = 42;

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -117,6 +117,12 @@ describe("type-check", () => {
         expect(isFabricValueLayer(arr)).toBe(false);
       });
 
+      it("returns `false` for an array with a symbol-keyed property", () => {
+        const arr = [1, 2, 3];
+        (arr as unknown as Record<symbol, unknown>)[Symbol("foo")] = "bar";
+        expect(isFabricValueLayer(arr)).toBe(false);
+      });
+
       it("returns `false` for a sparse array with extra named properties", () => {
         // Length 3, hole at index 1, plus a named property "foo": still
         // `false` because the named property isn't a valid array index.
@@ -289,6 +295,18 @@ describe("type-check", () => {
       it("returns `false` for a named-property array nested in the graph", () => {
         const arr = [1, 2] as unknown[] & { extra?: number };
         arr.extra = 42;
+        expect(isFabricValue({ data: arr })).toBe(false);
+      });
+
+      it("returns `false` for an array with a symbol-keyed property", () => {
+        const arr = [1, 2, 3];
+        (arr as unknown as Record<symbol, unknown>)[Symbol("foo")] = "bar";
+        expect(isFabricValue(arr)).toBe(false);
+      });
+
+      it("returns `false` for a symbol-keyed-property array nested in the graph", () => {
+        const arr = [1, 2];
+        (arr as unknown as Record<symbol, unknown>)[Symbol.for("extra")] = 42;
         expect(isFabricValue({ data: arr })).toBe(false);
       });
 

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -304,6 +304,12 @@ describe("type-check", () => {
         expect(isFabricValue(arr)).toBe(false);
       });
 
+      it("returns `false` for an array with a non-enumerable named property", () => {
+        const arr = [1, 2, 3];
+        Object.defineProperty(arr, "foo", { value: "bar", enumerable: false });
+        expect(isFabricValue(arr)).toBe(false);
+      });
+
       it("returns `false` for a symbol-keyed-property array nested in the graph", () => {
         const arr = [1, 2];
         (arr as unknown as Record<symbol, unknown>)[Symbol.for("extra")] = 42;

--- a/packages/pure-json/src/json-faithfulness.ts
+++ b/packages/pure-json/src/json-faithfulness.ts
@@ -26,8 +26,10 @@
 // objects, so for these the empty result is not a guarantee (all confirmed to
 // pass here while `JSON.stringify` alters them):
 //
-//   - A non-enumerable string data property is dropped by JSON but not seen
-//     here (the walk is enumerable-only).
+//   - A non-enumerable string data property on a PLAIN OBJECT is dropped by
+//     JSON but not seen here (that walk is enumerable-only). An array's
+//     properties are read with `Object.getOwnPropertyNames`, so the same
+//     property on an array _is_ reported.
 //   - An accessor-based `toJSON` (a getter) is missed: the own-descriptor check
 //     matches a data property whose value is a function, not an accessor -- and
 //     a plain read could fire the getter, which the check avoids on purpose.
@@ -37,10 +39,10 @@
 //     inherited numeric property masks a hole; this also does not match JSON's
 //     own-vs-inherited element read.
 //
-// A future hardening pass would inspect own property descriptors instead of
-// `Object.keys` / `Object.entries`, reject accessors and non-enumerable data
-// properties, use `Object.hasOwn` for array slots, and reject a nonstandard
-// array prototype or an inherited `toJSON`.
+// A future hardening pass would inspect own property descriptors for plain
+// objects too, instead of `Object.entries`, reject accessors and
+// non-enumerable data properties, use `Object.hasOwn` for array slots, and
+// reject a nonstandard array prototype or an inherited `toJSON`.
 
 import type { JSONValue } from "@commonfabric/api";
 

--- a/packages/pure-json/src/json-faithfulness.ts
+++ b/packages/pure-json/src/json-faithfulness.ts
@@ -134,9 +134,16 @@ function walk(
 
     if (Array.isArray(obj)) {
       // JSON serializes an array's indices only; any other own property is
-      // dropped. `Object.keys` yields the present indices plus those extras.
-      for (const key of Object.keys(obj)) {
-        if (!isArrayIndexPropertyName(key)) {
+      // dropped, whether or not it is enumerable -- hence own property *names*
+      // rather than `Object.keys`. `length` is the one non-index name every
+      // array carries, and JSON encodes it structurally rather than dropping
+      // it, so it is not an offender.
+      //
+      // A hole is a separate matter, reported by the element loop below: JSON
+      // cannot carry one, while a fabric value can. The two checks disagree
+      // there on purpose.
+      for (const key of Object.getOwnPropertyNames(obj)) {
+        if ((key !== "length") && !isArrayIndexPropertyName(key)) {
           out.push({
             pointer: pointerChild(pointer, key),
             reason: "non-index array property (dropped)",

--- a/packages/pure-json/test/json-faithfulness.test.ts
+++ b/packages/pure-json/test/json-faithfulness.test.ts
@@ -93,6 +93,35 @@ describe("findJsonUnfaithfulValues", () => {
     expect(found[0]!.reason).toContain("non-index");
   });
 
+  it("catches a NON-enumerable non-index property on an array", () => {
+    // `JSON.stringify` drops it just the same, so an enumerable-only walk
+    // would certify a value that JSON demonstrably mangles.
+    const withHidden: unknown[] = [1, 2];
+    Object.defineProperty(withHidden, "foo", { value: 3, enumerable: false });
+
+    const found = findJsonUnfaithfulValues({ default: withHidden });
+
+    expect(found).toHaveLength(1);
+    expect(found[0]!.pointer).toBe("/default/foo");
+    expect(found[0]!.reason).toContain("non-index");
+  });
+
+  it("does not report an array's own `length` as a dropped property", () => {
+    // `length` is a non-index own name on every array, so walking own property
+    // names rather than enumerable keys must not start flagging it.
+    expect(findJsonUnfaithfulValues({ default: [1, 2, 3] })).toHaveLength(0);
+  });
+
+  it("keeps reporting a non-enumerable index as faithful", () => {
+    // Such an index is a real element -- `JSON.stringify` emits it -- so it is
+    // not an offender even though it is invisible to an enumerable-only walk.
+    const arr: unknown[] = [1, 2, 3];
+    Object.defineProperty(arr, "0", { value: 9, enumerable: false });
+
+    expect(JSON.stringify(arr)).toBe("[9,2,3]");
+    expect(findJsonUnfaithfulValues({ default: arr })).toHaveLength(0);
+  });
+
   it("catches a toJSON hook, even non-enumerable", () => {
     // `toJSON` replaces the value before JSON sees its contents, so the walk
     // cannot certify what would be sent.

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -3243,15 +3243,20 @@ export function convertCellsToLinks(
   // it. Only annotated arrays are cleaned: an array carrying anything else
   // non-index is genuinely unrepresentable and must still be rejected.
   if (Array.isArray(value) && isCellResultForDereferencing(value)) {
+    // What this produces is a valid `FabricValueLayer` already, so it wants no
+    // further conversion.
     value = shallowCleanArray(value, false);
+  } else {
+    // Convert the (top level of) the value to fabric form (a valid
+    // `FabricValue`) if it isn't already, or throw if it's neither already
+    // valid nor convertible.
+    value = shallowFabricFromNativeValue(value);
   }
 
-  // Convert the (top level of) the value to fabric form (a valid `FabricValue`)
-  // if it isn't already, or throw if it's neither already valid nor
-  // convertible.
-  value = shallowFabricFromNativeValue(value);
-
   // Recursively process arrays and objects, if we ended up with one of those.
+  //
+  // TODO(danfuzz): Both container branches below build a fresh container,
+  // throwing away the copy just made above. One copy could serve both.
   if (!isRecord(value)) {
     // `shallowFabricFromNativeValue()` converted this into a primitive value of some sort.
     return value;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -10,6 +10,7 @@ import {
   FabricInstance,
   FabricSpecialObject,
   type FabricValue,
+  shallowCleanArray,
   shallowFabricFromNativeValue,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
@@ -3235,6 +3236,15 @@ export function convertCellsToLinks(
   // At this point `value` is a non-`null` object(ish) thing.
 
   seen.set(value, path); // ...which needs to be tracked for circularity.
+
+  // A schema-bearing read hangs a non-enumerable `toCell` symbol on the arrays
+  // it returns. That symbol is machinery, not content, and an array carrying it
+  // is not a `FabricValue`, so drop it before the conversion below would reject
+  // it. Only annotated arrays are cleaned: an array carrying anything else
+  // non-index is genuinely unrepresentable and must still be rejected.
+  if (Array.isArray(value) && isCellResultForDereferencing(value)) {
+    value = shallowCleanArray(value, false);
+  }
 
   // Convert the (top level of) the value to fabric form (a valid `FabricValue`)
   // if it isn't already, or throw if it's neither already valid nor

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -1,6 +1,7 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 import { isRecord } from "@commonfabric/utils/types";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { getTopFrame } from "./builder/pattern.ts";
 import { isStreamValue } from "./builder/types.ts";
 import { type BackToCellInternals, toCell } from "./back-to-cell.ts";
@@ -551,7 +552,20 @@ export function createQueryResultProxy<T>(
         : Reflect.ownKeys(value);
       if (Array.isArray(proxyTarget)) {
         if (!keys.includes("length")) {
-          keys.push("length");
+          // Insert `length` where a real array carries it -- after the index
+          // keys, ahead of any other name -- rather than appending it. Own-key
+          // order is load-bearing: a consumer can tell an index-only array from
+          // one carrying named properties by asking whether `length` comes
+          // last (`isArrayWithOnlyIndexProperties()` does exactly that), and
+          // appending would make a named property look like an index-only one.
+          const firstNonIndex = keys.findIndex((key) =>
+            !((typeof key === "string") && isArrayIndexPropertyName(key))
+          );
+          keys.splice(
+            (firstNonIndex === -1) ? keys.length : firstNonIndex,
+            0,
+            "length",
+          );
         }
         // Enumerating an array's keys (`Object.keys`/`values`/`entries`, a spread,
         // `for...in`) observes which index keys are present. For a dense array

--- a/packages/runner/test/convert-cells-to-links-annotations.test.ts
+++ b/packages/runner/test/convert-cells-to-links-annotations.test.ts
@@ -1,0 +1,84 @@
+// A schema-bearing read attaches a non-enumerable `toCell` symbol to the
+// values it returns (see `schema.ts`). That annotation is not content, so it
+// must not reach -- and be rejected by -- the fabric-conversion gate inside
+// `convertCellsToLinks()`.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { convertCellsToLinks } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+describe("convertCellsToLinks() with runtime-annotated arrays", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const listSchema = {
+    type: "object",
+    properties: { list: { type: "array", items: { type: "number" } } },
+  } as const;
+
+  it("converts a schema-read array under `doNotConvertCellResults`", () => {
+    // This is the path taken by the HTML reconciler for every array-valued
+    // element prop, and by the runtime client for cell gets and sink updates.
+    const cell = runtime.getCell(space, "annotated-nested", listSchema, tx);
+    cell.set({ list: [1, 2, 3] });
+
+    const list = (cell.get() as { list: number[] }).list;
+
+    expect(
+      convertCellsToLinks(list, {
+        doNotConvertCellResults: true,
+        includeSchema: true,
+      }),
+    ).toEqual([1, 2, 3]);
+  });
+
+  it("converts a schema-read top-level array under `doNotConvertCellResults`", () => {
+    const arraySchema = { type: "array", items: { type: "number" } } as const;
+    const cell = runtime.getCell(space, "annotated-top", arraySchema, tx);
+    cell.set([4, 5]);
+
+    expect(
+      convertCellsToLinks(cell.get(), {
+        doNotConvertCellResults: true,
+        includeSchema: true,
+      }),
+    ).toEqual([4, 5]);
+  });
+
+  it("still rejects an array carrying a genuine named property", () => {
+    // Dropping runtime annotations must not become a licence to drop content.
+    const arr = [1, 2] as unknown[] & { foo?: string };
+    arr.foo = "bar";
+
+    expect(() =>
+      convertCellsToLinks(arr, {
+        doNotConvertCellResults: true,
+        includeSchema: true,
+      })
+    ).toThrow("Cannot store array with non-index properties");
+  });
+});

--- a/packages/runner/test/query-result-proxy-array-key-order.test.ts
+++ b/packages/runner/test/query-result-proxy-array-key-order.test.ts
@@ -1,0 +1,83 @@
+// The `ownKeys` trap supplies a `length` key when the underlying value has
+// none of its own. Where it puts that key matters: own-key order is what
+// distinguishes an index-only array from one carrying named properties, and
+// `isArrayWithOnlyIndexProperties()` reads exactly that.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
+import { createQueryResultProxy } from "../src/query-result-proxy.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+describe("query result proxy array key order", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /**
+   * Builds a proxy whose target is array-shaped but whose stored value is
+   * record-shaped, which is the case in which the trap has to supply `length`
+   * itself. The proxy target is fixed when the proxy is built, so setting an
+   * array first and overwriting it afterwards produces the mismatch.
+   */
+  function arrayTargetOverRecord(cause: string, record: unknown): object {
+    const cell = runtime.getCell<unknown>(space, cause, undefined, tx);
+    cell.set([1, 2]);
+    const proxy = createQueryResultProxy<object>(
+      runtime,
+      tx,
+      cell.getAsNormalizedFullLink(),
+      0,
+      false,
+    );
+    cell.set(record);
+    return proxy;
+  }
+
+  it("places a supplied `length` after the index keys, not last", () => {
+    const proxy = arrayTargetOverRecord("order-named", { 0: "a", foo: "x" });
+
+    // A real array orders its own keys indices-first, then `length`, then any
+    // other name. Appending `length` instead would put it after `foo`.
+    expect(Reflect.ownKeys(proxy).map(String)).toEqual(["0", "length", "foo"]);
+  });
+
+  it("does not let a named property masquerade as index-only", () => {
+    const proxy = arrayTargetOverRecord("order-predicate", {
+      0: "a",
+      foo: "x",
+    });
+
+    // The whole point of the ordering: `foo` is a named property, so this
+    // must not read as an index-only array.
+    expect(isArrayWithOnlyIndexProperties(proxy)).toBe(false);
+  });
+
+  it("still reads as index-only when the value has no named properties", () => {
+    const proxy = arrayTargetOverRecord("order-clean", { 0: "a", 1: "b" });
+
+    expect(Reflect.ownKeys(proxy).map(String)).toEqual(["0", "1", "length"]);
+    expect(isArrayWithOnlyIndexProperties(proxy)).toBe(true);
+  });
+});

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -71,9 +71,15 @@ export function isArrayIndexPropertyName(name: string): boolean {
 }
 
 /**
- * Indicates whether all of the given array's enumerable own properties are
- * numeric indices (that is, it has no named properties). Returns `true` for
- * sparse arrays.
+ * Indicates whether all of the given array's own properties are array indices,
+ * that is, it has neither enumerable named (string-keyed) properties nor
+ * symbol-keyed properties. Returns `true` for sparse arrays.
+ *
+ * Symbol-keyed properties are rejected regardless of enumerability, because a
+ * symbol key is not expressible as a property name at all. Non-enumerable
+ * _string_-keyed properties are not considered, both because every array
+ * necessarily has one (`length`) and because such properties are conventionally
+ * implementation detail rather than content.
  *
  * **Note:** This function relies on `Object.keys()` on arrays producing output
  * which agrees with the JavaScript spec with regards to the ordering of index
@@ -88,17 +94,24 @@ export function isArrayIndexPropertyName(name: string): boolean {
  * assumpion, this function avoids having to iterate over _all_ keys.
  *
  * @param array The array to check.
- * @returns `true` if the array has only numeric properties, `false` otherwise.
+ * @returns `true` if the array has only index properties, `false` otherwise.
  */
 export function isArrayWithOnlyIndexProperties(array: unknown[]): boolean {
   const keys = Object.keys(array);
 
   // `Object.keys()` on an (ordinary) array yields all array-index keys first,
   // followed by any non-index keys. So if an array has _any_ non-index keys,
-  // then _one_ of them is always the final key. This means the array is
-  // index-only exactly when it has no keys or its last key is an index. (But
-  // see the doc comment above for potential `Proxy` troubles that this
-  // implementation _intentionally_ does not try to handle.)
+  // then _one_ of them is always the final key. This means the array's named
+  // properties are index-only exactly when it has no keys or its last key is an
+  // index. (But see the doc comment above for potential `Proxy` troubles that
+  // this implementation _intentionally_ does not try to handle.)
   const lastKey = keys.at(-1);
-  return lastKey === undefined || isArrayIndexPropertyName(lastKey);
+  if (!((lastKey === undefined) || isArrayIndexPropertyName(lastKey))) {
+    return false;
+  }
+
+  // `Object.keys()` doesn't report symbol keys at all, so they have to be asked
+  // about separately. A named-property rejection above short-circuits ahead of
+  // this, so such an array never pays for the symbol scan.
+  return Object.getOwnPropertySymbols(array).length === 0;
 }

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -77,6 +77,12 @@ export function isArrayIndexPropertyName(name: string): boolean {
  * none of them have any representation as array content. Returns `true` for
  * sparse arrays, whose holes are simply absent properties.
  *
+ * Anything that isn't actually an array is rejected, including an array-_like_
+ * object and one whose prototype is `Array.prototype`. Such a value can
+ * perfectly well name `length` as its final own property, so the key-order
+ * reasoning below says nothing about it. This also makes the function total:
+ * it answers rather than throwing no matter what it is handed.
+ *
  * **Note:** This function relies on the given array producing `Reflect.ownKeys()`
  * output which agrees with the JavaScript spec with regards to key ordering,
  * namely index keys in ascending numeric order, then the remaining string keys
@@ -95,6 +101,12 @@ export function isArrayIndexPropertyName(name: string): boolean {
  * @returns `true` if the array has only index properties, `false` otherwise.
  */
 export function isArrayWithOnlyIndexProperties(array: unknown[]): boolean {
+  // `Array.isArray()` sees through a `Proxy` to its target, so a proxied array
+  // is still recognized as one here.
+  if (!Array.isArray(array)) {
+    return false;
+  }
+
   // Given the key ordering described above, `length` -- which is created along
   // with the array itself, and so precedes every later-created string key --
   // is the last own key exactly when there is no other non-index key at all:

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -71,47 +71,33 @@ export function isArrayIndexPropertyName(name: string): boolean {
 }
 
 /**
- * Indicates whether all of the given array's own properties are array indices,
- * that is, it has neither enumerable named (string-keyed) properties nor
- * symbol-keyed properties. Returns `true` for sparse arrays.
+ * Indicates whether every one of the given array's own properties is an array
+ * index, `length` aside. Named (string-keyed) properties and symbol-keyed
+ * properties alike cause rejection, whether or not they are enumerable, because
+ * none of them have any representation as array content. Returns `true` for
+ * sparse arrays, whose holes are simply absent properties.
  *
- * Symbol-keyed properties are rejected regardless of enumerability, because a
- * symbol key is not expressible as a property name at all. Non-enumerable
- * _string_-keyed properties are not considered, both because every array
- * necessarily has one (`length`) and because such properties are conventionally
- * implementation detail rather than content.
- *
- * **Note:** This function relies on `Object.keys()` on arrays producing output
- * which agrees with the JavaScript spec with regards to the ordering of index
- * vs. non-index keys. Built-in arrays of course do this, but it's possible for
- * a `Proxy` to (a) effectively purport to be an array, and yet (b) have an
- * `ownKeys()` trap that diverges from the behavior of built-in arrays. In such
- * cases, this function can incorrectly return `true`, exactly because it
- * depends on the spec-defined ordering. The rationale for this implementation
- * is that it's reasonable to expect proxied arrays to implement `ownKeys()` in
- * agreement with the standard array order (even though the spec _does_ allow
- * leeway with regards to what `Proxy`s actually do), _and_ by making this
- * assumpion, this function avoids having to iterate over _all_ keys.
+ * **Note:** This function relies on the given array producing `Reflect.ownKeys()`
+ * output which agrees with the JavaScript spec with regards to key ordering,
+ * namely index keys in ascending numeric order, then the remaining string keys
+ * in property-creation order, then symbol keys in property-creation order.
+ * Built-in arrays of course do this, but it's possible for a `Proxy` to (a)
+ * effectively purport to be an array, and yet (b) have an `ownKeys()` trap that
+ * diverges from the behavior of built-in arrays. In such cases, this function
+ * can return an incorrect answer, exactly because it depends on the
+ * spec-defined ordering. The rationale for this implementation is that it's
+ * reasonable to expect proxied arrays to implement `ownKeys()` in agreement
+ * with the standard array order (even though the spec _does_ allow leeway with
+ * regards to what `Proxy`s actually do), _and_ by making this assumption, this
+ * function avoids having to inspect _every_ key.
  *
  * @param array The array to check.
  * @returns `true` if the array has only index properties, `false` otherwise.
  */
 export function isArrayWithOnlyIndexProperties(array: unknown[]): boolean {
-  const keys = Object.keys(array);
-
-  // `Object.keys()` on an (ordinary) array yields all array-index keys first,
-  // followed by any non-index keys. So if an array has _any_ non-index keys,
-  // then _one_ of them is always the final key. This means the array's named
-  // properties are index-only exactly when it has no keys or its last key is an
-  // index. (But see the doc comment above for potential `Proxy` troubles that
-  // this implementation _intentionally_ does not try to handle.)
-  const lastKey = keys.at(-1);
-  if (!((lastKey === undefined) || isArrayIndexPropertyName(lastKey))) {
-    return false;
-  }
-
-  // `Object.keys()` doesn't report symbol keys at all, so they have to be asked
-  // about separately. A named-property rejection above short-circuits ahead of
-  // this, so such an array never pays for the symbol scan.
-  return Object.getOwnPropertySymbols(array).length === 0;
+  // Given the key ordering described above, `length` -- which is created along
+  // with the array itself, and so precedes every later-created string key --
+  // is the last own key exactly when there is no other non-index key at all:
+  // a named property would sort after it, and a symbol key after that.
+  return Reflect.ownKeys(array).at(-1) === "length";
 }

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -97,10 +97,10 @@ export function isArrayIndexPropertyName(name: string): boolean {
  * regards to what `Proxy`s actually do), _and_ by making this assumption, this
  * function avoids having to inspect _every_ key.
  *
- * @param array The array to check.
+ * @param array The value to check.
  * @returns `true` if the array has only index properties, `false` otherwise.
  */
-export function isArrayWithOnlyIndexProperties(array: unknown[]): boolean {
+export function isArrayWithOnlyIndexProperties(array: unknown): boolean {
   // `Array.isArray()` sees through a `Proxy` to its target, so a proxied array
   // is still recognized as one here.
   if (!Array.isArray(array)) {

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -80,8 +80,14 @@ export function isArrayIndexPropertyName(name: string): boolean {
  * Anything that isn't actually an array is rejected, including an array-_like_
  * object and one whose prototype is `Array.prototype`. Such a value can
  * perfectly well name `length` as its final own property, so the key-order
- * reasoning below says nothing about it. This also makes the function total:
- * it answers rather than throwing no matter what it is handed.
+ * reasoning below says nothing about it. Ordinary values are all answered
+ * rather than thrown on, `null`, `undefined`, and primitives included.
+ *
+ * A `Proxy` is the exception, and unavoidably so: it can throw from its own
+ * traps, and such an error propagates rather than being reported as `false`.
+ * A revoked proxy fails the array test itself, and a live one can throw from
+ * `ownKeys()`. Reporting `false` there would mean reading "this is not an
+ * index-only array" into what is actually a failure to find out.
  *
  * **Note:** This function relies on the given array producing `Reflect.ownKeys()`
  * output which agrees with the JavaScript spec with regards to key ordering,

--- a/packages/utils/test/arrays.test.ts
+++ b/packages/utils/test/arrays.test.ts
@@ -138,6 +138,45 @@ describe("arrays", () => {
       expect(isArrayWithOnlyIndexProperties(arr)).toBe(false);
     });
 
+    it("returns `false` for an array with an enumerable symbol-keyed property", () => {
+      const arr = [1, 2, 3];
+      (arr as unknown as Record<symbol, unknown>)[Symbol("foo")] = "bar";
+      expect(isArrayWithOnlyIndexProperties(arr)).toBe(false);
+    });
+
+    it("returns `false` for an array with a non-enumerable symbol-keyed property", () => {
+      // A symbol key is not expressible as a property name at all, so unlike a
+      // non-enumerable string key it is rejected.
+      const arr = [1, 2, 3];
+      Object.defineProperty(arr, Symbol("foo"), {
+        value: "bar",
+        enumerable: false,
+      });
+      expect(isArrayWithOnlyIndexProperties(arr)).toBe(false);
+    });
+
+    it("returns `false` for an array with a registered symbol-keyed property", () => {
+      // Registry-interned symbols are portable across realms -- and so are
+      // valid fabric *values* -- but they are still not property *names*.
+      const arr = [1, 2, 3];
+      (arr as unknown as Record<symbol, unknown>)[Symbol.for("foo")] = "bar";
+      expect(isArrayWithOnlyIndexProperties(arr)).toBe(false);
+    });
+
+    it("returns `false` for an array with a well-known symbol-keyed property", () => {
+      const arr = [1, 2, 3];
+      (arr as unknown as Record<symbol, unknown>)[Symbol.toStringTag] = "Nope";
+      expect(isArrayWithOnlyIndexProperties(arr)).toBe(false);
+    });
+
+    it("returns `true` for an array with a non-enumerable string-keyed property", () => {
+      // Non-enumerable string keys are out of scope: every array has one
+      // (`length`), and they are conventionally implementation detail.
+      const arr = [1, 2, 3];
+      Object.defineProperty(arr, "foo", { value: "bar", enumerable: false });
+      expect(isArrayWithOnlyIndexProperties(arr)).toBe(true);
+    });
+
     describe("returns `false` for non-canonical index-shaped named keys", () => {
       // These keys are named properties, not array indices, but each has a
       // `Number(key)` that is an in-range non-negative integer -- so a naive

--- a/packages/utils/test/arrays.test.ts
+++ b/packages/utils/test/arrays.test.ts
@@ -169,12 +169,50 @@ describe("arrays", () => {
       expect(isArrayWithOnlyIndexProperties(arr)).toBe(false);
     });
 
-    it("returns `true` for an array with a non-enumerable string-keyed property", () => {
-      // Non-enumerable string keys are out of scope: every array has one
-      // (`length`), and they are conventionally implementation detail.
+    it("returns `false` for an array with a non-enumerable string-keyed property", () => {
       const arr = [1, 2, 3];
       Object.defineProperty(arr, "foo", { value: "bar", enumerable: false });
+      expect(isArrayWithOnlyIndexProperties(arr)).toBe(false);
+    });
+
+    it("returns `false` for an array with a non-enumerable index-shaped named key", () => {
+      // `"01"` is a named property, not an index, so it is rejected on the same
+      // footing as any other non-enumerable named key.
+      const arr = [1, 2, 3];
+      Object.defineProperty(arr, "01", { value: "bar", enumerable: false });
+      expect(isArrayWithOnlyIndexProperties(arr)).toBe(false);
+    });
+
+    it("returns `true` for an array whose only non-index key is `length`", () => {
+      // `length` is intrinsic to every array, so it can never be disqualifying.
+      const arr = [1, 2, 3];
+      expect(Object.getOwnPropertyNames(arr)).toContain("length");
       expect(isArrayWithOnlyIndexProperties(arr)).toBe(true);
+    });
+
+    it("returns `true` after `length` is redefined", () => {
+      // Redefining does not re-create the property, so it keeps its original
+      // position in own-key order.
+      const arr = [1, 2, 3];
+      Object.defineProperty(arr, "length", { value: 3, writable: true });
+      expect(isArrayWithOnlyIndexProperties(arr)).toBe(true);
+    });
+
+    it("returns `false` when a named property outlives a deleted sibling", () => {
+      // Deleting one named property must not restore index-only-ness while
+      // another remains.
+      const arr = [1, 2, 3] as unknown[] & { foo?: string; bar?: string };
+      arr.foo = "a";
+      arr.bar = "b";
+      delete arr.foo;
+      expect(isArrayWithOnlyIndexProperties(arr)).toBe(false);
+    });
+
+    it("returns `true` for an `Array` subclass instance with only indices", () => {
+      class Sub extends Array {}
+      const sub = new Sub();
+      sub.push(1, 2);
+      expect(isArrayWithOnlyIndexProperties(sub)).toBe(true);
     });
 
     describe("returns `false` for non-canonical index-shaped named keys", () => {

--- a/packages/utils/test/arrays.test.ts
+++ b/packages/utils/test/arrays.test.ts
@@ -117,9 +117,9 @@ describe("arrays", () => {
     });
 
     it("returns `false` for a sparse array whose extra key is a named property", () => {
-      // `length` is `3`, hole at index `1`, plus a named `foo` -- so
-      // `Object.keys()` yields `["0", "2", "foo"]`, a key count that equals
-      // `length` but still contains a non-index key.
+      // `length` is `3`, hole at index `1`, plus a named `foo` -- so the own
+      // keys are `["0", "2", "length", "foo"]`, a count that matches a dense
+      // index-only array of the same `length` but still has a non-index key.
       const sparse = [] as unknown[] & { foo?: string };
       sparse[0] = 1;
       sparse[2] = 3;
@@ -128,9 +128,10 @@ describe("arrays", () => {
     });
 
     it("returns `false` when a named property was added before any indices", () => {
-      // `Object.keys()` still orders indices first, so the named key is last:
-      // `["0", "1", "foo"]`. Pins the last-key optimization's reliance on that
-      // ordering rather than on insertion order.
+      // Own-key order puts indices first and `length` ahead of any later-added
+      // named key, so the keys are `["0", "1", "length", "foo"]`. Pins the
+      // last-key check's reliance on that ordering rather than on the order in
+      // which the properties were assigned.
       const arr = [] as unknown[] & { foo?: string };
       arr.foo = "bar";
       arr[0] = 1;
@@ -215,14 +216,74 @@ describe("arrays", () => {
       expect(isArrayWithOnlyIndexProperties(sub)).toBe(true);
     });
 
+    describe("returns `false` for anything that isn't an array", () => {
+      // Each of these can name `length` as its final own key, which is what the
+      // implementation keys on for real arrays -- so without an explicit
+      // array check they would be misreported as index-only.
+
+      it("rejects an array-like object", () => {
+        const arrayLike = { 0: "a", 1: "b", length: 2 };
+        expect(
+          isArrayWithOnlyIndexProperties(arrayLike as unknown as unknown[]),
+        )
+          .toBe(false);
+      });
+
+      it("rejects a non-array whose prototype is `Array.prototype`", () => {
+        // `constructor` is `Array` here, so type-tag dispatch that keys on the
+        // constructor can route such a value to array handling.
+        const fake = Object.create(Array.prototype) as Record<string, unknown>;
+        fake[0] = "a";
+        fake.length = 1;
+        expect(isArrayWithOnlyIndexProperties(fake as unknown as unknown[]))
+          .toBe(false);
+      });
+
+      it("rejects a plain object whose last own key is `length`", () => {
+        const obj = { a: 1, length: 3 };
+        expect(isArrayWithOnlyIndexProperties(obj as unknown as unknown[]))
+          .toBe(false);
+      });
+
+      it("answers rather than throwing for `null` and `undefined`", () => {
+        expect(isArrayWithOnlyIndexProperties(null as unknown as unknown[]))
+          .toBe(false);
+        expect(
+          isArrayWithOnlyIndexProperties(undefined as unknown as unknown[]),
+        )
+          .toBe(false);
+      });
+
+      it("answers rather than throwing for a primitive", () => {
+        expect(isArrayWithOnlyIndexProperties("abc" as unknown as unknown[]))
+          .toBe(false);
+        expect(isArrayWithOnlyIndexProperties(42 as unknown as unknown[]))
+          .toBe(false);
+      });
+
+      it("rejects a `Uint8Array`", () => {
+        const bytes = new Uint8Array([1, 2, 3]);
+        expect(isArrayWithOnlyIndexProperties(bytes as unknown as unknown[]))
+          .toBe(false);
+      });
+    });
+
+    it("returns `true` for a `Proxy` over an index-only array", () => {
+      // `Array.isArray()` sees through to the target, so the array check
+      // doesn't reject proxied arrays.
+      const proxied = new Proxy([1, 2, 3], {});
+      expect(isArrayWithOnlyIndexProperties(proxied)).toBe(true);
+    });
+
     describe("returns `false` for non-canonical index-shaped named keys", () => {
       // These keys are named properties, not array indices, but each has a
       // `Number(key)` that is an in-range non-negative integer -- so a naive
       // numeric coercion would misclassify the array as index-only.
       for (const key of ["01", " 1", "1.0", "1e1", "-0", ""]) {
         it(`rejects the named key ${JSON.stringify(key)}`, () => {
-          // A roomy all-holes array, so the named key sits below `length` and
-          // doesn't trip the `keys.length > length` quick check.
+          // A roomy all-holes array, so the key is numerically in range for
+          // this `length` -- denying an implementation any excuse to reject it
+          // on size alone rather than on the key not being an index.
           const arr: unknown[] = [];
           arr.length = 1000;
           (arr as unknown as Record<string, unknown>)[key] = "x";

--- a/packages/utils/test/arrays.test.ts
+++ b/packages/utils/test/arrays.test.ts
@@ -224,7 +224,7 @@ describe("arrays", () => {
       it("rejects an array-like object", () => {
         const arrayLike = { 0: "a", 1: "b", length: 2 };
         expect(
-          isArrayWithOnlyIndexProperties(arrayLike as unknown as unknown[]),
+          isArrayWithOnlyIndexProperties(arrayLike),
         )
           .toBe(false);
       });
@@ -235,35 +235,35 @@ describe("arrays", () => {
         const fake = Object.create(Array.prototype) as Record<string, unknown>;
         fake[0] = "a";
         fake.length = 1;
-        expect(isArrayWithOnlyIndexProperties(fake as unknown as unknown[]))
+        expect(isArrayWithOnlyIndexProperties(fake))
           .toBe(false);
       });
 
       it("rejects a plain object whose last own key is `length`", () => {
         const obj = { a: 1, length: 3 };
-        expect(isArrayWithOnlyIndexProperties(obj as unknown as unknown[]))
+        expect(isArrayWithOnlyIndexProperties(obj))
           .toBe(false);
       });
 
       it("answers rather than throwing for `null` and `undefined`", () => {
-        expect(isArrayWithOnlyIndexProperties(null as unknown as unknown[]))
+        expect(isArrayWithOnlyIndexProperties(null))
           .toBe(false);
         expect(
-          isArrayWithOnlyIndexProperties(undefined as unknown as unknown[]),
+          isArrayWithOnlyIndexProperties(undefined),
         )
           .toBe(false);
       });
 
       it("answers rather than throwing for a primitive", () => {
-        expect(isArrayWithOnlyIndexProperties("abc" as unknown as unknown[]))
+        expect(isArrayWithOnlyIndexProperties("abc"))
           .toBe(false);
-        expect(isArrayWithOnlyIndexProperties(42 as unknown as unknown[]))
+        expect(isArrayWithOnlyIndexProperties(42))
           .toBe(false);
       });
 
       it("rejects a `Uint8Array`", () => {
         const bytes = new Uint8Array([1, 2, 3]);
-        expect(isArrayWithOnlyIndexProperties(bytes as unknown as unknown[]))
+        expect(isArrayWithOnlyIndexProperties(bytes))
           .toBe(false);
       });
     });


### PR DESCRIPTION
`isArrayWithOnlyIndexProperties()` did not do what its name says: `Object.keys()`
never reports symbol-keyed properties, so an array carrying one passed as
"index-only". Tightening that led to tightening the rest of the contract.

## What the predicate now means

It returns `true` only for a genuine array (or a `Proxy` over one) whose own
properties are all array indices, `length` aside. Sparse arrays still pass —
holes are absent properties, and fabric carries them fine. Newly rejected:

- symbol-keyed properties, enumerable or not
- named string properties, enumerable or not
- non-arrays of every kind, including array-_likes_ and objects whose prototype
  is `Array.prototype`

Ordinary values are all answered rather than thrown on, `null`, `undefined`, and
primitives included. A `Proxy` is the unavoidable exception: a revoked one fails
the array test itself, and a live one can throw from `ownKeys()`. Reporting
`false` there would read "this is not an index-only array" into what is really a
failure to find out, so the error propagates.

The implementation rests on own-key order — `length` is created with the array,
so it precedes every later-created string key, and symbols sort after all
strings:

```js
if (!Array.isArray(array)) return false;
return Reflect.ownKeys(array).at(-1) === "length";
```

## Things a reader of `main` should know

**`isPureJson()` is wider, and it throws through `assertJsonTransportSafe()`.**
`findJsonUnfaithfulValues()` walked arrays with `Object.keys()`, so a
non-enumerable named property — which `JSON.stringify` drops exactly as it drops
an enumerable one — was reported as no issue. It now reports it. Because
`assertJsonTransportSafe()` throws on any finding, such a property reaching a
`generateObject` schema or a tool `inputSchema` is now a hard failure rather
than a silently mangled request. That is the direction that module exists to
enforce, but it is a new throw on a path that reaches real LLM calls.

**The predicate got ~5× slower on plain arrays.** `Reflect.ownKeys()` does not
get the V8 fast path `Object.keys()` gets, and the cost scales per element
rather than being fixed overhead: 320 ns → 1.6 µs at 100 elements, 3.3 µs →
19.3 µs at 1000. Accepted deliberately — benchmarks alone cannot say whether the
system suffers, and the decision is revisable with experience. For context on
where the gap comes from: V8's fast path today is the EnumCache, which stores
only enumerable named keys, and `Reflect.ownKeys` exists precisely to return
the things that cache excludes — so it is not a matter of that cache simply
not having been wired up. Engines change, though, and this is a statement
about the current implementation rather than a standing bound. It
also runs the other way on proxied arrays (~1.6× *faster*), because
`Object.keys()` on a `Proxy` fires a `getOwnPropertyDescriptor` trap per key to
filter for enumerability while `Reflect.ownKeys()` fires exactly one trap.

**A live bug in the query-result proxy, found via the coverage ratchet.** Its
`ownKeys` trap appended `length` after any named key rather than placing it
where a real array carries it, so an array whose backing value had a named
property read as index-only. Initially committed as unproven hardening; the
coverage check then flagged the untested lines, and chasing that produced the
construction — the proxy target is fixed when the proxy is built, so setting an
array, building the proxy, then overwriting with a record puts the trap on its
record-backed branch. Verified red: `isArrayWithOnlyIndexProperties()` returned
`true` for a proxy carrying a named property.

## `shallowCleanArray()`

A schema-bearing `cell.get()` hangs a non-enumerable `toCell` symbol on the
arrays it returns. That annotation is machinery, not content, so the new
`shallowCleanArray()` in `native-conversion.ts` returns a clone carrying nothing
but index properties and `length`, letting a caller that knows its extra
properties are not content say so explicitly. `convertCellsToLinks()` uses it for
annotated arrays only — an array carrying anything else non-index is genuinely
unrepresentable and is still rejected, which a test pins.

It iterates with `for...in` rather than counting to `length`, since a sparse
array's `length` can reach 2**32 - 2 while holding a handful of elements; a test
counts proxy traps to hold that bound. Note that index keys come first on an
ordinary array, which invites stopping at the first non-index key — but a
`Proxy` picks its own key order and `for...in` takes it as given, so that
shortcut silently drops elements. A test pins that too.

## Reviewing

The commits are split so the reasoning is followable; several of the later ones
repair specific defects in the earlier ones, which a squashed diff hides.
Reading them in order is the fastest way to see why each restriction is there.

Verified at each step: full workspace suite, `deno task check` (426 paths),
`deno task check-docs` (523 blocks), `fmt`, `lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJwf3YGTzF42U7WBdAq4Pf



## Coverage

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 6907 lines

The +1 is `packages/runner/src/builtins/fetch-utils.ts:69`
(`inputsOnly.options = normalizedOptions;`), which this PR does not touch —
`git diff origin/main...HEAD` for that file is empty. Attributed by merging every
`coverage-profile-*` artifact from this run and the baseline run and diffing the
zero-hit sets per file; it is the only differing line.

An earlier run of this PR reported +40 rather than +1. The other 39 were
`runner/src/traverse.ts` 2995-3026 plus the tracker `size`/`totalValues` getters
it calls, all inside `if (elapsed > 100)` — a slow-traversal diagnostic gated on
wall clock, so a loaded CI runner covers it and a fast one does not.
`traverse.ts` is byte-identical between this branch and the baseline's main,
which is what rules out this PR as the cause. Re-running the test jobs
regenerated the profiles and it came back covered.
