### PR TITLE
fix(state-inspector,cli): make `cf space verify` report what moved

### DIFF
--- a/docs/development/space-clone-rehearsal.md
+++ b/docs/development/space-clone-rehearsal.md
@@ -69,7 +69,7 @@ deno task cf inspect churn <space> --bucket 60      # confirm a quiet window
 deno task cf piece setsrc … --api-url http://localhost:8010 …
 
 # 5. Judge it.
-deno task cf space verify ~/clones/<name>           # nonzero exit = content moved
+deno task cf space verify ~/clones/<name> --expect-migration   # nonzero = baseline corrupt or entities REMOVED
 deno task cf inspect churn <space> --bucket 60 --since '<when you started>'
 
 # 6. Reset and go again.
@@ -82,6 +82,19 @@ deno task cf space reset ~/clones/<name>
 clone time:
 
 - **`removed 0`** — the signal that matters most. Nothing was destroyed.
+
+**Which verdict the exit code uses is your choice, because the tool cannot
+infer it.** By default `cf space verify` is strict: *any* change exits nonzero,
+which is right for checking a clone nobody has touched and for catching an
+accidental clobber. After a migration, pass `--expect-migration`: results are
+rewritten by design, so it gates on a corrupted baseline or removed entities
+instead, and a two-pass rehearsal can actually be scripted.
+
+Its blind spot is worth stating plainly: `--expect-migration` **cannot see a
+clobber**, because overwriting authored content is a *change*, not a removal —
+and nothing hash-shaped can tell a rewritten result from a destroyed body. That
+is exactly why authored content is checked separately below, and why that check
+is not optional.
 - **`content CHANGED` with `removed 0`** — **the expected result of a
   successful migration.** A schema update rewrites every piece's result value,
   and results are part of the fingerprint, so it cannot match afterwards.

--- a/docs/development/space-clone-rehearsal.md
+++ b/docs/development/space-clone-rehearsal.md
@@ -81,16 +81,31 @@ deno task cf space reset ~/clones/<name>
 `cf space verify` compares the working copy against the manifest written at
 clone time:
 
-- **`content unchanged`** — durable content survived. **Growing commit and
-  revision counts are expected**: a migration writes. The fingerprint is the
-  signal, not the counts.
-- **`content CHANGED`** — something authored moved. Diff per-entity hashes to
-  see what:
-  ```bash
-  deno task cf space fingerprint <clone>/engine-v3/engine-v3/<did>.sqlite --per-entity
-  ```
+- **`removed 0`** — the signal that matters most. Nothing was destroyed.
+- **`content CHANGED` with `removed 0`** — **the expected result of a
+  successful migration.** A schema update rewrites every piece's result value,
+  and results are part of the fingerprint, so it cannot match afterwards.
+  Check that `changed` is confined to pieces and their derived cells (the
+  per-kind tally shows this), then verify authored content separately — no
+  whole-store fingerprint can tell you titles and bodies survived.
+- **`removed` above zero** — durable content was destroyed. Stop and
+  investigate before anything else.
+- **`content unchanged`** — nothing moved at all. Correct for a clone that has
+  not been migrated yet; suspicious after one that has.
 - **`baseline CORRUPTED`** — the pristine snapshot no longer matches the
   manifest. Do not reset to it; re-clone.
+
+Per-entity hashes, when you need to see exactly which entities moved:
+
+```bash
+deno task cf space fingerprint <clone>/engine-v3/engine-v3/<did>.sqlite --per-entity
+```
+
+To compare **authored** content directly, read each topic's *input* (argument)
+cell from the pristine and working stores and diff titles, bodies, and comment
+and link counts. That is what "durable content fingerprint unchanged" meant in
+#4997, and it is a different check from `cf space verify` — the one that
+actually answers whether the content survived.
 
 Compiler-generated internal cells are excluded by default, because a pattern
 update rotates their identities on purpose. Including them (`--include-generated`)
@@ -100,6 +115,25 @@ answers "what moved at all?", never "did content survive?".
 is the storm shape: a jump to a **sustained plateau**, not a spike. The July 2026
 incident ran at ~1,300 commits/minute for twenty minutes. A settle means the rate
 returns to baseline *and stays there*.
+
+## Driving the migration
+
+Migrate serially, and make the driver **fail loudly when the server goes away**.
+In the first real rehearsal the toolshed wedged under memory pressure and every
+subsequent `setsrc` hung: no error, no log line, no progress — an operator
+watching a frozen log with no signal, mid-migration.
+
+Do **not** implement that check as a wall-clock probe. The same rehearsal showed
+`/api/meta` intermittently taking over 60 s while the server was healthy and
+still completing writes, so a `curl --max-time 15` liveness check would abort a
+working migration. Prefer a state check that carries no timing assumption —
+whether the server process is still alive — or classify *after* a failure
+rather than probing before every write.
+
+Budget resources before starting: serving a 1 GB store while compiling and
+deploying 74 patterns exhausted a laptop's memory and pushed swap to 95%, which
+is what wedged the server. Migrations survive it (the clone is durable and
+already-migrated pieces stay migrated), but the run stops.
 
 ## Things that will mislead you
 

