### PR TITLE
fix(integration): click the exact control proven settled

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -149,7 +149,6 @@ const path = ["x-root", "#shadow-root", "cf-input", "#shadow-root", "input"];
 ```typescript
 // Shown at module scope.
 import {
-  awaitViewSettled,
   env,
   waitForCondition,
 } from "@commonfabric/integration";
@@ -157,6 +156,10 @@ import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { Identity } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
+import {
+  clickCfButton,
+  fillCfInput,
+} from "./cfc-browser-helpers.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
@@ -193,15 +196,8 @@ describe("shadow DOM component test", () => {
       identity,
     });
 
-    // Settle the view so each control's handler is bound before acting (see
-    // "Waiting Until the UI Is Interactive" below), then act once.
-    await awaitViewSettled(page);
-    const input = await page.waitForSelector("cf-input[role='textbox']");
-    await input.type("Hello World");
-
-    await awaitViewSettled(page);
-    const button = await page.waitForSelector("cf-button[role='button']");
-    await button.click();
+    await fillCfInput(page, "cf-input[role='textbox']", "Hello World");
+    await clickCfButton(page, "cf-button[role='button']");
 
     // Verify the effect event-drivenly: waitForCondition resolves the instant
     // the result text appears, with no test-side poll.
@@ -241,47 +237,30 @@ fire, the click lands on whatever shifted into that spot instead of the control,
 and nothing happens. Settling the view drains the pending reflow so the target
 is stationary when it is clicked.
 
-**Use `awaitViewSettled(page)`** from `@commonfabric/integration` before issuing
-the first click or keystroke after navigation or any state change. It resolves
-once all three stages are done, so a single click then lands on a bound handler:
+**Use `awaitViewSettled(page)`** from `@commonfabric/integration` as the
+lower-level wait after navigation or a state change. When the next step
+clicks a control, use `clickCfButton` instead. It resolves, settles, and marks
+the exact click target in one page-side predicate:
 
 ```typescript
 // Shown at module scope.
-import {
-  awaitViewSettled,
-  waitForCondition,
-} from "@commonfabric/integration";
+import { waitForCondition } from "@commonfabric/integration";
+import { clickCfButton } from "./cfc-browser-helpers.ts";
 
-// Before interacting: settle the view on each check and pass only once a settle
-// has run with the control present, so the click lands on a bound handler. A
-// settle that ran before the control existed says nothing about it, and a check
-// that only watches the DOM never pumps the work that renders it.
-await waitForCondition(page, async (probe) => {
-  const settle = (globalThis as {
-    commonfabric?: { viewSettled?: () => Promise<void> };
-  }).commonfabric?.viewSettled;
-  if (!settle) return false;
-  await settle();
-  const target = probe.collect("cf-button[role='button']")[0];
-  return target !== undefined && probe.isRendered(target);
-});
-const button = await page.waitForSelector("cf-button[role='button']");
-await button.click(); // delivered to a bound handler
+await clickCfButton(page, "cf-button[role='button']");
 