--- a/docs/plans/space-clone-rehearsal.md
+++ b/docs/plans/space-clone-rehearsal.md
@@ -274,6 +274,27 @@ The write-storm history and the mis-pointed-client hazard drive four rails.
    on live spaces independent of cloning — it is the query that would have
    caught the July storm in minutes.
 
+## Corrected by the first real rehearsal (2026-07-29)
+
+This document claimed that excluding compiler-generated cells would leave the
+content fingerprint **unchanged** across a clean pattern update. That is wrong,
+and the first real rehearsal proved it: a schema migration rewrites every
+piece's *result* value, and results are part of the fingerprint, so
+`fingerprint.match` is false after any successful migration.
+
+Excluding generated cells was necessary but not sufficient. The single hash
+therefore cannot distinguish "the update worked" from "content was destroyed",
+which was the one job it was designed for.
+
+What does distinguish them is the **shape** of the change. On the Topics
+rehearsal: 149 changed (74 pieces, 73 owned cells, 2 modules), 3,189 added,
+and **0 removed** — while every authored title, body, comment and link stayed
+byte-identical (73 topics / 59 comments / 56 links, matching #4997). `removed`
+is the alarm; changes confined to pieces and their derived cells are the
+migration working. `cf space verify` now reports that breakdown, and authored
+content still has to be checked separately — no fingerprint over the whole
+store can answer "did the content survive?" on its own.
+
 ## Fidelity caveats the practice must state
 
 A clone is not the production system, and two gaps are worth naming so a

--- a/packages/cli/commands/space.ts
+++ b/packages/cli/commands/space.ts
@@ -178,6 +178,13 @@ export const space = new Command()
     "verify <dir:string>",
     "Check a clone against its manifest: baseline intact, content unchanged.",
   )
+  .option(
+    "--expect-migration",
+    "A migration was just run, so content is EXPECTED to differ: exit nonzero " +
+      "only on a corrupted baseline or removed entities. Without it, any change " +
+      "at all fails — which is right for checking an untouched clone, and wrong " +
+      "as a rehearsal gate.",
+  )
   .action(async (options, dir) => {
     const result = await verifyClone(dir);
     out(!!options.json, result, () => {
@@ -213,10 +220,18 @@ export const space = new Command()
               "cannot tell you it survived."),
       );
     });
+    // Which verdict applies depends on whether a migration was expected, and
+    // only the caller knows that — a hash cannot tell a rewritten result from a
+    // clobbered one. Default strict (catches an accidental clobber);
+    // --expect-migration gates on removal instead, so a rehearsal script does
+    // not treat every successful migration as a failure.
+    //
     // A failed verification is a RESULT, not a usage error: the report above is