-// After interacting: settle once, then wait for the click's specific effect
-// event-drivenly. The modal opening is a DOM mutation, so waitForCondition's
-// in-page waiter resolves the instant it appears.
-await awaitViewSettled(page);
+// Wait for the click's specific effect. The modal opening is a DOM mutation, so
+// the in-page waiter resolves when it appears.
 await waitForCondition(page, (probe) =>
   probe.collect("cf-modal[open]").length > 0);
 ```
 
-Pattern integration tests can reach for the higher-level wrappers in
+Pattern integration tests can use the higher-level wrappers in
 `packages/patterns/integration/cfc-browser-helpers.ts` — `waitForText`,
 `fillCfInput`, `clickCfButton`, `clickCfButtonAndWaitForText` — which bundle
-"settle the view with the control present, act once, wait for the effect" on top
-of these primitives. `clickCfButton` settles on each check and proceeds only
-once a settle has run with the control present; see
+the common waiting and interaction sequences. `clickCfButton` proceeds only
+when the same target remains rendered before and after a settle. It marks that
+target inside the successful predicate. See
 `docs/development/waiting-in-tests.md` for why that ordering is the load-bearing
 part, and for which helpers do not yet have it.
 
@@ -308,8 +287,8 @@ Each of the following is what `awaitViewSettled` replaces. They are either racy
   `waitForSelector` is itself a tight CDP poll, and a present element is not a
   ready one.
 
-The shape is always: settle the view, click once, then wait for the effect —
-never poll-and-pray, and never re-click.
+The shape is always: resolve the target, prove that exact rendered element
+survives a settle, and mark it. Then click once and wait for the effect.
 
 A CI check enforces this for the polling `waitFor`: `deno task check-no-waitfor`
 fails when an integration test imports `waitFor` as a value from

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -99,14 +99,14 @@ Waits split into two groups with different primitives.
   has finished its update cycle. This is the "is the control interactive yet"
   signal.
 - The higher-level wrappers in
-  `packages/patterns/integration/cfc-browser-helpers.ts` — `waitForText`,
-  `waitForSettledText`, `waitForTextAbsent`, `fillCfInput`, `clickCfButton`,
-  `clickNthCfButton`, `clickCfButtonAndWaitForText`, `waitForRuntimeIdle`,
-  `waitForRuntimeSynced` — bundle "settle the view with the control present,
-  act once, wait for the effect" on top of the two primitives above.
-  `clickCfButton` takes the first match and reaches through a host's shadow root
-  for its inner `[data-cf-button]`; `clickNthCfButton` takes the `index`-th
-  match of a selector that already resolves to the buttons themselves.
+  `packages/patterns/integration/cfc-browser-helpers.ts` compose the two
+  primitives above for common waits and interactions. `clickCfButton` and
+  `clickCfButtonsConcurrently` settle and mark the exact rendered targets before
+  clicking them. `clickCfButton` takes the first match and reaches through a
+  host's shadow root for its inner `[data-cf-button]`.
+  `clickNthCfButton` takes the `index`-th match of a selector that already
+  resolves to the buttons themselves. It does not yet have the same settlement
+  guarantee.
 
 To click a control that appears asynchronously, follow the `clickCfButton`
 shape rather than a find-and-click retry loop: a `waitForCondition` predicate
@@ -117,11 +117,11 @@ target to be rendered — laid out, and not `display:none` or `visibility:hidden
 clickable rather than tagged while it has no layout box and then failing to
 click.
 
-Settle the view inside that predicate, on every check, and let the check pass
-only on one the settle preceded. Settling is what makes a rendered control
-interactive, so a settle that ran before the control existed says nothing about
-it: the click lands on an element whose handler is not bound, is silently
-dropped, and the wait for its effect runs to the stuck-condition safety net.
+Resolve the target before settling the view inside that predicate. Let the
+check pass only when the same rendered element remains after the settle. A
+target that appears or is replaced during the settle is checked again after
+the DOM mutation. The next check gives that exact element a complete settle
+before marking it for the click.
 
 Do not reach instead for a check that only watches the DOM. Asking the worker
 whether it is idle queues runnable pull work that nothing else would start, so a
@@ -129,8 +129,9 @@ control that appears only once the page's own pending work runs never arrives
 under a purely passive wait. The settle is both the barrier and the pump, which
 is why it belongs inside the predicate rather than in front of it.
 
-When several controls are clicked as a group, resolve every one of them before
-marking any, so no settle falls between the marks and the clicks.
+When several controls are clicked as a group, prove that every target is stable
+before marking any of them. Mark the targets inside the successful predicate so
+the click addresses the elements that passed the settle check.
 
 `clickCfButton` and `clickCfButtonsConcurrently` work this way.
 `clickTrustedAction`, `submitViaEnter`, and `settleAndClickNoteButton` in

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -129,10 +129,6 @@ describe("CFC browser helpers", () => {
       let settleCalls = 0;
       let clickedAtSettle = 0;
       let bound = false;
-      // The shell binds a control's handler when the vdom batch that rendered
-      // it is applied, which is one of the things a view settle waits for. So
-      // the handler here is bound by the first settle that runs with the
-      // control present, and a click delivered before that reaches nothing.
       const bind = () => {
         const button = root.querySelector("#late-vote-button");
         if (!button || bound) return;
@@ -146,23 +142,17 @@ describe("CFC browser helpers", () => {
       }).commonfabric = {
         viewSettled: () => {
           settleCalls++;
+          if (!root.querySelector("#late-vote-button")) {
+            const button = document.createElement("button");
+            button.id = "late-vote-button";
+            button.textContent = "Veto";
+            root.append(button);
+            return Promise.resolve();
+          }
           bind();
           return Promise.resolve();
         },
       };
-
-      // The control arrives after the helper has started, the way an option
-      // card added by one browser reaches another. The delay states when the
-      // arrival happens rather than how long to wait for it: the helper's wait
-      // ends on the arrival, and only the five-minute stuck-condition net
-      // bounds it. What the delay has to outlast is one settle on the ordering
-      // this test guards against, which is a single protocol round trip.
-      setTimeout(() => {
-        const button = document.createElement("button");
-        button.id = "late-vote-button";
-        button.textContent = "Veto";
-        root.append(button);
-      }, 250);
 
       (globalThis as typeof globalThis & {
         __lateClickResult: () => {
@@ -187,7 +177,72 @@ describe("CFC browser helpers", () => {
       "the click reached no handler: the view never settled with the target " +
         "present before the click was dispatched",
     );
-    // One settle found no control, one found it, and one followed the click.
+    // One settle renders the control, one binds it, and one follows the click.
+    assertEquals(result.settleCalls, 3);
+  });
+
+  it("settles the same rendered control that it clicks", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const createButton = () => {
+        const button = document.createElement("button");
+        button.id = "replaced-join-button";
+        button.textContent = "Join";
+        return button;
+      };
+      root.append(createButton());
+      document.body.append(host);
+
+      let settleCalls = 0;
+      let clicks = 0;
+      let boundButton: HTMLButtonElement | undefined;
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+        __replacedClickResult: () => {
+          settleCalls: number;
+          clicks: number;
+        };
+      }).commonfabric = {
+        viewSettled: () => {
+          settleCalls++;
+          if (settleCalls === 1) {
+            root.replaceChildren(createButton());
+          } else {
+            const button = root.querySelector<HTMLButtonElement>(
+              "#replaced-join-button",
+            );
+            if (button && button !== boundButton) {
+              boundButton = button;
+              button.addEventListener("click", () => clicks++);
+            }
+          }
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __replacedClickResult: () => {
+          settleCalls: number;
+          clicks: number;
+        };
+      }).__replacedClickResult = () => ({ settleCalls, clicks });
+    });
+
+    await clickCfButton(page, "#replaced-join-button");
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __replacedClickResult: () => {
+          settleCalls: number;
+          clicks: number;
+        };
+      }).__replacedClickResult()
+    );
+    assertEquals(
+      result.clicks,
+      1,
+      "the click reached the replacement before its handler was bound",
+    );
     assertEquals(result.settleCalls, 3);
   });
 

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -251,70 +251,70 @@ const fillAndVerify = async (
   return verified;
 };
 
-// Tag the inner click target of the cf-button behind `selector` so the test can
-// resolve and click exactly that element. A click target that is still
-// detached, or not rendered — laid out, and not display:none or
-// visibility:hidden — is left untagged, so a re-check on the next DOM mutation
-// retries the mark once the control renders. The check is viewport-independent:
-// the click scrolls the element into view itself, so a control below the fold
-// is markable. It reads the click target alone because hiding the host or any
-// ancestor reaches the inner button either way: display:none zeroes its box,
-// and visibility:hidden inherits into its computed visibility.
-const markForClick = (
-  probe: ProbeApi,
-  selector: string,
-  token: string,
-  attr: string,
-): boolean => {
-  const target = probe.collect(selector)[0] as HTMLElement | undefined;
-  if (!target) return false;
-  const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
-    | HTMLElement
-    | null) ?? target;
-  if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
-  probe.addToken(clickTarget, attr, token);
-  return true;
-};
-
-// Settle the view, then report whether every selector resolves to a rendered
-// click target, using the same resolution and rendered-ness test as
-// `markForClick`. The resolution is spelled out again because a predicate is
-// serialized into the page and closes over nothing in this module.
+// Resolve every click target before settling the view. Mark them only when the
+// same rendered elements remain afterward. The resolution is spelled out here
+// because this predicate is serialized into the page and closes over nothing
+// in this module.
 //
-// The settle runs before the check, so a check that passes is a check on a
-// settled view: `viewSettled` returns only when a pass finds nothing pending,
-// so a target that rendered partway through is bound and drained by the time it
-// returns.
+// A target introduced or replaced during the settle is checked again when the
+// DOM mutation triggers the next evaluation. That evaluation gives the exact
+// element a full settle before marking it.
 //
 // The settle also drives the page forward. Asking the worker whether it is idle