-    // the output a script or an operator reads. Exit nonzero so a rehearsal
-    // script can gate on it, without cliffy appending usage help.
-    if (!result.ok) Deno.exit(1);
+    // what a script or an operator reads, so exit without cliffy's usage help.
+    const passed = options.expectMigration
+      ? result.okAfterMigration
+      : result.ok;
+    if (!passed) Deno.exit(1);
   })
   /* space reset */
   .command(

--- a/packages/cli/commands/space.ts
+++ b/packages/cli/commands/space.ts
@@ -181,24 +181,36 @@ export const space = new Command()
   .action(async (options, dir) => {
     const result = await verifyClone(dir);
     out(!!options.json, result, () => {
-      const { counts, fingerprint } = result;
+      const { counts, fingerprint, diff } = result;
+      const kinds = (m: Record<string, number>) =>
+        Object.entries(m).sort((a, b) => b[1] - a[1])
+          .map(([k, n]) => `${n} ${k}`).join(", ") || "none";
       console.log(
         `baseline   ${result.baselineIntact ? "intact" : "CORRUPTED"}\n` +
+          `removed    ${diff.removed}${
+            diff.removed > 0 ? `  ← ${kinds(diff.removedByKind)}` : ""
+          }\n` +
+          `changed    ${diff.changed}${
+            diff.changed > 0 ? `  (${kinds(diff.changedByKind)})` : ""
+          }\n` +
+          `added      ${diff.added}\n` +
           `content    ${fingerprint.match ? "unchanged" : "CHANGED"}\n` +
-          `           manifest ${fingerprint.manifest}\n` +
-          `           working  ${fingerprint.working}\n` +
           `commits    ${counts.manifest.commits} → ${counts.working.commits}\n` +
-          `revisions  ${counts.manifest.revisions} → ${counts.working.revisions}\n` +
-          `entities   ${counts.manifest.entities} → ${counts.working.entities}\n\n` +
-          (result.ok
-            ? "OK — durable content survived. Growing counts are expected: a " +
-              "migration writes."
-            : result.baselineIntact
-            ? "CONTENT CHANGED — run `cf space fingerprint <dir>/engine-v3/" +
-              "<did>.sqlite --per-entity` against the working copy and the " +
-              "pristine baseline to see which entities moved."
-            : "BASELINE CORRUPTED — the pristine snapshot no longer matches " +
-              "the manifest; do not reset to it."),
+          `revisions  ${counts.manifest.revisions} → ${counts.working.revisions}\n\n` +
+          (!result.baselineIntact
+            ? "BASELINE CORRUPTED — the pristine snapshot no longer matches the " +
+              "manifest; do not reset to it."
+            : diff.removed > 0
+            ? "ENTITIES REMOVED — durable content was destroyed. This is the " +
+              "unambiguous failure; investigate before doing anything else."
+            : fingerprint.match
+            ? "OK — nothing moved."
+            : "CHANGED, nothing removed. After a schema migration this is the " +
+              "EXPECTED result: every piece's result value is rewritten, so the " +
+              "fingerprint cannot match. Confirm the changes are confined to " +
+              "pieces and their derived cells, then check authored content " +
+              "(titles, bodies, comments) separately — the fingerprint alone " +
+              "cannot tell you it survived."),
       );
     });
     // A failed verification is a RESULT, not a usage error: the report above is

--- a/packages/cli/test/space.test.ts
+++ b/packages/cli/test/space.test.ts
@@ -194,6 +194,34 @@ describe("cf space", () => {
     });
   });
 
+  it("--expect-migration passes a rewrite and still fails a removal", async () => {
+    // The flag decides verify's EXIT CODE, which is the only machine-readable
+    // signal a rehearsal script has. Without it a successful migration exits
+    // nonzero and the script stops on success; with it, a removal must still
+    // fail or the gate is worthless.
+    await withFixture(async ({ snapshot, clone }) => {
+      await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
+
+      // What a migration looks like: derived values rewritten, nothing dropped.
+      writeToWorkingCopy(clone, [
+        ["of:named", { value: "rewritten", result: link("of:piece") }],
+      ]);
+      const strict = await cf(`space verify ${clone}`);
+      expect(strict.code).toBe(1); // any change fails the strict default
+      const relaxed = await cf(`space verify ${clone} --expect-migration`);
+      expect(relaxed.code).toBe(0); // ...but is the expected migration outcome
+      expect(text(relaxed.stdout)).toContain("removed    0");
+
+      // A removal must fail even with the flag, or the gate protects nothing.
+      const db = new Database(workingCopy(clone));
+      db.exec(`DELETE FROM revision WHERE id = 'of:named'`);
+      db.close();
+      const removed = await cf(`space verify ${clone} --expect-migration`);
+      expect(removed.code).toBe(1);
+      expect(text(removed.stdout)).toContain("ENTITIES REMOVED");
+    });
+  });
+
   it("requires --from and --to, and says what they are for", async () => {
     await withFixture(async ({ snapshot, clone }) => {
       const noFrom = await cf(`space clone ${SPACE} --to ${clone}`);

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -480,9 +480,11 @@ function assertSafeTarget(
       `refusing to clone into the snapshot's own directory (${sourceDir}).`,
     );
   }
+  // Blank entries are dropped by the caller before canonicalization (a blank
+  // would resolve to the working directory and forbid everything under it), so
+  // there is no empty-string case to re-check here.
   for (const raw of forbiddenDirs) {
     const forbidden = raw.replace(/\/+$/, "");
-    if (forbidden === "") continue;
     if (isWithin(dir, forbidden) || isWithin(forbidden, dir)) {
       throw new Error(
         `refusing to write a clone into ${dir}: it overlaps the live store ` +

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -63,6 +63,17 @@ export interface CloneManifest {
   createdAt: string;
   /** SHA-256 of the pristine snapshot file. */
   snapshotHash: string;
+  /**
+   * SHA-256 of the per-entity baseline sidecar.
+   *
+   * The sidecar feeds `diff` and therefore `okAfterMigration` — the verdict a
+   * rehearsal script gates on — so it gets the same integrity treatment as the
+   * snapshot. Without this, a corrupted-but-parseable sidecar (two hashes
+   * swapped inside valid JSON) would produce a confident, wrong diff while
+   * `baselineIntact` still reported true. Absent on clones taken before the
+   * sidecar existed, which fall back to recomputing.
+   */
+  baselineHash?: string;
   snapshotBytes: number;
   /** Durable counts at clone time — the cheap half of "did content survive?". */
   counts: {
@@ -200,6 +211,12 @@ export async function createClone(
     paths.baselinePath,
     JSON.stringify(fingerprint.perEntity),
   );
+  // Recorded after the write so the manifest describes what is actually on disk.
+  manifest.baselineHash = await hashFile(paths.baselinePath);
+  await Deno.writeTextFile(
+    paths.manifestPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
   await Deno.writeTextFile(
     `${dir}/${MARKER}`,
     `This directory is a CLONE of space ${options.space}, not production.\n` +
@@ -294,8 +311,19 @@ export interface VerifyResult {
  * the working copy still holds the same durable content.
  *
  * A migration rehearsal EXPECTS counts to grow — that is what a migration does.
- * The fingerprint is the signal that matters: generated cells are excluded, so
- * a clean pattern update should leave it unchanged even as commits climb.
+ *
+ * It also expects the content fingerprint to MOVE. Excluding generated cells is
+ * not enough to hold it still: a schema update rewrites every piece's result
+ * value, and results are part of the fingerprint. The first real rehearsal
+ * proved this — 74 pieces and 73 owned cells changed while every authored
+ * title, body, comment and link stayed byte-identical.
+ *
+ * So the hash cannot be the verdict after a migration. `diff` is: entities
+ * `removed` is the alarm, and changes confined to pieces and their derived
+ * cells are the update working. `ok` stays strict for checking an untouched
+ * clone; `okAfterMigration` is the one to gate a rehearsal on. Neither can see
+ * a clobber of authored content, which is why the runbook checks that
+ * separately.
  */
 export async function verifyClone(dir: string): Promise<VerifyResult> {
   const manifest = await readManifest(dir);
@@ -320,6 +348,16 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
   // taken before the sidecar existed falls back to computing it.
   let before: FingerprintReport;
   try {
+    if (manifest.baselineHash !== undefined) {
+      const actual = await hashFile(paths.baselinePath);
+      if (actual !== manifest.baselineHash) {
+        throw new Error(
+          `${paths.baselinePath} does not match the hash recorded in ` +
+            `${MANIFEST}; the baseline is damaged and its diff would be wrong. ` +
+            `Re-clone rather than trusting this verdict.`,
+        );
+      }
+    }
     const rows = JSON.parse(
       await Deno.readTextFile(paths.baselinePath),
     ) as FingerprintReport["perEntity"];
@@ -342,12 +380,27 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
   }
 
   const d = diffFingerprints(before, fingerprint);
-  const kindOf = new Map(fingerprint.perEntity.map((e) => [e.id, e.kind]));
-  const kindWas = new Map(before.perEntity.map((e) => [e.id, e.kind]));
-  const tally = (ids: string[], m: Map<string, string>) => {
+  // `diffFingerprints` keys by id AND scope, because one id can hold a shared
+  // space value plus per-user/per-session overrides that are genuinely
+  // different entities. Keying these lookups by id alone would let the last
+  // scope win and misclassify the tally — exactly the precision ("74 pieces vs
+  // 73 cells") the diff exists to provide. `diff` reports bare ids, so a
+  // by-id-only fallback keeps a lookup working when scopes disagree.
+  const kindIndex = (rows: FingerprintReport["perEntity"]) => {
+    const byIdAndScope = new Map<string, string>();
+    const byId = new Map<string, string>();
+    for (const e of rows) {
+      byIdAndScope.set(`${e.id} ${e.scope}`, e.kind);
+      byId.set(e.id, e.kind);
+    }
+    return (id: string) => byIdAndScope.get(id) ?? byId.get(id) ?? "unknown";
+  };
+  const kindOf = kindIndex(fingerprint.perEntity);
+  const kindWas = kindIndex(before.perEntity);
+  const tally = (ids: string[], lookup: (id: string) => string) => {
     const out: Record<string, number> = {};
     for (const id of ids) {
-      const k = m.get(id) ?? "unknown";
+      const k = lookup(id);
       out[k] = (out[k] ?? 0) + 1;
     }
     return out;

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -31,7 +31,11 @@ import {
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import { createHasher } from "@commonfabric/content-hash";
 import { openSpace } from "./db.ts";
-import { contentFingerprint, type FingerprintReport } from "./fingerprint.ts";
+import {
+  contentFingerprint,
+  diffFingerprints,
+  type FingerprintReport,
+} from "./fingerprint.ts";
 
 /** Filenames the layout depends on. */
 const MANIFEST = "clone.json";
@@ -226,6 +230,26 @@ export interface VerifyResult {
     match: boolean;
     excludedGenerated: number;
   };
+  /**
+   * WHAT moved, against the pristine baseline — the part an operator can act on.
+   *
+   * A schema migration necessarily rewrites every piece's result value, so
+   * `fingerprint.match` is false after ANY successful migration and cannot by
+   * itself distinguish "the update worked" from "content was destroyed". The
+   * shape of the change is what separates them: entities `removed` is the alarm,
+   * while `changed` confined to pieces and their derived cells is the migration
+   * doing its job. Measured on the July 2026 Topics rehearsal: 74 pieces and 73
+   * owned cells changed, 3,189 added, **0 removed**, with every authored title,
+   * body, comment and link byte-identical.
+   */
+  diff: {
+    removed: number;
+    changed: number;
+    added: number;
+    /** Counts per entity kind, so "74 pieces" reads differently from "74 cells". */
+    changedByKind: Record<string, number>;
+    removedByKind: Record<string, number>;
+  };
 }
 
 /**
@@ -253,6 +277,34 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
     space.close();
   }
 
+  // Diff against the pristine baseline so the report can say WHAT moved, not
+  // merely that something did.
+  const baseline = openSpace(paths.pristinePath);
+  let delta;
+  try {
+    const before = contentFingerprint(baseline);
+    const d = diffFingerprints(before, fingerprint);
+    const kindOf = new Map(fingerprint.perEntity.map((e) => [e.id, e.kind]));
+    const kindWas = new Map(before.perEntity.map((e) => [e.id, e.kind]));
+    const tally = (ids: string[], m: Map<string, string>) => {
+      const out: Record<string, number> = {};
+      for (const id of ids) {
+        const k = m.get(id) ?? "unknown";
+        out[k] = (out[k] ?? 0) + 1;
+      }
+      return out;
+    };
+    delta = {
+      removed: d.removed.length,
+      changed: d.changed.length,
+      added: d.added.length,
+      changedByKind: tally(d.changed, kindOf),
+      removedByKind: tally(d.removed, kindWas),
+    };
+  } finally {
+    baseline.close();
+  }
+
   const match = fingerprint.hash === manifest.fingerprint.hash;
   return {
     ok: baselineIntact && match,
@@ -264,6 +316,7 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
       match,
       excludedGenerated: fingerprint.excludedGenerated,
     },
+    diff: delta,
   };
 }
 

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -39,6 +39,16 @@ import {
 
 /** Filenames the layout depends on. */
 const MANIFEST = "clone.json";
+/**
+ * Per-entity baseline hashes, written beside the manifest at clone time.
+ *
+ * `createClone` already fingerprints the pristine snapshot; keeping its
+ * per-entity rows means `verify` diffs against a file instead of re-opening and
+ * re-fingerprinting a multi-gigabyte baseline on every call — measured at 43s
+ * vs 13s on the 1.0 GB Estuary store, on the operation a rehearsal runs most.
+ * Kept out of `clone.json` so that file stays small enough to read by eye.
+ */
+const BASELINE = "baseline-entities.json";
 const MARKER = ".cf-clone";
 const PRISTINE_DIR = "pristine";
 
@@ -84,6 +94,8 @@ export interface CreateCloneOptions {
 export interface ClonePaths {
   dir: string;
   manifestPath: string;
+  /** Per-entity baseline hashes (see {@link BASELINE}). */
+  baselinePath: string;
   pristinePath: string;
   workingPath: string;
 }
@@ -111,6 +123,7 @@ export function clonePaths(dir: string, space: string): ClonePaths {
   return {
     dir,
     manifestPath: `${dir}/${MANIFEST}`,
+    baselinePath: `${dir}/${BASELINE}`,
     pristinePath: `${dir}/${PRISTINE_DIR}/${space}.sqlite`,
     workingPath,
   };
@@ -184,6 +197,10 @@ export async function createClone(
     `${JSON.stringify(manifest, null, 2)}\n`,
   );
   await Deno.writeTextFile(
+    paths.baselinePath,
+    JSON.stringify(fingerprint.perEntity),
+  );
+  await Deno.writeTextFile(
     `${dir}/${MARKER}`,
     `This directory is a CLONE of space ${options.space}, not production.\n` +
       `Taken ${manifest.createdAt} from ${options.source}.\n` +
@@ -214,8 +231,28 @@ export async function resetClone(dir: string): Promise<CloneManifest> {
 }
 
 export interface VerifyResult {
-  /** True when the baseline is intact AND the working copy still matches it. */
+  /**
+   * Strict: the baseline is intact AND nothing moved at all.
+   *
+   * Correct for "is this clone still pristine?", and correct for catching an
+   * accidental clobber. NOT usable as the verdict after a migration: a schema
+   * update rewrites every piece's result value, so this is false after every
+   * successful one.
+   *
+   * Which of those two situations applies is something only the caller knows,
+   * so the tool does not guess — see `okAfterMigration`.
+   */
   ok: boolean;
+  /**
+   * Relaxed: the baseline is intact and nothing was REMOVED.
+   *
+   * The verdict to gate on when a migration was expected. Content *changing* is
+   * then information (results are rewritten by design); content *disappearing*
+   * is the alarm. It cannot distinguish a clobber from a migration — nothing
+   * hash-shaped can — which is why the runbook insists authored content be
+   * checked separately.
+   */
+  okAfterMigration: boolean;
   /** The pristine snapshot still hashes to what the manifest recorded. */
   baselineIntact: boolean;
   /** Working-copy counts, against the manifest's. */
@@ -277,37 +314,56 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
     space.close();
   }
 
-  // Diff against the pristine baseline so the report can say WHAT moved, not
-  // merely that something did.
-  const baseline = openSpace(paths.pristinePath);
-  let delta;
+  // Diff against the baseline recorded at clone time, so the report can say
+  // WHAT moved rather than merely that something did. Reading the sidecar
+  // avoids re-fingerprinting the pristine snapshot on every verify; a clone
+  // taken before the sidecar existed falls back to computing it.
+  let before: FingerprintReport;
   try {
-    const before = contentFingerprint(baseline);
-    const d = diffFingerprints(before, fingerprint);
-    const kindOf = new Map(fingerprint.perEntity.map((e) => [e.id, e.kind]));
-    const kindWas = new Map(before.perEntity.map((e) => [e.id, e.kind]));
-    const tally = (ids: string[], m: Map<string, string>) => {
-      const out: Record<string, number> = {};
-      for (const id of ids) {
-        const k = m.get(id) ?? "unknown";
-        out[k] = (out[k] ?? 0) + 1;
-      }
-      return out;
+    const rows = JSON.parse(
+      await Deno.readTextFile(paths.baselinePath),
+    ) as FingerprintReport["perEntity"];
+    before = {
+      hash: manifest.fingerprint.hash,
+      entities: rows.length,
+      excludedGenerated: manifest.fingerprint.excludedGenerated,
+      ambiguous: [],
+      unhashable: [],
+      perEntity: rows,
     };
-    delta = {
-      removed: d.removed.length,
-      changed: d.changed.length,
-      added: d.added.length,
-      changedByKind: tally(d.changed, kindOf),
-      removedByKind: tally(d.removed, kindWas),
-    };
-  } finally {
-    baseline.close();
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) throw error;
+    const baseline = openSpace(paths.pristinePath);
+    try {
+      before = contentFingerprint(baseline);
+    } finally {
+      baseline.close();
+    }
   }
+
+  const d = diffFingerprints(before, fingerprint);
+  const kindOf = new Map(fingerprint.perEntity.map((e) => [e.id, e.kind]));
+  const kindWas = new Map(before.perEntity.map((e) => [e.id, e.kind]));
+  const tally = (ids: string[], m: Map<string, string>) => {
+    const out: Record<string, number> = {};
+    for (const id of ids) {
+      const k = m.get(id) ?? "unknown";
+      out[k] = (out[k] ?? 0) + 1;
+    }
+    return out;
+  };
+  const delta = {
+    removed: d.removed.length,
+    changed: d.changed.length,
+    added: d.added.length,
+    changedByKind: tally(d.changed, kindOf),
+    removedByKind: tally(d.removed, kindWas),
+  };
 
   const match = fingerprint.hash === manifest.fingerprint.hash;
   return {
     ok: baselineIntact && match,
+    okAfterMigration: baselineIntact && delta.removed === 0,
     baselineIntact,
     counts: { manifest: manifest.counts, working: counts },
     fingerprint: {

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -189,6 +189,36 @@ Deno.test("verify reports WHAT moved, not merely that something did", async () =
   });
 });
 
+Deno.test("a migration-shaped change is a PASS, not a failure", async () => {
+  // The verdict and the message have to agree. An earlier version reported
+  // "this is the EXPECTED result of a migration" while returning ok=false, so
+  // the CLI exited nonzero — meaning a rehearsal script written from the
+  // documented procedure would treat every successful migration as a failure
+  // and refuse to proceed. Content CHANGING is information; content
+  // DISAPPEARING is the alarm.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+    // What a migration does: rewrite derived values, add new cells, drop nothing.
+    mutate(paths.workingPath, [
+      ["of:named", {
+        value: "rewritten-by-migration",
+        result: link("of:piece"),
+      }],
+      ["of:brand-new-derived-cell", { value: 1, result: link("of:piece") }],
+    ]);
+
+    const v = await verifyClone(clone);
+    assertEquals(v.diff.removed, 0);
+    assert(!v.fingerprint.match, "the hash necessarily moves");
+    assert(!v.ok, "strict stays strict — something DID change");
+    assert(
+      v.okAfterMigration,
+      "but the migration verdict passes: nothing lost",
+    );
+  });
+});
+
 Deno.test("verify catches a real content change", async () => {
   await withDirs(async ({ source, clone }) => {
     await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
@@ -199,9 +229,16 @@ Deno.test("verify catches a real content change", async () => {
     }]]);
 
     const v = await verifyClone(clone);
-    assert(!v.ok, "authored content moved");
-    assert(!v.fingerprint.match);
+    assert(!v.ok, "the strict verdict catches an accidental clobber");
+    assert(!v.fingerprint.match, "authored content moved");
+    assertEquals(v.diff.changed, 1);
     assert(v.baselineIntact, "the baseline itself is still fine");
+    // Honest limit: a clobber is a CHANGE, so the migration verdict cannot see
+    // it. That is why authored content must be checked separately after a run.
+    assert(
+      v.okAfterMigration,
+      "documented blind spot, asserted so it stays known",
+    );
   });
 });
 
@@ -217,7 +254,10 @@ Deno.test("reset discards the attempt, including WAL companions", async () => {
     mutate(paths.workingPath, [["of:input", {
       value: { title: "CLOBBERED" },
     }]]);
-    assert(!(await verifyClone(clone)).ok, "the attempt landed");
+    assert(
+      !(await verifyClone(clone)).ok,
+      "the attempt landed",
+    );
 
     await resetClone(clone);
 
@@ -231,6 +271,7 @@ Deno.test("reset discards the attempt, including WAL companions", async () => {
     }
     const v = await verifyClone(clone);
     assert(v.ok, "back to baseline");
+    assert(v.fingerprint.match, "and byte-for-byte identical again");
     assertEquals(v.counts.working.commits, v.counts.manifest.commits);
   });
 });

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -393,6 +393,35 @@ Deno.test("refuses a non-empty target rather than merging into it", async () => 
   });
 });
 
+Deno.test("the per-kind tally respects scope, not just id", async () => {
+  // One id can hold a shared space value AND per-user overrides that are
+  // genuinely different entities; `diffFingerprints` keys by id AND scope.
+  // Keying the kind lookup by id alone let the last scope win and misclassify
+  // the tally — the precision ("74 pieces vs 73 cells") the diff exists for.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const db = new Database(clonePaths(clone, SPACE).workingPath);
+    const seq = db.prepare(`SELECT max(seq) s FROM "commit"`)
+      .get<{ s: number }>()!.s + 1;
+    db.prepare(
+      `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+       VALUES (?, ?, ?, '{}', '{}')`,
+    ).run(seq, SESSION, seq);
+    // Same id as an existing space-scope cell, in a per-user scope.
+    db.prepare(
+      `INSERT INTO revision (id, scope_key, seq, op_index, op, data, commit_seq)
+       VALUES ('of:named', 'user:did%3Akey%3AzAlice', ?, 0, 'set', ?, ?)`,
+    ).run(seq, JSON.stringify({ value: "per-user override" }), seq);
+    db.close();
+
+    const v = await verifyClone(clone);
+    assertEquals(v.diff.removed, 0);
+    assertEquals(v.diff.added, 1, "the per-user entity is new, not a rewrite");
+    // Classified as its own kind rather than inheriting the space-scope row's.
+    assertEquals(Object.values(v.diff.removedByKind).length, 0);
+  });
+});
+
 Deno.test("a clone taken before the baseline sidecar still verifies", async () => {
   // Backward compatibility: clones made before per-entity baselines were
   // recorded have no sidecar, and must still produce a real diff by
@@ -414,6 +443,30 @@ Deno.test("a clone taken before the baseline sidecar still verifies", async () =
     const dirty = await verifyClone(clone);
     assertEquals(dirty.diff.changed, 1);
     assert(!dirty.ok);
+  });
+});
+
+Deno.test("a corrupted-but-PARSEABLE sidecar is caught by its hash", async () => {
+  // The dangerous case is not unparseable JSON — it is valid JSON with wrong
+  // contents. The sidecar feeds `diff` and therefore `okAfterMigration`, the
+  // verdict a rehearsal gates on, so a silently wrong baseline would produce a
+  // confident wrong answer while `baselineIntact` still reported true.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const path = clonePaths(clone, SPACE).baselinePath;
+    const rows = JSON.parse(await Deno.readTextFile(path)) as {
+      id: string;
+      hash: string | null;
+    }[];
+    // Still valid JSON, still the right shape — one hash quietly altered.
+    rows[0].hash = "fid1:tamperedtamperedtamperedtamperedtamperedta";
+    await Deno.writeTextFile(path, JSON.stringify(rows));
+
+    const error = await assertRejects(() => verifyClone(clone), Error);
+    assert(
+      error.message.includes("does not match the hash recorded"),
+      `expected an integrity failure, got: ${error.message}`,
+    );
   });
 });
 

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -167,6 +167,28 @@ Deno.test("a clean migration keeps the fingerprint even as commits climb", async
   });
 });
 
+Deno.test("verify reports WHAT moved, not merely that something did", async () => {
+  // The headline hash cannot distinguish a successful migration from data
+  // loss: a schema update rewrites every piece result, so it always differs.
+  // `removed` is the unambiguous alarm, and the per-kind tally is what lets an
+  // operator judge the rest.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+    mutate(paths.workingPath, [
+      ["of:named", { value: "named-v2", result: link("of:piece") }],
+      ["of:newcomer", { value: "hello" }],
+    ]);
+
+    const v = await verifyClone(clone);
+    assertEquals(v.diff.removed, 0, "nothing was destroyed");
+    assertEquals(v.diff.changed, 1);
+    assertEquals(v.diff.added, 1);
+    assertEquals(v.diff.changedByKind["owned-cell"], 1);
+    assertEquals(v.diff.removedByKind, {});
+  });
+});
+
 Deno.test("verify catches a real content change", async () => {
   await withDirs(async ({ source, clone }) => {
     await createClone({ source, space: SPACE, targetDir: clone, now: NOW });

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -393,6 +393,66 @@ Deno.test("refuses a non-empty target rather than merging into it", async () => 
   });
 });
 
+Deno.test("a clone taken before the baseline sidecar still verifies", async () => {
+  // Backward compatibility: clones made before per-entity baselines were
+  // recorded have no sidecar, and must still produce a real diff by
+  // recomputing from the pristine snapshot rather than silently comparing
+  // against nothing — which would report every entity as "added" and pass.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    await Deno.remove(clonePaths(clone, SPACE).baselinePath);
+
+    const clean = await verifyClone(clone);
+    assertEquals(clean.diff.added, 0, "not 'everything is new'");
+    assertEquals(clean.diff.changed, 0);
+    assert(clean.ok);
+
+    // And it still detects a real change without the sidecar.
+    mutate(clonePaths(clone, SPACE).workingPath, [
+      ["of:input", { value: { title: "CLOBBERED" } }],
+    ]);
+    const dirty = await verifyClone(clone);
+    assertEquals(dirty.diff.changed, 1);
+    assert(!dirty.ok);
+  });
+});
+
+Deno.test("a corrupt baseline sidecar fails loudly rather than recomputing", async () => {
+  // Absent is ordinary — an older clone simply has no sidecar. UNREADABLE is
+  // not: silently falling back to recomputation would produce a correct-looking
+  // verdict while hiding that the clone directory is damaged, and verify's job
+  // is to report damage, not paper over it.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    await Deno.writeTextFile(
+      clonePaths(clone, SPACE).baselinePath,
+      "{ this is not json",
+    );
+    await assertRejects(() => verifyClone(clone), Error);
+  });
+});
+
+Deno.test("an IO error while clearing the working set is surfaced", async () => {
+  // reset probes for `-wal`/`-shm` companions; only "absent" is an ordinary
+  // answer. A component that is not a directory yields NotADirectory, which
+  // must propagate rather than be read as "nothing there" — treating it as
+  // absent would skip a file it failed to delete and call the clone pristine.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const working = clonePaths(clone, SPACE).workingPath;
+    // Replace the directory holding the working copy with a regular file.
+    const dir = working.replace(/\/[^/]*$/, "");
+    await Deno.remove(dir, { recursive: true });
+    await Deno.writeTextFile(dir, "not a directory");
+
+    const error = await assertRejects(() => resetClone(clone), Error);
+    assert(
+      error instanceof Deno.errors.NotADirectory,
+      `expected the real IO error, got ${error.constructor.name}`,
+    );
+  });
+});
+
 Deno.test("a directory without a manifest is not a clone", async () => {
   await withDirs(async ({ root }) => {
     await assertRejects(


### PR DESCRIPTION
## Why

The first real rehearsal — 74 `setsrc` operations against a clone of the production Topics board — disproved a claim this tooling was built on.

`docs/plans/space-clone-rehearsal.md` said that excluding compiler-generated cells would leave the content fingerprint **unchanged** across a clean pattern update. It does not. A schema migration rewrites every piece's **result** value, and results are part of the fingerprint, so `fingerprint.match` is false after *any* successful migration.

Excluding generated cells was necessary and **insufficient**. The single hash therefore could not distinguish "the update worked" from "content was destroyed" — the one job it existed for. What the operator saw at the end of a perfectly good migration was:

```
content    CHANGED
CONTENT CHANGED — run `cf space fingerprint …` to see which entities moved.
```

…with no way to tell that from data loss.

## What Changed

`verifyClone` now diffs the working copy against the pristine baseline and reports **removed / changed / added** with a per-kind tally. Against the real rehearsal:

```
baseline   intact
removed    0
changed    149  (74 piece, 73 owned-cell, 2 module)
added      3189
content    CHANGED

CHANGED, nothing removed. After a schema migration this is the EXPECTED result:
every piece's result value is rewritten, so the fingerprint cannot match.
Confirm the changes are confined to pieces and their derived cells, then check
authored content (titles, bodies, comments) separately — the fingerprint alone
cannot tell you it survived.
```

`removed` is the alarm; changes confined to pieces and their derived cells are the migration working. Authored content was separately confirmed intact on that run — **73 topics, 59 comments, 56 links, every body byte-identical**, matching #4997's numbers exactly.

Both docs are corrected rather than left asserting the disproved claim, including an explicit "Corrected by the first real rehearsal" section in the design doc.

The runbook gains two operational notes that cost real time to learn:

- A migration driver **must fail loudly when the server goes away** — a wedged toolshed made every subsequent `setsrc` hang with no error, no log line, and no progress.
- But it must **not** implement that as a wall-clock probe. The same run saw `/api/meta` intermittently take **over 60 s** while the server was healthy and still committing writes, so a `curl --max-time 15` liveness check would abort a working migration. That is the failure `AGENTS.md` warns about, and my first attempt at the fix reintroduced it through `curl`.
- Resource budgeting: serving a 1 GB store while compiling and deploying 74 patterns exhausted a laptop's memory and pushed swap to 95%, which is what wedged the server.

## Test plan

- New test asserting the diff reports *what* moved, not merely that something did — including `removed 0` and the per-kind tally.
- `packages/state-inspector` — 80 passed; `packages/cli` — 123 passed; `deno task check-docs` — 523 blocks; `deno check`, `deno lint`, `deno fmt` clean.
- Verified against the **real migrated clone**, which is where the output above comes from.

## Not fixed here

Whether the fingerprint should exclude piece results entirely is a real design question — results *can* hold authored state, so narrowing it needs thought rather than a drive-by. Reporting the shape makes the tool honest today; narrowing the hash is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `cf space verify` report what moved and add a migration‑aware exit path via `--expect-migration`, backed by an integrity‑checked cached per‑entity baseline for faster, safer runs. Updates CLI output, docs, and tests, and tightens handling around baseline integrity, tally accuracy, and exit codes.

- **New Features**
  - `packages/state-inspector`: `verifyClone` returns a `diff` (removed/changed/added with per‑kind tallies) and `okAfterMigration`. `createClone` writes per‑entity hashes to `baseline-entities.json` and records `baselineHash` in the manifest; `verifyClone` validates it before diffing (falls back to recompute for older clones).
  - `packages/cli`: `cf space verify` prints baseline status and the diff, explains that CHANGED with no removals is expected after a migration, and adds `--expect-migration` so the exit code only fails on a corrupted baseline or removed entities.

- **Bug Fixes**
  - `packages/state-inspector`: Per‑kind tallies key by id+scope to avoid misclassification; a corrupted‑but‑parseable sidecar is detected via `baselineHash` and fails loudly; UNREADABLE sidecars fail; missing sidecars recompute; `reset` surfaces real IO errors; docstrings corrected.
  - Tests: Added coverage for sidecar integrity, scope‑aware tallies, the two verify verdicts, and `--expect-migration` exit behavior (rewrite passes; removal still fails).

<sup>Written for commit 2b05cc0bc2215d982f4a304c614b852c5d4c1535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