-// queues runnable pull work that nothing else would start, so a target reached
-// only by the page's own pending work arrives on a settling check and not on
-// one that watches the DOM alone.
-const settledClickTargetsRendered = async (
+// queues runnable pull work that nothing else would start. A target reached
+// only by the page's pending work arrives on a settling check.
+const settleAndMarkClickTargets = async (
   probe: ProbeApi,
   selectors: readonly string[],
+  tokens: readonly string[],
+  attr: string,
 ): Promise<boolean> => {
   const settle = (globalThis as typeof globalThis & {
     commonfabric?: { viewSettled?: () => Promise<void> };
   }).commonfabric?.viewSettled;
-  if (!settle) return false;
-  await settle();
-  return selectors.every((selector) => {
+  if (!settle || selectors.length !== tokens.length) return false;
+
+  const resolveClickTarget = (
+    selector: string,
+  ): HTMLElement | undefined => {
     const target = probe.collect(selector)[0] as HTMLElement | undefined;
-    if (!target) return false;
-    const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
+    if (!target) return undefined;
+    return (target.shadowRoot?.querySelector("[data-cf-button]") as
       | HTMLElement
       | null) ?? target;
-    return clickTarget.isConnected && probe.isRendered(clickTarget);
+  };
+  const targetsBefore = selectors.map(resolveClickTarget);
+  const renderedBefore = targetsBefore.map((target) =>
+    target !== undefined &&
+    target.isConnected &&
+    probe.isRendered(target)
+  );
+
+  await settle();
+
+  const settledTargets = selectors.map(resolveClickTarget);
+  const ready = settledTargets.every((target, index) => {
+    return renderedBefore[index] === true &&
+      target !== undefined &&
+      target === targetsBefore[index] &&
+      target.isConnected &&
+      probe.isRendered(target);
   });
+  if (!ready) return false;
+
+  for (let index = 0; index < settledTargets.length; index++) {
+    const target = settledTargets[index];
+    const token = tokens[index];
+    if (target === undefined || token === undefined) return false;
+    probe.addToken(target, attr, token);
+  }
+  return true;
 };
 
-// Tag the `index`-th element matching `selector` once it is rendered. Unlike
-// `markForClick`, the selector here already resolves to the clickable elements,
-// so the match is tagged directly rather than reached through a host's shadow
-// root. The check is viewport-independent for the same reason as `markForClick`:
-// the click scrolls the element into view itself, so requiring it on-screen at
-// tagging time only invites a wait that never satisfies.
+// Tag the `index`-th element matching `selector` once it is rendered. The
+// selector already resolves to clickable elements, so the match is tagged
+// directly rather than reached through a host's shadow root. The rendered check
+// is viewport-independent. The click scrolls the element into view.
 const markNthForClick = (
   probe: ProbeApi,
   selector: string,
@@ -703,61 +703,26 @@ export async function waitForDisabled(
   }
 }
 
-async function markRenderedCfButton(
-  page: Page,
-  selector: string,
-): Promise<string> {
-  const token = `cf-button-${crypto.randomUUID()}`;
-  try {
-    // Mark the rendered button exactly once. The mark is the predicate, so the
-    // re-check on each DOM mutation retries finding the button without
-    // re-clicking anything.
-    await waitForCondition(page, markForClick, {
-      args: [selector, token, CLICK_TARGET_ATTR],
-    });
-  } catch (cause) {
-    // The probe's per-match `rect` and `visible` report whether the control was
-    // absent or present without a layout box.
-    const probe = await readTextProbe(page, selector).catch(() => undefined);
-    // Indented for readable test-log output
-    throw new Error(
-      `Unable to mark ${selector} for click. Last probe: ${
-        toIndentedDebugString(probe)
-      }`,
-      { cause },
-    );
-  }
-  return token;
-}
-
-async function clickRenderedCfButton(
-  page: Page,
-  selector: string,
-) {
-  const token = await markRenderedCfButton(page, selector);
-  await clickMarked(page, token);
-}
-
 /**
- * Resolve once `page` has settled with every selector rendered.
+ * Resolve once every selector identifies the same rendered target before and
+ * after one settle. Mark those exact targets for the subsequent clicks.
  *
- * A settle that runs before its target exists says nothing about that target: a
- * control that appears afterwards is laid out with its handler not yet bound,
- * the click is delivered to nothing, and the wait for its effect runs to the
- * stuck-condition safety net.
- *
- * Every target is resolved before any of them is marked, so a grouped dispatch
- * marks all of its targets with no settle in between.
+ * Every target is ready before any target is marked. A grouped dispatch can
+ * therefore click all of its marks without a settle between them.
  */
 async function settleWithClickTargets(
   page: Page,
   selectors: readonly string[],
-): Promise<void> {
+): Promise<string[]> {
+  const tokens = selectors.map(() => `cf-button-${crypto.randomUUID()}`);
   try {
-    await waitForCondition(page, settledClickTargetsRendered, {
-      args: [selectors],
+    await waitForCondition(page, settleAndMarkClickTargets, {
+      args: [selectors, tokens, CLICK_TARGET_ATTR],
     });
   } catch (cause) {
+    await Promise.all(
+      tokens.map((token) => clearClickMark(page, token).catch(() => {})),
+    );
     // Matches per selector, so the failure names which of a grouped dispatch's
     // targets never rendered. Each match's `rect` and `visible` report whether
     // the control was absent or present without a layout box. Every probe reads
@@ -784,14 +749,18 @@ async function settleWithClickTargets(
       { cause },
     );
   }
+  return tokens;
 }
 
 export async function clickCfButton(
   page: Page,
   selector: string,
 ) {
-  await settleWithClickTargets(page, [selector]);
-  await clickRenderedCfButton(page, selector);
+  const [token] = await settleWithClickTargets(page, [selector]);
+  if (token === undefined) {
+    throw new Error(`Unable to mark ${selector} for click.`);
+  }
+  await clickMarked(page, token);
   await settleView(page);
 }
 
@@ -805,26 +774,20 @@ export async function clickCfButtonsConcurrently(
   targets: readonly { page: Page; selector: string }[],
 ): Promise<void> {
   const pages = [...new Set(targets.map(({ page }) => page))];
-  await Promise.all(pages.map((page) =>
-    settleWithClickTargets(
-      page,
-      targets.filter((target) => target.page === page).map(({ selector }) =>
-        selector
-      ),
-    )
-  ));
-
   const markedByPage = pages.map((page) => ({
     page,
     tokens: [] as string[],
   }));
   const markResults = await Promise.allSettled(
     markedByPage.map(async ({ page, tokens }) => {
-      for (
-        const { selector } of targets.filter((target) => target.page === page)
-      ) {
-        tokens.push(await markRenderedCfButton(page, selector));
-      }
+      tokens.push(
+        ...await settleWithClickTargets(
+          page,
+          targets.filter((target) => target.page === page).map(
+            ({ selector }) => selector,
+          ),
+        ),
+      );
     }),
   );
   const clearMarks = () =>


### PR DESCRIPTION
The lunch-poll vote test could fill a participant name and then lose the Join click. The click helper settled the view before separately resolving and marking its target. A control created or replaced during that settle could therefore be clicked before that exact element completed a settle and received its handler.

Add a deterministic browser regression that replaces a join-like control during the first settle and binds the replacement during the next. Resolve every target before settling, require the same rendered elements afterward, and mark them inside the successful page predicate. Grouped clicks retain one settlement boundary and mark every target before dispatch.

Replace the older timer-based late-target test with a controlled settlement sequence. Update the browser-testing guides to recommend the exact-target helper and state which related helpers do not yet provide the same guarantee.

Verified with the focused browser helper suite, the lunch-poll vote integration test, deno fmt --check, deno lint, and independent forward and reverse reviews.

deflaked by Hixie's agent

Agent: OpenAI Codex (GPT-5)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky clicks in integration tests by clicking the exact element proven settled, preventing lost actions like the lunch‑poll “Join” click. Targets are now resolved before a settle, rechecked after, then marked and clicked.

- **Bug Fixes**
  - `clickCfButton` now resolves the target, settles, verifies the same rendered element remains, marks it inside the predicate, then clicks. Prevents clicking a replaced element before its handler is bound.
  - `clickCfButtonsConcurrently` settles once per page and marks all targets before dispatch, avoiding settles between marks and clicks.
  - Adds a deterministic regression test that replaces a join-like control during the first settle and binds it on the next; removes the older timer-based test.
  - Updates docs to recommend the exact-target helper (`clickCfButton`) and note which helpers (e.g., `clickNthCfButton`) don’t yet provide the same guarantee.

<sup>Written for commit b8d9f6fd1888c423aff7143b768440fffcceeaba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

